### PR TITLE
fix(slack): classify slash command conversations correctly

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -289,12 +289,14 @@ class SlackChannel:
         thread_ts = event.get("thread_ts")
 
         # channel_type: "channel"/"group" = group, "im"/"mpim" = DM
-        # Fallback: infer from channel ID prefix (C/G = group, D = direct)
+        # Fallback: infer from channel ID prefix (C = public, G = private, D = direct)
         channel_type = event.get("channel_type")
         if channel_type is None:
             ch = event.get("channel", "")
-            if ch.startswith(("C", "G")):
+            if ch.startswith("C"):
                 channel_type = "channel"
+            elif ch.startswith("G"):
+                channel_type = "group"
             elif ch.startswith("D"):
                 channel_type = "im"
 
@@ -305,6 +307,8 @@ class SlackChannel:
             "channel_type": channel_type,
             "is_group": channel_type in {"channel", "group"},
         }
+        if interaction_type := event.get("interaction_type"):
+            metadata["interaction_type"] = interaction_type
 
         # Detect thread root: thread_ts == ts
         if thread_ts is not None and ts is not None:
@@ -731,7 +735,7 @@ class SlackChannel:
                         "user": str(form.get("user_id") or "unknown"),
                         "channel": str(form.get("channel_id") or self.slack_channel_id),
                         "text": f"{command} {text}".strip(),
-                        "channel_type": str(form.get("channel_name") or "channel"),
+                        "interaction_type": "slash_command",
                     }
                 )
             )

--- a/src/agentos/channels/types.py
+++ b/src/agentos/channels/types.py
@@ -47,6 +47,8 @@ class IncomingMessage(BaseModel):
     - ``native_parent_channel_id``: platform-native parent channel id.
     - ``native_root_id``: platform-native root message id.
     - ``reply_target_id``: platform-native message id to reply to.
