### PR TITLE
feat(webui): chat transcript redesign

### DIFF
--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -439,23 +439,22 @@
   margin-top: calc(-1 * var(--sp-5) + 6px);
 }
 
-/* User  -  transcript row: left-aligned, accent bar, no bubble fill */
+/* User  -  refined right bubble: light accent tint, no border, no shadow */
 .chat-msg--user,
 .msg.user {
-  align-items: flex-start;
+  align-items: flex-end;
 }
 
 .chat-msg--user .chat-msg-text,
 .msg.user .msg-body {
-  /* Transcript language: the 2px accent bar is the speaker signal; no fill,
-     no radius, no shadow. Text keeps the reading measure of the column. */
-  background: none;
+  /* Tint stays a low-alpha accent wash so text keeps AA contrast in both
+     themes; the bubble is the speaker signal, no border needed. */
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-surface));
   border: 0;
-  border-left: 2px solid var(--accent);
-  border-radius: 0;
+  border-radius: var(--radius-md);
   box-shadow: none;
   color: var(--text);
-  padding: var(--sp-1) var(--sp-4);
+  padding: var(--sp-2) var(--sp-4);
   font-size: var(--fs-sm);
   line-height: 1.6;
   display: flex;
@@ -465,9 +464,10 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
-  max-width: 100%;
+  max-width: 78%;
   min-width: 56px;
-  min-height: 24px;
+  min-height: 32px;
+  margin-left: auto;
 }
 
 /* Assistant  -  bubble aligns left naturally */
@@ -738,6 +738,8 @@
 .chat-msg-avatar svg,
 .role-label svg { width: 14px; height: 14px; opacity: 0.5; }
 
+.msg.user .role-label { text-align: right; }
+
 .msg-header {
   display: flex;
   align-items: center;
@@ -777,6 +779,9 @@
   opacity: 0.6;
   padding: 0 var(--sp-1);
 }
+
+.chat-msg--user .chat-msg-time,
+.msg.user .msg-time { text-align: right; }
 
 /* ─── Per-turn metadata footer (model + session tokens + combo) ─────── */
 .msg-meta {
@@ -1503,7 +1508,7 @@
 }
 
 .msg.user .msg-body.msg-body--has-attachments {
-  align-items: flex-start;
+  align-items: flex-end;
   background: transparent;
   border: 0;
   border-radius: 0;
@@ -1512,22 +1517,22 @@
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
-  max-width: min(520px, 100%);
+  max-width: min(520px, 78%);
   padding: 0;
 }
 
 .msg.user .msg-body--has-attachments .msg-attachment-text {
-  align-self: flex-start;
-  background: none;
-  border-left: 2px solid var(--accent);
-  border-radius: 0;
+  align-self: flex-end;
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-surface));
+  border: 0;
+  border-radius: var(--radius-md);
   box-shadow: none;
   color: var(--text);
   line-height: 1.6;
   max-width: 100%;
-  min-height: 24px;
+  min-height: 32px;
   min-width: 56px;
-  padding: var(--sp-1) var(--sp-4);
+  padding: var(--sp-2) var(--sp-4);
   text-align: start;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -1535,7 +1540,7 @@
 }
 
 .msg.user .msg-body--has-attachments .msg-attachments {
-  justify-content: flex-start;
+  justify-content: flex-end;
   max-width: 100%;
   margin: 0;
   user-select: text;
@@ -2318,14 +2323,23 @@
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  padding: var(--sp-2) var(--sp-4) var(--sp-1);
-  border-top: 1px solid var(--border);
-  background: var(--bg);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--bg-surface);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14), 0 1px 3px rgba(0, 0, 0, 0.10);
   flex-shrink: 0;
   /* Share the thread's reading axis so input and conversation align. */
   max-width: var(--chat-measure);
-  width: 100%;
-  margin: 0 auto;
+  width: calc(100% - var(--sp-6));
+  margin: 0 auto var(--sp-3);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.chat-input-bar:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14),
+    0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 /* ─── Router-fx dock ──────────────────────────────────────────────────────
@@ -2391,9 +2405,11 @@
   box-sizing: border-box;
   display: block;
   resize: none;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-surface);
+  /* The pill (.chat-input-bar) supplies the frame + focus ring; the textarea
+     stays chromeless so there are no seams inside the composer. */
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--text);
   padding: 10px var(--sp-3);
   font-family: inherit;
@@ -2404,12 +2420,12 @@
   max-height: 150px;
   overflow-y: auto;
   outline: none;
