### PR TITLE
docs(security): establish private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,13 +8,17 @@ still present in the current release line.
 
 ## Reporting a Vulnerability
 
-Do not open a public issue with exploit details, credentials, provider tokens,
-local transcripts, or account identifiers.
+Do not open a public issue with vulnerability details, exploit steps,
+credentials, provider tokens, local transcripts, or account identifiers.
 
-Use GitHub private vulnerability reporting for this repository when it is
-available. If private reporting is not available, open a minimal public issue
-asking for a secure maintainer contact path and do not include technical exploit
-details.
+Submit suspected vulnerabilities through
+[GitHub private vulnerability reporting](https://github.com/use-agent-os/agent-os/security/advisories/new).
+This repository has private reporting enabled so reports can be triaged and
+discussed with maintainers without public disclosure.
+
+If you cannot access the private report form, open a minimal public issue asking
+for a secure maintainer contact path. Do not include technical details in that
+issue.
 
 Helpful reports include:
 

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -171,6 +171,14 @@ def test_public_docs_do_not_use_key_shaped_placeholders() -> None:
     assert violations == []
 
 
+def test_security_policy_routes_vulnerability_reports_privately() -> None:
+    text = Path("SECURITY.md").read_text(encoding="utf-8")
+
+    assert "https://github.com/use-agent-os/agent-os/security/advisories/new" in text
+    assert "Do not open a public issue with vulnerability details" in text
+    assert "when it is available" not in text
+
+
 def test_release_sop_documents_github_only_validation_boundary() -> None:
     text = Path("RELEASES.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- enable GitHub Private Vulnerability Reporting for the repository and replace conditional security guidance with the direct private advisory form
- explicitly prohibit vulnerability details and exploit steps in public issues while retaining a detail-free fallback for access problems
- add an offline public-release hygiene regression test that keeps the private reporting route and disclosure boundary intact

## Security considerations

- no vulnerability details, reproduction steps, credentials, account identifiers, or private transcripts are included in this change
- the repository-level Private Vulnerability Reporting setting was verified through the GitHub API as enabled
- future technical triage can now proceed through the restricted security-advisory workflow

## Validation

- `uv run python scripts/build_control_ui.py build`
- `npm --prefix frontend run check` (1495 tests passed)
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes` (583 source files checked)
- `uv run pytest -q` (6226 passed, 27 skipped)
- `uv build --wheel`
- `gh api repos/use-agent-os/agent-os/private-vulnerability-reporting` (`enabled: true`)

Fixes #59