### PR TITLE
fix(webui): rename assistant label to AGENTOS

### DIFF
--- a/src/agentos/gateway/static/js/views/chat.js
+++ b/src/agentos/gateway/static/js/views/chat.js
@@ -672,7 +672,7 @@ const ChatView = (() => {
 
   function _displayRoleLabel(role) {
     return role === 'user' ? 'You'
-      : role === 'assistant' ? 'Cap'
+      : role === 'assistant' ? 'AGENTOS'
       : role === 'subagent' ? 'Sub-agent'
       : role ? role.charAt(0).toUpperCase() + role.slice(1)
       : '';

--- a/tests/test_gateway/test_chat_transcript_redesign_static.py
+++ b/tests/test_gateway/test_chat_transcript_redesign_static.py
@@ -41,6 +41,12 @@ def test_user_role_label_and_time_align_right() -> None:
     assert ".msg.user .role-label { text-align: right; }" in css
 
 
+def test_assistant_role_label_uses_agentos_name() -> None:
+    js = _js()
+    assert "role === 'assistant' ? 'AGENTOS'" in js
+    assert "role === 'assistant' ? 'Cap'" not in js
+
+
 def test_composer_input_bar_is_floating_pill() -> None:
     css = _css()
     start = css.index(".chat-input-bar {")


### PR DESCRIPTION
## Summary
- rename the WebUI chat assistant speaker label from `Cap` to `AGENTOS`
- add a regression test covering the assistant role-label mapping
- leave CAP page-dump detection markers unchanged

## Test Plan
- [x] `uv run ruff check src tests`
- [x] `uv run mypy src/agentos --show-error-codes`
- [x] `uv run pytest tests/test_gateway/test_chat_transcript_redesign_static.py -q` (19 passed)
- [x] `uv run pytest tests/test_gateway -q`
- [x] `uv build --wheel`
- [ ] `uv run pytest -q` (environmental failures: Docker daemon unavailable, macOS long-path limit, and virtualenv `ensurepip` SIGABRT)