### PR TITLE
feat(cli): mouse drag selection + copy in chat transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [2026.7.22.post1] - 2026-07-22
 
+### Added
+
+- Managed MCP server configuration in the Web UI, with stdio, SSE, and
+  Streamable HTTP transports, OAuth authorization, dynamic tool discovery, a
+  Robinhood Trading preset, and a bundled safety-focused Robinhood skill (#66).
+- Mouse-wheel scrolling and Home/End and Ctrl+A/Ctrl+E line navigation in the
+  full-screen `agentos chat` interface (#67).
+
+### Changed
+
+- Promoted the MCP SDK to a standard dependency so remote MCP integrations work
+  without installing an optional extra (#71).
+- Renamed the Web UI chat assistant label from `Cap` to `AGENTOS` (#73).
+
 ### Fixed
 
 - `agentos chat` full-screen transcript now responds to the first mouse wheel
   tick instead of needing several scrolls before the pane moves: the wheel step
   is larger and the tick that releases follow mode is compensated so the
-  wrapped-line cursor leaves the viewport immediately.
+  wrapped-line cursor leaves the viewport immediately (#69).
+- Unauthenticated OAuth MCP servers no longer connect during gateway startup;
+  authenticated servers continue to reconnect automatically (#72).
+- MCP cancellation cleanup now closes partial Streamable HTTP and discovery
+  state so slow or unavailable remote servers cannot leave open AnyIO contexts
+  or crash gateway startup (#71, #72).
 
 ## [2026.7.22] - 2026-07-22
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,6 +137,14 @@ branded welcome screen renders at the top of the pane on launch. `PgUp`/`PgDn`
 scroll back through history; the mouse wheel scrolls when the pointer is over
 the transcript. New output re-pins to the newest line.
 
+**Select and copy.** Drag with the left mouse button across the transcript
+to highlight any span (the selection shows in reverse video); releasing the
+button copies the plain text — ANSI styling stripped, CJK width-aware — to
+the system clipboard (`pbcopy` on macOS, `wl-copy`/`xclip`/`xsel` on Linux,
+`clip` on Windows, OSC 52 escape as a fallback). Click anywhere to clear the
+selection. The emulator's own selection gesture (typically `Shift+drag` on
+Linux, `Option+drag` in iTerm2) also still works if you prefer it.
+
 Input navigation follows the current logical line in multiline drafts:
 `Home`/`End` and `Ctrl+A`/`Ctrl+E` move to that line's start/end. On macOS,
 `Cmd+Left`/`Cmd+Right` work when the terminal maps those shortcuts to

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,6 +145,18 @@ the system clipboard (`pbcopy` on macOS, `wl-copy`/`xclip`/`xsel` on Linux,
 selection. The emulator's own selection gesture (typically `Shift+drag` on
 Linux, `Option+drag` in iTerm2) also still works if you prefer it.
 
+**Markdown rendering.** The assistant's streamed reply is styled inline as
+it arrives: `#`/`##`/`###` headings render in the brand accent, `>`
+quotes get a dimmed bar, `---` becomes a rule, list markers are tinted,
+tables keep their pipes aligned, fenced code blocks stream in a uniform
+code color (no waiting for the closing fence), and inline spans —
+`**bold**`, `*italic*`, `~~strike~~`, inline `` `code` ``, and
+`[text](url)` links —
+are styled in place. File names, branch names, and other important terms
+the model wraps in backticks stand out in the accent color. The render is
+write-once (no repaint loop), and `NO_COLOR` (or a non-color terminal)
+downgrades the stream to plain text so piped output stays greppable.
+
 Input navigation follows the current logical line in multiline drafts:
 `Home`/`End` and `Ctrl+A`/`Ctrl+E` move to that line's start/end. On macOS,
 `Cmd+Left`/`Cmd+Right` work when the terminal maps those shortcuts to

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,7 +153,10 @@ code color (no waiting for the closing fence), and inline spans —
 `**bold**`, `*italic*`, `~~strike~~`, inline `` `code` ``, and
 `[text](url)` links —
 are styled in place. File names, branch names, and other important terms
-the model wraps in backticks stand out in the accent color. The render is
+the model wraps in backticks stand out in the accent color. Reasoning-model
+`<think>…</think>` blocks render as a recessive gray-bar, dim-italic region
+(the tags themselves are hidden) so the chain-of-thought stays visible but
+never competes with the reply. The render is
 write-once (no repaint loop), and `NO_COLOR` (or a non-color terminal)
 downgrades the stream to plain text so piped output stays greppable.
 

--- a/src/agentos/cli/tui/terminal/app.py
+++ b/src/agentos/cli/tui/terminal/app.py
@@ -37,11 +37,17 @@ from prompt_toolkit.layout import (
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
-from prompt_toolkit.mouse_events import MouseEventType
+from prompt_toolkit.mouse_events import MouseButton, MouseEventType
 
+from agentos.cli.tui.terminal.clipboard import copy_to_system_clipboard
 from agentos.cli.tui.terminal.paste import (
     pasted_content_summary,
     should_collapse_pasted_content,
+)
+from agentos.cli.tui.terminal.selection import (
+    Selection,
+    extract_selection_text,
+    highlight_fragments,
 )
 from agentos.engine.commands import Surface
 
@@ -93,11 +99,29 @@ _MOUSE_SCROLL_LINES: int = 11
 
 
 class _TranscriptControl(FormattedTextControl):
-    """Formatted transcript content with wheel events routed to chat scroll state."""
+    """Formatted transcript content with wheel + selection mouse handling.
 
-    def __init__(self, *args, scroll: Callable[[int], None], **kwargs) -> None:  # noqa: ANN002, ANN003
+    Wheel events route to chat scroll state. Left-button drag builds a
+    :class:`~agentos.cli.tui.terminal.selection.Selection` in
+    content-coordinate space; mouse-up finalizes the selection and copies
+    the plain text to the system clipboard. The owning
+    :class:`ChatApplication` is notified so it can repaint the pane with
+    the highlight.
+    """
+
+    def __init__(
+        self,
+        *args,  # noqa: ANN002
+        scroll: Callable[[int], None],
+        on_selection_change: Callable[[Selection | None], None],
+        on_copy: Callable[[Selection], None],
+        **kwargs,  # noqa: ANN003
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._scroll = scroll
+        self._on_selection_change = on_selection_change
+        self._on_copy = on_copy
+        self._selection_anchor: tuple[int, int] | None = None
 
     def mouse_handler(self, mouse_event):  # type: ignore[no-untyped-def]
         if mouse_event.event_type == MouseEventType.SCROLL_UP:
@@ -106,6 +130,27 @@ class _TranscriptControl(FormattedTextControl):
         if mouse_event.event_type == MouseEventType.SCROLL_DOWN:
             self._scroll(-_MOUSE_SCROLL_LINES)
             return None
+        # Selection: left-drag within the transcript content. Positions are
+        # already in content coordinates (row = logical line, col = display
+        # column) thanks to prompt-toolkit's Window mouse wrapper.
+        if mouse_event.button is MouseButton.LEFT:
+            if mouse_event.event_type == MouseEventType.MOUSE_DOWN:
+                self._selection_anchor = (mouse_event.position.y, mouse_event.position.x)
+                self._on_selection_change(None)
+                return None
+            if mouse_event.event_type == MouseEventType.MOUSE_MOVE:
+                if self._selection_anchor is not None:
+                    cursor = (mouse_event.position.y, mouse_event.position.x)
+                    self._on_selection_change(Selection(self._selection_anchor, cursor))
+                return None
+            if mouse_event.event_type == MouseEventType.MOUSE_UP:
+                if self._selection_anchor is not None:
+                    cursor = (mouse_event.position.y, mouse_event.position.x)
+                    selection = Selection(self._selection_anchor, cursor)
+                    self._selection_anchor = None
+                    self._on_selection_change(selection)
+                    self._on_copy(selection)
+                return None
         return super().mouse_handler(mouse_event)
 
 
@@ -316,6 +361,10 @@ class ChatApplication:
         self._transcript_follow: bool = True
         self._transcript_scroll: int = 0
         self._transcript_window: Window | None = None
+        # Current mouse-driven selection in the transcript pane, or None.
+        # Set by ``_TranscriptControl`` callbacks; read when rendering the
+        # pane to layer the reverse-video highlight.
+        self._transcript_selection: Selection | None = None
         self._submit_queue: asyncio.Queue[str | object] = asyncio.Queue()
         self._eof_seen = False
         # Set for the duration of the inline approval suspend window
@@ -450,10 +499,18 @@ class ChatApplication:
         #    region — the cause of the over-tall frame).
         top_element: Window
         if self._fullscreen:
+
+            def _transcript_text():  # type: ignore[no-untyped-def]
+                if self._transcript_selection is not None:
+                    return highlight_fragments(self._transcript, self._transcript_selection)
+                return ANSI(self._transcript)
+
             top_element = Window(
                 content=_TranscriptControl(
-                    lambda: ANSI(self._transcript),
+                    _transcript_text,
                     scroll=self.scroll_transcript_with_mouse,
+                    on_selection_change=self._on_transcript_selection_change,
+                    on_copy=self._on_transcript_copy,
                     get_cursor_position=self._transcript_cursor_position,
                     focusable=False,
                     show_cursor=False,
@@ -597,6 +654,24 @@ class ChatApplication:
         except Exception:
             pass
 
+    def _on_transcript_selection_change(self, selection: Selection | None) -> None:
+        """Store the active selection and repaint the transcript pane."""
+        self._transcript_selection = selection
+        try:
+            self._app.invalidate()
+        except Exception:
+            pass
+
+    def _on_transcript_copy(self, selection: Selection) -> None:
+        """Copy the selected plain text to the system clipboard.
+
+        The selection highlight is kept visible after the copy so the user
+        gets confirmation of what was lifted; the next mouse-down clears it.
+        """
+        text = extract_selection_text(self._transcript, selection)
+        if text:
+            copy_to_system_clipboard(text)
+
     def append_transcript(self, text: str) -> None:
         """Append ANSI-encoded text to the full-screen transcript pane.
 
@@ -608,6 +683,9 @@ class ChatApplication:
         if not text:
             return
         self._transcript += text
+        # The transcript grew; drop any active selection because row indexes
+        # now refer to stale content.
+        self._transcript_selection = None
         # New output re-pins the view to the bottom (matches a terminal that
         # scrolls on write); an explicit user scroll re-latches follow=False.
         self._transcript_follow = True

--- a/src/agentos/cli/tui/terminal/clipboard.py
+++ b/src/agentos/cli/tui/terminal/clipboard.py
@@ -1,0 +1,161 @@
+"""Best-effort system clipboard for the terminal chat surface.
+
+The full-screen transcript pane copies mouse-selected text through this
+helper so users can lift chat content without leaving the app. Terminal
+emulators also honor OSC 52, but a native tool is preferred because it is
+not gated by emulator-specific allowlists.
+
+Selection of the concrete mechanism is done once at module import:
+  1. macOS ``pbcopy`` (always present on Darwin).
+  2. Linux/BSD ``wl-copy`` → ``xclip`` → ``xsel``.
+  3. Windows ``clip``.
+  4. OSC 52 escape written to ``/dev/tty`` (works in most xterm-class
+     emulators when the former are missing).
+If no mechanism is available the copy is a silent no-op — chat stays
+functional, the selection highlight still renders, and the user can still
+fall back to their emulator's own copy gesture.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+
+__all__ = ["copy_to_system_clipboard"]
+
+
+def _pbcopy(text: str) -> bool:
+    try:
+        subprocess.run(
+            ["pbcopy"],
+            input=text.encode("utf-8", errors="replace"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _wl_copy(text: str) -> bool:
+    try:
+        subprocess.run(
+            ["wl-copy"],
+            input=text.encode("utf-8", errors="replace"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _xclip(text: str) -> bool:
+    try:
+        subprocess.run(
+            ["xclip", "-selection", "clipboard"],
+            input=text.encode("utf-8", errors="replace"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _xsel(text: str) -> bool:
+    try:
+        subprocess.run(
+            ["xsel", "--clipboard", "--input"],
+            input=text.encode("utf-8", errors="replace"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _windows_clip(text: str) -> bool:
+    try:
+        # ``clip`` reads from stdin; encoding must match the console code page.
+        # ``utf-8`` works on all supported Windows builds when the input is
+        # written as bytes because ``clip`` accepts raw byte streams.
+        subprocess.run(
+            ["clip"],
+            input=text.encode("utf-8", errors="replace"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _osc52(text: str) -> bool:
+    """Write an OSC 52 escape directly to the controlling terminal.
+
+    Bypasses prompt-toolkit's output so the escape is not swallowed when
+    the full-screen app holds the terminal. Silently reports failure when
+    no tty is available (tests, piped output).
+    """
+    if not sys.stdout.isatty():
+        return False
+    try:
+        payload = base64.b64encode(text.encode("utf-8", errors="replace")).decode("ascii")
+        # ``\x07`` (BEL) terminator is the most portable variant.
+        sequence = f"\x1b]52;c;{payload}\x07"
+        with open("/dev/tty", "w", encoding="utf-8", errors="replace") as tty:
+            tty.write(sequence)
+            tty.flush()
+        return True
+    except Exception:
+        return False
+
+
+def _pick_writer() -> Callable[[str], bool] | None:
+    """Choose the first available clipboard writer for this platform."""
+    if sys.platform == "darwin" and shutil.which("pbcopy"):
+        return _pbcopy
+    if sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
+        # Wayland first (wl-copy), then X11 (xclip / xsel). Only probe the
+        # tools that are actually installed so headless boxes fall through.
+        if shutil.which("wl-copy"):
+            return _wl_copy
+        if shutil.which("xclip"):
+            return _xclip
+        if shutil.which("xsel"):
+            return _xsel
+    if sys.platform == "win32":
+        return _windows_clip
+    # Generic fallback: OSC 52. Always offered — the call itself gates on
+    # having a usable tty.
+    return _osc52
+
+
+_WRITER: Callable[[str], bool] | None = _pick_writer()
+
+
+def copy_to_system_clipboard(text: str) -> bool:
+    """Copy ``text`` to the OS clipboard. Returns True on (likely) success.
+
+    "Likely" because clipboard daemons can deny the write even when the
+    helper binary exists; the chat UI treats this as fire-and-forget and
+    does not surface an error on a False return.
+    """
+    if not text:
+        return False
+    if _WRITER is None:
+        return False
+    try:
+        return bool(_WRITER(text))
+    except Exception:
+        return False

--- a/src/agentos/cli/tui/terminal/markdown_stream.py
+++ b/src/agentos/cli/tui/terminal/markdown_stream.py
@@ -1,0 +1,624 @@
+"""Incremental markdown renderer for the terminal chat stream.
+
+The chat renderer writes sanitized model output straight to the terminal
+(write-once, no ``Rich.Live`` re-render — see ``stream.py`` for why that
+contract exists). This module layers a *line-buffered* markdown pass on
+top of that contract:
+
+  * Tokens are accumulated until a newline arrives, so every emitted line
+    is final and never needs repainting.
+  * Block-level constructs (``#``/``##``/``###`` headings, ``>`` quotes,
+    ``---`` rules, fenced code blocks, tables, list items) are detected
+    from the line prefix and styled with the brand palette.
+  * Inline spans (``**bold**``, ``*italic*``, ``~~strike~~``, inline
+    ``code``, links) are styled inside the line after block styling.
+  * Fenced code blocks stream their body lines immediately in a uniform
+    code style — no waiting for the closing fence, no syntax-highlight
+    delay, no re-render. The fence markers themselves are hidden so the
+    block reads as one continuous region.
+  * ``NO_COLOR`` (or a non-color console) downgrades every transform to a
+    plain-text passthrough so piped output stays greppable.
+
+The renderer is stateful and single-use per assistant turn; create one
+via ``MarkdownStreamRenderer(enabled=...)`` and feed deltas through
+``feed``. ``flush`` must be called at end-of-turn to emit any trailing
+partial line.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from rich.cells import cell_len
+from rich.markup import escape as _rich_escape
+
+from agentos.cli.ui import (
+    ACCENT,
+    ACCENT_DIM,
+    ACCENT_SOFT,
+    console,
+)
+
+__all__ = ["MarkdownStreamRenderer", "markdown_enabled", "render_markup_to_ansi"]
+
+
+# ---------------------------------------------------------------------------
+# Style vocabulary (brand palette, terminal-safe)
+# ---------------------------------------------------------------------------
+
+_HEADING_STYLE = f"bold {ACCENT}"
+_QUOTE_STYLE = "dim"
+_RULE_STYLE = ACCENT_DIM
+_CODE_STYLE = f"{ACCENT_SOFT} on #1a1a1a"
+_INLINE_CODE_STYLE = f"bold {ACCENT_SOFT}"
+_LIST_MARKER_STYLE = ACCENT
+_BOLD_STYLE = "bold"
+_ITALIC_STYLE = "italic"
+_STRIKE_STYLE = "strike"
+_LINK_STYLE = f"underline {ACCENT_SOFT}"
+_LINK_URL_STYLE = "dim"
+
+
+# ---------------------------------------------------------------------------
+# Regexes
+# ---------------------------------------------------------------------------
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_QUOTE_RE = re.compile(r"^>\s?(.*)$")
+_RULE_RE = re.compile(r"^(?:\*\s*){3,}$|^(?:-\s*){3,}$|^(?:_\s*){3,}$")
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+_LIST_RE = re.compile(r"^(\s*)([-*+]|\d+\.)\s+(.*)$")
+
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_BOLD_RE = re.compile(r"\*\*([^*\n]+)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*([^*\n]+)\*(?!\*)")
+_STRIKE_RE = re.compile(r"~~([^~\n]+)~~")
+_LINK_RE = re.compile(r"\[([^\]\n]+)\]\(([^)\s]+)\)")
+
+
+def _styled(text: str, style: str) -> str:
+    return f"[{style}]{text}[/]"
+
+
+# ---------------------------------------------------------------------------
+# Inline span rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_inline(text: str) -> str:
+    """Apply inline markdown styling to a single (already block-stripped)
+    line of text.
+
+    The line is tokenized into *spans* on the raw text first (links, then
+    inline code, bold, italic, strike — earlier claims win on overlap).
+    Plain segments are Rich-escaped; styled segments wrap their escaped
+    content. Building markup this way (instead of escaping the whole line
+    up front) keeps the ``\\[`` escape sequences from colliding with the
+    tag-insertion regexes, which previously produced unbalanced markup
+    for e.g. ``[text](url)`` links.
+    """
+    spans: list[tuple[int, int, str]] = []
+
+    def _claim(pattern: re.Pattern[str], make) -> None:  # type: ignore[no-untyped-def]
+        for m in pattern.finditer(text):
+            if any(s < m.end() and m.start() < e for s, e, _ in spans):
+                continue
+            spans.append((m.start(), m.end(), make(m)))
+
+    _claim(
+        _LINK_RE,
+        lambda m: (
+            f"[{_LINK_STYLE}]{_rich_escape(m.group(1))}[/]"
+            f" [{_LINK_URL_STYLE}]({_rich_escape(m.group(2))})[/]"
+        ),
+    )
+    _claim(
+        _INLINE_CODE_RE,
+        lambda m: f"[{_INLINE_CODE_STYLE}]{_rich_escape(m.group(1))}[/]",
+    )
+    _claim(
+        _BOLD_RE,
+        lambda m: f"[{_BOLD_STYLE}]{_rich_escape(m.group(1))}[/]",
+    )
+    _claim(
+        _ITALIC_RE,
+        lambda m: f"[{_ITALIC_STYLE}]{_rich_escape(m.group(1))}[/]",
+    )
+    _claim(
+        _STRIKE_RE,
+        lambda m: f"[{_STRIKE_STYLE}]{_rich_escape(m.group(1))}[/]",
+    )
+
+    spans.sort()
+    out: list[str] = []
+    pos = 0
+    for start, end, replacement in spans:
+        out.append(_rich_escape(text[pos:start]))
+        out.append(replacement)
+        pos = end
+    out.append(_rich_escape(text[pos:]))
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Block-level line rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_code_line(line: str) -> str:
+    """A line inside a fenced code block: uniform code style, escaped."""
+    return _styled(_rich_escape(line) or " ", _CODE_STYLE)
+
+
+# ---------------------------------------------------------------------------
+# Table block rendering
+# ---------------------------------------------------------------------------
+#
+# A markdown table cannot be aligned row-by-row during streaming (column
+# widths are not known until the last row arrives), so table lines are
+# buffered while the block is open and rendered as a unit when it closes.
+# This is the one intentional exception to the write-once contract, and it
+# is the same trade-off every streaming terminal markdown renderer makes.
+
+_TABLE_SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
+_TABLE_MIN_COL_WIDTH = 5
+_TABLE_PAD = 1  # spaces on each side of a cell
+
+
+def _is_table_line(line: str) -> bool:
+    return line.lstrip().startswith("|") and line.rstrip().endswith("|")
+
+
+def _split_table_row(line: str) -> list[str]:
+    """Split a ``| a | b |`` row into trimmed cell strings."""
+    cells = line.strip().strip("|").split("|")
+    return [c.strip() for c in cells]
+
+
+def _is_table_separator_row(line: str) -> bool:
+    cells = _split_table_row(line)
+    return bool(cells) and all(_TABLE_SEPARATOR_CELL_RE.match(c) for c in cells)
+
+
+def _parse_table_alignment(line: str, ncols: int) -> list[str]:
+    """Parse the ``:---`` / ``:--:`` / ``---:`` separator row into per-column
+    alignment (``left``/``center``/``right``)."""
+    aligns: list[str] = []
+    for cell in _split_table_row(line):
+        left = cell.startswith(":")
+        right = cell.endswith(":")
+        if left and right:
+            aligns.append("center")
+        elif right:
+            aligns.append("right")
+        else:
+            aligns.append("left")
+    while len(aligns) < ncols:
+        aligns.append("left")
+    return aligns[:ncols]
+
+
+def _cell_plain(text: str) -> str:
+    """Strip inline markdown markers for width measurement."""
+    out = _LINK_RE.sub(lambda m: f"{m.group(1)} ({m.group(2)})", text)
+    out = _INLINE_CODE_RE.sub(lambda m: m.group(1), out)
+    out = _BOLD_RE.sub(lambda m: m.group(1), out)
+    out = _ITALIC_RE.sub(lambda m: m.group(1), out)
+    out = _STRIKE_RE.sub(lambda m: m.group(1), out)
+    return out
+
+
+def _cell_width(text: str) -> int:
+    """Display width of a cell with inline markdown removed (CJK-aware)."""
+    return cell_len(_cell_plain(text))
+
+
+def _full_span_style(text: str) -> str | None:
+    """If the whole cell is one inline span (``**x**``, ``*x*``, ``~~x~~``,
+    ```x```), return its style so the padded cell can be wrapped uniformly
+    — this keeps alignment intact instead of leaving the padding unstyled.
+    """
+    for pattern, style in (
+        (_INLINE_CODE_RE, _INLINE_CODE_STYLE),
+        (_BOLD_RE, _BOLD_STYLE),
+        (_ITALIC_RE, _ITALIC_STYLE),
+        (_STRIKE_RE, _STRIKE_STYLE),
+    ):
+        m = pattern.fullmatch(text)
+        if m:
+            return style
+    return None
+
+
+def _render_cell_content(text: str, width: int, align: str, *, header: bool) -> str:
+    """Render one table cell padded to ``width`` display columns.
+
+    When the entire cell is a single inline span the span's style wraps the
+    *padded* content so the alignment padding is styled too; otherwise
+    inline spans are styled individually and padding is added as plain
+    space around the rendered content.
+    """
+    natural = _cell_width(text)
+    overflow = max(0, width - natural)
+    if align == "right":
+        left_pad, right_pad = overflow, 0
+    elif align == "center":
+        left_pad, right_pad = overflow // 2, overflow - overflow // 2
+    else:
+        left_pad, right_pad = 0, overflow
+    lpad = " " * left_pad
+    rpad = " " * right_pad
+
+    span_style = _full_span_style(text)
+    if span_style is not None:
+        m = next(
+            p.fullmatch(text)
+            for p in (_INLINE_CODE_RE, _BOLD_RE, _ITALIC_RE, _STRIKE_RE)
+            if p.fullmatch(text)
+        )
+        assert m is not None
+        inner = lpad + _rich_escape(m.group(1)) + rpad
+        rendered = f"[{span_style}]{inner}[/]"
+    else:
+        rendered = lpad + _render_inline(text) + rpad
+    if header:
+        return f"[bold]{rendered}[/]"
+    return rendered
+
+
+def _wrap_cell_text(text: str, width: int) -> list[str]:
+    """Wrap a *plain* cell string to at most ``width`` display columns.
+
+    Splits on spaces; a token longer than the width is hard-split by
+    display columns. Returns at least one (possibly empty) line. Cells are
+    wrapped on the plain text (markers stripped) so wrapping never cuts a
+    markdown span in half — the wrapped lines render as plain text.
+    """
+    if width < 1:
+        width = 1
+    words = text.split(" ")
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = word if not current else f"{current} {word}"
+        if cell_len(candidate) <= width:
+            current = candidate
+            continue
+        if current:
+            lines.append(current)
+            current = ""
+        # Hard-split an over-long token by display columns.
+        while cell_len(word) > width:
+            cut = 0
+            acc = 0
+            for ch in word:
+                w = cell_len(ch)
+                if acc + w > width:
+                    break
+                acc += w
+                cut += 1
+            lines.append(word[:cut])
+            word = word[cut:]
+        current = word
+    if current or not lines:
+        lines.append(current)
+    return lines
+
+
+def _allocate_table_widths(
+    rows: list[list[str]],
+    aligns: list[str],
+    max_total: int,
+) -> list[int]:
+    """Compute per-column display widths, shrinking to fit ``max_total``.
+
+    Natural widths win until the budget is exhausted; the widest columns
+    are then shrunk one column at a time (never below
+    ``_TABLE_MIN_COL_WIDTH``) so narrow columns keep their full width.
+    """
+    ncols = len(aligns)
+    widths = [
+        max(
+            [_TABLE_MIN_COL_WIDTH]
+            + [_cell_width(r[i]) for r in rows if i < len(r)]
+        )
+        for i in range(ncols)
+    ]
+
+    def total() -> int:
+        # total = sum(widths) + padding (2 per cell) + separators (ncols+1)
+        return sum(widths) + ncols * 2 * _TABLE_PAD + (ncols + 1)
+
+    while total() > max_total:
+        widest = max(range(ncols), key=lambda i: widths[i])
+        if widths[widest] <= _TABLE_MIN_COL_WIDTH:
+            break
+        widths[widest] -= 1
+    return widths
+
+
+def _render_table_block(table_lines: list[str]) -> str:
+    """Render a buffered table block as an aligned, styled unit.
+
+    The block starts with a header row and separator row; remaining rows
+    are body rows. Columns are width-allocated against the console width
+    and cells are padded (alignment-aware) so every column lines up.
+    """
+    if len(table_lines) < 2:
+        # Degenerate block (no separator row) — render as plain lines.
+        return "\n".join(_render_table_line(ln) for ln in table_lines)
+
+    header = _split_table_row(table_lines[0])
+    ncols = len(header)
+    aligns = _parse_table_alignment(table_lines[1], ncols)
+    body = [
+        _split_table_row(ln)
+        for ln in table_lines[2:]
+        if not _is_table_separator_row(ln)
+    ]
+    all_rows = [header, *body]
+
+    # Budget: console width, minus a small safety margin so the table never
+    # touches the terminal edge (which would cause an unwanted wrap).
+    budget = max(40, console.width - 2)
+    widths = _allocate_table_widths(all_rows, aligns, budget)
+
+    pipe = f"[{_RULE_STYLE}]|[/]"
+    pad = " " * _TABLE_PAD
+
+    def _render_row(cells: list[str], *, is_header: bool) -> list[str]:
+        # Normalize ragged rows to the column count.
+        normalized = [(cells[i] if i < len(cells) else "") for i in range(ncols)]
+        # Wrap any cell whose plain width exceeds its column budget.
+        wrapped = [
+            _wrap_cell_text(_cell_plain(normalized[i]), widths[i])
+            if _cell_width(normalized[i]) > widths[i]
+            else [normalized[i]]
+            for i in range(ncols)
+        ]
+        height = max(len(w) for w in wrapped)
+        out_lines: list[str] = []
+        for sub in range(height):
+            parts: list[str] = []
+            for i in range(ncols):
+                if sub < len(wrapped[i]):
+                    cell_text = wrapped[i][sub]
+                    # Wrapped continuation lines are plain (markers were
+                    # stripped by the wrapper); style the header row only.
+                    if len(wrapped[i]) > 1 and cell_len(_cell_plain(cell_text)) > widths[i]:
+                        # A hard-split fragment — render plain.
+                        natural = cell_len(_cell_plain(cell_text))
+                        content = _rich_escape(cell_text) + " " * max(0, widths[i] - natural)
+                    else:
+                        content = _render_cell_content(
+                            cell_text,
+                            widths[i],
+                            aligns[i],
+                            header=is_header and len(wrapped[i]) == 1,
+                        )
+                    parts.append(pad + content + pad)
+                else:
+                    parts.append(pad + " " * widths[i] + pad)
+            out_lines.append(pipe + pipe.join(parts) + pipe)
+        return out_lines
+
+    lines: list[str] = []
+    lines.extend(_render_row(header, is_header=True))
+    # Separator: dashes fill each column (padding included), dimmed.
+    sep_parts = [
+        _styled("─" * (widths[i] + 2 * _TABLE_PAD), _RULE_STYLE) for i in range(ncols)
+    ]
+    lines.append(pipe + pipe.join(sep_parts) + pipe)
+    for row in body:
+        lines.extend(_render_row(row, is_header=False))
+    return "\n".join(lines)
+
+
+def _render_table_line(line: str) -> str:
+    """Fallback for a degenerate (unparseable) table line: dim the pipes."""
+    stripped = line.rstrip()
+    escaped = _rich_escape(stripped)
+    escaped = escaped.replace("|", f"[{_RULE_STYLE}]|[/]")
+    return escaped
+
+
+def _render_list_line(line: str) -> str:
+    m = _LIST_RE.match(line)
+    if not m:
+        return _render_inline(line)
+    indent, marker, body = m.groups()
+    styled_marker = f"[{_LIST_MARKER_STYLE}]{_rich_escape(marker)}[/]"
+    return f"{_rich_escape(indent)}{styled_marker} {_render_inline(body)}"
+
+
+def _render_quote_line(line: str) -> str:
+    m = _QUOTE_RE.match(line)
+    if not m:
+        return _render_inline(line)
+    body = m.group(1)
+    return f"[{_QUOTE_STYLE}]▎ {_render_inline(body)}[/]"
+
+
+def _render_heading_line(line: str) -> str:
+    m = _HEADING_RE.match(line)
+    if not m:
+        return _render_inline(line)
+    _hashes, body = m.groups()
+    return _styled(_render_inline(body), _HEADING_STYLE)
+
+
+def _render_rule_line(_line: str) -> str:
+    # Replace any --- / *** / ___ run with a full-width brand rule. Keep it
+    # short so narrow terminals don't wrap it.
+    return _styled("─" * 40, _RULE_STYLE)
+
+
+# ---------------------------------------------------------------------------
+# Streaming state machine
+# ---------------------------------------------------------------------------
+
+
+class MarkdownStreamRenderer:
+    """Line-buffered markdown renderer for one assistant turn.
+
+    Feed sanitized model deltas through :meth:`feed`; each call returns the
+    styled markup for any lines completed by that delta. Call :meth:`flush`
+    at end-of-turn to emit the final partial line.
+
+    When ``enabled`` is False every transform is bypassed and input is
+    returned verbatim — this is the ``NO_COLOR`` / piped-output path.
+    """
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self._enabled = enabled
+        self._pending = ""
+        self._in_fence = False
+        # Blockquote continuation state: a `>` line opens a quote block;
+        # consecutive non-empty lines keep it so multiline quotes style
+        # uniformly. Cleared by a blank line or a non-quote block line.
+        self._in_quote = False
+        # Buffered table lines while a table block is open. Tables render
+        # as a unit when the block closes (see _render_table_block).
+        self._table_lines: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        """True when the markdown transform is active.
+
+        Callers must bypass *all* post-processing (including the
+        markup→ANSI render) when this is False so raw text reaches the
+        terminal byte-for-byte.
+        """
+        return self._enabled
+
+    def feed(self, delta: str) -> str:
+        """Consume a delta; return styled markup for completed lines."""
+        if not self._enabled:
+            return delta
+        self._pending += delta
+        out: list[str] = []
+        while "\n" in self._pending:
+            line, self._pending = self._pending.split("\n", 1)
+            rendered = self._render_line(line)
+            if rendered is None:
+                # Table line buffered for the block render — emit nothing.
+                continue
+            # Empty string is a real display line (blank separator between
+            # paragraphs, or a hidden fence marker): keep the newline so
+            # paragraph spacing is preserved.
+            out.append(rendered + "\n")
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Emit any trailing partial line at end-of-turn."""
+        if not self._enabled:
+            pending, self._pending = self._pending, ""
+            return pending
+        out: list[str] = []
+        if self._pending:
+            line, self._pending = self._pending, ""
+            rendered = self._render_line(line)
+            if rendered is not None and rendered:
+                out.append(rendered)
+        # A table block that never saw its closing boundary still renders.
+        table_out = self._flush_table()
+        if table_out:
+            if out and not out[-1].endswith("\n"):
+                out[-1] += "\n"
+            out.append(table_out)
+        return "".join(out)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _flush_table(self) -> str:
+        """Render and clear any buffered table block."""
+        if not self._table_lines:
+            return ""
+        lines, self._table_lines = self._table_lines, []
+        return _render_table_block(lines)
+
+    def _render_line(self, line: str) -> str | None:
+        """Render one logical line.
+
+        Returns ``None`` when the line was buffered for a table block
+        (emit nothing), otherwise the display text for the line — which
+        may be an empty string for blank separator lines and hidden fence
+        markers (the caller still emits the newline so paragraph spacing
+        is preserved).
+        """
+        # Fence open/close toggles state; the fence line itself is hidden
+        # so the block reads as one continuous region.
+        if _FENCE_RE.match(line):
+            self._in_fence = not self._in_fence
+            table_out = self._flush_table()
+            return (table_out + "\n") if table_out else ""
+        if self._in_fence:
+            return _render_code_line(line)
+        # Table lines buffer until the block closes.
+        if _is_table_line(line):
+            self._table_lines.append(line)
+            return None
+        table_out = self._flush_table()
+        prefix = (table_out + "\n") if table_out else ""
+        stripped = line.strip()
+        if not stripped:
+            # Blank line ends any open quote block.
+            self._in_quote = False
+            return prefix
+        if _RULE_RE.match(stripped):
+            self._in_quote = False
+            return prefix + _render_rule_line(line)
+        if _HEADING_RE.match(line):
+            self._in_quote = False
+            return prefix + _render_heading_line(line)
+        if _QUOTE_RE.match(line):
+            self._in_quote = True
+            return prefix + _render_quote_line(line)
+        # Lazily-wrapped quote continuation: inside a quote block, treat a
+        # plain-text line as a continuation; a list/table/heading line
+        # breaks out of the quote.
+        if self._in_quote and not _LIST_RE.match(line) and not line.lstrip().startswith("|"):
+            return prefix + _render_quote_line(f"> {line}")
+        self._in_quote = False
+        if _LIST_RE.match(line):
+            return prefix + _render_list_line(line)
+        return prefix + _render_inline(line)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers used by stream.py
+# ---------------------------------------------------------------------------
+
+
+def markdown_enabled() -> bool:
+    """True when terminal markdown styling should be applied.
+
+    Disabled by ``NO_COLOR`` or when the console has no color system
+    (piped output, dumb terminal), so the raw stream stays greppable.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    return console.color_system is not None
+
+
+def render_markup_to_ansi(markup: str) -> str:
+    """Render a Rich markup string to ANSI, with no Rich-side wrapping.
+
+    Uses ``soft_wrap=True`` so the terminal (or prompt_toolkit pane) owns
+    line wrapping — the same contract the raw stream relied on before this
+    renderer existed. ``highlight=False`` and ``emoji=False`` keep the
+    model's text byte-faithful (no auto-linkification, no ``:emoji:``
+    expansion) so the only styling is what this module explicitly added.
+    """
+    if not markup:
+        return ""
+    with console.capture() as capture:
+        console.print(markup, end="", soft_wrap=True, highlight=False, emoji=False)
+    return capture.get()

--- a/src/agentos/cli/tui/terminal/markdown_stream.py
+++ b/src/agentos/cli/tui/terminal/markdown_stream.py
@@ -83,14 +83,19 @@ _STRIKE_RE = re.compile(r"~~([^~\n]+)~~")
 _LINK_RE = re.compile(r"\[([^\]\n]+)\]\(([^)\s]+)\)")
 
 # Reasoning-model think tags. The block forms own a whole line; the
-# single-line form wraps content inline (``<think>…</think>``). A bare
-# ``<>`` line while a block is open is accepted as a defensive closer —
-# some models / transports mangle ``</think>`` into it, and without the
-# valve everything after would render dim forever.
+# single-line form wraps content inline (``<think>…</think>``).
 _THINK_OPEN_RE = re.compile(r"^\s*<think>\s*$")
 _THINK_CLOSE_RE = re.compile(r"^\s*</think>\s*$")
 _THINK_INLINE_RE = re.compile(r"^\s*<think>(.*?)</think>\s*$")
-_THINK_STRAY_CLOSER = "<>"
+# Stray think-tag artifacts: models occasionally emit a bare ``<>`` (or
+# ``</>``) line — a mangled ``</think>`` — which must never reach the
+# screen as literal text. The artifact is hidden in every state, and while
+# a think block is open it also closes the block (without that valve,
+# everything after would render dim forever). Matching is anchored to the
+# whole line so inline occurrences in prose, tables, and code (``a <> b``)
+# are left untouched; fenced code is checked before this and always stays
+# literal anyway.
+_STRAY_THINK_ARTIFACT_RE = re.compile(r"^\s*</?>\s*$")
 
 
 def _styled(text: str, style: str) -> str:
@@ -506,6 +511,16 @@ class MarkdownStreamRenderer:
         # Inside a ``<think>`` block (reasoning models). Body lines render
         # dim-italic with a near-gray bar until the closing tag.
         self._in_think = False
+        # Think-opener guard. A bare ``<think>`` line is only treated as a
+        # reasoning block opener (a) before the first content line of the
+        # turn, or (b) right after a block-level boundary (tool row, status
+        # row, fence close, table block, previous think close). Genuine
+        # reasoning streams only ever open think blocks in those positions;
+        # a ``<think>`` line appearing after prose is the model *quoting*
+        # the tag (e.g. answering "what tag is used for X?") and must
+        # render literally instead of swallowing the reply.
+        self._seen_content = False
+        self._block_boundary = True
         # Blockquote continuation state: a `>` line opens a quote block;
         # consecutive non-empty lines keep it so multiline quotes style
         # uniformly. Cleared by a blank line or a non-quote block line.
@@ -546,6 +561,17 @@ class MarkdownStreamRenderer:
             out.append(rendered + "\n")
         return "".join(out)
 
+    def mark_boundary(self) -> None:
+        """Mark a block-level boundary in the prose stream.
+
+        Called by the streaming renderer whenever a non-markdown payload
+        (tool row, status row) is emitted inline. Genuine think blocks only
+        ever open right after such boundaries (or at turn start), so this
+        is what lets the opener guard accept them while rejecting
+        ``<think>`` lines quoted inside prose.
+        """
+        self._block_boundary = True
+
     def flush(self) -> str:
         """Emit any trailing partial line at end-of-turn."""
         if not self._enabled:
@@ -574,10 +600,18 @@ class MarkdownStreamRenderer:
         if not self._table_lines:
             return ""
         lines, self._table_lines = self._table_lines, []
+        # A table block is a block-level boundary: a think block opening
+        # right after it is a genuine reasoning block, not a quoted tag.
+        self._block_boundary = True
         return _render_table_block(lines)
 
+    def _can_open_think(self) -> bool:
+        """Think-opener guard: accept a bare ``<think>`` line only at turn
+        start or right after a block-level boundary (see ``__init__``)."""
+        return self._block_boundary or not self._seen_content
+
     def _render_line(self, line: str) -> str | None:
-        """Render one logical line.
+        """Render one logical line, maintaining the think-opener guard flags.
 
         Returns ``None`` when the line was buffered for a table block
         (emit nothing), otherwise the display text for the line — which
@@ -585,6 +619,31 @@ class MarkdownStreamRenderer:
         markers (the caller still emits the newline so paragraph spacing
         is preserved).
         """
+        was_in_think = self._in_think
+        rendered = self._render_line_inner(line)
+        stripped = line.strip()
+        if not stripped or rendered is None:
+            # Blank lines and buffered table rows leave the guard flags
+            # untouched: a blank line after prose must NOT re-arm the
+            # think-opener guard (that's the quoted-tag case).
+            return rendered
+        if was_in_think or self._in_think:
+            # Think body, an accepted opener, or a genuine close — none of
+            # these are prose content. A close re-arms the boundary so a
+            # following think block opens.
+            if was_in_think and not self._in_think:
+                self._block_boundary = True
+            return rendered
+        if _FENCE_RE.match(line) or _STRAY_THINK_ARTIFACT_RE.match(line):
+            self._block_boundary = True
+            return rendered
+        # A genuine content line: the turn has prose and the boundary is
+        # gone, so a following bare ``<think>`` is quoted text.
+        self._seen_content = True
+        self._block_boundary = False
+        return rendered
+
+    def _render_line_inner(self, line: str) -> str | None:
         # Fence open/close toggles state; the fence line itself is hidden
         # so the block reads as one continuous region.
         if _FENCE_RE.match(line):
@@ -593,18 +652,28 @@ class MarkdownStreamRenderer:
             return (table_out + "\n") if table_out else ""
         if self._in_fence:
             return _render_code_line(line)
+        # Stray think-tag artifacts (a bare ``<>`` / ``</>`` line) are
+        # hidden in every state; inside a think block they also close it.
+        # Checked after fences so code stays literal, and anchored to the
+        # whole line so prose/table content like ``a <> b`` is untouched.
+        if _STRAY_THINK_ARTIFACT_RE.match(line):
+            if self._in_think:
+                self._in_think = False
+            return ""
         # Think blocks: tags own their line and are hidden; body lines
         # render dim-italic with a near-gray bar. Checked after fences so
-        # a ``<think>`` inside a code fence stays literal code.
-        inline_think = _THINK_INLINE_RE.match(line)
-        if inline_think:
-            return _render_think_line(inline_think.group(1))
-        if _THINK_OPEN_RE.match(line):
-            self._in_think = True
-            table_out = self._flush_table()
-            return (table_out + "\n") if table_out else ""
+        # a ``<think>`` inside a code fence stays literal code. The opener
+        # guard rejects tags quoted inside prose (they render literally).
+        if self._can_open_think():
+            inline_think = _THINK_INLINE_RE.match(line)
+            if inline_think:
+                return _render_think_line(inline_think.group(1))
+            if _THINK_OPEN_RE.match(line):
+                self._in_think = True
+                table_out = self._flush_table()
+                return (table_out + "\n") if table_out else ""
         if self._in_think:
-            if _THINK_CLOSE_RE.match(line) or line.strip() == _THINK_STRAY_CLOSER:
+            if _THINK_CLOSE_RE.match(line):
                 self._in_think = False
                 return ""
             return _render_think_line(line)

--- a/src/agentos/cli/tui/terminal/markdown_stream.py
+++ b/src/agentos/cli/tui/terminal/markdown_stream.py
@@ -58,6 +58,12 @@ _ITALIC_STYLE = "italic"
 _STRIKE_STYLE = "strike"
 _LINK_STYLE = f"underline {ACCENT_SOFT}"
 _LINK_URL_STYLE = "dim"
+# Think blocks (<think>…</think> from reasoning models): deliberately
+# *less* prominent than quotes — no accent color at all, just a near-gray
+# bar and dim italic text, so the reasoning reads as background context
+# and never competes with the actual reply.
+_THINK_BAR_STYLE = "#3a3a3a"
+_THINK_TEXT_STYLE = "dim italic"
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +81,16 @@ _BOLD_RE = re.compile(r"\*\*([^*\n]+)\*\*")
 _ITALIC_RE = re.compile(r"(?<!\*)\*([^*\n]+)\*(?!\*)")
 _STRIKE_RE = re.compile(r"~~([^~\n]+)~~")
 _LINK_RE = re.compile(r"\[([^\]\n]+)\]\(([^)\s]+)\)")
+
+# Reasoning-model think tags. The block forms own a whole line; the
+# single-line form wraps content inline (``<think>…</think>``). A bare
+# ``<>`` line while a block is open is accepted as a defensive closer —
+# some models / transports mangle ``</think>`` into it, and without the
+# valve everything after would render dim forever.
+_THINK_OPEN_RE = re.compile(r"^\s*<think>\s*$")
+_THINK_CLOSE_RE = re.compile(r"^\s*</think>\s*$")
+_THINK_INLINE_RE = re.compile(r"^\s*<think>(.*?)</think>\s*$")
+_THINK_STRAY_CLOSER = "<>"
 
 
 def _styled(text: str, style: str) -> str:
@@ -149,6 +165,19 @@ def _render_inline(text: str) -> str:
 def _render_code_line(line: str) -> str:
     """A line inside a fenced code block: uniform code style, escaped."""
     return _styled(_rich_escape(line) or " ", _CODE_STYLE)
+
+
+def _render_think_line(line: str) -> str:
+    """A line inside a ``<think>`` block: near-gray bar + dim italic text.
+
+    Intentionally plainer than the quote style — the accent palette is
+    reserved for the actual reply, so the reasoning stays visibly present
+    but visually recessive.
+    """
+    bar = _styled("▎", _THINK_BAR_STYLE)
+    if not line.strip():
+        return bar
+    return f"{bar} {_styled(_rich_escape(line), _THINK_TEXT_STYLE)}"
 
 
 # ---------------------------------------------------------------------------
@@ -474,6 +503,9 @@ class MarkdownStreamRenderer:
         self._enabled = enabled
         self._pending = ""
         self._in_fence = False
+        # Inside a ``<think>`` block (reasoning models). Body lines render
+        # dim-italic with a near-gray bar until the closing tag.
+        self._in_think = False
         # Blockquote continuation state: a `>` line opens a quote block;
         # consecutive non-empty lines keep it so multiline quotes style
         # uniformly. Cleared by a blank line or a non-quote block line.
@@ -561,6 +593,21 @@ class MarkdownStreamRenderer:
             return (table_out + "\n") if table_out else ""
         if self._in_fence:
             return _render_code_line(line)
+        # Think blocks: tags own their line and are hidden; body lines
+        # render dim-italic with a near-gray bar. Checked after fences so
+        # a ``<think>`` inside a code fence stays literal code.
+        inline_think = _THINK_INLINE_RE.match(line)
+        if inline_think:
+            return _render_think_line(inline_think.group(1))
+        if _THINK_OPEN_RE.match(line):
+            self._in_think = True
+            table_out = self._flush_table()
+            return (table_out + "\n") if table_out else ""
+        if self._in_think:
+            if _THINK_CLOSE_RE.match(line) or line.strip() == _THINK_STRAY_CLOSER:
+                self._in_think = False
+                return ""
+            return _render_think_line(line)
         # Table lines buffer until the block closes.
         if _is_table_line(line):
             self._table_lines.append(line)

--- a/src/agentos/cli/tui/terminal/prompt.py
+++ b/src/agentos/cli/tui/terminal/prompt.py
@@ -74,12 +74,13 @@ _toolbar_context: dict[str, object | None] = {
     # bottom toolbar so a pin set via ``/c3`` stays visible while typing.
     "router_tier": None,
     "suppress": None,
-    # Transient status surfaced in the assistant input header before the
-    # first streamed chunk lands. Holds a live WaitingIndicator instance
+    # Turn-lifetime status surfaced in the assistant input header above
+    # the pinned input frame. Holds a live WaitingIndicator instance
     # (see cli/repl/stream.py) whose toolbar_text() is read on every
     # redraw so the Braille spinner advances frame-by-frame. May also be
     # a plain string for ad-hoc callers using ChatApplication.set_toolbar().
-    # Cleared (set to None) when the stream starts or the turn ends.
+    # Mounted for the whole turn (pre-token, mid-stream, tool calls);
+    # cleared (set to None) when the turn ends.
     "status": None,
     # Assistant speaker label; sourced from DEFAULT_ASSISTANT_LABEL but
     # overridable per session. Read by the streamed renderer marker and
@@ -248,7 +249,7 @@ def _chrome_bottom() -> None:
 
 
 def _input_header_fragments() -> AnyFormattedText:
-    """Render pre-token waiting feedback on the assistant reply row."""
+    """Render the turn-lifetime waiting indicator on the assistant reply row."""
     status_obj = _toolbar_context.get("status")
     if status_obj is None:
         return HTML("")

--- a/src/agentos/cli/tui/terminal/selection.py
+++ b/src/agentos/cli/tui/terminal/selection.py
@@ -1,0 +1,187 @@
+"""Mouse-driven text selection for the full-screen transcript pane.
+
+The full-screen chat surface enables terminal mouse reporting so the
+transcript pane can handle wheel scrolls. That reporting also blocks the
+emulator's native drag-select, which previously made it impossible to
+copy chat text. This module adds an in-app selection model:
+
+  * ``MOUSE_DOWN`` (left) on the transcript starts a selection.
+  * ``MOUSE_MOVE`` extends it.
+  * ``MOUSE_UP`` finalizes the selection and copies the plain text
+    (ANSI-stripped, width-aware slice) to the system clipboard.
+
+The pane re-renders the transcript with a ``reverse`` style applied to
+the selected column ranges so the user sees the highlight. Scroll events
+continue to pass through to the existing wheel handler.
+
+Coordinates: prompt-toolkit's Window mouse wrapper already converts the
+absolute screen ``(x, y)`` into content ``(row, col)`` coordinates, where
+``row`` is the logical transcript line index and ``col`` is the display
+column within that line (CJK-aware). Selection math works in that
+content-coordinate space, so no additional scroll math is required here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from prompt_toolkit.formatted_text import ANSI, StyleAndTextTuples
+from prompt_toolkit.formatted_text.utils import split_lines
+from prompt_toolkit.utils import get_cwidth
+
+__all__ = [
+    "Selection",
+    "extract_selection_text",
+    "highlight_fragments",
+]
+
+
+# Match CSI/OSC/DCS/2-char escape sequences. Identical to the pattern in
+# ``stream.py`` — kept as a local copy so this module does not import the
+# streaming renderer (avoiding the Rich/UI import chain at startup).
+_ANSI_RE = re.compile(
+    r"\x1b(?:"
+    r"\[[0-?]*[ -/]*[@-~]"  # CSI ... final byte
+    r"|\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC ... BEL or ST
+    r"|P[^\x1b]*\x1b\\"  # DCS ... ST
+    r"|[@-Z\\-_]"  # 2-char ESC (RIS, IND, NEL, ...)
+    r")"
+)
+
+
+@dataclass(frozen=True)
+class Selection:
+    """A contiguous span across transcript logical lines.
+
+    ``anchor``/``cursor`` are ``(row, col)`` content-coordinate tuples
+    where ``row`` indexes ``transcript.split("\\n")`` and ``col`` is a
+    display column (CJK-aware). ``anchor`` is where the drag started;
+    ``cursor`` is where the mouse is now. The two may be in either order.
+    """
+
+    anchor: tuple[int, int]
+    cursor: tuple[int, int]
+
+    def normalized(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        """Return ``(start, end)`` in reading order."""
+        if self.anchor <= self.cursor:
+            return self.anchor, self.cursor
+        return self.cursor, self.anchor
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _slice_by_columns(plain_line: str, start_col: int, end_col: int) -> str:
+    """Slice ``plain_line`` by display columns (CJK-aware).
+
+    Returns the substring whose characters occupy columns in
+    ``[start_col, end_col)``. Characters wider than one column are
+    included only when they fit fully inside the window.
+    """
+    if end_col <= start_col:
+        return ""
+    out: list[str] = []
+    col = 0
+    for ch in plain_line:
+        w = get_cwidth(ch)
+        next_col = col + w
+        if col >= end_col:
+            break
+        if next_col > start_col and col < end_col:
+            # Include when the character overlaps the window.
+            if col >= start_col and next_col <= end_col:
+                out.append(ch)
+        col = next_col
+    return "".join(out)
+
+
+def extract_selection_text(transcript: str, selection: Selection) -> str:
+    """Return the plain-text content of ``selection`` from ``transcript``.
+
+    ANSI styling is stripped first; the column slicing is applied to the
+    plain lines. Multi-line selections preserve the newline separators.
+    """
+    plain = _strip_ansi(transcript)
+    lines = plain.split("\n")
+    (r1, c1), (r2, c2) = selection.normalized()
+    if r1 == r2:
+        if r1 >= len(lines):
+            return ""
+        return _slice_by_columns(lines[r1], c1, c2)
+    if r1 >= len(lines):
+        return ""
+    r2 = min(r2, len(lines) - 1)
+    pieces: list[str] = [_slice_by_columns(lines[r1], c1, 1 << 30)]
+    for row in range(r1 + 1, r2):
+        pieces.append(lines[row])
+    pieces.append(_slice_by_columns(lines[r2], 0, c2))
+    # Trim trailing whitespace introduced by column slicing on the tail.
+    return "\n".join(pieces).rstrip()
+
+
+def _highlight_line(
+    line: StyleAndTextTuples,
+    start_col: int,
+    end_col: int,
+    style_suffix: str,
+) -> StyleAndTextTuples:
+    """Return a copy of ``line`` with ``style_suffix`` appended to the style
+    of every fragment whose characters overlap ``[start_col, end_col)``.
+
+    Fragment tuples from prompt-toolkit are ``(style, text)`` or
+    ``(style, text, mouse_handler)``. We rebuild them preserving any
+    third element.
+    """
+    out: StyleAndTextTuples = []
+    col = 0
+    for item in line:
+        style = item[0]
+        text = item[1]
+        rest = item[2:] if len(item) > 2 else ()
+        w = get_cwidth(text)
+        next_col = col + w
+        overlaps = next_col > start_col and col < end_col
+        new_style = f"{style}{style_suffix}" if overlaps else style
+        new_item: tuple[Any, ...] = (new_style, text, *rest)
+        out.append(new_item)  # type: ignore[arg-type]
+        col = next_col
+    return out
+
+
+def highlight_fragments(
+    transcript: str,
+    selection: Selection,
+    style_suffix: str = " reverse",
+) -> StyleAndTextTuples:
+    """Return a fragment list of ``transcript`` with the selection
+    highlighted.
+
+    The transcript is parsed once with ``ANSI`` and the fragment list is
+    walked per line; ``style_suffix`` is appended to the existing style
+    string of overlapping fragments so the original colors are preserved
+    and only the reverse-video attribute is layered on top.
+    """
+    fragments = ANSI(transcript).__pt_formatted_text__()
+    lines = list(split_lines(fragments))
+    (r1, c1), (r2, c2) = selection.normalized()
+    highlighted: StyleAndTextTuples = []
+    for row, line in enumerate(lines):
+        if row < r1 or row > r2:
+            highlighted.extend(line)
+        elif r1 == r2:
+            highlighted.extend(_highlight_line(line, c1, c2, style_suffix))
+        elif row == r1:
+            highlighted.extend(_highlight_line(line, c1, 1 << 30, style_suffix))
+        elif row == r2:
+            highlighted.extend(_highlight_line(line, 0, c2, style_suffix))
+        else:
+            highlighted.extend(_highlight_line(line, 0, 1 << 30, style_suffix))
+        # ``split_lines`` drops the trailing newline; re-insert between
+        # logical lines so the rendered row count matches the source.
+        if row < len(lines) - 1:
+            highlighted.append(("", "\n"))
+    return highlighted

--- a/src/agentos/cli/tui/terminal/stream.py
+++ b/src/agentos/cli/tui/terminal/stream.py
@@ -517,6 +517,11 @@ class StreamingRenderer:
         payload += self._flush_markdown()
         if self._stream_started and self.buffer and not self.buffer.endswith("\n"):
             payload += "\n"
+        # A tool row / status row / finalize is a block-level interruption
+        # of the prose stream — genuine think blocks open right after such
+        # boundaries, so the markdown renderer's think-opener guard keys
+        # off this marker (see markdown_stream.mark_boundary).
+        self._markdown.mark_boundary()
         return payload
 
     def append_text(self, delta: str) -> None:

--- a/src/agentos/cli/tui/terminal/stream.py
+++ b/src/agentos/cli/tui/terminal/stream.py
@@ -11,6 +11,11 @@ from typing import Any, Literal
 from rich.text import Text
 
 from agentos.cli.chat.turn import TurnResult, UsageCounter, UsageSummary
+from agentos.cli.tui.terminal.markdown_stream import (
+    MarkdownStreamRenderer,
+    markdown_enabled,
+    render_markup_to_ansi,
+)
 from agentos.cli.tui.terminal.prompt import DEFAULT_ASSISTANT_LABEL, _toolbar_context
 from agentos.cli.ui import ACCENT, ACCENT_SOFT, console, error_panel
 
@@ -265,16 +270,17 @@ class _ToolCallStrip:
 
 
 class WaitingIndicator:
-    """Pre-token waiting renderable: spinner frame + verb + elapsed.
+    """Turn-lifetime waiting renderable: spinner frame + verb + elapsed.
 
-    The instance is parked in ``_toolbar_context['status']`` while the turn
-    is in flight but has not yet produced its first chunk. The
-    prompt-toolkit input header reads the slot on every redraw and calls
-    :meth:`toolbar_text` to pull the live frame; combined with the
-    ``PromptSession``'s ``refresh_interval`` this gives the assistant reply
-    row a real Braille spinner without mounting any Rich ``Live`` region
-    (which had historically caused ghost-panel artefacts on Windows
-    PowerShell).
+    The instance is parked in ``_toolbar_context['status']`` for the whole
+    turn — while the model is thinking pre-token, while tokens stream, and
+    while tool calls run — so the user always sees an "agent is working"
+    signal pinned above the input frame. The prompt-toolkit input header
+    reads the slot on every redraw and calls :meth:`toolbar_text` to pull
+    the live frame; combined with the ``PromptSession``'s
+    ``refresh_interval`` this gives the assistant reply row a real Braille
+    spinner without mounting any Rich ``Live`` region (which had
+    historically caused ghost-panel artefacts on Windows PowerShell).
 
     The verb tuple and dwell duration are mirrored in the gateway-side
     ``chat.js`` (``CAP_VERBS`` / ``CAP_DWELL_MS``) so the CLI and
@@ -324,18 +330,25 @@ class WaitingIndicator:
 class StreamingRenderer:
     """One streaming renderer for gateway and standalone responses.
 
-    Strategy: a transient assistant status header before the first token
-    (no Rich ``Live`` instance), then a plain-text token stream that writes
-    deltas straight to the terminal. There is no post-stream re-render —
-    the streamed text is the final view, matching how Claude Code, codex,
-    aider, and other agent CLIs present model output. This avoids the Rich
-    ``Live`` + ``Markdown`` + ``Panel`` update loop, which leaked ghost
-    panel borders on Windows PowerShell and other terminals whenever the
-    rendered height grew past the visible viewport (CJK width-measurement
-    made the overflow common), and it also avoids the doubled output a
-    one-shot re-render produces.
+    Strategy: a turn-lifetime assistant status indicator in the input
+    header (no Rich ``Live`` instance) — mounted from turn start through
+    the last token / tool call and cleared only at finalize / error /
+    cancel — plus a token stream that writes deltas straight to the
+    terminal through a line-buffered markdown pass
+    (:mod:`agentos.cli.tui.terminal.markdown_stream`). There is no
+    post-stream re-render — the streamed text is the final view, matching
+    how Claude Code, codex, aider, and other agent CLIs present model
+    output. The markdown pass preserves that contract: it buffers each
+    delta only until a newline arrives, styles the completed line once
+    (headings, quotes, rules, lists, tables, fenced code, inline
+    ``**bold**`` / ``*italic*`` / ``~~strike~~`` / ``code`` / links), and
+    never repaints — avoiding the Rich ``Live`` + ``Markdown`` + ``Panel``
+    update loop, which leaked ghost panel borders on Windows PowerShell
+    and other terminals whenever the rendered height grew past the
+    visible viewport (CJK width-measurement made the overflow common),
+    and also avoiding the doubled output a one-shot re-render produces.
 
-    The pre-token waiting state lives in the prompt-toolkit
+    The waiting indicator lives in the prompt-toolkit
     input-header slot via the shared ``_toolbar_context['status']`` key. We
     park a live :class:`WaitingIndicator` instance there and the header
     callable pulls the current spinner frame / verb / elapsed on every redraw.
@@ -369,6 +382,12 @@ class StreamingRenderer:
         self._visible_output = False
         self._strip = _ToolCallStrip()
         self._directive_sanitizer = _DirectiveStreamSanitizer()
+        # Line-buffered markdown pass over the sanitized stream. Disabled
+        # under NO_COLOR / non-color consoles so piped output stays plain.
+        # The raw text (pre-markdown) is what lands in ``self.buffer`` so
+        # downstream consumers (``/save``, transcript markdown) keep the
+        # source of truth; the styled form only reaches the terminal.
+        self._markdown = MarkdownStreamRenderer(enabled=markdown_enabled())
         # Optional TUI output handle. When provided, async callers can route
         # token writes through `aappend_text` so the output mutex serializes the
         # write-and-flush with concurrent slash-handler / input-echo writes.
@@ -416,6 +435,12 @@ class StreamingRenderer:
         return self
 
     def __exit__(self, exc_type, exc, tb) -> Literal[False]:
+        # Drain any line the markdown pass still holds (the with-block
+        # pattern has no explicit finalize call, so without this the
+        # trailing partial line would silently vanish).
+        flushed = self._flush_markdown()
+        if flushed:
+            self._write_payload(flushed)
         self.stop()
         return False
 
@@ -440,17 +465,39 @@ class StreamingRenderer:
         self._waiting_active = False
 
     def _begin_stream(self) -> str:
-        """Drop waiting feedback and return the assistant marker.
+        """Return the assistant marker once, when visible text actually starts.
 
         Called only once the first visible text delta lands, so control-only
-        chunks do not leave empty reply chrome in scrollback.
+        chunks do not leave empty reply chrome in scrollback. The waiting
+        indicator stays mounted in the input header — it is the turn-lifetime
+        "agent is working" signal, only cleared by :meth:`stop` (finalize /
+        error / cancel), not by the first token.
         """
         if self._stream_started:
             return ""
-        self._stop_waiting()
         marker = self._open_assistant_status_line()
         self._stream_started = True
         return marker
+
+    def _render_stream_payload(self, visible: str) -> str:
+        """Render a sanitized text delta for terminal display.
+
+        Runs the line-buffered markdown pass and converts the resulting
+        Rich markup to ANSI. When markdown is disabled (``NO_COLOR`` /
+        non-color console) the raw text is returned unchanged so model
+        bytes reach the terminal verbatim — no Rich markup parsing, no
+        tab expansion. The raw ``visible`` text still lands in
+        ``self.buffer``; only the *display* form is styled.
+        """
+        if not self._markdown.enabled:
+            return visible
+        return render_markup_to_ansi(self._markdown.feed(visible))
+
+    def _flush_markdown(self) -> str:
+        """Emit any trailing partial line the markdown pass still holds."""
+        if not self._markdown.enabled:
+            return self._markdown.flush()
+        return render_markup_to_ansi(self._markdown.flush())
 
     def _end_stream_line(self) -> str:
         """Ensure subsequent console.print starts on a fresh line."""
@@ -465,6 +512,9 @@ class StreamingRenderer:
             payload += trailing
             self.buffer += trailing
             self._visible_output = True
+        # Drain the markdown line buffer (no trailing newline added — the
+        # block below owns line termination).
+        payload += self._flush_markdown()
         if self._stream_started and self.buffer and not self.buffer.endswith("\n"):
             payload += "\n"
         return payload
@@ -487,7 +537,7 @@ class StreamingRenderer:
         # markdown), so raw model bytes that contain ANSI cannot resurface
         # via downstream consumers.
         self.buffer += visible
-        payload = self._begin_stream() + visible
+        payload = self._begin_stream() + self._render_stream_payload(visible)
         self._visible_output = True
         # Write straight to the underlying stream: no Rich markup parsing
         # (model output may contain ``[bracket]`` sequences), no auto-wrap
@@ -513,7 +563,7 @@ class StreamingRenderer:
         if not visible:
             return
         self.buffer += visible
-        payload = self._begin_stream() + visible
+        payload = self._begin_stream() + self._render_stream_payload(visible)
         self._visible_output = True
         await self._awrite_payload(payload)
 
@@ -522,10 +572,11 @@ class StreamingRenderer:
 
         Pre-token: the waiting indicator's own refresh loop keeps the elapsed
         counter alive; we just make sure it is still mounted. Mid-stream the
-        arriving tokens are the progress signal, so pulse is a no-op.
+        arriving tokens are the progress signal, but the indicator stays
+        mounted too (it is the turn-lifetime "agent is working" signal), so
+        pulse only re-mounts if something cleared it externally.
         """
-        if not self._stream_started:
-            self._start_waiting()
+        self._start_waiting()
 
     def error(self, message: str) -> None:
         payload = self._end_stream_line()
@@ -546,14 +597,12 @@ class StreamingRenderer:
 
     def status(self, message: str, *, style: str = "dim") -> None:
         payload = self._end_stream_line()
-        self._stop_waiting()
         self._visible_output = True
         payload += _capture_console_print(Text(message, style=style))
         self._write_payload(payload)
 
     async def astatus(self, message: str, *, style: str = "dim") -> None:
         payload = self._end_stream_line()
-        self._stop_waiting()
         self._visible_output = True
         payload += _capture_console_print(Text(message, style=style))
         await self._awrite_payload(payload)
@@ -565,7 +614,6 @@ class StreamingRenderer:
         tool_use_id: str | None = None,
     ) -> None:
         payload = self._end_stream_line()
-        self._stop_waiting()
         summary = _summarize_args(name, args)
         self._visible_output = True
         payload += self._strip.record_start_payload(name, summary, tool_use_id)
@@ -578,7 +626,6 @@ class StreamingRenderer:
         tool_use_id: str | None = None,
     ) -> None:
         payload = self._end_stream_line()
-        self._stop_waiting()
         summary = _summarize_args(name, args)
         self._visible_output = True
         payload += self._strip.record_start_payload(name, summary, tool_use_id)
@@ -720,22 +767,22 @@ class StreamingRenderer:
         self._stop_waiting()
 
     def start(self) -> None:
-        """Resume visible feedback after an external pause (e.g. approvals).
+        """Resume the turn-lifetime waiting indicator after an external pause.
 
-        If no content has streamed yet, bring back the waiting indicator so
-        the user still sees that work is in progress. Once token streaming
-        has begun the next ``append_text`` resumes naturally, so there is
-        nothing to restart here.
+        The indicator is mounted for the whole turn (pre-token, mid-stream,
+        tool calls), so ``start`` simply re-mounts it; :meth:`_start_waiting`
+        is idempotent when it is already active.
         """
-        if not self._stream_started:
-            self._start_waiting()
+        self._start_waiting()
 
     @contextmanager
     def paused(self) -> Iterator[None]:
+        """Suspend the indicator during an inline approval (which owns the
+        screen), restoring it on exit so the turn signal resumes."""
         had_waiting = self._waiting_active
         self.stop()
         try:
             yield
         finally:
-            if had_waiting and not self._stream_started:
+            if had_waiting:
                 self._start_waiting()

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -79,7 +79,14 @@ mouse wheel also scrolls when the pointer is over the transcript. Dragging the
 left mouse button across the transcript highlights a span in reverse video;
 releasing the button copies the plain text (ANSI stripped, CJK width-aware) to
 the system clipboard (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`, with
-an OSC 52 fallback). Click again to clear the selection. In the
+an OSC 52 fallback). Click again to clear the selection. The assistant's
+streamed reply is styled inline as it arrives: `#` headings in the brand
+accent, `>` quotes with a dimmed bar, `---` rules, tinted list markers,
+aligned tables, fenced code blocks streamed in a uniform code color, and
+inline `**bold**` / `*italic*` / `~~strike~~` / `code` / `[text](url)`
+links. Backticked file names and branch names stand out in the accent
+color. The render is write-once (no repaint); `NO_COLOR` or a non-color
+terminal downgrades the stream to plain text. In the
 multiline input, `Home`/`End` and `Ctrl+A`/`Ctrl+E` move to the current line's
 start/end; macOS `Cmd+Left`/`Cmd+Right` work when the terminal maps them to
 `Home`/`End`. Set `AGENTOS_CHAT_FULLSCREEN=0` to opt out to native scrollback;

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -75,7 +75,11 @@ top and bottom rule so it reads as a distinct box; the bottom toolbar renders
 default: the conversation renders in a scrollable pane above the pinned input
 frame (the branded welcome screen shows at the top on launch), so the frame
 stays visible while the assistant streams (`PgUp`/`PgDn` scroll history). The
-mouse wheel also scrolls when the pointer is over the transcript. In the
+mouse wheel also scrolls when the pointer is over the transcript. Dragging the
+left mouse button across the transcript highlights a span in reverse video;
+releasing the button copies the plain text (ANSI stripped, CJK width-aware) to
+the system clipboard (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`, with
+an OSC 52 fallback). Click again to clear the selection. In the
 multiline input, `Home`/`End` and `Ctrl+A`/`Ctrl+E` move to the current line's
 start/end; macOS `Cmd+Left`/`Cmd+Right` work when the terminal maps them to
 `Home`/`End`. Set `AGENTOS_CHAT_FULLSCREEN=0` to opt out to native scrollback;

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -85,7 +85,10 @@ accent, `>` quotes with a dimmed bar, `---` rules, tinted list markers,
 aligned tables, fenced code blocks streamed in a uniform code color, and
 inline `**bold**` / `*italic*` / `~~strike~~` / `code` / `[text](url)`
 links. Backticked file names and branch names stand out in the accent
-color. The render is write-once (no repaint); `NO_COLOR` or a non-color
+color. Reasoning-model `<think>…</think>` blocks render as a recessive
+gray-bar, dim-italic region with the tags hidden, so chain-of-thought
+stays visible but never competes with the reply. The render is
+write-once (no repaint); `NO_COLOR` or a non-color
 terminal downgrades the stream to plain text. In the
 multiline input, `Home`/`End` and `Ctrl+A`/`Ctrl+E` move to the current line's
 start/end; macOS `Cmd+Left`/`Cmd+Right` work when the terminal maps them to

--- a/tests/test_cli/test_repl_waiting_indicator.py
+++ b/tests/test_cli/test_repl_waiting_indicator.py
@@ -117,8 +117,8 @@ def test_pulse_restart_preserves_monotonic_elapsed() -> None:
 
 
 def test_streaming_renderer_uses_toolbar_status_not_rich_live() -> None:
-    """Lock down: pre-token feedback is a live ``WaitingIndicator`` parked
-    in the prompt-toolkit assistant header slot, not a Rich ``Live`` region.
+    """Lock down: turn feedback is a live ``WaitingIndicator`` parked in the
+    prompt-toolkit assistant header slot, not a Rich ``Live`` region.
 
     Historical context: a Markdown+Panel Live update loop produced ghost
     panel borders on Windows PowerShell whenever the rendered height grew
@@ -126,6 +126,9 @@ def test_streaming_renderer_uses_toolbar_status_not_rich_live() -> None:
     Live instance and routed waiting feedback through
     ``_toolbar_context['status']``; the header callable pulls the current
     spinner frame on every redraw driven by ``PromptSession.refresh_interval``.
+
+    The indicator is mounted for the *whole turn* — pre-token, mid-stream,
+    and across tool calls — and cleared only when the turn ends.
     """
     from agentos.cli.repl import prompt as prompt_mod
 
@@ -144,12 +147,75 @@ def test_streaming_renderer_uses_toolbar_status_not_rich_live() -> None:
             mounted = prompt_mod._toolbar_context.get("status")
             assert isinstance(mounted, WaitingIndicator)
             renderer.append_text("foo")
-            # First chunk clears the status block before any text writes.
-            assert prompt_mod._toolbar_context.get("status") is None
+            # Tokens do NOT clear the indicator — it is the turn-lifetime
+            # "agent is working" signal above the input frame.
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
             renderer.append_text("bar")
             renderer.pulse()
-        # On stop the status block stays cleared.
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+        # On exit the status block is cleared.
         assert prompt_mod._toolbar_context.get("status") is None
+    finally:
+        prompt_mod._toolbar_context["status"] = previous_status
+
+
+def test_waiting_indicator_survives_tool_rows_and_clears_at_finalize(
+    monkeypatch,
+) -> None:
+    """Tool rows, status rows, and streamed text must not drop the
+    turn-lifetime indicator; finalize/error are the only clears."""
+    from agentos.cli.repl import prompt as prompt_mod
+
+    buf = io.StringIO()
+    test_console = Console(file=buf, force_terminal=False, width=120, highlight=False)
+    monkeypatch.setattr(stream_module, "console", test_console)
+
+    previous_status = prompt_mod._toolbar_context.get("status")
+    try:
+        prompt_mod._toolbar_context["status"] = None
+        with StreamingRenderer() as renderer:
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+            renderer.tool_start("read_file", {"path": "x"}, None)
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+            renderer.append_text("answer text\n")
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+            renderer.status("working…")
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+            renderer.finalize(usage=None)
+            assert prompt_mod._toolbar_context.get("status") is None
+    finally:
+        prompt_mod._toolbar_context["status"] = previous_status
+
+
+def test_waiting_indicator_cleared_on_error() -> None:
+    from agentos.cli.repl import prompt as prompt_mod
+
+    previous_status = prompt_mod._toolbar_context.get("status")
+    try:
+        prompt_mod._toolbar_context["status"] = None
+        with StreamingRenderer() as renderer:
+            renderer.append_text("partial\n")
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+            renderer.error("boom")
+            assert prompt_mod._toolbar_context.get("status") is None
+    finally:
+        prompt_mod._toolbar_context["status"] = previous_status
+
+
+def test_waiting_indicator_restored_after_pause() -> None:
+    """The approval pause context suspends and restores the indicator,
+    even mid-stream."""
+    from agentos.cli.repl import prompt as prompt_mod
+
+    previous_status = prompt_mod._toolbar_context.get("status")
+    try:
+        prompt_mod._toolbar_context["status"] = None
+        with StreamingRenderer() as renderer:
+            renderer.append_text("stream started\n")
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
+            with renderer.paused():
+                assert prompt_mod._toolbar_context.get("status") is None
+            assert isinstance(prompt_mod._toolbar_context.get("status"), WaitingIndicator)
     finally:
         prompt_mod._toolbar_context["status"] = previous_status
 

--- a/tests/unit/cli/repl/test_markdown_stream.py
+++ b/tests/unit/cli/repl/test_markdown_stream.py
@@ -232,9 +232,9 @@ def test_think_single_line_form() -> None:
 
 
 def test_empty_think_block_produces_no_body_lines() -> None:
-    out = _render_all(["before\n", "<think>\n", "</think>\n", "after\n"])
+    out = _render_all(["<think>\n", "</think>\n", "after\n"])
     lines = _display_lines(out)
-    assert lines == ["before", "", "", "after"]
+    assert lines == ["", "", "after"]
 
 
 def test_think_stray_angle_bracket_closes_block() -> None:
@@ -269,22 +269,158 @@ def test_unclosed_think_flushes_dim() -> None:
 
 
 def test_think_state_resets_between_blocks() -> None:
-    out = _render_all(
-        [
-            "<think>\n",
-            "one\n",
-            "</think>\n",
-            "main content\n",
-            "<think>\n",
-            "two\n",
-            "</think>\n",
-            "more content\n",
-        ]
-    )
+    r = MarkdownStreamRenderer(enabled=True)
+    out = r.feed("<think>\n")
+    out += r.feed("one\n")
+    out += r.feed("</think>\n")
+    out += r.feed("main content\n")
+    # A tool row (or any block-level interruption) lands here in the real
+    # stream — that's what re-arms the think-opener guard.
+    r.mark_boundary()
+    out += r.feed("<think>\n")
+    out += r.feed("two\n")
+    out += r.feed("</think>\n")
+    out += r.feed("more content\n")
+    out += r.flush()
     assert "[dim italic]one[/]" in out
     assert "[dim italic]two[/]" in out
     assert "[dim italic]main content[/]" not in out
     assert "[dim italic]more content[/]" not in out
+
+
+# ---------------------------------------------------------------------------
+# Think-opener guard: quoted tags in prose must NOT open a think block
+# ---------------------------------------------------------------------------
+
+
+def test_bare_think_tag_after_prose_renders_literally() -> None:
+    """The user asks "what tag is used for X?" — the agent's reply quotes
+    the tag on its own line. It must stay visible, not open a think block."""
+    out = _render_all(
+        [
+            "The tag to use is:\n",
+            "<think>\n",
+            "and the closing tag is\n",
+            "</think>\n",
+        ]
+    )
+    lines = _display_lines(out)
+    assert "<think>" in lines
+    assert "</think>" in lines
+    assert "and the closing tag is" in lines
+    assert "[dim italic]" not in out
+
+
+def test_bare_think_tag_after_blank_prose_line_still_literal() -> None:
+    """Even with a paragraph break before it, a quoted tag after prose is
+    not a reasoning block (blanks do not re-arm the guard)."""
+    out = _render_all(["some explanation\n", "\n", "<think>\n", "body\n"])
+    lines = _display_lines(out)
+    assert "<think>" in lines
+    assert "[dim italic]" not in out
+
+
+def test_single_line_think_after_prose_renders_literally() -> None:
+    out = _render_all(["example format:\n", "<think>some content</think>\n"])
+    lines = _display_lines(out)
+    assert "<think>some content</think>" in lines
+
+
+def test_think_opens_after_tool_row_boundary() -> None:
+    """The genuine reasoning pattern: prose, tool call, then think."""
+    r = MarkdownStreamRenderer(enabled=True)
+    out = r.feed("Let me check the balance.\n")
+    r.mark_boundary()  # tool row emitted at this point in the real stream
+    out += r.feed("<think>\n")
+    out += r.feed("user has 0.897 ETH\n")
+    out += r.feed("</think>\n")
+    out += r.flush()
+    assert "[dim italic]user has 0.897 ETH[/]" in out
+    assert "<think>" not in out
+
+
+def test_think_opens_after_fence_close() -> None:
+    out = _render_all(["```\n", "code\n", "```\n", "<think>\n", "reasoning\n", "</think>\n"])
+    assert "[dim italic]reasoning[/]" in out
+
+
+def test_think_tag_in_backticks_untouched() -> None:
+    out = _render_all(["The tags are `<think>` and `</think>`.\n"])
+    assert "[bold #DDFF66]<think>[/]" in out
+    assert "[bold #DDFF66]</think>[/]" in out
+
+
+def test_think_tag_question_full_flow() -> None:
+    """End-to-end: a tag-explanation answer loses nothing."""
+    r = MarkdownStreamRenderer(enabled=True)
+    answer = (
+        "The tag for code snippets is `<code>` or a fenced block:\n"
+        "\n"
+        "```\n"
+        "<think>\n"
+        "```\n"
+        "\n"
+        "The reasoning tag is <think> (rarely seen in prose).\n"
+    )
+    out = r.feed(answer) + r.flush()
+    lines = _display_lines(out)
+    assert any("<code>" in ln for ln in lines)
+    # The fenced example stays literal code.
+    assert "[#DDFF66 on #1a1a1a]<think>[/]" in out
+    # The inline prose mention stays visible and undimmed.
+    assert any("<think> (rarely seen in prose)." in ln for ln in lines)
+    assert "[dim italic]" not in out
+
+
+# ---------------------------------------------------------------------------
+# Stray think-tag artifacts (bare ``<>`` / ``</>`` lines from the model)
+# ---------------------------------------------------------------------------
+
+
+def test_stray_angle_bracket_line_hidden_outside_think() -> None:
+    out = _render_all(["some answer\n", "<>\n", "next line\n"])
+    lines = _display_lines(out)
+    assert lines == ["some answer", "", "next line"]
+
+
+def test_stray_closing_angle_bracket_line_hidden() -> None:
+    out = _render_all(["text\n", "</>\n"])
+    lines = _display_lines(out)
+    assert lines == ["text", ""]
+
+
+def test_stray_artifact_between_think_blocks_hidden() -> None:
+    """The observed pattern: ``</think>`` followed by an extra bare ``<>``
+    line — neither may reach the screen."""
+    out = _render_all(
+        [
+            "<think>\n",
+            "reasoning\n",
+            "</think>\n",
+            "<>\n",
+            "real answer\n",
+        ]
+    )
+    lines = _display_lines(out)
+    assert "<>" not in "".join(lines)
+    assert lines[-1] == "real answer"
+
+
+def test_inline_angle_brackets_in_prose_preserved() -> None:
+    out = _render_all(["use Vec<> or a <> b syntax\n"])
+    assert "use Vec&lt;&gt; or a &lt;&gt; b syntax" in _display_lines(out)[0] or (
+        "use Vec<> or a <> b syntax" in _display_lines(out)[0]
+    )
+
+
+def test_angle_bracket_line_inside_fence_preserved() -> None:
+    out = _render_all(["```\n", "<>\n", "```\n"])
+    assert "[#DDFF66 on #1a1a1a]<>[/]" in out
+
+
+def test_angle_bracket_in_table_cell_preserved() -> None:
+    out = _render_all(["| a | b |\n|---|---|\n| <> | x |\n"])
+    assert "<>" in "".join(_display_lines(out))
 
 
 def test_table_cjk_cells_align_by_display_width() -> None:

--- a/tests/unit/cli/repl/test_markdown_stream.py
+++ b/tests/unit/cli/repl/test_markdown_stream.py
@@ -1,0 +1,386 @@
+"""Line-buffered markdown rendering for the chat token stream.
+
+Covers:
+  * block styles — headings, quotes (+lazy continuation), rules, lists,
+    tables, fenced code,
+  * inline styles — bold, italic, strike, inline code, links,
+  * streaming invariants — deltas held until newline, fence lines hidden,
+    trailing partial emitted by ``flush``, raw buffer untouched,
+  * safety — model text with Rich-like ``[brackets]`` cannot inject markup,
+    ANSI-stripping happens before the markdown pass,
+  * ``NO_COLOR`` / non-color console passthrough,
+  * integration through ``StreamingRenderer`` sync + async paths.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+import agentos.cli.tui.terminal.markdown_stream as md_module
+from agentos.cli.tui.terminal.markdown_stream import (
+    MarkdownStreamRenderer,
+    markdown_enabled,
+    render_markup_to_ansi,
+)
+from agentos.cli.tui.terminal.stream import StreamingRenderer
+
+
+@pytest.fixture
+def tty_console(monkeypatch: pytest.MonkeyPatch) -> Console:
+    """Force the module console to a color-capable terminal."""
+    fake = Console(file=io.StringIO(), width=100, force_terminal=True, color_system="truecolor")
+    monkeypatch.setattr(md_module, "console", fake)
+    return fake
+
+
+def _render_all(chunks: list[str], *, enabled: bool = True) -> str:
+    r = MarkdownStreamRenderer(enabled=enabled)
+    out = "".join(r.feed(c) for c in chunks)
+    return out + r.flush()
+
+
+# ---------------------------------------------------------------------------
+# Block styles
+# ---------------------------------------------------------------------------
+
+
+def test_heading_styled() -> None:
+    out = _render_all(["# Hello\n"])
+    assert "[bold #CCFF00]Hello[/]" in out
+
+
+def test_quote_and_lazy_continuation() -> None:
+    out = _render_all(["> first\nsecond\n\n"])
+    assert "[dim]▎ first[/]" in out
+    assert "[dim]▎ second[/]" in out
+
+
+def test_rule_replaces_dashes() -> None:
+    out = _render_all(["---\n"])
+    assert "─" in out and "---" not in out
+
+
+def test_list_marker_accented() -> None:
+    out = _render_all(["- one\n  - two\n1. three\n"])
+    assert "[#CCFF00]-[/] one" in out
+    assert "[#CCFF00]1.[/] three" in out
+
+
+def test_table_pipes_dimmed() -> None:
+    out = _render_all(["| a | b |\n"])
+    assert "[#6E9000]|[/]" in out
+    assert " a " in out
+
+
+# ---------------------------------------------------------------------------
+# Table block rendering
+# ---------------------------------------------------------------------------
+
+
+def _display_lines(markup: str) -> list[str]:
+    """Strip Rich markup tags, returning the display text per line.
+
+    Blank lines are kept (paragraph spacing is part of the contract);
+    only the trailing artifact of the final newline is dropped.
+    """
+    import re as _re
+
+    plain = _re.sub(r"\[[^\]]*\]", "", markup)
+    lines = plain.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def test_table_columns_aligned() -> None:
+    out = _render_all(["| a | bb |\n|---|---|\n| ccc | d |\n"])
+    lines = _display_lines(out)
+    # header, separator, one body row
+    assert len(lines) == 3
+    widths = {len(ln) for ln in lines}
+    assert len(widths) == 1, f"ragged table lines: {lines!r}"
+
+
+def test_table_header_bold_and_separator_dimmed() -> None:
+    out = _render_all(["| H |\n|---|\n| x |\n"])
+    assert "[bold]H" in out
+    assert "[#6E9000]─" in out
+
+
+def test_table_bold_full_span_cell_styled_with_padding() -> None:
+    out = _render_all(["| **one** | b |\n|---|---|\n| **two** | c |\n"])
+    # Full-span bold cells keep bold across the padded width.
+    assert "[bold]one" in out
+    assert "[bold]two" in out
+    lines = _display_lines(out)
+    assert len({len(ln) for ln in lines}) == 1
+
+
+def test_table_wraps_long_cells_within_console_width(
+    tty_console: Console, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(tty_console, "width", 60)
+    long_cell = "word " * 30
+    out = _render_all([f"| id | desc |\n|---|---|\n| 1 | {long_cell.strip()} |\n"])
+    from rich.cells import cell_len
+
+    for ln in _display_lines(out):
+        assert cell_len(ln) <= 60, f"line exceeds console width: {ln!r}"
+
+
+def test_table_alignment_markers() -> None:
+    out = _render_all(["| l | r |\n|:---|---:|\n| a | b |\n"])
+    lines = _display_lines(out)
+    body = lines[2]
+    # Left column pads right of content; right column pads left of content.
+    assert "| a " in body
+    assert " b |" in body and body.index(" b") > body.index("| a")
+
+
+def test_table_ragged_rows_padded() -> None:
+    out = _render_all(["| a | b | c |\n|---|---|---|\n| x | y |\n"])
+    lines = _display_lines(out)
+    assert len({len(ln) for ln in lines}) == 1
+
+
+def test_table_without_separator_falls_back_to_dim_pipes() -> None:
+    out = _render_all(["| not | a | table |\n"])
+    assert "[#6E9000]|[/]" in out
+    assert "─" not in out
+
+
+def test_table_block_closes_before_following_text() -> None:
+    out = _render_all(["| a |\n|---|\n| b |\n", "after\n"])
+    lines = _display_lines(out)
+    assert lines[-1] == "after"
+    # Table rendered as a unit before the trailing text.
+    assert any("─" in ln for ln in lines[:-1])
+
+
+def test_unclosed_table_flushed_at_turn_end() -> None:
+    r = MarkdownStreamRenderer(enabled=True)
+    out = r.feed("| a |\n|---|\n| b |\n")
+    # Still buffered — nothing emitted yet beyond completed non-table lines.
+    out += r.flush()
+    assert "─" in out
+    assert "b" in out
+
+
+# ---------------------------------------------------------------------------
+# Paragraph spacing (regression: blank lines must survive the table buffer)
+# ---------------------------------------------------------------------------
+
+
+def test_blank_lines_separate_paragraphs() -> None:
+    out = _render_all(["first para\n", "\n", "second para\n"])
+    lines = _display_lines(out)
+    assert lines == ["first para", "", "second para"]
+
+
+def test_blank_line_after_heading_preserved() -> None:
+    out = _render_all(["# H\n", "\n", "body\n"])
+    lines = _display_lines(out)
+    assert lines[1] == ""
+
+
+def test_blank_lines_around_fenced_code() -> None:
+    out = _render_all(["text\n", "\n", "```\n", "x = 1\n", "```\n", "\n", "after\n"])
+    lines = _display_lines(out)
+    # Source blank + hidden fence marker each contribute one display line,
+    # so the code block sits in a double-spaced well: text, blank, blank,
+    # code, blank, blank, after.
+    assert lines == ["text", "", "", "x = 1", "", "", "after"]
+
+
+def test_blank_line_before_table_preserved_and_table_not_glued() -> None:
+    out = _render_all(["intro\n", "\n", "| a |\n|---|\n| b |\n", "\n", "after\n"])
+    lines = _display_lines(out)
+    assert lines[0] == "intro"
+    assert lines[1] == ""
+    # table block (3 rows) then blank then text
+    assert lines[5] == ""
+    assert lines[6] == "after"
+
+
+def test_table_cjk_cells_align_by_display_width() -> None:
+    out = _render_all(["| 名前 | val |\n|---|---|\n| 世界 | 1 |\n"])
+    from rich.cells import cell_len
+
+    lines = _display_lines(out)
+    widths = {cell_len(ln) for ln in lines}
+    assert len(widths) == 1, f"CJK columns misaligned: {lines!r}"
+
+
+# ---------------------------------------------------------------------------
+# Fenced code
+# ---------------------------------------------------------------------------
+
+
+def test_fence_streams_body_hides_markers() -> None:
+    out = _render_all(["```py\n", "x = 1\n", "y = 2\n", "```\n"])
+    assert "```" not in out
+    assert "[#DDFF66 on #1a1a1a]x = 1[/]" in out
+    assert "[#DDFF66 on #1a1a1a]y = 2[/]" in out
+
+
+def test_fence_body_is_not_inline_processed() -> None:
+    out = _render_all(["```\n", "a **not bold** `raw`\n", "```\n"])
+    assert "**not bold**" in out
+    assert "[bold]" not in out.replace("[bold #DDFF66 on #1a1a1a]", "")
+
+
+def test_tilde_fence_supported() -> None:
+    out = _render_all(["~~~\n", "code\n", "~~~\n"])
+    assert "~~~" not in out
+    assert "[#DDFF66 on #1a1a1a]code[/]" in out
+
+
+def test_unclosed_fence_flushes_as_code() -> None:
+    out = _render_all(["```\n", "partial"])
+    assert "[#DDFF66 on #1a1a1a]partial[/]" in out
+
+
+# ---------------------------------------------------------------------------
+# Inline styles
+# ---------------------------------------------------------------------------
+
+
+def test_inline_bold_italic_strike_code() -> None:
+    out = _render_all(["a **b** *i* ~~s~~ `c`\n"])
+    assert "[bold]b[/]" in out
+    assert "[italic]i[/]" in out
+    assert "[strike]s[/]" in out
+    assert "[bold #DDFF66]c[/]" in out
+
+
+def test_inline_link_renders_text_plus_dim_url() -> None:
+    out = _render_all(["see [docs](https://example.com)\n"])
+    assert "[underline #DDFF66]docs[/]" in out
+    assert "[dim](https://example.com)[/]" in out
+
+
+def test_model_brackets_cannot_inject_markup(tty_console: Console) -> None:
+    out = _render_all(["literal [red]not a style[/red]\n"])
+    ansi = render_markup_to_ansi(out)
+    # No red SGR was emitted for the injected tag.
+    assert "\x1b[31m" not in ansi and "38;2" not in ansi.split("literal")[0]
+    assert "literal [red]not a style[/red]" in ansi
+
+
+# ---------------------------------------------------------------------------
+# Streaming invariants
+# ---------------------------------------------------------------------------
+
+
+def test_partial_line_held_until_newline() -> None:
+    r = MarkdownStreamRenderer(enabled=True)
+    assert r.feed("hello **bo") == ""
+    assert r.feed("ld** wor") == ""
+    out = r.feed("ld\n")
+    assert "[bold]bold[/]" in out
+    assert out.endswith("\n")
+
+
+def test_flush_emits_trailing_partial() -> None:
+    r = MarkdownStreamRenderer(enabled=True)
+    r.feed("tail **b**")
+    out = r.flush()
+    assert "[bold]b[/]" in out
+    assert not out.endswith("\n")
+
+
+def test_disabled_passthrough() -> None:
+    raw = "# H\n**b** `c`\n"
+    out = _render_all([raw], enabled=False)
+    assert out == raw
+
+
+# ---------------------------------------------------------------------------
+# markdown_enabled + render_markup_to_ansi
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_enabled_respects_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert markdown_enabled() is False
+
+
+def test_render_markup_to_ansi_emits_sgr(tty_console: Console) -> None:
+    ansi = render_markup_to_ansi("[bold]hi[/]")
+    assert "\x1b[1m" in ansi
+    assert ansi.endswith("\x1b[0m")
+
+
+def test_render_markup_soft_wrap_does_not_insert_newlines(tty_console: Console) -> None:
+    long_line = "[bold]" + "x" * 500 + "[/]"
+    ansi = render_markup_to_ansi(long_line)
+    assert "\n" not in ansi
+
+
+# ---------------------------------------------------------------------------
+# StreamingRenderer integration
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_renderer_styles_and_keeps_raw_buffer(
+    tty_console: Console, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    written: list[str] = []
+    monkeypatch.setattr(
+        "agentos.cli.tui.terminal.stream.StreamingRenderer._write_payload",
+        lambda self, payload: written.append(payload),
+    )
+    r = StreamingRenderer(title="agentos")
+    r.append_text("# Head\n")
+    r.append_text("body **bold**\n")
+    r.finalize()
+
+    joined = "".join(written)
+    # Styled output reached the terminal…
+    assert "\x1b[" in joined
+    # …but the raw buffer keeps the markdown source for /save etc.
+    assert r.buffer == "# Head\nbody **bold**\n"
+
+
+@pytest.mark.asyncio
+async def test_streaming_renderer_async_path_styles(
+    tty_console: Console, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    written: list[str] = []
+
+    async def _fake_awrite(self, payload: str) -> None:  # type: ignore[no-untyped-def]
+        written.append(payload)
+
+    monkeypatch.setattr(
+        "agentos.cli.tui.terminal.stream.StreamingRenderer._awrite_payload",
+        _fake_awrite,
+    )
+    r = StreamingRenderer(title="agentos")
+    await r.aappend_text("`code` here\n")
+    await r.afinalize()
+
+    joined = "".join(written)
+    assert "\x1b[" in joined
+    assert r.buffer == "`code` here\n"
+
+
+def test_streaming_renderer_flushes_trailing_partial_on_finalize(
+    tty_console: Console, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    written: list[str] = []
+    monkeypatch.setattr(
+        "agentos.cli.tui.terminal.stream.StreamingRenderer._write_payload",
+        lambda self, payload: written.append(payload),
+    )
+    r = StreamingRenderer(title="agentos")
+    r.append_text("no newline **b**")
+    r.finalize()
+
+    joined = "".join(written)
+    # The trailing partial line was rendered (bold SGR present) and the
+    # line was terminated before the footer meta line.
+    assert "\x1b[1m" in joined
+    assert "no newline \x1b[1mb\x1b[0m\n" in joined

--- a/tests/unit/cli/repl/test_markdown_stream.py
+++ b/tests/unit/cli/repl/test_markdown_stream.py
@@ -205,6 +205,88 @@ def test_blank_line_before_table_preserved_and_table_not_glued() -> None:
     assert lines[6] == "after"
 
 
+# ---------------------------------------------------------------------------
+# Think blocks (<think>…</think> from reasoning models)
+# ---------------------------------------------------------------------------
+
+
+def test_think_tags_hidden_and_body_dim_italic() -> None:
+    out = _render_all(["<think>\n", "reasoning here\n", "</think>\n"])
+    assert "<think>" not in out and "</think>" not in out
+    assert "[dim italic]reasoning here[/]" in out
+    assert "▎" in out
+
+
+def test_think_body_does_not_compete_with_reply() -> None:
+    out = _render_all(["<think>\n", "drafting\n", "</think>\n", "answer **bold**\n"])
+    # Think body carries no accent color; the reply keeps its styling.
+    think_part, _, reply_part = out.partition("[/]\n\n")  # end of think body
+    assert "#CCFF00" not in think_part and "#DDFF66" not in think_part
+    assert "[bold]bold[/]" in reply_part
+
+
+def test_think_single_line_form() -> None:
+    out = _render_all(["<think>quick thought</think>\n"])
+    assert "<think>" not in out
+    assert "[dim italic]quick thought[/]" in out
+
+
+def test_empty_think_block_produces_no_body_lines() -> None:
+    out = _render_all(["before\n", "<think>\n", "</think>\n", "after\n"])
+    lines = _display_lines(out)
+    assert lines == ["before", "", "", "after"]
+
+
+def test_think_stray_angle_bracket_closes_block() -> None:
+    """A bare ``<>`` line (mangled ``</think>``) must not leave the stream
+    stuck in think state forever."""
+    out = _render_all(["<think>\n", "reasoning\n", "<>\n", "real answer\n"])
+    assert "[dim italic]reasoning[/]" in out
+    assert "[dim italic]real answer[/]" not in out
+    assert "real answer" in _display_lines(out)[-1]
+
+
+def test_think_blank_line_keeps_bar_but_no_text() -> None:
+    out = _render_all(["<think>\n", "first\n", "\n", "second\n", "</think>\n"])
+    lines = _display_lines(out)
+    # Layout: blank (hidden open tag), bar+text, bare bar, bar+text,
+    # blank (hidden close tag).
+    assert lines[0] == ""
+    assert "▎" in lines[1] and "first" in lines[1]
+    assert lines[2] == "▎"
+    assert "▎" in lines[3] and "second" in lines[3]
+    assert lines[4] == ""
+
+
+def test_think_inside_fence_stays_literal_code() -> None:
+    out = _render_all(["```\n", "<think>\n", "```\n"])
+    assert "[#DDFF66 on #1a1a1a]<think>[/]" in out
+
+
+def test_unclosed_think_flushes_dim() -> None:
+    out = _render_all(["<think>\n", "trailing thought"])
+    assert "[dim italic]trailing thought[/]" in out
+
+
+def test_think_state_resets_between_blocks() -> None:
+    out = _render_all(
+        [
+            "<think>\n",
+            "one\n",
+            "</think>\n",
+            "main content\n",
+            "<think>\n",
+            "two\n",
+            "</think>\n",
+            "more content\n",
+        ]
+    )
+    assert "[dim italic]one[/]" in out
+    assert "[dim italic]two[/]" in out
+    assert "[dim italic]main content[/]" not in out
+    assert "[dim italic]more content[/]" not in out
+
+
 def test_table_cjk_cells_align_by_display_width() -> None:
     out = _render_all(["| 名前 | val |\n|---|---|\n| 世界 | 1 |\n"])
     from rich.cells import cell_len

--- a/tests/unit/cli/repl/test_transcript_selection.py
+++ b/tests/unit/cli/repl/test_transcript_selection.py
@@ -1,0 +1,284 @@
+"""Mouse-driven transcript selection + clipboard copy (issue: chat text could
+not be selected or copied while the full-screen surface held mouse capture).
+
+Covers:
+  * plain-text extraction across single- and multi-line selections,
+  * ANSI escape stripping before slicing,
+  * CJK (double-width) column math,
+  * reverse-drag normalization,
+  * fragment highlighting (reverse video on the selected span),
+  * mouse event plumbing on ``_TranscriptControl``,
+  * clipboard helper dispatch (with the actual write stubbed out),
+  * selection clearing when new transcript content arrives.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from prompt_toolkit.data_structures import Point, Size
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+from agentos.cli.repl.app import ChatApplication
+from agentos.cli.tui.terminal import clipboard as clipboard_module
+from agentos.cli.tui.terminal.selection import (
+    Selection,
+    extract_selection_text,
+    highlight_fragments,
+)
+from agentos.engine.commands import Surface
+
+
+@pytest.fixture
+def fullscreen_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_CHAT_FULLSCREEN", "1")
+
+
+def _build(pipe) -> ChatApplication:  # type: ignore[no-untyped-def]
+    return ChatApplication(
+        surface=Surface.CLI_GATEWAY,
+        toolbar_context={
+            "model": "m",
+            "session_id": "k",
+            "suppress": None,
+            "status": None,
+        },
+        bottom_toolbar=lambda: "title . model . [tier:c1]",
+        style=None,
+        input=pipe,
+        output=Vt100_Output(io.StringIO(), lambda: Size(rows=14, columns=54)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# extract_selection_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_single_line_span() -> None:
+    transcript = "hello world\nline 2\n"
+    sel = Selection(anchor=(0, 0), cursor=(0, 5))
+    assert extract_selection_text(transcript, sel) == "hello"
+
+
+def test_extract_multi_line_span() -> None:
+    transcript = "hello world\nline 2\nthird line\n"
+    sel = Selection(anchor=(0, 6), cursor=(2, 5))
+    assert extract_selection_text(transcript, sel) == "world\nline 2\nthird"
+
+
+def test_extract_normalizes_reverse_drag() -> None:
+    transcript = "hello world\n"
+    sel = Selection(anchor=(0, 5), cursor=(0, 0))
+    assert extract_selection_text(transcript, sel) == "hello"
+
+
+def test_extract_strips_ansi_codes() -> None:
+    transcript = "\x1b[32mhello\x1b[0m world\n"
+    sel = Selection(anchor=(0, 0), cursor=(0, 5))
+    assert extract_selection_text(transcript, sel) == "hello"
+
+
+def test_extract_cjk_width_aware() -> None:
+    # 世界 occupies columns 5..9 (two double-width chars).
+    transcript = "hello世界world\n"
+    sel = Selection(anchor=(0, 5), cursor=(0, 9))
+    assert extract_selection_text(transcript, sel) == "世界"
+    # Partial overlap at the left edge still picks the first wide char only
+    # when the window fully contains it.
+    sel = Selection(anchor=(0, 0), cursor=(0, 7))
+    assert extract_selection_text(transcript, sel) == "hello世"
+
+
+def test_extract_empty_when_row_out_of_range() -> None:
+    transcript = "one line\n"
+    sel = Selection(anchor=(5, 0), cursor=(5, 3))
+    assert extract_selection_text(transcript, sel) == ""
+
+
+def test_extract_multi_line_clamps_to_last_line() -> None:
+    transcript = "aaa\nbbb\n"
+    sel = Selection(anchor=(0, 0), cursor=(99, 2))
+    assert extract_selection_text(transcript, sel) == "aaa\nbbb"
+
+
+# ---------------------------------------------------------------------------
+# highlight_fragments
+# ---------------------------------------------------------------------------
+
+
+def _styles(frags) -> list[tuple[str, str]]:  # type: ignore[no-untyped-def]
+    return [(item[0], item[1]) for item in frags]
+
+
+def test_highlight_single_line_applies_reverse_to_span_only() -> None:
+    transcript = "hello world\n"
+    frags = highlight_fragments(transcript, Selection(anchor=(0, 0), cursor=(0, 5)))
+    styled = _styles(frags)
+    # First five chars highlighted, rest untouched.
+    assert styled[:5] == [(" reverse", ch) for ch in "hello"]
+    assert styled[5:11] == [("", ch) for ch in " world"]
+
+
+def test_highlight_multi_line_covers_full_middle_lines() -> None:
+    transcript = "aaa\nbbb\nccc\n"
+    frags = highlight_fragments(transcript, Selection(anchor=(0, 1), cursor=(2, 2)))
+    # Filter out the synthetic newline and empty EOL marker fragments.
+    styled = [
+        (style, text)
+        for style, text in _styles(frags)
+        if text not in {"\n", ""}
+    ]
+    assert styled == [
+        ("", "a"),
+        (" reverse", "a"),
+        (" reverse", "a"),
+        (" reverse", "b"),
+        (" reverse", "b"),
+        (" reverse", "b"),
+        (" reverse", "c"),
+        (" reverse", "c"),
+        ("", "c"),
+    ]
+
+
+def test_highlight_preserves_original_style_and_appends_reverse() -> None:
+    transcript = "\x1b[32mhello\x1b[0m\n"
+    frags = highlight_fragments(transcript, Selection(anchor=(0, 0), cursor=(0, 2)))
+    styled = _styles(frags)
+    assert styled[0] == ("ansigreen reverse", "h")
+    assert styled[1] == ("ansigreen reverse", "e")
+    # Untouched fragments keep their original style.
+    assert styled[2] == ("ansigreen", "l")
+
+
+# ---------------------------------------------------------------------------
+# _TranscriptControl mouse plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_mouse_drag_builds_selection_and_copies(
+    fullscreen_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    copied: list[str] = []
+    monkeypatch.setattr(
+        "agentos.cli.tui.terminal.app.copy_to_system_clipboard",
+        lambda text: copied.append(text),
+    )
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        chat.append_transcript("hello world\nline 2\n")
+
+        control = chat._transcript_window.content  # type: ignore[union-attr]
+
+        down = MouseEvent(
+            position=Point(x=0, y=0),
+            event_type=MouseEventType.MOUSE_DOWN,
+            button=MouseButton.LEFT,
+            modifiers=frozenset(),
+        )
+        move = MouseEvent(
+            position=Point(x=5, y=0),
+            event_type=MouseEventType.MOUSE_MOVE,
+            button=MouseButton.LEFT,
+            modifiers=frozenset(),
+        )
+        up = MouseEvent(
+            position=Point(x=5, y=0),
+            event_type=MouseEventType.MOUSE_UP,
+            button=MouseButton.LEFT,
+            modifiers=frozenset(),
+        )
+
+        control.mouse_handler(down)
+        # Anchor recorded; no selection visible yet.
+        assert chat._transcript_selection is None
+
+        control.mouse_handler(move)
+        assert chat._transcript_selection == Selection(anchor=(0, 0), cursor=(0, 5))
+
+        control.mouse_handler(up)
+        assert copied == ["hello"]
+        # Highlight stays after release.
+        assert chat._transcript_selection == Selection(anchor=(0, 0), cursor=(0, 5))
+
+
+def test_mouse_down_clears_prior_selection(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        chat.append_transcript("hello\n")
+        chat._transcript_selection = Selection(anchor=(0, 0), cursor=(0, 3))
+
+        control = chat._transcript_window.content  # type: ignore[union-attr]
+        down = MouseEvent(
+            position=Point(x=1, y=0),
+            event_type=MouseEventType.MOUSE_DOWN,
+            button=MouseButton.LEFT,
+            modifiers=frozenset(),
+        )
+        control.mouse_handler(down)
+        assert chat._transcript_selection is None
+
+
+def test_append_transcript_clears_selection(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        chat.append_transcript("hello\n")
+        chat._transcript_selection = Selection(anchor=(0, 0), cursor=(0, 3))
+        chat.append_transcript("world\n")
+        assert chat._transcript_selection is None
+
+
+def test_right_click_does_not_select(fullscreen_env: None) -> None:
+    with create_pipe_input() as pipe:
+        chat = _build(pipe)
+        chat.append_transcript("hello\n")
+        control = chat._transcript_window.content  # type: ignore[union-attr]
+        down = MouseEvent(
+            position=Point(x=0, y=0),
+            event_type=MouseEventType.MOUSE_DOWN,
+            button=MouseButton.RIGHT,
+            modifiers=frozenset(),
+        )
+        result = control.mouse_handler(down)
+        assert chat._transcript_selection is None
+        # Falls through to the parent handler (no fragment handlers here).
+        assert result is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# Clipboard helper
+# ---------------------------------------------------------------------------
+
+
+def test_copy_to_system_clipboard_noop_on_empty_text() -> None:
+    assert clipboard_module.copy_to_system_clipboard("") is False
+
+
+def test_copy_to_system_clipboard_uses_writer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(clipboard_module, "_WRITER", lambda text: seen.append(text) or True)
+    assert clipboard_module.copy_to_system_clipboard("payload") is True
+    assert seen == ["payload"]
+
+
+def test_copy_to_system_clipboard_swallows_writer_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(text: str) -> bool:  # noqa: ARG001
+        raise RuntimeError("no clipboard daemon")
+
+    monkeypatch.setattr(clipboard_module, "_WRITER", _boom)
+    assert clipboard_module.copy_to_system_clipboard("x") is False
+
+
+def test_copy_to_system_clipboard_returns_false_when_no_writer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(clipboard_module, "_WRITER", None)
+    assert clipboard_module.copy_to_system_clipboard("x") is False


### PR DESCRIPTION
## Why

`agentos chat` runs full-screen by default in a TTY, and enabling
`mouse_support` for the transcript pane routed every mouse event to
prompt_toolkit — so the terminal emulator's native drag-select was
blocked and chat text could not be selected or copied.

## What

Adds in-app mouse drag selection to the full-screen transcript pane:

- **Left-drag** across the transcript highlights the span in reverse
  video (original colors preserved, `reverse` attribute layered on).
- **Mouse-up** copies the plain text — ANSI escapes stripped, CJK
  width-aware column slicing — to the system clipboard.
- **Click** clears the selection; new transcript output also clears it
  (stale row indexes would otherwise mis-map).
- Selection can span scrollback beyond the visible screen; scroll
  wheel keeps working during an active selection.

## Implementation

| File | Change |
|---|---|
| `src/agentos/cli/tui/terminal/clipboard.py` | Cross-platform clipboard dispatcher: `pbcopy` (macOS), `wl-copy`/`xclip`/`xsel` (Linux), `clip` (Windows), OSC 52 escape fallback. Silent no-op when no mechanism is available. |
| `src/agentos/cli/tui/terminal/selection.py` | `Selection` model + helpers: ANSI strip, CJK-aware column slicing, fragment highlighting. |
| `src/agentos/cli/tui/terminal/app.py` | `_TranscriptControl` handles left-drag mouse events alongside wheel scroll; `ChatApplication` stores the selection, renders the highlight, fires the copy on mouse-up. |
| `tests/unit/cli/repl/test_transcript_selection.py` | 18 regression tests: extraction (single/multi-line, reverse-drag, ANSI, CJK, edge cases), highlight correctness, mouse plumbing, clipboard dispatch. |
| `docs/cli.md`, `src/agentos/skills/bundled/agentos/SKILL.md` | Document the drag-to-copy gesture so the bundled operator guide stays in sync with the CLI surface. |

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean (586 files)
- `uv run pytest tests/unit/cli/repl -q` — 278 passed, 1 skipped
- `uv build --wheel` — builds successfully
- The 3 pre-existing failures in `tests/test_artifacts.py` and
  `tests/test_ci/test_migrations_packaged.py` reproduce on a clean
  `main` and are unrelated to this change.

The emulator's native selection gesture (Shift+drag on Linux,
Option+drag in iTerm2) continues to work as before.