### PR TITLE
fix(telegram): allow admitted DM slash commands

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -135,9 +135,10 @@ sender denied by pairing or an allowlist cannot execute any command. Once
 admitted, a sender receives read-only command access, including `/help`,
 `/status`, `/model`, `/history`, `/memory`, `/skills`, and `/usage`.
 
-Commands that mutate a session or routing state require the sender to be listed
-in the top-level `channel_admin_senders` map. This includes `/new`, `/reset`,
-`/compact`, `/abort`, `/c0` through `/c3`, and `/auto`.
+In direct messages, admitted senders can also run commands that mutate a
+session or routing state, including `/new`, `/reset`, `/compact`, `/abort`,
+`/c0` through `/c3`, and `/auto`. In group chats, those commands require the
+sender to be listed in the top-level `channel_admin_senders` map.
 
 ```toml
 channel_admin_senders = { personal = ["123456789"], team = ["U0123ABC"] }

--- a/src/agentos/channels/command_registry.py
+++ b/src/agentos/channels/command_registry.py
@@ -26,6 +26,7 @@ from agentos.gateway.auth import Principal
 from agentos.gateway.routing import RouteEnvelope, SourceKind
 from agentos.gateway.rpc import RpcContext
 from agentos.gateway.scopes import READ_SCOPE, WRITE_SCOPE
+from agentos.session.keys import derive_chat_type
 
 
 class CommandRegistry:
@@ -115,13 +116,18 @@ def build_channel_rpc_context(
     gateway_config: Any,
     **handles: Any,
 ) -> RpcContext:
-    """Grant read access post-admission and reserve mutations for channel admins."""
+    """Grant write access to admitted DMs and configured channel admins."""
     admin_senders = getattr(gateway_config, "channel_admin_senders", {})
     sender_id = envelope.sender_id
     is_admin = bool(sender_id and sender_id in admin_senders.get(envelope.source_name, []))
+    is_direct_message = derive_chat_type(envelope.session_key) == "direct"
     principal = Principal(
         role="operator",
-        scopes=(frozenset({READ_SCOPE, WRITE_SCOPE}) if is_admin else frozenset({READ_SCOPE})),
+        scopes=(
+            frozenset({READ_SCOPE, WRITE_SCOPE})
+            if is_admin or is_direct_message
+            else frozenset({READ_SCOPE})
+        ),
         is_owner=False,
         authenticated=True,
     )

--- a/tests/test_channels/test_channel_command_registry.py
+++ b/tests/test_channels/test_channel_command_registry.py
@@ -20,6 +20,7 @@ def _envelope(
     *,
     source_name: str = "telegram",
     bot_username: str | None = None,
+    session_key: str = "agent:main:telegram:u1",
 ):
     metadata = {"bot_username": bot_username} if bot_username else {}
     msg = IncomingMessage(
@@ -30,7 +31,7 @@ def _envelope(
     )
     return build_channel_route_envelope(
         msg,
-        session_key="agent:main:telegram:u1",
+        session_key=session_key,
         session_prefix=source_name,
         agent_id="main",
     )
@@ -107,6 +108,39 @@ async def test_configured_channel_admin_gets_read_and_write_rpc_access() -> None
     assert context.principal.scopes == frozenset({READ_SCOPE, WRITE_SCOPE})
     assert read_response.ok is True
     assert write_response.ok is True
+
+
+@pytest.mark.asyncio
+async def test_admitted_direct_message_sender_gets_read_and_write_rpc_access() -> None:
+    context = build_channel_rpc_context(
+        _envelope(session_key="agent:main:telegram:dm:u1"),
+        gateway_config=SimpleNamespace(channel_admin_senders={}),
+    )
+    dispatcher = _permission_dispatcher()
+
+    read_response = await dispatcher.dispatch("read", "status", {}, context)
+    write_response = await dispatcher.dispatch("write", "sessions.reset", {}, context)
+
+    assert context.principal.role == "operator"
+    assert context.principal.scopes == frozenset({READ_SCOPE, WRITE_SCOPE})
+    assert read_response.ok is True
+    assert write_response.ok is True
+
+
+@pytest.mark.asyncio
+async def test_admitted_group_sender_stays_read_only_without_admin_access() -> None:
+    context = build_channel_rpc_context(
+        _envelope(session_key="agent:main:telegram:group:c1"),
+        gateway_config=SimpleNamespace(channel_admin_senders={}),
+    )
+    dispatcher = _permission_dispatcher()
+
+    write_response = await dispatcher.dispatch("write", "sessions.reset", {}, context)
+
+    assert context.principal.scopes == frozenset({READ_SCOPE})
+    assert write_response.ok is False
+    assert write_response.error is not None
+    assert write_response.error.code == ERROR_UNAUTHORIZED
 
 
 @pytest.mark.parametrize(
@@ -244,8 +278,7 @@ async def test_channel_history_handles_empty_and_bounds_long_content() -> None:
         "/history",
         {
             "messages": [
-                {"role": "user", "text": f"message {index} " + "x" * 800}
-                for index in range(10)
+                {"role": "user", "text": f"message {index} " + "x" * 800} for index in range(10)
             ],
             "loaded_count": 10,
         },
@@ -339,17 +372,13 @@ async def test_channel_information_commands_render_payloads() -> None:
 async def test_channel_models_and_skills_are_bounded() -> None:
     models = await _dispatch(
         "/model",
-        [
-            {"provider": "ollama", "id": f"model-{index}-" + "x" * 200}
-            for index in range(30)
-        ],
+        [{"provider": "ollama", "id": f"model-{index}-" + "x" * 200} for index in range(30)],
     )
     skills = await _dispatch(
         "/skills",
         {
             "skills": [
-                {"name": f"skill-{index}-" + "x" * 200, "status": "ready"}
-                for index in range(30)
+                {"name": f"skill-{index}-" + "x" * 200, "status": "ready"} for index in range(30)
             ]
         },
     )


### PR DESCRIPTION
## Summary
- grant admitted direct-message senders write RPC scope for slash commands
- preserve admin-only write access for group chats
- document the direct-message authorization behavior

## Testing
- uv run pytest tests/test_channels/test_channel_command_registry.py -q