### PR TITLE
fix(ci): publish wheelhouse release instead of leaving it as draft

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -419,3 +419,12 @@ jobs:
               )
               raise SystemExit(1)
           PY
+
+      - name: Publish release (remove draft)
+        if: ${{ github.event_name == 'push' || github.event.inputs.tag != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ env.RELEASE_TAG }}
+        shell: bash
+        run: gh release edit "${TAG}" --draft=false


### PR DESCRIPTION
## Problem
The `publish-release` job in `wheelhouse-release.yml` created the GitHub release with `--draft` and had no step to remove the draft flag. Result: every release stayed a draft — invisible on the public releases page and the `/releases/download/vX/...whl` URLs returned 404 (e.g. the README's `uv tool install` command failed for `v2026.7.15`).

## Fix
Add a final `Publish release (remove draft)` step that runs `gh release edit "$TAG" --draft=false`, placed after the "Verify GitHub Release assets" step so the release only goes public once its assets are confirmed complete.

Generated with [Claude Code](https://claude.com/claude-code)