### PR TITLE
feat(skills): fill Bankr browse descriptions and add brand-glyph logo fallback

### DIFF
--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 from typing import Any
 
 import typer
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -142,9 +143,7 @@ def _load_skill_rows() -> list[dict[str, Any]]:
                     "origin": provenance.origin if provenance else "unknown",
                     "license": provenance.license if provenance else "unknown",
                     "upstreamUrl": provenance.upstream_url if provenance else "",
-                    "maintainedBy": provenance.maintained_by
-                    if provenance
-                    else "AgentOS",
+                    "maintainedBy": provenance.maintained_by if provenance else "AgentOS",
                 },
             }
         )
@@ -169,10 +168,10 @@ def skills_list(
 
     for row in rows:
         table.add_row(
-            row["name"],
+            escape(row["name"]),
             row["layer"],
             "[green]yes[/]" if row["eligible"] else "[dim]no[/]",
-            (
+            escape(
                 row["description"][:60] + "..."
                 if len(row["description"]) > 60
                 else row["description"]
@@ -209,7 +208,14 @@ def skills_search(
         table.add_column("Description")
 
         for r in results:
-            table.add_row(r.name, r.source_id, r.trust_level, r.description[:60])
+            # Remote catalogs are community-controlled — never let their text
+            # be interpreted as rich markup.
+            table.add_row(
+                escape(r.name),
+                escape(r.source_id),
+                escape(r.trust_level),
+                escape(r.description[:60]),
+            )
         console.print(table)
 
     asyncio.run(_search())
@@ -302,8 +308,7 @@ def skills_install(
         "--source",
         "-s",
         help=(
-            "Source (clawhub, github). GitHub accepts owner/repo, "
-            "owner/repo:path, or GitHub URLs."
+            "Source (clawhub, github). GitHub accepts owner/repo, owner/repo:path, or GitHub URLs."
         ),
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Force install (skip security block)"),

--- a/src/agentos/gateway/static/js/views/skills.js
+++ b/src/agentos/gateway/static/js/views/skills.js
@@ -4,7 +4,7 @@ const SkillsView = (() => {
   // Show/hide the Bankr partner tab in the Skills view. Set to true to bring
   // the tab back — the BankrSource backend (browse/search/install) stays wired
   // either way, so Bankr skills remain reachable via the Community tab / CLI.
-  const _SHOW_BANKR = false;
+  const _SHOW_BANKR = true;
 
   let _el = null;
   let _rpc = null;

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -23,7 +23,7 @@ import time
 import structlog
 
 from agentos.env import trust_env as _trust_env
-from agentos.skills.hub.github import GitHubSource
+from agentos.skills.hub.github import GitHubSource, _frontmatter_field
 from agentos.skills.hub.source import SkillBundle, SkillMeta, SkillSource
 
 log = structlog.get_logger(__name__)
@@ -197,14 +197,22 @@ class BankrSource(SkillSource):
         return metas
 
     async def _load_catalog_entry(self, client, slug: str) -> SkillMeta | None:
-        """Fetch and parse one skill's catalog.json. Skips on any error.
+        """Fetch and parse one skill's catalog.json, then SKILL.md. Skips on
+        catalog error.
 
-        Only catalog.json is fetched (one request per skill) to keep browsing
-        fast; the description is filled in later at fetch()/install time.
+        Only *installable* skills get the second SKILL.md fetch — external
+        installs and malformed catalogs are discarded first, so we never spend
+        a request on a skill that won't be listed. The description is
+        load-bearing for browse search (it feeds the ``_matches`` haystack), so
+        it is fetched eagerly here, not lazily per card; a failed description
+        fetch degrades to an empty string rather than dropping the skill.
+        Results are cached for the catalog TTL, so browsing stays a bounded
+        burst per refresh.
         """
-        url = f"{self._raw_base}/{slug}/catalog.json"
+        headers = self._github._headers()
+        catalog_url = f"{self._raw_base}/{slug}/catalog.json"
         try:
-            resp = await client.get(url, headers=self._github._headers())
+            resp = await client.get(catalog_url, headers=headers)
             resp.raise_for_status()
             catalog = json.loads(resp.content)
         except Exception as exc:
@@ -212,7 +220,26 @@ class BankrSource(SkillSource):
             return None
         if not isinstance(catalog, dict):
             return None
-        return self._meta_from_catalog(slug, catalog)
+        meta = self._meta_from_catalog(slug, catalog)
+        if meta is None:
+            return None
+        skill_md_url = f"{self._raw_base}/{slug}/SKILL.md"
+        meta.description = await self._load_description(client, slug, skill_md_url, headers)
+        return meta
+
+    async def _load_description(self, client, slug: str, url: str, headers: dict) -> str:
+        """Fetch SKILL.md and read its frontmatter description. Empty on error."""
+        try:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+        except Exception as exc:
+            log.warning("bankr.skill_md_failed", slug=slug, error=str(exc))
+            return ""
+        try:
+            text = resp.content.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+        return _frontmatter_field(text, "description")
 
     def _meta_from_catalog(self, slug: str, catalog: dict) -> SkillMeta | None:
         """Build a browse-time SkillMeta from a parsed catalog.json.
@@ -220,9 +247,8 @@ class BankrSource(SkillSource):
         Returns ``None`` when the skill is not a directly-installable ``bankr``
         skill (e.g. an ``external`` install), so callers can skip it. The
         human-readable description lives in ``SKILL.md`` frontmatter
-        (``catalog.json`` has none); it is filled in at ``fetch()`` time to keep
-        browsing fast, so the browse card shows slug + provider + catalog
-        demo/setup, but no description.
+        (``catalog.json`` has none); ``_load_catalog_entry`` fills it in with a
+        follow-up SKILL.md fetch after this meta is built.
         """
         install = catalog.get("install")
         if not isinstance(install, dict) or install.get("type") != "bankr":

--- a/src/agentos/skills/hub/github.py
+++ b/src/agentos/skills/hub/github.py
@@ -126,14 +126,54 @@ def _decode_file(path: str, content: bytes) -> str | bytes:
         return content
 
 
+# YAML block-scalar indicator: > or |, one optional chomping/indentation
+# modifier, optional trailing comment. Deliberately strict so a plain value
+# that merely starts with > or | is not mistaken for a block scalar.
+_BLOCK_SCALAR_RE = re.compile(r"^[>|](?:[+-]?\d?|\d[+-]?)(?:\s+#.*)?$")
+# Remote frontmatter is community-controlled — bound every returned value so a
+# hostile SKILL.md (block scalar OR one huge line) cannot inflate browse payloads.
+_MAX_FOLDED_LEN = 2000
+
+
+def _frontmatter_region(skill_md: str) -> str:
+    """Return only the leading frontmatter block, so field lookups never read
+    the markdown body. Falls back to the whole text when no closing delimiter
+    exists (legacy-lenient)."""
+    if skill_md.startswith("---"):
+        end = skill_md.find("\n---", 3)
+        if end != -1:
+            return skill_md[: end + 1]
+    return skill_md
+
+
 def _frontmatter_field(skill_md: str, field: str) -> str:
-    match = re.search(rf"^{re.escape(field)}:\s*(.+?)\s*$", skill_md, re.MULTILINE)
+    region = _frontmatter_region(skill_md)
+    match = re.search(rf"^{re.escape(field)}:\s*(.+?)\s*$", region, re.MULTILINE)
     if match is None:
         return ""
     value = match.group(1).strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
+    if _BLOCK_SCALAR_RE.match(value):
+        # YAML block scalar — fold the following indented lines into one line,
+        # stopping once we have enough to fill the cap.
+        block: list[str] = []
+        total = 0
+        for line in region[match.end() :].split("\n")[1:]:
+            if not line.strip():
+                continue
+            if not line[0].isspace():
+                break
+            block.append(line.strip())
+            total += len(block[-1]) + 1
+            if total >= _MAX_FOLDED_LEN:
+                break
+        result = " ".join(block)
+    elif len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        result = value[1:-1]
+    else:
+        result = value
+    # Single choke point: every path is bounded, so no remote value ships
+    # unbounded regardless of which YAML form produced it.
+    return result[:_MAX_FOLDED_LEN]
 
 
 def _fallback_name(ref: _GitHubSkillRef) -> str:

--- a/tests/test_cli_skills_search_escape.py
+++ b/tests/test_cli_skills_search_escape.py
@@ -1,0 +1,38 @@
+"""CLI `skills search` must not interpret rich markup from remote descriptions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typer.testing import CliRunner
+
+from agentos.cli.skills_cmd import skills_app
+from agentos.skills.hub.source import SkillMeta
+
+
+class _StubRouter:
+    async def search(
+        self, query: str, limit: int = 20, source_id: str | None = None
+    ) -> list[SkillMeta]:
+        return [
+            SkillMeta(
+                name="evil",
+                description="[red]X[/red] spoof",
+                source_id="bankr",
+                trust_level="community",
+            )
+        ]
+
+
+def test_search_table_renders_remote_markup_literally(monkeypatch: Any) -> None:
+    from agentos.skills.hub import defaults
+
+    monkeypatch.setattr(defaults, "get_default_skill_router", lambda: _StubRouter())
+
+    runner = CliRunner()
+    result = runner.invoke(skills_app, ["search", "evil"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0
+    # Escaped markup renders as literal text; unescaped markup would be
+    # consumed by rich and "[red]" would not appear in the output.
+    assert "[red]X[/red]" in result.output

--- a/tests/test_gateway_static_skills_view.py
+++ b/tests/test_gateway_static_skills_view.py
@@ -27,13 +27,13 @@ def test_skills_view_browses_community_catalog_without_source_picker() -> None:
     assert "_communitySeq" in view
 
 
-def test_skills_view_bankr_tab_is_flag_gated_and_hidden_by_default() -> None:
+def test_skills_view_bankr_tab_is_flag_gated_and_shown_by_default() -> None:
     view = Path("src/agentos/gateway/static/js/views/skills.js").read_text(encoding="utf-8")
 
-    # The Bankr partner tab is behind a flag that is off by default (hidden
-    # from the UI) while the browse machinery stays wired for when it returns.
-    assert "const _SHOW_BANKR = false;" in view
-    assert 'data-tab="bankr"' in view  # markup preserved behind the flag
+    # The Bankr partner tab is behind a flag that is on by default (shown in
+    # the UI); the flag stays in place so the tab can be toggled off again.
+    assert "const _SHOW_BANKR = true;" in view
+    assert 'data-tab="bankr"' in view  # markup gated behind the flag
     assert "Bankr partner catalog" in view
     assert "params.source = 'bankr'" in view
     # Community only excludes Bankr while the Bankr tab is showing; otherwise

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -62,8 +62,13 @@ class _AsyncClient:
         "extern": _catalog("extern", install_type="external"),
         "broken": b"{ not json",
     }
+    skill_mds = {
+        "alchemy": b"---\nname: alchemy\ndescription: On-chain data APIs\n---\n# Alchemy\n",
+        "bankr": b"---\nname: bankr\ndescription: AI-powered crypto trading agent\n---\n# Bankr\n",
+    }
     tree_calls = 0
     catalog_calls = 0
+    skill_md_calls = 0
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
@@ -80,8 +85,14 @@ class _AsyncClient:
             return _Response(json_data={"tree": self.tree_entries, "truncated": False})
         marker = "raw.githubusercontent.com/BankrBot/skills/main/"
         if marker in url:
-            type(self).catalog_calls += 1
             slug = url.split(marker, 1)[1].split("/", 1)[0]
+            if url.endswith("/SKILL.md"):
+                type(self).skill_md_calls += 1
+                content = self.skill_mds.get(slug)
+                if content is None:
+                    return _Response(status_code=404)
+                return _Response(content=content)
+            type(self).catalog_calls += 1
             return _Response(content=self.catalogs.get(slug, b"{}"))
         raise AssertionError(f"unexpected URL: {url}")
 
@@ -90,6 +101,7 @@ class _AsyncClient:
 def _reset_client_counters() -> None:
     _AsyncClient.tree_calls = 0
     _AsyncClient.catalog_calls = 0
+    _AsyncClient.skill_md_calls = 0
 
 
 @pytest.mark.asyncio
@@ -145,6 +157,40 @@ async def test_search_carries_catalog_setup_demo_and_category(monkeypatch) -> No
     assert _infer_category("uniswap", "Uniswap") == "trading"
     assert _infer_category("aeon-defi-monitor", "Aeon") == "defi"
     assert _infer_category("zzz-unknown", "Nobody") == "other"
+
+
+@pytest.mark.asyncio
+async def test_search_fills_description_from_skill_md_frontmatter(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    results = await BankrSource().search("")
+    by_name = {r.name: r for r in results}
+
+    assert by_name["bankr"].description == "AI-powered crypto trading agent"
+    assert by_name["alchemy"].description == "On-chain data APIs"
+    # SKILL.md is fetched only for installable skills — external installs and
+    # broken catalogs never trigger a description fetch.
+    assert _AsyncClient.skill_md_calls == 2
+
+
+class _MissingSkillMdClient(_AsyncClient):
+    skill_mds: dict[str, bytes] = {}
+
+
+@pytest.mark.asyncio
+async def test_missing_skill_md_keeps_skill_with_empty_description(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MissingSkillMdClient)
+
+    results = await BankrSource().search("")
+    by_name = {r.name: r for r in results}
+
+    # A failed SKILL.md fetch must not drop the skill from the listing.
+    assert set(by_name) == {"alchemy", "bankr"}
+    assert by_name["bankr"].description == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills_hub_github.py
+++ b/tests/test_skills_hub_github.py
@@ -123,3 +123,71 @@ def test_default_gateway_router_exposes_github_without_token(monkeypatch) -> Non
         assert "github" in router.source_ids
     finally:
         defaults._default_router = None
+
+
+def test_frontmatter_field_reads_yaml_block_scalar() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    skill_md = (
+        "---\n"
+        "name: bankr-communities\n"
+        "description: >-\n"
+        "  Manage token-gated communities\n"
+        "  across Telegram and Farcaster.\n"
+        "homepage: https://bankr.bot\n"
+        "---\n"
+        "# Body\n"
+    )
+    assert _frontmatter_field(skill_md, "name") == "bankr-communities"
+    assert (
+        _frontmatter_field(skill_md, "description")
+        == "Manage token-gated communities across Telegram and Farcaster."
+    )
+    # Literal block scalars ("|") fold the same way for one-line display.
+    assert _frontmatter_field(skill_md.replace(">-", "|-"), "description") == (
+        "Manage token-gated communities across Telegram and Farcaster."
+    )
+
+
+def test_frontmatter_block_scalar_is_bounded_and_stops_at_frontmatter_end() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    # The fold must stop at the closing --- and never leak the body.
+    skill_md = (
+        "---\n"
+        "description: >-\n"
+        "  Short description.\n"
+        "---\n"
+        "  indented body line that must NOT be folded in\n"
+    )
+    assert _frontmatter_field(skill_md, "description") == "Short description."
+
+    # A hostile/unterminated block scalar cannot produce an unbounded value.
+    hostile = "---\ndescription: |\n" + ("  spam line\n" * 5000)
+    assert len(_frontmatter_field(hostile, "description")) <= 2000
+
+
+def test_frontmatter_block_scalar_indicator_variants() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    for indicator in ("|2", ">+", "> # a comment", "|-2"):
+        skill_md = f"---\ndescription: {indicator}\n  Folded text here.\n---\n"
+        assert _frontmatter_field(skill_md, "description") == "Folded text here.", indicator
+
+
+def test_frontmatter_plain_value_is_length_bounded() -> None:
+    from agentos.skills.hub.github import _MAX_FOLDED_LEN, _frontmatter_field
+
+    # A very long single-line (non-block) description must not ship unbounded.
+    hostile = "---\ndescription: " + ("A" * 1_000_000) + "\n---\n"
+    assert len(_frontmatter_field(hostile, "description")) <= _MAX_FOLDED_LEN
+
+    quoted = '---\ndescription: "' + ("B" * 1_000_000) + '"\n---\n'
+    assert len(_frontmatter_field(quoted, "description")) <= _MAX_FOLDED_LEN
+
+
+def test_frontmatter_handles_crlf_line_endings() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    skill_md = "---\r\ndescription: On-chain data\r\n---\r\n# Body\r\n"
+    assert _frontmatter_field(skill_md, "description") == "On-chain data"


### PR DESCRIPTION
## Summary

The Bankr browse catalog (`Skills → Bankr` tab) previously showed **no per-skill description** — only `catalog.json` was fetched, which carries none — and fell back to bare initials when a catalog entry shipped no logo. This fills in descriptions from each skill's `SKILL.md` frontmatter and renders the source's brand mark as the logo fallback.

## Changes

- **Descriptions** — `BankrSource` now fetches each *installable* skill's `SKILL.md` (external/malformed catalogs are skipped first, so no wasted requests) and fills `SkillMeta.description` from its frontmatter. A failed fetch degrades to an empty description rather than dropping the skill. Descriptions feed the browse search filter, so they are loaded eagerly, behind the existing 15-min catalog TTL + concurrency cap.
- **Hardened frontmatter parser** (`_frontmatter_field`) — folds YAML block scalars (`>`, `|`, chomping/indent/comment variants) into one line, confines reads to the `---…---` frontmatter region so it never leaks the markdown body, and bounds every returned value so community-controlled remote content cannot inflate the browse payload.
- **CLI injection fix** — remote catalog text is now escaped in the `skills list` / `skills search` tables, so a crafted description can't inject `rich` markup / ANSI into the terminal.
- **Logo fallback** — generalized through the `_BRANDS` registry, keyed on the server-set source id (so remote content can't spoof a brand), and the Bankr partner tab is surfaced.

## Tests

Adds coverage for: description fill from frontmatter, graceful 404 degrade (skill kept, empty description), block-scalar folding + length bounding + region confinement, CRLF handling, and CLI markup escaping. Verified live against the real `BankrBot/skills` catalog — all skills load with bounded descriptions; the two upstream skills without a `SKILL.md` degrade to empty rather than dropping.

## Quality gate

`ruff` + `ruff format` + `mypy` clean on touched files; JS syntax checked; 31 relevant tests pass.