-  box-shadow: var(--shadow-md);
-  transition: border-color var(--transition);
+  box-shadow: none;
 }
 
 .chat-textarea:focus {
-  border-color: var(--accent);
+  outline: none;
+  box-shadow: none;
 }
 
 .chat-textarea::placeholder {

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -2364,6 +2364,23 @@
 .chat-input-wrap {
   flex: 1;
   min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-1);
+}
+
+.chat-input-glyph {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+  color: var(--text-dim);
+  padding-top: var(--sp-2);
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.chat-composer:focus-within .chat-input-glyph {
+  color: var(--accent);
 }
 
 .chat-textarea {

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -757,6 +757,7 @@
   flex-wrap: wrap;
   gap: 4px 8px;
   font-size: var(--fs-xs);
+  font-family: var(--font-mono);
   /* --text-dim directly (4.98:1 dark / 5.69:1 light) instead of muted@0.75,
      which dropped light theme to ~4.39:1 and forced calc(1/0.75) lift hacks. */
   color: var(--text-dim);
@@ -2499,6 +2500,33 @@
 
 .msg-meta__saved-label {
   letter-spacing: 0.01em;
+}
+
+/* One-shot shimmer when a live turn lands significant routed savings.
+   Runs once (animation-iteration-count 1), then the chip rests. */
+.msg-meta__saved--flash .msg-meta__saved-label {
+  color: transparent;
+  background: linear-gradient(
+    100deg,
+    var(--accent) 0%,
+    var(--accent) 38%,
+    color-mix(in srgb, var(--accent) 30%, var(--text)) 50%,
+    var(--accent) 62%,
+    var(--accent) 100%
+  );
+  background-size: 220% 100%;
+  background-position: 140% 0;
+  -webkit-background-clip: text;
+  background-clip: text;
+  animation: contextSeparatorShimmer 1.4s ease-out 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .msg-meta__saved--flash .msg-meta__saved-label {
+    animation: none;
+    color: var(--accent);
+    background: none;
+  }
 }
 
 /* ─── "Saved ~X%" floating label  -  viewport-centered, headline weight ── */

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -517,14 +517,16 @@
 
 .chat-msg--assistant .chat-msg-text,
 .msg.assistant .msg-body {
-  background: var(--bg-surface);
-  border-radius: var(--radius-md);
-  padding: var(--sp-2) var(--sp-4);
-  box-shadow: var(--shadow-sm);
-  font-size: var(--fs-sm);
+  /* Bare prose on the page background: the transcript's reading voice.
+     One size up from machine lines so prose and mono chrome separate. */
+  background: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0 var(--sp-1);
+  font-size: var(--fs-md);
   line-height: 1.7;
   word-break: break-word;
-  max-width: 88%;
+  max-width: 100%;
   min-width: 56px;
   min-height: 32px;
 }
@@ -641,7 +643,7 @@
   content: '';
   display: block;
   position: absolute;
-  left: var(--sp-4);
+  left: 2px;
   bottom: var(--sp-2);
   width: 16px;
   height: 16px;
@@ -665,7 +667,7 @@
   content: '';
   display: block;
   position: absolute;
-  left: calc(var(--sp-4) - 4px);
+  left: -2px;
   bottom: calc(var(--sp-2) - 4px);
   width: 24px;
   height: 24px;

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -284,6 +284,7 @@
 
 /* Context warning */
 .chat-ctx-warn {
+  position: relative;
   font-size: var(--fs-xs);
   color: var(--warn);
   background: color-mix(in srgb, var(--warn) 10%, transparent);
@@ -294,6 +295,17 @@
   max-width: min(260px, 24vw);
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.chat-ctx-warn::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 1px;
+  width: var(--ctx-pct, 0%);
+  background: var(--warn);
+  transition: width 300ms ease;
 }
 
 @media (max-width: 1199px) {
@@ -670,6 +682,22 @@
 @keyframes blink {
   0%, 100% { opacity: 1; }
   50%      { opacity: 0.2; }
+}
+
+/* Live insertion caret: a block caret rides the end of the streaming text. */
+.msg.streaming .msg-body .msg-text-seg:last-of-type::after {
+  content: '\258d';            /* ▍ */
+  display: inline-block;
+  margin-left: 1px;
+  color: var(--accent);
+  animation: blink 1.1s steps(1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .msg.streaming .msg-body .msg-text-seg:last-of-type::after {
+    animation: none;
+    opacity: 0.6;
+  }
 }
 
 /* Interrupted-turn marker. Appended to the .msg-body when a streaming

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -1074,6 +1074,11 @@
   color: var(--danger);
 }
 
+.chat-tools-collapse--unknown > .chat-tools-summary .chat-tools-status::before {
+  content: '\2013';           /* – */
+  color: var(--warn);
+}
+
 .chat-tools-collapse--running > .chat-tools-summary .chat-tools-status::before {
   content: '';
   width: 10px;

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -928,22 +928,24 @@
   white-space: nowrap;
 }
 
-/* Tool collapse group -- hairline-bordered tile over flat field */
+/* Tool row group -- 1px left rail, no card chrome. The rail carries the
+   aggregate state color; each summary line is one tool call. */
 .chat-tools-collapse {
-  margin-top: var(--sp-2);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  margin-top: var(--sp-1);
+  background: none;
+  border: 0;
+  border-left: 1px solid var(--border);
+  border-radius: 0;
   overflow: hidden;
   transition: border-color var(--transition);
 }
 
 .chat-tools-summary {
-  padding: var(--sp-2) var(--sp-3);
+  padding: 2px var(--sp-3);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: var(--track-wide);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  letter-spacing: 0;
   color: var(--text-muted);
   cursor: pointer;
   user-select: none;
@@ -964,7 +966,7 @@
   border-right: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   transform: rotate(-45deg);
-  margin-left: auto;
+  margin-left: 0;
   opacity: 0.5;
   transition: transform 180ms ease, opacity var(--transition);
 }
@@ -977,6 +979,8 @@
 .chat-tools-body {
   padding: 0 var(--sp-3) var(--sp-2);
   animation: expandIn 200ms ease;
+  max-height: 40vh;
+  overflow: auto;
 }
 @keyframes expandIn {
   from { opacity: 0; transform: translateY(-4px); }
@@ -999,9 +1003,7 @@
 }
 
 /* Tool collapse states: running → success → error */
-.chat-tools-collapse--running {
-  border-left: 3px solid var(--accent);
-}
+.chat-tools-collapse--running { border-left-color: var(--accent); }
 /* Running tool: suppress click-to-expand affordance */
 .chat-tools-collapse--running > .chat-tools-summary,
 .chat-tools-summary[aria-disabled="true"] { cursor: progress; }
@@ -1010,16 +1012,46 @@
 .chat-tools-collapse--running > .chat-tools-summary::after,
 .chat-tools-summary[aria-disabled="true"]::after { opacity: 0.2; }
 
-.chat-tools-collapse--success {
-  border-left: 3px solid var(--ok);
+.chat-tools-collapse--success { border-left-color: var(--border); }
+.chat-tools-collapse--error   { border-left-color: var(--danger); }
+.chat-tools-collapse--unknown { border-left-color: var(--warn); }
+
+/* Status cell: right-aligned. Glyph from state class, duration text from JS. */
+.chat-tools-status {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
 }
 
-.chat-tools-collapse--error {
-  border-left: 3px solid var(--danger);
+.chat-tools-collapse--success > .chat-tools-summary .chat-tools-status::before {
+  content: '\2713';           /* ✓ */
+  color: var(--ok);
 }
 
-.chat-tools-collapse--unknown {
-  border-left: 3px solid var(--warn);
+.chat-tools-collapse--error > .chat-tools-summary .chat-tools-status::before {
+  content: '\2717';           /* ✗ */
+  color: var(--danger);
+}
+
+.chat-tools-collapse--running > .chat-tools-summary .chat-tools-status::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-top-color: var(--accent);
+  animation: cap-activity-spin 0.9s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-tools-collapse--running > .chat-tools-summary .chat-tools-status::before {
+    animation: none;
+    border-top-color: color-mix(in srgb, var(--accent) 35%, transparent);
+    border-left-color: var(--accent);
+  }
 }
 
 .chat-tool-result--warn {

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -478,23 +478,23 @@
   margin-top: calc(-1 * var(--sp-5) + 6px);
 }
 
-/* User  -  header and body align right */
+/* User  -  transcript row: left-aligned, accent bar, no bubble fill */
 .chat-msg--user,
 .msg.user {
-  align-items: flex-end;
+  align-items: flex-start;
 }
 
 .chat-msg--user .chat-msg-text,
 .msg.user .msg-body {
-  /* Low-tint surface, not a saturated-orange fill: keeps the accent as signal
-     and clears WCAG AA (>7:1 in both themes via color-mix) where #fff on a
-     solid accent fill would fall short. */
-  background: color-mix(in srgb, var(--accent) 12%, var(--bg-surface));
-  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border));
+  /* Transcript language: the 2px accent bar is the speaker signal; no fill,
+     no radius, no shadow. Text keeps the reading measure of the column. */
+  background: none;
+  border: 0;
+  border-left: 2px solid var(--accent);
+  border-radius: 0;
+  box-shadow: none;
   color: var(--text);
-  border-radius: var(--radius-md);
-  padding: var(--sp-2) var(--sp-4);
-  box-shadow: var(--shadow-sm);
+  padding: var(--sp-1) var(--sp-4);
   font-size: var(--fs-sm);
   line-height: 1.6;
   display: flex;
@@ -504,10 +504,9 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
-  max-width: 78%;
+  max-width: 100%;
   min-width: 56px;
-  min-height: 32px;
-  margin-left: auto;
+  min-height: 24px;
 }
 
 /* Assistant  -  bubble aligns left naturally */
@@ -760,8 +759,6 @@
 .chat-msg-avatar svg,
 .role-label svg { width: 14px; height: 14px; opacity: 0.5; }
 
-.msg.user .role-label { text-align: right; }
-
 .msg-header {
   display: flex;
   align-items: center;
@@ -801,8 +798,6 @@
   opacity: 0.6;
   padding: 0 var(--sp-1);
 }
-.chat-msg--user .chat-msg-time,
-.msg.user .msg-time { text-align: right; }
 
 /* ─── Per-turn metadata footer (model + session tokens + combo) ─────── */
 .msg-meta {
@@ -1496,7 +1491,7 @@
 }
 
 .msg.user .msg-body.msg-body--has-attachments {
-  align-items: flex-end;
+  align-items: flex-start;
   background: transparent;
   border: 0;
   border-radius: 0;
@@ -1505,21 +1500,22 @@
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
-  max-width: min(360px, 78%);
+  max-width: min(520px, 100%);
   padding: 0;
 }
 
 .msg.user .msg-body--has-attachments .msg-attachment-text {
-  align-self: flex-end;
-  background: var(--accent);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-  color: #fff;
+  align-self: flex-start;
+  background: none;
+  border-left: 2px solid var(--accent);
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--text);
   line-height: 1.6;
-  max-width: min(360px, 100%);
-  min-height: 32px;
+  max-width: 100%;
+  min-height: 24px;
   min-width: 56px;
-  padding: var(--sp-2) var(--sp-4);
+  padding: var(--sp-1) var(--sp-4);
   text-align: start;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -1527,7 +1523,7 @@
 }
 
 .msg.user .msg-body--has-attachments .msg-attachments {
-  justify-content: flex-end;
+  justify-content: flex-start;
   max-width: 100%;
   margin: 0;
   user-select: text;

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -404,57 +404,6 @@
   background: var(--border);
 }
 
-/* ─── Sidebar (tool output detail) ─────────────────────────────────────── */
-
-/* Tool-output detail sidebar -- hairline-bordered panel */
-.chat-sidebar {
-  width: 380px;
-  max-width: 40%;
-  border-left: 1px solid var(--border-strong);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-/* Sidebar header -- mono uppercase section label with hairline divider.
-   A faint accent thread below the header rail echoes the topbar pattern. */
-.chat-sidebar-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--sp-2) var(--sp-3);
-  border-bottom: 1px solid var(--border);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: var(--track-label);
-  text-transform: uppercase;
-  color: var(--text-dim);
-  flex-shrink: 0;
-  position: relative;
-}
-.chat-sidebar-header::after {
-  content: "";
-  position: absolute;
-  left: 0; right: 0; bottom: -1px;
-  height: 1px;
-  background: linear-gradient(90deg, transparent 0%, color-mix(in srgb, var(--accent) 28%, transparent) 20%, transparent 50%);
-  pointer-events: none;
-}
-
-.chat-sidebar-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--sp-3);
-  font-size: var(--fs-sm);
-}
-
-.chat-sidebar-body pre {
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
 /* ─── Message Bubbles ──────────────────────────────────────────────────── */
 
 /* Each .msg row is full-width; bubble alignment is done via margin on .msg-body. */

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -517,10 +517,10 @@
 }
 
 .chat-subagent-disclosure {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--ok);
