### PR TITLE
chore(release): bump version to 2026.7.25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,37 @@ Docs live in `docs/` (`docs/README.md` is the index); helper scripts in `scripts
   transcripts, local paths, or scratch/editor artifacts. `.gitignore` is
   hardened and `tests/test_public_release_hygiene.py` guards it.
 
+## Version bump (release cut)
+
+Versions are **CalVer, non-padded** (`2026.7.23`, not `2026.07.23`); same-day
+re-cuts use a PEP 440 post segment (`2026.7.22.post1`). The tag is `v<version>`
+and must match `pyproject.toml` exactly or the release smoke check fails.
+
+Do the bump on a `chore/bump-<version>` branch, one commit
+`chore(release): bump version to <version>`, PR to `main`. Every touchpoint
+below changes in that same commit — `tests/test_release_consistency.py` and
+`tests/test_install_scripts.py` fail the build if any is missed:
+
+| File | What changes |
+|---|---|
+| `pyproject.toml` | `[project] version` |
+| `uv.lock` | `use-agent-os` package version — regenerate with `uv lock`, never hand-edit |
+| `CHANGELOG.md` | move `[Unreleased]` entries into a `[<version>]` section; reopen an empty `[Unreleased]` |
+| `RELEASES.md` | new row at the top of the table (version, `v<version>`, date, notes) |
+| `README.md` | "AgentOS `<version>` is the current release", the pinned `uv tool install` example, and the wheel URL/filename |
+| `install.sh` / `install.ps1` | `default_version` / `$defaultVersion` plus the version shown in usage and error text |
+| `tests/test_release_consistency.py` | `CURRENT_VERSION` |
+| `tests/test_install_scripts.py` | `CURRENT_RELEASE_TAG` |
+
+Then run the full quality gate above (at minimum
+`uv run pytest tests/test_release_consistency.py tests/test_install_scripts.py -q`
+plus `uv build --wheel`).
+
+Tagging and publishing are a separate, human-gated step — do not tag or push a
+tag unless asked. The full SOP (tag, `wheelhouse-release.yml`, draft GitHub
+Release review, asset/URL checks) lives in **`RELEASES.md`**; PyPI publishing
+waits on a protected-environment approval.
+
 ## Security
 
 - Assist with defensive security, authorized testing, and the sandbox/safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.25] - 2026-07-25
+
 ### Added
 
 - Added one fail-closed Control UI build contract,
@@ -13,7 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Docker, wheel/sdist publication, and wheelhouse releases. It requires
   Node.js 22 or newer, performs a clean locked npm install, enforces bundle
   budgets, generates an exact third-party license ledger, and verifies the
-  resulting React bundle before packaging.
+   resulting React bundle before packaging.
+- OpenRouter's `openai/gpt-5.6-luna` is now the default LLM model.
 
 ### Changed
 
@@ -60,6 +63,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed the retired Jinja Control UI template and its hand-maintained
   JavaScript, CSS, fonts, images, and vendored browser libraries. There is no
   legacy frontend fallback at runtime or in release artifacts.
+
+### Fixed
+
+- Control UI settings preserve the active configuration state, Bankr icons
+  render correctly, and resetting a session reliably clears its client state.
+- The collapsed Control UI sidebar toggle has improved interaction and layout.
+- CLI onboarding prompts wrap correctly instead of overflowing narrow terminals.
 
 ## [2026.7.23] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope, and 20+
 other providers. You do not need to change your code or config to
 switch providers.
 
-AgentOS 2026.7.23 is the current release. The project website is
+AgentOS 2026.7.25 is the current release. The project website is
 [useagentos.dev](https://useagentos.dev). Follow
 [@useAgentOS](https://x.com/useAgentOS) on X for updates.
 
@@ -224,14 +224,14 @@ agentos gateway run
 > new terminal window. Or run the PATH command from step 1 again.
 
 For an install pinned to one exact version, add `==<version>` — for
-example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.23"` —
+example `uv tool install --python 3.12 "use-agent-os[recommended]==2026.7.25"` —
 or use the GitHub release wheel link directly:
-`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.23/use_agent_os-2026.7.23-py3-none-any.whl`.
+`https://github.com/use-agent-os/agent-os/releases/download/v2026.7.25/use_agent_os-2026.7.25-py3-none-any.whl`.
 
 > [!NOTE]
 > Release install commands use published GitHub release assets.
 > Python wheel installs use versioned wheel filenames — for example
-> `use_agent_os-2026.7.23-py3-none-any.whl` — because the installers validate the
+> `use_agent_os-2026.7.25-py3-none-any.whl` — because the installers validate the
 > version segment inside the wheel filename, so there is no `latest`
 > wheel alias. Only the Windows portable zip has a version-independent
 > `releases/latest/download/` alias.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 2026.7.25 | v2026.7.25 | 2026-07-25 | React Control UI is now the only verified production interface with settings/configuration transaction safety and hardened CSP; retired channel adapters and legacy UI removed; frontend settings, Bankr icons, session reset, collapsed sidebar, CLI onboarding prompt, and default `openai/gpt-5.6-luna` model fixes. |
 | 2026.7.23 | v2026.7.23 | 2026-07-23 | Mouse drag selection and copy in the full-screen `agentos chat` transcript (#76); turn-lifetime waiting indicator and markdown streaming fixes that remove ghost panels in Windows PowerShell; reasoning-model think-block rendering; Telegram keeps its native command menu across gateway restarts (#74). |
 | 2026.7.22.post1 | v2026.7.22.post1 | 2026-07-22 | `agentos chat` full-screen transcript mouse wheel scrolling is responsive on the first tick (larger wheel step plus follow-release compensation) (#69). |
 | 2026.7.22 | v2026.7.22 | 2026-07-22 | Native slash-command menus for Telegram, Slack, and Discord (#45); Ollama multi-turn tool-call history fixes and a `tools.enabled = false` plain-text fallback mode (#44); channel slash commands render their RPC results instead of a generic acknowledgement; Telegram delivery retries transient connection failures; `agentos chat` input frame supports multiline input (#62). |

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v2026.7.23'
+$defaultVersion = 'v2026.7.25'
 $repoSlug = if ($env:AGENTOS_REPOSITORY) { $env:AGENTOS_REPOSITORY } else { 'use-agent-os/agent-os' }
 $pythonVersion = if ($env:AGENTOS_PYTHON_VERSION) { $env:AGENTOS_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -92,7 +92,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.23. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported AGENTOS_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v2026.7.25. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v2026.7.23"
+default_version="v2026.7.25"
 repo_slug="${AGENTOS_REPOSITORY:-use-agent-os/agent-os}"
 python_version="${AGENTOS_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v2026.7.23|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v2026.7.25|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  AGENTOS_VERSION=v2026.7.23
+  AGENTOS_VERSION=v2026.7.25
   AGENTOS_INSTALL_PROFILE=recommended|core
   AGENTOS_INSTALL_EXTRAS=document-extras
   AGENTOS_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported AGENTOS_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.23." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v2026.7.25." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.7.23"
+version = "2026.7.25"
 description = "Token-Efficient AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -8,7 +8,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v2026.7.23"
+CURRENT_RELEASE_TAG = "v2026.7.25"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "2026.7.23"
+CURRENT_VERSION = "2026.7.25"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.0.1rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -3721,7 +3721,7 @@ wheels = [
 
 [[package]]
 name = "use-agent-os"
-version = "2026.7.23"
+version = "2026.7.25"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- bump AgentOS to 2026.7.25
- promote the Control UI and recent fixes in release notes
- synchronize installer, documentation, lockfile, and release tests

## Verification
- python scripts/build_control_ui.py build
- npm --prefix frontend run check
- uv run ruff check src tests
- uv run mypy src/agentos --show-error-codes
- uv run pytest tests/test_release_consistency.py tests/test_install_scripts.py -q
- uv run pytest -q (test runner exited 0 but omitted final summary; isolated legacy config and CLI cases passed)
- uv build --wheel