### PR TITLE
fix(memory): follow HF CDN redirects in embedding model download

### DIFF
--- a/src/agentos/memory/model_download.py
+++ b/src/agentos/memory/model_download.py
@@ -10,6 +10,9 @@ Remote Hugging Face paths use an ``onnx/`` subdirectory (e.g.
 root so the resulting layout matches what :mod:`agentos.memory.embedding`'s
 bundled-ONNX loader expects (``*.onnx`` glob at the top level, with the
 external-weights ``.onnx_data`` file sitting next to it).
+
+Fetches follow redirects: Hugging Face serves ``resolve/`` URLs as a 302 to a
+signed, short-lived CDN URL.
 """
 
 from __future__ import annotations
@@ -123,7 +126,15 @@ async def download_embedding_model(
     target_dir = user_models_dir() / manifest.target_dirname
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    async with httpx.AsyncClient(trust_env=_trust_env(), timeout=_DOWNLOAD_TIMEOUT_S) as client:
+    # follow_redirects: Hugging Face answers every ``resolve/`` URL with a 302 to
+    # a signed CDN URL, so redirects must be followed. Safe here because the URL
+    # comes from a hardcoded manifest, never from user input (unlike the
+    # deliberately non-following clients in agentos.tools.builtin).
+    async with httpx.AsyncClient(
+        trust_env=_trust_env(),
+        timeout=_DOWNLOAD_TIMEOUT_S,
+        follow_redirects=True,
+    ) as client:
         for remote_path in manifest.files:
             name = _flattened_name(remote_path)
             final_path = target_dir / name

--- a/tests/test_memory_model_download.py
+++ b/tests/test_memory_model_download.py
@@ -47,27 +47,44 @@ def test_downloaded_model_dir_unknown_model_returns_none(tmp_path, monkeypatch) 
     assert md.downloaded_model_dir("nope/none") is None
 
 
+_CDN_HOST = "https://cdn.example-xet.invalid/signed/"
+
+
 def _mock_transport(fetched: list[str]) -> httpx.MockTransport:
+    """Mirror Hugging Face: ``resolve/`` 302s to a signed CDN URL.
+
+    ``fetched`` records only the origin (pre-redirect) requests, so callers can
+    still count one entry per manifest file.
+    """
+
     def handler(request: httpx.Request) -> httpx.Response:
-        fetched.append(str(request.url))
-        name = str(request.url).rsplit("/", 1)[-1]
-        return httpx.Response(200, content=f"data-{name}".encode())
+        url = str(request.url)
+        name = url.rsplit("/", 1)[-1]
+        if url.startswith(_CDN_HOST):
+            return httpx.Response(200, content=f"data-{name}".encode())
+        fetched.append(url)
+        return httpx.Response(302, headers={"location": f"{_CDN_HOST}{name}"})
 
     return httpx.MockTransport(handler)
 
 
-@pytest.mark.asyncio
-async def test_download_streams_flattens_and_skips_existing(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(md, "user_models_dir", lambda: tmp_path)
-    fetched: list[str] = []
+def _patch_transport(monkeypatch, transport: httpx.MockTransport) -> None:
+    """Route the downloader's AsyncClient through ``transport``, keeping kwargs."""
+
     real_async_client = httpx.AsyncClient
-    transport = _mock_transport(fetched)
 
     def patched_async_client(*args, **kwargs):
         kwargs["transport"] = transport
         return real_async_client(*args, **kwargs)
 
     monkeypatch.setattr(md.httpx, "AsyncClient", patched_async_client)
+
+
+@pytest.mark.asyncio
+async def test_download_streams_flattens_and_skips_existing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(md, "user_models_dir", lambda: tmp_path)
+    fetched: list[str] = []
+    _patch_transport(monkeypatch, _mock_transport(fetched))
 
     path = await md.download_embedding_model("google/embeddinggemma-300m")
 
@@ -87,6 +104,32 @@ async def test_download_streams_flattens_and_skips_existing(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_download_follows_hf_cdn_redirect(tmp_path, monkeypatch) -> None:
+    """Hugging Face 302s every ``resolve/`` URL to a signed CDN URL.
+
+    httpx does not follow redirects by default, so raise_for_status() saw the
+    302 as an error and the download aborted before writing a byte.
+    """
+
+    monkeypatch.setattr(md, "user_models_dir", lambda: tmp_path)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        seen.append(url)
+        if url.startswith(_CDN_HOST):
+            return httpx.Response(200, content=b"weights")
+        return httpx.Response(302, headers={"location": f"{_CDN_HOST}model_quantized.onnx"})
+
+    _patch_transport(monkeypatch, httpx.MockTransport(handler))
+
+    path = await md.download_embedding_model("google/embeddinggemma-300m")
+
+    assert any(url.startswith(_CDN_HOST) for url in seen), "redirect was not followed"
+    assert (path / "model_quantized.onnx").read_bytes() == b"weights"
+
+
+@pytest.mark.asyncio
 async def test_download_unknown_model_raises() -> None:
     with pytest.raises(ValueError):
         await md.download_embedding_model("nope/none")
@@ -96,14 +139,7 @@ async def test_download_unknown_model_raises() -> None:
 async def test_download_reports_progress(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(md, "user_models_dir", lambda: tmp_path)
     fetched: list[str] = []
-    real_async_client = httpx.AsyncClient
-    transport = _mock_transport(fetched)
-
-    def patched_async_client(*args, **kwargs):
-        kwargs["transport"] = transport
-        return real_async_client(*args, **kwargs)
-
-    monkeypatch.setattr(md.httpx, "AsyncClient", patched_async_client)
+    _patch_transport(monkeypatch, _mock_transport(fetched))
 
     progress_calls: list[tuple[str, int, int | None]] = []
 


### PR DESCRIPTION
## Problem
`agentos memory embedding-download` crashed with `httpx.HTTPStatusError: Redirect response '302 Found'` before downloading any data. Reported traceback pointed at `model_download.py` -> `response.raise_for_status()`.

## Root cause
`httpx.AsyncClient` does not follow redirects by default. Hugging Face serves every `resolve/main/<file>` URL as a `302` to a signed Xet CDN URL (`cas-bridge.xethub.hf.co`), so `raise_for_status()` saw the redirect as an error status. This affected all 6 files in the manifest — the command had never worked against the live HF API.

## Fix
`follow_redirects=True` on the downloader's client.

This repo has two other httpx clients that intentionally set `follow_redirects=False` (`tools/builtin/web_fetch.py`, `tools/builtin/media.py`) because they fetch **user-supplied** URLs, where auto-following is an SSRF vector. The downloader is the opposite case: its URLs come from a hardcoded `ModelManifest`, never from user input, and following redirects is what `huggingface_hub` does natively. A comment at the call site records this so the line isn't "hardened" back by pattern-matching the other two.

## Tests
The existing tests passed against the broken code — their mock transport returned `200` unconditionally and never exercised a redirect. The mock now mirrors HF's real 302→CDN behaviour, and `test_download_follows_hf_cdn_redirect` covers the exact reported failure. Confirmed the tests fail before the fix (reproducing the user's exact traceback) and pass after.

## Verification
- `pytest tests/test_memory_model_download.py` — 7 passed
- ruff + mypy clean
- **Real download**: `agentos memory embedding-download` fetched all 6 files (326 MB), no leftover `.part` files
- **Weights are valid**: the downloaded model loads and produces real 768-dim embeddings
- Full suite: 5732 passed. The 2 failures (`test_artifacts.py`, `test_ci/test_migrations_packaged.py`) are pre-existing on main and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)