### PR TITLE
fix(router): make local providers work end-to-end (Ollama / LM Studio / OVMS / vLLM)

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -237,6 +237,14 @@ judge_short_circuit_enabled = true
 # Optional provider tier profile. Leave unset to preserve the built-in
 # OpenRouter defaults below. If set, it must match [llm].provider; the router
 # does not switch providers at runtime.
+#
+# INVARIANT: routing is single-provider. Tiers only select the MODEL for a
+# turn; every request still goes through the one [llm].provider client. A
+# tier whose `provider` differs from [llm].provider cannot reach that other
+# provider — on local providers (ollama / lm_studio / ovms / vllm) such a
+# tier is degraded to [llm].model at runtime (metadata: routing_degraded).
+# To get real multi-model routing, point every tier at a model that
+# [llm].provider itself serves (see the local example below).
 # tier_profile = "dashscope"  # openrouter | dashscope | deepseek | gemini | volcengine
 default_tier = "c1"
 confidence_threshold = 0.5
@@ -293,6 +301,34 @@ thinking_level = "medium"
 #
 # [agentos_router]
 # tier_profile = "dashscope"
+
+# Example: local provider (Ollama) with real multi-model routing. Local
+# providers have no tier profile — declare the tiers yourself, and point
+# every tier at a model your local server actually serves (`ollama list`).
+# Same pattern applies to lm_studio / ovms / vllm. Onboarding writes
+# self-consistent single-model tiers for local providers automatically.
+# [llm]
+# provider = "ollama"
+# model = "qwen3.5:2b"
+# base_url = "http://localhost:11434"
+#
+# [agentos_router.tiers.c0]
+# provider = "ollama"
+# model = "qwen3.5:2b"      # small + fast for trivial turns
+# [agentos_router.tiers.c1]
+# provider = "ollama"
+# model = "qwen3.5:9b"      # balanced default
+# [agentos_router.tiers.c2]
+# provider = "ollama"
+# model = "qwen3.5:9b"
+# [agentos_router.tiers.c3]
+# provider = "ollama"
+# model = "qwen3.5:latest"  # strongest local model for hard turns
+# [agentos_router.tiers.image_model]
+# provider = "ollama"
+# model = "qwen3.5:9b"      # must be a vision-capable local model
+# supports_image = true
+# image_only = true
 
 [agent_token_saving]
 # Project fresh tool results with the built-in tokenjuice reducer before they

--- a/docs/features/agentos-router.md
+++ b/docs/features/agentos-router.md
@@ -35,6 +35,25 @@ Both the Web UI setup wizard and the CLI (`agentos onboard`,
 **Off**. The "Judge model" field only appears when the LLM-based strategy is
 selected — it is irrelevant to the on-device strategy.
 
+## One Router, One Provider
+
+Routing is **single-provider**: the gateway builds one provider client from
+`[llm].provider` at boot, and tiers only choose which **model** each turn
+uses. The `provider` field on a tier is descriptive metadata — it never makes
+a request reach a different provider. Configure every tier with a model that
+`[llm].provider` itself serves.
+
+Local providers (Ollama, LM Studio, OVMS, vLLM) have no built-in tier
+profile. Onboarding writes self-consistent single-model tiers for them; to
+get real multi-model routing, edit the tiers to point at other models your
+local server has pulled (see the local example in `agentos.toml.example`).
+If a tier still points at a different provider than `[llm].provider` — for
+example leftover cloud defaults on an Ollama install — the router degrades
+that route to `[llm].model` instead of sending the local server a model name
+it does not have; the turn metadata carries `routing_degraded: true`,
+`agentos doctor` reports the mismatch, and the gateway logs a one-time
+warning at boot.
+
 ## Enable Routing
 
 Recommended first-run setup:

--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -1119,13 +1119,15 @@ def _degrade_model_for_local_provider(
 ) -> str:
     """Collapse a mismatched-provider tier model to the configured local model.
 
-    Local providers (ollama / lm_studio / ovms) always run through the single
-    configured ``llm.provider`` — the runtime never builds a per-tier provider
-    client. So a tier whose ``provider`` differs from the configured local
-    provider names a model the local server does not have. Pin such a route to
-    ``llm.model`` instead, and mark ``ctx.metadata['routing_degraded']``. A tier
-    whose ``provider`` matches the local provider is an intentional local
-    multi-model setup and is left untouched.
+    Local providers (ollama / lm_studio / ovms / vllm) always run through the
+    single configured ``llm.provider`` — the runtime never builds a per-tier
+    provider client. So a tier whose ``provider`` differs from the configured
+    local provider names a model the local server does not have. Pin such a
+    route to ``llm.model`` instead, and mark ``ctx.metadata['routing_degraded']``.
+    A tier whose ``provider`` matches the local provider is an intentional local
+    multi-model setup and is left untouched. When ``llm.model`` is empty there
+    is nothing safe to pin to, so the route is left as-is and the degraded flag
+    stays unset (the flag must never claim a degrade that did not happen).
     """
     from agentos.provider.registry import is_local_provider
 
@@ -1135,8 +1137,11 @@ def _degrade_model_for_local_provider(
         return routed_model
     tier_provider = str(tier_cfg.get("provider") or "").strip().lower()
     if tier_provider and tier_provider != provider:
+        fallback = str(getattr(llm_cfg, "model", "") or "")
+        if not fallback:
+            return routed_model
         ctx.metadata["routing_degraded"] = True
-        return str(getattr(llm_cfg, "model", "") or routed_model)
+        return fallback
     return routed_model
 
 
@@ -1504,5 +1509,6 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
         probabilities=routing_extra.get("probabilities"),
         margin=routing_extra.get("margin"),
         provider_state_continuity=ctx.metadata.get("provider_state_continuity"),
+        routing_degraded=ctx.metadata.get("routing_degraded"),
     )
     return ctx

--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -1111,6 +1111,35 @@ def _attachments_include_image(attachments: list[dict[str, Any]] | None) -> bool
     return False
 
 
+def _degrade_model_for_local_provider(
+    ctx: TurnContext,
+    *,
+    tier_cfg: dict,
+    routed_model: str,
+) -> str:
+    """Collapse a mismatched-provider tier model to the configured local model.
+
+    Local providers (ollama / lm_studio / ovms) always run through the single
+    configured ``llm.provider`` — the runtime never builds a per-tier provider
+    client. So a tier whose ``provider`` differs from the configured local
+    provider names a model the local server does not have. Pin such a route to
+    ``llm.model`` instead, and mark ``ctx.metadata['routing_degraded']``. A tier
+    whose ``provider`` matches the local provider is an intentional local
+    multi-model setup and is left untouched.
+    """
+    from agentos.provider.registry import is_local_provider
+
+    llm_cfg = getattr(ctx.config, "llm", None) if ctx.config else None
+    provider = str(getattr(llm_cfg, "provider", "") or "").strip().lower()
+    if not is_local_provider(provider):
+        return routed_model
+    tier_provider = str(tier_cfg.get("provider") or "").strip().lower()
+    if tier_provider and tier_provider != provider:
+        ctx.metadata["routing_degraded"] = True
+        return str(getattr(llm_cfg, "model", "") or routed_model)
+    return routed_model
+
+
 async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
     router_cfg = getattr(ctx.config, "agentos_router", None) if ctx.config else None
     if not router_cfg or not getattr(router_cfg, "enabled", False):
@@ -1162,7 +1191,9 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
         routing_applied = True
         ctx.metadata["baseline_model"] = ctx.model
         if routing_applied:
-            ctx.model = decision.model
+            ctx.model = _degrade_model_for_local_provider(
+                ctx, tier_cfg=image_tiers[tier_name], routed_model=decision.model
+            )
         ctx.metadata["routed_tier"] = decision.tier
         ctx.metadata["routed_model"] = decision.model
         ctx.metadata["routing_applied"] = routing_applied
@@ -1201,7 +1232,9 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
                 source="router_control_hold",
             )
             ctx.metadata["baseline_model"] = ctx.model
-            ctx.model = decision.model
+            ctx.model = _degrade_model_for_local_provider(
+                ctx, tier_cfg=tiers.get(hold.tier, {}), routed_model=decision.model
+            )
             ctx.metadata["routed_tier"] = decision.tier
             ctx.metadata["routed_model"] = decision.model
             ctx.metadata["routing_applied"] = True