+    - ``interaction_type``: explicit native interaction kind, such as
+      ``slash_command``.
     - ``is_group``: bool consumed by ``ChannelManager`` for session keys.
     """
 

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -992,11 +992,13 @@ def _should_skip_unmentioned(
     from agentos.session.keys import derive_chat_type
 
     is_group = derive_chat_type(session_key) == "group"
+    interaction_type = (msg.metadata or {}).get("interaction_type")
+    is_explicit_interaction = interaction_type == "slash_command"
     policy = getattr(channel, "policy", None)
     custom_evaluator = getattr(channel, "evaluate_access", None)
     if callable(custom_evaluator):
-        mentioned = True
-        if is_group:
+        mentioned = not is_group or is_explicit_interaction
+        if is_group and not is_explicit_interaction:
             hook = getattr(channel, "is_group_mentioned", None)
             if not callable(hook):
                 _warn_missing_mention_hook(channel)
@@ -1026,7 +1028,7 @@ def _should_skip_unmentioned(
                 sender_id=msg.sender_id,
             )
             return _record_access_denial(channel, msg, decision)
-        if not policy.mention_required_in_group:
+        if not policy.mention_required_in_group or is_explicit_interaction:
             decision = evaluate_policy(
                 policy,
                 is_group=True,
@@ -1035,8 +1037,8 @@ def _should_skip_unmentioned(
             )
             return _record_access_denial(channel, msg, decision)
 
-    if not is_group:
-        return False  # DMs always processed for legacy adapters.
+    if not is_group or is_explicit_interaction:
+        return False
 
     hook = getattr(channel, "is_group_mentioned", None)
     if not callable(hook):

--- a/tests/test_channels/test_native_commands.py
+++ b/tests/test_channels/test_native_commands.py
@@ -299,6 +299,9 @@ async def test_slack_start_survives_manifest_sync_failure() -> None:
 class _SlashRequest:
     headers = {"content-type": "application/x-www-form-urlencoded"}
 
+    def __init__(self, channel_id: str = "C1") -> None:
+        self.channel_id = channel_id
+
     async def body(self) -> bytes:
         return b"command=%2Fstatus"
 
@@ -307,19 +310,34 @@ class _SlashRequest:
             "command": "/status",
             "text": "",
             "user_id": "U1",
-            "channel_id": "C1",
+            "channel_id": self.channel_id,
             "channel_name": "general",
         }
 
 
+@pytest.mark.parametrize(
+    ("channel_id", "channel_type", "is_group"),
+    [
+        ("C1", "channel", True),
+        ("G1", "group", True),
+        ("D1", "im", False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_slack_slash_command_form_is_enqueued_for_channel_dispatch() -> None:
+async def test_slack_slash_command_form_uses_channel_id_conversation_type(
+    channel_id: str,
+    channel_type: str,
+    is_group: bool,
+) -> None:
     channel = SlackChannel(token="token", slack_channel_id="C1")
 
-    response = await channel._handle_webhook(_SlashRequest())  # noqa: SLF001
+    response = await channel._handle_webhook(_SlashRequest(channel_id))  # noqa: SLF001
 
     assert response.status_code == 200
     message = await channel.receive()
     assert message.content == "/status"
     assert message.sender_id == "U1"
-    assert message.channel_id == "C1"
+    assert message.channel_id == channel_id
+    assert message.metadata["channel_type"] == channel_type
+    assert message.metadata["is_group"] is is_group
+    assert message.metadata["interaction_type"] == "slash_command"

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from agentos.artifacts import ArtifactStore
+from agentos.channels._util import ChannelAccessPolicy
 from agentos.channels.stream_policy import resolve_channel_stream_policy
 from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
 from agentos.channels.types import Attachment, IncomingMessage, OutgoingMessage
@@ -37,6 +38,7 @@ from agentos.gateway.channel_dispatch import (
     _run_turn_batch_path,
     _run_turn_with_streaming,
     _RuntimeChannelStreamRelay,
+    _should_skip_unmentioned,
 )
 from agentos.gateway.config import AgentEntryConfig, GatewayConfig
 from agentos.gateway.protocol import make_ok_res
@@ -67,6 +69,59 @@ def _message() -> IncomingMessage:
 
 def _tool_ctx(agent_id: str = "main") -> SimpleNamespace:
     return SimpleNamespace(agent_id=agent_id)
+
+
+def test_explicit_slash_interaction_satisfies_group_mention_policy() -> None:
+    class MentionOnlyChannel:
+        policy = ChannelAccessPolicy(
+            dm_allowed=True,
+            group_allowed=True,
+            mention_required_in_group=True,
+        )
+
+        def is_group_mentioned(self, _msg: IncomingMessage) -> bool:
+            raise AssertionError("explicit interactions must not invoke the mention parser")
+
+    msg = IncomingMessage(
+        sender_id="U1",
+        channel_id="C1",
+        content="/status",
+        metadata={"is_group": True, "interaction_type": "slash_command"},
+    )
+
+    assert (
+        _should_skip_unmentioned(
+            MentionOnlyChannel(),
+            msg,
+            "agent:main:slack:group:C1",
+        )
+        is False
+    )
+
+
+def test_explicit_slash_interaction_does_not_bypass_group_access_policy() -> None:
+    channel = SimpleNamespace(
+        policy=ChannelAccessPolicy(
+            dm_allowed=True,
+            group_allowed=False,
+            mention_required_in_group=True,
+        )
+    )
+    msg = IncomingMessage(
+        sender_id="U1",
+        channel_id="C1",
+        content="/status",
+        metadata={"is_group": True, "interaction_type": "slash_command"},
+    )
+
+    assert (
+        _should_skip_unmentioned(
+            channel,
+            msg,
+            "agent:main:slack:group:C1",
+        )
+        is True
+    )
 
 
 def _exact_pdf(size: int) -> bytes:


### PR DESCRIPTION
## Summary

- derive Slack conversation types from channel ID prefixes instead of treating channel names as API channel types
- mark native slash command forms as explicit interactions so group commands satisfy mention-only gating
- preserve group access and allowlist enforcement while adding regression coverage for public, private, and direct conversations

## Testing

- uv run ruff check src tests
- uv run mypy src/agentos --show-error-codes
- uv run pytest -q (6212 passed, 27 skipped)

Refs #56