### PR TITLE
fix(release): allow router bundle PROVENANCE.md in the release wheel

### DIFF
--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -34,6 +34,7 @@ LFS_POINTER_LINE = "version https://git-lfs.github.com/spec/v1"
 RELEASE_NOTICE_RELS = ("LICENSE", "THIRD_PARTY_NOTICES.md")
 WHEEL_EMBEDDING_PREFIX = "agentos/memory/models"
 TOKENJUICE_PROVENANCE_WHEEL_PATH = "agentos/plugins/tokenjuice/PROVENANCE.md"
+ROUTER_MODEL_WHEEL_PREFIX = "agentos/agentos_router/models/"
 ALLOWED_SKILL_REFERENCE_WHEEL_PATHS = frozenset(
     {
         "agentos/skills/bundled/pptx/references/pptxgenjs.md",
@@ -223,6 +224,11 @@ def _is_allowed_runtime_markdown(path: str) -> bool:
     if name in ALLOWED_SKILL_REFERENCE_WHEEL_PATHS:
         return True
     if name.startswith("agentos/skills/bundled/") and name.endswith("/SKILL.md"):
+        return True
+    # Router model bundles ship their PROVENANCE.md: the weights are derived
+    # from OpenSquilla (Apache-2.0), so their attribution must travel with them
+    # in the wheel rather than stay behind in the repo.
+    if name.startswith(ROUTER_MODEL_WHEEL_PREFIX) and name.endswith("/PROVENANCE.md"):
         return True
     return name.startswith("agentos/identity/templates/bootstrap/") and name.endswith(".md")
 

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -166,6 +166,46 @@ def test_release_wheel_allows_tokenjuice_provenance_markdown() -> None:
     assert unrelated_skill_reference in violations
 
 
+def test_release_wheel_allows_router_bundle_provenance_markdown() -> None:
+    module = load_script()
+    bundle_provenance = (
+        "agentos/agentos_router/models/v4.2_phase3_inference/PROVENANCE.md"
+    )
+    other_bundle_doc = (
+        "agentos/agentos_router/models/v4.2_phase3_inference/NOTES.md"
+    )
+
+    violations = module.forbidden_release_wheel_entries(
+        (bundle_provenance, other_bundle_doc)
+    )
+
+    # The weights are OpenSquilla-derived (Apache-2.0), so their attribution
+    # ships with them; unrelated bundle markdown stays forbidden.
+    assert bundle_provenance not in violations
+    assert other_bundle_doc in violations
+
+
+def test_real_router_bundle_markdown_passes_release_guard() -> None:
+    """Guard the real bundle tree, not just synthetic names.
+
+    The wheel-path guard otherwise only runs against a built wheel during the
+    tagged release job, so a new .md dropped into the bundle passes PR CI and
+    only fails after the tag is pushed.
+    """
+
+    module = load_script()
+    models_root = REPO_ROOT / "src" / "agentos" / "agentos_router" / "models"
+    if not models_root.is_dir():
+        pytest.skip("router model bundle not present in this checkout")
+
+    wheel_names = tuple(
+        f"agentos/agentos_router/models/{path.relative_to(models_root).as_posix()}"
+        for path in sorted(models_root.rglob("*.md"))
+    )
+
+    assert module.forbidden_release_wheel_entries(wheel_names) == []
+
+
 def test_release_wheel_allows_dist_info_license_files() -> None:
     module = load_script()
     license_md = "use_agent_os-2026.7.15.dist-info/licenses/THIRD_PARTY_NOTICES.md"


### PR DESCRIPTION
## Problem
The `v2026.7.17` release failed. The Windows Release Assets job errored:

```
Built wheel contains forbidden release entries:
  agentos/agentos_router/models/v4.2_phase3_inference/PROVENANCE.md
```

PyPI never published — its publish job was still waiting on the `pypi` environment gate and has been cancelled, so `2026.7.17` is not burned and remains the release number.

## Root cause
`forbidden_release_wheel_entries` treats **every** `.md` in the wheel as forbidden unless allowlisted (`build_wheelhouse_zip.py`). Restoring the v4_phase3 router bundle (#19) added a `PROVENANCE.md` inside the bundle, which nothing allowlisted. Not caused by the version bump (#21).

## Fix
Allowlist `PROVENANCE.md` under `agentos/agentos_router/models/`, mirroring the existing `TOKENJUICE_PROVENANCE_WHEEL_PATH` exception.

Allowing it — rather than dropping the file from the wheel — is deliberate: the router weights are OpenSquilla-derived (Apache-2.0), so their attribution must travel with them. Shipping the weights without their provenance doc would undo the attribution work in #19. Unrelated bundle markdown (e.g. `NOTES.md`) stays forbidden.

## Why PR CI missed it
The guard only ran against a **real built wheel** in the tagged release job; the unit tests only fed it synthetic filenames. So #19 merged green and this only surfaced after the tag was pushed. `test_real_router_bundle_markdown_passes_release_guard` now runs the guard over the actual bundle tree, closing that gap at PR time.

## Verification
- Both new tests fail without the fix and pass with it (so they genuinely cover the regression)
- `tests/test_scripts/` + release/install suites: 77 passed
- **Real wheel**: rebuilt `use_agent_os-2026.7.17-py3-none-any.whl` and ran the exact release guard against it — no forbidden entries, no text-marker hits
- All 30 bundle files still ship, `PROVENANCE.md` included

Generated with [Claude Code](https://claude.com/claude-code)