### PR TITLE
fix(cli): wrap onboarding prompt input

### DIFF
--- a/src/agentos/cli/init_cmd.py
+++ b/src/agentos/cli/init_cmd.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import questionary
+import questionary as _questionary
 import tomli_w
 import typer
 
-from agentos.cli.ui import console
+from agentos.cli.ui import console, styled_questionary
 from agentos.onboarding import get_provider_setup_spec
 from agentos.paths import default_agentos_home
 
@@ -46,6 +46,8 @@ def run_init() -> None:
     config_path = home / "config.toml"
     home.mkdir(parents=True, exist_ok=True)
     (home / "state").mkdir(parents=True, exist_ok=True)
+
+    questionary = styled_questionary(_questionary)
 
     provider = questionary.select(
         "Choose provider:",

--- a/src/agentos/cli/ui.py
+++ b/src/agentos/cli/ui.py
@@ -15,8 +15,10 @@ from agentos.ui import (
     error_console,
     error_panel,
     markup_escape,
+    prompt_message,
     questionary_style,
     section_rule,
+    styled_questionary,
     warning_panel,
 )
 
@@ -84,7 +86,9 @@ __all__ = [
     "error_panel",
     "markup_escape",
     "notice_panel",
+    "prompt_message",
     "questionary_style",
     "section_rule",
+    "styled_questionary",
     "warning_panel",
 ]

--- a/src/agentos/onboarding/flow.py
+++ b/src/agentos/onboarding/flow.py
@@ -70,56 +70,21 @@ from agentos.ui import (
     ACCENT_SOFT,
     console,
     markup_escape,
-    questionary_style,
     setup_cockpit_panel,
     setup_step_panel,
+    styled_questionary,
     warning_panel,
 )
 
-_QSTYLE = None
-
-
-def _qs():
-    global _QSTYLE
-    if _QSTYLE is None:
-        built = questionary_style()
-        if built is None:
-            return None
-        _QSTYLE = built
-    return _QSTYLE
-
 
 def _styled(q):
-    """Wrap the questionary module so every prompt inherits the brand style.
+    """Wrap the questionary module so every prompt inherits the brand layout.
 
-    When ``questionary_style()`` returns ``None`` (e.g. test stub or missing
-    optional dep) the wrapper passes calls through unchanged.
+    Delegates to :func:`agentos.ui.styled_questionary`, which is shared with the
+    other interactive CLI surfaces. When the brand style is unavailable (e.g.
+    test stub or missing optional dep) the module passes through unchanged.
     """
-    from types import SimpleNamespace
-
-    style = _qs()
-    if style is None:
-        return q
-    try:
-        import questionary.prompts.common as questionary_common
-
-        questionary_common.INDICATOR_SELECTED = "☑"
-        questionary_common.INDICATOR_UNSELECTED = "☐"
-    except Exception:
-        pass
-
-    def _wrap(name):
-        fn = getattr(q, name)
-        return lambda *a, **kw: fn(*a, **{"style": style, **kw})
-
-    return SimpleNamespace(
-        select=_wrap("select"),
-        text=_wrap("text"),
-        confirm=_wrap("confirm"),
-        password=_wrap("password"),
-        checkbox=_wrap("checkbox"),
-        Choice=getattr(q, "Choice", None),
-    )
+    return styled_questionary(q)
 
 
 @dataclass(frozen=True)

--- a/src/agentos/ui.py
+++ b/src/agentos/ui.py
@@ -350,3 +350,94 @@ def questionary_style():
             ("disabled", "fg:#666666 italic"),
         ]
     )
+
+
+PROMPT_CARET = "›"
+
+# Free-text prompts render their input buffer inline with the question label.
+# Only these two get the caret treatment: ``select`` already lists its choices
+# below the question and ``confirm`` renders ``(y/N)`` inline by convention.
+_NEXT_LINE_PROMPTS = ("text", "password")
+
+_WRAPPED_PROMPTS = ("select", "text", "confirm", "password", "checkbox")
+
+
+def prompt_message(message: str, default: object = None) -> str:
+    """Format a prompt label so the caret lands on the line below the question.
+
+    questionary renders its prompt tokens as ``"? " + " {message} "``, so a
+    trailing newline breaks the line and the caret prefixes the input buffer.
+    A non-empty ``default`` moves onto the question line as a hint instead of
+    being pre-filled into the buffer, so typing replaces it rather than
+    appending to it.
+    """
+    hint = f" ({default})" if default not in (None, "") else ""
+    return f"{message}{hint}\n{PROMPT_CARET}"
+
+
+class _DefaultOnEmpty:
+    """Question proxy substituting ``default`` for an empty submission.
+
+    The default is no longer pre-filled into the input buffer, so Enter on an
+    untouched prompt yields ``""``. ``None`` (Ctrl+C / Esc) passes through
+    untouched so callers can still detect cancellation.
+    """
+
+    def __init__(self, question: object, default: object) -> None:
+        self._question = question
+        self._default = default
+
+    def _resolve(self, answer: object) -> object:
+        return self._default if answer == "" else answer
+
+    def ask(self, *args: object, **kwargs: object) -> object:
+        return self._resolve(self._question.ask(*args, **kwargs))  # type: ignore[attr-defined]
+
+    def unsafe_ask(self, *args: object, **kwargs: object) -> object:
+        return self._resolve(self._question.unsafe_ask(*args, **kwargs))  # type: ignore[attr-defined]
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._question, name)
+
+
+def styled_questionary(q):
+    """Wrap the questionary module so every prompt inherits the brand layout.
+
+    Prompts get the brand style, and free-text prompts get their input caret on
+    the line below the question (see :func:`prompt_message`).
+
+    When ``questionary_style()`` returns ``None`` (e.g. test stub or missing
+    optional dep) the module is passed through unchanged.
+    """
+    from types import SimpleNamespace
+
+    style = questionary_style()
+    if style is None:
+        return q
+    try:
+        import questionary.prompts.common as questionary_common
+
+        questionary_common.INDICATOR_SELECTED = "☑"
+        questionary_common.INDICATOR_UNSELECTED = "☐"
+    except Exception:
+        pass
+
+    def _wrap(name):
+        fn = getattr(q, name)
+        if name not in _NEXT_LINE_PROMPTS:
+            return lambda *a, **kw: fn(*a, **{"style": style, **kw})
+
+        def call(message, *a, **kw):
+            # Only ``text`` carries a value default; ``password`` never does.
+            default = kw.pop("default", "") if name == "text" else ""
+            question = fn(
+                prompt_message(message, default), *a, **{"style": style, **kw}
+            )
+            return _DefaultOnEmpty(question, default) if default else question
+
+        return call
+
+    return SimpleNamespace(
+        **{name: _wrap(name) for name in _WRAPPED_PROMPTS},
+        Choice=getattr(q, "Choice", None),
+    )

--- a/tests/test_prompt_layout.py
+++ b/tests/test_prompt_layout.py
@@ -1,0 +1,146 @@
+"""Prompt layout contract for interactive CLI surfaces (issue #86).
+
+Free-text questions must own their line, with the input caret on the line
+below and the default offered as a hint instead of being pre-filled into the
+buffer (typing must replace the default, not append to it).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos import ui
+
+
+class _Answer:
+    def __init__(self, value):
+        self.value = value
+
+    def ask(self):
+        return self.value
+
+    def unsafe_ask(self):
+        return self.value
+
+
+class _FakeQuestionary:
+    """Records the message/kwargs each prompt was constructed with."""
+
+    def __init__(self, answer=""):
+        self.calls: list[tuple[str, str, dict]] = []
+        self._answer = answer
+
+    def _record(self, kind):
+        def build(message, **kwargs):
+            self.calls.append((kind, message, kwargs))
+            return _Answer(self._answer)
+
+        return build
+
+    def __getattr__(self, name):
+        if name in {"select", "text", "confirm", "password", "checkbox"}:
+            return self._record(name)
+        raise AttributeError(name)
+
+    Choice = object()
+
+
+@pytest.fixture
+def styled(monkeypatch):
+    """Force the styled path; without a Style the wrapper passes through."""
+
+    monkeypatch.setattr(ui, "questionary_style", lambda: object())
+    return ui.styled_questionary
+
+
+def test_prompt_message_puts_caret_on_the_next_line():
+    assert ui.prompt_message("Channel name") == f"Channel name\n{ui.PROMPT_CARET}"
+
+
+def test_prompt_message_offers_a_non_empty_default_as_a_hint():
+    assert (
+        ui.prompt_message("Channel name", "telegram")
+        == f"Channel name (telegram)\n{ui.PROMPT_CARET}"
+    )
+
+
+@pytest.mark.parametrize("default", [None, ""])
+def test_prompt_message_omits_the_hint_when_there_is_no_default(default):
+    assert ui.prompt_message("Channel name", default) == (f"Channel name\n{ui.PROMPT_CARET}")
+
+
+@pytest.mark.parametrize("kind", ["text", "password"])
+def test_free_text_prompts_are_reformatted(styled, kind):
+    fake = _FakeQuestionary()
+
+    getattr(styled(fake), kind)("Bot token")
+
+    assert fake.calls[0][1] == f"Bot token\n{ui.PROMPT_CARET}"
+
+
+@pytest.mark.parametrize("kind", ["select", "confirm"])
+def test_choice_prompts_keep_their_message(styled, kind):
+    fake = _FakeQuestionary()
+
+    getattr(styled(fake), kind)("Channel type", choices=["telegram"])
+
+    assert fake.calls[0][1] == "Channel type"
+
+
+def test_text_default_is_not_prefilled_into_the_buffer(styled):
+    fake = _FakeQuestionary()
+
+    styled(fake).text("Channel name", default="telegram")
+
+    _kind, message, kwargs = fake.calls[0]
+    assert message == f"Channel name (telegram)\n{ui.PROMPT_CARET}"
+    assert "default" not in kwargs
+
+
+def test_empty_submission_falls_back_to_the_default(styled):
+    fake = _FakeQuestionary(answer="")
+
+    answer = styled(fake).text("Channel name", default="telegram").ask()
+
+    assert answer == "telegram"
+
+
+def test_typed_value_replaces_the_default(styled):
+    fake = _FakeQuestionary(answer="mybot")
+
+    answer = styled(fake).text("Channel name", default="telegram").ask()
+
+    assert answer == "mybot"
+
+
+def test_cancellation_is_not_swallowed_by_the_default(styled):
+    """``None`` means Ctrl+C / Esc; callers turn it into UserCancelledError."""
+
+    fake = _FakeQuestionary(answer=None)
+
+    answer = styled(fake).text("Channel name", default="telegram").ask()
+
+    assert answer is None
+
+
+def test_unsafe_ask_applies_the_same_fallback(styled):
+    fake = _FakeQuestionary(answer="")
+
+    answer = styled(fake).text("Channel name", default="telegram").unsafe_ask()
+
+    assert answer == "telegram"
+
+
+def test_prompt_without_a_default_is_returned_unwrapped(styled):
+    fake = _FakeQuestionary(answer="")
+
+    assert styled(fake).text("Model id").ask() == ""
+
+
+def test_passthrough_when_the_brand_style_is_unavailable(monkeypatch):
+    """Test stubs and installs without questionary must keep raw messages."""
+
+    monkeypatch.setattr(ui, "questionary_style", lambda: None)
+    fake = _FakeQuestionary()
+
+    assert ui.styled_questionary(fake) is fake


### PR DESCRIPTION
## Summary

- move onboarding free-text input to a new line after the prompt
- apply the shared prompt layout to CLI onboarding flows
- add regression coverage for prompt formatting and default handling

## Testing

- `uv run pytest tests/test_prompt_layout.py -q`
- `uv run ruff check src/agentos/cli/init_cmd.py src/agentos/cli/ui.py src/agentos/onboarding/flow.py src/agentos/ui.py tests/test_prompt_layout.py`

Fixes #86
