### PR TITLE
feat(router): force-migrate v4_phase3 configs to pilot-v1 on load

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -224,9 +224,11 @@ strategy = "pilot-v1"    # "pilot-v1" (default; local ONNX+MiniLM router,
                          # models/pilot_v1/ bundle + the bundled MiniLM embedder;
                          # a missing bundle degrades to the default tier unless
                          # require_router_runtime is set. See [agentos_router.pilot].
-# strategy = "v4_phase3" # legacy local ML bundle (BGE+LightGBM, no LLM call) —
-                         # the one-line rollback from pilot-v1. | "llm_judge"
-                         # routes via a small LLM judge call.
+# strategy = "llm_judge" # the only other selectable strategy: routes via a small
+                         # LLM judge call (see judge_* settings below).
+# NOTE: the legacy "v4_phase3" local ML strategy is no longer a supported
+# persisted choice — a config that still pins it is automatically migrated to
+# "pilot-v1" on the next load (the original is backed up next to this file).
 # LLM judge (strategy = "llm_judge"): leave judge_model unset for Auto — the
 # judge follows the tier profile's cheapest text tier (c0 first), so profile
 # switches auto-update it. judge_provider must match [llm].provider.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,12 +146,12 @@ classifies each turn:
 | Strategy | Default | Behavior |
 | --- | --- | --- |
 | `pilot-v1` | Yes | English-optimized local ML router: an AgentOS-native, self-trained model (MiniLM embeddings + ONNX inference). Decides on-device with no LLM call and nothing leaves the machine. The bundle ships in the wheel under `src/agentos/agentos_router/models/pilot_v1/`; when it's missing (e.g. a source checkout without `git lfs pull`) the strategy tags the decision `pilot_unavailable` and routes the turn to the default tier (c1). Runtime deps are `numpy`/`onnxruntime`/`tokenizers` (in the `recommended` and `ml-router` extras); a minimal install without them degrades the same graceful way. Tunable via the `[agentos_router.pilot]` sub-table below. See [`features/agentos-router.md`](features/agentos-router.md#the-pilot-strategy) for status and rollback. |