-  border-radius: var(--radius-md);
+  background: none;
+  border: 0;
+  border-left: 1px solid var(--ok);
+  border-radius: 0;
   overflow: hidden;
 }
 
@@ -904,10 +904,10 @@
 
 /* Thinking indicator bubble */
 .msg.thinking .msg-body {
-  background: var(--bg-surface);
-  border-left: 3px solid var(--accent);
-  border-radius: var(--radius-lg);
-  padding: var(--sp-3) var(--sp-4);
+  background: none;
+  border-left: 2px solid var(--accent);
+  border-radius: 0;
+  padding: var(--sp-1) var(--sp-4);
   box-shadow: none;
   animation: msgFadeIn 150ms ease;
 }

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -157,7 +157,7 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.40), 0 2px 8px rgba(0, 0, 0, 0.20);
   display: flex;
   flex-direction: column;
-  width: 320px;
+  width: 360px;
   max-height: 380px;
   overflow: hidden;
   font-family: var(--font-sans);
@@ -1841,7 +1841,8 @@
   min-width: 0;
   min-height: 42px;
   cursor: pointer;
-  font-size: var(--fs-sm);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
   transition: background var(--transition);
 }
 
@@ -2336,6 +2337,8 @@
   max-width: var(--chat-measure);
   margin: 0 auto;
   padding: 0 var(--sp-4);
+  max-height: 220px;
+  overflow-y: auto;
 }
 .chat-routerfx-dock:empty { display: none; }
 .chat-routerfx-dock > .router-fx {

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -120,6 +120,10 @@
   background: var(--bg-hover);
 }
 
+.chat-topbar-export {
+  flex-shrink: 0;
+}
+
 .chat-session-copy-btn svg {
   width: 14px;
   height: 14px;
@@ -2324,10 +2328,14 @@
   align-items: center;
   gap: var(--sp-2);
   padding: var(--sp-2) var(--sp-3);
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
   border-radius: 22px;
   background: var(--bg-surface);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14), 0 1px 3px rgba(0, 0, 0, 0.10);
