### PR TITLE
feat(packaging): publish distribution as use-agent-os on PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,95 @@
+name: Publish to PyPI
+
+# Publishes the use-agent-os distribution to PyPI via Trusted Publishing (OIDC).
+# One-time setup on pypi.org before the first run: add a (pending) trusted
+# publisher for project "use-agent-os" pointing at this repository, workflow file
+# "pypi-publish.yml", and environment "pypi".
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Hydrate LFS embedding model assets
+        run: git lfs pull --include="src/agentos/memory/models/**"
+
+      - name: Verify LFS assets are hydrated
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          for path in Path("src/agentos/memory/models").rglob("*"):
+              if not path.is_file():
+                  continue
+              prefix = path.read_bytes()[:64]
+              assert not prefix.startswith(b"version https://git-lfs.github.com/spec/v1"), (
+                  f"LFS pointer not hydrated: {path}"
+              )
+          PY
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Check tag matches package version
+        run: |
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          tag = os.environ["GITHUB_REF_NAME"]
+          assert tag == f"v{version}", (
+              f"tag {tag!r} does not match pyproject version {version!r}"
+          )
+          PY
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Trusted Publishing exchanges this OIDC token for a short-lived
+      # PyPI upload token — no stored API token or secret is involved.
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "agentos"
+name = "use-agent-os"
 version = "2026.7.14"
 description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "MIT"

--- a/src/agentos/__init__.py
+++ b/src/agentos/__init__.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _resolve_version
 
-try:
-    __version__ = _resolve_version("agentos")
-except PackageNotFoundError:  # pragma: no cover - source tree without dist metadata
+# The distribution is published as "use-agent-os" (PyPI); "agentos" covers
+# environments installed before the rename.
+for _dist_name in ("use-agent-os", "agentos"):
+    try:
+        __version__ = _resolve_version(_dist_name)
+        break
+    except PackageNotFoundError:
+        continue
+else:  # pragma: no cover - source tree without dist metadata
     # Editable/source checkouts without installed distribution metadata fall
     # back to a sentinel rather than a hardcoded semver that silently goes
     # stale (the bug this module exists to prevent).

--- a/src/agentos/dist/workspace_state.py
+++ b/src/agentos/dist/workspace_state.py
@@ -98,9 +98,15 @@ _FALLBACK_PYTHON_REQUIRES = ">=3.12"
 def _read_package_metadata() -> tuple[str, str]:
     """Return (version, python_requires) from installed agentos metadata."""
 
-    try:
-        meta = _pkg_metadata("agentos")
-    except PackageNotFoundError:
+    # The distribution is published as "use-agent-os" (PyPI); "agentos" covers
+    # environments installed before the rename.
+    for dist_name in ("use-agent-os", "agentos"):
+        try:
+            meta = _pkg_metadata(dist_name)
+            break
+        except PackageNotFoundError:
+            continue
+    else:
         return _FALLBACK_VERSION, _FALLBACK_PYTHON_REQUIRES
     version = meta["Version"] or _FALLBACK_VERSION
     python_requires = meta.get("Requires-Python") or _FALLBACK_PYTHON_REQUIRES

--- a/tests/test_ci/test_migrations_packaged.py
+++ b/tests/test_ci/test_migrations_packaged.py
@@ -30,7 +30,7 @@ def test_wheel_contains_migration(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, f"uv build failed: {result.stderr}"
 
-    wheels = list(tmp_path.glob("agentos-*.whl"))
+    wheels = list(tmp_path.glob("use_agent_os-*.whl"))
     assert len(wheels) == 1, f"Expected 1 wheel, got {wheels}"
 
     with zipfile.ZipFile(wheels[0]) as wheel:
@@ -57,7 +57,7 @@ def test_installed_wheel_resolves_migrations(tmp_path: Path) -> None:
         capture_output=True,
         timeout=180,
     )
-    wheels = list(wheel_dir.glob("agentos-*.whl"))
+    wheels = list(wheel_dir.glob("use_agent_os-*.whl"))
     # 120s was tight enough that Windows CI runners began timing out as
     # the base dependency list grew (each transitive wheel adds I/O the
     # Defender real-time scanner has to walk through). Ubuntu still

