### PR TITLE
fix(cli): make chat transcript mouse wheel scrolling responsive

### DIFF
--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -71,6 +71,7 @@ class LockedFileHistory(FileHistory):
         with self._write_lock:
             super().store_string(string)
 
+
 if TYPE_CHECKING:
     from prompt_toolkit.input.base import Input
     from prompt_toolkit.output.base import Output
@@ -88,7 +89,7 @@ _EOF_SENTINEL: object = object()
 _DOUBLE_CTRL_C_WINDOW_S: float = 1.5
 _ACTIVE_INPUT_PREFIX_WIDTH: int = 7
 _MAX_INPUT_HEIGHT: int = 10
-_MOUSE_SCROLL_LINES: int = 3
+_MOUSE_SCROLL_LINES: int = 11
 
 
 class _TranscriptControl(FormattedTextControl):
@@ -452,7 +453,7 @@ class ChatApplication:
             top_element = Window(
                 content=_TranscriptControl(
                     lambda: ANSI(self._transcript),
-                    scroll=self.scroll_transcript,
+                    scroll=self.scroll_transcript_with_mouse,
                     get_cursor_position=self._transcript_cursor_position,
                     focusable=False,
                     show_cursor=False,
@@ -465,6 +466,7 @@ class ChatApplication:
             top_element = Window()
         children: list = [top_element]
         if input_header is not None:
+
             def _header_fragments():  # type: ignore[no-untyped-def]
                 try:
                     rendered = input_header() if callable(input_header) else input_header
@@ -572,6 +574,17 @@ class ChatApplication:
             self._app.invalidate()
         except Exception:
             pass
+
+    def scroll_transcript_with_mouse(self, lines: int) -> None:
+        """Scroll by wheel, compensating when releasing transcript follow."""
+        # With ``wrap_lines=True`` prompt-toolkit only re-scrolls the pane when
+        # the virtual cursor moves far enough to leave the current viewport.
+        # Right at the follow->scroll transition the cursor is still pinned
+        # near the tail, so the first wheel tick barely moves it and the pane
+        # looks unresponsive ("have to wheel several times before it kicks
+        # in"). Compensate by doubling the step on the releasing tick so the
+        # cursor visibly exits the viewport on the first wheel event.
+        self.scroll_transcript(lines * 2 if self._transcript_follow and lines > 0 else lines)
 
     def scroll_transcript_to_bottom(self) -> None:
         """Re-pin the transcript pane to the newest line (resume follow)."""
@@ -853,6 +866,7 @@ class ChatApplication:
                 return
             if self._app.is_running:
                 async with in_terminal():
+
                     def _write(payload: str) -> None:
                         if not payload:
                             return

--- a/tests/unit/cli/repl/test_fullscreen_transcript.py
+++ b/tests/unit/cli/repl/test_fullscreen_transcript.py
@@ -26,6 +26,7 @@ from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
 from prompt_toolkit.output.vt100 import Vt100_Output
 
 from agentos.cli.repl.app import ChatApplication
+from agentos.cli.tui.terminal.app import _MOUSE_SCROLL_LINES
 from agentos.engine.commands import Surface
 
 
@@ -131,7 +132,7 @@ def test_scroll_transcript_releases_and_relatches_follow(fullscreen_env: None) -
         assert chat._transcript_follow is True
         assert chat._transcript_scroll == 0
 
-        # Scroll up into history: follow releases, offset grows.
+        # Generic scrolling preserves the requested offset (for example, Page Up).
         chat.scroll_transcript(10)
         assert chat._transcript_follow is False
         assert chat._transcript_scroll == 10
@@ -178,7 +179,12 @@ def test_mouse_wheel_scrolls_through_transcript_control(fullscreen_env: None) ->
         )
 
         assert control.mouse_handler(scroll_up) is None
-        assert chat._transcript_scroll == 3
+        # First wheel tick is doubled so the wrapped cursor visibly exits the viewport.
+        assert chat._transcript_scroll == _MOUSE_SCROLL_LINES * 2
+        assert chat._transcript_follow is False
+
+        assert control.mouse_handler(scroll_down) is None
+        assert chat._transcript_scroll == _MOUSE_SCROLL_LINES
         assert chat._transcript_follow is False
 
         assert control.mouse_handler(scroll_down) is None


### PR DESCRIPTION
## Problem
Mouse wheel scrolling in `agentos chat` fullscreen transcript felt unresponsive — needed several wheel ticks before the pane visibly moved and the wrapped-line cursor exited the viewport.

## Solution
- Raised mouse wheel step from 3 to 11 lines per tick
- Doubled the first tick that releases transcript follow mode (from 0.5 to 1.0), making the pane movement immediately visible

## Testing
- `uv run pytest tests/unit/cli` — 323 passed, 1 skipped
- `ruff` and `mypy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)