### PR TITLE
feat(onboarding): rename router mode labels to benefit-oriented names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,9 +154,9 @@ strategy = "v4_phase3"   # or "llm_judge"
 ```
 
 Both strategies are also selectable from the Mode dropdown in onboarding
-(Web UI wizard and CLI): **AgentOS Router (Local ML)**, **AgentOS Router (LLM
-Judge)**, or **Disabled**. The "Judge model" field only appears for the LLM
-Judge strategy.
+(Web UI wizard and CLI): **Smart routing (on-device)** (`v4_phase3`), **Smart
+routing (LLM-based)** (`llm_judge`), or **Off**. The "Judge model" field only
+appears for the LLM-based strategy.
 
 ### Local judge (Ollama / LM Studio)
 

--- a/docs/features/agentos-router.md
+++ b/docs/features/agentos-router.md
@@ -26,14 +26,14 @@ AgentOS Router has two selectable strategies, set via
 
 | Strategy | Mode label | How it decides |
 | --- | --- | --- |
-| `v4_phase3` (default) | AgentOS Router (Local ML) | An on-device ML ensemble (BGE embeddings + LightGBM) scores each turn locally — no LLM call, nothing leaves your machine. The ~75MB model bundle is **not** distributed with the repo or the wheel yet, and the installers do not fetch it. When it is missing, the router logs a warning at boot and pins every turn to the default tier (c1) instead of failing the turn. To enable per-turn routing, restore the bundle into `src/agentos/agentos_router/models/v4.2_phase3_inference/`, or switch to `llm_judge` (which needs no local model files). |
-| `llm_judge` | AgentOS Router (LLM Judge) | A small "judge" model classifies each turn (R0–R3) via a forced tool call. The judge can be a cloud model (default: the cheapest tier of your active provider) or a local OpenAI-compatible endpoint (Ollama, LM Studio, llama.cpp, vLLM) configured with `judge_model` / `judge_base_url`. |
+| `v4_phase3` (default) | Smart routing (on-device) | An on-device ML ensemble (BGE embeddings + LightGBM) scores each turn locally — no LLM call, nothing leaves your machine. The ~75MB model bundle is **not** distributed with the repo or the wheel yet, and the installers do not fetch it. When it is missing, the router logs a warning at boot and pins every turn to the default tier (c1) instead of failing the turn. To enable per-turn routing, restore the bundle into `src/agentos/agentos_router/models/v4.2_phase3_inference/`, or switch to `llm_judge` (which needs no local model files). |
+| `llm_judge` | Smart routing (LLM-based) | A small "judge" model classifies each turn (R0–R3) via a forced tool call. The judge can be a cloud model (default: the cheapest tier of your active provider) or a local OpenAI-compatible endpoint (Ollama, LM Studio, llama.cpp, vLLM) configured with `judge_model` / `judge_base_url`. |
 
 Both the Web UI setup wizard and the CLI (`agentos onboard`,
 `agentos configure router`) offer a Mode dropdown with three options:
-**AgentOS Router (Local ML)**, **AgentOS Router (LLM Judge)**, and
-**Disabled**. The "Judge model" field only appears when LLM Judge is
-selected — it is irrelevant to the local ML strategy.
+**Smart routing (on-device)**, **Smart routing (LLM-based)**, and
+**Off**. The "Judge model" field only appears when the LLM-based strategy is
+selected — it is irrelevant to the on-device strategy.
 
 ## Enable Routing
 

--- a/src/agentos/gateway/static/js/views/setup.js
+++ b/src/agentos/gateway/static/js/views/setup.js
@@ -514,9 +514,9 @@ const SetupView = (() => {
         <div class="setup-router-toolbar">
           <label><span>Mode</span>
             <select id="setup-router-mode" name="setup_router_mode" data-router-mode${routerDisabled}>
-              <option value="v4_phase3"${mode === 'v4_phase3' ? ' selected' : ''}>AgentOS Router (Local ML)</option>
-              <option value="llm_judge"${mode === 'llm_judge' ? ' selected' : ''}>AgentOS Router (LLM Judge)</option>
-              <option value="disabled"${mode === 'disabled' ? ' selected' : ''}>Disabled</option>
+              <option value="v4_phase3"${mode === 'v4_phase3' ? ' selected' : ''}>Smart routing (on-device)</option>
+              <option value="llm_judge"${mode === 'llm_judge' ? ' selected' : ''}>Smart routing (LLM-based)</option>
+              <option value="disabled"${mode === 'disabled' ? ' selected' : ''}>Off</option>
             </select>
           </label>
           <label><span>Default text model</span>
@@ -1184,8 +1184,8 @@ const SetupView = (() => {
     _el.querySelector('[data-image-enabled]')?.addEventListener('change', _syncImageProviderDefaults);
     _el.querySelector('[data-audio-provider]')?.addEventListener('change', _syncAudioProviderDefaults);
     _el.querySelector('[data-audio-enabled]')?.addEventListener('change', _syncAudioProviderDefaults);
-    // Router Mode drives the Judge model field visibility: only the LLM Judge
-    // strategy uses a judge model, so hide it for Local ML / Disabled.
+    // Router Mode drives the Judge model field visibility: only the llm_judge
+    // strategy uses a judge model, so hide it for v4_phase3 / disabled.
     _el.querySelector('[data-router-mode]')?.addEventListener('change', (e) => {
       const field = _el.querySelector('[data-judge-model-field]');
       const judge = _el.querySelector('[data-judge-model]');

--- a/src/agentos/onboarding/flow.py
+++ b/src/agentos/onboarding/flow.py
@@ -950,10 +950,9 @@ _IMAGE_TIER_LABEL = "Image model"
 _DONE_LABEL = "Done"
 
 
-_ROUTER_LOCAL_ML_LABEL = "AgentOS Router (Local ML)"
-_ROUTER_LLM_JUDGE_LABEL = "AgentOS Router (LLM Judge)"
-_ROUTER_MODE_LABEL = _ROUTER_LOCAL_ML_LABEL  # back-compat alias
-_ROUTER_DISABLED_LABEL = "Disabled"
+_ROUTER_LOCAL_ML_LABEL = "Smart routing (on-device)"
+_ROUTER_LLM_JUDGE_LABEL = "Smart routing (LLM-based)"
+_ROUTER_DISABLED_LABEL = "Off"
 _JUDGE_AUTO_LABEL = "Auto (recommended)"
 _JUDGE_MANUAL_LABEL = "Pick a specific model"
 _JUDGE_LOCAL_LABEL = "Local endpoint (Ollama / LM Studio)"

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -321,12 +321,12 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
                 return _Answer("Use environment variable OPENROUTER_API_KEY")
             if message == "Router mode":
                 assert kwargs.get("choices") == [
-                    "AgentOS Router (Local ML)",
-                    "AgentOS Router (LLM Judge)",
-                    "Disabled",
+                    "Smart routing (on-device)",
+                    "Smart routing (LLM-based)",
+                    "Off",
                 ]
-                assert kwargs.get("default") == "AgentOS Router (Local ML)"
-                return _Answer("AgentOS Router (Local ML)")
+                assert kwargs.get("default") == "Smart routing (on-device)"
+                return _Answer("Smart routing (on-device)")
             if message == "Default text model":
                 assert kwargs.get("choices") == [
                     "Route c0",
@@ -2033,7 +2033,7 @@ def test_interactive_configure_router_persists(tmp_path, monkeypatch):
     class _Questionary(types.SimpleNamespace):
         def select(self, message: str, **kwargs):
             if message == "Router mode":
-                return _Answer("Disabled")
+                return _Answer("Off")
             raise AssertionError(f"unexpected select prompt: {message}")
 
         def text(self, message: str, **_kwargs):


### PR DESCRIPTION
## Summary

The onboarding **Router mode** picker exposed internal jargon and a redundant prefix. The prompt header already says "Router mode", so `AgentOS Router (...)` was repeated on every option, and `Local ML` / `LLM Judge` describe the *mechanism* rather than what the user gets. This renames the user-facing labels to be benefit-oriented and consistent across every surface that shows them.

| Before | After |
| --- | --- |
| `AgentOS Router (Local ML)` | **`Smart routing (on-device)`** |
| `AgentOS Router (LLM Judge)` | **`Smart routing (LLM-based)`** |
| `Disabled` | **`Off`** |

### Before / after (CLI)

```
Before                                 After
? Router mode                          ? Router mode
 » AgentOS Router (Local ML)            » Smart routing (on-device)
   AgentOS Router (LLM Judge)             Smart routing (LLM-based)
   Disabled                               Off
