### PR TITLE
chore(release): bump version to 2026.7.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.19] - 2026-07-19
+
+### Added
+
+- Bundled `agentos` self-operation skill so the agent can drive its own
+  AgentOS CLI and gateway. (#37)
+
+### Changed
+
+- AgentOS Pilot (`pilot-v1`), the self-trained on-device English router, is now
+  the default router strategy. (#26)
+- Router strategy migration: persisted `v4_phase3` selections are force-migrated
+  to `pilot-v1` at gateway boot, and `v4_phase3` is dropped from the
+  human-facing onboarding and router selectors. (#36)
+- Bankr skills browse source: limited to two curated skills to avoid GitHub rate
+  limiting, filled the skill descriptions, and added a brand-glyph logo
+  fallback, a 📺 emoji avatar fallback, and an "Update" button backed by the
+  `skills.update` RPC. (#39, supersedes #35)
+
+### Fixed
+
+- Skills UI: the installed badge desynced between cards after an install and
+  reverted to "not installed" after a page refresh — installed skills are now
+  matched by both name and identifier. (#39)
+- Skill browsing crashed on an explicit JSON `null` description returned from the
+  GitHub/Clawhub search boundary; the description now defaults safely. (#39)
+- Local single-provider setups keep self-consistent router tiers, and several
+  local-provider degrade gaps were closed (vLLM handling, empty-model honesty,
+  and log visibility). (#30)
+
 ## [2026.7.18.post1] - 2026-07-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.18.post1 is the current release. The project website is
+AgentOS 2026.7.19 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.18.post1"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.19"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.18.post1/use_agent_os-2026.7.18.post1-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.19/use_agent_os-2026.7.19-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.18.post1-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.19-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.19 | v2026.7.19 | 2026-07-19 | AgentOS Pilot (`pilot-v1`) is now the default router strategy with force-migration off `v4_phase3` (#26, #36); bundled `agentos` self-operation skill (#37); Bankr browse source limited to two skills with Update button, emoji avatar, brand-glyph logo, and null-description crash fix (#39). |
 | 2026.7.18.post1 | v2026.7.18.post1 | 2026-07-18 | Release-hygiene re-cut: propagate the 2026.7.18 version across `uv.lock`, consistency/install tests, `RELEASES.md`, `CHANGELOG.md`, README install examples, and `install.sh`/`install.ps1`. No runtime code changes. |
 | 2026.7.18 | v2026.7.18 | 2026-07-18 | Gateway: interactive auth provisioning on public bind, host/port CLI-only (#25); browser-threat hardening on loopback binds — CSWSH/DNS-rebinding guards (#24); rebrand to "Token-Efficient AI agent with on-device Pilot Router" |
 | 2026.7.17.post1 | v2026.7.17.post1 | 2026-07-17 | `session_status` tool fix: resolve the calling session from the tool context instead of a `SessionManager` method that never existed |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.18.post1'
+$defaultVersion = 'v2026.7.19'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.18.post1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.19. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.18.post1"
+default_version="v2026.7.19"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.18.post1|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.19|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.18.post1
+  AGENTOS_VERSION=v2026.7.19
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=matrix
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.18.post1." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.19." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.18.post1"
+version = "2026.7.19"
 description = "Token-Efficient AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.18.post1"
+CURRENT_RELEASE_TAG = "v2026.7.19"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.18.post1"
+CURRENT_VERSION = "2026.7.19"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3900,7 +3900,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.18.post1"
+version = "2026.7.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps the AgentOS version from `2026.7.18.post1` to `2026.7.19` across all release surfaces: `pyproject.toml`, `uv.lock`, `install.sh`, `install.ps1`, README install examples, the `test_release_consistency.py` / `test_install_scripts.py` guard tests, `CHANGELOG.md`, and `RELEASES.md`.

## Release highlights (since v2026.7.18.post1)
- **Router:** AgentOS Pilot (`pilot-v1`) is now the default router strategy, with persisted `v4_phase3` selections force-migrated at boot (#26, #36)
- **Skills:** bundled `agentos` self-operation skill (#37)
- **Bankr browse:** limited to two curated skills, Update button, emoji avatar, brand-glyph logo, and null-description crash fix (#39)

## Verification
- `uv run pytest tests/test_release_consistency.py tests/test_install_scripts.py` → 18 passed

Generated with [Claude Code](https://claude.com/claude-code)