+  /* Depth shadow + a soft resting accent halo so the composer glows in the
+     brand color; the ring intensifies on focus (below). */
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14),
+    0 0 0 1px color-mix(in srgb, var(--accent) 14%, transparent),
+    0 0 24px color-mix(in srgb, var(--accent) 18%, transparent);
   flex-shrink: 0;
   /* Share the thread's reading axis so input and conversation align. */
   max-width: var(--chat-measure);
@@ -2338,8 +2346,9 @@
 
 .chat-input-bar:focus-within {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14),
-    0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16),
+    0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent),
+    0 0 34px color-mix(in srgb, var(--accent) 34%, transparent);
 }
 
 /* ─── Router-fx dock ──────────────────────────────────────────────────────

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -641,6 +641,7 @@ const ChatView = (() => {
   let _attachPreview = null;
   let _slashEl = null;
   let _ctxWarn = null;
+  let _sessionPaletteKeyHandler = null;
   let _fileInput = null;
   let _toolbar = null;
   let _elevatedPill = null;
@@ -1280,6 +1281,7 @@ const ChatView = (() => {
               </div>
             </div>
             <div class="chat-input-wrap">
+              <span class="chat-input-glyph" aria-hidden="true">&gt;</span>
               <textarea class="chat-textarea" id="chat-textarea" rows="1"
                         placeholder="Send a message..." maxlength="100000"
                         aria-label="Message to send"></textarea>
@@ -2072,6 +2074,18 @@ const ChatView = (() => {
       });
       search.focus();
     });
+
+    _sessionPaletteKeyHandler = (e) => {
+      const isPaletteKey = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k';
+      if (!isPaletteKey) return;
+      const chip = document.getElementById('chat-session-chip');
+      if (!chip) return;
+      e.preventDefault();
+      if (!chip.classList.contains('is-active')) chip.click();
+      const search = document.querySelector('.chat-session-popover-search');
+      if (search) search.focus();
+    };
+    document.addEventListener('keydown', _sessionPaletteKeyHandler);
   }
 
   /* ── Composer Toolbar Popover (gear button) ────────────────────────── */
