### PR TITLE
fix(frontend): refine collapsed sidebar toggle

### DIFF
--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -316,6 +316,7 @@ describe('app shell chrome', () => {
     const collapse = screen.getByRole('button', { name: 'Collapse navigation' })
     expect(collapse).toHaveAttribute('aria-controls', 'sidebar-nav')
     expect(collapse).toHaveAttribute('aria-expanded', 'true')
+    expect(collapse.querySelector('svg')).toHaveClass('lucide-chevron-left')
     fireEvent.click(collapse)
 
     expect(sidebar).toHaveAttribute('data-collapsed', 'true')
@@ -324,6 +325,7 @@ describe('app shell chrome', () => {
 
     const expand = screen.getByRole('button', { name: 'Expand navigation' })
     expect(expand).toHaveAttribute('aria-expanded', 'false')
+    expect(expand.querySelector('svg')).toHaveClass('lucide-chevron-right')
     fireEvent.click(expand)
     expect(sidebar).toHaveAttribute('data-collapsed', 'false')
     expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe('false')

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -14,13 +14,13 @@ import {
   BarChart3,
   Bot,
   CalendarClock,
+  ChevronLeft,
+  ChevronRight,
   LayoutDashboard,
   Menu,
   MessageSquare,
   Moon,
   Network,
-  PanelLeftClose,
-  PanelLeftOpen,
   Puzzle,
   Radio,
   ScrollText,
@@ -367,9 +367,9 @@ export function AppShell() {
             onClick={toggleSidebarCollapsed}
           >
             {compactSidebar ? (
-              <PanelLeftOpen className="size-4" />
+              <ChevronRight className="size-4" />
             ) : (
-              <PanelLeftClose className="size-4" />
+              <ChevronLeft className="size-4" />
             )}
           </Button>
         </div>

--- a/frontend/src/app/control-surface-css.test.ts
+++ b/frontend/src/app/control-surface-css.test.ts
@@ -8,9 +8,27 @@ const configCss = readFileSync('src/views/config/config.css', 'utf8')
 const cronCss = readFileSync('src/views/cron/cron.css', 'utf8')
 
 describe('Control surface CSS contract', () => {
-  it('keeps the collapsed desktop sidebar as a centered floating icon rail', () => {
+  it('keeps the rail logo centered and pins the toggle to the sidebar edge', () => {
     expect(controlCss).toMatch(
       /\.shell\[data-design='unified'\] \.shell-sidebar\[data-collapsed='true'\] \{\s*width: 5rem;/,
+    )
+    expect(controlCss).toMatch(
+      /\.shell\[data-design='unified'\] \.shell-sidebar\[data-collapsed='true'\] \.shell-sidebar__head \{[\s\S]*?justify-content: center;[\s\S]*?background: transparent;/,
+    )
+    expect(controlCss).toMatch(
+      /\.shell\[data-design='unified'\] \.shell-sidebar\[data-collapsed='true'\] \.shell-sidebar__brand \{[\s\S]*?max-width: none;[\s\S]*?gap: 0;[\s\S]*?opacity: 1;/,
+    )
+    expect(controlCss).toMatch(
+      /\.shell\[data-design='unified'\] \.shell-sidebar\[data-collapsed='true'\] \.shell-sidebar__collapse \{[\s\S]*?position: absolute;[\s\S]*?right: 0;[\s\S]*?translate: 50% -50%;/,
+    )
+    expect(controlCss).toMatch(
+      /\.shell\[data-design='unified'\] \.shell-sidebar__head \{[\s\S]*?background: color-mix\(in srgb, var\(--elevated\) 78%, var\(--sidebar\)\);/,
+    )
+    expect(controlCss).toMatch(
+      /\.shell\[data-design='unified'\] \.shell-sidebar\[data-collapsed='true'\] \.shell-sidebar__collapse \{[\s\S]*?border: 0;[\s\S]*?box-shadow: none;/,
+    )
+    expect(controlCss).toMatch(
+      /\.shell-sidebar\[data-collapsed='true'\][\s\S]*?\.shell-sidebar__collapse::after \{[\s\S]*?inset: 0 0 0 50%;[\s\S]*?border: 1px solid var\(--sidebar-border\);[\s\S]*?border-left: 0;/,
     )
     expect(controlCss).toMatch(
       /\.shell\[data-design='unified'\][\s\S]*?\.shell-sidebar\[data-collapsed='true'\][\s\S]*?\.shell-nav-link \{[\s\S]*?justify-content: center;[\s\S]*?padding-inline: 0;/,

--- a/frontend/src/styles/control-surface.css
+++ b/frontend/src/styles/control-surface.css
@@ -164,30 +164,44 @@
 
   .shell[data-design='unified'] .shell-sidebar[data-collapsed='true'] .shell-sidebar__head {
     justify-content: center;
-    gap: 0.25rem;
     padding-inline: 0.25rem;
+    background: transparent;
   }
 
   .shell[data-design='unified'] .shell-sidebar[data-collapsed='true'] .shell-sidebar__brand {
-    flex: none;
     max-width: none;
+    gap: 0;
     opacity: 1;
   }
 
-  .shell[data-design='unified'] .shell-sidebar[data-collapsed='true'] .shell-sidebar__brand-mark {
-    width: 1.5rem;
-    height: 1.5rem;
-  }
-
   .shell[data-design='unified'] .shell-sidebar[data-collapsed='true'] .shell-sidebar__brand-copy {
-    max-width: 0;
-    opacity: 0;
+    display: none;
   }
 
   .shell[data-design='unified'] .shell-sidebar[data-collapsed='true'] .shell-sidebar__collapse {
-    width: 1.75rem;
-    height: 1.75rem;
+    position: absolute;
+    z-index: 2;
+    top: 2.375rem;
+    right: 0;
+    width: 2rem;
+    height: 2rem;
     margin-left: 0;
+    translate: 50% -50%;
+    border: 0;
+    background: var(--sidebar);
+    box-shadow: none;
+  }
+
+  .shell[data-design='unified']
+    .shell-sidebar[data-collapsed='true']
+    .shell-sidebar__collapse::after {
+    position: absolute;
+    inset: 0 0 0 50%;
+    border: 1px solid var(--sidebar-border);
+    border-left: 0;
+    border-radius: 0 var(--radius-control) var(--radius-control) 0;
+    content: '';
+    pointer-events: none;
   }
 
   .shell[data-design='unified'] .shell-sidebar[data-collapsed='true'] .shell-sidebar__nav {


### PR DESCRIPTION
## Summary
- preserve the original expanded sidebar header layout
- center the brand mark in the collapsed rail and pin the expand chevron to its outer edge
- draw only the exposed half of the toggle border and keep collapse/expand icons consistent
- add regression coverage for icon direction and collapsed shell geometry

## Testing
- `uv run python scripts/build_control_ui.py build`
- `npm --prefix frontend run check`
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- `uv run pytest -q` (6138 passed, 27 skipped)
- `uv build --wheel`