### PR TITLE
docs: add upgrade instructions to README and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,34 @@ or use the GitHub release wheel link directly:
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.
 
+### Upgrade
+
+Upgrade a `uv tool` install to the latest release:
+
+```sh
+uv tool upgrade use-agent-os
+```
+
+This keeps the extras from the original install (for example
+`[recommended]`). A version-pinned install (`==<version>`) stays on
+its pin — to move it, re-run the install command with the new
+version. For a `pip` fallback install, use
+`python -m pip install --user --upgrade "use-agent-os[recommended]"`.
+
+For an [install from source](#install-from-source), pull and re-run
+the installer:
+
+```sh
+cd agent-os
+git pull
+git lfs pull --include="src/agentos/memory/models/**"
+bash scripts/install_source.sh        # Windows: scripts/install_source.ps1
+```
+
+After any upgrade, restart the gateway so it runs the new code. Your
+configuration and data in `~/.agentos/` are not touched by upgrades.
+To check the installed version, run `uv tool list`.
+
 ### Install from source
 
 Use this path to run AgentOS from a Git checkout, without changing

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -183,6 +183,21 @@ agentos gateway stop
 agentos gateway restart
 ```
 
+## Upgrade
+
+Upgrade a `uv tool` install to the latest release, then restart the
+gateway so it runs the new code:
+
+```sh
+uv tool upgrade use-agent-os
+agentos gateway restart
+```
+
+The upgrade keeps the extras from the original install, and your
+configuration and data in `~/.agentos/` are not touched. To check
+the installed version, run `uv tool list`. For source installs, see
+the [README upgrade section](../README.md#upgrade).
+
 ## Next Steps
 
 After the first run:


### PR DESCRIPTION
## Problem

The install docs cover fresh installs only — README has `uv tool install`, source-install, and develop-from-source paths, and the quickstart walks through first-run setup, but neither says how to move an **existing** install to a new release. With releases shipping regularly, users have no documented path from an older wheel to the current one.

## Changes

**README** — new `### Upgrade` section between the install instructions and *Install from source*:

- `uv tool upgrade use-agent-os` for the standard path, noting it keeps the extras from the original install (e.g. `[recommended]`);
- version-pinned installs (`==<version>`) stay on their pin — re-run the install command with the new version to move;
- `python -m pip install --user --upgrade` for pip-fallback installs;
- source checkouts: `git pull` + `git lfs pull` + re-run the installer;
- restart the gateway after upgrading, and a note that `~/.agentos/` configuration and data are untouched;
- `uv tool list` to check the installed version.

**docs/quickstart.md** — new `## Upgrade` section after *Stop or Restart* with the short `uv tool upgrade` + `agentos gateway restart` path, linking to the README section for source installs.

## Notes

- Docs-only; no code changes.
- `tests/test_readme_links.py`, `tests/test_release_consistency.py`, and `tests/test_install_scripts.py` all pass (18 tests) — no version strings were added, and all new anchors resolve.