### PR TITLE
fix(mcp): prevent OAuth servers from crashing startup

### DIFF
--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1475,6 +1475,68 @@ async def preload_agentos_router_runtime(config: GatewayConfig) -> None:
         )
 
 
+async def _discover_configured_mcp_servers(
+    config: GatewayConfig,
+    tool_registry: ToolRegistry,
+) -> None:
+    """Connect configured MCP servers without starting an interactive OAuth flow."""
+    if not config.mcp.enabled:
+        return
+    if not config.mcp.servers:
+        log.info("build_services.mcp_enabled_no_servers")
+        return
+
+    from agentos.mcp.discovery import discover_and_register
+    from agentos.mcp.streamable_http import FileOAuthStorage
+    from agentos.mcp.types import MCPServerConfig
+
+    timeout = config.mcp.connect_timeout_seconds
+    for entry in config.mcp.servers:
+        try:
+            mcp_cfg = MCPServerConfig(
+                name=entry.name,
+                transport=entry.transport,
+                command=entry.command,
+                args=entry.args,
+                url=entry.url,
+                env=entry.env,
+                headers=entry.headers,
+                oauth=entry.oauth,
+                state_dir=config.state_dir,
+                tool_timeout_seconds=entry.tool_timeout_seconds,
+            )
+            if mcp_cfg.oauth and mcp_cfg.url:
+                storage = FileOAuthStorage(mcp_cfg.name, mcp_cfg.url, mcp_cfg.state_dir)
+                if not await storage.is_authenticated():
+                    log.info(
+                        "build_services.mcp_server_authentication_required",
+                        server=entry.name,
+                    )
+                    continue
+
+            names = await asyncio.wait_for(
+                discover_and_register(mcp_cfg, tool_registry),
+                timeout=timeout,
+            )
+            log.info(
+                "build_services.mcp_server_registered",
+                server=entry.name,
+                tools=len(names),
+            )
+        except TimeoutError:
+            log.warning(
+                "build_services.mcp_server_timeout",
+                server=entry.name,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            log.warning(
+                "build_services.mcp_server_failed",
+                server=entry.name,
+                error=str(exc),
+            )
+
+
 async def build_services(
     config: GatewayConfig | None = None,
     session_manager: Any = None,
@@ -1900,48 +1962,7 @@ async def build_services(
         log.warning("build_services.search_provider_failed", error=str(e))
 
     # ── MCP discovery (boot order 22) ───────────────────────────────
-    if config.mcp.enabled and config.mcp.servers:
-        from agentos.mcp.discovery import discover_and_register
-        from agentos.mcp.types import MCPServerConfig
-
-        timeout = config.mcp.connect_timeout_seconds
-        for entry in config.mcp.servers:
-            try:
-                mcp_cfg = MCPServerConfig(
-                    name=entry.name,
-                    transport=entry.transport,
-                    command=entry.command,
-                    args=entry.args,
-                    url=entry.url,
-                    env=entry.env,
-                    headers=entry.headers,
-                    oauth=entry.oauth,
-                    state_dir=config.state_dir,
-                    tool_timeout_seconds=entry.tool_timeout_seconds,
-                )
-                names = await asyncio.wait_for(
-                    discover_and_register(mcp_cfg, tool_registry),
-                    timeout=timeout,
-                )
-                log.info(
-                    "build_services.mcp_server_registered",
-                    server=entry.name,
-                    tools=len(names),
-                )
-            except TimeoutError:
-                log.warning(
-                    "build_services.mcp_server_timeout",
-                    server=entry.name,
-                    timeout=timeout,
-                )
-            except Exception as e:
-                log.warning(
-                    "build_services.mcp_server_failed",
-                    server=entry.name,
-                    error=str(e),
-                )
-    elif config.mcp.enabled:
-        log.info("build_services.mcp_enabled_no_servers")
+    await _discover_configured_mcp_servers(config, tool_registry)
 
     flush_service = build_flush_service(
         tool_registry=tool_registry,

--- a/src/agentos/mcp/discovery.py
+++ b/src/agentos/mcp/discovery.py
@@ -155,7 +155,7 @@ async def discover_and_register(
             registered_tools=tuple(registered),
         )
         _active_clients.append(entry)
-    except Exception:
+    except BaseException:
         if entry is not None:
             try:
                 _active_clients.remove(entry)

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -196,7 +196,7 @@ class MCPStreamableHTTPClient(MCPClient):
                 )
             )
             await session.initialize()
-        except Exception:
+        except BaseException:
             await stack.aclose()
             raise
 

--- a/tests/test_gateway/test_mcp_boot.py
+++ b/tests/test_gateway/test_mcp_boot.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agentos.gateway.boot import _discover_configured_mcp_servers
+from agentos.gateway.config import GatewayConfig
+from agentos.mcp.streamable_http import FileOAuthStorage
+from agentos.tools.registry import ToolRegistry
+
+
+def _oauth_config(tmp_path) -> GatewayConfig:
+    return GatewayConfig(
+        state_dir=str(tmp_path),
+        mcp={
+            "enabled": True,
+            "servers": [
+                {
+                    "name": "robinhood-trading",
+                    "transport": "streamable_http",
+                    "url": "https://agent.robinhood.com/mcp/trading",
+                    "oauth": True,
+                }
+            ],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_boot_skips_oauth_server_until_user_authenticates(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentos.mcp import discovery
+
+    discover = AsyncMock(return_value=[])
+    monkeypatch.setattr(discovery, "discover_and_register", discover)
+    monkeypatch.setattr(FileOAuthStorage, "is_authenticated", AsyncMock(return_value=False))
+
+    await _discover_configured_mcp_servers(_oauth_config(tmp_path), ToolRegistry())
+
+    discover.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_boot_reconnects_oauth_server_after_authentication(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentos.mcp import discovery
+
+    discover = AsyncMock(return_value=["mcp_portfolio"])
+    monkeypatch.setattr(discovery, "discover_and_register", discover)
+    monkeypatch.setattr(FileOAuthStorage, "is_authenticated", AsyncMock(return_value=True))
+
+    await _discover_configured_mcp_servers(_oauth_config(tmp_path), ToolRegistry())
+
+    discover.assert_awaited_once()

--- a/tests/test_mcp/test_discovery_lifecycle.py
+++ b/tests/test_mcp/test_discovery_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -121,6 +122,27 @@ async def test_failed_mcp_discovery_closes_client_without_leaking(
     monkeypatch.setattr(discovery, "create_client", lambda _config: client)
 
     with pytest.raises(RuntimeError, match="list failed"):
+        await discovery.discover_and_register(config, ToolRegistry())
+
+    assert client.closed is True
+    assert discovery.active_clients_snapshot() == ()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mcp_discovery_closes_client_without_leaking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentos.mcp import discovery
+
+    class CancelledMCPClient(FakeMCPClient):
+        async def list_tools(self) -> list[MCPToolDef]:
+            raise asyncio.CancelledError
+
+    config = MCPServerConfig(name="cancelled", transport="stdio", command="mock-mcp")
+    client = CancelledMCPClient(config)
+    monkeypatch.setattr(discovery, "create_client", lambda _config: client)
+
+    with pytest.raises(asyncio.CancelledError):
         await discovery.discover_and_register(config, ToolRegistry())
 
     assert client.closed is True

--- a/tests/test_mcp/test_streamable_http_client.py
+++ b/tests/test_mcp/test_streamable_http_client.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import stat
+from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
 
@@ -57,3 +60,53 @@ async def test_oauth_storage_round_trips_privately(tmp_path) -> None:
 
     restored.clear()
     assert not restored.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_connect_closes_all_partial_transport_contexts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp.client import session as session_module
+    from mcp.client import streamable_http as transport_module
+
+    closed: list[str] = []
+
+    @asynccontextmanager
+    async def fake_http_client(**_kwargs: Any):
+        try:
+            yield object()
+        finally:
+            closed.append("http")
+
+    @asynccontextmanager
+    async def fake_transport(_url: str, **_kwargs: Any):
+        try:
+            yield object(), object(), None
+        finally:
+            closed.append("transport")
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            closed.append("session")
+
+        async def initialize(self) -> None:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("agentos.mcp.streamable_http.httpx.AsyncClient", fake_http_client)
+    monkeypatch.setattr(transport_module, "streamable_http_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_args, **_kwargs: FakeSession())
+    client = MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="remote",
+            transport="streamable_http",
+            url="https://example.test/mcp",
+        )
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.connect()
+
+    assert closed == ["session", "transport", "http"]


### PR DESCRIPTION
## Summary

Prevent an incomplete OAuth MCP configuration from contacting the provider or crashing AgentOS during gateway startup.

A configured OAuth server without stored credentials now remains in an authentication-required state. The connection starts only when the user chooses **Authenticate / Connect** in the MCP UI. Authenticated servers continue to reconnect normally on boot.

## Root cause

The gateway eagerly discovered saved OAuth servers before authorization completed. A connection timeout cancelled MCP initialization, while cleanup only caught `Exception`. On Python 3.12, `asyncio.CancelledError` inherits from `BaseException`, which left AnyIO contexts open and later crashed startup with a cancel-scope error.

## Changes

- skip unauthenticated OAuth MCP servers during gateway boot
- retain automatic reconnect for servers with stored credentials
- close partial Streamable HTTP contexts on cancellation in the originating task
- close discovery clients when cancellation occurs
- add regression coverage for OAuth boot behavior and cancellation cleanup

## Validation

- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- MCP, gateway, packaging, and MCP-server tests: **42 passed**
- blackhole MCP reproduction now returns a clean timeout and the event loop remains healthy

## User impact

Installing or starting AgentOS no longer initiates a Robinhood OAuth connection before the user authenticates, and an unavailable MCP server cannot take down the gateway.