@@ -1362,7 +1395,9 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
 
     routing_applied = rollout_phase != "observe"
     if routing_applied:
-        ctx.model = decision.model
+        ctx.model = _degrade_model_for_local_provider(
+            ctx, tier_cfg=tiers.get(decision.tier, {}), routed_model=decision.model
+        )
     ctx.metadata["routed_tier"] = decision.tier
     ctx.metadata["routed_model"] = decision.model
     ctx.metadata["routing_applied"] = routing_applied

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1336,6 +1336,26 @@ def _log_resolved_judge(config: GatewayConfig, router_cfg: Any) -> None:
     )
 
 
+def _should_build_provider_selector(*, provider: str, api_key: str) -> bool:
+    """Whether boot has enough to construct a runtime ``provider_selector``.
+
+    True when an API key is present, or when the provider does not require one
+    (local providers — ollama / lm_studio / ovms). Key-requiring providers with
+    no key stay ``False`` so the turn runner surfaces ``no_provider``, the
+    correct signal for a missing credential. Unknown provider ids fall back to
+    key presence rather than raising during boot.
+    """
+    if api_key:
+        return True
+    from agentos.provider.registry import UnknownProviderError, get_provider_spec
+
+    try:
+        spec = get_provider_spec(provider)
+    except UnknownProviderError:
+        return False
+    return not spec.requires_api_key()
+
+
 def _agentos_router_bundle_dir(router_cfg: Any) -> Path:
     """Resolve the v4_phase3 bundle root, honoring the v4_bundle_dir override."""
     configured = getattr(router_cfg, "v4_bundle_dir", None)
@@ -1541,7 +1561,7 @@ async def build_services(
     resolved_base = llm_runtime.base_url
     proxy = llm_runtime.proxy
     if provider_selector is None:
-        if api_key:
+        if _should_build_provider_selector(provider=llm_runtime.provider, api_key=api_key):
             from agentos.provider.selector import (
                 ModelSelector,
                 ProviderConfig,

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1356,6 +1356,52 @@ def _should_build_provider_selector(*, provider: str, api_key: str) -> bool:
     return not spec.requires_api_key()
 
 
+def _router_tier_provider_mismatches(
+    *, config: GatewayConfig, llm_provider: str
+) -> dict[str, str]:
+    """Router tiers whose declared provider differs from the runtime provider.
+
+    Routing is single-provider: boot builds ONE client from ``llm.provider``;
+    ``agentos_router.tiers[*].provider`` is metadata and never builds a client.
+    A tier pointing elsewhere silently misroutes (local providers 404 and the
+    engine degrades such routes to ``llm.model``), so boot surfaces the
+    mismatch. Returns ``{tier_name: tier_provider}`` for the offending tiers;
+    tiers without a non-empty ``provider`` value do not participate.
+    """
+    router_cfg = getattr(config, "agentos_router", None)
+    if router_cfg is None or not getattr(router_cfg, "enabled", False):
+        return {}
+    tiers = getattr(router_cfg, "tiers", None)
+    if not isinstance(tiers, dict):
+        return {}
+    runtime_provider = str(llm_provider).strip().lower()
+    mismatched: dict[str, str] = {}
+    for tier_name, tier in tiers.items():
+        if not isinstance(tier, dict):
+            continue
+        tier_provider = str(tier.get("provider") or "").strip()
+        if tier_provider and tier_provider.lower() != runtime_provider:
+            mismatched[str(tier_name)] = tier_provider
+    return mismatched
+
+
+def _warn_on_tier_provider_mismatch(config: GatewayConfig, llm_provider: str) -> None:
+    """One-time boot warning for router tiers that point at a foreign provider."""
+    mismatched = _router_tier_provider_mismatches(config=config, llm_provider=llm_provider)
+    if not mismatched:
+        return
+    log.warning(
+        "agentos_router.tier_provider_mismatch",
+        llm_provider=llm_provider,
+        mismatched_tiers=mismatched,
+        note=(
+            "tiers only select the MODEL; requests always go through "
+            "llm.provider — mismatched tiers are degraded to llm.model "
+            "on local providers"
+        ),
+    )
+
+
 def _agentos_router_bundle_dir(router_cfg: Any) -> Path:
     """Resolve the v4_phase3 bundle root, honoring the v4_bundle_dir override."""
     configured = getattr(router_cfg, "v4_bundle_dir", None)
@@ -1587,6 +1633,10 @@ async def build_services(
                 provider=llm_runtime.provider,
                 model=llm_runtime.model,
             )
+
+    # Routing is single-provider: warn once when enabled router tiers declare a
+    # provider that differs from the one client boot just selected.
+    _warn_on_tier_provider_mismatch(config, llm_runtime.provider)
 
     # ── Model catalog (boot order: after provider selector) ──────────
     # Keep a catalog for every provider so direct-provider runtime paths still

--- a/src/agentos/gateway/rpc_doctor.py
+++ b/src/agentos/gateway/rpc_doctor.py
@@ -236,6 +236,21 @@ def _router_payload(ctx: RpcContext) -> dict[str, Any]:
             "runtimeValid": True,
         }
 
+    # Routing is single-provider: tiers only select the model, every request
+    # goes through llm.provider. Surface each tier's declared provider so
+    # evaluate_router can flag tiers pointing at a provider the runtime never
+    # builds a client for. Tiers without a non-empty provider are omitted.
+    llm_provider = str(getattr(getattr(config, "llm", None), "provider", "") or "")
+    raw_tiers = getattr(router, "tiers", None)
+    tier_providers: dict[str, str] = {}
+    if isinstance(raw_tiers, dict):
+        for tier_name, tier in raw_tiers.items():
+            if not isinstance(tier, dict):
+                continue
+            tier_provider = str(tier.get("provider") or "").strip()
+            if tier_provider:
+                tier_providers[str(tier_name)] = tier_provider
+
     runtime_valid = True
     error: str | None = None
     # Distinguishes WHY the router runtime is invalid so health/evaluator can
@@ -278,6 +293,8 @@ def _router_payload(ctx: RpcContext) -> dict[str, Any]:
             "judgeModel": None,
             "judgeSource": None,
             "judgeBaseUrl": None,
+            "llmProvider": llm_provider,
+            "tierProviders": tier_providers,
             "error": error,
         }
 
@@ -392,6 +409,8 @@ def _router_payload(ctx: RpcContext) -> dict[str, Any]:
         "judgeModel": judge_model,
         "judgeSource": judge_source,
         "judgeBaseUrl": judge_base_url,
+        "llmProvider": llm_provider,
+        "tierProviders": tier_providers,
         "error": error,
     }
 

--- a/src/agentos/health/evaluator.py
+++ b/src/agentos/health/evaluator.py
@@ -889,6 +889,58 @@ def _router_runtime_invalid_finding(
     )
 
 
+def _router_tier_provider_mismatch_findings(
+    payload: dict[str, Any],
+) -> list[HealthFinding]:
+    """Flag enabled-router tiers that declare a provider other than llm.provider.
+
+    Routing is single-provider: the runtime builds one client from
+    ``llm.provider``; tier ``provider`` values are metadata and never build a
+    client, so a mismatched tier silently misroutes (the engine degrades such
+    routes to ``llm.model`` on local providers). Providers are compared after
+    strip/lower normalization; tiers without a provider value do not participate.
+    """
+    llm_provider = str(payload.get("llmProvider") or "").strip()
+    tier_providers = payload.get("tierProviders")
+    if not llm_provider or not isinstance(tier_providers, dict):
+        return []
+    normalized_llm = llm_provider.lower()
+    mismatched: dict[str, str] = {}
+    for tier_name, provider in tier_providers.items():
+        tier_provider = str(provider or "").strip()
+        if tier_provider and tier_provider.lower() != normalized_llm:
+            mismatched[str(tier_name)] = tier_provider
+    if not mismatched:
+        return []
+    return [
+        HealthFinding(
+            id="router.tiers.provider_mismatch",
+            severity="warn",
+            surface="router",
+            title="Router tiers point at a different provider",
+            detail=(
+                f"{len(mismatched)} router tier(s) declare a provider other than "
+                f"llm.provider ({llm_provider}). Tiers only select the model — "
+                "requests always go through llm.provider, so mismatched tiers "
+                "are silently degraded to llm.model on local providers."
+            ),
+            evidence={"llmProvider": llm_provider, "mismatchedTiers": mismatched},
+            fix_steps=[
+                FixStep(
+                    label="Align tier providers with llm.provider",
+                    detail=(
+                        "Point the mismatched tiers' provider and model at models "
+                        f"served by llm.provider ({llm_provider}), or remove the "
+                        "custom tiers to fall back to the built-in profile."
+                    ),
+                ),
+                FixStep(label="Restart gateway", command="agentos gateway restart"),
+            ],
+            restart_required=True,
+        )
+    ]
+
+
 def evaluate_router(payload: dict[str, Any]) -> list[HealthFinding]:
     if "enabled" not in payload:
         return _diagnostic_incomplete(
@@ -941,8 +993,12 @@ def evaluate_router(payload: dict[str, Any]) -> list[HealthFinding]:
                 restart_required=True,
             )
         ]
