### PR TITLE
feat(gateway): interactive auth provisioning on public bind; host/port CLI-only

### DIFF
--- a/src/agentos/agents/registry.py
+++ b/src/agentos/agents/registry.py
@@ -16,6 +16,28 @@ from agentos.identity.bootstrap import (
 )
 from agentos.session.keys import normalize_agent_id
 
+
+def _dotted_paths(payload: Any, prefix: str) -> set[str]:
+    """Recursively collect dotted paths under ``prefix`` for dict/list payloads.
+
+    List indices become numeric path segments (``agents.0.name``) so every
+    concrete leaf the config carries is named. Scalars contribute nothing beyond
+    the ``prefix`` the caller already added.
+    """
+    paths: set[str] = set()
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            current = f"{prefix}.{key}"
+            paths.add(current)
+            paths.update(_dotted_paths(value, current))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current = f"{prefix}.{index}"
+            paths.add(current)
+            paths.update(_dotted_paths(value, current))
+    return paths
+
+
 _WORKSPACE_AGENT_FILE_NAMES = (
     *CORE_BOOTSTRAP_TEMPLATE_FILENAMES,
     ONE_SHOT_BOOTSTRAP_FILENAME,
@@ -177,13 +199,33 @@ class AgentRegistry:
     async def _persist(self) -> None:
         if not self.persist_changes:
             return
-        from agentos.onboarding.config_store import persist_config
+        # Route through the override-aware gateway writer (NOT the onboarding
+        # writer directly) so a one-off CLI --listen/--port/--debug that
+        # run_gateway injected into this in-memory config is never frozen into
+        # config.toml by an agents.* mutation. The registry only ever mutates
+        # ``agents``, so ``agents`` (and its dotted descendants) are the sole
+        # explicit paths — the runtime-override map restores everything else to
+        # its on-disk original. Imported lazily to avoid an import cycle.
+        from agentos.gateway.config_persist import persist_config
 
-        persist_config(
-            self.config,
-            path=self.config_path or self.config.config_path,
-            restart_required=True,
-        )
+        target = self.config_path or self.config.config_path
+        if target is not None and not getattr(self.config, "config_path", None):
+            self.config.config_path = str(target)
+        persist_config(self.config, explicit_paths=self._agents_explicit_paths())
+
+    def _agents_explicit_paths(self) -> set[str]:
+        """Every dotted path under ``agents`` this registry may have changed.
+
+        The registry mutates only ``agents``, so persisting exactly those paths
+        (top-level ``agents`` plus each nested entry path) marks the agent edit
+        as an explicit change that must survive, while leaving bind/auth fields
+        to the runtime-override restore.
+        """
+        toml = self.config.to_toml_dict() if hasattr(self.config, "to_toml_dict") else {}
+        agents = toml.get("agents")
+        paths: set[str] = {"agents"}
+        paths.update(_dotted_paths(agents, "agents"))
+        return paths
 
     def _main_agent_summary(self) -> dict[str, Any]:
         return {

--- a/src/agentos/cli/gateway_auth_prompt.py
+++ b/src/agentos/cli/gateway_auth_prompt.py
@@ -1,0 +1,141 @@
+"""Interactive auth provisioning when the gateway resolves a public bind.
+
+The CLI is the single control point for bind posture: when ``gateway run``
+resolves a wildcard bind whose auth does not protect it, this prompt offers
+to generate + persist a token (recommended), serve break-glass for this
+session only, or cancel. Non-interactive invocations never prompt — the
+startup guard (``enforce_public_bind_auth_guard``) raises exactly as before.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Callable
+from enum import Enum
+
+from agentos.gateway.config import (
+    GatewayConfig,
+    _mode_protects_public_bind,
+    is_public_bind,
+)
+from agentos.gateway.config_persist import persist_config
+
+
+class AuthProvisionOutcome(Enum):
+    PROCEED = "proceed"  # config is ready to serve (token set, or opt-in set)
+    CANCEL = "cancel"  # operator chose to abort; CLI exits 0
+    UNCHANGED = "unchanged"  # nothing to do (not public, or already decided)
+
+
+# ASCII-only glyphs so the warnings still print on Windows consoles configured
+# for legacy GBK code pages (where U+26A0 / em-dash crash Rich's legacy
+# renderer with UnicodeEncodeError).
+_WILDCARD_WARNING = (
+    "[yellow]WARNING: gateway is bound to a wildcard address - "
+    "reachable from every interface.[/yellow]"
+)
+_LAN_OPEN_WARNING = (
+    "[yellow]  auth.mode=none + wildcard bind + "
+    "allow_unauthenticated_public = LAN-open. "
+    "Anyone reachable on this network can use the chat, sessions, "
+    "and config surfaces with your provider credentials.[/yellow]"
+)
+_BYPASS_NOTE = (
+    "[yellow]  Bypass / elevated mode remains owner-only and "
+    "is unreachable from non-loopback peers; the chat UI will "
+    "self-disable that pill.[/yellow]"
+)
+
+
+def provision_public_bind_auth(
+    config: GatewayConfig,
+    *,
+    interactive: bool,
+    prompt: Callable[[str], str] = input,
+    emit: Callable[[str], None] = print,
+) -> tuple[AuthProvisionOutcome, GatewayConfig]:
+    """Ensure a public bind is authenticated before the gateway starts.
+
+    Returns the outcome plus the (possibly updated) config. Loopback binds
+    and already-protected/opted-in public binds return ``UNCHANGED``; so do
+    non-interactive runs, which fall through to the startup guard unchanged.
+    """
+    if not is_public_bind(config.host):
+        return (AuthProvisionOutcome.UNCHANGED, config)
+
+    emit(_WILDCARD_WARNING)
+    if config.auth.mode == "none" and config.auth.allow_unauthenticated_public:
+        # Without the opt-in, start_gateway_server refuses the unauthenticated
+        # combination outright (enforce_public_bind_auth_guard) — no point
+        # warning that the network is open right before the refusal explains
+        # itself.
+        emit(_LAN_OPEN_WARNING)
+    emit(_BYPASS_NOTE)
+
+    if _mode_protects_public_bind(config.auth) or config.auth.allow_unauthenticated_public:
+        return (AuthProvisionOutcome.UNCHANGED, config)
+
+    if not interactive:
+        # Non-TTY (CI, pipes): never prompt; the startup guard raises
+        # ValueError downstream exactly as today.
+        return (AuthProvisionOutcome.UNCHANGED, config)
+
+    emit(
+        "[yellow]This public bind has no authentication configured. "
+        "Choose how to proceed:[/yellow]"
+    )
+    emit("  [1] Generate a token and enable auth (recommended)")
+    emit("  [2] Serve without authentication (break-glass, this run only)")
+    emit("  [3] Cancel")
+    try:
+        choice = prompt("Select [1/2/3] (default 1): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return (AuthProvisionOutcome.CANCEL, config)
+
+    if choice == "3":
+        return (AuthProvisionOutcome.CANCEL, config)
+
+    if choice == "2":
+        new_config = config.model_copy(
+            update={"auth": config.auth.model_copy(update={"allow_unauthenticated_public": True})}
+        )
+        emit(_LAN_OPEN_WARNING)
+        emit("[yellow]  Break-glass is session-only; nothing was written to the config.[/yellow]")
+        return (AuthProvisionOutcome.PROCEED, new_config)
+
+    # [1] and everything else (empty / invalid input) — the safe default.
+    token = secrets.token_urlsafe(32)
+    new_config = config.model_copy(
+        update={"auth": config.auth.model_copy(update={"mode": "token", "token": token})}
+    )
+    _persist_auth_only(new_config, emit)
+    emit(f"[bold]Gateway token:[/bold] {token}")
+    emit("[dim]Clients authenticate with: Authorization: Bearer <token>[/dim]")
+    return (AuthProvisionOutcome.PROCEED, new_config)
+
+
+def _persist_auth_only(new_config: GatewayConfig, emit: Callable[[str], None]) -> None:
+    """Persist ONLY the auth change, not the one-off CLI overrides.
+
+    ``run_gateway`` injects ``host``/``port``/``debug`` from CLI flags into the
+    in-memory config before this prompt runs, so writing ``new_config`` wholesale
+    would freeze a one-off ``--listen 0.0.0.0 --debug`` into the config file. We
+    instead reload the on-disk config and apply only the new auth, so a plain
+    ``agentos gateway run`` next time is unaffected.
+    """
+    config_path = new_config.config_path
+    try:
+        to_write = (
+            GatewayConfig.load(config_path) if config_path else new_config.model_copy(deep=True)
+        )
+        to_write = to_write.model_copy(update={"auth": new_config.auth})
+        if config_path and not to_write.config_path:
+            to_write.config_path = config_path
+        persist_config(to_write)
+    except OSError as exc:
+        emit(
+            f"[yellow]WARNING: could not persist the token to the config file ({exc}). "
+            "It stays active for this session only.[/yellow]"
+        )
+    else:
+        emit(f"[green]auth.mode=token enabled; token saved to {config_path}[/green]")

--- a/src/agentos/cli/gateway_auth_prompt.py
+++ b/src/agentos/cli/gateway_auth_prompt.py
@@ -16,9 +16,9 @@ from enum import Enum
 from agentos.gateway.config import (
     GatewayConfig,
     _mode_protects_public_bind,
-    is_public_bind,
 )
 from agentos.gateway.config_persist import persist_config
+from agentos.gateway.scopes import is_loopback_bind
 
 
 class AuthProvisionOutcome(Enum):
@@ -60,7 +60,11 @@ def provision_public_bind_auth(
     and already-protected/opted-in public binds return ``UNCHANGED``; so do
     non-interactive runs, which fall through to the startup guard unchanged.
     """
-    if not is_public_bind(config.host):
+    # Use the SAME predicate as enforce_public_bind_auth_guard: any non-loopback
+    # bind (a wildcard 0.0.0.0/:: OR a specific LAN IP like 192.168.1.50) needs
+    # auth. is_public_bind only catches wildcards, so a LAN bind would otherwise
+    # skip the prompt and hit the raw startup ValueError (PR #25 review, P1 #2).
+    if is_loopback_bind(config.host):
         return (AuthProvisionOutcome.UNCHANGED, config)
 
     emit(_WILDCARD_WARNING)
@@ -96,8 +100,19 @@ def provision_public_bind_auth(
         return (AuthProvisionOutcome.CANCEL, config)
 
     if choice == "2":
+        # Break-glass means "serve openly", so force auth.mode="none" too — not
+        # just the opt-in flag. Leaving an unsupported mode (password /
+        # trusted-proxy / typo) in place would let the guard start the gateway
+        # while resolve_auth has no resolver for it, so the WS/chat surface
+        # still rejects everyone — the operator's "serve without auth" intent
+        # would silently not hold (PR #25 review, P2). None is session-only;
+        # nothing is persisted (host/mode/opt-in are all runtime-only here).
         new_config = config.model_copy(
-            update={"auth": config.auth.model_copy(update={"allow_unauthenticated_public": True})}
+            update={
+                "auth": config.auth.model_copy(
+                    update={"mode": "none", "allow_unauthenticated_public": True}
+                )
+            }
         )
         emit(_LAN_OPEN_WARNING)
         emit("[yellow]  Break-glass is session-only; nothing was written to the config.[/yellow]")
@@ -108,34 +123,17 @@ def provision_public_bind_auth(
     new_config = config.model_copy(
         update={"auth": config.auth.model_copy(update={"mode": "token", "token": token})}
     )
-    _persist_auth_only(new_config, emit)
-    emit(f"[bold]Gateway token:[/bold] {token}")
-    emit("[dim]Clients authenticate with: Authorization: Bearer <token>[/dim]")
-    return (AuthProvisionOutcome.PROCEED, new_config)
-
-
-def _persist_auth_only(new_config: GatewayConfig, emit: Callable[[str], None]) -> None:
-    """Persist ONLY the auth change, not the one-off CLI overrides.
-
-    ``run_gateway`` injects ``host``/``port``/``debug`` from CLI flags into the
-    in-memory config before this prompt runs, so writing ``new_config`` wholesale
-    would freeze a one-off ``--listen 0.0.0.0 --debug`` into the config file. We
-    instead reload the on-disk config and apply only the new auth, so a plain
-    ``agentos gateway run`` next time is unaffected.
-    """
-    config_path = new_config.config_path
+    # persist_config writes only the auth change: host/port/debug are runtime-
+    # only and are never frozen from the in-memory config (see config_persist).
     try:
-        to_write = (
-            GatewayConfig.load(config_path) if config_path else new_config.model_copy(deep=True)
-        )
-        to_write = to_write.model_copy(update={"auth": new_config.auth})
-        if config_path and not to_write.config_path:
-            to_write.config_path = config_path
-        persist_config(to_write)
+        persist_config(new_config)
     except OSError as exc:
         emit(
             f"[yellow]WARNING: could not persist the token to the config file ({exc}). "
             "It stays active for this session only.[/yellow]"
         )
     else:
-        emit(f"[green]auth.mode=token enabled; token saved to {config_path}[/green]")
+        emit(f"[green]auth.mode=token enabled; token saved to {new_config.config_path}[/green]")
+    emit(f"[bold]Gateway token:[/bold] {token}")
+    emit("[dim]Clients authenticate with: Authorization: Bearer <token>[/dim]")
+    return (AuthProvisionOutcome.PROCEED, new_config)

--- a/src/agentos/cli/gateway_auth_prompt.py
+++ b/src/agentos/cli/gateway_auth_prompt.py
@@ -16,8 +16,13 @@ from enum import Enum
 from agentos.gateway.config import (
     GatewayConfig,
     _mode_protects_public_bind,
+    is_public_bind,
 )
-from agentos.gateway.config_persist import persist_config
+from agentos.gateway.config_persist import (
+    get_runtime_overrides,
+    persist_config,
+    set_runtime_overrides,
+)
 from agentos.gateway.scopes import is_loopback_bind
 
 
@@ -30,10 +35,23 @@ class AuthProvisionOutcome(Enum):
 # ASCII-only glyphs so the warnings still print on Windows consoles configured
 # for legacy GBK code pages (where U+26A0 / em-dash crash Rich's legacy
 # renderer with UnicodeEncodeError).
-_WILDCARD_WARNING = (
-    "[yellow]WARNING: gateway is bound to a wildcard address - "
-    "reachable from every interface.[/yellow]"
-)
+def _bind_warning(host: str) -> str:
+    """Accurate for BOTH a wildcard (0.0.0.0 / ::) AND a specific LAN IP.
+
+    The prompt fires for any non-loopback bind, so the message must name the
+    actual host rather than always claiming a wildcard 'every interface' bind.
+    """
+    if is_public_bind(host):
+        return (
+            f"[yellow]WARNING: gateway is bound to the wildcard address {host} - "
+            "reachable from every interface.[/yellow]"
+        )
+    return (
+        f"[yellow]WARNING: gateway is bound to a non-loopback address {host} - "
+        "reachable beyond this machine.[/yellow]"
+    )
+
+
 _LAN_OPEN_WARNING = (
     "[yellow]  auth.mode=none + wildcard bind + "
     "allow_unauthenticated_public = LAN-open. "
@@ -59,6 +77,15 @@ def provision_public_bind_auth(
     Returns the outcome plus the (possibly updated) config. Loopback binds
     and already-protected/opted-in public binds return ``UNCHANGED``; so do
     non-interactive runs, which fall through to the startup guard unchanged.
+
+    Bind provenance is handled by the process-global runtime-override map
+    (``config_persist.set_runtime_overrides``), recorded by ``run_gateway``
+    before it injects ``--bind``/``--port``/``--debug`` in memory. When choice
+    [1] persists a token, that map restores those fields so a one-off
+    ``--listen`` / ``--debug`` is never frozen into ``config.toml``. When choice
+    [2] forces ``auth.mode=none`` for the session, this function augments the
+    map with the on-disk auth originals so a later RPC write cannot freeze the
+    break-glass posture either.
     """
     # Use the SAME predicate as enforce_public_bind_auth_guard: any non-loopback
     # bind (a wildcard 0.0.0.0/:: OR a specific LAN IP like 192.168.1.50) needs
@@ -67,7 +94,7 @@ def provision_public_bind_auth(
     if is_loopback_bind(config.host):
         return (AuthProvisionOutcome.UNCHANGED, config)
 
-    emit(_WILDCARD_WARNING)
+    emit(_bind_warning(config.host))
     if config.auth.mode == "none" and config.auth.allow_unauthenticated_public:
         # Without the opt-in, start_gateway_server refuses the unauthenticated
         # combination outright (enforce_public_bind_auth_guard) — no point
@@ -107,6 +134,16 @@ def provision_public_bind_auth(
         # still rejects everyone — the operator's "serve without auth" intent
         # would silently not hold (PR #25 review, P2). None is session-only;
         # nothing is persisted (host/mode/opt-in are all runtime-only here).
+        # Record the ON-DISK auth posture in the runtime-override map BEFORE we
+        # flip it in memory, so a later config.patch (which persists ctx.config)
+        # restores the original auth.mode / opt-in instead of freezing the
+        # session-only break-glass posture into config.toml (PR #25 review, P1).
+        overrides = get_runtime_overrides()
+        overrides["auth.mode"] = config.auth.mode
+        overrides["auth.allow_unauthenticated_public"] = (
+            config.auth.allow_unauthenticated_public
+        )
+        set_runtime_overrides(overrides)
         new_config = config.model_copy(
             update={
                 "auth": config.auth.model_copy(
@@ -123,8 +160,10 @@ def provision_public_bind_auth(
     new_config = config.model_copy(
         update={"auth": config.auth.model_copy(update={"mode": "token", "token": token})}
     )
-    # persist_config writes only the auth change: host/port/debug are runtime-
-    # only and are never frozen from the in-memory config (see config_persist).
+    # Persist the token. The process-global runtime-override map restores the
+    # CLI bind overrides (host/port/debug) to their on-disk values, so a one-off
+    # --listen / --port / --debug is not frozen in. ``auth`` is NOT in the map,
+    # so the new token persists.
     try:
         persist_config(new_config)
     except OSError as exc:

--- a/src/agentos/cli/gateway_auth_prompt.py
+++ b/src/agentos/cli/gateway_auth_prompt.py
@@ -165,14 +165,18 @@ def provision_public_bind_auth(
     # --listen / --port / --debug is not frozen in. ``auth`` is NOT in the map,
     # so the new token persists.
     try:
-        persist_config(new_config)
+        # persist_config returns the RESOLVED path (and back-fills config_path);
+        # on a true first run config.config_path is None and the onboarding writer
+        # resolves the home path internally, so emit the returned path — never the
+        # None placeholder.
+        saved_path = persist_config(new_config)
     except OSError as exc:
         emit(
             f"[yellow]WARNING: could not persist the token to the config file ({exc}). "
             "It stays active for this session only.[/yellow]"
         )
     else:
-        emit(f"[green]auth.mode=token enabled; token saved to {new_config.config_path}[/green]")
+        emit(f"[green]auth.mode=token enabled; token saved to {saved_path}[/green]")
     emit(f"[bold]Gateway token:[/bold] {token}")
     emit("[dim]Clients authenticate with: Authorization: Bearer <token>[/dim]")
     return (AuthProvisionOutcome.PROCEED, new_config)

--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 
 import typer
 
+from agentos.cli.gateway_auth_prompt import (
+    AuthProvisionOutcome,
+    provision_public_bind_auth,
+)
 from agentos.cli.gateway_lifecycle import (
     GatewayLifecycleManager,
     GatewayLifecycleResult,
@@ -17,6 +22,11 @@ from agentos.cli.ui import ACCENT_MARKUP, console
 from agentos.gateway.boot import start_gateway_server
 from agentos.gateway.config import GatewayConfig, is_public_bind, resolve_listen_address
 from agentos.paths import default_agentos_home
+
+
+def _stdin_isatty() -> bool:
+    """Seam for tests — CliRunner replaces sys.stdin, so patch this instead."""
+    return sys.stdin.isatty()
 
 
 def gateway_startup_guidance(host: str, port: int, scheme: str = "http") -> tuple[str, ...]:
@@ -62,6 +72,18 @@ def run_gateway(
     resolved_port = port if port is not None else config.port
     config = config.model_copy(update={"host": host, "port": resolved_port, "debug": debug})
 
+    # Public-bind auth provisioning: the helper owns all public-bind warning
+    # messaging and, on an interactive TTY, prompts to secure an unprotected
+    # public bind (generate+persist a token / break-glass / cancel). Non-TTY
+    # runs never prompt — enforce_public_bind_auth_guard still refuses the
+    # unsafe combination downstream, exactly as before.
+    outcome, config = provision_public_bind_auth(
+        config, interactive=_stdin_isatty(), emit=console.print
+    )
+    if outcome is AuthProvisionOutcome.CANCEL:
+        console.print("[yellow]Gateway start cancelled.[/yellow]")
+        raise typer.Exit(0)
+
     banner_host = f"[red]{host}[/red]" if is_public_bind(host) else f"[{ACCENT_MARKUP}]{host}[/]"
     console.print(
         f"[bold green]Starting AgentOS gateway[/bold green] on {banner_host}:{resolved_port}"
@@ -69,29 +91,6 @@ def run_gateway(
     scheme = "https" if (config.tls.keyfile and config.tls.certfile) else "http"
     for line in gateway_startup_guidance(host, resolved_port, scheme=scheme):
         console.print(line)
-    if is_public_bind(host):
-        # Use ASCII-only glyphs here so the warning still prints on Windows
-        # consoles configured for legacy GBK code pages (where U+26A0 / em-dash
-        # crash Rich's legacy renderer with UnicodeEncodeError).
-        console.print(
-            "[yellow]WARNING: gateway is bound to a wildcard address - "
-            "reachable from every interface.[/yellow]"
-        )
-        if config.auth.mode == "none" and config.auth.allow_unauthenticated_public:
-            # Without the opt-in, start_gateway_server refuses this combination
-            # outright (enforce_public_bind_auth_guard) — no point warning that
-            # the network is open right before the refusal explains itself.
-            console.print(
-                "[yellow]  auth.mode=none + wildcard bind + "
-                "allow_unauthenticated_public = LAN-open. "
-                "Anyone reachable on this network can use the chat, sessions, "
-                "and config surfaces with your provider credentials.[/yellow]"
-            )
-        console.print(
-            "[yellow]  Bypass / elevated mode remains owner-only and "
-            "is unreachable from non-loopback peers; the chat UI will "
-            "self-disable that pill.[/yellow]"
-        )
 
     async def _run() -> None:
         # Subscription manager is gateway-specific (WS event routing)

--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -21,6 +21,7 @@ from agentos.cli.gateway_lifecycle import (
 from agentos.cli.ui import ACCENT_MARKUP, console
 from agentos.gateway.boot import start_gateway_server
 from agentos.gateway.config import GatewayConfig, is_public_bind, resolve_listen_address
+from agentos.gateway.config_persist import set_runtime_overrides
 from agentos.paths import default_agentos_home
 
 
@@ -70,6 +71,19 @@ def run_gateway(
     explicit_flag: str | None = listen or (bind if bind and bind != "127.0.0.1" else None)
     host = resolve_listen_address(explicit_flag, default=config.host or "127.0.0.1")
     resolved_port = port if port is not None else config.port
+    # Record the on-disk values BEFORE overriding them in memory, in the
+    # process-global runtime-override map that every config writer consults. A
+    # one-off --listen/--port/--debug (or a later break-glass mode=none) must
+    # never be frozen into config.toml by ANY config write; each key maps to its
+    # pre-override on-disk value so persist restores it unless a writer marks
+    # that exact field explicitly changed.
+    set_runtime_overrides(
+        {
+            "host": config.host,
+            "port": config.port,
+            "debug": config.debug,
+        }
+    )
     config = config.model_copy(update={"host": host, "port": resolved_port, "debug": debug})
 
     # Public-bind auth provisioning: the helper owns all public-bind warning
@@ -78,7 +92,9 @@ def run_gateway(
     # runs never prompt — enforce_public_bind_auth_guard still refuses the
     # unsafe combination downstream, exactly as before.
     outcome, config = provision_public_bind_auth(
-        config, interactive=_stdin_isatty(), emit=console.print
+        config,
+        interactive=_stdin_isatty(),
+        emit=console.print,
     )
     if outcome is AuthProvisionOutcome.CANCEL:
         console.print("[yellow]Gateway start cancelled.[/yellow]")

--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -21,7 +21,7 @@ from agentos.cli.gateway_lifecycle import (
 from agentos.cli.ui import ACCENT_MARKUP, console
 from agentos.gateway.boot import start_gateway_server
 from agentos.gateway.config import GatewayConfig, is_public_bind, resolve_listen_address
-from agentos.gateway.config_persist import set_runtime_overrides
+from agentos.gateway.config_persist import read_raw_bind_overrides, set_runtime_overrides
 from agentos.paths import default_agentos_home
 
 
@@ -71,19 +71,20 @@ def run_gateway(
     explicit_flag: str | None = listen or (bind if bind and bind != "127.0.0.1" else None)
     host = resolve_listen_address(explicit_flag, default=config.host or "127.0.0.1")
     resolved_port = port if port is not None else config.port
-    # Record the on-disk values BEFORE overriding them in memory, in the
+    # Record the RAW on-disk values BEFORE overriding them in memory, in the
     # process-global runtime-override map that every config writer consults. A
     # one-off --listen/--port/--debug (or a later break-glass mode=none) must
     # never be frozen into config.toml by ANY config write; each key maps to its
     # pre-override on-disk value so persist restores it unless a writer marks
     # that exact field explicitly changed.
-    set_runtime_overrides(
-        {
-            "host": config.host,
-            "port": config.port,
-            "debug": config.debug,
-        }
-    )
+    #
+    # Read the literal TOML — NOT config.host/port/debug, which GatewayConfig.load
+    # has already env-merged (AGENTOS_GATEWAY_HOST etc.). An env-supplied posture
+    # is itself transient (env vars are per-invocation), so recording the effective
+    # value as the "on-disk original" would let a later config.patch freeze it. A
+    # key absent from the TOML records as None -> persist drops it, so the
+    # load-time default/env re-applies at the next boot.
+    set_runtime_overrides(read_raw_bind_overrides(config.config_path))
     config = config.model_copy(update={"host": host, "port": resolved_port, "debug": debug})
 
     # Public-bind auth provisioning: the helper owns all public-bind warning

--- a/src/agentos/gateway/config_persist.py
+++ b/src/agentos/gateway/config_persist.py
@@ -1,92 +1,127 @@
-"""Shared config persistence — the single TOML write path.
+"""Shared config persistence — the single TOML write path for live writers.
 
-Both the config RPC surface (``rpc_config``) and the CLI auth provisioning
-prompt persist :class:`~agentos.gateway.config.GatewayConfig` through this
-helper so the on-disk representation is produced identically everywhere.
+Every live writer (the config RPC surface ``rpc_config``, the onboarding RPC
+surface ``rpc_onboarding``, and the CLI auth-provisioning prompt) persists
+:class:`~agentos.gateway.config.GatewayConfig` through :func:`persist_config`.
+It delegates the actual write to
+:func:`agentos.onboarding.config_store.persist_config`, so every live writer
+shares one atomic + ``0600`` contract (temp file + ``os.replace`` + ``chmod``);
+a freshly generated bearer token is never world-readable.
 
-**Runtime-only fields never persist from the in-memory config.** ``host``,
-``port``, ``debug`` and ``auth.allow_unauthenticated_public`` are set for a
-single run (CLI ``--bind`` / ``--port`` / ``--debug`` flags, break-glass) and
-are deliberately *not* written back — the in-memory config carries a one-off
-override that must not be frozen into ``config.toml`` (PR #25 review). To
-change them permanently, edit ``config.toml`` directly. Every writer routes
-through here, so this one rule keeps bind posture CLI-only across the CLI
-prompt and all config RPCs.
+**Provenance, not field names.** ``run_gateway`` and break-glass inject one-off
+overrides (``--bind`` / ``--port`` / ``--debug``; break-glass ``auth.mode`` /
+``allow_unauthenticated_public``) into the in-memory config, which then flows
+into ``ctx.config`` for every RPC. Writing those wholesale would freeze a
+one-off ``--listen 0.0.0.0 --debug`` into ``config.toml``. So at boot the CLI
+records the ON-DISK original values of exactly those fields in a process-global
+override map via :func:`set_runtime_overrides`, and every ``persist_config``
+call restores each recorded field to its original on-disk value (or drops the
+field when the original was ``None`` — it was absent, so the load-time default
+applies) — UNLESS that exact dotted path is named in ``explicit_paths``,
+meaning the user explicitly changed it this write and the new value must
+persist. A genuine config edit (UI "Save" via ``config.patch``/``apply``, or an
+onboarding mutation) passes ``explicit_paths`` for what it actually changed, so
+it is never silently discarded.
 """
 
 from __future__ import annotations
 
-import tomllib
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
-from agentos.paths import default_agentos_home
+if TYPE_CHECKING:
+    from agentos.gateway.config import GatewayConfig
 
-# Dot-paths whose in-memory value is treated as a one-off runtime override:
-# never written from the live config, always taken from the existing on-disk
-# file (or dropped, so load-time defaults apply, when no file exists).
-_RUNTIME_ONLY_PATHS: tuple[tuple[str, ...], ...] = (
-    ("host",),
-    ("port",),
-    ("debug",),
-    ("auth", "allow_unauthenticated_public"),
-)
+# Process-global map recorded at boot by ``run_gateway`` (and augmented by the
+# break-glass prompt). Keys are dotted paths (``host``, ``port``, ``debug``,
+# ``auth.mode``, ``auth.allow_unauthenticated_public``); values are the original
+# on-disk value, or ``None`` meaning "was absent -> drop so the default applies".
+_RUNTIME_OVERRIDES: dict[str, Any] = {}
 
 
-def _existing_value(on_disk: dict, path: tuple[str, ...]) -> tuple[bool, Any]:
-    node: Any = on_disk
-    for key in path:
-        if not isinstance(node, dict) or key not in node:
-            return (False, None)
-        node = node[key]
-    return (True, node)
+def set_runtime_overrides(mapping: dict[str, Any] | None) -> None:
+    """Record (or clear) the boot-time runtime override map.
 
-
-def _apply_runtime_only_rule(data: dict, on_disk: dict) -> None:
-    """In-place: replace each runtime-only field with its on-disk value, or
-    drop it entirely when the file did not have one (defaults apply on reload)."""
-    for path in _RUNTIME_ONLY_PATHS:
-        present, value = _existing_value(on_disk, path)
-        node = data
-        for key in path[:-1]:
-            child = node.get(key)
-            if not isinstance(child, dict):
-                child = {}
-                node[key] = child
-            node = child
-        leaf = path[-1]
-        if present:
-            node[leaf] = value
-        else:
-            node.pop(leaf, None)
-
-
-def persist_config(config: Any) -> None:
-    """Write config to TOML, defaulting to the user config path when unset.
-
-    Runtime-only fields (see module docstring) are excluded — their on-disk
-    value is preserved and the live override is discarded.
+    Called once by ``run_gateway`` before it overrides ``host``/``port``/
+    ``debug`` in memory, and augmented by the break-glass prompt when it forces
+    ``auth.mode=none``. ``None`` clears the map (used by tests and by a plain
+    loopback run that overrode nothing).
     """
-    if not getattr(config, "config_path", None) and hasattr(config, "config_path"):
-        config.config_path = str(default_agentos_home() / "config.toml")
+    global _RUNTIME_OVERRIDES
+    _RUNTIME_OVERRIDES = dict(mapping) if mapping else {}
 
-    if not getattr(config, "config_path", None):
-        return
 
-    import tomli_w  # TOML writer (tomllib is read-only)
+def get_runtime_overrides() -> dict[str, Any]:
+    """Return a copy of the current runtime override map."""
+    return dict(_RUNTIME_OVERRIDES)
 
-    path = Path(config.config_path)
-    on_disk: dict = {}
-    if path.exists():
-        try:
-            with open(path, "rb") as f:
-                on_disk = tomllib.load(f)
-        except (OSError, tomllib.TOMLDecodeError):
-            on_disk = {}
 
+def _set_dotted(data: dict, path: str, value: Any) -> None:
+    keys = path.split(".")
+    node = data
+    for key in keys[:-1]:
+        child = node.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            node[key] = child
+        node = child
+    node[keys[-1]] = value
+
+
+def _drop_dotted(data: dict, path: str) -> None:
+    keys = path.split(".")
+    node: Any = data
+    for key in keys[:-1]:
+        node = node.get(key)
+        if not isinstance(node, dict):
+            return
+    node.pop(keys[-1], None)
+
+
+def persist_config(
+    config: Any,
+    *,
+    explicit_paths: set[str] | None = None,
+) -> None:
+    """Write config to TOML atomically (0600), restoring any runtime overrides.
+
+    The process-global runtime-override map (see :func:`set_runtime_overrides`)
+    maps each CLI/break-glass-overridden dotted path to the value that was on
+    disk before the override. Each such field is restored to its original value
+    (or dropped when the original was ``None``) so a transient
+    ``--listen``/``--debug``/break-glass posture never persists — UNLESS the
+    path is in ``explicit_paths``, meaning the user explicitly changed it this
+    write and the new value must persist verbatim.
+    """
+    from agentos.onboarding.config_store import persist_config as _store_persist
+
+    explicit = explicit_paths or set()
     data = config.to_toml_dict()
-    _apply_runtime_only_rule(data, on_disk)
+    for path, original in _RUNTIME_OVERRIDES.items():
+        if path in explicit:
+            continue
+        if original is None:
+            _drop_dotted(data, path)
+        else:
+            _set_dotted(data, path, original)
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "wb") as f:
-        tomli_w.dump(data, f)
+    _store_persist(
+        cast("GatewayConfig", _TomlDictConfig(data)),
+        path=getattr(config, "config_path", None),
+        backup=True,
+    )
+
+
+class _TomlDictConfig:
+    """Adapter so a plain (override-corrected) TOML dict can be persisted
+    through the onboarding writer, which re-serializes and re-validates via
+    ``GatewayConfig``; we hand it the already-corrected dict via
+    ``to_toml_dict`` and let it validate + write.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def to_toml_dict(self) -> dict[str, Any]:
+        return self._data

--- a/src/agentos/gateway/config_persist.py
+++ b/src/agentos/gateway/config_persist.py
@@ -1,0 +1,29 @@
+"""Shared config persistence — the single TOML write path.
+
+Both the config RPC surface (``rpc_config``) and the CLI auth provisioning
+prompt persist :class:`~agentos.gateway.config.GatewayConfig` through this
+helper so the on-disk representation is produced identically everywhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agentos.paths import default_agentos_home
+
+
+def persist_config(config: Any) -> None:
+    """Write config to TOML, defaulting to the user config path when unset."""
+    if not getattr(config, "config_path", None) and hasattr(config, "config_path"):
+        config.config_path = str(default_agentos_home() / "config.toml")
+
+    if not getattr(config, "config_path", None):
+        return
+
+    import tomli_w  # TOML writer (tomllib is read-only)
+
+    path = Path(config.config_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        tomli_w.dump(config.to_toml_dict(), f)

--- a/src/agentos/gateway/config_persist.py
+++ b/src/agentos/gateway/config_persist.py
@@ -3,18 +3,70 @@
 Both the config RPC surface (``rpc_config``) and the CLI auth provisioning
 prompt persist :class:`~agentos.gateway.config.GatewayConfig` through this
 helper so the on-disk representation is produced identically everywhere.
+
+**Runtime-only fields never persist from the in-memory config.** ``host``,
+``port``, ``debug`` and ``auth.allow_unauthenticated_public`` are set for a
+single run (CLI ``--bind`` / ``--port`` / ``--debug`` flags, break-glass) and
+are deliberately *not* written back — the in-memory config carries a one-off
+override that must not be frozen into ``config.toml`` (PR #25 review). To
+change them permanently, edit ``config.toml`` directly. Every writer routes
+through here, so this one rule keeps bind posture CLI-only across the CLI
+prompt and all config RPCs.
 """
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Any
 
 from agentos.paths import default_agentos_home
 
+# Dot-paths whose in-memory value is treated as a one-off runtime override:
+# never written from the live config, always taken from the existing on-disk
+# file (or dropped, so load-time defaults apply, when no file exists).
+_RUNTIME_ONLY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("host",),
+    ("port",),
+    ("debug",),
+    ("auth", "allow_unauthenticated_public"),
+)
+
+
+def _existing_value(on_disk: dict, path: tuple[str, ...]) -> tuple[bool, Any]:
+    node: Any = on_disk
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return (False, None)
+        node = node[key]
+    return (True, node)
+
+
+def _apply_runtime_only_rule(data: dict, on_disk: dict) -> None:
+    """In-place: replace each runtime-only field with its on-disk value, or
+    drop it entirely when the file did not have one (defaults apply on reload)."""
+    for path in _RUNTIME_ONLY_PATHS:
+        present, value = _existing_value(on_disk, path)
+        node = data
+        for key in path[:-1]:
+            child = node.get(key)
+            if not isinstance(child, dict):
+                child = {}
+                node[key] = child
+            node = child
+        leaf = path[-1]
+        if present:
+            node[leaf] = value
+        else:
+            node.pop(leaf, None)
+
 
 def persist_config(config: Any) -> None:
-    """Write config to TOML, defaulting to the user config path when unset."""
+    """Write config to TOML, defaulting to the user config path when unset.
+
+    Runtime-only fields (see module docstring) are excluded — their on-disk
+    value is preserved and the live override is discarded.
+    """
     if not getattr(config, "config_path", None) and hasattr(config, "config_path"):
         config.config_path = str(default_agentos_home() / "config.toml")
 
@@ -24,6 +76,17 @@ def persist_config(config: Any) -> None:
     import tomli_w  # TOML writer (tomllib is read-only)
 
     path = Path(config.config_path)
+    on_disk: dict = {}
+    if path.exists():
+        try:
+            with open(path, "rb") as f:
+                on_disk = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            on_disk = {}
+
+    data = config.to_toml_dict()
+    _apply_runtime_only_rule(data, on_disk)
+
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "wb") as f:
-        tomli_w.dump(config.to_toml_dict(), f)
+        tomli_w.dump(data, f)

--- a/src/agentos/gateway/config_persist.py
+++ b/src/agentos/gateway/config_persist.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from agentos.gateway.config import GatewayConfig
 
 # Process-global map recorded at boot by ``run_gateway`` (and augmented by the
@@ -53,6 +55,40 @@ def set_runtime_overrides(mapping: dict[str, Any] | None) -> None:
 def get_runtime_overrides() -> dict[str, Any]:
     """Return a copy of the current runtime override map."""
     return dict(_RUNTIME_OVERRIDES)
+
+
+def read_raw_bind_overrides(config_path: str | None) -> dict[str, Any]:
+    """Return the RAW on-disk ``host``/``port``/``debug`` for the override map.
+
+    ``run_gateway`` must record the values that are literally in ``config.toml``,
+    NOT the env-merged effective values that ``GatewayConfig.load`` produces
+    (``env_prefix="AGENTOS_GATEWAY_"`` merges ``AGENTOS_GATEWAY_HOST`` etc.).
+    An env-supplied bind posture is itself transient — env vars are per-invocation
+    — so recording the env value as the "on-disk original" would let a later
+    ``config.patch`` freeze it into the file. A key absent from the TOML maps to
+    ``None`` so ``persist_config`` drops it and the load-time default/env applies
+    at the next boot. A missing/unreadable file yields all-``None`` (nothing to
+    restore beyond the defaults).
+    """
+    keys = ("host", "port", "debug")
+    result: dict[str, Any] = {key: None for key in keys}
+    if not config_path:
+        return result
+    try:
+        import tomllib
+
+        with open(config_path, "rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, ValueError):
+        # ValueError covers tomllib.TOMLDecodeError (a subclass); a malformed or
+        # unreadable file leaves every original None so only defaults apply.
+        return result
+    if not isinstance(data, dict):
+        return result
+    for key in keys:
+        if key in data:
+            result[key] = data[key]
+    return result
 
 
 def _set_dotted(data: dict, path: str, value: Any) -> None:
@@ -81,7 +117,7 @@ def persist_config(
     config: Any,
     *,
     explicit_paths: set[str] | None = None,
-) -> None:
+) -> Path:
     """Write config to TOML atomically (0600), restoring any runtime overrides.
 
     The process-global runtime-override map (see :func:`set_runtime_overrides`)
@@ -91,6 +127,12 @@ def persist_config(
     ``--listen``/``--debug``/break-glass posture never persists — UNLESS the
     path is in ``explicit_paths``, meaning the user explicitly changed it this
     write and the new value must persist verbatim.
+
+    Returns the resolved file path the write landed on. On a true first run the
+    caller's ``config.config_path`` is ``None`` and the onboarding writer
+    resolves the home path internally; that resolved path is returned AND
+    back-filled onto ``config.config_path`` so callers can report where the
+    token was saved instead of "None".
     """
     from agentos.onboarding.config_store import persist_config as _store_persist
 
@@ -104,11 +146,19 @@ def persist_config(
         else:
             _set_dotted(data, path, original)
 
-    _store_persist(
+    result = _store_persist(
         cast("GatewayConfig", _TomlDictConfig(data)),
         path=getattr(config, "config_path", None),
         backup=True,
     )
+    # Back-fill the resolved path so a first-run caller (config_path was None)
+    # can name the real file, and subsequent writes target the same one.
+    if not getattr(config, "config_path", None):
+        try:
+            config.config_path = str(result.path)
+        except (AttributeError, TypeError):
+            pass
+    return result.path
 
 
 class _TomlDictConfig:

--- a/src/agentos/gateway/rpc_config.py
+++ b/src/agentos/gateway/rpc_config.py
@@ -397,7 +397,7 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
     _sync_provider_selector(ctx, new_config)
     _update_config_in_place(ctx.config, new_config)
     _sync_image_generation(new_config)
-    _persist_config(ctx.config)
+    _persist_config(ctx.config, explicit_paths=explicit_paths)
     return {
         "restartRequired": _restart_required(
             old_memory_fingerprint=old_memory_fingerprint,
@@ -476,7 +476,7 @@ async def _handle_config_patch(params: dict | None, ctx: RpcContext) -> dict[str
     _update_config_in_place(ctx.config, new_config)
     _sync_image_generation(new_config)
 
-    _persist_config(ctx.config)
+    _persist_config(ctx.config, explicit_paths=explicit_paths)
     return {
         "patched": list(dot_patches.keys()) + (["(merge)"] if patch_data else []),
         "restartRequired": _restart_required(
@@ -525,6 +525,17 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
         raise ValueError("params.config is required")
 
     config_payload = dict(config_payload)
+    # YAML-mode Save seeds the payload from the RUNNING config (config.get), so
+    # every CLI/break-glass override it carries (host/port/debug/auth.mode/
+    # opt-in) is echoed back verbatim and would otherwise count as an explicit
+    # edit. Subtract the full runtime-override key set — mirroring
+    # rpc_onboarding._onboarding_explicit_paths — so persist_config restores
+    # their on-disk originals instead of freezing the transient posture. (A
+    # genuine edit still persists: form-mode config.patch sends only the dirty
+    # keys, which are not in the override map.)
+    from agentos.gateway.config_persist import get_runtime_overrides
+
+    explicit_paths = _collect_paths(config_payload) - set(get_runtime_overrides())
     if ctx.config is not None and not config_payload.get("config_path"):
         config_payload["config_path"] = getattr(ctx.config, "config_path", None)
     # Full replace preserves the RUNNING bind posture (host/port are CLI-only).
@@ -550,7 +561,10 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
     if ctx.config is not None:
         _update_config_in_place(ctx.config, new_config)
     _sync_image_generation(new_config)
-    _persist_config(ctx.config if ctx.config is not None else new_config)
+    _persist_config(
+        ctx.config if ctx.config is not None else new_config,
+        explicit_paths=explicit_paths,
+    )
     return {
         "restartRequired": _restart_required(
             old_memory_fingerprint=old_memory_fingerprint,

--- a/src/agentos/gateway/rpc_config.py
+++ b/src/agentos/gateway/rpc_config.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import copy
-from pathlib import Path
 from typing import Any, cast
 
+from agentos.gateway.config_persist import persist_config as _persist_config
 from agentos.gateway.rpc import RpcContext, get_dispatcher
-from agentos.paths import default_agentos_home
 
 _d = get_dispatcher()
 
@@ -18,22 +17,6 @@ def _update_config_in_place(old: Any, new: Any) -> None:
         setattr(old, field_name, getattr(new, field_name))
     if hasattr(old, "inherit_runtime_secrets"):
         old.inherit_runtime_secrets(new)
-
-
-def _persist_config(config: Any) -> None:
-    """Write config to TOML, defaulting to the user config path when unset."""
-    if not getattr(config, "config_path", None) and hasattr(config, "config_path"):
-        config.config_path = str(default_agentos_home() / "config.toml")
-
-    if not getattr(config, "config_path", None):
-        return
-
-    import tomli_w  # TOML writer (tomllib is read-only)
-
-    path = Path(config.config_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "wb") as f:
-        tomli_w.dump(config.to_toml_dict(), f)
 
 
 def _inherit_runtime_secrets(source: Any, target: Any) -> None:
@@ -302,8 +285,10 @@ def _sync_image_generation(config: Any) -> None:
     configure_audio(getattr(config, "audio", None))
 
 
-# Read-only paths that cannot be modified via config.set/patch/apply
-_READONLY_PATHS = frozenset({"auth.token", "auth.password"})
+# Read-only paths that cannot be modified via config.set/patch/apply.
+# host/port: bind posture is CLI-only (agentos gateway run --bind / --port),
+# so the config UI/RPC can never persist an unsafe public-bind config.
+_READONLY_PATHS = frozenset({"auth.token", "auth.password", "host", "port"})
 _SAFE_WRITE_PATCH_PATHS = frozenset(
     {
         "skills.filter_enabled",
@@ -318,6 +303,20 @@ _SAFE_WRITE_PATCH_PATHS = frozenset(
         "agentos_router.confidence_threshold",
     }
 )
+
+
+def _preserve_readonly_bind(payload: dict, config: Any) -> dict:
+    """Copy the RUNNING host/port into *payload* — bind posture is CLI-only.
+
+    Preserve, do not reject: a UI full-config round-trip that echoes the
+    current host must not fail, and a submitted host/port must never replace
+    the running one.
+    """
+    payload = dict(payload)
+    if config is not None:
+        payload["host"] = config.host
+        payload["port"] = config.port
+    return payload
 
 
 def _resolve_path(obj: dict, path: str) -> Any:
@@ -455,6 +454,9 @@ async def _handle_config_patch(params: dict | None, ctx: RpcContext) -> dict[str
         patch_data, merge_restored_paths = _restore_redacted_values(patch_data, source_cfg_dict)
         redacted_paths.update(merge_restored_paths)
         cfg_dict = _deep_merge(cfg_dict, patch_data)
+        # The merge path bypasses the per-path _READONLY_PATHS skip above, so
+        # re-assert the running bind posture (host/port are CLI-only).
+        cfg_dict = _preserve_readonly_bind(cfg_dict, ctx.config)
 
     explicit_paths = set(dot_patches.keys()) | _collect_paths(patch_data)
     for path, value in dot_patches.items():
@@ -525,6 +527,8 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
     config_payload = dict(config_payload)
     if ctx.config is not None and not config_payload.get("config_path"):
         config_payload["config_path"] = getattr(ctx.config, "config_path", None)
+    # Full replace preserves the RUNNING bind posture (host/port are CLI-only).
+    config_payload = _preserve_readonly_bind(config_payload, ctx.config)
 
     old_memory_fingerprint = _memory_restart_fingerprint(ctx.config)
     old_channels_fingerprint = _channels_restart_fingerprint(ctx.config)

--- a/src/agentos/gateway/rpc_config.py
+++ b/src/agentos/gateway/rpc_config.py
@@ -41,6 +41,35 @@ def _collect_paths(payload: Any, prefix: str = "") -> set[str]:
     return paths
 
 
+def diff_paths(old: Any, new: Any, prefix: str = "") -> set[str]:
+    """Dotted paths that DIFFER between two nested dicts (added/removed/changed).
+
+    Recurses through matching dict subtrees; a key present in exactly one side,
+    or whose leaf value differs, yields its dotted path. Non-dict values (lists,
+    scalars) are compared by equality — a changed list yields the list's own
+    path, not per-index paths. Used by ``config.apply`` to treat a YAML-mode
+    Save as an edit of only the fields the operator actually changed versus the
+    baseline they were shown (``config.get``), so a field left at its runtime
+    echo is restored while a deliberately edited overridden field persists.
+    """
+    if isinstance(old, dict) and isinstance(new, dict):
+        changed: set[str] = set()
+        for key in old.keys() | new.keys():
+            current = f"{prefix}.{key}" if prefix else key
+            if key not in old or key not in new:
+                changed.add(current)
+                # A whole added/removed subtree: name every leaf inside it too so
+                # nested edits under a newly added section are all explicit.
+                changed.update(_collect_paths(new.get(key), current))
+                changed.update(_collect_paths(old.get(key), current))
+            else:
+                changed.update(diff_paths(old[key], new[key], current))
+        return changed
+    if old != new and prefix:
+        return {prefix}
+    return set()
+
+
 def _align_auto_router_profile_for_provider_patch(
     source_config: Any,
     cfg_dict: dict[str, Any],
@@ -392,7 +421,11 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
     if _memory_restart_required_for_paths({path}):
         _validate_memory_embedding_semantics(new_config)
     _inherit_runtime_secrets(ctx.config, new_config)
-    explicit_paths = {path} | _collect_paths(value, path)
+    # host/port are never persistable via RPC (bind posture is CLI-only), so a
+    # readonly path echoed inside a nested value must never enter explicit_paths
+    # — otherwise it short-circuits the runtime-override restore in persist_config
+    # and freezes a transient CLI bind. Subtract them unconditionally.
+    explicit_paths = ({path} | _collect_paths(value, path)) - _READONLY_PATHS
     _clear_runtime_secret_paths(new_config, explicit_paths - redacted_paths)
     _sync_provider_selector(ctx, new_config)
     _update_config_in_place(ctx.config, new_config)
@@ -461,6 +494,11 @@ async def _handle_config_patch(params: dict | None, ctx: RpcContext) -> dict[str
     explicit_paths = set(dot_patches.keys()) | _collect_paths(patch_data)
     for path, value in dot_patches.items():
         explicit_paths.update(_collect_paths(value, path))
+    # A UI form can echo the display-only host/port alongside a genuine edit;
+    # they are read-only paths (skipped when applied), so they must not enter
+    # explicit_paths and short-circuit the runtime-override restore. host/port
+    # are never persistable via RPC regardless.
+    explicit_paths -= _READONLY_PATHS
     _align_auto_router_profile_for_provider_patch(ctx.config, cfg_dict, explicit_paths)
 
     from agentos.gateway.config import GatewayConfig
@@ -515,11 +553,14 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
 
     from agentos.gateway.config import GatewayConfig
 
+    baseline_payload: Any = None
     config_payload = params.get("config")
     if config_payload is None and "config_yaml" in params:
         import yaml  # type: ignore[import-untyped]
 
         config_payload = yaml.safe_load(params["config_yaml"]) or {}
+        if "baseline_yaml" in params:
+            baseline_payload = yaml.safe_load(params["baseline_yaml"]) or {}
 
     if not isinstance(config_payload, dict):
         raise ValueError("params.config is required")
@@ -527,15 +568,24 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
     config_payload = dict(config_payload)
     # YAML-mode Save seeds the payload from the RUNNING config (config.get), so
     # every CLI/break-glass override it carries (host/port/debug/auth.mode/
-    # opt-in) is echoed back verbatim and would otherwise count as an explicit
-    # edit. Subtract the full runtime-override key set — mirroring
-    # rpc_onboarding._onboarding_explicit_paths — so persist_config restores
-    # their on-disk originals instead of freezing the transient posture. (A
-    # genuine edit still persists: form-mode config.patch sends only the dirty
-    # keys, which are not in the override map.)
+    # opt-in) is echoed back verbatim.
     from agentos.gateway.config_persist import get_runtime_overrides
 
-    explicit_paths = _collect_paths(config_payload) - set(get_runtime_overrides())
+    if isinstance(baseline_payload, dict):
+        # The client sent the baseline it showed the operator (the config.get
+        # snapshot). A field that DIFFERS from that baseline is a real edit and
+        # must persist even while it carries a runtime override; a field left at
+        # its echo is not an edit and is restored to its on-disk original by
+        # persist_config. Subtract _READONLY_PATHS: host/port are never
+        # persistable via RPC regardless of a diff.
+        explicit_paths = diff_paths(baseline_payload, config_payload) - _READONLY_PATHS
+    else:
+        # Older client (or config= dict payload): no baseline to diff against.
+        # Fall back to the round-2 safe behavior — subtract the full runtime-
+        # override key set (mirroring rpc_onboarding._onboarding_explicit_paths)
+        # so an echoed transient posture never freezes. (A form-mode config.patch
+        # sends only the dirty keys, which are not in the override map.)
+        explicit_paths = _collect_paths(config_payload) - set(get_runtime_overrides())
     if ctx.config is not None and not config_payload.get("config_path"):
         config_payload["config_path"] = getattr(ctx.config, "config_path", None)
     # Full replace preserves the RUNNING bind posture (host/port are CLI-only).

--- a/src/agentos/gateway/rpc_onboarding.py
+++ b/src/agentos/gateway/rpc_onboarding.py
@@ -111,8 +111,37 @@ def _sync_search_provider(config: Any) -> None:
     )
 
 
+def _onboarding_explicit_paths(new_cfg: Any) -> set[str]:
+    """Every dotted path the onboarding write carries EXCEPT the fields the CLI
+    runtime-override map owns (host/port/debug/auth bind posture).
+
+    Onboarding mutations persist the whole config, like ``config.apply``. To
+    avoid freezing a one-off ``--listen``/``--debug`` (or break-glass
+    ``auth.mode=none``) that ``run_gateway`` injected into ``ctx.config``, we
+    hand ``persist_config`` an explicit-paths set that includes everything the
+    onboarding change touches but deliberately omits the runtime-override keys,
+    so those restore to their on-disk originals.
+    """
+    from agentos.gateway.config_persist import get_runtime_overrides
+
+    override_keys = set(get_runtime_overrides())
+    toml = new_cfg.to_toml_dict() if hasattr(new_cfg, "to_toml_dict") else {}
+    return _all_dotted_paths(toml) - override_keys
+
+
+def _all_dotted_paths(payload: Any, prefix: str = "") -> set[str]:
+    paths: set[str] = set()
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            current = f"{prefix}.{key}" if prefix else key
+            paths.add(current)
+            paths.update(_all_dotted_paths(value, current))
+    return paths
+
+
 def _persist(ctx: RpcContext, new_cfg: Any, *, restart_required: bool) -> str:
-    from agentos.onboarding.config_store import persist_config
+    from agentos.gateway.config_persist import persist_config as _shared_persist
+    from agentos.onboarding.config_store import resolve_config_path
 
     if (
         ctx.config is not None
@@ -121,18 +150,23 @@ def _persist(ctx: RpcContext, new_cfg: Any, *, restart_required: bool) -> str:
     ):
         new_cfg.inherit_runtime_secrets(ctx.config)
     path = _config_path_for(ctx, new_cfg) or _config_path_for(ctx, ctx.config)
-    persist = persist_config(new_cfg, path=path, restart_required=restart_required)
+    # Route through the shared gateway writer so the runtime-override map is
+    # honoured (a CLI --listen/--debug or break-glass mode=none is never frozen
+    # by an onboarding save). Ensure ``config_path`` is set so the shared writer
+    # targets the same file the onboarding writer would have resolved.
+    resolved_path = str(path) if path else str(resolve_config_path(None)[0])
+    if not getattr(new_cfg, "config_path", None):
+        new_cfg.config_path = resolved_path
+    _shared_persist(new_cfg, explicit_paths=_onboarding_explicit_paths(new_cfg))
     # Preserve the resolved path on the running config so subsequent saves
     # round-trip to the same file.
-    if hasattr(new_cfg, "config_path") and not getattr(new_cfg, "config_path", None):
-        new_cfg.config_path = str(persist.path)
     if (
         ctx.config is not None
         and hasattr(ctx.config, "config_path")
         and not getattr(ctx.config, "config_path", None)
     ):
-        ctx.config.config_path = str(persist.path)
-    return str(persist.path)
+        ctx.config.config_path = resolved_path
+    return resolved_path
 
 
 def _status_payload(ctx: RpcContext) -> dict[str, Any]:

--- a/src/agentos/gateway/static/css/views/config.css
+++ b/src/agentos/gateway/static/css/views/config.css
@@ -314,6 +314,20 @@
   width: 140px;
 }
 
+/* Display-only value (CLI-managed keys like host/port) */
+.cfg-readonly-value {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 var(--sp-3);
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+}
+
 .cfg-input-json {
   width: 100%;
   min-height: 88px;

--- a/src/agentos/gateway/static/js/views/config.js
+++ b/src/agentos/gateway/static/js/views/config.js
@@ -31,9 +31,9 @@ const ConfigView = (() => {
   // Per-field help, keyed by config path. Falls back to a generic message.
   const _HELP = {
     'host':
-      'Network interface the gateway binds to. Defaults to 127.0.0.1 (loopback). Use 0.0.0.0 to expose on all interfaces — opt-in only, never on an untrusted network.',
+      'Network interface the gateway binds to. Read-only here — set via agentos gateway run --bind (CLI only). Defaults to 127.0.0.1 (loopback); 0.0.0.0 exposes on all interfaces and requires auth.',
     'port':
-      'TCP port for the ASGI gateway. Default 18791. Pick a free port; the WebSocket and REST endpoints share it.',
+      'TCP port for the ASGI gateway. Read-only here — set via agentos gateway run --port (CLI only). Default 18791; the WebSocket and REST endpoints share it.',
     'debug':
       'Security-sensitive developer mode. Auth scope expansion can take effect immediately for new connections; Starlette debug, uvicorn log level, and some startup wiring need a gateway restart. Keep it off in shared deployments.',
     'diagnostics_enabled':
@@ -509,6 +509,10 @@ const ConfigView = (() => {
     return k;
   }
 
+  // Bind posture is CLI-only (agentos gateway run --bind / --port): these keys
+  // render display-only — no editable input, and the RPC rejects writes anyway.
+  const _READONLY_KEYS = new Set(['host', 'port']);
+
   function _fieldHtml(k, v, groupId) {
     // Sensitive-key masking tests the FULL dotted key, so a nested leaf like
     // memory.embedding.remote.api_key is still masked after flattening.
@@ -524,7 +528,12 @@ const ConfigView = (() => {
     const inputId = `cfg-input-${_safeId(k)}`;
 
     let inputHtml;
-    if (typeof v === 'boolean') {
+    if (_READONLY_KEYS.has(k)) {
+      // No data-cfg-key: save/dirty tracking never sees read-only fields.
+      inputHtml = `<div class="cfg-input-row">
+        <span id="${inputId}" class="cfg-readonly-value" data-cfg-readonly="${ek}">${_esc(String(curVal ?? ''))}</span>
+      </div>`;
+    } else if (typeof v === 'boolean') {
       inputHtml = `<label class="cfg-switch">
         <input id="${inputId}" type="checkbox" data-cfg-key="${ek}" data-cfg-type="boolean"${curVal ? ' checked' : ''} aria-label="${ek}">
         <span class="cfg-switch-track" aria-hidden="true"><span class="cfg-switch-thumb"></span></span>

--- a/src/agentos/gateway/static/js/views/config.js
+++ b/src/agentos/gateway/static/js/views/config.js
@@ -722,7 +722,13 @@ const ConfigView = (() => {
   function _save() {
     if (_mode === 'yaml') {
       const text = _el.querySelector('#cfg-yaml-area').value;
-      _rpc.call('config.apply', { config_yaml: text })
+      // Send the YAML baseline (the config.get snapshot the user was shown) so
+      // the server can diff it against the submitted text and persist only the
+      // fields the user actually changed. A field left at its runtime echo
+      // (a CLI --listen / --debug / break-glass posture) is unchanged vs the
+      // baseline, so the server restores its on-disk original instead of
+      // freezing the transient value.
+      _rpc.call('config.apply', { config_yaml: text, baseline_yaml: _yamlText })
         .then(res => { UI.toast(res && res.restartRequired ? 'Config applied. Gateway restart required for the change to take effect.' : 'Config applied', res && res.restartRequired ? 'info' : 'ok'); _dirty = {}; _invalidJson = {}; _jsonDrafts = {}; _yamlDirty = false; _yamlDraft = ''; _loadData(); })
         .catch(err => UI.toast('Apply failed: ' + err.message, 'err'));
     } else {

--- a/tests/test_cli/test_gateway_auth_prompt.py
+++ b/tests/test_cli/test_gateway_auth_prompt.py
@@ -11,6 +11,15 @@ from agentos.cli.gateway_auth_prompt import (
     provision_public_bind_auth,
 )
 from agentos.gateway.config import AuthConfig, GatewayConfig
+from agentos.gateway.config_persist import get_runtime_overrides, set_runtime_overrides
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_overrides():
+    """The runtime-override map is process-global; isolate every test."""
+    set_runtime_overrides(None)
+    yield
+    set_runtime_overrides(None)
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +79,21 @@ def test_lan_bind_prompts_like_any_non_loopback(tmp_path) -> None:
 
     assert prompted == [True]
     assert outcome is AuthProvisionOutcome.CANCEL
+
+
+def test_warning_names_the_specific_lan_host_not_only_wildcard(tmp_path) -> None:
+    """The bind warning fires for specific LAN IPs too, so it must not claim
+    'wildcard ... every interface' — it should name the actual bound host."""
+    config = _config(tmp_path, host="192.168.1.50")
+    emitted: list[str] = []
+
+    provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _m: "3", emit=emitted.append
+    )
+
+    output = "\n".join(emitted)
+    assert "192.168.1.50" in output
+    assert "non-loopback" in output
 
 
 def test_break_glass_forces_mode_none_for_unsupported_modes(tmp_path) -> None:
@@ -176,8 +200,13 @@ def test_choice_1_persists_only_auth_not_one_off_cli_flags(tmp_path) -> None:
         config_path=str(cfg_path),
     )
 
+    # run_gateway recorded the pre-override on-disk values in the global map.
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
     outcome, result = provision_public_bind_auth(
-        config, interactive=True, prompt=lambda _msg: "1", emit=lambda _m: None
+        config,
+        interactive=True,
+        prompt=lambda _msg: "1",
+        emit=lambda _m: None,
     )
 
     assert outcome is AuthProvisionOutcome.PROCEED
@@ -232,6 +261,30 @@ def test_choice_2_break_glass_is_session_only(tmp_path) -> None:
     assert not (tmp_path / "agentos.toml").exists()
 
 
+def test_choice_2_break_glass_registers_auth_overrides_in_global_map(tmp_path) -> None:
+    """Break-glass forces auth.mode=none in memory; a LATER RPC write would
+    freeze that unless the prompt records the on-disk auth originals in the
+    runtime-override map. Assert the map now carries auth.mode / opt-in."""
+    # Runtime posture is an unprotected mode (only token is enforced), so the
+    # prompt fires; break-glass [2] will flip it to none for the session.
+    config = _config(tmp_path, auth=AuthConfig(mode="password"))
+    # run_gateway already recorded the bind overrides before the prompt.
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+
+    outcome, _ = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "2", emit=lambda _m: None
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    overrides = get_runtime_overrides()
+    # The bind overrides survive...
+    assert overrides["host"] == "127.0.0.1"
+    # ...and the on-disk auth posture is now restorable, so no later writer
+    # can freeze the break-glass mode=none / opt-in.
+    assert overrides["auth.mode"] == "password"
+    assert overrides["auth.allow_unauthenticated_public"] is False
+
+
 def test_choice_3_cancels(tmp_path) -> None:
     config = _config(tmp_path)
 
@@ -262,7 +315,7 @@ def test_prompt_interrupt_is_cancel(tmp_path, exc) -> None:
 def test_persist_failure_warns_but_still_proceeds(tmp_path, monkeypatch) -> None:
     from agentos.cli import gateway_auth_prompt
 
-    def failing_persist(_config: object) -> None:
+    def failing_persist(_config: object, **_kwargs: object) -> None:
         raise OSError("read-only file system")
 
     monkeypatch.setattr(gateway_auth_prompt, "persist_config", failing_persist)

--- a/tests/test_cli/test_gateway_auth_prompt.py
+++ b/tests/test_cli/test_gateway_auth_prompt.py
@@ -53,6 +53,41 @@ def test_loopback_bind_is_unchanged_and_silent(tmp_path) -> None:
     assert emitted == []
 
 
+def test_lan_bind_prompts_like_any_non_loopback(tmp_path) -> None:
+    """[P1 #2] A specific LAN IP is non-loopback, so the guard rejects it —
+    the prompt must fire for it too, not only for wildcard 0.0.0.0 / ::.
+    Uses the same is_loopback_bind predicate as the startup guard."""
+    config = _config(tmp_path, host="192.168.1.50")
+    prompted: list[bool] = []
+
+    def _prompt(_msg: str) -> str:
+        prompted.append(True)
+        return "3"  # cancel — we only assert the prompt fired
+
+    outcome, _ = provision_public_bind_auth(
+        config, interactive=True, prompt=_prompt, emit=lambda _m: None
+    )
+
+    assert prompted == [True]
+    assert outcome is AuthProvisionOutcome.CANCEL
+
+
+def test_break_glass_forces_mode_none_for_unsupported_modes(tmp_path) -> None:
+    """[P2] The prompt fires for password/trusted-proxy/typo (only token is
+    enforced). Break-glass [2] must set mode="none" so the gateway actually
+    serves openly — otherwise the guard starts it but resolve_auth has no
+    resolver for the mode, so the WS/chat surface rejects everyone."""
+    config = _config(tmp_path, auth=AuthConfig(mode="password"))
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _m: "2", emit=lambda _m: None
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.mode == "none"
+    assert result.auth.allow_unauthenticated_public is True
+
+
 def test_public_bind_with_token_mode_is_unchanged(tmp_path) -> None:
     config = _config(tmp_path, auth=AuthConfig(mode="token", token="secret"))
 

--- a/tests/test_cli/test_gateway_auth_prompt.py
+++ b/tests/test_cli/test_gateway_auth_prompt.py
@@ -1,0 +1,329 @@
+"""Tests for the interactive public-bind auth provisioning prompt (Part A)."""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+from agentos.cli.gateway_auth_prompt import (
+    AuthProvisionOutcome,
+    provision_public_bind_auth,
+)
+from agentos.gateway.config import AuthConfig, GatewayConfig
+
+
+@pytest.fixture(autouse=True)
+def _clean_auth_env(monkeypatch, tmp_path):
+    """Keep ambient auth env vars from leaking into constructed configs."""
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+    for var in (
+        "AGENTOS_AUTH_MODE",
+        "AGENTOS_AUTH_TOKEN",
+        "AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _config(tmp_path, *, host: str = "0.0.0.0", auth: AuthConfig | None = None) -> GatewayConfig:
+    return GatewayConfig(
+        host=host,
+        auth=auth if auth is not None else AuthConfig(),
+        config_path=str(tmp_path / "agentos.toml"),
+    )
+
+
+def _no_prompt(_msg: str) -> str:
+    raise AssertionError("prompt must not be called")
+
+
+# --- UNCHANGED paths -------------------------------------------------------
+
+
+def test_loopback_bind_is_unchanged_and_silent(tmp_path) -> None:
+    config = _config(tmp_path, host="127.0.0.1")
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=_no_prompt, emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.UNCHANGED
+    assert result is config
+    assert emitted == []
+
+
+def test_public_bind_with_token_mode_is_unchanged(tmp_path) -> None:
+    config = _config(tmp_path, auth=AuthConfig(mode="token", token="secret"))
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=_no_prompt, emit=lambda _msg: None
+    )
+
+    assert outcome is AuthProvisionOutcome.UNCHANGED
+    assert result is config
+
+
+def test_public_bind_with_opt_in_is_unchanged_and_warns_lan_open(tmp_path) -> None:
+    config = _config(tmp_path, auth=AuthConfig(mode="none", allow_unauthenticated_public=True))
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=_no_prompt, emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.UNCHANGED
+    assert result is config
+    output = "\n".join(emitted)
+    assert "wildcard" in output
+    assert "LAN-open" in output
+
+
+def test_public_bind_non_interactive_is_unchanged_without_prompt(tmp_path) -> None:
+    """Non-TTY never prompts — the startup guard raises downstream as today."""
+    config = _config(tmp_path)
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=False, prompt=_no_prompt, emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.UNCHANGED
+    assert result is config
+    output = "\n".join(emitted)
+    # The wildcard warning still prints, but not the contradictory LAN-open
+    # notice (the guard is about to refuse this combination).
+    assert "wildcard" in output
+    assert "LAN-open" not in output
+
+
+# --- interactive choices ---------------------------------------------------
+
+
+def test_choice_1_generates_token_and_persists(tmp_path) -> None:
+    config = _config(tmp_path)
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "1", emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.mode == "token"
+    assert result.auth.token
+    assert len(result.auth.token) >= 32
+    # The operator must be shown the token or they can never authenticate.
+    assert any(result.auth.token in line for line in emitted)
+
+    with open(tmp_path / "agentos.toml", "rb") as f:
+        persisted = tomllib.load(f)
+    assert persisted["auth"]["mode"] == "token"
+    assert persisted["auth"]["token"] == result.auth.token
+
+
+def test_choice_1_persists_only_auth_not_one_off_cli_flags(tmp_path) -> None:
+    """Provisioning a token must NOT freeze one-off CLI flags (host, port,
+    debug that run_gateway injected via model_copy) into the config file.
+    Only the auth change is persisted; the on-disk bind/debug stay as they
+    were so a plain `agentos gateway run` next time is unaffected."""
+    import tomli_w
+
+    cfg_path = tmp_path / "agentos.toml"
+    # Seed the on-disk config as a plain loopback, non-debug deployment.
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"host": "127.0.0.1", "debug": False}, f)
+
+    # The in-memory config carries one-off CLI overrides (public bind + debug).
+    config = GatewayConfig(
+        host="0.0.0.0",
+        debug=True,
+        auth=AuthConfig(),
+        config_path=str(cfg_path),
+    )
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "1", emit=lambda _m: None
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.mode == "token"
+
+    with open(cfg_path, "rb") as f:
+        persisted = tomllib.load(f)
+    # Auth WAS persisted...
+    assert persisted["auth"]["mode"] == "token"
+    assert persisted["auth"]["token"] == result.auth.token
+    # ...but the one-off CLI overrides were NOT frozen into the file.
+    assert persisted.get("host") == "127.0.0.1"
+    assert persisted.get("debug") is False
+
+
+def test_empty_input_defaults_to_token_choice(tmp_path) -> None:
+    config = _config(tmp_path)
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "", emit=lambda _msg: None
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.mode == "token"
+    assert result.auth.token
+
+
+def test_invalid_input_defaults_to_token_choice(tmp_path) -> None:
+    config = _config(tmp_path)
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "banana", emit=lambda _msg: None
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.mode == "token"
+
+
+def test_choice_2_break_glass_is_session_only(tmp_path) -> None:
+    config = _config(tmp_path)
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "2", emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.allow_unauthenticated_public is True
+    assert result.auth.mode == "none"
+    assert "LAN-open" in "\n".join(emitted)
+    # Break-glass must NOT be written to disk — the stored config stays safe.
+    assert not (tmp_path / "agentos.toml").exists()
+
+
+def test_choice_3_cancels(tmp_path) -> None:
+    config = _config(tmp_path)
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "3", emit=lambda _msg: None
+    )
+
+    assert outcome is AuthProvisionOutcome.CANCEL
+    assert result is config
+    assert not (tmp_path / "agentos.toml").exists()
+
+
+@pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
+def test_prompt_interrupt_is_cancel(tmp_path, exc) -> None:
+    config = _config(tmp_path)
+
+    def raising_prompt(_msg: str) -> str:
+        raise exc
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=raising_prompt, emit=lambda _msg: None
+    )
+
+    assert outcome is AuthProvisionOutcome.CANCEL
+    assert result is config
+
+
+def test_persist_failure_warns_but_still_proceeds(tmp_path, monkeypatch) -> None:
+    from agentos.cli import gateway_auth_prompt
+
+    def failing_persist(_config: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(gateway_auth_prompt, "persist_config", failing_persist)
+    config = _config(tmp_path)
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "1", emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    assert result.auth.mode == "token"
+    assert result.auth.token
+    output = "\n".join(emitted)
+    assert "could not persist" in output.lower() or "persist" in output.lower()
+
+
+# --- shared persistence path ----------------------------------------------
+
+
+def test_rpc_persist_path_is_the_shared_helper() -> None:
+    """The RPC config write path and the CLI prompt must share one writer."""
+    from agentos.gateway import config_persist, rpc_config
+
+    assert rpc_config._persist_config is config_persist.persist_config
+
+
+def test_persist_config_writes_toml_round_trip(tmp_path) -> None:
+    from agentos.gateway.config_persist import persist_config
+
+    config = _config(tmp_path, auth=AuthConfig(mode="token", token="abc123"))
+    persist_config(config)
+
+    with open(tmp_path / "agentos.toml", "rb") as f:
+        persisted = tomllib.load(f)
+    assert persisted["auth"]["mode"] == "token"
+    assert persisted["auth"]["token"] == "abc123"
+
+
+# --- CLI integration (gateway run call site) -------------------------------
+
+
+def _invoke_gateway_run(tmp_path, monkeypatch, *, stdin: str, captured: dict):
+    from typer.testing import CliRunner
+
+    from agentos.cli import gateway_cmd
+    from agentos.cli.main import app
+
+    target = tmp_path / "agentos.toml"
+    if not target.exists():
+        target.write_text("", encoding="utf-8")
+    monkeypatch.setattr(gateway_cmd, "_stdin_isatty", lambda: True)
+
+    async def fake_start_gateway_server(**kwargs):
+        captured["config"] = kwargs.get("config")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
+
+    runner = CliRunner()
+    return runner.invoke(
+        app,
+        ["gateway", "run", "--config", str(target), "--listen", "0.0.0.0"],
+        input=stdin,
+    )
+
+
+def test_gateway_run_cancel_exits_zero_without_starting(tmp_path, monkeypatch) -> None:
+    captured: dict = {}
+
+    result = _invoke_gateway_run(tmp_path, monkeypatch, stdin="3\n", captured=captured)
+
+    assert result.exit_code == 0
+    assert "config" not in captured  # server never started
+
+
+def test_gateway_run_token_choice_starts_with_token_auth(tmp_path, monkeypatch) -> None:
+    captured: dict = {}
+
+    result = _invoke_gateway_run(tmp_path, monkeypatch, stdin="1\n", captured=captured)
+
+    assert result.exit_code == 0
+    assert captured["config"].auth.mode == "token"
+    assert captured["config"].auth.token
+    # Token was persisted, so the next run will not prompt again.
+    with open(tmp_path / "agentos.toml", "rb") as f:
+        persisted = tomllib.load(f)
+    assert persisted["auth"]["token"] == captured["config"].auth.token
+
+
+def test_gateway_run_break_glass_starts_without_persisting(tmp_path, monkeypatch) -> None:
+    captured: dict = {}
+
+    result = _invoke_gateway_run(tmp_path, monkeypatch, stdin="2\n", captured=captured)
+
+    assert result.exit_code == 0
+    assert captured["config"].auth.allow_unauthenticated_public is True
+    assert (tmp_path / "agentos.toml").read_text(encoding="utf-8") == ""
+    assert "LAN-open" in result.stdout

--- a/tests/test_cli/test_gateway_auth_prompt.py
+++ b/tests/test_cli/test_gateway_auth_prompt.py
@@ -222,6 +222,37 @@ def test_choice_1_persists_only_auth_not_one_off_cli_flags(tmp_path) -> None:
     assert persisted.get("debug") is False
 
 
+def test_choice_1_first_run_message_names_resolved_path_not_none(tmp_path) -> None:
+    """[FIX 5] On a TRUE first run config_path is unset; the onboarding writer
+    resolves the home path internally. The success message must name that
+    resolved path, not literally 'None'."""
+    from agentos.onboarding.config_store import resolve_config_path
+
+    # No config_path set -> first-run resolution kicks in (AGENTOS_STATE_DIR from
+    # the _clean_auth_env fixture points home under tmp_path).
+    config = GatewayConfig(host="0.0.0.0", auth=AuthConfig())
+    assert config.config_path is None
+    emitted: list[str] = []
+
+    outcome, result = provision_public_bind_auth(
+        config, interactive=True, prompt=lambda _msg: "1", emit=emitted.append
+    )
+
+    assert outcome is AuthProvisionOutcome.PROCEED
+    resolved = resolve_config_path(None)[0]
+    output = "\n".join(emitted)
+    # The message names the real resolved path...
+    assert str(resolved) in output
+    # ...and never the None placeholder.
+    saved_line = [ln for ln in emitted if "saved to" in ln]
+    assert saved_line, "expected a 'saved to <path>' success line"
+    assert "None" not in saved_line[0]
+    # And the token was actually persisted there.
+    with open(resolved, "rb") as f:
+        persisted = tomllib.load(f)
+    assert persisted["auth"]["token"] == result.auth.token
+
+
 def test_empty_input_defaults_to_token_choice(tmp_path) -> None:
     config = _config(tmp_path)
 

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -179,6 +179,74 @@ def test_gateway_run_warns_lan_open_when_opt_in_set(tmp_path, monkeypatch) -> No
     assert "LAN-open" in output
 
 
+def test_gateway_run_records_raw_toml_bind_originals_not_env_merged(
+    tmp_path, monkeypatch
+) -> None:
+    """[FIX 3] The runtime-override map must record the RAW on-disk host/port/
+    debug, never the env-merged effective values. With AGENTOS_GATEWAY_HOST set,
+    GatewayConfig.load reports host=0.0.0.0; recording THAT as the on-disk
+    original would let a later config.patch freeze 0.0.0.0. The TOML here has an
+    explicit host=127.0.0.1, so the recorded original must be 127.0.0.1."""
+    target = tmp_path / "agentos.toml"
+    target.write_text("host = \"127.0.0.1\"\n", encoding="utf-8")
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.setenv("AGENTOS_GATEWAY_HOST", "0.0.0.0")
+    monkeypatch.setenv("AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC", "true")
+    monkeypatch.delenv("AGENTOS_AUTH_MODE", raising=False)
+
+    captured: dict = {}
+
+    def capturing_set_overrides(mapping):
+        captured["overrides"] = dict(mapping) if mapping else {}
+        return gateway_cmd.set_runtime_overrides(mapping)
+
+    monkeypatch.setattr(gateway_cmd, "set_runtime_overrides", capturing_set_overrides)
+
+    async def fake_start_gateway_server(**_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
+
+    runner.invoke(app, ["gateway", "run", "--config", str(target), "--listen", "0.0.0.0"])
+
+    overrides = captured["overrides"]
+    assert overrides["host"] == "127.0.0.1"  # raw TOML value, NOT env 0.0.0.0
+    assert overrides["port"] is None  # absent in TOML -> None (drop on persist)
+    assert overrides["debug"] is None  # absent in TOML -> None
+
+
+def test_gateway_run_records_none_when_host_absent_and_env_public(
+    tmp_path, monkeypatch
+) -> None:
+    """[FIX 3] host absent from TOML + AGENTOS_GATEWAY_HOST=0.0.0.0: the recorded
+    original is None (drop on persist so the env/default re-applies at next
+    boot), never the env-supplied 0.0.0.0."""
+    target = tmp_path / "agentos.toml"
+    target.write_text("debug = false\n", encoding="utf-8")  # NO host
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.setenv("AGENTOS_GATEWAY_HOST", "0.0.0.0")
+    monkeypatch.setenv("AGENTOS_AUTH_ALLOW_UNAUTHENTICATED_PUBLIC", "true")
+    monkeypatch.delenv("AGENTOS_AUTH_MODE", raising=False)
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        gateway_cmd,
+        "set_runtime_overrides",
+        lambda m: captured.setdefault("overrides", dict(m) if m else {}),
+    )
+
+    async def fake_start_gateway_server(**_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
+
+    runner.invoke(app, ["gateway", "run", "--config", str(target)])
+
+    overrides = captured["overrides"]
+    assert overrides["host"] is None  # NOT the env-supplied 0.0.0.0
+    assert overrides["debug"] is False  # raw literal
+
+
 def test_gateway_lifecycle_paths_use_state_root(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
 

--- a/tests/test_gateway/test_agent_registry_persist_no_freeze.py
+++ b/tests/test_gateway/test_agent_registry_persist_no_freeze.py
@@ -1,0 +1,113 @@
+"""AgentRegistry persistence must route through the override-aware gateway
+writer, so an agents.* mutation never freezes a one-off CLI ``--listen`` /
+``--port`` / ``--debug`` (recorded in the process-global runtime-override map)
+into config.toml. The agent change itself must still persist.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+import tomli_w
+
+from agentos.agents.registry import AgentRegistry
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.config_persist import set_runtime_overrides
+
+
+@pytest.fixture(autouse=True)
+def _reset_overrides():
+    """The override map is process-global; isolate every test."""
+    set_runtime_overrides(None)
+    yield
+    set_runtime_overrides(None)
+
+
+def _seed_disk(path, data: dict) -> None:
+    with open(path, "wb") as f:
+        tomli_w.dump(data, f)
+
+
+def _read(path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+@pytest.mark.asyncio
+async def test_create_agent_does_not_freeze_cli_bind_overrides(tmp_path):
+    """AgentRegistry.create_agent with a runtime config (public bind + debug that
+    run_gateway injected in memory) must NOT freeze host/port/debug into the file
+    — the runtime-override map restores the on-disk originals — while the new
+    agent IS persisted."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1", "port": 18791, "debug": False})
+
+    # run_gateway recorded the on-disk originals before overriding in memory.
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = GatewayConfig(
+        host="0.0.0.0",
+        port=19999,
+        debug=True,
+        config_path=str(cfg_path),
+    )
+    registry = AgentRegistry(cfg, persist_changes=True)
+
+    await registry.create_agent(agent_id="bot", name="Bot")
+
+    saved = _read(cfg_path)
+    # Bind posture NOT frozen to the transient runtime values.
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"
+    assert saved.get("port", 18791) == 18791
+    assert saved.get("debug", False) is False
+    # The agent change WAS persisted.
+    assert [a["id"] for a in saved.get("agents", [])] == ["bot"]
+
+
+@pytest.mark.asyncio
+async def test_update_agent_does_not_freeze_cli_bind_overrides(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(
+        cfg_path,
+        {
+            "host": "127.0.0.1",
+            "agents": [{"id": "bot", "name": "Bot"}],
+        },
+    )
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = GatewayConfig.load(str(cfg_path))
+    cfg = cfg.model_copy(update={"host": "0.0.0.0", "debug": True})
+    cfg.config_path = str(cfg_path)
+    registry = AgentRegistry(cfg, persist_changes=True)
+
+    await registry.update_agent("bot", name="Renamed")
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # NOT frozen to 0.0.0.0
+    assert saved.get("debug", False) is False
+    assert saved["agents"][0]["name"] == "Renamed"  # the edit persisted
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_does_not_freeze_cli_bind_overrides(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(
+        cfg_path,
+        {
+            "host": "127.0.0.1",
+            "agents": [{"id": "bot", "name": "Bot"}, {"id": "ops", "name": "Ops"}],
+        },
+    )
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = GatewayConfig.load(str(cfg_path))
+    cfg = cfg.model_copy(update={"host": "0.0.0.0"})
+    cfg.config_path = str(cfg_path)
+    registry = AgentRegistry(cfg, persist_changes=True)
+
+    await registry.delete_agent("bot")
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # NOT frozen
+    assert [a["id"] for a in saved.get("agents", [])] == ["ops"]  # delete persisted

--- a/tests/test_gateway/test_config_persist_no_freeze_rpc.py
+++ b/tests/test_gateway/test_config_persist_no_freeze_rpc.py
@@ -1,0 +1,205 @@
+"""A one-off CLI ``--listen``/``--debug`` (or break-glass ``mode=none``) recorded
+in the process-global runtime-override map must NEVER be frozen into config.toml
+by a later RPC write — through EITHER live writer path (rpc_config config.patch
+AND rpc_onboarding). An explicit change of the overridden field still persists.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+import agentos.gateway.rpc_config  # noqa: F401  ensures config.* registration
+import agentos.gateway.rpc_onboarding  # noqa: F401  ensures onboarding.* registration
+from agentos.gateway.auth import Principal
+from agentos.gateway.config import AuthConfig, GatewayConfig
+from agentos.gateway.config_persist import set_runtime_overrides
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+
+
+@pytest.fixture(autouse=True)
+def _reset_overrides():
+    set_runtime_overrides(None)
+    yield
+    set_runtime_overrides(None)
+
+
+def _admin_ctx(config: GatewayConfig) -> RpcContext:
+    return RpcContext(
+        conn_id="t",
+        config=config,
+        principal=Principal(
+            role="operator",
+            scopes=frozenset({"operator.admin", "operator.write"}),
+            is_owner=True,
+            authenticated=True,
+        ),
+    )
+
+
+def _seed_disk(path, data: dict) -> None:
+    import tomli_w
+
+    with open(path, "wb") as f:
+        tomli_w.dump(data, f)
+
+
+def _read(path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _running_config(path, **overrides) -> GatewayConfig:
+    """A live config as run_gateway leaves it: host/debug overridden in memory,
+    config_path set to the on-disk file."""
+    base = {"config_path": str(path)}
+    base.update(overrides)
+    return GatewayConfig(**base)
+
+
+# --- rpc_config path -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_patch_unrelated_field_does_not_freeze_cli_host_override(tmp_path):
+    """[finding a — rpc_config] --listen 0.0.0.0 recorded at boot; a config.patch
+    of an UNRELATED field must not freeze the public bind into config.toml."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1", "debug": False})
+
+    # run_gateway recorded the on-disk originals before overriding host in memory.
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = _running_config(cfg_path, host="0.0.0.0")
+
+    res = await get_dispatcher().dispatch(
+        "r1", "config.patch", {"patches": {"agentos_router.enabled": True}}, _admin_ctx(cfg)
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # NOT frozen to 0.0.0.0
+    assert saved.get("debug", False) is False
+
+
+@pytest.mark.asyncio
+async def test_config_patch_explicit_debug_persists_despite_override(tmp_path):
+    """[finding b] An explicit config.patch of debug=true DOES persist — the
+    explicit_paths exception wins over the runtime-override restore."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1", "debug": False})
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = _running_config(cfg_path, host="0.0.0.0", debug=True)
+
+    res = await get_dispatcher().dispatch(
+        "r1", "config.patch", {"patches": {"debug": True}}, _admin_ctx(cfg)
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved["debug"] is True  # explicit change persisted
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # host still not frozen
+
+
+@pytest.mark.asyncio
+async def test_break_glass_mode_none_not_frozen_by_later_patch_safe(tmp_path):
+    """[finding c] break-glass set auth.mode=none in memory; a later
+    config.patch.safe of an unrelated safe path must not freeze mode=none."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"auth": {"mode": "token", "token": "keep"}})
+
+    # break-glass recorded the on-disk auth originals at the prompt.
+    set_runtime_overrides(
+        {"auth.mode": "token", "auth.allow_unauthenticated_public": False}
+    )
+    cfg = _running_config(
+        cfg_path,
+        host="0.0.0.0",
+        auth=AuthConfig(mode="none", allow_unauthenticated_public=True, token="keep"),
+    )
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch.safe",
+        {"patches": {"agentos_router.enabled": True}},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved["auth"]["mode"] == "token"  # break-glass mode NOT frozen
+    assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
+
+
+@pytest.mark.asyncio
+async def test_config_apply_yaml_mode_does_not_freeze_break_glass_auth(tmp_path):
+    """[verify finding] YAML-mode Save seeds the payload from the RUNNING config
+    (which carries the break-glass mode=none + opt-in), so config.apply must
+    subtract the FULL override-map key set from explicit_paths — not just
+    host/port — or it freezes the transient break-glass posture and disables
+    auth on disk permanently."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"auth": {"mode": "token", "token": "keep"}})
+
+    set_runtime_overrides(
+        {"auth.mode": "token", "auth.allow_unauthenticated_public": False}
+    )
+    cfg = _running_config(
+        cfg_path,
+        auth=AuthConfig(mode="none", allow_unauthenticated_public=True, token="keep"),
+    )
+    # YAML-mode Save: the payload IS the running config (echoes the overrides).
+    payload = cfg.model_dump(mode="python")
+
+    res = await get_dispatcher().dispatch(
+        "r1", "config.apply", {"config": payload}, _admin_ctx(cfg)
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved["auth"]["mode"] == "token"  # break-glass mode NOT frozen
+    assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
+
+
+@pytest.mark.asyncio
+async def test_config_apply_yaml_mode_does_not_freeze_cli_debug(tmp_path):
+    """Same class: a one-off --debug must not survive a YAML-mode Save of an
+    unrelated field."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"debug": False})
+
+    set_runtime_overrides({"debug": False})
+    cfg = _running_config(cfg_path, debug=True)
+    payload = cfg.model_dump(mode="python")
+
+    res = await get_dispatcher().dispatch(
+        "r1", "config.apply", {"config": payload}, _admin_ctx(cfg)
+    )
+    assert res.error is None, res.error
+    assert _read(cfg_path).get("debug", False) is False
+
+
+# --- rpc_onboarding path ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_onboarding_configure_does_not_freeze_cli_host_override(tmp_path):
+    """[finding a — onboarding] An onboarding mutation persists via the same
+    override-aware writer, so a CLI --listen 0.0.0.0 is not frozen either."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1", "debug": False})
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = _running_config(cfg_path, host="0.0.0.0")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.search.configure",
+        {"providerId": "duckduckgo"},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # NOT frozen to 0.0.0.0

--- a/tests/test_gateway/test_config_persist_no_freeze_rpc.py
+++ b/tests/test_gateway/test_config_persist_no_freeze_rpc.py
@@ -83,6 +83,57 @@ async def test_config_patch_unrelated_field_does_not_freeze_cli_host_override(tm
 
 
 @pytest.mark.asyncio
+async def test_config_patch_echoing_readonly_host_does_not_freeze_bind(tmp_path):
+    """[FIX 2 — rpc_config] A UI form can echo the display-only host/port in the
+    same config.patch as a genuine edit. host/port are read-only paths (skipped
+    when applied), but they used to leak into ``explicit_paths`` and short-circuit
+    the runtime-override restore, freezing the transient public bind. Subtracting
+    _READONLY_PATHS from explicit_paths keeps the bind restorable."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1", "port": 18791})
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = _running_config(cfg_path, host="0.0.0.0")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patches": {"host": "0.0.0.0", "port": 19999, "agentos_router.enabled": True}},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # NOT frozen to 0.0.0.0
+    assert saved.get("port", 18791) == 18791  # NOT frozen to 19999
+    # The genuine (non-readonly) edit in the same call still persisted.
+    assert saved["agentos_router"]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_patch_merge_echoing_readonly_host_does_not_freeze_bind(tmp_path):
+    """[FIX 2 — merge path] The dict-merge branch of config.patch collects host
+    from the merge payload into explicit_paths. It must be subtracted too."""
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1", "port": 18791})
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = _running_config(cfg_path, host="0.0.0.0")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patch": {"host": "0.0.0.0", "agentos_router": {"enabled": True}}},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # NOT frozen
+    assert saved["agentos_router"]["enabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_config_patch_explicit_debug_persists_despite_override(tmp_path):
     """[finding b] An explicit config.patch of debug=true DOES persist — the
     explicit_paths exception wins over the runtime-override restore."""
@@ -160,6 +211,121 @@ async def test_config_apply_yaml_mode_does_not_freeze_break_glass_auth(tmp_path)
     saved = _read(cfg_path)
     assert saved["auth"]["mode"] == "token"  # break-glass mode NOT frozen
     assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
+
+
+@pytest.mark.asyncio
+async def test_config_apply_baseline_diff_persists_deliberate_auth_mode_edit(tmp_path):
+    """[FIX 4] With a baseline_yaml, a field the user ACTUALLY changed vs the
+    baseline they saw persists — even while that field has a runtime override.
+    The round-2 blanket 'subtract the whole override keyset' made this
+    impossible; the snapshot-baseline diff restores the ability to persist a
+    deliberate YAML edit of an overridden field.
+
+    Distinguishing setup: the on-disk original (password), the running echo
+    (none, break-glass), and the deliberate edit (token) are all different, so
+    the two strategies give different final states — round-2 restores password
+    (wrong), baseline-diff persists token (correct)."""
+    import yaml
+
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"auth": {"mode": "password"}})
+
+    # break-glass recorded the on-disk auth originals; running is mode=none.
+    set_runtime_overrides(
+        {"auth.mode": "password", "auth.allow_unauthenticated_public": False}
+    )
+    cfg = _running_config(
+        cfg_path,
+        auth=AuthConfig(mode="none", allow_unauthenticated_public=True),
+    )
+    # Baseline = what config.get showed (running config, auth echoed none).
+    baseline = cfg.model_dump(mode="json")
+    baseline_yaml = yaml.safe_dump(baseline)
+    # User deliberately switches auth.mode none -> token in the YAML.
+    edited = dict(baseline)
+    edited["auth"] = dict(baseline["auth"])
+    edited["auth"]["mode"] = "token"
+    edited["auth"]["token"] = "fresh-token"
+    edited_yaml = yaml.safe_dump(edited)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.apply",
+        {"config_yaml": edited_yaml, "baseline_yaml": baseline_yaml},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    # Deliberate edit (none in baseline -> token submitted) persisted; NOT
+    # restored to the on-disk password original the way round-2 would.
+    assert saved["auth"]["mode"] == "token"
+
+
+@pytest.mark.asyncio
+async def test_config_apply_baseline_diff_restores_unedited_break_glass_echo(tmp_path):
+    """[FIX 4] A field UNCHANGED vs the baseline is a runtime echo, so it is
+    restored to its on-disk original — the break-glass mode=none the operator
+    never touched in the YAML must not freeze."""
+    import yaml
+
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"auth": {"mode": "token", "token": "keep"}})
+
+    set_runtime_overrides(
+        {"auth.mode": "token", "auth.allow_unauthenticated_public": False}
+    )
+    cfg = _running_config(
+        cfg_path,
+        auth=AuthConfig(mode="none", allow_unauthenticated_public=True, token="keep"),
+    )
+    baseline = cfg.model_dump(mode="json")
+    baseline_yaml = yaml.safe_dump(baseline)
+    # User edits an UNRELATED field, leaving auth untouched (still the echo).
+    edited = dict(baseline)
+    edited["debug"] = True
+    edited_yaml = yaml.safe_dump(edited)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.apply",
+        {"config_yaml": edited_yaml, "baseline_yaml": baseline_yaml},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+
+    saved = _read(cfg_path)
+    # auth was NOT edited vs baseline -> break-glass echo restored to disk.
+    assert saved["auth"]["mode"] == "token"
+    assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
+
+
+@pytest.mark.asyncio
+async def test_config_apply_baseline_diff_never_persists_readonly_host(tmp_path):
+    """[FIX 4] Even if host somehow differs from the baseline, it is a read-only
+    path and must never persist via config.apply."""
+    import yaml
+
+    cfg_path = tmp_path / "config.toml"
+    _seed_disk(cfg_path, {"host": "127.0.0.1"})
+
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+    cfg = _running_config(cfg_path, host="0.0.0.0")
+    baseline = cfg.model_dump(mode="json")
+    baseline["host"] = "127.0.0.1"  # baseline showed loopback
+    baseline_yaml = yaml.safe_dump(baseline)
+    edited = dict(baseline)
+    edited["host"] = "0.0.0.0"  # user tries to change host in YAML
+    edited_yaml = yaml.safe_dump(edited)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.apply",
+        {"config_yaml": edited_yaml, "baseline_yaml": baseline_yaml},
+        _admin_ctx(cfg),
+    )
+    assert res.error is None, res.error
+    assert _read(cfg_path).get("host", "127.0.0.1") == "127.0.0.1"  # never persisted
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_config_persist_runtime_only.py
+++ b/tests/test_gateway/test_config_persist_runtime_only.py
@@ -1,21 +1,45 @@
-"""persist_config never writes runtime-only overrides to disk.
+"""persist_config distinguishes transient CLI/break-glass overrides from
+explicit user changes by *provenance*, not by field name.
 
-host / port / debug / auth.allow_unauthenticated_public are set for a single
-run (CLI flags, break-glass) and must NOT be frozen into config.toml by any
-config writer — the CLI token prompt or any config RPC. Changing them
-permanently is done by editing config.toml directly. This is the single rule
-that prevents the whole class of "a one-off --listen 0.0.0.0 --debug got
-persisted" leaks (PR #25 review, P1 #1/#3/#4).
+At boot, ``run_gateway`` records the ON-DISK original values of the fields it
+overrides (``host``/``port``/``debug``; break-glass ``auth.mode`` /
+``allow_unauthenticated_public``) in a process-global override map via
+``set_runtime_overrides``. Every live writer goes through ``persist_config``,
+which restores each recorded field to its original on-disk value (or drops it
+when the original was absent, so the load-time default applies) — UNLESS that
+exact dotted path is in ``explicit_paths``, meaning the user explicitly changed
+it this write and it must persist. This closes the whole class of "a one-off
+--listen 0.0.0.0 --debug got frozen into config.toml" leaks (PR #25 review)
+WITHOUT silently discarding a genuine UI edit of the same field.
+
+The writer is also atomic and 0600 (delegated to the onboarding writer), so a
+freshly generated bearer token is never world-readable.
 """
 
 from __future__ import annotations
 
+import os
+import stat
+import sys
 import tomllib
 
+import pytest
 import tomli_w
 
 from agentos.gateway.config import AuthConfig, GatewayConfig
-from agentos.gateway.config_persist import persist_config
+from agentos.gateway.config_persist import (
+    get_runtime_overrides,
+    persist_config,
+    set_runtime_overrides,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_overrides():
+    """The override map is process-global; isolate every test."""
+    set_runtime_overrides(None)
+    yield
+    set_runtime_overrides(None)
 
 
 def _read(path) -> dict:
@@ -23,66 +47,121 @@ def _read(path) -> dict:
         return tomllib.load(f)
 
 
-def test_runtime_overrides_are_not_written_over_on_disk_values(tmp_path):
+def test_runtime_overrides_are_restored_to_their_original_values(tmp_path):
     cfg_path = tmp_path / "config.toml"
-    # On disk: a loopback, non-debug deployment.
     with open(cfg_path, "wb") as f:
         tomli_w.dump({"host": "127.0.0.1", "port": 18791, "debug": False}, f)
 
-    # In memory: one-off CLI overrides plus a real change we DO want to keep.
+    # Boot records the on-disk originals of the fields the CLI overrode.
+    set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
+
     runtime = GatewayConfig(
         host="0.0.0.0",
         port=19999,
         debug=True,
-        auth=AuthConfig(mode="token", token="keep-me", allow_unauthenticated_public=True),
+        auth=AuthConfig(mode="token", token="keep-me"),
         config_path=str(cfg_path),
     )
-
     persist_config(runtime)
 
     saved = _read(cfg_path)
-    # The real change is persisted...
     assert saved["auth"]["mode"] == "token"
     assert saved["auth"]["token"] == "keep-me"
-    # ...but every runtime-only field keeps its on-disk value.
     assert saved["host"] == "127.0.0.1"
     assert saved["port"] == 18791
     assert saved["debug"] is False
+
+
+def test_explicit_change_persists_even_for_an_overridden_field(tmp_path):
+    """A UI 'Save' of debug=true names ``debug`` in ``explicit_paths``, so it
+    must actually persist — not be silently restored to the boot original."""
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"debug": False}, f)
+
+    # CLI ran with --debug this session (boot recorded the on-disk False).
+    set_runtime_overrides({"debug": False})
+
+    runtime = GatewayConfig(debug=True, config_path=str(cfg_path))
+    persist_config(runtime, explicit_paths={"debug"})  # user explicitly set it
+
+    assert _read(cfg_path)["debug"] is True
+
+
+def test_explicit_change_without_overrides_persists_verbatim(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"debug": False}, f)
+
+    runtime = GatewayConfig(debug=True, config_path=str(cfg_path))
+    persist_config(runtime)  # no overrides recorded -> explicit change
+
+    assert _read(cfg_path)["debug"] is True
+
+
+def test_break_glass_mode_and_opt_in_are_restorable_overrides(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"auth": {"mode": "password"}}, f)
+
+    # break-glass forced mode=none + opt-in for this run only; boot recorded the
+    # on-disk auth values so a later writer cannot freeze the break-glass posture.
+    set_runtime_overrides(
+        {
+            "auth.mode": "password",
+            "auth.allow_unauthenticated_public": False,
+        }
+    )
+    runtime = GatewayConfig(
+        auth=AuthConfig(mode="none", allow_unauthenticated_public=True),
+        config_path=str(cfg_path),
+    )
+    persist_config(runtime)
+
+    saved = _read(cfg_path)
+    assert saved["auth"]["mode"] == "password"  # break-glass mode not frozen
     assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
 
 
-def test_first_run_without_a_file_uses_safe_defaults_not_overrides(tmp_path):
-    cfg_path = tmp_path / "config.toml"  # does NOT exist yet
+def test_missing_original_drops_the_field_so_defaults_apply(tmp_path):
+    """First run: no on-disk value existed for the overridden field, so it is
+    dropped (load-time default applies), never the override."""
+    cfg_path = tmp_path / "config.toml"  # does not exist
+
+    set_runtime_overrides({"host": None, "debug": None})
     runtime = GatewayConfig(
         host="0.0.0.0",
-        port=19999,
         debug=True,
-        auth=AuthConfig(mode="token", token="tok", allow_unauthenticated_public=True),
+        auth=AuthConfig(mode="token", token="tok"),
         config_path=str(cfg_path),
     )
-
     persist_config(runtime)
 
     saved = _read(cfg_path)
     assert saved["auth"]["token"] == "tok"
-    # No file existed, so runtime-only fields fall back to safe defaults, never
-    # the wildcard/debug/opt-in override.
     assert saved.get("host", "127.0.0.1") == "127.0.0.1"
     assert saved.get("debug", False) is False
-    assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
 
 
-def test_editing_the_file_directly_is_still_honored(tmp_path):
-    """The escape hatch: a host deliberately written into config.toml stays."""
+def test_set_and_get_runtime_overrides_round_trip():
+    assert get_runtime_overrides() == {}
+    set_runtime_overrides({"host": "127.0.0.1", "debug": None})
+    assert get_runtime_overrides() == {"host": "127.0.0.1", "debug": None}
+    # Returned map is a copy — mutating it must not corrupt module state.
+    got = get_runtime_overrides()
+    got["host"] = "0.0.0.0"
+    assert get_runtime_overrides()["host"] == "127.0.0.1"
+    set_runtime_overrides(None)
+    assert get_runtime_overrides() == {}
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode")
+def test_written_config_is_owner_only_0600(tmp_path):
     cfg_path = tmp_path / "config.toml"
-    with open(cfg_path, "wb") as f:
-        tomli_w.dump({"host": "0.0.0.0", "port": 18791}, f)
-
-    # A later write of an unrelated field must not clobber the on-disk host.
-    runtime = GatewayConfig.load(cfg_path)
-    runtime = runtime.model_copy(update={"debug": True})  # runtime-only override
+    runtime = GatewayConfig(
+        auth=AuthConfig(mode="token", token="secret"), config_path=str(cfg_path)
+    )
     persist_config(runtime)
 
-    saved = _read(cfg_path)
-    assert saved["host"] == "0.0.0.0"  # the deliberately-edited value survives
-    assert saved.get("debug", False) is False  # the runtime override is not frozen
+    mode = stat.S_IMODE(os.stat(cfg_path).st_mode)
+    assert mode == 0o600, f"config with a bearer token must be 0600, got {oct(mode)}"

--- a/tests/test_gateway/test_config_persist_runtime_only.py
+++ b/tests/test_gateway/test_config_persist_runtime_only.py
@@ -1,0 +1,88 @@
+"""persist_config never writes runtime-only overrides to disk.
+
+host / port / debug / auth.allow_unauthenticated_public are set for a single
+run (CLI flags, break-glass) and must NOT be frozen into config.toml by any
+config writer — the CLI token prompt or any config RPC. Changing them
+permanently is done by editing config.toml directly. This is the single rule
+that prevents the whole class of "a one-off --listen 0.0.0.0 --debug got
+persisted" leaks (PR #25 review, P1 #1/#3/#4).
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import tomli_w
+
+from agentos.gateway.config import AuthConfig, GatewayConfig
+from agentos.gateway.config_persist import persist_config
+
+
+def _read(path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def test_runtime_overrides_are_not_written_over_on_disk_values(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    # On disk: a loopback, non-debug deployment.
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"host": "127.0.0.1", "port": 18791, "debug": False}, f)
+
+    # In memory: one-off CLI overrides plus a real change we DO want to keep.
+    runtime = GatewayConfig(
+        host="0.0.0.0",
+        port=19999,
+        debug=True,
+        auth=AuthConfig(mode="token", token="keep-me", allow_unauthenticated_public=True),
+        config_path=str(cfg_path),
+    )
+
+    persist_config(runtime)
+
+    saved = _read(cfg_path)
+    # The real change is persisted...
+    assert saved["auth"]["mode"] == "token"
+    assert saved["auth"]["token"] == "keep-me"
+    # ...but every runtime-only field keeps its on-disk value.
+    assert saved["host"] == "127.0.0.1"
+    assert saved["port"] == 18791
+    assert saved["debug"] is False
+    assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
+
+
+def test_first_run_without_a_file_uses_safe_defaults_not_overrides(tmp_path):
+    cfg_path = tmp_path / "config.toml"  # does NOT exist yet
+    runtime = GatewayConfig(
+        host="0.0.0.0",
+        port=19999,
+        debug=True,
+        auth=AuthConfig(mode="token", token="tok", allow_unauthenticated_public=True),
+        config_path=str(cfg_path),
+    )
+
+    persist_config(runtime)
+
+    saved = _read(cfg_path)
+    assert saved["auth"]["token"] == "tok"
+    # No file existed, so runtime-only fields fall back to safe defaults, never
+    # the wildcard/debug/opt-in override.
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"
+    assert saved.get("debug", False) is False
+    assert saved["auth"].get("allow_unauthenticated_public") in (False, None)
+
+
+def test_editing_the_file_directly_is_still_honored(tmp_path):
+    """The escape hatch: a host deliberately written into config.toml stays."""
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"host": "0.0.0.0", "port": 18791}, f)
+
+    # A later write of an unrelated field must not clobber the on-disk host.
+    runtime = GatewayConfig.load(cfg_path)
+    runtime = runtime.model_copy(update={"debug": True})  # runtime-only override
+    persist_config(runtime)
+
+    saved = _read(cfg_path)
+    assert saved["host"] == "0.0.0.0"  # the deliberately-edited value survives
+    assert saved.get("debug", False) is False  # the runtime override is not frozen

--- a/tests/test_gateway/test_config_persist_runtime_only.py
+++ b/tests/test_gateway/test_config_persist_runtime_only.py
@@ -155,6 +155,69 @@ def test_set_and_get_runtime_overrides_round_trip():
     assert get_runtime_overrides() == {}
 
 
+def test_read_raw_bind_overrides_reads_literal_toml_values(tmp_path):
+    from agentos.gateway.config_persist import read_raw_bind_overrides
+
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"host": "0.0.0.0", "port": 19999, "debug": True}, f)
+
+    assert read_raw_bind_overrides(str(cfg_path)) == {
+        "host": "0.0.0.0",
+        "port": 19999,
+        "debug": True,
+    }
+
+
+def test_read_raw_bind_overrides_absent_keys_map_to_none(tmp_path, monkeypatch):
+    """A key absent from the TOML is None (dropped on persist) even when an env
+    var would make the EFFECTIVE loaded value non-default — the raw file wins."""
+    from agentos.gateway.config_persist import read_raw_bind_overrides
+
+    monkeypatch.setenv("AGENTOS_GATEWAY_HOST", "0.0.0.0")
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"debug": False}, f)  # NO host / port
+
+    got = read_raw_bind_overrides(str(cfg_path))
+    assert got["host"] is None  # absent in TOML -> None, NOT the env 0.0.0.0
+    assert got["port"] is None
+    assert got["debug"] is False
+
+
+def test_read_raw_bind_overrides_missing_file_is_all_none(tmp_path):
+    from agentos.gateway.config_persist import read_raw_bind_overrides
+
+    assert read_raw_bind_overrides(str(tmp_path / "nope.toml")) == {
+        "host": None,
+        "port": None,
+        "debug": None,
+    }
+    assert read_raw_bind_overrides(None) == {"host": None, "port": None, "debug": None}
+
+
+def test_env_supplied_host_is_not_frozen_by_a_later_persist(tmp_path, monkeypatch):
+    """End-to-end: AGENTOS_GATEWAY_HOST=0.0.0.0 makes the effective bind public,
+    but because the raw TOML has no host, the override original is None, so a
+    later persist DROPS host (default/env re-applies) instead of freezing
+    0.0.0.0 into the file."""
+    from agentos.gateway.config_persist import read_raw_bind_overrides
+
+    monkeypatch.setenv("AGENTOS_GATEWAY_HOST", "0.0.0.0")
+    cfg_path = tmp_path / "config.toml"
+    with open(cfg_path, "wb") as f:
+        tomli_w.dump({"debug": False}, f)
+
+    # run_gateway records the RAW originals (host absent -> None).
+    set_runtime_overrides(read_raw_bind_overrides(str(cfg_path)))
+    # The running config carries the effective public bind (from env).
+    runtime = GatewayConfig(host="0.0.0.0", config_path=str(cfg_path))
+    persist_config(runtime)  # unrelated save, host not explicit
+
+    saved = _read(cfg_path)
+    assert saved.get("host", "127.0.0.1") == "127.0.0.1"  # dropped, NOT frozen
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode")
 def test_written_config_is_owner_only_0600(tmp_path):
     cfg_path = tmp_path / "config.toml"

--- a/tests/test_gateway/test_config_view_static.py
+++ b/tests/test_gateway/test_config_view_static.py
@@ -259,6 +259,36 @@ def test_config_control_ui_help_documents_ws_origin_allowlist() -> None:
     assert "loopback" in help_text.lower()
 
 
+def test_config_host_and_port_render_read_only() -> None:
+    source = CONFIG_JS.read_text(encoding="utf-8")
+
+    # Bind posture is CLI-only: host/port render display-only, no editable input.
+    assert "_READONLY_KEYS" in source
+    readonly_decl = source.split("_READONLY_KEYS = new Set(", 1)[1].split(")", 1)[0]
+    assert "'host'" in readonly_decl
+    assert "'port'" in readonly_decl
+    field_block = source.split("function _fieldHtml(", 1)[1].split("function ", 1)[0]
+    assert "_READONLY_KEYS.has(k)" in field_block
+    assert "cfg-readonly-value" in field_block
+
+
+def test_config_readonly_value_has_display_styling() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+
+    assert ".cfg-readonly-value {" in css
+
+
+def test_config_host_port_help_text_names_the_cli_flags() -> None:
+    source = CONFIG_JS.read_text(encoding="utf-8")
+
+    host_help = source.split("'host':", 1)[1].split("',", 1)[0]
+    assert "--bind" in host_help
+    assert "cli" in host_help.lower()
+    port_help = source.split("'port':", 1)[1].split("',", 1)[0]
+    assert "--port" in port_help
+    assert "cli" in port_help.lower()
+
+
 def test_config_form_flattens_nested_objects_into_dotted_leaf_fields() -> None:
     source = CONFIG_JS.read_text(encoding="utf-8")
 

--- a/tests/test_gateway/test_config_view_static.py
+++ b/tests/test_gateway/test_config_view_static.py
@@ -320,6 +320,19 @@ def test_config_form_labels_strip_group_prefix_but_keep_full_key_for_save() -> N
     assert "test(k)" in sensitive_line
 
 
+def test_config_yaml_save_sends_baseline_yaml_for_snapshot_diff() -> None:
+    source = CONFIG_JS.read_text(encoding="utf-8")
+
+    # YAML-mode Save must send the baseline snapshot (_yamlText) so the server
+    # diffs it against the submitted text and persists only real edits, leaving
+    # runtime-echoed fields (CLI --listen/--debug/break-glass) to restore.
+    save_block = source.split("function _save(", 1)[1].split("function ", 1)[0]
+    assert "config.apply" in save_block
+    apply_call = save_block.split("config.apply", 1)[1].split(")", 1)[0]
+    assert "config_yaml: text" in apply_call
+    assert "baseline_yaml: _yamlText" in apply_call
+
+
 def test_config_form_reads_dirty_baseline_via_dotted_path_getter() -> None:
     source = CONFIG_JS.read_text(encoding="utf-8")
 

--- a/tests/test_gateway/test_rpc_config_diff_paths.py
+++ b/tests/test_gateway/test_rpc_config_diff_paths.py
@@ -1,0 +1,48 @@
+"""Unit tests for ``rpc_config.diff_paths`` — the structural dotted-path diff
+that lets YAML-mode ``config.apply`` persist only the fields the operator
+actually changed versus the baseline they were shown.
+"""
+
+from __future__ import annotations
+
+from agentos.gateway.rpc_config import diff_paths
+
+
+def test_identical_dicts_have_no_diff():
+    d = {"a": 1, "b": {"c": 2}}
+    assert diff_paths(d, dict(d)) == set()
+
+
+def test_changed_leaf_yields_its_dotted_path():
+    old = {"debug": False, "auth": {"mode": "none"}}
+    new = {"debug": False, "auth": {"mode": "token"}}
+    assert diff_paths(old, new) == {"auth.mode"}
+
+
+def test_added_key_yields_path_and_nested_leaves():
+    old = {"a": 1}
+    new = {"a": 1, "auth": {"mode": "token", "token": "x"}}
+    assert diff_paths(old, new) == {"auth", "auth.mode", "auth.token"}
+
+
+def test_removed_key_yields_path_and_nested_leaves():
+    old = {"a": 1, "section": {"x": 1, "y": 2}}
+    new = {"a": 1}
+    assert diff_paths(old, new) == {"section", "section.x", "section.y"}
+
+
+def test_changed_list_yields_list_path_not_indices():
+    old = {"tiers": [1, 2, 3]}
+    new = {"tiers": [1, 2, 4]}
+    assert diff_paths(old, new) == {"tiers"}
+
+
+def test_multiple_independent_changes():
+    old = {"host": "127.0.0.1", "debug": False, "auth": {"mode": "none"}}
+    new = {"host": "0.0.0.0", "debug": True, "auth": {"mode": "none"}}
+    assert diff_paths(old, new) == {"host", "debug"}
+
+
+def test_empty_baseline_marks_everything_changed():
+    new = {"a": 1, "b": {"c": 2}}
+    assert diff_paths({}, new) == {"a", "b", "b.c"}

--- a/tests/test_gateway/test_rpc_config_memory_embedding.py
+++ b/tests/test_gateway/test_rpc_config_memory_embedding.py
@@ -183,9 +183,11 @@ async def test_config_patch_auth_mode_reports_restart_required(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_config_patch_host_reports_restart_required(tmp_path):
-    """host changes do NOT rebind the live socket, so hot-applying host must be
-    flagged restart-required (the process still listens on the old address)."""
+async def test_config_patch_host_is_skipped_and_reports_no_restart(tmp_path):
+    """Bind posture is CLI-only: host is a read-only path, so patching it is
+    skipped entirely — nothing changed, so no restart is required either.
+    (Previously host was patchable and flagged restart-required; Part B of the
+    auth-provisioning design removed that door.)"""
     cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))  # host defaults to 127.0.0.1
     res = await get_dispatcher().dispatch(
         "r1",
@@ -195,7 +197,8 @@ async def test_config_patch_host_reports_restart_required(tmp_path):
     )
 
     assert res.error is None, res.error
-    assert res.payload["restartRequired"] is True
+    assert cfg.host == "127.0.0.1"
+    assert res.payload["restartRequired"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_config_readonly_bind.py
+++ b/tests/test_gateway/test_rpc_config_readonly_bind.py
@@ -1,0 +1,116 @@
+"""Part B — bind posture (host/port) is CLI-only: read-only via config RPC.
+
+`config.set`/`config.patch` must not change `host`/`port`, and `config.apply`
+(full replace) must preserve the RUNNING host/port instead of applying a
+submitted one, so the UI can never persist an unsafe public-bind config.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+import agentos.gateway.rpc_config  # noqa: F401  ensures registration
+from agentos.gateway.auth import Principal
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+
+
+def _admin_ctx(config: GatewayConfig) -> RpcContext:
+    return RpcContext(
+        conn_id="t",
+        config=config,
+        principal=Principal(
+            role="operator",
+            scopes=frozenset({"operator.admin"}),
+            is_owner=True,
+            authenticated=True,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_config_set_host_is_read_only(tmp_path):
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.set",
+        {"path": "host", "value": "0.0.0.0"},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is not None
+    assert "read-only" in res.error.message
+    assert cfg.host == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_config_set_port_is_read_only(tmp_path):
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.set",
+        {"path": "port", "value": 1},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is not None
+    assert "read-only" in res.error.message
+    assert cfg.port == 18791
+
+
+@pytest.mark.asyncio
+async def test_config_patch_skips_host_and_port_but_applies_other_paths(tmp_path):
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patches": {"host": "0.0.0.0", "port": 1, "debug": True}},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    # host/port are read-only paths: skipped, not applied.
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 18791
+    # Other patches in the same call still apply.
+    assert cfg.debug is True
+
+
+@pytest.mark.asyncio
+async def test_config_patch_merge_cannot_change_host_or_port(tmp_path):
+    cfg = GatewayConfig(config_path=str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.patch",
+        {"patch": {"host": "0.0.0.0", "port": 1, "debug": True}},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 18791
+    assert cfg.debug is True
+
+
+@pytest.mark.asyncio
+async def test_config_apply_preserves_running_host_and_port(tmp_path):
+    config_path = tmp_path / "c.toml"
+    cfg = GatewayConfig(config_path=str(config_path))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "config.apply",
+        {"config": {"host": "0.0.0.0", "port": 9999, "debug": True}},
+        _admin_ctx(cfg),
+    )
+
+    assert res.error is None, res.error
+    # Full replace preserves (not rejects) the running bind posture.
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 18791
+    assert cfg.debug is True
+
+    persisted = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted.get("host", "127.0.0.1") == "127.0.0.1"
+    assert persisted.get("port", 18791) == 18791


### PR DESCRIPTION
## Why

Follows up the browser-threat hardening (#24). That PR made the gateway *refuse* to start on a public bind without enforced auth — safe, but the operator hit a raw `ValueError` and had to hand-edit `config.toml`. Comparable runtimes (Hermes Agent) prompt interactively. This PR does the same, adapted to AgentOS: **the CLI is the single control point for bind posture, and auth is guaranteed there.**

## What

**Part A — interactive prompt.** When `gateway run` resolves a **non-loopback** bind (wildcard `0.0.0.0`/`::` *or* a specific LAN IP) whose auth doesn't protect it, on a TTY the CLI offers:

```
This public bind has no authentication configured. Choose how to proceed:
  [1] Generate a token and enable auth (recommended)
  [2] Serve without authentication (break-glass, this run only)
  [3] Cancel
```

- `[1]` generates `secrets.token_urlsafe(32)`, sets `auth.mode=token`, prints the token, and persists it.
- `[2]` forces `auth.mode="none"` + `allow_unauthenticated_public` **for this run only** (never persisted — see the override map below).
- `[3]` cancels (exit 0). Empty/invalid input defaults to `[1]`; EOF/Ctrl-C cancels. Non-TTY runs never prompt — the startup guard raises as before.

**Provenance-based persistence (single rule, all writers).** `run_gateway` injects one-off CLI flags (`--bind`/`--port`/`--debug`) into the in-memory config, which flows into `ctx.config` for every RPC. To stop any writer from freezing a one-off flag into `config.toml`, the CLI records the **on-disk originals** of those fields in a process-global override map at boot. Every live writer (`config.set/patch/apply`, `rpc_onboarding`, the CLI prompt) routes through one `persist_config`, which restores each overridden field to its on-disk original **unless** the operator explicitly changed it this write (`explicit_paths`). So a genuine UI edit of `debug`/`auth` persists, but a transient CLI/break-glass posture never does. The shared writer is atomic (`mkstemp` + `os.replace`) and `chmod 0600`, so a bearer token is never world-readable. To change `host`/`port` permanently, edit `config.toml` directly.

**Part B — host/port are CLI-only.** `host`/`port` are in `_READONLY_PATHS` (config.set/patch can't target them) and `config.apply` preserves the running values; the config UI renders them read-only.

`enforce_public_bind_auth_guard` is unchanged — still the fail-closed backstop.

## Testing

TDD throughout. Two rounds of adversarial code review (8 findings total, all reproduced and fixed), including a verify pass that caught YAML-mode `config.apply` freezing break-glass auth. Green: `ruff`, `mypy`, **5859 passed** (3 unrelated embedding/wheel failures pre-exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)