### PR TITLE
fix(cli): support multiline chat input

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,6 +116,14 @@ toolbar:
  title · model · [tier:cN]
 ```
 
+Press `Enter` to submit the current message. Use `Alt+Enter` or
+`Shift+Enter` to insert a newline when your terminal reports those modified
+keys distinctly; `Ctrl+J` is the portable newline fallback. The input frame
+grows with the message up to 10 visible lines, then scrolls internally while
+remaining pinned above the bottom toolbar. `Up` and `Down` move between lines
+in a multiline draft before moving through chat input history at the first or
+last line.
+
 The bottom toolbar renders `title · model · [tier:cN]` while typing. The
 title comes from `/new <title>` (or is loaded from the gateway on
 `/resume`); the tier chip appears only while a Pilot Router hold is

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -86,6 +86,7 @@ _EOF_SENTINEL: object = object()
 # level so tests can monkeypatch it if they need a tighter window.
 _DOUBLE_CTRL_C_WINDOW_S: float = 1.5
 _ACTIVE_INPUT_PREFIX_WIDTH: int = 7
+_MAX_INPUT_HEIGHT: int = 10
 
 
 def _fullscreen_env() -> bool | None:
@@ -139,6 +140,18 @@ def _build_key_bindings() -> KeyBindings:
     cancel an in-flight turn task without tearing down the input surface.
     """
     bindings = KeyBindings()
+
+    @bindings.add("enter")
+    def _submit(event) -> None:  # type: ignore[no-untyped-def]
+        event.current_buffer.validate_and_handle()
+
+    @bindings.add("escape", "enter")
+    @bindings.add("c-j")
+    def _newline(event) -> None:  # type: ignore[no-untyped-def]
+        # Alt+Enter arrives as Escape followed by Enter. Terminals that can
+        # distinguish Shift+Enter commonly emit LF, the same sequence as
+        # Ctrl+J, so Ctrl+J is also the portable fallback.
+        event.current_buffer.newline(copy_margin=False)
 
     @bindings.add("c-c")
     def _ctrl_c(event) -> None:  # type: ignore[no-untyped-def]
@@ -322,7 +335,7 @@ class ChatApplication:
         self._next_paste_index = 1
 
         self._buffer = Buffer(
-            multiline=False,
+            multiline=True,
             accept_handler=self._on_accept,
             completer=completer,
             auto_suggest=auto_suggest,
@@ -357,14 +370,23 @@ class ChatApplication:
         def _input_prefix_width():  # type: ignore[no-untyped-def]
             return Dimension.exact(_ACTIVE_INPUT_PREFIX_WIDTH)
 
+        def _input_height() -> Dimension:
+            visible_lines = min(_MAX_INPUT_HEIGHT, self._buffer.document.line_count)
+            return Dimension.exact(max(1, visible_lines))
+
         input_window = VSplit(
             [
                 Window(
                     FormattedTextControl(_input_prefix_fragments),
                     width=_input_prefix_width,
                 ),
-                Window(BufferControl(buffer=self._buffer), height=Dimension.exact(1)),
-            ]
+                Window(
+                    BufferControl(buffer=self._buffer),
+                    height=_input_height,
+                    dont_extend_height=True,
+                ),
+            ],
+            height=_input_height,
         )
         toolbar_window = Window(
             FormattedTextControl(_toolbar_fragments),

--- a/tests/unit/cli/repl/test_input_frame.py
+++ b/tests/unit/cli/repl/test_input_frame.py
@@ -17,6 +17,7 @@ import io
 
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.data_structures import Size
+from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.layout.controls import BufferControl
 from prompt_toolkit.output.vt100 import Vt100_Output
@@ -25,7 +26,7 @@ from agentos.cli.repl.app import ChatApplication
 from agentos.engine.commands import Surface
 
 
-def _build_app(pipe) -> ChatApplication:  # type: ignore[no-untyped-def]
+def _build_app(pipe, *, history=None) -> ChatApplication:  # type: ignore[no-untyped-def]
     return ChatApplication(
         surface=Surface.CLI_GATEWAY,
         toolbar_context={
@@ -38,6 +39,7 @@ def _build_app(pipe) -> ChatApplication:  # type: ignore[no-untyped-def]
         style=None,
         input=pipe,
         output=Vt100_Output(io.StringIO(), lambda: Size(rows=30, columns=80)),
+        history=history,
     )
 
 
@@ -46,21 +48,19 @@ def _has_buffer_control(window: object) -> bool:
     return isinstance(content, BufferControl)
 
 
-def test_input_buffer_height_is_fixed_single_line() -> None:
-    """The buffer window is pinned to exactly one row.
-
-    An unbounded ``Dimension(min=1)`` let the input balloon to fill the
-    reserved region and pushed the bottom rule + toolbar far below the
-    ``you`` row (issue: frame too tall on entry).
-    """
+def test_input_buffer_height_grows_from_one_to_ten_lines() -> None:
+    """The input grows with its draft but cannot exceed ten visible rows."""
     with create_pipe_input() as pipe:
         chat = _build_app(pipe)
         body = chat.application.layout.container.content
         input_row = next(c for c in body.children if getattr(c, "children", None))
         buffer_window = next(w for w in input_row.children if _has_buffer_control(w))
         height = buffer_window.height
-        assert height is not None
-        assert height.max == 1  # fixed single line, never grows
+        assert callable(height)
+        assert height().preferred == 1
+
+        chat._buffer.text = "\n".join(str(number) for number in range(12))
+        assert height().preferred == 10
 
 
 def test_first_layout_child_is_greedy_spacer() -> None:
@@ -120,8 +120,7 @@ def test_frame_stays_compact_and_pinned_to_bottom() -> None:
     assert rows[0] == ""
 
 
-def test_buffer_is_single_line() -> None:
-    """Sanity: the input buffer is single-line (so exact(1) can't clip)."""
+def test_buffer_is_multiline() -> None:
     with create_pipe_input() as pipe:
         chat = _build_app(pipe)
         body = chat.application.layout.container.content
@@ -129,4 +128,72 @@ def test_buffer_is_single_line() -> None:
         buffer_window = next(w for w in input_row.children if _has_buffer_control(w))
         buf = buffer_window.content.buffer
         assert isinstance(buf, Buffer)
-        assert buf.multiline() is False
+        assert buf.multiline() is True
+
+
+def test_multiline_arrow_navigation_precedes_history_navigation() -> None:
+    """Up/Down traverse draft lines and only enter history at boundaries."""
+    async def _exercise() -> None:
+        history = InMemoryHistory()
+        history.append_string("previous prompt")
+
+        with create_pipe_input() as pipe:
+            chat = _build_app(pipe, history=history)
+            app = chat.application
+
+            async def _probe() -> None:
+                await asyncio.sleep(0.05)
+                try:
+                    buf = chat._buffer
+                    buf.text = "first line\nsecond line"
+                    buf.cursor_position = len(buf.text)
+
+                    buf.auto_up()
+                    assert buf.text == "first line\nsecond line"
+                    assert buf.document.cursor_position_row == 0
+
+                    buf.auto_up()
+                    assert buf.text == "previous prompt"
+
+                    buf.auto_down()
+                    assert buf.text == "first line\nsecond line"
+                    assert buf.document.cursor_position_row == 1
+                finally:
+                    app.exit()
+
+            app.create_background_task(_probe())
+            await app.run_async()
+
+    asyncio.run(_exercise())
+
+
+def test_frame_with_more_than_ten_lines_keeps_toolbar_at_bottom() -> None:
+    async def _render() -> list[str]:
+        with create_pipe_input() as pipe:
+            chat = _build_app(pipe)
+            chat._buffer.text = "\n".join(f"line {number}" for number in range(12))
+            app = chat.application
+            captured: list[str] = []
+
+            async def _probe() -> None:
+                await asyncio.sleep(0.05)
+                app.renderer._min_available_height = 15  # type: ignore[attr-defined]
+                app._redraw()
+                screen = app.renderer._last_screen  # type: ignore[attr-defined]
+                assert screen is not None
+                for y in range(screen.height):
+                    row = screen.data_buffer[y]
+                    captured.append("".join(row[x].char for x in sorted(row)).rstrip())
+                app.exit()
+
+            app.create_background_task(_probe())
+            await app.run_async()
+            return captured
+
+    rows = asyncio.run(_render())
+
+    assert "title . model . [tier:c1]" in rows[-1]
+    rule_rows = [index for index, row in enumerate(rows) if row and set(row) == {"─"}]
+    assert len(rule_rows) == 2
+    assert rule_rows[1] == len(rows) - 2
+    assert rule_rows[1] - rule_rows[0] == 11

--- a/tests/unit/cli/repl/test_interactive_session_lifecycle.py
+++ b/tests/unit/cli/repl/test_interactive_session_lifecycle.py
@@ -37,9 +37,9 @@ async def test_interactive_session_yields_submitted_lines() -> None:
     """Two newline-terminated payloads on the pipe surface as two lines."""
     with create_pipe_input() as pipe:
         async with interactive_session(input=pipe, output=DummyOutput()) as handle:
-            pipe.send_text("hello\n")
+            pipe.send_text("hello\r")
             first = await asyncio.wait_for(handle.next_line(), timeout=2.0)
-            pipe.send_text("world\n")
+            pipe.send_text("world\r")
             second = await asyncio.wait_for(handle.next_line(), timeout=2.0)
 
     assert first == "hello"
@@ -123,8 +123,8 @@ async def test_chat_application_submit_iter_round_trips_lines() -> None:
 
         collector = asyncio.create_task(collect())
         await asyncio.sleep(0.05)
-        pipe.send_text("alpha\n")
-        pipe.send_text("beta\n")
+        pipe.send_text("alpha\r")
+        pipe.send_text("beta\r")
         lines = await asyncio.wait_for(collector, timeout=2.0)
         chat_app.application.exit()
         try:
@@ -133,6 +133,40 @@ async def test_chat_application_submit_iter_round_trips_lines() -> None:
             app_task.cancel()
 
     assert lines == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("newline_sequence", "shortcut"),
+    [
+        ("\x1b\r", "Alt+Enter"),
+        ("\n", "Shift+Enter/Ctrl+J"),
+    ],
+)
+async def test_multiline_shortcut_inserts_newline_without_submitting(
+    newline_sequence: str,
+    shortcut: str,
+) -> None:
+    """Modified Enter inserts a newline; plain Enter submits the draft."""
+    with create_pipe_input() as pipe:
+        chat_app = _fresh_chat_app(pipe_input=pipe)
+        app_task = asyncio.create_task(chat_app.application.run_async())
+        await asyncio.sleep(0.05)
+
+        pipe.send_text(f"first{newline_sequence}second")
+        await asyncio.sleep(0.05)
+
+        assert chat_app._buffer.text == "first\nsecond", shortcut
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(chat_app.next_line(), timeout=0.05)
+
+        pipe.send_text("\r")
+        submitted = await asyncio.wait_for(chat_app.next_line(), timeout=2.0)
+        chat_app.application.exit()
+        await asyncio.wait_for(app_task, timeout=1.0)
+
+    assert submitted == "first\nsecond"
+    assert chat_app._buffer.text == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Support multiline `agentos chat` input with Alt+Enter, Shift+Enter-compatible LF, and Ctrl+J fallback.
- Grow the OpenCode-style input frame up to 10 visible lines while keeping it pinned above the toolbar.
- Preserve plain Enter submission and native multiline/history arrow navigation.
- Add regression tests and document the keyboard behavior.

## Verification

- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- `uv run pytest tests/unit/cli/repl -q` (`254 passed, 1 skipped`)
- `uv build --wheel`

Full `uv run pytest -q` could not collect locally because the environment is missing optional `numpy` dependencies used by Pilot Router tests.

Fixes #61