### PR TITLE
chore(release): bump version to 2026.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.17] - 2026-07-17
+
+### Added
+
+- Curated memory stores, embedding refresh, and a pluggable memory
+  provider layer (mem0). (#17)
+- Restored the missing v4_phase3 local ML router bundle so the default
+  router runs on-device instead of pinning to a single class, and
+  corrected its attribution to OpenSquilla upstream. (#19)
+
+### Changed
+
+- Redesigned the Web UI chat transcript. (#15)
+
+### Fixed
+
+- `agentos memory embedding-download` now follows Hugging Face's CDN
+  redirects. Every `resolve/main/...` URL answers with a 302 to a signed
+  Xet CDN URL, but `httpx` does not follow redirects by default, so the
+  download aborted with an `HTTPStatusError` before writing any data and
+  the command never worked against the live API. (#20)
+
 ## [2026.7.15.post1] - 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.15.post1 is the current release. The project website is
+AgentOS 2026.7.17 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.15.post1"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.17"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.15.post1/use_agent_os-2026.7.15.post1-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.17/use_agent_os-2026.7.17-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.15.post1-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.17-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.17 | v2026.7.17 | 2026-07-17 | Memory provider layer (mem0) + curated stores; v4_phase3 router bundle restored; Web UI transcript redesign; embedding-download redirect fix |
 | 2026.7.15.post1 | v2026.7.15.post1 | 2026-07-15 | Partner-catalog skills system + Robinhood RWA address lookup skill (Bankr hub) |
 | 2026.7.15 | v2026.7.15 | 2026-07-15 | Relicense to Apache-2.0 with `NOTICE` + OpenSquilla attribution; wheels ship license files |
 | 2026.7.14.post1 | v2026.7.14.post1 | 2026-07-14 | PyPI distribution rename to `use-agent-os`; first PyPI release |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.15.post1'
+$defaultVersion = 'v2026.7.17'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.15.post1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.17. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.15.post1"
+default_version="v2026.7.17"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.15.post1|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.17|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.15.post1
+  AGENTOS_VERSION=v2026.7.17
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=matrix
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.15.post1." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.17." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.15.post1"
+version = "2026.7.17"
 description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.15.post1"
+CURRENT_RELEASE_TAG = "v2026.7.17"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.15.post1"
+CURRENT_VERSION = "2026.7.17"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3270,7 +3270,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.15.post1"
+version = "2026.7.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
Bumps `2026.7.15.post1` → `2026.7.17` (CalVer `YYYY.M.D`, today's date) ahead of the `v2026.7.17` release.

## Version choice
The requested version was `2026.05.17`, but PEP 440 normalizes that to `2026.5.17`, which sorts **below** the current `2026.7.15.post1` — a downgrade that would never become latest on PyPI and would permanently burn the version number. `RELEASES.md` documents the no-zero-padding rule for exactly this reason. Bumping to `2026.7.17` (today) instead, confirmed as a true upgrade.

## Changed
- `pyproject.toml` + `uv.lock` → `2026.7.17`
- `install.sh` / `install.ps1` default version → `v2026.7.17`
- `README.md` version + pinned wheel URLs
- `RELEASES.md` new row
- `CHANGELOG.md` new `[2026.7.17]` section (the `[Unreleased]` section was empty despite four landed commits), `[Unreleased]` reopened
- Release-consistency test pins (`tests/test_release_consistency.py`, `tests/test_install_scripts.py`)

## Included since 2026.7.15.post1
- Memory: curated stores, embedding refresh, pluggable provider layer (mem0) (#17)
- Router: restored v4_phase3 ML bundle + attribution fix (#19)
- Web UI: chat transcript redesign (#15)
- Memory: embedding-download HF CDN redirect fix (#20)

## Verification
- `tests/test_release_consistency.py` + `tests/test_install_scripts.py` — 18 passed
- Built wheel is `use_agent_os-2026.7.17-py3-none-any.whl`, matching tag `v2026.7.17` (this is what the release smoke check validates)
- Full suite: 5732 passed. The 2 failures (`test_artifacts.py`, `test_ci/test_migrations_packaged.py`) are pre-existing on main and environmental — the latter is `ensurepip` aborting with SIGABRT while bootstrapping a temp venv locally, before the wheel is ever exercised.

Generated with [Claude Code](https://claude.com/claude-code)