@@ -8785,6 +8799,10 @@ const ChatView = (() => {
     _stopRequestedByUser = false;
     _messages = [];
     _clearContextStatus();
+    if (_sessionPaletteKeyHandler) {
+      document.removeEventListener('keydown', _sessionPaletteKeyHandler);
+      _sessionPaletteKeyHandler = null;
+    }
     _lastHeaderRole = '';
     _lastHeaderDay = '';
     _composing = false;

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -5267,6 +5267,7 @@ const ChatView = (() => {
     }
     _ctxWarn.classList.remove('hidden');
     _ctxWarn.textContent = `Request ctx ${Math.round(pressure * 100)}% (~${Math.round(tokens / 1000)}k/${Math.round(windowTokens / 1000)}k)`;
+    _ctxWarn.style.setProperty('--ctx-pct', `${Math.min(100, Math.round(pressure * 100))}%`);
   }
 
   /* ── Chat History ───────────────────────────────────────────────────── */

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -1009,7 +1009,7 @@ const ChatView = (() => {
     return model ? `${model}|${u?.routed_tier || ''}` : '';
   }
 
-  function _attachTurnMeta(bubble, model, totalIn, totalOut, turnUsage) {
+  function _attachTurnMeta(bubble, model, totalIn, totalOut, turnUsage, opts = {}) {
     if (!bubble) return;
     bubble.querySelectorAll(':scope > .msg-meta').forEach((el) => el.remove());
     const hasModel = model && model.trim();
@@ -1089,6 +1089,12 @@ const ChatView = (() => {
         : (turnSavedPct > 0 ? `Saved ~${Math.round(turnSavedPct)}%` : 'Cost optimized');
       span.appendChild(label);
       meta.appendChild(span);
+      if (opts.flash && turnSavedPct >= 20) {
+        span.classList.add('msg-meta__saved--flash');
+        span.addEventListener('animationend', () => {
+          span.classList.remove('msg-meta__saved--flash');
+        }, { once: true });
+      }
     }
     if (hasCombo) {
       const span = document.createElement('span');
@@ -5078,7 +5084,7 @@ const ChatView = (() => {
         _maybeFireSavingsPopup(_finishedBubble, u, { animate: !isReplayedFrame });
 
         // Attach model + session token footer below the assistant bubble
-        _attachTurnMeta(_finishedBubble, _usageModel, u.input_tokens | 0, u.output_tokens | 0, u);
+        _attachTurnMeta(_finishedBubble, _usageModel, u.input_tokens | 0, u.output_tokens | 0, u, { flash: !isReplayedFrame });
         const _metaIdx = _messages.filter(m => m.role === 'assistant').length - 1;
         if (_metaIdx >= 0) {
           _storeTurnMeta(_sessionKey, _metaIdx, _usageModel, u.input_tokens | 0, u.output_tokens | 0, {

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -7113,7 +7113,7 @@ const ChatView = (() => {
   }
 
   function _visibleToolSummaryStatus(status, durationMs) {
-    if (status === 'running') return '';           // spinner is CSS-drawn
+    // running renders no text (spinner is CSS-drawn); only settled rows show a duration.
     if (status === 'success' || status === 'error') return _fmtToolDuration(durationMs);
     return '';
   }

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -7048,6 +7048,7 @@ const ChatView = (() => {
     details.className = 'chat-tools-collapse' + (isRunning ? ' chat-tools-collapse--running' : '');
     if (toolId) details.setAttribute('data-tool-id', toolId);
     details.setAttribute('data-tool-name', name || 'tool');
+    if (isRunning) details.dataset.startedAt = String(Date.now());
 
     const summary = document.createElement('summary');
     summary.className = 'chat-tools-summary';
@@ -7082,18 +7083,30 @@ const ChatView = (() => {
     return details;
   }
 
-  function _visibleToolSummaryStatus(status) {
-    return status === 'running' ? 'running' : '';
+  function _fmtToolDuration(ms) {
+    if (!ms || ms < 0) return '';
+    const s = ms / 1000;
+    if (s < 10) return `${s.toFixed(1)}s`;
+    if (s < 60) return `${Math.round(s)}s`;
+    return `${Math.floor(s / 60)}m${Math.round(s % 60)}s`;
   }
 
-  function _applyToolSummaryStatus(statusSpan, status) {
-    const visibleStatus = _visibleToolSummaryStatus(status || '');
+  function _visibleToolSummaryStatus(status, durationMs) {
+    if (status === 'running') return '';           // spinner is CSS-drawn
+    if (status === 'success' || status === 'error') return _fmtToolDuration(durationMs);
+    return '';
+  }
+
+  function _applyToolSummaryStatus(statusSpan, status, durationMs) {
+    const visibleStatus = _visibleToolSummaryStatus(status || '', durationMs | 0);
     statusSpan.dataset.status = status || '';
     statusSpan.textContent = visibleStatus;
-    statusSpan.hidden = !visibleStatus;
+    // The span stays in the DOM even when empty: the state glyph (::before)
+    // and the running spinner are CSS-drawn from data-status / parent class.
+    statusSpan.hidden = false;
   }
 
-  function _setToolSummaryStatus(details, status) {
+  function _setToolSummaryStatus(details, status, durationMs) {
     if (!details) return;
     const summary = details.querySelector('.chat-tools-summary');
     if (!summary) return;
@@ -7103,7 +7116,7 @@ const ChatView = (() => {
       statusSpan.className = 'chat-tools-status';
       summary.appendChild(statusSpan);
     }
-    _applyToolSummaryStatus(statusSpan, status || '');
+    _applyToolSummaryStatus(statusSpan, status || '', durationMs | 0);
   }
 
   function _retitleToolCallDOM(details, name, input) {
@@ -7358,7 +7371,9 @@ const ChatView = (() => {
         toolName = toolName || details.getAttribute('data-tool-name') || '';
         details.classList.remove('chat-tools-collapse--running');
         details.classList.add(_toolResultStateClass(payload));
-        _setToolSummaryStatus(details, isError ? 'error' : 'done');
+        const startedAt = Number(details.dataset.startedAt || 0);
+        const elapsedMs = startedAt ? Date.now() - startedAt : 0;
+        _setToolSummaryStatus(details, isError ? 'error' : 'success', elapsedMs);
         const summary = details.querySelector('.chat-tools-summary');
         if (summary) summary.removeAttribute('aria-disabled');
         const toolsBody = details.querySelector('.chat-tools-body');

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -7169,7 +7169,9 @@ const ChatView = (() => {
     toolName = toolName || details.getAttribute('data-tool-name') || '';
     details.classList.remove('chat-tools-collapse--running');
     details.classList.add(_toolResultStateClass(payload));
-    _setToolSummaryStatus(details, isError ? 'error' : 'done');
+    const startedAt = Number(details.dataset.startedAt || 0);
+    const elapsedMs = startedAt ? Date.now() - startedAt : 0;
+    _setToolSummaryStatus(details, isError ? 'error' : 'success', elapsedMs);
     const summary = details.querySelector('.chat-tools-summary');
     if (summary) summary.removeAttribute('aria-disabled');
     return details;

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -1224,6 +1224,7 @@ const ChatView = (() => {
           <span class="chat-session-chip-caret" aria-hidden="true">${_iconChevronDown()}</span>
         </button>
         <button class="chat-session-copy-btn" id="chat-session-copy" title="Copy session key" aria-label="Copy session key">${icons.copy()}</button>
+        <button class="btn btn--icon btn--ghost chat-topbar-export" id="chat-btn-export" title="Export as Markdown" aria-label="Export as Markdown">${icons.download()}</button>
         <span class="chip" id="chat-run-status" title="Idle">Idle</span>
         <span class="chat-ctx-warn hidden" id="chat-ctx-warn">Request ctx</span>`;
       topbarCenter.classList.remove('hidden');
@@ -1244,7 +1245,6 @@ const ChatView = (() => {
           <div class="chat-attachments hidden" id="chat-attach-preview"></div>
           <div class="chat-slash hidden" id="chat-slash"></div>
           <div class="chat-input-bar">
-            <button class="btn btn--icon btn--ghost" id="chat-btn-attach" title="Attach files: PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON" aria-label="Attach files">${icons.paperclip()}</button>
             <div class="chat-toolbar-wrap">
               <button type="button" class="btn btn--icon btn--ghost chat-toolbar-trigger" id="chat-toolbar-trigger"
                       title="Run modes — execution, router"
@@ -1280,6 +1280,7 @@ const ChatView = (() => {
                 </div>
               </div>
             </div>
+            <button class="btn btn--icon btn--ghost" id="chat-btn-attach" title="Attach files: PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON" aria-label="Attach files">${icons.paperclip()}</button>
             <div class="chat-input-wrap">
               <span class="chat-input-glyph" aria-hidden="true">&gt;</span>
               <textarea class="chat-textarea" id="chat-textarea" rows="1"
@@ -1288,7 +1289,6 @@ const ChatView = (() => {
             </div>
             <button class="btn btn--icon btn--ghost" id="chat-btn-mic" title="Record voice input" aria-label="Record voice input">${icons.microphone ? icons.microphone() : icons.chat()}</button>
             <button class="btn btn--icon btn--ghost" id="chat-btn-new" title="New chat session in the current agent" aria-label="New chat session in the current agent">${icons.plus()}</button>
-            <button class="btn btn--icon btn--ghost" id="chat-btn-export" title="Export as Markdown" aria-label="Export as Markdown">${icons.download()}</button>
             <button class="btn btn--icon btn--primary" id="chat-btn-send" title="Send (queues while streaming)" aria-label="Send message">${icons.send()}</button>
             <button class="btn btn--icon btn--danger hidden" id="chat-btn-stop" title="Stop current response (Esc)" aria-label="Stop current response">${icons.stop()}</button>
           </div>
@@ -2347,7 +2347,7 @@ const ChatView = (() => {
   function _bindEvents() {
     const attachBtn = _el.querySelector('#chat-btn-attach');
     const newBtn    = _el.querySelector('#chat-btn-new');
-    const exportBtn = _el.querySelector('#chat-btn-export');
+    const exportBtn = document.getElementById('chat-btn-export');
 
     // Send
     _sendBtn.addEventListener('click', _onSend);
@@ -2383,7 +2383,7 @@ const ChatView = (() => {
     });
 
     // Export
-    exportBtn.addEventListener('click', _exportMarkdown);
+    if (exportBtn) exportBtn.addEventListener('click', _exportMarkdown);
 
     // File picker
     attachBtn.addEventListener('click', () => _fileInput.click());

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -18,28 +18,42 @@ def _js() -> str:
     return CHAT_JS.read_text(encoding="utf-8")
 
 
-def test_user_turn_is_left_aligned_accent_bar_row() -> None:
+def test_user_turn_is_refined_right_bubble() -> None:
     css = _css()
     start = css.index(".chat-msg--user .chat-msg-text,")
     end = css.index("/* Assistant", start)
     block = css[start:end]
 
-    assert "border-left: 2px solid var(--accent);" in block
-    assert "background: none;" in block
+    assert "background: color-mix(in srgb, var(--accent) 10%, var(--bg-surface));" in block
+    assert "border: 0;" in block
+    assert "border-radius: var(--radius-md);" in block
     assert "box-shadow: none;" in block
-    assert "border-radius: 0;" in block
-    assert "max-width: 100%;" in block
-    assert "margin-left: auto" not in block
+    assert "max-width: 78%;" in block
+    assert "margin-left: auto;" in block
 
     align_start = css.index(".chat-msg--user,")
     align_block = css[align_start : css.index("}", align_start)]
-    assert "align-items: flex-start;" in align_block
+    assert "align-items: flex-end;" in align_block
 
 
-def test_user_role_label_and_time_are_not_right_aligned() -> None:
+def test_user_role_label_and_time_align_right() -> None:
     css = _css()
-    assert ".msg.user .role-label { text-align: right; }" not in css
-    assert ".msg.user .msg-time { text-align: right; }" not in css
+    assert ".msg.user .role-label { text-align: right; }" in css
+
+
+def test_composer_input_bar_is_floating_pill() -> None:
+    css = _css()
+    start = css.index(".chat-input-bar {")
+    block = css[start : css.index("}", start)]
+    assert "border-radius: 22px;" in block
+    assert "border: 1px solid var(--border);" in block
+    assert "box-shadow:" in block
+    assert "border-top:" not in block
+
+    assert ".chat-input-bar:focus-within" in css
+    focus_start = css.index(".chat-input-bar:focus-within")
+    focus_block = css[focus_start : css.index("}", focus_start)]
+    assert "var(--accent)" in focus_block
 
 
 def test_assistant_turn_is_bare_prose() -> None:

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -40,3 +40,17 @@ def test_user_role_label_and_time_are_not_right_aligned() -> None:
     css = _css()
     assert ".msg.user .role-label { text-align: right; }" not in css
     assert ".msg.user .msg-time { text-align: right; }" not in css
+
+
+def test_assistant_turn_is_bare_prose() -> None:
+    css = _css()
+    start = css.index(".chat-msg--assistant .chat-msg-text,")
+    end = css.index("/* Tool / system */", start)
+    block = css[start:end]
+
+    assert "background: none;" in block
+    assert "box-shadow: none;" in block
+    assert "font-size: var(--fs-md);" in block
+    assert "line-height: 1.7;" in block
+    assert "max-width: 100%;" in block
+    assert "background: var(--bg-surface);" not in block

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -76,6 +76,7 @@ def test_tool_status_shows_duration_from_js() -> None:
     assert "function _fmtToolDuration(ms)" in js
     assert "details.dataset.startedAt" in js
     assert "_setToolSummaryStatus(details, " in js
+    assert "_setToolSummaryStatus(details, isError ? 'error' : 'done')" not in js
 
 
 def test_tool_state_glyphs_come_from_css_state_classes() -> None:

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -103,6 +103,10 @@ def test_tool_state_glyphs_come_from_css_state_classes() -> None:
         ".chat-tools-collapse--error > .chat-tools-summary .chat-tools-status::before"
         in css
     )
+    assert (
+        ".chat-tools-collapse--unknown > .chat-tools-summary .chat-tools-status::before"
+        in css
+    )
 
 
 def test_turn_meta_is_mono_voice() -> None:
@@ -197,3 +201,9 @@ def test_input_pill_has_accent_glow() -> None:
     focus_start = css.index(".chat-input-bar:focus-within")
     focus_block = css[focus_start : css.index("}", focus_start)]
     assert "var(--accent)" in focus_block
+
+    # The resting halo is an accent-tinted box-shadow layer, not just the border.
+    assert "color-mix(in srgb, var(--accent)" in block
+    assert block.count("color-mix(in srgb, var(--accent)") >= 2  # border + shadow layer(s)
+    focus_shadow = focus_block
+    assert "color-mix(in srgb, var(--accent)" in focus_shadow

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -121,3 +121,16 @@ def test_streaming_caret_blinks_at_insertion_point() -> None:
 def test_ctx_warn_renders_hairline_gauge() -> None:
     assert "--ctx-pct" in _css()
     assert "setProperty('--ctx-pct'" in _js()
+
+
+def test_composer_has_prompt_glyph() -> None:
+    js = _js()
+    assert 'class="chat-input-glyph"' in js
+    assert ".chat-input-glyph" in _css()
+
+
+def test_cmd_k_opens_session_palette_and_is_torn_down() -> None:
+    js = _js()
+    assert "_sessionPaletteKeyHandler" in js
+    assert js.count("_sessionPaletteKeyHandler") >= 3  # declare, add, remove
+    assert "e.key.toLowerCase() === 'k'" in js

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -1,0 +1,42 @@
+"""Source-pattern tests for the chat transcript redesign.
+
+The chat view renders a single-column transcript (no left/right bubbles).
+These tests pin the transcript visual language in chat.css / chat.js.
+"""
+
+from pathlib import Path
+
+CHAT_JS = Path("src/agentos/gateway/static/js/views/chat.js")
+CHAT_CSS = Path("src/agentos/gateway/static/css/views/chat.css")
+
+
+def _css() -> str:
+    return CHAT_CSS.read_text(encoding="utf-8")
+
+
+def _js() -> str:
+    return CHAT_JS.read_text(encoding="utf-8")
+
+
+def test_user_turn_is_left_aligned_accent_bar_row() -> None:
+    css = _css()
+    start = css.index(".chat-msg--user .chat-msg-text,")
+    end = css.index("/* Assistant", start)
+    block = css[start:end]
+
+    assert "border-left: 2px solid var(--accent);" in block
+    assert "background: none;" in block
+    assert "box-shadow: none;" in block
+    assert "border-radius: 0;" in block
+    assert "max-width: 100%;" in block
+    assert "margin-left: auto" not in block
+
+    align_start = css.index(".chat-msg--user,")
+    align_block = css[align_start : css.index("}", align_start)]
+    assert "align-items: flex-start;" in align_block
+
+
+def test_user_role_label_and_time_are_not_right_aligned() -> None:
+    css = _css()
+    assert ".msg.user .role-label { text-align: right; }" not in css
+    assert ".msg.user .msg-time { text-align: right; }" not in css

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -108,3 +108,16 @@ def test_saved_chip_flashes_once_on_live_turns_only() -> None:
     idx = css.index(".msg-meta__saved--flash")
     reduced = css.index("prefers-reduced-motion", idx)
     assert reduced > idx  # a reduced-motion override follows the flash rule
+
+
+def test_streaming_caret_blinks_at_insertion_point() -> None:
+    css = _css()
+    assert ".msg.streaming .msg-body .msg-text-seg:last-of-type::after" in css
+    idx = css.index(".msg.streaming .msg-body .msg-text-seg:last-of-type::after")
+    block = css[idx : css.index("}", idx)]
+    assert "'\\258d'" in block.lower() or "'▍'" in block  # ▍
+
+
+def test_ctx_warn_renders_hairline_gauge() -> None:
+    assert "--ctx-pct" in _css()
+    assert "setProperty('--ctx-pct'" in _js()

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -59,3 +59,32 @@ def test_assistant_turn_is_bare_prose() -> None:
 def test_tool_sidebar_is_fully_removed() -> None:
     assert "chat-sidebar" not in _css()
     assert "chat-sidebar" not in _js()
+
+
+def test_tool_rows_have_left_rail_and_mono_row_styling() -> None:
+    css = _css()
+    start = css.index(".chat-tools-collapse {")
+    end = css.index(".chat-tools-summary {", start)
+    block = css[start:end]
+    assert "border-left: 1px solid var(--border);" in block
+    assert "border-radius: 0;" in block
+    assert "background: none;" in block
+
+
+def test_tool_status_shows_duration_from_js() -> None:
+    js = _js()
+    assert "function _fmtToolDuration(ms)" in js
+    assert "details.dataset.startedAt" in js
+    assert "_setToolSummaryStatus(details, " in js
+
+
+def test_tool_state_glyphs_come_from_css_state_classes() -> None:
+    css = _css()
+    assert (
+        ".chat-tools-collapse--success > .chat-tools-summary .chat-tools-status::before"
+        in css
+    )
+    assert (
+        ".chat-tools-collapse--error > .chat-tools-summary .chat-tools-status::before"
+        in css
+    )

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -89,3 +89,22 @@ def test_tool_state_glyphs_come_from_css_state_classes() -> None:
         ".chat-tools-collapse--error > .chat-tools-summary .chat-tools-status::before"
         in css
     )
+
+
+def test_turn_meta_is_mono_voice() -> None:
+    css = _css()
+    start = css.index(".msg-meta {")
+    block = css[start : css.index("}", start)]
+    assert "font-family: var(--font-mono);" in block
+
+
+def test_saved_chip_flashes_once_on_live_turns_only() -> None:
+    js = _js()
+    assert "function _attachTurnMeta(bubble, model, totalIn, totalOut, turnUsage, opts" in js
+    assert "msg-meta__saved--flash" in js
+    assert "{ flash: !isReplayedFrame }" in js
+    css = _css()
+    assert ".msg-meta__saved--flash" in css
+    idx = css.index(".msg-meta__saved--flash")
+    reduced = css.index("prefers-reduced-motion", idx)
+    assert reduced > idx  # a reduced-motion override follows the flash rule

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -54,3 +54,8 @@ def test_assistant_turn_is_bare_prose() -> None:
     assert "line-height: 1.7;" in block
     assert "max-width: 100%;" in block
     assert "background: var(--bg-surface);" not in block
+
+
+def test_tool_sidebar_is_fully_removed() -> None:
+    assert "chat-sidebar" not in _css()
+    assert "chat-sidebar" not in _js()

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -46,7 +46,7 @@ def test_composer_input_bar_is_floating_pill() -> None:
     start = css.index(".chat-input-bar {")
     block = css[start : css.index("}", start)]
     assert "border-radius: 22px;" in block
-    assert "border: 1px solid var(--border);" in block
+    assert "border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));" in block
     assert "box-shadow:" in block
     assert "border-top:" not in block
 
@@ -159,3 +159,41 @@ def test_popover_surfaces_share_palette_language() -> None:
     dock_start = css.index(".chat-routerfx-dock {")
     dock_block = css[dock_start : css.index("}", dock_start)]
     assert "max-height" in dock_block
+
+
+def test_settings_gear_is_first_child_of_input_bar() -> None:
+    js = _js()
+    bar_start = js.index('<div class="chat-input-bar">')
+    bar_end = js.index('<div class="chat-routerfx-dock"', bar_start)
+    bar = js[bar_start:bar_end]
+    # The toolbar wrap (gear) appears before the attach button.
+    assert bar.index('class="chat-toolbar-wrap"') < bar.index('id="chat-btn-attach"')
+
+
+def test_export_button_lives_in_topbar_not_pill() -> None:
+    js = _js()
+    # Export button is emitted in the topbar block, right after copy-session.
+    topbar_start = js.index('<label class="chat-label">Chat session</label>')
+    topbar_end = js.index('_el.innerHTML', topbar_start)
+    topbar = js[topbar_start:topbar_end]
+    assert 'id="chat-btn-export"' in topbar
+    assert topbar.index('id="chat-session-copy"') < topbar.index('id="chat-btn-export"')
+
+    # It is NOT inside the input bar anymore.
+    bar_start = js.index('<div class="chat-input-bar">')
+    bar_end = js.index('<div class="chat-routerfx-dock"', bar_start)
+    bar = js[bar_start:bar_end]
+    assert 'id="chat-btn-export"' not in bar
+
+
+def test_input_pill_has_accent_glow() -> None:
+    css = _css()
+    start = css.index(".chat-input-bar {")
+    block = css[start : css.index("}", start)]
+    # Rest-state box-shadow includes an accent-tinted halo layer.
+    assert "var(--accent)" in block
+
+    assert ".chat-input-bar:focus-within" in css
+    focus_start = css.index(".chat-input-bar:focus-within")
+    focus_block = css[focus_start : css.index("}", focus_start)]
+    assert "var(--accent)" in focus_block

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -134,3 +134,14 @@ def test_cmd_k_opens_session_palette_and_is_torn_down() -> None:
     assert "_sessionPaletteKeyHandler" in js
     assert js.count("_sessionPaletteKeyHandler") >= 3  # declare, add, remove
     assert "e.key.toLowerCase() === 'k'" in js
+
+
+def test_popover_surfaces_share_palette_language() -> None:
+    css = _css()
+    slash_start = css.index(".chat-slash-item {")
+    slash_block = css[slash_start : css.index("}", slash_start)]
+    assert "font-family: var(--font-mono);" in slash_block
+
+    dock_start = css.index(".chat-routerfx-dock {")
+    dock_block = css[dock_start : css.index("}", dock_start)]
+    assert "max-height" in dock_block

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -112,10 +112,11 @@ def test_chat_sent_attachment_images_render_as_separate_thumbnail_attachments() 
     thumb_end = css.index("/* ─── Pending Queue", thumb_start)
     thumb_block = css[thumb_start:thumb_end]
 
-    assert "max-width: min(360px, 78%);" in body_block
+    assert "max-width: min(520px, 100%);" in body_block
     assert "border: 0;" in body_block
     assert "background: transparent;" in body_block
-    assert "max-width: min(360px, 100%);" in text_block
+    assert "max-width: 100%;" in text_block
+    assert "border-left: 2px solid var(--accent);" in text_block
     assert "max-width: 100%;" in attachments_block
     assert "user-select: text;" in attachments_block
     assert "width: min(260px, 42vw);" in thumb_block

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -388,9 +388,9 @@ def test_chat_streaming_indicator_uses_delayed_bottom_dock() -> None:
     # Mark is corner-aligned to the content-left edge and centered in the
     # reserved footer band, so the orbiting ring clears the tool card above
     # and the bubble's bottom edge — no overlap, no rightward-inset orphan.
-    assert "left: var(--sp-4);" in css
+    assert "left: 2px;" in css
     assert "bottom: var(--sp-2);" in css
-    assert "left: calc(var(--sp-4) - 4px);" in css
+    assert "left: -2px;" in css
     assert "bottom: calc(var(--sp-2) - 4px);" in css
     assert "left: calc(var(--sp-4) + 16px);" not in css
     assert "background-image: url('../../img/agentos-mark.png');" in css

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -2455,9 +2455,9 @@ def test_savings_popup_does_not_fire_for_replayed_done_frames() -> None:
 
 def test_tool_summary_exposes_visible_running_status() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    assert "function _setToolSummaryStatus(details, status)" in source
-    assert "function _visibleToolSummaryStatus(status)" in source
-    assert "return status === 'running' ? 'running' : '';" in source
+    assert "function _visibleToolSummaryStatus(status, durationMs)" in source
+    assert "statusSpan.hidden = false;" in source
+    assert "return _fmtToolDuration(durationMs);" in source
     build_start = source.index("function _buildToolCallDOM(")
     build_end = source.index("function _retitleToolCallDOM", build_start)
     build_body = source[build_start:build_end]
@@ -2469,8 +2469,10 @@ def test_tool_summary_exposes_visible_running_status() -> None:
         result_start,
     )
     result_body = source[result_start:result_end]
-    assert "_setToolSummaryStatus(details, isError ? 'error' : 'done');" in result_body
-    assert "statusSpan.hidden = !visibleStatus;" in source
+    assert (
+        "_setToolSummaryStatus(details, isError ? 'error' : 'success', elapsedMs);"
+        in result_body
+    )
 
 
 def test_router_fx_settles_but_preserves_winner_animation_when_output_begins() -> None:

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -112,11 +112,11 @@ def test_chat_sent_attachment_images_render_as_separate_thumbnail_attachments() 
     thumb_end = css.index("/* ─── Pending Queue", thumb_start)
     thumb_block = css[thumb_start:thumb_end]
 
-    assert "max-width: min(520px, 100%);" in body_block
+    assert "max-width: min(520px, 78%);" in body_block
     assert "border: 0;" in body_block
     assert "background: transparent;" in body_block
     assert "max-width: 100%;" in text_block
-    assert "border-left: 2px solid var(--accent);" in text_block
+    assert "border-radius: var(--radius-md);" in text_block
     assert "max-width: 100%;" in attachments_block
     assert "user-select: text;" in attachments_block
     assert "width: min(260px, 42vw);" in thumb_block
@@ -3224,16 +3224,20 @@ def test_chat_thread_does_not_duplicate_composer_bottom_clearance() -> None:
 
 def test_chat_input_bar_tightens_desktop_bottom_padding_but_keeps_mobile_safe_area() -> None:
     css = CHAT_CSS.read_text(encoding="utf-8")
-    desktop_padding = "padding: var(--sp-2) var(--sp-4) var(--sp-1);"
+    # The floating pill uses a symmetric base padding; the exact desktop value
+    # is pinned inside the .chat-input-bar block below.
+    bar_start = css.index(".chat-input-bar {")
+    bar_block = css[bar_start : css.index("}", bar_start)]
+    desktop_padding = "padding: var(--sp-2) var(--sp-3);"
     mobile_safe_area = (
         "padding-bottom: calc(var(--sp-2) + env(safe-area-inset-bottom, 0px));"
     )
 
     assert ".content:has(> .chat)" in css
     assert "padding-bottom: 0;" in css
-    assert desktop_padding in css
+    assert desktop_padding in bar_block
     assert mobile_safe_area in css
-    assert css.rfind(mobile_safe_area) > css.index(desktop_padding)
+    assert css.rfind(mobile_safe_area) > bar_start
 
 
 def test_chat_task_lifecycle_events_are_session_scoped() -> None:


### PR DESCRIPTION
## What

Redesigns the gateway web-UI **chat view** into a cleaner "transcript" language, then two rounds of live-review polish. Presentation-only: CSS + the vanilla-JS `chat.js` view module + source-pattern tests. No backend, RPC, session, or markdown-pipeline changes.

## Highlights

- **Assistant turns** render as bare transcript prose (no surface box) at a larger reading size; **user turns** are refined right-aligned bubbles (light accent tint, no border/shadow).
- **Tool calls** collapse to one-line rows with a CSS-drawn status glyph (spinner → ✓ / ✗ / – for unknown) and a JS-measured duration; inline expansion capped at 40vh. The dead 380px tool-detail sidebar CSS is removed.
- **Router savings** kept as the hero metric: a mono per-turn meta line (`model · tokens · saved N%`) with a one-shot shimmer on live turns that clear the savings threshold. The viewport-centered savings burst stays disabled.
- **Streaming**: a blinking block caret at the insertion point; a hairline context-pressure gauge on the topbar ctx pill.
- **Composer**: a floating pill with an accent glow (brighter on focus), a `>` prompt glyph, the settings gear moved to the far-left, and the export-Markdown button moved up to the topbar. `⌘K` / `Ctrl+K` opens the session palette with search focused.
- Slash menu, session popover, router dock, subagent disclosure, and thinking bubble aligned to the transcript language.

## Testing

- New `tests/test_gateway/test_chat_transcript_redesign_static.py` (source-pattern tests) plus updates to the existing chat static suites; the chat test suites pass (221) and `ruff` is clean.
- Full gate: `mypy` clean (557 files), `pytest` 5513 passed / 31 skipped, `uv build --wheel` succeeds. The 3 failing tests (`test_migrations_packaged`, `test_local_embedding_tokenizes_for_onnx_inputs`) are pre-existing and fail identically on a clean `main` — unrelated to this branch.
- Verified live in Chrome (light + dark themes): transcript layout, tool rows, savings meta, ⌘K palette, composer glow, and reduced-motion fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
