### PR TITLE
fix(release): allow PEP 639 dist-info license files in wheelhouse check

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -93,3 +93,7 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Tolerate re-pushed tags: files already on PyPI are skipped
+          # instead of failing the whole run.
+          skip-existing: true

--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -208,8 +208,16 @@ def _contains_forbidden_release_segment(path: str) -> bool:
     return any(part in FORBIDDEN_RELEASE_SEGMENTS for part in _release_name(path).split("/"))
 
 
+def _is_dist_info_license_file(name: str) -> bool:
+    """Wheel metadata license files (PEP 639): <dist>.dist-info/licenses/**."""
+    parts = name.split("/")
+    return len(parts) >= 3 and parts[0].endswith(".dist-info") and parts[1] == "licenses"
+
+
 def _is_allowed_runtime_markdown(path: str) -> bool:
     name = _release_name(path)
+    if _is_dist_info_license_file(name):
+        return True
     if name == TOKENJUICE_PROVENANCE_WHEEL_PATH:
         return True
     if name in ALLOWED_SKILL_REFERENCE_WHEEL_PATHS:

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -166,6 +166,21 @@ def test_release_wheel_allows_tokenjuice_provenance_markdown() -> None:
     assert unrelated_skill_reference in violations
 
 
+def test_release_wheel_allows_dist_info_license_files() -> None:
+    module = load_script()
+    license_md = "use_agent_os-2026.7.15.dist-info/licenses/THIRD_PARTY_NOTICES.md"
+    license_plain = "use_agent_os-2026.7.15.dist-info/licenses/NOTICE"
+    stray_md = "use_agent_os-2026.7.15.dist-info/STRAY.md"
+
+    violations = module.forbidden_release_wheel_entries(
+        (license_md, license_plain, stray_md)
+    )
+
+    assert license_md not in violations
+    assert license_plain not in violations
+    assert stray_md in violations
+
+
 def test_pyproject_release_wheel_config_excludes_forbidden_skill_resources() -> None:
     module = load_script()
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Unblocks the failed `v2026.7.15` Windows release-assets run.

**Root cause:** `scripts/build_wheelhouse_zip.py`'s `forbidden_release_wheel_entries` rejects every `.md` wheel entry outside its runtime-markdown allowlist. Since #9, wheels ship `THIRD_PARTY_NOTICES.md` under `use_agent_os-<version>.dist-info/licenses/` (PEP 639 `license-files`), so the wheel self-check failed:

```
Built wheel contains forbidden release entries:
  use_agent_os-2026.7.15.dist-info/licenses/THIRD_PARTY_NOTICES.md
```

## Changes

- `_is_dist_info_license_file()`: markdown under `<dist>.dist-info/licenses/` is allowed — wheel license metadata is always release-safe. Stray `.md` elsewhere in `dist-info/` remains forbidden.
- New test `test_release_wheel_allows_dist_info_license_files` covering allowed (`THIRD_PARTY_NOTICES.md`, `NOTICE`) and still-forbidden (`dist-info/STRAY.md`) entries.
- `pypi-publish.yml`: `skip-existing: true` on the publish action. The wheelhouse workflow checks out the release tag, so this fix must be reachable from the tag — after merge, `v2026.7.15` will be re-pointed at `main`, and the re-triggered PyPI run should skip the already-published `2026.7.15` files instead of failing.

## Verification

- `uv run pytest tests/test_scripts/test_build_wheelhouse_zip.py -q` — 28 passed
- `uv run ruff check` — clean
- Fed a real wheel built from the relicensed tree (containing `dist-info/licenses/THIRD_PARTY_NOTICES.md`) through the fixed `forbidden_release_wheel_paths` and `forbidden_release_text_hits` — zero violations

## After merge

1. Delete tag `v2026.7.15` on upstream, re-tag the merge commit, push.
2. `pypi-publish` re-runs → skips existing files (PyPI already has 2026.7.15) → green.
3. `wheelhouse-release` re-runs from the fixed tag → builds Windows assets and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)