### PR TITLE
feat(release): migrate wheel filename and install specs to use-agent-os

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -136,7 +136,7 @@ jobs:
           import shutil
           from pathlib import Path
 
-          wheels = sorted(Path("build/wheelhouse-zip/wheels").glob("agentos-*.whl"))
+          wheels = sorted(Path("build/wheelhouse-zip/wheels").glob("use_agent_os-*.whl"))
           assert len(wheels) == 1, f"expected one built wheel, got {len(wheels)}"
           shutil.copy2(wheels[0], Path("dist") / wheels[0].name)
           PY
@@ -156,14 +156,14 @@ jobs:
               if path.name != "AgentOS-windows-x64-portable.zip"
           )
           wheels = sorted(
-              path for path in Path("dist").glob("agentos-*.whl")
+              path for path in Path("dist").glob("use_agent_os-*.whl")
           )
           assert len(zips) == 1, f"expected one versioned portable zip, got {len(zips)}"
           assert len(wheels) == 1, f"expected one versioned wheel, got {len(wheels)}"
           assert zips[0].name == (
               f"AgentOS-{version}-windows-x64-py312-recommended-portable.zip"
           )
-          assert wheels[0].name == f"agentos-{version}-py3-none-any.whl"
+          assert wheels[0].name == f"use_agent_os-{version}-py3-none-any.whl"
 
           with ZipFile(zips[0]) as archive:
               names = set(archive.namelist())
@@ -214,7 +214,7 @@ jobs:
               if path.name != "AgentOS-windows-x64-portable.zip"
           )
           wheels = sorted(
-              path for path in dist.glob("agentos-*.whl")
+              path for path in dist.glob("use_agent_os-*.whl")
           )
           assert len(zips) == 1, f"expected one versioned portable zip, got {len(zips)}"
           assert len(wheels) == 1, f"expected one versioned wheel, got {len(wheels)}"
@@ -271,7 +271,7 @@ jobs:
               if path.name != "AgentOS-windows-x64-portable.zip"
           )
           versioned_wheels = sorted(
-              path for path in dist.glob("agentos-*.whl")
+              path for path in dist.glob("use_agent_os-*.whl")
           )
           stable_zip = dist / "AgentOS-windows-x64-portable.zip"
           sha256s = dist / "SHA256SUMS"
@@ -350,7 +350,7 @@ jobs:
               managed = (
                   name == "SHA256SUMS"
                   or name.startswith("AgentOS-")
-                  or name.startswith("agentos-")
+                  or name.startswith("use_agent_os-")
                   or name.endswith(".sha256")
               )
               if managed:
@@ -395,7 +395,7 @@ jobs:
           ]
           versioned_wheel = [
               name for name in names
-              if name.startswith("agentos-")
+              if name.startswith("use_agent_os-")
               and name.endswith("-py3-none-any.whl")
           ]
           allowed = expected | set(versioned_zip) | set(versioned_wheel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The Python distribution is now published to PyPI as **`use-agent-os`**
+  (`uv tool install "use-agent-os[recommended]"`). The import package
+  (`import agentos`) and the `agentos` CLI are unchanged. PyPI's project-name
+  similarity rules reject `agentos`/`agent-os` variants (the bare name is held
+  by an unrelated, abandoned 2022 project), hence the org-matching name.
+- Built wheels are named `use_agent_os-<version>-py3-none-any.whl` (PEP 427
+  normalization). Install scripts, the wheelhouse builder, the release
+  workflow, and the README now reference the new filename; the README's
+  primary terminal install is the PyPI command instead of a pinned wheel URL.
+
 ## [2026.7.14] - 2026-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install AgentOS.** This command is the same on every system.
 
 ```sh
-uv tool install --python 3.12 "agentos[recommended] @ https://github.com/use-agent-os/agent-os/releases/download/v2026.7.14/agentos-2026.7.14-py3-none-any.whl"
+uv tool install --python 3.12 "use-agent-os[recommended]"
 ```
 
-This installs the AgentOS file from the link above. Then `uv`
+This installs the latest AgentOS release from PyPI. Then `uv`
 downloads whatever else that install needs. The default
 `recommended` extra brings in local memory embedding's tools, like ONNX
 Runtime, NumPy, and tokenizers. So the first install needs internet
@@ -222,13 +222,15 @@ agentos gateway run
 > If `agentos` is not found right after installing with `uv`, open a
 > new terminal window. Or run the PATH command from step 1 again.
 
-For an install pinned to one exact version, use this full link:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.15/agentos-2026.7.15-py3-none-any.whl`.
+For an install pinned to one exact version, add `==<version>` — for
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.15"` —
+or use the GitHub release wheel link directly:
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.14/use_agent_os-2026.7.14-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `agentos-2026.7.15-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.15-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.
@@ -544,7 +546,7 @@ settings are all in `agentos.toml.example`.
 | **Token-efficient routing** | `AgentOS Router` defaults to `v4_phase3`, a small local AI model (BGE embeddings + LightGBM; the `recommended` extra installs its runtime dependencies) that looks at each message — its length, language, code, keywords, and meaning — and picks one of four levels (c0–c3), then routes it to the cheapest model that can still do the job well. This check runs on your own device, so your message never has to leave your computer just to make this choice. The ~75MB model bundle is not distributed yet; without it the router falls back to a single tier, so pick the `llm_judge` strategy instead (a small LLM call, optionally a local Ollama/LM Studio endpoint) for per-turn routing with no local model files. Choose either in onboarding. |
 | **Adaptive reasoning and prompts** | AgentOS only asks for deep, extended thinking when the router sees the message is hard. The system instructions also grow to match: short and simple for easy messages, full and detailed for hard ones. |
 | **20+ LLM providers** | AgentOS can talk to 20+ AI providers — OpenRouter (used by default), the Bankr LLM Gateway, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, DashScope/Qwen, Moonshot, Mistral, Groq, Zhipu, SiliconFlow, vLLM, LM Studio, and more. It picks a main provider first, with backups ready if needed. The first-time setup shows you the providers that are fully tested. |
-| **On-demand skills and MCP** | AgentOS comes with 37 built-in skills (coding, GitHub, cron jobs, pptx/docx/xlsx/pdf files, summaries, tmux, weather, and more). Each skill only loads when a task actually needs it. AgentOS can use other MCP tools, and can also act as an MCP tool for others — `agentos mcp-server run` needs the `mcp` extra (install with `agentos[recommended,mcp]`). You can write, install, and share your own skills from the CLI. |
+| **On-demand skills and MCP** | AgentOS comes with 37 built-in skills (coding, GitHub, cron jobs, pptx/docx/xlsx/pdf files, summaries, tmux, weather, and more). Each skill only loads when a task actually needs it. AgentOS can use other MCP tools, and can also act as an MCP tool for others — `agentos mcp-server run` needs the `mcp` extra (install with `use-agent-os[recommended,mcp]`). You can write, install, and share your own skills from the CLI. |
 | **Persistent local memory** | AgentOS remembers things between sessions, using a main `MEMORY.md` file plus dated notes in Markdown. You can search this memory two ways: by keyword (SQLite full-text search) or by meaning (`sqlite-vec`). The meaning search runs on your device using a built-in ONNX model, or you can switch to OpenAI or Ollama instead. There are optional extra features too: old memories can slowly fade, and a "dream" mode can clean up and merge memories (you must turn this on yourself). |
 | **Layered security sandbox** | There are three safety levels: Standard, Strict, and Locked. Each one controls what tools are allowed to do. On Linux, Bubblewrap keeps code running in its own safe space. On macOS, this job is done by `sandbox-exec` (Apple's Seatbelt). Windows does not have this sandbox yet. If AgentOS is denied the same action too many times in a row, it pauses itself automatically and does not keep trying. Any blocked output is deleted right away. Skill details and tool results are also cleaned (escaped) so they can't trick the AI into doing something unsafe. |
 | **Built-in tools** | AgentOS can read, write, and edit files; run shell commands and background tasks; use git; search the web (with Brave or DuckDuckGo) and fetch pages safely (blocking unsafe internal network requests); create spreadsheets, PPTX, and PDF files; generate images; and turn text into speech. |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,13 +8,13 @@
 
 Versions follow CalVer (`YYYY.M.D`). PEP 440 normalizes wheel filenames and drops
 leading zeros, so tags must use the same non-padded form — tag `v2026.7.15`, not
-`v2026.07.15`, or the wheel filename (`agentos-2026.7.15-py3-none-any.whl`) will
+`v2026.07.15`, or the wheel filename (`use_agent_os-2026.7.15-py3-none-any.whl`) will
 not match the tag and the release smoke check fails.
 
 Preview releases publish only versioned assets:
 
 - `AgentOS-<version>-windows-x64-py312-recommended-portable.zip`
-- `agentos-<version>-py3-none-any.whl`
+- `use_agent_os-<version>-py3-none-any.whl`
 - `SHA256SUMS`
 
 Non-preview releases additionally publish a version-independent alias for the
@@ -34,7 +34,7 @@ Preview releases are GitHub pre-releases. Their README install commands must
 use tag-pinned URLs such as:
 
 - `https://github.com/use-agent-os/agent-os/releases/download/v0.0.1rc1/AgentOS-0.0.1rc1-windows-x64-py312-recommended-portable.zip`
-- `https://github.com/use-agent-os/agent-os/releases/download/v0.0.1rc1/agentos-0.0.1rc1-py3-none-any.whl`
+- `https://github.com/use-agent-os/agent-os/releases/download/v0.0.1rc1/use_agent_os-0.0.1rc1-py3-none-any.whl`
 
 0.0.1 install commands use versioned wheel URLs because Python installers
 validate wheel filenames. The Windows portable zip may use the
@@ -42,7 +42,7 @@ validate wheel filenames. The Windows portable zip may use the
 exists. Fully pinned URLs remain available:
 
 - `https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/AgentOS-0.0.1-windows-x64-py312-recommended-portable.zip`
-- `https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/agentos-0.0.1-py3-none-any.whl`
+- `https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/use_agent_os-0.0.1-py3-none-any.whl`
 
 ## Release SOP
 
@@ -60,7 +60,7 @@ exists. Fully pinned URLs remain available:
 
    ```sh
    curl --fail --head --location https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/AgentOS-0.0.1-windows-x64-py312-recommended-portable.zip
-   curl --fail --head --location https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/agentos-0.0.1-py3-none-any.whl
+   curl --fail --head --location https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/use_agent_os-0.0.1-py3-none-any.whl
    ```
 
 9. Run the post-publish latest URL check:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -11,8 +11,8 @@ UI, CLI, channels, and gateway control console.
 
 Install AgentOS with the `mcp` extra when you need this bridge. Follow the
 [Installation](../README.md#installation) section of the README, and add `mcp`
-to the extras list — use `agentos[recommended,mcp]` in place of
-`agentos[recommended]`.
+to the extras list — use `use-agent-os[recommended,mcp]` in place of
+`use-agent-os[recommended]`.
 
 Start the AgentOS gateway:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -174,8 +174,8 @@ agentos mcp-server run
 ```
 
 Install by following the [Installation](../README.md#installation) section of
-the README, adding the `mcp` extra — use `agentos[recommended,mcp]` in place of
-`agentos[recommended]`.
+the README, adding the `mcp` extra — use `use-agent-os[recommended,mcp]` in place of
+`use-agent-os[recommended]`.
 
 Use this when another MCP-capable client should access AgentOS-managed tools
 or runtime surfaces.

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -316,7 +316,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 2 - install AgentOS with the recommended extras (AgentOS Router)
 uv tool install --python 3.12 \
-  "agentos[recommended] @ https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/agentos-0.0.1-py3-none-any.whl"
+  "use-agent-os[recommended] @ https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/use_agent_os-0.0.1-py3-none-any.whl"
 
 # 3 - verify
 agentos --help</pre>

--- a/install.ps1
+++ b/install.ps1
@@ -83,9 +83,9 @@ switch ($profileName) {
 
 $targetExtras += $installExtras
 $packageName = if ($targetExtras.Count -gt 0) {
-    "agentos[$($targetExtras -join ',')]"
+    "use-agent-os[$($targetExtras -join ',')]"
 } else {
-    'agentos'
+    'use-agent-os'
 }
 
 function Test-ReleaseVersion {
@@ -112,20 +112,20 @@ switch -Regex ($Version) {
             exit 1
         }
         $releaseVersion = if ($releaseTag.StartsWith('v')) { $releaseTag.Substring(1) } else { $releaseTag }
-        $wheelUrl = "https://github.com/$repoSlug/releases/download/$releaseTag/agentos-$releaseVersion-py3-none-any.whl"
+        $wheelUrl = "https://github.com/$repoSlug/releases/download/$releaseTag/use_agent_os-$releaseVersion-py3-none-any.whl"
         $displayVersion = $releaseTag
         break
     }
     '^v' {
         $releaseVersion = $Version.Substring(1)
-        $wheelUrl = "https://github.com/$repoSlug/releases/download/$Version/agentos-$releaseVersion-py3-none-any.whl"
+        $wheelUrl = "https://github.com/$repoSlug/releases/download/$Version/use_agent_os-$releaseVersion-py3-none-any.whl"
         $displayVersion = $Version
         break
     }
     default {
         $releaseVersion = $Version
         $releaseTag = "v$releaseVersion"
-        $wheelUrl = "https://github.com/$repoSlug/releases/download/$releaseTag/agentos-$releaseVersion-py3-none-any.whl"
+        $wheelUrl = "https://github.com/$repoSlug/releases/download/$releaseTag/use_agent_os-$releaseVersion-py3-none-any.whl"
         $displayVersion = $releaseTag
     }
 }
@@ -226,7 +226,7 @@ function Install-WindowsVCRedistIfNeeded {
 
 if ($dryRun) {
     Write-Host "install.ps1: dry-run - would install AgentOS $displayVersion"
-    Write-Host "install.ps1: dry-run - would run: uv tool install --python $pythonVersion --force --reinstall-package agentos `"$installSpec`""
+    Write-Host "install.ps1: dry-run - would run: uv tool install --python $pythonVersion --force --reinstall-package use-agent-os `"$installSpec`""
     exit 0
 }
 
@@ -244,7 +244,7 @@ if (-not $uvBin) {
 Install-WindowsVCRedistIfNeeded
 
 Write-Host "install.ps1: installing AgentOS $displayVersion ($profileName)"
-& $uvBin tool install --python $pythonVersion --force --reinstall-package agentos $installSpec
+& $uvBin tool install --python $pythonVersion --force --reinstall-package use-agent-os $installSpec
 if ($LASTEXITCODE -ne 0) {
     Write-Error "install.ps1: install command failed with exit code $LASTEXITCODE."
     exit $LASTEXITCODE

--- a/install.sh
+++ b/install.sh
@@ -126,9 +126,9 @@ if (( ${#install_extras[@]} > 0 )); then
 fi
 
 if (( ${#target_extras[@]} > 0 )); then
-    package_name="agentos[$(IFS=,; echo "${target_extras[*]}")]"
+    package_name="use-agent-os[$(IFS=,; echo "${target_extras[*]}")]"
 else
-    package_name="agentos"
+    package_name="use-agent-os"
 fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
@@ -162,18 +162,18 @@ case "${release_selector}" in
             exit 1
         fi
         release_version="${latest_tag#v}"
-        wheel_url="https://github.com/${repo_slug}/releases/download/${latest_tag}/agentos-${release_version}-py3-none-any.whl"
+        wheel_url="https://github.com/${repo_slug}/releases/download/${latest_tag}/use_agent_os-${release_version}-py3-none-any.whl"
         display_version="${latest_tag}"
         ;;
     v*)
         release_version="${release_selector#v}"
-        wheel_url="https://github.com/${repo_slug}/releases/download/${release_selector}/agentos-${release_version}-py3-none-any.whl"
+        wheel_url="https://github.com/${repo_slug}/releases/download/${release_selector}/use_agent_os-${release_version}-py3-none-any.whl"
         display_version="${release_selector}"
         ;;
     *)
         release_version="${release_selector}"
         release_tag="v${release_version}"
-        wheel_url="https://github.com/${repo_slug}/releases/download/${release_tag}/agentos-${release_version}-py3-none-any.whl"
+        wheel_url="https://github.com/${repo_slug}/releases/download/${release_tag}/use_agent_os-${release_version}-py3-none-any.whl"
         display_version="${release_tag}"
         ;;
 esac
@@ -210,7 +210,7 @@ resolve_uv() {
 
 if [[ "${dry_run}" == "1" ]]; then
     echo "install.sh: dry-run - would install AgentOS ${display_version}"
-    echo "install.sh: dry-run - would run: uv tool install --python ${python_version} --force --reinstall-package agentos \"${install_spec}\""
+    echo "install.sh: dry-run - would run: uv tool install --python ${python_version} --force --reinstall-package use-agent-os \"${install_spec}\""
     exit 0
 fi
 
@@ -228,7 +228,7 @@ if [[ -z "${uv_bin}" ]]; then
 fi
 
 echo "install.sh: installing AgentOS ${display_version} (${profile})"
-"${uv_bin}" tool install --python "${python_version}" --force --reinstall-package agentos "${install_spec}"
+"${uv_bin}" tool install --python "${python_version}" --force --reinstall-package use-agent-os "${install_spec}"
 
 tool_bin_dir="$("${uv_bin}" tool dir --bin 2>/dev/null || true)"
 

--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -272,7 +272,7 @@ def missing_required_runtime_modules_in_wheel(wheel_path: Path) -> list[str]:
 
 
 def find_built_wheel(wheel_dir: Path) -> Path:
-    wheels = sorted(wheel_dir.glob("agentos-*.whl"))
+    wheels = sorted(wheel_dir.glob("use_agent_os-*.whl"))
     if len(wheels) != 1:
         raise SystemExit(f"Expected one AgentOS wheel in {wheel_dir}, found {len(wheels)}")
     return wheels[0]
@@ -737,7 +737,7 @@ if [[ ! -d "${PACKAGE_DIR}" ]]; then
   exit 1
 fi
 AGENTOS_WHEEL="$(
-  find "${PACKAGE_DIR}" -maxdepth 1 -type f -name 'agentos-*.whl' |
+  find "${PACKAGE_DIR}" -maxdepth 1 -type f -name 'use_agent_os-*.whl' |
     sort |
     head -n 1
 )"
@@ -1116,7 +1116,7 @@ function Repair-WindowsVCRedistForOnnxIfNeeded {
 if (-not (Test-Path $VenvRoot)) {
     New-Item -ItemType Directory -Path $VenvRoot -Force | Out-Null
 }
-$AgentOSWheel = Get-ChildItem -Path $PackageDir -Filter 'agentos-*.whl' |
+$AgentOSWheel = Get-ChildItem -Path $PackageDir -Filter 'use_agent_os-*.whl' |
     Sort-Object Name |
     Select-Object -First 1
 if (-not $AgentOSWheel) {

--- a/scripts/install_source.ps1
+++ b/scripts/install_source.ps1
@@ -227,7 +227,7 @@ $installArgs = @()
 
 if (Get-Command uv -ErrorAction SilentlyContinue) {
     $installer = 'uv'
-    $installArgs = @('tool', 'install', '--force', '--reinstall-package', 'agentos', $installTarget)
+    $installArgs = @('tool', 'install', '--force', '--reinstall-package', 'use-agent-os', $installTarget)
 } elseif (Get-Command python -ErrorAction SilentlyContinue) {
     $installer = 'pip'
     $installArgs = @('-m', 'pip', 'install', '--user', $installTarget)

--- a/scripts/install_source.sh
+++ b/scripts/install_source.sh
@@ -178,7 +178,7 @@ installer=""
 install_args=()
 if command -v uv >/dev/null 2>&1; then
     installer="uv"
-    install_args=(uv tool install --force --reinstall-package agentos "${install_target}")
+    install_args=(uv tool install --force --reinstall-package use-agent-os "${install_target}")
 elif command -v python3 >/dev/null 2>&1; then
     installer="pip"
     install_args=(python3 -m pip install --user "${install_target}")

--- a/src/agentos/mcp_server/server.py
+++ b/src/agentos/mcp_server/server.py
@@ -20,7 +20,7 @@ def create_mcp_server(
             from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
         except ImportError as exc:  # pragma: no cover - exercised through CLI behavior.
             raise RuntimeError(
-                "The MCP server requires the optional dependency: install agentos[mcp]."
+                "The MCP server requires the optional dependency: install 'use-agent-os[mcp]'."
             ) from exc
         fastmcp_cls = FastMCP
 

--- a/src/agentos/skills/bundled/html-to-pdf/SKILL.md
+++ b/src/agentos/skills/bundled/html-to-pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: html-to-pdf
-description: "Render HTML (with CSS) to a PDF file. Trigger when the user wants to export a styled report, invoice, label, or any HTML/Jinja-rendered page to PDF. Uses WeasyPrint, which supports a meaningful subset of CSS Paged Media (page size, margins, headers/footers, page-break-before/after). Optional dependency — install via `pip install agentos[document-extras]` or `uv add weasyprint` because WeasyPrint pulls in native libraries (Pango, Cairo, fontconfig) that need OS-level packages."
+description: "Render HTML (with CSS) to a PDF file. Trigger when the user wants to export a styled report, invoice, label, or any HTML/Jinja-rendered page to PDF. Uses WeasyPrint, which supports a meaningful subset of CSS Paged Media (page size, margins, headers/footers, page-break-before/after). Optional dependency — install via `pip install 'use-agent-os[document-extras]'` or `uv add weasyprint` because WeasyPrint pulls in native libraries (Pango, Cairo, fontconfig) that need OS-level packages."
 homepage: https://weasyprint.org/
 provenance:
   origin: clawhub-mit0

--- a/src/agentos/skills/bundled/html-to-pdf/scripts/render.py
+++ b/src/agentos/skills/bundled/html-to-pdf/scripts/render.py
@@ -25,7 +25,7 @@ def render(html_spec: str, out_path: Path, page_size: str | None) -> None:
         from weasyprint import CSS, HTML
     except ImportError as exc:  # pragma: no cover - covered by --help path
         print(
-            "error: weasyprint is not installed — `pip install agentos[document-extras]`",
+            "error: weasyprint is not installed — `pip install 'use-agent-os[document-extras]'`",
             file=sys.stderr,
         )
         raise SystemExit(2) from exc

--- a/src/agentos/skills/bundled/multi-search-engine/SKILL.md
+++ b/src/agentos/skills/bundled/multi-search-engine/SKILL.md
@@ -34,7 +34,7 @@ entrypoint:
 A unified CLI for querying several web search engines in parallel and
 returning a normalized result list. Built on `httpx` and `beautifulsoup4`
 (both already in AgentOS default dependencies, so no extra install
-beyond `pip install agentos`).
+beyond `pip install use-agent-os`).
 
 ## Use cases
 

--- a/start.ps1
+++ b/start.ps1
@@ -261,7 +261,7 @@ function Repair-WindowsVCRedistForOnnxIfNeeded {
 if (-not (Test-Path $VenvRoot)) {
     New-Item -ItemType Directory -Path $VenvRoot -Force | Out-Null
 }
-$AgentOSWheel = Get-ChildItem -Path $PackageDir -Filter 'agentos-*.whl' |
+$AgentOSWheel = Get-ChildItem -Path $PackageDir -Filter 'use_agent_os-*.whl' |
     Sort-Object Name |
     Select-Object -First 1
 if (-not $AgentOSWheel) {

--- a/tests/test_channels/test_base_imports.py
+++ b/tests/test_channels/test_base_imports.py
@@ -2,7 +2,7 @@
 
 After 0.1.0's refactor each vendor SDK (lark-oapi / python-telegram-bot /
 dingtalk-stream / qq-botpy / cryptography) lives in base ``dependencies``
-rather than in an opt-in extra. A bare ``pip install agentos`` must
+rather than in an opt-in extra. A bare ``pip install use-agent-os`` must
 therefore be enough to ``import`` any of the in-tree channel adapters
 without raising ``ImportError``.
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -14,8 +14,8 @@ def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:
     ps1 = SOURCE_PS1.read_text(encoding="utf-8")
     sh = SOURCE_SH.read_text(encoding="utf-8")
 
-    assert "'--force', '--reinstall-package', 'agentos'" in ps1
-    assert "--force --reinstall-package agentos" in sh
+    assert "'--force', '--reinstall-package', 'use-agent-os'" in ps1
+    assert "--force --reinstall-package use-agent-os" in sh
 
 
 def test_install_scripts_do_not_run_onboarding_or_gateway() -> None:
@@ -40,10 +40,10 @@ def test_release_installers_install_version_pinned_wheel_with_uv() -> None:
 
     for script in (ps1, sh):
         assert CURRENT_RELEASE_TAG in script
-        assert "agentos-$releaseVersion-py3-none-any.whl" in script or (
-            "agentos-${release_version}-py3-none-any.whl" in script
+        assert "use_agent_os-$releaseVersion-py3-none-any.whl" in script or (
+            "use_agent_os-${release_version}-py3-none-any.whl" in script
         )
-        assert "agentos-latest-py3-none-any.whl" not in script
+        assert "use_agent_os-latest-py3-none-any.whl" not in script
         assert "releases/latest/download" not in script
         assert "--python" in script
         assert "--force" in script

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -191,7 +191,7 @@ def test_release_sop_documents_github_only_validation_boundary() -> None:
 def test_readme_documents_quick_and_manual_terminal_install_commands() -> None:
     text = Path("README.md").read_text(encoding="utf-8")
 
-    assert 'uv tool install --python 3.12 "agentos[recommended] @ https://github.com' in text
+    assert 'uv tool install --python 3.12 "use-agent-os[recommended]"' in text
     assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in text
     assert '. "$HOME/.local/bin/env"' in text
     assert 'powershell -c "irm https://astral.sh/uv/install.ps1 | iex"' in text

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -110,10 +110,10 @@ def test_readme_release_install_uses_latest_assets_and_pinned_alternative() -> N
         in readme
     )
     assert (
-        f"releases/download/{CURRENT_TAG}/agentos-{CURRENT_VERSION}-py3-none-any.whl"
+        f"releases/download/{CURRENT_TAG}/use_agent_os-{CURRENT_VERSION}-py3-none-any.whl"
         in readme
     )
-    assert "agentos-latest-py3-none-any.whl" not in readme
+    assert "use_agent_os-latest-py3-none-any.whl" not in readme
     assert "Python wheel installs use versioned wheel filenames" in readme
     assert "Release install commands use published GitHub release assets" in readme
 
@@ -122,10 +122,10 @@ def test_release_installers_default_to_current_tag() -> None:
     for path in [Path("install.sh"), Path("install.ps1")]:
         text = path.read_text(encoding="utf-8")
         assert CURRENT_TAG in text
-        assert "agentos-$releaseVersion-py3-none-any.whl" in text or (
-            "agentos-${release_version}-py3-none-any.whl" in text
+        assert "use_agent_os-$releaseVersion-py3-none-any.whl" in text or (
+            "use_agent_os-${release_version}-py3-none-any.whl" in text
         )
-        assert "agentos-latest-py3-none-any.whl" not in text
+        assert "use_agent_os-latest-py3-none-any.whl" not in text
 
 
 def test_release_workflow_marks_preview_tags_as_prereleases() -> None:
@@ -137,4 +137,4 @@ def test_release_workflow_marks_preview_tags_as_prereleases() -> None:
     assert "is_prerelease = bool(re.search" in workflow
     assert "if not is_prerelease:" in workflow
     assert "expected.add(\"AgentOS-windows-x64-portable.zip\")" in workflow
-    assert "agentos-latest-py3-none-any.whl" not in workflow
+    assert "use_agent_os-latest-py3-none-any.whl" not in workflow

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -40,7 +40,7 @@ def load_script():
 
 def test_build_wheel_retries_once_after_transient_uv_failure(monkeypatch, tmp_path: Path) -> None:
     module = load_script()
-    wheel_path = tmp_path / "wheels" / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "wheels" / "use_agent_os-0.1.0-py3-none-any.whl"
     calls = []
 
     def fake_run(args, *, cwd, env):
@@ -108,7 +108,7 @@ def test_python_runtime_asset_name_uses_platform_triple() -> None:
 def test_cross_platform_wheelhouse_requires_target_host(tmp_path: Path) -> None:
     module = load_script()
     module.platform_tag = lambda: "linux-x64"
-    wheel_path = tmp_path / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "use_agent_os-0.1.0-py3-none-any.whl"
     package_dir = tmp_path / "packages"
 
     with pytest.raises(SystemExit, match="must run on the target platform"):
@@ -125,7 +125,7 @@ def test_cross_platform_wheelhouse_requires_target_host(tmp_path: Path) -> None:
 def test_portable_recommended_wheelhouse_uses_recommended_extra_only(tmp_path: Path) -> None:
     module = load_script()
     module.platform_tag = lambda: "windows-x64"
-    wheel_path = tmp_path / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "use_agent_os-0.1.0-py3-none-any.whl"
     package_dir = tmp_path / "packages"
 
     command = module.build_wheelhouse_command(
@@ -203,12 +203,12 @@ def test_public_release_docs_avoid_private_kol_language() -> None:
 
 def test_release_wheel_content_scanner_flags_internal_markers(tmp_path: Path) -> None:
     module = load_script()
-    wheel_path = tmp_path / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "use_agent_os-0.1.0-py3-none-any.whl"
 
     with ZipFile(wheel_path, "w") as archive:
         archive.writestr("agentos/__init__.py", "__version__ = '0.1.0'\n")
         archive.writestr(
-            "agentos-0.1.0.dist-info/METADATA",
+            "use_agent_os-0.1.0.dist-info/METADATA",
             "\n".join(
                 [
                     "Author: INTERNAL_ORG_NAME",
@@ -219,8 +219,8 @@ def test_release_wheel_content_scanner_flags_internal_markers(tmp_path: Path) ->
         )
 
     assert module.forbidden_release_text_hits(wheel_path) == [
-        "agentos-0.1.0.dist-info/METADATA: INTERNAL_ORG_NAME",
-        "agentos-0.1.0.dist-info/METADATA: github.com/internal-org/agentos",
+        "use_agent_os-0.1.0.dist-info/METADATA: INTERNAL_ORG_NAME",
+        "use_agent_os-0.1.0.dist-info/METADATA: github.com/internal-org/agentos",
     ]
 
 
@@ -228,13 +228,13 @@ def test_install_scripts_install_from_local_wheelhouse_and_run_onboarding() -> N
     module = load_script()
 
     sh_script = module.render_install_sh(
-        wheel_name="agentos-0.1.0-py3-none-any.whl",
+        wheel_name="use_agent_os-0.1.0-py3-none-any.whl",
         profile="recommended",
         python_major=3,
         python_minor=12,
     )
     ps_script = module.render_install_ps1(
-        wheel_name="agentos-0.1.0-py3-none-any.whl",
+        wheel_name="use_agent_os-0.1.0-py3-none-any.whl",
         profile="recommended",
         python_major=3,
         python_minor=12,
@@ -244,7 +244,7 @@ def test_install_scripts_install_from_local_wheelhouse_and_run_onboarding() -> N
     assert 'REQUIRED_PYTHON_MINOR=12' in sh_script
     assert "uv tool install" in sh_script
     assert '--find-links "${PACKAGE_DIR}"' in sh_script
-    assert '"${PACKAGE_DIR}/agentos-0.1.0-py3-none-any.whl[recommended]"' in sh_script
+    assert '"${PACKAGE_DIR}/use_agent_os-0.1.0-py3-none-any.whl[recommended]"' in sh_script
     assert '"${AGENTOS_BIN}" onboard' in sh_script
     assert '"${AGENTOS_BIN}" onboard --if-needed' in sh_script
     assert "agentos gateway run" in sh_script
@@ -253,7 +253,7 @@ def test_install_scripts_install_from_local_wheelhouse_and_run_onboarding() -> N
     assert "$RequiredPythonMinor = 12" in ps_script
     assert "uv tool install" in ps_script
     assert "--find-links" in ps_script
-    assert "agentos-0.1.0-py3-none-any.whl[recommended]" in ps_script
+    assert "use_agent_os-0.1.0-py3-none-any.whl[recommended]" in ps_script
     assert "& $AgentOSBin onboard --if-needed" in ps_script
     assert 'throw "AgentOS installation failed with exit code $LASTEXITCODE."' in ps_script
     assert 'throw "AgentOS onboarding failed with exit code $LASTEXITCODE."' in ps_script
@@ -406,7 +406,7 @@ def test_install_script_reexecs_under_bash_before_pipefail() -> None:
     module = load_script()
 
     script = module.render_install_sh(
-        wheel_name="agentos-0.1.0-py3-none-any.whl",
+        wheel_name="use_agent_os-0.1.0-py3-none-any.whl",
         profile="recommended",
         python_major=3,
         python_minor=12,
@@ -490,7 +490,7 @@ def test_render_readme_is_platform_specific_for_macos_portable() -> None:
 def test_prepare_release_tree_writes_user_surface_and_manifest(tmp_path: Path) -> None:
     module = load_script()
     release_root = tmp_path / "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse"
-    wheel_path = tmp_path / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "use_agent_os-0.1.0-py3-none-any.whl"
     wheel_path.write_bytes(b"wheel")
 
     bundled_wheel = module.prepare_release_tree(
@@ -535,7 +535,7 @@ def test_prepare_release_tree_writes_user_surface_and_manifest(tmp_path: Path) -
 def test_prepare_portable_release_tree_includes_runtime_and_start_scripts(tmp_path: Path) -> None:
     module = load_script()
     release_root = tmp_path / "AgentOS-0.1.0-macos-arm64-py312-recommended-portable"
-    wheel_path = tmp_path / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "use_agent_os-0.1.0-py3-none-any.whl"
     runtime_root = tmp_path / "runtime"
     (runtime_root / "bin").mkdir(parents=True)
     (runtime_root / "bin" / "python3").write_text("python", encoding="utf-8")
@@ -633,7 +633,7 @@ def test_prepare_windows_portable_release_tree_includes_double_click_launcher(
 ) -> None:
     module = load_script()
     release_root = tmp_path / "AgentOS-0.1.0-windows-x64-py312-recommended-portable"
-    wheel_path = tmp_path / "agentos-0.1.0-py3-none-any.whl"
+    wheel_path = tmp_path / "use_agent_os-0.1.0-py3-none-any.whl"
     runtime_root = tmp_path / "runtime"
     runtime_root.mkdir()
     (runtime_root / "python.exe").write_text("python", encoding="utf-8")
@@ -717,7 +717,7 @@ def test_create_zip_contains_release_directory_and_preserves_install_mode(tmp_pa
     release_root = tmp_path / "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse"
     packages = release_root / "packages"
     packages.mkdir(parents=True)
-    (packages / "agentos-0.1.0-py3-none-any.whl").write_bytes(b"wheel")
+    (packages / "use_agent_os-0.1.0-py3-none-any.whl").write_bytes(b"wheel")
     install_script = release_root / "install.sh"
     install_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
     install_script.chmod(0o755)
@@ -739,7 +739,7 @@ def test_create_zip_contains_release_directory_and_preserves_install_mode(tmp_pa
         "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse/install.ps1",
         "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse/install.sh",
         "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse/manifest.json",
-        "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse/packages/agentos-0.1.0-py3-none-any.whl",
+        "AgentOS-0.1.0-macos-arm64-py312-recommended-wheelhouse/packages/use_agent_os-0.1.0-py3-none-any.whl",
     }
     assert stat.S_IMODE(install_info.external_attr >> 16) & stat.S_IXUSR
 
@@ -823,7 +823,7 @@ def test_release_workflow_publishes_windows_portable_zip_and_wheel() -> None:
     assert "is_prerelease = bool(re.search" in workflow
     assert "if not is_prerelease:" in workflow
     assert "AgentOS-windows-x64-portable.zip" in workflow
-    assert "agentos-latest-py3-none-any.whl" not in workflow
+    assert "use_agent_os-latest-py3-none-any.whl" not in workflow
     assert "dist/*.zip dist/*.whl dist/SHA256SUMS" in workflow
     assert "dist/*.zip dist/*.zip.sha256 dist/SHA256SUMS" not in workflow
     assert "Git LFS pointer leaked into wheel" in workflow

--- a/tests/test_skill_html_to_pdf.py
+++ b/tests/test_skill_html_to_pdf.py
@@ -49,7 +49,7 @@ def test_eligibility_with_python(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_render_html_to_pdf(tmp_path: Path) -> None:
     pytest.importorskip(
         "weasyprint",
-        reason="weasyprint is opt-in via agentos[document-extras]; skip when absent",
+        reason="weasyprint is opt-in via use-agent-os[document-extras]; skip when absent",
     )
     sys.path.insert(0, str(SCRIPTS))
     try:


### PR DESCRIPTION
## Why

Follow-up to #5. The distribution rename left the release pipeline and install surfaces referencing the old `agentos-*.whl` wheel filename — the next tagged release would have failed the wheelhouse workflow's wheel globs, and every documented install command still pointed at the old package spec. **This PR must land before the next release tag.**

## What changed

**Release pipeline (the breakage fix):**
- `.github/workflows/wheelhouse-release.yml` — wheel globs, expected-asset name, and `startswith` prefix checks now use `use_agent_os-*.whl`
- `scripts/build_wheelhouse_zip.py` — wheel discovery globs (Python, sh heredoc, ps1 heredoc)
- `start.ps1` — regenerated from `render_start_ps1("recommended")` (pinned by `test_root_start_scripts`)

**Install surfaces:**
- `install.sh` / `install.ps1` — install spec `use-agent-os[<extras>]`, wheel URL `use_agent_os-<version>-py3-none-any.whl`, `--reinstall-package use-agent-os`. Dry-run verified:
  ```
  uv tool install --python 3.12 --force --reinstall-package use-agent-os "use-agent-os[recommended] @ .../v2026.7.14/use_agent_os-2026.7.14-py3-none-any.whl"
  ```
- `scripts/install_source.{sh,ps1}` — `--reinstall-package use-agent-os`

**Docs & user-facing strings:**
- README — the primary terminal install is now the PyPI command `uv tool install --python 3.12 "use-agent-os[recommended]"`; pinned installs use `==<version>` or the versioned release-wheel link
- RELEASES.md, CHANGELOG (Unreleased), docs/operations.md, docs/mcp-server.md, docs/setup-guide.html
- Bundled skill docs (html-to-pdf, multi-search-engine) and install-hint error strings (`mcp_server/server.py`, weasyprint `render.py`)

**Contract tests** updated alongside: install scripts, release consistency, release hygiene, wheelhouse builder, channel base imports.

## Notes for the release after merge

- Bump version to `2026.7.15` and push the tag — this triggers both `wheelhouse-release.yml` (GitHub assets, now with `use_agent_os-*.whl`) and `pypi-publish.yml` (first PyPI upload via trusted publishing; requires the pending publisher + `pypi` environment already configured).
- The README's pinned wheel link references the new filename, which only exists from the next release onward — one more reason to tag promptly after merging.
- The Homebrew formula (`Formula/agentos.rb`) installs from source and is unaffected; its `v0.0.1` URL/sha are pre-existing placeholders.

## Testing

- `uv run ruff check src tests scripts` clean; mypy clean on touched source
- Full offline suite: **5468 passed**; the 3 remaining failures are pre-existing local-environment issues (ensurepip SIGABRT in venv-creation tests, docker smoke, missing numpy) — the same tests pass in CI
- `AGENTOS_INSTALL_DRY_RUN=1 bash install.sh` produces the correct new install command
- `test_root_start_scripts` passes against the regenerated `start.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)