### PR TITLE
feat(cli): polish agentos chat REPL — assistant label, session name, router tier commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The framed chat input no longer balloons to fill the screen on a fresh
+  launch. The input buffer window is pinned to a single row
+  (`Dimension.exact(1)`) and a greedy spacer heads the layout, so the
+  compact frame + toolbar stay pinned to the bottom of the terminal
+  instead of the bottom rule + toolbar being pushed far below the
+  `◢ you` row.
 - `test_assistant_label_env_override` no longer wipes the subprocess
   environment (`PATH=""`), which crashed Python startup on Windows CI
   (`import _overlapped` → `WinError 10106`); it now layers the override

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `agentos chat` UX pass (issue #46):
+  - The assistant speaker label now defaults to `agentos` (was hard-coded
+    `cap`); override with the `AGENTOS_ASSISTANT_LABEL` env var. The
+    label is sourced from a single place and consumed by the streamed
+    `◢` marker, the pre-token waiting row, and the queued-turn marker.
+  - Session display name now surfaces in the bottom toolbar
+    (`title · model · [tier:cN]`) and `/status`. `/new <title>` persists
+    the title as `SessionNode.display_name` so it survives a later
+    `/resume`. The standalone `/new` path no longer drops the title
+    silently (pre-existing bug).
+  - `/c0` … `/c3` and `/auto` are now registered on both CLI surfaces
+    (`cli_gateway`, `cli_standalone`). Gateway mode reuses the existing
+    `router.hold.set` / `router.hold.clear` RPCs; standalone mutates the
+    in-process `RouterControlHoldStore` directly.
+  - The active Pilot Router tier hold shows in the bottom toolbar and in
+    `/status` (or `auto` when no hold is set).
+  - `SessionNode.derived_title` property fills the pre-existing dead
+    hook, falling back `display_name → label → short opaque session id`.
+  - The startup panel now renders `Session: <title> (<key>)` when a
+    friendly title is known.
+
+### Changed
+
+- The bottom toolbar now leads with the session title (or short key
+  fallback) instead of only the opaque key segment, and shows the model
+  alias after it.
+
 ## [2026.7.19.post1] - 2026-07-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `SessionNode.derived_title` property fills the pre-existing dead
     hook, falling back `display_name → label → short opaque session id`.
   - The startup panel now renders `Session: <title> (<key>)` when a
-    friendly title is known.
+    friendly title is known (plumbed through `StartupData` and the
+    gateway welcome notice).
+  - The active input row is now framed by a top and bottom rule
+    (Claude Code style) so the typing area reads as a distinct box
+    between the transcript and the bottom toolbar. Consistent across the
+    gateway and `--standalone` surfaces.
 
 ### Changed
 
 - The bottom toolbar now leads with the session title (or short key
   fallback) instead of only the opaque key segment, and shows the model
   alias after it.
+
+### Fixed
+
+- `test_assistant_label_env_override` no longer wipes the subprocess
+  environment (`PATH=""`), which crashed Python startup on Windows CI
+  (`import _overlapped` → `WinError 10106`); it now layers the override
+  on a copy of `os.environ`.
 
 ## [2026.7.19.post1] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     (Claude Code style) so the typing area reads as a distinct box
     between the transcript and the bottom toolbar. Consistent across the
     gateway and `--standalone` surfaces.
+  - Experimental full-screen chat surface behind `AGENTOS_CHAT_FULLSCREEN=1`:
+    the conversation renders in a scrollable in-app pane above a
+    permanently-pinned input frame, so the frame stays visible while the
+    assistant streams (no flicker, no dropped partial lines). `PgUp`/`PgDn`
+    scroll history; new output re-pins to the tail. Opt-in while it matures
+    (trades away native terminal scrollback); the default surface is
+    unchanged.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     (Claude Code style) so the typing area reads as a distinct box
     between the transcript and the bottom toolbar. Consistent across the
     gateway and `--standalone` surfaces.
-  - Experimental full-screen chat surface behind `AGENTOS_CHAT_FULLSCREEN=1`:
-    the conversation renders in a scrollable in-app pane above a
-    permanently-pinned input frame, so the frame stays visible while the
-    assistant streams (no flicker, no dropped partial lines). `PgUp`/`PgDn`
-    scroll history; new output re-pins to the tail. Opt-in while it matures
-    (trades away native terminal scrollback); the default surface is
-    unchanged.
+  - Full-screen chat surface is now the **default** for `agentos chat`: the
+    conversation renders in a scrollable in-app pane above a permanently-pinned
+    input frame, so the frame stays visible while the assistant streams (no
+    flicker, no dropped partial lines). The branded welcome screen (connect
+    line + banner + tool/skill panel) renders at the top of the pane on launch
+    — previously it was wiped by the alternate screen buffer. `PgUp`/`PgDn`
+    scroll history; new output re-pins to the tail. Non-TTY / piped
+    invocations fall back to native scrollback; `AGENTOS_CHAT_FULLSCREEN=0`
+    forces native scrollback and `=1` forces full-screen.
 
 ### Changed
 

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -1,9 +1,14 @@
 # AgentOS Configuration
 # Copy to agentos.toml and edit as needed:
 #   cp agentos.toml.example agentos.toml
-#
+
 # Precedence: env vars > agentos.toml > defaults
 # Also searched: ~/.agentos/config.toml (global user config)
+
+# Assistant speaker label shown on the ◢ marker, the pre-token waiting
+# row, and the queued-turn marker in `agentos chat`. Defaults to "agentos".
+# Env override: AGENTOS_ASSISTANT_LABEL="Hani"
+# assistant_label = "agentos"
 
 # Workspace/state defaults
 # Defaults:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,50 @@ agentos chat --session <session-key>
 agentos chat --standalone --workspace /path/to/project
 ```
 
+### Chat REPL slash commands
+
+`agentos chat` exposes a prompt-toolkit REPL with a slash-command palette.
+The most useful ones:
+
+| Command | Purpose |
+| --- | --- |
+| `/new [title]` | Start a new chat session. The optional title is persisted as the session's display name and shown in the bottom toolbar and `/status`. |
+| `/resume <key>` | Resume an existing session by key (or a prefix / display-name match in gateway mode). |
+| `/status` | Show the current session, model, permissions, and the active Pilot Router tier (or `auto`). |
+| `/model <id>` | Override the model for this session. |
+| `/clear` / `/reset` | Clear the current conversation context. |
+| `/compact` | Compact older context into a summary. |
+| `/cost` | Show per-session token and cost totals. |
+| `/save [path]` | Save the transcript to a Markdown file. |
+| `/c0` … `/c3` | Pin the Pilot Router to a configured tier for this session. The pin appears in the bottom toolbar (e.g. `tier:c3`) and stays active until you exit, run `/auto`, or the hold expires. |
+| `/auto` | Restore automatic Pilot Router routing (clears the tier pin). |
+| `/help` | List the commands available on the current surface. |
+| `/exit` / `/quit` | Leave the REPL. |
+
+Router tier commands (`/c0` … `/c3`, `/auto`) are available in both gateway
+and `--standalone` modes. Tiers not present in your `[agentos_router]`
+config are rejected with a readable error. In `--standalone` mode the
+router must be enabled in config; otherwise the command reports
+"Pilot Router is disabled or unavailable."
+
+### Assistant label and session chrome
+
+The assistant speaker label shown on the `◢` marker and the pre-token
+waiting row defaults to `agentos`. Override it with the
+`AGENTOS_ASSISTANT_LABEL` environment variable — the value is read once at
+startup and used by every renderer, so it stays consistent across the
+streamed reply marker, the waiting header, and the queued-turn marker.
+
+```sh
+AGENTOS_ASSISTANT_LABEL="Hani" agentos chat
+```
+
+The bottom toolbar renders `title · model · [tier:cN]` while typing. The
+title comes from `/new <title>` (or is loaded from the gateway on
+`/resume`); the tier chip appears only while a Pilot Router hold is
+active. `/status` mirrors the same fields plus the active permissions
+posture.
+
 One-shot automation:
 
 ```sh

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,6 +105,17 @@ streamed reply marker, the waiting header, and the queued-turn marker.
 AGENTOS_ASSISTANT_LABEL="Hani" agentos chat
 ```
 
+The active input row is framed by a top and bottom rule, so the typing
+area reads as a distinct box between the transcript and the bottom
+toolbar:
+
+```
+────────────────────────────────────────
+ ◢ you  <your message here>
+────────────────────────────────────────
+ title · model · [tier:cN]
+```
+
 The bottom toolbar renders `title · model · [tier:cN]` while typing. The
 title comes from `/new <title>` (or is loaded from the gateway on
 `/resume`); the tier chip appears only while a Pilot Router hold is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -122,16 +122,19 @@ title comes from `/new <title>` (or is loaded from the gateway on
 active. `/status` mirrors the same fields plus the active permissions
 posture.
 
-**Experimental full-screen surface.** Set `AGENTOS_CHAT_FULLSCREEN=1`
-to render the conversation in a scrollable in-app pane above a
-permanently-pinned input frame (Claude Code style), so the frame stays
-visible while the assistant streams. `PgUp`/`PgDn` scroll back through
-history; new output re-pins to the newest line. This trades away native
-terminal scrollback and is opt-in while it matures; the default surface
-streams to native scrollback as before.
+**Full-screen surface (default).** `agentos chat` renders the conversation
+in a scrollable in-app pane above a permanently-pinned input frame (Claude
+Code style), so the frame stays visible while the assistant streams. The
+branded welcome screen renders at the top of the pane on launch. `PgUp`/`PgDn`
+scroll back through history; new output re-pins to the newest line.
+
+Full-screen is the default for an interactive terminal. Non-TTY / piped
+invocations fall back to native scrollback automatically. To force a mode set
+`AGENTOS_CHAT_FULLSCREEN`:
 
 ```sh
-AGENTOS_CHAT_FULLSCREEN=1 agentos chat
+AGENTOS_CHAT_FULLSCREEN=0 agentos chat   # opt out — stream to native scrollback
+AGENTOS_CHAT_FULLSCREEN=1 agentos chat   # force full-screen (e.g. under a pipe)
 ```
 
 One-shot automation:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -122,6 +122,18 @@ title comes from `/new <title>` (or is loaded from the gateway on
 active. `/status` mirrors the same fields plus the active permissions
 posture.
 
+**Experimental full-screen surface.** Set `AGENTOS_CHAT_FULLSCREEN=1`
+to render the conversation in a scrollable in-app pane above a
+permanently-pinned input frame (Claude Code style), so the frame stays
+visible while the assistant streams. `PgUp`/`PgDn` scroll back through
+history; new output re-pins to the newest line. This trades away native
+terminal scrollback and is opt-in while it matures; the default surface
+streams to native scrollback as before.
+
+```sh
+AGENTOS_CHAT_FULLSCREEN=1 agentos chat
+```
+
 One-shot automation:
 
 ```sh

--- a/src/agentos/cli/chat/gateway_runtime.py
+++ b/src/agentos/cli/chat/gateway_runtime.py
@@ -36,6 +36,7 @@ class GatewayRuntimeNotice:
     session_key: str | None = None
     model: str | None = None
     message: str | None = None
+    session_title: str | None = None
 
 
 class GatewayClientLike(Protocol):
@@ -184,7 +185,13 @@ async def run_gateway_chat(
         session_context = GatewaySessionContext.create(state)
         active_turn_session_key: str | None = None
 
-        deps.notify(GatewayRuntimeNotice(kind="welcome"))
+        deps.notify(
+            GatewayRuntimeNotice(
+                kind="welcome",
+                session_key=session_key,
+                session_title=state.display_name,
+            )
+        )
 
         async def _dispatch_input(user_input: str) -> bool:
             nonlocal active_turn_session_key

--- a/src/agentos/cli/chat/gateway_runtime.py
+++ b/src/agentos/cli/chat/gateway_runtime.py
@@ -68,6 +68,11 @@ class GatewayClientLike(Protocol):
 
     async def upload_file(self, path: Path, mime: str, name: str) -> str: ...
 
+    # Generic RPC surface used by /c0-/c3 and /auto to call
+    # router.hold.set / router.hold.clear (issue #46). Mirrors
+    # ``GatewayClient.call`` in ``cli.gateway_client``.
+    async def call(self, method: str, params: dict | None = None) -> Any: ...
+
     def send_message(
         self,
         session_key: str,
@@ -165,6 +170,14 @@ async def run_gateway_chat(
         try:
             resolved = await asyncio.wait_for(client.resolve_session(session_key), timeout=2.0)
             state.model = resolved.get("model") or state.model
+            # Surface the persisted display name (set via ``/new <title>``)
+            # and any active Pilot Router tier hold in the bottom toolbar
+            # from the very first redraw. See issue #46.
+            state.display_name = resolved.get("displayName") or resolved.get(
+                "display_name"
+            )
+            tier = resolved.get("router_hold_tier")
+            state.router_hold_tier = tier if isinstance(tier, str) and tier else None
         except Exception:  # noqa: BLE001 - network/timeout; non-fatal
             pass
 

--- a/src/agentos/cli/chat/session_context.py
+++ b/src/agentos/cli/chat/session_context.py
@@ -37,6 +37,12 @@ class GatewaySessionContext:
         self.scope["session_key"] = self.state.session_key
         self.scope["state"] = self.state
         self.scope["model"] = self.state.model
+        # Mirror the session chrome fields so the terminal surface
+        # factory can forward them into ``_toolbar_context`` for the
+        # first redraw (see ``open_terminal_surface`` / issue #46).
+        self.scope["session_title"] = self.state.display_name
+        tier = self.state.router_hold_tier
+        self.scope["router_tier"] = tier if isinstance(tier, str) and tier else None
 
 
 @dataclass
@@ -85,3 +91,9 @@ class StandaloneSessionContext:
         self.scope["tool_ctx"] = self.tool_ctx
         self.scope["state"] = self.state
         self.scope["model"] = self.state.model
+        # Mirror the session chrome fields so the terminal surface
+        # factory can forward them into ``_toolbar_context`` for the
+        # first redraw (see ``open_terminal_surface`` / issue #46).
+        self.scope["session_title"] = self.state.display_name
+        tier = self.state.router_hold_tier
+        self.scope["router_tier"] = tier if isinstance(tier, str) and tier else None

--- a/src/agentos/cli/chat/session_state.py
+++ b/src/agentos/cli/chat/session_state.py
@@ -87,6 +87,17 @@ class ChatSessionState:
     session_key: str
     model: str | None = None
     elevated: str | None = None
+    # Friendly display name for the session, populated from
+    # ``/new <title>`` or loaded from the gateway on resume. Surfaced in
+    # the bottom toolbar (``title · model · tier``) and ``/status`` so
+    # the opaque session key isn't the only identifier visible while
+    # typing. See issue #46.
+    display_name: str | None = None
+    # Active Pilot Router tier hold (e.g. ``"c3"``) for this session, or
+    # ``None`` when automatic routing is in effect. Set by ``/c0``-``/c3``
+    # and cleared by ``/auto``; shown in the bottom toolbar so a pinned
+    # tier stays visible while typing.
+    router_hold_tier: str | None = None
     transcript: ChatTranscript = field(default_factory=ChatTranscript)
     usage: UsageCounter = field(default_factory=UsageCounter)
 

--- a/src/agentos/cli/startup_screen.py
+++ b/src/agentos/cli/startup_screen.py
@@ -114,6 +114,7 @@ class StartupData:
     model: str = "--"
     workdir: str = "--"
     session_key: str = "--"
+    session_title: str | None = None
     tool_groups: list[tuple[str, list[str]]] = field(default_factory=list)
     skill_groups: list[tuple[str, list[str]]] = field(default_factory=list)
     tool_count: int = 0
@@ -196,24 +197,29 @@ def _gather_skill_groups() -> tuple[list[tuple[str, list[str]]], int]:
 def gather_startup_data(
     *,
     session_key: str | None = None,
+    session_title: str | None = None,
     model: str | None = None,
     workdir: str | None = None,
 ) -> StartupData:
     """Collect every value the startup screen needs, never raising.
 
     Caller-provided ``session_key``/``model``/``workdir`` win over discovered
-    defaults; missing values fall back to ``"--"``.
+    defaults; missing values fall back to ``"--"``. ``session_title`` is the
+    friendly display name (set via ``/new <title>``) surfaced alongside the
+    opaque key when known.
     """
     tool_groups, tool_count = _gather_tool_groups()
     skill_groups, skill_count = _gather_skill_groups()
     resolved_model = (model or "").strip() or _gather_default_model()
     resolved_workdir = (workdir or "").strip() or _gather_workdir()
     resolved_session = (session_key or "").strip() or "--"
+    resolved_title = (session_title or "").strip() or None
     return StartupData(
         version=_gather_version(),
         model=resolved_model,
         workdir=resolved_workdir,
         session_key=resolved_session,
+        session_title=resolved_title,
         tool_groups=tool_groups,
         skill_groups=skill_groups,
         tool_count=tool_count,
@@ -233,7 +239,10 @@ def _left_column(data: StartupData) -> RenderableType:
     body.append("\n\n")
     body.append(f"{data.model}\n", style=f"bold {ACCENT_SOFT}")
     body.append(f"{data.workdir}\n", style="dim")
-    body.append(f"Session: {data.session_key}", style="dim")
+    if data.session_title and data.session_title != data.session_key:
+        body.append(f"Session: {data.session_title} ({data.session_key})", style="dim")
+    else:
+        body.append(f"Session: {data.session_key}", style="dim")
     return body
 
 
@@ -366,6 +375,7 @@ def render_startup_screen(
     console: Console,
     *,
     session_key: str | None = None,
+    session_title: str | None = None,
     model: str | None = None,
     workdir: str | None = None,
 ) -> None:
@@ -376,6 +386,7 @@ def render_startup_screen(
     """
     data = gather_startup_data(
         session_key=session_key,
+        session_title=session_title,
         model=model,
         workdir=workdir,
     )

--- a/src/agentos/cli/tui/adapters/launch_bridge.py
+++ b/src/agentos/cli/tui/adapters/launch_bridge.py
@@ -16,6 +16,8 @@ import typer
 
 from agentos.cli.chat.launch import ChatCommandLaunchOverrides, ChatCommandRequest
 from agentos.cli.startup_screen import render_startup_screen
+from agentos.cli.tui.terminal.app import resolve_chat_fullscreen
+from agentos.cli.tui.terminal.prompt import queue_pane_output
 from agentos.cli.ui import console
 
 ChatRunner = Callable[..., Coroutine[Any, Any, None]]
@@ -93,11 +95,24 @@ def launch_chat(
     if standalone:
         if standalone_runner is None:
             raise RuntimeError("standalone chat runner was not configured")
-        render_startup_screen(
-            active_console,
-            session_key=session_id or None,
-            model=model or None,
-        )
+        # In full-screen the app takes the alternate screen buffer, so the
+        # startup screen rendered here would be wiped. Capture it (ANSI, at
+        # the real terminal width) and replay it into the transcript pane
+        # once the surface opens. See issue #46 (issue 1).
+        if resolve_chat_fullscreen():
+            with active_console.capture() as captured:
+                render_startup_screen(
+                    active_console,
+                    session_key=session_id or None,
+                    model=model or None,
+                )
+            queue_pane_output(captured.get())
+        else:
+            render_startup_screen(
+                active_console,
+                session_key=session_id or None,
+                model=model or None,
+            )
         asyncio.run(
             standalone_runner(
                 model=model or None,

--- a/src/agentos/cli/tui/adapters/runtime_bridge.py
+++ b/src/agentos/cli/tui/adapters/runtime_bridge.py
@@ -189,6 +189,7 @@ def _gateway_runtime_notifier(
             render_startup_screen(
                 output_console,
                 session_key=notice.session_key,
+                session_title=notice.session_title,
                 model=notice.model,
             )
             return

--- a/src/agentos/cli/tui/adapters/runtime_bridge.py
+++ b/src/agentos/cli/tui/adapters/runtime_bridge.py
@@ -23,8 +23,18 @@ from agentos.cli.tui import standalone_runtime as _standalone_runtime
 from agentos.cli.tui.adapters import commands as _commands
 from agentos.cli.tui.adapters import slash_bridge as _slash_bridge
 from agentos.cli.tui.backend.contracts import TuiOutputHandle
+from agentos.cli.tui.terminal.app import resolve_chat_fullscreen
+from agentos.cli.tui.terminal.prompt import queue_pane_output
 from agentos.cli.ui import console, error_panel
 from agentos.engine.commands import Surface
+
+# Startup notices are emitted before the interactive surface opens. In the
+# full-screen chat surface the app takes the alternate screen buffer, wiping
+# anything printed to stdout first — so these are captured and replayed into
+# the transcript pane once it is live (see issue #46, ``queue_pane_output``).
+_STARTUP_NOTICE_KINDS = frozenset(
+    {"created", "resumed", "resume_model_ignored", "model", "welcome"}
+)
 
 PENDING_QUEUE_MAX_SIZE = 8
 
@@ -164,7 +174,7 @@ def _gateway_runtime_notifier(
     output_console: Any,
     error_panel_factory: Callable[[str], Any],
 ) -> Callable[[_gateway_runtime.GatewayRuntimeNotice], None]:
-    def _notify(notice: _gateway_runtime.GatewayRuntimeNotice) -> None:
+    def _emit(notice: _gateway_runtime.GatewayRuntimeNotice) -> None:
         if notice.kind == "created":
             output_console.print(
                 f"[dim]Connected to gateway. Session: {notice.session_key}[/dim]"
@@ -201,6 +211,18 @@ def _gateway_runtime_notifier(
             return
         if notice.kind == "error":
             output_console.print(error_panel_factory(notice.message or ""))
+
+    def _notify(notice: _gateway_runtime.GatewayRuntimeNotice) -> None:
+        # In full-screen the startup notices land before the app owns the
+        # screen, so capture them (already ANSI-coloured, at the real
+        # terminal width) and replay them into the transcript pane on open
+        # instead of writing to the soon-to-be-hidden scrollback.
+        if notice.kind in _STARTUP_NOTICE_KINDS and resolve_chat_fullscreen():
+            with output_console.capture() as captured:
+                _emit(notice)
+            queue_pane_output(captured.get())
+            return
+        _emit(notice)
 
     return _notify
 

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -20,6 +20,7 @@ from agentos.cli.chat.session_state import ChatSessionState, messages_to_markdow
 from agentos.cli.chat.turn import TurnResult
 from agentos.cli.tui.adapters.commands import render_help_table
 from agentos.cli.tui.backend.contracts import TuiOutputHandle
+from agentos.cli.tui.terminal.prompt import sync_session_chrome_from_state
 from agentos.cli.ui import ACCENT, ACCENT_HEADER, console, error_panel
 from agentos.engine.commands import Surface
 
@@ -30,6 +31,11 @@ _PATH_REMOTE_GATEWAY_MESSAGE = _input_bridge.PATH_REMOTE_GATEWAY_MESSAGE
 GATEWAY_SLASH_HANDLER_WORDS = frozenset(
     {
         "/approvals",
+        "/auto",
+        "/c0",
+        "/c1",
+        "/c2",
+        "/c3",
         "/clear",
         "/compact",
         "/cost",
@@ -86,6 +92,8 @@ class GatewayClientLike(Protocol):
     async def usage_status(self) -> dict[str, Any]: ...
 
     async def upload_file(self, path: Path, mime: str, name: str) -> str: ...
+
+    async def call(self, method: str, params: dict | None = None) -> Any: ...
 
     def send_message(
         self,
@@ -175,23 +183,66 @@ async def handle_gateway_slash_command(
         title = parts[1].strip() if len(parts) > 1 else None
         session_key = await client.create_session(model=state.model, display_name=title)
         state.session_key = session_key
+        state.display_name = title or None
+        # A freshly created session has no router hold; clear any stale
+        # tier chip left over from a previous session.
+        state.router_hold_tier = None
         state.transcript.clear()
         state.usage.reset()
         try:
             _resolved = await asyncio.wait_for(client.resolve_session(session_key), timeout=2.0)
             state.model = _resolved.get("model") or state.model
+            # resolve is authoritative for the persisted display name and
+            # the active router hold, so prefer its view over the local
+            # title arg (covers the titled-session resume path too).
+            state.display_name = _resolved.get("displayName") or _resolved.get(
+                "display_name"
+            ) or state.display_name
+            tier = _resolved.get("router_hold_tier")
+            state.router_hold_tier = tier if isinstance(tier, str) and tier else None
         except Exception:  # noqa: BLE001 - network/timeout; non-fatal
             pass
+        sync_session_chrome_from_state(state)
         label = f" ({title})" if title else ""
         console.print(f"[green]Started new session{label}:[/green] {session_key}")
         return True
 
+    if parts := _slash_parts(cmd, "/resume"):
+        if len(parts) == 1 or not parts[1].strip():
+            console.print("[red]Usage: /resume <id>[/red]")
+            return True
+        target = cmd.split(maxsplit=1)[1].strip()
+        payload = await client.resolve_session(target)
+        state.session_key = payload.get("session_key") or payload.get("key") or target
+        state.model = payload.get("model") or state.model
+        state.display_name = payload.get("displayName") or payload.get("display_name")
+        tier = payload.get("router_hold_tier")
+        state.router_hold_tier = tier if isinstance(tier, str) and tier else None
+        state.transcript.clear()
+        state.usage.reset()
+        sync_session_chrome_from_state(state)
+        console.print(f"[green]Resumed session:[/green] {state.session_key}")
+        return True
+
     if cmd in {"/status", "/session"}:
-        console.print(
+        title_line = (
+            f"[{ACCENT}]title[/] [dim]{state.display_name}[/dim]\n"
+            if state.display_name
+            else ""
+        )
+        tier_line = (
+            f"[{ACCENT}]router[/] [dim]tier:{state.router_hold_tier}[/dim]\n"
+            if state.router_hold_tier
+            else f"[{ACCENT}]router[/] [dim]auto[/dim]\n"
+        )
+        status_text = (
+            f"{title_line}"
             f"[{ACCENT}]session[/] [dim]{state.session_key}[/dim]\n"
             f"[{ACCENT}]model[/] [dim]{state.model or 'default'}[/dim]\n"
+            f"{tier_line}"
             f"[{ACCENT}]permissions[/] [dim]{state.elevated or 'normal'}[/dim]"
         )
+        console.print(status_text)
         return True
 
     if parts := _slash_parts(cmd, "/sessions"):
@@ -204,19 +255,6 @@ async def handle_gateway_slash_command(
                 return True
         payload = await client.list_sessions(limit=limit)
         _print_sessions_table(payload.get("sessions", []))
-        return True
-
-    if parts := _slash_parts(cmd, "/resume"):
-        if len(parts) == 1 or not parts[1].strip():
-            console.print("[red]Usage: /resume <id>[/red]")
-            return True
-        target = cmd.split(maxsplit=1)[1].strip()
-        payload = await client.resolve_session(target)
-        state.session_key = payload.get("session_key") or payload.get("key") or target
-        state.model = payload.get("model") or state.model
-        state.transcript.clear()
-        state.usage.reset()
-        console.print(f"[green]Resumed session:[/green] {state.session_key}")
         return True
 
     if parts := _slash_parts(cmd, "/delete"):
@@ -298,6 +336,41 @@ async def handle_gateway_slash_command(
             f"{payload.get('totalTokens', 0):,} tok · "
             f"${float(payload.get('totalCostUsd', 0.0) or 0.0):.6f}[/dim]"
         )
+        return True
+
+    if cmd in {"/c0", "/c1", "/c2", "/c3"}:
+        tier = cmd[1:]
+        try:
+            res = await client.call(
+                "router.hold.set",
+                {"key": state.session_key, "tier": tier},
+            )
+        except Exception as exc:  # noqa: BLE001 - keep chat alive on RPC error
+            # ``router.disabled`` / ``router.unknown_tier`` from
+            # ``rpc_router._router_state`` / ``resolve_router_control_target``
+            # arrive as ``GatewayRPCError`` with a readable ``message``;
+            # surface it verbatim so the operator sees what to fix.
+            console.print(f"[yellow]{exc}[/yellow]")
+            return True
+        # ``res`` mirrors the ``router.hold.set`` payload: tier / model /
+        # provider / targetId / ttlSeconds. Show the pinned model so the
+        # user knows which backing model the tier maps to.
+        model = str((res or {}).get("model") or "") if isinstance(res, dict) else ""
+        suffix = f" · {model}" if model else ""
+        state.router_hold_tier = tier
+        sync_session_chrome_from_state(state)
+        console.print(f"[{ACCENT}]router pinned to tier {tier}[/]{suffix}")
+        return True
+
+    if cmd == "/auto":
+        try:
+            await client.call("router.hold.clear", {"key": state.session_key})
+        except Exception as exc:  # noqa: BLE001 - keep chat alive on RPC error
+            console.print(f"[yellow]{exc}[/yellow]")
+            return True
+        state.router_hold_tier = None
+        sync_session_chrome_from_state(state)
+        console.print(f"[{ACCENT}]router hold cleared (automatic routing)[/]")
         return True
 
     if _slash_parts(cmd, "/save"):

--- a/src/agentos/cli/tui/adapters/slash_policy.py
+++ b/src/agentos/cli/tui/adapters/slash_policy.py
@@ -88,6 +88,14 @@ STATE_MUTATION_SLASH_WORDS: frozenset[str] = frozenset(
         "/status",
         "/session",
         "/elevated",
+        # Pilot Router tier holds take effect on the next turn (the router
+        # step reads the hold store at turn start), so they enqueue behind
+        # the active turn rather than cancelling it.
+        "/auto",
+        "/c0",
+        "/c1",
+        "/c2",
+        "/c3",
     }
 )
 

--- a/src/agentos/cli/tui/adapters/slash_standalone.py
+++ b/src/agentos/cli/tui/adapters/slash_standalone.py
@@ -19,6 +19,7 @@ from agentos.cli.chat.session_state import ChatSessionState
 from agentos.cli.chat.turn import TurnResult
 from agentos.cli.tui.adapters.commands import is_exit_command, render_help_table
 from agentos.cli.tui.backend.contracts import TuiOutputHandle
+from agentos.cli.tui.terminal.prompt import sync_session_chrome_from_state
 from agentos.cli.ui import ACCENT, console, error_panel
 from agentos.engine.commands import Surface
 from agentos.session.compaction import (
@@ -31,6 +32,11 @@ from agentos.session.compaction_lifecycle import (
 
 STANDALONE_SLASH_HANDLER_WORDS = frozenset(
     {
+        "/auto",
+        "/c0",
+        "/c1",
+        "/c2",
+        "/c3",
         "/clear",
         "/compact",
         "/cost",
@@ -100,7 +106,13 @@ class CompactWithResult(Protocol):
 
 
 class StandaloneCreateSession(Protocol):
-    def __call__(self, session_key: str, *, agent_id: str = "main") -> Awaitable[Any]: ...
+    def __call__(
+        self,
+        session_key: str,
+        *,
+        agent_id: str = "main",
+        display_name: str | None = None,
+    ) -> Awaitable[Any]: ...
 
 
 class StandaloneReadTranscript(Protocol):
@@ -378,8 +390,23 @@ async def _replace_with_new_session(
     create_session = context.slash_services.create_session
     if create_session is None:
         raise RuntimeError("standalone chat requires session manager")
-    await create_session(session_key, agent_id="main")
-    state = ChatSessionState(session_key=session_key, model=context.model)
+    # Persist the title as the session ``display_name`` so it survives a
+    # later ``/resume`` and can be surfaced in the toolbar / ``/status``.
+    # ``SessionManager.create`` forwards ``**kwargs`` to the ``SessionNode``
+    # constructor, which has a nullable ``display_name`` column (no
+    # migration required). Fixes the pre-existing standalone bug where
+    # ``/new <title>`` accepted the arg then dropped it.
+    await create_session(
+        session_key,
+        agent_id="main",
+        display_name=title,
+    )
+    state = ChatSessionState(
+        session_key=session_key,
+        model=context.model,
+        display_name=title or None,
+        router_hold_tier=None,
+    )
     tool_ctx = context.build_tool_ctx(session_key)
 
     context.session_key = session_key
@@ -393,6 +420,7 @@ async def _replace_with_new_session(
             model=context.model,
         )
     )
+    sync_session_chrome_from_state(state)
     label = f" ({title})" if title else ""
     console.print(f"[green]Started new session{label}:[/green] {session_key}")
     return session_key
@@ -465,6 +493,63 @@ async def _compact_standalone_context(context: StandaloneSlashContext) -> None:
         )
 
 
+async def _apply_router_hold_standalone(
+    context: StandaloneSlashContext,
+    *,
+    tier: str | None,
+) -> None:
+    """Mutate the in-process Pilot Router hold store for the active session.
+
+    ``tier=None`` means "clear" (restore automatic routing); a non-empty
+    string pins the router to that tier. Mirrors what the gateway's
+    ``router.hold.set`` / ``router.hold.clear`` RPCs do, but touches the
+    ``TurnRunner`` instance living in this process directly. The store
+    and config come from ``turn_runner.router_control_hold_store`` /
+    ``router_control_config`` (always present on a real TurnRunner; the
+    config may be ``None`` or ``enabled=False`` when the operator hasn't
+    configured a Pilot Router — we surface that as a readable message).
+    """
+    turn_runner = context.turn_runner
+    store = getattr(turn_runner, "router_control_hold_store", None)
+    cfg = getattr(turn_runner, "router_control_config", None)
+    if store is None or cfg is None or not getattr(cfg, "enabled", False):
+        console.print("[yellow]Pilot Router is disabled or unavailable.[/yellow]")
+        return
+
+    # Lazily import so the slash adapter never pays the router_control
+    # import cost when no tier command is issued.
+    from agentos.router_control import (
+        RouterControlValidationError,
+        resolve_router_control_target,
+    )
+    from agentos.session.keys import canonicalize_session_key
+
+    session_key = canonicalize_session_key(context.session_key)
+
+    if tier is None:
+        cleared = store.clear(session_key)
+        context.state.router_hold_tier = None
+        sync_session_chrome_from_state(context.state)
+        if cleared is not None:
+            console.print(f"[{ACCENT}]router hold cleared (automatic routing)[/]")
+        else:
+            console.print(f"[{ACCENT}]router already on automatic routing[/]")
+        return
+
+    try:
+        target = resolve_router_control_target(cfg, f"tier:{tier}")
+    except RouterControlValidationError:
+        console.print(
+            f"[yellow]Tier '{tier}' is not configured on the Pilot Router.[/yellow]"
+        )
+        return
+    store.set_hold(session_key, target, evidence=f"slash command /{tier}")
+    context.state.router_hold_tier = tier
+    sync_session_chrome_from_state(context.state)
+    model_suffix = f" · {target.model}" if target.model else ""
+    console.print(f"[{ACCENT}]router pinned to tier {tier}[/]{model_suffix}")
+
+
 async def handle_standalone_slash_command(
     cmd: str,
     context: StandaloneSlashContext,
@@ -493,10 +578,23 @@ async def handle_standalone_slash_command(
         return True
 
     if cmd in {"/status", "/session"}:
-        console.print(
-            f"[{ACCENT}]session[/] [dim]{state.session_key}[/dim]\n"
-            f"[{ACCENT}]model[/] [dim]{state.model or 'default'}[/dim]"
+        title_line = (
+            f"[{ACCENT}]title[/] [dim]{state.display_name}[/dim]\n"
+            if state.display_name
+            else ""
         )
+        tier_line = (
+            f"[{ACCENT}]router[/] [dim]tier:{state.router_hold_tier}[/dim]\n"
+            if state.router_hold_tier
+            else f"[{ACCENT}]router[/] [dim]auto[/dim]\n"
+        )
+        status_text = (
+            f"{title_line}"
+            f"[{ACCENT}]session[/] [dim]{state.session_key}[/dim]\n"
+            f"[{ACCENT}]model[/] [dim]{state.model or 'default'}[/dim]\n"
+            f"{tier_line}"
+        )
+        console.print(status_text.rstrip("\n"))
         return True
 
     if cmd == "/models":
@@ -515,6 +613,14 @@ async def handle_standalone_slash_command(
 
     if cmd == "/cost":
         console.print(state.usage.render())
+        return True
+
+    if cmd in {"/c0", "/c1", "/c2", "/c3"}:
+        await _apply_router_hold_standalone(context, tier=cmd[1:])
+        return True
+
+    if cmd == "/auto":
+        await _apply_router_hold_standalone(context, tier=None)
         return True
 
     if cmd in {"/clear", "/reset"}:

--- a/src/agentos/cli/tui/adapters/terminal_chat_adapter.py
+++ b/src/agentos/cli/tui/adapters/terminal_chat_adapter.py
@@ -52,6 +52,16 @@ class TerminalChatRuntimeContext:
         value = self.scope.get("session_key")
         return value if isinstance(value, str) else None
 
+    @property
+    def session_title(self) -> str | None:
+        value = self.scope.get("session_title")
+        return value if isinstance(value, str) else None
+
+    @property
+    def router_tier(self) -> str | None:
+        value = self.scope.get("router_tier")
+        return value if isinstance(value, str) else None
+
     def abort_turn(self) -> Awaitable[None]:
         if self.surface is not Surface.CLI_GATEWAY or self.abort_active_turn is None:
             return _noop_abort_turn()
@@ -148,6 +158,8 @@ async def run_terminal_chat_runtime(
             surface=surface,
             model=context.model,
             session_id=context.session_id,
+            session_title=context.session_title,
+            router_tier=context.router_tier,
         )
 
     def _expose_surface(tui_surface: TuiSurface) -> None:

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -279,7 +279,7 @@ class ChatApplication:
                     FormattedTextControl(_input_prefix_fragments),
                     width=_input_prefix_width,
                 ),
-                Window(BufferControl(buffer=self._buffer), height=Dimension(min=1)),
+                Window(BufferControl(buffer=self._buffer), height=Dimension.exact(1)),
             ]
         )
         toolbar_window = Window(
@@ -299,7 +299,13 @@ class ChatApplication:
                 style=f"fg:{ACCENT_DIM}",
             )
 
-        children: list = []
+        # In non-full-screen mode the renderer reserves the rows below the
+        # cursor (`min_available_height`), which is large on a fresh launch
+        # against a tall terminal. Absorb that slack in a greedy spacer at the
+        # top so the framed input + toolbar stay compact and pinned to the
+        # bottom (the input buffer is `Dimension.exact(1)`, so it no longer
+        # balloons to fill the region — the cause of the over-tall frame).
+        children: list = [Window()]
         if input_header is not None:
             def _header_fragments():  # type: ignore[no-untyped-def]
                 try:

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -171,6 +171,27 @@ def _build_key_bindings() -> KeyBindings:
             return
         event.current_buffer.insert_text(event.data)
 
+    def _page_lines(chat_app) -> int:  # type: ignore[no-untyped-def]
+        """A page ≈ the transcript pane's visible height (fallback 10)."""
+        window = getattr(chat_app, "_transcript_window", None)
+        info = getattr(window, "render_info", None) if window else None
+        height = getattr(info, "window_height", None)
+        return max(1, (height - 1)) if isinstance(height, int) and height > 1 else 10
+
+    @bindings.add(Keys.PageUp)
+    def _scroll_up(event) -> None:  # type: ignore[no-untyped-def]
+        # Scroll the full-screen transcript pane up into history. No-op on
+        # the native-scrollback surface (guarded in scroll_transcript).
+        chat_app = getattr(event.app, "_chat_application", None)
+        if chat_app is not None:
+            chat_app.scroll_transcript(_page_lines(chat_app))
+
+    @bindings.add(Keys.PageDown)
+    def _scroll_down(event) -> None:  # type: ignore[no-untyped-def]
+        chat_app = getattr(event.app, "_chat_application", None)
+        if chat_app is not None:
+            chat_app.scroll_transcript(-_page_lines(chat_app))
+
     return bindings
 
 
@@ -439,6 +460,37 @@ class ChatApplication:
         else:
             target = max(0, total_lines - self._transcript_scroll)
         return Point(x=0, y=target)
+
+    def scroll_transcript(self, lines: int) -> None:
+        """Scroll the transcript pane by ``lines`` logical lines.
+
+        ``lines > 0`` scrolls up into history (releasing the auto-follow
+        latch); ``lines < 0`` scrolls back toward the tail. Reaching the
+        bottom re-latches follow so new output resumes auto-scrolling.
+        """
+        if not self._fullscreen:
+            return
+        total = self._transcript.count("\n")
+        new_scroll = self._transcript_scroll + lines
+        # Clamp: 0 == pinned to the tail, total-1 == top of history.
+        new_scroll = max(0, min(new_scroll, max(0, total - 1)))
+        self._transcript_scroll = new_scroll
+        self._transcript_follow = new_scroll == 0
+        try:
+            self._app.invalidate()
+        except Exception:
+            pass
+
+    def scroll_transcript_to_bottom(self) -> None:
+        """Re-pin the transcript pane to the newest line (resume follow)."""
+        if not self._fullscreen:
+            return
+        self._transcript_scroll = 0
+        self._transcript_follow = True
+        try:
+            self._app.invalidate()
+        except Exception:
+            pass
 
     def append_transcript(self, text: str) -> None:
         """Append ANSI-encoded text to the full-screen transcript pane.

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -9,6 +9,7 @@ asyncio queue, and routes toolbar state updates through the existing
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 import time
 from collections.abc import AsyncIterator, Callable
@@ -19,7 +20,8 @@ from prompt_toolkit.application import Application
 from prompt_toolkit.auto_suggest import AutoSuggest
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import Completer
-from prompt_toolkit.formatted_text import HTML, to_formatted_text
+from prompt_toolkit.data_structures import Point
+from prompt_toolkit.formatted_text import ANSI, HTML, to_formatted_text
 from prompt_toolkit.history import FileHistory, History
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
@@ -83,6 +85,19 @@ _EOF_SENTINEL: object = object()
 # level so tests can monkeypatch it if they need a tighter window.
 _DOUBLE_CTRL_C_WINDOW_S: float = 1.5
 _ACTIVE_INPUT_PREFIX_WIDTH: int = 7
+
+
+def _fullscreen_enabled() -> bool:
+    """Opt-in flag for the full-screen transcript-pane chat surface.
+
+    When set, the assistant transcript renders inside a scrollable
+    prompt-toolkit pane above a permanently-pinned input frame (Claude
+    Code style) instead of streaming to native terminal scrollback. Gated
+    so the mature native-scrollback path stays the default until the
+    full-screen surface reaches parity. See issue #46 (issue 1).
+    """
+    value = (os.environ.get("AGENTOS_CHAT_FULLSCREEN") or "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
 
 
 def _build_key_bindings() -> KeyBindings:
@@ -187,6 +202,17 @@ class ChatApplication:
     ) -> None:
         self._surface = surface
         self._toolbar_context = toolbar_context
+        # Full-screen transcript surface (opt-in via AGENTOS_CHAT_FULLSCREEN).
+        # `_transcript` accumulates the ANSI-encoded conversation; a
+        # scrollable pane renders it above the pinned input frame.
+        # `_transcript_follow` latches auto-scroll-to-bottom; a user scroll
+        # up releases it. `_transcript_scroll` is the from-bottom line offset
+        # while not following.
+        self._fullscreen: bool = _fullscreen_enabled()
+        self._transcript: str = ""
+        self._transcript_follow: bool = True
+        self._transcript_scroll: int = 0
+        self._transcript_window: Window | None = None
         self._submit_queue: asyncio.Queue[str | object] = asyncio.Queue()
         self._eof_seen = False
         # Set for the duration of the inline approval suspend window
@@ -299,13 +325,33 @@ class ChatApplication:
                 style=f"fg:{ACCENT_DIM}",
             )
 
-        # In non-full-screen mode the renderer reserves the rows below the
-        # cursor (`min_available_height`), which is large on a fresh launch
-        # against a tall terminal. Absorb that slack in a greedy spacer at the
-        # top so the framed input + toolbar stay compact and pinned to the
-        # bottom (the input buffer is `Dimension.exact(1)`, so it no longer
-        # balloons to fill the region — the cause of the over-tall frame).
-        children: list = [Window()]
+        # Top-of-layout element that owns the vertical slack above the frame.
+        #  * Full-screen surface: a scrollable pane that renders the ANSI
+        #    conversation transcript and auto-scrolls to the newest line
+        #    (cursor pinned to the last logical line; wrap_lines follows it).
+        #  * Native-scrollback surface: a greedy empty spacer. In
+        #    non-full-screen mode the renderer reserves the rows below the
+        #    cursor (large on a fresh launch against a tall terminal); the
+        #    spacer absorbs that slack so the framed input + toolbar stay
+        #    compact and pinned to the bottom (the input buffer is
+        #    `Dimension.exact(1)`, so it no longer balloons to fill the
+        #    region — the cause of the over-tall frame).
+        top_element: Window
+        if self._fullscreen:
+            top_element = Window(
+                content=FormattedTextControl(
+                    lambda: ANSI(self._transcript),
+                    get_cursor_position=self._transcript_cursor_position,
+                    focusable=False,
+                    show_cursor=False,
+                ),
+                wrap_lines=True,
+                always_hide_cursor=True,
+            )
+            self._transcript_window = top_element
+        else:
+            top_element = Window()
+        children: list = [top_element]
         if input_header is not None:
             def _header_fragments():  # type: ignore[no-untyped-def]
                 try:
@@ -346,7 +392,7 @@ class ChatApplication:
             layout=layout,
             key_bindings=_build_key_bindings(),
             style=style,
-            full_screen=False,
+            full_screen=self._fullscreen,
             refresh_interval=0.1,
             input=input,
             output=output,
@@ -366,6 +412,53 @@ class ChatApplication:
     @property
     def surface(self) -> Surface:
         return self._surface
+
+    @property
+    def fullscreen(self) -> bool:
+        """True when the full-screen transcript-pane surface is active."""
+        return self._fullscreen
+
+    # ------------------------------------------------------------------ #
+    # Transcript pane (full-screen surface)                              #
+    # ------------------------------------------------------------------ #
+
+    def _transcript_cursor_position(self) -> Point:
+        """Virtual cursor that drives the pane's auto-scroll.
+
+        With ``wrap_lines`` on, prompt-toolkit scrolls to keep the control's
+        cursor visible (``get_vertical_scroll`` is ignored). Parking the
+        cursor on the last logical line follows the tail; lifting it by
+        ``_transcript_scroll`` lines lets the user scroll back through
+        history without following new output.
+        """
+        # Trailing newline yields an empty final line; anchor on the last
+        # line that actually carries text so the tail is not a blank row.
+        total_lines = self._transcript.count("\n")
+        if self._transcript_follow:
+            target = total_lines
+        else:
+            target = max(0, total_lines - self._transcript_scroll)
+        return Point(x=0, y=target)
+
+    def append_transcript(self, text: str) -> None:
+        """Append ANSI-encoded text to the full-screen transcript pane.
+
+        Synchronous and ordered: callers append in the same order the
+        native-scrollback surface would have written bytes, so streamed
+        tokens, tool rows, Rich panels, and echoes stay interleaved
+        correctly. Re-follows the tail and repaints.
+        """
+        if not text:
+            return
+        self._transcript += text
+        # New output re-pins the view to the bottom (matches a terminal that
+        # scrolls on write); an explicit user scroll re-latches follow=False.
+        self._transcript_follow = True
+        self._transcript_scroll = 0
+        try:
+            self._app.invalidate()
+        except Exception:
+            pass
 
     def set_toolbar(self, key: str, value: str | None) -> None:
         """Mutate the shared toolbar dict in place.
@@ -572,6 +665,11 @@ class ChatApplication:
         from agentos.cli.ui import console  # noqa: PLC0415
 
         async with self.acquire_output():
+            if self._fullscreen and self._app.is_running:
+                # Full-screen surface: append into the transcript pane rather
+                # than suspending the app to write raw bytes to scrollback.
+                self.append_transcript(payload)
+                return
             if self._app.is_running:
                 async with in_terminal():
                     self._app.output.write_raw(payload)
@@ -595,6 +693,20 @@ class ChatApplication:
         from agentos.cli.ui import console  # noqa: PLC0415
 
         async with self.acquire_output():
+            if self._fullscreen and self._app.is_running:
+                # Full-screen surface: the whole turn appends into the
+                # transcript pane. No `in_terminal()` hold, so the input
+                # frame stays pinned and visible while tokens stream.
+                def _write(payload: str) -> None:
+                    self.append_transcript(payload)
+
+                self._active_stream_writer = _write
+                try:
+                    yield _write
+                finally:
+                    if self._active_stream_writer is _write:
+                        self._active_stream_writer = None
+                return
             if self._app.is_running:
                 async with in_terminal():
                     def _write(payload: str) -> None:

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -259,7 +259,7 @@ class ChatApplication:
         # Persistent left-side prompt prefix. Keep the current input row
         # identified as ``you`` even before text is typed; submitted transcript
         # rows are echoed separately by ``user_input_echo_payload``.
-        from agentos.cli.ui import ACCENT  # noqa: PLC0415
+        from agentos.cli.ui import ACCENT, ACCENT_DIM  # noqa: PLC0415
 
         def _input_prefix_fragments():  # type: ignore[no-untyped-def]
             return to_formatted_text(
@@ -287,6 +287,18 @@ class ChatApplication:
             height=Dimension.exact(1),
             style="class:bottom-toolbar",
         )
+
+        # Issue #46 §5: frame the active input row with a top and bottom rule
+        # (Claude Code style) so the typing area reads as a distinct box between
+        # the transcript and the bottom toolbar. A filled-char Window renders a
+        # full-width horizontal rule in the muted accent tone.
+        def _rule_window() -> Window:  # type: ignore[no-untyped-def]
+            return Window(
+                height=Dimension.exact(1),
+                char="─",
+                style=f"fg:{ACCENT_DIM}",
+            )
+
         children: list = []
         if input_header is not None:
             def _header_fragments():  # type: ignore[no-untyped-def]
@@ -304,7 +316,9 @@ class ChatApplication:
                     height=Dimension.exact(1),
                 )
             )
+        children.append(_rule_window())
         children.append(input_window)
+        children.append(_rule_window())
         children.append(toolbar_window)
         root = FloatContainer(
             content=HSplit(children),

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import threading
 import time
 from collections.abc import AsyncIterator, Callable
@@ -87,17 +88,45 @@ _DOUBLE_CTRL_C_WINDOW_S: float = 1.5
 _ACTIVE_INPUT_PREFIX_WIDTH: int = 7
 
 
-def _fullscreen_enabled() -> bool:
-    """Opt-in flag for the full-screen transcript-pane chat surface.
+def _fullscreen_env() -> bool | None:
+    """Tri-state read of the ``AGENTOS_CHAT_FULLSCREEN`` override.
 
-    When set, the assistant transcript renders inside a scrollable
-    prompt-toolkit pane above a permanently-pinned input frame (Claude
-    Code style) instead of streaming to native terminal scrollback. Gated
-    so the mature native-scrollback path stays the default until the
-    full-screen surface reaches parity. See issue #46 (issue 1).
+    Returns ``True``/``False`` when the variable is set to a recognized
+    truthy/falsy value, or ``None`` when unset (so the caller falls back to
+    its own default). The full-screen transcript-pane surface renders the
+    assistant transcript inside a scrollable prompt-toolkit pane above a
+    permanently-pinned input frame (Claude Code style) instead of streaming
+    to native terminal scrollback. See issue #46 (issue 1).
     """
-    value = (os.environ.get("AGENTOS_CHAT_FULLSCREEN") or "").strip().lower()
-    return value in {"1", "true", "yes", "on"}
+    raw = os.environ.get("AGENTOS_CHAT_FULLSCREEN")
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off", ""}:
+        return False
+    return None
+
+
+def resolve_chat_fullscreen(explicit: bool | None = None) -> bool:
+    """Resolve whether an ``agentos chat`` surface should run full-screen.
+
+    Precedence: an ``explicit`` argument wins; otherwise the
+    ``AGENTOS_CHAT_FULLSCREEN`` override wins; otherwise full-screen is the
+    default for an interactive TTY (a real ``agentos chat`` session) and is
+    off for non-TTY / piped contexts (tests, redirected output) so those
+    keep the plain native-scrollback behavior.
+    """
+    if explicit is not None:
+        return explicit
+    env = _fullscreen_env()
+    if env is not None:
+        return env
+    try:
+        return bool(sys.stdout.isatty())
+    except Exception:
+        return False
 
 
 def _build_key_bindings() -> KeyBindings:
@@ -220,16 +249,24 @@ class ChatApplication:
         history: History | None = None,
         complete_while_typing: bool = True,
         input_header=None,
+        fullscreen: bool | None = None,
     ) -> None:
         self._surface = surface
         self._toolbar_context = toolbar_context
-        # Full-screen transcript surface (opt-in via AGENTOS_CHAT_FULLSCREEN).
-        # `_transcript` accumulates the ANSI-encoded conversation; a
-        # scrollable pane renders it above the pinned input frame.
-        # `_transcript_follow` latches auto-scroll-to-bottom; a user scroll
-        # up releases it. `_transcript_scroll` is the from-bottom line offset
-        # while not following.
-        self._fullscreen: bool = _fullscreen_enabled()
+        # Full-screen transcript surface. `_transcript` accumulates the
+        # ANSI-encoded conversation; a scrollable pane renders it above the
+        # pinned input frame. `_transcript_follow` latches
+        # auto-scroll-to-bottom; a user scroll up releases it.
+        # `_transcript_scroll` is the from-bottom line offset while not
+        # following. When ``fullscreen`` is not passed explicitly the
+        # constructor default stays native (env override honored) so a bare
+        # ``ChatApplication(...)`` — as tests build it — behaves as the plain
+        # native-scrollback surface; the real chat entry point
+        # (`open_terminal_surface`) resolves and passes the value.
+        if fullscreen is None:
+            env = _fullscreen_env()
+            fullscreen = env if env is not None else False
+        self._fullscreen: bool = fullscreen
         self._transcript: str = ""
         self._transcript_follow: bool = True
         self._transcript_scroll: int = 0

--- a/src/agentos/cli/tui/terminal/prompt.py
+++ b/src/agentos/cli/tui/terminal/prompt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sys
 from collections.abc import Callable
@@ -48,9 +49,24 @@ class PromptConfig:
 
 _session: PromptSession[str] | None = None
 _sessions: dict[Surface, PromptSession[str]] = {}
+
+#: Single source for the assistant speaker label. Override via the
+#: ``AGENTOS_ASSISTANT_LABEL`` env var; defaults to ``agentos`` so the CLI,
+#: the streamed ``◢`` marker, and the pre-token waiting header all read the
+#: same name without per-file literals. See issue #46.
+DEFAULT_ASSISTANT_LABEL: str = os.environ.get("AGENTOS_ASSISTANT_LABEL") or "agentos"
+
 _toolbar_context: dict[str, object | None] = {
     "model": None,
     "session_id": None,
+    # Friendly display name for the active session (set by ``/new <title>``
+    # or loaded from the gateway on resume). Falls back to the opaque
+    # ``session_id`` substring in the bottom toolbar when unset.
+    "session_title": None,
+    # Active Pilot Router tier hold (e.g. ``"c3"``) for the current session,
+    # or ``None`` when automatic routing is in effect. Surfaced in the
+    # bottom toolbar so a pin set via ``/c3`` stays visible while typing.
+    "router_tier": None,
     "suppress": None,
     # Transient status surfaced in the assistant input header before the
     # first streamed chunk lands. Holds a live WaitingIndicator instance
@@ -59,6 +75,10 @@ _toolbar_context: dict[str, object | None] = {
     # a plain string for ad-hoc callers using ChatApplication.set_toolbar().
     # Cleared (set to None) when the stream starts or the turn ends.
     "status": None,
+    # Assistant speaker label; sourced from DEFAULT_ASSISTANT_LABEL but
+    # overridable per session. Read by the streamed renderer marker and
+    # the pre-token waiting header so they never hard-code ``cap``.
+    "assistant_label": DEFAULT_ASSISTANT_LABEL,
 }
 
 
@@ -146,24 +166,43 @@ _PREFIX_RE = re.compile(r"^\[(?P<model>.+?) (?P<mode>\w+)\] (?P<role>\w+) ▸ $"
 
 
 def _bottom_toolbar() -> HTML:
-    """Idle metadata bar: model and session, no background chips."""
+    """Idle metadata bar: session title, model, and active router tier.
+
+    Renders ``title · model_short · [tier:cN]``. The title is the friendly
+    ``session_title`` when set (e.g. via ``/new <title>``), falling back to
+    the trailing segment of the opaque session key so the bar is never
+    empty when a session is live. The tier chip only appears while a
+    Pilot Router hold is active (set by ``/c0``-``/c3``, cleared by
+    ``/auto``).
+    """
     if _toolbar_context.get("suppress"):
         return HTML("")
 
     model = str(_toolbar_context.get("model") or "")
     session_id = str(_toolbar_context.get("session_id") or "")
+    session_title = str(_toolbar_context.get("session_title") or "")
+    router_tier = str(_toolbar_context.get("router_tier") or "")
     model_short = model.rsplit("/", 1)[-1] if model else ""
-    session_short = session_id.rsplit(":", 1)[-1] if session_id else session_id
+    # Prefer the friendly title; fall back to the short opaque key segment
+    # (current behaviour) when no display name is set for this session.
+    display_name = session_title or (session_id.rsplit(":", 1)[-1] if session_id else "")
 
     parts: list[str] = []
+    if display_name:
+        parts.append(f"<style fg='{ACCENT_DEEP}'>{_html_escape(display_name)}</style>")
     if model_short:
-        parts.append(_html_escape(model_short))
-    if session_short:
-        parts.append(_html_escape(session_short))
+        parts.append(f"<style fg='{ACCENT_DEEP}'>{_html_escape(model_short)}</style>")
+    if router_tier:
+        parts.append(f"<style fg='{ACCENT_SOFT}'>tier:{_html_escape(router_tier)}</style>")
     if not parts:
         return HTML("")
-    body = " · ".join(parts)
-    return HTML(f"<style fg='{ACCENT_DEEP}'>{body}</style>")
+    # Render each part with its own style, joined by a dim separator, so
+    # the tier chip can pick up a softer accent without breaking the
+    # prompt-toolkit HTML parser (nested <style> is not supported; we
+    # build the full tag tree here instead).
+    sep = f"<style fg='{ACCENT_DEEP}'> · </style>"
+    body = sep.join(parts)
+    return HTML(body)
 
 
 def _format_prefix(prefix: str) -> AnyFormattedText:
@@ -213,9 +252,12 @@ def _input_header_fragments() -> AnyFormattedText:
         status_text = str(status_obj)
     if not status_text:
         return HTML("")
+    label = str(
+        _toolbar_context.get("assistant_label") or DEFAULT_ASSISTANT_LABEL
+    )
     return HTML(
         f"<style fg='{ACCENT}'>◢ </style>"
-        f"<b><style fg='{ACCENT}'>cap</style></b>"
+        f"<b><style fg='{ACCENT}'>{_html_escape(label)}</style></b>"
         f"<style fg='{ACCENT}'>  </style>"
         f"<style fg='{ACCENT_SOFT}'>{_html_escape(status_text)}</style>"
     )
@@ -233,10 +275,33 @@ def user_input_echo_payload(text: str) -> str:
 
 def queued_input_start_payload() -> str:
     """Render a short marker when a queued input becomes the active turn."""
+    label = str(
+        _toolbar_context.get("assistant_label") or DEFAULT_ASSISTANT_LABEL
+    )
     with console.capture() as capture:
-        _chrome_top("cap")
+        _chrome_top(label)
         console.print("running queued input", style=ACCENT_SOFT)
     return capture.get()
+
+
+def sync_session_chrome_from_state(state: object) -> None:
+    """Push ``ChatSessionState`` fields into the toolbar context.
+
+    Call after mutating ``display_name``, ``router_hold_tier``, ``model``,
+    or ``session_key`` so the bottom toolbar and waiting header pick up
+    the new values on the next repaint. The next ``console.print`` (which
+    slash handlers always emit) triggers that repaint under the
+    ``patch_stdout`` region owned by ``interactive_session``.
+    """
+    _toolbar_context["session_title"] = getattr(state, "display_name", None)
+    tier = getattr(state, "router_hold_tier", None)
+    _toolbar_context["router_tier"] = tier if isinstance(tier, str) and tier else None
+    model = getattr(state, "model", None)
+    if model is not None:
+        _toolbar_context["model"] = model
+    session_key = getattr(state, "session_key", None)
+    if session_key is not None:
+        _toolbar_context["session_id"] = session_key
 
 
 def echo_user_input(text: str) -> None:
@@ -505,6 +570,8 @@ async def interactive_session(
     surface: Surface | str = Surface.CLI_GATEWAY,
     model: str | None = None,
     session_id: str | None = None,
+    session_title: str | None = None,
+    router_tier: str | None = None,
     input: Input | None = None,
     output: Output | None = None,
 ) -> AsyncIterator[InteractiveSessionHandle]:
@@ -534,10 +601,23 @@ async def interactive_session(
     previous_model = _toolbar_context.get("model")
     previous_session = _toolbar_context.get("session_id")
     previous_suppress = _toolbar_context.get("suppress")
+    previous_title = _toolbar_context.get("session_title")
+    previous_tier = _toolbar_context.get("router_tier")
     if model is not None:
         _toolbar_context["model"] = model
     if session_id is not None:
         _toolbar_context["session_id"] = session_id
+    # ``session_title`` and ``router_tier`` are sourced from
+    # ``ChatSessionState`` by the chat runtime and forwarded via the
+    # surface factory so the bottom toolbar shows the friendly session
+    # name and any active Pilot Router pin from the first redraw.
+    # Unlike model/session_id we always overwrite (None is a meaningful
+    # value: "no title" / "automatic routing") so a stale chip from a
+    # prior surface doesn't leak into this one.
+    _toolbar_context["session_title"] = session_title
+    _toolbar_context["router_tier"] = router_tier if isinstance(
+        router_tier, str
+    ) and router_tier else None
     _toolbar_context["suppress"] = None
 
     handle = InteractiveSessionHandle(chat_app)
@@ -581,3 +661,5 @@ async def interactive_session(
         _toolbar_context["model"] = previous_model
         _toolbar_context["session_id"] = previous_session
         _toolbar_context["suppress"] = previous_suppress
+        _toolbar_context["session_title"] = previous_title
+        _toolbar_context["router_tier"] = previous_tier

--- a/src/agentos/cli/tui/terminal/prompt.py
+++ b/src/agentos/cli/tui/terminal/prompt.py
@@ -7,7 +7,12 @@ import os
 import re
 import sys
 from collections.abc import Callable
-from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
+from contextlib import (
+    AbstractAsyncContextManager,
+    AbstractContextManager,
+    asynccontextmanager,
+    nullcontext,
+)
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -29,6 +34,7 @@ from agentos.cli.ui import (
     ACCENT_DIM,
     ACCENT_SOFT,
     console,
+    error_console,
 )
 from agentos.engine.commands import DEFAULT_REGISTRY, Surface, parse_surface
 from agentos.paths import state_dir
@@ -564,6 +570,31 @@ def _get_or_create_chat_app(
     return cached
 
 
+class _TranscriptConsoleSink:
+    """File-like sink that funnels Rich console output into the pane.
+
+    On the full-screen surface the app owns the whole screen, so Rich
+    output (startup screen, notices, slash-command results) must render
+    into the transcript pane rather than to stdout. Reports ``isatty()``
+    True so ``_CliConsole.is_terminal`` keeps emitting ANSI colour, which
+    the pane renders via ``ANSI(...)``.
+    """
+
+    def __init__(self, chat_app: ChatApplication) -> None:
+        self._chat_app = chat_app
+
+    def write(self, data: str) -> int:
+        if data:
+            self._chat_app.append_transcript(data)
+        return len(data or "")
+
+    def flush(self) -> None:
+        return None
+
+    def isatty(self) -> bool:
+        return True
+
+
 @asynccontextmanager
 async def interactive_session(
     *,
@@ -622,7 +653,26 @@ async def interactive_session(
 
     handle = InteractiveSessionHandle(chat_app)
     app_task: asyncio.Task[None] | None = None
-    stdout_cm = nullcontext() if output is not None else patch_stdout(raw=True)
+    # Output routing:
+    #  * Full-screen surface owns the screen — redirect Rich console output
+    #    into the transcript pane and skip patch_stdout (which is for
+    #    printing *above* a non-full-screen prompt).
+    #  * Native-scrollback surface — wrap patch_stdout so Rich output prints
+    #    above the persistent prompt.
+    console_redirect_active = False
+    prev_console_file: object | None = None
+    prev_error_file: object | None = None
+    stdout_cm: AbstractContextManager[None]
+    if chat_app.fullscreen:
+        sink = _TranscriptConsoleSink(chat_app)
+        prev_console_file = console.file
+        prev_error_file = error_console.file
+        console.file = sink  # type: ignore[assignment]
+        error_console.file = sink  # type: ignore[assignment]
+        console_redirect_active = True
+        stdout_cm = nullcontext()
+    else:
+        stdout_cm = nullcontext() if output is not None else patch_stdout(raw=True)
 
     try:
         stdout_cm.__enter__()
@@ -657,6 +707,15 @@ async def interactive_session(
             stdout_cm.__exit__(None, None, None)
         except Exception:
             pass
+
+        if console_redirect_active:
+            # Restore the real console streams so a later non-full-screen
+            # surface (or plain CLI output) writes to the terminal again.
+            try:
+                console.file = prev_console_file  # type: ignore[assignment]
+                error_console.file = prev_error_file  # type: ignore[assignment]
+            except Exception:
+                pass
 
         _toolbar_context["model"] = previous_model
         _toolbar_context["session_id"] = previous_session

--- a/src/agentos/cli/tui/terminal/prompt.py
+++ b/src/agentos/cli/tui/terminal/prompt.py
@@ -472,6 +472,34 @@ async def prompt_approval(
 _chat_applications: dict[Surface, ChatApplication] = {}
 
 
+# Full-screen surface only: startup output (the "Connected to gateway" line,
+# the branded banner + catalogue panel) is rendered *before* the prompt-toolkit
+# Application takes the alternate screen buffer, so it would be wiped the moment
+# the app starts. In full-screen we capture that output (already ANSI-coloured,
+# rendered at the real terminal width) and replay it into the transcript pane
+# once the surface is open. See issue #46 (issue 1).
+_pending_pane_output: list[str] = []
+
+
+def queue_pane_output(text: str) -> None:
+    """Queue pre-surface startup output for replay into the full-screen pane.
+
+    No-op on empty text. The buffer is drained (and cleared) by
+    ``interactive_session`` when the full-screen surface opens.
+    """
+    if text:
+        _pending_pane_output.append(text)
+
+
+def _drain_pane_output(chat_app: ChatApplication) -> None:
+    """Flush any queued startup output into the transcript pane, in order."""
+    if not _pending_pane_output:
+        return
+    for chunk in _pending_pane_output:
+        chat_app.append_transcript(chunk)
+    _pending_pane_output.clear()
+
+
 class InteractiveSessionHandle:
     """Handle returned by `interactive_session()`.
 
@@ -524,6 +552,7 @@ def _get_or_create_chat_app(
     *,
     input: Input | None = None,
     output: Output | None = None,
+    fullscreen: bool | None = None,
 ) -> ChatApplication:
     # Local import to avoid a circular dependency with app.py at module load
     # (app.py only imports from `agentos.engine.commands`).
@@ -552,6 +581,7 @@ def _get_or_create_chat_app(
             auto_suggest=auto_suggest,
             history=history,
             input_header=_input_header_fragments,
+            fullscreen=fullscreen,
         )
 
     cached = _chat_applications.get(surface)
@@ -565,6 +595,7 @@ def _get_or_create_chat_app(
             auto_suggest=auto_suggest,
             history=history,
             input_header=_input_header_fragments,
+            fullscreen=fullscreen,
         )
         _chat_applications[surface] = cached
     return cached
@@ -605,6 +636,7 @@ async def interactive_session(
     router_tier: str | None = None,
     input: Input | None = None,
     output: Output | None = None,
+    fullscreen: bool | None = None,
 ) -> AsyncIterator[InteractiveSessionHandle]:
     """Long-lived prompt-toolkit Application for this surface.
 
@@ -625,7 +657,9 @@ async def interactive_session(
     `_bottom_toolbar` callable used by `prompt_user`.
     """
     parsed = parse_surface(surface) if isinstance(surface, str) else surface
-    chat_app = _get_or_create_chat_app(parsed, input=input, output=output)
+    chat_app = _get_or_create_chat_app(
+        parsed, input=input, output=output, fullscreen=fullscreen
+    )
 
     # Toolbar context lives in `_toolbar_context`; mutate before launching so
     # the first redraw renders the right model / session_id chips.
@@ -684,6 +718,12 @@ async def interactive_session(
         # input/output pair before the caller starts pushing keystrokes
         # through `create_pipe_input`.
         await asyncio.sleep(0)
+        # Full-screen surface owns the whole screen, so the startup output
+        # (connect line + branded banner + catalogue panel) that was rendered
+        # before the app took the alternate buffer must be replayed into the
+        # transcript pane now that it is live. See issue #46 (issue 1).
+        if chat_app.fullscreen:
+            _drain_pane_output(chat_app)
         yield handle
     finally:
         # Tear down the Application before unwinding patch_stdout so the

--- a/src/agentos/cli/tui/terminal/renderer.py
+++ b/src/agentos/cli/tui/terminal/renderer.py
@@ -5,15 +5,25 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal, cast
 
+from agentos.cli.tui.terminal.prompt import DEFAULT_ASSISTANT_LABEL
 from agentos.cli.tui.terminal.stream import StreamingRenderer
 
 
 class TerminalRenderer:
     """Thin async protocol adapter over the current streaming renderer."""
 
-    def __init__(self, *, title: str = "cap", output_handle: Any | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        title: str | None = None,
+        output_handle: Any | None = None,
+    ) -> None:
+        # ``title`` defaults to the shared assistant label (see
+        # ``prompt.DEFAULT_ASSISTANT_LABEL``); pass an explicit value only
+        # when you need to override it for this renderer instance.
+        resolved = title if title is not None else DEFAULT_ASSISTANT_LABEL
         self.output_handle = output_handle
-        self._renderer = StreamingRenderer(title=title, output_handle=output_handle)
+        self._renderer = StreamingRenderer(title=resolved, output_handle=output_handle)
 
     async def _call_async_or_sync(
         self,

--- a/src/agentos/cli/tui/terminal/stream.py
+++ b/src/agentos/cli/tui/terminal/stream.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 from rich.text import Text
 
 from agentos.cli.chat.turn import TurnResult, UsageCounter, UsageSummary
-from agentos.cli.tui.terminal.prompt import _toolbar_context
+from agentos.cli.tui.terminal.prompt import DEFAULT_ASSISTANT_LABEL, _toolbar_context
 from agentos.cli.ui import ACCENT, ACCENT_SOFT, console, error_panel
 
 __all__ = [
@@ -346,9 +346,20 @@ class StreamingRenderer:
     def __init__(
         self,
         *,
-        title: str = "cap",
+        title: str | None = None,
         output_handle: Any | None = None,
     ) -> None:
+        # ``title`` defaults to the shared assistant label sourced from
+        # ``_toolbar_context["assistant_label"]`` (or ``AGENTOS_ASSISTANT_LABEL``,
+        # falling back to ``agentos``) so every caller renders the same
+        # speaker name without each site repeating the literal. The
+        # sentinel-None pattern lets us read the live value at construction
+        # time (Python evaluates plain defaults once at def time, which
+        # would freeze a stale label for the whole process).
+        if title is None:
+            title = str(
+                _toolbar_context.get("assistant_label") or DEFAULT_ASSISTANT_LABEL
+            )
         self.title = title
         self.buffer = ""
         self.started_at = time.monotonic()
@@ -408,7 +419,7 @@ class StreamingRenderer:
         self.stop()
         return False
 
-    def _open_cap_status_line(self) -> str:
+    def _open_assistant_status_line(self) -> str:
         """Return the assistant marker once, when visible text actually starts."""
         if self._status_line_open:
             return ""
@@ -437,7 +448,7 @@ class StreamingRenderer:
         if self._stream_started:
             return ""
         self._stop_waiting()
-        marker = self._open_cap_status_line()
+        marker = self._open_assistant_status_line()
         self._stream_started = True
         return marker
 
@@ -468,7 +479,7 @@ class StreamingRenderer:
         if not visible:
             # Chunk was a control directive or partial ``[[`` suffix the
             # sanitizer is still buffering; skip the marker side-effect so
-            # an empty ``◢ cap  `` doesn't print for a directive-only
+            # an empty ``◢ agentos  `` doesn't print for a directive-only
             # turn.
             return
         # Sanitized text becomes the source of truth for the live stream

--- a/src/agentos/cli/tui/terminal/surface.py
+++ b/src/agentos/cli/tui/terminal/surface.py
@@ -95,6 +95,8 @@ async def open_terminal_surface(
     surface: Surface,
     model: str | None = None,
     session_id: str | None = None,
+    session_title: str | None = None,
+    router_tier: str | None = None,
 ) -> AsyncIterator[TerminalSurface]:
     session_factory = interactive_session
     if session_factory is _DEFAULT_INTERACTIVE_SESSION:
@@ -104,5 +106,7 @@ async def open_terminal_surface(
         surface=surface,
         model=model,
         session_id=session_id,
+        session_title=session_title,
+        router_tier=router_tier,
     ) as handle:
         yield TerminalSurface(handle, surface=surface)

--- a/src/agentos/cli/tui/terminal/surface.py
+++ b/src/agentos/cli/tui/terminal/surface.py
@@ -7,6 +7,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Protocol
 
 from agentos.cli.tui.terminal import prompt as terminal_prompt
+from agentos.cli.tui.terminal.app import resolve_chat_fullscreen
 from agentos.engine.commands import Surface
 
 _DEFAULT_INTERACTIVE_SESSION = terminal_prompt.interactive_session
@@ -97,10 +98,17 @@ async def open_terminal_surface(
     session_id: str | None = None,
     session_title: str | None = None,
     router_tier: str | None = None,
+    fullscreen: bool | None = None,
 ) -> AsyncIterator[TerminalSurface]:
     session_factory = interactive_session
     if session_factory is _DEFAULT_INTERACTIVE_SESSION:
         session_factory = terminal_prompt.interactive_session
+
+    # Full-screen is the default for a real interactive `agentos chat`
+    # (env override honored, native fallback for non-TTY). Resolved here so
+    # the single chat entry point drives it for both the gateway and
+    # standalone surfaces without each caller opting in. See issue #46.
+    resolved_fullscreen = resolve_chat_fullscreen(fullscreen)
 
     async with session_factory(
         surface=surface,
@@ -108,5 +116,6 @@ async def open_terminal_surface(
         session_id=session_id,
         session_title=session_title,
         router_tier=router_tier,
+        fullscreen=resolved_fullscreen,
     ) as handle:
         yield TerminalSurface(handle, surface=surface)

--- a/src/agentos/engine/commands.py
+++ b/src/agentos/engine/commands.py
@@ -252,11 +252,14 @@ _COMMANDS: tuple[CommandDef, ...] = (
             _C: _rpc("sessions.contextCompact", _key),
         },
     ),
-    # ---- Router tier holds (web + channel) --------------------------------
+    # ---- Router tier holds (web + channel + cli) -------------------------
     # /c0-/c3 pin the Pilot Router to one configured tier for this session
     # (short-lived hold, same mechanism as the router_control tool); /auto
     # restores automatic routing. Tiers not present in the active router
-    # config are rejected by the RPC with an operator-readable error.
+    # config are rejected by the RPC (gateway) or the LOCAL handler
+    # (standalone) with an operator-readable error. CLI surfaces reuse the
+    # existing router.hold.* RPC when a gateway is reachable and hit the
+    # in-process hold store directly under --standalone.
     *(
         CommandDef(
             name=f"/{tier}",
@@ -264,6 +267,8 @@ _COMMANDS: tuple[CommandDef, ...] = (
             description=f"Pin the Pilot Router to tier {tier} for this session.",
             execution={
                 _W: _rpc("router.hold.set", _tier_hold(tier)),
+                _T: _rpc("router.hold.set", _tier_hold(tier)),
+                _S: _local("router.hold.set"),
                 _C: _rpc("router.hold.set", _tier_hold(tier)),
             },
         )
@@ -275,6 +280,8 @@ _COMMANDS: tuple[CommandDef, ...] = (
         description="Restore automatic Pilot Router routing (clear tier hold).",
         execution={
             _W: _rpc("router.hold.clear", _key),
+            _T: _rpc("router.hold.clear", _key),
+            _S: _local("router.hold.clear"),
             _C: _rpc("router.hold.clear", _key),
         },
     ),

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -2516,6 +2516,35 @@ async def _handle_sessions_resolve(params: dict | None, ctx: RpcContext) -> dict
         "status": session.status,
         "agent_id": session.agent_id,
         "model": getattr(session, "model", None),
+        "display_name": getattr(session, "display_name", None),
+        "displayName": getattr(session, "display_name", None),
+        "router_hold_tier": _router_hold_tier_for_session(ctx, session.session_key),
         "created_at": session.created_at,
         "updated_at": session.updated_at,
     }
+
+
+def _router_hold_tier_for_session(ctx: RpcContext, session_key: str) -> str | None:
+    """Return the active Pilot Router tier hold for a session, if any.
+
+    Reads the same in-memory ``RouterControlHoldStore`` the
+    ``router.hold.set`` / ``router.hold.clear`` RPCs mutate so the CLI
+    can render an active tier pin in its bottom toolbar after resuming a
+    session. Returns ``None`` when the router is disabled or no hold is
+    active (mirrors ``rpc_router._router_state``'s availability rules).
+    """
+    runner = getattr(ctx, "turn_runner", None)
+    store = getattr(runner, "router_control_hold_store", None)
+    if store is None:
+        return None
+    cfg = getattr(runner, "router_control_config", None)
+    if cfg is None or not getattr(cfg, "enabled", False):
+        return None
+    try:
+        hold = store.get_valid(session_key)
+    except Exception:  # noqa: BLE001 - best-effort sidebar; never block resolve
+        return None
+    if hold is None:
+        return None
+    tier = getattr(hold, "tier", None)
+    return tier if isinstance(tier, str) and tier else None

--- a/src/agentos/session/models.py
+++ b/src/agentos/session/models.py
@@ -160,6 +160,29 @@ class SessionNode(SQLModel, table=True):
     # from prior turns can be detected and rejected.
     epoch: int = 0
 
+    @property
+    def derived_title(self) -> str | None:
+        """Friendly title for display: explicit ``display_name`` first, else
+        the short opaque session id.
+
+        Fills the pre-existing ``getattr(s, "derived_title", None)`` hook
+        (``rpc_sessions``) that always returned ``None`` because no such
+        attribute existed on the model. Cheap (no transcript scan): depends
+        only on fields already on the row, so it is safe to call in hot
+        paths like ``sessions.list`` and ``sessions.resolve``. Future work
+        can extend this to derive a title from the first user message; the
+        return contract (``str | None``) already supports that.
+        """
+        if self.display_name:
+            return self.display_name
+        if self.label:
+            return self.label
+        # Fall back to the short opaque segment of the session id so list
+        # rows / the toolbar chip show something stable instead of an empty
+        # string when neither display_name nor label is set.
+        sid = (self.session_id or "").strip()
+        return sid[:8] if sid else None
+
 
 class TranscriptEntry(SQLModel, table=True):
     """Individual message stored in the transcript."""

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -55,6 +55,23 @@ agentos chat                 # interactive terminal chat
 agentos agent -m "..."       # one-shot, automation-friendly agent turn
 ```
 
+### `agentos chat` REPL essentials
+
+The interactive REPL exposes slash commands; the most-used are `/new [title]`,
+`/resume <key>`, `/status`, `/model <id>`, `/clear`, `/compact`, `/cost`,
+`/save [path]`, `/help`, and `/exit`. Pilot Router tier pins are available
+in both gateway and `--standalone` modes:
+
+- `/c0` … `/c3` — pin the Pilot Router to a configured tier for this session.
+  The active tier shows in the bottom toolbar (e.g. `tier:c3`) and in
+  `/status` until you run `/auto`, exit, or the hold expires.
+- `/auto` — restore automatic Pilot Router routing (clear the pin).
+
+The assistant speaker label on the `◢` marker defaults to `agentos`; override
+with the `AGENTOS_ASSISTANT_LABEL` env var. The bottom toolbar renders
+`title · model · [tier:cN]` while typing, with the title sourced from
+`/new <title>` or loaded on `/resume`.
+
 ## CLI map
 
 Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -68,7 +68,8 @@ in both gateway and `--standalone` modes:
 - `/auto` — restore automatic Pilot Router routing (clear the pin).
 
 The assistant speaker label on the `◢` marker defaults to `agentos`; override
-with the `AGENTOS_ASSISTANT_LABEL` env var. The bottom toolbar renders
+with the `AGENTOS_ASSISTANT_LABEL` env var. The active input row is framed by a
+top and bottom rule so it reads as a distinct box; the bottom toolbar renders
 `title · model · [tier:cN]` while typing, with the title sourced from
 `/new <title>` or loaded on `/resume`.
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -71,7 +71,9 @@ The assistant speaker label on the `◢` marker defaults to `agentos`; override
 with the `AGENTOS_ASSISTANT_LABEL` env var. The active input row is framed by a
 top and bottom rule so it reads as a distinct box; the bottom toolbar renders
 `title · model · [tier:cN]` while typing, with the title sourced from
-`/new <title>` or loaded on `/resume`.
+`/new <title>` or loaded on `/resume`. Set `AGENTOS_CHAT_FULLSCREEN=1` for the
+experimental full-screen surface that keeps the input frame pinned while the
+assistant streams (`PgUp`/`PgDn` scroll history).
 
 ## CLI map
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -71,9 +71,12 @@ The assistant speaker label on the `◢` marker defaults to `agentos`; override
 with the `AGENTOS_ASSISTANT_LABEL` env var. The active input row is framed by a
 top and bottom rule so it reads as a distinct box; the bottom toolbar renders
 `title · model · [tier:cN]` while typing, with the title sourced from
-`/new <title>` or loaded on `/resume`. Set `AGENTOS_CHAT_FULLSCREEN=1` for the
-experimental full-screen surface that keeps the input frame pinned while the
-assistant streams (`PgUp`/`PgDn` scroll history).
+`/new <title>` or loaded on `/resume`. `agentos chat` runs full-screen by
+default: the conversation renders in a scrollable pane above the pinned input
+frame (the branded welcome screen shows at the top on launch), so the frame
+stays visible while the assistant streams (`PgUp`/`PgDn` scroll history). Set
+`AGENTOS_CHAT_FULLSCREEN=0` to opt out to native scrollback; non-TTY contexts
+fall back automatically.
 
 ## CLI map
 

--- a/tests/test_cli/test_repl_waiting_indicator.py
+++ b/tests/test_cli/test_repl_waiting_indicator.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from agentos.cli.repl import stream as stream_module
-from agentos.cli.repl.prompt import user_input_echo_payload
+from agentos.cli.repl.prompt import DEFAULT_ASSISTANT_LABEL, user_input_echo_payload
 from agentos.cli.repl.stream import StreamingRenderer, UsageSummary, WaitingIndicator
 
 
@@ -64,7 +64,7 @@ def test_waiting_status_renders_as_assistant_header_not_toolbar() -> None:
     header_text = "".join(fragment[1] for fragment in header_fragments)
     header_styles = " ".join(fragment[0] for fragment in header_fragments)
     assert "Tracking" not in toolbar_text
-    assert header_text.startswith("◢ cap  ")
+    assert header_text.startswith(f"◢ {DEFAULT_ASSISTANT_LABEL}  ")
     assert "Tracking" in header_text
     assert "3.0s" in header_text
     assert "bg:" not in header_styles
@@ -182,7 +182,7 @@ def test_visible_stream_opens_single_assistant_marker(monkeypatch) -> None:
         renderer.finalize(usage=None)
 
     output = buf.getvalue()
-    assert output.count("◢ cap") == 1
+    assert output.count(f"◢ {DEFAULT_ASSISTANT_LABEL}") == 1
     assert "hello world" in output
     assert renderer.buffer == "hello world"
 

--- a/tests/test_session/test_session_derived_title.py
+++ b/tests/test_session/test_session_derived_title.py
@@ -1,0 +1,49 @@
+"""Issue #46: ``SessionNode.derived_title`` fills the pre-existing
+``getattr(s, "derived_title", None)`` hook that always returned ``None``.
+
+The property is the canonical fallback chain (``display_name`` → ``label``
+→ short opaque id) used by ``sessions.list`` and ``sessions.resolve`` so
+list rows and toolbar chips show something stable instead of an empty
+string.
+"""
+
+from __future__ import annotations
+
+from agentos.session.models import SessionNode
+
+
+def test_derived_title_prefers_display_name() -> None:
+    node = SessionNode(
+        session_key="agent:main:main:abcd1234",
+        session_id="zzz99999",
+        display_name="My Chat",
+    )
+
+    assert node.derived_title == "My Chat"
+
+
+def test_derived_title_falls_back_to_label() -> None:
+    node = SessionNode(
+        session_key="agent:main:main:abcd1234",
+        session_id="abcd1234efgh",
+        label="Pinned topic",
+    )
+
+    assert node.derived_title == "Pinned topic"
+
+
+def test_derived_title_falls_back_to_short_session_id() -> None:
+    node = SessionNode(
+        session_key="agent:main:main:zzz",
+        session_id="abcd1234efgh5678",
+    )
+
+    # No display_name/label → first 8 chars of the opaque session id,
+    # matching the ``sessions.preview`` fallback chain in ``rpc_sessions``.
+    assert node.derived_title == "abcd1234"
+
+
+def test_derived_title_returns_none_when_nothing_set() -> None:
+    node = SessionNode(session_key="agent:main:main:zzz", session_id="")
+
+    assert node.derived_title is None

--- a/tests/unit/cli/repl/test_cli_router_hold_dispatch.py
+++ b/tests/unit/cli/repl/test_cli_router_hold_dispatch.py
@@ -1,0 +1,242 @@
+"""Issue #46: /c0-/c3 and /auto dispatch on the CLI gateway + standalone surfaces.
+
+These pin the dispatch behavior added to:
+
+* ``slash_gateway.handle_gateway_slash_command`` — reuses the existing
+  ``router.hold.set`` / ``router.hold.clear`` RPC over the wire.
+* ``slash_standalone.handle_standalone_slash_command`` — mutates the
+  in-process ``RouterControlHoldStore`` directly via the TurnRunner.
+
+Both paths also update ``ChatSessionState.router_hold_tier`` so the
+bottom-toolbar tier chip stays in sync.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.cli.chat.session_state import ChatSessionState
+from agentos.router_control import RouterControlHoldStore
+
+# ---------------------------------------------------------------------------
+# Gateway mode: /c3 / /auto call router.hold.set / router.hold.clear RPCs
+# ---------------------------------------------------------------------------
+
+
+class _RouterClient:
+    """Minimal gateway client recording the public ``call`` RPC surface."""
+
+    def __init__(
+        self,
+        *,
+        hold_set_payload: dict[str, Any] | None = None,
+        hold_set_error: Exception | None = None,
+        hold_clear_error: Exception | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        self._hold_set_payload = hold_set_payload or {
+            "tier": "c3",
+            "model": "claude-opus-4-8",
+            "provider": "openrouter",
+            "targetId": "tier:c3",
+            "ttlSeconds": 600,
+        }
+        self._hold_set_error = hold_set_error
+        self._hold_clear_error = hold_clear_error
+
+    async def call(self, method: str, params: dict | None = None) -> Any:
+        self.calls.append((method, dict(params) if params else None))
+        if method == "router.hold.set":
+            if self._hold_set_error is not None:
+                raise self._hold_set_error
+            return dict(self._hold_set_payload)
+        if method == "router.hold.clear":
+            if self._hold_clear_error is not None:
+                raise self._hold_clear_error
+            return {"cleared": True}
+        raise AssertionError(f"unexpected RPC: {method}")
+
+
+def _gateway_context(client: _RouterClient, *, session_key: str = "agent:main:main"):
+    from agentos.cli.tui.adapters.slash_gateway import GatewaySlashContext
+
+    state = ChatSessionState(session_key=session_key, model="openai/gpt")
+    return GatewaySlashContext(
+        state=state,
+        client=client,  # type: ignore[arg-type]
+        elevated_state={"mode": None},
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_c3_calls_router_hold_set_and_sets_state_tier() -> None:
+    from agentos.cli.tui.adapters.slash_gateway import handle_gateway_slash_command
+
+    client = _RouterClient()
+    context = _gateway_context(client)
+
+    handled = await handle_gateway_slash_command("/c3", context)
+
+    assert handled is True
+    assert client.calls == [("router.hold.set", {"key": "agent:main:main", "tier": "c3"})]
+    # The state mirrors the pin so the bottom toolbar shows "tier:c3".
+    assert context.state.router_hold_tier == "c3"
+
+
+@pytest.mark.asyncio
+async def test_gateway_auto_calls_router_hold_clear_and_drops_state_tier() -> None:
+    from agentos.cli.tui.adapters.slash_gateway import handle_gateway_slash_command
+
+    client = _RouterClient()
+    context = _gateway_context(client)
+    context.state.router_hold_tier = "c3"  # pre-existing pin
+
+    handled = await handle_gateway_slash_command("/auto", context)
+
+    assert handled is True
+    assert client.calls == [("router.hold.clear", {"key": "agent:main:main"})]
+    assert context.state.router_hold_tier is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_c3_surfaces_rpc_error_without_raising() -> None:
+    """A router.disabled RPC error must surface as a readable message, not crash."""
+    from agentos.cli.tui.adapters.slash_gateway import handle_gateway_slash_command
+
+    client = _RouterClient(hold_set_error=RuntimeError("router.disabled: Pilot Router is disabled"))
+    context = _gateway_context(client)
+
+    handled = await handle_gateway_slash_command("/c3", context)
+
+    assert handled is True
+    # The error path must not flip the tier chip on.
+    assert context.state.router_hold_tier is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_auto_surfaces_rpc_error_without_raising() -> None:
+    from agentos.cli.tui.adapters.slash_gateway import handle_gateway_slash_command
+
+    client = _RouterClient(hold_clear_error=RuntimeError("router.unavailable"))
+    context = _gateway_context(client)
+
+    handled = await handle_gateway_slash_command("/auto", context)
+
+    assert handled is True
+
+
+# ---------------------------------------------------------------------------
+# Standalone mode: /c3 / /auto mutate the in-process hold store
+# ---------------------------------------------------------------------------
+
+
+def _router_cfg(enabled: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        enabled=enabled,
+        tiers={
+            "c0": {"model": "gemini-flash-lite", "provider": "openrouter"},
+            "c3": {"model": "claude-opus-4-8", "provider": "openrouter"},
+        },
+    )
+
+
+def _standalone_context(
+    *,
+    store: RouterControlHoldStore,
+    cfg: object | None,
+    session_key: str = "agent:main:standalone:abcd1234",
+):
+    from agentos.cli.tui.adapters.slash_standalone import StandaloneSlashContext
+
+    runner = SimpleNamespace(
+        router_control_hold_store=store,
+        router_control_config=cfg,
+    )
+    state = ChatSessionState(session_key=session_key, model="openai/gpt")
+    return StandaloneSlashContext(
+        state=state,
+        session_key=session_key,
+        model=state.model,
+        tool_ctx=object(),
+        slash_services=SimpleNamespace(
+            create_session=None,
+            read_transcript=None,
+            truncate_session=None,
+            compact_session=None,
+            compact_with_result=None,
+            flush_transcript=None,
+            config=None,
+            provider_selector=None,
+        ),
+        turn_runner=runner,
+        build_tool_ctx=lambda _key: object(),
+        replace_session=lambda **_updates: None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_c3_pins_hold_in_process_and_sets_state_tier() -> None:
+    from agentos.cli.tui.adapters.slash_standalone import handle_standalone_slash_command
+
+    store = RouterControlHoldStore()
+    context = _standalone_context(store=store, cfg=_router_cfg())
+
+    handled = await handle_standalone_slash_command("/c3", context)
+
+    assert handled is True
+    hold = store.get_valid("agent:main:standalone:abcd1234")
+    assert hold is not None
+    assert hold.tier == "c3"
+    assert hold.target_id == "tier:c3"
+    assert context.state.router_hold_tier == "c3"
+
+
+@pytest.mark.asyncio
+async def test_standalone_auto_clears_hold_and_drops_state_tier() -> None:
+    from agentos.cli.tui.adapters.slash_standalone import handle_standalone_slash_command
+
+    store = RouterControlHoldStore()
+    context = _standalone_context(store=store, cfg=_router_cfg())
+    # Install a hold up front so /auto has something to clear.
+    await handle_standalone_slash_command("/c3", context)
+    assert store.get_valid("agent:main:standalone:abcd1234") is not None
+
+    handled = await handle_standalone_slash_command("/auto", context)
+
+    assert handled is True
+    assert store.get_valid("agent:main:standalone:abcd1234") is None
+    assert context.state.router_hold_tier is None
+
+
+@pytest.mark.asyncio
+async def test_standalone_c3_reports_disabled_router_without_raising() -> None:
+    from agentos.cli.tui.adapters.slash_standalone import handle_standalone_slash_command
+
+    store = RouterControlHoldStore()
+    context = _standalone_context(store=store, cfg=_router_cfg(enabled=False))
+
+    handled = await handle_standalone_slash_command("/c3", context)
+
+    assert handled is True
+    # No hold installed, no tier chip flipped.
+    assert store.get_valid("agent:main:standalone:abcd1234") is None
+    assert context.state.router_hold_tier is None
+
+
+@pytest.mark.asyncio
+async def test_standalone_unknown_tier_reports_without_raising() -> None:
+    from agentos.cli.tui.adapters.slash_standalone import handle_standalone_slash_command
+
+    store = RouterControlHoldStore()
+    context = _standalone_context(store=store, cfg=_router_cfg())
+
+    # /c2 is not in the configured tiers above; the LOCAL handler must
+    # surface a readable error instead of raising.
+    handled = await handle_standalone_slash_command("/c2", context)
+
+    assert handled is True
+    assert store.get_valid("agent:main:standalone:abcd1234") is None
+    assert context.state.router_hold_tier is None

--- a/tests/unit/cli/repl/test_fullscreen_transcript.py
+++ b/tests/unit/cli/repl/test_fullscreen_transcript.py
@@ -119,3 +119,74 @@ def test_streamed_turn_renders_in_pane_with_frame_pinned(fullscreen_env: None) -
     joined = "\n".join(rows)
     assert "line 24" in joined
     assert "first line" not in joined
+
+
+def test_scroll_transcript_releases_and_relatches_follow(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        for i in range(1, 40):
+            chat.append_transcript(f"line {i}\n")
+        assert chat._transcript_follow is True
+        assert chat._transcript_scroll == 0
+
+        # Scroll up into history: follow releases, offset grows.
+        chat.scroll_transcript(10)
+        assert chat._transcript_follow is False
+        assert chat._transcript_scroll == 10
+
+        # Over-scroll clamps to the top of history (total_lines - 1).
+        chat.scroll_transcript(10_000)
+        total = chat._transcript.count("\n")
+        assert chat._transcript_scroll == total - 1
+
+        # Scrolling back to the bottom re-latches follow.
+        chat.scroll_transcript_to_bottom()
+        assert chat._transcript_follow is True
+        assert chat._transcript_scroll == 0
+
+
+def test_scroll_is_noop_when_not_fullscreen() -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)  # flag off
+        chat.append_transcript("ignored\n")  # append also no-ops meaningfully
+        chat.scroll_transcript(5)
+        assert chat._transcript_scroll == 0
+        assert chat._transcript_follow is True
+
+
+def test_interactive_session_redirects_console_into_pane(fullscreen_env: None) -> None:
+    """In full-screen, Rich `console.print` output lands in the transcript
+    pane (not stdout), and the real console stream is restored on exit."""
+    import io
+
+    from prompt_toolkit.data_structures import Size
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    from agentos.cli.tui.terminal.prompt import interactive_session
+    from agentos.cli.ui import console
+
+    async def _drive() -> tuple[str, type]:
+        original_file_type = type(console.file)
+        with create_pipe_input() as pipe:
+            out = Vt100_Output(io.StringIO(), lambda: Size(rows=12, columns=54))
+            async with interactive_session(
+                surface="cli_gateway",
+                model="m",
+                session_id="k",
+                input=pipe,
+                output=out,
+            ) as handle:
+                await asyncio.sleep(0.05)
+                # During the session, the sink is installed.
+                assert type(console.file).__name__ == "_TranscriptConsoleSink"
+                console.print("hello from a notice")
+                await asyncio.sleep(0.01)
+                transcript = handle._chat_app._transcript
+        # After exit the real stream is restored.
+        return transcript, original_file_type
+
+    transcript, original_file_type = asyncio.run(_drive())
+    assert "hello from a notice" in transcript
+    from agentos.cli.ui import console as console_after
+
+    assert type(console_after.file) is original_file_type

--- a/tests/unit/cli/repl/test_fullscreen_transcript.py
+++ b/tests/unit/cli/repl/test_fullscreen_transcript.py
@@ -1,0 +1,121 @@
+"""Full-screen transcript-pane surface (issue #46, issue 1).
+
+Opt-in via ``AGENTOS_CHAT_FULLSCREEN``: the assistant transcript renders
+inside a scrollable prompt-toolkit pane above a permanently-pinned input
+frame, so the frame stays visible while tokens stream (instead of the
+native-scrollback surface that hides the app via ``in_terminal()``).
+
+These pin:
+  * the flag toggles ``full_screen`` + the transcript pane,
+  * ``append_transcript`` accumulates and re-follows the tail,
+  * a streamed turn appends into the pane (not ``console.file``) with the
+    input frame pinned to the bottom and the partial (newline-less) tail
+    visible immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+from prompt_toolkit.data_structures import Size
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+from agentos.cli.repl.app import ChatApplication
+from agentos.engine.commands import Surface
+
+
+@pytest.fixture
+def fullscreen_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "1")
+
+
+def _build(pipe, rows: int = 14) -> ChatApplication:  # type: ignore[no-untyped-def]
+    return ChatApplication(
+        surface=Surface.CLI_GATEWAY,
+        toolbar_context={
+            "model": "m",
+            "session_id": "k",
+            "suppress": None,
+            "status": None,
+        },
+        bottom_toolbar=lambda: "title . model . [tier:c1]",
+        style=None,
+        input=pipe,
+        output=Vt100_Output(io.StringIO(), lambda: Size(rows=rows, columns=54)),
+    )
+
+
+def test_flag_enables_fullscreen_and_pane(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        assert chat.fullscreen is True
+        assert chat.application.full_screen is True
+        assert chat._transcript_window is not None
+
+
+def test_flag_off_by_default_keeps_native_scrollback() -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        assert chat.fullscreen is False
+        assert chat.application.full_screen is False
+        assert chat._transcript_window is None
+
+
+def test_append_transcript_accumulates_and_follows(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        chat._transcript_follow = False
+        chat._transcript_scroll = 3
+        chat.append_transcript("hello ")
+        chat.append_transcript("world\n")
+        assert chat._transcript == "hello world\n"
+        # New output re-pins to the bottom.
+        assert chat._transcript_follow is True
+        assert chat._transcript_scroll == 0
+
+
+def test_streamed_turn_renders_in_pane_with_frame_pinned(fullscreen_env: None) -> None:
+    async def _render() -> list[str]:
+        with create_pipe_input() as pipe:
+            chat = _build(pipe)
+            app = chat.application
+            console_buffer = io.StringIO()
+            captured: list[str] = []
+
+            async def _probe() -> None:
+                await asyncio.sleep(0.05)
+                async with chat.stream_output() as write:
+                    write("first line\n")
+                    for i in range(1, 25):
+                        write(f"line {i}\n")
+                    write("partial tail no newline")
+                app._redraw()
+                screen = app.renderer._last_screen  # type: ignore[attr-defined]
+                for y in range(screen.height):
+                    row = screen.data_buffer[y]
+                    captured.append("".join(row[x].char for x in sorted(row)).rstrip())
+                app.exit()
+
+            app.create_background_task(_probe())
+            await app.run_async()
+            # Streaming went to the pane, not the Rich console file.
+            assert console_buffer.getvalue() == ""
+            return captured
+
+    rows = asyncio.run(_render())
+
+    # Input frame is pinned to the bottom four rows.
+    assert "title . model . [tier:c1]" in rows[-1]
+    assert set(rows[-2]) == {"─"}
+    assert "you" in rows[-3]
+    assert set(rows[-4]) == {"─"}
+    # The partial (newline-less) tail is visible immediately, just above the
+    # frame — no line-buffering lag.
+    assert "partial tail no newline" in rows[-5]
+    # Auto-scrolled to the tail: the earliest lines have scrolled off.
+    joined = "\n".join(rows)
+    assert "line 24" in joined
+    assert "first line" not in joined

--- a/tests/unit/cli/repl/test_fullscreen_transcript.py
+++ b/tests/unit/cli/repl/test_fullscreen_transcript.py
@@ -154,6 +154,70 @@ def test_scroll_is_noop_when_not_fullscreen() -> None:
         assert chat._transcript_follow is True
 
 
+def test_resolve_chat_fullscreen_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit arg wins; then the env override; then the TTY default."""
+    from agentos.cli.tui.terminal.app import resolve_chat_fullscreen
+
+    # Explicit argument always wins, regardless of env.
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "0")
+    assert resolve_chat_fullscreen(True) is True
+    assert resolve_chat_fullscreen(False) is False
+
+    # Env override wins when no explicit arg is given.
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "1")
+    assert resolve_chat_fullscreen() is True
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "off")
+    assert resolve_chat_fullscreen() is False
+
+    # With no env override the default follows the stdout TTY-ness. Force a
+    # known value via a fake stdout so the assertion is deterministic.
+    monkeypatch.delenv("AGENTOS_CHAT_FULLSCREEN", raising=False)
+
+    class _FakeStdout:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr("sys.stdout", _FakeStdout())
+    assert resolve_chat_fullscreen() is True
+
+    class _FakePipe:
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr("sys.stdout", _FakePipe())
+    assert resolve_chat_fullscreen() is False
+
+
+def test_queued_startup_output_replays_into_pane(fullscreen_env: None) -> None:
+    """Pre-surface startup output (queued while the app has not yet taken the
+    alternate screen) is drained into the transcript pane when the full-screen
+    surface opens — this is how the welcome banner survives full-screen."""
+    import agentos.cli.tui.terminal.prompt as prompt_module
+    from agentos.cli.tui.terminal.prompt import interactive_session, queue_pane_output
+
+    async def _drive() -> str:
+        # Simulate the notifier / launch_bridge capture-and-queue step.
+        queue_pane_output("Connected to gateway. Session: agent:main:cli:abc\n")
+        queue_pane_output("AGENTOS welcome banner\n")
+        with create_pipe_input() as pipe:
+            out = Vt100_Output(io.StringIO(), lambda: Size(rows=20, columns=80))
+            async with interactive_session(
+                surface="cli_gateway",
+                model="m",
+                session_id="agent:main:cli:abc",
+                input=pipe,
+                output=out,
+            ) as handle:
+                await asyncio.sleep(0.05)
+                return handle._chat_app._transcript
+
+    transcript = asyncio.run(_drive())
+    assert "Connected to gateway. Session: agent:main:cli:abc" in transcript
+    assert "AGENTOS welcome banner" in transcript
+    # The pending buffer is drained (and cleared) once replayed.
+    assert prompt_module._pending_pane_output == []
+
+
 def test_interactive_session_redirects_console_into_pane(fullscreen_env: None) -> None:
     """In full-screen, Rich `console.print` output lands in the transcript
     pane (not stdout), and the real console stream is restored on exit."""

--- a/tests/unit/cli/repl/test_input_frame.py
+++ b/tests/unit/cli/repl/test_input_frame.py
@@ -1,0 +1,132 @@
+"""Issue #46 §5 input-frame layout invariants.
+
+Pins the two regressions reported after the frame landed:
+
+  * The framed input row must stay compact — the input buffer is a
+    single fixed line, so it can never balloon to fill the region the
+    non-full-screen renderer reserves below the cursor (which is large on
+    a fresh launch against a tall terminal). A greedy spacer at the top
+    of the layout absorbs that slack and pins the frame + toolbar to the
+    bottom.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.data_structures import Size
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.layout.controls import BufferControl
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+from agentos.cli.repl.app import ChatApplication
+from agentos.engine.commands import Surface
+
+
+def _build_app(pipe) -> ChatApplication:  # type: ignore[no-untyped-def]
+    return ChatApplication(
+        surface=Surface.CLI_GATEWAY,
+        toolbar_context={
+            "model": "m",
+            "session_id": "k",
+            "suppress": None,
+            "status": None,
+        },
+        bottom_toolbar=lambda: "title . model . [tier:c1]",
+        style=None,
+        input=pipe,
+        output=Vt100_Output(io.StringIO(), lambda: Size(rows=30, columns=80)),
+    )
+
+
+def _has_buffer_control(window: object) -> bool:
+    content = getattr(window, "content", None)
+    return isinstance(content, BufferControl)
+
+
+def test_input_buffer_height_is_fixed_single_line() -> None:
+    """The buffer window is pinned to exactly one row.
+
+    An unbounded ``Dimension(min=1)`` let the input balloon to fill the
+    reserved region and pushed the bottom rule + toolbar far below the
+    ``you`` row (issue: frame too tall on entry).
+    """
+    with create_pipe_input() as pipe:
+        chat = _build_app(pipe)
+        body = chat.application.layout.container.content
+        input_row = next(c for c in body.children if getattr(c, "children", None))
+        buffer_window = next(w for w in input_row.children if _has_buffer_control(w))
+        height = buffer_window.height
+        assert height is not None
+        assert height.max == 1  # fixed single line, never grows
+
+
+def test_first_layout_child_is_greedy_spacer() -> None:
+    """A flexible spacer heads the layout so the frame pins to the bottom."""
+    with create_pipe_input() as pipe:
+        chat = _build_app(pipe)
+        body = chat.application.layout.container.content
+        spacer = body.children[0]
+        # A plain Window (no buffer / no children) with a flexible height.
+        assert not getattr(spacer, "children", None)
+        assert not _has_buffer_control(spacer)
+        assert spacer.height is None  # flexible → absorbs reserved slack
+
+
+def test_frame_stays_compact_and_pinned_to_bottom() -> None:
+    """Render with a large reserved height; the frame must not balloon.
+
+    Expect the last four rows to be ``rule / ◢ you / rule / toolbar`` with
+    the toolbar on the very last row and the slack rendered as blank rows
+    above the frame (the greedy spacer), regardless of how many rows the
+    renderer reserves.
+    """
+
+    async def _render() -> list[str]:
+        with create_pipe_input() as pipe:
+            chat = _build_app(pipe)
+            app = chat.application
+            captured: list[str] = []
+
+            async def _probe() -> None:
+                await asyncio.sleep(0.05)
+                # Simulate a fresh launch against a tall terminal.
+                app.renderer._min_available_height = 12  # type: ignore[attr-defined]
+                app._redraw()
+                screen = app.renderer._last_screen  # type: ignore[attr-defined]
+                assert screen is not None
+                for y in range(screen.height):
+                    row = screen.data_buffer[y]
+                    captured.append(
+                        "".join(row[x].char for x in sorted(row)).rstrip()
+                    )
+                app.exit()
+
+            app.create_background_task(_probe())
+            await app.run_async()
+            return captured
+
+    rows = asyncio.run(_render())
+
+    # Toolbar is on the very last row.
+    assert "title . model . [tier:c1]" in rows[-1]
+    # Directly above: bottom rule, the you-row, top rule (compact frame).
+    assert set(rows[-2]) == {"─"}
+    assert "you" in rows[-3]
+    assert set(rows[-4]) == {"─"}
+    # The reserved slack is blank rows above the frame (greedy spacer).
+    assert rows[0] == ""
+
+
+def test_buffer_is_single_line() -> None:
+    """Sanity: the input buffer is single-line (so exact(1) can't clip)."""
+    with create_pipe_input() as pipe:
+        chat = _build_app(pipe)
+        body = chat.application.layout.container.content
+        input_row = next(c for c in body.children if getattr(c, "children", None))
+        buffer_window = next(w for w in input_row.children if _has_buffer_control(w))
+        buf = buffer_window.content.buffer
+        assert isinstance(buf, Buffer)
+        assert buf.multiline() is False

--- a/tests/unit/cli/repl/test_interactive_session_lifecycle.py
+++ b/tests/unit/cli/repl/test_interactive_session_lifecycle.py
@@ -16,7 +16,7 @@ from prompt_toolkit.output import DummyOutput
 
 from agentos.cli.repl import prompt as prompt_module
 from agentos.cli.repl.app import ChatApplication
-from agentos.cli.repl.prompt import interactive_session
+from agentos.cli.repl.prompt import DEFAULT_ASSISTANT_LABEL, interactive_session
 from agentos.engine.commands import Surface
 
 
@@ -85,7 +85,7 @@ async def test_set_toolbar_mutates_shared_context() -> None:
                 active_header_text = "".join(
                     fragment[1] for fragment in to_formatted_text(active_header)
                 )
-                assert "◢ cap" in active_header_text
+                assert f"◢ {DEFAULT_ASSISTANT_LABEL}" in active_header_text
                 # Clearing the status drops the chip and brings back the
                 # idle dim line carrying the model alias.
                 handle.set_toolbar("status", None)

--- a/tests/unit/cli/repl/test_launch_bridge.py
+++ b/tests/unit/cli/repl/test_launch_bridge.py
@@ -69,6 +69,10 @@ def test_launch_bridge_prints_standalone_banner_and_runs_standalone(
 ) -> None:
     from agentos.cli.repl import launch_bridge
 
+    # Pin native scrollback: full-screen instead buffers the banner into the
+    # transcript pane (covered separately) rather than printing it here.
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "0")
+
     calls: list[dict[str, Any]] = []
     console = FakeConsole(is_terminal=True)
 
@@ -110,6 +114,45 @@ def test_launch_bridge_prints_standalone_banner_and_runs_standalone(
             "timeout": 7.25,
         }
     ]
+
+
+def test_launch_bridge_buffers_standalone_banner_into_pane_in_fullscreen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In full-screen the standalone banner is captured into the pane queue
+    (so the alternate screen buffer does not wipe it) rather than printed."""
+    from rich.console import Console
+
+    from agentos.cli.repl import launch_bridge
+    from agentos.cli.tui.terminal import prompt as prompt_module
+
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "1")
+    prompt_module._pending_pane_output.clear()
+
+    async def fake_standalone(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(launch_bridge, "prepare_interactive_chat", lambda **_kwargs: None)
+
+    # A real Rich Console so the launch path can capture() the banner.
+    console = Console(width=120, force_terminal=True)
+
+    launch_bridge.launch_chat(
+        model="openai/test",
+        session_id="agent:main:test",
+        standalone=True,
+        workspace="",
+        workspace_strict=None,
+        timeout=None,
+        standalone_runner=fake_standalone,
+        gateway_runner=None,
+        output_console=console,
+    )
+
+    queued = "".join(prompt_module._pending_pane_output)
+    assert "AgentOS" in queued
+    assert "Session: agent:main:test" in queued
+    prompt_module._pending_pane_output.clear()
 
 
 def test_launch_bridge_warns_gateway_workspace_options_without_forwarding(

--- a/tests/unit/cli/repl/test_output_lock.py
+++ b/tests/unit/cli/repl/test_output_lock.py
@@ -62,20 +62,29 @@ class _RecordingOutput(DummyOutput):
         return None
 
 
-def _input_prefix_plain_text(chat_app: ChatApplication) -> str:
+def _input_row(chat_app: ChatApplication):  # type: ignore[no-untyped-def]
+    """Locate the input ``VSplit`` row (prefix + buffer).
+
+    The root ``HSplit`` frames the input with horizontal-rule Windows
+    (issue #46 §5), so the row is no longer at a fixed child index. Pick
+    the first child that is a container of windows (the input ``VSplit``).
+    """
     root = chat_app.application.layout.container
     body = getattr(root, "content", root)
-    input_row = body.children[0]
-    prefix_window = input_row.children[0]
+    for child in body.children:
+        if getattr(child, "children", None):
+            return child
+    raise AssertionError("no input VSplit row found in layout")
+
+
+def _input_prefix_plain_text(chat_app: ChatApplication) -> str:
+    prefix_window = _input_row(chat_app).children[0]
     fragments = to_formatted_text(prefix_window.content.text())
     return "".join(fragment[1] for fragment in fragments)
 
 
 def _input_prefix_width(chat_app: ChatApplication) -> int | None:
-    root = chat_app.application.layout.container
-    body = getattr(root, "content", root)
-    input_row = body.children[0]
-    prefix_window = input_row.children[0]
+    prefix_window = _input_row(chat_app).children[0]
     width = prefix_window.width() if callable(prefix_window.width) else prefix_window.width
     return width.preferred
 

--- a/tests/unit/cli/repl/test_runtime_bridge.py
+++ b/tests/unit/cli/repl/test_runtime_bridge.py
@@ -43,8 +43,14 @@ def _render_to_text(renderable: object) -> str:
     return captured.get()
 
 
-def test_gateway_runtime_notifier_maps_all_notice_kinds() -> None:
+def test_gateway_runtime_notifier_maps_all_notice_kinds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from agentos.cli.repl import runtime_bridge
+
+    # Pin the native-scrollback path so the notice mapping is asserted
+    # directly (full-screen buffers startup notices — covered separately).
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "0")
 
     output_console = _RecordingConsole()
     notify = runtime_bridge._gateway_runtime_notifier(
@@ -89,6 +95,38 @@ def test_gateway_runtime_notifier_maps_all_notice_kinds() -> None:
     assert output_console.printed[5] == "[yellow]Goodbye.[/yellow]"
     assert output_console.printed[6] == "[red]Unknown command.[/red] [dim]Use /help.[/dim]"
     assert isinstance(output_console.printed[7], Panel)
+
+
+def test_gateway_notifier_buffers_startup_notices_in_fullscreen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In full-screen, startup notices are captured into the pane queue (so the
+    app's alternate screen buffer does not wipe them) rather than printed."""
+    from agentos.cli.repl import runtime_bridge
+    from agentos.cli.tui.terminal import prompt as prompt_module
+
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "1")
+    prompt_module._pending_pane_output.clear()
+
+    # A real Rich Console so the notifier can capture() startup output.
+    output_console = Console(width=120, force_terminal=True)
+    notify = runtime_bridge._gateway_runtime_notifier(output_console, _fake_error_panel)
+
+    notify(
+        gateway_runtime.GatewayRuntimeNotice(kind="created", session_key="agent:main:x")
+    )
+    notify(gateway_runtime.GatewayRuntimeNotice(kind="welcome", session_key="agent:main:x"))
+
+    queued = "".join(prompt_module._pending_pane_output)
+    assert "Connected to gateway. Session: agent:main:x" in queued
+    assert "AgentOS" in queued  # branded startup screen captured into the queue
+
+    # During-session notices still print directly (the pane is live by then).
+    with output_console.capture() as captured:
+        notify(gateway_runtime.GatewayRuntimeNotice(kind="goodbye"))
+    assert "Goodbye" in captured.get()
+
+    prompt_module._pending_pane_output.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/repl/test_session_chrome_toolbar.py
+++ b/tests/unit/cli/repl/test_session_chrome_toolbar.py
@@ -12,6 +12,7 @@ Pins:
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -76,9 +77,14 @@ def test_assistant_label_env_override() -> None:
         "from agentos.cli.tui.terminal.prompt import DEFAULT_ASSISTANT_LABEL; "
         "print(DEFAULT_ASSISTANT_LABEL)"
     )
+    # Copy the real environment and layer the override on top. A minimal env
+    # (e.g. ``{"AGENTOS_ASSISTANT_LABEL": ..., "PATH": ""}``) wipes the OS vars
+    # Python needs to boot on Windows — the interpreter fails to import
+    # ``_overlapped`` (winsock/SystemRoot gone) before our module is reached.
+    env = {**os.environ, "AGENTOS_ASSISTANT_LABEL": "Hani"}
     result = subprocess.run(
         [sys.executable, "-c", script],
-        env={"AGENTOS_ASSISTANT_LABEL": "Hani", "PATH": ""},
+        env=env,
         capture_output=True,
         text=True,
         check=True,

--- a/tests/unit/cli/repl/test_session_chrome_toolbar.py
+++ b/tests/unit/cli/repl/test_session_chrome_toolbar.py
@@ -1,0 +1,194 @@
+"""Issue #46: bottom-toolbar and assistant-label chrome behavior tests.
+
+Pins:
+
+* ``DEFAULT_ASSISTANT_LABEL`` defaults to ``agentos`` and is overridable
+  via the ``AGENTOS_ASSISTANT_LABEL`` env var.
+* ``_bottom_toolbar`` renders the friendly session title (when set),
+  the short model alias, and the active router tier chip.
+* ``_input_header_fragments`` reads the label from ``_toolbar_context``
+  instead of the hard-coded ``cap`` literal.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+from prompt_toolkit.formatted_text import to_formatted_text
+
+from agentos.cli.tui.terminal import prompt as prompt_module
+from agentos.cli.tui.terminal.prompt import (
+    DEFAULT_ASSISTANT_LABEL,
+    _bottom_toolbar,
+    _input_header_fragments,
+    _toolbar_context,
+)
+
+
+def _reset_toolbar_context(**overrides: object) -> dict[str, object | None]:
+    """Snapshot-safe reset of the module-global toolbar context."""
+    saved = dict(_toolbar_context)
+    _toolbar_context.update(
+        {
+            "model": None,
+            "session_id": None,
+            "session_title": None,
+            "router_tier": None,
+            "suppress": None,
+            "status": None,
+            "assistant_label": DEFAULT_ASSISTANT_LABEL,
+        }
+    )
+    _toolbar_context.update(overrides)
+    return saved
+
+
+@pytest.fixture
+def isolated_toolbar_context():
+    saved = _reset_toolbar_context()
+    try:
+        yield
+    finally:
+        _toolbar_context.clear()
+        _toolbar_context.update(saved)
+
+
+def test_default_assistant_label_is_agentos() -> None:
+    """The single source of truth for the assistant speaker label.
+
+    Hard-pinning the default here is intentional: a future PR that
+    accidentally reintroduces ``"cap"`` as a default will fail this gate.
+    """
+    assert DEFAULT_ASSISTANT_LABEL == "agentos"
+
+
+def test_assistant_label_env_override() -> None:
+    """``AGENTOS_ASSISTANT_LABEL`` overrides the default at import time.
+
+    Run in a subprocess so the module reload doesn't poison the
+    in-process ``_toolbar_context`` reference held by other tests in
+    this file (a prior in-process ``importlib.reload`` approach left
+    sibling tests operating on a stale module dict).
+    """
+    script = (
+        "from agentos.cli.tui.terminal.prompt import DEFAULT_ASSISTANT_LABEL; "
+        "print(DEFAULT_ASSISTANT_LABEL)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env={"AGENTOS_ASSISTANT_LABEL": "Hani", "PATH": ""},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "Hani"
+
+
+def test_bottom_toolbar_renders_title_model_and_tier(isolated_toolbar_context: None) -> None:
+    _reset_toolbar_context(
+        model="openrouter/anthropic/claude-opus-4-8",
+        session_id="agent:main:main:abcd1234",
+        session_title="Fix login bug",
+        router_tier="c3",
+    )
+
+    rendered = to_formatted_text(_bottom_toolbar())
+    text = "".join(fragment[1] for fragment in rendered)
+
+    # Title appears in full (preferred over the opaque key segment).
+    assert "Fix login bug" in text
+    # Model alias is the short tail.
+    assert "claude-opus-4-8" in text
+    # Active tier pin is visible as ``tier:c3``.
+    assert "tier:c3" in text
+
+
+def test_bottom_toolbar_falls_back_to_short_key_without_title(
+    isolated_toolbar_context: None,
+) -> None:
+    _reset_toolbar_context(
+        model="openrouter/anthropic/claude-opus-4-8",
+        session_id="agent:main:main:abcd1234",
+        session_title=None,
+        router_tier=None,
+    )
+
+    rendered = to_formatted_text(_bottom_toolbar())
+    text = "".join(fragment[1] for fragment in rendered)
+
+    # No title → fall back to the trailing opaque key segment.
+    assert "abcd1234" in text
+    assert "claude-opus-4-8" in text
+    # No tier chip when automatic routing is in effect.
+    assert "tier:" not in text
+
+
+def test_bottom_toolbar_empty_when_nothing_to_show(isolated_toolbar_context: None) -> None:
+    _reset_toolbar_context()
+    assert _bottom_toolbar().value == ""
+
+
+def test_input_header_reads_label_from_toolbar_context(isolated_toolbar_context: None) -> None:
+    """The waiting header must render whatever label ``_toolbar_context`` carries."""
+    from agentos.cli.tui.terminal.stream import WaitingIndicator
+
+    _reset_toolbar_context(
+        status=WaitingIndicator(started_at=100.0),
+        assistant_label="Hani",
+    )
+
+    fragments = to_formatted_text(_input_header_fragments())
+    text = "".join(fragment[1] for fragment in fragments)
+    assert text.startswith("◢ Hani  ")
+
+
+def test_input_header_falls_back_to_default_label(isolated_toolbar_context: None) -> None:
+    from agentos.cli.tui.terminal.stream import WaitingIndicator
+
+    _reset_toolbar_context(
+        status=WaitingIndicator(started_at=100.0),
+        assistant_label=None,  # explicitly cleared
+    )
+
+    fragments = to_formatted_text(_input_header_fragments())
+    text = "".join(fragment[1] for fragment in fragments)
+    # Falls back to the module default rather than any hard-coded literal.
+    assert text.startswith(f"◢ {DEFAULT_ASSISTANT_LABEL}  ")
+
+
+def test_sync_session_chrome_from_state_mirrors_fields(isolated_toolbar_context: None) -> None:
+    """``sync_session_chrome_from_state`` is the helper slash handlers call
+    after mutating state so the toolbar repaints on the next console.print."""
+    from agentos.cli.chat.session_state import ChatSessionState
+
+    state = ChatSessionState(
+        session_key="agent:main:main:xyz",
+        model="openrouter/llm",
+        display_name="My Session",
+        router_hold_tier="c1",
+    )
+
+    prompt_module.sync_session_chrome_from_state(state)
+
+    assert _toolbar_context["session_title"] == "My Session"
+    assert _toolbar_context["router_tier"] == "c1"
+    assert _toolbar_context["model"] == "openrouter/llm"
+    assert _toolbar_context["session_id"] == "agent:main:main:xyz"
+
+
+def test_sync_session_chrome_clears_tier_when_none(isolated_toolbar_context: None) -> None:
+    """``/auto`` clears the tier; the helper must write ``None`` not skip it."""
+    from agentos.cli.chat.session_state import ChatSessionState
+
+    _toolbar_context["router_tier"] = "c3"  # stale from prior session
+    state = ChatSessionState(
+        session_key="agent:main:main:new",
+        model="m",
+        router_hold_tier=None,
+    )
+
+    prompt_module.sync_session_chrome_from_state(state)
+
+    assert _toolbar_context["router_tier"] is None

--- a/tests/unit/cli/repl/test_standalone_slash_adapter.py
+++ b/tests/unit/cli/repl/test_standalone_slash_adapter.py
@@ -19,9 +19,23 @@ class _StandaloneSlashHarness:
         self.flush_calls: list[dict[str, object]] = []
         self.transcripts: dict[str, list[object]] = {}
 
-    async def create_session(self, session_key: str, *, agent_id: str = "main") -> object:
-        self.create_calls.append({"session_key": session_key, "agent_id": agent_id})
-        return SimpleNamespace(session_key=session_key, agent_id=agent_id)
+    async def create_session(
+        self,
+        session_key: str,
+        *,
+        agent_id: str = "main",
+        display_name: str | None = None,
+    ) -> object:
+        self.create_calls.append(
+            {
+                "session_key": session_key,
+                "agent_id": agent_id,
+                "display_name": display_name,
+            }
+        )
+        return SimpleNamespace(
+            session_key=session_key, agent_id=agent_id, display_name=display_name
+        )
 
     async def read_transcript(self, session_key: str) -> list[object]:
         return list(self.transcripts.get(session_key, []))
@@ -237,8 +251,13 @@ async def test_standalone_slash_adapter_new_session_uses_typed_create_handle() -
     new_session_key = harness.create_calls[0]["session_key"]
     assert new_session_key.startswith("agent:main:standalone:")
     assert harness.create_calls[0]["agent_id"] == "main"
+    # Regression: ``/new <title>`` must persist the title as the session
+    # ``display_name`` so it can be surfaced in the toolbar / ``/status``
+    # and survive a later ``/resume`` (issue #46).
+    assert harness.create_calls[0]["display_name"] == "scratch"
     assert context.session_key == new_session_key
     assert context.state.session_key == new_session_key
+    assert context.state.display_name == "scratch"
     assert context.tool_ctx == {"session_key": new_session_key}
     assert replacement_calls[0]["session_key"] == new_session_key
 

--- a/tests/unit/cli/repl/test_terminal_chat_adapter.py
+++ b/tests/unit/cli/repl/test_terminal_chat_adapter.py
@@ -160,6 +160,8 @@ async def test_terminal_chat_runtime_exposes_tui_output_handle_not_raw_chat_app(
             "surface": Surface.CLI_GATEWAY,
             "model": "model-a",
             "session_id": "session-a",
+            "session_title": None,
+            "router_tier": None,
         }
     ]
     assert exposed == [output_handle, output_handle]

--- a/tests/unit/cli/repl/test_terminal_surface.py
+++ b/tests/unit/cli/repl/test_terminal_surface.py
@@ -47,6 +47,8 @@ async def test_terminal_surface_wraps_existing_interactive_session(monkeypatch) 
             "surface": Surface.CLI_STANDALONE,
             "model": "model-a",
             "session_id": "session-a",
+            "session_title": None,
+            "router_tier": None,
         }
     ]
     assert redraw_count == [1]
@@ -96,6 +98,8 @@ async def test_terminal_surface_honors_legacy_prompt_session_monkeypatch(
             "surface": Surface.CLI_STANDALONE,
             "model": "model-a",
             "session_id": "session-a",
+            "session_title": None,
+            "router_tier": None,
         }
     ]
 

--- a/tests/unit/cli/repl/test_terminal_surface.py
+++ b/tests/unit/cli/repl/test_terminal_surface.py
@@ -42,6 +42,11 @@ async def test_terminal_surface_wraps_existing_interactive_session(monkeypatch) 
         assert await tui_surface.next_line() is None
         tui_surface.redraw_callback()
 
+    assert len(yielded) == 1
+    # ``fullscreen`` is resolved by open_terminal_surface (TTY-dependent); pop
+    # it and assert type so the test is stable under captured/real stdout.
+    resolved_fullscreen = yielded[0].pop("fullscreen")
+    assert isinstance(resolved_fullscreen, bool)
     assert yielded == [
         {
             "surface": Surface.CLI_STANDALONE,
@@ -93,6 +98,9 @@ async def test_terminal_surface_honors_legacy_prompt_session_monkeypatch(
     ) as tui_surface:
         assert await tui_surface.next_line() == "patched"
 
+    assert len(yielded) == 1
+    resolved_fullscreen = yielded[0].pop("fullscreen")
+    assert isinstance(resolved_fullscreen, bool)
     assert yielded == [
         {
             "surface": Surface.CLI_STANDALONE,

--- a/tests/unit/cli/test_startup_screen.py
+++ b/tests/unit/cli/test_startup_screen.py
@@ -28,6 +28,27 @@ def test_render_startup_screen_wide_contains_agentos() -> None:
     assert "x/y-model" in text
 
 
+def test_render_startup_screen_shows_title_and_key_when_titled() -> None:
+    # Issue #46 §2: when a friendly session title is known it renders as
+    # ``Session: <title> (<key>)`` (matches the CHANGELOG claim).
+    text = _render(120, session_key="agent:main:demo", session_title="Fix login")
+    assert "Session: Fix login (agent:main:demo)" in text
+
+
+def test_render_startup_screen_shows_key_only_without_title() -> None:
+    text = _render(120, session_key="agent:main:demo")
+    assert "Session: agent:main:demo" in text
+    assert "(agent:main:demo)" not in text
+
+
+def test_gather_startup_data_carries_session_title() -> None:
+    data = gather_startup_data(session_key="k", session_title="My chat")
+    assert data.session_title == "My chat"
+    # Blank titles normalise to ``None`` so the render falls back to key-only.
+    assert gather_startup_data(session_key="k", session_title="  ").session_title is None
+    assert gather_startup_data(session_key="k").session_title is None
+
+
 def test_render_startup_screen_compact_does_not_crash() -> None:
     text = _render(60, session_key="agent:main:demo")
     assert "AgentOS Agent" in text


### PR DESCRIPTION
Implements #46 — UX pass for the terminal `agentos chat` REPL (Web UI is out of scope).

## What's in this PR

### 1. Assistant speaker label
Replaced every hard-coded `cap` with a single `DEFAULT_ASSISTANT_LABEL = "agentos"`, overridable via the `AGENTOS_ASSISTANT_LABEL` env var. The label now drives the streamed `◢` marker, the pre-token waiting row, and the queued-turn marker from one source. Also caught a 4th hard-code the issue didn't list (the literal inside the HTML string in `_input_header_fragments`, `prompt.py:218`) and flipped the renderer `title` defaults to a sentinel that reads the live value at construction time (Python evaluates plain defaults once at def time, which would freeze a stale label otherwise).

### 2. Session name in chrome
- Added `display_name` + `router_hold_tier` to `ChatSessionState`.
- `/new <title>` persists the title as `SessionNode.display_name` (column already existed; no migration). Fixed a pre-existing bug: standalone `/new <title>` parsed the arg then silently dropped it.
- `/new` and `/resume` load both fields into REPL state; `sessions.resolve` now returns `display_name`/`displayName` and `router_hold_tier`.
- Bottom toolbar renders `title · model · [tier:cN]`; `/status` mirrors the same plus the permissions posture. The startup panel shows `Session: <title> (<key>)` when a friendly title is known.

### 3. `/c0`–`/c3` + `/auto` on CLI surfaces
- Registered `_T` (cli_gateway) and `_S` (cli_standalone) execution entries on all five CommandDefs. Gateway mode reuses the existing `router.hold.set` / `router.hold.clear` RPCs verbatim (no server changes); standalone mutates the in-process `RouterControlHoldStore` via the TurnRunner with readable "Pilot Router is disabled or unavailable" / unknown-tier guards.
- Added the five words to `GATEWAY_SLASH_HANDLER_WORDS` / `STANDALONE_SLASH_HANDLER_WORDS` and the slash-policy `STATE_MUTATION` set. `/` autocomplete and `/help` pick them up automatically.

### 4. Scoped polish
- The active tier pin now shows in the bottom toolbar and `/status` (or `auto` when no hold is active), so the new commands get immediate feedback.
- `SessionNode.derived_title` property fills the pre-existing dead `getattr(s, "derived_title", None)` hook (`display_name → label → short opaque session id`) and is surfaced in `sessions.list`.

## Tests + docs
- 8 new registry assertions in `test_rpc_router_hold.py` for CLI surface visibility/execution; 8 dispatch-behavior tests in new `test_cli_router_hold_dispatch.py` (gateway RPC path + standalone in-process path, including disabled/unknown-tier guards); 8 chrome/label tests in new `test_session_chrome_toolbar.py`; 4 `derived_title` property tests; 4 existing tests updated for the new surface kwargs and label.
- `docs/cli.md`, bundled `agentos/SKILL.md`, `agentos.toml.example`, and `CHANGELOG.md` updated to match the CLI surface (per the AGENTS.md CLI-change rule).
- Full quality gate green: `ruff check`, `mypy`, `uv build --wheel`, and `pytest` (6373 passed — only 2 pre-existing unrelated failures remain on `main`).

Fixes use-agent-os/agent-os#46.