+    # Router is enabled from here on: append the tier/provider mismatch finding
+    # (if any) to whichever primary finding applies — the mismatch is an
+    # independent config problem that must not be masked by runtime state.
+    mismatch_findings = _router_tier_provider_mismatch_findings(payload)
     if not runtime_valid:
-        return [_router_runtime_invalid_finding(payload, evidence)]
+        return [_router_runtime_invalid_finding(payload, evidence), *mismatch_findings]
     if rollout_phase not in {"full", "observe"}:
         return [
             HealthFinding(
@@ -960,7 +1016,8 @@ def evaluate_router(payload: dict[str, Any]) -> list[HealthFinding]:
                     FixStep(label="Restart gateway", command="agentos gateway restart"),
                 ],
                 restart_required=True,
-            )
+            ),
+            *mismatch_findings,
         ]
     if rollout_phase != "full":
         return [
@@ -982,7 +1039,8 @@ def evaluate_router(payload: dict[str, Any]) -> list[HealthFinding]:
                     FixStep(label="Restart gateway", command="agentos gateway restart"),
                 ],
                 restart_required=True,
-            )
+            ),
+            *mismatch_findings,
         ]
     return [
         HealthFinding(
@@ -992,7 +1050,8 @@ def evaluate_router(payload: dict[str, Any]) -> list[HealthFinding]:
             title="Router ready",
             detail=f"{strategy} router is active with {tier_profile} profile.",
             evidence=evidence,
-        )
+        ),
+        *mismatch_findings,
     ]
 
 

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -16,6 +16,8 @@ from agentos.gateway.config import (
     GatewayConfig,
     LlmProviderConfig,
     MemoryEmbeddingConfig,
+    _bankr_tiers,
+    _openrouter_tiers,
     _router_tier_profile_defaults,
 )
 from agentos.onboarding.audio_specs import get_audio_provider_setup_spec
@@ -32,6 +34,7 @@ from agentos.onboarding.redaction import (
     redact_search_payload,
 )
 from agentos.onboarding.search_specs import get_search_provider_setup_spec
