### PR TITLE
fix(telegram): preserve native commands on shutdown

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -134,7 +134,6 @@ class TelegramChannel:
     _update_offset: int | None = field(default=None, init=False, repr=False)
     _dedupe: EventDedupeCache = field(init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
-    _commands_registered: bool = field(default=False, init=False, repr=False)
     _last_message_at: datetime | None = field(default=None, init=False, repr=False)
     _known_sender_profiles: dict[str, dict[str, str]] = field(
         default_factory=dict, init=False, repr=False
@@ -500,7 +499,6 @@ class TelegramChannel:
         commands = telegram_bot_commands()
         scope = {"type": "default"}
         await self._api("setMyCommands", {"commands": commands, "scope": scope})
-        self._commands_registered = True
         log.info("telegram.commands_registered", count=len(commands))
 
     async def stop(self) -> None:
@@ -512,12 +510,6 @@ class TelegramChannel:
                 await task
             except asyncio.CancelledError:
                 pass
-        if self._commands_registered:
-            try:
-                await self._api("deleteMyCommands", {"scope": {"type": "default"}})
-            except TelegramApiError as exc:
-                log.warning("telegram.commands_cleanup_failed", error=str(exc))
-            self._commands_registered = False
         if self._client is not None and self._owns_client:
             await self._client.aclose()
         self._client = None

--- a/tests/test_channels/test_native_commands.py
+++ b/tests/test_channels/test_native_commands.py
@@ -82,7 +82,7 @@ async def test_telegram_registration_pushes_the_unified_command_menu() -> None:
 
 
 @pytest.mark.asyncio
-async def test_telegram_start_registers_and_stop_cleans_up_commands() -> None:
+async def test_telegram_start_and_stop_preserves_registered_commands() -> None:
     channel = TelegramChannel(
         TelegramChannelConfig(
             token="token",
@@ -102,12 +102,9 @@ async def test_telegram_start_registers_and_stop_cleans_up_commands() -> None:
     await channel.start()
     await channel.stop()
 
-    assert [method for method, _ in calls] == [
-        "getMe",
-        "setMyCommands",
-        "setWebhook",
-        "deleteMyCommands",
-    ]
+    methods = [method for method, _ in calls]
+    assert methods == ["getMe", "setMyCommands", "setWebhook"]
+    assert "deleteMyCommands" not in methods
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve Telegram native command menus across normal adapter shutdowns
- remove the command-registration state that only existed to trigger cleanup
- add regression coverage proving start registers commands and stop does not delete them

## Testing

- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- `uv run pytest tests/test_channels/test_native_commands.py -q` (13 passed)
- `uv build --wheel`
- Full suite: 6475 passed; 7 failures and 3 errors reproduce unchanged on `origin/main` and are caused by unhydrated Git LFS models, unavailable Docker daemon, and local `ensurepip` environment failure.

Fixes #52