--- a/tests/test_gateway/test_status_version_provider.py
+++ b/tests/test_gateway/test_status_version_provider.py
@@ -36,7 +36,7 @@ def _openrouter_selector() -> ModelSelector:
 
 
 def test_package_version_tracks_metadata_not_stale_literal() -> None:
-    assert agentos.__version__ == _pkg_version("agentos")
+    assert agentos.__version__ == _pkg_version("use-agent-os")
     assert agentos.__version__ != "0.1.0"
 
 

--- a/tests/test_packaging/test_pyproject_invariants.py
+++ b/tests/test_packaging/test_pyproject_invariants.py
@@ -25,7 +25,7 @@ def project_table() -> dict:
 @pytest.fixture(scope="module")
 def lock_package() -> dict:
     data = tomllib.loads(UV_LOCK.read_text(encoding="utf-8"))
-    return next(package for package in data["package"] if package["name"] == "agentos")
+    return next(package for package in data["package"] if package["name"] == "use-agent-os")
 
 
 def _dep_names(specs: list[str]) -> set[str]:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -19,7 +19,7 @@ def test_pyproject_version_matches_current_release() -> None:
 
 def test_lockfile_version_matches_current_release() -> None:
     lock = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
-    package = next(item for item in lock["package"] if item["name"] == "agentos")
+    package = next(item for item in lock["package"] if item["name"] == "use-agent-os")
 
     assert package["version"] == CURRENT_VERSION
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,174 +8,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "agentos"
-version = "2026.7.14"
-source = { editable = "." }
-dependencies = [
-    { name = "aiosqlite" },
-    { name = "anyio" },
-    { name = "apscheduler" },
-    { name = "beautifulsoup4" },
-    { name = "brotli" },
-    { name = "cachetools" },
-    { name = "croniter" },
-    { name = "cryptography" },
-    { name = "dingtalk-stream" },
-    { name = "html2text" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "openpyxl" },
-    { name = "pdfplumber" },
-    { name = "pillow" },
-    { name = "prompt-toolkit" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pypdf" },
-    { name = "python-docx" },
-    { name = "python-multipart" },
-    { name = "python-pptx" },
-    { name = "python-telegram-bot" },
-    { name = "pyyaml" },
-    { name = "qq-botpy" },
-    { name = "questionary" },
-    { name = "readability-lxml" },
-    { name = "reportlab" },
-    { name = "rich" },
-    { name = "sqlite-vec" },
-    { name = "sqlmodel" },
-    { name = "starlette" },
-    { name = "structlog" },
-    { name = "tomli-w" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "websockets" },
-    { name = "yoyo-migrations" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-document-extras = [
-    { name = "weasyprint" },
-]
-matrix = [
-    { name = "markdown" },
-    { name = "matrix-nio" },
-]
-matrix-e2e = [
-    { name = "markdown" },
-    { name = "matrix-nio", extra = ["e2e"] },
-]
-mcp = [
-    { name = "mcp" },
-]
-memory = [
-    { name = "jieba" },
-    { name = "tiktoken" },
-]
-ml-router = [
-    { name = "joblib" },
-    { name = "lightgbm" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "scikit-learn" },
-]
-recommended = [
-    { name = "jieba" },
-    { name = "joblib" },
-    { name = "lightgbm" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "scikit-learn" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "laboratory" },
-    { name = "syrupy" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.20" },
-    { name = "anyio", specifier = ">=4.0" },
-    { name = "apscheduler", specifier = ">=3.10" },
-    { name = "beautifulsoup4", specifier = ">=4.12" },
-    { name = "brotli", specifier = ">=1.1" },
-    { name = "cachetools", specifier = ">=5.3" },
-    { name = "croniter", specifier = ">=2.0" },
-    { name = "cryptography", specifier = ">=42" },
-    { name = "dingtalk-stream", specifier = ">=0.24.3,<0.25" },
-    { name = "html2text", specifier = ">=2024.2" },
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "jieba", marker = "extra == 'memory'", specifier = ">=0.42" },
-    { name = "jieba", marker = "extra == 'recommended'", specifier = ">=0.42" },
-    { name = "jinja2", specifier = ">=3.1" },
-    { name = "joblib", marker = "extra == 'ml-router'", specifier = ">=1.3" },
-    { name = "joblib", marker = "extra == 'recommended'", specifier = ">=1.3" },
-    { name = "lightgbm", marker = "extra == 'ml-router'", specifier = ">=4.0" },
-    { name = "lightgbm", marker = "extra == 'recommended'", specifier = ">=4.0" },
-    { name = "markdown", marker = "extra == 'matrix'", specifier = ">=3.0" },
-    { name = "markdown", marker = "extra == 'matrix-e2e'", specifier = ">=3.0" },
-    { name = "matrix-nio", marker = "extra == 'matrix'", specifier = ">=0.25,<0.26" },
-    { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix-e2e'", specifier = ">=0.25,<0.26" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "numpy", marker = "extra == 'ml-router'", specifier = ">=1.26" },
-    { name = "numpy", marker = "extra == 'recommended'", specifier = ">=1.26" },
-    { name = "onnxruntime", marker = "extra == 'ml-router'", specifier = ">=1.17" },
-    { name = "onnxruntime", marker = "extra == 'recommended'", specifier = ">=1.17" },
-    { name = "openpyxl", specifier = ">=3.1.0" },
-    { name = "pdfplumber", specifier = ">=0.11" },
-    { name = "pillow", specifier = ">=10.0" },
-    { name = "prompt-toolkit", specifier = ">=3.0" },
-    { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "pypdf", specifier = ">=4.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "python-docx", specifier = ">=1.1.0" },
-    { name = "python-multipart", specifier = ">=0.0.20" },
-    { name = "python-pptx", specifier = ">=1.0.0" },
-    { name = "python-telegram-bot", specifier = ">=20.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "qq-botpy", specifier = ">=1.2.1,<1.3" },
-    { name = "questionary", specifier = ">=2.0" },
-    { name = "readability-lxml", specifier = ">=0.8" },
-    { name = "reportlab", specifier = ">=4.0.0" },
-    { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
-    { name = "scikit-learn", marker = "extra == 'ml-router'", specifier = ">=1.8,<1.9" },
-    { name = "scikit-learn", marker = "extra == 'recommended'", specifier = ">=1.8,<1.9" },
-    { name = "sqlite-vec", specifier = ">=0.1" },
-    { name = "sqlmodel", specifier = ">=0.0.20" },
-    { name = "starlette", specifier = ">=0.40" },
-    { name = "structlog", specifier = ">=24.0" },
-    { name = "tiktoken", marker = "extra == 'memory'", specifier = ">=0.5" },
-    { name = "tiktoken", marker = "extra == 'recommended'", specifier = ">=0.5" },
-    { name = "tokenizers", marker = "extra == 'recommended'", specifier = ">=0.15" },
-    { name = "tomli-w", specifier = ">=1.0" },
-    { name = "typer", specifier = ">=0.12" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
-    { name = "weasyprint", marker = "extra == 'document-extras'", specifier = ">=60.0" },
-    { name = "websockets", specifier = ">=13.0" },
-    { name = "yoyo-migrations", specifier = ">=8.2" },
-]
-provides-extras = ["dev", "mcp", "memory", "recommended", "ml-router", "matrix", "matrix-e2e", "document-extras"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "laboratory", specifier = ">=1.0.2" },
-    { name = "syrupy", specifier = ">=5.1.0" },
-]
-
-[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3201,6 +3033,174 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "use-agent-os"
+version = "2026.7.14"
+source = { editable = "." }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "anyio" },
+    { name = "apscheduler" },
+    { name = "beautifulsoup4" },
+    { name = "brotli" },
+    { name = "cachetools" },
+    { name = "croniter" },
+    { name = "cryptography" },
+    { name = "dingtalk-stream" },
+    { name = "html2text" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "openpyxl" },
+    { name = "pdfplumber" },
+    { name = "pillow" },
+    { name = "prompt-toolkit" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pypdf" },
+    { name = "python-docx" },
+    { name = "python-multipart" },
+    { name = "python-pptx" },
+    { name = "python-telegram-bot" },
+    { name = "pyyaml" },
+    { name = "qq-botpy" },
+    { name = "questionary" },
+    { name = "readability-lxml" },
+    { name = "reportlab" },
+    { name = "rich" },
+    { name = "sqlite-vec" },
+    { name = "sqlmodel" },
+    { name = "starlette" },
+    { name = "structlog" },
+    { name = "tomli-w" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
+    { name = "yoyo-migrations" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+document-extras = [
+    { name = "weasyprint" },
+]
+matrix = [
+    { name = "markdown" },
+    { name = "matrix-nio" },
+]
+matrix-e2e = [
+    { name = "markdown" },
+    { name = "matrix-nio", extra = ["e2e"] },
+]
+mcp = [
+    { name = "mcp" },
+]
+memory = [
+    { name = "jieba" },
+    { name = "tiktoken" },
+]
+ml-router = [
+    { name = "joblib" },
+    { name = "lightgbm" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "scikit-learn" },
+]
+recommended = [
+    { name = "jieba" },
+    { name = "joblib" },
+    { name = "lightgbm" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "scikit-learn" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "laboratory" },
+    { name = "syrupy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "anyio", specifier = ">=4.0" },
+    { name = "apscheduler", specifier = ">=3.10" },
+    { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "brotli", specifier = ">=1.1" },
+    { name = "cachetools", specifier = ">=5.3" },
+    { name = "croniter", specifier = ">=2.0" },
+    { name = "cryptography", specifier = ">=42" },
+    { name = "dingtalk-stream", specifier = ">=0.24.3,<0.25" },
+    { name = "html2text", specifier = ">=2024.2" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "jieba", marker = "extra == 'memory'", specifier = ">=0.42" },
+    { name = "jieba", marker = "extra == 'recommended'", specifier = ">=0.42" },
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "joblib", marker = "extra == 'ml-router'", specifier = ">=1.3" },
+    { name = "joblib", marker = "extra == 'recommended'", specifier = ">=1.3" },
+    { name = "lightgbm", marker = "extra == 'ml-router'", specifier = ">=4.0" },
+    { name = "lightgbm", marker = "extra == 'recommended'", specifier = ">=4.0" },
+    { name = "markdown", marker = "extra == 'matrix'", specifier = ">=3.0" },
+    { name = "markdown", marker = "extra == 'matrix-e2e'", specifier = ">=3.0" },
+    { name = "matrix-nio", marker = "extra == 'matrix'", specifier = ">=0.25,<0.26" },
+    { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix-e2e'", specifier = ">=0.25,<0.26" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "numpy", marker = "extra == 'ml-router'", specifier = ">=1.26" },
+    { name = "numpy", marker = "extra == 'recommended'", specifier = ">=1.26" },
+    { name = "onnxruntime", marker = "extra == 'ml-router'", specifier = ">=1.17" },
+    { name = "onnxruntime", marker = "extra == 'recommended'", specifier = ">=1.17" },
+    { name = "openpyxl", specifier = ">=3.1.0" },
+    { name = "pdfplumber", specifier = ">=0.11" },
+    { name = "pillow", specifier = ">=10.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pypdf", specifier = ">=4.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "python-docx", specifier = ">=1.1.0" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "python-pptx", specifier = ">=1.0.0" },
+    { name = "python-telegram-bot", specifier = ">=20.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "qq-botpy", specifier = ">=1.2.1,<1.3" },
+    { name = "questionary", specifier = ">=2.0" },
+    { name = "readability-lxml", specifier = ">=0.8" },
+    { name = "reportlab", specifier = ">=4.0.0" },
+    { name = "rich", specifier = ">=13.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+    { name = "scikit-learn", marker = "extra == 'ml-router'", specifier = ">=1.8,<1.9" },
+    { name = "scikit-learn", marker = "extra == 'recommended'", specifier = ">=1.8,<1.9" },
+    { name = "sqlite-vec", specifier = ">=0.1" },
+    { name = "sqlmodel", specifier = ">=0.0.20" },
+    { name = "starlette", specifier = ">=0.40" },
+    { name = "structlog", specifier = ">=24.0" },
+    { name = "tiktoken", marker = "extra == 'memory'", specifier = ">=0.5" },
+    { name = "tiktoken", marker = "extra == 'recommended'", specifier = ">=0.5" },
+    { name = "tokenizers", marker = "extra == 'recommended'", specifier = ">=0.15" },
+    { name = "tomli-w", specifier = ">=1.0" },
+    { name = "typer", specifier = ">=0.12" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
+    { name = "weasyprint", marker = "extra == 'document-extras'", specifier = ">=60.0" },
+    { name = "websockets", specifier = ">=13.0" },
+    { name = "yoyo-migrations", specifier = ">=8.2" },
+]
+provides-extras = ["dev", "mcp", "memory", "recommended", "ml-router", "matrix", "matrix-e2e", "document-extras"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "laboratory", specifier = ">=1.0.2" },
+    { name = "syrupy", specifier = ">=5.1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The `agentos` name on PyPI belongs to an unrelated, abandoned project (agentos.org, last release 2022-03), so `uv tool install agentos` / `pip install agentos` resolves to the wrong package. PyPI's typosquatting similarity check also rejects `agent-os` (it collides with `agentos` after separator-stripping normalization). This PR renames the distribution to **`use-agent-os`** — matching the GitHub org and useagentos.dev domain — and adds a Trusted Publishing workflow so tagged releases upload automatically, enabling:

```sh
uv tool install "use-agent-os[recommended]"
```

The import package (`import agentos`) and the `agentos` CLI entry point are **unchanged** — only the distribution name changes.

## Scope (intentionally minimal)

Only what PyPI publishing requires:

- **`pyproject.toml`** — `name = "use-agent-os"`
- **`uv.lock`** — regenerated for the new root package name
- **`src/agentos/__init__.py`**, **`src/agentos/dist/workspace_state.py`** — resolve version metadata from `use-agent-os` first, falling back to `agentos` so pre-rename installs keep reporting their real version
- **Tests** — the three dist-name pins updated (lockfile consistency, pyproject invariants fixture, status version provider)
- **`.github/workflows/pypi-publish.yml`** *(new)* — tag-triggered (`v*`); build job hydrates + verifies LFS embedding models and checks tag == pyproject version; publish job is separated per PyPA best practice and uses OIDC Trusted Publishing (`id-token: write`, no stored token), gated on a `pypi` environment

## One-time maintainer setup before the first tagged release

1. PyPI → *Account → Publishing → Add a new pending publisher*: project `use-agent-os`, owner `use-agent-os`, repo `agent-os`, workflow `pypi-publish.yml`, environment `pypi`
2. GitHub repo → *Settings → Environments* → create `pypi` (optionally add required reviewers to gate each publish)

## Deferred to a follow-up (before the next tag)

README install commands, `install.sh` / `install.ps1`, and the wheelhouse tooling still reference the old `agentos-*.whl` wheel filename; after this rename `uv build` produces `use_agent_os-*.whl` (PEP 427 normalization). A follow-up PR migrates those references — it must land before the next release tag or the existing wheelhouse release workflow will fail its wheel globs.

## Testing

- `uv run ruff check` / `uv run mypy` — clean on changed files
- Full offline suite: **5466 passed**; remaining 3 failures are pre-existing on a clean tree (Docker-migration tests noted in AGENTS.md + a local-env missing `numpy`)
- `uv build --wheel` → `use_agent_os-2026.7.14-py3-none-any.whl` (17MB, BGE ONNX assets + entry points verified)
- End-to-end: installed the wheel into a clean venv — `agentos.__version__` resolves to `2026.7.14` via the new metadata lookup, `agentos --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)