+from agentos.provider.registry import is_local_provider
 from agentos.router_tiers import (
     DEFAULT_TEXT_TIER,
     TEXT_TIERS,
@@ -84,14 +87,103 @@ def _positive_int(value: int | str, *, label: str) -> int:
     return parsed
 
 
+# Only the routing-relevant flags survive a local-tier rewrite. thinking_level
+# and the image flags MUST be preserved so thinking tiering and image-aware
+# routing keep working; the free-text description is dropped so the rewritten
+# tiers stay minimal and round-trip cleanly.
+_LOCAL_TIER_PRESERVED_KEYS = ("thinking_level", "supports_image", "image_only")
+
+
+def _local_provider_tiers(
+    base_tiers: dict[str, Any],
+    provider_id: str,
+    model: str,
+) -> dict[str, Any]:
+    """Rewrite every base tier to point at a local provider's single model.
+
+    Local providers run one endpoint serving only locally-pulled models, so the
+    router cannot fan out across per-tier cloud model ids. Pin all tiers
+    (c0..c3 and image_model) to ``provider_id``/``model`` while preserving each
+    tier's routing flags (thinking_level, supports_image, image_only).
+    """
+    rewritten: dict[str, Any] = {}
+    for name, tier in base_tiers.items():
+        entry: dict[str, Any] = {"provider": provider_id, "model": model}
+        for key in _LOCAL_TIER_PRESERVED_KEYS:
+            if key in tier:
+                entry[key] = tier[key]
+        rewritten[name] = entry
+    return rewritten
+
+
+def _tiers_are_machine_written_defaults(
+    tiers: dict[str, Any],
+    old_provider: str,
+    old_model: str,
+) -> bool:
+    """True when ``tiers`` are safe to rewrite (not operator-customised).
+
+    Two shapes count as machine-written:
+      * the shipped default tier sets (openrouter or bankr), matched exactly,
+        exactly as :meth:`GatewayConfig._default_agentos_router_profile_for_direct_provider`
+        detects "not custom"; and
+      * tiers this reconcile already local-pinned — every entry's provider equals
+        the OLD llm provider AND every entry's model equals the OLD llm model
+        (a local→local switch, e.g. ollama→vllm, must re-pin these).
+    Anything else is treated as a custom, operator-authored tier set and left
+    untouched.
+    """
+    if tiers in (_openrouter_tiers(), _bankr_tiers()):
+        return True
+    old_provider = str(old_provider or "").strip().lower()
+    old_model = str(old_model or "").strip()
+    if not old_provider or not old_model or not is_local_provider(old_provider):
+        return False
+    if not tiers:
+        return False
+    for tier in tiers.values():
+        if not isinstance(tier, dict):
+            return False
+        if str(tier.get("provider") or "").strip().lower() != old_provider:
+            return False
+        if str(tier.get("model") or "").strip() != old_model:
+            return False
+    return True
+
+
 def _reconcile_router_profile_for_provider(
     cfg: GatewayConfig,
     provider_id: str,
+    *,
+    model: str = "",
+    old_provider: str = "",
+    old_model: str = "",
 ) -> list[str]:
     current_profile = getattr(cfg.agentos_router, "tier_profile", None)
     if not getattr(cfg.agentos_router, "enabled", True):
         return []
     if current_profile and str(current_profile).strip().lower() == provider_id:
+        return []
+    if is_local_provider(provider_id) and not current_profile:
+        # Local providers have no tier profile and build no per-tier client.
+        # When the current tiers are the untouched shipped defaults OR tiers a
+        # previous reconcile local-pinned, rewrite them to this provider+model so
+        # the persisted config is self-consistent (the runtime degrade guard then
+        # becomes a no-op).
+        if _tiers_are_machine_written_defaults(
+            cfg.agentos_router.tiers, old_provider, old_model
+        ):
+            router_payload = cfg.agentos_router.model_dump(mode="python")
+            router_payload["tier_profile"] = None
+            router_payload["tiers"] = _local_provider_tiers(
+                cfg.agentos_router.tiers, provider_id, model
+            )
+            cfg.agentos_router = AgentOSRouterConfig(**router_payload)
+            return []
+        # Operator-customised tiers: leave the router exactly as the operator
+        # authored it (enabled + custom tiers). The runtime degrade guard pins
+        # any mismatched-provider tier to llm.model per turn, so custom local
+        # tiers stay safe without being clobbered here.
         return []
     if (
         not current_profile
@@ -299,6 +391,8 @@ def upsert_llm_provider(
     if spec.requires_base_url and not effective_base_url:
         raise ValueError(f"provider {provider_id!r} requires a base_url")
 
+    old_provider = str(config.llm.provider or "")
+    old_model = str(config.llm.model or "")
     new_cfg = _clone(config)
     new_cfg.llm = LlmProviderConfig(
         provider=provider_id,
@@ -309,7 +403,13 @@ def upsert_llm_provider(
         proxy=proxy,
         provider_routing=dict(provider_routing or {}),
     )
-    reconcile_warnings = _reconcile_router_profile_for_provider(new_cfg, provider_id)
+    reconcile_warnings = _reconcile_router_profile_for_provider(
+        new_cfg,
+        provider_id,
+        model=model_clean,
+        old_provider=old_provider,
+        old_model=old_model,
+    )
     if api_key:
         new_cfg.clear_runtime_secret("llm.api_key")
 

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -621,11 +621,8 @@ def upsert_router(
         )
         public_payload.update({"enabled": True, "tier_profile": None})
     else:
-        if provider not in ROUTER_TIER_PROFILE_IDS:
-            router_payload["enabled"] = False
-            router_payload["tier_profile"] = None
-            public_payload.update({"enabled": False, "tier_profile": None})
-        else:
+        llm_model = str(config.llm.model or "").strip()
+        if provider in ROUTER_TIER_PROFILE_IDS:
             router_payload["enabled"] = True
             router_payload["tier_profile"] = provider
             router_payload["tiers"] = _merge_router_tiers(
@@ -633,6 +630,35 @@ def upsert_router(
                 tiers,
             )
             public_payload.update({"enabled": True, "tier_profile": provider})
+        elif is_local_provider(provider) and llm_model:
+            # Local providers have no tier profile, but "recommended" must not
+            # disable the router and resurrect the openrouter default tiers
+            # (clobbering the local pin the provider step just wrote). Keep an
+            # operator-customised table verbatim; otherwise pin every tier to
+            # the configured local model.
+            router_payload["enabled"] = True
+            router_payload["tier_profile"] = None
+            current_tiers = {
+                name: dict(tier)
+                for name, tier in (config.agentos_router.tiers or {}).items()
+                if isinstance(tier, dict)
+            }
+            if current_tiers and not _tiers_are_machine_written_defaults(
+                current_tiers, provider, llm_model
+            ):
+                router_payload["tiers"] = _merge_router_tiers(current_tiers, tiers)
+            else:
+                router_payload["tiers"] = _merge_router_tiers(
+                    _local_provider_tiers(
+                        _router_tier_profile_defaults("openrouter"), provider, llm_model
+                    ),
+                    tiers,
+                )
+            public_payload.update({"enabled": True, "tier_profile": None})
+        else:
+            router_payload["enabled"] = False
+            router_payload["tier_profile"] = None
+            public_payload.update({"enabled": False, "tier_profile": None})
     warnings: list[str] = []
     if router_payload.get("enabled"):
         warnings.extend(

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -609,6 +609,18 @@ def upsert_router(
     if router_mode == "disabled":
         router_payload["enabled"] = False
         router_payload["tier_profile"] = None
+        if is_local_provider(provider):
+            # Keep a local pin in the persisted config while the router is off:
+            # dropping the tiers here would resurrect the openrouter defaults
+            # via the config default factory, leaving a local config that lies
+            # about its providers.
+            current_tiers = {
+                name: dict(tier)
+                for name, tier in (config.agentos_router.tiers or {}).items()
+                if isinstance(tier, dict)
+            }
+            if current_tiers:
+                router_payload["tiers"] = current_tiers
         public_payload.update({"enabled": False, "tier_profile": None})
     elif router_mode == "openrouter-mix":
         if provider != "openrouter":

--- a/src/agentos/provider/registry.py
+++ b/src/agentos/provider/registry.py
@@ -42,7 +42,7 @@ class ProviderSpec:
     capabilities: frozenset[str] = field(default_factory=lambda: frozenset({"chat"}))
 
     _LOCAL_PROVIDERS: ClassVar[frozenset[str]] = frozenset(
-        {"ollama", "lm_studio", "ovms"}
+        {"ollama", "lm_studio", "ovms", "vllm"}
     )
 
     def requires_api_key(self) -> bool:
@@ -344,7 +344,7 @@ def get_provider_spec(provider_id: str) -> ProviderSpec:
 
 
 def is_local_provider(provider_id: str) -> bool:
-    """True for local, self-hosted providers (ollama / lm_studio / ovms).
+    """True for local, self-hosted providers (ollama / lm_studio / ovms / vllm).
 
     Local providers run a single configured endpoint and serve only the models
     the operator has pulled locally; the runtime never builds a per-tier

--- a/src/agentos/provider/registry.py
+++ b/src/agentos/provider/registry.py
@@ -341,3 +341,13 @@ def get_provider_spec(provider_id: str) -> ProviderSpec:
         raise UnknownProviderError(
             f"Unknown provider '{provider_id}'. Available: {available}"
         ) from exc
+
+
+def is_local_provider(provider_id: str) -> bool:
+    """True for local, self-hosted providers (ollama / lm_studio / ovms).
+
+    Local providers run a single configured endpoint and serve only the models
+    the operator has pulled locally; the runtime never builds a per-tier
+    provider client for them. Unknown provider ids are treated as non-local.
+    """
+    return str(provider_id or "").strip().lower() in ProviderSpec._LOCAL_PROVIDERS

--- a/tests/test_engine/test_router_local_provider_degrade.py
+++ b/tests/test_engine/test_router_local_provider_degrade.py
@@ -133,3 +133,107 @@ async def test_cloud_provider_applies_tier_model_unchanged(
 
     assert routed.model == "minimax/minimax-m3"
     assert routed.metadata.get("routing_degraded") is not True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "lm_studio", "ovms", "vllm"])
+async def test_every_local_provider_degrades_cloud_tier_model(
+    monkeypatch: pytest.MonkeyPatch, provider: str
+) -> None:
+    # The full local set — not just ollama — must be covered by the degrade.
+    config = GatewayConfig(llm={"provider": provider, "model": "local-model", "api_key": ""})
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context(config)
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.model == "local-model"
+    assert routed.metadata["routing_degraded"] is True
+
+
+@pytest.mark.asyncio
+async def test_empty_llm_model_keeps_route_and_does_not_lie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With no llm.model there is nothing safe to pin to: the route must stay
+    # unchanged and routing_degraded must NOT claim a degrade that never happened.
+    config = GatewayConfig(llm={"provider": "ollama", "model": "", "api_key": ""})
+    config.llm.model = ""  # guard against default-model backfill
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context(config)
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.model == "minimax/minimax-m3"
+    assert routed.metadata.get("routing_degraded") is not True
+
+
+@pytest.mark.asyncio
+async def test_image_route_degrades_under_local_provider() -> None:
+    # The image branch is a separate ctx.model write site with an early return;
+    # a cloud image_model tier must degrade for a local provider too.
+    config = _ollama_config_with_cloud_tiers()
+    ctx = _make_context(config)
+    ctx.attachments = [{"type": "image/png", "name": "shot.png"}]
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.model == "qwen3.5:2b"
+    assert routed.metadata["routing_degraded"] is True
+    assert routed.metadata["routed_tier"] == "image_model"
+
+
+@pytest.mark.asyncio
+async def test_router_control_hold_degrades_under_local_provider() -> None:
+    # The router-control-hold branch is the third ctx.model write site.
+    from agentos.router_control import (
+        RouterControlHoldStore,
+        resolve_router_control_target,
+    )
+
+    config = _ollama_config_with_cloud_tiers()
+    ctx = _make_context(config)
+    store = RouterControlHoldStore()
+    target = resolve_router_control_target(config.agentos_router, "tier:c3")
+    store.set_hold(ctx.session_key, target, evidence="hold on c3")
+    ctx.metadata["router_control_hold_store"] = store
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.metadata["router_control_hold_applied"] is True
+    assert routed.model == "qwen3.5:2b"
+    assert routed.metadata["routing_degraded"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("pinned_tier", "expected_model", "expect_degraded"),
+    [
+        ("c0", "qwen3.5:2b", False),  # matching-provider tier honored
+        ("c1", "qwen3.5:2b", True),  # mismatched tier degraded to llm.model
+    ],
+)
+async def test_mixed_tier_table_degrades_only_mismatched_tiers(
+    monkeypatch: pytest.MonkeyPatch,
+    pinned_tier: str,
+    expected_model: str,
+    expect_degraded: bool,
+) -> None:
+    # A hand-mixed table: one intentional local tier, one leftover cloud tier.
+    config = GatewayConfig(
+        llm={"provider": "ollama", "model": "qwen3.5:2b", "api_key": ""},
+        agentos_router={
+            "enabled": True,
+            "tiers": {
+                "c0": {"provider": "ollama", "model": "qwen3.5:2b"},
+                "c1": {"provider": "openrouter", "model": "minimax/minimax-m3"},
+            },
+        },
+    )
+    _pin_strategy(monkeypatch, pinned_tier)
+    ctx = _make_context(config)
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.model == expected_model
+    assert routed.metadata.get("routing_degraded", False) is expect_degraded

--- a/tests/test_engine/test_router_local_provider_degrade.py
+++ b/tests/test_engine/test_router_local_provider_degrade.py
@@ -1,0 +1,135 @@
+"""Router single-model degrade for local providers.
+
+When ``llm.provider`` is local (ollama / lm_studio / ovms) the runtime always
+sends requests through that one configured provider — it never builds a
+per-tier provider client. So a routed tier whose ``model`` belongs to a
+*different* provider (the baked-in cloud defaults point at openrouter models)
+hands the local server a model name it does not have → 404.
+
+Degrade rule: when the chosen tier's ``provider`` differs from the configured
+local provider, pin the model to ``llm.model`` instead of the tier's model.
+The router still runs (classification, thinking-level, prompt policy) — only
+the unusable model string is neutralized. A local user who intentionally sets
+per-tier models to their *own* provider is honored unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps import agentos_router as agentos_router_step
+from agentos.engine.steps.agentos_router import apply_agentos_router
+from agentos.gateway.config import GatewayConfig
+
+
+@pytest.fixture(autouse=True)
+def reset_agentos_router_state(monkeypatch: pytest.MonkeyPatch):
+    agentos_router_step._history_store.clear()
+    agentos_router_step._strategy = None
+    agentos_router_step._strategy_key = None
+    yield
+    agentos_router_step._history_store.clear()
+    agentos_router_step._strategy = None
+    agentos_router_step._strategy_key = None
+    monkeypatch.undo()
+
+
+class _FixedStrategy:
+    requires_history = False
+
+    def __init__(self, tier: str) -> None:
+        self._tier = tier
+
+    async def classify(self, message, valid_tiers, routing_history=None):
+        return self._tier, 0.99, "llm_judge", {}
+
+
+def _pin_strategy(monkeypatch: pytest.MonkeyPatch, tier: str) -> None:
+    monkeypatch.setattr(
+        agentos_router_step,
+        "_get_strategy",
+        lambda _config, _llm_cfg=None: _FixedStrategy(tier),
+    )
+
+
+def _make_context(config: GatewayConfig, message: str = "Do something.") -> TurnContext:
+    config.agentos_router.rollout_phase = "full"
+    return TurnContext(
+        message=message,
+        session_key="degrade-session",
+        config=config,
+        provider=None,
+        model=config.llm.model,
+        tool_defs=[],
+        system_prompt="system",
+        raw_message=None,
+        attachments=[],
+    )
+
+
+def _ollama_config_with_cloud_tiers() -> GatewayConfig:
+    # Local provider, but tiers still carry the baked-in cloud defaults.
+    return GatewayConfig(llm={"provider": "ollama", "model": "qwen3.5:2b", "api_key": ""})
+
+
+@pytest.mark.asyncio
+async def test_local_provider_degrades_cloud_tier_model_to_llm_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _ollama_config_with_cloud_tiers()
+    # Default c1 tier points at "minimax/minimax-m3" via provider="openrouter".
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context(config)
+
+    routed = await apply_agentos_router(ctx)
+
+    # Degrade: the local server only knows "qwen3.5:2b", never the cloud model.
+    assert routed.model == "qwen3.5:2b"
+    assert routed.metadata["applied_model"] == "qwen3.5:2b"
+    assert routed.metadata["routing_degraded"] is True
+    # The tier is still recorded so thinking/prompt policy for c1 still applies.
+    assert routed.metadata["routed_tier"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_local_provider_honors_matching_provider_tier_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # User intentionally configured real per-tier Ollama models.
+    config = GatewayConfig(
+        llm={"provider": "ollama", "model": "qwen3.5:2b", "api_key": ""},
+        agentos_router={
+            "enabled": True,
+            "tiers": {
+                "c0": {"provider": "ollama", "model": "qwen3.5:2b"},
+                "c1": {"provider": "ollama", "model": "qwen3.5:9b"},
+                "c2": {"provider": "ollama", "model": "qwen3.5:9b"},
+                "c3": {"provider": "ollama", "model": "qwen3.5:latest"},
+            },
+        },
+    )
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context(config)
+
+    routed = await apply_agentos_router(ctx)
+
+    # Honored: matching-provider tier keeps its own model, no degrade.
+    assert routed.model == "qwen3.5:9b"
+    assert routed.metadata.get("routing_degraded") is not True
+    assert routed.metadata["routed_tier"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_cloud_provider_applies_tier_model_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # openrouter is not local: full multi-model routing, no degrade.
+    config = GatewayConfig(llm={"provider": "openrouter", "api_key": "sk-x"})
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context(config)
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.model == "minimax/minimax-m3"
+    assert routed.metadata.get("routing_degraded") is not True

--- a/tests/test_gateway/test_boot_local_provider_selector.py
+++ b/tests/test_gateway/test_boot_local_provider_selector.py
@@ -1,0 +1,36 @@
+"""Boot must build a provider selector for local (no-key) providers.
+
+Regression: ``build_services`` only constructed ``provider_selector`` when an
+API key was present (``if api_key:``). Local providers — ollama / lm_studio /
+ovms — legitimately have no key, so the selector was never built and every
+turn failed with ``no_provider``. The registry already models this via
+``ProviderSpec.requires_api_key()``; boot must honor it.
+"""
+
+from __future__ import annotations
+
+from agentos.gateway.boot import _should_build_provider_selector
+
+
+def test_local_provider_without_key_builds_selector() -> None:
+    # Ollama has no API key but does not require one.
+    assert _should_build_provider_selector(provider="ollama", api_key="") is True
+
+
+def test_lm_studio_without_key_builds_selector() -> None:
+    assert _should_build_provider_selector(provider="lm_studio", api_key="") is True
+
+
+def test_remote_provider_without_key_does_not_build_selector() -> None:
+    # Missing key for a key-requiring provider stays no_provider (correct signal).
+    assert _should_build_provider_selector(provider="openrouter", api_key="") is False
+
+
+def test_remote_provider_with_key_builds_selector() -> None:
+    assert _should_build_provider_selector(provider="openrouter", api_key="sk-x") is True
+
+
+def test_unknown_provider_falls_back_to_key_presence() -> None:
+    # Unknown provider id must not raise during boot; gate on key presence.
+    assert _should_build_provider_selector(provider="totally-made-up", api_key="") is False
+    assert _should_build_provider_selector(provider="totally-made-up", api_key="k") is True

--- a/tests/test_gateway/test_boot_tier_provider_mismatch.py
+++ b/tests/test_gateway/test_boot_tier_provider_mismatch.py
@@ -1,0 +1,114 @@
+"""Boot must warn when router tiers declare a provider other than llm.provider.
+
+AgentOS routing is single-provider: boot builds ONE provider client from
+``llm.provider``; ``agentos_router.tiers[*].provider`` is metadata and never
+builds a client. A tier pointing at a different provider silently misroutes
+(the runtime degrades such routes to ``llm.model`` on local providers), so
+boot must surface the mismatch as a one-time structured warning.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import agentos.gateway.boot as boot
+from agentos.gateway.boot import (
+    _router_tier_provider_mismatches,
+    _warn_on_tier_provider_mismatch,
+)
+
+
+def _config(*, enabled: bool = True, tiers: dict | None = None, router: bool = True):
+    router_ns = SimpleNamespace(enabled=enabled, tiers=tiers if tiers is not None else {})
+    return SimpleNamespace(agentos_router=router_ns if router else None)
+
+
+def test_local_llm_with_cloud_tiers_reports_all_mismatches() -> None:
+    config = _config(
+        tiers={
+            "c0": {"provider": "openrouter", "model": "deepseek/deepseek-v4-flash"},
+            "c1": {"provider": "openrouter", "model": "minimax/minimax-m3"},
+        }
+    )
+    assert _router_tier_provider_mismatches(config=config, llm_provider="ollama") == {
+        "c0": "openrouter",
+        "c1": "openrouter",
+    }
+
+
+def test_cloud_llm_with_different_cloud_tiers_reports_mismatch() -> None:
+    config = _config(tiers={"c2": {"provider": "openrouter", "model": "z-ai/glm-5.2"}})
+    assert _router_tier_provider_mismatches(config=config, llm_provider="deepseek") == {
+        "c2": "openrouter"
+    }
+
+
+def test_disabled_router_reports_nothing() -> None:
+    config = _config(enabled=False, tiers={"c0": {"provider": "openrouter", "model": "x"}})
+    assert _router_tier_provider_mismatches(config=config, llm_provider="ollama") == {}
+
+
+def test_missing_router_config_reports_nothing() -> None:
+    config = _config(router=False)
+    assert _router_tier_provider_mismatches(config=config, llm_provider="ollama") == {}
+
+
+def test_matching_tiers_after_normalization_report_nothing() -> None:
+    config = _config(tiers={"c0": {"provider": " OpenRouter ", "model": "x"}})
+    assert _router_tier_provider_mismatches(config=config, llm_provider="openrouter") == {}
+
+
+def test_tiers_without_provider_key_report_nothing() -> None:
+    config = _config(tiers={"c0": {"model": "x"}, "c1": {"provider": "", "model": "y"}})
+    assert _router_tier_provider_mismatches(config=config, llm_provider="ollama") == {}
+
+
+def test_mixed_tiers_report_only_mismatched_entries() -> None:
+    config = _config(
+        tiers={
+            "c0": {"provider": "ollama", "model": "llama3"},
+            "c1": {"provider": "openrouter", "model": "minimax/minimax-m3"},
+            "c2": {"model": "no-provider-key"},
+        }
+    )
+    assert _router_tier_provider_mismatches(config=config, llm_provider="ollama") == {
+        "c1": "openrouter"
+    }
+
+
+class _WarningRecorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def warning(self, event: str, **kwargs) -> None:
+        self.calls.append((event, kwargs))
+
+
+def test_warn_helper_logs_exactly_one_warning(monkeypatch) -> None:
+    recorder = _WarningRecorder()
+    monkeypatch.setattr(boot, "log", recorder)
+    config = _config(
+        tiers={
+            "c0": {"provider": "openrouter", "model": "a"},
+            "c1": {"provider": "openrouter", "model": "b"},
+        }
+    )
+
+    _warn_on_tier_provider_mismatch(config, "ollama")
+
+    assert len(recorder.calls) == 1
+    event, kwargs = recorder.calls[0]
+    assert event == "agentos_router.tier_provider_mismatch"
+    assert kwargs["llm_provider"] == "ollama"
+    assert kwargs["mismatched_tiers"] == {"c0": "openrouter", "c1": "openrouter"}
+    assert "llm.provider" in kwargs["note"]
+
+
+def test_warn_helper_is_silent_without_mismatch(monkeypatch) -> None:
+    recorder = _WarningRecorder()
+    monkeypatch.setattr(boot, "log", recorder)
+    config = _config(tiers={"c0": {"provider": "ollama", "model": "llama3"}})
+
+    _warn_on_tier_provider_mismatch(config, "ollama")
+
+    assert recorder.calls == []

--- a/tests/test_gateway/test_rpc_doctor.py
+++ b/tests/test_gateway/test_rpc_doctor.py
@@ -845,6 +845,49 @@ def test_router_payload_v4_phase3_skips_judge_resolution() -> None:
     assert payload["judgeBaseUrl"] is None
 
 
+def test_router_payload_reports_tier_providers_for_v4_phase3() -> None:
+    """The payload carries llm.provider plus each tier's declared provider so
+    evaluate_router can flag tiers pointing at a provider the runtime never
+    builds a client for (routing is single-provider; tiers only pick the model).
+    """
+    import agentos.gateway.rpc_doctor as rpc_doctor
+
+    config = GatewayConfig(
+        llm={"provider": "ollama", "model": "llama3"},
+        agentos_router={"strategy": "v4_phase3"},
+    )
+    ctx = RpcContext(conn_id="test", config=config)
+
+    payload = rpc_doctor._router_payload(ctx)
+
+    assert payload["llmProvider"] == "ollama"
+    # Default tier profile is OpenRouter: every tier declares provider=openrouter.
+    assert payload["tierProviders"]["c0"] == "openrouter"
+    assert set(payload["tierProviders"]) == set(config.agentos_router.tiers)
+
+
+def test_router_payload_reports_tier_providers_for_llm_judge() -> None:
+    import agentos.gateway.rpc_doctor as rpc_doctor
+
+    config = GatewayConfig(
+        llm={"provider": "deepseek", "model": "deepseek-chat"},
+        agentos_router={"strategy": "llm_judge"},
+    )
+    ctx = RpcContext(conn_id="test", config=config)
+
+    payload = rpc_doctor._router_payload(ctx)
+
+    assert payload["llmProvider"] == "deepseek"
+    # tierProviders mirrors the resolved tier mapping's provider fields verbatim
+    # (the config layer may rewrite the tier profile for the active provider).
+    assert payload["tierProviders"] == {
+        name: tier["provider"]
+        for name, tier in config.agentos_router.tiers.items()
+        if str(tier.get("provider") or "").strip()
+    }
+    assert payload["tierProviders"]
+
+
 def test_router_payload_marks_runtime_invalid_for_cross_provider_auto_judge() -> None:
     """Findings #2/#4: in AUTO mode (no judge_model) resolve_judge_target takes a
     tier entry's own provider field. When that resolved provider differs from

--- a/tests/test_health/test_evaluator.py
+++ b/tests/test_health/test_evaluator.py
@@ -984,6 +984,124 @@ def test_router_evaluator_flags_ignored_local_endpoint() -> None:
     assert "judge_model" in findings[0].fix_steps[0].detail
 
 
+def test_router_evaluator_flags_tier_provider_mismatch_on_local_llm() -> None:
+    findings = evaluate_router(
+        {
+            "enabled": True,
+            "rolloutPhase": "full",
+            "strategy": "v4_phase3",
+            "tierProfile": "openrouter",
+            "runtimeValid": True,
+            "llmProvider": "ollama",
+            "tierProviders": {"c0": "openrouter", "c1": "openrouter"},
+        }
+    )
+
+    ids = [finding.id for finding in findings]
+    assert "router.ready" in ids
+    assert "router.tiers.provider_mismatch" in ids
+    mismatch = next(f for f in findings if f.id == "router.tiers.provider_mismatch")
+    assert mismatch.severity == "warn"
+    assert _impact(mismatch) == "degrades"
+    assert mismatch.restart_required is True
+    assert mismatch.evidence["llmProvider"] == "ollama"
+    assert mismatch.evidence["mismatchedTiers"] == {
+        "c0": "openrouter",
+        "c1": "openrouter",
+    }
+    # Fix steps steer the operator to align tiers with llm.provider or drop them.
+    assert "llm.provider" in mismatch.fix_steps[0].detail
+
+
+def test_router_evaluator_flags_tier_provider_mismatch_across_clouds() -> None:
+    findings = evaluate_router(
+        {
+            "enabled": True,
+            "rolloutPhase": "full",
+            "strategy": "llm_judge",
+            "tierProfile": "openrouter",
+            "runtimeValid": True,
+            "llmProvider": "deepseek",
+            "tierProviders": {"c2": "openrouter"},
+        }
+    )
+
+    ids = [finding.id for finding in findings]
+    assert "router.tiers.provider_mismatch" in ids
+
+
+def test_router_evaluator_reports_mismatch_alongside_invalid_runtime() -> None:
+    findings = evaluate_router(
+        {
+            "enabled": True,
+            "rolloutPhase": "full",
+            "strategy": "llm_judge",
+            "tierProfile": "openrouter",
+            "runtimeValid": False,
+            "error": "judge target could not be resolved",
+            "llmProvider": "ollama",
+            "tierProviders": {"c0": "openrouter"},
+        }
+    )
+
+    ids = [finding.id for finding in findings]
+    assert "router.runtime.missing" in ids
+    assert "router.tiers.provider_mismatch" in ids
+
+
+def test_router_evaluator_skips_tier_mismatch_when_disabled() -> None:
+    findings = evaluate_router(
+        {
+            "enabled": False,
+            "rolloutPhase": "full",
+            "strategy": "v4_phase3",
+            "tierProfile": "openrouter",
+            "runtimeValid": True,
+            "llmProvider": "ollama",
+            "tierProviders": {"c0": "openrouter"},
+        }
+    )
+
+    assert [finding.id for finding in findings] == ["router.disabled"]
+
+
+def test_router_evaluator_skips_tier_mismatch_when_providers_match() -> None:
+    findings = evaluate_router(
+        {
+            "enabled": True,
+            "rolloutPhase": "full",
+            "strategy": "v4_phase3",
+            "tierProfile": "openrouter",
+            "runtimeValid": True,
+            "llmProvider": "OpenRouter",
+            "tierProviders": {"c0": " openrouter "},
+        }
+    )
+
+    assert [finding.id for finding in findings] == ["router.ready"]
+
+
+def test_router_evaluator_skips_tier_mismatch_without_tier_providers() -> None:
+    payload = {
+        "enabled": True,
+        "rolloutPhase": "full",
+        "strategy": "v4_phase3",
+        "tierProfile": "openrouter",
+        "runtimeValid": True,
+        "llmProvider": "ollama",
+    }
+
+    assert [f.id for f in evaluate_router(payload)] == ["router.ready"]
+    assert [
+        f.id for f in evaluate_router({**payload, "tierProviders": {}})
+    ] == ["router.ready"]
+    # Tiers that omit the provider key are filtered by the payload builder;
+    # empty values that slip through must not fire either.
+    assert [
+        f.id for f in evaluate_router({**payload, "tierProviders": {"c0": ""}})
+    ] == ["router.ready"]
+
+
 def test_memory_embedding_evaluator_flags_explicit_remote_without_key() -> None:
     findings = evaluate_memory_embedding(
         {

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -382,6 +382,139 @@ def test_upsert_llm_provider_recomputes_openrouter_mix_on_provider_switch():
     assert "tiers" not in res.config.to_toml_dict()["agentos_router"]
 
 
+def test_ollama_onboarding_rewrites_default_tiers_to_local_provider():
+    # A local provider has no tier profile and builds no per-tier client. The
+    # shipped openrouter default tiers name cloud model ids the local server does
+    # not have, so onboarding must rewrite every tier to provider+the configured
+    # local model. The runtime degrade guard is then a no-op.
+    cfg = GatewayConfig()
+    assert cfg.agentos_router.tier_profile is None
+
+    res = upsert_llm_provider(cfg, provider_id="ollama", model="qwen3.5:9b")
+    router = res.config.agentos_router
+
+    assert router.enabled is True
+    assert router.tier_profile is None
+    assert set(router.tiers) == {"c0", "c1", "c2", "c3", "image_model"}
+    for name in ("c0", "c1", "c2", "c3", "image_model"):
+        assert router.tiers[name]["provider"] == "ollama"
+        assert router.tiers[name]["model"] == "qwen3.5:9b"
+    # thinking_level survives so thinking tiering still works.
+    assert router.tiers["c1"]["thinking_level"] == "high"
+    # image_model keeps its role flags so image-aware routing still works.
+    assert router.tiers["image_model"]["supports_image"] is True
+    assert router.tiers["image_model"]["image_only"] is True
+
+
+def test_ollama_onboarding_round_trips_and_degrade_guard_is_noop():
+    import tomllib
+
+    import tomli_w
+
+    res = upsert_llm_provider(GatewayConfig(), provider_id="ollama", model="qwen3.5:9b")
+    reloaded = GatewayConfig(**tomllib.loads(tomli_w.dumps(res.config.to_toml_dict())))
+
+    router = reloaded.agentos_router
+    assert router.tier_profile is None
+    for tier in router.tiers.values():
+        assert tier["provider"] == "ollama"
+        assert tier["model"] == "qwen3.5:9b"
+    # Every tier's provider equals llm.provider, so the runtime degrade guard
+    # (_degrade_model_for_local_provider) leaves the route as-is.
+    from agentos.engine.steps.agentos_router import _degrade_model_for_local_provider
+
+    class _Ctx:
+        def __init__(self, cfg):
+            self.config = cfg
+            self.metadata: dict = {}
+
+    ctx = _Ctx(reloaded)
+    routed = _degrade_model_for_local_provider(
+        ctx, tier_cfg=router.tiers["c1"], routed_model="qwen3.5:9b"
+    )
+    assert routed == "qwen3.5:9b"
+    assert ctx.metadata.get("routing_degraded") is not True
+
+
+def test_ollama_onboarding_leaves_custom_tiers_untouched():
+    custom = {
+        "c0": {"provider": "ollama", "model": "hand-a", "thinking_level": "low"},
+        "c1": {"provider": "ollama", "model": "hand-b", "thinking_level": "high"},
+        "c2": {"provider": "ollama", "model": "hand-c", "thinking_level": "high"},
+        "c3": {"provider": "ollama", "model": "hand-d", "thinking_level": "high"},
+        "image_model": {
+            "provider": "ollama",
+            "model": "hand-i",
+            "supports_image": True,
+            "image_only": True,
+        },
+    }
+    cfg = GatewayConfig(
+        llm={"provider": "openrouter", "model": "x"},
+        agentos_router={"enabled": True, "tiers": custom},
+    )
+
+    res = upsert_llm_provider(cfg, provider_id="ollama", model="qwen3.5:9b")
+    router = res.config.agentos_router
+
+    # Operator-authored tiers are not the shipped defaults and are not
+    # previous-local-pinned, so they are left exactly as configured.
+    assert router.tiers["c0"]["model"] == "hand-a"
+    assert router.tiers["c0"]["thinking_level"] == "low"
+    assert router.tiers["image_model"]["model"] == "hand-i"
+
+
+def test_local_to_local_switch_repins_machine_written_tiers():
+    from agentos.onboarding.mutations import _reconcile_router_profile_for_provider
+
+    ollama = upsert_llm_provider(GatewayConfig(), provider_id="ollama", model="qwen3.5:9b").config
+
+    # vllm is not runtime-supported by the onboarding upsert path, so exercise
+    # the reconcile hook directly (ollama -> vllm). The ollama-pinned tiers are
+    # machine-written and must be re-pinned to vllm/the new model.
+    switched = ollama.model_copy(deep=True)
+    switched.llm.provider = "vllm"
+    switched.llm.model = "llama3:8b"
+    warnings = _reconcile_router_profile_for_provider(
+        switched,
+        "vllm",
+        model="llama3:8b",
+        old_provider="ollama",
+        old_model="qwen3.5:9b",
+    )
+
+    assert warnings == []
+    router = switched.agentos_router
+    assert router.tier_profile is None
+    for tier in router.tiers.values():
+        assert tier["provider"] == "vllm"
+        assert tier["model"] == "llama3:8b"
+
+
+def test_vllm_is_treated_as_local_provider():
+    from agentos.provider.registry import is_local_provider
+
+    assert is_local_provider("vllm") is True
+
+
+def test_local_to_cloud_switch_restores_tier_profile():
+    # Switching FROM a local provider back to a cloud/profile provider must
+    # restore normal profile behavior (the local-pinned tiers are dropped).
+    ollama = upsert_llm_provider(GatewayConfig(), provider_id="ollama", model="qwen3.5:9b").config
+
+    res = upsert_llm_provider(
+        ollama,
+        provider_id="deepseek",
+        model="deepseek-chat",
+        api_key_env="DEEPSEEK_API_KEY",
+    )
+    router = res.config.agentos_router
+
+    assert router.enabled is True
+    assert router.tier_profile == "deepseek"
+    assert router.tiers["c0"]["provider"] == "deepseek"
+
+
 def test_upsert_router_recommended_writes_profile_without_expanded_tiers():
     cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
 

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -604,6 +604,21 @@ def test_upsert_router_recommended_respects_custom_local_tiers():
     assert router.tiers["c3"]["model"] == "qwen3.5:latest"
 
 
+def test_upsert_router_disabled_keeps_local_pinned_tiers_in_config():
+    """Choosing Off must not resurrect openrouter tiers in a local config."""
+    cfg = GatewayConfig()
+    provider_res = upsert_llm_provider(
+        cfg, provider_id="ollama", model="qwen3.5:2b", base_url="http://localhost:11434"
+    )
+
+    res = upsert_router(provider_res.config, mode="disabled")
+
+    assert res.config.agentos_router.enabled is False
+    persisted = res.config.to_toml_dict().get("agentos_router", {}).get("tiers", {})
+    assert persisted, "local pin must stay persisted while the router is off"
+    assert all(t.get("provider") == "ollama" for t in persisted.values())
+
+
 def test_upsert_router_recommended_still_disables_unknown_nonlocal_provider():
     # Non-local providers without a tier profile keep today's disable behavior.
     cfg = GatewayConfig(llm={"provider": "anthropic", "model": "claude-sonnet-4-6"})

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -558,6 +558,62 @@ def test_upsert_router_can_disable():
     assert res.public_payload["mode"] == "disabled"
 
 
+def test_upsert_router_recommended_keeps_local_provider_enabled_with_pinned_tiers():
+    """First-run wizard order: provider step then router step.
+
+    The router step must not clobber the local pin the provider step wrote —
+    previously it disabled the router and resurrected the openrouter default
+    tiers via the config default factory.
+    """
+    cfg = GatewayConfig()
+    provider_res = upsert_llm_provider(
+        cfg, provider_id="ollama", model="qwen3.5:2b", base_url="http://localhost:11434"
+    )
+
+    res = upsert_router(provider_res.config, mode="recommended", strategy="v4_phase3")
+    router = res.config.agentos_router
+
+    assert router.enabled is True
+    assert router.tier_profile is None
+    for name in ("c0", "c1", "c2", "c3", "image_model"):
+        assert router.tiers[name]["provider"] == "ollama", name
+        assert router.tiers[name]["model"] == "qwen3.5:2b", name
+    assert router.tiers["image_model"]["supports_image"] is True
+    assert router.tiers["image_model"]["image_only"] is True
+    assert res.public_payload["enabled"] is True
+
+
+def test_upsert_router_recommended_respects_custom_local_tiers():
+    # An operator-customised local multi-model table must survive the router step.
+    custom = {
+        "c0": {"provider": "ollama", "model": "qwen3.5:2b"},
+        "c1": {"provider": "ollama", "model": "qwen3.5:9b"},
+        "c2": {"provider": "ollama", "model": "qwen3.5:9b"},
+        "c3": {"provider": "ollama", "model": "qwen3.5:latest"},
+    }
+    cfg = GatewayConfig(
+        llm={"provider": "ollama", "model": "qwen3.5:2b", "api_key": ""},
+        agentos_router={"enabled": True, "tiers": custom},
+    )
+
+    res = upsert_router(cfg, mode="recommended", strategy="v4_phase3")
+    router = res.config.agentos_router
+
+    assert router.enabled is True
+    assert router.tiers["c1"]["model"] == "qwen3.5:9b"
+    assert router.tiers["c3"]["model"] == "qwen3.5:latest"
+
+
+def test_upsert_router_recommended_still_disables_unknown_nonlocal_provider():
+    # Non-local providers without a tier profile keep today's disable behavior.
+    cfg = GatewayConfig(llm={"provider": "anthropic", "model": "claude-sonnet-4-6"})
+
+    res = upsert_router(cfg, mode="recommended")
+
+    assert res.config.agentos_router.enabled is False
+    assert res.config.agentos_router.tier_profile is None
+
+
 def test_upsert_router_rejects_openrouter_mix_for_direct_provider():
     cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
 

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -12,7 +12,7 @@ def test_provider_spec_requires_api_key_for_openrouter():
     assert spec.requires_api_key() is True
 
 
-@pytest.mark.parametrize("provider", ["ollama", "lm_studio", "ovms"])
+@pytest.mark.parametrize("provider", ["ollama", "lm_studio", "ovms", "vllm"])
 def test_is_local_provider_true_for_self_hosted(provider):
     assert is_local_provider(provider) is True
 

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -4,12 +4,28 @@ from __future__ import annotations
 
 import pytest
 
-from agentos.provider.registry import get_provider_spec
+from agentos.provider.registry import get_provider_spec, is_local_provider
 
 
 def test_provider_spec_requires_api_key_for_openrouter():
     spec = get_provider_spec("openrouter")
     assert spec.requires_api_key() is True
+
+
+@pytest.mark.parametrize("provider", ["ollama", "lm_studio", "ovms"])
+def test_is_local_provider_true_for_self_hosted(provider):
+    assert is_local_provider(provider) is True
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "openai", "deepseek", "anthropic"])
+def test_is_local_provider_false_for_cloud(provider):
+    assert is_local_provider(provider) is False
+
+
+def test_is_local_provider_normalizes_and_tolerates_unknown():
+    assert is_local_provider("  Ollama  ") is True
+    assert is_local_provider("") is False
+    assert is_local_provider("totally-made-up") is False
 
 
 def test_provider_spec_does_not_require_api_key_for_ollama():


### PR DESCRIPTION
## Problem

Running AgentOS against a local provider (Ollama, LM Studio, OVMS, vLLM) fails in several compounding ways:

1. **Every turn fails with `no_provider`.** `build_services()` only constructed the provider selector when an API key was present — local providers legitimately have none, so no selector was ever built.
2. **Enabling the router breaks turns.** Routing is single-provider: tiers only select the *model*; requests always go through the one `llm.provider` client. The shipped default tiers point at cloud model ids, so a local server was handed models it doesn't have → 404 on every routed turn.
3. **Onboarding produces a misleading config.** The first-run wizard's router step disabled the router for local providers and re-persisted the cloud default tiers, and the provider step never rewrote them — so a fresh Ollama install ends up with `provider = "ollama"` next to `openrouter` tier entries.
4. **All of this was silent.** No boot warning, no doctor finding, nothing in the routed log.

## Changes

**Runtime**
- `boot.py`: gate selector construction on `ProviderSpec.requires_api_key()` instead of raw key presence — local providers boot without a key; key-requiring providers with a missing key still correctly surface `no_provider`.
- `agentos_router.py`: new degrade guard — when the chosen tier's `provider` differs from a local `llm.provider`, pin the route to `llm.model` and set `metadata.routing_degraded` (also emitted in the `agentos_router.routed` log). Applied at all three `ctx.model` write sites (text / image / router-control hold). Tiers that match the local provider are honored, preserving intentional local multi-model routing. No-op when `llm.model` is empty (the flag never claims a degrade that didn't happen). Cloud providers unchanged.
- `registry.py`: public `is_local_provider()` predicate; `vllm` added to the local set (onboarding already treated it as local).

**Observability**
- One-time boot warning `agentos_router.tier_provider_mismatch` when any tier declares a different provider than `llm.provider` (covers cloud↔cloud mismatches too).
- New `agentos doctor` / Health view finding `router.tiers.provider_mismatch` with fix steps (findings render data-driven — no UI changes).

**Onboarding** (shared by CLI wizard, web setup, and the setup engine)
- Selecting a local provider rewrites machine-written default tiers to self-consistent `provider`/`model` entries (thinking levels and image flags preserved); operator-customised tiers are left verbatim.
- The router step no longer clobbers that pin: `recommended` keeps local providers enabled with pinned tiers, and `disabled` keeps the local pin persisted instead of resurrecting cloud defaults.

**Docs**
- `agentos.toml.example` and `docs/features/agentos-router.md` now state the single-provider invariant explicitly and include a commented local multi-model tier example.

## Testing

- ~35 new tests: degrade parametrized across all four local providers, image-route and hold-path degrade (previously untested `ctx.model` write sites), empty-model honesty, mixed matched/mismatched tier tables, boot-warning helper, doctor payload plumbing + finding, onboarding rewrite/round-trip/custom-tiers/local↔cloud switches.
- Full gate: `ruff` clean, `mypy` clean, `pytest` 5900+ passed with no regressions (the only failures on my machine are pre-existing optional-dependency ones — onnx/tokenizers/docker — identical on a clean checkout of `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Compatibility (existing installs)

No config schema changes and no migration: existing configs load unchanged, and nothing is written in a new format (downgrade-safe). Onboarding changes only apply to future wizard runs — existing configs are never auto-rewritten.

Per population:

- **Cloud providers** — no behavior change. The degrade guard short-circuits for non-local providers; profile-based onboarding paths are untouched.
- **Local provider, router disabled** — turns start working (the `no_provider` fix); the boot warning and doctor finding both skip a disabled router, so nothing new is reported.
- **Local provider, router enabled with leftover cloud default tiers** — previously 404'd on every routed turn; now routes to `llm.model` with a boot warning and a doctor finding explaining why.
- **Local provider with matching hand-written tiers** — honored verbatim, unchanged.
- **Known behavior change (narrow):** a config whose `llm.provider` is a local id but whose `base_url` points at a gateway/proxy that really does serve the cloud-named tier models, *and* whose tiers explicitly declare a different `provider`, previously passed those model ids through — such routed turns now degrade to `llm.model`. Escape hatch: set each tier's `provider` to match `llm.provider` (or omit the per-tier `provider` key — the guard only fires on an explicit mismatch). The boot warning and doctor finding identify exactly these tiers.
- Local installs pointing at an unreachable server now fail at request time with a connection error instead of failing every turn upfront with `no_provider` — a more accurate signal.
