### PR TITLE
chore: bump version to 2026.7.15 for the Apache-2.0 relicense release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.15] - 2026-07-15
+
 ### Changed
 
 - Relicensed the repository from MIT to **Apache-2.0** and added a root
@@ -35,11 +37,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Re-release aligning the current version tag to 2026.7.14.
-
-## [2026.7.15] - 2026-07-14
-
-### Changed
-
 - Adopted CalVer versioning (`YYYY.M.D`). Because PEP 440 normalizes the version
   segment in wheel filenames (leading zeros dropped), tags use the same
   non-padded form, e.g. `v2026.7.15`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.14.post1 is the current release. The project website is
+AgentOS 2026.7.15 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -223,14 +223,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.14.post1"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.15"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.14.post1/use_agent_os-2026.7.14.post1-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.15/use_agent_os-2026.7.15-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.14.post1-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.15-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,9 +2,9 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.15 | v2026.7.15 | 2026-07-15 | Relicense to Apache-2.0 with `NOTICE` + OpenSquilla attribution; wheels ship license files |
 | 2026.7.14.post1 | v2026.7.14.post1 | 2026-07-14 | PyPI distribution rename to `use-agent-os`; first PyPI release |
 | 2026.7.14 | v2026.7.14 | 2026-07-14 | Release |
-| 2026.7.15 | v2026.7.15 | 2026-07-14 | CalVer release; version-independent install docs |
 | 0.0.1 | v0.0.1 | 2026-07-05 | AgentOS baseline release |
 
 Versions follow CalVer (`YYYY.M.D`). PEP 440 normalizes wheel filenames and drops

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.14.post1'
+$defaultVersion = 'v2026.7.15'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.14.post1"
+default_version="v2026.7.15"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.14.post1"
+version = "2026.7.15"
 description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.14.post1"
+CURRENT_RELEASE_TAG = "v2026.7.15"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.14.post1"
+CURRENT_VERSION = "2026.7.15"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"


### PR DESCRIPTION
## Summary

Prepares release **2026.7.15** — the first release carrying the Apache-2.0 relicense and OpenSquilla attribution from #9, so the published PyPI artifact and GitHub release assets ship the corrected license metadata (`License-Expression: Apache-2.0` plus `LICENSE`, `NOTICE`, and `THIRD_PARTY_NOTICES.md` in `dist-info/licenses/`).

## Changes

- Version bump `2026.7.14.post1` → `2026.7.15` in `pyproject.toml`, `install.sh`, `install.ps1`, README, and the release-consistency test constants.
- **CHANGELOG**: the `[Unreleased]` relicense entry is promoted to `[2026.7.15] - 2026-07-15`. The stale `[2026.7.15] - 2026-07-14` section (from the earlier, abandoned tag attempt) is removed; its bullets are folded into `[2026.7.14]`, where that content actually shipped — verified against the `v2026.7.14` tag's tree.
- **RELEASES.md**: stale mid-table `2026.7.15` row replaced with a new top row for this release.

## Release-pipeline check

- A `v2026.7.15` tag was briefly pushed on 2026-07-13 and later deleted. Confirmed clean: no GitHub release exists for it, no PyPI upload ever happened (PyPI has only `2026.7.14.post1`), and the stray local tag has been deleted — so re-tagging `v2026.7.15` after this PR merges is conflict-free.
- `pypi-publish.yml` and `wheelhouse-release.yml` both assert the pushed tag equals `v<pyproject version>`; with this bump, tag `v2026.7.15` builds `use_agent_os-2026.7.15-py3-none-any.whl` and publishes via the already-proven Trusted Publishing flow.
- Installer version regexes accept plain CalVer `v2026.7.15` (covered by `tests/test_install_scripts.py`).

## Verification

- `uv run ruff check src tests` — clean
- `uv run pytest -q` — **5470 passed**, 31 skipped; 3 pre-existing local-environment failures unrelated to this diff

## After merge

Tag the merge commit as `v2026.7.15` and push the tag; the PyPI publish and Windows release-asset workflows fire from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)