### PR TITLE
feat(config): default LLM model to openai/gpt-5.6-luna

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -71,7 +71,7 @@
 
 [llm]
 provider = "openrouter"
-model = "deepseek/deepseek-v4-flash"
+model = "openai/gpt-5.6-luna"
 # api_key = ""          # OpenRouter API key; env OPENROUTER_API_KEY also works
 base_url = "https://openrouter.ai/api/v1"
 # proxy = ""            # e.g. http://127.0.0.1:7890
@@ -289,8 +289,8 @@ safety_net_threshold = 0.5
 
 [agentos_router.tiers.c0]
 provider = "openrouter"
-model = "deepseek/deepseek-v4-flash"
-description = "Fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
+model = "openai/gpt-5.6-luna"
+description = "Fast GPT-5.6 Luna route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
 supports_image = false
 thinking_level = "high"
 

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -625,7 +625,7 @@ agentos agent -m "summarize today's commits"</pre>
       <div data-code class="mt-4">
 <pre data-lang="toml">[llm]
 provider  = "openrouter"
-model     = "deepseek/deepseek-v4-flash"
+model     = "openai/gpt-5.6-luna"
 base_url  = "https://openrouter.ai/api/v1"
 # api_key is read from OPENROUTER_API_KEY
 

--- a/src/agentos/engine/pricing.py
+++ b/src/agentos/engine/pricing.py
@@ -341,6 +341,7 @@ _PRICING_TABLE: list[tuple[str, PriceEntry]] = [
     ("z-ai/glm-4.5-air", PriceEntry(0.13, 0.85)),
     ("minimax/minimax-m2.5", PriceEntry(0.118, 0.99)),
     ("minimax/minimax-m3", PriceEntry(0.0825, 0.33)),
+    ("openai/gpt-5.6-luna", PriceEntry(0.20, 1.25)),
     ("deepseek/deepseek-v4-flash", PriceEntry(0.14, 0.28)),
     ("deepseek/deepseek-v4-pro", PriceEntry(1.74, 3.48)),
     ("deepseek/deepseek-v3.2", PriceEntry(0.26, 0.38)),

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -255,7 +255,7 @@ class LlmProviderConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="AGENTOS_LLM_")
 
     provider: str = "openrouter"
-    model: str = "deepseek/deepseek-v4-flash"
+    model: str = "openai/gpt-5.6-luna"
     api_key: str = ""
     api_key_env: str = ""
     base_url: str = "https://openrouter.ai/api/v1"
@@ -276,6 +276,7 @@ class LlmProviderConfig(BaseSettings):
         aliases = {
             "deepseek/deepseek-v4-flash": "deepseek-v4-flash",
             "deepseek/deepseek-v4-pro": "deepseek-v4-pro",
+            "openai/gpt-5.6-luna": "gpt-5.6-luna",
         }
         model = str(self.model or "").strip()
         if model in aliases:
@@ -698,9 +699,9 @@ def _openrouter_tiers() -> dict:
     return {
         "c0": {
             "provider": "openrouter",
-            "model": "deepseek/deepseek-v4-flash",
+            "model": "openai/gpt-5.6-luna",
             "description": (
-                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, "
+                "fast GPT-5.6 Luna route for trivial chat, short rewrites, "
                 "extraction, and low-risk simple Q&A"
             ),
             "supports_image": False,

--- a/src/agentos/provider/model_catalog.py
+++ b/src/agentos/provider/model_catalog.py
@@ -30,6 +30,7 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "stepfun/step-3.5-flash": (16_384, 256_000),
     "z-ai/glm-4.5-air": (98_304, 131_072),
     "minimax/minimax-m2.5": (65_536, 196_608),
+    "openai/gpt-5.6-luna": (128_000, 1_050_000),
     "deepseek/deepseek-v4-flash": (16_384, 1_048_576),
     "deepseek/deepseek-v4-pro": (16_384, 1_048_576),
     "deepseek-v4-flash": (393_216, 1_048_576),

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -103,7 +103,14 @@ def test_artifact_store_skips_existing_deliverable_with_bad_material(
 
 
 def test_artifact_store_uses_short_material_paths_for_uuid_sessions(tmp_path: Path) -> None:
-    store = ArtifactStore(tmp_path)
+    # A UUID session id and a long unicode artifact name must both collapse into
+    # fixed-width hashed segments, so the path the store appends to the caller's
+    # media root stays far inside the Windows MAX_PATH (260) budget.
+    #
+    # The length check is store-relative on purpose: the absolute path also
+    # carries the host's temp prefix, which the store cannot control and which
+    # alone runs ~120 chars on macOS (/private/var/folders/...). The 100-char
+    # budget is MAX_PATH minus a 160-char allowance for the media root itself.
     long_root = tmp_path / ("deep-root-" + ("x" * 80))
     store = ArtifactStore(long_root)
     session_id = "532d5065-abce-499f-97b0-bbf2a067d5ab"
@@ -120,7 +127,7 @@ def test_artifact_store_uses_short_material_paths_for_uuid_sessions(tmp_path: Pa
     material_path = store.path_for(ref)
     assert material_path.name == "data"
     assert session_id not in str(material_path)
-    assert len(str(material_path)) < 260
+    assert len(str(material_path.relative_to(long_root))) < 100
     resolved_ref, resolved_path = store.resolve_for_download(ref.id, session_id=session_id)
     assert resolved_ref == ref
     assert resolved_path == material_path

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -58,7 +58,7 @@ def test_agentos_router_defaults_match_runtime_router_config() -> None:
     assert not hasattr(cfg, "v4_use_aux_head")
     assert cfg.require_router_runtime is False
 
-    assert cfg.tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert cfg.tiers["c0"]["model"] == "openai/gpt-5.6-luna"
     assert cfg.tiers["c0"]["thinking_level"] == "high"
     assert cfg.tiers["c1"]["model"] == "minimax/minimax-m3"
     assert cfg.tiers["c1"]["thinking_level"] == "high"
@@ -419,7 +419,7 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     agentos_router = data["agentos_router"]
 
     assert data["llm"]["provider"] == "openrouter"
-    assert data["llm"]["model"] == "deepseek/deepseek-v4-flash"
+    assert data["llm"]["model"] == "openai/gpt-5.6-luna"
     assert agentos_router["enabled"] is True
     assert agentos_router["auto_thinking"] is True
     assert agentos_router["rollout_phase"] == "full"
@@ -444,7 +444,7 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert "require_router_runtime" not in agentos_router
 
     tiers = agentos_router["tiers"]
-    assert tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert tiers["c0"]["model"] == "openai/gpt-5.6-luna"
     assert tiers["c0"]["thinking_level"] == "high"
     assert tiers["c1"]["model"] == "minimax/minimax-m3"
     assert tiers["c1"]["thinking_level"] == "high"

--- a/tests/test_provider_bankr.py
+++ b/tests/test_provider_bankr.py
@@ -54,7 +54,7 @@ def test_openrouter_sorts_first_in_setup_list() -> None:
 def test_llm_defaults_are_openrouter() -> None:
     cfg = LlmProviderConfig()
     assert cfg.provider == "openrouter"
-    assert cfg.model == "deepseek/deepseek-v4-flash"
+    assert cfg.model == "openai/gpt-5.6-luna"
     assert cfg.base_url == "https://openrouter.ai/api/v1"
 
 
@@ -62,7 +62,7 @@ def test_default_tiers_route_through_openrouter() -> None:
     tiers = _default_tiers()
     assert tiers == _openrouter_tiers()
     assert tiers["c0"]["provider"] == "openrouter"
-    assert tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert tiers["c0"]["model"] == "openai/gpt-5.6-luna"
     assert tiers["c1"]["model"] == "minimax/minimax-m3"
     assert tiers["c2"]["model"] == "z-ai/glm-5.2"
     assert tiers["c3"]["model"] == "anthropic/claude-opus-4.8"


### PR DESCRIPTION
## Purpose
Change the default LLM model to `openai/gpt-5.6-luna` (previously `deepseek/deepseek-v4-flash`).

## Changes
- **`gateway/config.py`** — `LlmProviderConfig.model` default, alias map entry, and the `_openrouter_tiers()` c0 model + description.
- **`provider/model_catalog.py`** — added a static offline-boot fallback entry for the prefixed `openai/gpt-5.6-luna` id. Lookup is exact-key, so the existing bare `gpt-5.6-luna` entry did not cover the OpenRouter id and it would have fallen through to the 16K default.
- **`engine/pricing.py`** — added the prefixed pricing entry. The pricing table is prefix-matched, so the bare `gpt-5.6-luna` entry never matched `openai/gpt-5.6-luna`.
- **`agentos.toml.example`**, **`docs/setup-guide.html`** — example configs brought in sync.
- **tests** — assertions repointed at the new default.

## Drive-by test fix
\`test_artifact_store_uses_short_material_paths_for_uuid_sessions\` was failing before this change on macOS. It asserted \`len(str(material_path)) < 260\` on the **absolute** path, which includes pytest's temp prefix (119 chars on macOS) plus the test's own 90-char root padding — landing at exactly 260 and failing by one character. Nothing about \`ArtifactStore\` was wrong.

The store's contribution is fixed-width by construction (\`artifacts/s/<16hex>/<16hex>/data\`, 49 chars) regardless of session UUID or filename length, which is the invariant the test exists to prove. The assertion now measures the store-relative segment against a 100-char budget (MAX_PATH minus a 160-char media-root allowance), with the derivation documented. A dead \`ArtifactStore(tmp_path)\` line that was overwritten on the very next line was also removed.

Note: the length check is a coarse backstop — the \`name == "data"\` and \`session_id not in path\` assertions above it are what actually guard against raw ids or filenames leaking into the path.

## Testing
- \`uv run pytest tests/\` — **6138 passed, 27 skipped, 0 failed**
- \`uv run ruff check src tests\` — clean
- \`uv run mypy src\` — no issues in 583 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)