-| `v4_phase3` | No (legacy) | The previous default: an on-device ML router (BGE embeddings + LightGBM ensemble). No LLM call, nothing leaves the machine. Fully selectable and the one-line rollback from `pilot-v1`. Its bundle ships in the wheel under `src/agentos/agentos_router/models/v4.2_phase3_inference/`; when missing the router logs a warning at boot and pins every turn to the default tier (c1). Install its runtime deps with `uv sync --extra recommended` (or the `ml-router` extra); `git lfs pull` restores the bundle in a source checkout — or use `llm_judge`, which needs no local model files. |
+| `v4_phase3` | No (legacy) | The previous default: an on-device ML router (BGE embeddings + LightGBM ensemble). Retained in-tree only as an evaluation baseline (removed in Phase C). **Not a supported persisted strategy:** a config that still pins `v4_phase3` is automatically migrated to `pilot-v1` on the next load (see [Upgrading from v4_phase3](#upgrading-from-v4_phase3) below). |
 | `llm_judge` | No | Each turn is classified by a small LLM judge call instead of the local ML bundle. See "Local judge" below. |
 
 ```toml
 [agentos_router]
-strategy = "pilot-v1"   # default; or "v4_phase3" (legacy) or "llm_judge"
+strategy = "pilot-v1"   # default; or "llm_judge"
 ```
 
 Router runtime dependencies (`onnxruntime`, `numpy`, `tokenizers`) stay in the
@@ -165,6 +165,24 @@ All three strategies are also selectable from the Mode dropdown in onboarding
 **Smart routing (LLM-based)** (`llm_judge`), or **Off**. The "Judge model" field
 only appears for the LLM-based strategy; the "Pilot safety net" field only
 appears for the Pilot strategy.
+
+#### Upgrading from v4_phase3
+
+Historical onboarding persisted `strategy = "v4_phase3"` explicitly in
+`~/.agentos/config.toml`. The default has since flipped to `pilot-v1`, so on the
+next config load AgentOS **automatically migrates** any config still pinning
+`v4_phase3`:
+
+- the strategy is rewritten to `pilot-v1`;
+- the original file is backed up verbatim next to it as
+  `config.toml.backup.<timestamp>` (mode `0600`);
+- the flip is logged, and the rewrite is idempotent (a config already on
+  `pilot-v1` is left untouched, with no backup).
+
+There is no supported way to keep `v4_phase3` in config — the legacy engine
+remains in-tree only as an evaluation baseline until its scheduled removal
+(Phase C). Selecting **Smart routing (on-device)** in onboarding therefore
+resolves to `pilot-v1` on the next load.
 
 #### Pilot strategy settings
 

--- a/docs/features/agentos-router.md
+++ b/docs/features/agentos-router.md
@@ -26,8 +26,8 @@ AgentOS Router has three selectable strategies, set via
 
 | Strategy | Mode label | How it decides |
 | --- | --- | --- |
-| `pilot-v1` (default) | Local ML — English-optimized (Pilot) | An AgentOS-native, English-optimized local router (MiniLM embeddings + a self-trained AgentOS model, ONNX). Decides on-device with no LLM call, nothing leaving your machine. The bundle ships in the wheel under `src/agentos/agentos_router/models/pilot_v1/`; a missing bundle degrades to the default tier (c1). See [The Pilot strategy](#the-pilot-strategy) below for status, config, and rollback. |
-| `v4_phase3` (legacy) | Smart routing (on-device) | The previous default: an on-device ML ensemble (BGE embeddings + LightGBM) scoring each turn locally — no LLM call. Fully selectable and the one-line rollback from `pilot-v1`. The bundle ships in the wheel under `src/agentos/agentos_router/models/v4.2_phase3_inference/`; when missing, the router logs a warning at boot and pins every turn to the default tier (c1) instead of failing. To restore it, `git lfs pull` the bundle or switch to `llm_judge` (which needs no local model files). |
+| `pilot-v1` (default) | Local ML — English-optimized (Pilot) | An AgentOS-native, English-optimized local router (MiniLM embeddings + a self-trained AgentOS model, ONNX). Decides on-device with no LLM call, nothing leaving your machine. The bundle ships in the wheel under `src/agentos/agentos_router/models/pilot_v1/`; a missing bundle degrades to the default tier (c1). See [The Pilot strategy](#the-pilot-strategy) below for status, config, and upgrade-from-v4 behavior. |
+| `v4_phase3` (legacy) | Smart routing (on-device) | The previous default: an on-device ML ensemble (BGE embeddings + LightGBM) scoring each turn locally — no LLM call. Retained in-tree only as an evaluation baseline (removed in Phase C); a config that still pins it is **auto-migrated to `pilot-v1`** on the next load — see [Upgrading from v4_phase3](#the-pilot-strategy). Not a supported persisted strategy. |
 | `llm_judge` | Smart routing (LLM-based) | A small "judge" model classifies each turn (R0–R3) via a forced tool call. The judge can be a cloud model (default: the cheapest tier of your active provider) or a local OpenAI-compatible endpoint (Ollama, LM Studio, llama.cpp, vLLM) configured with `judge_model` / `judge_base_url`. |
 
 Both the Web UI setup wizard and the CLI (`agentos onboard`,
@@ -49,7 +49,9 @@ nothing leaves your machine.
 fresh install routes through it with no config change. It was promoted from
 opt-in after passing the owner's relative-to-incumbent ship gate (it beats the
 `v4_phase3` incumbent on 11/12 evaluation axes; see `DATA.md` /
-`eval_report.md`). `v4_phase3` remains fully selectable as the legacy fallback.
+`eval_report.md`). The legacy `v4_phase3` engine remains in-tree only as an
+evaluation baseline (removed in Phase C); a config that still pins it is
+auto-migrated to `pilot-v1` on the next load (see **Upgrading from v4_phase3**).
 
 The default needs no config, but the Pilot safety-net floor is tunable:
 
@@ -73,9 +75,14 @@ checkout without `git lfs pull`), the strategy tags the decision
 `pilot_unavailable` and routes the turn to the default tier (the same graceful
 degrade `v4_phase3` uses when its bundle is missing).
 
-**Rollback to v4.** Reverting to the legacy router is one config line — set
-`strategy = "v4_phase3"` (in `[agentos_router]`) and restart. The `v4_phase3`
-bundle still ships in the wheel, so rollback is always available.
+**Upgrading from v4_phase3.** Historical installs persisted
+`strategy = "v4_phase3"` explicitly in `~/.agentos/config.toml`. On the next
+config load AgentOS **automatically migrates** any such config to `pilot-v1`:
+the old file is backed up verbatim next to it (`config.toml.backup.<timestamp>`)
+and rewritten with `strategy = "pilot-v1"`, and the flip is logged. The
+migration is idempotent — once rewritten there is nothing left to migrate. There
+is no supported way to keep `v4_phase3` in config; the legacy engine stays
+in-tree only as an evaluation baseline until its scheduled removal (Phase C).
 
 ## One Router, One Provider
 
@@ -174,7 +181,7 @@ For routine use, start with `recommended`. Disable routing only when the model
 choice itself is the thing you are testing.
 
 This table covers the install/provider profile (`--router`). It is
-independent of the `strategy` choice above — both `v4_phase3` and
+independent of the `strategy` choice above — both `pilot-v1` and
 `llm_judge` work under any profile.
 
 ## Example Requests

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -17,6 +17,7 @@ from typing import Any
 import tomli_w
 
 from agentos.paths import default_agentos_home
+from agentos.router_strategies import PILOT_STRATEGY_ID, V4_STRATEGY_ID
 
 DEPRECATED_MEMORY_FIELDS: frozenset[str] = frozenset(
     {
@@ -313,11 +314,27 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
 
     agentos_router = builder.payload.get("agentos_router")
     if isinstance(agentos_router, dict):
-        # pilot-v1 is now the default strategy (v4_phase3 remains selectable) —
-        # do NOT rewrite an explicit strategy here. An earlier release migrated
-        # v4_phase3 -> llm_judge on load; that rewrite is intentionally removed
-        # so installed TOMLs keep whatever local router they set. "pilot-v1",
-        # "v4_phase3", and "llm_judge" all pass schema validation.
+        # Force default-flip: pilot-v1 is the default strategy, but historical
+        # onboarding persisted `strategy = "v4_phase3"` explicitly, so an upgraded
+        # install would silently stay on the legacy router. Unconditionally rewrite
+        # a persisted v4_phase3 to pilot-v1 on load — there is no supported way to
+        # keep v4_phase3 in config; the legacy engine stays in-tree only as an
+        # evaluation baseline (removed in Phase C). The rewrite is idempotent:
+        # once flipped the value is pilot-v1, so re-running is a no-op. "pilot-v1"
+        # and "llm_judge" configs are left untouched, and a config with no strategy
+        # key already resolves to the default and is not rewritten here.
+        strategy = agentos_router.get("strategy")
+        if isinstance(strategy, str) and strategy.strip() == V4_STRATEGY_ID:
+            agentos_router["strategy"] = PILOT_STRATEGY_ID
+            builder.changes.append(
+                f"agentos_router.strategy: {V4_STRATEGY_ID} -> {PILOT_STRATEGY_ID} "
+                "(default flip; legacy router auto-migrated on load)"
+            )
+            logging.getLogger(__name__).info(
+                "AgentOS router strategy force-migrated %s -> %s on config load",
+                V4_STRATEGY_ID,
+                PILOT_STRATEGY_ID,
+            )
 
         # confidence_threshold gained a strict [0.0, 1.0] bound with the judge
         # migration. Under the old v4 confidence gate an out-of-range value was a

--- a/src/agentos/gateway/static/js/views/setup.js
+++ b/src/agentos/gateway/static/js/views/setup.js
@@ -556,13 +556,14 @@ const SetupView = (() => {
     const profile = provider ? profiles.find(p => p.providerId === provider) || {} : {};
     const tiers = provider ? Object.assign({}, profile.tiers || {}, router.tiers || {}) : {};
     const defaultTier = router.default_tier || catalog.defaultTier || 'c1';
-    // The Mode control is a single 4-way selector encoding both enabled and
+    // The Mode control is a single 3-way selector encoding both enabled and
     // strategy: 'disabled' (router off) or one of the enabled strategy ids the
-    // backend registry accepts — 'pilot-v1' (English-optimized local ML, the
-    // config default), 'v4_phase3' (legacy on-device ML), 'llm_judge' (LLM-judge
-    // routing). The strategy is derived by explicit id, never a judge-else-v4
-    // fallback, so a persisted 'v4_phase3' config always shows v4 selected.
-    const ROUTER_STRATEGIES = ['pilot-v1', 'v4_phase3', 'llm_judge'];
+    // human-facing selector offers — 'pilot-v1' (English-optimized local ML, the
+    // config default) or 'llm_judge' (LLM-judge routing). The legacy 'v4_phase3'
+    // strategy is intentionally NOT selectable: it is force-migrated to pilot-v1
+    // on load, so a persisted (or otherwise unknown) strategy falls back to
+    // pilot-v1 and shows the Pilot option selected.
+    const ROUTER_STRATEGIES = ['pilot-v1', 'llm_judge'];
     const mode = router.enabled === false
       ? 'disabled'
       : (ROUTER_STRATEGIES.includes(router.strategy) ? router.strategy : 'pilot-v1');
@@ -597,7 +598,6 @@ const SetupView = (() => {
           <label><span>Mode</span>
             <select id="setup-router-mode" name="setup_router_mode" data-router-mode${routerDisabled}>
               <option value="pilot-v1"${mode === 'pilot-v1' ? ' selected' : ''}>Local ML — English-optimized (Pilot)</option>
-              <option value="v4_phase3"${mode === 'v4_phase3' ? ' selected' : ''}>Smart routing (on-device)</option>
               <option value="llm_judge"${mode === 'llm_judge' ? ' selected' : ''}>Smart routing (LLM-based)</option>
               <option value="disabled"${mode === 'disabled' ? ' selected' : ''}>Off</option>
             </select>
@@ -1783,9 +1783,10 @@ const SetupView = (() => {
       tiers[row.dataset.tier] = tier;
     });
     // The Mode dropdown encodes both enabled and strategy: 'pilot-v1' /
-    // 'v4_phase3' / 'llm_judge' → router enabled with that strategy id (forwarded
-    // verbatim to upsert_router, which validates it against the registry);
-    // 'disabled' → off. The option value IS the strategy id, so no remapping.
+    // 'llm_judge' → router enabled with that strategy id (forwarded verbatim to
+    // upsert_router, which validates it against the registry); 'disabled' → off.
+    // The option value IS the strategy id, so no remapping. Legacy 'v4_phase3' is
+    // not offered (force-migrated to pilot-v1 on load).
     const sel = _el.querySelector('[data-router-mode]')?.value || 'pilot-v1';
     const routerMode = sel === 'disabled' ? 'disabled' : 'recommended';
     const strategy = sel === 'disabled' ? undefined : sel;

--- a/src/agentos/onboarding/flow.py
+++ b/src/agentos/onboarding/flow.py
@@ -950,7 +950,6 @@ _IMAGE_TIER_LABEL = "Image model"
 _DONE_LABEL = "Done"
 
 
-_ROUTER_LOCAL_ML_LABEL = "Smart routing (on-device)"
 _ROUTER_LLM_JUDGE_LABEL = "Smart routing (LLM-based)"
 _ROUTER_PILOT_LABEL = "Local ML — English-optimized (Pilot)"
 _ROUTER_DISABLED_LABEL = "Off"
@@ -975,8 +974,11 @@ def _search_fallback_choice_to_value(choice: str | None) -> str:
 
 
 def _router_mode_choices(provider_id: str) -> list[str]:
+    # The legacy on-device ML strategy (v4_phase3) is intentionally NOT offered:
+    # it is no longer a supported persisted strategy (a config pinning it is
+    # force-migrated to pilot-v1 on load), so the human-facing selector is a
+    # clean 3-way — Pilot / LLM judge / off.
     return [
-        _ROUTER_LOCAL_ML_LABEL,
         _ROUTER_PILOT_LABEL,
         _ROUTER_LLM_JUDGE_LABEL,
         _ROUTER_DISABLED_LABEL,
@@ -988,9 +990,9 @@ def _router_mode_default(provider_id: str, requested: str) -> str:
         return _ROUTER_DISABLED_LABEL
     if requested == "llm_judge":
         return _ROUTER_LLM_JUDGE_LABEL
-    if requested == "pilot-v1":
-        return _ROUTER_PILOT_LABEL
-    return _ROUTER_LOCAL_ML_LABEL
+    # pilot-v1 is the default, and a legacy v4_phase3 request maps to it too:
+    # v4 is force-migrated away, so it must never preselect a dropped option.
+    return _ROUTER_PILOT_LABEL
 
 
 def _router_mode_to_internal(selected: str | None) -> str:
@@ -1001,14 +1003,16 @@ def _router_mode_to_internal(selected: str | None) -> str:
 
 
 def _router_mode_to_strategy(selected: str | None) -> str | None:
-    """Return the router ``strategy`` for the choice (None when disabled)."""
+    """Return the router ``strategy`` for the choice (None when disabled).
+
+    Any enabled selection other than the LLM judge resolves to pilot-v1 (the
+    default); the legacy v4_phase3 label was dropped from the selector.
+    """
     if selected == _ROUTER_DISABLED_LABEL:
         return None
     if selected == _ROUTER_LLM_JUDGE_LABEL:
         return "llm_judge"
-    if selected == _ROUTER_PILOT_LABEL:
-        return "pilot-v1"
-    return "v4_phase3"
+    return "pilot-v1"
 
 
 def _text_tier_label(tier: str | None) -> str:

--- a/tests/test_gateway/test_config_migration_router.py
+++ b/tests/test_gateway/test_config_migration_router.py
@@ -4,36 +4,85 @@ import pytest
 
 from agentos.gateway.config_migration import migrate_config_payload
 
+# ---------------------------------------------------------------------------
+# Force default-flip migration: v4_phase3 -> pilot-v1 (unconditional).
+#
+# The default strategy flipped v4_phase3 -> pilot-v1, but historical onboarding
+# persisted `strategy = "v4_phase3"` explicitly, so an upgraded install would
+# silently stay on the legacy router. This migration force-rewrites every such
+# config to pilot-v1 on load — there is no supported way to persist v4_phase3
+# (the legacy engine remains in-tree only as an evaluation baseline). The flip
+# is idempotent: once rewritten, the strategy is pilot-v1 and re-running is a
+# no-op.
+#
+# Semantics table (each case below is a test):
+#   (a) no strategy key      -> untouched (default already applies)
+#   (b) v4_phase3            -> pilot-v1, changed=True
+#   (c) pilot-v1 / llm_judge -> untouched
+#   idempotency: migrating an already-migrated payload -> changed=False
+# ---------------------------------------------------------------------------
 
-def test_v4_phase3_strategy_is_preserved_on_load() -> None:
-    # v4_phase3 (local ML router) is the default strategy again: the load-time
-    # rewrite v4_phase3 -> llm_judge was removed, so an installed TOML pinning
-    # v4_phase3 keeps it verbatim across migration.
+
+def _router(result) -> dict:
+    return result.payload["agentos_router"]
+
+
+def test_case_a_missing_strategy_key_is_untouched() -> None:
+    # (a) A config without an explicit strategy already gets the new default;
+    # do NOT touch it.
+    result = migrate_config_payload({"agentos_router": {"enabled": True}})
+
+    assert result.changed is False
+    assert "strategy" not in _router(result)
+
+    # An empty payload has no router section at all.
+    assert migrate_config_payload({}).changed is False
+
+
+def test_case_b_v4_phase3_is_force_migrated_to_pilot() -> None:
+    # (b) The core migration: a persisted v4_phase3 is unconditionally rewritten
+    # to pilot-v1 and changed=True so the loader backs up and rewrites the file.
     result = migrate_config_payload(
         {"agentos_router": {"enabled": True, "strategy": "v4_phase3"}}
     )
 
-    assert result.payload["agentos_router"]["strategy"] == "v4_phase3"
-    assert not any(
-        "strategy" in change for change in result.changes
+    assert result.changed is True
+    assert _router(result)["strategy"] == "pilot-v1"
+    assert any("strategy" in change and "pilot-v1" in change for change in result.changes)
+
+
+def test_case_c_pilot_and_judge_strategies_are_untouched() -> None:
+    # (c) A config already on pilot-v1 or llm_judge is left entirely alone.
+    for strategy in ("pilot-v1", "llm_judge"):
+        result = migrate_config_payload(
+            {"agentos_router": {"enabled": True, "strategy": strategy}}
+        )
+        assert result.changed is False
+        assert _router(result)["strategy"] == strategy
+
+
+def test_migration_is_idempotent_on_already_migrated_payload() -> None:
+    # Running the migration on its own output is a no-op: the strategy is now
+    # pilot-v1, so no further rewrite (changed=False).
+    once = migrate_config_payload(
+        {"agentos_router": {"enabled": True, "strategy": "v4_phase3"}}
     )
+    assert once.changed is True
+
+    twice = migrate_config_payload(once.payload)
+    assert twice.changed is False
+    assert _router(twice)["strategy"] == "pilot-v1"
 
 
-def test_llm_judge_strategy_is_left_untouched() -> None:
+def test_migrated_payload_boots_the_router_config() -> None:
+    # The migrated payload must construct AgentOSRouterConfig without raising.
+    from agentos.gateway.config import AgentOSRouterConfig
+
     result = migrate_config_payload(
-        {"agentos_router": {"enabled": True, "strategy": "llm_judge"}}
+        {"agentos_router": {"enabled": True, "strategy": "v4_phase3"}}
     )
-
-    assert result.changed is False
-    assert result.payload["agentos_router"]["strategy"] == "llm_judge"
-
-
-def test_missing_router_section_or_strategy_is_left_untouched() -> None:
-    assert migrate_config_payload({}).changed is False
-
-    result = migrate_config_payload({"agentos_router": {"enabled": True}})
-    assert result.changed is False
-    assert "strategy" not in result.payload["agentos_router"]
+    cfg = AgentOSRouterConfig(**_router(result))
+    assert cfg.strategy == "pilot-v1"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -998,26 +998,29 @@ def test_setup_router_step_uses_effective_provider_without_hardcoded_fallback():
     assert "Save the provider before saving router tiers." in save_body
 
 
-def test_setup_router_step_offers_four_way_selector_with_explicit_pilot():
-    """T10: the Mode control is a 4-way selector with explicit per-strategy
-    handling (v4_phase3 / pilot-v1 / llm_judge / disabled). The mode must be
-    derived by explicit strategy id — a persisted ``pilot-v1`` config shows
-    Pilot selected, never silently re-derived to judge or v4."""
+def test_setup_router_step_offers_three_way_selector_with_explicit_pilot():
+    """The Mode control is a 3-way selector (pilot-v1 / llm_judge / disabled).
+    The legacy v4_phase3 strategy is dropped from the human-facing dropdown — it
+    is force-migrated to pilot-v1 on load — so a persisted (or otherwise unknown)
+    strategy falls back to pilot-v1 and shows the Pilot option selected."""
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     start = txt.index("function _renderRouterStep()")
     end = txt.index("  function _tierRow", start)
     body = txt[start:end]
 
     # Explicit strategy derivation: the render must recognise 'pilot-v1' and
-    # 'llm_judge' by id and fall back to v4_phase3, not a judge-else-v4 branch.
+    # 'llm_judge' by id and fall back to pilot-v1, not a judge-else-v4 branch.
     assert "router.strategy === 'llm_judge' ? 'llm_judge'" not in body
     assert "'pilot-v1'" in body
 
-    # All four options present, each selected off the explicit `mode` value.
-    assert "<option value=\"v4_phase3\"" in body
+    # The three offered options are present; v4_phase3 is NOT offered.
     assert "<option value=\"pilot-v1\"" in body
     assert "<option value=\"llm_judge\"" in body
     assert "<option value=\"disabled\"" in body
+    assert "<option value=\"v4_phase3\"" not in body
+    # v4_phase3 is not one of the selectable strategy ids the mode derives from.
+    assert "const ROUTER_STRATEGIES = ['pilot-v1', 'llm_judge'];" in body
+    assert "'v4_phase3'" not in body.replace("legacy 'v4_phase3'", "")
 
     # The Pilot option carries the CLI-consistent label + a short description.
     assert "Local ML — English-optimized (Pilot)" in body

--- a/tests/test_gateway_config_legacy.py
+++ b/tests/test_gateway_config_legacy.py
@@ -120,6 +120,46 @@ def test_load_migrates_010_turn_capture_fields(tmp_path: Path) -> None:
     assert "prefetch_min_score" not in data
 
 
+def test_load_force_migrates_pinned_v4_strategy_to_pilot_with_backup(
+    tmp_path: Path,
+) -> None:
+    """A config explicitly pinning the legacy default (v4_phase3) is force-flipped
+    to pilot-v1 on load, the file is rewritten, and the original is backed up
+    verbatim."""
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text(
+        "\n".join(["[agentos_router]", 'strategy = "v4_phase3"', ""]),
+        encoding="utf-8",
+    )
+
+    cfg = GatewayConfig.load(toml_path)
+
+    assert cfg.agentos_router.strategy == "pilot-v1"
+
+    backups = sorted(tmp_path.glob("config.toml.backup.*"))
+    assert backups
+    backup_text = backups[-1].read_text(encoding="utf-8")
+    assert 'strategy = "v4_phase3"' in backup_text
+
+    migrated = toml_path.read_text(encoding="utf-8")
+    assert 'strategy = "pilot-v1"' in migrated
+    assert "v4_phase3" not in migrated
+
+
+def test_load_leaves_already_migrated_pilot_strategy_untouched(tmp_path: Path) -> None:
+    """A config already on pilot-v1 reloads without a rewrite or a backup."""
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text(
+        "\n".join(["[agentos_router]", 'strategy = "pilot-v1"', ""]),
+        encoding="utf-8",
+    )
+
+    cfg = GatewayConfig.load(toml_path)
+
+    assert cfg.agentos_router.strategy == "pilot-v1"
+    assert not sorted(tmp_path.glob("config.toml.backup.*"))
+
+
 def test_load_from_toml_migrates_010_turn_capture_fields(tmp_path: Path) -> None:
     toml_path = tmp_path / "config.toml"
     toml_path.write_text(

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -8,22 +8,23 @@ from io import StringIO
 from rich.console import Console
 
 
-def test_router_mode_selector_is_four_way_with_pilot_label():
+def test_router_mode_selector_is_three_way_with_pilot_label():
     from agentos.onboarding import flow
 
     choices = flow._router_mode_choices("openrouter")
 
-    # 4-way: on-device v4, Pilot, LLM-judge, off.
-    assert len(choices) == 4
+    # 3-way: Pilot, LLM-judge, off. The legacy on-device v4 strategy is dropped
+    # from the human-facing selector (it is force-migrated to pilot-v1 on load).
+    assert len(choices) == 3
     assert flow._ROUTER_PILOT_LABEL == "Local ML — English-optimized (Pilot)"
     assert flow._ROUTER_PILOT_LABEL in choices
+    assert "Smart routing (on-device)" not in choices
 
 
 def test_router_mode_to_strategy_maps_pilot_choice():
     from agentos.onboarding import flow
 
     assert flow._router_mode_to_strategy(flow._ROUTER_PILOT_LABEL) == "pilot-v1"
-    assert flow._router_mode_to_strategy(flow._ROUTER_LOCAL_ML_LABEL) == "v4_phase3"
     assert flow._router_mode_to_strategy(flow._ROUTER_LLM_JUDGE_LABEL) == "llm_judge"
     assert flow._router_mode_to_strategy(flow._ROUTER_DISABLED_LABEL) is None
     # A pilot choice keeps the router enabled (mode="recommended").
@@ -35,6 +36,17 @@ def test_router_mode_default_selects_pilot_for_existing_pilot_config():
 
     assert (
         flow._router_mode_default("openrouter", "pilot-v1")
+        == flow._ROUTER_PILOT_LABEL
+    )
+
+
+def test_router_mode_default_maps_legacy_v4_request_to_pilot():
+    # A legacy v4_phase3 request must never preselect a dropped option — it maps
+    # to the Pilot label (the strategy it force-migrates to).
+    from agentos.onboarding import flow
+
+    assert (
+        flow._router_mode_default("openrouter", "v4_phase3")
         == flow._ROUTER_PILOT_LABEL
     )
 
@@ -352,13 +364,12 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
                 return _Answer("Use environment variable OPENROUTER_API_KEY")
             if message == "Router mode":
                 assert kwargs.get("choices") == [
-                    "Smart routing (on-device)",
                     "Local ML — English-optimized (Pilot)",
                     "Smart routing (LLM-based)",
                     "Off",
                 ]
-                assert kwargs.get("default") == "Smart routing (on-device)"
-                return _Answer("Smart routing (on-device)")
+                assert kwargs.get("default") == "Local ML — English-optimized (Pilot)"
+                return _Answer("Local ML — English-optimized (Pilot)")
             if message == "Default text model":
                 assert kwargs.get("choices") == [
                     "Route c0",

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -692,6 +692,19 @@ def test_upsert_router_still_accepts_v4_and_judge_strategies():
     )
 
 
+def test_upsert_router_accepts_v4_phase3_despite_selector_drop():
+    """v4_phase3 remains a valid id at the API/registry level even though the
+    human-facing selectors (CLI + setup UI) dropped it: the engine and eval
+    baseline still use it, and direct API callers may set it (a persisted
+    v4_phase3 is force-migrated to pilot-v1 on the next config load, not
+    rejected here)."""
+    cfg = GatewayConfig(llm={"provider": "openrouter", "model": "deepseek/x"})
+
+    result = upsert_router(cfg, mode="recommended", strategy="v4_phase3")
+
+    assert result.config.agentos_router.strategy == "v4_phase3"
+
+
 def test_upsert_router_rejects_unknown_strategy():
     cfg = GatewayConfig(llm={"provider": "openrouter", "model": "deepseek/x"})
 


### PR DESCRIPTION
Ensures every upgrading install actually receives the new default router (#26). Historical onboarding persisted `strategy = "v4_phase3"` explicitly, so upgraded configs would silently stay on the legacy engine.

## What this does

- **Config migration (unconditional):** any loaded config carrying `strategy = "v4_phase3"` is rewritten to `pilot-v1` via the existing migration pipeline — timestamped backup written next to the file, structlog record, idempotent on re-load. Runs on the first `agentos` command after upgrade; no user action needed.
- **Selector coherence:** the CLI onboarding selector and the web setup dropdown drop the v4 option (now 3-way: Pilot / LLM judge / Off) — offering a choice that migration immediately rewrites would be incoherent. `v4_phase3` remains a valid registry id for the engine and evaluation baseline; the bundle stays in-tree.
- **Docs:** upgrade note replaces the old "one-line rollback" wording; `agentos.toml.example` updated.

## Verified

- Migration semantics table-tested (missing key / v4 / pilot / judge / idempotency / backup verbatim); full suite 6,281 passed, mypy + ruff clean.
- Live-tested on a real upgraded machine: pinned-v4 config → one `gateway restart` → file migrated + backup created + `bundle_ready strategy=pilot-v1` + real turns routing ("hi" → R0 → c0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)