### PR TITLE
fix(cli): support chat mouse and line navigation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,7 +134,13 @@ posture.
 in a scrollable in-app pane above a permanently-pinned input frame (Claude
 Code style), so the frame stays visible while the assistant streams. The
 branded welcome screen renders at the top of the pane on launch. `PgUp`/`PgDn`
-scroll back through history; new output re-pins to the newest line.
+scroll back through history; the mouse wheel scrolls when the pointer is over
+the transcript. New output re-pins to the newest line.
+
+Input navigation follows the current logical line in multiline drafts:
+`Home`/`End` and `Ctrl+A`/`Ctrl+E` move to that line's start/end. On macOS,
+`Cmd+Left`/`Cmd+Right` work when the terminal maps those shortcuts to
+`Home`/`End`; use `Ctrl+A`/`Ctrl+E` as the portable fallback.
 
 Full-screen is the default for an interactive terminal. Non-TTY / piped
 invocations fall back to native scrollback automatically. To force a mode set

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -37,6 +37,7 @@ from prompt_toolkit.layout import (
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
+from prompt_toolkit.mouse_events import MouseEventType
 
 from agentos.cli.tui.terminal.paste import (
     pasted_content_summary,
@@ -87,6 +88,24 @@ _EOF_SENTINEL: object = object()
 _DOUBLE_CTRL_C_WINDOW_S: float = 1.5
 _ACTIVE_INPUT_PREFIX_WIDTH: int = 7
 _MAX_INPUT_HEIGHT: int = 10
+_MOUSE_SCROLL_LINES: int = 3
+
+
+class _TranscriptControl(FormattedTextControl):
+    """Formatted transcript content with wheel events routed to chat scroll state."""
+
+    def __init__(self, *args, scroll: Callable[[int], None], **kwargs) -> None:  # noqa: ANN002, ANN003
+        super().__init__(*args, **kwargs)
+        self._scroll = scroll
+
+    def mouse_handler(self, mouse_event):  # type: ignore[no-untyped-def]
+        if mouse_event.event_type == MouseEventType.SCROLL_UP:
+            self._scroll(_MOUSE_SCROLL_LINES)
+            return None
+        if mouse_event.event_type == MouseEventType.SCROLL_DOWN:
+            self._scroll(-_MOUSE_SCROLL_LINES)
+            return None
+        return super().mouse_handler(mouse_event)
 
 
 def _fullscreen_env() -> bool | None:
@@ -152,6 +171,18 @@ def _build_key_bindings() -> KeyBindings:
         # distinguish Shift+Enter commonly emit LF, the same sequence as
         # Ctrl+J, so Ctrl+J is also the portable fallback.
         event.current_buffer.newline(copy_margin=False)
+
+    @bindings.add(Keys.Home)
+    @bindings.add("c-a")
+    def _start_of_line(event) -> None:  # type: ignore[no-untyped-def]
+        buffer = event.current_buffer
+        buffer.cursor_position += buffer.document.get_start_of_line_position()
+
+    @bindings.add(Keys.End)
+    @bindings.add("c-e")
+    def _end_of_line(event) -> None:  # type: ignore[no-untyped-def]
+        buffer = event.current_buffer
+        buffer.cursor_position += buffer.document.get_end_of_line_position()
 
     @bindings.add("c-c")
     def _ctrl_c(event) -> None:  # type: ignore[no-untyped-def]
@@ -419,8 +450,9 @@ class ChatApplication:
         top_element: Window
         if self._fullscreen:
             top_element = Window(
-                content=FormattedTextControl(
+                content=_TranscriptControl(
                     lambda: ANSI(self._transcript),
+                    scroll=self.scroll_transcript,
                     get_cursor_position=self._transcript_cursor_position,
                     focusable=False,
                     show_cursor=False,
@@ -473,6 +505,7 @@ class ChatApplication:
             key_bindings=_build_key_bindings(),
             style=style,
             full_screen=self._fullscreen,
+            mouse_support=self._fullscreen,
             refresh_interval=0.1,
             input=input,
             output=output,

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -74,9 +74,12 @@ top and bottom rule so it reads as a distinct box; the bottom toolbar renders
 `/new <title>` or loaded on `/resume`. `agentos chat` runs full-screen by
 default: the conversation renders in a scrollable pane above the pinned input
 frame (the branded welcome screen shows at the top on launch), so the frame
-stays visible while the assistant streams (`PgUp`/`PgDn` scroll history). Set
-`AGENTOS_CHAT_FULLSCREEN=0` to opt out to native scrollback; non-TTY contexts
-fall back automatically.
+stays visible while the assistant streams (`PgUp`/`PgDn` scroll history). The
+mouse wheel also scrolls when the pointer is over the transcript. In the
+multiline input, `Home`/`End` and `Ctrl+A`/`Ctrl+E` move to the current line's
+start/end; macOS `Cmd+Left`/`Cmd+Right` work when the terminal maps them to
+`Home`/`End`. Set `AGENTOS_CHAT_FULLSCREEN=0` to opt out to native scrollback;
+non-TTY contexts fall back automatically.
 
 ## CLI map
 

--- a/tests/unit/cli/repl/test_fullscreen_transcript.py
+++ b/tests/unit/cli/repl/test_fullscreen_transcript.py
@@ -19,8 +19,10 @@ import asyncio
 import io
 
 import pytest
-from prompt_toolkit.data_structures import Size
+from prompt_toolkit.data_structures import Point, Size
 from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.layout.controls import BufferControl
+from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
 from prompt_toolkit.output.vt100 import Vt100_Output
 
 from agentos.cli.repl.app import ChatApplication
@@ -152,6 +154,62 @@ def test_scroll_is_noop_when_not_fullscreen() -> None:
         chat.scroll_transcript(5)
         assert chat._transcript_scroll == 0
         assert chat._transcript_follow is True
+
+
+def test_mouse_wheel_scrolls_through_transcript_control(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        for i in range(1, 40):
+            chat.append_transcript(f"line {i}\n")
+
+        assert chat._transcript_window is not None
+        control = chat._transcript_window.content
+        scroll_up = MouseEvent(
+            position=Point(x=0, y=0),
+            event_type=MouseEventType.SCROLL_UP,
+            button=MouseButton.NONE,
+            modifiers=frozenset(),
+        )
+        scroll_down = MouseEvent(
+            position=Point(x=0, y=0),
+            event_type=MouseEventType.SCROLL_DOWN,
+            button=MouseButton.NONE,
+            modifiers=frozenset(),
+        )
+
+        assert control.mouse_handler(scroll_up) is None
+        assert chat._transcript_scroll == 3
+        assert chat._transcript_follow is False
+
+        assert control.mouse_handler(scroll_down) is None
+        assert chat._transcript_scroll == 0
+        assert chat._transcript_follow is True
+
+        input_control = next(
+            window.content
+            for window in chat.application.layout.find_all_windows()
+            if isinstance(window.content, BufferControl)
+        )
+        assert input_control.mouse_handler(scroll_up) is NotImplemented
+        assert chat._transcript_scroll == 0
+        assert chat._transcript_follow is True
+
+
+def test_mouse_reporting_is_enabled_only_for_fullscreen(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        fullscreen_chat = _build(pipe)
+        assert fullscreen_chat.application.mouse_support() is True
+
+    with create_pipe_input() as pipe:
+        native_chat = ChatApplication(
+            surface=Surface.CLI_GATEWAY,
+            toolbar_context={"model": None, "session_id": None, "suppress": None},
+            bottom_toolbar=lambda: "",
+            input=pipe,
+            output=Vt100_Output(io.StringIO(), lambda: Size(rows=14, columns=54)),
+            fullscreen=False,
+        )
+        assert native_chat.application.mouse_support() is False
 
 
 def test_resolve_chat_fullscreen_precedence(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/repl/test_input_frame.py
+++ b/tests/unit/cli/repl/test_input_frame.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 import asyncio
 import io
 
+import pytest
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.data_structures import Size
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout.controls import BufferControl
 from prompt_toolkit.output.vt100 import Vt100_Output
 
@@ -165,6 +167,44 @@ def test_multiline_arrow_navigation_precedes_history_navigation() -> None:
             await app.run_async()
 
     asyncio.run(_exercise())
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_column"),
+    [
+        (Keys.Home, 0),
+        ("c-a", 0),
+        (Keys.End, len("middle text")),
+        ("c-e", len("middle text")),
+    ],
+)
+def test_line_boundary_shortcuts_stay_within_current_draft_line(
+    key: Keys | str,
+    expected_column: int,
+) -> None:
+    from agentos.cli.repl.app import _build_key_bindings
+
+    bindings = _build_key_bindings()
+    matching = [binding for binding in bindings.bindings if tuple(binding.keys) == (key,)]
+    assert len(matching) == 1
+
+    with create_pipe_input() as pipe:
+        chat = _build_app(pipe)
+        chat._buffer.text = "first\nmiddle text\nlast"
+        chat._buffer.cursor_position = len("first\nmiddle")
+
+        class _Event:
+            app = chat.application
+
+            @property
+            def current_buffer(self) -> Buffer:
+                return chat._buffer
+
+        matching[0].handler(_Event())
+
+        document = chat._buffer.document
+        assert document.cursor_position_row == 1
+        assert document.cursor_position_col == expected_column
 
 
 def test_frame_with_more_than_ten_lines_keeps_toolbar_at_bottom() -> None:


### PR DESCRIPTION
## Summary
- enable mouse-wheel scrolling when the pointer is over the full-screen chat transcript
- add Home/End and Ctrl+A/Ctrl+E navigation for the current line in multiline input
- document terminal-dependent macOS Cmd+Left/Cmd+Right behavior and add regression coverage

## Test plan
- [x] `uv run pytest tests/unit/cli/repl/test_fullscreen_transcript.py tests/unit/cli/repl/test_input_frame.py tests/unit/cli/repl/test_boundary_keybindings.py tests/unit/cli/repl/test_interactive_session_lifecycle.py -q`
- [x] `uv run ruff check src tests`
- [x] `uv run mypy src/agentos --show-error-codes`
- [x] `uv build --wheel`
- [x] full pytest suite passes with two environment-only migration smoke tests deselected

## Environment notes
- `test_installed_wheel_resolves_migrations` fails identically on clean `main` because the uv-managed Python cannot locate `libpython3.12.dylib` when `venv.create()` runs in the macOS temporary directory.
- `test_docker_image_resolves_migrations` fails identically on clean `main` because the local Docker daemon is not running.