### PR TITLE
refactor: rename display name "AgentOS Router" to "Pilot Router"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,9 +180,9 @@ Initial release of AgentOS.
 - Durable sessions, chat history, and replay data persisted in SQLite, with a
   per-agent workspace folder and bounded-depth subagents.
 
-### AgentOS Router
+### Pilot Router
 
-- AgentOS Router picks the cheapest capable model tier (c0–c3) for each turn.
+- Pilot Router picks the cheapest capable model tier (c0–c3) for each turn.
   The default `recommended` install ships the router; `AGENTOS_INSTALL_PROFILE=core`
   or `--router disabled` turns it off and routes every turn to one model.
 - Two selectable routing strategies. The default `v4_phase3` runs an on-device
@@ -196,7 +196,7 @@ Initial release of AgentOS.
   a local OpenAI-compatible endpoint (Ollama / LM Studio / llama.cpp / vLLM)
   set with `judge_model` / `judge_base_url` — and needs no local model files.
 - Onboarding (Web UI wizard and CLI) offers the strategy via the Mode dropdown —
-  "AgentOS Router (Local ML)", "AgentOS Router (LLM Judge)", or "Disabled". The
+  "Pilot Router (Local ML)", "Pilot Router (LLM Judge)", or "Disabled". The
   "Judge model" field applies to, and appears only for, the LLM Judge strategy.
 - `/c0`–`/c3` slash commands (web chat and messaging channels) pin the router
   to a tier for the current session; `/auto` restores automatic routing. These

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -61,7 +61,7 @@ Most user-facing pages should answer:
 5. Where should I go next?
 
 Independent features should stay on independent pages. For example, memory,
-skills, AgentOS Router, tool compression, compaction, channels, and
+skills, Pilot Router, tool compression, compaction, channels, and
 artifacts should not be merged into one broad mechanism page.
 
 ---

--- a/docs/diagnostics-and-replay.md
+++ b/docs/diagnostics-and-replay.md
@@ -39,7 +39,7 @@ agentos diagnostics off
 Use diagnostics for:
 
 - provider retries, timeouts, or empty responses;
-- AgentOS Router model decisions;
+- Pilot Router model decisions;
 - prompt-cache or cache-break investigation;
 - compaction lifecycle events;
 - large tool-result compression;

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,7 +15,7 @@ channels, scheduling, and reusable skills.
 
 ## Distinctive Features
 
-### AgentOS Router
+### Pilot Router
 
 Local routing for model tier selection. It is designed to keep easy turns cheap
 and reserve expensive models for work that needs them.

--- a/docs/features/agentos-router.md
+++ b/docs/features/agentos-router.md
@@ -1,6 +1,6 @@
-# AgentOS Router
+# Pilot Router
 
-AgentOS Router is AgentOS's local model-routing layer. It helps the agent
+Pilot Router is AgentOS's local model-routing layer. It helps the agent
 choose an appropriate model tier for each turn so routine work does not always
 run on the most expensive model.
 
@@ -9,7 +9,7 @@ decide whether a fixed provider/model is better for a specific run.
 
 ## Why Use It
 
-AgentOS Router is useful when you want:
+Pilot Router is useful when you want:
 
 - lower cost for simple chat, edits, summaries, and routine tool work;
 - stronger models reserved for hard reasoning, recovery, and long tasks;
@@ -21,7 +21,7 @@ It is not required. AgentOS can also run in direct single-model mode.
 
 ## Strategies
 
-AgentOS Router has three selectable strategies, set via
+Pilot Router has three selectable strategies, set via
 `agentos_router.strategy` in `agentos.toml` (or the onboarding wizard):
 
 | Strategy | Mode label | How it decides |
@@ -151,7 +151,7 @@ by the local catalog.
 
 ## What the Router Can Affect
 
-Depending on configuration, AgentOS Router may influence:
+Depending on configuration, Pilot Router may influence:
 
 - selected model tier;
 - direct model fallback;
