### PR TITLE
feat(skills): Bankr two-skill limit, Update button, emoji avatar (supersedes #35)

### DIFF
--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -214,7 +214,7 @@ def skills_search(
                 escape(r.name),
                 escape(r.source_id),
                 escape(r.trust_level),
-                escape(r.description[:60]),
+                escape((r.description or "")[:60]),
             )
         console.print(table)
 

--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 from typing import Any
 
 import typer
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -142,9 +143,7 @@ def _load_skill_rows() -> list[dict[str, Any]]:
                     "origin": provenance.origin if provenance else "unknown",
                     "license": provenance.license if provenance else "unknown",
                     "upstreamUrl": provenance.upstream_url if provenance else "",
-                    "maintainedBy": provenance.maintained_by
-                    if provenance
-                    else "AgentOS",
+                    "maintainedBy": provenance.maintained_by if provenance else "AgentOS",
                 },
             }
         )
@@ -169,10 +168,10 @@ def skills_list(
 
     for row in rows:
         table.add_row(
-            row["name"],
+            escape(row["name"]),
             row["layer"],
             "[green]yes[/]" if row["eligible"] else "[dim]no[/]",
-            (
+            escape(
                 row["description"][:60] + "..."
                 if len(row["description"]) > 60
                 else row["description"]
@@ -209,7 +208,14 @@ def skills_search(
         table.add_column("Description")
 
         for r in results:
-            table.add_row(r.name, r.source_id, r.trust_level, r.description[:60])
+            # Remote catalogs are community-controlled — never let their text
+            # be interpreted as rich markup.
+            table.add_row(
+                escape(r.name),
+                escape(r.source_id),
+                escape(r.trust_level),
+                escape(r.description[:60]),
+            )
         console.print(table)
 
     asyncio.run(_search())
@@ -302,8 +308,7 @@ def skills_install(
         "--source",
         "-s",
         help=(
-            "Source (clawhub, github). GitHub accepts owner/repo, "
-            "owner/repo:path, or GitHub URLs."
+            "Source (clawhub, github). GitHub accepts owner/repo, owner/repo:path, or GitHub URLs."
         ),
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Force install (skip security block)"),

--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -17,6 +17,7 @@ from agentos.skills.eligibility import (
 from agentos.skills.hub.defaults import (
     build_default_skill_installer,
     get_default_skill_router,
+    installed_skill_identifiers,
     installed_skill_names,
 )
 from agentos.skills.hub.deps import install_deps
@@ -351,12 +352,13 @@ async def _handle_skills_search(params: dict | None, ctx: RpcContext) -> dict[st
     if source_id is not None and not isinstance(source_id, str):
         source_id = None
     results = await router.search(query, limit=limit, source_id=source_id)
-    installed = _installed_names()
-    # Lockfile keys are the installer's name — which for ClawHub is the
-    # slug (``identifier``), not the human-readable ``displayName`` a
-    # source may return as ``SkillMeta.name``. Check both so we catch
-    # either convention; a future source that matches on name directly
-    # still works.
+    # Match a browse result to a lockfile install by BOTH name and identifier.
+    # Lockfile keys are the installer's name (SKILL.md frontmatter), which may
+    # be neither the ``displayName`` a source returns as ``SkillMeta.name`` nor
+    # the catalog slug — e.g. Bankr's ``bankr-token-scam-analysis`` slug
+    # installs under the name ``token-scam-analysis``. The lockfile entry's
+    # identifier (the source URL) is the reliable join key across a reload.
+    installed = _installed_names() | installed_skill_identifiers()
     return {
         "results": [
             {
@@ -369,6 +371,7 @@ async def _handle_skills_search(params: dict | None, ctx: RpcContext) -> dict[st
                 "identifier": r.identifier,
                 "provider": r.provider,
                 "logo": r.logo,
+                "emoji": r.emoji,
                 "category": r.category,
                 "setup": r.setup,
                 "demo": r.demo,
@@ -529,6 +532,7 @@ async def _handle_skills_deps_install(params: dict | None, ctx: RpcContext) -> d
 # ---------------------------------------------------------------------------
 # Default router/installer (lazy init)
 # ---------------------------------------------------------------------------
+
 
 def _get_default_router():
     return get_default_skill_router()

--- a/src/agentos/gateway/static/css/views/skills.css
+++ b/src/agentos/gateway/static/css/views/skills.css
@@ -524,6 +524,11 @@
   color: var(--text-muted);
   border: 1px solid var(--border);
 }
+.sk-rcard__logo--emoji {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 18px; line-height: 1;
+  border: 1px solid var(--border);
+}
 .sk-rcard__titles { display: flex; flex-direction: column; min-width: 0; flex: 1; }
 .sk-rcard__name {
   font-weight: 700; font-size: var(--fs-sm); color: var(--text);
@@ -690,6 +695,11 @@
   font-family: var(--font-mono);
   font-size: 14px; font-weight: 700;
   color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+.sk-dialog__logo--emoji {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 22px; line-height: 1;
   border: 1px solid var(--border);
 }
 .sk-dialog__provider { font-size: var(--fs-sm); color: var(--text-dim); margin-top: 2px; }

--- a/src/agentos/gateway/static/js/views/skills.js
+++ b/src/agentos/gateway/static/js/views/skills.js
@@ -259,6 +259,11 @@ const SkillsView = (() => {
         _uninstallSkill(uninstallBtn.dataset.uninstall, uninstallBtn);
         return;
       }
+      const updateBtn = e.target.closest('[data-update]');
+      if (updateBtn) {
+        _updateSkill(updateBtn.dataset.update, updateBtn);
+        return;
+      }
       const statusPill = e.target.closest('[data-status-filter]');
       if (statusPill) {
         _statusFilter = statusPill.dataset.statusFilter;
@@ -640,7 +645,12 @@ const SkillsView = (() => {
     // static onerror handler — never interpolate data into inline JS.
     const initials = _esc(_initials(r.provider || r.name));
     const logoUrl = _safeUrl(r.logo);
-    if (!logoUrl) return `<span class="${cls} ${cls}--initials">${initials}</span>`;
+    if (!logoUrl) {
+      // No logo asset: prefer the skill's emoji avatar (like other skills),
+      // falling back to initials only when there's no emoji either.
+      if (r.emoji) return `<span class="${cls} ${cls}--emoji">${_esc(r.emoji)}</span>`;
+      return `<span class="${cls} ${cls}--initials">${initials}</span>`;
+    }
     return `<img class="${cls}" src="${_esc(logoUrl)}" alt="" loading="lazy" onerror="this.style.display='none';if(this.nextElementSibling)this.nextElementSibling.style.display='inline-flex'" /><span class="${cls} ${cls}--initials" style="display:none">${initials}</span>`;
   }
 
@@ -821,6 +831,11 @@ const SkillsView = (() => {
       ? `<small class="sk-dim sk-dialog__path">${_esc(skill.file_path)}</small>`
       : '';
 
+    // Managed skills were installed from a source, so they can be re-pulled
+    // ("Update") and removed. Bundled/user skills have neither.
+    const updateBtn = skill.layer === 'managed'
+      ? `<button class="btn btn--sm" data-update="${_esc(skill.name)}">Update</button>`
+      : '';
     const removeBtn = skill.layer === 'managed'
       ? `<button class="btn btn--sm" data-uninstall="${_esc(skill.name)}">Remove</button>`
       : '';
@@ -843,6 +858,7 @@ const SkillsView = (() => {
       </section>
       <footer class="sk-dialog__foot">
         ${footer}
+        ${updateBtn}
         ${removeBtn}
       </footer>`);
   }
@@ -922,6 +938,13 @@ const SkillsView = (() => {
         // Mark the item installed in-place so the badge flips without
         // discarding the browsed catalog.
         _markInstalled(identifier, res.name, true);
+        // Re-render the browse grid so its card shows the same green "Installed"
+        // chip as skills installed on load. The manual button mutation above
+        // only restyles the one clicked element (e.g. the dialog button),
+        // which left grid cards looking inconsistent with each other.
+        const group = btn.closest('[data-group]')?.dataset.group
+          || (_activeTab === 'bankr' || _activeTab === 'community' ? _activeTab : null);
+        if (group) _renderRegistryResults(group);
         _loadData();
         return;
       }
@@ -965,6 +988,25 @@ const SkillsView = (() => {
         _loadData();
       } else { btn.textContent = 'Failed'; UI.toast(res.message || 'Uninstall failed', 'err'); }
     } catch (err) { btn.textContent = 'Error'; UI.toast(err.message, 'err'); }
+  }
+
+  async function _updateSkill(name, btn) {
+    if (!_rpc) return;
+    btn.disabled = true;
+    btn.textContent = 'Updating…';
+    try {
+      // Re-pulls the latest code from the skill's source and overwrites it.
+      const res = await _rpc.call('skills.update', { name });
+      const result = (res.results || [])[0] || {};
+      if (result.success) {
+        UI.toast(result.message || `Updated ${name}`, 'ok');
+        _loadData();
+      } else {
+        btn.disabled = false;
+        btn.textContent = 'Update';
+        UI.toast(result.message || res.message || 'Update failed', 'err');
+      }
+    } catch (err) { btn.disabled = false; btn.textContent = 'Update'; UI.toast(err.message, 'err'); }
   }
 
   // ── helpers ────────────────────────────────────────────────────────────

--- a/src/agentos/gateway/static/js/views/skills.js
+++ b/src/agentos/gateway/static/js/views/skills.js
@@ -4,7 +4,7 @@ const SkillsView = (() => {
   // Show/hide the Bankr partner tab in the Skills view. Set to true to bring
   // the tab back — the BankrSource backend (browse/search/install) stays wired
   // either way, so Bankr skills remain reachable via the Community tab / CLI.
-  const _SHOW_BANKR = false;
+  const _SHOW_BANKR = true;
 
   let _el = null;
   let _rpc = null;

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -3,10 +3,15 @@
 The Bankr repository (https://github.com/BankrBot/skills) publishes each skill
 as a directory containing ``SKILL.md`` + ``catalog.json``. This source reads the
 catalog live from GitHub (cached in-memory for a short TTL) so users can browse
-the full catalog and install with one click. Downloading and installation are
-delegated to :class:`GitHubSource`, which already fetches the whole skill
-directory and reads the ``SKILL.md`` frontmatter; the security scan, quarantine,
-and lockfile handling live in :class:`SkillInstaller` and are reused unchanged.
+and install with one click. Downloading and installation are delegated to
+:class:`GitHubSource`, which already fetches the whole skill directory and reads
+the ``SKILL.md`` frontmatter; the security scan, quarantine, and lockfile
+handling live in :class:`SkillInstaller` and are reused unchanged.
+
+Rather than crawling the whole repository tree (~100 skills — two HTTP requests
+each, which trips GitHub's rate limit), this source loads only the fixed
+allowlist in ``_ALLOWED_SLUGS``: the slugs are known ahead of time, so it fetches
+their ``catalog.json`` + ``SKILL.md`` directly and never calls the git-tree API.
 
 Only skills whose ``catalog.json`` declares ``install.type == "bankr"`` (i.e.
 they live in the repo and install directly) are listed. ``external`` skills —
@@ -19,6 +24,7 @@ import asyncio
 import json
 import re
 import time
+from collections.abc import Sequence
 
 import structlog
 
@@ -30,6 +36,15 @@ log = structlog.get_logger(__name__)
 
 _DEFAULT_REPO = "BankrBot/skills"
 _DEFAULT_REF = "main"
+# Only these skills are loaded from BankrBot/skills. Fetching the whole repo tree
+# and every skill's catalog.json + SKILL.md (~100 skills) trips GitHub's rate
+# limit (429); since the slugs are fixed we fetch just these directly.
+_ALLOWED_SLUGS: tuple[str, ...] = ("bankr", "bankr-token-scam-analysis")
+# Brand avatar for Bankr cards. The catalogs ship ``logo: null`` and store their
+# emoji in SKILL.md frontmatter (in formats the browse layer can't reliably
+# parse), so browse cards fall back to this shared brand mark instead of a bare
+# initials box.
+_BANKR_EMOJI = "📺"
 _CATALOG_TTL_SECONDS = 15 * 60
 # After a failed catalog fetch, don't retry for this long — the router fans
 # every search out to all sources, so an un-throttled retry would add the full
@@ -38,20 +53,6 @@ _FAILURE_RETRY_SECONDS = 60
 _CATALOG_CONCURRENCY = 16
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
-
-
-def _catalog_slugs(tree: dict) -> list[str]:
-    """Return skill slugs that own a top-level ``<slug>/catalog.json`` path."""
-    slugs: list[str] = []
-    for item in tree.get("tree", []):
-        if item.get("type") != "blob":
-            continue
-        path = str(item.get("path") or "")
-        parts = path.split("/")
-        # Only top-level skill directories: exactly "<slug>/catalog.json".
-        if len(parts) == 2 and parts[1] == "catalog.json" and parts[0]:
-            slugs.append(parts[0])
-    return slugs
 
 
 # Coarse category buckets inferred from the slug/provider so the browse UI can
@@ -111,11 +112,12 @@ class BankrSource(SkillSource):
         *,
         repo: str = _DEFAULT_REPO,
         ref: str = _DEFAULT_REF,
+        allowlist: Sequence[str] = _ALLOWED_SLUGS,
     ) -> None:
         self._github = GitHubSource(token=token)
         self._repo = repo
         self._ref = ref
-        self._tree_api_url = f"https://api.github.com/repos/{repo}/git/trees/{ref}?recursive=1"
+        self._allowlist = tuple(allowlist)
         self._raw_base = f"https://raw.githubusercontent.com/{repo}/{ref}"
         self._cache_metas: list[SkillMeta] | None = None
         self._cache_at = 0.0
@@ -165,34 +167,37 @@ class BankrSource(SkillSource):
             return metas
 
     async def _fetch_catalog(self) -> list[SkillMeta] | None:
-        """Fetch the tree + all catalog.json files. Returns None on tree failure."""
+        """Fetch catalog.json + SKILL.md for each allowlisted slug directly.
+
+        No git-tree crawl: the slugs are fixed, so this issues at most two HTTP
+        requests per skill. Returns ``None`` on total failure (so the negative
+        cache retries after a short delay) — including when every entry errors
+        (e.g. a 429 burst), which would otherwise cache an empty list for the
+        full TTL.
+        """
         import httpx
+
+        if not self._allowlist:
+            return []
 
         try:
             async with httpx.AsyncClient(timeout=15, trust_env=_trust_env()) as client:
-                tree_resp = await client.get(self._tree_api_url, headers=self._github._headers())
-                tree_resp.raise_for_status()
-                tree = tree_resp.json()
-                if tree.get("truncated"):
-                    log.warning("bankr.tree_truncated")
-                    return None
-
-                slugs = _catalog_slugs(tree)
-                if not slugs:
-                    return []
-
                 sem = asyncio.Semaphore(_CATALOG_CONCURRENCY)
 
                 async def _load_one(slug: str) -> SkillMeta | None:
                     async with sem:
                         return await self._load_catalog_entry(client, slug)
 
-                loaded = await asyncio.gather(*(_load_one(s) for s in slugs))
+                loaded = await asyncio.gather(*(_load_one(s) for s in self._allowlist))
         except Exception as exc:
-            log.warning("bankr.tree_failed", error=str(exc))
+            log.warning("bankr.fetch_failed", error=str(exc))
             return None
 
         metas = [m for m in loaded if m is not None]
+        if not metas:
+            # Every allowlisted skill failed to load (outage / rate limit) —
+            # treat as a fetch failure so we retry rather than cache empty.
+            return None
         metas.sort(key=lambda m: m.name)
         return metas
 
@@ -267,6 +272,10 @@ class BankrSource(SkillSource):
         demo_raw = catalog.get("demo")
         demo = demo_raw if isinstance(demo_raw, dict) else {}
 
+        # Prefer a catalog-declared emoji; otherwise fall back to the Bankr
+        # brand mark so cards never render a bare initials box.
+        emoji = str(catalog.get("emoji") or "") or _BANKR_EMOJI
+
         return SkillMeta(
             name=slug,
             description="",
@@ -276,6 +285,7 @@ class BankrSource(SkillSource):
             homepage=str(catalog.get("providerUrl") or self._skill_url(slug)),
             provider=provider,
             logo=logo,
+            emoji=emoji,
             category=_infer_category(slug, provider),
             setup=setup,
             demo=demo,

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -23,7 +23,7 @@ import time
 import structlog
 
 from agentos.env import trust_env as _trust_env
-from agentos.skills.hub.github import GitHubSource
+from agentos.skills.hub.github import GitHubSource, _frontmatter_field
 from agentos.skills.hub.source import SkillBundle, SkillMeta, SkillSource
 
 log = structlog.get_logger(__name__)
@@ -197,14 +197,22 @@ class BankrSource(SkillSource):
         return metas
 
     async def _load_catalog_entry(self, client, slug: str) -> SkillMeta | None:
-        """Fetch and parse one skill's catalog.json. Skips on any error.
+        """Fetch and parse one skill's catalog.json, then SKILL.md. Skips on
+        catalog error.
 
-        Only catalog.json is fetched (one request per skill) to keep browsing
-        fast; the description is filled in later at fetch()/install time.
+        Only *installable* skills get the second SKILL.md fetch — external
+        installs and malformed catalogs are discarded first, so we never spend
+        a request on a skill that won't be listed. The description is
+        load-bearing for browse search (it feeds the ``_matches`` haystack), so
+        it is fetched eagerly here, not lazily per card; a failed description
+        fetch degrades to an empty string rather than dropping the skill.
+        Results are cached for the catalog TTL, so browsing stays a bounded
+        burst per refresh.
         """
-        url = f"{self._raw_base}/{slug}/catalog.json"
+        headers = self._github._headers()
+        catalog_url = f"{self._raw_base}/{slug}/catalog.json"
         try:
-            resp = await client.get(url, headers=self._github._headers())
+            resp = await client.get(catalog_url, headers=headers)
             resp.raise_for_status()
             catalog = json.loads(resp.content)
         except Exception as exc:
@@ -212,7 +220,26 @@ class BankrSource(SkillSource):
             return None
         if not isinstance(catalog, dict):
             return None
-        return self._meta_from_catalog(slug, catalog)
+        meta = self._meta_from_catalog(slug, catalog)
+        if meta is None:
+            return None
+        skill_md_url = f"{self._raw_base}/{slug}/SKILL.md"
+        meta.description = await self._load_description(client, slug, skill_md_url, headers)
+        return meta
+
+    async def _load_description(self, client, slug: str, url: str, headers: dict) -> str:
+        """Fetch SKILL.md and read its frontmatter description. Empty on error."""
+        try:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+        except Exception as exc:
+            log.warning("bankr.skill_md_failed", slug=slug, error=str(exc))
+            return ""
+        try:
+            text = resp.content.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+        return _frontmatter_field(text, "description")
 
     def _meta_from_catalog(self, slug: str, catalog: dict) -> SkillMeta | None:
         """Build a browse-time SkillMeta from a parsed catalog.json.
@@ -220,9 +247,8 @@ class BankrSource(SkillSource):
         Returns ``None`` when the skill is not a directly-installable ``bankr``
         skill (e.g. an ``external`` install), so callers can skip it. The
         human-readable description lives in ``SKILL.md`` frontmatter
-        (``catalog.json`` has none); it is filled in at ``fetch()`` time to keep
-        browsing fast, so the browse card shows slug + provider + catalog
-        demo/setup, but no description.
+        (``catalog.json`` has none); ``_load_catalog_entry`` fills it in with a
+        follow-up SKILL.md fetch after this meta is built.
         """
         install = catalog.get("install")
         if not isinstance(install, dict) or install.get("type") != "bankr":

--- a/src/agentos/skills/hub/clawhub.py
+++ b/src/agentos/skills/hub/clawhub.py
@@ -58,7 +58,10 @@ class ClawHubSource(SkillSource):
             results.append(
                 SkillMeta(
                     name=item.get("displayName", item.get("name", item.get("slug", ""))),
-                    description=item.get("summary", item.get("description", "")),
+                    # `or ""` (not a .get default): the API may send an explicit
+                    # null, which .get returns as None and would break the str
+                    # contract downstream (e.g. CLI description slicing).
+                    description=item.get("summary") or item.get("description") or "",
                     version=item.get("version", ""),
                     author=item.get("author", ""),
                     source_id=self.source_id,
@@ -156,7 +159,7 @@ class ClawHubSource(SkillSource):
 
         return SkillMeta(
             name=item.get("name", item.get("slug", identifier)),
-            description=item.get("description", ""),
+            description=item.get("description") or "",
             version=item.get("version", ""),
             author=item.get("author", ""),
             source_id=self.source_id,

--- a/src/agentos/skills/hub/defaults.py
+++ b/src/agentos/skills/hub/defaults.py
@@ -46,3 +46,21 @@ def installed_skill_names() -> set[str]:
 
     lockfile_path = default_agentos_home() / "skills-lock.json"
     return set(Lockfile.load(lockfile_path).installed.keys())
+
+
+def installed_skill_identifiers() -> set[str]:
+    """Return the source identifiers recorded as Community installs.
+
+    The lockfile is keyed by the installed skill's *name* (from its SKILL.md
+    frontmatter), which can differ from the catalog slug a browse card carries
+    (e.g. Bankr's ``bankr-token-scam-analysis`` slug installs as
+    ``token-scam-analysis``). Matching a browse result by identifier as well as
+    by name keeps its "installed" badge correct across a page reload.
+    """
+
+    lockfile_path = default_agentos_home() / "skills-lock.json"
+    return {
+        entry.identifier
+        for entry in Lockfile.load(lockfile_path).installed.values()
+        if entry.identifier
+    }

--- a/src/agentos/skills/hub/github.py
+++ b/src/agentos/skills/hub/github.py
@@ -232,7 +232,10 @@ class GitHubSource(SkillSource):
             results.append(
                 SkillMeta(
                     name=skill_name,
-                    description=repo.get("description", ""),
+                    # `or ""` (not a .get default): GitHub's repo API sends an
+                    # explicit null description, which .get returns as None and
+                    # would break the str contract downstream.
+                    description=repo.get("description") or "",
                     source_id=self.source_id,
                     trust_level=self.trust_level,
                     identifier=f"{full_name}:{path}",

--- a/src/agentos/skills/hub/github.py
+++ b/src/agentos/skills/hub/github.py
@@ -126,14 +126,54 @@ def _decode_file(path: str, content: bytes) -> str | bytes:
         return content
 
 
+# YAML block-scalar indicator: > or |, one optional chomping/indentation
+# modifier, optional trailing comment. Deliberately strict so a plain value
+# that merely starts with > or | is not mistaken for a block scalar.
+_BLOCK_SCALAR_RE = re.compile(r"^[>|](?:[+-]?\d?|\d[+-]?)(?:\s+#.*)?$")
+# Remote frontmatter is community-controlled — bound every returned value so a
+# hostile SKILL.md (block scalar OR one huge line) cannot inflate browse payloads.
+_MAX_FOLDED_LEN = 2000
+
+
+def _frontmatter_region(skill_md: str) -> str:
+    """Return only the leading frontmatter block, so field lookups never read
+    the markdown body. Falls back to the whole text when no closing delimiter
+    exists (legacy-lenient)."""
+    if skill_md.startswith("---"):
+        end = skill_md.find("\n---", 3)
+        if end != -1:
+            return skill_md[: end + 1]
+    return skill_md
+
+
 def _frontmatter_field(skill_md: str, field: str) -> str:
-    match = re.search(rf"^{re.escape(field)}:\s*(.+?)\s*$", skill_md, re.MULTILINE)
+    region = _frontmatter_region(skill_md)
+    match = re.search(rf"^{re.escape(field)}:\s*(.+?)\s*$", region, re.MULTILINE)
     if match is None:
         return ""
     value = match.group(1).strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
+    if _BLOCK_SCALAR_RE.match(value):
+        # YAML block scalar — fold the following indented lines into one line,
+        # stopping once we have enough to fill the cap.
+        block: list[str] = []
+        total = 0
+        for line in region[match.end() :].split("\n")[1:]:
+            if not line.strip():
+                continue
+            if not line[0].isspace():
+                break
+            block.append(line.strip())
+            total += len(block[-1]) + 1
+            if total >= _MAX_FOLDED_LEN:
+                break
+        result = " ".join(block)
+    elif len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        result = value[1:-1]
+    else:
+        result = value
+    # Single choke point: every path is bounded, so no remote value ships
+    # unbounded regardless of which YAML form produced it.
+    return result[:_MAX_FOLDED_LEN]
 
 
 def _fallback_name(ref: _GitHubSkillRef) -> str:

--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -51,6 +51,7 @@ class InstallResult:
     message: str = ""
     scan: ScanResult | None = None
     path: str = ""
+    sha256: str = ""
 
 
 class SkillInstaller:
@@ -181,6 +182,7 @@ class SkillInstaller:
             message=f"Installed '{name}' from {source_id}",
             scan=scan_result,
             path=str(install_dir),
+            sha256=sha,
         )
 
     async def uninstall(self, name: str) -> InstallResult:
@@ -207,7 +209,13 @@ class SkillInstaller:
         return InstallResult(success=True, name=name, message=f"Uninstalled '{name}'")
 
     async def update(self, name: str | None = None) -> list[InstallResult]:
-        """Re-install skills from lockfile. If name is None, update all."""
+        """Re-install skills from lockfile (re-fetches the latest source code).
+
+        If ``name`` is None, update all. The message distinguishes a genuine
+        update from a no-op by comparing the content hash before and after: the
+        source identifier tracks a branch (e.g. ``.../tree/main/bankr``), so a
+        re-fetch pulls whatever the branch tip is now.
+        """
         lockfile = Lockfile.load(self._lockfile_path)
         results = []
         entries = {name: lockfile.get(name)} if name else lockfile.installed
@@ -217,6 +225,12 @@ class SkillInstaller:
                     InstallResult(success=False, name=skill_name, message="Not in lockfile")
                 )
                 continue
+            old_sha = entry.sha256
             result = await self.install(entry.identifier, entry.source, force=True)
+            if result.success:
+                if old_sha and result.sha256 == old_sha:
+                    result.message = f"'{result.name}' is already up to date"
+                else:
+                    result.message = f"Updated '{result.name}' to the latest version"
             results.append(result)
         return results

--- a/src/agentos/skills/hub/source.py
+++ b/src/agentos/skills/hub/source.py
@@ -24,6 +24,7 @@ class SkillMeta:
     platforms: list[str] = field(default_factory=list)
     provider: str = ""  # publisher/brand (e.g. Bankr catalog "provider")
     logo: str = ""  # raw URL to a logo asset, or "" for an initials fallback
+    emoji: str = ""  # avatar emoji shown when no logo asset is available
     category: str = ""  # coarse grouping for browse filters (e.g. "defi")
     setup: list[str] = field(default_factory=list)  # ordered setup steps, if any
     demo: dict[str, Any] = field(default_factory=dict)  # {title, language, code}

--- a/tests/test_cli_skills_search_escape.py
+++ b/tests/test_cli_skills_search_escape.py
@@ -1,0 +1,38 @@
+"""CLI `skills search` must not interpret rich markup from remote descriptions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typer.testing import CliRunner
+
+from agentos.cli.skills_cmd import skills_app
+from agentos.skills.hub.source import SkillMeta
+
+
+class _StubRouter:
+    async def search(
+        self, query: str, limit: int = 20, source_id: str | None = None
+    ) -> list[SkillMeta]:
+        return [
+            SkillMeta(
+                name="evil",
+                description="[red]X[/red] spoof",
+                source_id="bankr",
+                trust_level="community",
+            )
+        ]
+
+
+def test_search_table_renders_remote_markup_literally(monkeypatch: Any) -> None:
+    from agentos.skills.hub import defaults
+
+    monkeypatch.setattr(defaults, "get_default_skill_router", lambda: _StubRouter())
+
+    runner = CliRunner()
+    result = runner.invoke(skills_app, ["search", "evil"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0
+    # Escaped markup renders as literal text; unescaped markup would be
+    # consumed by rich and "[red]" would not appear in the output.
+    assert "[red]X[/red]" in result.output

--- a/tests/test_gateway/test_rpc_skills_search_payload.py
+++ b/tests/test_gateway/test_rpc_skills_search_payload.py
@@ -27,6 +27,7 @@ async def test_skills_search_payload_carries_catalog_fields(monkeypatch) -> None
     result row — dropping any of them silently breaks the registry cards and
     the detail dialog."""
     monkeypatch.setattr(rpc_skills, "_installed_names", lambda: set())
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
     meta = SkillMeta(
         name="alchemy",
         source_id="bankr",
@@ -55,10 +56,37 @@ async def test_skills_search_payload_carries_catalog_fields(monkeypatch) -> None
 
 
 @pytest.mark.asyncio
+async def test_skills_search_marks_installed_by_identifier(monkeypatch) -> None:
+    """A skill whose lockfile name differs from its catalog slug must still show
+    as installed. Bankr's ``bankr-token-scam-analysis`` slug installs under the
+    name ``token-scam-analysis``, so name-only matching misses it — the source
+    identifier is the reliable join key across a page reload."""
+    # Lockfile records only the installed *name*, which does not match the
+    # browse card's name; the identifier is what lines up.
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"token-scam-analysis"})
+    monkeypatch.setattr(
+        rpc_skills,
+        "installed_skill_identifiers",
+        lambda: {"https://github.com/BankrBot/skills/tree/main/bankr-token-scam-analysis"},
+    )
+    meta = SkillMeta(
+        name="bankr-token-scam-analysis",
+        source_id="bankr",
+        identifier="https://github.com/BankrBot/skills/tree/main/bankr-token-scam-analysis",
+    )
+    router = _StubRouter([meta])
+
+    res = await rpc_skills._handle_skills_search({"query": "", "source": "bankr"}, _Ctx(router))
+
+    assert res["results"][0]["installed"] is True
+
+
+@pytest.mark.asyncio
 async def test_skills_search_limit_accommodates_full_catalog_browse(monkeypatch) -> None:
     """Browse requests whole catalogs (Bankr is ~100 skills); a cap sized for
     paged search results would silently truncate them."""
     monkeypatch.setattr(rpc_skills, "_installed_names", lambda: set())
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
     metas = [SkillMeta(name=f"skill-{i:03d}", source_id="bankr") for i in range(150)]
     router = _StubRouter(metas)
 

--- a/tests/test_gateway_static_skills_view.py
+++ b/tests/test_gateway_static_skills_view.py
@@ -27,19 +27,29 @@ def test_skills_view_browses_community_catalog_without_source_picker() -> None:
     assert "_communitySeq" in view
 
 
-def test_skills_view_bankr_tab_is_flag_gated_and_hidden_by_default() -> None:
+def test_skills_view_bankr_tab_is_flag_gated_and_shown() -> None:
     view = Path("src/agentos/gateway/static/js/views/skills.js").read_text(encoding="utf-8")
 
-    # The Bankr partner tab is behind a flag that is off by default (hidden
-    # from the UI) while the browse machinery stays wired for when it returns.
-    assert "const _SHOW_BANKR = false;" in view
-    assert 'data-tab="bankr"' in view  # markup preserved behind the flag
+    # The Bankr partner tab is behind a flag that is on — the source lists only
+    # a small fixed set of skills, so the dedicated tab is surfaced.
+    assert "const _SHOW_BANKR = true;" in view
+    assert 'data-tab="bankr"' in view
     assert "Bankr partner catalog" in view
     assert "params.source = 'bankr'" in view
     # Community only excludes Bankr while the Bankr tab is showing; otherwise
     # Bankr skills fall through into Community so they stay reachable.
     assert "_communityFilter" in view
     assert "_SHOW_BANKR ? results.filter(r => r.source !== 'bankr') : results" in view
+
+
+def test_skills_view_managed_skill_has_update_control() -> None:
+    view = Path("src/agentos/gateway/static/js/views/skills.js").read_text(encoding="utf-8")
+
+    # Managed skills expose an Update button that re-pulls the latest source
+    # code via the skills.update RPC.
+    assert 'data-update="${_esc(skill.name)}"' in view
+    assert "_updateSkill(updateBtn.dataset.update, updateBtn)" in view
+    assert "_rpc.call('skills.update', { name })" in view
 
 
 def test_skills_view_has_dedicated_robinhood_tab() -> None:
@@ -74,6 +84,9 @@ def test_skills_view_renders_registry_cards_with_provider_and_logo() -> None:
     # hidden sibling revealed by a static onerror (no data in inline JS).
     assert "_logoBadge" in view
     assert "${cls}--initials" in view
+    # With no logo asset, an emoji avatar is preferred over the initials box.
+    assert "${cls}--emoji" in view
+    assert "_esc(r.emoji)" in view
 
 
 def test_skills_view_registry_detail_shows_demo_and_setup() -> None:
@@ -125,4 +138,3 @@ def test_skills_view_distinguishes_bundled_from_local_layers() -> None:
     assert "Bundled skills ship with AgentOS." in view
     assert "Managed skills are locally installed into AgentOS state." in view
     assert "Personal skills are local user installs, not bundled." in view
-

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import pytest
 
-from agentos.skills.hub.bankr import BankrSource
+from agentos.skills.hub.bankr import _ALLOWED_SLUGS, BankrSource
+
+# The fake catalog exercises the filtering paths (installable / external /
+# malformed). We hand BankrSource this slug set via ``allowlist=`` so the source
+# fetches exactly these directly — no repo tree crawl.
+_FIXTURE_SLUGS = ("alchemy", "bankr", "extern", "broken")
 
 
 def _catalog(slug: str, *, install_type: str = "bankr", logo: str | None = None) -> bytes:
@@ -45,17 +50,12 @@ class _Response:
 
 
 class _AsyncClient:
-    """Mocks the BankrBot/skills tree + catalog.json fetches."""
+    """Mocks the per-skill BankrBot/skills catalog.json + SKILL.md fetches.
 
-    tree_entries = [
-        {"path": "alchemy/catalog.json", "type": "blob"},
-        {"path": "alchemy/SKILL.md", "type": "blob"},
-        {"path": "bankr/catalog.json", "type": "blob"},
-        {"path": "extern/catalog.json", "type": "blob"},
-        {"path": "broken/catalog.json", "type": "blob"},
-        {"path": ".github/workflows/ci.yml", "type": "blob"},
-        {"path": "nested/dir/catalog.json", "type": "blob"},  # too deep — ignored
-    ]
+    The source no longer crawls the git tree, so hitting the trees API here is a
+    regression — it raises instead.
+    """
+
     catalogs = {
         "alchemy": _catalog("alchemy", logo="alchemy.svg"),
         "bankr": _catalog("bankr", logo=None),
@@ -66,7 +66,6 @@ class _AsyncClient:
         "alchemy": b"---\nname: alchemy\ndescription: On-chain data APIs\n---\n# Alchemy\n",
         "bankr": b"---\nname: bankr\ndescription: AI-powered crypto trading agent\n---\n# Bankr\n",
     }
-    tree_calls = 0
     catalog_calls = 0
     skill_md_calls = 0
 
@@ -81,8 +80,7 @@ class _AsyncClient:
 
     async def get(self, url: str, **kwargs: Any) -> _Response:
         if "/git/trees/" in url:
-            type(self).tree_calls += 1
-            return _Response(json_data={"tree": self.tree_entries, "truncated": False})
+            raise AssertionError(f"tree API must not be called: {url}")
         marker = "raw.githubusercontent.com/BankrBot/skills/main/"
         if marker in url:
             slug = url.split(marker, 1)[1].split("/", 1)[0]
@@ -99,9 +97,12 @@ class _AsyncClient:
 
 @pytest.fixture(autouse=True)
 def _reset_client_counters() -> None:
-    _AsyncClient.tree_calls = 0
     _AsyncClient.catalog_calls = 0
     _AsyncClient.skill_md_calls = 0
+
+
+def _source() -> BankrSource:
+    return BankrSource(allowlist=_FIXTURE_SLUGS)
 
 
 @pytest.mark.asyncio
@@ -110,10 +111,10 @@ async def test_search_empty_query_lists_all_bankr_skills(monkeypatch) -> None:
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    results = await BankrSource().search("")
+    results = await _source().search("")
 
     names = {r.name for r in results}
-    # bankr + alchemy kept; external skipped; broken JSON skipped; nested ignored.
+    # bankr + alchemy kept; external skipped; broken JSON skipped.
     assert names == {"alchemy", "bankr"}
     assert all(r.source_id == "bankr" for r in results)
     assert all(r.trust_level == "community" for r in results)
@@ -125,7 +126,7 @@ async def test_search_builds_provider_logo_and_identifier(monkeypatch) -> None:
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    results = await BankrSource().search("")
+    results = await _source().search("")
     by_name = {r.name: r for r in results}
 
     alchemy = by_name["alchemy"]
@@ -135,8 +136,11 @@ async def test_search_builds_provider_logo_and_identifier(monkeypatch) -> None:
     )
     assert alchemy.identifier == "https://github.com/BankrBot/skills/tree/main/alchemy"
 
-    # Null logo in the catalog → empty logo (UI renders initials).
+    # Null logo in the catalog → empty logo, but the Bankr brand emoji fills in
+    # as the avatar so cards never render a bare initials box.
     assert by_name["bankr"].logo == ""
+    assert by_name["bankr"].emoji == "📺"
+    assert by_name["alchemy"].emoji == "📺"
 
 
 @pytest.mark.asyncio
@@ -145,7 +149,7 @@ async def test_search_carries_catalog_setup_demo_and_category(monkeypatch) -> No
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    results = await BankrSource().search("")
+    results = await _source().search("")
     bankr = next(r for r in results if r.name == "bankr")
 
     assert bankr.setup == ["Install bankr", "Set env var"]
@@ -165,7 +169,7 @@ async def test_search_fills_description_from_skill_md_frontmatter(monkeypatch) -
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    results = await BankrSource().search("")
+    results = await _source().search("")
     by_name = {r.name: r for r in results}
 
     assert by_name["bankr"].description == "AI-powered crypto trading agent"
@@ -185,7 +189,7 @@ async def test_missing_skill_md_keeps_skill_with_empty_description(monkeypatch) 
 
     monkeypatch.setattr(httpx, "AsyncClient", _MissingSkillMdClient)
 
-    results = await BankrSource().search("")
+    results = await _source().search("")
     by_name = {r.name: r for r in results}
 
     # A failed SKILL.md fetch must not drop the skill from the listing.
@@ -199,7 +203,9 @@ async def test_external_install_type_is_excluded(monkeypatch) -> None:
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    results = await BankrSource().search("extern")
+    # "extern" is allowlisted but its catalog declares install.type == external,
+    # so it is dropped and never matches a query.
+    results = await _source().search("extern")
 
     assert results == []
 
@@ -210,7 +216,7 @@ async def test_search_filters_by_query(monkeypatch) -> None:
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    results = await BankrSource().search("alche")
+    results = await _source().search("alche")
 
     assert [r.name for r in results] == ["alchemy"]
 
@@ -221,35 +227,66 @@ async def test_catalog_is_cached_across_searches(monkeypatch) -> None:
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
-    src = BankrSource()
+    src = _source()
     await src.search("")
-    first_tree = _AsyncClient.tree_calls
     first_catalog = _AsyncClient.catalog_calls
-    assert first_tree == 1
+    # One catalog.json fetch per allowlisted slug — no tree crawl.
+    assert first_catalog == len(_FIXTURE_SLUGS)
 
     await src.search("bankr")
 
     # Second search hits the cache — no additional network calls.
-    assert _AsyncClient.tree_calls == first_tree
     assert _AsyncClient.catalog_calls == first_catalog
 
 
-class _FailingTreeClient(_AsyncClient):
+class _FailingCatalogClient(_AsyncClient):
     async def get(self, url: str, **kwargs: Any) -> _Response:
-        if "/git/trees/" in url:
+        if url.endswith("/catalog.json"):
             raise RuntimeError("boom")
         return await super().get(url, **kwargs)
 
 
 @pytest.mark.asyncio
-async def test_tree_failure_returns_empty_without_raising(monkeypatch) -> None:
+async def test_all_entries_failing_returns_empty_without_raising(monkeypatch) -> None:
     import httpx
 
-    monkeypatch.setattr(httpx, "AsyncClient", _FailingTreeClient)
+    monkeypatch.setattr(httpx, "AsyncClient", _FailingCatalogClient)
+
+    results = await _source().search("")
+
+    assert results == []
+
+
+class _DefaultAllowlistClient(_AsyncClient):
+    """Serves only the two real default slugs."""
+
+    catalogs = {
+        "bankr": _catalog("bankr", logo=None),
+        "bankr-token-scam-analysis": _catalog("bankr-token-scam-analysis", logo=None),
+    }
+    skill_mds = {
+        "bankr": b"---\nname: bankr\ndescription: Trading agent\n---\n# Bankr\n",
+        "bankr-token-scam-analysis": (
+            b"---\nname: scam\ndescription: Scans tokens for scams\n---\n# Scan\n"
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_default_allowlist_loads_only_two_skills(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _DefaultAllowlistClient)
+
+    # Default (no allowlist arg) → exactly the two Bankr slugs, nothing else.
+    assert _ALLOWED_SLUGS == ("bankr", "bankr-token-scam-analysis")
 
     results = await BankrSource().search("")
 
-    assert results == []
+    assert {r.name for r in results} == {"bankr", "bankr-token-scam-analysis"}
+    # Two skills → two catalog.json + two SKILL.md fetches, and no tree crawl.
+    assert _DefaultAllowlistClient.catalog_calls == 2
+    assert _DefaultAllowlistClient.skill_md_calls == 2
 
 
 @pytest.mark.asyncio
@@ -270,7 +307,7 @@ async def test_fetch_and_inspect_delegate_to_github(monkeypatch) -> None:
     monkeypatch.setattr(GitHubSource, "inspect", _fake_inspect)
 
     src = BankrSource()
-    ident = "https://github.com/BankrBot/skills/tree/main/alchemy"
+    ident = "https://github.com/BankrBot/skills/tree/main/bankr"
     assert await src.fetch(ident) == "bundle"
     assert await src.inspect(ident) == "meta"
     assert calls == {"fetch": ident, "inspect": ident}

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -62,8 +62,13 @@ class _AsyncClient:
         "extern": _catalog("extern", install_type="external"),
         "broken": b"{ not json",
     }
+    skill_mds = {
+        "alchemy": b"---\nname: alchemy\ndescription: On-chain data APIs\n---\n# Alchemy\n",
+        "bankr": b"---\nname: bankr\ndescription: AI-powered crypto trading agent\n---\n# Bankr\n",
+    }
     tree_calls = 0
     catalog_calls = 0
+    skill_md_calls = 0
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
@@ -80,8 +85,14 @@ class _AsyncClient:
             return _Response(json_data={"tree": self.tree_entries, "truncated": False})
         marker = "raw.githubusercontent.com/BankrBot/skills/main/"
         if marker in url:
-            type(self).catalog_calls += 1
             slug = url.split(marker, 1)[1].split("/", 1)[0]
+            if url.endswith("/SKILL.md"):
+                type(self).skill_md_calls += 1
+                content = self.skill_mds.get(slug)
+                if content is None:
+                    return _Response(status_code=404)
+                return _Response(content=content)
+            type(self).catalog_calls += 1
             return _Response(content=self.catalogs.get(slug, b"{}"))
         raise AssertionError(f"unexpected URL: {url}")
 
@@ -90,6 +101,7 @@ class _AsyncClient:
 def _reset_client_counters() -> None:
     _AsyncClient.tree_calls = 0
     _AsyncClient.catalog_calls = 0
+    _AsyncClient.skill_md_calls = 0
 
 
 @pytest.mark.asyncio
@@ -145,6 +157,40 @@ async def test_search_carries_catalog_setup_demo_and_category(monkeypatch) -> No
     assert _infer_category("uniswap", "Uniswap") == "trading"
     assert _infer_category("aeon-defi-monitor", "Aeon") == "defi"
     assert _infer_category("zzz-unknown", "Nobody") == "other"
+
+
+@pytest.mark.asyncio
+async def test_search_fills_description_from_skill_md_frontmatter(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    results = await BankrSource().search("")
+    by_name = {r.name: r for r in results}
+
+    assert by_name["bankr"].description == "AI-powered crypto trading agent"
+    assert by_name["alchemy"].description == "On-chain data APIs"
+    # SKILL.md is fetched only for installable skills — external installs and
+    # broken catalogs never trigger a description fetch.
+    assert _AsyncClient.skill_md_calls == 2
+
+
+class _MissingSkillMdClient(_AsyncClient):
+    skill_mds: dict[str, bytes] = {}
+
+
+@pytest.mark.asyncio
+async def test_missing_skill_md_keeps_skill_with_empty_description(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MissingSkillMdClient)
+
+    results = await BankrSource().search("")
+    by_name = {r.name: r for r in results}
+
+    # A failed SKILL.md fetch must not drop the skill from the listing.
+    assert set(by_name) == {"alchemy", "bankr"}
+    assert by_name["bankr"].description == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills_hub_github.py
+++ b/tests/test_skills_hub_github.py
@@ -123,3 +123,71 @@ def test_default_gateway_router_exposes_github_without_token(monkeypatch) -> Non
         assert "github" in router.source_ids
     finally:
         defaults._default_router = None
+
+
+def test_frontmatter_field_reads_yaml_block_scalar() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    skill_md = (
+        "---\n"
+        "name: bankr-communities\n"
+        "description: >-\n"
+        "  Manage token-gated communities\n"
+        "  across Telegram and Farcaster.\n"
+        "homepage: https://bankr.bot\n"
+        "---\n"
+        "# Body\n"
+    )
+    assert _frontmatter_field(skill_md, "name") == "bankr-communities"
+    assert (
+        _frontmatter_field(skill_md, "description")
+        == "Manage token-gated communities across Telegram and Farcaster."
+    )
+    # Literal block scalars ("|") fold the same way for one-line display.
+    assert _frontmatter_field(skill_md.replace(">-", "|-"), "description") == (
+        "Manage token-gated communities across Telegram and Farcaster."
+    )
+
+
+def test_frontmatter_block_scalar_is_bounded_and_stops_at_frontmatter_end() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    # The fold must stop at the closing --- and never leak the body.
+    skill_md = (
+        "---\n"
+        "description: >-\n"
+        "  Short description.\n"
+        "---\n"
+        "  indented body line that must NOT be folded in\n"
+    )
+    assert _frontmatter_field(skill_md, "description") == "Short description."
+
+    # A hostile/unterminated block scalar cannot produce an unbounded value.
+    hostile = "---\ndescription: |\n" + ("  spam line\n" * 5000)
+    assert len(_frontmatter_field(hostile, "description")) <= 2000
+
+
+def test_frontmatter_block_scalar_indicator_variants() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    for indicator in ("|2", ">+", "> # a comment", "|-2"):
+        skill_md = f"---\ndescription: {indicator}\n  Folded text here.\n---\n"
+        assert _frontmatter_field(skill_md, "description") == "Folded text here.", indicator
+
+
+def test_frontmatter_plain_value_is_length_bounded() -> None:
+    from agentos.skills.hub.github import _MAX_FOLDED_LEN, _frontmatter_field
+
+    # A very long single-line (non-block) description must not ship unbounded.
+    hostile = "---\ndescription: " + ("A" * 1_000_000) + "\n---\n"
+    assert len(_frontmatter_field(hostile, "description")) <= _MAX_FOLDED_LEN
+
+    quoted = '---\ndescription: "' + ("B" * 1_000_000) + '"\n---\n'
+    assert len(_frontmatter_field(quoted, "description")) <= _MAX_FOLDED_LEN
+
+
+def test_frontmatter_handles_crlf_line_endings() -> None:
+    from agentos.skills.hub.github import _frontmatter_field
+
+    skill_md = "---\r\ndescription: On-chain data\r\n---\r\n# Body\r\n"
+    assert _frontmatter_field(skill_md, "description") == "On-chain data"

--- a/tests/test_skills_hub_installer_update.py
+++ b/tests/test_skills_hub_installer_update.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.skills.hub.installer import SkillInstaller
+from agentos.skills.hub.source import SkillBundle, SkillMeta
+
+
+def _skill_md(body: str) -> str:
+    return f"---\nname: demo\ndescription: Use when testing.\n---\n\n# Demo\n{body}\n"
+
+
+class MutableRouter:
+    """Router whose fetched bundle content can change between fetches, to
+    simulate a source (git branch) that has moved on."""
+
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    def set_body(self, body: str) -> None:
+        self._body = body
+
+    async def fetch(self, identifier: str, source_id: str) -> SkillBundle | None:
+        return SkillBundle(name="demo", files={"SKILL.md": _skill_md(self._body)}, meta=None)
+
+    async def inspect(self, identifier: str, source_id: str) -> SkillMeta | None:
+        return None
+
+
+def _installer(router: MutableRouter, tmp_path: Path) -> SkillInstaller:
+    return SkillInstaller(
+        router=router,
+        managed_dir=tmp_path / "managed",
+        quarantine_dir=tmp_path / "quarantine",
+        lockfile_path=tmp_path / "lock.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_reports_already_up_to_date_when_unchanged(tmp_path: Path) -> None:
+    router = MutableRouter("v1")
+    installer = _installer(router, tmp_path)
+
+    installed = await installer.install(
+        "https://github.com/BankrBot/skills/tree/main/demo", "bankr"
+    )
+    assert installed.success is True
+
+    # Re-fetch returns identical content → hash matches → no-op update.
+    results = await installer.update("demo")
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert "already up to date" in results[0].message
+
+
+@pytest.mark.asyncio
+async def test_update_pulls_new_code_and_reports_updated(tmp_path: Path) -> None:
+    router = MutableRouter("v1")
+    installer = _installer(router, tmp_path)
+
+    await installer.install("https://github.com/BankrBot/skills/tree/main/demo", "bankr")
+
+    # Source moves on: the branch tip now has new content.
+    router.set_body("v2-new-code")
+    results = await installer.update("demo")
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert "Updated" in results[0].message
+    # Managed dir is overwritten with the freshly-fetched code.
+    installed_md = (tmp_path / "managed" / "demo" / "SKILL.md").read_text(encoding="utf-8")
+    assert "v2-new-code" in installed_md
+
+
+@pytest.mark.asyncio
+async def test_update_unknown_skill_reports_not_in_lockfile(tmp_path: Path) -> None:
+    installer = _installer(MutableRouter("v1"), tmp_path)
+
+    results = await installer.update("does-not-exist")
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "Not in lockfile" in results[0].message


### PR DESCRIPTION
Supersedes #35 — this branch includes @keyKQ's original Bankr browse commit plus the follow-up fixes below.

## What changed
- **Two-skill limit (no 429):** `BankrSource` now fetches only the allowlisted `bankr` and `bankr-token-scam-analysis` catalog.json + SKILL.md directly, instead of crawling the full `BankrBot/skills` git tree (~99 skills) which tripped GitHub rate limits.
- **Update button:** managed skills expose an Update control that re-pulls the latest source via the `skills.update` RPC, reporting "Updated to the latest version" vs "already up to date".
- **Emoji avatar:** Bankr cards with no logo asset render a brand 📺 emoji avatar (emoji preferred over the initials box).
- **Installed-badge sync:** installed skills are matched by identifier as well as name, and the browse grid re-renders after install so both cards show a consistent "installed" state across refreshes.
- **None-description crash fix:** null `description` values are coalesced to `""` at the clawhub/github source boundary, plus a defensive CLI guard.

## Tests
- `ruff check`, `ruff format --check`, `node --check`, `mypy` all clean.
- 31 tests pass across `test_skills_hub_bankr.py`, `test_skills_hub_installer_update.py` (new), `test_rpc_skills_search_payload.py`, `test_gateway_static_skills_view.py`, `test_cli_skills_search_escape.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)