```

## Scope: display-only

This is strictly a **label** change. The on-disk config strategy values (`v4_phase3` / `llm_judge` / `disabled`) and the Web UI `<option value=...>` attributes are **unchanged**, so:

- Existing configs keep working — no migration needed.
- The label→strategy mapping stays intact (verified: `Smart routing (on-device)` → `v4_phase3`, `Smart routing (LLM-based)` → `llm_judge`, `Off` → disabled).

> Naming note: the on-device label intentionally omits "free" — the ~75MB ML bundle is not shipped with the repo/wheel, so promising "free" out-of-the-box would overstate the default behavior.

## Changes

- `src/agentos/onboarding/flow.py` — rename the three CLI label constants; drop the now-unreferenced `_ROUTER_MODE_LABEL` back-compat alias.
- `src/agentos/gateway/static/js/views/setup.js` — rename the three dropdown `<option>` texts (values untouched); refresh a stale comment to reference strategy IDs instead of old labels.
- `docs/configuration.md`, `docs/features/agentos-router.md` — update the documented Mode-dropdown labels to match.
- `tests/test_onboarding/test_flow.py` — update assertions on the old label strings.

## Testing

- `pytest tests/test_onboarding/test_flow.py` — 42 passed.
- `ruff check` — clean.
- Verified the label→strategy mapping end-to-end and confirmed no stale label strings remain in `src/`, `docs/`, or `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)