### PR TITLE
fix(frontend): repair settings, Bankr icons, and session reset

### DIFF
--- a/frontend/src/app/control-surface-css.test.ts
+++ b/frontend/src/app/control-surface-css.test.ts
@@ -137,6 +137,18 @@ describe('Control surface CSS contract', () => {
     expect(configCss).toMatch(
       /\.control-surface \.cfg-stage--embedded \.cfg-stage__header--embedded \{[\s\S]*?min-height: 0;[\s\S]*?margin-bottom: 0\.75rem;/,
     )
+    expect(configCss).toMatch(
+      /\.control-surface \.cfg-stage--embedded \.cfg-group \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);[\s\S]*?border: 0;[\s\S]*?background: transparent;[\s\S]*?box-shadow: none;/,
+    )
+    expect(configCss).toMatch(
+      /\.control-surface \.cfg-stage--embedded \.cfg-group__head \{[\s\S]*?border-right: 0;[\s\S]*?border-bottom: 1px solid var\(--hairline\);/,
+    )
+    expect(configCss).toMatch(
+      /\.control-surface \.cfg-stage \.cfg-yaml__area \{[\s\S]*?min-height: 60vh;/,
+    )
+    expect(configCss).toMatch(
+      /@media \(max-width: 840px\) \{[\s\S]*?\.control-surface \.cfg-stage--embedded \.cfg-group__fields \{[\s\S]*?grid-template-columns: 1fr;/,
+    )
     expect(controlCss).toMatch(
       /\.control-surface \.setup-router-toolbar input\[type='number'\] \{[\s\S]*?box-sizing: border-box;[\s\S]*?padding: 0\.58rem 2\.65rem 0\.58rem 0\.75rem;/,
     )

--- a/frontend/src/views/chat/ChatPage.test.tsx
+++ b/frontend/src/views/chat/ChatPage.test.tsx
@@ -790,6 +790,8 @@ describe('ChatPage', () => {
   it('opens the complete tool output from View full and closes the dialog (chat.js:7311)', async () => {
     mockRpc = makeRpc()
     renderPage()
+    const thread = document.querySelector('.chat-thread') as HTMLElement
+    await waitFor(() => expect(thread).toHaveAttribute('data-history-ready', 'true'))
     const fullOutput = `exit_code=0 ${'provider output '.repeat(20)}<not-html>`
 
     await act(async () => {

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -23,6 +23,7 @@ import {
   type PendingAttachment,
 } from './logic'
 import { PendingQueue } from './PendingQueue'
+import { resetSession as requestSessionReset } from './resetSession'
 import { SessionChip } from './SessionChip'
 import { SlashMenu, type SlashMenuHandle } from './SlashMenu'
 import { Toolbar } from './Toolbar'
@@ -328,12 +329,7 @@ export function ChatPage() {
   // and let the terminal `sessions.changed` resync history (useTranscript owns
   // that path); toast the outcome.
   const resetSession = useCallback(() => {
-    rpc
-      .call('sessions.reset', { key: sessionKey })
-      .then(() => toast.info('Session reset'))
-      .catch((err: unknown) =>
-        toast.error('Reset failed: ' + (err instanceof Error ? err.message : String(err))),
-      )
+    void requestSessionReset(rpc, sessionKey)
   }, [rpc, sessionKey])
 
   // Slash catalog + execution (chat.js:2615/2842). `new_chat` is now WIRED through

--- a/frontend/src/views/chat/resetSession.test.ts
+++ b/frontend/src/views/chat/resetSession.test.ts
@@ -1,0 +1,72 @@
+import { waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { resetSession } from './resetSession'
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function makeRpc() {
+  return {
+    call: vi.fn<(...args: [string, Record<string, unknown>?]) => Promise<unknown>>(),
+  }
+}
+
+describe('resetSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the safe reset path when transcript flushing is available', async () => {
+    const rpc = makeRpc()
+    rpc.call.mockResolvedValue({})
+
+    await resetSession(rpc, 'agent:main:webchat:default')
+
+    expect(rpc.call).toHaveBeenCalledWith('sessions.reset', {
+      key: 'agent:main:webchat:default',
+    })
+    expect(toast.info).toHaveBeenCalledWith('Session reset')
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  it('offers a destructive recovery action when transcript backup is unavailable', async () => {
+    const rpc = makeRpc()
+    rpc.call
+      .mockRejectedValueOnce(
+        Object.assign(new Error('backend force instruction must not be shown'), {
+          code: 'flush_unavailable',
+        }),
+      )
+      .mockResolvedValueOnce({})
+
+    await resetSession(rpc, 'agent:main:webchat:default')
+
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.warning).toHaveBeenCalledWith(
+      'Transcript backup is unavailable.',
+      expect.objectContaining({
+        description: 'Discard the current transcript and reset this session?',
+        duration: Infinity,
+      }),
+    )
+
+    const options = vi.mocked(toast.warning).mock.calls[0]?.[1] as
+      { action?: { label?: string; onClick?: () => void } } | undefined
+    expect(options?.action?.label).toBe('Discard & reset')
+    options?.action?.onClick?.()
+
+    await waitFor(() =>
+      expect(rpc.call).toHaveBeenLastCalledWith('sessions.reset', {
+        key: 'agent:main:webchat:default',
+        force: true,
+      }),
+    )
+    expect(toast.info).toHaveBeenCalledWith('Session reset without transcript backup')
+  })
+})

--- a/frontend/src/views/chat/resetSession.ts
+++ b/frontend/src/views/chat/resetSession.ts
@@ -1,0 +1,66 @@
+import { toast } from 'sonner'
+
+interface SessionResetRpc {
+  call(method: string, params?: Record<string, unknown>): Promise<unknown>
+}
+
+interface CodedError {
+  code?: unknown
+  message?: unknown
+}
+
+function errorCode(error: unknown): string {
+  if (!error || typeof error !== 'object') return ''
+  const code = (error as CodedError).code
+  return typeof code === 'string' ? code : ''
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object') {
+    const message = (error as CodedError).message
+    if (typeof message === 'string') return message
+  }
+  return String(error)
+}
+
+async function discardAndReset(rpc: SessionResetRpc, sessionKey: string): Promise<void> {
+  try {
+    await rpc.call('sessions.reset', { key: sessionKey, force: true })
+    toast.info('Session reset without transcript backup')
+  } catch (error) {
+    if (errorCode(error) === 'permission_denied') {
+      toast.error('Reset without backup requires a local owner connection.')
+      return
+    }
+    toast.error('Reset failed: ' + errorMessage(error))
+  }
+}
+
+/**
+ * Reset through the safe flush path first. If transcript backup is disabled,
+ * offer the local owner an explicit destructive recovery action instead of
+ * leaking the backend-only `force=true` instruction into the UI.
+ */
+export async function resetSession(rpc: SessionResetRpc, sessionKey: string): Promise<void> {
+  try {
+    await rpc.call('sessions.reset', { key: sessionKey })
+    toast.info('Session reset')
+  } catch (error) {
+    if (errorCode(error) === 'flush_unavailable') {
+      toast.warning('Transcript backup is unavailable.', {
+        id: 'session-reset-flush-unavailable',
+        description: 'Discard the current transcript and reset this session?',
+        duration: Infinity,
+        action: {
+          label: 'Discard & reset',
+          onClick: () => {
+            void discardAndReset(rpc, sessionKey)
+          },
+        },
+      })
+      return
+    }
+    toast.error('Reset failed: ' + errorMessage(error))
+  }
+}

--- a/frontend/src/views/chat/useSlashCommands.ts
+++ b/frontend/src/views/chat/useSlashCommands.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useRpc } from '@/app/providers'
 import { normalizeSlashCommand, slashCommandKey, type SlashCommand } from './logic'
+import { resetSession } from './resetSession'
 
 /**
  * Slash-command catalog + execution (React).
@@ -151,12 +152,7 @@ export function useSlashCommands(opts?: {
         case 'reset_session':
         case 'sessions.reset':
         case '/reset': {
-          rpc
-            .call('sessions.reset', { key })
-            .then(() => toast.info('Session reset'))
-            .catch((err: unknown) =>
-              toast.error('Reset failed: ' + (err instanceof Error ? err.message : String(err))),
-            )
+          void resetSession(rpc, key)
           return
         }
         // chat.js:2738-2763 — manual compaction. The RPC is fired; the in-thread

--- a/frontend/src/views/config/config.css
+++ b/frontend/src/views/config/config.css
@@ -412,20 +412,27 @@
   color: var(--danger);
 }
 
-.cfg-stage--embedded .cfg-group {
+.control-surface .cfg-stage--embedded .cfg-group {
+  grid-template-columns: minmax(0, 1fr);
   border: 0;
   border-top: 1px solid var(--hairline);
   background: transparent;
   box-shadow: none;
 }
 
-.cfg-stage--embedded .cfg-group__head {
+.control-surface .cfg-stage--embedded .cfg-group__head {
+  padding-inline: 0;
+  border-right: 0;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.control-surface .cfg-stage--embedded .cfg-group__fields {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   padding-inline: 0;
 }
 
-.cfg-stage--embedded .cfg-group__fields {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  padding-inline: 0;
+.control-surface .cfg-stage .cfg-yaml__area {
+  min-height: 60vh;
 }
 
 /* Sticky save bar. */
@@ -529,7 +536,7 @@
     width: 100%;
   }
 
-  .cfg-stage--embedded .cfg-group__fields {
+  .control-surface .cfg-stage--embedded .cfg-group__fields {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/views/skills/SkillsPage.test.tsx
+++ b/frontend/src/views/skills/SkillsPage.test.tsx
@@ -71,6 +71,13 @@ const CATALOG_ITEM = {
   category: 'defi',
   demo: { code: 'swap(1, ETH)', language: 'python', title: 'Quote a swap' },
 }
+const BANKR_CATALOG_ITEM = {
+  name: 'bankr-token-scam-analysis',
+  identifier: 'bankr-token-scam-analysis',
+  provider: 'BankrBot',
+  source: 'bankr',
+  description: 'Analyze token risk.',
+}
 // A needs_setup skill carrying both a Requirements manifest and Missing bins/env
 // (skills.js:743-777,792-803). requirements.items exercises the ready /
 // needs_setup / missing_skill status branches plus the missing + requires detail.
@@ -304,6 +311,16 @@ describe('SkillsPage', () => {
 
     expect(logo).toHaveAttribute('src', CATALOG_ITEM.logo)
     expect(logo).toHaveAttribute('referrerpolicy', 'no-referrer')
+  })
+
+  it('uses the official Bankr icon when a Bankr catalog item has no logo metadata', async () => {
+    wireRpc({ searchResults: [BANKR_CATALOG_ITEM] })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('tab', { name: 'Bankr' }))
+
+    const card = await screen.findByLabelText('Catalog skill bankr-token-scam-analysis')
+    expect(within(card).getByRole('presentation')).toHaveAttribute('src', bankrSymbolUrl)
   })
 
   // ── Install (per-item busy, correct RPC + params + invalidation) ─────────

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -126,6 +126,9 @@ function LogoBadge({ item, cls }: { item: RegistryItem; cls: string }) {
   const logoUrl = safeUrl(item.logo)
   const [broken, setBroken] = useState(false)
   if (!logoUrl || broken) {
+    if (item.source?.toLowerCase() === 'bankr') {
+      return <PartnerLogo brand="bankr" className={cls} decorative />
+    }
     return <span className={`${cls} ${cls}--initials`}>{initials(item.provider || item.name)}</span>
   }
   return (


### PR DESCRIPTION
## Summary

- restore the embedded Settings configuration layout and keep the YAML editor at a usable responsive height
- render the official Bankr asset when Bankr catalog entries omit per-skill logo metadata
- share a safe session-reset flow between the chat action and slash command, with an explicit discard-and-reset recovery when transcript backup is unavailable

## Validation

- `uv run python scripts/build_control_ui.py build`
- `npm --prefix frontend run check` (1,494 tests)
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- `uv run pytest -q` (6,138 passed, 27 skipped)
- `uv build --wheel`
- browser QA at the issue viewport sizes for Settings Form/YAML and the Bankr catalog icon

Fixes #82
Fixes #84
Fixes #85