### PR TITLE
fix(discord): complete native interaction responses

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -55,6 +55,8 @@ _DISCORD_MENTION_RE = re.compile(r"<@!?(\d+)>")
 _DISCORD_DM_CHANNEL_TYPES = {1}
 _DISCORD_GROUP_DM_CHANNEL_TYPES = {3}
 _DISCORD_THREAD_CHANNEL_TYPES = {10, 11, 12}
+_DISCORD_APPLICATION_COMMAND_INTERACTION_TYPE = 2
+_DISCORD_DEFERRED_CHANNEL_MESSAGE_RESPONSE_TYPE = 5
 
 # Gateway intents bitmask
 GATEWAY_INTENTS = (
@@ -387,10 +389,12 @@ class DiscordChannel:
                 return
             self._enqueue_reaction(self._annotate_channel_context(data))
         elif event_type == "INTERACTION_CREATE":
+            if data.get("type") != _DISCORD_APPLICATION_COMMAND_INTERACTION_TYPE:
+                return
             interaction_id = str(data.get("id") or "")
             if interaction_id and not self._dedupe.check_and_add(f"interaction:{interaction_id}"):
                 return
-            self._handle_interaction(self._annotate_channel_context(data))
+            await self._handle_interaction(self._annotate_channel_context(data))
         elif event_type in {"CHANNEL_CREATE", "CHANNEL_UPDATE", "THREAD_CREATE", "THREAD_UPDATE"}:
             self._cache_channel_context(data)
         elif event_type == "GUILD_CREATE":
@@ -468,31 +472,76 @@ class DiscordChannel:
         )
         self.enqueue(msg)
 
