### PR TITLE
fix(cli): self-heal upgrade venv for uv-tool and pipx installs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,9 +228,13 @@ agentos upgrade --timeout 900   # bound the upgrade subprocess (default 600s)
 
 Per install method:
 
-- **uv tool / pipx** — delegated automatically (`uv tool upgrade use-agent-os`
-  / `pipx upgrade use-agent-os`), resolving the tool to an absolute path over a
-  hardened PATH.
+- **uv tool / pipx** — delegated automatically (`uv tool upgrade use-agent-os
+  --reinstall` / `pipx upgrade use-agent-os --force`), resolving the tool to an
+  absolute path over a hardened PATH. Both rebuild the managed venv rather than
+  bumping it in place — `--reinstall` (uv, implies `--refresh`) and `--force`
+  (pipx) self-heal a stale cache or an orphaned interpreter (e.g. after the base
+  Python moves) that would otherwise force a manual reinstall. Extras recorded
+  in the tool receipt are preserved.
 - **pip / editable / source checkout** — not faked: prints the exact manual
   command (e.g. `python -m pip install --upgrade "use-agent-os"`) and exits
   with a distinct code.

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -222,39 +222,56 @@ def build_upgrade_plan(
     resolved_method = method if method is not None else detect_install_method()
 
     if resolved_method is InstallMethod.UV_TOOL:
+        # ``--reinstall`` (which implies ``--refresh``) is what makes ``upgrade``
+        # a safe, self-healing operation rather than a fragile in-place bump. A
+        # plain ``uv tool upgrade`` no-ops or fails when the tool venv is in a
+        # broken state — a stale PyPI cache, or an orphaned interpreter after the
+        # base Python moved (e.g. a Homebrew bump). Both leave operators forced
+        # to hand-run ``uv tool install … --force``. ``--reinstall`` rebuilds the
+        # venv from scratch and bypasses the cache, matching install.sh's
+        # ``--force`` posture, while ``upgrade`` (not ``install``) preserves the
+        # extras recorded in uv's tool receipt — ``uv tool upgrade`` takes only a
+        # bare tool NAME and rejects a ``dist[extra]`` spec.
         uv = resolve_tool("uv", env)
         if uv is not None:
             return UpgradePlan(
                 method=resolved_method,
                 delegated=True,
                 tool=uv,
-                command=[uv, "tool", "upgrade", dist],
-                manual_hint=f"uv tool upgrade {dist}",
+                command=[uv, "tool", "upgrade", dist, "--reinstall"],
+                manual_hint=f"uv tool upgrade {dist} --reinstall",
             )
         return UpgradePlan(
             method=resolved_method,
             delegated=False,
             tool=None,
-            command=["uv", "tool", "upgrade", dist],
-            manual_hint=f"uv tool upgrade {dist}",
+            command=["uv", "tool", "upgrade", dist, "--reinstall"],
+            manual_hint=f"uv tool upgrade {dist} --reinstall",
         )
 
     if resolved_method is InstallMethod.PIPX:
+        # ``--force`` is pipx's counterpart to uv's ``--reinstall``: it rebuilds
+        # the managed venv instead of no-op'ing or failing when it is in a broken
+        # state (stale wheel, orphaned interpreter after the base Python moved).
+        # ``pipx upgrade`` (not ``pipx reinstall``) is the right verb — ``upgrade
+        # --force`` still moves to the newest version, whereas ``reinstall`` only
+        # re-lays-down the currently pinned version. Extras are preserved by pipx
+        # across the forced upgrade.
         pipx = resolve_tool("pipx", env)
         if pipx is not None:
             return UpgradePlan(
                 method=resolved_method,
                 delegated=True,
                 tool=pipx,
-                command=[pipx, "upgrade", dist],
-                manual_hint=f"pipx upgrade {dist}",
+                command=[pipx, "upgrade", dist, "--force"],
+                manual_hint=f"pipx upgrade {dist} --force",
             )
         return UpgradePlan(
             method=resolved_method,
             delegated=False,
             tool=None,
-            command=["pipx", "upgrade", dist],
-            manual_hint=f"pipx upgrade {dist}",
+            command=["pipx", "upgrade", dist, "--force"],
+            manual_hint=f"pipx upgrade {dist} --force",
         )
 
     if resolved_method is InstallMethod.EDITABLE:
@@ -264,8 +281,7 @@ def build_upgrade_plan(
             tool=None,
             command=["git", "pull"],
             manual_hint=(
-                "editable / source checkout — pull the repo and reinstall: "
-                "git pull && uv sync"
+                "editable / source checkout — pull the repo and reinstall: git pull && uv sync"
             ),
         )
 

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -41,14 +41,9 @@ from agentos.cli.install_method import InstallMethod
         ),
     ],
 )
-def test_detect_install_method(
-    exe: str, pkg: str, expected: InstallMethod
-) -> None:
+def test_detect_install_method(exe: str, pkg: str, expected: InstallMethod) -> None:
     # Empty env so a real UV_TOOL_DIR in the test host cannot skew classification.
-    assert (
-        im.detect_install_method(executable=exe, package_dir=Path(pkg), env={})
-        == expected
-    )
+    assert im.detect_install_method(executable=exe, package_dir=Path(pkg), env={}) == expected
 
 
 def test_uv_tool_dir_override_classified_as_uv_tool(tmp_path: Path) -> None:
@@ -100,17 +95,13 @@ def test_uv_tool_dir_unset_leaves_default_behavior(tmp_path: Path) -> None:
     exe = "/home/u/venv/bin/python"
     pkg = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "agentos"
     pkg.mkdir(parents=True)
-    assert (
-        im.detect_install_method(executable=exe, package_dir=pkg, env={})
-        == InstallMethod.PIP
-    )
+    assert im.detect_install_method(executable=exe, package_dir=pkg, env={}) == InstallMethod.PIP
     # And the default ~/.local/share/uv/tools path still matches on the heuristic.
     assert (
         im.detect_install_method(
             executable="/home/u/.local/share/uv/tools/use-agent-os/bin/python",
             package_dir=Path(
-                "/home/u/.local/share/uv/tools/use-agent-os/lib/python3.12/"
-                "site-packages/agentos"
+                "/home/u/.local/share/uv/tools/use-agent-os/lib/python3.12/site-packages/agentos"
             ),
             env={},
         )
@@ -156,9 +147,7 @@ def test_hardened_path_no_duplicates() -> None:
     reason="hardened login-dir PATH semantics are POSIX-specific; "
     "Windows resolution uses standard which/PATHEXT",
 )
-def test_resolve_tool_uses_hardened_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_resolve_tool_uses_hardened_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # uv lives in a login dir NOT on the base PATH.
     brew = tmp_path / "opt" / "homebrew" / "bin"
     brew.mkdir(parents=True)
@@ -210,7 +199,7 @@ def test_build_plan_uv_tool_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
     plan = im.build_upgrade_plan(method=InstallMethod.UV_TOOL)
     assert plan.delegated is True
     assert plan.tool == "/abs/uv"
-    assert plan.command == ["/abs/uv", "tool", "upgrade", "use-agent-os"]
+    assert plan.command == ["/abs/uv", "tool", "upgrade", "use-agent-os", "--reinstall"]
 
 
 def test_build_plan_uv_tool_missing_uv_not_delegated(
@@ -227,7 +216,7 @@ def test_build_plan_pipx_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: "/abs/pipx")
     plan = im.build_upgrade_plan(method=InstallMethod.PIPX)
     assert plan.delegated is True
-    assert plan.command == ["/abs/pipx", "upgrade", "use-agent-os"]
+    assert plan.command == ["/abs/pipx", "upgrade", "use-agent-os", "--force"]
 
 
 def test_build_plan_pip_never_delegates() -> None:

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -30,8 +30,8 @@ def _delegated_plan() -> UpgradePlan:
         method=InstallMethod.UV_TOOL,
         delegated=True,
         tool="/abs/uv",
-        command=["/abs/uv", "tool", "upgrade", "use-agent-os"],
-        manual_hint="uv tool upgrade use-agent-os",
+        command=["/abs/uv", "tool", "upgrade", "use-agent-os", "--reinstall"],
+        manual_hint="uv tool upgrade use-agent-os --reinstall",
     )
 
 
@@ -104,7 +104,7 @@ def test_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     result = runner.invoke(_app(), ["upgrade", "--dry-run"])
     assert result.exit_code == 0
-    assert "Would run: /abs/uv tool upgrade use-agent-os" in result.stdout
+    assert "Would run: /abs/uv tool upgrade use-agent-os --reinstall" in result.stdout
     assert ran["run"] is False
 
 


### PR DESCRIPTION
## Problem

`agentos upgrade` delegated to a bare `uv tool upgrade use-agent-os` (or `pipx upgrade use-agent-os`). Both upgrade the managed venv **in place**, so they no-op or fail outright when that venv is in a broken state:

- a stale PyPI / wheel cache, or
- an **orphaned interpreter** after the base Python moves (e.g. a Homebrew Python bump leaves the tool venv pointing at a Python that no longer exists).

When that happens the only recovery is to hand-run the full reinstall:

```
uv tool install --python 3.12 "use-agent-os[recommended]" --refresh --force
```

which defeats the purpose of having an `upgrade` command.

## Fix

Rebuild the managed venv from scratch on the delegated path so `agentos upgrade` self-heals both failure modes:

| Method | Before | After |
|---|---|---|
| uv-tool | `uv tool upgrade use-agent-os` | `uv tool upgrade use-agent-os --reinstall` |
| pipx | `pipx upgrade use-agent-os` | `pipx upgrade use-agent-os --force` |

- **uv:** `--reinstall` implies `--refresh`, so it bypasses the cache and rebuilds the venv — matching `install.sh`'s `--force` posture. `uv tool upgrade` takes only a bare tool **NAME** and rejects a `dist[extra]` spec, so extras (`[recommended]`) are preserved via uv's tool receipt, not the command line.
- **pipx:** `--force` is the pipx counterpart. `upgrade --force` still moves to the newest version — unlike `pipx reinstall`, which only re-lays the currently pinned version. Extras are preserved across the forced upgrade.

## Notes

- `--reinstall` / `--force` on `upgrade` are safe when nothing is wrong: they simply re-materialize the same latest version.
- No version bump; docs and the plan-builder tests are updated in the same change.

## Test plan

- `docs/cli.md` updated to describe the self-heal behavior.
- `tests/test_cli/test_install_method.py` / `tests/test_cli/test_upgrade_cmd.py` plan assertions updated.
- Quality gate green locally: `ruff check` + `ruff format` + `mypy` clean; `pytest tests/test_cli/test_install_method.py tests/test_cli/test_upgrade_cmd.py` → 29 passed. Release/install-script tests unaffected (21 passed).