@@ -223,7 +223,7 @@ If routing does not appear to work:
    agentos doctor
    ```
 
-3. If AgentOS Router optional ML dependencies (`lightgbm`, `joblib`,
+3. If Pilot Router optional ML dependencies (`lightgbm`, `joblib`,
    `scikit-learn`, `onnxruntime` — install via `uv sync --extra recommended`
    or the `ml-router` extra) or the local model bundle are missing, the
    `v4_phase3` strategy degrades to the default tier rather than failing the

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -100,7 +100,7 @@ that AgentOS can load when needed.
 
 Read: [`features/skills.md`](features/skills.md)
 
-## AgentOS Router
+## Pilot Router
 
 AgentOS's local routing layer for choosing an appropriate model tier per
 turn.

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -1,7 +1,7 @@
 # Providers and Models
 
 AgentOS supports multiple LLM providers through one configuration surface.
-You can run direct single-model mode or enable AgentOS Router for tiered routing.
+You can run direct single-model mode or enable Pilot Router for tiered routing.
 
 Use this page when you need to configure a provider, inspect model support, or
 choose between direct model mode and router mode.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 This guide gets AgentOS installed, configured, and running locally. It
 assumes you want the standard product experience: terminal commands, local Web
-UI, AgentOS Router, memory/search support, and safe local defaults.
+UI, Pilot Router, memory/search support, and safe local defaults.
 
 ## Requirements
 
@@ -18,7 +18,7 @@ Install the current release (recommended extras included) by following the
 release assets are always on the
 [Releases page](https://github.com/use-agent-os/agent-os/releases/latest).
 
-The `recommended` extra includes AgentOS Router dependencies and memory/search
+The `recommended` extra includes Pilot Router dependencies and memory/search
 support used by the default product experience.
 
 If `agentos` is not found after install, open a new shell or run:
@@ -210,7 +210,7 @@ After the first run:
    [`features/memory.md`](features/memory.md).
 4. Review tool permissions before unattended automation:
    [`tools-and-sandbox.md`](tools-and-sandbox.md).
-5. Learn AgentOS Router if you want cost-aware model routing:
+5. Learn Pilot Router if you want cost-aware model routing:
    [`features/agentos-router.md`](features/agentos-router.md).
 6. Use the glossary if product terms are unfamiliar:
    [`glossary.md`](glossary.md).

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -218,7 +218,7 @@
         <a href="#what" class="anchor-link text-[var(--accent)]">#</a>
       </h2>
       <p class="mt-5 max-w-[68ch] text-[16px] leading-relaxed text-[var(--text-dim)]">
-        AgentOS is a microkernel Python agent runtime. A local model router (AgentOS Router) sends each turn to the
+        AgentOS is a microkernel Python agent runtime. A local model router (Pilot Router) sends each turn to the
         cheapest model that can handle it, while persistent memory, a layered sandbox, built-in web search, and
         on-device embeddings round out a single shared turn loop. Every entry point (Web UI, CLI, and chat
         channels) runs through that same loop.
@@ -229,7 +229,7 @@
           <div class="mb-3 text-[var(--accent)]">
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M3 12h4l3-8 4 16 3-8h4"/></svg>
           </div>
-          <h3 class="text-[15px] font-semibold">AgentOS Router</h3>
+          <h3 class="text-[15px] font-semibold">Pilot Router</h3>
           <p class="mt-2 text-[13.5px] leading-relaxed text-[var(--text-dim)]">An on-device router scores each turn and routes it across tiers c0 to c3, so an easy turn never pays for a frontier model.</p>
         </div>
         <div class="bg-[var(--bg-2)] p-6">
@@ -278,7 +278,7 @@
           <span class="mono mt-0.5 text-[var(--accent)]">03</span>
           <div>
             <p class="font-medium">Git with LFS (source install only)</p>
-            <p class="mt-1 text-[13.5px] text-[var(--text-dim)]">The AgentOS Router model files ship via Git LFS. Run <span class="mono text-[var(--text)]">git lfs install</span> before cloning if you build from source.</p>
+            <p class="mt-1 text-[13.5px] text-[var(--text-dim)]">The Pilot Router model files ship via Git LFS. Run <span class="mono text-[var(--text)]">git lfs install</span> before cloning if you build from source.</p>
           </div>
         </li>
       </ul>
@@ -314,7 +314,7 @@
 <pre data-lang="bash"># 1 - install uv (macOS / Linux)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 2 - install AgentOS with the recommended extras (AgentOS Router)
+# 2 - install AgentOS with the recommended extras (Pilot Router)
 uv tool install --python 3.12 \
   "use-agent-os[recommended] @ https://github.com/use-agent-os/agent-os/releases/download/v0.0.1/use_agent_os-0.0.1-py3-none-any.whl"
 
@@ -401,7 +401,7 @@ agentos onboard status</pre>
         </div>
         <div class="bg-[var(--bg-2)] p-5">
           <div class="flex items-center gap-2"><span class="mono text-[12px] text-[var(--accent)]">02</span><span class="text-[14px] font-semibold">Router</span><span class="ml-auto mono text-[10px] uppercase tracking-wider text-[var(--accent)]">required</span></div>
-          <p class="mt-2 text-[13px] text-[var(--text-dim)]">AgentOS Router on, or direct single-model.</p>
+          <p class="mt-2 text-[13px] text-[var(--text-dim)]">Pilot Router on, or direct single-model.</p>
         </div>
         <div class="bg-[var(--bg-2)] p-5">
           <div class="flex items-center gap-2"><span class="mono text-[12px] text-[var(--text-faint)]">03</span><span class="text-[14px] font-semibold">Channels</span><span class="ml-auto mono text-[10px] uppercase tracking-wider text-[var(--text-faint)]">optional</span></div>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,7 +87,7 @@ agentos configure provider --provider openai --api-key-env OPENAI_API_KEY
 
 ## Router Dependency Problems
 
-If AgentOS Router cannot load, AgentOS can still run with direct model
+If Pilot Router cannot load, AgentOS can still run with direct model
 routing. To disable the router:
 
 ```sh

