### PR TITLE
fix(channels): grant admitted senders read access

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -28,6 +28,11 @@
 # run forever. Zero means unlimited.
 # agent_max_iterations = 8
 
+# Admitted channel senders get read-only slash commands. List trusted sender
+# IDs here to allow mutating commands and owner-level tools. Keys are configured
+# channel entry names, not platform types; keep IDs quoted as strings.
+# channel_admin_senders = { personal = ["123456789"], team = ["U0123ABC"] }
+
 # WebSocket per-connection outbound writer queue. When enabled (default),
 # each WS connection gets a bounded asyncio queue + dedicated writer task.
 # Producers enqueue and return immediately; slow clients trigger a fast

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -128,6 +128,26 @@ DM modes are `pairing`, `allowlist`, `open`, and `disabled`; group modes are
 where the adapter's mention policy applies. Use `open` only when unrestricted
 access is intentional.
 
+## Channel Command Authorization
+
+Channel access policy runs before native or text slash-command dispatch. A
+sender denied by pairing or an allowlist cannot execute any command. Once
+admitted, a sender receives read-only command access, including `/help`,
+`/status`, `/model`, `/history`, `/memory`, `/skills`, and `/usage`.
+
+Commands that mutate a session or routing state require the sender to be listed
+in the top-level `channel_admin_senders` map. This includes `/new`, `/reset`,
+`/compact`, `/abort`, `/c0` through `/c3`, and `/auto`.
+
+```toml
+channel_admin_senders = { personal = ["123456789"], team = ["U0123ABC"] }
+```
+
+Each map key is the configured channel entry `name` (`personal` and `team`
+above), not the platform `type` (`telegram`, `slack`, or `discord`). Keep sender
+IDs as quoted strings and add only trusted accounts: channel admins also receive
+owner-level tool access for normal agent turns from that channel.
+
 ## Slack Modes
 
 Slack Socket Mode uses an outbound websocket and does not require a public

--- a/src/agentos/channels/command_registry.py
+++ b/src/agentos/channels/command_registry.py
@@ -115,12 +115,13 @@ def build_channel_rpc_context(
     gateway_config: Any,
     **handles: Any,
 ) -> RpcContext:
+    """Grant read access post-admission and reserve mutations for channel admins."""
     admin_senders = getattr(gateway_config, "channel_admin_senders", {})
     sender_id = envelope.sender_id
-    is_operator = bool(sender_id and sender_id in admin_senders.get(envelope.source_name, []))
+    is_admin = bool(sender_id and sender_id in admin_senders.get(envelope.source_name, []))
     principal = Principal(
-        role="operator" if is_operator else "viewer",
-        scopes=frozenset({READ_SCOPE, WRITE_SCOPE}) if is_operator else frozenset(),
+        role="operator",
+        scopes=(frozenset({READ_SCOPE, WRITE_SCOPE}) if is_admin else frozenset({READ_SCOPE})),
         is_owner=False,
         authenticated=True,
     )

--- a/tests/test_channels/test_channel_command_registry.py
+++ b/tests/test_channels/test_channel_command_registry.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
-from agentos.channels.command_registry import DEFAULT_COMMAND_REGISTRY
+from agentos.channels.command_registry import (
+    DEFAULT_COMMAND_REGISTRY,
+    build_channel_rpc_context,
+)
 from agentos.channels.types import IncomingMessage
 from agentos.engine.commands import DEFAULT_REGISTRY, Surface
-from agentos.gateway.protocol import make_error_res, make_ok_res
+from agentos.gateway.protocol import ERROR_UNAUTHORIZED, make_error_res, make_ok_res
 from agentos.gateway.routing import build_channel_route_envelope
