### PR TITLE
feat(telegram): show typing indicators during turns

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -188,6 +188,14 @@ The command endpoint acknowledges Slack's form submission and routes the
 resulting `/command` through the same channel dispatcher. Keep text command
 interception as the fallback for platforms without native command menus.
 
+## In-Flight Reply Feedback
+
+Telegram and Discord show their native typing indicator while AgentOS is
+working on a reply. Telegram refreshes `sendChatAction` every four seconds
+because Telegram clients expire the status after at most five seconds. Forum
+topic replies keep the typing indicator scoped to the incoming topic. Typing
+feedback is best-effort and never interrupts the underlying agent turn.
+
 ## Webhook Channels
 
 Slack webhook mode requires a public, provider-reachable URL. Telegram may

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import httpx
 import structlog
@@ -117,6 +117,7 @@ class TelegramChannel:
     pairing_store: ChannelPairingStore = field(default_factory=ChannelPairingStore)
 
     supports_slash_commands: bool = True
+    typing_keepalive_interval_s: ClassVar[float] = 4.0
     policy: ChannelAccessPolicy = field(
         default_factory=lambda: ChannelAccessPolicy(
             dm_allowed=True,
@@ -351,6 +352,7 @@ class TelegramChannel:
             channel_type="telegram",
             group_chat=True,
             mentions=True,
+            typing_indicator=True,
             native_file_upload=True,
             media=True,
             reply=True,
@@ -836,6 +838,28 @@ class TelegramChannel:
         if (thread_id := inbound.metadata.get("thread_id")) is not None:
             metadata["thread_id"] = thread_id
         return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)
+
+    async def send_typing(
+        self,
+        channel_id: str | None = None,
+        *,
+        thread_id: str | None = None,
+    ) -> ChannelSendResult:
+        """Show Telegram's native typing status in a chat or forum topic."""
+        target = channel_id or self.config.default_chat_id
+        if not target:
+            return ChannelSendResult.unsupported(
+                capability=ChannelCapabilities.TYPING_INDICATOR,
+                reason="no chat target",
+            )
+        payload: dict[str, Any] = {"chat_id": str(target), "action": "typing"}
+        if thread_id:
+            payload["message_thread_id"] = _coerce_telegram_int(thread_id)
+        await self._api("sendChatAction", payload)
+        return ChannelSendResult.sent(
+            capability=ChannelCapabilities.TYPING_INDICATOR,
+            target_id=str(target),
+        )
 
     async def send(self, message: OutgoingMessage) -> dict[str, Any]:
         payload = self._build_send_payload(message)

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -68,6 +68,8 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger(__name__)
 
+_DEFAULT_TYPING_KEEPALIVE_INTERVAL_S = 8.0
+
 
 def _terminal_payload_from_exception(exc: BaseException) -> dict[str, str]:
     is_timeout = isinstance(exc, TimeoutError)
@@ -1065,9 +1067,9 @@ def _should_skip_unmentioned(
 def _start_typing_keepalive(
     channel: Any,
     inbound: IncomingMessage | None = None,
-    interval: float = 8.0,
+    interval: float | None = None,
 ) -> asyncio.Task | None:
-    """Start a background task that re-sends typing every ``interval`` seconds.
+    """Start a background task that periodically refreshes the typing status.
 
     Uses ``asyncio.create_task`` so typing continues even during long tool calls
     where no events are yielded (a timestamp-in-loop approach would fail here).
@@ -1081,16 +1083,45 @@ def _start_typing_keepalive(
     if not callable(send_typing):
         return None
 
+    raw_interval = (
+        interval
+        if interval is not None
+        else getattr(
+            channel,
+            "typing_keepalive_interval_s",
+            _DEFAULT_TYPING_KEEPALIVE_INTERVAL_S,
+        )
+    )
+    try:
+        keepalive_interval = float(raw_interval)
+    except (TypeError, ValueError):
+        keepalive_interval = _DEFAULT_TYPING_KEEPALIVE_INTERVAL_S
+    if keepalive_interval <= 0:
+        keepalive_interval = _DEFAULT_TYPING_KEEPALIVE_INTERVAL_S
+
+    typing_kwargs: dict[str, Any] = {}
+    if inbound is not None:
+        if _accepts_keyword_arg(send_typing, "channel_id"):
+            typing_kwargs["channel_id"] = inbound.channel_id
+        if _accepts_keyword_arg(send_typing, "thread_id"):
+            thread_id = next(
+                (
+                    inbound.metadata[key]
+                    for key in ("native_thread_id", "thread_id", "message_thread_id")
+                    if inbound.metadata.get(key) not in (None, "")
+                ),
+                None,
+            )
+            if thread_id is not None:
+                typing_kwargs["thread_id"] = str(thread_id)
+
     async def _keepalive() -> None:
         while True:
             try:
-                if inbound is not None and _accepts_keyword_arg(send_typing, "channel_id"):
-                    await send_typing(channel_id=inbound.channel_id)
-                else:
-                    await send_typing()
+                await send_typing(**typing_kwargs)
             except Exception:
                 pass  # typing is best-effort, never crash the loop
-            await asyncio.sleep(interval)
+            await asyncio.sleep(keepalive_interval)
 
     return asyncio.create_task(_keepalive())
 

--- a/tests/test_channels/test_channel_capabilities.py
+++ b/tests/test_channels/test_channel_capabilities.py
@@ -312,7 +312,7 @@ def test_telegram_profile_matches_current_bot_api_adapter_surface() -> None:
     assert profile.supports(ChannelCapabilities.THREAD_REPLY)
     assert profile.supports(ChannelCapabilities.EDIT)
     assert profile.supports(ChannelCapabilities.DELETE)
-    assert not profile.supports(ChannelCapabilities.TYPING_INDICATOR)
+    assert profile.supports(ChannelCapabilities.TYPING_INDICATOR)
     assert profile.supports(ChannelCapabilities.NATIVE_FILE_UPLOAD)
 
 

--- a/tests/test_channels/test_telegram_typing.py
+++ b/tests/test_channels/test_telegram_typing.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.channels.contract import ChannelCapabilities, ChannelSendStatus
+from agentos.channels.stream_policy import resolve_channel_stream_policy
+from agentos.channels.telegram import TelegramApiError, TelegramChannel, TelegramChannelConfig
+from agentos.channels.types import IncomingMessage
+from agentos.gateway import channel_dispatch
+
+
+def _install_blocking_keepalive_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[float], asyncio.Event]:
+    sleep_intervals: list[float] = []
+    sleep_started = asyncio.Event()
+    block_sleep = asyncio.Event()
+
+    async def fake_sleep(interval: float) -> None:
+        sleep_intervals.append(interval)
+        sleep_started.set()
+        await block_sleep.wait()
+
+    monkeypatch.setattr(
+        channel_dispatch,
+        "asyncio",
+        SimpleNamespace(create_task=asyncio.create_task, sleep=fake_sleep),
+    )
+    return sleep_intervals, sleep_started
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_typing_posts_native_chat_action_for_topic() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> bool:
+        calls.append((method, payload))
+        return True
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    result = await channel.send_typing(channel_id="-100123", thread_id="777")
+
+    assert calls == [
+        (
+            "sendChatAction",
+            {
+                "chat_id": "-100123",
+                "action": "typing",
+                "message_thread_id": 777,
+            },
+        )
+    ]
+    assert result.status == ChannelSendStatus.SENT
+    assert result.capability == ChannelCapabilities.TYPING_INDICATOR
+    assert result.target_id == "-100123"
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_typing_uses_default_target() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="token", default_chat_id="default-chat"))
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> bool:
+        calls.append((method, payload))
+        return True
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    result = await channel.send_typing()
+
+    assert calls == [("sendChatAction", {"chat_id": "default-chat", "action": "typing"})]
+    assert result.status == ChannelSendStatus.SENT
+    assert result.target_id == "default-chat"
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_typing_without_target_is_unsupported() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+
+    async def unexpected_api(_method: str, _payload: dict[str, Any] | None = None) -> bool:
+        raise AssertionError("sendChatAction must not run without a target")
+
+    channel._api = unexpected_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    result = await channel.send_typing()
+
+    assert result.status == ChannelSendStatus.UNSUPPORTED
+    assert result.capability == ChannelCapabilities.TYPING_INDICATOR
+    assert result.reason == "no chat target"
+
+
+def test_telegram_typing_capability_selects_keepalive_policy() -> None:
+    channel = TelegramChannel(TelegramChannelConfig())
+
+    policy = resolve_channel_stream_policy(channel)
+
+    assert channel.capability_profile.typing_indicator is True
+    assert ChannelCapabilities.TYPING_INDICATOR in channel.capabilities
+    assert policy.mode == "typing_final"
+    assert policy.relay_stream is False
+    assert policy.typing_keepalive is True
+    assert 0 < channel.typing_keepalive_interval_s < 5
+
+
+@pytest.mark.asyncio
+async def test_telegram_keepalive_uses_inbound_chat_topic_and_adapter_cadence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    api_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> bool:
+        api_calls.append((method, payload))
+        return True
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+    sleep_intervals, sleep_started = _install_blocking_keepalive_sleep(monkeypatch)
+    inbound = IncomingMessage(
+        sender_id="user-1",
+        channel_id="-100123",
+        content="hello",
+        metadata={"is_group": True, "thread_id": "777"},
+    )
+
+    task = channel_dispatch._start_typing_keepalive(channel, inbound)  # noqa: SLF001
+
+    assert task is not None
+    await asyncio.wait_for(sleep_started.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert api_calls == [
+        (
+            "sendChatAction",
+            {
+                "chat_id": "-100123",
+                "action": "typing",
+                "message_thread_id": 777,
+            },
+        )
+    ]
+    assert sleep_intervals == [4.0]
+
+
+@pytest.mark.asyncio
+async def test_telegram_keepalive_treats_api_failure_as_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    attempts = 0
+
+    async def failing_api(_method: str, _payload: dict[str, Any] | None = None) -> bool:
+        nonlocal attempts
+        attempts += 1
+        raise TelegramApiError("rate limited")
+
+    channel._api = failing_api  # type: ignore[method-assign]  # noqa: SLF001
+    sleep_intervals, sleep_started = _install_blocking_keepalive_sleep(monkeypatch)
+    inbound = IncomingMessage(
+        sender_id="user-1",
+        channel_id="chat-1",
+        content="hello",
+    )
+
+    task = channel_dispatch._start_typing_keepalive(channel, inbound)  # noqa: SLF001
+
+    assert task is not None
+    await asyncio.wait_for(sleep_started.wait(), timeout=1)
+    assert task.done() is False
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert attempts == 1
+    assert sleep_intervals == [4.0]


### PR DESCRIPTION
## Problem

Telegram users receive no visible feedback while AgentOS is generating a response. The adapter did not expose `send_typing`, did not advertise the typing capability, and therefore resolved to the `final_only` stream policy. The shared eight-second Discord keepalive cadence would also be too slow for Telegram, where [`sendChatAction`](https://core.telegram.org/bots/api#sendchataction) expires after at most five seconds.

## Solution

- implement Telegram `send_typing` through `sendChatAction` with `action=typing`
- return a structured `UNSUPPORTED` result when neither an inbound nor configured chat target is available
- advertise `TYPING_INDICATOR`, allowing the shared policy to select `typing_final`
- add an adapter-specific four-second keepalive interval so the indicator remains continuous
- propagate the inbound chat and forum-topic IDs into each keepalive request
- keep typing failures best-effort so Bot API errors never interrupt the underlying agent turn
- document the user-visible feedback behavior and lifecycle

## Verification

Added deterministic offline regression coverage for:

- native Bot API method and payload, including forum topics
- configured fallback targets and missing-target behavior
- capability tags and stream-policy selection
- inbound routing and the four-second refresh cadence
- Bot API failure isolation

Full local quality gate on the latest `main`:

- `python scripts/build_control_ui.py build`
- `npm --prefix frontend run check` — 1,495 tests passed
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes` — 583 source files clean
- `uv run pytest -q` — 6,232 passed, 27 skipped
- `uv build --wheel`

## Risk and compatibility

No configuration or migration changes are required. Typing feedback is optional and isolated from turn execution; existing adapters retain the eight-second default cadence unless they opt into an adapter-specific interval.

Fixes #92