### PR TITLE
fix(tools): resolve session_status from tool context, bump 2026.7.17.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.17.post1] - 2026-07-17
+
+### Fixed
+
+- The `session_status` tool no longer fails on every call in a running
+  gateway. It called `SessionManager.get_current_session()`, a method that
+  exists only on test fakes and never on the production `SessionManager`, so
+  the attribute access raised `AttributeError` and surfaced as
+  `ToolError: Session manager not available`. It now resolves the calling
+  session from the tool context — the same source the surrounding session
+  tools already prefer — and loads it via `SessionManager.get_session()`.
+
 ## [2026.7.17] - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.17 is the current release. The project website is
+AgentOS 2026.7.17.post1 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.17"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.17.post1"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.17/use_agent_os-2026.7.17-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.17.post1/use_agent_os-2026.7.17.post1-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.17-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.17.post1-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.17.post1 | v2026.7.17.post1 | 2026-07-17 | `session_status` tool fix: resolve the calling session from the tool context instead of a `SessionManager` method that never existed |
 | 2026.7.17 | v2026.7.17 | 2026-07-17 | Memory provider layer (mem0) + curated stores; v4_phase3 router bundle restored; Web UI transcript redesign; embedding-download redirect fix |
 | 2026.7.15.post1 | v2026.7.15.post1 | 2026-07-15 | Partner-catalog skills system + Robinhood RWA address lookup skill (Bankr hub) |
 | 2026.7.15 | v2026.7.15 | 2026-07-15 | Relicense to Apache-2.0 with `NOTICE` + OpenSquilla attribution; wheels ship license files |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.17'
+$defaultVersion = 'v2026.7.17.post1'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.17. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.17.post1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.17"
+default_version="v2026.7.17.post1"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.17|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.17.post1|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.17
+  AGENTOS_VERSION=v2026.7.17.post1
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=matrix
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.17." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.17.post1." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.17"
+version = "2026.7.17.post1"
 description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/src/agentos/tools/builtin/sessions.py
