### PR TITLE
fix(telegram): preserve forum command reply targets

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -855,23 +855,28 @@ class TelegramChannel:
         )
 
     def _build_send_payload(self, message: OutgoingMessage) -> dict[str, Any]:
+        metadata = message.metadata
+        route_chat_id = metadata.get("channel")
         chat_id = (
-            message.metadata.get("chat_id")
-            or message.metadata.get("channel_id")
+            metadata.get("chat_id")
+            or metadata.get("channel_id")
+            or route_chat_id
             or message.reply_to
             or self.config.default_chat_id
         )
         if not chat_id:
             raise ValueError("telegram.send requires chat_id via metadata, reply_to, or config")
         payload: dict[str, Any] = {"chat_id": str(chat_id), "text": message.content}
-        thread_id = message.metadata.get("thread_id") or message.metadata.get("message_thread_id")
+        thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
+        if thread_id is None and route_chat_id and message.reply_to:
+            thread_id = message.reply_to
         if thread_id:
             payload["message_thread_id"] = _coerce_telegram_int(thread_id)
-        if (reply_message_id := message.metadata.get("reply_to_message_id")) is not None:
+        if (reply_message_id := metadata.get("reply_to_message_id")) is not None:
             payload["reply_parameters"] = {
                 "message_id": _coerce_telegram_int(reply_message_id),
             }
-        if parse_mode := message.metadata.get("parse_mode"):
+        if parse_mode := metadata.get("parse_mode"):
             payload["parse_mode"] = str(parse_mode)
         return payload
 

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -10,6 +10,7 @@ import pytest
 
 from agentos.artifacts import ArtifactStore
 from agentos.channels.stream_policy import resolve_channel_stream_policy
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
 from agentos.channels.types import Attachment, IncomingMessage, OutgoingMessage
 from agentos.engine.types import (
     ArtifactEvent,
@@ -147,6 +148,70 @@ async def test_registered_slash_command_preserves_channel_for_thread_target() ->
     assert reply.reply_to == "1700000000.000100"
     assert reply.metadata["channel"] == "C42"
     assert reply.metadata["command"] == "compact"
+
+
+@pytest.mark.asyncio
+async def test_telegram_forum_command_reply_keeps_chat_and_topic_targets() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    msg = channel.parse_incoming(
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 10,
+                "message_thread_id": 777,
+                "chat": {"id": -100123, "type": "supergroup"},
+                "from": {"id": 42},
+                "text": "/compact",
+            },
+        }
+    )
+    route_envelope = build_channel_route_envelope(
+        msg,
+        session_key="agent:main:telegram:group:-100123:thread:777",
+        session_prefix="telegram",
+        agent_id="main",
+    )
+
+    class FakeDispatcher:
+        async def dispatch(self, req_id, method, params, ctx):
+            return make_ok_res(
+                req_id,
+                {
+                    "status": "skipped",
+                    "compacted": False,
+                },
+            )
+
+    reply = await _dispatch_channel_slash_command(
+        route_envelope=route_envelope,
+        msg=msg,
+        session_manager=object(),
+        session_key=route_envelope.session_key,
+        session_prefix="telegram",
+        rpc_dispatcher=FakeDispatcher(),
+        context_factory=lambda _envelope: object(),
+    )
+    assert reply is not None
+
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_api(method: str, payload: dict | None = None) -> dict:
+        calls.append((method, payload or {}))
+        return {"message_id": 11}
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+    await channel.send(reply)
+
+    assert calls == [
+        (
+            "sendMessage",
+            {
+                "chat_id": "-100123",
+                "text": "Already within context budget; no compact was applied.",
+                "message_thread_id": 777,
+            },
+        )
+    ]
 
 
 def test_channel_stream_policy_prefers_adapter_stream_updates() -> None:


### PR DESCRIPTION
## Summary

- Preserve the original Telegram chat ID for command replies originating inside forum topics.
- Map the gateway thread target to the Telegram Bot API message_thread_id field.
- Add end-to-end regression coverage from an inbound Telegram update through command dispatch and sendMessage payload construction.

## Problem

For a command sent inside a Telegram forum topic, the gateway produces a routed reply with the topic ID in reply_to and the originating chat ID in metadata.channel. TelegramChannel._build_send_payload previously ignored metadata.channel, so it used the topic ID as chat_id and omitted message_thread_id. The Bot API request was therefore addressed to the wrong destination.

## Implementation

- Treat metadata.channel as the routed Telegram chat target after the explicit chat_id and channel_id metadata fields.
- When metadata.channel identifies the chat and no explicit thread metadata is present, interpret reply_to as the forum topic ID and send it as message_thread_id.
- Keep existing precedence for explicit chat_id, channel_id, thread_id, message_thread_id, and the configured default chat.
- Exercise the complete command-reply path in a regression test: parse an inbound supergroup update with message_thread_id, build the route envelope, dispatch /compact, send the reply, and assert the final Bot API payload contains both the original chat_id and topic message_thread_id.

## Verification

- Control UI production build passed.
- Frontend checks passed: TypeScript, ESLint, Prettier, and 1,494 Vitest tests.
- Ruff passed across src and tests.
- Mypy passed across 583 source files.
- Python test suite passed: 6,155 passed, 27 skipped.
- Wheel build passed.

Fixes #50