### PR TITLE
feat(router): restore missing v4_phase3 ML bundle and fix its attribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,17 @@
 *.sh text eol=lf
 
-# Bundled BGE ONNX export for memory local embedding (relocated from the
-# removed agentos_router v4 bundle).
+# Bundled BGE ONNX export. Shared by memory's local embedder and the
+# agentos_router v4 bundle, which no longer carries its own copy.
 src/agentos/memory/models/bge_onnx/*.onnx filter=lfs diff=lfs merge=lfs -text
 src/agentos/memory/models/bge_onnx/*.json text eol=lf
 src/agentos/memory/models/bge_onnx/*.txt text eol=lf
+
+# V4 Phase 3 ML router bundle: LightGBM heads, MLP ONNX, and the sklearn/joblib
+# feature artifacts.
+src/agentos/agentos_router/models/v4.2_phase3_inference/*.bin filter=lfs diff=lfs merge=lfs -text
+src/agentos/agentos_router/models/v4.2_phase3_inference/**/*.onnx filter=lfs diff=lfs merge=lfs -text
+src/agentos/agentos_router/models/v4.2_phase3_inference/**/*.pkl filter=lfs diff=lfs merge=lfs -text
+src/agentos/agentos_router/models/v4.2_phase3_inference/**/*.joblib filter=lfs diff=lfs merge=lfs -text
+src/agentos/agentos_router/models/v4.2_phase3_inference/*.json text eol=lf
+src/agentos/agentos_router/models/v4.2_phase3_inference/*.yaml text eol=lf
+src/agentos/agentos_router/models/v4.2_phase3_inference/**/*.json text eol=lf

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -27,21 +27,42 @@ jobs:
         with:
           lfs: true
 
-      - name: Hydrate LFS embedding model assets
-        run: git lfs pull --include="src/agentos/memory/models/**"
+      - name: Hydrate LFS embedding and router model assets
+        run: |
+          git lfs pull --include="src/agentos/memory/models/**"
+          git lfs pull --include="src/agentos/agentos_router/models/**"
 
       - name: Verify LFS assets are hydrated
         run: |
           python3 - <<'PY'
           from pathlib import Path
 
-          for path in Path("src/agentos/memory/models").rglob("*"):
-              if not path.is_file():
-                  continue
-              prefix = path.read_bytes()[:64]
-              assert not prefix.startswith(b"version https://git-lfs.github.com/spec/v1"), (
-                  f"LFS pointer not hydrated: {path}"
-              )
+          roots = [
+              Path("src/agentos/memory/models"),
+              Path("src/agentos/agentos_router/models"),
+          ]
+          for root in roots:
+              for path in root.rglob("*"):
+                  if not path.is_file():
+                      continue
+                  prefix = path.read_bytes()[:64]
+                  assert not prefix.startswith(b"version https://git-lfs.github.com/spec/v1"), (
+                      f"LFS pointer not hydrated: {path}"
+                  )
+
+          # The v4_phase3 router bundle is the wheel's routing brain; a missing
+          # weight silently degrades every turn to the default tier.
+          bundle = Path("src/agentos/agentos_router/models/v4.2_phase3_inference")
+          for name in (
+              "lgbm_main.bin",
+              "lgbm_aux.bin",
+              "mlp/model.onnx",
+              "features/tfidf.pkl",
+              "features/svd.pkl",
+              "router.runtime.yaml",
+              "runtime_src/src/router/inference/core.py",
+          ):
+              assert (bundle / name).is_file(), f"missing router asset: {name}"
           PY
 
       - name: Set up Python

--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -61,17 +61,20 @@ jobs:
           persist-credentials: false
           ref: ${{ env.RELEASE_TAG != '' && env.RELEASE_TAG || github.ref }}
 
-      - name: Hydrate embedding assets
+      - name: Hydrate embedding and router assets
         shell: bash
-        run: git lfs pull --include="src/agentos/memory/models/**"
+        run: |
+          git lfs pull --include="src/agentos/memory/models/**"
+          git lfs pull --include="src/agentos/agentos_router/models/**"
 
-      - name: Verify embedding assets are hydrated
+      - name: Verify embedding and router assets are hydrated
         shell: bash
         run: |
           python - <<'PY'
           from pathlib import Path
 
           root = Path("src/agentos/memory/models/bge_onnx")
+          bundle = Path("src/agentos/agentos_router/models/v4.2_phase3_inference")
           required = [
               root / "config.json",
               root / "model.onnx",
@@ -79,6 +82,17 @@ jobs:
               root / "tokenizer.json",
               root / "tokenizer_config.json",
               root / "vocab.txt",
+              # v4_phase3 router bundle. It shares the bge_onnx export above
+              # rather than carrying a second copy.
+              bundle / "lgbm_main.bin",
+              bundle / "lgbm_aux.bin",
+              bundle / "mlp/model.onnx",
+              bundle / "mlp/scaler.joblib",
+              bundle / "features/tfidf.pkl",
+              bundle / "features/svd.pkl",
+              bundle / "features/bge_pca.joblib",
+              bundle / "router.runtime.yaml",
+              bundle / "runtime_src/src/router/inference/core.py",
           ]
           for path in required:
               assert path.is_file(), f"missing embedding asset: {path}"
@@ -186,13 +200,18 @@ jobs:
               assert any(name.startswith(root + "runtime/python/") for name in names)
 
           with ZipFile(wheels[0]) as archive:
+              names = set(archive.namelist())
               for info in archive.infolist():
-                  if not info.filename.endswith(".onnx"):
+                  if not info.filename.endswith((".onnx", ".bin", ".pkl", ".joblib")):
                       continue
                   prefix = archive.read(info)[:80]
                   assert not prefix.startswith(b"version https://git-lfs.github.com/spec/v1"), (
                       f"Git LFS pointer leaked into wheel: {info.filename}"
                   )
+
+              bundle = "agentos/agentos_router/models/v4.2_phase3_inference/"
+              for name in ("lgbm_main.bin", "router.runtime.yaml", "features/tfidf.pkl"):
+                  assert bundle + name in names, f"router bundle missing from wheel: {name}"
           PY
 
       - name: Create release assets

--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,6 @@ agentos.toml
 data/
 # Checked-in router eval dataset used by the test suite.
 !tests/data/
-# V4 Phase 3 ML router bundle (~75MB: lgbm/onnx/features). Kept OUT of git so the
-# public repo stays lean; it is not distributed with the repo or wheel yet.
-# Restore it locally to run strategy="v4_phase3".
-/src/agentos/agentos_router/models/
 .agentos/
 benchmarks/
 specs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,15 @@ RUN python - <<'PY'
 from pathlib import Path
 
 root = Path("src/agentos/memory/models/bge_onnx")
+bundle = Path("src/agentos/agentos_router/models/v4.2_phase3_inference")
 required = [
     root / "model.onnx",
+    # v4_phase3 router bundle: without these every turn silently degrades to
+    # the default tier.
+    bundle / "lgbm_main.bin",
+    bundle / "mlp" / "model.onnx",
+    bundle / "features" / "tfidf.pkl",
+    bundle / "router.runtime.yaml",
 ]
 pointer = "version https://git-lfs.github.com/spec/v1"
 missing = [str(path) for path in required if not path.is_file()]
@@ -61,8 +68,9 @@ for path in required:
         pointers.append(str(path))
 if missing or pointers:
     raise SystemExit(
-        "Bundled BGE embedding assets are unavailable in this build context. "
-        'Run `git lfs pull --include="src/agentos/memory/models/**"` '
+        "Bundled BGE embedding or v4_phase3 router assets are unavailable in this "
+        'build context. Run `git lfs pull --include="src/agentos/memory/models/**"` '
+        'and `git lfs pull --include="src/agentos/agentos_router/models/**"` '
         f"before docker build. Missing={missing} Pointers={pointers}"
     )
 PY

--- a/README.md
+++ b/README.md
@@ -102,14 +102,15 @@ file name.
 
 The default `recommended` profile installs **AgentOS Router** — AgentOS's
 own on-device model router (strategy `v4_phase3`) — along with the Python
-dependencies it needs (ONNX Runtime, LightGBM, scikit-learn). Its ~75MB
-model bundle is **not** distributed with the repo or the wheel yet, and the
-installers do not fetch it. When the bundle is absent, the router degrades
-gracefully at boot: it logs a warning and pins every turn to the default
-tier (c1) instead of crashing. To get per-turn routing today, either restore
-the bundle into `src/agentos/agentos_router/models/v4.2_phase3_inference/`
-or switch to the `llm_judge` strategy, which needs no local model files —
-pick it during onboarding or set `agentos_router.strategy = "llm_judge"`.
+dependencies it needs (ONNX Runtime, LightGBM, scikit-learn). Its model
+bundle ships inside the wheel, so routing works offline with no extra
+download. If you install from a source checkout, run
+`git lfs pull` first; without it the bundle is only pointer stubs, and the
+router degrades gracefully — it logs a warning at boot and pins every turn to
+the default tier (c1) rather than crashing. The `llm_judge` strategy needs no
+local model files at all (it routes via a small LLM call, optionally against a
+local Ollama/LM Studio endpoint) — pick it during onboarding or set
+`agentos_router.strategy = "llm_judge"`.
 Set `AGENTOS_INSTALL_PROFILE=core` to skip the router dependencies, or use
 the `--router disabled` flag during first-time setup to keep them installed
 but turn the router off.
@@ -543,7 +544,7 @@ settings are all in `agentos.toml.example`.
 
 | Capability | What it does |
 | --- | --- |
-| **Token-efficient routing** | `AgentOS Router` defaults to `v4_phase3`, a small local AI model (BGE embeddings + LightGBM; the `recommended` extra installs its runtime dependencies) that looks at each message — its length, language, code, keywords, and meaning — and picks one of four levels (c0–c3), then routes it to the cheapest model that can still do the job well. This check runs on your own device, so your message never has to leave your computer just to make this choice. The ~75MB model bundle is not distributed yet; without it the router falls back to a single tier, so pick the `llm_judge` strategy instead (a small LLM call, optionally a local Ollama/LM Studio endpoint) for per-turn routing with no local model files. Choose either in onboarding. |
+| **Token-efficient routing** | `AgentOS Router` defaults to `v4_phase3`, a small local AI model (BGE embeddings + LightGBM; the `recommended` extra installs its runtime dependencies) that looks at each message — its length, language, code, keywords, and meaning — and picks one of four levels (c0–c3), then routes it to the cheapest model that can still do the job well. This check runs on your own device, so your message never has to leave your computer just to make this choice. The model bundle ships inside the wheel, so this works offline out of the box. Prefer no local model files at all? Pick the `llm_judge` strategy instead (a small LLM call, optionally a local Ollama/LM Studio endpoint). Choose either in onboarding. |
 | **Adaptive reasoning and prompts** | AgentOS only asks for deep, extended thinking when the router sees the message is hard. The system instructions also grow to match: short and simple for easy messages, full and detailed for hard ones. |
 | **20+ LLM providers** | AgentOS can talk to 20+ AI providers — OpenRouter (used by default), the Bankr LLM Gateway, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, DashScope/Qwen, Moonshot, Mistral, Groq, Zhipu, SiliconFlow, vLLM, LM Studio, and more. It picks a main provider first, with backups ready if needed. The first-time setup shows you the providers that are fully tested. |
 | **On-demand skills and MCP** | AgentOS comes with 37 built-in skills (coding, GitHub, cron jobs, pptx/docx/xlsx/pdf files, summaries, tmux, weather, and more). Each skill only loads when a task actually needs it. AgentOS can use other MCP tools, and can also act as an MCP tool for others — `agentos mcp-server run` needs the `mcp` extra (install with `use-agent-os[recommended,mcp]`). You can write, install, and share your own skills from the CLI. |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5,13 +5,18 @@ AgentOS. It covers:
 
 - Core runtime modules derived from OpenSquilla (Apache-2.0); see the
   first section below.
+- The V4 Phase 3 local ML router bundle under
+  `src/agentos/agentos_router/models/v4.2_phase3_inference/` — trained model
+  weights and inference code originating from OpenSquilla (Apache-2.0); see the
+  first section below.
 - The bundled skill descriptors under `src/agentos/skills/bundled/`, which
   include OpenClaw-derived MIT descriptors and AgentOS-original descriptors.
 - The bundled pptx skill references the python-pptx and PptxGenJS libraries;
   AgentOS does not vendor those libraries, but the skill instructs the
   agent runtime to invoke them and is documented here for transparency.
-- The bundled BGE (bge-small-zh-v1.5) ONNX export used for local memory
-  embedding under `src/agentos/memory/models/bge_onnx/`.
+- The bundled BGE (bge-small-zh-v1.5) ONNX export under
+  `src/agentos/memory/models/bge_onnx/`, shared by local memory embedding and
+  the V4 Phase 3 router's BGE feature channel.
 - The built-in tokenjuice tool-result projection backend and bundled
   reduction rules under `src/agentos/plugins/tokenjuice/`.
 - The cron prompt-injection scanner was reviewed against Hermes Agent
@@ -23,7 +28,9 @@ AgentOS. It covers:
 
 ## OpenSquilla-derived core modules
 
