### PR TITLE
fix(mcp): install SDK by default and harden OAuth startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+        run: uv sync --extra dev --extra recommended --frozen
 
       - name: Lint
         shell: bash
@@ -178,7 +178,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+        run: uv sync --extra dev --extra recommended --frozen
 
       - name: Test
         shell: bash
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+        run: uv sync --extra dev --extra recommended --frozen
 
       - name: Run release packaging contract tests
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ messaging (Web UI, CLI, chat). One shared turn loop drives every client.
 
 ```sh
 uv sync --extra dev --extra recommended                        # dev deps + local embeddings
-uv sync --extra dev --extra recommended --extra mcp --frozen   # match CI exactly
+uv sync --extra dev --extra recommended --frozen               # match CI exactly
 ```
 
 ## Quality gate — run before every commit / PR

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,13 +328,9 @@ oauth = true
 tool_timeout_seconds = 30
 ```
 
-Supported transports are `stdio`, `sse`, and `streamable_http`. Streamable HTTP
-uses the optional MCP SDK, so install the MCP extra when it is not already
-present:
-
-```sh
-uv sync --extra mcp
-```
+Supported transports are `stdio`, `sse`, and `streamable_http`. The MCP SDK is
+included in the standard AgentOS installation, so Streamable HTTP and OAuth work
+without installing an additional package extra.
 
 OAuth access and refresh tokens are not written to `config.toml`. AgentOS keeps
 them in a server-scoped JSON file under the configured state directory with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "sqlmodel>=0.0.20",
     "anyio>=4.0",
     "httpx>=0.27",
+    "mcp>=1.2.0",
     "brotli>=1.1",
     "jinja2>=3.1",
     "structlog>=24.0",
@@ -70,7 +71,6 @@ dev = [
     "mypy>=1.10",
     "ruff>=0.5",
 ]
-mcp = ["mcp>=1.2.0"]
 memory = [
     "tiktoken>=0.5",
     "jieba>=0.42",

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -23,7 +23,7 @@ from agentos.paths import state_dir as default_state_dir
 
 
 class MCPDependencyError(RuntimeError):
-    """Raised when Streamable HTTP is selected without the optional MCP SDK."""
+    """Raised when the required MCP SDK is missing from the installation."""
 
 
 class FileOAuthStorage:
@@ -153,7 +153,8 @@ class MCPStreamableHTTPClient(MCPClient):
             from mcp.shared.auth import OAuthClientMetadata
         except ImportError as exc:
             raise MCPDependencyError(
-                'Streamable HTTP requires the optional dependency: uv sync --extra mcp'
+                "Streamable HTTP support is unavailable because the MCP SDK is missing. "
+                "Reinstall or upgrade AgentOS."
             ) from exc
 
         auth = None

--- a/src/agentos/mcp_server/server.py
+++ b/src/agentos/mcp_server/server.py
@@ -20,7 +20,8 @@ def create_mcp_server(
             from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
         except ImportError as exc:  # pragma: no cover - exercised through CLI behavior.
             raise RuntimeError(
-                "The MCP server requires the optional dependency: install 'use-agent-os[mcp]'."
+                "The MCP SDK is missing from this AgentOS installation. "
+                "Reinstall or upgrade AgentOS."
             ) from exc
         fastmcp_cls = FastMCP
 

--- a/tests/test_mcp_server/test_fastmcp_app.py
+++ b/tests/test_mcp_server/test_fastmcp_app.py
@@ -98,8 +98,8 @@ def test_create_mcp_server_has_no_benchmark_or_mock_public_tools() -> None:
     assert "mock" not in names
 
 
-def test_optional_mcp_dependency_minimum_supports_fastmcp() -> None:
+def test_base_mcp_dependency_minimum_supports_fastmcp() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-    mcp_specs = pyproject["project"]["optional-dependencies"]["mcp"]
+    dependencies = pyproject["project"]["dependencies"]
 
-    assert "mcp>=1.2.0" in mcp_specs
+    assert "mcp>=1.2.0" in dependencies

--- a/tests/test_packaging/test_pyproject_invariants.py
+++ b/tests/test_packaging/test_pyproject_invariants.py
@@ -55,6 +55,16 @@ def test_channel_sdks_in_base(project_table: dict) -> None:
     assert not missing, f"channel SDKs missing from base deps: {sorted(missing)}"
 
 
+def test_mcp_sdk_is_a_base_dependency(project_table: dict) -> None:
+    """The built-in MCP UI and server must work without an install extra."""
+
+    base = _dep_names(project_table["dependencies"])
+    extras = project_table.get("optional-dependencies", {})
+
+    assert "mcp" in base
+    assert "mcp" not in extras
+
+
 def test_no_dead_extras(project_table: dict) -> None:
     """msteams extra is intentionally absent; matrix extra installs matrix-nio."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -3898,6 +3898,7 @@ dependencies = [
     { name = "html2text" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "mcp" },
     { name = "openpyxl" },
     { name = "pdfplumber" },
     { name = "pillow" },
@@ -3943,9 +3944,6 @@ matrix = [
 matrix-e2e = [
     { name = "markdown" },
     { name = "matrix-nio", extra = ["e2e"] },
-]
-mcp = [
-    { name = "mcp" },
 ]
 mem0 = [
     { name = "mem0ai" },
@@ -4003,7 +4001,7 @@ requires-dist = [
     { name = "markdown", marker = "extra == 'matrix-e2e'", specifier = ">=3.0" },
     { name = "matrix-nio", marker = "extra == 'matrix'", specifier = ">=0.25,<0.26" },
     { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix-e2e'", specifier = ">=0.25,<0.26" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0" },
+    { name = "mcp", specifier = ">=1.2.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.70" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "numpy", marker = "extra == 'ml-router'", specifier = ">=1.26" },
@@ -4045,7 +4043,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=13.0" },
     { name = "yoyo-migrations", specifier = ">=8.2" },
 ]
-provides-extras = ["dev", "mcp", "memory", "recommended", "ml-router", "mem0", "matrix", "matrix-e2e", "document-extras"]
+provides-extras = ["dev", "memory", "recommended", "ml-router", "mem0", "matrix", "matrix-e2e", "document-extras"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Make remote MCP support work out of the box without allowing an incomplete OAuth configuration to block AgentOS startup.

The MCP SDK is promoted from an optional extra to a standard dependency. Separately, gateway boot now treats OAuth as an explicit user action: configured OAuth servers without stored credentials remain in an authentication-required state and are not contacted until the user starts the flow from the UI.

## Root cause

A saved Robinhood configuration was discovered eagerly during gateway startup before OAuth had completed. The connection timeout cancelled MCP initialization, but cleanup only caught `Exception`. On Python 3.12, `asyncio.CancelledError` inherits from `BaseException`, leaving AnyIO contexts open and later crashing startup with a cancel-scope error.

## Changes

- include `mcp>=1.2.0` in the standard AgentOS installation
- remove the redundant `mcp` optional extra and update CI/docs
- skip unauthenticated OAuth MCP servers during gateway boot
- reconnect authenticated OAuth servers normally
- close partial Streamable HTTP and discovery state on cancellation in the same task
- add packaging, OAuth boot, and cancellation-cleanup regressions

## Validation

- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- MCP, gateway, packaging, and MCP-server tests: **42 passed**
- wheel build passed
- blackhole MCP reproduction now exits with a clean timeout and the event loop continues running

## User impact

Installing AgentOS does not initiate a Robinhood connection. A configured but unauthenticated Robinhood server waits for the user to choose **Authenticate / Connect** in the MCP UI, and a slow or unavailable server cannot crash the gateway.