### PR TITLE
chore(release): v2026.7.18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AgentOS — Agent Instructions
 
-Microkernel Python agent runtime with MCP-native tools, a local model
-router, durable memory, a layered sandbox, and multi-channel messaging
-(Web UI, CLI, chat). One shared turn loop drives every client.
+Token-efficient Python agent runtime with MCP-native tools, on-device
+Pilot Router, durable memory, a layered sandbox, and multi-channel
+messaging (Web UI, CLI, chat). One shared turn loop drives every client.
 
 - **Language / runtime:** Python **3.12+** only.
 - **Package manager:** **uv** (not pip/poetry). Never edit lockfiles by hand.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AgentOS — Token-Efficient AI Agent
+# AgentOS — Token-Efficient AI Agent with On-Device Pilot Router
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-hero-banner.png" alt="AgentOS — The Open Agent Operating System">
@@ -6,7 +6,7 @@
 
 <p align="center">
   <b>Stop overpaying for AI. Let the router cook.</b><br>
-  A microkernel AI agent for your CLI, Web UI, and chat channels.
+  A token-efficient AI agent with on-device Pilot Router for your CLI, Web UI, and chat channels.
 </p>
 
 <p align="center">
@@ -23,8 +23,8 @@
 ## Overview
 
 AgentOS is an AI agent. It saves tokens, so it costs less to run.
-It has a small core (this is called "microkernel"). A local model
-router picks the cheapest model that can do each job. AgentOS also
+It has a small core. A local Pilot Router picks the cheapest model
+that can do each job. AgentOS also
 has memory that stays after you close it, a safe sandbox with many
 layers, built-in web search, and on-device embeddings.
 
@@ -51,11 +51,11 @@ For step-by-step guides, start with the
 
 Every client — the Web UI, the CLI, and the chat channels — talks to
 one local gateway. This gateway handles sessions, approvals, and
-scheduling. It sends each turn to the AgentOS Router, which picks the
+scheduling. It sends each turn to the Pilot Router, which picks the
 model. Then it runs tool calls inside the safe sandbox.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-architecture.png" alt="AgentOS architecture: Web UI, CLI, and channels connect to the gateway (sessions, approvals, scheduler), which drives the AgentOS Router and the sandboxed tools layer">
+  <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-architecture.png" alt="AgentOS architecture: Web UI, CLI, and channels connect to the gateway (sessions, approvals, scheduler), which drives the Pilot Router and the sandboxed tools layer">
 </p>
 
 Here is what happens to one message: it comes in through a channel,
@@ -100,7 +100,7 @@ file name.
 | Git + Git LFS | — | — | required | required |
 | `uv` | — | installed if missing | recommended | required |
 
-The default `recommended` profile installs **AgentOS Router** — AgentOS's
+The default `recommended` profile installs **Pilot Router** — AgentOS's
 own on-device model router (strategy `v4_phase3`) — along with the Python
 dependencies it needs (ONNX Runtime, LightGBM, scikit-learn). Its model
 bundle ships inside the wheel, so routing works offline with no extra
@@ -115,8 +115,8 @@ Set `AGENTOS_INSTALL_PROFILE=core` to skip the router dependencies, or use
 the `--router disabled` flag during first-time setup to keep them installed
 but turn the router off.
 
-On Windows, AgentOS Router needs the Visual C++ runtime too (it comes
-with the ONNX engine inside AgentOS Router). The Windows portable
+On Windows, Pilot Router needs the Visual C++ runtime too (it comes
+with the ONNX engine inside Pilot Router). The Windows portable
 launcher and the from-source PowerShell installer install this
 runtime for you, using `winget`. The **Quick terminal install**
 (`uv tool install`) does not do this step. If you see a
