### PR TITLE
chore(release): bump version to 2026.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.22] - 2026-07-22
+
 ### Added
 
 - `tools.enabled = false` provides an explicit plain-text mode for Ollama and
@@ -13,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `agentos chat` input frame now supports multiline input instead of
+  submitting on every `Enter` (#62).
 - Ollama multi-turn tool conversations now preserve assistant tool calls,
   correlate tool results by name, normalize native arguments, and retain the
   provider's model and completion reason, preventing repeated searches caused

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.20 is the current release. The project website is
+AgentOS 2026.7.22 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.20"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.22"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.20/use_agent_os-2026.7.20-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.22/use_agent_os-2026.7.22-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.20-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.22-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.22 | v2026.7.22 | 2026-07-22 | Native slash-command menus for Telegram, Slack, and Discord (#45); Ollama multi-turn tool-call history fixes and a `tools.enabled = false` plain-text fallback mode (#44); channel slash commands render their RPC results instead of a generic acknowledgement; Telegram delivery retries transient connection failures; `agentos chat` input frame supports multiline input (#62). |
 | 2026.7.20 | v2026.7.20 | 2026-07-20 | `agentos chat` CLI UX pass (#46/#47): assistant speaker label defaults to `agentos` and is configurable via `AGENTOS_ASSISTANT_LABEL`; session title in the bottom toolbar and startup panel; `/c0`–`/c3` and `/auto` router-tier holds on both CLI surfaces; framed input box; full-screen chat transcript pane now the default. |
 | 2026.7.19.post1 | v2026.7.19.post1 | 2026-07-19 | Remove legacy v4_phase3 router engine and model bundle; rename to Pilot Router; sync router docs |
 | 2026.7.19 | v2026.7.19 | 2026-07-19 | AgentOS Pilot (`pilot-v1`) is now the default router strategy with force-migration off `v4_phase3` (#26, #36); bundled `agentos` self-operation skill (#37); Bankr browse source limited to two skills with Update button, emoji avatar, brand-glyph logo, and null-description crash fix (#39). |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.20'
+$defaultVersion = 'v2026.7.22'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.20. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.22. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.20"
+default_version="v2026.7.22"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.20|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.22|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.20
+  AGENTOS_VERSION=v2026.7.22
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=matrix
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.20." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.22." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.20"
+version = "2026.7.22"
 description = "Token-Efficient AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.20"
+CURRENT_RELEASE_TAG = "v2026.7.22"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.20"
+CURRENT_VERSION = "2026.7.22"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3883,7 +3883,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.20"
+version = "2026.7.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump version 2026.7.20 → 2026.7.22 across `pyproject.toml`, `uv.lock`, release-consistency tests, install scripts, README, and RELEASES.md.
- Move CHANGELOG `[Unreleased]` entries (native channel slash commands, Ollama tool-flow fixes, multiline chat input) into a new `[2026.7.22]` section.

## Test plan
- [x] `uv run ruff check src tests`
- [x] `uv run mypy src/agentos --show-error-codes`
- [x] `uv run pytest -q` (6458 passed; 2 pre-existing local-environment failures unrelated to this change, verified to also fail on a clean `main` checkout: a tmp-path-length assertion in `test_artifacts.py` and a broken local venv/dyld link in `test_ci/test_migrations_packaged.py`)
- [x] `uv run pytest tests/test_release_consistency.py tests/test_install_scripts.py -q` (18 passed)
- [x] `uv build --wheel` succeeds, produces `use_agent_os-2026.7.22-py3-none-any.whl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)