-- Component: core runtime modules under `src/agentos/`.
+- Component: core runtime modules under `src/agentos/`, and the V4 Phase 3
+  local ML router bundle (trained model weights and inference code) under
+  `src/agentos/agentos_router/models/v4.2_phase3_inference/`.
 - Upstream project: https://github.com/opensquilla/opensquilla
 - License: Apache License 2.0
 - Copyright notice: OpenSquilla contributors (the upstream project ships
@@ -41,6 +48,37 @@ The highest-overlap modules include:
 - `src/agentos/gateway_client.py` and
   `src/agentos/cli/gateway_client.py` — gateway client plumbing
 - `src/agentos/agentos_router/v4_phase3.py` — router phase logic
+
+### V4 Phase 3 router bundle (model weights and inference code)
+
+The local ML router bundle under
+`src/agentos/agentos_router/models/v4.2_phase3_inference/` is OpenSquilla's,
+carried over from upstream
+`src/opensquilla/squilla_router/models/v4.2_phase3_inference/`. It is **not**
+trained or authored by the AgentOS contributors. This covers:
+
+- `lgbm_main.bin` and `lgbm_aux.bin` — LightGBM boosters for the router heads.
+- `mlp/model.onnx` and `mlp/scaler.joblib` — the PyTorch-exported MLP head and
+  its scaler.
+- `features/tfidf.pkl`, `features/svd.pkl`, `features/config.pkl`, and
+  `features/bge_pca.joblib` — fitted scikit-learn/joblib feature artifacts.
+- `runtime_src/src/router/**` — the inference core the router loads at runtime.
+- `router.runtime.yaml`, `version.json`, `inference_manifest.json` — runtime
+  configuration and inference metadata.
+
+The weights are used byte-for-byte unmodified: `lgbm_main.bin` carries the same
+Git LFS object as upstream
+(`sha256:5f312db09577bbaf30f87358941974eef6edce7f1424d0e9de21cbd38a646d53`,
+39684725 bytes). Modifications made by the AgentOS contributors are limited to
+namespace/branding renames, and to `runtime_src/.../inference/artifacts.py`,
+which resolves the BGE export from the shared
+`src/agentos/memory/models/bge_onnx/` location so it ships once instead of
+twice. `src/agentos/agentos_router/models/v4.2_phase3_inference/PROVENANCE.md`
+records the per-file detail.
+
+Note that only the BGE embedding channel is third-party relative to
+OpenSquilla (MIT; see the BAAI section below). The routing decision itself
+comes from OpenSquilla's own trained LightGBM and MLP heads.
 
 Other modules across the runtime may also contain OpenSquilla-derived
 code in modified form. In accordance with Section 4(b) of the Apache

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -219,7 +219,7 @@ max_pending_per_session = 64
 enabled = true           # auto tier router
 auto_thinking = true
 rollout_phase = "full"
-strategy = "llm_judge"   # "llm_judge" (default; "v4_phase3" is removed but still accepted)
+strategy = "v4_phase3"   # "v4_phase3" (default; local ML bundle, no LLM call) | "llm_judge"
 # LLM judge (strategy = "llm_judge"): leave judge_model unset for Auto — the
 # judge follows the tier profile's cheapest text tier (c0 first), so profile
 # switches auto-update it. judge_provider must match [llm].provider.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,8 +200,8 @@ module = [
     "numpy.*",
     "onnxruntime.*",
     "readability.*",
-    # v4_phase3 loads its inference core dynamically from the git-ignored
-    # bundle's runtime_src (added to sys.path at runtime); mypy can't resolve it.
+    # v4_phase3 loads its inference core dynamically from the bundle's
+    # runtime_src (added to sys.path at runtime); mypy can't resolve it.
     "src.router.*",
     "tiktoken.*",
     "tokenizers.*",

--- a/scripts/install_source.sh
+++ b/scripts/install_source.sh
@@ -134,9 +134,16 @@ check_embedding_assets() {
     fi
 
     local model_root="src/agentos/memory/models/bge_onnx"
+    local router_root="src/agentos/agentos_router/models/v4.2_phase3_inference"
     local pointer_line="version https://git-lfs.github.com/spec/v1"
+    # The router bundle is checked here too: strategy="v4_phase3" is the default,
+    # and an unhydrated bundle degrades every turn to the default tier with only
+    # a boot warning rather than failing.
     local required=(
         "${model_root}/model.onnx"
+        "${router_root}/lgbm_main.bin"
+        "${router_root}/mlp/model.onnx"
+        "${router_root}/features/tfidf.pkl"
     )
     local missing=()
     local pointers=()
@@ -152,9 +159,9 @@ check_embedding_assets() {
     done
     if (( ${#missing[@]} > 0 || ${#pointers[@]} > 0 )); then
         if [[ "${mode}" == "warn" ]]; then
-            echo "install_source.sh: dry-run note — real recommended install would fail until the bundled BGE embedding assets are available in this checkout." >&2
+            echo "install_source.sh: dry-run note — real recommended install would fail until the bundled BGE embedding and v4 router assets are available in this checkout." >&2
         else
-            echo "install_source.sh: bundled BGE embedding assets are unavailable in this checkout." >&2
+            echo "install_source.sh: bundled BGE embedding or v4 router assets are unavailable in this checkout." >&2
         fi
         if (( ${#missing[@]} > 0 )); then
             echo "install_source.sh: missing assets: ${missing[*]}" >&2
@@ -164,6 +171,7 @@ check_embedding_assets() {
         fi
         echo 'install_source.sh: run `git lfs install` once, then:' >&2
         echo 'install_source.sh:   git lfs pull --include="src/agentos/memory/models/**"' >&2
+        echo 'install_source.sh:   git lfs pull --include="src/agentos/agentos_router/models/**"' >&2
         echo 'install_source.sh: or retry with AGENTOS_INSTALL_PROFILE=core for the minimal runtime.' >&2
         if [[ "${mode}" == "warn" ]]; then
             return 0

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/PROVENANCE.md
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/PROVENANCE.md
@@ -1,0 +1,110 @@
+# AgentOSRouter V4 Phase 3 Bundle Provenance
+
+This directory contains the local inference bundle used by
+`agentos.agentos_router.v4_phase3.V4Phase3Strategy`.
+
+## Purpose
+
+The bundle provides the V4 Phase 3 local model router used to classify a turn
+into route classes `R0` through `R3`, which are then mapped to configured model
+tiers by AgentOS gateway configuration. This provenance file does not change
+runtime behavior; it records the assets that the existing runtime loads.
+
+## Bundled Asset Groups
+
+- `lgbm_main.bin` and `lgbm_aux.bin`: LightGBM booster files for router heads.
+- `mlp/model.onnx` and `mlp/scaler.joblib`: MLP head model and scaler.
+- `features/tfidf.pkl`, `features/svd.pkl`, `features/config.pkl`, and
+  `features/bge_pca.joblib`: scikit-learn/joblib feature extraction artifacts.
+- The BGE ONNX export and tokenizer files derived from `BAAI/bge-small-zh-v1.5`
+  are **not** stored in this directory. They ship once under
+  `src/agentos/memory/models/bge_onnx` and are shared with memory's local
+  embedder; `inference/artifacts.py::_resolve_bge_onnx_dir` resolves them via
+  `agentos.memory.embedding.LocalEmbeddingProvider.resolve_onnx_dir`.
+- `router.runtime.yaml`, `version.json`, and `inference_manifest.json`: router
+  runtime configuration and inference metadata.
+
+## Upstream Bundle Origin
+
+This bundle — the trained model artifacts **and** the `runtime_src/` inference
+code — originates from OpenSquilla and is **not** trained or authored by the
+AgentOS contributors:
+
+- Upstream project: https://github.com/opensquilla/opensquilla
+- Upstream path: `src/opensquilla/squilla_router/models/v4.2_phase3_inference/`
+- License: Apache License 2.0
+- Copyright notice: OpenSquilla contributors (the upstream project ships the
+  stock Apache-2.0 text without a filled-in copyright line and no NOTICE file).
+
+The LightGBM boosters, the PyTorch-exported MLP head, and the fitted
+scikit-learn feature artifacts are OpenSquilla's trained weights, used here
+byte-for-byte unmodified — `lgbm_main.bin` carries the same Git LFS object
+(`sha256:5f312db09577bbaf30f87358941974eef6edce7f1424d0e9de21cbd38a646d53`,
+39684725 bytes) as upstream, and the `runtime_src/` modules are byte-identical
+apart from the modifications recorded below.
+
+In accordance with Section 4(b) of the Apache License 2.0, this notice records
+that the following files have been modified by the AgentOS contributors
+relative to upstream:
+
+- Namespace/branding renames throughout (`opensquilla` → `agentos`,
+  `squilla_router` → `agentos_router`).
+- `runtime_src/src/router/inference/artifacts.py` — `_resolve_bge_onnx_dir`
+  falls back to the shared BGE export under `src/agentos/memory/models/bge_onnx`
+  so the ~23MB export is shipped once rather than duplicated in this bundle.
+- `artifact_manifest.json` and this file — `bge_onnx/*` entries removed to match
+  that deduplication.
+
+The whole AgentOS repository is licensed under the Apache License 2.0 (see
+`LICENSE`), so the upstream license terms apply uniformly. The repository-root
+`THIRD_PARTY_NOTICES.md` records this bundle under its OpenSquilla section.
+
+## Upstream Model Attribution
+
+The BGE assets this bundle consumes (from `src/agentos/memory/models/bge_onnx`)
+are derived from `BAAI/bge-small-zh-v1.5`:
+
+- Hugging Face model: https://huggingface.co/BAAI/bge-small-zh-v1.5
+- Upstream project: https://github.com/FlagOpen/FlagEmbedding
+- License: MIT
+
+The upstream MIT notice is recorded in the repository root
+`THIRD_PARTY_NOTICES.md`.
+
+Note that the BGE model is a dependency of the router's `bge_x3` feature
+channel, not its base: the routing decision comes from OpenSquilla's LightGBM +
+MLP heads, which consume BGE embeddings as one of several input channels.
+
+## Conversion Notes
+
+The repository contains runtime router metadata including feature dimensions,
+route classes, and the BGE model name. Runtime behavior is defined by the
+checked-in artifacts and configuration listed below.
+
+Current known metadata:
+
+- `version.json` records the router version, feature channels,
+  `BAAI/bge-small-zh-v1.5`, and backend `onnx`.
+- `inference_manifest.json` records feature dimensions, route classes,
+  temperature, class alpha values, BGE backend, and BGE ONNX directory.
+
+## Safety Notes
+
+The current runtime deserializes `.pkl` and `.joblib` artifacts through
+`joblib.load`. Treat those files as executable-code-equivalent inputs. Only use
+assets shipped with a trusted AgentOS release or assets whose size and
+sha256 match `artifact_manifest.json`.
+
+## Update Procedure
+
+When any router asset changes:
+
+1. Regenerate the `sha256`/`size_bytes` entries in `artifact_manifest.json` for
+   every file in this directory except `bge_onnx/*` (shared, see above).
+   Upstream's `scripts/update_router_artifact_manifest.py` and
+   `tests/test_ci/test_router_artifact_manifest.py` do this, but neither was
+   carried over into AgentOS — regenerate by hand or port them back.
+2. Review the changed `artifact_manifest.json` entries.
+3. Run `uv run pytest tests/test_agentos_router/test_v4_phase3_bundle.py -q` to
+   confirm the bundle still loads and produces real (non-degraded) predictions.
+4. Include any required notice or provenance changes in the same commit.

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/artifact_manifest.json
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/artifact_manifest.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "bundle": "src/agentos/agentos_router/models/v4.2_phase3_inference",
+  "description": "Checksums and provenance notes for the V4 Phase 3 router assets. The bundle originates from OpenSquilla (Apache-2.0, https://github.com/opensquilla/opensquilla) and is not trained by the AgentOS contributors; see PROVENANCE.md and the repository-root THIRD_PARTY_NOTICES.md. The BGE ONNX export is not listed here: it is shipped once under src/agentos/memory/models/bge_onnx and shared with memory's local embedder.",
+  "files": [
+    {
+      "path": "features/bge_pca.joblib",
+      "size_bytes": 135059,
+      "sha256": "9ee12bcd481a94516b074160e39f0b909c089393d73ffbf0167d3beba995fc23",
+      "kind": "pickle_joblib_artifact",
+      "source_note": "Router runtime feature extraction artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "features/config.pkl",
+      "size_bytes": 26,
+      "sha256": "9e1225d053527975dca018deab6e3ae3fea2070ded20cd01ef0e7eea711cce82",
+      "kind": "pickle_joblib_artifact",
+      "source_note": "Router runtime feature extraction artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "features/meta.json",
+      "size_bytes": 160,
+      "sha256": "fa7c412e32fee37088e03480494e3d0b8ed859b12222e37f22e33aec3778a3de",
+      "kind": "json_metadata",
+      "source_note": "Router runtime feature extraction artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "features/svd.pkl",
+      "size_bytes": 8003143,
+      "sha256": "5d2af9e78565e58e919fb83c7a01973e394436fd43cf6813c7cd2280aa140172",
+      "kind": "pickle_joblib_artifact",
+      "source_note": "Router runtime feature extraction artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "features/tfidf.pkl",
+      "size_bytes": 344158,
+      "sha256": "bb90fb1af13ff1b15104d22b8d1dfc712ae32bf8d7db959ca56b3d7c92872293",
+      "kind": "pickle_joblib_artifact",
+      "source_note": "Router runtime feature extraction artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "inference_manifest.json",
+      "size_bytes": 679,
+      "sha256": "1addef2deddaac2a60800eb631c5878765a49ad100ede4d54022d2d3bf8e2df2",
+      "kind": "json_metadata",
+      "source_note": "Router V4 Phase 3 bundle metadata or runtime configuration. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "lgbm_aux.bin",
+      "size_bytes": 3481929,
+      "sha256": "e8749e412d2db861928cb9d8a9b39cdd134a4d71091430ffae014337d4b1aed4",
+      "kind": "lightgbm_model",
+      "source_note": "Router runtime LightGBM head artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "lgbm_main.bin",
+      "size_bytes": 39684725,
+      "sha256": "5f312db09577bbaf30f87358941974eef6edce7f1424d0e9de21cbd38a646d53",
+      "kind": "lightgbm_model",
+      "source_note": "Router runtime LightGBM head artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "mlp/model.onnx",
+      "size_bytes": 2367544,
+      "sha256": "e7358ac3f827e8f38a6384ba4f7c6f3227c18898ced95d145adb9272c72137d6",
+      "kind": "onnx_model",
+      "source_note": "Router runtime MLP head artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "mlp/scaler.joblib",
+      "size_bytes": 37447,
+      "sha256": "be1d8d9615ac5d20d26b7287dae485f13804b22fdb42c3aea1e1a9186914b9ee",
+      "kind": "pickle_joblib_artifact",
+      "source_note": "Router runtime MLP head artifact. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "router.runtime.yaml",
+      "size_bytes": 5069,
+      "sha256": "b49ae2024242bb56a3428e9fde0dfd57ddf2d3cc04f362b1d886e90c1aef965c",
+      "kind": "yaml_config",
+      "source_note": "Router V4 Phase 3 bundle metadata or runtime configuration. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    },
+    {
+      "path": "version.json",
+      "size_bytes": 240,
+      "sha256": "806a413d0a8caa5f6b566060c0131b38466e68efce0b09b2d4902f4aef8bfd1c",
+      "kind": "json_metadata",
+      "source_note": "Router V4 Phase 3 bundle metadata or runtime configuration. Sourced unmodified from OpenSquilla (Apache-2.0)."
+    }
+  ]
+}

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/features/bge_pca.joblib
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/features/bge_pca.joblib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ee12bcd481a94516b074160e39f0b909c089393d73ffbf0167d3beba995fc23
+size 135059

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/features/config.pkl
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/features/config.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e1225d053527975dca018deab6e3ae3fea2070ded20cd01ef0e7eea711cce82
+size 26

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/features/meta.json
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/features/meta.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "use_bge": false,
+  "use_context": false,
+  "use_hist": false,
+  "feature_dim": 151,
+  "channel_order": [
+    "HC",
+    "TFIDF"
+  ]
+}

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/features/svd.pkl
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/features/svd.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d2af9e78565e58e919fb83c7a01973e394436fd43cf6813c7cd2280aa140172
+size 8003143

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/features/tfidf.pkl
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/features/tfidf.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb90fb1af13ff1b15104d22b8d1dfc712ae32bf8d7db959ca56b3d7c92872293
+size 344158

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/inference_manifest.json
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/inference_manifest.json
@@ -1,0 +1,42 @@
+{
+  "bundle_version": 1,
+  "source_model_version": "v4",
+  "feature_dim": 390,
+  "route_classes": [
+    "R0",
+    "R1",
+    "R2",
+    "R3"
+  ],
+  "mlp_input_dim": 1536,
+  "temperature": 0.8092449307441711,
+  "per_class_alpha": [
+    0.5,
+    0.05,
+    0.5,
+    0.8500000000000001
+  ],
+  "bge_backend": "onnx",
+  "bge_onnx_dir": "bge_onnx",
+  "feature_channels": [
+    "hc",
+    "tfidf",
+    "ctx",
+    "hist",
+    "bge_x3",
+    "asst_hc",
+    "cont_hc",
+    "reasoning_hc"
+  ],
+  "feature_meta": {
+    "schema_version": 2,
+    "use_bge": false,
+    "use_context": false,
+    "use_hist": false,
+    "feature_dim": 151,
+    "channel_order": [
+      "HC",
+      "TFIDF"
+    ]
+  }
+}

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/lgbm_aux.bin
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/lgbm_aux.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8749e412d2db861928cb9d8a9b39cdd134a4d71091430ffae014337d4b1aed4
+size 3481929

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/lgbm_main.bin
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/lgbm_main.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f312db09577bbaf30f87358941974eef6edce7f1424d0e9de21cbd38a646d53
+size 39684725

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/mlp/model.onnx
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/mlp/model.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7358ac3f827e8f38a6384ba4f7c6f3227c18898ced95d145adb9272c72137d6
+size 2367544

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/mlp/scaler.joblib
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/mlp/scaler.joblib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be1d8d9615ac5d20d26b7287dae485f13804b22fdb42c3aea1e1a9186914b9ee
+size 37447

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/router.runtime.yaml
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/router.runtime.yaml
@@ -1,0 +1,113 @@
+route_classes: [R0, R1, R2, R3]
+
+tier_mapping:
+  R0: S
+  R1: M
+  R2: L
+  R3: XL
+
+tier_registry:
+  S: [deepseek/deepseek-v4-flash]    # Fast direct-answer tier for trivial turns and short acknowledgements.
+  M: [deepseek/deepseek-v4-pro]      # Default general tier for normal Q&A, editing, and bounded coding tasks.
+  L: [z-ai/glm-5.1]                  # Reasoning tier for debugging, multi-step analysis, and structured planning.
+  XL: [anthropic/claude-opus-4.7]    # Frontier tier for architecture, high-risk work, and hard recovery turns.
+
+tier_explanations:
+  S:
+    route_class: R0
+    model: deepseek/deepseek-v4-flash
+    intent: "Fast direct answers for trivial turns, acknowledgements, simple rewrites, and short factual responses."
+    expected_controls: "No explicit thinking; P0 prompt hint may shorten responses."
+  M:
+    route_class: R1
+    model: deepseek/deepseek-v4-pro
+    intent: "General-purpose default for routine product, coding, writing, and comparison tasks with bounded complexity."
+    expected_controls: "Light or default thinking; P1 prompt policy unless the task is clearly trivial or high risk."
+  L:
+    route_class: R2
+    model: z-ai/glm-5.1
+    intent: "Reasoning tier for debugging, multi-signal diagnosis, multi-step implementation plans, and non-trivial technical analysis."
+    expected_controls: "High thinking; P1/P2 prompt policy depending on flags and difficulty."
+  XL:
+    route_class: R3
+    model: anthropic/claude-opus-4.7
+    intent: "Highest tier for architecture design, cross-system tradeoffs, high-risk production decisions, and complex recovery turns."
+    expected_controls: "High thinking; P1/P2 prompt policy depending on flags and difficulty."
+
+thresholds:
+  margin_upgrade: 0.10           # v4.1 P0a: tightened from 0.15 to reduce OOD over-routing
+  high_confidence: 0.7
+  r1_rescue:
+    from_r0_max_gap: 0.10        # v4.1 P0a: tightened from 0.20 (sweep winner; +1.45 pp L2)
+  cascade_stage1_threshold: 0.4
+  under_routing_safety: 0.45
+  kv_cache_aware: true
+
+flag_rules:
+  high_risk:
+    keywords_zh: ["生产", "部署", "回滚", "迁移", "删除", "客户", "法务", "财务"]
+    keywords_en: ["deploy", "rollback", "migration", "delete", "overwrite", "production", "customer-facing"]
+  debug:
+    keywords: ["error", "bug", "exception", "traceback", "failed", "root cause", "报错", "根因", "修复"]
+    patterns: ["Traceback \\(most recent", "stderr:", "FAILED"]
+  repo_arch:
+    keywords: ["repo", "codebase", "monorepo", "architecture", "重构", "架构", "module", "dependency"]
+  strict_format:
+    keywords: ["JSON", "YAML", "CSV", "schema", "只返回", "不要解释", "按格式"]
+  long_context:
+    char_threshold: 6000
+    code_block_threshold: 1500
+    log_block_threshold: 1500
+    file_ref_threshold: 2
+
+thinking_mode_rules:
+  T0: {max_class: R0, min_margin: 0.5}
+  T1: {max_class: R1, min_margin: 0.4}
+  T2: {default: true}
+  T3: {min_class: R2, flags: [debug, long_context, high_risk]}
+
+prompt_policies:
+  P0:
+    hint_zh: "直接作答，缩短思考长度，避免无关展开。"
+    hint_en: "Answer directly, keep thinking short, avoid irrelevant expansion."
+    conditions: {max_difficulty: 0.8, min_margin: 0.4, no_flags: [high_risk, strict_format, debug]}
+  P1:
+    hint_zh: ""
+    hint_en: ""
+  P2:
+    hint_zh: "充分分析，覆盖关键约束，避免遗漏。"
+    hint_en: "Analyze thoroughly, cover key constraints, avoid omissions."
+    conditions: {any_flag: [high_risk, long_context, debug, strict_format]}
+
+optuna:
+  alpha: 1.0
+  beta: 0.3
+  gamma: 0.3
+
+context_rules:
+  deep_conversation_threshold: 4
+  heavy_context_tokens: 2000
+  heavy_context_min_class: R1
+  deep_conversation_min_class: R1
+
+trajectory:
+  delta_threshold: 0.3
+  history_max_turns: 5
+
+v4:
+  aux_head_inference: false      # default off; v4.2 needs this true for aux_downgrade
+  bge_model_name: BAAI/bge-small-zh-v1.5
+  bge_backend: onnx              # v4.2: 'onnx' (INT8 quantized) or 'sentence_transformers' (FP32)
+  bge_onnx_dir: bge_onnx
+  pca_dim: 64
+  feature_dim: 390               # v4.2 Phase 3: was 385; +5 dims for reasoning HC channel
+  history_user_max_turns: 4      # how many prior user turns to concat for history channel
+  bge_truncate_tokens: 510       # leave 2 tokens for [CLS]/[SEP]
+  aux_downgrade:                 # v4.2: gate downgrades via aux head's downgrade prob
+    enabled: false               # default off; turn on per-deployment after evaluation
+    threshold: 0.55              # require aux_probs["downgrade"] >= threshold
+    # When enabled and conditions met, force route_idx -= 1 (no effect at R0).
+    # Step fires AFTER margin upgrade; suppressed if margin upgrade just promoted.
+  sticky_tier:                   # v4.2 Phase 1 (deferred): block tier downgrade on short continuation turns
+    enabled: false               # default off — depends on accurate prev_route which router itself produces wrong on R2/R3 failure mode A; revisit after Phase 2 retrain
+    max_user_len: 200            # only applies when current user text length <= this

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/__init__.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/bge_onnx.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/bge_onnx.py
@@ -1,0 +1,86 @@
+"""ONNX-INT8 backend for BGE encoder.
+
+Public surface intentionally mirrors the small slice of the
+`sentence_transformers.SentenceTransformer` API used by the router:
+`encode(texts, batch_size=..., show_progress_bar=..., convert_to_numpy=True)`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+_DEFAULT_MAX_LENGTH = 510
+
+
+class OnnxBGE:
+    """Lazy, pickle-safe ONNX BGE wrapper."""
+
+    def __init__(self, model_dir: str | Path, max_length: int = _DEFAULT_MAX_LENGTH):
+        self.model_dir = str(Path(model_dir))
+        self.max_length = max_length
+        self._tokenizer = None
+        self._session = None
+
+    def _ensure_loaded(self):
+        if self._session is None:
+            import onnxruntime as ort
+            from tokenizers import Tokenizer
+
+            tokenizer = Tokenizer.from_file(
+                str(Path(self.model_dir) / "tokenizer.json")
+            )
+            tokenizer.enable_truncation(max_length=self.max_length)
+            pad_token = "[PAD]"
+            tokenizer.enable_padding(
+                pad_id=tokenizer.token_to_id(pad_token) or 0,
+                pad_token=pad_token,
+            )
+            self._tokenizer = tokenizer
+            self._session = ort.InferenceSession(
+                str(Path(self.model_dir) / "model.onnx"),
+                providers=["CPUExecutionProvider"],
+            )
+        return self._tokenizer, self._session
+
+    def encode(
+        self,
+        texts,
+        *,
+        batch_size: int = 64,
+        show_progress_bar: bool = False,
+        convert_to_numpy: bool = True,
+        **_kwargs,
+    ) -> np.ndarray:
+        if isinstance(texts, str):
+            texts = [texts]
+
+        tokenizer, session = self._ensure_loaded()
+        outputs = []
+        for start in range(0, len(texts), batch_size):
+            batch = list(texts[start : start + batch_size])
+            encoded = tokenizer.encode_batch(batch)
+            ort_inputs = {
+                "input_ids": np.asarray([enc.ids for enc in encoded], dtype=np.int64),
+                "attention_mask": np.asarray(
+                    [enc.attention_mask for enc in encoded], dtype=np.int64
+                ),
+                "token_type_ids": np.asarray(
+                    [enc.type_ids for enc in encoded], dtype=np.int64
+                ),
+            }
+            last_hidden = session.run(None, ort_inputs)[0]
+            cls = last_hidden[:, 0, :]
+            norms = np.linalg.norm(cls, axis=1, keepdims=True)
+            outputs.append((cls / np.maximum(norms, 1e-12)).astype(np.float32))
+
+        return np.concatenate(outputs, axis=0)
+
+    def __getstate__(self):
+        return {"model_dir": self.model_dir, "max_length": self.max_length}
+
+    def __setstate__(self, state):
+        self.model_dir = state["model_dir"]
+        self.max_length = state["max_length"]
+        self._tokenizer = None
+        self._session = None

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/features.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/features.py
@@ -1,0 +1,476 @@
+"""Feature extraction for the cap-router.
+
+Three channels:
+  1. Hand-crafted features (~41 dims) — always available
+  2. TF-IDF + TruncatedSVD (100 dims) — requires fit()
+  3. BGE embedding + PCA (64 dims) — requires fit(), optional
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+import joblib
+import numpy as np
+from sklearn.decomposition import TruncatedSVD
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+# ---------------------------------------------------------------------------
+# Channel 1: Hand-crafted features
+# ---------------------------------------------------------------------------
+
+_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+_JSON_RE = re.compile(r"\{[\s\S]*?[\"'][\w]+[\"']\s*:")
+_YAML_RE = re.compile(r"^[\w_]+:\s+\S", re.MULTILINE)
+_CSV_RE = re.compile(r"^[^,\n]+,[^,\n]+,[^,\n]+", re.MULTILINE)
+_TABLE_RE = re.compile(r"\|.*\|.*\|")
+_FILE_PATH_RE = re.compile(
+    r"(?:^|[\s\"'`(])([a-zA-Z_][\w.-]*/[\w./-]+\.[\w]+)", re.MULTILINE,
+)
+_URL_RE = re.compile(r"https?://\S+")
+_LOG_RE = re.compile(
+    r"(\d{4}[-/]\d{2}[-/]\d{2}[\sT]\d{2}:\d{2}.*\n){3,}"
+    r"|"
+    r"(^\[?(INFO|WARN|ERROR|DEBUG)\]?\s.*\n){3,}",
+    re.MULTILINE,
+)
+_SHELL_RE = re.compile(r"^\$\s+\w|^>\s+\w|```(?:bash|sh|shell)", re.MULTILINE)
+_TRACEBACK_RE = re.compile(r"Traceback \(most recent|stderr:|\.py\", line \d+")
+_BULLET_RE = re.compile(r"^[\s]*[-*]\s", re.MULTILINE)
+_NUMBERED_RE = re.compile(r"^[\s]*\d+[.)]\s", re.MULTILINE)
+
+_DEBUG_KW = ["error", "bug", "exception", "traceback", "failed", "root cause",
+             "报错", "根因", "修复", "stack trace", "debug"]
+_RESEARCH_KW = ["调研", "research", "对比", "compare", "survey", "分析报告",
+                "competitive analysis", "综述"]
+_ARCH_KW = ["architecture", "架构", "重构", "refactor", "monorepo", "codebase",
+            "module", "dependency"]
+_COMPARE_KW = ["对比", "compare", "audit", "审计", "review", "评估"]
+_PLANNING_KW = ["plan", "规划", "roadmap", "设计方案", "workflow", "pipeline",
+                "步骤", "step by step"]
+_STRICT_FMT_KW = ["JSON", "YAML", "CSV", "schema", "只返回", "不要解释",
+                  "按格式", "only return", "no explanation"]
+_HIGH_RISK_KW = ["deploy", "rollback", "migration", "delete", "overwrite",
+                 "production", "生产", "部署", "删除", "客户", "法务", "财务"]
+_PRODUCTION_KW = ["production", "生产", "prod", "线上", "正式环境"]
+_CUSTOMER_KW = ["customer", "客户", "用户邮件", "client"]
+_DELETE_KW = ["delete", "remove", "drop", "truncate", "删除", "清空", "覆盖",
+              "overwrite"]
+_FORMAL_KW = ["formal", "正式", "official", "公文", "合同", "法律"]
+_CONSTRAINT_KW = ["必须", "不能", "不要", "只能", "must", "shall",
+                  "required", "forbidden", "不允许", "至少", "最多"]
+
+# R1-specific keyword lists
+_TEACHING_KW = ["how does", "explain", "what is", "why does", "how to",
+                "教我", "解释", "为什么", "怎么", "是什么", "how can",
+                "tell me about", "walk me through", "介绍", "说明"]
+_IMPLEMENT_KW = ["implement", "write function", "write a", "create a",
+                 "写个", "实现", "用法", "帮我写", "生成代码", "add a",
+                 "build a", "make a", "写一个", "编写"]
+
+
+def _char_type_ratios(text: str) -> tuple[float, float, float]:
+    if not text:
+        return 0.0, 0.0, 0.0
+    n = len(text)
+    zh = sum(1 for c in text if "\u4e00" <= c <= "\u9fff")
+    en = sum(1 for c in text if c.isascii() and c.isalpha())
+    code = sum(1 for c in text if c in "{}[]();=<>|&!@#$%^*~`\\")
+    return zh / n, en / n, code / n
+
+
+def _keyword_count(text: str, keywords: list[str]) -> int:
+    text_lower = text.lower()
+    return sum(1 for kw in keywords if kw.lower() in text_lower)
+
+
+HANDCRAFTED_DIMS = 51
+
+# ---------------------------------------------------------------------------
+# Channel 4: Context features
+# ---------------------------------------------------------------------------
+
+CONTEXT_DIMS = 10
+
+# ---------------------------------------------------------------------------
+# Channel 5: History features
+# ---------------------------------------------------------------------------
+
+HIST_DIMS = 16
+_HIST_ONEHOT_SLOTS = 8  # must match len(Trajectory); checked at first call
+_ROUTE_TO_IDX = {"R0": 0, "R1": 1, "R2": 2, "R3": 3}
+
+
+def extract_hist_features(
+    history: list | None = None,
+    trajectory: object | None = None,
+) -> np.ndarray:
+    """Extract 16-dimensional history feature vector.
+
+    Layout:
+      [0] prev_route_idx   [1] prev_difficulty  [2] prev_margin
+      [3] max_route_idx    [4] turn_index       [5] history_len
+      [6] dominant_route   [7] switches
+      [8..15] trajectory one-hot (8 Trajectory enum values)
+    """
+    from src.router.trajectory import Trajectory, classify
+    assert len(Trajectory) <= _HIST_ONEHOT_SLOTS, \
+        f"Trajectory enum has {len(Trajectory)} members but only {_HIST_ONEHOT_SLOTS} one-hot slots"
+
+    vec = np.zeros(HIST_DIMS, dtype=np.float32)
+
+    if not history:
+        history = []
+
+    if trajectory is None:
+        trajectory = classify(history)
+
+    if history:
+        last = history[-1]
+        vec[0] = _ROUTE_TO_IDX.get(last.route_class, -1)
+        vec[1] = last.difficulty
+        vec[2] = last.margin
+        vec[3] = max(_ROUTE_TO_IDX.get(h.route_class, -1) for h in history)
+        vec[4] = len(history) + 1
+        vec[5] = len(history)
+        ridx = [_ROUTE_TO_IDX.get(h.route_class, 0) for h in history]
+        counts = Counter(ridx)
+        max_count = max(counts.values())
+        # Tie-break: highest route index wins (prefer over-routing)
+        vec[6] = max(route_idx for route_idx, c in counts.items() if c == max_count)
+        vec[7] = sum(1 for a, b in zip(ridx, ridx[1:]) if a != b)
+    else:
+        vec[0] = -1
+        vec[3] = -1
+        vec[4] = 1
+        vec[6] = -1
+        vec[7] = 0
+
+    traj_names = [t.value for t in Trajectory]
+    tval = trajectory.value if isinstance(trajectory, Trajectory) else str(trajectory)
+    try:
+        vec[8 + traj_names.index(tval)] = 1.0
+    except ValueError:
+        vec[8 + traj_names.index(Trajectory.UNCLEAR.value)] = 1.0
+
+    return vec
+
+
+@dataclass
+class ContextMetadata:
+    """Session and tool context for context-aware routing."""
+    turn_index: int = 0
+    context_tokens_est: int = 0
+    n_tools: int = 0
+    tool_result_length: int = 0
+    has_code_block: bool = False
+    has_file_reference: bool = False
+    has_url: bool = False
+    has_tool_results: bool = False
+
+    @classmethod
+    def from_sample(cls, sample: dict) -> ContextMetadata:
+        """Parse from a training data JSONL sample dict."""
+        sc = sample.get("session_context", {})
+        tc = sample.get("tool_context", {})
+        return cls(
+            turn_index=sc.get("turn_index", 0),
+            context_tokens_est=sc.get("context_tokens_est", 0),
+            n_tools=len(tc.get("available_tools", [])),
+            tool_result_length=tc.get("tool_result_length", 0),
+            has_code_block=bool(sc.get("has_code_block", False)),
+            has_file_reference=bool(sc.get("has_file_reference", False)),
+            has_url=bool(sc.get("has_url", False)),
+            has_tool_results=bool(tc.get("has_tool_results", False)),
+        )
+
+
+def extract_context_features(ctx: ContextMetadata | None) -> np.ndarray:
+    """Extract 10-dimensional context feature vector.
+
+    Returns all zeros when ctx is None (backward compat).
+    """
+    feats = np.zeros(CONTEXT_DIMS, dtype=np.float32)
+    if ctx is None:
+        return feats
+
+    # Normalized numerics (clamped to handle dirty data)
+    feats[0] = min(max(ctx.turn_index, 0), 20) / 20.0
+    feats[1] = min(max(ctx.context_tokens_est, 0), 20000) / 20000.0
+    feats[2] = min(max(ctx.n_tools, 0), 5) / 5.0
+    feats[3] = min(max(ctx.tool_result_length, 0), 5000) / 5000.0
+
+    # Boolean flags
+    feats[4] = float(ctx.has_code_block)
+    feats[5] = float(ctx.has_file_reference)
+    feats[6] = float(ctx.has_url)
+    feats[7] = float(ctx.has_tool_results)
+
+    # Derived signals
+    feats[8] = float(ctx.turn_index >= 4)   # is_deep_conversation
+    feats[9] = float(ctx.context_tokens_est > 2000)  # is_heavy_context
+
+    return feats
+
+
+def extract_handcrafted(text: str) -> np.ndarray:
+    """Extract 51-dimensional hand-crafted feature vector from text."""
+    feats = np.zeros(HANDCRAFTED_DIMS, dtype=np.float32)
+
+    # Basic (0-3)
+    feats[0] = len(text)
+    words = text.split()
+    feats[1] = len(words)
+    lines = text.split("\n")
+    feats[2] = len(lines)
+    feats[3] = feats[0] / max(feats[2], 1)
+
+    # Language (4-7)
+    zh, en, code = _char_type_ratios(text)
+    feats[4] = zh
+    feats[5] = en
+    feats[6] = code
+    feats[7] = 1.0 if (zh > 0.1 and en > 0.1) else 0.0
+
+    # Structure (8-14)
+    code_blocks = _CODE_BLOCK_RE.findall(text)
+    feats[8] = 1.0 if code_blocks else 0.0
+    feats[9] = len(code_blocks)
+    feats[10] = sum(len(b) for b in code_blocks)
+    feats[11] = 1.0 if _JSON_RE.search(text) else 0.0
+    feats[12] = 1.0 if _YAML_RE.search(text) else 0.0
+    feats[13] = 1.0 if _CSV_RE.search(text) else 0.0
+    feats[14] = 1.0 if _TABLE_RE.search(text) else 0.0
+
+    # Punctuation (15-18)
+    feats[15] = text.count("?") + text.count("\uff1f")
+    feats[16] = text.count("!") + text.count("\uff01")
+    feats[17] = len(_BULLET_RE.findall(text))
+    feats[18] = len(_NUMBERED_RE.findall(text))
+
+    # 19-21 reserved
+
+    # Keyword signals (22-27)
+    feats[22] = _keyword_count(text, _DEBUG_KW)
+    feats[23] = _keyword_count(text, _RESEARCH_KW)
+    feats[24] = _keyword_count(text, _ARCH_KW)
+    feats[25] = _keyword_count(text, _COMPARE_KW)
+    feats[26] = _keyword_count(text, _PLANNING_KW)
+    feats[27] = _keyword_count(text, _STRICT_FMT_KW)
+
+    # Risk (28-32)
+    feats[28] = _keyword_count(text, _HIGH_RISK_KW)
+    feats[29] = _keyword_count(text, _PRODUCTION_KW)
+    feats[30] = _keyword_count(text, _CUSTOMER_KW)
+    feats[31] = _keyword_count(text, _DELETE_KW)
+    feats[32] = _keyword_count(text, _FORMAL_KW)
+
+    # File/tool (33-37)
+    feats[33] = 1.0 if _FILE_PATH_RE.search(text) else 0.0
+    feats[34] = 1.0 if _URL_RE.search(text) else 0.0
+    feats[35] = 1.0 if _LOG_RE.search(text) else 0.0
+    feats[36] = 1.0 if _SHELL_RE.search(text) else 0.0
+    feats[37] = 1.0 if _TRACEBACK_RE.search(text) else 0.0
+
+    # Intensity (38-40)
+    feats[38] = _keyword_count(text, _CONSTRAINT_KW)
+    quoted = re.findall(r"[\"'`](.*?)[\"'`]", text)
+    feats[39] = sum(len(q) for q in quoted) / max(len(text), 1)
+    words_lower = [w.lower() for w in words]
+    feats[40] = len(set(words_lower)) / max(len(words_lower), 1)
+
+    # R1-specific signals (41-50)
+    # Teaching intent (41)
+    feats[41] = _keyword_count(text, _TEACHING_KW)
+    # Implementation intent (42)
+    feats[42] = _keyword_count(text, _IMPLEMENT_KW)
+    # File reference count bucketing (43-45): 0 / 1-2 / 3+
+    file_refs = _FILE_PATH_RE.findall(text)
+    n_files = len(set(file_refs))
+    feats[43] = 1.0 if n_files == 0 else 0.0
+    feats[44] = 1.0 if 1 <= n_files <= 2 else 0.0
+    feats[45] = 1.0 if n_files >= 3 else 0.0
+    # Code without debug (46): has code block but no debug keywords
+    has_debug = _keyword_count(text, _DEBUG_KW) > 0
+    feats[46] = 1.0 if (code_blocks and not has_debug) else 0.0
+    # Length bucketing (47-49): <200 / 200-1000 / >1000
+    text_len = len(text)
+    feats[47] = 1.0 if text_len < 200 else 0.0
+    feats[48] = 1.0 if 200 <= text_len <= 1000 else 0.0
+    feats[49] = 1.0 if text_len > 1000 else 0.0
+    # Low keyword density (50): total keyword signals < 2
+    total_kw = (feats[22] + feats[23] + feats[24] + feats[25]
+                + feats[26] + feats[27] + feats[28])
+    feats[50] = 1.0 if total_kw < 2 else 0.0
+
+    return feats
+
+
+# ---------------------------------------------------------------------------
+# Channel 2 + 3: TF-IDF/SVD + BGE/PCA via FeatureExtractor
+# ---------------------------------------------------------------------------
+
+_TFIDF_SVD_DIMS = 100
+_BGE_PCA_DIMS = 64
+
+
+class FeatureExtractor:
+    """Three-channel feature extractor: hand-crafted + TF-IDF/SVD + BGE/PCA.
+
+    Args:
+        use_bge: Whether to include BGE embedding channel.
+    """
+
+    def __init__(self, use_bge: bool = True):
+        self.use_bge = use_bge
+        self.use_context: bool = False
+        self.use_hist: bool = False
+        self._fitted = False
+        self._tfidf: TfidfVectorizer | None = None
+        self._svd: TruncatedSVD | None = None
+        self._bge_model = None
+        self._pca = None
+
+    def fit(self, texts: list[str]) -> FeatureExtractor:
+        self._tfidf = TfidfVectorizer(
+            analyzer="char_wb",
+            ngram_range=(2, 4),
+            max_features=10000,
+            sublinear_tf=True,
+        )
+        tfidf_matrix = self._tfidf.fit_transform(texts)
+
+        n_svd = min(_TFIDF_SVD_DIMS, tfidf_matrix.shape[1])
+        self._svd = TruncatedSVD(n_components=n_svd, random_state=42)
+        self._svd.fit(tfidf_matrix)
+
+        if self.use_bge:
+            self._fit_bge(texts)
+
+        self._fitted = True
+        return self
+
+    def _fit_bge(self, texts: list[str]) -> None:
+        from sentence_transformers import SentenceTransformer
+        from sklearn.decomposition import PCA
+
+        self._bge_model = SentenceTransformer("BAAI/bge-small-zh-v1.5")
+        embeddings = self._bge_model.encode(texts, show_progress_bar=True,
+                                            batch_size=256)
+        self._pca = PCA(n_components=_BGE_PCA_DIMS, random_state=42)
+        self._pca.fit(embeddings)
+
+    def transform(self, text: str, context: ContextMetadata | None = None,
+                  history: list | None = None, trajectory: object | None = None) -> np.ndarray:
+        if not self._fitted:
+            raise RuntimeError("FeatureExtractor not fitted. Call fit() first.")
+        contexts = [context] if context is not None else None
+        histories = [history] if history is not None else None
+        trajectories = [trajectory] if trajectory is not None else None
+        return self.transform_batch([text], contexts=contexts,
+                                    histories=histories, trajectories=trajectories)[0]
+
+    def transform_batch(self, texts: list[str], contexts: list[ContextMetadata] | None = None,
+                         histories: list[list] | None = None,
+                         trajectories: list | None = None) -> np.ndarray:
+        if not self._fitted:
+            raise RuntimeError("FeatureExtractor not fitted. Call fit() first.")
+
+        n = len(texts)
+        if histories is not None and len(histories) != n:
+            raise ValueError(f"histories length {len(histories)} != texts length {n}")
+        if trajectories is not None and len(trajectories) != n:
+            raise ValueError(f"trajectories length {len(trajectories)} != texts length {n}")
+
+        hand = np.array([extract_handcrafted(t) for t in texts])
+        tfidf_raw = self._tfidf.transform(texts)
+        tfidf_svd = self._svd.transform(tfidf_raw)
+
+        channels = [hand]
+
+        # Context channel: included when contexts passed (backward compat) OR use_context is True
+        if contexts is not None or self.use_context:
+            if contexts is not None:
+                ctx_feats = np.array([extract_context_features(c) for c in contexts])
+            else:
+                ctx_feats = np.zeros((len(texts), CONTEXT_DIMS), dtype=np.float32)
+            channels.append(ctx_feats)
+
+        channels.append(tfidf_svd)
+
+        if self.use_bge and self._bge_model is not None:
+            embeddings = self._bge_model.encode(texts, show_progress_bar=False,
+                                                 batch_size=256)
+            bge_pca = self._pca.transform(embeddings)
+            channels.append(bge_pca)
+
+        if self.use_hist:
+            hist_feats = np.array([
+                extract_hist_features(
+                    histories[i] if histories else None,
+                    trajectories[i] if trajectories else None,
+                )
+                for i in range(len(texts))
+            ])
+            channels.append(hist_feats)
+
+        return np.hstack(channels).astype(np.float32)
+
+    def save(self, path: str) -> None:
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        if not self._fitted:
+            raise RuntimeError("Cannot save unfitted extractor.")
+        joblib.dump(self._tfidf, p / "tfidf.pkl")
+        joblib.dump(self._svd, p / "svd.pkl")
+        if self._pca is not None:
+            joblib.dump(self._pca, p / "pca.pkl")
+        joblib.dump({"use_bge": self.use_bge}, p / "config.pkl")
+
+        # Write meta.json schema descriptor
+        dim = HANDCRAFTED_DIMS
+        ch = ["HC"]
+        if self.use_context:
+            dim += CONTEXT_DIMS
+            ch.append("context")
+        dim += _TFIDF_SVD_DIMS
+        ch.append("TFIDF")
+        if self.use_bge:
+            dim += _BGE_PCA_DIMS
+            ch.append("BGE")
+        if self.use_hist:
+            dim += HIST_DIMS
+            ch.append("hist")
+        meta = {
+            "schema_version": 2,
+            "use_bge": self.use_bge,
+            "use_context": self.use_context,
+            "use_hist": self.use_hist,
+            "feature_dim": dim,
+            "channel_order": ch,
+        }
+        (p / "meta.json").write_text(json.dumps(meta, indent=2))
+
+    @classmethod
+    def load(cls, path: str) -> FeatureExtractor:
+        p = Path(path)
+        config = joblib.load(p / "config.pkl")
+        ext = cls(use_bge=config["use_bge"])
+        ext._tfidf = joblib.load(p / "tfidf.pkl")
+        ext._svd = joblib.load(p / "svd.pkl")
+        if ext.use_bge and (p / "pca.pkl").exists():
+            ext._pca = joblib.load(p / "pca.pkl")
+            from sentence_transformers import SentenceTransformer
+            ext._bge_model = SentenceTransformer("BAAI/bge-small-zh-v1.5")
+        # Restore v2 flags from meta.json if present
+        meta_path = p / "meta.json"
+        if meta_path.exists():
+            meta = json.loads(meta_path.read_text())
+            ext.use_context = meta.get("use_context", False)
+            ext.use_hist = meta.get("use_hist", False)
+        ext._fitted = True
+        return ext

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/flags.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/flags.py
@@ -1,0 +1,110 @@
+"""Rule-based routing flag computation.
+
+Computes five boolean flags from raw text using keyword matching
+and pattern detection. All rules are config-driven via router.yaml.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from src.router.features import ContextMetadata
+
+
+@dataclass
+class RoutingFlags:
+    high_risk: bool
+    long_context: bool
+    debug: bool
+    repo_arch: bool
+    strict_format: bool
+
+
+_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+_LOG_BLOCK_RE = re.compile(
+    r"(\d{4}[-/]\d{2}[-/]\d{2}[\sT]\d{2}:\d{2}.*\n){3,}"
+    r"|"
+    r"(^\[?(INFO|WARN|ERROR|DEBUG)\]?\s.*\n){3,}",
+    re.MULTILINE,
+)
+_FILE_PATH_RE = re.compile(
+    r"(?:^|[\s\"'`(])([a-zA-Z_][\w.-]*/[\w./-]+\.[\w]+)",
+    re.MULTILINE,
+)
+
+
+def _has_keyword(text: str, keywords: list[str]) -> bool:
+    text_lower = text.lower()
+    return any(kw.lower() in text_lower for kw in keywords)
+
+
+def _has_pattern(text: str, patterns: list[str]) -> bool:
+    return any(re.search(p, text) for p in patterns)
+
+
+def _code_block_total_len(text: str) -> int:
+    return sum(len(m.group()) for m in _CODE_BLOCK_RE.finditer(text))
+
+
+def _log_block_total_len(text: str) -> int:
+    return sum(len(m.group()) for m in _LOG_BLOCK_RE.finditer(text))
+
+
+def _file_ref_count(text: str) -> int:
+    return len(_FILE_PATH_RE.findall(text))
+
+
+def compute_flags(text: str, config: dict, context: ContextMetadata | None = None) -> RoutingFlags:
+    """Compute routing flags from text using rules in config['flag_rules'].
+
+    Optional context metadata can enhance flag detection — e.g. heavy accumulated
+    context tokens trigger long_context even if the current message is short.
+    """
+    rules = config.get("flag_rules", {})
+
+    hr = rules.get("high_risk", {})
+    high_risk = (
+        _has_keyword(text, hr.get("keywords_zh", []))
+        or _has_keyword(text, hr.get("keywords_en", []))
+    )
+
+    dbg = rules.get("debug", {})
+    debug = (
+        _has_keyword(text, dbg.get("keywords", []))
+        or _has_pattern(text, dbg.get("patterns", []))
+    )
+
+    ra = rules.get("repo_arch", {})
+    repo_arch = _has_keyword(text, ra.get("keywords", []))
+
+    sf = rules.get("strict_format", {})
+    strict_format = _has_keyword(text, sf.get("keywords", []))
+
+    lc = rules.get("long_context", {})
+    char_thresh = lc.get("char_threshold", 6000)
+    code_thresh = lc.get("code_block_threshold", 1500)
+    log_thresh = lc.get("log_block_threshold", 1500)
+    file_thresh = lc.get("file_ref_threshold", 2)
+
+    long_context = (
+        len(text) >= char_thresh
+        or _code_block_total_len(text) >= code_thresh
+        or _log_block_total_len(text) >= log_thresh
+        or _file_ref_count(text) >= file_thresh
+    )
+
+    # Enhance long_context flag with context metadata
+    if context is not None:
+        ctx_rules = config.get("context_rules", {})
+        heavy_tokens = ctx_rules.get("heavy_context_tokens", 2000)
+        if context.context_tokens_est > heavy_tokens:
+            long_context = True
+
+    return RoutingFlags(
+        high_risk=high_risk,
+        long_context=long_context,
+        debug=debug,
+        repo_arch=repo_arch,
+        strict_format=strict_format,
+    )

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/__init__.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/__init__.py
@@ -1,0 +1,17 @@
+from src.router.inference.core import InferenceCore
+from src.router.inference.types import (
+    FeatureBundle,
+    FinalDecision,
+    HeadOutputs,
+    InferenceRequest,
+    InferenceResult,
+)
+
+__all__ = [
+    "InferenceCore",
+    "FeatureBundle",
+    "FinalDecision",
+    "HeadOutputs",
+    "InferenceRequest",
+    "InferenceResult",
+]

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/artifacts.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/artifacts.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+_V4_TFIDF_DIMS = 102
+
+
+class V3FeatureRuntime:
+    """Minimal runtime surface for the Phase 3 online feature builder."""
+
+    def __init__(self, tfidf_vectorizer, svd_model):
+        self._tfidf = tfidf_vectorizer
+        self._svd = svd_model
+
+    def extract_handcrafted(self, text: str) -> np.ndarray:
+        from src.router.features import extract_handcrafted
+
+        return extract_handcrafted(text).astype(np.float32)
+
+    def extract_tfidf(self, text: str) -> np.ndarray:
+        tfidf_raw = self._tfidf.transform([text])
+        tfidf_svd = self._svd.transform(tfidf_raw)[0]
+        tfidf = np.zeros(_V4_TFIDF_DIMS, dtype=np.float32)
+        width = min(tfidf_svd.shape[0], _V4_TFIDF_DIMS)
+        tfidf[:width] = tfidf_svd[:width]
+        return tfidf
+
+    def extract_context(self, metadata: dict) -> np.ndarray:
+        from src.router.features import ContextMetadata, extract_context_features
+
+        if not metadata:
+            return extract_context_features(None)
+        allowed = ContextMetadata.__dataclass_fields__.keys()
+        context = ContextMetadata(**{k: v for k, v in metadata.items() if k in allowed})
+        return extract_context_features(context)
+
+    def extract_hist(self, prev_route_decisions: list) -> np.ndarray:
+        from src.router.features import extract_hist_features
+
+        return extract_hist_features(prev_route_decisions or None)
+
+
+@dataclass
+class InferenceArtifacts:
+    model_dir: Path
+    manifest: dict
+
+    @classmethod
+    def load(cls, model_dir: str) -> InferenceArtifacts:
+        root = Path(model_dir)
+        manifest_path = root / "inference_manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+
+        if manifest.get("feature_dim") != 390:
+            raise ValueError(
+                f"feature_dim mismatch: {manifest.get('feature_dim')}"
+            )
+        if manifest.get("mlp_input_dim") != 1536:
+            raise ValueError(
+                f"mlp_input_dim mismatch: {manifest.get('mlp_input_dim')}"
+            )
+        if "temperature" not in manifest:
+            raise ValueError("temperature missing from inference manifest")
+
+        alpha = manifest.get("per_class_alpha")
+        if not isinstance(alpha, list) or len(alpha) != 4:
+            raise ValueError("per_class_alpha must be a list of length 4")
+
+        return cls(model_dir=root, manifest=manifest)
+
+    def required_paths(self) -> dict[str, Path]:
+        return {
+            "main_model": self.model_dir / "lgbm_main.bin",
+            "aux_model": self.model_dir / "lgbm_aux.bin",
+            "tfidf": self.model_dir / "features" / "tfidf.pkl",
+            "svd": self.model_dir / "features" / "svd.pkl",
+            "config": self.model_dir / "features" / "config.pkl",
+            "meta": self.model_dir / "features" / "meta.json",
+            "bge_pca": self.model_dir / "features" / "bge_pca.joblib",
+            "mlp_onnx": self.model_dir / "mlp" / "model.onnx",
+            "mlp_scaler": self.model_dir / "mlp" / "scaler.joblib",
+        }
+
+    def _resolve_bge_onnx_dir(self, candidate: object) -> str | None:
+        bundled = self.model_dir / "bge_onnx"
+        candidate_path: Path | None = None
+        if candidate:
+            candidate_path = Path(str(candidate))
+            if not candidate_path.is_absolute():
+                candidate_path = self.model_dir / candidate_path
+            if candidate_path.is_dir():
+                return str(candidate_path.resolve())
+
+        if bundled.is_dir():
+            return str(bundled.resolve())
+
+        # The BGE export is shipped once under memory/models/bge_onnx and shared
+        # with memory's local embedder; this bundle no longer carries a copy.
+        from agentos.memory.embedding import LocalEmbeddingProvider
+
+        shared = LocalEmbeddingProvider.resolve_onnx_dir(LocalEmbeddingProvider.DEFAULT_MODEL)
+        if shared is not None and shared.is_dir():
+            return str(shared.resolve())
+
+        if candidate_path is not None:
+            return str(candidate_path)
+        return None
+
+    def load_runtime_objects(self, config: dict, *, use_aux_head: bool) -> dict[str, object]:
+        import joblib
+        import lightgbm as lgb
+        import onnxruntime as ort
+
+        from src.router.v4_features import BGEChannelExtractor
+
+        paths = self.required_paths()
+        main_model = lgb.Booster(model_file=str(paths["main_model"]))
+        aux_model = None
+        if use_aux_head and paths["aux_model"].exists():
+            aux_model = lgb.Booster(model_file=str(paths["aux_model"]))
+
+        tfidf_vectorizer = joblib.load(paths["tfidf"])
+        svd_model = joblib.load(paths["svd"])
+        v3_extractor = V3FeatureRuntime(tfidf_vectorizer, svd_model)
+
+        bge_extractor = BGEChannelExtractor.load(paths["bge_pca"])
+        v4_cfg = (config or {}).get("v4", {})
+        bge_backend = (
+            v4_cfg.get("bge_backend")
+            or self.manifest.get("bge_backend")
+            or bge_extractor.backend
+        )
+        bge_onnx_dir = (
+            v4_cfg.get("bge_onnx_dir")
+            or self.manifest.get("bge_onnx_dir")
+            or bge_extractor.onnx_model_dir
+        )
+        bge_onnx_dir = self._resolve_bge_onnx_dir(bge_onnx_dir)
+        bge_extractor.backend = bge_backend
+        bge_extractor.onnx_model_dir = bge_onnx_dir
+        bge_extractor._bge = None
+        if bge_backend == "onnx" and not bge_onnx_dir:
+            raise ValueError("ONNX BGE runtime requires bge_onnx_dir")
+
+        mlp_scaler = joblib.load(paths["mlp_scaler"])
+        mlp_session = ort.InferenceSession(
+            str(paths["mlp_onnx"]),
+            providers=["CPUExecutionProvider"],
+        )
+
+        return {
+            "main_model": main_model,
+            "aux_model": aux_model,
+            "mlp_session": mlp_session,
+            "mlp_scaler": mlp_scaler,
+            "v3_extractor": v3_extractor,
+            "bge_extractor": bge_extractor,
+        }

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/core.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/core.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import numpy as np
+
+from src.router.inference.artifacts import InferenceArtifacts
+from src.router.inference.ensemble import fuse_probabilities
+from src.router.inference.features import build_feature_bundle
+from src.router.inference.heads import run_heads
+from src.router.inference.postprocess import apply_postprocess
+from src.router.inference.types import InferenceRequest, InferenceResult
+from src.router.predictor import ROUTE_CLASSES
+
+
+class InferenceCore:
+    def __init__(
+        self,
+        *,
+        config: dict,
+        alpha: np.ndarray,
+        temperature: float,
+        main_model,
+        aux_model,
+        mlp_session,
+        mlp_scaler,
+        v3_extractor,
+        bge_extractor,
+    ):
+        self.config = config
+        self.alpha = np.asarray(alpha, dtype=np.float64)
+        self.temperature = float(temperature)
+        self.main_model = main_model
+        self.aux_model = aux_model
+        self.mlp_session = mlp_session
+        self.mlp_scaler = mlp_scaler
+        self.v3_extractor = v3_extractor
+        self.bge_extractor = bge_extractor
+
+    @classmethod
+    def from_model_dir(
+        cls,
+        model_dir: str,
+        config: dict,
+        *,
+        use_aux_head: bool,
+    ) -> InferenceCore:
+        artifacts = InferenceArtifacts.load(model_dir)
+        loaded = artifacts.load_runtime_objects(
+            config=config,
+            use_aux_head=use_aux_head,
+        )
+        return cls(
+            config=config,
+            alpha=np.asarray(artifacts.manifest["per_class_alpha"], dtype=np.float64),
+            temperature=float(artifacts.manifest["temperature"]),
+            main_model=loaded["main_model"],
+            aux_model=loaded["aux_model"],
+            mlp_session=loaded["mlp_session"],
+            mlp_scaler=loaded["mlp_scaler"],
+            v3_extractor=loaded["v3_extractor"],
+            bge_extractor=loaded["bge_extractor"],
+        )
+
+    def predict(self, request: InferenceRequest) -> InferenceResult:
+        bundle = self._build_features(request)
+        outputs = self._run_heads(bundle)
+        fused = self._fuse(outputs)
+        decision = self._postprocess(fused, outputs.p_aux_lgbm, request)
+        return InferenceResult(
+            decision=decision,
+            probabilities={
+                route_class: float(fused[idx])
+                for idx, route_class in enumerate(ROUTE_CLASSES)
+            },
+            aux_decision_probs=self._aux_probs_dict(outputs.p_aux_lgbm),
+            intermediates={
+                "bge_channels_used": bundle.bge_channels_used,
+                "asst_signal_present": bundle.asst_signal_present,
+            },
+        )
+
+    def _build_features(self, request: InferenceRequest):
+        return build_feature_bundle(
+            request=request,
+            v3_extractor=self.v3_extractor,
+            bge_extractor=self.bge_extractor,
+        )
+
+    def _run_heads(self, bundle):
+        return run_heads(
+            bundle=bundle,
+            main_model=self.main_model,
+            aux_model=self.aux_model,
+            mlp_session=self.mlp_session,
+            mlp_scaler=self.mlp_scaler,
+            temperature=self.temperature,
+        )
+
+    def _fuse(self, outputs) -> np.ndarray:
+        return fuse_probabilities(
+            outputs.p_main_lgbm,
+            outputs.p_mlp_calibrated,
+            self.alpha,
+        )
+
+    def _postprocess(self, fused_probs: np.ndarray, aux_probs: np.ndarray | None,
+                     request: InferenceRequest):
+        return apply_postprocess(
+            fused_probs=fused_probs,
+            aux_probs=self._aux_probs_dict(aux_probs),
+            request=request,
+            config=self.config,
+        )
+
+    @staticmethod
+    def _aux_probs_dict(aux_probs: np.ndarray | None) -> dict[str, float] | None:
+        if aux_probs is None:
+            return None
+        aux_probs = np.asarray(aux_probs, dtype=np.float64)
+        return {
+            "initial": float(aux_probs[0]),
+            "maintain": float(aux_probs[1]),
+            "upgrade": float(aux_probs[2]),
+            "downgrade": float(aux_probs[3]),
+        }

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/ensemble.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/ensemble.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def fuse_probabilities(
+    p_main: np.ndarray, p_mlp: np.ndarray, alpha: np.ndarray
+) -> np.ndarray:
+    p_main = np.asarray(p_main, dtype=np.float64)
+    p_mlp = np.asarray(p_mlp, dtype=np.float64)
+    alpha = np.asarray(alpha, dtype=np.float64)
+
+    if p_main.shape != (4,) or p_mlp.shape != (4,) or alpha.shape != (4,):
+        raise ValueError("Phase 3 ensemble expects 4-class vectors")
+    if not (
+        np.isfinite(p_main).all()
+        and np.isfinite(p_mlp).all()
+        and np.isfinite(alpha).all()
+    ):
+        raise ValueError("ensemble inputs must be finite")
+    if not ((alpha >= 0).all() and (alpha <= 1).all()):
+        raise ValueError("alpha must stay within [0, 1]")
+
+    mixed = alpha * p_main + (1.0 - alpha) * p_mlp
+    if not np.isfinite(mixed).all():
+        raise ValueError("fused probability vector must be finite")
+    total = mixed.sum()
+    if total <= 0:
+        raise ValueError("fused probability mass must be positive")
+
+    return mixed / total

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/features.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/features.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import numpy as np
+
+from src.router.inference.types import FeatureBundle, InferenceRequest
+from src.router.v4_features import (
+    extract_assistant_handcrafted,
+    extract_continuation_features,
+    extract_reasoning_features,
+    make_history_user_text,
+)
+
+
+def build_feature_bundle(
+    request: InferenceRequest,
+    v3_extractor,
+    bge_extractor,
+) -> FeatureBundle:
+    prev_assistant_text = (
+        request.prev_assistant_text if request.prev_assistant_text else None
+    )
+    history_text = make_history_user_text(request.history_user_texts)
+    pca_192, raw_1536 = bge_extractor.transform_triplet(
+        request.current_user_text,
+        history_text,
+        prev_assistant_text,
+    )
+    hc = v3_extractor.extract_handcrafted(request.current_user_text)
+    tfidf = v3_extractor.extract_tfidf(request.current_user_text)
+    ctx = v3_extractor.extract_context(request.context_metadata)
+    hist = v3_extractor.extract_hist(request.prev_route_decisions)
+    asst = extract_assistant_handcrafted(
+        prev_assistant_text,
+        request.prev_assistant_usage,
+        request.current_user_text,
+    )
+    cont = extract_continuation_features(
+        request.prev_assistant_usage,
+        request.current_user_text,
+    )
+    reasoning = extract_reasoning_features(
+        request.prev_assistant_usage,
+        request.current_user_text,
+    )
+    features_390 = np.concatenate(
+        [hc, tfidf, ctx, hist, pca_192, asst, cont, reasoning]
+    ).astype(np.float32)
+
+    if features_390.shape != (390,):
+        raise ValueError(
+            f"feature dim mismatch: expected 390, got {features_390.shape}"
+        )
+    if raw_1536.shape != (1536,):
+        raise ValueError(
+            f"raw BGE dim mismatch: expected 1536, got {raw_1536.shape}"
+        )
+
+    bge_channels = ["user_curr", "user_hist"]
+    if prev_assistant_text is not None:
+        bge_channels.append("asst")
+
+    return FeatureBundle(
+        features_390=features_390,
+        raw_bge_1536=raw_1536.astype(np.float32),
+        bge_channels_used=bge_channels,
+        asst_signal_present=prev_assistant_text is not None,
+        history_user_text_compacted=history_text,
+    )

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/heads.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/heads.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import numpy as np
+
+from src.router.inference.types import FeatureBundle, HeadOutputs
+
+
+def _softmax(logits: np.ndarray) -> np.ndarray:
+    shifted = logits - np.max(logits)
+    exps = np.exp(shifted)
+    return exps / np.sum(exps)
+
+
+def _get_session_input_name(mlp_session) -> str:
+    inputs = mlp_session.get_inputs()
+    if not inputs:
+        raise ValueError("ONNX MLP session exposes no inputs")
+    return inputs[0].name
+
+
+def run_heads(
+    bundle: FeatureBundle,
+    main_model,
+    aux_model,
+    mlp_session,
+    mlp_scaler,
+    temperature: float,
+) -> HeadOutputs:
+    if not np.isfinite(temperature) or temperature <= 0:
+        raise ValueError("temperature must be finite and > 0")
+
+    p_main = np.asarray(
+        main_model.predict(bundle.features_390[None, :])[0], dtype=np.float64
+    )
+    p_aux = None
+    if aux_model is not None:
+        p_aux = np.asarray(
+            aux_model.predict(bundle.features_390[None, :])[0], dtype=np.float64
+        )
+
+    scaled = mlp_scaler.transform(bundle.raw_bge_1536[None, :]).astype(np.float32)
+    input_name = _get_session_input_name(mlp_session)
+    logits = np.asarray(
+        mlp_session.run(None, {input_name: scaled})[0][0], dtype=np.float64
+    )
+    calibrated = _softmax(logits / temperature)
+    return HeadOutputs(
+        p_main_lgbm=p_main,
+        p_aux_lgbm=p_aux,
+        logits_mlp=logits,
+        p_mlp_calibrated=calibrated,
+    )

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/postprocess.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/postprocess.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.router.features import ContextMetadata
+from src.router.flags import compute_flags
+from src.router.inference.types import FinalDecision, InferenceRequest
+from src.router.predictor import (
+    ROUTE_CLASSES,
+    _apply_flag_overrides,
+    _apply_margin_upgrade,
+    _apply_r1_rescue,
+    _apply_sticky_tier,
+    _derive_prompt_policy,
+    _derive_thinking_mode,
+    _select_model,
+)
+
+_CLASS_TO_IDX = {route_class: idx for idx, route_class in enumerate(ROUTE_CLASSES)}
+_TRIVIAL_ACK_TEXTS = frozenset(
+    {
+        "thanks",
+        "thank you",
+        "ok",
+        "okay",
+        "yes",
+        "no",
+        "收到",
+        "好的",
+        "谢谢",
+        "是的",
+        "不用了",
+    }
+)
+
+
+def _apply_aux_downgrade(
+    route_class: str,
+    aux_probs: Mapping[str, float] | None,
+    config: dict,
+) -> tuple[str, bool]:
+    aux_cfg = config.get("v4", {}).get("aux_downgrade", {})
+    if not aux_cfg.get("enabled", False) or not aux_probs:
+        return route_class, False
+
+    downgrade_threshold = float(aux_cfg.get("threshold", 0.55))
+    non_initial_mass = (
+        float(aux_probs.get("maintain", 0.0))
+        + float(aux_probs.get("upgrade", 0.0))
+        + float(aux_probs.get("downgrade", 0.0))
+    )
+    downgrade_prob = (
+        float(aux_probs.get("downgrade", 0.0)) / non_initial_mass
+        if non_initial_mass > 0
+        else 0.0
+    )
+    if downgrade_prob < downgrade_threshold or route_class == "R0":
+        return route_class, False
+
+    downgraded = ROUTE_CLASSES[max(0, _CLASS_TO_IDX[route_class] - 1)]
+    return downgraded, downgraded != route_class
+
+
+def _apply_optional_sticky_tier(
+    route_class: str,
+    fused_probs: np.ndarray,
+    request: InferenceRequest,
+    config: dict,
+) -> tuple[str, bool]:
+    sticky_cfg = config.get("v4", {}).get("sticky_tier", {})
+    if not sticky_cfg.get("enabled", False):
+        return route_class, False
+
+    max_user_len = sticky_cfg.get("max_user_len")
+    if max_user_len is not None and len(request.current_user_text) > int(max_user_len):
+        return route_class, False
+
+    sticky_config = {
+        **config,
+        "thresholds": {
+            **config.get("thresholds", {}),
+            "kv_cache_aware": True,
+        },
+    }
+
+    sticky_route = _apply_sticky_tier(
+        route_class,
+        fused_probs,
+        _normalize_history(request.prev_route_decisions),
+        sticky_config,
+    )
+    return sticky_route, sticky_route != route_class
+
+
+def _context_from_request(request: InferenceRequest) -> ContextMetadata | None:
+    metadata = request.context_metadata or {}
+    if not metadata:
+        return None
+    allowed = ContextMetadata.__dataclass_fields__.keys()
+    return ContextMetadata(**{key: value for key, value in metadata.items() if key in allowed})
+
+
+def _apply_under_routing_safety(
+    route_class: str,
+    fused_probs: np.ndarray,
+    config: dict,
+) -> str:
+    if _CLASS_TO_IDX[route_class] >= _CLASS_TO_IDX["R2"]:
+        return route_class
+    safety_threshold = config.get("thresholds", {}).get("under_routing_safety", 0.45)
+    heavy_prob = float(fused_probs[2] + fused_probs[3])
+    if heavy_prob > safety_threshold:
+        return "R2"
+    return route_class
+
+
+def _apply_context_rules(
+    route_class: str,
+    context: ContextMetadata | None,
+    config: dict,
+) -> str:
+    if context is None:
+        return route_class
+    ctx_rules = config.get("context_rules", {})
+    deep_threshold = int(ctx_rules.get("deep_conversation_threshold", 4))
+    if context.turn_index >= deep_threshold:
+        deep_min = ctx_rules.get("deep_conversation_min_class", "R1")
+        idx = max(_CLASS_TO_IDX[route_class], _CLASS_TO_IDX.get(deep_min, _CLASS_TO_IDX["R1"]))
+        return ROUTE_CLASSES[idx]
+    return route_class
+
+
+def _is_trivial_ack(text: str) -> bool:
+    normalized = text.strip().lower()
+    normalized = normalized.strip(" \t\r\n.!?。！？,，;；:：")
+    return normalized in _TRIVIAL_ACK_TEXTS
+
+
+def _normalize_history(prev_route_decisions: list) -> list:
+    normalized = []
+    for item in prev_route_decisions or []:
+        if hasattr(item, "route_class"):
+            normalized.append(item)
+        elif isinstance(item, dict) and "route_class" in item:
+            normalized.append(SimpleNamespace(route_class=item["route_class"]))
+        else:
+            raise ValueError(
+                "prev_route_decisions entries must expose route_class"
+            )
+    return normalized
+
+
+def apply_postprocess(
+    fused_probs: np.ndarray,
+    aux_probs: Mapping[str, float] | None,
+    request: InferenceRequest,
+    config: dict,
+) -> FinalDecision:
+    fused_probs = np.asarray(fused_probs, dtype=np.float64)
+    if fused_probs.shape != (4,):
+        raise ValueError("postprocess expects a 4-class probability vector")
+
+    idx = int(np.argmax(fused_probs))
+    route = ROUTE_CLASSES[idx]
+    sorted_p = np.sort(fused_probs)[::-1]
+    margin = float(sorted_p[0] - sorted_p[1])
+    difficulty = float(np.dot(fused_probs, np.arange(4, dtype=np.float64)))
+
+    pre_upgrade_route = route
+    route = _apply_margin_upgrade(route, margin, config)
+    margin_upgraded = route != pre_upgrade_route
+    if margin_upgraded:
+        aux_downgrade_applied = False
+    else:
+        route, aux_downgrade_applied = _apply_aux_downgrade(route, aux_probs, config)
+    route = _apply_r1_rescue(route, fused_probs, config)
+    route = _apply_under_routing_safety(route, fused_probs, config)
+
+    flags_text = (
+        request.flags_text_override
+        if request.flags_text_override is not None
+        else request.current_user_text
+    )
+    context = _context_from_request(request)
+    flags = compute_flags(flags_text, config, context=context)
+    route = _apply_flag_overrides(route, flags, config)
+    route = _apply_context_rules(route, context, config)
+    route, sticky_applied = _apply_optional_sticky_tier(
+        route, fused_probs, request, config
+    )
+
+    thinking_mode = _derive_thinking_mode(route, margin, flags, config)
+    prompt_policy = _derive_prompt_policy(difficulty, margin, flags, config)
+    if route == "R0" and _is_trivial_ack(flags_text):
+        thinking_mode = "T0"
+        prompt_policy = "P0"
+    _, selected_model = _select_model(route, config)
+
+    return FinalDecision(
+        route_class=route,
+        margin=margin,
+        difficulty_score=difficulty,
+        flags=asdict(flags),
+        thinking_mode=thinking_mode,
+        prompt_policy=prompt_policy,
+        selected_model=selected_model,
+        aux_downgrade_applied=aux_downgrade_applied,
+        sticky_applied=sticky_applied,
+    )

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/types.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/inference/types.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class InferenceRequest:
+    current_user_text: str
+    history_user_texts: list[str]
+    prev_assistant_text: str | None
+    prev_assistant_usage: dict | None
+    prev_route_decisions: list
+    flags_text_override: str | None = None
+    context_metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class FeatureBundle:
+    features_390: np.ndarray
+    raw_bge_1536: np.ndarray
+    bge_channels_used: list[str]
+    asst_signal_present: bool
+    history_user_text_compacted: str | None = None
+
+
+@dataclass
+class HeadOutputs:
+    p_main_lgbm: np.ndarray
+    p_aux_lgbm: np.ndarray | None
+    logits_mlp: np.ndarray
+    p_mlp_calibrated: np.ndarray
+
+
+@dataclass
+class FinalDecision:
+    route_class: str
+    margin: float
+    difficulty_score: float
+    flags: dict
+    thinking_mode: str
+    prompt_policy: str
+    selected_model: str
+    aux_downgrade_applied: bool
+    sticky_applied: bool
+
+
+@dataclass
+class InferenceResult:
+    decision: FinalDecision
+    probabilities: dict[str, float]
+    aux_decision_probs: dict[str, float] | None
+    intermediates: dict | None = None

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/predictor.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/predictor.py
@@ -1,0 +1,442 @@
+"""Cap router inference orchestrator.
+
+Loads a trained LightGBM model and feature pipeline, predicts R0-R3
+route class, applies post-processing (margin upgrade, flag overrides),
+and derives thinking mode, prompt policy, and model selection.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from src.router.features import ContextMetadata
+from src.router.flags import RoutingFlags, compute_flags
+
+ROUTE_CLASSES = ["R0", "R1", "R2", "R3"]
+_CLASS_TO_IDX = {c: i for i, c in enumerate(ROUTE_CLASSES)}
+
+
+@dataclass
+class RoutingResult:
+    route_class: str
+    probabilities: dict
+    difficulty_score: float
+    margin: float
+    flags: RoutingFlags
+    tier: str
+    thinking_mode: str
+    prompt_policy: str
+    prompt_hint: str
+    selected_model: str
+    trajectory: str = "COLD_START"
+    model_version: str = "v1"
+    # v4 additions (optional, default no-op for v1/v2/v3 callers):
+    aux_decision_probs: dict | None = None
+    bge_channels_used: list = field(default_factory=list)
+    asst_signal_present: bool = False
+    aux_downgrade_applied: bool = False
+    sticky_applied: bool = False
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _apply_margin_upgrade(route_class: str, margin: float,
+                          config: dict) -> str:
+    threshold = config.get("thresholds", {}).get("margin_upgrade", 0.15)
+    if margin < threshold:
+        idx = _CLASS_TO_IDX[route_class]
+        if idx < len(ROUTE_CLASSES) - 1:
+            return ROUTE_CLASSES[idx + 1]
+    return route_class
+
+
+def _apply_r1_rescue(route_class: str, probs: np.ndarray,
+                     config: dict) -> str:
+    """Rescue R1 from R0 only (safe upward direction).
+
+    Only promotes R0→R1 when R1 is a close second. Never demotes R2→R1
+    because that would increase under-routing (complex task on weak model).
+    """
+    rescue = config.get("thresholds", {}).get("r1_rescue", {})
+    r0_gap = rescue.get("from_r0_max_gap", 0.20)
+
+    if route_class == "R0":
+        r1_prob = float(probs[1])
+        r0_prob = float(probs[0])
+        if r0_prob - r1_prob < r0_gap:
+            return "R1"
+    return route_class
+
+
+def _apply_flag_overrides(route_class: str, flags: RoutingFlags,
+                          config: dict) -> str:
+    idx = _CLASS_TO_IDX[route_class]
+    if flags.high_risk:
+        idx = max(idx, _CLASS_TO_IDX["R2"])
+    if flags.debug and flags.long_context:
+        idx = max(idx, _CLASS_TO_IDX["R2"])
+    if flags.repo_arch:
+        idx = max(idx, _CLASS_TO_IDX["R1"])
+    return ROUTE_CLASSES[idx]
+
+
+def _derive_thinking_mode(route_class: str, margin: float,
+                          flags: RoutingFlags, config: dict) -> str:
+    rules = config.get("thinking_mode_rules", {})
+    if route_class == "R3":
+        return "T3"
+    t3_flags = rules.get("T3", {}).get("flags", ["debug", "long_context", "high_risk"])
+    if _CLASS_TO_IDX[route_class] >= _CLASS_TO_IDX.get(
+            rules.get("T3", {}).get("min_class", "R2"), 2):
+        for flag_name in t3_flags:
+            if getattr(flags, flag_name, False):
+                return "T3"
+    t0_rule = rules.get("T0", {})
+    max_class_t0 = t0_rule.get("max_class", "R0")
+    if (_CLASS_TO_IDX[route_class] <= _CLASS_TO_IDX.get(max_class_t0, 0)
+            and margin >= t0_rule.get("min_margin", 0.5)):
+        return "T0"
+    t1_rule = rules.get("T1", {})
+    max_class_t1 = t1_rule.get("max_class", "R1")
+    if (_CLASS_TO_IDX[route_class] <= _CLASS_TO_IDX.get(max_class_t1, 1)
+            and margin >= t1_rule.get("min_margin", 0.4)):
+        return "T1"
+    return "T2"
+
+
+def _derive_prompt_policy(difficulty_score: float, margin: float,
+                          flags: RoutingFlags, config: dict) -> str:
+    policies = config.get("prompt_policies", {})
+    p2_conds = policies.get("P2", {}).get("conditions", {})
+    any_flags = p2_conds.get("any_flag", ["high_risk", "long_context", "debug", "strict_format"])
+    for flag_name in any_flags:
+        if getattr(flags, flag_name, False):
+            return "P2"
+    p0_conds = policies.get("P0", {}).get("conditions", {})
+    max_diff = p0_conds.get("max_difficulty", 0.8)
+    min_margin = p0_conds.get("min_margin", 0.4)
+    no_flags = p0_conds.get("no_flags", ["high_risk", "strict_format", "debug"])
+    has_blocking_flag = any(getattr(flags, f, False) for f in no_flags)
+    if difficulty_score <= max_diff and margin >= min_margin and not has_blocking_flag:
+        return "P0"
+    return "P1"
+
+
+def _select_model(route_class: str, config: dict) -> tuple[str, str]:
+    tier_mapping = config.get("tier_mapping", {})
+    tier_registry = config.get("tier_registry", {})
+    tier = tier_mapping.get(route_class, "M")
+    models = tier_registry.get(tier, ["unknown"])
+    return tier, models[0]
+
+
+def _prompt_hint_locale(text: str | None) -> str:
+    if not text:
+        return "en"
+    cjk_count = 0
+    latin_count = 0
+    for char in text:
+        if (
+            "\u4e00" <= char <= "\u9fff"
+            or "\u3400" <= char <= "\u4dbf"
+            or "\uf900" <= char <= "\ufaff"
+        ):
+            cjk_count += 1
+        elif char.isascii() and char.isalpha():
+            latin_count += 1
+    if cjk_count >= 2:
+        return "zh"
+    return "en"
+
+
+def _get_prompt_hint(policy: str, config: dict, text: str | None = None) -> str:
+    policies = config.get("prompt_policies", {})
+    p = policies.get(policy, {})
+    if _prompt_hint_locale(text) == "zh":
+        return p.get("hint_zh", "") or p.get("hint_en", "")
+    return p.get("hint_en", "") or p.get("hint_zh", "")
+
+
+def _detect_model_version(model_dir: Path) -> tuple[str, dict]:
+    """Read version.json from model directory; default to v1 if absent."""
+    vjson = model_dir / "version.json"
+    if vjson.exists():
+        meta = json.loads(vjson.read_text())
+        return meta.get("version", "v1"), meta
+    return "v1", {}
+
+
+def _reconcile_extractor_schema(extractor, booster) -> None:
+    """Infer use_context / use_hist from booster dim when meta.json is missing."""
+    num_feat = booster.num_feature()
+    bge_offset = 64 if extractor.use_bge else 0
+    core = num_feat - bge_offset
+    known = {
+        151: (False, False),
+        161: (True, False),
+        167: (False, True),
+        177: (True, True),
+    }
+    if core not in known:
+        raise ValueError(
+            f"unexpected booster dim {num_feat} with use_bge={extractor.use_bge}"
+        )
+    extractor.use_context, extractor.use_hist = known[core]
+
+
+def _apply_sticky_tier(pred_class: str, probs: np.ndarray,
+                       history: list | None, cfg: dict) -> str:
+    """Layer 6: KV-cache-aware sticky tier.
+
+    When the current prediction is lower than the previous turn's class, stick
+    with the previous class to avoid unnecessary KV-cache invalidation from
+    tier downgrades.
+    """
+    if not history or not cfg.get("thresholds", {}).get("kv_cache_aware", False):
+        return pred_class
+    prev_idx = _CLASS_TO_IDX[history[-1].route_class]
+    pred_idx = _CLASS_TO_IDX[pred_class]
+    if prev_idx > pred_idx:
+        return history[-1].route_class
+    return pred_class
+
+
+def apply_post_processing(
+    probs: np.ndarray,
+    text: str,
+    config: dict,
+    context: ContextMetadata | None = None,
+    history: list | None = None,
+) -> tuple[int, RoutingFlags]:
+    """Apply the full 6-layer post-processing pipeline.
+
+    Steps: argmax -> margin upgrade -> R1 rescue -> safety net -> flag overrides
+           -> context-based routing rules -> sticky tier.
+    Returns (final_class_idx, flags).
+    """
+    sorted_probs = sorted(probs, reverse=True)
+    margin = float(sorted_probs[0] - sorted_probs[1])
+
+    base_class = ROUTE_CLASSES[int(np.argmax(probs))]
+    flags = compute_flags(text, config, context=context)
+
+    route_class = _apply_margin_upgrade(base_class, margin, config)
+    route_class = _apply_r1_rescue(route_class, probs, config)
+
+    # Safety net
+    safety_threshold = config.get("thresholds", {}).get(
+        "under_routing_safety", 0.45)
+    if _CLASS_TO_IDX[route_class] < 2:
+        heavy_prob = float(probs[2] + probs[3])
+        if heavy_prob > safety_threshold:
+            route_class = "R2"
+
+    route_class = _apply_flag_overrides(route_class, flags, config)
+
+    # Context-based routing rules
+    if context is not None:
+        ctx_rules = config.get("context_rules", {})
+        deep_threshold = ctx_rules.get("deep_conversation_threshold", 4)
+        if context.turn_index >= deep_threshold:
+            deep_min = ctx_rules.get("deep_conversation_min_class", "R1")
+            idx = max(_CLASS_TO_IDX[route_class], _CLASS_TO_IDX[deep_min])
+            route_class = ROUTE_CLASSES[idx]
+
+    # Layer 6: sticky tier (KV-cache-aware)
+    route_class = _apply_sticky_tier(route_class, probs, history, config)
+
+    return _CLASS_TO_IDX[route_class], flags
+
+
+class CapRouter:
+    """Factory + standard 4-class router.
+
+    Auto-dispatches to ``V4Router`` when ``<model_dir>/version.json`` declares
+    ``version: "v4"``. v1/v2 callers see the original behavior.
+    """
+
+    def __new__(cls, model_dir: str = "models/", *args, **kwargs):
+        version_path = Path(model_dir) / "version.json"
+        if version_path.exists():
+            try:
+                ver = json.loads(version_path.read_text()).get("version")
+            except (json.JSONDecodeError, OSError):
+                ver = None
+            if ver == "v4":
+                from src.router.v4_predictor import V4Router
+                return V4Router(model_dir, *args, **kwargs)
+        # Fall through to default v1/v2 initialization.
+        # Returning a CapRouter instance causes Python to invoke
+        # __init__ with the original args/kwargs.
+        return super().__new__(cls)
+
+    def __init__(self, model_dir: str = "models/",
+                 config_path: str = "configs/router.yaml"):
+        with open(config_path) as f:
+            self._config = yaml.safe_load(f)
+        self._model_dir = Path(model_dir)
+        self._version, self._meta = _detect_model_version(self._model_dir)
+        import lightgbm as lgb
+        self._model = lgb.Booster(model_file=str(self._model_dir / "lgbm_model.bin"))
+        from src.router.features import FeatureExtractor
+        self._extractor = FeatureExtractor.load(str(self._model_dir / "features"))
+        if not (self._model_dir / "features" / "meta.json").exists():
+            _reconcile_extractor_schema(self._extractor, self._model)
+
+    def predict(self, text: str, context: ContextMetadata | None = None, *,
+                history: list | None = None,
+                trajectory=None) -> RoutingResult:
+        from src.router.trajectory import classify as classify_trajectory
+        if trajectory is None:
+            trajectory = classify_trajectory(history or [])
+
+        features = self._extractor.transform(
+            text, context=context, history=history, trajectory=trajectory,
+        ).reshape(1, -1)
+        expected_dims = self._model.num_feature()
+        actual_dims = features.shape[1]
+        if actual_dims != expected_dims:
+            raise ValueError(
+                f"Feature dimension mismatch: model expects {expected_dims}, "
+                f"got {actual_dims}. Check if model was trained with --context."
+            )
+        raw_probs = self._model.predict(features)[0]
+        probs = {c: float(p) for c, p in zip(ROUTE_CLASSES, raw_probs)}
+        sorted_probs = sorted(raw_probs, reverse=True)
+        margin = float(sorted_probs[0] - sorted_probs[1])
+        difficulty_score = float(sum(i * p for i, p in enumerate(raw_probs)))
+
+        cls_idx, flags = apply_post_processing(
+            raw_probs, text, self._config, context=context, history=history,
+        )
+        route_class = ROUTE_CLASSES[cls_idx]
+
+        thinking_mode = _derive_thinking_mode(route_class, margin, flags, self._config)
+        prompt_policy = _derive_prompt_policy(difficulty_score, margin, flags, self._config)
+        prompt_hint = _get_prompt_hint(prompt_policy, self._config, text)
+        tier, selected_model = _select_model(route_class, self._config)
+        return RoutingResult(
+            route_class=route_class, probabilities=probs,
+            difficulty_score=difficulty_score, margin=margin,
+            flags=flags, tier=tier, thinking_mode=thinking_mode,
+            prompt_policy=prompt_policy, prompt_hint=prompt_hint,
+            selected_model=selected_model,
+            trajectory=trajectory.value if hasattr(trajectory, 'value') else str(trajectory),
+            model_version=self._version,
+        )
+
+    def route(self, text: str, context: ContextMetadata | None = None, *,
+              history: list | None = None, trajectory=None) -> RoutingResult:
+        return self.predict(text, context=context, history=history, trajectory=trajectory)
+
+
+class CascadeRouter:
+    """Two-stage cascade router: Stage1 (light/heavy) → Stage2a/2b."""
+
+    def __init__(self, model_dir: str = "models/",
+                 config_path: str = "configs/router.yaml"):
+        with open(config_path) as f:
+            self._config = yaml.safe_load(f)
+        model_path = Path(model_dir)
+        self._version, self._meta = _detect_model_version(model_path)
+        import lightgbm as lgb
+        self._stage1 = lgb.Booster(
+            model_file=str(model_path / "cascade_stage1.bin"))
+        self._stage2a = lgb.Booster(
+            model_file=str(model_path / "cascade_stage2a.bin"))
+        self._stage2b = lgb.Booster(
+            model_file=str(model_path / "cascade_stage2b.bin"))
+        from src.router.features import FeatureExtractor
+        self._extractor = FeatureExtractor.load(str(model_path / "features"))
+
+    def predict(self, text: str, context: ContextMetadata | None = None, *,
+                history: list | None = None,
+                trajectory=None) -> RoutingResult:
+        features = self._extractor.transform(text, context=context).reshape(1, -1)
+
+        # Stage 1: light(0) vs heavy(1)
+        # Bias toward "heavy" to minimize under-routing: threshold 0.4
+        # (uncertain samples go to R2/R3 rather than risk under-routing)
+        s1_threshold = self._config.get("thresholds", {}).get(
+            "cascade_stage1_threshold", 0.4)
+        s1_prob = float(self._stage1.predict(features)[0])
+        is_heavy = s1_prob > s1_threshold
+
+        if is_heavy:
+            # Stage 2b: R2(0) vs R3(1)
+            s2b_prob = float(self._stage2b.predict(features)[0])
+            if s2b_prob > 0.5:
+                base_class = "R3"
+                probs = {
+                    "R0": 0.0, "R1": 0.0,
+                    "R2": (1 - s2b_prob) * s1_prob,
+                    "R3": s2b_prob * s1_prob,
+                }
+            else:
+                base_class = "R2"
+                probs = {
+                    "R0": 0.0, "R1": 0.0,
+                    "R2": (1 - s2b_prob) * s1_prob,
+                    "R3": s2b_prob * s1_prob,
+                }
+        else:
+            # Stage 2a: R0(0) vs R1(1)
+            s2a_prob = float(self._stage2a.predict(features)[0])
+            if s2a_prob > 0.5:
+                base_class = "R1"
+                probs = {
+                    "R0": (1 - s2a_prob) * (1 - s1_prob),
+                    "R1": s2a_prob * (1 - s1_prob),
+                    "R2": 0.0, "R3": 0.0,
+                }
+            else:
+                base_class = "R0"
+                probs = {
+                    "R0": (1 - s2a_prob) * (1 - s1_prob),
+                    "R1": s2a_prob * (1 - s1_prob),
+                    "R2": 0.0, "R3": 0.0,
+                }
+
+        # Normalize probabilities
+        total = sum(probs.values()) or 1.0
+        probs = {k: v / total for k, v in probs.items()}
+
+        raw_probs = np.array([probs[c] for c in ROUTE_CLASSES])
+        sorted_p = sorted(raw_probs, reverse=True)
+        margin = float(sorted_p[0] - sorted_p[1])
+        difficulty_score = float(
+            sum(i * p for i, p in enumerate(raw_probs)))
+
+        flags = compute_flags(text, self._config)
+        route_class = _apply_flag_overrides(base_class, flags, self._config)
+        thinking_mode = _derive_thinking_mode(
+            route_class, margin, flags, self._config)
+        prompt_policy = _derive_prompt_policy(
+            difficulty_score, margin, flags, self._config)
+        prompt_hint = _get_prompt_hint(prompt_policy, self._config, text)
+        tier, selected_model = _select_model(route_class, self._config)
+
+        # Derive trajectory for RoutingResult v2 fields
+        from src.router.trajectory import classify as classify_trajectory
+        if trajectory is None:
+            trajectory = classify_trajectory(history or [])
+
+        return RoutingResult(
+            route_class=route_class, probabilities=probs,
+            difficulty_score=difficulty_score, margin=margin,
+            flags=flags, tier=tier, thinking_mode=thinking_mode,
+            prompt_policy=prompt_policy, prompt_hint=prompt_hint,
+            selected_model=selected_model,
+            trajectory=trajectory.value if hasattr(trajectory, 'value') else str(trajectory),
+            model_version=self._version,
+        )
+
+    def route(self, text: str, context: ContextMetadata | None = None, *,
+              history: list | None = None, trajectory=None) -> RoutingResult:
+        return self.predict(text, context=context, history=history, trajectory=trajectory)

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/trajectory.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/trajectory.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Trajectory(StrEnum):
+    COLD_START = "COLD_START"
+    STABLE_LOW = "STABLE_LOW"
+    STABLE_HIGH = "STABLE_HIGH"
+    ESCALATING = "ESCALATING"
+    DESCALATING = "DESCALATING"
+    OSCILLATING = "OSCILLATING"
+    UNCLEAR = "UNCLEAR"
+    MIXED = "MIXED"
+
+
+@dataclass(frozen=True)
+class TurnDecision:
+    turn_index: int
+    route_class: str
+    difficulty: float
+    margin: float
+    top1_label: str
+
+
+_LOW = {"R0", "R1"}
+_HIGH = {"R2", "R3"}
+
+
+def classify(
+    history: list[TurnDecision],
+    delta_threshold: float = 0.3,
+) -> Trajectory:
+    if not history:
+        return Trajectory.COLD_START
+    if len(history) < 2:
+        return Trajectory.UNCLEAR
+
+    tiers = [h.route_class for h in history]
+    diffs = [h.difficulty for h in history]
+
+    if all(t in _LOW for t in tiers):
+        return Trajectory.STABLE_LOW
+    if all(t in _HIGH for t in tiers):
+        return Trajectory.STABLE_HIGH
+
+    diffs_deltas = [b - a for a, b in zip(diffs, diffs[1:])]
+    signs = [
+        1 if d > delta_threshold else (-1 if d < -delta_threshold else 0)
+        for d in diffs_deltas
+    ]
+    nonzero = [s for s in signs if s != 0]
+
+    if len(nonzero) >= 2 and all(s == 1 for s in nonzero):
+        return Trajectory.ESCALATING
+    if len(nonzero) >= 2 and all(s == -1 for s in nonzero):
+        return Trajectory.DESCALATING
+
+    direction_changes = sum(
+        1 for a, b in zip(nonzero, nonzero[1:]) if a != b
+    )
+    if direction_changes >= 2:
+        return Trajectory.OSCILLATING
+
+    return Trajectory.MIXED

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/v4_features.py
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/runtime_src/src/router/v4_features.py
@@ -1,0 +1,451 @@
+"""V4 router feature extraction: helper surface + legacy pre-Phase3 assembly.
+
+Three logical channels added to the legacy v4 baseline:
+  * BGE × 3 segments (current_user, history_user, prev_assistant) → PCA(64) each
+  * 12-dim assistant handcrafted features (refusal/clarification/usage stats)
+  * History-user concatenation helper
+
+Phase 3's 390-dim online assembly lives in `src.router.inference.features`.
+This module still contains the legacy 383-dim `V4FeatureExtractor` for
+backward compatibility while exposing the low-level helper functions reused
+by the new inference package.
+"""
+from __future__ import annotations
+
+import re
+
+import joblib
+import numpy as np
+from sklearn.decomposition import PCA
+
+__all__ = [
+    "extract_assistant_handcrafted",
+    "extract_continuation_features",
+    "extract_reasoning_features",
+    "make_history_user_text",
+    "BGEChannelExtractor",
+    "V4FeatureExtractor",
+]
+
+
+# ---------------------------------------------------------------------------
+# Channel: assistant handcrafted features (12 dims)
+# ---------------------------------------------------------------------------
+
+_RE_CLAR = re.compile(
+    r"(?:能否|请\s*提供|需要(?:更多|具体).{0,8}信息"
+    r"|could you (?:clarify|provide)|please (?:specify|provide)|clarify which)",
+    re.I,
+)
+_RE_REFUSAL = re.compile(
+    r"(?:I cannot|I can't help|对不起.{0,5}无法|抱歉.{0,5}不能"
+    r"|作为(?:AI|大语言模型))",
+    re.I,
+)
+_RE_SELF_DOUBT = re.compile(
+    r"(?:我不(?:确定|清楚)|可能(?:不太|不一定)"
+    r"|not sure|might not be|I'm not entirely)",
+    re.I,
+)
+_RE_CODE_INLINE = re.compile(r"`[^`]{4,}`")
+_RE_NUMBERED_LIST = re.compile(r"^\s*\d+[\.、]\s", re.M)
+_RE_CONTINUATION = re.compile(
+    r"(?:请继续|继续|接着|续写|展开一下|再说|more|continue|go on|carry on|next)",
+    re.I,
+)
+_RE_REASONING = re.compile(
+    r"(?:why|compare|trade[ -]?off|analy[sz]e|architecture|reasoning|design"
+    r"|解释|原因|对比|分析|架构|设计|权衡)",
+    re.I,
+)
+
+
+def _zh_char_ratio(text: str) -> float:
+    if not text:
+        return 0.0
+    zh = sum(1 for c in text if "一" <= c <= "鿿")
+    return zh / max(len(text), 1)
+
+
+def _normalize_log_usage(usage: dict | None, key: str, divisor: float = 10.0) -> float:
+    value = (usage or {}).get(key, 0) or 0
+    return float(np.log1p(max(value, 0)) / divisor)
+
+
+def extract_assistant_handcrafted(prev_assistant_text: str | None,
+                                   prev_assistant_usage: dict | None,
+                                   current_user_text: str) -> np.ndarray:
+    """Return a 12-dim float32 vector of assistant signal features.
+
+    Layout:
+      0:  has_prev_asst              (0/1)
+      1:  has_clarification_question (0/1)
+      2:  has_refusal                (0/1)
+      3:  self_doubt                 (0/1)
+      4:  has_code_block             (0/1)
+      5:  has_steps_list             (0/1)
+      6:  log_output_tokens          (log1p / 10, soft-bounded)
+      7:  log_reasoning_tokens       (log1p / 10)
+      8:  log_duration_ms            (log1p / 10)
+      9:  ans_user_ratio             (clip [0, 1])
+      10: zh_ratio                   ([0, 1])
+      11: cached_token_ratio         ([0, 1])
+    """
+    if prev_assistant_text is None:
+        return np.zeros(12, dtype=np.float32)
+    t = prev_assistant_text
+    u = prev_assistant_usage or {}
+    return np.array([
+        1.0,
+        float(_RE_CLAR.search(t) is not None),
+        float(_RE_REFUSAL.search(t) is not None),
+        float(_RE_SELF_DOUBT.search(t) is not None),
+        float("```" in t or _RE_CODE_INLINE.search(t) is not None),
+        float(_RE_NUMBERED_LIST.search(t) is not None),
+        np.log1p(u.get("output_tokens", 0) or 0) / 10.0,
+        np.log1p(u.get("reasoning_tokens", 0) or 0) / 10.0,
+        np.log1p(u.get("duration_ms", 0) or 0) / 10.0,
+        min(len(t) / max(len(current_user_text), 1), 5.0) / 5.0,
+        _zh_char_ratio(t),
+        (u.get("cached_tokens", 0) or 0) / max(u.get("input_tokens", 1) or 1, 1),
+    ], dtype=np.float32)
+
+
+def extract_continuation_features(prev_assistant_usage: dict | None,
+                                  current_user_text: str) -> np.ndarray:
+    """Return a 2-dim float32 vector for short continuation prompts.
+
+    Layout:
+      0: has_continuation_cue     (0/1)
+      1: prev_output_tokens_log   (log1p / 10)
+    """
+    text = (current_user_text or "").strip()
+    is_short = len(text) <= 24
+    has_cue = bool(text) and is_short and _RE_CONTINUATION.search(text) is not None
+    return np.array([
+        float(has_cue),
+        _normalize_log_usage(prev_assistant_usage, "output_tokens"),
+    ], dtype=np.float32)
+
+
+def extract_reasoning_features(prev_assistant_usage: dict | None,
+                               current_user_text: str) -> np.ndarray:
+    """Return a 5-dim float32 vector for reasoning-heavy prompt cues.
+
+    Layout:
+      0: has_reasoning_cue         (0/1)
+      1: question_density          (clipped [0, 1])
+      2: prompt_length_log         (log1p / 10)
+      3: prev_reasoning_tokens_log (log1p / 10)
+      4: prev_duration_ms_log      (log1p / 10)
+    """
+    text = (current_user_text or "").strip()
+    qmarks = text.count("?") + text.count("？")
+    return np.array([
+        float(_RE_REASONING.search(text) is not None),
+        min(qmarks / max(len(text), 1) * 20.0, 1.0),
+        float(np.log1p(len(text)) / 10.0),
+        _normalize_log_usage(prev_assistant_usage, "reasoning_tokens"),
+        _normalize_log_usage(prev_assistant_usage, "duration_ms"),
+    ], dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Helper: history user text concatenation
+# ---------------------------------------------------------------------------
+
+_HISTORY_SEP = "\n[SEP]\n"
+
+
+def make_history_user_text(prior_user_turns: list[str], max_turns: int = 4,
+                           max_chars: int = 1500) -> str:
+    """Concatenate up to max_turns prior user turns, oldest→newest, [SEP]-separated.
+
+    BGE tokenizer has a 512-token limit. Empirically 1500 chars is a safe
+    upper bound (zh ~750 tokens at worst, en ~375). If the result exceeds
+    max_chars, truncate from the front (drop oldest turns first).
+    """
+    if not prior_user_turns:
+        return ""
+    selected = list(prior_user_turns[-max_turns:])  # oldest→newest of the window
+    text = _HISTORY_SEP.join(selected)
+    while len(text) > max_chars and len(selected) > 1:
+        selected = selected[1:]   # drop the oldest
+        text = _HISTORY_SEP.join(selected)
+    if len(text) > max_chars:
+        # only one turn left and still too long: hard truncate from the front
+        text = text[-max_chars:]
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Channel: BGE × 3 segments + shared PCA(64)
+# ---------------------------------------------------------------------------
+
+class BGEChannelExtractor:
+    """Shared BGE encoder + shared PCA(64) for three text segments.
+
+    Each call to transform_one runs the BGE encoder three times on
+    [current_user, history_user, prev_assistant] (None → empty string).
+    PCA is fitted once on the union of all three text types.
+
+    Output shape: (192,) = concat of 3 × PCA(64).
+    """
+
+    def __init__(self, bge_model_name: str = "BAAI/bge-small-zh-v1.5",
+                 pca_dim: int = 64, seed: int = 42,
+                 backend: str = "sentence_transformers",
+                 onnx_model_dir: str | None = None):
+        self.bge_model_name = bge_model_name
+        self.pca_dim = pca_dim
+        self.seed = seed
+        self.backend = backend
+        self.onnx_model_dir = onnx_model_dir
+        if backend == "onnx" and not onnx_model_dir:
+            raise ValueError("backend='onnx' requires onnx_model_dir")
+        self._bge = None
+        self.pca: PCA | None = None
+        self.fitted = False
+
+    def _ensure_bge(self):
+        if self._bge is None:
+            if self.backend == "onnx":
+                from src.router.bge_onnx import OnnxBGE
+
+                self._bge = OnnxBGE(self.onnx_model_dir)
+            else:
+                from sentence_transformers import SentenceTransformer
+
+                self._bge = SentenceTransformer(self.bge_model_name)
+        return self._bge
+
+    def _encode_triplet(
+        self,
+        current_user: str | None,
+        history_user: str | None,
+        prev_assistant: str | None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if not self.fitted:
+            raise RuntimeError("Call fit() before transform_one().")
+        bge = self._ensure_bge()
+        texts = [current_user or "", history_user or "", prev_assistant or ""]
+        raw = bge.encode(texts, batch_size=3, show_progress_bar=False,
+                         convert_to_numpy=True).astype(np.float32)   # (3, 512)
+        reduced = self.pca.transform(raw)                            # (3, k)
+        if reduced.shape[1] < self.pca_dim:
+            pad = np.zeros((reduced.shape[0], self.pca_dim - reduced.shape[1]),
+                           dtype=reduced.dtype)
+            reduced = np.concatenate([reduced, pad], axis=1)
+        return reduced.astype(np.float32), raw
+
+    def fit(self, sessions: list[dict]) -> None:
+        """Fit the shared PCA on all three text channels' BGE embeddings.
+
+        sessions: list of dicts with `turns: [{text, prev_assistant_text, context.turn_index}, ...]`
+
+        If the union of all texts has fewer samples than `pca_dim`, the PCA is
+        fitted with a clamped n_components and the transform output is padded
+        with zeros to preserve the (3 * pca_dim,) output contract.
+        """
+        bge = self._ensure_bge()
+        all_texts: list[str] = []
+        for s in sessions:
+            user_history: list[str] = []
+            for turn in s["turns"]:
+                cur = turn.get("text", "") or ""
+                hist = make_history_user_text(user_history)
+                prev_asst = turn.get("prev_assistant_text") or ""
+                all_texts.extend([cur, hist, prev_asst])
+                user_history.append(cur)
+        # BGE handles empty strings fine (returns near-constant vector)
+        embs = bge.encode(all_texts, batch_size=64, show_progress_bar=False,
+                          convert_to_numpy=True)
+        # PCA needs n_components <= min(n_samples, n_features). Clamp for tiny
+        # fit corpora; transform_one pads back to self.pca_dim with zeros.
+        n_components = min(self.pca_dim, embs.shape[0], embs.shape[1])
+        self.pca = PCA(n_components=n_components, random_state=self.seed).fit(embs)
+        self.fitted = True
+
+    def transform_one(self, current_user: str | None, history_user: str | None,
+                      prev_assistant: str | None) -> np.ndarray:
+        reduced, _ = self._encode_triplet(
+            current_user,
+            history_user,
+            prev_assistant,
+        )
+        return np.concatenate(reduced, axis=0).astype(np.float32)
+
+    def transform_triplet(self, current_user: str | None, history_user: str | None,
+                          prev_assistant: str | None) -> tuple[np.ndarray, np.ndarray]:
+        reduced, raw = self._encode_triplet(
+            current_user,
+            history_user,
+            prev_assistant,
+        )
+        return (
+            np.concatenate(reduced, axis=0).astype(np.float32),
+            raw.reshape(-1).astype(np.float32),
+        )
+
+    def transform_batch(self, triplets: list[tuple[str | None, str | None, str | None]],
+                        bge_batch_size: int = 128,
+                        show_progress: bool = False) -> np.ndarray:
+        """Batched 3-segment BGE encoding for training-time featurization.
+
+        Flattens N triplets to 3N texts, encodes in large batches (much
+        faster than calling transform_one N times), applies PCA, and
+        reshapes back to (N, 192).
+        """
+        if not self.fitted:
+            raise RuntimeError("Call fit() before transform_batch().")
+        bge = self._ensure_bge()
+        flat_texts: list[str] = []
+        for cur, hist, prev in triplets:
+            flat_texts.extend([cur or "", hist or "", prev or ""])
+        embs = bge.encode(flat_texts, batch_size=bge_batch_size,
+                          show_progress_bar=show_progress,
+                          convert_to_numpy=True)            # (3N, 512)
+        reduced = self.pca.transform(embs)                  # (3N, k)
+        if reduced.shape[1] < self.pca_dim:
+            pad = np.zeros((reduced.shape[0], self.pca_dim - reduced.shape[1]),
+                           dtype=reduced.dtype)
+            reduced = np.concatenate([reduced, pad], axis=1)  # (3N, pca_dim)
+        # Reshape (3N, pca_dim) → (N, 3, pca_dim) → (N, 3*pca_dim=192)
+        n_triplets = len(triplets)
+        return reduced.reshape(n_triplets, 3 * self.pca_dim).astype(np.float32)
+
+    def save(self, path) -> None:
+        joblib.dump({
+            "bge_model_name": self.bge_model_name,
+            "pca_dim": self.pca_dim,
+            "seed": self.seed,
+            "backend": self.backend,
+            "onnx_model_dir": self.onnx_model_dir,
+            "pca": self.pca,
+            "fitted": self.fitted,
+        }, path)
+
+    @classmethod
+    def load(cls, path) -> BGEChannelExtractor:
+        state = joblib.load(path)
+        ex = cls(
+            state["bge_model_name"],
+            state["pca_dim"],
+            state["seed"],
+            state.get("backend", "sentence_transformers"),
+            state.get("onnx_model_dir"),
+        )
+        ex.pca = state["pca"]
+        ex.fitted = state["fitted"]
+        return ex
+
+
+# ---------------------------------------------------------------------------
+# Top-level: V4FeatureExtractor (orchestrator)
+# ---------------------------------------------------------------------------
+
+# Plan-defined v4 TFIDF dim is 102; v3 baseline uses 100. We zero-pad
+# (or truncate) v3's TFIDF SVD output to this fixed width so the v4 layout
+# is stable across v3 version drift.
+_V4_TFIDF_DIMS = 102
+
+
+class V4FeatureExtractor:
+    """Legacy pre-Phase3 v4 feature assembly.
+
+    Wraps the v3 FeatureExtractor (HC + TFIDF + ctx + hist) and adds
+    the v4 BGE 3-channel + asst HC channels.
+
+    Output: 383-dim float32 vector.
+
+    Phase 3's online inference path is 390-dim and is assembled in
+    `src.router.inference.features.build_feature_bundle`. This class remains
+    only to preserve the older v4 path until the adapter migration is complete.
+
+    Layout:
+       [0:51]    HC                                    (51 dims)
+       [51:153]  TFIDF SVD (zero-padded to 102)        (102 dims)
+       [153:163] context                               (10 dims)
+       [163:179] history stats (last route, traj, ...) (16 dims)
+       [179:243] BGE current_user                      (64 dims)
+       [243:307] BGE history_user                      (64 dims)
+       [307:371] BGE prev_assistant                    (64 dims)
+       [371:383] assistant HC                          (12 dims)
+    """
+
+    FEATURE_DIM = 383
+    HC_SLICE        = slice(0, 51)
+    TFIDF_SLICE     = slice(51, 153)
+    CTX_SLICE       = slice(153, 163)
+    HIST_SLICE      = slice(163, 179)
+    BGE_CURR_SLICE  = slice(179, 243)
+    BGE_HIST_SLICE  = slice(243, 307)
+    BGE_ASST_SLICE  = slice(307, 371)
+    ASST_HC_SLICE   = slice(371, 383)
+
+    def __init__(self, v3_extractor, bge_extractor: BGEChannelExtractor):
+        self.v3 = v3_extractor
+        self.bge = bge_extractor
+
+    def build_feature_vector(self, *,
+                              current_user_text: str,
+                              prior_user_turns: list[str],
+                              prev_assistant_text: str | None,
+                              prev_assistant_usage: dict | None,
+                              context_metadata: dict,
+                              prev_route_decisions: list) -> np.ndarray:
+        # Lazy imports to avoid circular ones
+        from src.router.features import (
+            ContextMetadata,
+            extract_context_features,
+            extract_handcrafted,
+            extract_hist_features,
+        )
+
+        # v3 channels — built individually to match v4 layout (HC + TFIDF + ctx + hist).
+        # v3.transform() returns a different layout (HC + ctx + TFIDF + ...), so we
+        # don't use it; we recompute each block ourselves.
+        hc = extract_handcrafted(current_user_text)                      # (51,)
+
+        # TFIDF: access v3's private _tfidf + _svd directly. Pad/truncate to
+        # _V4_TFIDF_DIMS (102) so the v4 layout is stable even if v3's SVD width
+        # drifts (currently 100; clamped further when fit corpus is tiny).
+        tfidf_raw = self.v3._tfidf.transform([current_user_text])
+        tfidf_svd = self.v3._svd.transform(tfidf_raw)[0]                 # (k,) k <= 100
+        tfidf = np.zeros(_V4_TFIDF_DIMS, dtype=np.float32)
+        k = min(tfidf_svd.shape[0], _V4_TFIDF_DIMS)
+        tfidf[:k] = tfidf_svd[:k]
+
+        # Context: build a ContextMetadata if a dict was passed
+        if isinstance(context_metadata, dict):
+            if context_metadata:
+                # Filter keys to defined dataclass fields to be tolerant of extras
+                allowed = ContextMetadata.__dataclass_fields__.keys()
+                ctx_obj = ContextMetadata(
+                    **{k: v for k, v in context_metadata.items() if k in allowed}
+                )
+            else:
+                ctx_obj = None
+        else:
+            ctx_obj = context_metadata
+        ctx = extract_context_features(ctx_obj)                          # (10,)
+
+        # History stats: pass prev_route_decisions as the history list
+        hist = extract_hist_features(prev_route_decisions or None)       # (16,)
+
+        # v4 BGE 3-channel: build history_user_text from prior_user_turns
+        history_user_text = make_history_user_text(prior_user_turns or [])
+        bge = self.bge.transform_one(current_user_text, history_user_text,
+                                     prev_assistant_text)                # (192,)
+
+        # v4 assistant HC channel
+        asst_hc = extract_assistant_handcrafted(prev_assistant_text,
+                                                prev_assistant_usage,
+                                                current_user_text)       # (12,)
+
+        out = np.concatenate([hc, tfidf, ctx, hist, bge, asst_hc]).astype(np.float32)
+        if out.shape[0] != self.FEATURE_DIM:
+            raise ValueError(
+                f"feature dim mismatch: expected {self.FEATURE_DIM}, got {out.shape[0]}"
+            )
+        return out

--- a/src/agentos/agentos_router/models/v4.2_phase3_inference/version.json
+++ b/src/agentos/agentos_router/models/v4.2_phase3_inference/version.json
@@ -1,0 +1,16 @@
+{
+  "version": "v4",
+  "feature_dim": 390,
+  "channels": [
+    "hc",
+    "tfidf",
+    "ctx",
+    "hist",
+    "bge_x3",
+    "asst_hc",
+    "cont_hc",
+    "reasoning_hc"
+  ],
+  "bge_model": "BAAI/bge-small-zh-v1.5",
+  "bge_backend": "onnx"
+}

--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -30,6 +30,7 @@ from agentos.engine.pricing import lookup_price
 from agentos.provider.context_capabilities import provider_state_continuity_diagnostic
 from agentos.router_control import RouterControlHoldStore
 from agentos.router_tiers import (
+    DEFAULT_ROUTER_STRATEGY,
     DEFAULT_TEXT_TIER,
     HIGHEST_TEXT_TIER,
     ROUTE_CLASS_TO_TIER,
@@ -509,15 +510,17 @@ _KNOWN_STRATEGIES = frozenset({"llm_judge", "v4_phase3"})
 
 
 def _strategy_name(config: object) -> str:
-    configured = str(getattr(config, "strategy", "llm_judge") or "llm_judge").strip()
+    configured = str(
+        getattr(config, "strategy", DEFAULT_ROUTER_STRATEGY) or DEFAULT_ROUTER_STRATEGY
+    ).strip()
     if configured in _KNOWN_STRATEGIES:
         return configured
     log.warning(
         "agentos_router.unknown_strategy_ignored",
         strategy=configured,
-        using="llm_judge",
+        using=DEFAULT_ROUTER_STRATEGY,
     )
-    return "llm_judge"
+    return DEFAULT_ROUTER_STRATEGY
 
 
 def _requires_history(strategy: object) -> bool:

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -50,6 +50,7 @@ from agentos.gateway.session_streams import get_session_streams
 from agentos.gateway.websocket import get_registry
 from agentos.paths import default_agentos_home
 from agentos.permissions import configured_default_elevated
+from agentos.router_tiers import DEFAULT_ROUTER_STRATEGY
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 
 log = structlog.get_logger(__name__)
@@ -1356,7 +1357,9 @@ def validate_agentos_router_runtime(config: GatewayConfig) -> None:
     if router_cfg is None or not getattr(router_cfg, "enabled", False):
         return
 
-    strategy = str(getattr(router_cfg, "strategy", "v4_phase3") or "v4_phase3").strip()
+    strategy = str(
+        getattr(router_cfg, "strategy", DEFAULT_ROUTER_STRATEGY) or DEFAULT_ROUTER_STRATEGY
+    ).strip()
     if strategy == "v4_phase3":
         bundle_dir = _agentos_router_bundle_dir(router_cfg)
         required = ("runtime_src", "router.runtime.yaml")
@@ -1387,7 +1390,9 @@ async def preload_agentos_router_runtime(config: GatewayConfig) -> None:
     if router_cfg is None or not getattr(router_cfg, "enabled", False):
         return
 
-    strategy_name = str(getattr(router_cfg, "strategy", "llm_judge") or "llm_judge").strip()
+    strategy_name = str(
+        getattr(router_cfg, "strategy", DEFAULT_ROUTER_STRATEGY) or DEFAULT_ROUTER_STRATEGY
+    ).strip()
     try:
         log.info("gateway.agentos_router_preload_started", strategy=strategy_name)
         await asyncio.to_thread(

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -28,6 +28,7 @@ from agentos.gateway.config_migration import (
 )
 from agentos.paths import default_agentos_home
 from agentos.router_tiers import (
+    DEFAULT_ROUTER_STRATEGY,
     DEFAULT_TEXT_TIER,
     normalize_text_tier,
     normalize_tier_mapping,
@@ -1037,10 +1038,10 @@ class AgentOSRouterConfig(BaseSettings):
     auto_thinking: bool = True
     rollout_phase: str = "full"  # "observe" | "prompt_only" | "full"
     # "v4_phase3" (default: local ML router — BGE+LightGBM bundle, no LLM call)
-    # | "llm_judge" (routes via a small LLM judge call). The v4 bundle lives
-    # out-of-git under agentos_router/models/; a missing bundle degrades to the
+    # | "llm_judge" (routes via a small LLM judge call). The v4 bundle ships in
+    # the wheel under agentos_router/models/; a missing bundle degrades to the
     # default tier unless require_router_runtime is set.
-    strategy: str = "v4_phase3"
+    strategy: str = DEFAULT_ROUTER_STRATEGY
     tier_profile: str | None = None
     tiers: dict = Field(default_factory=_default_tiers)
     default_tier: str = DEFAULT_TEXT_TIER
@@ -1075,8 +1076,9 @@ class AgentOSRouterConfig(BaseSettings):
     v4_bundle_dir: str | None = None  # V4 Phase 3 bundle root; defaults to bundled assets
     v4_use_aux_head: bool | None = True  # override router.runtime.yaml aux head when set
     # When True, a missing/broken v4 bundle raises at boot instead of degrading
-    # to the default tier. Defaults False (pre-removal was True): the ~75MB bundle
-    # is git-ignored, so a strict default would crash any machine lacking it.
+    # to the default tier. Defaults False: the bundle ships in the wheel, but a
+    # source checkout without `git lfs pull` still has only pointer stubs, and a
+    # strict default would turn that into a hard boot failure.
     require_router_runtime: bool = False
     routing_timeout_seconds: float = Field(default=10.0, gt=0.0)
     kv_cache_anti_downgrade_enabled: bool = True

--- a/src/agentos/router_tiers.py
+++ b/src/agentos/router_tiers.py
@@ -10,6 +10,11 @@ DEFAULT_TEXT_TIER = "c1"
 HIGHEST_TEXT_TIER = "c3"
 IMAGE_TIER = "image_model"
 
+# Canonical router strategy default. Config, boot preflight, boot preload, and
+# the engine dispatch step all resolve it from here; they previously carried
+# four independent literals that had drifted apart.
+DEFAULT_ROUTER_STRATEGY = "v4_phase3"
+
 LEGACY_TEXT_TIER_ALIASES: dict[str, str] = {
     "t0": "c0",
     "t1": "c1",

--- a/tests/test_agentos_router/test_v4_phase3_bundle.py
+++ b/tests/test_agentos_router/test_v4_phase3_bundle.py
@@ -1,0 +1,126 @@
+"""The v4_phase3 bundle must actually load and route.
+
+Every other v4 test constructs the strategy with ``bundle_dir="/nonexistent"``
+and asserts the degradation path (tier c1, confidence 0.0, source
+"v4_unavailable"). That is worth keeping, but on its own it let the bundle go
+missing from the wheel while ``strategy="v4_phase3"`` stayed the default: the
+router loaded, reported no error beyond one boot warning, and pinned every turn
+to c1. These tests exercise the real artifacts so that regression cannot repeat
+silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.agentos_router.v4_phase3 import V4Phase3Strategy, default_bundle_dir
+
+_LFS_POINTER = b"version https://git-lfs.github.com/spec/v1"
+
+_WEIGHTS = (
+    "lgbm_main.bin",
+    "lgbm_aux.bin",
+    "mlp/model.onnx",
+    "mlp/scaler.joblib",
+    "features/tfidf.pkl",
+    "features/svd.pkl",
+    "features/bge_pca.joblib",
+)
+
+TIERS = ["c0", "c1", "c2", "c3"]
+
+
+def _require_bundle() -> Path:
+    """Skip when the ML extras or hydrated weights are unavailable.
+
+    Both are present in CI (``uv sync --extra recommended`` plus an
+    ``lfs: true`` checkout) and in any wheel install, but a bare ``--extra dev``
+    venv or a source clone without ``git lfs pull`` has neither.
+    """
+    for module in ("numpy", "lightgbm", "onnxruntime", "sklearn", "joblib", "tokenizers"):
+        pytest.importorskip(module)
+
+    bundle = default_bundle_dir()
+    if not bundle.is_dir():
+        pytest.skip(f"v4 bundle not present at {bundle}")
+    for name in _WEIGHTS:
+        path = bundle / name
+        if not path.is_file():
+            pytest.skip(f"v4 bundle weight missing: {name}")
+        if path.read_bytes()[:64].startswith(_LFS_POINTER):
+            pytest.skip(f"v4 bundle weight is an unhydrated LFS pointer: {name}")
+    return bundle
+
+
+def test_bundle_loads_from_the_shipped_assets() -> None:
+    _require_bundle()
+
+    # require_router_runtime=True turns the silent degradation into a raise, so
+    # a broken bundle fails here as an error rather than a passing assertion
+    # about c1.
+    strategy = V4Phase3Strategy(require_router_runtime=True)
+
+    assert strategy._available is True
+    assert strategy._model_version == "v4"
+
+
+def test_bundle_does_not_duplicate_the_shared_bge_export() -> None:
+    bundle = _require_bundle()
+
+    # ~23MB of the wheel. memory/models/bge_onnx is the single copy; the router
+    # resolves it through LocalEmbeddingProvider rather than shipping its own.
+    assert not (bundle / "bge_onnx").exists()
+
+    strategy = V4Phase3Strategy(require_router_runtime=True)
+    extractor = strategy._core.bge_extractor
+    resolved = Path(extractor.onnx_model_dir)
+
+    assert extractor.backend == "onnx"
+    assert resolved.is_dir()
+    assert resolved.parts[-3:] == ("memory", "models", "bge_onnx")
+    assert (resolved / "model.onnx").is_file()
+    assert (resolved / "tokenizer.json").is_file()
+
+
+async def test_classify_returns_a_real_prediction() -> None:
+    _require_bundle()
+    strategy = V4Phase3Strategy(require_router_runtime=True)
+
+    tier, confidence, source, meta = await strategy.classify("hi", list(TIERS))
+
+    assert source == "v4_phase3"  # not "v4_unavailable"
+    assert tier in TIERS
+    assert confidence > 0.0
+    assert meta["route_class"] in {"R0", "R1", "R2", "R3"}
+    assert meta["model_version"] == "v4"
+
+
+async def test_classify_separates_trivial_from_hard_turns() -> None:
+    """The whole point of the router. A constant classifier passes every
+    assertion above but fails this one."""
+    _require_bundle()
+    strategy = V4Phase3Strategy(require_router_runtime=True)
+
+    trivial_tier, _, trivial_source, _ = await strategy.classify("hi", list(TIERS))
+    hard_tier, _, hard_source, _ = await strategy.classify(
+        "My deploy is failing. Traceback (most recent call last):\n"
+        '  File "app/main.py", line 42, in handler\n'
+        "    result = client.fetch(url)\n"
+        "ConnectionResetError: [Errno 104] Connection reset by peer\n"
+        "This only reproduces in production under load. What is the root cause?",
+        list(TIERS),
+    )
+
+    assert trivial_source == hard_source == "v4_phase3"
+    assert TIERS.index(hard_tier) > TIERS.index(trivial_tier)
+
+
+async def test_classify_honours_the_valid_tier_allowlist() -> None:
+    _require_bundle()
+    strategy = V4Phase3Strategy(require_router_runtime=True)
+
+    for _ in range(2):
+        tier, _, _, _ = await strategy.classify("hi", ["c2", "c3"])
+        assert tier in {"c2", "c3"}

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -52,6 +52,11 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     # self-contained provider client, and gateway boot/doctor + onboarding
     # resolve the judge target for observability and setup.
     ("agentos_router", "provider"),
+    # The v4 bundle's BGE channel reuses the single BGE ONNX export shipped
+    # under memory/models/bge_onnx (~23MB) instead of carrying a second copy,
+    # and resolves it via LocalEmbeddingProvider.resolve_onnx_dir rather than
+    # duplicating the path convention.
+    ("agentos_router", "memory"),
     ("gateway", "agentos_router"),
     ("onboarding", "agentos_router"),
     ("gateway", "agents"),

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -324,9 +324,29 @@ def test_wheelhouse_release_hydrates_current_embedding_bundle() -> None:
     assert 'root / "model.onnx"' in text
     assert 'root / "tokenizer.json"' in text
     assert 'root / "vocab.txt"' in text
-    # The deleted v4 ML bundle assets must not linger in the verify list.
-    assert "v4.2_phase3_inference" not in text
-    assert "lgbm_main.bin" not in text
-    assert "tfidf.pkl" not in text
-    assert "router.runtime.yaml" not in text
+    # The retired E3b router bundle must not linger in the verify list.
     assert "intent_head.joblib" not in text
+
+
+def test_wheelhouse_release_hydrates_v4_router_bundle() -> None:
+    """strategy="v4_phase3" is the default; a bundle that fails to hydrate
+    degrades every turn to the default tier with only a boot warning, so the
+    release must fail loudly instead."""
+    text = (WORKFLOW_DIR / "wheelhouse-release.yml").read_text(encoding="utf-8")
+
+    assert 'git lfs pull --include="src/agentos/agentos_router/models/**"' in text
+    assert "v4.2_phase3_inference" in text
+    assert 'bundle / "lgbm_main.bin"' in text
+    assert 'bundle / "features/tfidf.pkl"' in text
+    assert 'bundle / "router.runtime.yaml"' in text
+    # The bundle shares memory's bge_onnx export rather than carrying a copy.
+    assert "v4.2_phase3_inference/bge_onnx" not in text
+
+
+def test_pypi_publish_hydrates_v4_router_bundle() -> None:
+    text = (WORKFLOW_DIR / "pypi-publish.yml").read_text(encoding="utf-8")
+
+    assert 'git lfs pull --include="src/agentos/memory/models/**"' in text
+    assert 'git lfs pull --include="src/agentos/agentos_router/models/**"' in text
+    assert "v4.2_phase3_inference" in text
+    assert "lgbm_main.bin" in text

--- a/tests/test_engine/test_router_llm_judge_guards.py
+++ b/tests/test_engine/test_router_llm_judge_guards.py
@@ -21,6 +21,7 @@ from agentos.engine.steps.agentos_router import (
     apply_agentos_router,
 )
 from agentos.gateway.config import GatewayConfig
+from agentos.router_tiers import DEFAULT_ROUTER_STRATEGY
 
 # The D3 stable extra shape both judge-unavailable paths must emit: the
 # LLMJudgeStrategy runtime path (pinned by test_llm_judge_strategy.py) and the
@@ -190,12 +191,21 @@ async def test_unavailable_judge_extra_matches_d3_contract() -> None:
     assert extra["difficulty"] is None
 
 
-def test_strategy_name_dispatches_and_defaults_to_llm_judge() -> None:
+def test_strategy_name_dispatches_and_defaults_to_the_canonical_strategy() -> None:
+    """Unset/None/unknown all resolve to DEFAULT_ROUTER_STRATEGY. These used to
+    fall back to llm_judge while AgentOSRouterSettings.strategy defaulted to
+    v4_phase3, so the effective default depended on which code path asked."""
     assert agentos_router_step._strategy_name(SimpleNamespace(strategy="llm_judge")) == "llm_judge"
     assert agentos_router_step._strategy_name(SimpleNamespace(strategy="v4_phase3")) == "v4_phase3"
-    assert agentos_router_step._strategy_name(SimpleNamespace(strategy=None)) == "llm_judge"
-    assert agentos_router_step._strategy_name(SimpleNamespace(strategy="bogus")) == "llm_judge"
-    assert agentos_router_step._strategy_name(SimpleNamespace()) == "llm_judge"
+    assert (
+        agentos_router_step._strategy_name(SimpleNamespace(strategy=None))
+        == DEFAULT_ROUTER_STRATEGY
+    )
+    assert (
+        agentos_router_step._strategy_name(SimpleNamespace(strategy="bogus"))
+        == DEFAULT_ROUTER_STRATEGY
+    )
+    assert agentos_router_step._strategy_name(SimpleNamespace()) == DEFAULT_ROUTER_STRATEGY
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from agentos.gateway.config import ROUTER_TIER_PROFILE_IDS
+from agentos.router_tiers import DEFAULT_ROUTER_STRATEGY
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 # openrouter is the baked-in default tier set, so it never auto-selects a
@@ -420,7 +421,10 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert agentos_router["enabled"] is True
     assert agentos_router["auto_thinking"] is True
     assert agentos_router["rollout_phase"] == "full"
-    assert agentos_router["strategy"] == "llm_judge"
+    # Must match AgentOSRouterSettings.strategy: copying the example over a
+    # fresh config previously flipped the router to a different strategy than
+    # an unset config would pick.
+    assert agentos_router["strategy"] == DEFAULT_ROUTER_STRATEGY
     assert "judge_model" not in agentos_router  # unset = AUTO judge resolution
     assert agentos_router["judge_input_max_chars"] == 4000
     assert agentos_router["judge_short_circuit_enabled"] is True


### PR DESCRIPTION
## Problem

`agentos_router.strategy` defaults to `v4_phase3`, but the model bundle it
needs was git-ignored and never shipped in the wheel. `V4Phase3Strategy`
swallows the resulting `FileNotFoundError`, so the router loaded, logged one
boot warning, and then pinned **every turn to tier `c1`** with confidence
`0.0`. Users installed lightgbm/scikit-learn via the `recommended` extra and
got a constant function.

## What changed

- **Bundle restored** and shipped in the wheel via git LFS (16MB -> 44MB,
  under the 100MB PyPI limit). It reuses the BGE export already shipped under
  `memory/models/bge_onnx` rather than carrying a second ~23MB copy.
- **Guards added** so this cannot regress silently: LFS hydration + asset
  checks in both release workflows, the Dockerfile preflight, and
  `install_source.sh`.
- **Defaults consolidated.** Four sites disagreed on the default strategy
  (two in the same file); they now all resolve `DEFAULT_ROUTER_STRATEGY`.
  Note `strategy = "bogus"` now falls back to `v4_phase3` rather than
  `llm_judge`, so unset/None/unknown no longer give three different answers.
- **Attribution fixed.** The bundle is OpenSquilla's (Apache-2.0), not
  AgentOS-trained. `PROVENANCE.md` was a rebranded copy of upstream's and
  implied otherwise.

## Verification

- Fresh wheel install, outside the repo: `source=v4_phase3`, tiers vary by
  prompt (`hi` -> c0, a stack trace -> c3). Previously every prompt -> c1.
- The restored weights reproduce the original bundle **exactly**: running the
  eval against upstream-era code with the original bundle gives the same
  numbers (classification 0.6116, applied 0.562). All 12 assets match their
  `artifact_manifest.json` sha256.
- The checked-in `baseline_v4_phase3.json` (0.5372/0.5455) is stale and does
  not match even the original bundle at its own commit. Left untouched; no
  test reads it.
- Gate: ruff clean, mypy clean, 5731 passed. Two failures
  (`test_migrations_packaged`, `test_artifacts`) are pre-existing and fail on
  clean `main` too.

## Notes for review

- Adds the `agentos_router -> memory` package import edge (declared in the
  architecture contract): the router resolves the shared BGE export through
  `LocalEmbeddingProvider.resolve_onnx_dir`.
- Silent `c1` degradation is kept deliberately as the safety net for source
  checkouts without `git lfs pull`.
- Training-data provenance of the upstream weights is not something this PR
  can establish; only OpenSquilla can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)