+from agentos.gateway.rpc import RpcDispatcher
+from agentos.gateway.scopes import READ_SCOPE, WRITE_SCOPE
 
 
-def _envelope(*, bot_username: str | None = None):
+def _envelope(
+    *,
+    source_name: str = "telegram",
+    bot_username: str | None = None,
+):
     metadata = {"bot_username": bot_username} if bot_username else {}
     msg = IncomingMessage(
         sender_id="u1",
@@ -20,7 +31,7 @@ def _envelope(*, bot_username: str | None = None):
     return build_channel_route_envelope(
         msg,
         session_key="agent:main:telegram:u1",
-        session_prefix="telegram",
+        session_prefix=source_name,
         agent_id="main",
     )
 
@@ -38,6 +49,19 @@ async def _dispatch(command: str, payload):
     )
 
 
+def _permission_dispatcher() -> RpcDispatcher:
+    async def read_handler(_params, _ctx):
+        return {"allowed": "read"}
+
+    async def write_handler(_params, _ctx):
+        return {"allowed": "write"}
+
+    dispatcher = RpcDispatcher()
+    dispatcher.register("status", read_handler, READ_SCOPE)
+    dispatcher.register("sessions.reset", write_handler, WRITE_SCOPE)
+    return dispatcher
+
+
 def test_channel_command_names_include_usage_and_registry_words() -> None:
     expected = {
         word.lstrip("/").lower()
@@ -47,6 +71,42 @@ def test_channel_command_names_include_usage_and_registry_words() -> None:
 
     assert "usage" in DEFAULT_COMMAND_REGISTRY.command_names
     assert expected <= DEFAULT_COMMAND_REGISTRY.command_names
+
+
+@pytest.mark.asyncio
+async def test_admitted_non_admin_sender_gets_read_only_rpc_access() -> None:
+    context = build_channel_rpc_context(
+        _envelope(),
+        gateway_config=SimpleNamespace(channel_admin_senders={}),
+    )
+    dispatcher = _permission_dispatcher()
+
+    read_response = await dispatcher.dispatch("read", "status", {}, context)
+    write_response = await dispatcher.dispatch("write", "sessions.reset", {}, context)
+
+    assert context.principal.role == "operator"
+    assert context.principal.scopes == frozenset({READ_SCOPE})
+    assert read_response.ok is True
+    assert write_response.ok is False
+    assert write_response.error is not None
+    assert write_response.error.code == ERROR_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_configured_channel_admin_gets_read_and_write_rpc_access() -> None:
+    context = build_channel_rpc_context(
+        _envelope(source_name="personal"),
+        gateway_config=SimpleNamespace(channel_admin_senders={"personal": ["u1"]}),
+    )
+    dispatcher = _permission_dispatcher()
+
+    read_response = await dispatcher.dispatch("read", "status", {}, context)
+    write_response = await dispatcher.dispatch("write", "sessions.reset", {}, context)
+
+    assert context.principal.role == "operator"
+    assert context.principal.scopes == frozenset({READ_SCOPE, WRITE_SCOPE})
+    assert read_response.ok is True
+    assert write_response.ok is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_channels/test_telegram_access_approvals.py
+++ b/tests/test_channels/test_telegram_access_approvals.py
@@ -201,11 +201,12 @@ def test_populated_legacy_allowlist_remains_strict_without_explicit_flag() -> No
 
 
 @pytest.mark.asyncio
-async def test_unapproved_sender_is_gated_before_slash_command_dispatch() -> None:
+@pytest.mark.parametrize("command", ["/status", "/reset"])
+async def test_unapproved_sender_is_gated_before_slash_command_dispatch(command: str) -> None:
     message = IncomingMessage(
         sender_id="42",
         channel_id="42",
-        content="/status",
+        content=command,
         metadata={"is_group": False},
     )
 


### PR DESCRIPTION
## Summary

- grant operator.read to channel senders after access-policy admission
- reserve operator.write commands for configured channel admins
- document channel_admin_senders key semantics and owner-level tool implications
- cover unapproved, admitted non-admin, and admin read/write authorization

## Validation

- Control UI production build passed
- Frontend check passed: 1,495 tests
- Ruff passed
- Mypy passed across 583 source files
- Python suite passed: 6,211 tests, 27 skipped
- Wheel build passed

Refs #57