--- a/docs/usage-and-cost.md
+++ b/docs/usage-and-cost.md
@@ -33,7 +33,7 @@ estimated cost.
 agentos cost --by-model
 ```
 
-Use this when AgentOS Router is enabled and you want to see which models carried
+Use this when Pilot Router is enabled and you want to see which models carried
 the recent workload.
 
 ## Use JSON Output

--- a/src/agentos/cli/onboard_cmd.py
+++ b/src/agentos/cli/onboard_cmd.py
@@ -86,7 +86,7 @@ def _section_status_display(status: OnboardingStatus, name: str) -> str:
     if (
         name == "router"
         and state is SectionStatus.OK
-        and _section_detail(status, name) == "uses AgentOS Router after provider setup"
+        and _section_detail(status, name) == "uses Pilot Router after provider setup"
     ):
         return "Provider first"
     return _status_display(state)
@@ -372,7 +372,7 @@ def _print_optional_action_handoff(
 
 onboard_app = typer.Typer(
     help=(
-        "AgentOS setup cockpit for providers, AgentOS Router, "
+        "AgentOS setup cockpit for providers, Pilot Router, "
         "channels, search, images, and memory."
     ),
     invoke_without_command=True,
@@ -614,7 +614,7 @@ _CATALOG_SECTION_COMMANDS = {
 
 _CATALOG_TITLES = {
     "providers": "Text providers",
-    "routerProfiles": "AgentOS Router profiles",
+    "routerProfiles": "Pilot Router profiles",
     "searchProviders": "Web search providers",
     "channels": "Channel types",
     "imageGenerationProviders": "Image generation providers",
@@ -763,7 +763,7 @@ def _print_catalog_recipe_hint() -> None:
 
 
 def _catalog_provider_route(row: dict[str, object]) -> str:
-    return "AgentOS Router ready" if row.get("routerSupported") else "Direct only"
+    return "Pilot Router ready" if row.get("routerSupported") else "Direct only"
 
 
 def _print_list_catalog(
@@ -851,7 +851,7 @@ def _router_tier_summary(profile: dict[str, object]) -> str:
 def _print_router_catalog(catalog: dict[str, object], config_arg: str = "") -> None:
     modes = catalog.get("modes")
     if isinstance(modes, list):
-        console.print("[bold]AgentOS router modes[/bold]")
+        console.print("[bold]Pilot router modes[/bold]")
         for row in modes:
             if not isinstance(row, dict):
                 continue
@@ -870,7 +870,7 @@ def _print_router_catalog(catalog: dict[str, object], config_arg: str = "") -> N
                 f"- {_catalog_value(row, 'profileId')}: {_catalog_value(row, 'label')}"
                 f" | {_router_tier_summary(row)}"
             )
-    console.print("Copy a Try line to keep the default AgentOS router profile.")
+    console.print("Copy a Try line to keep the default Pilot router profile.")
     _print_catalog_line(f"  Try: {_catalog_command('routerProfiles', config_arg)}")
 
 

--- a/src/agentos/engine/commands.py
+++ b/src/agentos/engine/commands.py
@@ -253,7 +253,7 @@ _COMMANDS: tuple[CommandDef, ...] = (
         },
     ),
     # ---- Router tier holds (web + channel) --------------------------------
-    # /c0-/c3 pin the AgentOS Router to one configured tier for this session
+    # /c0-/c3 pin the Pilot Router to one configured tier for this session
     # (short-lived hold, same mechanism as the router_control tool); /auto
     # restores automatic routing. Tiers not present in the active router
     # config are rejected by the RPC with an operator-readable error.
@@ -261,7 +261,7 @@ _COMMANDS: tuple[CommandDef, ...] = (
         CommandDef(
             name=f"/{tier}",
             usage=f"/{tier}",
-            description=f"Pin the AgentOS Router to tier {tier} for this session.",
+            description=f"Pin the Pilot Router to tier {tier} for this session.",
             execution={
                 _W: _rpc("router.hold.set", _tier_hold(tier)),
                 _C: _rpc("router.hold.set", _tier_hold(tier)),
@@ -272,7 +272,7 @@ _COMMANDS: tuple[CommandDef, ...] = (
     CommandDef(
         name="/auto",
         usage="/auto",
-        description="Restore automatic AgentOS Router routing (clear tier hold).",
+        description="Restore automatic Pilot Router routing (clear tier hold).",
         execution={
             _W: _rpc("router.hold.clear", _key),
             _C: _rpc("router.hold.clear", _key),

--- a/src/agentos/engine/pricing.py
+++ b/src/agentos/engine/pricing.py
@@ -191,7 +191,7 @@ def _apply_discount_inverse(price_per_token: float, discount: float) -> float:
     """Return the non-discounted token price when OpenRouter reports a discount.
 
     OpenRouter endpoint pricing also includes cache-read rates. Those are not
-    used here: AgentOS Router savings and AgentOS estimates must use the normal
+    used here: Pilot Router savings and AgentOS estimates must use the normal
     prompt/completion price, then remove any explicit endpoint discount.
     """
     if discount <= 0:
@@ -336,7 +336,7 @@ def seed_live_price_cache_for_tests(model_id: str, price: PriceEntry) -> None:
 
 # Built-in pricing table: model_prefix → (input_per_M, output_per_M)
 _PRICING_TABLE: list[tuple[str, PriceEntry]] = [
-    # Offline fallback for AgentOS Router tier models.
+    # Offline fallback for Pilot Router tier models.
     ("stepfun/step-3.5-flash", PriceEntry(0.10, 0.30)),
     ("z-ai/glm-4.5-air", PriceEntry(0.13, 0.85)),
     ("minimax/minimax-m2.5", PriceEntry(0.118, 0.99)),

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -1517,7 +1517,7 @@ class TurnRunner:
 
     @property
     def router_control_config(self) -> Any:
-        """Active AgentOS Router config section, or None when not configured."""
+        """Active Pilot Router config section, or None when not configured."""
         return getattr(self._config, "agentos_router", None)
 
     def has_compacted_this_turn(self, session_key: str) -> bool:
@@ -1909,7 +1909,7 @@ class TurnRunner:
         1. Resolve provider (cloned selector — no shared state mutation)
         2. Build tools + handler from registry (filtered by tool_context)
         3. Assemble identity system prompt
-        4. Run pre-turn pipeline (model routing, AgentOS Router, skills, prompt cache)
+        4. Run pre-turn pipeline (model routing, Pilot Router, skills, prompt cache)
         5. Load session history
         6. Construct and run Agent
         7. Persist assistant response to transcript
@@ -3966,7 +3966,7 @@ class TurnRunner:
                 )
                 return commit_deferred_router_history(routed)
             except TimeoutError as exc:
-                raise TimeoutError(f"AgentOS Router timed out after {router_timeout:g}s") from exc
+                raise TimeoutError(f"Pilot Router timed out after {router_timeout:g}s") from exc
 
         _bounded_apply_agentos_router.__name__ = "apply_agentos_router"
 
@@ -4246,7 +4246,7 @@ class TurnRunner:
                 router_cfg = getattr(self._config, "agentos_router", None)
                 agentos_router_tiers = getattr(router_cfg, "tiers", {})
 
-                # AgentOS Router
+                # Pilot Router
                 savings_telemetry.routed_model = metadata.get("routed_model")
                 savings_telemetry.baseline_model = metadata.get("baseline_model")
                 savings_telemetry.routing_confidence = metadata.get("routing_confidence")

--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -1,4 +1,4 @@
-"""Step 2: AgentOS Router — classify message complexity and route to appropriate model.
+"""Step 2: Pilot Router — classify message complexity and route to appropriate model.
 
 Runs 2-level ThinkingController + PromptController on top of the routing
 output.  Rollout is gated via ``agentos_router.rollout_phase`` so existing
@@ -364,7 +364,7 @@ _RESPONSE_POLICY_OPEN = "[RESPONSE_POLICY:"
 
 @dataclass
 class RoutingDecision:
-    """Result of AgentOS Router classification."""
+    """Result of Pilot Router classification."""
 
     tier: str
     model: str
@@ -1243,7 +1243,7 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
                 note="image detected but no supports_image tier",
             )
             raise RuntimeError(
-                "No image-capable AgentOS Router tier is configured for this image request. "
+                "No image-capable Pilot Router tier is configured for this image request. "
                 "Configure agentos_router.tiers.image_model with supports_image=true."
             )
         tier_name = random.choice(list(image_tiers.keys()))

--- a/src/agentos/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/agentos/engine/turn_runner/prompt_assembler_stage.py
@@ -244,7 +244,7 @@ class PromptAssemblerStageOutput:
       etc.). Downstream stages read ``turn.metadata`` and ``turn.tool_defs``.
     - ``effective_runtime_message``: the message string the agent loop
       should pass to the provider — may be the post-pipeline-rewritten
-      ``turn.message`` (e.g. AgentOS Router rewrites).
+      ``turn.message`` (e.g. Pilot Router rewrites).
     - ``final_prompt``: the resolved system prompt string.
     - ``cache_breakpoints``: the cache-break list for the provider call,
       or ``None``.

--- a/src/agentos/engine/types.py
+++ b/src/agentos/engine/types.py
@@ -173,7 +173,7 @@ class DoneEvent:
 
 @dataclass
 class RouterDecisionEvent:
-    """AgentOS Router's decision for this turn, emitted once after the
+    """Pilot Router's decision for this turn, emitted once after the
     pre-turn pipeline resolves the tier/model. Frontend uses this to drive
     the router HUD (tier pill, tier-shift highlight, scanner popover).
 

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -331,7 +331,7 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
                 "(default flip; legacy router auto-migrated on load)"
             )
             logging.getLogger(__name__).info(
-                "AgentOS router strategy force-migrated %s -> %s on config load",
+                "Pilot router strategy force-migrated %s -> %s on config load",
                 V4_STRATEGY_ID,
                 PILOT_STRATEGY_ID,
             )

--- a/src/agentos/gateway/rpc_router.py
+++ b/src/agentos/gateway/rpc_router.py
@@ -1,4 +1,4 @@
-"""RPC handlers for user-directed AgentOS Router tier holds.
+"""RPC handlers for user-directed Pilot Router tier holds.
 
 Backs the /c0-/c3 and /auto slash commands: a session-scoped, short-lived
 tier hold set through the same ``RouterControlHoldStore`` the LLM-facing
@@ -42,7 +42,7 @@ def _router_state(ctx: RpcContext) -> tuple[Any, RouterControlHoldStore]:
     if cfg is None or not getattr(cfg, "enabled", False):
         raise RpcHandlerError(
             "router.disabled",
-            "AgentOS Router is disabled or unavailable",
+            "Pilot Router is disabled or unavailable",
         )
     return cfg, store
 
@@ -60,7 +60,7 @@ async def _handle_router_hold_set(params: dict | None, ctx: RpcContext) -> dict[
     except RouterControlValidationError as exc:
         raise RpcHandlerError(
             "router.unknown_tier",
-            f"Tier '{tier}' is not configured on the AgentOS Router",
+            f"Tier '{tier}' is not configured on the Pilot Router",
             details={"tier": tier},
         ) from exc
 

--- a/src/agentos/gateway/static/css/views/chat.css
+++ b/src/agentos/gateway/static/css/views/chat.css
@@ -2176,7 +2176,7 @@
     z-index: 2500;
   }
   /* When the run-modes popover is open, mute the toast stack so transient
-     "AgentOS Router: ON/OFF" confirmations don't cover the popover content
+     "Pilot Router: ON/OFF" confirmations don't cover the popover content
      the user is still interacting with. The toggle's own visible state is
      the canonical feedback in this moment. */
   body:has(.chat-toolbar-popover.is-open) .toast-stack {
@@ -2255,7 +2255,7 @@
   color: #fff;
 }
 
-/* ─── Toggle Switch (AgentOS Router) ──────────────────────────────────────── */
+/* ─── Toggle Switch (Pilot Router) ──────────────────────────────────────── */
 
 .toggle-switch-wrap {
   display: flex;
@@ -2357,7 +2357,7 @@
 }
 
 /* ─── Router-fx dock ──────────────────────────────────────────────────────
- * Hosts the AgentOS Router auto-select strip BELOW the chat input bar, in
+ * Hosts the Pilot Router auto-select strip BELOW the chat input bar, in
  * the slot where the routed model is displayed. One strip at a time; the
  * dock collapses to nothing while empty so the composer keeps its height. */
 .chat-routerfx-dock {
@@ -2483,7 +2483,7 @@
   50% { box-shadow: 0 0 8px 3px rgba(239, 68, 68, 0.25); }
 }
 
-/* ─── AgentOS Router & Prompt-Cache per-turn chips ────────────────────────── */
+/* ─── Pilot Router & Prompt-Cache per-turn chips ────────────────────────── */
 
 .msg-savings-bar {
   display: flex;
@@ -2512,7 +2512,7 @@
   to   { opacity: 1; transform: scale(1); }
 }
 
-/* AgentOS Router tier routing  -  amber. Token-based: color-mix(var(--warn))
+/* Pilot Router tier routing  -  amber. Token-based: color-mix(var(--warn))
    resolves per theme, so the hand-written [data-theme] twins are gone. */
 .savings-chip--tier {
   background: color-mix(in srgb, var(--warn) 14%, transparent);
@@ -2776,7 +2776,7 @@
 
 /* ──────────────────────────────────────────────────────────────────
  * Router slider  -  arcade-brutalist whac-a-mole grid that fires when
- * the AgentOS Router lands a tier.
+ * the Pilot Router lands a tier.
  *
  * The strip is a compact grid of real candidates for the current
  * request kind. A square hammer-selector hops between cells with

--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -541,7 +541,7 @@ const ChatView = (() => {
   // invoked on session boundaries so a fresh chat can fire on the very
   // first qualifying turn.
   const _SAVINGS_POPUP_COOLDOWN_MS = 10 * 60 * 1000;
-  // Product decision: the AgentOS Router scanning strip stays, but the celebratory
+  // Product decision: the Pilot Router scanning strip stays, but the celebratory
   // savings popup (viewport-centered particle burst + "Saved ~X%" float) is
   // disabled by default — it distracts more than it informs and the figure is a
   // vs-flagship estimate, not realized spend. Streak/combo bookkeeping and the
@@ -647,7 +647,7 @@ const ChatView = (() => {
   let _elevatedPill = null;
   let _composer = null;
   let _composerObserver = null;
-  // Router-fx dock: the auto-select (AgentOS Router) visualisation renders
+  // Router-fx dock: the auto-select (Pilot Router) visualisation renders
   // HERE, below the chat input bar where the routed model is displayed — the
   // strip never mounts inside the chat thread anymore.
   let _routerFxDock = null;
@@ -1068,7 +1068,7 @@ const ChatView = (() => {
                   : turnSavedPct >= 45 ? ' msg-meta__saved--high'
                   : '';
       span.className = 'msg-meta__saved' + tier;
-      span.title = `AgentOS Router routed this turn (~${Math.round(turnSavedPct)}% vs flagship)`;
+      span.title = `Pilot Router routed this turn (~${Math.round(turnSavedPct)}% vs flagship)`;
       const NS = 'http://www.w3.org/2000/svg';
       const flame = document.createElementNS(NS, 'svg');
       flame.setAttribute('class', 'msg-meta__saved-flame');
@@ -1103,7 +1103,7 @@ const ChatView = (() => {
                   : streak >= 3 ? ' msg-meta__combo--hot'
                   : '';
       span.className = 'msg-meta__combo' + tier;
-      span.title = 'AgentOS Router combo — ' + streak + ' consecutive savings turns';
+      span.title = 'Pilot Router combo — ' + streak + ' consecutive savings turns';
       span.setAttribute('aria-label', 'Combo ' + streak);
       // Inline SVG flame — color is owned by CSS so it always reads as red,
       // independent of the OS-rendered emoji palette.
@@ -1260,9 +1260,9 @@ const ChatView = (() => {
                             title="Approval prompts are active. Click to enable approval bypass for this browser session.">Approval prompts</button>
                   </div>
                   <div class="chat-toolbar-row">
-                    <span class="chat-toolbar-row-label">AgentOS Router</span>
-                    <div class="toggle-switch-wrap" id="pill-router-group" title="AgentOS Router">
-                      <label class="toggle-switch" aria-label="AgentOS Router">
+                    <span class="chat-toolbar-row-label">Pilot Router</span>
+                    <div class="toggle-switch-wrap" id="pill-router-group" title="Pilot Router">
+                      <label class="toggle-switch" aria-label="Pilot Router">
                         <input type="checkbox" id="toggle-router" />
                         <span class="toggle-track"><span class="toggle-thumb"></span></span>
                       </label>
@@ -1389,7 +1389,7 @@ const ChatView = (() => {
     window.addEventListener('agentos:elevated-mode', elevatedListener);
     _unsubs.push(() => window.removeEventListener('agentos:elevated-mode', elevatedListener));
 
-    // AgentOS Router toggle switch
+    // Pilot Router toggle switch
     const routerToggle = _el.querySelector('#toggle-router');
     if (routerToggle) {
       routerToggle.addEventListener('change', async () => {
@@ -1405,7 +1405,7 @@ const ChatView = (() => {
           });
           _toolbarState.router = enabled;
           _refreshToolbarTriggerGlow();
-          UI.toast('AgentOS Router: ' + (enabled ? 'ON' : 'OFF'), 'info');
+          UI.toast('Pilot Router: ' + (enabled ? 'ON' : 'OFF'), 'info');
         } catch (e) {
           // Revert on failure
           _routerFeatureEnabled = previousRouterFeatureEnabled;
@@ -2817,7 +2817,7 @@ const ChatView = (() => {
         break;
       }
       case 'router.hold.set': {
-        // /c0-/c3 — pin the AgentOS Router to one tier for this session.
+        // /c0-/c3 — pin the Pilot Router to one tier for this session.
         const tier = (commandName || '').replace(/^\//, '').toLowerCase();
         _rpc.call('router.hold.set', { key: _sessionKey, tier })
           .then((res) => {

--- a/src/agentos/gateway/static/js/views/setup.js
+++ b/src/agentos/gateway/static/js/views/setup.js
@@ -384,7 +384,7 @@ const SetupView = (() => {
             </select>
           </label>
           <div class="setup-provider-meta" data-provider-router-support>
-            <span>AgentOS Router tiers</span>
+            <span>Pilot Router tiers</span>
             <strong class="setup-provider-meta__badge ${_esc(routerSupportTone)}" data-provider-router-support-label>${_esc(_providerRouterSupportText(selected ? spec : null))}</strong>
           </div>
           ${_renderNeedList(selected ? spec.whatYouNeed : ['Choose a provider to see required fields.'], 'Provider needs', 'data-provider-needs')}
@@ -405,7 +405,7 @@ const SetupView = (() => {
 
   function _providerRouterSupportText(spec) {
     if (!spec || !spec.providerId) return 'choose provider';
-    return spec.routerSupported === true ? 'AgentOS Router ready' : 'Direct only';
+    return spec.routerSupported === true ? 'Pilot Router ready' : 'Direct only';
   }
 
   function _providerRouterSupportTone(spec) {
@@ -624,7 +624,7 @@ const SetupView = (() => {
             <span>Tier</span><span>Provider</span><span>Model</span><span>Thinking</span><span>Image</span>
           </div>
           ${Object.entries(tiers).filter(([name]) => TEXT_TIERS.includes(name) || name === 'image_model').map(([name, tier]) => _tierRow(name, tier)).join('')}
-        </div>` : `<div class="setup-warning" data-router-provider-needed>Choose a provider first to preview and save AgentOS Router tiers.</div>`}
+        </div>` : `<div class="setup-warning" data-router-provider-needed>Choose a provider first to preview and save Pilot Router tiers.</div>`}
         ${provider && !canSaveRouter ? `<div class="setup-warning" data-router-provider-unsaved>Save the provider before saving router tiers.</div>` : ''}
         <div class="setup-actions">
           <button class="setup-btn" data-prev="provider">Back</button>
@@ -1079,10 +1079,10 @@ const SetupView = (() => {
     const configuredProvider = _configuredProvider();
     const providerSummary = configuredProvider || 'not configured';
     const modelSummary = configuredProvider
-      ? ((_config.llm || {}).model || 'AgentOS Router defaults')
+      ? ((_config.llm || {}).model || 'Pilot Router defaults')
       : 'not configured';
     const routerSummary = configuredProvider
-      ? (router.enabled === false ? 'disabled' : 'AgentOS Router')
+      ? (router.enabled === false ? 'disabled' : 'Pilot Router')
       : 'choose a provider first';
     const providerProxy = configuredProvider ? ((_config.llm || {}).proxy || '').trim() : '';
     const configArg = _configCliArg(_status.configPath);
@@ -1250,7 +1250,7 @@ const SetupView = (() => {
   function _routerNeedsProvider(detail, name) {
     return name === 'router'
       && detail.status === 'ok'
-      && detail.detail === 'uses AgentOS Router after provider setup';
+      && detail.detail === 'uses Pilot Router after provider setup';
   }
 
   function _readinessActionLabel(detail, name) {

--- a/src/agentos/gateway/static/js/views/usage.js
+++ b/src/agentos/gateway/static/js/views/usage.js
@@ -757,7 +757,7 @@ const UsageView = (() => {
     if (!el) return;
     const visibleRows = _visibleSessions();
 
-    // Group by actual per-model usage when available. AgentOS Router can route
+    // Group by actual per-model usage when available. Pilot Router can route
     // different turns in the same session to different models, while row.model
     // represents only the current/latest session model.
     const map = {};

--- a/src/agentos/observability/decision_log.py
+++ b/src/agentos/observability/decision_log.py
@@ -54,7 +54,7 @@ RoutingSource = Literal[
 class SavingsTelemetry:
     """Per-turn savings telemetry."""
 
-    # AgentOS Router (V4_phase3 ML + heuristic)
+    # Pilot Router (V4_phase3 ML + heuristic)
     routed_model: str | None = None
     baseline_model: str | None = None
     routing_confidence: float | None = None

--- a/src/agentos/onboarding/flow.py
+++ b/src/agentos/onboarding/flow.py
@@ -1847,7 +1847,7 @@ def _keep_imported_provider(questionary, cfg: Any) -> bool:
         console.print(f"  Provider: [{ACCENT_SOFT}]{markup_escape(provider)}[/]")
         if router_supported:
             console.print(
-                "  Model: [dim]will use AgentOS Router defaults; "
+                "  Model: [dim]will use Pilot Router defaults; "
                 "old direct model is not imported[/dim]"
             )
         elif model:
@@ -2027,7 +2027,7 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
             steps=[
                 ("1 Migration", "Import existing agent data if detected", "ready"),
                 ("2 Provider", "Pick LLM credentials and model access", "required"),
-                ("3 AgentOS Router", "Route c0-c3 work to the right model tier", "required"),
+                ("3 Pilot Router", "Route c0-c3 work to the right model tier", "required"),
                 ("4 Channels", "Slack, Discord, Telegram, webhook adapters", "later"),
                 ("5 Search", "Optional web-search capability", "later"),
                 ("6 Memory", "Embeddings for long-lived context", "later"),
@@ -2274,7 +2274,7 @@ def _run_action_required_optional_sections(
 ) -> None:
     actions = {
         "router": {
-            "prompt": "Configure AgentOS Router now?",
+            "prompt": "Configure Pilot Router now?",
             "section": "router",
             "label": "router",
             "runner": run_interactive_router_configure,

--- a/src/agentos/onboarding/next_steps.py
+++ b/src/agentos/onboarding/next_steps.py
@@ -263,7 +263,7 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
     router_line = (
         "  Router: disabled"
         if not router.enabled
-        else f"  Router: AgentOS Router, default={router_default}"
+        else f"  Router: Pilot Router, default={router_default}"
     )
     config_arg = _config_cli_arg(config_path)
     key_source = status.llm_source

--- a/src/agentos/onboarding/provider_specs.py
+++ b/src/agentos/onboarding/provider_specs.py
@@ -144,7 +144,7 @@ def _model_description(spec: ProviderSpec, *, router_supported: bool) -> str:
     if router_supported:
         return (
             "Optional direct fallback model. Leave blank to use the selected "
-            "AgentOS Router default tier."
+            "Pilot Router default tier."
         )
     if spec.provider_id in _LOCAL_PROVIDER_IDS:
         return "Required local model id. Use a model available from your local model server."

--- a/src/agentos/onboarding/status.py
+++ b/src/agentos/onboarding/status.py
@@ -132,12 +132,12 @@ def _router_detail(cfg: GatewayConfig, llm_source: str) -> str:
         return "disabled"
     llm = getattr(cfg, "llm", None)
     if llm_source == "none" or not getattr(llm, "provider", ""):
-        return "uses AgentOS Router after provider setup"
+        return "uses Pilot Router after provider setup"
     profile = str(getattr(router, "tier_profile", "") or "").strip()
     if profile:
-        return f"AgentOS Router profile: {profile}"
+        return f"Pilot Router profile: {profile}"
     default_tier = str(getattr(router, "default_tier", "") or "c1").strip()
-    return f"AgentOS Router default tier: {default_tier}"
+    return f"Pilot Router default tier: {default_tier}"
 
 
 def _llm_source(cfg: GatewayConfig, status: SectionStatus) -> tuple[str, str]:

--- a/src/agentos/tools/builtin/router_control.py
+++ b/src/agentos/tools/builtin/router_control.py
@@ -1,4 +1,4 @@
-"""Built-in tool for LLM-directed AgentOS Router control."""
+"""Built-in tool for LLM-directed Pilot Router control."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from agentos.tools.types import current_tool_context
 @tool(
     name="router_control",
     description=(
-        "Control the AgentOS Router for this session. Use only when the user asks "
+        "Control the Pilot Router for this session. Use only when the user asks "
         "to switch to a configured route or restore automatic routing."
     ),
     params={
@@ -55,7 +55,7 @@ async def router_control(
     router_cfg = getattr(ctx, "router_control_config", None)
     if router_cfg is None or not getattr(router_cfg, "enabled", False):
         return router_control_rejection_payload(
-            reason="AgentOS Router is disabled or unavailable",
+            reason="Pilot Router is disabled or unavailable",
             evidence=evidence,
         )
     session_key = getattr(ctx, "session_key", None)

--- a/tests/test_cli/test_help_theme.py
+++ b/tests/test_cli/test_help_theme.py
@@ -64,7 +64,7 @@ def test_onboard_help_explains_first_run_inputs() -> None:
     assert result.exit_code == 0, result.output
     output = click.unstyle(result.output)
     assert "AgentOS setup cockpit" in output
-    assert "AgentOS Router" in output
+    assert "Pilot Router" in output
     assert "Provider id to configure" in output
     assert "Model id for the provider" in output
     assert "Read the provider key from this environment" in output

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -849,7 +849,7 @@ def test_onboard_catalog_provider_rows_name_agentos_router_tier_support():
     result = runner.invoke(app, ["onboard", "catalog", "providers"])
 
     assert result.exit_code == 0, result.stdout
-    assert "route AgentOS Router ready" in result.stdout
+    assert "route Pilot Router ready" in result.stdout
     assert "route Direct only" in result.stdout
     openrouter_row = next(
         line for line in result.stdout.splitlines() if line.startswith("- openrouter:")
@@ -857,14 +857,14 @@ def test_onboard_catalog_provider_rows_name_agentos_router_tier_support():
     anthropic_row = next(
         line for line in result.stdout.splitlines() if line.startswith("- anthropic:")
     )
-    assert openrouter_row.index("route AgentOS Router ready") < openrouter_row.index(
+    assert openrouter_row.index("route Pilot Router ready") < openrouter_row.index(
         "key OPENROUTER_API_KEY"
     )
     assert anthropic_row.index("route Direct only") < anthropic_row.index(
         "key ANTHROPIC_API_KEY"
     )
-    assert "AgentOS Router tiers yes" not in result.stdout
-    assert "AgentOS Router tiers no" not in result.stdout
+    assert "Pilot Router tiers yes" not in result.stdout
+    assert "Pilot Router tiers no" not in result.stdout
     assert "router yes" not in result.stdout
     assert "router no" not in result.stdout
 
@@ -1226,7 +1226,7 @@ def test_onboard_status_explains_router_ready_before_provider_setup(
     assert "Router" in result.stdout
     collapsed = "".join(result.stdout.split()).replace("│", "")
     assert "Provider first" in result.stdout
-    assert "usesAgentOSRouterafter" in collapsed
+    assert "usesPilotRouterafter" in collapsed
     assert "providersetup" in collapsed
 
     json_result = runner.invoke(
@@ -1237,7 +1237,7 @@ def test_onboard_status_explains_router_ready_before_provider_setup(
     payload = _json.loads(json_result.stdout)
     assert (
         payload["sectionDetails"]["router"]["detail"]
-        == "uses AgentOS Router after provider setup"
+        == "uses Pilot Router after provider setup"
     )
 
 

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -3294,7 +3294,7 @@ def test_chat_queue_drain_preserves_draft_typed_during_stream() -> None:
 
 
 def test_savings_burst_popup_is_disabled_by_default() -> None:
-    """The AgentOS Router scanning strip stays, but the celebratory savings burst +
+    """The Pilot Router scanning strip stays, but the celebratory savings burst +
     'Saved ~X%' float is gated off. noteTurn() must still run (streak/meta
     footer), and the gate must short-circuit before SavingsFX.fire()."""
     source = CHAT_JS.read_text(encoding="utf-8")

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -779,7 +779,7 @@ def test_setup_view_preserves_selected_image_generation_provider():
 
 def test_setup_router_controls_use_user_facing_labels():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
-    assert "AgentOS Router" in txt
+    assert "Pilot Router" in txt
     assert "OpenRouter mix" not in txt
     assert "Route c1" in txt
     assert "Route c2" in txt
@@ -940,14 +940,14 @@ def test_setup_provider_step_surfaces_agentos_router_tier_support():
     assert "function _providerRouterSupportText" in txt
     assert "function _providerRouterSupportTone" in txt
     assert "spec.routerSupported === true" in txt
-    assert "'AgentOS Router ready'" in txt
+    assert "'Pilot Router ready'" in txt
     assert "'Direct only'" in txt
     assert "'available'" not in body
     assert "'direct model only'" not in body
     assert "data-provider-router-support" in body
     assert "data-provider-router-support-label" in body
     assert "setup-provider-meta__badge" in body
-    assert "AgentOS Router tiers" in body
+    assert "Pilot Router tiers" in body
     assert "_providerRouterSupportText(selected ? spec : null)" in body
     assert "_providerRouterSupportTone(selected ? spec : null)" in body
     assert "routerSupport.textContent = _providerRouterSupportText(spec);" in sync_body
@@ -1351,7 +1351,7 @@ def test_setup_finish_readiness_names_router_provider_prerequisite():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
 
     assert "function _routerNeedsProvider" in txt
-    assert "uses AgentOS Router after provider setup" in txt
+    assert "uses Pilot Router after provider setup" in txt
 
     start = txt.index("function _setupStepForSection")
     end = txt.index("  function _readinessActionLabel", start)
@@ -1382,12 +1382,12 @@ def test_setup_finish_summary_stays_neutral_before_provider_is_configured():
     assert "const providerSummary = configuredProvider || 'not configured'" in body
     assert (
         "const modelSummary = configuredProvider"
-        "\n      ? ((_config.llm || {}).model || 'AgentOS Router defaults')"
+        "\n      ? ((_config.llm || {}).model || 'Pilot Router defaults')"
         "\n      : 'not configured'"
     ) in body
     assert (
         "const routerSummary = configuredProvider"
-        "\n      ? (router.enabled === false ? 'disabled' : 'AgentOS Router')"
+        "\n      ? (router.enabled === false ? 'disabled' : 'Pilot Router')"
         "\n      : 'choose a provider first'"
     ) in body
     assert "router.tier_profile || 'openrouter-mix'" not in body

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -756,7 +756,7 @@ async def test_image_attachment_without_image_tier_fails_locally(
 
     with pytest.raises(
         RuntimeError,
-        match="No image-capable AgentOS Router tier is configured",
+        match="No image-capable Pilot Router tier is configured",
     ):
         await apply_agentos_router(ctx)
 

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -532,7 +532,7 @@ def test_interactive_onboard_migration_defaults_to_all_sources_and_keeps_importe
         def select(self, message: str, **_kwargs):
             calls.append(message)
             if message == "Router mode":
-                return _Answer("AgentOS Router")
+                return _Answer("Pilot Router")
             if message == "Default text model":
                 return _Answer(_kwargs.get("default"))
             if message == "Router judge model":
@@ -646,7 +646,7 @@ def test_interactive_onboard_imported_provider_prefers_inline_key_over_env(
         def select(self, message: str, **kwargs):
             calls.append(message)
             if message == "Router mode":
-                return _Answer("AgentOS Router")
+                return _Answer("Pilot Router")
             if message == "Default text model":
                 return _Answer(kwargs.get("default"))
             if message == "Router judge model":
@@ -768,7 +768,7 @@ def test_interactive_onboard_imported_provider_finalize_error_continues_setup(
             if message == "LLM API key source":
                 return _Answer("Use environment variable OPENROUTER_API_KEY")
             if message == "Router mode":
-                return _Answer("AgentOS Router")
+                return _Answer("Pilot Router")
             if message == "Default text model":
                 return _Answer(kwargs.get("default"))
             if message == "Router judge model":
@@ -960,7 +960,7 @@ def test_interactive_onboard_migration_preview_failure_continues_provider_setup(
             if message == "LLM API key source":
                 return _Answer("Use environment variable OPENROUTER_API_KEY")
             if message == "Router mode":
-                return _Answer("AgentOS Router")
+                return _Answer("Pilot Router")
             if message == "Default text model":
                 return _Answer(kwargs.get("default"))
             if message == "Router judge model":
@@ -1073,7 +1073,7 @@ def test_interactive_onboard_migration_prompts_for_missing_imported_provider_key
                 assert kwargs.get("default") == "Paste API key now"
                 return _Answer("Paste API key now")
             if message == "Router mode":
-                return _Answer("AgentOS Router")
+                return _Answer("Pilot Router")
             if message == "Default text model":
                 return _Answer(kwargs.get("default"))
             if message == "Router judge model":
@@ -1136,7 +1136,7 @@ def test_interactive_onboard_can_enable_image_generation(tmp_path, monkeypatch):
                 )
                 return _Answer("Use environment variable OPENROUTER_API_KEY (detected)")
             if message == "Router mode":
-                return _Answer("AgentOS Router")
+                return _Answer("Pilot Router")
             if message == "Default text model":
                 return _Answer(kwargs.get("default"))
             if message == "Router judge model":

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -69,7 +69,7 @@ def test_onboarding_finish_output_uses_product_router_label():
 
     text = format_next_steps(GatewayConfig(), config_path="/tmp/agentos/custom.toml")
 
-    assert "  Router: AgentOS Router, default=c1" in text
+    assert "  Router: Pilot Router, default=c1" in text
     assert "profile=openrouter-mix" not in text
 
 

--- a/tests/test_onboarding/test_status.py
+++ b/tests/test_onboarding/test_status.py
@@ -190,7 +190,7 @@ def test_router_detail_explains_provider_dependency_before_provider_setup():
 
     assert (
         s.section_details["router"]["detail"]
-        == "uses AgentOS Router after provider setup"
+        == "uses Pilot Router after provider setup"
     )
     assert s.section_details["router"]["actionRequired"] is False
 


### PR DESCRIPTION
## Summary

- Rename the user-facing display name "AgentOS Router" → "Pilot Router" across CLI/UI strings, frontend (chat.js, setup.js, usage.js, chat.css), docs, and CHANGELOG.
- Update all test assertions accordingly (including the whitespace-collapsed variant).
- Leave wire/config/import identifiers untouched: `[agentos_router]` config key, `AGENTOS_ROUTER_` env prefix, `AgentOSRouterConfig` class, `agentos_router` package paths, and the `pilot-v1` strategy slug.

## Verification

- ruff check clean
- mypy clean
- 757 affected tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)