### PR TITLE
feat(cli): agentos upgrade — one-command upgrade with gateway restart+verify, skew policy, update notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,31 +238,68 @@ or use the GitHub release wheel link directly:
 
 ### Upgrade
 
-Upgrade a `uv tool` install to the latest release:
+The primary path is the built-in command, which detects how AgentOS was
+installed, upgrades it, and — crucially — restarts the managed gateway so it
+runs the new code (a "successful" upgrade that leaves the daemon on old code is
+the #1 documented upgrade regret):
 
 ```sh
-uv tool upgrade use-agent-os
+agentos upgrade
 ```
 
-This keeps the extras from the original install (for example
-`[recommended]`). A version-pinned install (`==<version>`) stays on
-its pin — to move it, re-run the install command with the new
-version. For a `pip` fallback install, use
-`python -m pip install --user --upgrade "use-agent-os[recommended]"`.
+On a `uv tool` or `pipx` install this runs the matching upgrade command for
+you, then restarts the managed gateway and **verifies** the running gateway
+reports the new version before printing `Gateway: restarted and verified
+(<version>)`. It prints the `old → new` versions on success.
 
-For an [install from source](#install-from-source), pull and re-run
-the installer:
+Flags:
+
+| Flag | Effect |
+|---|---|
+| `--check` | Report whether a newer release exists on PyPI; change nothing. Offline → `could not check (offline)`, exit 0. |
+| `--dry-run` | Print the exact upgrade command that would run; touch nothing. |
+| `--no-restart` | Upgrade the package but leave the gateway running the OLD code. Prints an unmissable warning; you must then run `agentos gateway restart` yourself. |
+| `--timeout <s>` | Upgrade-subprocess timeout (default 600s). On timeout the tool's process group is killed and recovery guidance is printed — never a half-state. |
+| `--json` | Machine-readable output. |
+
+For a plain-`pip` or editable / source install, `agentos upgrade` will **not**
+fake it — it prints the exact manual command and exits non-zero. Run it
+yourself:
 
 ```sh
+# pip install
+python -m pip install --user --upgrade "use-agent-os[recommended]"
+
+# install from source
 cd agent-os
 git pull
 git lfs pull --include="src/agentos/memory/models/**"
 bash scripts/install_source.sh        # Windows: scripts/install_source.ps1
 ```
 
-After any upgrade, restart the gateway so it runs the new code. Your
-configuration and data in `~/.agentos/` are not touched by upgrades.
-To check the installed version, run `uv tool list`.
+**Version skew.** Commands that talk to the gateway compare the CLI and gateway
+versions once per run. A gateway running an *older* version than the CLI (the
+normal state right after a package upgrade, before a restart) prints a warning
+but never blocks. A gateway running a *newer* version than the CLI (you
+downgraded the CLI, or are driving a newer gateway from a stale environment) is
+**refused** — a newer gateway may have written config with a newer schema, so
+acting on it from an older CLI risks corruption. Fix it by upgrading the CLI or
+restarting the gateway from this environment; in an emergency, set
+`AGENTOS_ALLOW_VERSION_SKEW=1` to override.
+
+**Update notices.** On gateway-connected commands the CLI checks PyPI at most
+once every 24h and, if a newer release exists, prints a one-line notice on
+stderr. It is suppressed on non-interactive / CI runs, and you can turn it off
+entirely with `updates.notify = false` (see
+[docs/configuration.md](docs/configuration.md#update-notifications) or the
+setup UI's Finish step).
+
+**Config & data are safe.** Your configuration and data in `~/.agentos/` are
+not touched by upgrades. Config migrations run at gateway start and write a
+timestamped backup before rewriting any file. A version-pinned install
+(`==<version>`) stays on its pin — to move it, re-run the install command with
+the new version. To check the installed version, run `agentos gateway status`
+(shows both the CLI and running-gateway versions) or `uv tool list`.
 
 ### Install from source
 

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -46,6 +46,13 @@
 # debug = false
 # diagnostics_enabled = false
 
+# Update notifications. On gateway-connected commands the CLI checks PyPI at
+# most once every 24h and prints a one-line notice on stderr when a newer
+# use-agent-os release exists (suppressed on non-TTY / CI runs). Set notify =
+# false to silence it. See docs/configuration.md#update-notifications.
+# [updates]
+# notify = true
+
 # Web search settings
 # Use Brave when a key is configured, otherwise keep DuckDuckGo.
 # search_provider = "duckduckgo"  # "duckduckgo" or "brave"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ agentos <command> --help
 | Command | Purpose |
 | --- | --- |
 | `agentos init` | Initialize a workspace. |
+| `agentos upgrade` | Upgrade AgentOS and restart the managed gateway to match. |
 | `agentos doctor` | Diagnose readiness and print recovery steps. |
 | `agentos onboard` | Run or inspect first-run setup. |
 | `agentos configure` | Reconfigure provider, router, channels, search, image generation, or memory embedding. |
@@ -51,6 +52,12 @@ agentos gateway restart
 agentos gateway stop
 ```
 
+`agentos gateway status` (and `--json`) reports **both** the installed CLI
+version (`cliVersion`) and the running gateway's version (`gatewayVersion`);
+when they differ it sets `versionMismatch` and prints a diagnostic advising a
+restart — the normal state right after a package upgrade with `--no-restart`,
+or after a manual upgrade.
+
 Terminal chat:
 
 ```sh
@@ -86,6 +93,72 @@ Useful automation flags:
 | `--transcript-path` | Write a JSONL transcript for automation. |
 | `--usage-path` | Write usage JSON. |
 | `--session-db-path` | Persist session replay across invocations. |
+
+## Upgrade
+
+`agentos upgrade` is the primary upgrade path. It detects how AgentOS was
+installed, upgrades it, and — by default — restarts the managed gateway and
+**verifies** the running gateway reports the new version before declaring
+success (a "successful" upgrade that leaves the daemon on old code is the
+common upgrade regret).
+
+```sh
+agentos upgrade                 # upgrade, restart the gateway, verify
+agentos upgrade --check         # is a newer release available? change nothing
+agentos upgrade --dry-run       # print the exact command that would run
+agentos upgrade --no-restart    # upgrade only; leave the gateway on OLD code
+agentos upgrade --timeout 900   # bound the upgrade subprocess (default 600s)
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--check` | Query PyPI for a newer release (5s timeout); offline prints `could not check (offline)`. Changes nothing. |
+| `--dry-run` | Print the upgrade command that would run and whether the gateway would be restarted; touch nothing. |
+| `--no-restart` | Upgrade the package but do not restart the gateway. Prints an unmissable warning that it still runs the old version; run `agentos gateway restart` yourself. |
+| `--timeout` | Upgrade-subprocess timeout in seconds (default 600). On timeout the tool's process group is killed with recovery guidance — never a half-state. |
+| `--config` | Target a specific config file for the gateway restart. |
+| `--json` | Machine-readable output. |
+
+Per install method:
+
+- **uv tool / pipx** — delegated automatically (`uv tool upgrade use-agent-os`
+  / `pipx upgrade use-agent-os`), resolving the tool to an absolute path over a
+  hardened PATH.
+- **pip / editable / source checkout** — not faked: prints the exact manual
+  command (e.g. `python -m pip install --upgrade "use-agent-os"`) and exits
+  with a distinct code.
+
+Exit codes: **0** success (upgraded + verified, or `--check`/`--dry-run`);
+**3** this install method needs a manual command (printed); **1** the upgrade
+failed, timed out, or the post-restart version could not be verified.
+
+Config migrations run at gateway start and write a timestamped backup before
+rewriting any file, so `~/.agentos/` config and data are safe across upgrades.
+
+### Version skew
+
+Commands that talk to the gateway compare the CLI and gateway versions once per
+run:
+
+- **Gateway older than the CLI** (normal right after an upgrade, before a
+  restart) — prints a warning on stderr, never blocks.
+- **Gateway newer than the CLI** (you downgraded the CLI, or drive a newer
+  gateway from a stale environment) — **refused**, because a newer gateway may
+  have written config with a newer schema. Fix by upgrading the CLI or
+  restarting the gateway from this environment; override in an emergency with
+  `AGENTOS_ALLOW_VERSION_SKEW=1`.
+
+### Update notifications
+
+On gateway-connected commands the CLI checks PyPI at most once every 24h and,
+if a newer release exists, prints a one-line notice on stderr. It is suppressed
+on non-interactive runs (no TTY) and in CI. Control it with:
+
+- `updates.notify = false` in `agentos.toml` (or the setup UI's Finish step) —
+  turns the notice off entirely.
+- `AGENTOS_NO_UPDATE_NOTICE=1` — silences it for a single run.
+
+See [`configuration.md`](configuration.md#update-notifications).
 
 ## Configuration Commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -350,10 +350,15 @@ Managed:
 
 ```sh
 agentos gateway start --json
-agentos gateway status
+agentos gateway status   # shows both the CLI and running-gateway versions
 agentos gateway stop
 agentos gateway restart
 ```
+
+`agentos gateway status` reports the installed CLI version and the running
+gateway's version; when they differ it appends a mismatch line advising a
+restart (typically after `agentos upgrade --no-restart` or a manual package
+upgrade).
 
 Bind precedence:
 
@@ -363,6 +368,29 @@ Bind precedence:
 4. `AGENTOS_GATEWAY_HOST`
 5. config host
 6. `127.0.0.1`
+
+## Update Notifications
+
+On commands that connect to the gateway, the CLI checks PyPI at most once every
+24h and, if a newer release of `use-agent-os` exists, prints a one-line notice
+on stderr suggesting `agentos upgrade`. The check is silent on failure and is
+suppressed on non-interactive runs (no TTY) and in CI.
+
+```toml
+[updates]
+notify = true   # set false to silence the "new release available" notice
+```
+
+`updates.notify` defaults to `true`. Set it from the setup UI (Finish step →
+Updates), with `agentos config` (a `config.patch` on `updates.notify`), or by
+editing the config file directly. The state file
+`~/.agentos/state/update_notice.json` tracks the last check time for
+throttling; delete it to force a re-check. To silence the notice for a single
+run without changing config, set `AGENTOS_NO_UPDATE_NOTICE=1`.
+
+Related: `agentos upgrade` (the primary upgrade path), the version-skew policy,
+and the `AGENTOS_ALLOW_VERSION_SKEW=1` escape hatch are documented in the
+[README Upgrade section](../README.md#upgrade).
 
 ## Raw Config Editing
 

--- a/src/agentos/cli/gateway_client.py
+++ b/src/agentos/cli/gateway_client.py
@@ -71,6 +71,7 @@ class GatewayClient:
         self._closing = False
         self._http_base: str | None = None
         self._auth_token: str | None = None
+        self._server_version: str | None = None
 
     async def connect(
         self,
@@ -148,6 +149,11 @@ class GatewayClient:
         hello = json.loads(raw)
         if hello.get("type") != "hello-ok":
             raise SystemExit(f"Handshake failed: {hello}")
+        # Capture the gateway's reported version from the handshake so callers
+        # can detect version skew without a second RPC round-trip.
+        server_info = hello.get("server") if isinstance(hello.get("server"), dict) else {}
+        version = server_info.get("version")
+        self._server_version = version if isinstance(version, str) and version else None
         policy = hello.get("policy") if isinstance(hello.get("policy"), dict) else {}
         self._heartbeat_interval = _heartbeat_interval_from_policy(policy)
 
@@ -165,6 +171,12 @@ class GatewayClient:
         """True when the connected gateway URL is loopback/same-machine."""
 
         return gateway_base_is_local(self._http_base)
+
+    @property
+    def server_version(self) -> str | None:
+        """Gateway version reported in the connect handshake, if any."""
+
+        return self._server_version
 
     async def upload_file(
         self,

--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -234,6 +234,80 @@ def start_gateway(
     _emit_lifecycle_result(manager.start(), json_output=json_output)
 
 
+def gateway_handshake_version(
+    *,
+    gateway_url: str | None = None,
+    config_path: str | None = None,
+) -> str | None:
+    """Return the running gateway's version from the connect handshake.
+
+    Lightweight: the version is carried in the hello-ok ServerInfo, so no RPC
+    method call is needed. Returns ``None`` when the gateway is unreachable.
+    """
+
+    import asyncio
+
+    from agentos.cli import gateway_client as gcm
+    from agentos.cli.gateway_rpc import _target_gateway_url, default_gateway_token
+
+    async def _go() -> str | None:
+        client = gcm.GatewayClient()
+        try:
+            url = _target_gateway_url(gateway_url=gateway_url, config_path=config_path)
+            await client.connect(url, token=default_gateway_token(config_path))
+            return client.server_version
+        except SystemExit:
+            return None
+        except (ConnectionError, OSError):
+            return None
+        finally:
+            await client.close()
+
+    try:
+        return asyncio.run(_go())
+    except Exception:  # noqa: BLE001 - status must never crash on a version probe
+        return None
+
+
+def _emit_status_with_versions(
+    result: GatewayLifecycleResult,
+    *,
+    gateway_version: str | None,
+    json_output: bool,
+) -> None:
+    """Emit a status result annotated with BOTH versions + a skew diagnostic."""
+
+    from agentos import __version__
+
+    cli_version = __version__
+    mismatch = bool(
+        gateway_version and gateway_version != cli_version
+    )
+
+    if json_output:
+        payload = result.to_payload()
+        payload["cliVersion"] = cli_version
+        payload["gatewayVersion"] = gateway_version
+        payload["versionMismatch"] = mismatch
+        typer.echo(json.dumps(payload, ensure_ascii=False, default=str))
+    else:
+        if result.ok:
+            typer.echo(f"{result.state}: {result.url}")
+        else:
+            typer.echo(f"Error: {result.message or result.code or result.state}", err=True)
+        typer.echo(f"CLI version:     {cli_version}")
+        typer.echo(f"Gateway version: {gateway_version or 'unknown (not running / unreachable)'}")
+        if mismatch:
+            typer.echo(
+                "⚠ Version mismatch — the running gateway does not match the installed "
+                "CLI. Run 'agentos gateway restart' (or 'agentos upgrade') to apply it.",
+                err=True,
+            )
+
+    if result.exit_code != 0:
+        raise typer.Exit(code=result.exit_code)
+
+
 def status_gateway(
     port: int | None = typer.Option(18791, "--port", "-p", help="Port to inspect"),
     bind: str | None = typer.Option("127.0.0.1", "--bind", "-b", help="Host to inspect"),
@@ -242,14 +316,26 @@ def status_gateway(
     gateway_url: str | None = typer.Option(None, "--gateway", help="Remote gateway URL"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """Inspect the managed gateway process without mutating state."""
+    """Inspect the managed gateway process without mutating state.
+
+    Reports BOTH the installed CLI version and the running gateway's
+    RPC-reported version; a mismatch appends a restart diagnostic.
+    """
 
     if gateway_url:
-        _emit_lifecycle_result(remote_gateway_status(gateway_url), json_output=json_output)
+        result = remote_gateway_status(gateway_url)
+        version = (
+            gateway_handshake_version(gateway_url=gateway_url) if result.ok else None
+        )
+        _emit_status_with_versions(result, gateway_version=version, json_output=json_output)
         return
 
     manager = _lifecycle_manager(port=port, bind=bind, listen=listen, config_path=config_path)
-    _emit_lifecycle_result(manager.status(), json_output=json_output)
+    result = manager.status()
+    version = None
+    if result.ok and result.state in ("running", "unmanaged"):
+        version = gateway_handshake_version(config_path=config_path)
+    _emit_status_with_versions(result, gateway_version=version, json_output=json_output)
 
 
 def stop_gateway(

--- a/src/agentos/cli/gateway_rpc.py
+++ b/src/agentos/cli/gateway_rpc.py
@@ -108,6 +108,46 @@ def rpc_error_exit_code(code: str | None) -> int:
     return 1
 
 
+def _apply_version_skew_policy(client: Any, *, json_output: bool) -> None:
+    """Warn (gateway older) or refuse (gateway newer) on CLI/gateway skew.
+
+    Runs once per invocation off the version reported in the connect
+    handshake. A gateway-newer refusal exits non-zero with remediation; the
+    ``AGENTOS_ALLOW_VERSION_SKEW=1`` escape hatch is honoured inside the policy.
+    """
+
+    from agentos import __version__
+    from agentos.cli.version_skew import SkewReporter, VersionSkewError
+
+    gateway_version = getattr(client, "server_version", None)
+    try:
+        SkewReporter().check(cli_version=__version__, gateway_version=gateway_version)
+    except VersionSkewError as exc:
+        emit_error(str(exc), json_output=json_output, code="VERSION_SKEW")
+        raise typer.Exit(3) from exc
+
+
+def _maybe_emit_update_notice(*, config_path: str | Path | None) -> None:
+    """Best-effort passive update notice; never affects command outcome."""
+
+    try:
+        from agentos import __version__
+        from agentos.cli.update_notice import maybe_emit_update_notice
+        from agentos.gateway.config import GatewayConfig
+
+        try:
+            config = GatewayConfig.load(
+                str(config_path)
+                if config_path is not None
+                else os.environ.get("AGENTOS_GATEWAY_CONFIG_PATH") or None
+            )
+        except Exception:  # noqa: BLE001 - config-loader robustness; notice is optional
+            config = None
+        maybe_emit_update_notice(current_version=__version__, config=config)
+    except Exception:  # noqa: BLE001 - a courtesy line must never break a command
+        pass
+
+
 async def run_gateway_call(
     action: Callable[[Any], Awaitable[Any]],
     *,
@@ -123,7 +163,10 @@ async def run_gateway_call(
     try:
         target_url = _target_gateway_url(gateway_url=gateway_url, config_path=config_path)
         await client.connect(target_url, token=default_gateway_token(config_path))
-        return await action(client)
+        _apply_version_skew_policy(client, json_output=json_output)
+        result = await action(client)
+        _maybe_emit_update_notice(config_path=config_path)
+        return result
     except SystemExit as exc:
         message = str(exc)
         emit_error(message, json_output=json_output, code="GATEWAY_UNAVAILABLE")

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -1,0 +1,232 @@
+"""Detect how the running ``agentos`` was installed and how to upgrade it.
+
+Two independent hazards from the OpenClaw / Hermes case studies drive this
+module:
+
+* **Wrong upgrade channel** — running ``pip install -U`` against a uv-tool
+  install silently no-ops (or corrupts the tool venv). We inspect where the
+  running executable / package actually lives and pick the matching upgrade
+  command, and for plain-pip / editable installs we refuse to fake it.
+
+* **PATH gaps on macOS** (Hermes's #1 incident cluster) — the upgrade
+  subprocess hangs or fails because ``uv`` / ``pipx`` is not on the ``PATH``
+  the daemon inherited. We resolve the delegated tool to an ABSOLUTE path
+  against an environment augmented with the standard login locations before
+  spawning anything.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+DIST_NAME = "use-agent-os"
+
+# Standard login-shell locations that a GUI-launched or daemon-inherited
+# environment frequently drops. Appended (not prepended) so an operator's own
+# PATH ordering still wins.
+_LOGIN_PATH_DIRS = (
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+)
+
+
+class InstallMethod(StrEnum):
+    UV_TOOL = "uv-tool"
+    PIPX = "pipx"
+    PIP = "pip"
+    EDITABLE = "editable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class UpgradePlan:
+    """How to upgrade the running install.
+
+    ``delegated`` is True when AgentOS can run the upgrade itself (uv-tool /
+    pipx). When False, ``command`` is the exact command the operator must run
+    by hand and the ``upgrade`` command exits 3 rather than pretending.
+    """
+
+    method: InstallMethod
+    delegated: bool
+    tool: str | None
+    command: list[str]
+    manual_hint: str
+
+
+def _package_location() -> Path:
+    """Absolute path to the installed ``agentos`` package directory."""
+
+    import agentos
+
+    return Path(agentos.__file__).resolve().parent
+
+
+def _looks_editable(pkg_dir: Path) -> bool:
+    """True when the package is imported from a source checkout (editable/-e).
+
+    An editable install lives in the project tree (``src/agentos``) rather than
+    under a ``site-packages`` directory.
+    """
+
+    parts = pkg_dir.parts
+    if "site-packages" in parts or "dist-packages" in parts:
+        return False
+    # ``src/agentos`` layout is the tell-tale of this repo's editable install.
+    return pkg_dir.parent.name == "src" or (pkg_dir.parent / "pyproject.toml").exists()
+
+
+def _under(path: Path, *needles: str) -> bool:
+    lowered = [part.lower() for part in path.parts]
+    return any(needle in lowered for needle in needles)
+
+
+def detect_install_method(
+    *,
+    executable: str | None = None,
+    package_dir: Path | None = None,
+) -> InstallMethod:
+    """Classify the running install.
+
+    ``executable`` / ``package_dir`` are injectable for tests; they default to
+    ``sys.executable`` and the real ``agentos`` package location.
+    """
+
+    exe = Path(executable or sys.executable).resolve()
+    pkg_dir = package_dir if package_dir is not None else _package_location()
+
+    # Editable / source checkout first: it can otherwise masquerade as pip.
+    if _looks_editable(pkg_dir):
+        return InstallMethod.EDITABLE
+
+    # uv tool installs live under the uv tools root, e.g.
+    #   ~/.local/share/uv/tools/use-agent-os/...
+    #   $XDG_DATA_HOME/uv/tools/... / $UV_TOOL_DIR/...
+    for candidate in (exe, pkg_dir):
+        parts = [p.lower() for p in candidate.parts]
+        if "uv" in parts and "tools" in parts:
+            return InstallMethod.UV_TOOL
+
+    # pipx venvs: ~/.local/share/pipx/venvs/<name>/ or $PIPX_HOME/venvs/...
+    for candidate in (exe, pkg_dir):
+        if _under(candidate, "pipx"):
+            return InstallMethod.PIPX
+
+    if "site-packages" in [p.lower() for p in pkg_dir.parts] or "dist-packages" in [
+        p.lower() for p in pkg_dir.parts
+    ]:
+        return InstallMethod.PIP
+
+    return InstallMethod.UNKNOWN
+
+
+def hardened_path_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Return an env copy whose ``PATH`` includes the standard login dirs.
+
+    The augmented directories are *appended* so an operator's own ordering is
+    preserved; only genuinely-missing login locations are added.
+    """
+
+    env = dict(base_env if base_env is not None else os.environ)
+    current = env.get("PATH", "")
+    entries = [p for p in current.split(os.pathsep) if p]
+    seen = set(entries)
+    home = env.get("HOME") or str(Path.home())
+    login_dirs = list(_LOGIN_PATH_DIRS) + [str(Path(home) / ".local" / "bin")]
+    for extra in login_dirs:
+        if extra not in seen:
+            entries.append(extra)
+            seen.add(extra)
+    env["PATH"] = os.pathsep.join(entries)
+    return env
+
+
+def resolve_tool(tool: str, env: dict[str, str] | None = None) -> str | None:
+    """Resolve ``tool`` (``uv`` / ``pipx``) to an ABSOLUTE path.
+
+    Uses a PATH-hardened environment so a daemon-inherited PATH missing
+    ``/opt/homebrew/bin`` etc. still finds the tool. Returns ``None`` when the
+    tool genuinely cannot be found.
+    """
+
+    hardened = hardened_path_env(env)
+    resolved = shutil.which(tool, path=hardened.get("PATH"))
+    if resolved:
+        return str(Path(resolved).resolve())
+    return None
+
+
+def build_upgrade_plan(
+    *,
+    method: InstallMethod | None = None,
+    env: dict[str, str] | None = None,
+    dist: str = DIST_NAME,
+) -> UpgradePlan:
+    """Build the :class:`UpgradePlan` for the running install."""
+
+    resolved_method = method if method is not None else detect_install_method()
+
+    if resolved_method is InstallMethod.UV_TOOL:
+        uv = resolve_tool("uv", env)
+        if uv is not None:
+            return UpgradePlan(
+                method=resolved_method,
+                delegated=True,
+                tool=uv,
+                command=[uv, "tool", "upgrade", dist],
+                manual_hint=f"uv tool upgrade {dist}",
+            )
+        return UpgradePlan(
+            method=resolved_method,
+            delegated=False,
+            tool=None,
+            command=["uv", "tool", "upgrade", dist],
+            manual_hint=f"uv tool upgrade {dist}",
+        )
+
+    if resolved_method is InstallMethod.PIPX:
+        pipx = resolve_tool("pipx", env)
+        if pipx is not None:
+            return UpgradePlan(
+                method=resolved_method,
+                delegated=True,
+                tool=pipx,
+                command=[pipx, "upgrade", dist],
+                manual_hint=f"pipx upgrade {dist}",
+            )
+        return UpgradePlan(
+            method=resolved_method,
+            delegated=False,
+            tool=None,
+            command=["pipx", "upgrade", dist],
+            manual_hint=f"pipx upgrade {dist}",
+        )
+
+    if resolved_method is InstallMethod.EDITABLE:
+        return UpgradePlan(
+            method=resolved_method,
+            delegated=False,
+            tool=None,
+            command=["git", "pull"],
+            manual_hint=(
+                "editable / source checkout — pull the repo and reinstall: "
+                "git pull && uv sync"
+            ),
+        )
+
+    # PIP + UNKNOWN: hand back the exact pip command, never fake it.
+    pip_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", dist]
+    return UpgradePlan(
+        method=resolved_method,
+        delegated=False,
+        tool=None,
+        command=pip_cmd,
+        manual_hint=f"{sys.executable} -m pip install --upgrade {dist}",
+    )

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -88,27 +88,75 @@ def _under(path: Path, *needles: str) -> bool:
     return any(needle in lowered for needle in needles)
 
 
+def _uv_tools_roots(env: dict[str, str]) -> list[Path]:
+    """Resolved uv-tools root directories to prefix-match against.
+
+    ``UV_TOOL_DIR`` overrides the default ``~/.local/share/uv/tools`` location
+    entirely (uv honours it), so a custom value must be treated as a first-class
+    tools root — otherwise a uv-tool install under it is misclassified and we
+    hand back the actively-wrong ``pip`` suggestion (a uv tool venv has no pip).
+    """
+
+    roots: list[Path] = []
+    override = env.get("UV_TOOL_DIR", "").strip()
+    if override:
+        try:
+            roots.append(Path(override).resolve())
+        except OSError:
+            pass
+    return roots
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """True when ``path`` is ``root`` or lives beneath it (both resolved)."""
+
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def detect_install_method(
     *,
     executable: str | None = None,
     package_dir: Path | None = None,
+    env: dict[str, str] | None = None,
 ) -> InstallMethod:
     """Classify the running install.
 
-    ``executable`` / ``package_dir`` are injectable for tests; they default to
-    ``sys.executable`` and the real ``agentos`` package location.
+    ``executable`` / ``package_dir`` / ``env`` are injectable for tests; they
+    default to ``sys.executable``, the real ``agentos`` package location, and
+    ``os.environ``.
     """
 
-    exe = Path(executable or sys.executable).resolve()
+    environ = env if env is not None else dict(os.environ)
+    raw_exe = Path(executable or sys.executable)
+    exe = raw_exe.resolve()
     pkg_dir = package_dir if package_dir is not None else _package_location()
 
     # Editable / source checkout first: it can otherwise masquerade as pip.
     if _looks_editable(pkg_dir):
         return InstallMethod.EDITABLE
 
+    # A custom UV_TOOL_DIR relocates the whole tools tree; the executable may
+    # even be a symlink from a bin dir INTO that tree, so check both the raw path
+    # and its symlink-resolved target against the override root.
+    uv_roots = _uv_tools_roots(environ)
+    if uv_roots:
+        candidates: list[Path] = []
+        for candidate in (raw_exe, exe, pkg_dir):
+            candidates.append(candidate)
+            try:
+                candidates.append(candidate.resolve())
+            except OSError:
+                pass
+        if any(_is_within(c, root) for c in candidates for root in uv_roots):
+            return InstallMethod.UV_TOOL
+
     # uv tool installs live under the uv tools root, e.g.
     #   ~/.local/share/uv/tools/use-agent-os/...
-    #   $XDG_DATA_HOME/uv/tools/... / $UV_TOOL_DIR/...
+    #   $XDG_DATA_HOME/uv/tools/...
     for candidate in (exe, pkg_dir):
         parts = [p.lower() for p in candidate.parts]
         if "uv" in parts and "tools" in parts:
@@ -221,12 +269,28 @@ def build_upgrade_plan(
             ),
         )
 
-    # PIP + UNKNOWN: hand back the exact pip command, never fake it.
-    pip_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", dist]
+    if resolved_method is InstallMethod.PIP:
+        # A genuine site-packages install: pip is the right upgrade tool.
+        pip_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", dist]
+        return UpgradePlan(
+            method=resolved_method,
+            delegated=False,
+            tool=None,
+            command=pip_cmd,
+            manual_hint=f"{sys.executable} -m pip install --upgrade {dist}",
+        )
+
+    # UNKNOWN: we could not classify the install, so a blind ``python -m pip``
+    # may be actively wrong (e.g. a uv/pipx venv has no pip). List all three
+    # installers and let the operator pick the one they originally used.
     return UpgradePlan(
         method=resolved_method,
         delegated=False,
         tool=None,
-        command=pip_cmd,
-        manual_hint=f"{sys.executable} -m pip install --upgrade {dist}",
+        command=[sys.executable, "-m", "pip", "install", "--upgrade", dist],
+        manual_hint=(
+            "could not detect the install method — reinstall/upgrade with your "
+            f"original installer, e.g.:\n    uv tool install {dist}\n    "
+            f"pipx install {dist}\n    {sys.executable} -m pip install --upgrade {dist}"
+        ),
     )

--- a/src/agentos/cli/main.py
+++ b/src/agentos/cli/main.py
@@ -34,6 +34,7 @@ from agentos.cli.sandbox_cmd import sandbox_app  # noqa: E402
 from agentos.cli.search_cmd import search_app  # noqa: E402
 from agentos.cli.sessions_cmd import app as sessions_app  # noqa: E402
 from agentos.cli.skills_cmd import skills_app  # noqa: E402
+from agentos.cli.upgrade_cmd import upgrade_command  # noqa: E402
 
 app = typer.Typer(
     name="agentos",
@@ -62,6 +63,7 @@ app.add_typer(skills_app, name="skills")
 
 app.command("init")(init_command)
 app.command("doctor")(doctor_command)
+app.command("upgrade")(upgrade_command)
 app.add_typer(onboard_app, name="onboard")
 app.command("configure")(configure_command)
 

--- a/src/agentos/cli/pypi_client.py
+++ b/src/agentos/cli/pypi_client.py
@@ -1,0 +1,59 @@
+"""Tiny isolated PyPI client for the upgrade check + passive update notice.
+
+Network access is quarantined here so every caller (``agentos upgrade
+--check``, the passive update notice, the skew path) shares one code path that
+is trivially mockable in tests. The client never raises on a network / offline
+failure: it returns ``None`` so callers degrade to "could not check" instead of
+crashing a command whose real job is something else.
+"""
+
+from __future__ import annotations
+
+DIST_NAME = "use-agent-os"
+_PYPI_JSON_URL = "https://pypi.org/pypi/{dist}/json"
+
+
+def latest_version(
+    dist: str = DIST_NAME,
+    *,
+    timeout: float = 5.0,
+) -> str | None:
+    """Return the latest released version string of ``dist`` on PyPI.
+
+    Returns ``None`` on any failure (offline, timeout, HTTP error, malformed
+    body). Yanked-only / pre-release-only edge cases fall back to the
+    ``info.version`` field PyPI reports as canonical.
+    """
+
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - httpx is a hard dependency
+        return None
+
+    url = _PYPI_JSON_URL.format(dist=dist)
+    try:
+        response = httpx.get(
+            url,
+            timeout=timeout,
+            headers={"Accept": "application/json"},
+            follow_redirects=True,
+        )
+    except Exception:  # noqa: BLE001 - offline / DNS / TLS / timeout all degrade to None
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    try:
+        body = response.json()
+    except Exception:  # noqa: BLE001 - malformed body
+        return None
+
+    if not isinstance(body, dict):
+        return None
+    info = body.get("info")
+    if isinstance(info, dict):
+        version = info.get("version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None

--- a/src/agentos/cli/update_notice.py
+++ b/src/agentos/cli/update_notice.py
@@ -1,0 +1,123 @@
+"""Passive, gh-style "a new release is available" notice.
+
+Emitted at most once per 24h on RPC-connected commands only (never on offline
+paths). Every failure mode is silent — this is a courtesy line, never a reason
+to slow down or break a command.
+
+Suppression matrix (any one suppresses):
+  * stderr is not a TTY            (piped / captured output)
+  * a CI environment variable set  (CI / GITHUB_ACTIONS / …)
+  * config ``updates.notify = false``
+  * checked within the last 24h    (state file timestamp)
+  * ``AGENTOS_NO_UPDATE_NOTICE=1`` escape hatch
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from agentos.paths import state_dir
+
+_CHECK_INTERVAL_S = 24 * 60 * 60
+_STATE_FILE = ("update_notice.json",)
+# Env vars that mark an automated / non-interactive context.
+_CI_ENV_VARS = ("CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS", "BUILDKITE", "GITLAB_CI")
+
+
+def notice_state_path() -> Path:
+    return state_dir(*_STATE_FILE)
+
+
+def _stderr_is_tty() -> bool:
+    try:
+        return bool(sys.stderr.isatty())
+    except Exception:  # noqa: BLE001 - defensive; a broken stderr just suppresses
+        return False
+
+
+def _ci_active() -> bool:
+    return any(os.environ.get(var, "").strip() for var in _CI_ENV_VARS)
+
+
+def _read_state(path: Path) -> dict[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_state(path: Path, last_checked: float, latest: str | None) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, object] = {"last_checked": last_checked}
+        if latest:
+            payload["latest"] = latest
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass  # best-effort; a read-only home just means we re-check next time
+
+
+def _due_for_check(path: Path, now: float) -> bool:
+    state = _read_state(path)
+    last = state.get("last_checked")
+    if not isinstance(last, int | float):
+        return True
+    return (now - float(last)) >= _CHECK_INTERVAL_S
+
+
+def _config_notify_enabled(config: object | None) -> bool:
+    updates = getattr(config, "updates", None)
+    if updates is None:
+        return True
+    return bool(getattr(updates, "notify", True))
+
+
+def maybe_emit_update_notice(
+    *,
+    current_version: str,
+    config: object | None = None,
+    now: float | None = None,
+    force: bool = False,
+) -> str | None:
+    """Emit the update notice to stderr if all suppression checks pass.
+
+    Returns the message that was emitted (for tests), or ``None`` when
+    suppressed. Network access is delegated to :mod:`pypi_client` and fully
+    mockable; failures are silent.
+    """
+
+    if os.environ.get("AGENTOS_NO_UPDATE_NOTICE", "").strip() == "1":
+        return None
+    if not force:
+        if not _stderr_is_tty():
+            return None
+        if _ci_active():
+            return None
+    if not _config_notify_enabled(config):
+        return None
+
+    now = time.time() if now is None else now
+    path = notice_state_path()
+    if not force and not _due_for_check(path, now):
+        return None
+
+    from agentos.cli.pypi_client import latest_version
+    from agentos.cli.version_utils import is_newer
+
+    latest = latest_version(timeout=2.0)
+    # Record the check regardless of outcome so an offline run still throttles.
+    _write_state(path, now, latest)
+    if not latest or not is_newer(latest, current_version):
+        return None
+
+    message = (
+        f"A new release of use-agent-os is available: "
+        f"{current_version} → {latest}. Run 'agentos upgrade'."
+    )
+    print(message, file=sys.stderr)
+    return message

--- a/src/agentos/cli/upgrade_cmd.py
+++ b/src/agentos/cli/upgrade_cmd.py
@@ -1,0 +1,359 @@
+"""``agentos upgrade`` — upgrade the package and restart the managed gateway.
+
+Design derived from the OpenClaw / Nous Hermes daemon+CLI case studies. Two
+regrets drive the whole command:
+
+* **Silent version skew** — a "successful" upgrade that leaves the daemon on
+  old code. So a successful package upgrade restarts the managed gateway by
+  default and then VERIFIES the running version equals the new one before
+  reporting success.
+* **Upgrade subprocess hangs on macOS** (Hermes) — PATH gaps and no timeout.
+  So the delegated tool is resolved to an absolute path against a hardened
+  PATH, the subprocess runs under a bounded timeout, and on timeout the whole
+  process group is killed with recovery guidance. Never a half-state.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+import typer
+
+from agentos import __version__
+from agentos.cli.install_method import build_upgrade_plan, hardened_path_env
+from agentos.cli.ui import console
+
+# Default upgrade-subprocess timeout (seconds). Overridable via --timeout.
+_DEFAULT_TIMEOUT_S = 600.0
+# Bounded wait for the restarted gateway to report the new version.
+_VERIFY_TIMEOUT_S = 30.0
+_VERIFY_POLL_S = 0.5
+
+
+@dataclass
+class UpgradeRunResult:
+    ok: bool
+    timed_out: bool
+    returncode: int | None
+    stdout: str
+    stderr: str
+
+
+def _installed_version_via(executable: str, *, env: dict[str, str]) -> str | None:
+    """Read the installed dist version using a FRESH subprocess of ``executable``.
+
+    Running in a fresh process of the (possibly upgraded) interpreter avoids
+    the stale ``importlib.metadata`` cache of the currently-running process.
+    """
+
+    code = "import importlib.metadata as m; print(m.version('use-agent-os'))"
+    try:
+        proc = subprocess.run(  # noqa: S603 - argv built internally
+            [executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=15.0,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = (proc.stdout or "").strip()
+    return out or None
+
+
+def _run_upgrade_subprocess(
+    command: list[str],
+    *,
+    env: dict[str, str],
+    timeout: float,
+) -> UpgradeRunResult:
+    """Run the delegated upgrade command under a hard timeout.
+
+    On timeout the whole process group is killed (SIGKILL after SIGTERM) so no
+    half-finished child survives — a hung ``uv``/``pipx`` invocation must never
+    leave a background zombie.
+    """
+
+    start_new_session = os.name != "nt"
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - argv built internally
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            start_new_session=start_new_session,
+        )
+    except OSError as exc:
+        return UpgradeRunResult(
+            ok=False, timed_out=False, returncode=None, stdout="", stderr=str(exc)
+        )
+
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_group(proc)
+        stdout, stderr = proc.communicate()
+        return UpgradeRunResult(
+            ok=False,
+            timed_out=True,
+            returncode=proc.returncode,
+            stdout=stdout or "",
+            stderr=stderr or "",
+        )
+
+    return UpgradeRunResult(
+        ok=proc.returncode == 0,
+        timed_out=False,
+        returncode=proc.returncode,
+        stdout=stdout or "",
+        stderr=stderr or "",
+    )
+
+
+def _kill_process_group(proc: subprocess.Popen[str]) -> None:
+    if os.name == "nt":
+        proc.kill()
+        return
+    try:
+        pgid = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        return
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return
+        except OSError:
+            return
+        time.sleep(0.2)
+        if proc.poll() is not None:
+            return
+
+
+def _query_gateway_version(config_path: str | None) -> str | None:
+    """Return the gateway's handshake-reported version (or ``None``)."""
+
+    from agentos.cli.gateway_cmd import gateway_handshake_version
+
+    return gateway_handshake_version(config_path=config_path)
+
+
+def _restart_and_verify(
+    *,
+    config_path: str | None,
+    expected_version: str,
+    json_output: bool,
+) -> bool:
+    """Restart the managed gateway (if running) and verify the new version.
+
+    Returns True on verified restart (or nothing-to-restart), False on failure.
+    """
+
+    from agentos.cli.gateway_cmd import _lifecycle_manager
+
+    manager = _lifecycle_manager(port=None, bind=None, listen="", config_path=config_path)
+    status = manager.status()
+    if not (status.state == "running" and status.managed):
+        console.print(
+            "[dim]Gateway is not running (managed) — nothing to restart. "
+            "It will pick up the new version on next start.[/dim]"
+        )
+        return True
+
+    console.print("Restarting managed gateway…")
+    result = manager.restart()
+    if result.exit_code != 0:
+        console.print(
+            f"[red]Gateway restart failed:[/red] {result.message or result.code or result.state}"
+        )
+        return False
+
+    deadline = time.monotonic() + _VERIFY_TIMEOUT_S
+    observed: str | None = None
+    while time.monotonic() <= deadline:
+        observed = _query_gateway_version(config_path)
+        if observed == expected_version:
+            console.print(f"Gateway: restarted and verified ({expected_version}).")
+            return True
+        time.sleep(_VERIFY_POLL_S)
+
+    console.print(
+        f"[red]Gateway restart could not be verified.[/red] Expected "
+        f"{expected_version}, gateway reports {observed or 'unreachable'}.\n"
+        "Recovery: run 'agentos gateway status' to inspect, then "
+        "'agentos gateway restart' to retry.",
+    )
+    return False
+
+
+def _emit_no_restart_warning(new_version: str) -> None:
+    old = __version__
+    print(
+        f"⚠ Gateway still running OLD version {old} — run 'agentos gateway restart' "
+        f"to apply {new_version}.",
+        file=sys.stderr,
+    )
+
+
+def upgrade_command(
+    check: bool = typer.Option(
+        False, "--check", help="Only report whether a newer version exists; change nothing."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print what would run and touch nothing."
+    ),
+    no_restart: bool = typer.Option(
+        False, "--no-restart", help="Do not restart the managed gateway after upgrading."
+    ),
+    timeout: float = typer.Option(
+        _DEFAULT_TIMEOUT_S, "--timeout", help="Upgrade subprocess timeout in seconds."
+    ),
+    config_path: str | None = typer.Option(None, "--config", help="Override config path."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Upgrade AgentOS and restart the managed gateway to match.
+
+    Detects the install method (uv-tool / pipx / pip / editable) and delegates
+    to the right upgrade command. Config migrations (with an automatic
+    timestamped backup) run at gateway start.
+    """
+
+    from agentos.cli.output import print_json
+
+    plan = build_upgrade_plan()
+    env = hardened_path_env()
+
+    # --check: query PyPI without changing anything.
+    if check:
+        from agentos.cli.pypi_client import latest_version
+        from agentos.cli.version_utils import is_newer
+
+        latest = latest_version(timeout=5.0)
+        if latest is None:
+            msg = "could not check (offline)"
+            if json_output:
+                print_json({"current": __version__, "latest": None, "status": "offline"})
+            else:
+                console.print(msg)
+            raise typer.Exit(0)
+        newer = is_newer(latest, __version__)
+        if json_output:
+            print_json(
+                {
+                    "current": __version__,
+                    "latest": latest,
+                    "status": "outdated" if newer else "up-to-date",
+                }
+            )
+        elif newer:
+            console.print(f"A newer version is available: {__version__} → {latest}")
+        else:
+            console.print(f"Up to date ({__version__}).")
+        raise typer.Exit(0)
+
+    # Non-delegated installs: print the exact manual command, exit 3.
+    if not plan.delegated:
+        message = (
+            f"AgentOS was installed via {plan.method.value}; automatic upgrade is not "
+            f"available for this method.\nRun this to upgrade:\n    {plan.manual_hint}"
+        )
+        if json_output:
+            print_json(
+                {
+                    "method": plan.method.value,
+                    "delegated": False,
+                    "manualCommand": plan.manual_hint,
+                }
+            )
+        else:
+            console.print(message)
+        raise typer.Exit(3)
+
+    # --dry-run: print what would run, touch nothing.
+    if dry_run:
+        printable = " ".join(plan.command)
+        if json_output:
+            print_json(
+                {
+                    "method": plan.method.value,
+                    "command": plan.command,
+                    "wouldRestart": not no_restart,
+                    "dryRun": True,
+                }
+            )
+        else:
+            console.print(f"Would run: {printable}")
+            console.print(
+                "Would then restart and verify the managed gateway."
+                if not no_restart
+                else "Would NOT restart the gateway (--no-restart)."
+            )
+        raise typer.Exit(0)
+
+    # Execute the delegated upgrade under a bounded timeout.
+    console.print(f"Upgrading use-agent-os via {plan.method.value}…")
+    result = _run_upgrade_subprocess(plan.command, env=env, timeout=timeout)
+    if result.stdout.strip():
+        console.print(result.stdout.strip())
+
+    if result.timed_out:
+        console.print(
+            f"[red]Upgrade timed out after {timeout:.0f}s and was terminated.[/red]\n"
+            "The upgrade tool was killed (process group), so no half-finished child "
+            "is left running.\nRecovery: re-run 'agentos upgrade' (optionally with a "
+            f"larger --timeout), or run '{plan.manual_hint}' manually.",
+        )
+        raise typer.Exit(1)
+
+    if not result.ok:
+        console.print(
+            f"[red]Upgrade failed (exit {result.returncode}).[/red]\n"
+            f"{result.stderr.strip()}"
+        )
+        raise typer.Exit(1)
+
+    # Report old → new by reading the version from a fresh subprocess of the
+    # (now upgraded) executable, avoiding this process's stale metadata cache.
+    new_version = _installed_version_via(sys.executable, env=env) or "unknown"
+    console.print(f"Upgraded: {__version__} → {new_version}")
+    console.print(
+        "[dim]Config migrations (with an automatic timestamped backup) run at "
+        "gateway start.[/dim]"
+    )
+
+    if no_restart:
+        _emit_no_restart_warning(new_version)
+        if json_output:
+            print_json(
+                {
+                    "old": __version__,
+                    "new": new_version,
+                    "restarted": False,
+                    "gatewayVersionApplied": False,
+                }
+            )
+        raise typer.Exit(0)
+
+    verified = _restart_and_verify(
+        config_path=config_path,
+        expected_version=new_version,
+        json_output=json_output,
+    )
+    if json_output:
+        print_json(
+            {
+                "old": __version__,
+                "new": new_version,
+                "restarted": True,
+                "verified": verified,
+            }
+        )
+    if not verified:
+        raise typer.Exit(1)
+    raise typer.Exit(0)

--- a/src/agentos/cli/version_skew.py
+++ b/src/agentos/cli/version_skew.py
@@ -1,0 +1,103 @@
+"""Version-skew policy for CLI commands that talk to the running gateway.
+
+The #1 documented post-upgrade regret across the case studies is SILENT VERSION
+SKEW: the package upgrades, the daemon keeps running old code, the command
+reports success, and the operator then debugs phantom config bugs. This module
+makes skew loud.
+
+Two directions, asymmetric on purpose:
+
+* **Gateway OLDER than CLI** (the typical post-upgrade state): warn on stderr,
+  never block. The operator just needs to restart the gateway.
+* **Gateway NEWER than CLI** (operator downgraded the CLI, or is driving a
+  newer gateway from a stale environment): REFUSE. A newer gateway may have
+  written config with newer schema; an older CLI acting on it risks
+  corruption. An ``AGENTOS_ALLOW_VERSION_SKEW=1`` escape hatch exists for
+  emergencies.
+
+Throttled to a single warning line per invocation via ``SkewReporter``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from agentos.cli.version_utils import compare_versions
+
+ALLOW_SKEW_ENV = "AGENTOS_ALLOW_VERSION_SKEW"
+
+
+class VersionSkewError(Exception):
+    """Raised when the gateway is NEWER than the CLI and skew is not allowed."""
+
+
+def _skew_allowed() -> bool:
+    return os.environ.get(ALLOW_SKEW_ENV, "").strip() == "1"
+
+
+def evaluate_skew(*, cli_version: str, gateway_version: str | None) -> str | None:
+    """Classify the CLI/gateway version relationship.
+
+    Returns one of ``None`` (equal / unknown), ``"gateway_older"``, or
+    ``"gateway_newer"``.
+    """
+
+    if not gateway_version:
+        return None
+    cmp = compare_versions(gateway_version, cli_version)
+    if cmp < 0:
+        return "gateway_older"
+    if cmp > 0:
+        return "gateway_newer"
+    return None
+
+
+class SkewReporter:
+    """Emits at most one skew warning per invocation; enforces the refusal."""
+
+    def __init__(self) -> None:
+        self._warned = False
+
+    def check(
+        self,
+        *,
+        cli_version: str,
+        gateway_version: str | None,
+    ) -> None:
+        """Warn or refuse based on the skew direction.
+
+        Raises :class:`VersionSkewError` when the gateway is newer and the
+        escape hatch is not set. Warns to stderr (once) when the gateway is
+        older.
+        """
+
+        state = evaluate_skew(cli_version=cli_version, gateway_version=gateway_version)
+        if state == "gateway_older":
+            if self._warned:
+                return
+            self._warned = True
+            print(
+                f"⚠ Gateway is running an OLDER version ({gateway_version}) than the "
+                f"CLI ({cli_version}). Run 'agentos gateway restart' to apply the "
+                f"upgrade.",
+                file=sys.stderr,
+            )
+            return
+        if state == "gateway_newer":
+            if _skew_allowed():
+                if not self._warned:
+                    self._warned = True
+                    print(
+                        f"⚠ Gateway ({gateway_version}) is NEWER than the CLI "
+                        f"({cli_version}); proceeding because {ALLOW_SKEW_ENV}=1.",
+                        file=sys.stderr,
+                    )
+                return
+            raise VersionSkewError(
+                f"Gateway ({gateway_version}) is NEWER than this CLI ({cli_version}). "
+                "The gateway may have written config with a newer schema, so this "
+                "older CLI refuses to act on it. Upgrade the CLI (agentos upgrade) "
+                "or restart the gateway from this environment. To override in an "
+                f"emergency, set {ALLOW_SKEW_ENV}=1."
+            )

--- a/src/agentos/cli/version_utils.py
+++ b/src/agentos/cli/version_utils.py
@@ -1,0 +1,122 @@
+"""Dependency-free version comparison for the upgrade / skew machinery.
+
+AgentOS ships CalVer / PEP 440 style versions (``2026.7.18``,
+``2026.7.18.post1``, ``0.0.0+unknown``). The upgrade command, the passive
+update notice, and the version-skew policy all need to answer one question:
+"is version A older / newer / equal to version B?" — without pulling in a new
+runtime dependency (``packaging``) purely for that.
+
+The parser here handles the release segment plus the common pre-release
+(``rcN`` / ``aN`` / ``bN``), ``.postN``, and ``.devN`` tails, and ignores the
+local version label (``+unknown``) for ordering. It is intentionally small: it
+is NOT a full PEP 440 implementation, but it is exact for the versions AgentOS
+actually ships, and it degrades to a stable total ordering for anything it does
+not fully understand rather than raising.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import Any
+
+# release [ {a|b|rc}N ] [ .postN ] [ .devN ] [ +local ]
+_VERSION_RE = re.compile(
+    r"^\s*v?"
+    r"(?P<release>\d+(?:\.\d+)*)"
+    r"(?:[._-]?(?P<pre_l>a|b|c|rc|alpha|beta|pre|preview)[._-]?(?P<pre_n>\d+)?)?"
+    r"(?:[._-]?post[._-]?(?P<post>\d+)?)?"
+    r"(?:[._-]?dev[._-]?(?P<dev>\d+)?)?"
+    r"(?:\+(?P<local>[a-zA-Z0-9.]+))?"
+    r"\s*$"
+)
+
+# Ordering weight for the pre-release phase (lower = earlier).
+_PRE_ORDER = {"a": 0, "alpha": 0, "b": 1, "beta": 1, "c": 2, "rc": 2, "pre": 2, "preview": 2}
+
+
+@total_ordering
+@dataclass(frozen=True)
+class Version:
+    """A parsed, comparable version.
+
+    Phase ordering within one release number is
+    ``dev < pre < final < post``. Unparsable input sorts below every real
+    release so a stale ``0.0.0+unknown`` never spuriously looks *newer* than a
+    running gateway.
+    """
+
+    raw: str
+    release: tuple[int, ...]
+    pre: tuple[int, int] | None
+    post: int | None
+    dev: int | None
+    parsed: bool
+
+    def sort_key(self, width: int) -> tuple[Any, ...]:
+        release = self.release + (0,) * (width - len(self.release))
+        if not self.parsed:
+            # All unparsable versions sort together, below any real release,
+            # but a given raw string stays equal to itself.
+            return ((-1,) * width, (-1,), self.raw)
+        if self.dev is not None and self.pre is None and self.post is None:
+            phase: tuple[int, ...] = (0, self.dev)
+        elif self.pre is not None:
+            dev_tie = -1 if self.dev is None else self.dev
+            phase = (1, self.pre[0], self.pre[1], dev_tie)
+        elif self.post is not None:
+            dev_tie = -1 if self.dev is None else self.dev
+            phase = (3, self.post, dev_tie)
+        else:
+            phase = (2,)
+        return (release, phase, "")
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        width = max(len(self.release), len(other.release))
+        return self.sort_key(width) == other.sort_key(width)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        width = max(len(self.release), len(other.release))
+        return self.sort_key(width) < other.sort_key(width)
+
+
+def parse_version(value: str | None) -> Version:
+    """Parse ``value`` into a :class:`Version` (never raises)."""
+
+    raw = (value or "").strip()
+    match = _VERSION_RE.match(raw)
+    if not match:
+        return Version(raw=raw, release=(-1,), pre=None, post=None, dev=None, parsed=False)
+
+    release = tuple(int(part) for part in match.group("release").split("."))
+    pre: tuple[int, int] | None = None
+    if match.group("pre_l"):
+        pre = (_PRE_ORDER.get(match.group("pre_l"), 2), int(match.group("pre_n") or 0))
+    post = int(match.group("post")) if match.group("post") is not None else None
+    if post is None and re.search(r"[._-]?post", raw):
+        post = 0
+    dev = int(match.group("dev")) if match.group("dev") is not None else None
+    return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
+
+
+def compare_versions(a: str | None, b: str | None) -> int:
+    """Return -1 if ``a < b``, 0 if equal, 1 if ``a > b``."""
+
+    va = parse_version(a)
+    vb = parse_version(b)
+    if va < vb:
+        return -1
+    if va > vb:
+        return 1
+    return 0
+
+
+def is_newer(candidate: str | None, current: str | None) -> bool:
+    """True when ``candidate`` is strictly newer than ``current``."""
+
+    return compare_versions(candidate, current) > 0

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1588,6 +1588,20 @@ class SubagentsGatewayConfig(BaseModel):
     """When enabled, subagent bootstrap prompts keep only AGENTS.md and TOOLS.md."""
 
 
+class UpdatesConfig(BaseModel):
+    """Update-notice preferences.
+
+    ``notify`` gates the passive, gh-style "a new release is available" line
+    the CLI prints (at most once per 24h, on gateway-connected commands only).
+    Set to ``false`` to silence it entirely; the CLI also suppresses it on
+    non-TTY / CI runs regardless of this flag.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    notify: bool = True
+
+
 class TlsConfig(BaseSettings):
     """Optional TLS termination at the gateway itself.
 
@@ -1666,6 +1680,8 @@ class GatewayConfig(BaseSettings):
     agents: list[AgentEntryConfig] = Field(default_factory=list)
     agents_defaults: AgentDefaults = Field(default_factory=AgentDefaults)
     subagents: SubagentsGatewayConfig = Field(default_factory=SubagentsGatewayConfig)
+
+    updates: UpdatesConfig = Field(default_factory=UpdatesConfig)
 
     # Component enable flags
     control_ui: ControlUiConfig = Field(default_factory=ControlUiConfig)

--- a/src/agentos/gateway/static/js/views/setup.js
+++ b/src/agentos/gateway/static/js/views/setup.js
@@ -1150,10 +1150,26 @@ const SetupView = (() => {
           <div><span>Channels</span><strong>${_esc(String(_status.channelCount || 0))}</strong></div>
         </div>
         ${_renderReadinessSummary()}
+        ${_renderUpdatePreferences()}
         <div class="setup-actions">
           <button class="setup-btn" data-prev="extras">Back</button>
           <button class="setup-btn" data-reload>Refresh</button>
           <button class="setup-btn setup-btn--primary" data-exit-setup>Open Overview</button>
+        </div>
+      </section>`;
+  }
+
+  function _renderUpdatePreferences() {
+    const notify = ((_config.updates || {}).notify) !== false;
+    return `
+      <section class="setup-subpanel" aria-label="Update preferences">
+        <h4>Updates</h4>
+        <label class="setup-check">
+          <input id="setup-updates-notify" name="setup_updates_notify" type="checkbox" data-updates-notify${notify ? ' checked' : ''}>
+          <span>Notify me when a new release of use-agent-os is available</span>
+        </label>
+        <div class="setup-actions">
+          <button class="setup-btn" data-save-updates-notify>Save update preference</button>
         </div>
       </section>`;
   }
@@ -1340,6 +1356,19 @@ const SetupView = (() => {
     _el.querySelector('[data-save-memory-settings]')?.addEventListener('click', _saveMemorySettings);
     _el.querySelector('[data-save-image]')?.addEventListener('click', _saveImage);
     _el.querySelector('[data-save-audio]')?.addEventListener('click', _saveAudio);
+    _el.querySelector('[data-save-updates-notify]')?.addEventListener('click', _saveUpdatesNotify);
+  }
+
+  async function _saveUpdatesNotify() {
+    const notify = _el.querySelector('[data-updates-notify]')?.checked !== false;
+    try {
+      await _rpc.call('config.patch', { patches: { 'updates.notify': notify } });
+      UI.toast('Update preference saved.', 'info');
+      await _load();
+      _draw();
+    } catch (err) {
+      UI.toast('Save failed: ' + err.message, 'err');
+    }
   }
 
   async function _onSetupCommandCopy(event) {

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -57,8 +57,8 @@ agentos agent -m "..."       # one-shot, automation-friendly agent turn
 
 ## CLI map
 
-Top-level: `init`, `onboard`, `configure`, `doctor`, `chat`, `agent`,
-`reset`, plus these groups (each supports `--help`):
+Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
+`agent`, `reset`, plus these groups (each supports `--help`):
 
 | Group | Subcommands |
 | --- | --- |
@@ -107,6 +107,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`) |
 | `[auth]` | gateway auth: `mode` (`none`/`token`/`password`), `token`, `allow_unauthenticated_public` |
 | `[control_ui]` | `allowed_origins` for reverse-proxy setups |
+| `[updates]` | `notify` (default true) — the once-per-24h "new release available" notice |
 | `[channels]` | messaging channels (`[[channels.channels]]` entries) |
 | `[compaction]`, `[agent_token_saving]`, `[task_runtime]` | context compaction, tool-result projection, concurrency |
 
@@ -131,7 +132,34 @@ agentos gateway stop
 ```
 
 Default port **18791**, loopback bind. `--listen HOST:PORT` overrides
-`--bind`/`--port` together.
+`--bind`/`--port` together. `gateway status` (and `--json`) reports **both**
+the installed CLI version (`cliVersion`) and the running gateway's version
+(`gatewayVersion`); a `versionMismatch` diagnostic means the gateway is running
+old code — restart it.
+
+**Upgrading AgentOS:**
+
+```sh
+agentos upgrade                # upgrade, then restart + verify the gateway
+agentos upgrade --check        # is a newer release available? changes nothing
+agentos upgrade --dry-run      # print the command that would run; touch nothing
+agentos upgrade --no-restart   # upgrade only; gateway keeps running OLD code
+```
+
+`agentos upgrade` is the primary path: it detects the install method and
+delegates (`uv tool upgrade` / `pipx upgrade`), then by default restarts the
+managed gateway and verifies it reports the new version before declaring
+success. For pip / editable / source installs it prints the exact manual
+command and exits non-zero (**exit 3**) rather than faking it; a failed or
+unverifiable upgrade is **exit 1**. Flags: `--timeout` (subprocess bound,
+default 600s; kills the process group on timeout), `--config`, `--json`.
+
+Commands that reach the gateway compare CLI and gateway versions: a gateway
+**older** than the CLI warns (post-upgrade, before restart); a gateway
+**newer** than the CLI is *refused* (schema-corruption risk) unless
+`AGENTOS_ALLOW_VERSION_SKEW=1`. On gateway-connected commands the CLI also
+prints a once-per-24h "new release available" notice on stderr (TTY only, not
+in CI); silence it with `updates.notify = false` or `AGENTOS_NO_UPDATE_NOTICE=1`.
 
 **Public / LAN bind (security-gated):** with `auth.mode = "none"` the
 gateway *refuses* non-loopback binds by design. The right fix is enabling

--- a/tests/test_cli/test_gateway_rpc_skew.py
+++ b/tests/test_cli/test_gateway_rpc_skew.py
@@ -1,0 +1,77 @@
+"""Skew policy + passive notice wired into the shared run_gateway_call seam."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import typer
+
+import agentos
+from agentos.cli import gateway_rpc
+
+
+class _FakeClient:
+    def __init__(self, server_version: str | None) -> None:
+        self.server_version = server_version
+        self.closed = False
+
+    async def connect(self, url: str, token: str | None = None) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("AGENTOS_ALLOW_VERSION_SKEW", raising=False)
+    # Never touch the network in this test module.
+    monkeypatch.setattr("agentos.cli.pypi_client.latest_version", lambda timeout=2.0: None)
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, version: str | None) -> _FakeClient:
+    client = _FakeClient(version)
+    from agentos.cli import gateway_client as gcm
+
+    monkeypatch.setattr(gcm, "GatewayClient", lambda: client)
+    return client
+
+
+async def _noop(_client: Any) -> str:
+    return "ok"
+
+
+@pytest.mark.asyncio
+async def test_gateway_older_warns_but_runs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    older = "0.0.1"  # guaranteed older than the installed CLI
+    assert agentos.__version__ != older
+    _install_fake_client(monkeypatch, older)
+    result = await gateway_rpc.run_gateway_call(_noop)
+    assert result == "ok"
+    assert "OLDER" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_gateway_newer_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    newer = "99999.1.1"
+    _install_fake_client(monkeypatch, newer)
+    with pytest.raises(typer.Exit) as exc:
+        await gateway_rpc.run_gateway_call(_noop)
+    assert exc.value.exit_code == 3
+
+
+@pytest.mark.asyncio
+async def test_gateway_newer_escape_hatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_ALLOW_VERSION_SKEW", "1")
+    _install_fake_client(monkeypatch, "99999.1.1")
+    assert await gateway_rpc.run_gateway_call(_noop) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_no_version_no_skew(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_client(monkeypatch, None)
+    assert await gateway_rpc.run_gateway_call(_noop) == "ok"

--- a/tests/test_cli/test_gateway_status_versions.py
+++ b/tests/test_cli/test_gateway_status_versions.py
@@ -1,0 +1,92 @@
+"""Two-version gateway status: CLI + gateway version, mismatch diagnostic."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import agentos
+from agentos.cli import gateway_cmd
+from agentos.cli.gateway_lifecycle import GatewayLifecycleResult
+
+runner = CliRunner()
+
+
+def _app() -> typer.Typer:
+    app = typer.Typer()
+    app.command("status")(gateway_cmd.status_gateway)
+
+    @app.command("noop")
+    def _noop() -> None:  # keeps Typer in multi-command mode
+        return None
+
+    return app
+
+
+class _FakeManager:
+    def __init__(self, state: str) -> None:
+        self._state = state
+
+    def status(self) -> GatewayLifecycleResult:
+        return GatewayLifecycleResult(
+            action="status", state=self._state, ok=True, managed=True, port=18791
+        )
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, state: str, gateway_version: str | None) -> None:
+    monkeypatch.setattr(gateway_cmd, "_lifecycle_manager", lambda **_: _FakeManager(state))
+    monkeypatch.setattr(
+        gateway_cmd, "gateway_handshake_version", lambda **_: gateway_version
+    )
+
+
+def test_status_shows_both_versions_matching(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, "running", agentos.__version__)
+    result = runner.invoke(_app(), ["status"])
+    assert result.exit_code == 0
+    assert f"CLI version:     {agentos.__version__}" in result.output
+    assert f"Gateway version: {agentos.__version__}" in result.output
+    assert "Version mismatch" not in result.output
+
+
+def test_status_flags_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, "running", "0.0.1")
+    result = runner.invoke(_app(), ["status"])
+    assert result.exit_code == 0
+    assert "Gateway version: 0.0.1" in result.output
+    assert "Version mismatch" in result.output
+    assert "gateway restart" in result.output
+
+
+def test_status_not_running_reports_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        gateway_cmd,
+        "_lifecycle_manager",
+        lambda **_: _FakeManager("not_started"),
+    )
+    calls: dict[str, Any] = {"handshake": 0}
+
+    def _hs(**_: Any) -> None:
+        calls["handshake"] += 1
+        return None
+
+    monkeypatch.setattr(gateway_cmd, "gateway_handshake_version", _hs)
+    result = runner.invoke(_app(), ["status"])
+    assert result.exit_code == 0
+    assert "unknown (not running" in result.output
+    # No handshake attempted for a non-running gateway.
+    assert calls["handshake"] == 0
+
+
+def test_status_json_carries_both_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, "running", "0.0.1")
+    result = runner.invoke(_app(), ["status", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["cliVersion"] == agentos.__version__
+    assert payload["gatewayVersion"] == "0.0.1"
+    assert payload["versionMismatch"] is True

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -44,7 +44,78 @@ from agentos.cli.install_method import InstallMethod
 def test_detect_install_method(
     exe: str, pkg: str, expected: InstallMethod
 ) -> None:
-    assert im.detect_install_method(executable=exe, package_dir=Path(pkg)) == expected
+    # Empty env so a real UV_TOOL_DIR in the test host cannot skew classification.
+    assert (
+        im.detect_install_method(executable=exe, package_dir=Path(pkg), env={})
+        == expected
+    )
+
+
+def test_uv_tool_dir_override_classified_as_uv_tool(tmp_path: Path) -> None:
+    # A custom UV_TOOL_DIR relocates the whole tools tree away from the default
+    # ~/.local/share/uv/tools heuristic.
+    tool_dir = tmp_path / "custom-uv-tools"
+    exe = tool_dir / "use-agent-os" / "bin" / "python"
+    pkg = tool_dir / "use-agent-os" / "lib" / "python3.12" / "site-packages" / "agentos"
+    pkg.mkdir(parents=True)
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+    assert (
+        im.detect_install_method(
+            executable=str(exe),
+            package_dir=pkg,
+            env={"UV_TOOL_DIR": str(tool_dir)},
+        )
+        == InstallMethod.UV_TOOL
+    )
+
+
+def test_uv_tool_dir_symlinked_bin_classified_as_uv_tool(tmp_path: Path) -> None:
+    # The executable is a symlink from a bin dir OUTSIDE the tools tree into a
+    # real python UNDER UV_TOOL_DIR — resolving the symlink must still classify.
+    tool_dir = tmp_path / "uv-tools"
+    real_exe = tool_dir / "use-agent-os" / "bin" / "python"
+    real_exe.parent.mkdir(parents=True)
+    real_exe.write_text("")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    link = bin_dir / "agentos"
+    link.symlink_to(real_exe)
+    # package_dir is elsewhere (a shim location) so only the symlink target ties
+    # the install to the tools tree.
+    pkg = tmp_path / "shim" / "agentos"
+    pkg.mkdir(parents=True)
+    assert (
+        im.detect_install_method(
+            executable=str(link),
+            package_dir=pkg,
+            env={"UV_TOOL_DIR": str(tool_dir)},
+        )
+        == InstallMethod.UV_TOOL
+    )
+
+
+def test_uv_tool_dir_unset_leaves_default_behavior(tmp_path: Path) -> None:
+    # Without UV_TOOL_DIR, a plain site-packages install stays PIP.
+    exe = "/home/u/venv/bin/python"
+    pkg = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "agentos"
+    pkg.mkdir(parents=True)
+    assert (
+        im.detect_install_method(executable=exe, package_dir=pkg, env={})
+        == InstallMethod.PIP
+    )
+    # And the default ~/.local/share/uv/tools path still matches on the heuristic.
+    assert (
+        im.detect_install_method(
+            executable="/home/u/.local/share/uv/tools/use-agent-os/bin/python",
+            package_dir=Path(
+                "/home/u/.local/share/uv/tools/use-agent-os/lib/python3.12/"
+                "site-packages/agentos"
+            ),
+            env={},
+        )
+        == InstallMethod.UV_TOOL
+    )
 
 
 def test_editable_checkout_detected(tmp_path: Path) -> None:
@@ -169,3 +240,13 @@ def test_build_plan_editable_never_delegates() -> None:
     plan = im.build_upgrade_plan(method=InstallMethod.EDITABLE)
     assert plan.delegated is False
     assert "git pull" in plan.manual_hint
+
+
+def test_build_plan_unknown_lists_all_installers() -> None:
+    # Unclassifiable install: never blindly recommend pip (a uv/pipx venv has
+    # no pip); list all three installers instead.
+    plan = im.build_upgrade_plan(method=InstallMethod.UNKNOWN)
+    assert plan.delegated is False
+    assert "uv tool install use-agent-os" in plan.manual_hint
+    assert "pipx install use-agent-os" in plan.manual_hint
+    assert "pip install --upgrade use-agent-os" in plan.manual_hint

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -1,0 +1,132 @@
+"""Install-method detection + PATH hardening (Hermes lesson)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agentos.cli import install_method as im
+from agentos.cli.install_method import InstallMethod
+
+
+@pytest.mark.parametrize(
+    ("exe", "pkg", "expected"),
+    [
+        # uv tool install
+        (
+            "/home/u/.local/share/uv/tools/use-agent-os/bin/python",
+            "/home/u/.local/share/uv/tools/use-agent-os/lib/python3.12/site-packages/agentos",
+            InstallMethod.UV_TOOL,
+        ),
+        # pipx venv
+        (
+            "/home/u/.local/share/pipx/venvs/use-agent-os/bin/python",
+            "/home/u/.local/share/pipx/venvs/use-agent-os/lib/python3.12/site-packages/agentos",
+            InstallMethod.PIPX,
+        ),
+        # plain pip into a virtualenv site-packages
+        (
+            "/home/u/venv/bin/python",
+            "/home/u/venv/lib/python3.12/site-packages/agentos",
+            InstallMethod.PIP,
+        ),
+        # system dist-packages
+        (
+            "/usr/bin/python3",
+            "/usr/lib/python3/dist-packages/agentos",
+            InstallMethod.PIP,
+        ),
+    ],
+)
+def test_detect_install_method(
+    exe: str, pkg: str, expected: InstallMethod
+) -> None:
+    assert im.detect_install_method(executable=exe, package_dir=Path(pkg)) == expected
+
+
+def test_editable_checkout_detected(tmp_path: Path) -> None:
+    # Mimic a src/agentos editable layout with a sibling pyproject.toml.
+    src = tmp_path / "src"
+    pkg = src / "agentos"
+    pkg.mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='use-agent-os'\n")
+    assert (
+        im.detect_install_method(executable="/usr/bin/python3", package_dir=pkg)
+        == InstallMethod.EDITABLE
+    )
+
+
+def test_hardened_path_appends_login_dirs() -> None:
+    env = {"PATH": "/custom/bin", "HOME": "/home/u"}
+    out = im.hardened_path_env(env)
+    parts = out["PATH"].split(os.pathsep)
+    assert parts[0] == "/custom/bin"  # operator ordering preserved
+    assert "/opt/homebrew/bin" in parts
+    assert "/usr/local/bin" in parts
+    assert "/home/u/.local/bin" in parts
+
+
+def test_hardened_path_no_duplicates() -> None:
+    env = {"PATH": "/opt/homebrew/bin:/x", "HOME": "/home/u"}
+    parts = im.hardened_path_env(env)["PATH"].split(os.pathsep)
+    assert parts.count("/opt/homebrew/bin") == 1
+
+
+def test_resolve_tool_uses_hardened_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # uv lives in a login dir NOT on the base PATH.
+    brew = tmp_path / "opt" / "homebrew" / "bin"
+    brew.mkdir(parents=True)
+    uv_bin = brew / "uv"
+    uv_bin.write_text("#!/bin/sh\n")
+    uv_bin.chmod(0o755)
+
+    import agentos.cli.install_method as mod
+
+    monkeypatch.setattr(mod, "_LOGIN_PATH_DIRS", (str(brew),))
+    resolved = im.resolve_tool("uv", {"PATH": "/nowhere", "HOME": str(tmp_path)})
+    assert resolved == str(uv_bin.resolve())
+
+
+def test_resolve_tool_missing_returns_none() -> None:
+    assert im.resolve_tool("definitely-not-a-real-tool-xyz", {"PATH": "/nonexistent"}) is None
+
+
+def test_build_plan_uv_tool_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: "/abs/uv")
+    plan = im.build_upgrade_plan(method=InstallMethod.UV_TOOL)
+    assert plan.delegated is True
+    assert plan.tool == "/abs/uv"
+    assert plan.command == ["/abs/uv", "tool", "upgrade", "use-agent-os"]
+
+
+def test_build_plan_uv_tool_missing_uv_not_delegated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: None)
+    plan = im.build_upgrade_plan(method=InstallMethod.UV_TOOL)
+    assert plan.delegated is False
+    assert plan.tool is None
+    assert "uv tool upgrade" in plan.manual_hint
+
+
+def test_build_plan_pipx_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: "/abs/pipx")
+    plan = im.build_upgrade_plan(method=InstallMethod.PIPX)
+    assert plan.delegated is True
+    assert plan.command == ["/abs/pipx", "upgrade", "use-agent-os"]
+
+
+def test_build_plan_pip_never_delegates() -> None:
+    plan = im.build_upgrade_plan(method=InstallMethod.PIP)
+    assert plan.delegated is False
+    assert "pip install --upgrade use-agent-os" in plan.manual_hint
+
+
+def test_build_plan_editable_never_delegates() -> None:
+    plan = im.build_upgrade_plan(method=InstallMethod.EDITABLE)
+    assert plan.delegated is False
+    assert "git pull" in plan.manual_hint

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -58,6 +59,11 @@ def test_editable_checkout_detected(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="hardened login-dir PATH semantics are POSIX-specific; "
+    "Windows resolution uses standard which/PATHEXT",
+)
 def test_hardened_path_appends_login_dirs() -> None:
     env = {"PATH": "/custom/bin", "HOME": "/home/u"}
     out = im.hardened_path_env(env)
@@ -74,6 +80,11 @@ def test_hardened_path_no_duplicates() -> None:
     assert parts.count("/opt/homebrew/bin") == 1
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="hardened login-dir PATH semantics are POSIX-specific; "
+    "Windows resolution uses standard which/PATHEXT",
+)
 def test_resolve_tool_uses_hardened_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -93,6 +104,34 @@ def test_resolve_tool_uses_hardened_path(
 
 def test_resolve_tool_missing_returns_none() -> None:
     assert im.resolve_tool("definitely-not-a-real-tool-xyz", {"PATH": "/nonexistent"}) is None
+
+
+def test_resolve_tool_falls_back_to_which(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cross-platform: resolve_tool defers to shutil.which and returns its hit.
+
+    Runs on both POSIX and Windows — shutil.which is mocked so no real binary
+    (or PATHEXT / executable-bit) semantics are involved, only that resolve_tool
+    hardens the PATH, delegates to which, and returns the absolute path without
+    crashing.
+    """
+
+    seen: dict[str, object] = {}
+    resolved_path = str(Path("some") / "abs" / "uv")
+
+    def fake_which(tool: str, path: str | None = None) -> str:
+        seen["tool"] = tool
+        seen["path"] = path
+        return resolved_path
+
+    monkeypatch.setattr(im.shutil, "which", fake_which)
+    result = im.resolve_tool("uv", {"PATH": "/base", "HOME": "/home/u"})
+
+    assert result == str(Path(resolved_path).resolve())
+    assert seen["tool"] == "uv"
+    # resolve_tool hardens the PATH before delegating, so which sees the
+    # augmented PATH, not the bare base.
+    assert isinstance(seen["path"], str)
+    assert "/base" in seen["path"] or "\\base" in seen["path"]
 
 
 def test_build_plan_uv_tool_delegates(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli/test_pypi_client.py
+++ b/tests/test_cli/test_pypi_client.py
@@ -1,0 +1,70 @@
+"""Isolated PyPI client — fully mocked, never hits the network."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.cli import pypi_client
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def _patch_get(monkeypatch: pytest.MonkeyPatch, fn: Any) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fn)
+
+
+def test_latest_version_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, **_: Any) -> _FakeResponse:
+        assert "use-agent-os" in url
+        return _FakeResponse(200, {"info": {"version": "2026.8.1"}})
+
+    _patch_get(monkeypatch, fake_get)
+    assert pypi_client.latest_version() == "2026.8.1"
+
+
+def test_offline_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, **_: Any) -> _FakeResponse:
+        raise OSError("network down")
+
+    _patch_get(monkeypatch, fake_get)
+    assert pypi_client.latest_version() is None
+
+
+def test_non_200_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, lambda url, **_: _FakeResponse(404, {}))
+    assert pypi_client.latest_version() is None
+
+
+def test_malformed_body_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, lambda url, **_: _FakeResponse(200, ValueError("bad json")))
+    assert pypi_client.latest_version() is None
+
+
+def test_missing_version_field_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, lambda url, **_: _FakeResponse(200, {"info": {}}))
+    assert pypi_client.latest_version() is None
+
+
+def test_timeout_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        seen.update(kwargs)
+        return _FakeResponse(200, {"info": {"version": "1.0"}})
+
+    _patch_get(monkeypatch, fake_get)
+    pypi_client.latest_version(timeout=2.0)
+    assert seen["timeout"] == 2.0

--- a/tests/test_cli/test_update_notice.py
+++ b/tests/test_cli/test_update_notice.py
@@ -1,0 +1,98 @@
+"""Passive update-notice throttle + suppression matrix (network mocked)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.cli import update_notice
+
+
+@pytest.fixture(autouse=True)
+def _state_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("AGENTOS_NO_UPDATE_NOTICE", raising=False)
+    for var in update_notice._CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _mock_latest(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(
+        "agentos.cli.pypi_client.latest_version", lambda timeout=2.0: value
+    )
+
+
+def _tty(monkeypatch: pytest.MonkeyPatch, is_tty: bool) -> None:
+    monkeypatch.setattr(update_notice, "_stderr_is_tty", lambda: is_tty)
+
+
+def test_emits_when_newer_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    _mock_latest(monkeypatch, "2026.8.1")
+    msg = update_notice.maybe_emit_update_notice(current_version="2026.7.18")
+    assert msg is not None
+    assert "2026.7.18 → 2026.8.1" in msg
+    assert "agentos upgrade" in msg
+
+
+def test_suppressed_when_up_to_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    _mock_latest(monkeypatch, "2026.7.18")
+    assert update_notice.maybe_emit_update_notice(current_version="2026.7.18") is None
+
+
+def test_suppressed_non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, False)
+    _mock_latest(monkeypatch, "2026.9.9")
+    assert update_notice.maybe_emit_update_notice(current_version="2026.7.18") is None
+
+
+def test_suppressed_in_ci(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    monkeypatch.setenv("CI", "true")
+    _mock_latest(monkeypatch, "2026.9.9")
+    assert update_notice.maybe_emit_update_notice(current_version="2026.7.18") is None
+
+
+def test_suppressed_when_config_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    _mock_latest(monkeypatch, "2026.9.9")
+    config = SimpleNamespace(updates=SimpleNamespace(notify=False))
+    assert (
+        update_notice.maybe_emit_update_notice(current_version="2026.7.18", config=config)
+        is None
+    )
+
+
+def test_env_escape_hatch_suppresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    monkeypatch.setenv("AGENTOS_NO_UPDATE_NOTICE", "1")
+    _mock_latest(monkeypatch, "2026.9.9")
+    assert update_notice.maybe_emit_update_notice(current_version="2026.7.18") is None
+
+
+def test_throttled_within_24h(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    _mock_latest(monkeypatch, "2026.9.9")
+    # First call at t=0 records the check.
+    first = update_notice.maybe_emit_update_notice(current_version="2026.7.18", now=0.0)
+    assert first is not None
+    # 1 hour later — throttled.
+    second = update_notice.maybe_emit_update_notice(current_version="2026.7.18", now=3600.0)
+    assert second is None
+    # 25 hours later — due again.
+    third = update_notice.maybe_emit_update_notice(
+        current_version="2026.7.18", now=25 * 3600.0
+    )
+    assert third is not None
+
+
+def test_offline_records_check_and_stays_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _tty(monkeypatch, True)
+    _mock_latest(monkeypatch, None)
+    assert update_notice.maybe_emit_update_notice(current_version="2026.7.18", now=0.0) is None
+    # The offline attempt still throttles the next call.
+    state = update_notice._read_state(update_notice.notice_state_path())
+    assert "last_checked" in state

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -1,0 +1,191 @@
+"""`agentos upgrade` command — delegate, check, dry-run, restart+verify."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from agentos.cli import upgrade_cmd
+from agentos.cli.install_method import InstallMethod, UpgradePlan
+
+runner = CliRunner()
+
+
+def _app() -> typer.Typer:
+    app = typer.Typer()
+    app.command("upgrade")(upgrade_cmd.upgrade_command)
+
+    @app.command("noop")
+    def _noop() -> None:  # keeps Typer in multi-command mode
+        return None
+
+    return app
+
+
+def _delegated_plan() -> UpgradePlan:
+    return UpgradePlan(
+        method=InstallMethod.UV_TOOL,
+        delegated=True,
+        tool="/abs/uv",
+        command=["/abs/uv", "tool", "upgrade", "use-agent-os"],
+        manual_hint="uv tool upgrade use-agent-os",
+    )
+
+
+def _pip_plan() -> UpgradePlan:
+    return UpgradePlan(
+        method=InstallMethod.PIP,
+        delegated=False,
+        tool=None,
+        command=["python", "-m", "pip", "install", "--upgrade", "use-agent-os"],
+        manual_hint="python -m pip install --upgrade use-agent-os",
+    )
+
+
+def _ok_run(*_: Any, **__: Any) -> upgrade_cmd.UpgradeRunResult:
+    return upgrade_cmd.UpgradeRunResult(
+        ok=True, timed_out=False, returncode=0, stdout="upgraded", stderr=""
+    )
+
+
+# --- --check ---------------------------------------------------------------
+
+
+def test_check_reports_newer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr("agentos.cli.pypi_client.latest_version", lambda timeout=5.0: "99999.1.1")
+    result = runner.invoke(_app(), ["upgrade", "--check"])
+    assert result.exit_code == 0
+    assert "newer version is available" in result.stdout
+
+
+def test_check_offline_exit_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr("agentos.cli.pypi_client.latest_version", lambda timeout=5.0: None)
+    result = runner.invoke(_app(), ["upgrade", "--check"])
+    assert result.exit_code == 0
+    assert "could not check (offline)" in result.stdout
+
+
+def test_check_changes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {"run": False}
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr("agentos.cli.pypi_client.latest_version", lambda timeout=5.0: "99999.1.1")
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "_run_upgrade_subprocess",
+        lambda *a, **k: called.__setitem__("run", True),
+    )
+    runner.invoke(_app(), ["upgrade", "--check"])
+    assert called["run"] is False
+
+
+# --- non-delegated (pip/editable) ------------------------------------------
+
+
+def test_pip_prints_manual_and_exits_3(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _pip_plan)
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 3
+    assert "pip install --upgrade use-agent-os" in result.stdout
+
+
+# --- --dry-run -------------------------------------------------------------
+
+
+def test_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    ran = {"run": False}
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(
+        upgrade_cmd, "_run_upgrade_subprocess", lambda *a, **k: ran.__setitem__("run", True)
+    )
+    result = runner.invoke(_app(), ["upgrade", "--dry-run"])
+    assert result.exit_code == 0
+    assert "Would run: /abs/uv tool upgrade use-agent-os" in result.stdout
+    assert ran["run"] is False
+
+
+# --- successful delegate + restart+verify ----------------------------------
+
+
+def test_upgrade_success_restarts_and_verifies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "99999.2.0")
+    seen: dict[str, Any] = {}
+
+    def fake_restart(**kwargs: Any) -> bool:
+        seen.update(kwargs)
+        return True
+
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", fake_restart)
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 0
+    assert "Upgraded:" in result.stdout
+    assert "→ 99999.2.0" in result.stdout
+    assert seen["expected_version"] == "99999.2.0"
+
+
+def test_upgrade_verify_failure_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "99999.2.0")
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: False)
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 1
+
+
+# --- --no-restart ----------------------------------------------------------
+
+
+def test_no_restart_loud_warning_exit_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "99999.2.0")
+    restarted = {"called": False}
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "_restart_and_verify",
+        lambda **k: restarted.__setitem__("called", True),
+    )
+    result = runner.invoke(_app(), ["upgrade", "--no-restart"])
+    assert result.exit_code == 0
+    assert restarted["called"] is False
+    # Loud warning, prefixed ⚠ (emitted to stderr; CliRunner merges streams).
+    assert "⚠" in result.output
+    assert "OLD version" in result.output
+
+
+# --- timeout ---------------------------------------------------------------
+
+
+def test_upgrade_timeout_exits_one_with_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "_run_upgrade_subprocess",
+        lambda *a, **k: upgrade_cmd.UpgradeRunResult(
+            ok=False, timed_out=True, returncode=None, stdout="", stderr=""
+        ),
+    )
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 1
+    assert "timed out" in result.stdout
+    assert "process group" in result.stdout
+
+
+def test_upgrade_failure_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "_run_upgrade_subprocess",
+        lambda *a, **k: upgrade_cmd.UpgradeRunResult(
+            ok=False, timed_out=False, returncode=2, stdout="", stderr="boom"
+        ),
+    )
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 1
+    assert "Upgrade failed" in result.stdout

--- a/tests/test_cli/test_version_skew.py
+++ b/tests/test_cli/test_version_skew.py
@@ -1,0 +1,59 @@
+"""Version-skew policy: warn when gateway older, refuse when gateway newer."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.cli.version_skew import (
+    ALLOW_SKEW_ENV,
+    SkewReporter,
+    VersionSkewError,
+    evaluate_skew,
+)
+
+
+def test_evaluate_skew_directions() -> None:
+    assert evaluate_skew(cli_version="2026.7.19", gateway_version="2026.7.18") == "gateway_older"
+    assert evaluate_skew(cli_version="2026.7.18", gateway_version="2026.7.19") == "gateway_newer"
+    assert evaluate_skew(cli_version="2026.7.18", gateway_version="2026.7.18") is None
+    assert evaluate_skew(cli_version="2026.7.18", gateway_version=None) is None
+
+
+def test_gateway_older_warns_not_blocks(capsys: pytest.CaptureFixture[str]) -> None:
+    reporter = SkewReporter()
+    reporter.check(cli_version="2026.7.19", gateway_version="2026.7.18")
+    err = capsys.readouterr().err
+    assert "OLDER" in err
+    assert "gateway restart" in err
+
+
+def test_gateway_older_warns_once_per_invocation(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reporter = SkewReporter()
+    reporter.check(cli_version="2026.7.19", gateway_version="2026.7.18")
+    reporter.check(cli_version="2026.7.19", gateway_version="2026.7.18")
+    assert capsys.readouterr().err.count("OLDER") == 1
+
+
+def test_gateway_newer_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ALLOW_SKEW_ENV, raising=False)
+    reporter = SkewReporter()
+    with pytest.raises(VersionSkewError) as exc:
+        reporter.check(cli_version="2026.7.18", gateway_version="2026.7.19")
+    assert "NEWER" in str(exc.value)
+    assert ALLOW_SKEW_ENV in str(exc.value)
+
+
+def test_gateway_newer_escape_hatch(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ALLOW_SKEW_ENV, "1")
+    reporter = SkewReporter()
+    reporter.check(cli_version="2026.7.18", gateway_version="2026.7.19")
+    assert "proceeding because" in capsys.readouterr().err
+
+
+def test_equal_versions_silent(capsys: pytest.CaptureFixture[str]) -> None:
+    SkewReporter().check(cli_version="2026.7.18", gateway_version="2026.7.18")
+    assert capsys.readouterr().err == ""

--- a/tests/test_cli/test_version_utils.py
+++ b/tests/test_cli/test_version_utils.py
@@ -1,0 +1,78 @@
+"""Version-compare logic used by upgrade, update-notice, and skew policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.cli.version_utils import compare_versions, is_newer, parse_version
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        ("2026.7.18", "2026.7.18", 0),
+        ("2026.7.18", "2026.7.19", -1),
+        ("2026.7.19", "2026.7.18", 1),
+        # post-release is newer than its base release
+        ("2026.7.18.post1", "2026.7.18", 1),
+        ("2026.7.18", "2026.7.18.post1", -1),
+        ("2026.7.18.post2", "2026.7.18.post1", 1),
+        # release-segment length differences pad with zeros
+        ("2026.7", "2026.7.0", 0),
+        ("2026.7.1", "2026.7", 1),
+        # CalVer month/day rollover
+        ("2026.10.1", "2026.7.30", 1),
+        ("2027.1.1", "2026.12.31", 1),
+        # pre-releases sort below the final release
+        ("2026.7.18rc1", "2026.7.18", -1),
+        ("2026.7.18a1", "2026.7.18b1", -1),
+        ("2026.7.18rc2", "2026.7.18rc1", 1),
+        # dev sorts below everything of the same release
+        ("2026.7.18.dev1", "2026.7.18rc1", -1),
+        ("2026.7.18.dev1", "2026.7.18", -1),
+        # leading v is tolerated
+        ("v2026.7.18", "2026.7.18", 0),
+    ],
+)
+def test_compare_versions(a: str, b: str, expected: int) -> None:
+    assert compare_versions(a, b) == expected
+
+
+def test_local_label_ignored_for_ordering() -> None:
+    assert compare_versions("2026.7.18+abc", "2026.7.18") == 0
+
+
+def test_unparsable_sorts_below_real_release() -> None:
+    assert compare_versions("0.0.0+unknown", "2026.7.18") == -1
+    assert compare_versions("garbage", "2026.7.18") == -1
+    # an unparsable string equals itself
+    assert compare_versions("garbage", "garbage") == 0
+
+
+def test_is_newer() -> None:
+    assert is_newer("2026.7.19", "2026.7.18") is True
+    assert is_newer("2026.7.18", "2026.7.18") is False
+    assert is_newer("2026.7.18", "2026.7.19") is False
+    assert is_newer("2026.7.18.post1", "2026.7.18") is True
+
+
+def test_parse_version_fields() -> None:
+    v = parse_version("2026.7.18.post1")
+    assert v.release == (2026, 7, 18)
+    assert v.post == 1
+    assert v.parsed is True
+
+    bad = parse_version("nonsense")
+    assert bad.parsed is False
+
+
+def test_ordering_is_total_and_sortable() -> None:
+    versions = ["2026.7.18", "2026.7.18.post1", "2026.7.18rc1", "2026.7.19", "0.0.0+unknown"]
+    ordered = sorted(versions, key=parse_version)
+    assert ordered == [
+        "0.0.0+unknown",
+        "2026.7.18rc1",
+        "2026.7.18",
+        "2026.7.18.post1",
+        "2026.7.19",
+    ]

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -1500,4 +1500,23 @@ def test_setup_view_memory_settings_card_saves_via_config_patch():
     assert "memory.curated_memory_char_limit" in body
     assert "memory.curated_user_char_limit" in body
     assert "memory.inject_limit" in body
+
+
+def test_setup_view_has_update_notify_toggle():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    # The toggle renders in the finish step and reflects config.updates.notify.
+    assert "data-updates-notify" in txt
+    assert "_config.updates" in txt
+    assert "new release of use-agent-os" in txt
+
+
+def test_setup_view_saves_update_notify_via_config_patch():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("async function _saveUpdatesNotify()")
+    end = txt.index("\n  }", start)
+    body = txt[start:end]
+    assert "'config.patch'" in body
+    assert "'updates.notify'" in body
+    # Bound to a click handler in _bindStep.
+    assert "data-save-updates-notify" in txt
     assert "data-save-memory-settings" in txt

--- a/tests/test_gateway/test_updates_config.py
+++ b/tests/test_gateway/test_updates_config.py
@@ -1,0 +1,31 @@
+"""updates.notify config: default, round-trip, and public-dict surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.gateway.config import GatewayConfig, UpdatesConfig
+
+
+def test_updates_notify_defaults_true() -> None:
+    assert GatewayConfig().updates.notify is True
+
+
+def test_updates_config_forbids_extra() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        UpdatesConfig(notify=True, bogus=1)  # type: ignore[call-arg]
+
+
+def test_updates_notify_toml_round_trip(tmp_path: Path) -> None:
+    cfg = tmp_path / "agentos.toml"
+    cfg.write_text("[updates]\nnotify = false\n", encoding="utf-8")
+    loaded = GatewayConfig.load_from_toml(cfg)
+    assert loaded.updates.notify is False
+
+
+def test_updates_in_public_dict() -> None:
+    public = GatewayConfig().to_public_dict()
+    assert public.get("updates") == {"notify": True}


### PR DESCRIPTION
Closes the upgrade-UX gap left by the pilot-v1 rollout (#26, #36): users previously had to know to `uv tool upgrade` **and** remember to restart the gateway, or silently run mixed versions.

Design is grounded in a 15-tool case study (deep dives: OpenClaw and Nous Hermes agent — the closest daemon+CLI analogs; also Tailscale, Caddy, Syncthing, Home Assistant, gh, uv, Airflow/Prefect). The two most-documented failure modes in the wild are **silent CLI↔daemon version skew** after upgrade and **upgrade subprocesses hanging on macOS PATH gaps** — both are engineered around here.

## What ships

- **`agentos upgrade`** — detects the install method (uv tool / pipx; plain pip prints the exact manual command) and delegates with an absolute tool path, hardened PATH, and a process-group-killing timeout. `--check`, `--dry-run`, `--timeout`, `--json`.
- **Gateway restart by default + verification**: a running managed gateway is restarted and the new version is confirmed over the RPC handshake before printing `Gateway: restarted and verified`. `--no-restart` opts out with an unmissable warning — an upgrade can never end in silent skew.
- **Two-version status**: `agentos gateway status` now reports CLI and live gateway versions side by side with a mismatch diagnostic.
- **Version-skew policy** at the single shared RPC seam: older gateway → one warning, never blocks; gateway *newer* than CLI → refuse (config-corruption direction) with an `AGENTOS_ALLOW_VERSION_SKEW=1` escape hatch. Lifecycle/upgrade commands bypass the seam, so skew can always be fixed.
- **Passive update notice** (gh-style): 24h TTL, TTY-only, CI-suppressed, silent on network failure; opt-out via `updates.notify = false` (config + setup-UI toggle) or `AGENTOS_NO_UPDATE_NOTICE=1`.
- Docs: README upgrade section rewritten around the new command; configuration reference updated.

## Testing

77 new tests (install-method detection per path, restart+verify sequencing, both skew directions + hatch, notice suppression matrix, config/UI round-trip; all network mocked). Full suite 6,360 passed; ruff/mypy clean; wheel builds. Independently reviewed against 8 named risks before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)