### PR TITLE
chore(license): relicense to Apache-2.0 with OpenSquilla attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ router, durable memory, a layered sandbox, and multi-channel messaging
 
 - **Language / runtime:** Python **3.12+** only.
 - **Package manager:** **uv** (not pip/poetry). Never edit lockfiles by hand.
-- **License:** MIT. Default LLM provider: **OpenRouter** (Bankr selectable).
+- **License:** Apache-2.0 (see `LICENSE` + `NOTICE`; core derived from
+  OpenSquilla — attribution in `THIRD_PARTY_NOTICES.md`). Default LLM
+  provider: **OpenRouter** (Bankr selectable).
 - **PRs target `main`.** Keep them small, focused, and test-covered.
 
 ## Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Relicensed the repository from MIT to **Apache-2.0** and added a root
+  `NOTICE` file. Core modules derived from
+  [OpenSquilla](https://github.com/opensquilla/opensquilla) (Apache-2.0)
+  are now credited in `THIRD_PARTY_NOTICES.md`; the README credits
+  OpenSquilla (built on) plus OpenClaw and Hermes Agent (influences).
+  Wheels now ship `LICENSE`, `NOTICE`, and `THIRD_PARTY_NOTICES.md` in
+  their dist-info license files.
+
 ## [2026.7.14.post1] - 2026-07-14
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2026 AgentOS contributors
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+AgentOS
+Copyright 2026 AgentOS contributors
+
+This product includes software derived from OpenSquilla
+(https://github.com/opensquilla/opensquilla), licensed under the
+Apache License, Version 2.0. The derived files have been modified by
+the AgentOS contributors; see THIRD_PARTY_NOTICES.md for the list of
+affected modules.
+
+Additional third-party attributions (bundled skills, models, vendored
+web assets, and adapted tooling) are recorded in
+THIRD_PARTY_NOTICES.md.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://x.com/useAgentOS"><img src="https://img.shields.io/badge/follow-%40useAgentOS-CCFF00?style=for-the-badge&logo=x&logoColor=black" alt="Follow @useAgentOS on X"></a>
   <a href="https://github.com/use-agent-os/agent-os/releases"><img src="https://img.shields.io/github/v/release/use-agent-os/agent-os?include_prereleases&style=for-the-badge&color=CCFF00" alt="GitHub release"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12%2B-CCFF00?style=for-the-badge" alt="Python 3.12+"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-CCFF00?style=for-the-badge" alt="MIT License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-CCFF00?style=for-the-badge" alt="Apache-2.0 License"></a>
 </p>
 
 ---
@@ -584,10 +584,14 @@ agentos gateway restart
 
 ## Credits
 
-AgentOS took ideas from
-[OpenClaw](https://github.com/openclaw/openclaw). Other tools and
-code used inside AgentOS are credited in
-[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+AgentOS is built on
+[OpenSquilla](https://github.com/opensquilla/opensquilla)
+(Apache-2.0) and influenced by
+[OpenClaw](https://github.com/openclaw/openclaw) and
+[Hermes Agent](https://github.com/NousResearch/hermes-agent). Other
+tools and code used inside AgentOS are credited in
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and the root
+[`NOTICE`](NOTICE) file.
 
 ---
 
@@ -600,4 +604,4 @@ request on
 [GitHub](https://github.com/use-agent-os/agent-os).
 
 [Code of Conduct](CODE_OF_CONDUCT.md) · [Security](SECURITY.md) ·
-[Support](SUPPORT.md) · [License](LICENSE) (MIT)
+[Support](SUPPORT.md) · [License](LICENSE) (Apache-2.0)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,8 +1,10 @@
 # Third Party Notices
 
-This file records third-party attribution for assets bundled with AgentOS.
-It covers:
+This file records third-party attribution for code and assets bundled with
+AgentOS. It covers:
 
+- Core runtime modules derived from OpenSquilla (Apache-2.0); see the
+  first section below.
 - The bundled skill descriptors under `src/agentos/skills/bundled/`, which
   include OpenClaw-derived MIT descriptors and AgentOS-original descriptors.
 - The bundled pptx skill references the python-pptx and PptxGenJS libraries;
@@ -18,6 +20,35 @@ It covers:
 - The vendored front-end JavaScript libraries served from
   `src/agentos/gateway/static/vendor/` for the Web UI console (Markdown
   rendering, HTML sanitization, and code-block syntax highlighting).
+
+## OpenSquilla-derived core modules
+
+- Component: core runtime modules under `src/agentos/`.
+- Upstream project: https://github.com/opensquilla/opensquilla
+- License: Apache License 2.0
+- Copyright notice: OpenSquilla contributors (the upstream project ships
+  the stock Apache-2.0 text without a filled-in copyright line and no
+  NOTICE file).
+
+AgentOS is built on OpenSquilla. Parts of the AgentOS core were copied
+from and then substantially modified relative to the upstream project.
+The highest-overlap modules include:
+
+- `src/agentos/application/approval_queue.py` and
+  `src/agentos/gateway/approval_queue.py` — approval queue handling
+- `src/agentos/cli/agent_cmd.py` — agent CLI command surface
+- `src/agentos/channels/command_registry.py` — channel slash-command dispatch
+- `src/agentos/gateway_client.py` and
+  `src/agentos/cli/gateway_client.py` — gateway client plumbing
+- `src/agentos/agentos_router/v4_phase3.py` — router phase logic
+
+Other modules across the runtime may also contain OpenSquilla-derived
+code in modified form. In accordance with Section 4(b) of the Apache
+License 2.0, this notice records that the derived files have been
+modified by the AgentOS contributors. The entire AgentOS repository is
+licensed under the Apache License 2.0 (see `LICENSE`), so the upstream
+license terms apply uniformly; the full license text is included in the
+`LICENSE` file at the repository root.
 
 ## OpenClaw-derived bundled skill descriptors
 
@@ -69,7 +100,7 @@ SOFTWARE.
 ## AgentOS-original bundled skills
 
 These bundled skill descriptors are authored and maintained by AgentOS and
-are released under AgentOS's repository license (MIT; see `LICENSE`):
+are released under AgentOS's repository license (Apache-2.0; see `LICENSE`):
 
 - `cron`
 - `deep-research`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "use-agent-os"
 version = "2026.7.14.post1"
 description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
-license = "MIT"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]
 readme = "README.md"
 authors = [
     { name = "AgentOS contributors" },
@@ -10,7 +11,7 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
 keywords = ["agent", "llm", "mcp", "gateway", "router", "chatbot"]


### PR DESCRIPTION
## Summary

Relicenses the repository from MIT to **Apache-2.0** and adds formal upstream attribution for OpenSquilla, ahead of the next PyPI release.

AgentOS's core includes modules derived from [OpenSquilla](https://github.com/opensquilla/opensquilla) (Apache-2.0). Apache-2.0 requires that redistributed derivative work carries the license, attribution, and a statement that files were modified. Moving the whole repository to Apache-2.0 is the simplest compliant posture: one license applies uniformly, with no per-file license split.

## Changes

- **`LICENSE`** — replaced MIT with the canonical Apache-2.0 text (fetched verbatim from apache.org).
- **`NOTICE`** (new) — Apache-convention notice file: AgentOS copyright plus OpenSquilla attribution and modified-files statement.
- **`THIRD_PARTY_NOTICES.md`** — new *"OpenSquilla-derived core modules"* section listing the highest-overlap modules (`approval_queue`, `agent_cmd`, `command_registry`, `gateway_client`, `v4_phase3`) with a Section 4(b) modification notice; repo-license reference updated.
- **`README.md`** — license badge/footer updated to Apache-2.0; Credits now state AgentOS is built on OpenSquilla and influenced by OpenClaw and Hermes Agent.
- **`pyproject.toml`** — `license = "Apache-2.0"` (PEP 639 expression), Apache classifier, and explicit `license-files` so built wheels ship `LICENSE`, `NOTICE`, and `THIRD_PARTY_NOTICES.md` in `dist-info/licenses/`.
- **`AGENTS.md` / `CHANGELOG.md`** — updated to match; changelog entry added under `[Unreleased]`.

## Compatibility

MIT → Apache-2.0 is a permissive-to-permissive move; all existing third-party notices (OpenClaw MIT, ClawHub MIT-0, tokenjuice MIT, BGE MIT, vendored web assets) remain valid and unchanged.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos` — no issues in 556 source files
- `uv run pytest -q` — **5470 passed**, 31 skipped; 3 failures are pre-existing local-environment issues (confirmed identical on a clean tree: `ensurepip` SIGABRT in sandboxed venv, missing Docker, missing `numpy` for the ONNX test) and unrelated to this diff
- `uv build --wheel` — wheel METADATA carries `License-Expression: Apache-2.0` and `License-File` entries for all three files; verified present in `dist-info/licenses/`

## Release note

The next PyPI upload (after `2026.7.14.post1`) should be cut from a tree that includes this PR so the published artifact ships the corrected license metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)