### PR TITLE
chore(release): bump version to 2026.7.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.23] - 2026-07-23
+
+### Added
+
+- Mouse drag selection and copy in the full-screen `agentos chat` transcript:
+  left-drag highlights text in the transcript pane and mouse-up copies the
+  plain text (ANSI stripped, CJK width-aware) to the system clipboard via a
+  cross-platform dispatcher (pbcopy, wl-copy, xclip, xsel, clip, OSC 52
+  fallback) (#76).
+- Rendering for reasoning-model think blocks in the CLI, with hidden tags and
+  boundary markers so partial think content streams cleanly.
+
+### Changed
+
+- The waiting indicator is now turn-lifetime: it persists across the pre-token,
+  mid-stream, and tool-call phases to give a consistent "agent is working"
+  signal. `StreamingRenderer` uses the waiting indicator instead of a Rich
+  `Live` instance, which removes ghost panel artifacts in Windows PowerShell.
+- Markdown streaming keeps block and inline styles intact while preserving the
+  raw buffer for downstream consumers.
+
+### Fixed
+
+- Telegram no longer deletes its persistent native command menu on adapter
+  shutdown. Bot command menus are server-side configuration and must survive
+  gateway restarts and overlapping adapter lifecycles (#74, fixes #52).
+
 ## [2026.7.22.post1] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.22.post1 is the current release. The project website is
+AgentOS 2026.7.23 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.22.post1"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.23"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.22.post1/use_agent_os-2026.7.22.post1-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.23/use_agent_os-2026.7.23-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.22.post1-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.23-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.23 | v2026.7.23 | 2026-07-23 | Mouse drag selection and copy in the full-screen `agentos chat` transcript (#76); turn-lifetime waiting indicator and markdown streaming fixes that remove ghost panels in Windows PowerShell; reasoning-model think-block rendering; Telegram keeps its native command menu across gateway restarts (#74). |
 | 2026.7.22.post1 | v2026.7.22.post1 | 2026-07-22 | `agentos chat` full-screen transcript mouse wheel scrolling is responsive on the first tick (larger wheel step plus follow-release compensation) (#69). |
 | 2026.7.22 | v2026.7.22 | 2026-07-22 | Native slash-command menus for Telegram, Slack, and Discord (#45); Ollama multi-turn tool-call history fixes and a `tools.enabled = false` plain-text fallback mode (#44); channel slash commands render their RPC results instead of a generic acknowledgement; Telegram delivery retries transient connection failures; `agentos chat` input frame supports multiline input (#62). |
 | 2026.7.20 | v2026.7.20 | 2026-07-20 | `agentos chat` CLI UX pass (#46/#47): assistant speaker label defaults to `agentos` and is configurable via `AGENTOS_ASSISTANT_LABEL`; session title in the bottom toolbar and startup panel; `/c0`–`/c3` and `/auto` router-tier holds on both CLI surfaces; framed input box; full-screen chat transcript pane now the default. |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.22.post1'
+$defaultVersion = 'v2026.7.23'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.22.post1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.23. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.22.post1"
+default_version="v2026.7.23"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.22.post1|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.23|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.22.post1
+  AGENTOS_VERSION=v2026.7.23
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=matrix
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.22.post1." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.23." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.22.post1"
+version = "2026.7.23"
 description = "Token-Efficient AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.22.post1"
+CURRENT_RELEASE_TAG = "v2026.7.23"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.22.post1"
+CURRENT_VERSION = "2026.7.23"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3883,7 +3883,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.22.post1"
+version = "2026.7.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to `2026.7.23` (CalVer).

## What's in this release

**Added**
- Mouse drag selection and copy in the full-screen `agentos chat` transcript, with a cross-platform clipboard dispatcher (pbcopy, wl-copy, xclip, xsel, clip, OSC 52 fallback) (#76).
- Reasoning-model think-block rendering in the CLI, with hidden tags and boundary markers.

**Changed**
- Waiting indicator is now turn-lifetime across pre-token, mid-stream, and tool-call phases; `StreamingRenderer` no longer uses a Rich `Live` instance, removing ghost panel artifacts in Windows PowerShell.
- Markdown streaming preserves block/inline styles while keeping the raw buffer intact for downstream consumers.

**Fixed**
- Telegram keeps its persistent native command menu on adapter shutdown, so menus survive gateway restarts and overlapping adapter lifecycles (#74, fixes #52).

## Files updated

`pyproject.toml`, `README.md`, `install.sh`, `install.ps1`, `tests/test_release_consistency.py`, `tests/test_install_scripts.py`, `CHANGELOG.md`, `RELEASES.md`, `uv.lock`.

## Verification

- `ruff check .` — clean
- `mypy src` — clean, 587 source files
- `pytest --extra recommended` — 6566 passed, 39 skipped, 3 failed
- Wheel builds as `use_agent_os-2026.7.23-py3-none-any.whl`

The 3 failures are pre-existing on unmodified `main`, not regressions:
- `test_artifacts.py::test_artifact_store_uses_short_material_paths_for_uuid_sessions` — asserts a path-length bound that depends on the local pytest tmpdir prefix (`assert 260 < 260`).
- `test_ci/test_migrations_packaged.py` (2 tests) — require Docker / a working `ensurepip`; environment-only.

`ruff format --check` reports pre-existing drift across 488 files, also present on `main`.

## After merge

Create and push tag `v2026.7.23` to trigger `.github/workflows/wheelhouse-release.yml`. PyPI publish will pause at the approval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)