### PR TITLE
chore(release): v2026.7.18.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.18.post1] - 2026-07-18
+
+### Fixed
+
+- Release-hygiene re-cut of 2026.7.18. The initial 2026.7.18 tag only bumped
+  `pyproject.toml`, so the repo's release-consistency guards
+  (`tests/test_release_consistency.py`, `tests/test_install_scripts.py`) failed
+  and the install docs/scripts still pointed at the prior tag. This post-release
+  propagates the version across `uv.lock`, both consistency tests, `RELEASES.md`,
+  `CHANGELOG.md`, the README install examples, and `install.sh`/`install.ps1`.
+  No runtime code changes — the distributed software is identical to 2026.7.18.
+
 ## [2026.7.18] - 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.18 is the current release. The project website is
+AgentOS 2026.7.18.post1 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.18"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.18.post1"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.18/use_agent_os-2026.7.18-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.18.post1/use_agent_os-2026.7.18.post1-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.18-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.18.post1-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.18.post1 | v2026.7.18.post1 | 2026-07-18 | Release-hygiene re-cut: propagate the 2026.7.18 version across `uv.lock`, consistency/install tests, `RELEASES.md`, `CHANGELOG.md`, README install examples, and `install.sh`/`install.ps1`. No runtime code changes. |
 | 2026.7.18 | v2026.7.18 | 2026-07-18 | Gateway: interactive auth provisioning on public bind, host/port CLI-only (#25); browser-threat hardening on loopback binds — CSWSH/DNS-rebinding guards (#24); rebrand to "Token-Efficient AI agent with on-device Pilot Router" |
 | 2026.7.17.post1 | v2026.7.17.post1 | 2026-07-17 | `session_status` tool fix: resolve the calling session from the tool context instead of a `SessionManager` method that never existed |
 | 2026.7.17 | v2026.7.17 | 2026-07-17 | Memory provider layer (mem0) + curated stores; v4_phase3 router bundle restored; Web UI transcript redesign; embedding-download redirect fix |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.18'
+$defaultVersion = 'v2026.7.18.post1'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.18. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.18.post1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.18"
+default_version="v2026.7.18.post1"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.18|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.18.post1|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.18
+  AGENTOS_VERSION=v2026.7.18.post1
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=matrix
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.18." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.18.post1." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.18"
+version = "2026.7.18.post1"
 description = "Token-Efficient AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.18"
+CURRENT_RELEASE_TAG = "v2026.7.18.post1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.18"
+CURRENT_VERSION = "2026.7.18.post1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3270,7 +3270,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.18"
+version = "2026.7.18.post1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Release v2026.7.18.post1

Release-hygiene re-cut of `2026.7.18`. Bumps the version across **all** files in this repo's release contract (enforced by `tests/test_release_consistency.py` + `tests/test_install_scripts.py`):

- `pyproject.toml`, `uv.lock`
- `tests/test_release_consistency.py`, `tests/test_install_scripts.py`
- `RELEASES.md` (new row), `CHANGELOG.md` (new `[2026.7.18.post1]` section)
- `README.md` (current-release line + pinned install example + wheel filename)
- `install.sh` / `install.ps1` default release tag

**No runtime code changes** — the distributed software is identical to `2026.7.18`. This is a PEP 440 post-release capturing the packaging/metadata consistency fixes.

Verified: `pytest tests/test_release_consistency.py tests/test_install_scripts.py` → 18 passed; `uv lock --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)