### PR TITLE
feat(gateway): harden against browser-originated attacks on loopback binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Browser-threat hardening for the gateway (#24). A loopback bind is not a
+  boundary against a page in the operator's browser, so four fail-closed
+  guards were added: a startup guard that refuses `auth.mode="none"` on a
+  non-loopback bind (opt out with `auth.allow_unauthenticated_public=true`),
+  WebSocket-handshake Origin validation (CSWSH), a `Host`-header allowlist
+  (DNS rebinding), and an HTTP cross-origin guard on `/api/*`. Runtime
+  `config.apply`/`config.patch` of `host` or `auth.mode` now reports
+  `restartRequired: true`, since a host change does not rebind the live
+  socket.
+
+### Changed
+
+- **BREAKING (opt-in deployments only):** the gateway now refuses to start
+  when `auth.mode="none"` is combined with a non-loopback bind
+  (`0.0.0.0`, a LAN IP, ...). If you deliberately run an unauthenticated
+  gateway behind a reverse proxy / VPN / firewall, set
+  `auth.allow_unauthenticated_public = true` (or
+  `AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC=true`). Default loopback
+  deployments are unaffected. (#24)
+- **BREAKING (opt-in deployments only):** `auth.mode="trusted-proxy"` no
+  longer satisfies the public-bind guard. It only string-matched the
+  client-suppliable `X-Forwarded-For` header (spoofable) and has no
+  end-to-end resolver, so it did not actually authenticate. Use
+  `auth.mode="token"` on public binds until real peer-IP validation ships.
+  (#24)
+- Reaching a loopback gateway through a custom hostname (e.g. an
+  `/etc/hosts` alias to `127.0.0.1`) or a reverse-proxied Control UI now
+  requires adding that origin to `control_ui.allowed_origins`; otherwise the
+  `Host`/Origin guards reject it. The rejection message names the config key.
+  (#24)
+
 ## [2026.7.17.post1] - 2026-07-17
 
 ### Fixed

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -341,6 +341,20 @@ default_mode = "bypass"                 # off | on | bypass | full
 # [auth]
 # mode = "none"         # none | token | password
 # token = ""
+# Startup guard: with mode = "none" the gateway refuses to bind a non-loopback
+# host (0.0.0.0, a LAN IP, ...). Enable auth, keep the loopback bind, or — only
+# behind an external auth layer (reverse proxy auth, VPN, firewall) — opt in:
+# allow_unauthenticated_public = false
+
+# [control_ui]
+# On a loopback bind the WebSocket handshake, cross-origin HTTP requests, and
+# the HTTP Host header are pinned to loopback origins to block cross-site
+# WebSocket hijacking, drive-by API calls, and DNS rebinding from a page in
+# the operator's browser. When serving the Control UI through a reverse proxy
+# on another host, add that browser origin here (scheme + host [+ port];
+# default ports 80/443 are normalized, so "https://agent.example.com" and
+# "https://agent.example.com:443" are equivalent):
+# allowed_origins = ["https://agent.example.com"]
 
 # [channels]
 # [[channels.channels]]

--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -77,9 +77,13 @@ def run_gateway(
             "[yellow]WARNING: gateway is bound to a wildcard address - "
             "reachable from every interface.[/yellow]"
         )
-        if config.auth.mode == "none":
+        if config.auth.mode == "none" and config.auth.allow_unauthenticated_public:
+            # Without the opt-in, start_gateway_server refuses this combination
+            # outright (enforce_public_bind_auth_guard) — no point warning that
+            # the network is open right before the refusal explains itself.
             console.print(
-                "[yellow]  auth.mode=none + wildcard bind = LAN-open. "
+                "[yellow]  auth.mode=none + wildcard bind + "
+                "allow_unauthenticated_public = LAN-open. "
                 "Anyone reachable on this network can use the chat, sessions, "
                 "and config surfaces with your provider credentials.[/yellow]"
             )

--- a/src/agentos/gateway/app.py
+++ b/src/agentos/gateway/app.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import time
 from typing import Any
+from urllib.parse import urlsplit
 
+import structlog
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -20,6 +22,8 @@ from agentos.gateway.control_ui import create_control_ui_routes
 from agentos.gateway.middleware import (
     AuthMiddleware,
     ErrorHandlingMiddleware,
+    LoopbackHostMiddleware,
+    LoopbackOriginMiddleware,
     RateLimitMiddleware,
     SecurityHeadersMiddleware,
 )
@@ -27,6 +31,52 @@ from agentos.gateway.rpc import RpcContext, get_dispatcher
 from agentos.gateway.websocket import handle_ws_connection
 
 _start_time = time.time()
+
+log = structlog.get_logger(__name__)
+
+
+def resolve_trusted_hosts(config: GatewayConfig) -> list[str]:
+    """Return the ``LoopbackHostMiddleware`` allowlist for the current bind.
+
+    On a loopback bind the middleware itself admits every literal loopback
+    ``Host`` via the shared ``scopes.is_loopback_address`` predicate — the
+    same one the startup guard and the WS-origin guard use, so any bind the
+    gateway blesses as loopback (all of ``127.0.0.0/8``, ``::1``,
+    ``localhost``, IPv4-mapped forms) is reachable at its own address. This
+    list only carries the extra hostnames from ``control_ui.allowed_origins``
+    (a reverse-proxied UI on another name). A DNS-rebinding page can use none
+    of them: its request carries the attacker's foreign hostname in ``Host``
+    (CVE-2026-53869 class).
+
+    On a non-loopback bind the gateway only starts past
+    ``enforce_public_bind_auth_guard`` — auth is enabled or the operator
+    explicitly opted in — and the operator deliberately serves other names,
+    so we do not constrain ``Host`` (``["*"]``).
+    """
+    from agentos.gateway.scopes import is_loopback_bind
+
+    if not is_loopback_bind(config.host):
+        return ["*"]
+
+    hosts: list[str] = []
+    for origin in config.control_ui.allowed_origins:
+        try:
+            hostname = urlsplit(origin).hostname
+        except ValueError:
+            hostname = None
+        if not hostname:
+            # A dead entry would silently match nothing here AND in the
+            # WS-origin guard — tell the operator at startup instead.
+            log.warning(
+                "gateway.allowed_origin_unparseable",
+                origin=origin,
+                hint="control_ui.allowed_origins entries must be full origins: "
+                "scheme://host[:port], e.g. https://agent.example.com",
+            )
+            continue
+        if hostname not in hosts:
+            hosts.append(hostname)
+    return hosts
 
 
 def create_gateway_app(
@@ -492,6 +542,14 @@ def create_gateway_app(
 
     middleware = [
         Middleware(ErrorHandlingMiddleware),
+        # DNS-rebinding guard: reject foreign Host headers on a loopback bind
+        # (no-op ["*"] on a public bind, which is already auth-gated).
+        Middleware(LoopbackHostMiddleware, allowed_hosts=resolve_trusted_hosts(config)),
+        # Cross-site browser guard for the HTTP surface: reject foreign page
+        # Origins before CORS can reflect them (same predicate as the WS
+        # handshake guard). No-op without an Origin header, and on
+        # non-loopback (auth-gated) binds.
+        Middleware(LoopbackOriginMiddleware, config=config),
         Middleware(
             CORSMiddleware,
             allow_origins=config.cors.allowed_origins,

--- a/src/agentos/gateway/app.py
+++ b/src/agentos/gateway/app.py
@@ -481,6 +481,13 @@ def create_gateway_app(
             status_code=_rpc_status_code(result),
         )
 
+    # Capture the bind posture once, at app-build time. config.apply mutates
+    # config.host in place without rebinding the live socket, so the guards
+    # must not re-read it per request (P2).
+    from agentos.gateway.scopes import is_loopback_bind
+
+    bind_is_loopback = is_loopback_bind(config.host)
+
     async def ws_endpoint(ws: WebSocket) -> None:
         await handle_ws_connection(
             ws,
@@ -504,6 +511,7 @@ def create_gateway_app(
             memory_managers=memory_managers,
             memory_stores=memory_stores,
             memory_retrievers=memory_retrievers,
+            bind_is_loopback=bind_is_loopback,
         )
 
     # ── Routes ───────────────────────────────────────────────────────────────
@@ -549,7 +557,11 @@ def create_gateway_app(
         # Origins before CORS can reflect them (same predicate as the WS
         # handshake guard). No-op without an Origin header, and on
         # non-loopback (auth-gated) binds.
-        Middleware(LoopbackOriginMiddleware, config=config),
+        Middleware(
+            LoopbackOriginMiddleware,
+            config=config,
+            bind_is_loopback=bind_is_loopback,
+        ),
         Middleware(
             CORSMiddleware,
             allow_origins=config.cors.allowed_origins,

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -36,7 +36,11 @@ from agentos.agents.scope import resolve_agent_model, resolve_agent_workspace_di
 from agentos.asyncio_utils import create_background_task
 from agentos.engine.usage import UsageTracker as _UsageTracker
 from agentos.gateway.app import create_gateway_app
-from agentos.gateway.config import GatewayConfig, is_public_bind
+from agentos.gateway.config import (
+    GatewayConfig,
+    enforce_public_bind_auth_guard,
+    is_public_bind,
+)
 from agentos.gateway.llm_runtime import resolve_llm_runtime_config
 from agentos.gateway.rpc import get_dispatcher
 from agentos.gateway.session_events import build_sessions_changed_payload
@@ -2016,6 +2020,11 @@ async def start_gateway_server(
     # Apply runtime port override
     if port is not None:
         config = config.model_copy(update={"port": port})
+
+    # Fail closed on auth.mode="none" + non-loopback bind (issue #18, V3).
+    # Runs before any side effect (file logging, PID lock, services) so a
+    # refused start leaves no partial state.
+    enforce_public_bind_auth_guard(config)
 
     _setup_file_logging(config)
     if config.config_path:

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -2023,18 +2023,18 @@ def is_public_bind(host: str) -> bool:
 def _mode_protects_public_bind(auth: AuthConfig) -> bool:
     """True if ``auth.mode`` actually enforces credentials end-to-end.
 
-    Only these count as "authenticated" for the public-bind guard:
-    ``token`` (validated in AuthMiddleware and resolve_auth), and
-    ``trusted-proxy`` *when a proxy is configured* (AuthMiddleware checks
-    ``x-forwarded-for`` against it). ``password`` has no HTTP-surface
-    enforcement yet, and an unknown/typo mode has no resolver — both must be
-    treated as unauthenticated so they cannot open a public port.
+    Only ``token`` qualifies today — it is validated in ``AuthMiddleware`` and
+    has a resolver in ``resolve_auth``. Every other mode is treated as
+    unauthenticated for the public-bind guard:
+
+    * ``password`` has no HTTP-surface enforcement yet.
+    * ``trusted-proxy`` only string-matches the client-supplied
+      ``X-Forwarded-For`` header (trivially spoofable) and has no resolver in
+      ``resolve_auth``, so it is not enforced end-to-end. Re-admit it here
+      only once it validates the real transport peer IP and ships a resolver.
+    * an unknown/typo mode has no resolver at all.
     """
-    if auth.mode == "token":
-        return True
-    if auth.mode == "trusted-proxy" and auth.trusted_proxy:
-        return True
-    return False
+    return auth.mode == "token"
 
 
 def enforce_public_bind_auth_guard(config: GatewayConfig) -> None:
@@ -2080,8 +2080,7 @@ def enforce_public_bind_auth_guard(config: GatewayConfig) -> None:
         "Anyone who can reach this port would get full access to chat, sessions, "
         "and config with your provider credentials. Fix one of these: "
         '(1) enable enforced auth — set auth.mode="token" in agentos.toml '
-        "(a token is auto-generated at startup when unset), or "
-        'auth.mode="trusted-proxy" with auth.trusted_proxy set; '
+        "(a token is auto-generated at startup when unset); "
         '(2) bind loopback — remove the --listen/--bind flag or set host = "127.0.0.1"; '
         "(3) explicit break-glass opt-in — set auth.allow_unauthenticated_public = true "
         "(or AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC=true) only if an external "

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -60,6 +60,15 @@ class AuthConfig(BaseSettings):
     trusted_proxy: str | None = None
     token_scopes: list[str] = Field(default_factory=lambda: ["operator.admin"])
     allowed_roles: list[str] = Field(default_factory=lambda: ["operator", "node"])
+    allow_unauthenticated_public: bool = False
+    """Break-glass opt-in: serve with ``mode="none"`` on a non-loopback bind.
+
+    Off by default — ``enforce_public_bind_auth_guard`` refuses that
+    combination at startup because it hands the chat/sessions/config
+    surfaces (and the operator's provider credentials) to anyone who can
+    reach the port. Only set this behind an external auth layer or a
+    network boundary you trust (reverse proxy auth, VPN, firewall).
+    """
 
 
 class CorsConfig(BaseSettings):
@@ -2009,6 +2018,49 @@ PUBLIC_BIND_ADDRESSES: frozenset[str] = frozenset({"0.0.0.0", "::"})
 def is_public_bind(host: str) -> bool:
     """Return True if ``host`` resolves to an IPv4/IPv6 wildcard."""
     return host in PUBLIC_BIND_ADDRESSES
+
+
+def enforce_public_bind_auth_guard(config: GatewayConfig) -> None:
+    """Refuse to serve when ``auth.mode="none"`` on a non-loopback bind.
+
+    "No auth by default" is only safe while the gateway stays on loopback,
+    where ownership checks already require a loopback peer. On a wildcard
+    or LAN bind it hands the chat/sessions/config surfaces to anyone who
+    can reach the port, so startup fails closed unless the operator sets
+    ``auth.allow_unauthenticated_public = true`` (issue #18, V3).
+
+    Uses the same loopback predicate as the ownership check
+    (``scopes.is_loopback_bind``) so the set of binds the guard allows is
+    exactly the set ownership treats as local. Raises ``ValueError`` — the
+    CLI boundary surfaces that as a startup error with recovery guidance.
+    """
+    from agentos.gateway.scopes import is_loopback_bind
+
+    if config.auth.mode != "none":
+        return
+    if is_loopback_bind(config.host):
+        return
+    if config.auth.allow_unauthenticated_public:
+        import structlog
+
+        structlog.get_logger(__name__).warning(
+            "gateway.unauthenticated_public_bind_opt_in",
+            host=config.host,
+            hint="auth.allow_unauthenticated_public=true — every peer that "
+            "can reach this port has full operator access",
+        )
+        return
+    raise ValueError(
+        f'Refusing to serve: auth.mode="none" with non-loopback bind {config.host!r}. '
+        "Anyone who can reach this port would get full access to chat, sessions, "
+        "and config with your provider credentials. Fix one of these: "
+        '(1) enable auth — set auth.mode="token" or "password" in agentos.toml '
+        "(a token is auto-generated at startup when unset); "
+        '(2) bind loopback — remove the --listen/--bind flag or set host = "127.0.0.1"; '
+        "(3) explicit break-glass opt-in — set auth.allow_unauthenticated_public = true "
+        "(or AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC=true) only if an external "
+        "layer (reverse proxy auth, VPN, firewall) already protects this port."
+    )
 
 
 def resolve_listen_address(

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -2020,6 +2020,23 @@ def is_public_bind(host: str) -> bool:
     return host in PUBLIC_BIND_ADDRESSES
 
 
+def _mode_protects_public_bind(auth: AuthConfig) -> bool:
+    """True if ``auth.mode`` actually enforces credentials end-to-end.
+
+    Only these count as "authenticated" for the public-bind guard:
+    ``token`` (validated in AuthMiddleware and resolve_auth), and
+    ``trusted-proxy`` *when a proxy is configured* (AuthMiddleware checks
+    ``x-forwarded-for`` against it). ``password`` has no HTTP-surface
+    enforcement yet, and an unknown/typo mode has no resolver — both must be
+    treated as unauthenticated so they cannot open a public port.
+    """
+    if auth.mode == "token":
+        return True
+    if auth.mode == "trusted-proxy" and auth.trusted_proxy:
+        return True
+    return False
+
+
 def enforce_public_bind_auth_guard(config: GatewayConfig) -> None:
     """Refuse to serve when ``auth.mode="none"`` on a non-loopback bind.
 
@@ -2033,10 +2050,17 @@ def enforce_public_bind_auth_guard(config: GatewayConfig) -> None:
     (``scopes.is_loopback_bind``) so the set of binds the guard allows is
     exactly the set ownership treats as local. Raises ``ValueError`` — the
     CLI boundary surfaces that as a startup error with recovery guidance.
+
+    A mode "protects" a public bind only when it is actually enforced
+    end-to-end (HTTP + WS). Today that is ``token`` (auto-generated at
+    startup) and ``trusted-proxy`` *with a proxy configured*. Any other
+    value — ``password`` (not yet implemented on the HTTP surface),
+    ``trusted-proxy`` without a proxy, or a typo — is treated as *not*
+    authenticated, so it cannot silently open a public port.
     """
     from agentos.gateway.scopes import is_loopback_bind
 
-    if config.auth.mode != "none":
+    if _mode_protects_public_bind(config.auth):
         return
     if is_loopback_bind(config.host):
         return
@@ -2051,11 +2075,13 @@ def enforce_public_bind_auth_guard(config: GatewayConfig) -> None:
         )
         return
     raise ValueError(
-        f'Refusing to serve: auth.mode="none" with non-loopback bind {config.host!r}. '
+        f"Refusing to serve: auth.mode={config.auth.mode!r} does not enforce "
+        f"credentials on a non-loopback bind {config.host!r}. "
         "Anyone who can reach this port would get full access to chat, sessions, "
         "and config with your provider credentials. Fix one of these: "
-        '(1) enable auth — set auth.mode="token" or "password" in agentos.toml '
-        "(a token is auto-generated at startup when unset); "
+        '(1) enable enforced auth — set auth.mode="token" in agentos.toml '
+        "(a token is auto-generated at startup when unset), or "
+        'auth.mode="trusted-proxy" with auth.trusted_proxy set; '
         '(2) bind loopback — remove the --listen/--bind flag or set host = "127.0.0.1"; '
         "(3) explicit break-glass opt-in — set auth.allow_unauthenticated_public = true "
         "(or AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC=true) only if an external "

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -20,6 +20,28 @@ from agentos.gateway.scopes import is_loopback_address
 # guard (defined before AuthMiddleware) and AuthMiddleware share one source.
 _PUBLIC_PATHS = frozenset({"/health", "/healthz", "/ready", "/readyz"})
 
+# The RPC/API surface the cross-origin guard exists to protect. A UI base_path
+# that overlaps this must NOT be trusted as an exemption prefix.
+_API_PREFIX = "/api"
+
+
+def _safe_ui_exempt_prefix(base_path: str) -> str | None:
+    """Return the Control UI prefix safe to exempt from the Origin guard, or None.
+
+    The UI shell/static routes are served content, not RPC sinks, so exempting
+    them is fine — but only when the prefix is a real, non-empty path that does
+    not overlap ``/api``. ``base_path="/"`` (normalized to "") or ``"/api"``
+    would otherwise wholesale-exempt every request, disabling the guard; those
+    fail closed to None (the shell is a top-level navigation and sends no
+    Origin, so gating it costs nothing).
+    """
+    prefix = base_path.rstrip("/")
+    if not prefix:
+        return None
+    if prefix == _API_PREFIX or prefix.startswith(_API_PREFIX + "/"):
+        return None
+    return prefix
+
 
 class LoopbackHostMiddleware(BaseHTTPMiddleware):
     """Reject requests whose ``Host`` header is neither loopback nor allowlisted.
@@ -91,16 +113,29 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     RPC surface — the drive-by target — is gated.
     """
 
-    def __init__(self, app: ASGIApp, config: GatewayConfig) -> None:
+    def __init__(
+        self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool
+    ) -> None:
         super().__init__(app)
         self._config = config
         self._cors_origins = [o for o in config.cors.allowed_origins if o != "*"]
+        self._ui_prefix = _safe_ui_exempt_prefix(config.control_ui.base_path)
+        # Passed in from create_gateway_app, computed eagerly at build time.
+        # Starlette instantiates BaseHTTPMiddleware lazily (first request), so
+        # capturing here would read an already-mutated config.host; the caller
+        # captures the posture before config.apply can change it (P2).
+        self._bind_is_loopback = bind_is_loopback
+
+    def _is_ui_path(self, path: str) -> bool:
+        if self._ui_prefix is None:
+            return False
+        # Exact shell ("/control") or anything under it ("/control/..."),
+        # never a bare-prefix match that would swallow sibling routes.
+        return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         path = request.url.path
-        if path in _PUBLIC_PATHS or path.startswith(
-            self._config.control_ui.base_path
-        ):
+        if path in _PUBLIC_PATHS or self._is_ui_path(path):
             return await call_next(request)  # type: ignore[no-any-return]
         origin = request.headers.get("origin")
         if origin:
@@ -112,7 +147,9 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
             )
 
             if not (
-                is_allowed_ws_origin(origin, self._config)
+                is_allowed_ws_origin(
+                    origin, self._config, bind_is_loopback=self._bind_is_loopback
+                )
                 or origin_in_allowlist(origin, self._cors_origins)
             ):
                 return PlainTextResponse("Origin not allowed", status_code=403)

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -5,19 +5,124 @@ from __future__ import annotations
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from urllib.parse import urlsplit
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.types import ASGIApp
 
 from agentos.gateway.config import GatewayConfig
+from agentos.gateway.scopes import is_loopback_address
+
+# Endpoints that carry no credentials and expose no admin surface; exempt from
+# both token auth and the cross-origin guard. Kept module-level so the origin
+# guard (defined before AuthMiddleware) and AuthMiddleware share one source.
+_PUBLIC_PATHS = frozenset({"/health", "/healthz", "/ready", "/readyz"})
+
+
+class LoopbackHostMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose ``Host`` header is neither loopback nor allowlisted.
+
+    A drop-in replacement for Starlette's ``TrustedHostMiddleware`` that
+    parses the ``Host`` header with ``urlsplit`` so **bracketed IPv6** hosts
+    (``[::1]:18791``) compare correctly — Starlette's ``split(":")[0]``
+    mangles those and would 400 a legitimate IPv6-loopback bind.
+
+    This is the DNS-rebinding guard: when the check is active (loopback
+    binds), any literal loopback ``Host`` — the shared
+    ``scopes.is_loopback_address`` predicate, i.e. all of ``127.0.0.0/8``,
+    ``::1``, ``localhost``, IPv4-mapped forms; exactly the binds the startup
+    guard blesses — is admitted, plus the extra hostnames in
+    ``allowed_hosts``. A page that rebinds a hostname to ``127.0.0.1`` still
+    carries its foreign hostname in ``Host`` and is rejected. ``["*"]``
+    disables the check (public binds, already auth-gated).
+    """
+
+    def __init__(self, app: ASGIApp, allowed_hosts: list[str]) -> None:
+        super().__init__(app)
+        self._allow_any = "*" in allowed_hosts
+        # Normalize allowlist to bare lowercased hosts (strip scheme/port/brackets).
+        self._allowed = {self._normalize(h) for h in allowed_hosts if h != "*"}
+
+    @staticmethod
+    def _normalize(host: str) -> str:
+        value = host.strip().lower()
+        # urlsplit needs a scheme-relative authority to parse host:port / [ipv6].
+        parsed = urlsplit(f"//{value}") if "//" not in value else urlsplit(value)
+        return (parsed.hostname or value.strip("[]")).rstrip(".")
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if self._allow_any:
+            return await call_next(request)  # type: ignore[no-any-return]
+        raw_host = request.headers.get("host", "")
+        try:
+            host = self._normalize(raw_host)
+        except ValueError:
+            host = ""
+        if host in self._allowed or is_loopback_address(host):
+            return await call_next(request)  # type: ignore[no-any-return]
+        return PlainTextResponse("Invalid host header", status_code=400)
+
+
+class LoopbackOriginMiddleware(BaseHTTPMiddleware):
+    """Reject cross-site browser requests to the HTTP surface on a loopback bind.
+
+    The sibling of the WS handshake Origin guard (``is_allowed_ws_origin``),
+    covering the same browser threat over plain HTTP: with
+    ``auth.mode="none"`` a loopback peer is granted operator scopes and the
+    default CORS posture (``["*"]`` + credentials) reflects any page Origin,
+    so a malicious page in the victim's browser could otherwise ``fetch()``
+    the same admin RPC surface the WS guard protects (``/api/config``,
+    ``/api/sessions``, ``/api/chat``) and read the responses.
+
+    Requests without an ``Origin`` header (CLI, curl, browser navigations)
+    pass through untouched. A browser request carries the page origin, which
+    must be loopback or explicitly allowed — ``control_ui.allowed_origins``
+    or a non-wildcard ``cors.allowed_origins`` entry (deliberate operator
+    intent; the wildcard default is exactly the posture this guard fences).
+    On a non-loopback bind the check is a no-op, matching the WS guard: the
+    gateway only starts there with auth on or an explicit opt-in.
+
+    Public paths are exempt, mirroring ``AuthMiddleware.PUBLIC_PATHS`` and the
+    Control UI prefix: health probes carry no credentials and no admin surface,
+    and the Control UI shell is a served page (guarded by CSP /
+    ``SecurityHeadersMiddleware``), not an RPC sink. Only the ``/api/*`` and
+    RPC surface — the drive-by target — is gated.
+    """
+
+    def __init__(self, app: ASGIApp, config: GatewayConfig) -> None:
+        super().__init__(app)
+        self._config = config
+        self._cors_origins = [o for o in config.cors.allowed_origins if o != "*"]
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        path = request.url.path
+        if path in _PUBLIC_PATHS or path.startswith(
+            self._config.control_ui.base_path
+        ):
+            return await call_next(request)  # type: ignore[no-any-return]
+        origin = request.headers.get("origin")
+        if origin:
+            # Shared predicate with the WS handshake guard (one threat model,
+            # one allowlist). Local import: websocket.py pulls the RPC stack.
+            from agentos.gateway.websocket import (
+                is_allowed_ws_origin,
+                origin_in_allowlist,
+            )
+
+            if not (
+                is_allowed_ws_origin(origin, self._config)
+                or origin_in_allowlist(origin, self._cors_origins)
+            ):
+                return PlainTextResponse("Origin not allowed", status_code=403)
+        return await call_next(request)  # type: ignore[no-any-return]
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
     """Token-based auth middleware. Skips public paths."""
 
-    PUBLIC_PATHS = {"/health", "/healthz", "/ready", "/readyz"}
+    PUBLIC_PATHS = _PUBLIC_PATHS
 
     def __init__(self, app: ASGIApp, config: GatewayConfig) -> None:
         super().__init__(app)

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -84,7 +84,16 @@ class LoopbackHostMiddleware(BaseHTTPMiddleware):
             host = ""
         if host in self._allowed or is_loopback_address(host):
             return await call_next(request)  # type: ignore[no-any-return]
-        return PlainTextResponse("Invalid host header", status_code=400)
+        # A non-loopback Host on a loopback bind is usually DNS rebinding, but
+        # it can also be a legitimate user reaching the gateway via a custom
+        # hostname (e.g. an /etc/hosts alias to 127.0.0.1). Name the config key
+        # that unblocks that case instead of a bare rejection.
+        return PlainTextResponse(
+            f"Rejected Host header {host!r}: only loopback hosts are accepted on a "
+            "loopback bind (DNS-rebinding guard). If you reach this gateway via a "
+            "custom hostname, add its origin to control_ui.allowed_origins.",
+            status_code=400,
+        )
 
 
 class LoopbackOriginMiddleware(BaseHTTPMiddleware):

--- a/src/agentos/gateway/rpc_config.py
+++ b/src/agentos/gateway/rpc_config.py
@@ -216,18 +216,44 @@ def _sandbox_posture_restart_fingerprint(config: Any) -> dict[str, Any]:
     }
 
 
+def _bind_restart_fingerprint(config: Any) -> dict[str, Any]:
+    """Fingerprint the bind posture (host) and auth mode.
+
+    Neither takes full effect on a hot apply: ``host`` does not rebind the
+    live uvicorn socket, and while ``auth.mode`` is read live by
+    AuthMiddleware, the startup guard and the captured loopback posture only
+    re-evaluate on restart. Flagging these restart-required keeps the operator
+    from believing a host/auth change is fully live when it is not.
+    """
+    if config is None or not hasattr(config, "model_dump"):
+        return {}
+    data = config.model_dump(mode="python")
+    if not isinstance(data, dict):
+        return {}
+    auth = data.get("auth")
+    return {
+        "host": data.get("host"),
+        "auth_mode": auth.get("mode") if isinstance(auth, dict) else None,
+    }
+
+
 def _restart_required(
     *,
     old_memory_fingerprint: dict[str, Any],
     old_channels_fingerprint: Any,
     old_sandbox_posture_fingerprint: dict[str, Any],
     new_config: Any,
+    old_bind_fingerprint: dict[str, Any] | None = None,
 ) -> bool:
     return (
         old_memory_fingerprint != _memory_restart_fingerprint(new_config)
         or old_channels_fingerprint != _channels_restart_fingerprint(new_config)
         or old_sandbox_posture_fingerprint
         != _sandbox_posture_restart_fingerprint(new_config)
+        or (
+            old_bind_fingerprint is not None
+            and old_bind_fingerprint != _bind_restart_fingerprint(new_config)
+        )
     )
 
 
@@ -347,6 +373,7 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
     old_memory_fingerprint = _memory_restart_fingerprint(ctx.config)
     old_channels_fingerprint = _channels_restart_fingerprint(ctx.config)
     old_sandbox_posture_fingerprint = _sandbox_posture_restart_fingerprint(ctx.config)
+    old_bind_fingerprint = _bind_restart_fingerprint(ctx.config)
     cfg_dict = ctx.config.model_dump() if hasattr(ctx.config, "model_dump") else {}
     # Validate path exists
     source_value = _resolve_path(cfg_dict, path)
@@ -377,6 +404,7 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
             old_memory_fingerprint=old_memory_fingerprint,
             old_channels_fingerprint=old_channels_fingerprint,
             old_sandbox_posture_fingerprint=old_sandbox_posture_fingerprint,
+            old_bind_fingerprint=old_bind_fingerprint,
             new_config=new_config,
         )
     }
@@ -400,6 +428,7 @@ async def _handle_config_patch(params: dict | None, ctx: RpcContext) -> dict[str
     old_memory_fingerprint = _memory_restart_fingerprint(ctx.config)
     old_channels_fingerprint = _channels_restart_fingerprint(ctx.config)
     old_sandbox_posture_fingerprint = _sandbox_posture_restart_fingerprint(ctx.config)
+    old_bind_fingerprint = _bind_restart_fingerprint(ctx.config)
     cfg_dict = ctx.config.model_dump() if hasattr(ctx.config, "model_dump") else {}
     source_cfg_dict = copy.deepcopy(cfg_dict) if isinstance(cfg_dict, dict) else {}
     redacted_paths: set[str] = set()
@@ -452,6 +481,7 @@ async def _handle_config_patch(params: dict | None, ctx: RpcContext) -> dict[str
             old_memory_fingerprint=old_memory_fingerprint,
             old_channels_fingerprint=old_channels_fingerprint,
             old_sandbox_posture_fingerprint=old_sandbox_posture_fingerprint,
+            old_bind_fingerprint=old_bind_fingerprint,
             new_config=new_config,
         ),
     }
@@ -499,6 +529,7 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
     old_memory_fingerprint = _memory_restart_fingerprint(ctx.config)
     old_channels_fingerprint = _channels_restart_fingerprint(ctx.config)
     old_sandbox_posture_fingerprint = _sandbox_posture_restart_fingerprint(ctx.config)
+    old_bind_fingerprint = _bind_restart_fingerprint(ctx.config)
     old_payload = (
         ctx.config.model_dump(mode="python")
         if ctx.config is not None and hasattr(ctx.config, "model_dump")
@@ -521,6 +552,7 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
             old_memory_fingerprint=old_memory_fingerprint,
             old_channels_fingerprint=old_channels_fingerprint,
             old_sandbox_posture_fingerprint=old_sandbox_posture_fingerprint,
+            old_bind_fingerprint=old_bind_fingerprint,
             new_config=new_config,
         )
     }

--- a/src/agentos/gateway/static/js/views/config.js
+++ b/src/agentos/gateway/static/js/views/config.js
@@ -118,6 +118,10 @@ const ConfigView = (() => {
       '"auto_summarize" compacts older history via a small LLM; "hard_truncate" drops oldest turns; "refuse" rejects the turn with a stable error.',
     'auth_mode':
       'Gateway auth scheme. "token" requires a static bearer token; "none" is open (loopback only); other modes per deployment.',
+    'auth.allow_unauthenticated_public':
+      'Break-glass opt-in. By default the gateway refuses to start with auth.mode "none" on a non-loopback bind; enabling this serves anyway, giving every peer that can reach the port full operator access. Only enable behind a reverse proxy with auth, VPN, or firewall.',
+    'control_ui.allowed_origins':
+      'Extra browser origins allowed to open the Control UI WebSocket, call the HTTP API, and send Host headers, beyond loopback (which is always allowed). Add your reverse-proxy origin here (e.g. https://agent.example.com) when serving the UI off another host; default ports 80/443 are normalized. Cross-origin requests are otherwise rejected to block cross-site WebSocket hijacking and DNS rebinding.',
   };
 
   function _helpFor(key) {

--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -72,7 +72,12 @@ def origin_in_allowlist(origin: str, allowed: list[str]) -> bool:
     return any(_origin_key(entry) == key for entry in allowed)
 
 
-def is_allowed_ws_origin(origin: str | None, config: GatewayConfig) -> bool:
+def is_allowed_ws_origin(
+    origin: str | None,
+    config: GatewayConfig,
+    *,
+    bind_is_loopback: bool | None = None,
+) -> bool:
     """Return True if a WebSocket handshake ``Origin`` may be accepted.
 
     The WS upgrade skips ``AuthMiddleware`` and a loopback peer is
@@ -107,7 +112,14 @@ def is_allowed_ws_origin(origin: str | None, config: GatewayConfig) -> bool:
 
     from agentos.gateway.scopes import is_loopback_address, is_loopback_bind
 
-    if not is_loopback_bind(config.host):
+    # Prefer the bind posture captured when the app was built: config.host is
+    # mutated in place by config.apply without rebinding the live socket, so
+    # reading it here would let a runtime host change silently disable the
+    # guard while the process still listens on loopback (P2).
+    on_loopback = (
+        bind_is_loopback if bind_is_loopback is not None else is_loopback_bind(config.host)
+    )
+    if not on_loopback:
         return True
 
     if origin_in_allowlist(origin, config.control_ui.allowed_origins):
@@ -628,6 +640,7 @@ async def handle_ws_connection(
     memory_managers: dict[str, Any] | None = None,
     memory_stores: dict[str, Any] | None = None,
     memory_retrievers: dict[str, Any] | None = None,
+    bind_is_loopback: bool | None = None,
 ) -> None:
     """Main WebSocket connection handler."""
     conn_id = str(uuid.uuid4())
@@ -638,9 +651,10 @@ async def handle_ws_connection(
     # whose Origin is neither loopback nor an explicitly allowed UI origin,
     # before accept(). A cross-site page cannot forge Origin, so this stops it
     # from opening a socket to the loopback gateway and inheriting operator
-    # scopes. Starlette Headers.get is case-insensitive.
+    # scopes. Starlette Headers.get is case-insensitive. bind_is_loopback is
+    # the posture captured at app-build time (P2) — see is_allowed_ws_origin.
     origin = ws.headers.get("origin")
-    if not is_allowed_ws_origin(origin, config):
+    if not is_allowed_ws_origin(origin, config, bind_is_loopback=bind_is_loopback):
         log.warning("ws.origin_rejected", conn_id=conn_id, origin=origin)
         await ws.close(code=1008)  # policy violation
         return

--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -32,6 +32,93 @@ from agentos.gateway.rpc import RpcContext, RpcDispatcher
 log = structlog.get_logger(__name__)
 
 
+_ORIGIN_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin_key(value: str) -> tuple[str, str, int | None] | None:
+    """Parse an origin string into a comparable ``(scheme, host, port)`` key.
+
+    Browsers send ``Origin`` in canonical form (lowercase host, default port
+    omitted); operators type whatever variant comes to mind. Normalizing both
+    sides — lowercase, brackets/trailing dot stripped, scheme default port
+    applied — makes semantically equal origins compare equal:
+    ``https://agent.example.com:443`` == ``https://agent.example.com`` ==
+    ``https://agent.example.com.``. Returns ``None`` for values that do not
+    parse as ``scheme://host[:port]`` (they can never match anything).
+    """
+    from urllib.parse import urlsplit
+
+    try:
+        parts = urlsplit(value.strip())
+        host = (parts.hostname or "").rstrip(".")  # lowercased, brackets stripped
+        port = parts.port
+    except ValueError:
+        return None
+    scheme = parts.scheme.lower()
+    scheme = {"ws": "http", "wss": "https"}.get(scheme, scheme)
+    if not scheme or not host:
+        return None
+    if port is None:
+        port = _ORIGIN_DEFAULT_PORTS.get(scheme)
+    return (scheme, host, port)
+
+
+def origin_in_allowlist(origin: str, allowed: list[str]) -> bool:
+    """True if ``origin`` matches an ``allowed`` entry, normalized per
+    ``_origin_key`` (unparseable entries or origins never match)."""
+    key = _origin_key(origin)
+    if key is None:
+        return False
+    return any(_origin_key(entry) == key for entry in allowed)
+
+
+def is_allowed_ws_origin(origin: str | None, config: GatewayConfig) -> bool:
+    """Return True if a WebSocket handshake ``Origin`` may be accepted.
+
+    The WS upgrade skips ``AuthMiddleware`` and a loopback peer is
+    auto-upgraded to operator scopes by ``peer_ip`` alone, so a malicious
+    page in the victim's browser could otherwise open a socket to the local
+    gateway and drive the admin RPC surface (Cross-Site WebSocket Hijacking;
+    the CVE-2026-53869 class). Browsers always send ``Origin`` on WS
+    handshakes and page JS cannot forge it, so it is the correct gate.
+
+    Allow when:
+
+    * No ``Origin`` header — non-browser clients (CLI, node peers) never send
+      one; browsers always do. Rejecting here would break the CLI.
+    * The gateway is on a **non-loopback bind**. It only starts there past
+      ``enforce_public_bind_auth_guard`` (auth on, or explicit opt-in), the
+      socket is authenticated after ``accept()`` via ``connect.challenge`` /
+      ``resolve_auth``, and the loopback auto-admin upgrade is off. A remote
+      browser's ``Origin`` names whatever host it navigated to (a LAN IP, a
+      DNS name) — never the bind address (``0.0.0.0``/``::``) — so gating
+      here would reject every legitimate browser without adding security.
+    * The origin's host is loopback (``127.0.0.0/8``, ``::1``, ``localhost``)
+      on any port — the same-origin Control UI and local tools.
+    * The origin matches an entry in ``control_ui.allowed_origins`` (opt-in
+      for a reverse-proxied UI on another host), compared normalized —
+      scheme/host case, default ports, trailing dot/slash.
+
+    Anything else — a cross-site page, a rebound hostname — is rejected. A
+    malformed, unparseable ``Origin`` fails closed (rejected).
+    """
+    if not origin:
+        return True
+
+    from agentos.gateway.scopes import is_loopback_address, is_loopback_bind
+
+    if not is_loopback_bind(config.host):
+        return True
+
+    if origin_in_allowlist(origin, config.control_ui.allowed_origins):
+        return True
+
+    key = _origin_key(origin)
+    if key is None:
+        return False
+    return is_loopback_address(key[1])
+
+
 # ---------------------------------------------------------------------------
 # Outbound writer queue primitives
 # ---------------------------------------------------------------------------
@@ -546,6 +633,17 @@ async def handle_ws_connection(
     conn_id = str(uuid.uuid4())
     conn = WsConnection(conn_id=conn_id, ws=ws)
     registry = get_registry()
+
+    # CSWSH / DNS-rebinding guard (loopback binds): reject a browser handshake
+    # whose Origin is neither loopback nor an explicitly allowed UI origin,
+    # before accept(). A cross-site page cannot forge Origin, so this stops it
+    # from opening a socket to the loopback gateway and inheriting operator
+    # scopes. Starlette Headers.get is case-insensitive.
+    origin = ws.headers.get("origin")
+    if not is_allowed_ws_origin(origin, config):
+        log.warning("ws.origin_rejected", conn_id=conn_id, origin=origin)
+        await ws.close(code=1008)  # policy violation
+        return
 
     await ws.accept()
     log.info("ws.connected", conn_id=conn_id, remote=str(ws.client))

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -136,6 +136,49 @@ def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
     assert "Traceback" not in output
 
 
+def test_gateway_run_refuses_wildcard_bind_without_auth(tmp_path, monkeypatch) -> None:
+    """auth.mode="none" + non-loopback bind fails closed at startup (issue #18, V3)."""
+    target = tmp_path / "agentos.toml"
+    target.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.delenv("AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC", raising=False)
+    monkeypatch.delenv("AGENTOS_AUTH_MODE", raising=False)
+
+    result = runner.invoke(
+        app, ["gateway", "run", "--config", str(target), "--listen", "0.0.0.0"]
+    )
+
+    assert result.exit_code == 1
+    output = result.stdout + (result.stderr or "")
+    assert "Gateway could not start" in output
+    assert "allow_unauthenticated_public" in output
+    # The "LAN-open" warning implies the server will serve — contradictory
+    # noise right before a refusal. It belongs to the opt-in path only.
+    assert "LAN-open" not in output
+
+
+def test_gateway_run_warns_lan_open_when_opt_in_set(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "agentos.toml"
+    target.write_text(
+        "[auth]\nallow_unauthenticated_public = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.delenv("AGENTOS_AUTH_MODE", raising=False)
+
+    async def fake_start_gateway_server(**_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
+
+    result = runner.invoke(
+        app, ["gateway", "run", "--config", str(target), "--listen", "0.0.0.0"]
+    )
+
+    output = result.stdout + (result.stderr or "")
+    assert "LAN-open" in output
+
+
 def test_gateway_lifecycle_paths_use_state_root(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
 

--- a/tests/test_gateway/test_config_view_static.py
+++ b/tests/test_gateway/test_config_view_static.py
@@ -242,6 +242,23 @@ def test_config_memory_help_text_documents_external_provider_keys() -> None:
     assert "restart" in provider_help.lower()
 
 
+def test_config_auth_help_text_documents_public_bind_opt_in() -> None:
+    source = CONFIG_JS.read_text(encoding="utf-8")
+
+    assert "'auth.allow_unauthenticated_public':" in source
+    # The help must convey this is a break-glass override of the startup guard.
+    opt_in_help = source.split("'auth.allow_unauthenticated_public':", 1)[1].split("',", 1)[0]
+    assert "refuse" in opt_in_help.lower()
+
+
+def test_config_control_ui_help_documents_ws_origin_allowlist() -> None:
+    source = CONFIG_JS.read_text(encoding="utf-8")
+
+    assert "'control_ui.allowed_origins':" in source
+    help_text = source.split("'control_ui.allowed_origins':", 1)[1].split("',", 1)[0]
+    assert "loopback" in help_text.lower()
+
+
 def test_config_form_flattens_nested_objects_into_dotted_leaf_fields() -> None:
     source = CONFIG_JS.read_text(encoding="utf-8")
 

--- a/tests/test_gateway/test_public_bind_auth_guard.py
+++ b/tests/test_gateway/test_public_bind_auth_guard.py
@@ -1,0 +1,94 @@
+"""Startup guard: refuse to serve with auth.mode="none" on a non-loopback bind.
+
+Covers the V3 hardening from issue #18 — "no auth by default" is safe only
+while the gateway stays on loopback. Binding a wildcard or LAN address with
+auth disabled must fail closed unless the operator explicitly opts in via
+``auth.allow_unauthenticated_public``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.gateway.config import (
+    AuthConfig,
+    GatewayConfig,
+    enforce_public_bind_auth_guard,
+)
+from agentos.gateway.scopes import is_loopback_bind
+
+
+def _config(host: str, auth_mode: str = "none", allow_public: bool = False) -> GatewayConfig:
+    return GatewayConfig(
+        host=host,
+        auth=AuthConfig(mode=auth_mode, allow_unauthenticated_public=allow_public),
+    )
+
+
+class TestIsLoopbackBind:
+    """The guard reuses the same predicate as the ownership check (auth.py),
+    so a bind the guard allows is exactly a bind ownership treats as local."""
+
+    @pytest.mark.parametrize(
+        "host",
+        ["127.0.0.1", "127.1.2.3", "::1", "localhost", "::ffff:127.0.0.1"],
+    )
+    def test_loopback_hosts(self, host: str) -> None:
+        assert is_loopback_bind(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        ["0.0.0.0", "::", "192.168.1.5", "10.0.0.7", "example.com", ""],
+    )
+    def test_non_loopback_hosts(self, host: str) -> None:
+        assert is_loopback_bind(host) is False
+
+
+class TestEnforcePublicBindAuthGuard:
+    def test_refuses_wildcard_bind_without_auth(self) -> None:
+        with pytest.raises(ValueError, match="auth.mode"):
+            enforce_public_bind_auth_guard(_config("0.0.0.0"))
+
+    def test_refuses_lan_bind_without_auth(self) -> None:
+        with pytest.raises(ValueError, match="auth.mode"):
+            enforce_public_bind_auth_guard(_config("192.168.1.5"))
+
+    def test_error_message_names_remediations(self) -> None:
+        """The refusal must tell the operator every way out."""
+        with pytest.raises(ValueError) as exc_info:
+            enforce_public_bind_auth_guard(_config("0.0.0.0"))
+        message = str(exc_info.value)
+        assert "auth.mode" in message
+        assert "allow_unauthenticated_public" in message
+        assert "0.0.0.0" in message
+
+    def test_allows_loopback_bind_without_auth(self) -> None:
+        enforce_public_bind_auth_guard(_config("127.0.0.1"))
+
+    def test_allows_wildcard_bind_with_token_auth(self) -> None:
+        enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode="token"))
+
+    def test_allows_wildcard_bind_with_password_auth(self) -> None:
+        enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode="password"))
+
+    def test_explicit_opt_in_allows_unauthenticated_public_bind(self) -> None:
+        enforce_public_bind_auth_guard(_config("0.0.0.0", allow_public=True))
+
+
+class TestAuthConfigOptIn:
+    def test_opt_in_defaults_to_false(self) -> None:
+        assert AuthConfig().allow_unauthenticated_public is False
+
+    def test_opt_in_env_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC", "true")
+        assert AuthConfig().allow_unauthenticated_public is True
+
+
+class TestStartGatewayServerWiring:
+    @pytest.mark.asyncio
+    async def test_start_gateway_server_refuses_unauthenticated_public_bind(self) -> None:
+        """The guard must run inside start_gateway_server, before any services boot."""
+        from agentos.gateway.boot import start_gateway_server
+
+        with pytest.raises(ValueError, match="allow_unauthenticated_public"):
+            await start_gateway_server(config=_config("0.0.0.0"))

--- a/tests/test_gateway/test_public_bind_auth_guard.py
+++ b/tests/test_gateway/test_public_bind_auth_guard.py
@@ -18,10 +18,19 @@ from agentos.gateway.config import (
 from agentos.gateway.scopes import is_loopback_bind
 
 
-def _config(host: str, auth_mode: str = "none", allow_public: bool = False) -> GatewayConfig:
+def _config(
+    host: str,
+    auth_mode: str = "none",
+    allow_public: bool = False,
+    trusted_proxy: str | None = None,
+) -> GatewayConfig:
     return GatewayConfig(
         host=host,
-        auth=AuthConfig(mode=auth_mode, allow_unauthenticated_public=allow_public),
+        auth=AuthConfig(
+            mode=auth_mode,
+            allow_unauthenticated_public=allow_public,
+            trusted_proxy=trusted_proxy,
+        ),
     )
 
 
@@ -70,16 +79,30 @@ class TestEnforcePublicBindAuthGuard:
 
     @pytest.mark.parametrize("mode", ["password", "trusted-proxy", "tokenn", "on", ""])
     def test_refuses_public_bind_with_unenforced_auth_mode(self, mode: str) -> None:
-        """[P1b] Only modes actually enforced end-to-end (token) count as
-        "authenticated". password/trusted-proxy are not enforced on the HTTP
-        surface, and a typo must never be read as "auth is on"."""
+        """[P1b] Only token is enforced end-to-end. password/trusted-proxy are
+        not enforced on the HTTP surface, and a typo must never be read as
+        "auth is on"."""
         with pytest.raises(ValueError, match="auth.mode"):
             enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode=mode))
 
-    def test_error_message_does_not_recommend_unimplemented_password(self) -> None:
+    def test_refuses_trusted_proxy_even_with_proxy_configured(self) -> None:
+        """[P1] AuthMiddleware only string-matches the client-controlled
+        X-Forwarded-For header — trivially spoofable — and resolve_auth has no
+        trusted-proxy resolver, so the mode is not enforced end-to-end. It must
+        not pass the public-bind guard until real peer-IP validation lands."""
+        with pytest.raises(ValueError, match="auth.mode"):
+            enforce_public_bind_auth_guard(
+                _config("0.0.0.0", auth_mode="trusted-proxy", trusted_proxy="10.0.0.1")
+            )
+
+    def test_error_message_only_recommends_enforced_modes(self) -> None:
         with pytest.raises(ValueError) as exc_info:
             enforce_public_bind_auth_guard(_config("0.0.0.0"))
-        assert '"password"' not in str(exc_info.value)
+        message = str(exc_info.value)
+        # Neither unimplemented/spoofable mode should be recommended.
+        assert '"password"' not in message
+        assert "trusted-proxy" not in message
+        assert '"token"' in message
 
     def test_explicit_opt_in_allows_unauthenticated_public_bind(self) -> None:
         enforce_public_bind_auth_guard(_config("0.0.0.0", allow_public=True))

--- a/tests/test_gateway/test_public_bind_auth_guard.py
+++ b/tests/test_gateway/test_public_bind_auth_guard.py
@@ -68,8 +68,18 @@ class TestEnforcePublicBindAuthGuard:
     def test_allows_wildcard_bind_with_token_auth(self) -> None:
         enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode="token"))
 
-    def test_allows_wildcard_bind_with_password_auth(self) -> None:
-        enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode="password"))
+    @pytest.mark.parametrize("mode", ["password", "trusted-proxy", "tokenn", "on", ""])
+    def test_refuses_public_bind_with_unenforced_auth_mode(self, mode: str) -> None:
+        """[P1b] Only modes actually enforced end-to-end (token) count as
+        "authenticated". password/trusted-proxy are not enforced on the HTTP
+        surface, and a typo must never be read as "auth is on"."""
+        with pytest.raises(ValueError, match="auth.mode"):
+            enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode=mode))
+
+    def test_error_message_does_not_recommend_unimplemented_password(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            enforce_public_bind_auth_guard(_config("0.0.0.0"))
+        assert '"password"' not in str(exc_info.value)
 
     def test_explicit_opt_in_allows_unauthenticated_public_bind(self) -> None:
         enforce_public_bind_auth_guard(_config("0.0.0.0", allow_public=True))

--- a/tests/test_gateway/test_readiness.py
+++ b/tests/test_gateway/test_readiness.py
@@ -11,7 +11,10 @@ def test_ready_endpoint_reports_starting_until_gateway_marks_ready() -> None:
     app = create_gateway_app(GatewayConfig())
     app.state.gateway_ready = False
 
-    with TestClient(app) as client:
+    # base_url uses a loopback Host so TrustedHostMiddleware (DNS-rebinding
+    # guard) admits the request — the default "testserver" Host is rejected,
+    # matching how a real browser can only reach the loopback gateway.
+    with TestClient(app, base_url="http://localhost") as client:
         starting = client.get("/ready")
         assert starting.status_code == 503
         assert starting.json()["ready"] is False

--- a/tests/test_gateway/test_rpc_config_memory_embedding.py
+++ b/tests/test_gateway/test_rpc_config_memory_embedding.py
@@ -166,6 +166,70 @@ async def test_config_apply_memory_retrieval_mode_reports_restart_required(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_config_patch_auth_mode_reports_restart_required(tmp_path):
+    """auth.mode is applied to AuthMiddleware live, but the startup guard and
+    the captured bind posture only re-evaluate on restart — so a hot change
+    must be flagged restart-required so the operator isn't misled."""
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))  # mode defaults to "none"
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patches": {"auth.mode": "token"}},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["restartRequired"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_patch_host_reports_restart_required(tmp_path):
+    """host changes do NOT rebind the live socket, so hot-applying host must be
+    flagged restart-required (the process still listens on the old address)."""
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))  # host defaults to 127.0.0.1
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patches": {"host": "0.0.0.0"}},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["restartRequired"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_patch_same_auth_and_host_does_not_report_restart_required(tmp_path):
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patches": {"prompt_cache.mode": "auto"}},  # unrelated, non-restart change
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["restartRequired"] is False
+
+
+@pytest.mark.asyncio
+async def test_config_apply_auth_mode_reports_restart_required(tmp_path):
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))
+    payload = cfg.model_dump(mode="python")
+    payload["auth"]["mode"] = "token"
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.apply",
+        {"config": payload},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["restartRequired"] is True
+
+
+@pytest.mark.asyncio
 async def test_config_get_redacts_memory_remote_api_key(tmp_path):
     cfg = GatewayConfig(
         config_path=str(tmp_path / "c.toml"),

--- a/tests/test_gateway/test_trusted_host_guard.py
+++ b/tests/test_gateway/test_trusted_host_guard.py
@@ -28,11 +28,12 @@ def _config(
     allow_public: bool = False,
     ui_origins: list[str] | None = None,
     cors_origins: list[str] | None = None,
+    base_path: str = "/control",
 ) -> GatewayConfig:
     return GatewayConfig(
         host=host,
         auth=AuthConfig(mode=auth_mode, allow_unauthenticated_public=allow_public),
-        control_ui=ControlUiConfig(allowed_origins=ui_origins or []),
+        control_ui=ControlUiConfig(allowed_origins=ui_origins or [], base_path=base_path),
         cors=CorsConfig(allowed_origins=cors_origins)
         if cors_origins is not None
         else CorsConfig(),
@@ -232,3 +233,17 @@ class TestLoopbackOriginGuardHttp:
         client = self._client()
         resp = client.get("/control/", headers={"origin": "http://evil.com"})
         assert resp.status_code != 403
+
+    @pytest.mark.parametrize("base_path", ["/", "/api", "/api/v1"])
+    def test_root_or_api_base_path_does_not_disable_guard(self, base_path: str) -> None:
+        """[P1a] A UI base_path of "/" (normalized to "") or one overlapping the
+        API surface must NOT wholesale-exempt /api/* from the Origin guard."""
+        from agentos.gateway.app import create_gateway_app
+
+        client = TestClient(
+            create_gateway_app(_config(base_path=base_path)),
+            base_url="http://localhost",
+        )
+        resp = client.get("/api/config", headers={"origin": "http://evil.com"})
+        assert resp.status_code == 403
+        assert "access-control-allow-origin" not in resp.headers

--- a/tests/test_gateway/test_trusted_host_guard.py
+++ b/tests/test_gateway/test_trusted_host_guard.py
@@ -1,0 +1,234 @@
+"""TrustedHostMiddleware wiring — Host-header allowlist against DNS rebinding.
+
+A loopback bind is not a boundary against a browser: a malicious page can
+rebind ``attacker.com`` to ``127.0.0.1`` and reach the local gateway, with
+the attacker's hostname in the ``Host`` header (CVE-2026-53869 class). On a
+loopback bind we therefore pin ``Host`` to a loopback allowlist. On a
+non-loopback bind (which only starts past ``enforce_public_bind_auth_guard``
+— so auth is on, or the operator explicitly opted in) we do not constrain
+Host, since the operator deliberately serves other names.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agentos.gateway.app import resolve_trusted_hosts
+from agentos.gateway.config import AuthConfig, ControlUiConfig, CorsConfig, GatewayConfig
+from agentos.gateway.middleware import LoopbackHostMiddleware
+
+
+def _config(
+    host: str = "127.0.0.1",
+    auth_mode: str = "none",
+    allow_public: bool = False,
+    ui_origins: list[str] | None = None,
+    cors_origins: list[str] | None = None,
+) -> GatewayConfig:
+    return GatewayConfig(
+        host=host,
+        auth=AuthConfig(mode=auth_mode, allow_unauthenticated_public=allow_public),
+        control_ui=ControlUiConfig(allowed_origins=ui_origins or []),
+        cors=CorsConfig(allowed_origins=cors_origins)
+        if cors_origins is not None
+        else CorsConfig(),
+    )
+
+
+class TestResolveTrustedHosts:
+    def test_loopback_bind_constrains_host(self) -> None:
+        """No wildcard on a loopback bind — loopback Host values themselves are
+        admitted by LoopbackHostMiddleware via scopes.is_loopback_address."""
+        hosts = resolve_trusted_hosts(_config(host="127.0.0.1"))
+        assert "*" not in hosts
+
+    def test_non_loopback_bind_does_not_constrain(self) -> None:
+        """Past the startup guard a public bind has auth (or explicit opt-in)."""
+        hosts = resolve_trusted_hosts(_config(host="0.0.0.0", auth_mode="token"))
+        assert hosts == ["*"]
+
+    def test_loopback_bind_includes_configured_ui_origin_host(self) -> None:
+        hosts = resolve_trusted_hosts(
+            _config(host="127.0.0.1", ui_origins=["https://ui.example.com"])
+        )
+        assert "ui.example.com" in hosts
+
+    def test_unparseable_ui_origin_warns_instead_of_dying_silently(self) -> None:
+        """A scheme-less entry can never match anything (here or in the WS
+        guard) — the operator must hear about it at startup, not debug a
+        dead allowlist entry."""
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            hosts = resolve_trusted_hosts(
+                _config(host="127.0.0.1", ui_origins=["ui.example.com"])
+            )
+        assert "ui.example.com" not in hosts
+        assert any("origin" in entry["event"] for entry in logs)
+
+
+class TestLoopbackHostMiddlewareIntegration:
+    def _app(self, config: GatewayConfig) -> Starlette:
+        from starlette.middleware import Middleware
+
+        async def ok(_request: object) -> PlainTextResponse:
+            return PlainTextResponse("ok")
+
+        return Starlette(
+            routes=[Route("/probe", ok)],
+            middleware=[
+                Middleware(
+                    LoopbackHostMiddleware,
+                    allowed_hosts=resolve_trusted_hosts(config),
+                )
+            ],
+        )
+
+    def test_rebound_host_header_rejected_on_loopback_bind(self) -> None:
+        client = TestClient(self._app(_config(host="127.0.0.1")))
+        resp = client.get("/probe", headers={"host": "attacker.com"})
+        assert resp.status_code == 400
+
+    def test_loopback_host_header_allowed(self) -> None:
+        client = TestClient(self._app(_config(host="127.0.0.1")))
+        resp = client.get("/probe", headers={"host": "127.0.0.1"})
+        assert resp.status_code == 200
+        resp2 = client.get("/probe", headers={"host": "localhost:18791"})
+        assert resp2.status_code == 200
+
+    def test_ipv6_loopback_host_header_allowed(self) -> None:
+        """Regression: Starlette's TrustedHostMiddleware split-on-':' mangles
+        bracketed IPv6 and 400s a legit ``[::1]`` bind. This must admit it."""
+        client = TestClient(self._app(_config(host="::1")))
+        resp = client.get("/probe", headers={"host": "[::1]:18791"})
+        assert resp.status_code == 200
+        resp2 = client.get("/probe", headers={"host": "[::1]"})
+        assert resp2.status_code == 200
+
+    def test_ipv6_rebound_host_rejected(self) -> None:
+        client = TestClient(self._app(_config(host="::1")))
+        resp = client.get("/probe", headers={"host": "attacker.com"})
+        assert resp.status_code == 400
+
+    def test_public_bind_allows_any_host(self) -> None:
+        client = TestClient(self._app(_config(host="0.0.0.0", auth_mode="token")))
+        resp = client.get("/probe", headers={"host": "anything.example.com"})
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        ("bind", "host_header"),
+        [
+            ("127.0.0.2", "127.0.0.2:18791"),
+            ("127.1.2.3", "127.1.2.3:18791"),
+            ("::ffff:127.0.0.1", "[::ffff:127.0.0.1]:18791"),
+        ],
+    )
+    def test_alternate_loopback_bind_reachable_at_its_own_address(
+        self, bind: str, host_header: str
+    ) -> None:
+        """Regression: every bind is_loopback_bind blesses (all of 127/8,
+        IPv4-mapped loopback) must be reachable at its own address — the Host
+        guard shares the loopback predicate with the startup and WS guards."""
+        client = TestClient(self._app(_config(host=bind)))
+        resp = client.get("/probe", headers={"host": host_header})
+        assert resp.status_code == 200
+
+    def test_trailing_dot_loopback_host_admitted(self) -> None:
+        client = TestClient(self._app(_config(host="127.0.0.1")))
+        resp = client.get("/probe", headers={"host": "localhost.:18791"})
+        assert resp.status_code == 200
+
+
+class TestRealAppWiring:
+    """Mutation guard: LoopbackHostMiddleware must be wired into the real
+    ``create_gateway_app`` middleware stack. The throwaway-app tests above
+    cannot detect the wiring line being dropped."""
+
+    def _real_app(self):  # noqa: ANN202
+        from agentos.gateway.app import create_gateway_app
+
+        return create_gateway_app(GatewayConfig())
+
+    def test_foreign_host_rejected_by_real_app(self) -> None:
+        client = TestClient(self._real_app())  # default Host: testserver
+        assert client.get("/ready").status_code == 400
+        assert (
+            client.get("/ready", headers={"host": "attacker.com"}).status_code == 400
+        )
+
+    def test_loopback_host_admitted_by_real_app(self) -> None:
+        client = TestClient(self._real_app(), base_url="http://localhost")
+        assert client.get("/ready").status_code in (200, 503)
+
+
+class TestLoopbackOriginGuardHttp:
+    """Cross-site browser requests to the HTTP ``/api/*`` surface must be
+    rejected on a loopback bind — the same drive-by threat the WS handshake
+    guard covers, over the sibling transport. Without this, default CORS
+    (``["*"]`` + credentials) reflects the attacker Origin and a page on
+    evil.com can read config/sessions and drive chat.send."""
+
+    def _client(self, **cfg_kwargs: object) -> TestClient:
+        from agentos.gateway.app import create_gateway_app
+
+        return TestClient(
+            create_gateway_app(_config(**cfg_kwargs)),  # type: ignore[arg-type]
+            base_url="http://localhost",
+        )
+
+    def test_cross_site_origin_rejected(self) -> None:
+        client = self._client()
+        resp = client.get("/api/sessions", headers={"origin": "http://evil.com"})
+        assert resp.status_code == 403
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_loopback_origin_allowed(self) -> None:
+        client = self._client()
+        resp = client.get(
+            "/api/sessions", headers={"origin": "http://localhost:18791"}
+        )
+        assert resp.status_code == 200
+
+    def test_no_origin_allowed(self) -> None:
+        """CLI/curl requests carry no Origin and must be untouched."""
+        client = self._client()
+        assert client.get("/api/sessions").status_code == 200
+
+    def test_allowlisted_ui_origin_allowed(self) -> None:
+        client = self._client(ui_origins=["https://agent.example.com"])
+        resp = client.get(
+            "/api/sessions", headers={"origin": "https://agent.example.com"}
+        )
+        assert resp.status_code == 200
+
+    def test_explicit_cors_origin_allowed(self) -> None:
+        """A deliberate non-wildcard cors.allowed_origins entry keeps working."""
+        client = self._client(cors_origins=["https://myapp.example"])
+        resp = client.get(
+            "/api/sessions", headers={"origin": "https://myapp.example"}
+        )
+        assert resp.status_code == 200
+
+    def test_wildcard_cors_default_does_not_admit_foreign_origin(self) -> None:
+        client = self._client(cors_origins=["*"])
+        resp = client.get("/api/sessions", headers={"origin": "http://evil.com"})
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("path", ["/health", "/healthz", "/ready", "/readyz"])
+    def test_public_health_paths_never_origin_gated(self, path: str) -> None:
+        """Health probes (monitoring, load balancers) may carry an Origin and
+        must never be blocked — AuthMiddleware exempts them too."""
+        client = self._client()
+        resp = client.get(path, headers={"origin": "http://monitoring.example.com"})
+        assert resp.status_code == 200
+
+    def test_control_ui_shell_not_origin_gated(self) -> None:
+        """The Control UI surface is served, not an RPC sink; the origin guard
+        must not 403 it (CSP/SecurityHeaders cover that surface)."""
+        client = self._client()
+        resp = client.get("/control/", headers={"origin": "http://evil.com"})
+        assert resp.status_code != 403

--- a/tests/test_gateway/test_trusted_host_guard.py
+++ b/tests/test_gateway/test_trusted_host_guard.py
@@ -94,6 +94,16 @@ class TestLoopbackHostMiddlewareIntegration:
         resp = client.get("/probe", headers={"host": "attacker.com"})
         assert resp.status_code == 400
 
+    def test_rejected_host_message_points_to_the_config_fix(self) -> None:
+        """A user reaching the gateway via a custom loopback hostname (e.g.
+        /etc/hosts) is a legitimate false-positive; the 400 body must name the
+        config key that unblocks them instead of a bare 'Invalid host'."""
+        client = TestClient(self._app(_config(host="127.0.0.1")))
+        resp = client.get("/probe", headers={"host": "myagent.local"})
+        assert resp.status_code == 400
+        assert "control_ui.allowed_origins" in resp.text
+        assert "myagent.local" in resp.text
+
     def test_loopback_host_header_allowed(self) -> None:
         client = TestClient(self._app(_config(host="127.0.0.1")))
         resp = client.get("/probe", headers={"host": "127.0.0.1"})

--- a/tests/test_gateway/test_websocket_handshake.py
+++ b/tests/test_gateway/test_websocket_handshake.py
@@ -15,6 +15,7 @@ class _DisconnectingChallengeWebSocket:
 
     def __init__(self) -> None:
         self.accepted = False
+        self.headers: dict[str, str] = {}
 
     async def accept(self) -> None:
         self.accepted = True

--- a/tests/test_gateway/test_ws_origin_guard.py
+++ b/tests/test_gateway/test_ws_origin_guard.py
@@ -240,3 +240,30 @@ class TestRealAppHandshake:
         with client.websocket_connect("/ws") as ws:
             frame = ws.receive_json()
             assert frame["event"] == "connect.challenge"
+
+
+class TestBindPostureIsCaptured:
+    """[P2] The guards must key off the bind posture captured when the app is
+    built, not a mutable ``config.host`` read at request time. ``config.apply``
+    mutates the config in place without rebinding the live socket; a host
+    change to a public address must NOT silently disable the Origin/Host
+    guards while the process still listens on loopback."""
+
+    def test_ws_origin_guard_survives_runtime_host_mutation(self) -> None:
+        from agentos.gateway.app import create_gateway_app
+
+        cfg = GatewayConfig()  # loopback bind, socket built now
+        client = TestClient(create_gateway_app(cfg), base_url="http://localhost")
+        cfg.host = "0.0.0.0"  # config.apply-style in-place mutation, no rebind
+        resp = client.get("/api/config", headers={"origin": "http://evil.com"})
+        assert resp.status_code == 403
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_host_guard_survives_runtime_host_mutation(self) -> None:
+        from agentos.gateway.app import create_gateway_app
+
+        cfg = GatewayConfig()
+        client = TestClient(create_gateway_app(cfg), base_url="http://localhost")
+        cfg.host = "0.0.0.0"
+        # Host allowlist must still reject a rebound foreign Host.
+        assert client.get("/ready", headers={"host": "attacker.com"}).status_code == 400

--- a/tests/test_gateway/test_ws_origin_guard.py
+++ b/tests/test_gateway/test_ws_origin_guard.py
@@ -1,0 +1,242 @@
+"""WebSocket Origin/Host validation — defense against CSWSH + DNS rebinding.
+
+The WS upgrade path skips ``AuthMiddleware`` (middleware.py:33), and on a
+loopback bind any browser peer is auto-upgraded to operator scopes purely by
+``peer_ip`` proximity (auth.py:152). A malicious web page the victim visits
+can therefore open ``ws://127.0.0.1:<port>/ws`` and drive the admin RPC
+surface — this is the CVE-2026-53869 (Hermes) / CSWSH class. The handshake
+must reject cross-origin and rebound-Host connections before ``accept()``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.testclient import TestClient, WebSocketDenialResponse
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from agentos.gateway.config import AuthConfig, ControlUiConfig, GatewayConfig
+from agentos.gateway.websocket import handle_ws_connection, is_allowed_ws_origin
+
+
+def _config(port: int = 18791, allowed_origins: list[str] | None = None) -> GatewayConfig:
+    return GatewayConfig(
+        port=port,
+        control_ui=ControlUiConfig(allowed_origins=allowed_origins or []),
+    )
+
+
+class TestIsAllowedWsOrigin:
+    def test_missing_origin_is_allowed(self) -> None:
+        """Non-browser clients (CLI, node) send no Origin — must not be blocked."""
+        assert is_allowed_ws_origin(None, _config()) is True
+        assert is_allowed_ws_origin("", _config()) is True
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "http://127.0.0.1:18791",
+            "http://127.0.0.1:3000",
+            "http://localhost:18791",
+            "https://localhost",
+            "http://[::1]:18791",
+        ],
+    )
+    def test_loopback_origins_allowed(self, origin: str) -> None:
+        assert is_allowed_ws_origin(origin, _config()) is True
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "http://evil.com",
+            "https://attacker.example",
+            "http://127.0.0.1.evil.com",
+            "http://192.168.1.5",
+            "https://localhost.evil.com",
+            "null",
+        ],
+    )
+    def test_cross_origin_rejected(self, origin: str) -> None:
+        assert is_allowed_ws_origin(origin, _config()) is False
+
+    def test_explicit_allowlist_origin_allowed(self) -> None:
+        cfg = _config(allowed_origins=["https://ui.example.com"])
+        assert is_allowed_ws_origin("https://ui.example.com", cfg) is True
+
+    def test_explicit_allowlist_does_not_widen_others(self) -> None:
+        cfg = _config(allowed_origins=["https://ui.example.com"])
+        assert is_allowed_ws_origin("https://other.example.com", cfg) is False
+
+    def test_origin_match_is_exact_not_prefix(self) -> None:
+        cfg = _config(allowed_origins=["https://ui.example.com"])
+        assert is_allowed_ws_origin("https://ui.example.com.evil.com", cfg) is False
+
+    @pytest.mark.parametrize(
+        "origin",
+        ["http://[::1", "http://[gg::1]", "http://[::1]%00.evil"],
+    )
+    def test_malformed_origin_rejected_not_raised(self, origin: str) -> None:
+        """A browser-sendable but unparseable Origin must fail closed, not crash."""
+        assert is_allowed_ws_origin(origin, _config()) is False
+
+    def test_public_bind_allows_own_bind_origin(self) -> None:
+        """A legit remote browser hitting a public+auth deployment is admitted."""
+        cfg = GatewayConfig(
+            host="203.0.113.7",
+            port=18791,
+            control_ui=ControlUiConfig(allowed_origins=[]),
+        )
+        assert is_allowed_ws_origin("http://203.0.113.7:18791", cfg) is True
+
+    def test_public_bind_does_not_gate_origin(self) -> None:
+        """On a non-loopback bind Origin gating buys no security: the WS is
+        authenticated after accept() (connect.challenge -> resolve_auth) and
+        the loopback auto-admin upgrade is off. A remote browser's Origin is
+        whatever host it navigated to — never the bind address — so gating
+        would only reject legitimate browsers."""
+        cfg = GatewayConfig(host="203.0.113.7", port=18791)
+        assert is_allowed_ws_origin("http://evil.com", cfg) is True
+
+    @pytest.mark.parametrize(
+        ("host", "origin"),
+        [
+            # Wildcard binds: no browser ever carries "0.0.0.0"/"::" in Origin —
+            # the Control UI connects with the Origin the user navigated to.
+            ("0.0.0.0", "http://192.168.1.10:18791"),
+            ("::", "http://[2001:db8::7]:18791"),
+            # Specific public IP reached via a DNS name.
+            ("192.168.1.5", "http://myserver.lan:18791"),
+        ],
+    )
+    def test_non_loopback_bind_admits_remote_browser_origin(
+        self, host: str, origin: str
+    ) -> None:
+        cfg = GatewayConfig(host=host, port=18791, auth=AuthConfig(mode="token"))
+        assert is_allowed_ws_origin(origin, cfg) is True
+
+
+class TestAllowedOriginNormalization:
+    """control_ui.allowed_origins entries and the browser Origin must compare
+    semantically (default ports, trailing slash/dot, case), not byte-for-byte —
+    browsers always send the canonical form."""
+
+    def test_explicit_default_port_entry_matches_canonical_origin(self) -> None:
+        cfg = _config(allowed_origins=["https://agent.example.com:443"])
+        assert is_allowed_ws_origin("https://agent.example.com", cfg) is True
+
+    def test_bare_entry_matches_origin_with_explicit_default_port(self) -> None:
+        cfg = _config(allowed_origins=["https://agent.example.com"])
+        assert is_allowed_ws_origin("https://agent.example.com:443", cfg) is True
+
+    def test_trailing_slash_entry_matches(self) -> None:
+        cfg = _config(allowed_origins=["https://agent.example.com/"])
+        assert is_allowed_ws_origin("https://agent.example.com", cfg) is True
+
+    def test_trailing_dot_fqdn_origin_matches_dotless_entry(self) -> None:
+        cfg = _config(allowed_origins=["https://agent.example.com"])
+        assert is_allowed_ws_origin("https://agent.example.com.", cfg) is True
+
+    def test_host_case_is_normalized(self) -> None:
+        cfg = _config(allowed_origins=["https://Agent.Example.com"])
+        assert is_allowed_ws_origin("https://agent.example.com", cfg) is True
+
+    def test_trailing_dot_loopback_origin_allowed(self) -> None:
+        assert is_allowed_ws_origin("http://localhost.:18791", _config()) is True
+
+    def test_normalization_does_not_widen_scheme_or_port(self) -> None:
+        cfg = _config(allowed_origins=["https://agent.example.com"])
+        assert is_allowed_ws_origin("http://agent.example.com", cfg) is False
+        assert is_allowed_ws_origin("https://agent.example.com:8443", cfg) is False
+
+    def test_schemeless_entry_matches_nothing(self) -> None:
+        """A scheme-less entry cannot express an origin — it must not match
+        (and resolve_trusted_hosts warns about it at startup)."""
+        cfg = _config(allowed_origins=["agent.example.com"])
+        assert is_allowed_ws_origin("https://agent.example.com", cfg) is False
+
+
+class _RecordingWebSocket:
+    """Fake WS capturing accept/close and carrying request headers."""
+
+    client_state = WebSocketState.CONNECTED
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+        self.accepted = False
+        self.closed_code: int | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed_code = code
+
+
+class TestHandshakeOriginEnforcement:
+    @pytest.mark.asyncio
+    async def test_cross_origin_handshake_rejected_before_accept(self) -> None:
+        ws = _RecordingWebSocket(headers={"origin": "http://evil.com"})
+
+        await handle_ws_connection(ws, _config(), dispatcher=object())
+
+        assert ws.accepted is False
+        assert ws.closed_code is not None
+
+    @pytest.mark.asyncio
+    async def test_loopback_origin_handshake_accepts(self) -> None:
+        ws = _RecordingWebSocket(headers={"origin": "http://127.0.0.1:18791"})
+
+        # Reaches accept() then disconnects on the challenge send (no send_text).
+        try:
+            await handle_ws_connection(ws, _config(), dispatcher=object())
+        except AttributeError:
+            pass  # fake lacks send_text; we only assert accept happened
+
+        assert ws.accepted is True
+
+    @pytest.mark.asyncio
+    async def test_no_origin_handshake_accepts(self) -> None:
+        ws = _RecordingWebSocket(headers={})
+
+        try:
+            await handle_ws_connection(ws, _config(), dispatcher=object())
+        except AttributeError:
+            pass
+
+        assert ws.accepted is True
+
+
+class TestRealAppHandshake:
+    """The Origin guard through the real ASGI stack — real ``/ws`` route
+    wiring in ``create_gateway_app``, a real starlette ``WebSocket`` denied
+    before ``accept()``, and real case-insensitive ``Headers`` semantics.
+    A fake-only suite would stay green if the guard were unwired."""
+
+    def _client(self) -> TestClient:
+        from agentos.gateway.app import create_gateway_app
+
+        return TestClient(create_gateway_app(GatewayConfig()))
+
+    def test_cross_origin_handshake_denied_through_real_app(self) -> None:
+        client = self._client()
+        with pytest.raises((WebSocketDisconnect, WebSocketDenialResponse)):
+            with client.websocket_connect(
+                "/ws", headers={"Origin": "http://evil.com"}
+            ):
+                pass  # pragma: no cover — handshake must not complete
+
+    def test_loopback_origin_handshake_accepted_through_real_app(self) -> None:
+        client = self._client()
+        with client.websocket_connect(
+            "/ws", headers={"origin": "http://127.0.0.1:18791"}
+        ) as ws:
+            frame = ws.receive_json()
+            assert frame["event"] == "connect.challenge"
+
+    def test_no_origin_handshake_accepted_through_real_app(self) -> None:
+        client = self._client()
+        with client.websocket_connect("/ws") as ws:
+            frame = ws.receive_json()
+            assert frame["event"] == "connect.challenge"


### PR DESCRIPTION
## Why

A loopback bind is **not** a security boundary against a page running in the operator's own browser. That page can reach `127.0.0.1`, and the gateway currently grants any loopback peer full operator scopes by `peer_ip` alone (`auth.py` `is_loopback_address`). So any website the operator visits can drive the agent's shell/tools and provider credentials — the confused-deputy / CSWSH / DNS-rebinding class that hit comparable agent runtimes in 2026 (CVE-2026-53869, CVE-2026-26317, CVE-2026-26316).

This also closes **V3 of #18** (no-auth default on a non-loopback bind).

## What

Four defense layers, all fail-closed and off the hot path:

| Layer | File | Threat |
|---|---|---|
| **Startup guard** | `config.py` `enforce_public_bind_auth_guard`, wired in `boot.py` | Refuses to serve `auth.mode="none"` on a non-loopback bind unless `auth.allow_unauthenticated_public=true` (break-glass opt-in, logged). |
| **WS Origin guard** | `websocket.py` `is_allowed_ws_origin` (before `accept()`) | Rejects cross-origin WebSocket handshakes (close 1008) → Cross-Site WebSocket Hijacking. |
| **Host allowlist** | `LoopbackHostMiddleware` + `resolve_trusted_hosts` (`app.py`) | Pins `Host` to loopback names on a loopback bind → DNS rebinding. Parses bracketed IPv6 (`[::1]:port`) correctly, which Starlette's `TrustedHostMiddleware` mangles. |
| **HTTP cross-origin guard** | `LoopbackOriginMiddleware` (`middleware.py`) | 403s cross-origin `/api/*` requests on a loopback bind even under the CORS `["*"]`+credentials default. Exempts health paths + Control UI shell. |

### Behavior / compatibility
- **Loopback + no-auth (default)** keeps working for the local CLI and same-origin Control UI; only cross-origin browser traffic is fenced.
- **CLI / node clients** (no `Origin`) are untouched.
- **Non-loopback bind** only starts past the startup guard (auth on, or explicit opt-in), so the Origin/Host guards become no-ops there — a legitimate remote browser is not blocked.
- All three guards share `scopes.is_loopback_address`, so the "trusted as local" set is identical to the existing ownership check.

New config keys (`auth.allow_unauthenticated_public`, and the existing `control_ui.allowed_origins` for a reverse-proxied UI) are documented in `agentos.toml.example` and surfaced in the Config UI help text.

## Testing

TDD throughout — every guard has tests that were watched fail first, including real-ASGI-stack tests (mutation-verified: they fail if a guard is unwired) and end-to-end drives (DNS-rebind → 400, cross-origin WS → close 1008, cross-origin `/api/*` → 403 with no ACAO reflection, loopback/health/CLI → pass).

Quality gate green: `ruff` ✅, `mypy` ✅, `pytest` **5800 passed** (3 unrelated embedding/wheel failures pre-exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)