@@ -267,7 +267,7 @@ you plan to change the code, use
    powershell -ExecutionPolicy Bypass -File ./scripts/install_source.ps1
    ```
 
-   This script installs `.[recommended]` (AgentOS Router + memory + local
+   This script installs `.[recommended]` (Pilot Router + memory + local
    models). It uses `uv tool install`, in its own environment. If
    `uv` is not there, it falls back to `python -m pip install
    --user`. If `agentos` is not found after install, open a new
@@ -329,7 +329,7 @@ only apply in new terminal windows.
 **Installer environment variables and PATH checks**
 
 ```sh
-AGENTOS_INSTALL_PROFILE=core   bash scripts/install_source.sh   # small install, no AgentOS Router
+AGENTOS_INSTALL_PROFILE=core   bash scripts/install_source.sh   # small install, no Pilot Router
 AGENTOS_INSTALL_DRY_RUN=1      bash scripts/install_source.sh   # just show the plan, don't install
 ```
 
@@ -354,7 +354,7 @@ uv sync --extra recommended --extra dev
 uv run agentos --help
 ```
 
-The `recommended` extra also brings AgentOS Router here. The `dev` extra
+The `recommended` extra also brings Pilot Router here. The `dev` extra
 adds the test, lint, and type-check tools. To add more extras to
 this same setup:
 
@@ -377,7 +377,7 @@ uses a different Python setup.
 `agentos onboard` is the wizard you run the first time. It writes
 your config file. It keeps provider secret keys as environment
 variables, if you pass `--api-key-env`. The router is set to
