### PR TITLE
chore: bump version to 2026.7.14.post1 for the first PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.14.post1] - 2026-07-14
+
 ### Changed
 
 - The Python distribution is now published to PyPI as **`use-agent-os`**

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.14 is the current release. The project website is
+AgentOS 2026.7.14.post1 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -223,14 +223,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.15"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.14.post1"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.14/use_agent_os-2026.7.14-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.14.post1/use_agent_os-2026.7.14.post1-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.15-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.14.post1-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.14.post1 | v2026.7.14.post1 | 2026-07-14 | PyPI distribution rename to `use-agent-os`; first PyPI release |
 | 2026.7.14 | v2026.7.14 | 2026-07-14 | Release |
 | 2026.7.15 | v2026.7.15 | 2026-07-14 | CalVer release; version-independent install docs |
 | 0.0.1 | v0.0.1 | 2026-07-05 | AgentOS baseline release |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.14'
+$defaultVersion = 'v2026.7.14.post1'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -90,7 +90,7 @@ $packageName = if ($targetExtras.Count -gt 0) {
 
 function Test-ReleaseVersion {
     param([string]$Value)
-    return $Value -match '^v?\d+\.\d+\.\d+((a|b|rc)\d+)?$'
+    return $Value -match '^v?\d+\.\d+\.\d+((a|b|rc)\d+)?(\.post\d+)?$'
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.14"
+default_version="v2026.7.14.post1"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -71,7 +71,7 @@ profile="${cli_profile:-${AGENTOS_INSTALL_PROFILE:-recommended}}"
 dry_run="${AGENTOS_INSTALL_DRY_RUN:-0}"
 
 is_release_version() {
-    [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$ ]]
+    [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?(\.post[0-9]+)?$ ]]
 }
 
 valid_extras=" matrix matrix-e2e document-extras "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.14"
+version = "2026.7.14.post1"
 description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "MIT"
 readme = "README.md"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.14"
+CURRENT_RELEASE_TAG = "v2026.7.14.post1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.14"
+CURRENT_VERSION = "2026.7.14.post1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3037,7 +3037,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.14"
+version = "2026.7.14.post1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

Re-release of `2026.7.14` under the renamed **`use-agent-os`** distribution (#5, #6) — the release that puts AgentOS on PyPI for the first time.

**Version choice:** `2026.7.14` is already tagged, and `2026.7.15` was burned by the earlier re-release shuffle (still documented as a historical release in CHANGELOG/RELEASES.md even though its tag was deleted). PEP 440's `.post1` suffix is the standard way to re-release on the same CalVer date, so `2026.7.14.post1` keeps the version history unambiguous.

## What changed

- `pyproject.toml` / `uv.lock` — `2026.7.14.post1`
- `install.sh` / `install.ps1` — `default_version v2026.7.14.post1`; release-version validators widened to accept a `.postN` suffix (previously only `X.Y.Z` + `a/b/rc`)
- README — current-release line, pinned-install examples (`==2026.7.14.post1`), release wheel URL
- CHANGELOG — `[Unreleased]` promoted to `[2026.7.14.post1] - 2026-07-14`; empty `[Unreleased]` reopened
- RELEASES.md — new table row
- Tests — `CURRENT_VERSION` / `CURRENT_RELEASE_TAG` pins

## Release steps after merge (per RELEASES.md SOP)

```sh
git tag -a v2026.7.14.post1 -m "AgentOS 2026.7.14.post1"
git push upstream v2026.7.14.post1
```

The tag triggers **both** workflows:
- `wheelhouse-release.yml` → GitHub release assets (`use_agent_os-2026.7.14.post1-py3-none-any.whl`, Windows portable zip)
- `pypi-publish.yml` → first PyPI upload via trusted publishing (pending publisher + `pypi` environment are already configured; approve the `publish` job if required reviewers are enabled)

After publish: `uv tool install "use-agent-os[recommended]"` works globally.

Note: `.post1` does not match the prerelease pattern (`a|b|rc`), so the GitHub release is correctly treated as a normal (non-preview) release.

## Testing

- ruff clean; 41 release/install/packaging contract tests pass
- Full offline suite: **5469 passed**; 3 remaining failures are the known local-environment issues (docker smoke, ensurepip SIGABRT, missing numpy) that pass in CI
- `uv build --wheel` → `use_agent_os-2026.7.14.post1-py3-none-any.whl`
- Installer dry-runs (default and explicit `AGENTOS_VERSION=v2026.7.14.post1`) produce the correct command — the widened validator accepts the suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)