### PR TITLE
chore: sync uv.lock to version 2026.7.15

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3037,7 +3037,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.14.post1"
+version = "2026.7.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Follow-up to #10: the version bump missed regenerating `uv.lock`, so the locked `use-agent-os` version is still `2026.7.14.post1`. This fails `test_lockfile_version_matches_current_release` in the CI run currently in progress on `main`.

One-line fix: lock regenerated so the root package records `2026.7.15`.

Needs to land before tagging `v2026.7.15` so the release is cut from a green `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)