-    def _handle_interaction(self, data: dict[str, Any]) -> None:
+    async def _defer_interaction_response(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+    ) -> bool:
+        try:
+            response = await self._get_client().post(
+                f"/interactions/{interaction_id}/{interaction_token}/callback",
+                json={"type": _DISCORD_DEFERRED_CHANNEL_MESSAGE_RESPONSE_TYPE},
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            status_code = (
+                exc.response.status_code if isinstance(exc, httpx.HTTPStatusError) else None
+            )
+            log.warning(
+                "discord.interaction_ack_failed",
+                interaction_id=interaction_id,
+                error_type=type(exc).__name__,
+                status_code=status_code,
+            )
+            return False
+        log.debug("discord.interaction_deferred", interaction_id=interaction_id)
+        return True
+
+    async def _handle_interaction(self, data: dict[str, Any]) -> None:
         """Parse a slash command interaction into IncomingMessage."""
-        interaction_data = data.get("data", {})
-        user = data.get("member", {}).get("user", data.get("user", {}))
-        channel_id = data.get("channel_id", "unknown")
+        interaction_data = data.get("data")
+        interaction_id = str(data.get("id") or "")
+        interaction_token = str(data.get("token") or "")
+        if not isinstance(interaction_data, dict) or not interaction_id or not interaction_token:
+            return
+
+        command_name = interaction_data.get("name")
+        if not isinstance(command_name, str) or not command_name:
+            return
+        if not await self._defer_interaction_response(interaction_id, interaction_token):
+            return
+
+        member = data.get("member")
+        member_user = member.get("user") if isinstance(member, dict) else None
+        direct_user = data.get("user")
+        user = member_user if isinstance(member_user, dict) else direct_user
+        if not isinstance(user, dict):
+            user = {}
+        channel_id = str(data.get("channel_id") or "unknown")
 
         # Build content from command name and options
-        command_name = interaction_data.get("name", "")
-        options = interaction_data.get("options", [])
-        option_parts = [opt.get("value", "") for opt in options if opt.get("value")]
+        raw_options = interaction_data.get("options")
+        options = raw_options if isinstance(raw_options, list) else []
+        option_parts = [
+            opt.get("value", "") for opt in options if isinstance(opt, dict) and opt.get("value")
+        ]
         content = f"/{command_name} {' '.join(str(v) for v in option_parts)}".strip()
         channel_type = self._channel_type(data.get("channel_type"))
         thread_id = self._native_thread_id(data, channel_type)
         conversation_kind = self._conversation_kind(data, channel_type, thread_id)
         parent_channel_id = data.get("thread_parent_channel_id")
+        application_id = str(data.get("application_id") or self.config.application_id)
 
         msg = IncomingMessage(
-            sender_id=user.get("id", "unknown"),
+            sender_id=str(user.get("id") or "unknown"),
             channel_id=channel_id,
             content=content,
             metadata={
                 "interaction_type": "slash_command",
                 "command_name": command_name,
-                "interaction_id": data.get("id"),
-                "interaction_token": data.get("token"),
+                "interaction_id": interaction_id,
+                "interaction_token": interaction_token,
+                "interaction_application_id": application_id,
                 "guild_id": data.get("guild_id"),
                 "channel_type": channel_type,
                 "is_group": conversation_kind in {"group", "group_dm", "thread", "topic"},
@@ -693,6 +742,38 @@ class DiscordChannel:
     # Outbound
     # ------------------------------------------------------------------
 
+    def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
+        """Route replies to the triggering interaction or channel."""
+        metadata: dict[str, Any] = {}
+        if inbound.metadata.get("interaction_type") == "slash_command":
+            for key in (
+                "interaction_id",
+                "interaction_token",
+                "interaction_application_id",
+            ):
+                value = inbound.metadata.get(key)
+                if isinstance(value, str) and value:
+                    metadata[key] = value
+        return OutgoingMessage(
+            content=content,
+            reply_to=inbound.channel_id,
+            metadata=metadata,
+        )
+
+    def streaming_reply_kwargs(self, inbound: IncomingMessage) -> dict[str, Any]:
+        """Route streaming replies to the triggering interaction or channel."""
+        kwargs: dict[str, Any] = {"channel_id": inbound.channel_id}
+        if inbound.metadata.get("interaction_type") == "slash_command":
+            for key in (
+                "interaction_id",
+                "interaction_token",
+                "interaction_application_id",
+            ):
+                value = inbound.metadata.get(key)
+                if isinstance(value, str) and value:
+                    kwargs[key] = value
+        return kwargs
+
     async def send(self, message: OutgoingMessage) -> ChannelSendResult:
         await self._rate_limiter.acquire()
         client = self._get_client()
@@ -707,6 +788,39 @@ class DiscordChannel:
             payload["message_reference"] = {
                 "message_id": message.metadata["reply_to_message_id"],
             }
+
+        interaction_token = message.metadata.get("interaction_token")
+        if isinstance(interaction_token, str) and interaction_token:
+            application_id = message.metadata.get("interaction_application_id")
+            if not isinstance(application_id, str) or not application_id:
+                application_id = self.config.application_id
+            interaction_id = str(message.metadata.get("interaction_id") or "")
+            if not application_id:
+                return ChannelSendResult.failed(
+                    capability=ChannelCapabilities.GROUP_CHAT,
+                    target_id=interaction_id or channel_id,
+                    reason="missing Discord application id for interaction response",
+                )
+            resp = await retry_request(
+                client.patch,
+                f"/webhooks/{application_id}/{interaction_token}/messages/@original",
+                json=payload,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            message_id = str(data.get("id") or "")
+            if message_id:
+                self._sent_messages[message_id] = channel_id
+            log.debug(
+                "discord.interaction_response_completed",
+                interaction_id=interaction_id,
+                message_id=message_id,
+            )
+            return ChannelSendResult.sent(
+                capability=ChannelCapabilities.GROUP_CHAT,
+                target_id=interaction_id or channel_id,
+                provider_message_id=message_id,
+            )
 
         resp = await retry_request(
             client.post,
@@ -837,6 +951,8 @@ class DiscordChannel:
 
     def is_group_mentioned(self, msg: IncomingMessage) -> bool:
         """Uniform mention check for group gating. Delegates to is_mentioned."""
+        if msg.metadata.get("interaction_type") == "slash_command":
+            return True
         return self.is_mentioned(msg.content)
 
     # ------------------------------------------------------------------
@@ -870,6 +986,9 @@ class DiscordChannel:
         chunks: AsyncIterator[str],
         *,
         channel_id: str | None = None,
+        interaction_id: str | None = None,
+        interaction_token: str | None = None,
+        interaction_application_id: str | None = None,
         update_interval_ms: int = 500,
     ) -> str | None:
         """Stream a message: post first chunk, PATCH edits for subsequent.
@@ -883,27 +1002,47 @@ class DiscordChannel:
         client = self._get_client()
         throttle = StreamThrottle(interval_s=update_interval_ms / 1000.0)
         message_id: str | None = None
+        interaction_path: str | None = None
+        if interaction_token:
+            application_id = interaction_application_id or self.config.application_id
+            if not application_id:
+                raise ValueError("missing Discord application id for interaction response")
+            interaction_path = f"/webhooks/{application_id}/{interaction_token}/messages/@original"
 
         async def _post(text: str) -> None:
             nonlocal message_id
             await self._rate_limiter.acquire()
-            resp = await retry_request(
-                client.post,
-                f"/channels/{target}/messages",
-                json={"content": text},
-                headers=self._auth_headers(),
-            )
+            if interaction_path is not None:
+                resp = await retry_request(
+                    client.patch,
+                    interaction_path,
+                    json={"content": text},
+                )
+            else:
+                resp = await retry_request(
+                    client.post,
+                    f"/channels/{target}/messages",
+                    json={"content": text},
+                    headers=self._auth_headers(),
+                )
             resp.raise_for_status()
             message_id = resp.json().get("id")
 
         async def _edit(text: str) -> None:
             await self._rate_limiter.acquire()
-            await retry_request(
-                client.patch,
-                f"/channels/{target}/messages/{message_id}",
-                json={"content": text},
-                headers=self._auth_headers(),
-            )
+            if interaction_path is not None:
+                await retry_request(
+                    client.patch,
+                    interaction_path,
+                    json={"content": text},
+                )
+            else:
+                await retry_request(
+                    client.patch,
+                    f"/channels/{target}/messages/{message_id}",
+                    json={"content": text},
+                    headers=self._auth_headers(),
+                )
 
         async for chunk in chunks:
             throttle.add(chunk)

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -385,7 +385,9 @@ async def run_channel_dispatch(
                 else:
                     event = "channel.command_intercepted"
                 emit(event, command=command_reply.metadata.get("command"), method=command_reply.metadata.get("method"), session_key=session_key)  # noqa: E501
-                await channel.send(command_reply)
+                await channel.send(
+                    _build_command_reply_message(channel, command_reply, msg)
+                )
                 continue
         # fmt: on
 
@@ -1240,6 +1242,29 @@ def _build_reply_message(channel: Any, content: str, msg: IncomingMessage) -> Ou
         if isinstance(reply, OutgoingMessage):
             return _sanitize_outgoing_message(reply)
     return _sanitize_outgoing_message(OutgoingMessage(content=content))
+
+
+def _build_command_reply_message(
+    channel: Any,
+    reply: OutgoingMessage,
+    inbound: IncomingMessage,
+) -> OutgoingMessage:
+    """Preserve command metadata while applying adapter-specific reply routing."""
+    builder = getattr(channel, "build_reply_message", None)
+    if not callable(builder):
+        return _sanitize_outgoing_message(reply)
+    routed = builder(reply.content, inbound)
+    if not isinstance(routed, OutgoingMessage):
+        return _sanitize_outgoing_message(reply)
+    metadata = {**routed.metadata, **reply.metadata}
+    return _sanitize_outgoing_message(
+        reply.model_copy(
+            update={
+                "metadata": metadata,
+                "reply_to": routed.reply_to,
+            }
+        )
+    )
 
 
 def _route_envelope_reply_message(

--- a/tests/test_channels/test_discord_interactions.py
+++ b/tests/test_channels/test_discord_interactions.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from agentos.channels.contract import ChannelSendStatus
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.channels.types import OutgoingMessage
+from agentos.gateway.channel_dispatch import (
+    _build_command_reply_message,
+    _should_skip_unmentioned,
+)
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self.headers: dict[str, str] = {}
+        self._payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeDiscordClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def post(self, path: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("POST", path, kwargs))
+        return _FakeResponse(status_code=204)
+
+    async def patch(self, path: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("PATCH", path, kwargs))
+        return _FakeResponse(status_code=200, payload={"id": "response-message-1"})
+
+
+def _application_command(
+    *,
+    interaction_id: str = "interaction-1",
+    interaction_type: int = 2,
+) -> dict[str, Any]:
+    return {
+        "id": interaction_id,
+        "application_id": "event-app-id",
+        "type": interaction_type,
+        "token": "interaction-token",
+        "guild_id": "guild-1",
+        "channel_id": "channel-1",
+        "channel_type": 0,
+        "member": {"user": {"id": "user-1"}},
+        "data": {
+            "type": 1,
+            "name": "status",
+            "options": [],
+        },
+    }
+
+
+async def test_discord_application_command_is_deferred_before_group_dispatch() -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(
+        DiscordChannelConfig(token="bot-token", application_id="configured-app-id")
+    )
+    channel._client = client
+
+    await channel._handle_dispatch("INTERACTION_CREATE", _application_command())
+
+    assert client.calls == [
+        (
+            "POST",
+            "/interactions/interaction-1/interaction-token/callback",
+            {"json": {"type": 5}},
+        )
+    ]
+    message = await channel.receive()
+    assert message.content == "/status"
+    assert message.metadata["interaction_type"] == "slash_command"
+    assert message.metadata["interaction_application_id"] == "event-app-id"
+    assert message.metadata["is_group"] is True
+    assert channel.is_group_mentioned(message) is True
+    assert (
+        _should_skip_unmentioned(
+            channel,
+            message,
+            "agent:main:discord:group:channel-1",
+        )
+        is False
+    )
+
+
+async def test_discord_command_reply_completes_original_interaction_response() -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(
+        DiscordChannelConfig(token="bot-token", application_id="configured-app-id")
+    )
+    channel._client = client
+    await channel._handle_dispatch("INTERACTION_CREATE", _application_command())
+    inbound = await channel.receive()
+    command_reply = OutgoingMessage(
+        content="All systems operational.",
+        reply_to=inbound.channel_id,
+        metadata={"command": "status", "method": "status"},
+    )
+
+    routed_reply = _build_command_reply_message(channel, command_reply, inbound)
+    result = await channel.send(routed_reply)
+
+    assert routed_reply.metadata["interaction_token"] == "interaction-token"
+    assert routed_reply.metadata["command"] == "status"
+    assert client.calls[-1] == (
+        "PATCH",
+        "/webhooks/event-app-id/interaction-token/messages/@original",
+        {"json": {"content": "All systems operational."}},
+    )
+    assert not any("/channels/" in path for _method, path, _kwargs in client.calls)
+    assert result.status is ChannelSendStatus.SENT
+    assert result.provider_message_id == "response-message-1"
+
+
+async def test_discord_streaming_reply_completes_original_interaction_response() -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(
+        DiscordChannelConfig(token="bot-token", application_id="configured-app-id")
+    )
+    channel._client = client
+    await channel._handle_dispatch("INTERACTION_CREATE", _application_command())
+    inbound = await channel.receive()
+    client.calls.clear()
+
+    async def _chunks() -> AsyncIterator[str]:
+        yield "Streaming response."
+
+    message_id = await channel.send_streaming(
+        _chunks(),
+        **channel.streaming_reply_kwargs(inbound),
+    )
+
+    assert client.calls
+    assert all(
+        method == "PATCH" and path == "/webhooks/event-app-id/interaction-token/messages/@original"
+        for method, path, _kwargs in client.calls
+    )
+    assert client.calls[-1][2] == {"json": {"content": "Streaming response."}}
+    assert not any("/channels/" in path for _method, path, _kwargs in client.calls)
+    assert message_id == "response-message-1"
+
+
+async def test_discord_duplicate_interaction_id_is_acknowledged_and_enqueued_once() -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token"))
+    channel._client = client
+    payload = _application_command()
+
+    await channel._handle_dispatch("INTERACTION_CREATE", payload)
+    await channel._handle_dispatch("INTERACTION_CREATE", payload)
+
+    assert channel._queue.qsize() == 1
+    assert [method for method, _path, _kwargs in client.calls] == ["POST"]
+
+
+@pytest.mark.parametrize("interaction_type", [1, 3, 4, 5])
+async def test_discord_non_command_interaction_types_are_ignored(
+    interaction_type: int,
+) -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token"))
+    channel._client = client
+
+    await channel._handle_dispatch(
+        "INTERACTION_CREATE",
+        _application_command(interaction_type=interaction_type),
+    )
+
+    assert channel._queue.empty()
+    assert client.calls == []

--- a/tests/test_channels/test_discord_routing.py
+++ b/tests/test_channels/test_discord_routing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 from agentos.channels.contract import ChannelCapabilities
 from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
 from agentos.channels.manager import ChannelManager
@@ -271,6 +273,7 @@ async def test_discord_thread_reaction_uses_cached_thread_session() -> None:
 
 async def test_discord_group_dm_interaction_uses_cached_group_session() -> None:
     channel = DiscordChannel(DiscordChannelConfig(token="token"))
+    channel._defer_interaction_response = AsyncMock(return_value=True)
 
     await channel._handle_dispatch(
         "CHANNEL_CREATE",
@@ -280,6 +283,8 @@ async def test_discord_group_dm_interaction_uses_cached_group_session() -> None:
         "INTERACTION_CREATE",
         {
             "id": "interaction-1",
+            "type": 2,
+            "token": "interaction-token",
             "channel_id": "group-dm-channel",
             "user": {"id": "user-1"},
             "data": {


### PR DESCRIPTION
## Summary

- acknowledge Discord application-command interactions with a deferred callback before dispatch and ignore unrelated interaction types
- treat slash commands as explicit group mentions and complete the deferred original response for command, batch, and streaming reply paths
- add regression coverage for deferred acknowledgement, original-response completion, group dispatch, duplicate IDs, and non-command interactions

## Validation

- `uv run python scripts/build_control_ui.py build`
- `npm --prefix frontend run check` (1495 tests passed)
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes` (583 source files checked)
- `uv run pytest -q` (6216 passed, 27 skipped)
- `uv build --wheel`

Fixes #53