-`recommended` by default (this means AgentOS Router, on the providers it
+`recommended` by default (this means Pilot Router, on the providers it
 supports). Pass `--router disabled` if you want one single model
 with no routing.
 
@@ -544,7 +544,7 @@ settings are all in `agentos.toml.example`.
 
 | Capability | What it does |
 | --- | --- |
-| **Token-efficient routing** | `AgentOS Router` defaults to `v4_phase3`, a small local AI model (BGE embeddings + LightGBM; the `recommended` extra installs its runtime dependencies) that looks at each message — its length, language, code, keywords, and meaning — and picks one of four levels (c0–c3), then routes it to the cheapest model that can still do the job well. This check runs on your own device, so your message never has to leave your computer just to make this choice. The model bundle ships inside the wheel, so this works offline out of the box. Prefer no local model files at all? Pick the `llm_judge` strategy instead (a small LLM call, optionally a local Ollama/LM Studio endpoint). Choose either in onboarding. |
+| **Token-efficient routing** | The `Pilot Router` defaults to `v4_phase3`, a small local AI model (BGE embeddings + LightGBM; the `recommended` extra installs its runtime dependencies) that looks at each message — its length, language, code, keywords, and meaning — and picks one of four levels (c0–c3), then routes it to the cheapest model that can still do the job well. This check runs on your own device, so your message never has to leave your computer just to make this choice. The model bundle ships inside the wheel, so this works offline out of the box. Prefer no local model files at all? Pick the `llm_judge` strategy instead (a small LLM call, optionally a local Ollama/LM Studio endpoint). Choose either in onboarding. |
 | **Adaptive reasoning and prompts** | AgentOS only asks for deep, extended thinking when the router sees the message is hard. The system instructions also grow to match: short and simple for easy messages, full and detailed for hard ones. |
 | **20+ LLM providers** | AgentOS can talk to 20+ AI providers — OpenRouter (used by default), the Bankr LLM Gateway, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, DashScope/Qwen, Moonshot, Mistral, Groq, Zhipu, SiliconFlow, vLLM, LM Studio, and more. It picks a main provider first, with backups ready if needed. The first-time setup shows you the providers that are fully tested. |
 | **On-demand skills and MCP** | AgentOS comes with 37 built-in skills (coding, GitHub, cron jobs, pptx/docx/xlsx/pdf files, summaries, tmux, weather, and more). Each skill only loads when a task actually needs it. AgentOS can use other MCP tools, and can also act as an MCP tool for others — `agentos mcp-server run` needs the `mcp` extra (install with `use-agent-os[recommended,mcp]`). You can write, install, and share your own skills from the CLI. |

--- a/README.product.md
+++ b/README.product.md
@@ -4,8 +4,8 @@
 
 # AgentOS Product Guide
 
-AgentOS is a token-efficient personal agent runtime for the terminal, a
-local Web UI, and messaging channels. It is designed for users who want one
+AgentOS is a token-efficient AI agent with on-device Pilot Router, for
+the terminal, a local Web UI, and messaging channels. It is designed for users who want one
 agent surface that can chat, use tools, remember useful context, run scheduled
 work, publish artifacts, and route work across multiple LLM providers without
 rewriting their workflow for each provider.
@@ -46,7 +46,7 @@ single-turn chat alone.
 
 | Product capability | What users get |
 | --- | --- |
-| AgentOS Router | Local, on-device routing that chooses an appropriate model tier per turn so simple tasks avoid premium-model cost. |
+| Pilot Router | Local, on-device routing that chooses an appropriate model tier per turn so simple tasks avoid premium-model cost. |
 | Tool compression | Large tool outputs stay useful without flooding the model context; raw results can be preserved while compact previews are sent to the model. |
 | Unified surfaces | CLI, Web UI, gateway RPC, and channels share the same runtime path, tools, memory, approvals, and usage accounting. |
 | Durable sessions | Conversations, transcripts, compaction summaries, artifacts, cost, and replay data are persisted for later inspection. |
@@ -68,7 +68,7 @@ single-turn chat alone.
 | Choose and inspect LLM providers/models | [`docs/providers-and-models.md`](docs/providers-and-models.md) |
 | Configure web search | [`docs/search.md`](docs/search.md) |
 | Understand the main product capabilities | [`docs/features.md`](docs/features.md) |
-| Use AgentOS Router | [`docs/features/agentos-router.md`](docs/features/agentos-router.md) |
+| Use Pilot Router | [`docs/features/agentos-router.md`](docs/features/agentos-router.md) |
 | Understand tool compression and tool-result handles | [`docs/features/tool-compression.md`](docs/features/tool-compression.md) |
 | Work with memory | [`docs/features/memory.md`](docs/features/memory.md) |
 | Work with skills | [`docs/features/skills.md`](docs/features/skills.md) |
@@ -141,9 +141,9 @@ See [`docs/configuration.md`](docs/configuration.md) for details.
 
 ## Feature Highlights
 
-### AgentOS Router
+### Pilot Router
 
-AgentOS Router is AgentOS's local routing layer. It keeps lightweight tasks
+Pilot Router is AgentOS's local routing layer. It keeps lightweight tasks
 on cheaper models and reserves stronger tiers for harder turns. Router
 decisions stay local; the user's prompt is not sent to a separate external
 classifier just to decide the model.

--- a/README.release.md
+++ b/README.release.md
@@ -1,7 +1,8 @@
 # AgentOS
 
-AgentOS is a Python agent runtime with MCP-native tools, durable sessions,
-local memory, multi-channel messaging, and a local web control UI.
+AgentOS is a token-efficient AI agent with on-device Pilot Router,
+MCP-native tools, durable sessions, local memory, multi-channel messaging,
+and a local web control UI.
 
 The package is published as part of an AgentOS release zip. Install from the
 release bundle rather than from a source checkout so the wheel, dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.17.post1"
-description = "AgentOS — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
+version = "2026.7.18"
+description = "Token-Efficient AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]
 readme = "README.md"


### PR DESCRIPTION
## Release v2026.7.18

Bumps version `2026.7.17.post1` → `2026.7.18` and finalizes the product rebrand.

### Changes since v2026.7.17.post1
- **feat(gateway):** interactive auth provisioning on public bind; host/port CLI-only (#25)
- **feat(gateway):** harden against browser-originated attacks on loopback binds (#24)
- **chore(branding):** rebrand to "Token-Efficient AI agent with on-device Pilot Router" across `pyproject.toml`, `README.md`, `README.product.md`, `README.release.md`, and `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)