### PR TITLE
feat(skills): add bundled 'agentos' self-operation skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,12 @@ Docs live in `docs/` (`docs/README.md` is the index); helper scripts in `scripts
 - **Third-party origin:** vendored/adapted/ported code must be declared in the PR
   with upstream URL + license, and update `THIRD_PARTY_NOTICES.md`. Permissive
   (MIT/BSD/ISC/Apache-2.0) is fine; (A/L)GPL/SSPL/unclear needs maintainer sign-off.
+- **CLI changes update the self-operation skill.** Any change to the CLI surface
+  or its contracts — commands/subcommands, flags, config keys or precedence,
+  default port, state paths — must be checked against
+  `src/agentos/skills/bundled/agentos/SKILL.md` (and `docs/cli.md`) and those
+  docs updated in the same PR so the bundled operator guide never drifts from
+  the real CLI.
 
 ## Commits & PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,8 @@
 This project keeps a single source of truth for agent instructions in
 **[AGENTS.md](AGENTS.md)**. Read it — setup, the quality gate (uv + ruff +
 mypy + pytest), source layout, conventions, and commit/PR rules all live there.
+
+One rule worth repeating here: whenever you update the CLI surface (commands,
+flags, config keys, ports, paths), always check
+`src/agentos/skills/bundled/agentos/SKILL.md` and `docs/cli.md` and bring them
+up to date in the same change.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -146,6 +146,7 @@ SOFTWARE.
 These bundled skill descriptors are authored and maintained by AgentOS and
 are released under AgentOS's repository license (Apache-2.0; see `LICENSE`):
 
+- `agentos`
 - `cron`
 - `deep-research`
 - `docx`

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: agentos
+description: "Operate and configure AgentOS itself: the `agentos` CLI, agentos.toml, gateway/Web UI, providers and models, skills, channels, sessions, cron, sandbox, and memory. Use when: (1) the user asks to change an AgentOS setting (model, provider, router tier, auth, channels, search), (2) starting, stopping, or debugging the gateway or Web UI, (3) installing, updating, or removing skills and taps, (4) inspecting sessions, usage/cost, cron jobs, or diagnostics, (5) migrating from another agent runtime. NOT for: authoring new skills (see docs/features/skills.md), operating other agent CLIs, or modifying AgentOS source code."
+always: false
+triggers:
+  - agentos
+  - config.toml
+  - agentos.toml
+  - gateway
+  - provider
+  - "change model"
+  - "install skill"
+  - onboard
+  - doctor
+provenance:
+  origin: agentos-original
+  license: MIT
+metadata:
+  agentos:
+    emoji: "🧭"
+---
+
+# AgentOS self-operation
+
+AgentOS is the agent runtime you are (or may be) running inside: a Python
+framework (`pip install use-agent-os`) with a Typer CLI (`agentos`), a local
+gateway server with a Web UI, messaging channels, a skills system, memory,
+cron, and a model router. This skill teaches you to configure and operate
+AgentOS on the user's behalf through its CLI and config file.
+
+Docs: local `docs/` in the repo, published at https://useagentos.dev/docs/
+
+## Scope & verification — read first
+
+This skill is a condensed operating guide, not the full source of truth.
+Rules that prevent broken commands:
+
+- **Never invent flags or subcommands.** If a flag is not written here, run
+  `agentos <command> --help` first and use what it prints.
+- Command *groups* are exact: it is `agentos providers configure`, not
+  `agentos configure provider`; `agentos migrate hermes`, not
+  `agentos hermes`.
+- If a command is missing from this skill, that is not evidence it does not
+  exist — check `agentos --help` before answering "impossible".
+- Config keys go through `agentos config get <dot.key>` / `config set` —
+  verify a key exists with `config get` before setting it.
+
+## Quick start
+
+```sh
+agentos onboard              # first-run setup wizard (or: agentos init, agentos configure)
+agentos doctor               # diagnose readiness, print recovery steps
+agentos gateway run          # gateway + Web UI, foreground (default port 18791)
+agentos chat                 # interactive terminal chat
+agentos agent -m "..."       # one-shot, automation-friendly agent turn
+```
+
+## CLI map
+
+Top-level: `init`, `onboard`, `configure`, `doctor`, `chat`, `agent`,
+`reset`, plus these groups (each supports `--help`):
+
+| Group | Subcommands |
+| --- | --- |
+| `gateway` | `run`, `start`, `status`, `stop`, `restart` (`--port`, `--bind`, `--listen`, `--config`, `--json`, `--debug`) |
+| `config` | `get [key]` (empty key = show all), `set <dot.key> <value>` |
+| `providers` | `list`, `status`, `configure <id> [-m MODEL] [-k API_KEY] [--base-url] [--proxy]` |
+| `models` | `list` |
+| `skills` | `list`, `search`, `view`, `install`, `uninstall`, `update`, `publish`, `tap add/list/remove` |
+| `sessions` | `list`, `show`, `resume`, `abort`, `delete`, `export` |
+| `cron` | `list`, `status`, `add`, `update`, `remove`, `run`, `runs` |
+| `channels` | `list`, `status`, `types`, `describe`, `add`, `remove`, `enable`, `disable`, `edit`, `restart`, `logout`, `pairing …` |
+| `memory` | `status`, `index`, `list`, `search`, `show`, `dream`, `embedding-download`, `repair …`, `raw-fallbacks …` |
+| `sandbox` | `status`, `on`, `bypass`, `full`, `reset` |
+| `search` | `list`, `status`, `query`, `configure` |
+| `cost` | usage and estimated cost report |
+| `diagnostics` | `status`, `on`, `off` |
+| `migrate` | `openclaw`, `hermes` (`--source`, `--profile`, `--apply`, `--migrate-secrets`; dry-run without `--apply`) |
+| `agents` | `list`, `add`, `delete` (durable agents) |
+| `mcp-server` | `run` (MCP bridge) |
+| `replay`, `dist`, `onboard` | replay recorded turns / workspace inventory / setup status |
+
+## Configuration
+
+File resolution (highest precedence first):
+
+1. Environment variables
+2. `./agentos.toml` (current directory)
+3. `~/.agentos/config.toml` (user-global; `AGENTOS_STATE_DIR` moves `~/.agentos`)
+4. Built-in defaults
+
+Most commands accept `--config <path>` to target a specific file. On load,
+AgentOS auto-migrates outdated config schemas and writes a backup next to
+the file before rewriting it.
+
+Main `agentos.toml` sections (full commented reference:
+`agentos.toml.example` in the repo):
+
+| Section | Controls |
+| --- | --- |
+| top-level | `workspace_dir`, `state_dir`, logging, `search_provider`/`search_api_key`, timeouts |
+| `[llm]` | `provider`, `model`, `api_key`, `base_url`, `proxy`, `[llm.provider_routing]` |
+| `[agentos_router]` | router on/off, `strategy` (`pilot-v1`), tier settings under `[agentos_router.tiers.c0..c3]` |
+| `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode` |
+| `[memory]` | memory source and embedding model, `[memory.dream]` |
+| `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |
+| `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`) |
+| `[auth]` | gateway auth: `mode` (`none`/`token`/`password`), `token`, `allow_unauthenticated_public` |
+| `[control_ui]` | `allowed_origins` for reverse-proxy setups |
+| `[channels]` | messaging channels (`[[channels.channels]]` entries) |
+| `[compaction]`, `[agent_token_saving]`, `[task_runtime]` | context compaction, tool-result projection, concurrency |
+
+## Common operations (verified recipes)
+
+**Change the model/provider (persistently):**
+
+```sh
+agentos providers configure openrouter -m anthropic/claude-sonnet-4   # provider + model in one step
+agentos config set llm.model "anthropic/claude-sonnet-4"              # just the model key
+agentos configure                                                     # interactive wizard
+agentos gateway restart                                               # apply to a running gateway
+```
+
+**Gateway lifecycle:**
+
+```sh
+agentos gateway start          # background; `run` = foreground
+agentos gateway start --port 9000   # `run`/`start` share --port/--bind/--listen
+agentos gateway status --json  # machine-readable status
+agentos gateway stop
+```
+
+Default port **18791**, loopback bind. `--listen HOST:PORT` overrides
+`--bind`/`--port` together.
+
+**Public / LAN bind (security-gated):** with `auth.mode = "none"` the
+gateway *refuses* non-loopback binds by design. The right fix is enabling
+auth, not bypassing the guard:
+
+```sh
+agentos config set auth.mode token
+agentos config set auth.token "<long random secret>"
+agentos gateway restart
+```
+
+Only set `auth.allow_unauthenticated_public = true` when an external layer
+(reverse-proxy auth, VPN, firewall) already gates access. Behind a reverse
+proxy on another origin, also set `control_ui.allowed_origins`.
+
+**Skills:**
+
+```sh
+agentos skills list                    # installed, per layer
+agentos skills search <query>
+agentos skills install <name>                    # from ClawHub (default source)
+agentos skills install owner/repo:path -s github # from a GitHub repo/URL
+agentos skills tap add owner/repo      # register a GitHub repo as a skill source
+agentos skills tap list
+agentos skills update
+agentos skills uninstall <name>
+```
+
+Skill layers (later overrides earlier): `extra` (config dirs) → `bundled`
+(shipped) → `managed` (`~/.agentos/skills`, where installs land) →
+`personal` (`~/.agents/skills`) → `project` (`<workspace>/.agents/skills`)
+→ `workspace` (`<workspace>/skills`).
+
+**One-shot automation:**
+
+```sh
+agentos agent -m "summarize README.md" --model gpt-5.4-mini --timeout 120
+agentos agent --json -m "Return a machine-readable summary"
+agentos agent --workspace /path --workspace-strict -m "Inspect this repo"
+```
+
+Bounding flags: `--timeout` (wall-clock seconds), `--max-iterations`,
+`--iteration-timeout-seconds`, `--tool-timeout-seconds`; containment:
+`--workspace-strict` (reads), `--workspace-lockdown` (writes),
+`--scratch-dir`.
+
+**Day-two operations:**
+
+```sh
+agentos sessions list / show <id> / export <id> <out>
+agentos cron list / add / run <id> / runs
+agentos cost                   # usage + estimated spend
+agentos diagnostics on         # runtime diagnostics logging
+agentos migrate hermes --source <dir> [--apply]   # dry-run first, then --apply
+```
+
+## Gateway HTTP API
+
+The gateway is also a REST + WebSocket server on port 18791:
+`GET /api/config|sessions|agents|cron|usage|system/status|channels/status`,
+`POST /api/chat`, `GET /api/chat/history`, approvals endpoints under
+`/api/approvals*`, and `WS /ws` (primary RPC transport). On loopback binds
+auth is optional; on public binds the `[auth]` token gates every request.
+Full reference: `docs/http-api.md` (https://useagentos.dev/docs/http-api).
+
+## Key paths
+
+| Path | What |
+| --- | --- |
+| `~/.agentos/` | state root (override: `AGENTOS_STATE_DIR`) |
+| `~/.agentos/config.toml` | user-global config |
+| `./agentos.toml` | project-local config (wins over global) |
+| `~/.agentos/skills/` | managed skills (installed via `skills install`) |
+| `~/.agentos/skills-taps.json` | registered skill taps |
+| `~/.agents/skills/` | personal skills layer |
+
+## Troubleshooting
+
+- **Anything broken** → `agentos doctor` first; it prints recovery steps.
+- **Setting doesn't take effect** → confirm which file won:
+  `agentos config get <key>`; remember `./agentos.toml` beats
+  `~/.agentos/config.toml`; restart the gateway after edits.
+- **Gateway won't bind publicly** → intentional auth guard; see the
+  public-bind recipe above.
+- **Provider/model errors** → `agentos providers status`,
+  `agentos models list`, then `agentos providers configure …`.
+- **Skill missing from prompt** → `agentos skills list` (check layer and
+  enablement), then `[skills]` filter settings (`filter_top_k`,
+  `filter_strategy`).
+- **Deep debugging** → `agentos diagnostics on`, reproduce, then
+  `agentos replay` on the recorded turn.
+
+## Docs map
+
+`docs/README.md` is the index; per-topic pages mirror to
+`https://useagentos.dev/docs/<page>`: `quickstart`, `cli`, `configuration`,
+`gateway`, `http-api`, `providers-and-models`, `channels`, `operations`,
+`scheduling`, `sessions`, `usage-and-cost`, `tools-and-sandbox`,
+`approvals-and-permissions`, `mcp-server`, `troubleshooting`, and
+`features/skills`, `features/agentos-router`, `features/memory`.

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -22,6 +22,7 @@ AUDIO_DEFAULTS = {
     "voiceover-studio",
 }
 DEFAULTS = {
+    "agentos",
     "ai-video-script",
     "cron",
     "deep-research",
@@ -106,9 +107,7 @@ def _ctx(
 
 def test_bundled_directory_only_contains_retained_default_skills() -> None:
     bundled_names = {
-        path.name
-        for path in BUNDLED.iterdir()
-        if path.is_dir() and (path / "SKILL.md").is_file()
+        path.name for path in BUNDLED.iterdir() if path.is_dir() and (path / "SKILL.md").is_file()
     }
 
     assert bundled_names == DEFAULTS | INTERNAL_HELPERS
@@ -159,7 +158,6 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
     for name in INTERNAL_HELPERS:
         assert f"<name>{name}</name>" not in prompt
     assert "<name>healthcheck</name>" not in prompt
-
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -9,6 +9,7 @@ BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
 NOTICES = ROOT / "THIRD_PARTY_NOTICES.md"
 ORIGINALS = {
     "advanced-dubbing-studio",
+    "agentos",
     "cron",
     "deep-research",
     "docx",


### PR DESCRIPTION
## What

Adds a bundled **`agentos` self-operation skill** (`src/agentos/skills/bundled/agentos/SKILL.md`): an operator guide that teaches any agent running on AgentOS to configure and drive AgentOS itself — the same pattern hermes-agent uses for its own in-repo `hermes-agent` skill.

Contents (every command verified against the current Typer definitions in `src/agentos/cli/`):

- **Scope & verification rules** — never invent flags; run `agentos <cmd> --help` before using anything not listed; exact group names (`providers configure`, not `configure provider`).
- **CLI map** — top-level commands plus all subcommand groups with key flags.
- **Configuration** — file resolution/precedence (env > `./agentos.toml` > `~/.agentos/config.toml` > defaults), main section table, auto-migration behavior.
- **Verified recipes** — change model/provider, gateway lifecycle (default port 18791), the public-bind auth guard (token auth first; `allow_unauthenticated_public` only behind an external auth layer), skills/taps install, one-shot `agentos agent` automation, day-two ops.
- **Gateway HTTP API** (`/api/*`, `/ws`), key paths, troubleshooting, docs map.

## Contract updates

- `tests/test_skills_third_party_notices.py` — add `agentos` to `ORIGINALS`.
- `tests/test_skills_default_prompt_contract.py` — add `agentos` to the retained-defaults allowlist (the injection test now also proves the skill lands in the default system prompt).
- `THIRD_PARTY_NOTICES.md` — list `agentos` under AgentOS-original bundled skills.

## New convention

`AGENTS.md` (+ a pointer in `CLAUDE.md`): any change to the CLI surface — commands, flags, config keys, default port, state paths — must update this skill and `docs/cli.md` in the same PR, so the bundled operator guide can't drift from the real CLI.

## Validation

- Skill content retrieval-tested: an agent restricted to only this SKILL.md answered 6/6 operator questions with exact, correct commands (baseline without the skill invented subcommands and flags).
- `uv run ruff check src tests` / `ruff format --check` — clean.
- `uv run mypy src/agentos --show-error-codes` — no issues (575 files).
- `uv run pytest -q -k "skill"` — 166 passed, 4 skipped.
- `uv build --wheel` — skill ships in the wheel (`agentos/skills/bundled/agentos/SKILL.md`).
