### PR TITLE
fix(slack): dispatch socket mode slash commands

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -9,7 +9,7 @@ import hmac
 import json
 import re
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -683,9 +683,13 @@ class SlackChannel:
             with contextlib.suppress(Exception):
                 await ws.close()
             return
+        payload = msg.get("payload")
+        if mtype == "slash_commands":
+            if isinstance(payload, dict):
+                self._ingest_slash_command(payload)
+            return
         if mtype != "events_api":
             return
-        payload = msg.get("payload")
         if isinstance(payload, dict) and payload.get("type") == "event_callback":
             self._ingest_event_callback(payload)
 
@@ -725,20 +729,8 @@ class SlackChannel:
         content_type = request.headers.get("content-type", "")
         if content_type.startswith("application/x-www-form-urlencoded"):
             form = await request.form()
-            command = str(form.get("command") or "").strip()
-            if not command.startswith("/"):
+            if not self._ingest_slash_command(form):
                 return Response(status_code=400)
-            text = str(form.get("text") or "").strip()
-            self.enqueue(
-                self.parse_event(
-                    {
-                        "user": str(form.get("user_id") or "unknown"),
-                        "channel": str(form.get("channel_id") or self.slack_channel_id),
-                        "text": f"{command} {text}".strip(),
-                        "interaction_type": "slash_command",
-                    }
-                )
-            )
             return Response(status_code=200)
 
         try:
@@ -756,6 +748,25 @@ class SlackChannel:
             self._ingest_event_callback(data)
 
         return Response(status_code=200)
+
+    def _ingest_slash_command(self, payload: Mapping[str, Any]) -> bool:
+        """Normalize and enqueue a Slack slash command from either transport."""
+        command = str(payload.get("command") or "").strip()
+        if not command.startswith("/"):
+            return False
+        text = str(payload.get("text") or "").strip()
+        self.enqueue(
+            self.parse_event(
+                {
+                    "user": str(payload.get("user_id") or "unknown"),
+                    "channel": str(payload.get("channel_id") or self.slack_channel_id),
+                    "text": f"{command} {text}".strip(),
+                    "team": payload.get("team_id"),
+                    "interaction_type": "slash_command",
+                }
+            )
+        )
+        return True
 
     def _ingest_event_callback(self, data: dict[str, Any]) -> None:
         """Shared inbound path for an Events API ``event_callback`` payload,

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -218,6 +218,29 @@ async def test_socket_frame_acks_and_dispatches_events_api_payload() -> None:
     assert ch._queue.qsize() == 1
 
 
+async def test_socket_frame_acks_and_dispatches_slash_command_payload() -> None:
+    ch = _mk()
+    ws = _FakeSocket()
+    await ch._handle_socket_frame(
+        ws,
+        (
+            '{"envelope_id":"env-command","type":"slash_commands","payload":'
+            '{"team_id":"T1","channel_id":"C123","channel_name":"general",'
+            '"user_id":"UUSER","command":"/status","text":""}}'
+        ),
+    )
+
+    assert ws.sent == ['{"envelope_id": "env-command"}']
+    assert ch._queue.qsize() == 1
+    msg = ch._queue.get_nowait()
+    assert msg.sender_id == "UUSER"
+    assert msg.channel_id == "C123"
+    assert msg.content == "/status"
+    assert msg.metadata["is_group"] is True
+    assert msg.metadata["team"] == "T1"
+    assert msg.metadata["interaction_type"] == "slash_command"
+
+
 async def test_socket_frame_disconnect_closes_socket_after_ack() -> None:
     ch = _mk()
     ws = _FakeSocket()


### PR DESCRIPTION
## Summary

- Dispatch Slack Socket Mode slash_commands envelopes after acknowledging them.
- Normalize webhook form submissions and Socket Mode slash commands through one shared inbound path.
- Preserve sender, channel, team, command text, group classification, and explicit interaction metadata.
- Add regression coverage for acknowledgement, routing metadata, classification, and command enqueue behavior.

## Problem

SlackChannel._handle_socket_frame acknowledged every Socket Mode envelope but only dispatched events_api payloads. Slack delivers native slash commands as slash_commands envelopes, so those commands were acknowledged and then silently dropped.

The webhook transport normalized the same slash-command payload shape separately. Keeping transport-specific normalization paths made it easy for Socket Mode and webhook behavior to drift.

## Implementation

- Add a slash_commands branch to the Socket Mode frame handler while preserving acknowledgement-before-dispatch behavior.
- Introduce a shared _ingest_slash_command helper used by both Socket Mode and webhook form submissions.
- Reuse the existing Slack event parser for conversation classification.
- Preserve team_id as normalized team metadata and mark the message as a slash_command interaction so the existing explicit-interaction access path applies.
- Add a Socket Mode regression test that verifies the envelope acknowledgement, queue insertion, sender and channel IDs, command content, team metadata, group classification, and interaction metadata.

## Integration note

The branch was rebased after #96 and #97 merged. The conflict was resolved by retaining the conversation-classification and group access-policy behavior already on main while limiting this PR to Socket Mode dispatch and shared normalization.

## Verification

- Control UI production build passed.
- Frontend checks passed: TypeScript, ESLint, Prettier, and 1,495 Vitest tests.
- Ruff passed across src and tests.
- Mypy passed across 583 source files.
- Python test suite passed: 6,226 passed, 27 skipped.
- Wheel build passed.

Fixes #55