+++ b/src/agentos/tools/builtin/sessions.py
@@ -751,7 +751,13 @@ async def sessions_yield(
 async def session_status() -> str:
     try:
         mgr = _get_session_manager()
-        current = await mgr.get_current_session()
+        # The gateway serves many concurrent sessions, so there is no global
+        # "current" one — the calling session is the ContextVar's.
+        ctx = current_tool_context.get()
+        session_key = ctx.session_key if ctx is not None else None
+        if not session_key:
+            raise ToolError("No active session")
+        current = await mgr.get_session(session_key)
         if current is None:
             raise ToolError("No active session")
         # Convert session object to dict

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.17"
+CURRENT_RELEASE_TAG = "v2026.7.17.post1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.17"
+CURRENT_VERSION = "2026.7.17.post1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/tests/test_tools/test_sessions_status_regression.py
+++ b/tests/test_tools/test_sessions_status_regression.py
@@ -1,0 +1,131 @@
+"""Regression tests for session_status against the real SessionManager surface.
+
+session_status used to call ``mgr.get_current_session()``, a method that exists
+only on test fakes — the production SessionManager
+(``agentos.session.manager.SessionManager``) has never defined it. In a live
+gateway the attribute access raised AttributeError, which session_status
+converted into a hard ToolError, so the tool failed 100% of the time.
+
+The fakes here deliberately expose ONLY the production method surface
+(``get_session``), so a reintroduction of the ``get_current_session()`` call
+fails these tests instead of passing against a fake that flatters it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from agentos.tools.builtin import sessions as sessions_tool
+from agentos.tools.types import ToolContext, ToolError, current_tool_context
+
+
+@dataclass
+class _StubSession:
+    session_key: str = "agent:main:webchat:abc123"
+    session_id: str = "sess-1"
+    status: str = "running"
+    model: str = "claude-opus-4-8"
+    model_provider: str = "anthropic"
+    input_tokens: int = 120
+    output_tokens: int = 30
+    estimated_cost_usd: float = 0.42
+    cache_read: int = 7
+    cache_write: int = 3
+    compaction_count: int = 1
+    context_tokens: int = 900
+    spawn_depth: int = 0
+    started_at: int = 1_700_000_000_000
+    runtime_ms: int = 5_000
+
+
+class _ProductionSurfaceManager:
+    """Mirrors the real SessionManager: get_session, no get_current_session."""
+
+    def __init__(self, sessions: dict[str, _StubSession]) -> None:
+        self._sessions = sessions
+        self.requested_keys: list[str] = []
+
+    async def get_session(self, session_key: str) -> _StubSession | None:
+        self.requested_keys.append(session_key)
+        return self._sessions.get(session_key)
+
+
+@pytest.fixture
+def _restore_manager():
+    original = sessions_tool._session_manager
+    yield
+    sessions_tool.set_session_manager(original)
+
+
+def _set_ctx(session_key: str | None) -> object:
+    return current_tool_context.set(ToolContext(session_key=session_key))
+
+
+@pytest.mark.asyncio
+async def test_session_status_works_without_get_current_session(_restore_manager):
+    """The bug: this raised ToolError because the real mgr lacks the method."""
+    session = _StubSession()
+    mgr = _ProductionSurfaceManager({session.session_key: session})
+    sessions_tool.set_session_manager(mgr)
+    token = _set_ctx(session.session_key)
+    try:
+        raw = await sessions_tool.session_status()
+    finally:
+        current_tool_context.reset(token)
+
+    data = json.loads(raw)
+    assert data["session_key"] == session.session_key
+    assert data["session_id"] == "sess-1"
+    assert data["model"] == "claude-opus-4-8"
+    assert data["model_provider"] == "anthropic"
+    assert data["input_tokens"] == 120
+    assert data["output_tokens"] == 30
+    assert data["total_tokens"] == 150
+    assert data["estimated_cost_usd"] == 0.42
+    assert data["compaction_count"] == 1
+    assert data["spawn_depth"] == 0
+    # Resolution must go through the ContextVar session_key, not a global.
+    assert mgr.requested_keys == [session.session_key]
+
+
+@pytest.mark.asyncio
+async def test_session_status_resolves_the_calling_sessions_key(_restore_manager):
+    """With several live sessions, it must report the caller's, not an arbitrary one."""
+    mine = _StubSession(session_key="agent:main:webchat:mine", session_id="sess-mine")
+    other = _StubSession(session_key="agent:main:webchat:other", session_id="sess-other")
+    mgr = _ProductionSurfaceManager({mine.session_key: mine, other.session_key: other})
+    sessions_tool.set_session_manager(mgr)
+    token = _set_ctx(mine.session_key)
+    try:
+        data = json.loads(await sessions_tool.session_status())
+    finally:
+        current_tool_context.reset(token)
+
+    assert data["session_id"] == "sess-mine"
+
+
+@pytest.mark.asyncio
+async def test_session_status_reports_no_active_session_without_ctx(_restore_manager):
+    sessions_tool.set_session_manager(_ProductionSurfaceManager({}))
+    token = _set_ctx(None)
+    try:
+        with pytest.raises(ToolError, match="No active session"):
+            await sessions_tool.session_status()
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_session_status_reports_no_active_session_when_key_is_unknown(
+    _restore_manager,
+):
+    sessions_tool.set_session_manager(_ProductionSurfaceManager({}))
+    token = _set_ctx("agent:main:webchat:vanished")
+    try:
+        with pytest.raises(ToolError, match="No active session"):
+            await sessions_tool.session_status()
+    finally:
+        current_tool_context.reset(token)

--- a/uv.lock
+++ b/uv.lock
@@ -3270,7 +3270,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.17"
+version = "2026.7.17.post1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## The bug

`session_status` failed on **every call** in a running gateway:

```
dispatch.tool_failed agent_id=main error_class=ToolError retry_allowed=False tool=gateway
ToolError: Session manager not available: 'SessionManager' object has no attribute 'get_current_session'
```

`session_status` called `await mgr.get_current_session()`. That method **exists only on
test fakes** — the production `SessionManager` (`src/agentos/session/manager.py`) has
never defined it, and there is no `__getattr__` fallback. `gateway/boot.py` injects the
real class, so the attribute access raised `AttributeError`, which the function's
`except (ImportError, AttributeError, NotImplementedError)` converted into a hard
`ToolError`.

**Why only this tool broke.** There are 5 `get_current_session()` call sites in `src/`.
The other 4 (`agents.py:45`, `sessions.py:346`, `sessions.py:384`, `sessions.py:663`)
already wrap the call in `except (AttributeError, NotImplementedError): pass` and fall
back to the `current_tool_context` ContextVar. `session_status` was the only site with
no fallback.

**Why CI missed it.** Every fake session manager in the test suite defines
`get_current_session`, so the tests exercised a method production never had.

## The fix

Resolve the calling session from `current_tool_context` and load it via
`SessionManager.get_session()`. A gateway serves many concurrent sessions, so there is
no meaningful global "current" session — the ContextVar is the source of truth, which is
exactly why the four other call sites already prefer it. `get_current_session()` was
deliberately **not** added to `SessionManager`, since that would bake in an ambiguous
global-current-session concept.

## Test

New `tests/test_tools/test_sessions_status_regression.py` uses a fake exposing **only**
the production method surface (`get_session`, no `get_current_session`), so
reintroducing the call fails at PR time instead of in a live gateway. All 4 tests fail
before the fix with the exact production error and pass after.

Verified end-to-end against a real `SessionStorage` + real `SessionManager`, mirroring
gateway boot: `session_status()` returns real usage/cost/model JSON, and the old call
still raises `AttributeError` on the real class.

## Release

Bumps `2026.7.17` → `2026.7.17.post1` across pyproject, uv.lock, installers, README,
RELEASES.md, and the release-consistency pins. Both installers already accept `.post1`
(`(\.post[0-9]+)?`), and `2026.7.15.post1` is precedent. The built wheel is
`use_agent_os-2026.7.17.post1-py3-none-any.whl`, matching tag `v2026.7.17.post1` — built
and inspected locally, and the router-bundle `PROVENANCE.md` release guard passes against
the real wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
