### PR TITLE
fix(gateway): non-destructive /new and /reset when flush unavailable

### DIFF
--- a/src/agentos/channels/manager.py
+++ b/src/agentos/channels/manager.py
@@ -48,6 +48,9 @@ class ChannelManager:
     # Per-channel in-flight reply task sets.
     # Keyed by channel name; populated in _safe_start and consumed in stop_channel.
     _in_flight_sets: dict[str, Any] = field(default_factory=dict)
+    # Per-channel "current session" pointer maps for channel /new (fresh-key)
+    # semantics. Keyed by channel name; populated in _safe_start.
+    _session_pointers: dict[str, Any] = field(default_factory=dict)
     # Dispatch state machine — see _dispatch_with_retry for the lifecycle.
     # Values: "running" | "exhausted" | "restarting" | "dead". Unset entries
     # are treated as "unknown" by health() so a channel that never started
@@ -186,7 +189,11 @@ class ChannelManager:
 
     async def _safe_start(self, name: str) -> None:
         """Start a single channel with 30 s timeout, then launch dispatch loop."""
-        from agentos.gateway.channel_dispatch import _ChannelInFlightSet, _compute_channel_cap
+        from agentos.gateway.channel_dispatch import (
+            ChannelSessionPointers,
+            _ChannelInFlightSet,
+            _compute_channel_cap,
+        )
 
         adapter = self._channels[name]
         startup_timeout = float(getattr(adapter, "startup_timeout_s", 30.0))
@@ -206,6 +213,10 @@ class ChannelManager:
         cap = _compute_channel_cap(self._config)
         in_flight = _ChannelInFlightSet(cap)
         self._in_flight_sets[name] = in_flight
+        # One pointer map per channel instance: backs channel /new "fresh session"
+        # semantics so a /new points the chat at a brand-new key (see
+        # ChannelSessionPointers). Recreated on (re)start; cleared on restart.
+        self._session_pointers[name] = ChannelSessionPointers()
         self._tasks[name] = asyncio.create_task(
             self._dispatch_with_retry(name, key_builder, in_flight=in_flight),
             name=f"channel:{name}",
@@ -242,6 +253,7 @@ class ChannelManager:
                     debounce_coordinator=self._debounce_coordinator,
                     debounce_window_s=getattr(self._channels[name], "debounce_window_s", 0.0),
                     _in_flight=in_flight,
+                    session_pointers=self._session_pointers.get(name),
                 )
             except asyncio.CancelledError:
                 raise  # intentional shutdown — never retry

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -17,6 +17,7 @@ import contextlib
 import inspect
 import json
 import re
+import uuid
 import weakref
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any, cast
@@ -61,6 +62,7 @@ from agentos.gateway.attachment_ingest import AttachmentIngestResult, ingest_att
 from agentos.gateway.session_events import build_sessions_changed_payload
 from agentos.paths import media_root_from_config
 from agentos.permissions import configured_default_elevated
+from agentos.session.keys import canonicalize_session_key as _canonicalize_session_key
 from agentos.session.terminal_reply import build_terminal_reply
 
 if TYPE_CHECKING:
@@ -206,9 +208,8 @@ def _compute_channel_cap(config: Any) -> int:
     formula_cap = max(2 * max_concurrency, 1)
     return min(raw_cap, formula_cap)
 
-_DIRECTIVE_TAG_RE = re.compile(
-    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
-)
+
+_DIRECTIVE_TAG_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
 _INTERNAL_COMPACTION_MARKER_RE = re.compile(
     r"(?m)^[ \t]*\["
     r"(?:agentos_compacted:[^\]\r\n]*|"
@@ -252,9 +253,7 @@ def _split_pending_internal_compaction_marker(content: str) -> tuple[str, str]:
 
 
 def _sanitize_outgoing_message(message: OutgoingMessage) -> OutgoingMessage:
-    cleaned = _strip_internal_compaction_markers(
-        _strip_inline_directive_tags(message.content)
-    )
+    cleaned = _strip_internal_compaction_markers(_strip_inline_directive_tags(message.content))
     if cleaned == message.content:
         return message
     return message.model_copy(update={"content": cleaned})
@@ -269,23 +268,15 @@ class _DirectiveTagStreamSanitizer:
     def clean(self, chunk: str) -> str:
         text = self._pending + chunk
         self._pending = ""
-        cleaned = _strip_internal_compaction_markers(
-            _strip_inline_directive_tags(text)
-        )
+        cleaned = _strip_internal_compaction_markers(_strip_inline_directive_tags(text))
         start = cleaned.rfind("[[")
         if start == -1:
-            cleaned, pending_marker = _split_pending_internal_compaction_marker(
-                cleaned
-            )
+            cleaned, pending_marker = _split_pending_internal_compaction_marker(cleaned)
             if pending_marker:
                 self._pending = pending_marker
             return cleaned
         suffix = cleaned[start:]
-        if (
-            "]]" not in suffix
-            and "\n" not in suffix
-            and len(suffix) <= _DIRECTIVE_TAG_BUFFER_LIMIT
-        ):
+        if "]]" not in suffix and "\n" not in suffix and len(suffix) <= _DIRECTIVE_TAG_BUFFER_LIMIT:
             self._pending = suffix
             return cleaned[:start]
         cleaned, pending_marker = _split_pending_internal_compaction_marker(cleaned)
@@ -324,6 +315,44 @@ async def _maybe_lock(lock: asyncio.Lock | None) -> AsyncIterator[None]:
         yield
 
 
+class ChannelSessionPointers:
+    """Per-chat "current session key" pointer for channel ``/new``.
+
+    Channel session keys are a pure function of ``(channel, chat_id)`` that is
+    recomputed on every inbound message, so a channel ``/new`` cannot simply
+    "switch to a fresh key" the way the WebUI "New Chat" button does — the next
+    message would recompute the old key and orphan the new session. This class
+    adds the missing indirection: an in-memory map from the *derived* (base)
+    session key to the *current* session key for that chat.
+
+    ``/new`` mints a fresh key, stores it here, and subsequent messages for the
+    same chat resolve to it via :meth:`resolve`. The old session is left
+    untouched (non-destructive), matching the WebUI "New Chat" semantics.
+
+    In-memory by design: a gateway restart clears the pointers, after which each
+    chat deterministically falls back to its derived base key. This is the same
+    best-effort semantics as the WebUI (whose pointer is ``localStorage``).
+    """
+
+    def __init__(self) -> None:
+        self._map: dict[str, str] = {}
+
+    @staticmethod
+    def _canon(key: str) -> str:
+        try:
+            return _canonicalize_session_key(key)
+        except Exception:  # noqa: BLE001 — canonicalization is best-effort
+            return key
+
+    def resolve(self, base_key: str) -> str:
+        """Return the current key for ``base_key`` (the pointer if set, else base)."""
+        return self._map.get(self._canon(base_key), base_key)
+
+    def set(self, base_key: str, new_key: str) -> None:
+        """Point ``base_key`` at ``new_key``."""
+        self._map[self._canon(base_key)] = new_key
+
+
 # ── Main dispatch loop (thin orchestrator) ───────────────────────────────
 
 
@@ -341,6 +370,7 @@ async def run_channel_dispatch(
     debounce_coordinator: Any = None,
     debounce_window_s: float = 0.0,
     _in_flight: _ChannelInFlightSet | None = None,
+    session_pointers: ChannelSessionPointers | None = None,
 ) -> None:
     """Receive-dispatch-respond loop for a channel adapter.
 
@@ -356,7 +386,14 @@ async def run_channel_dispatch(
         _in_flight = _ChannelInFlightSet(cap)
     while True:
         msg = await channel.receive()
-        session_key = session_key_builder(msg)
+        base_session_key = session_key_builder(msg)
+        # Resolve any per-chat "current session" pointer set by a prior /new.
+        # The derived base key stays the stable pointer-map handle.
+        session_key = (
+            session_pointers.resolve(base_session_key)
+            if session_pointers is not None
+            else base_session_key
+        )
         raw_content = msg.content
         from agentos.gateway.routing import build_channel_route_envelope
 
@@ -376,7 +413,7 @@ async def run_channel_dispatch(
         # fmt: off
         if getattr(channel, "supports_slash_commands", False) and rpc_dispatcher is not None and channel_rpc_context_factory is not None:  # noqa: E501
             command_reply = await _dispatch_channel_slash_command(
-                route_envelope=route_envelope, msg=msg, session_manager=session_manager, session_key=session_key, session_prefix=session_prefix, rpc_dispatcher=rpc_dispatcher, context_factory=channel_rpc_context_factory  # noqa: E501
+                route_envelope=route_envelope, msg=msg, session_manager=session_manager, session_key=session_key, session_prefix=session_prefix, rpc_dispatcher=rpc_dispatcher, context_factory=channel_rpc_context_factory, session_pointers=session_pointers, base_session_key=base_session_key  # noqa: E501
             )
             if command_reply is not None:
                 emit = log.warning if command_reply.metadata.get("denied") else log.info
@@ -481,17 +518,11 @@ async def run_channel_dispatch(
             # concurrent senders cannot interleave between the two steps.
             try:
                 async with _maybe_lock(session_lock):
-                    channel_overflow_policy = _resolve_channel_overflow_policy(
-                        channel, config
-                    )
+                    channel_overflow_policy = _resolve_channel_overflow_policy(channel, config)
                     if channel_overflow_policy is not None:
-                        apply_policy = getattr(
-                            task_runtime, "apply_overflow_policy", None
-                        )
+                        apply_policy = getattr(task_runtime, "apply_overflow_policy", None)
                         if callable(apply_policy):
-                            await apply_policy(
-                                session_key, policy=channel_overflow_policy
-                            )
+                            await apply_policy(session_key, policy=channel_overflow_policy)
                     handle = await start_turn_via_runtime(
                         task_runtime,
                         route_envelope,
@@ -642,6 +673,8 @@ async def _dispatch_channel_slash_command(
     session_prefix: str,
     rpc_dispatcher: Any,
     context_factory: Callable[[Any], Any],
+    session_pointers: ChannelSessionPointers | None = None,
+    base_session_key: str | None = None,
 ) -> OutgoingMessage | None:
     from agentos.channels.command_registry import DEFAULT_COMMAND_REGISTRY
 
@@ -666,6 +699,8 @@ async def _dispatch_channel_slash_command(
             session_prefix=session_prefix,
             rpc_dispatcher=rpc_dispatcher,
             context_factory=context_factory,
+            session_pointers=session_pointers,
+            base_session_key=base_session_key or session_key,
         )
 
     reply = await DEFAULT_COMMAND_REGISTRY.dispatch(
@@ -679,6 +714,17 @@ async def _dispatch_channel_slash_command(
     return _preserve_route_channel_metadata(reply, route_envelope)
 
 
+def _mint_fresh_channel_key(base_session_key: str) -> str:
+    """Derive a fresh, never-before-used session key for a channel ``/new``.
+
+    The base (derived) key ends with the chat's peer/thread id, so we append a
+    unique ``:new:<rand8>`` suffix. This guarantees a brand-new session key that
+    cannot collide with the existing session, mirroring the WebUI "New Chat"
+    button's client-side random key.
+    """
+    return f"{base_session_key}:new:{uuid.uuid4().hex[:8]}"
+
+
 async def _dispatch_channel_new_command(
     *,
     route_envelope: Any,
@@ -688,8 +734,9 @@ async def _dispatch_channel_new_command(
     session_prefix: str,
     rpc_dispatcher: Any,
     context_factory: Callable[[Any], Any],
+    session_pointers: ChannelSessionPointers | None = None,
+    base_session_key: str | None = None,
 ) -> OutgoingMessage:
-    from agentos.channels.command_registry import DEFAULT_COMMAND_REGISTRY
     from agentos.gateway.scopes import WRITE_SCOPE, authorize_call
 
     ctx = context_factory(route_envelope)
@@ -703,13 +750,38 @@ async def _dispatch_channel_new_command(
     if not allowed:
         detail = f": missing {missing}" if missing else ""
         return _route_envelope_reply_message(
-            (
-                "/new denied: Insufficient scope for method: "
-                f"sessions.reset{detail}"
-            ),
+            (f"/new denied: Insufficient scope for method: sessions.reset{detail}"),
             route_envelope,
             metadata={"command": "new", "method": "sessions.reset", "denied": True},
         )
+
+    # True "New Chat" parity: mint a FRESH session key and point this chat at it,
+    # leaving the current session untouched (non-destructive — no flush gate, no
+    # transcript deletion). The new session is created lazily on the next send,
+    # exactly like the WebUI "New Chat" button.
+    if session_pointers is not None:
+        base = base_session_key or session_key
+        fresh_key = _mint_fresh_channel_key(base)
+        session_pointers.set(base, fresh_key)
+        log.info(
+            "channel.new_command.session_pointer_set",
+            base_session_key=base,
+            new_session_key=fresh_key,
+        )
+        return _route_envelope_reply_message(
+            "Started a new chat session.",
+            route_envelope,
+            metadata={
+                "command": "new",
+                "method": "sessions.new",
+                "denied": False,
+                "session_key": fresh_key,
+            },
+        )
+
+    # Fallback (no pointer map wired): retain the legacy destructive reset so the
+    # command still functions in tests/shims that bypass the pointer.
+    from agentos.channels.command_registry import DEFAULT_COMMAND_REGISTRY
 
     await _record_delivery_context(
         session_manager,
@@ -1470,11 +1542,7 @@ class _RuntimeChannelStreamRelay:
         while True:
             if self._coalesce_chars and size >= self._coalesce_chars:
                 return "".join(buffer), None
-            remaining = (
-                deadline - asyncio.get_event_loop().time()
-                if deadline is not None
-                else None
-            )
+            remaining = deadline - asyncio.get_event_loop().time() if deadline is not None else None
             if remaining is not None and remaining <= 0:
                 return "".join(buffer), None
             try:
@@ -1579,9 +1647,7 @@ class _RuntimeChannelStreamRelay:
                     continue
                 if isinstance(item, str):
                     queued_remainder.append(item)
-            undelivered_yielded = "".join(
-                self._yielded_chunks[self._undelivered_index :]
-            )
+            undelivered_yielded = "".join(self._yielded_chunks[self._undelivered_index :])
             fallback_text = undelivered_yielded + "".join(queued_remainder)
             if fallback_text:
                 try:
@@ -2283,9 +2349,7 @@ async def _run_turn_streaming_path(
         tail = stream_sanitizer.flush()
         if tail:
             queued_remainder.append(tail)
-        undelivered_yielded = "".join(
-            yielded_stream_chunks[stream_delivered_index:]
-        )
+        undelivered_yielded = "".join(yielded_stream_chunks[stream_delivered_index:])
         fallback_text = undelivered_yielded + "".join(queued_remainder)
         if fallback_text:
             try:

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -80,10 +80,7 @@ def _clean_cancel_source(value: Any, default: str) -> str:
     text = str(value or "").strip()
     if not text:
         return default
-    safe = "".join(
-        ch if ch.isalnum() or ch in {"_", "-", ".", ":"} else "_"
-        for ch in text
-    )
+    safe = "".join(ch if ch.isalnum() or ch in {"_", "-", ".", ":"} else "_" for ch in text)
     return (safe.strip("_") or default)[:80]
 
 
@@ -171,12 +168,12 @@ def _trusted_elevated_hint(ctx: RpcContext, source_hint: dict[str, Any]) -> str 
 def _normalize_session_send_source_hint(params: dict[str, Any]) -> dict[str, Any]:
     raw_hint = params.get("_source")
     source_hint = dict(raw_hint) if isinstance(raw_hint, dict) else {}
-    caller_kind = str(
-        source_hint.get("caller_kind") or source_hint.get("callerKind") or ""
-    ).strip().lower()
-    channel_kind = str(
-        source_hint.get("channel_kind") or source_hint.get("channelKind") or ""
-    ).strip().lower()
+    caller_kind = (
+        str(source_hint.get("caller_kind") or source_hint.get("callerKind") or "").strip().lower()
+    )
+    channel_kind = (
+        str(source_hint.get("channel_kind") or source_hint.get("channelKind") or "").strip().lower()
+    )
     if caller_kind:
         source_hint.setdefault("caller_kind", caller_kind)
     if channel_kind:
@@ -249,6 +246,7 @@ async def _drain_task_runtime_for_reset(task_runtime: Any, session_key: str) -> 
         log.warning("sessions.reset.task_runtime_drain_timeout", session_key=session_key)
     except Exception:
         log.warning("sessions.reset.task_runtime_drain_failed", session_key=session_key)
+
 
 def _optional_positive_timeout(config: Any, attr: str, default: float) -> float | None:
     raw = getattr(config, attr, default)
@@ -545,8 +543,7 @@ def _normalize_terminal_event_payload(event_name: str, payload: dict[str, Any]) 
     is_timeout = "timeout" in code_text or "stream idle" in raw_text.lower()
     terminal_payload = {
         "status": "timeout" if is_timeout else "failed",
-        "terminal_reason": payload.get("terminal_reason")
-        or ("timeout" if is_timeout else "error"),
+        "terminal_reason": payload.get("terminal_reason") or ("timeout" if is_timeout else "error"),
         "error_class": code,
         "error_message": raw_text,
         **payload,
@@ -1292,9 +1289,7 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
                     "error_message": _STREAM_IDLE_TIMEOUT_MESSAGE,
                 }
             )
-            await ctx.session_manager.append_message(
-                key, role="system", content=timeout_message
-            )
+            await ctx.session_manager.append_message(key, role="system", content=timeout_message)
             await _emit_terminal_once(
                 "session.event.error",
                 {"message": _STREAM_IDLE_TIMEOUT_MESSAGE, "code": _STREAM_IDLE_TIMEOUT_CODE},
@@ -1310,9 +1305,7 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
                 fallback_error_class="agent_error",
                 fallback_error_message=str(exc) or "Agent error",
             )
-            event_code = (
-                error_code if error_code == "provider_request_too_large" else "agent_error"
-            )
+            event_code = error_code if error_code == "provider_request_too_large" else "agent_error"
             log.error("sessions.send.agent_failed", session_key=key, error=str(exc), exc_info=True)
             await ctx.session_manager.append_message(
                 key,
@@ -1601,40 +1594,105 @@ async def _handle_sessions_reset(params: dict | None, ctx: RpcContext) -> dict[s
         transcript = await ctx.session_manager.get_transcript(key)
 
         if ctx.flush_service is None:
-            # Fail-closed when flush is unavailable: refuse to clear a non-empty
-            # transcript without an explicit admin override or a covering
-            # checkpoint receipt. The whole read -> gate -> rotate window stays
-            # under the same per-session lock used by sends.
+            # Flush service unavailable (the default kill-switch path). Rather
+            # than hard-fail a plain reset of a non-empty transcript, fall back
+            # to a NON-destructive archive-then-rotate: the transcript is dumped
+            # to disk and the session_id rotates, but the old rows are left in
+            # storage so nothing is lost. This matches the "New Chat" button's
+            # safety semantics — the reset always succeeds and data is preserved.
+            #
+            # A destructive reset (old transcript rows deleted) is still possible
+            # via force=true (admin) when a durable checkpoint receipt covers the
+            # transcript; without a covering receipt even force=true performs the
+            # non-destructive archive rotation, since destroying un-backed-up
+            # history is never what an operator intends.
             if transcript and not force:
-                checkpoint_safe = (
-                    await _durable_receipt_allows_covered_destructive_compaction(
-                        storage,
-                        key,
-                        previous_session_id,
-                        transcript,
-                    )
+                checkpoint_safe = await _durable_receipt_allows_covered_destructive_compaction(
+                    storage,
+                    key,
+                    previous_session_id,
+                    transcript,
                 )
-                if not checkpoint_safe:
-                    raise RpcHandlerError(
-                        code="flush_unavailable",
-                        message=(
-                            "Reset aborted: flush service is unavailable and the "
-                            "transcript is non-empty. Re-run with force=true (admin) "
-                            "to discard without backup."
-                        ),
-                        details={
-                            "key": key,
-                            "session_id": previous_session_id,
-                            "reason": "flush_service_disabled",
-                            "message_count": len(transcript),
-                        },
+                if checkpoint_safe:
+                    # A durable checkpoint already covers this transcript, so the
+                    # destructive rotation is safe even without the flush service.
+                    updated, rotated = await ctx.session_manager.apply_intent(
+                        key,
+                        SessionIntent.RESET_SAME_KEY,
                     )
+                    new_epoch = await _increment_and_emit_epoch(ctx, storage, key)
+                    await _notify_provider_session_boundary(
+                        ctx,
+                        agent_id=agent_id,
+                        transcript=transcript,
+                        new_session_id=updated.session_id,
+                    )
+                    return {
+                        "key": key,
+                        "reset": True,
+                        "rotated": rotated,
+                        "previous_session_id": previous_session_id,
+                        "session_id": updated.session_id,
+                        "epoch": new_epoch,
+                        "reset_mode": "destructive_checkpoint_covered",
+                    }
+
+                # No covering checkpoint: archive + rotate without deleting.
+                updated = await ctx.session_manager.rotate_session_id_archive_only(key)
+                new_epoch = await _increment_and_emit_epoch(ctx, storage, key)
+                await _notify_provider_session_boundary(
+                    ctx,
+                    agent_id=agent_id,
+                    transcript=transcript,
+                    new_session_id=updated.session_id,
+                )
+                return {
+                    "key": key,
+                    "reset": True,
+                    "rotated": True,
+                    "previous_session_id": previous_session_id,
+                    "session_id": updated.session_id,
+                    "epoch": new_epoch,
+                    "reset_mode": "archive_only",
+                    "message_count": len(transcript),
+                }
+
             if transcript and force and "operator.admin" not in ctx.principal.scopes:
                 raise RpcHandlerError(
                     code="permission_denied",
                     message="force=true on sessions.reset requires operator.admin scope.",
                     details={"key": key, "session_id": previous_session_id},
                 )
+
+            if transcript and force:
+                # Admin force: still prefer the non-destructive archive rotation
+                # unless a durable checkpoint receipt covers the transcript, since
+                # destroying un-backed-up history is never the real intent.
+                checkpoint_safe = await _durable_receipt_allows_covered_destructive_compaction(
+                    storage,
+                    key,
+                    previous_session_id,
+                    transcript,
+                )
+                if not checkpoint_safe:
+                    updated = await ctx.session_manager.rotate_session_id_archive_only(key)
+                    new_epoch = await _increment_and_emit_epoch(ctx, storage, key)
+                    await _notify_provider_session_boundary(
+                        ctx,
+                        agent_id=agent_id,
+                        transcript=transcript,
+                        new_session_id=updated.session_id,
+                    )
+                    return {
+                        "key": key,
+                        "reset": True,
+                        "rotated": True,
+                        "previous_session_id": previous_session_id,
+                        "session_id": updated.session_id,
+                        "epoch": new_epoch,
+                        "reset_mode": "archive_only",
+                        "message_count": len(transcript),
+                    }
 
             updated, rotated = await ctx.session_manager.apply_intent(
                 key,
@@ -2091,9 +2149,8 @@ async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext)
                 compact_kwargs: dict[str, Any] = {
                     "custom_instructions": custom_instructions,
                 }
-                if (
-                    flush_receipt_status is not None
-                    and _accepts_keyword_arg(compact_with_result, "flush_receipt_status")
+                if flush_receipt_status is not None and _accepts_keyword_arg(
+                    compact_with_result, "flush_receipt_status"
                 ):
                     compact_kwargs["flush_receipt_status"] = flush_receipt_status
                 result = await compact_with_result(
@@ -2108,9 +2165,7 @@ async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext)
                 kept_count = len(getattr(result, "kept_entries", []) or [])
                 tokens_before = int(getattr(result, "tokens_before", 0) or 0)
                 tokens_after = int(getattr(result, "tokens_after", 0) or 0)
-                remaining_budget_tokens = int(
-                    getattr(result, "remaining_budget_tokens", 0) or 0
-                )
+                remaining_budget_tokens = int(getattr(result, "remaining_budget_tokens", 0) or 0)
                 chunk_count = int(getattr(result, "chunks_processed", 0) or 0)
                 coverage_status = str(getattr(result, "coverage_status", "unknown") or "unknown")
                 skip_reason = str(getattr(result, "skip_reason", "") or "")
@@ -2188,9 +2243,7 @@ async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext)
         if flush_receipt_status is not None:
             payload["flush_receipt_status"] = flush_receipt_status
         final_event = (
-            COMPACTION_PERSISTED_EVENT
-            if removed_count > 0
-            else COMPACTION_TRIGGERED_EVENT
+            COMPACTION_PERSISTED_EVENT if removed_count > 0 else COMPACTION_TRIGGERED_EVENT
         )
         final_lifecycle_payload = compaction_lifecycle_payload(compaction_id, final_event)
         final_lifecycle_payload.pop("coverage_status", None)

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -518,14 +518,21 @@ class SessionManager:
         await self._storage.upsert_session(node)
         return node
 
-    async def _archive_session_identity(self, node: SessionNode) -> None:
-        """Best-effort raw archive before a same-key transcript reset."""
+    async def _archive_session_identity(self, node: SessionNode) -> bool:
+        """Best-effort raw archive before a same-key transcript reset.
+
+        Returns ``True`` when a non-empty archive file was written to disk,
+        ``False`` when there was nothing to archive or the write failed. The
+        reset path uses the return value to decide whether a destructive
+        rotation is safe to fall back to when the memory-flush service is
+        unavailable.
+        """
 
         try:
             entries = await self._storage.get_canonical_transcript(node.session_id)
             summaries = await self._storage.get_all_summaries(node.session_id)
             if not entries and not summaries:
-                return
+                return False
             archive_dir = _archive_dir()
             archive_dir.mkdir(parents=True, exist_ok=True)
             safe_key = _safe_archive_part(node.session_key)
@@ -542,8 +549,49 @@ class SessionManager:
                 "summaries": [summary.model_dump(mode="json") for summary in summaries],
             }
             path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            return True
         except Exception:
-            return
+            return False
+
+    async def rotate_session_id_archive_only(self, session_key: str) -> SessionNode:
+        """Rotate ``session_id`` after archiving, without deleting transcript rows.
+
+        Non-destructive counterpart to :meth:`_rotate_session_id` used by the
+        ``sessions.reset`` kill-switch path when the memory-flush service is
+        unavailable. The full transcript + summaries are first archived to
+        disk via :meth:`_archive_session_identity`; the old rows are then left
+        in storage (keyed under the old ``session_id``) so nothing is lost.
+        A fresh ``session_id`` makes the session read as empty going forward,
+        matching the "New Chat" semantics while guaranteeing no data loss.
+        """
+
+        session_key = canonicalize_session_key(session_key)
+        node = await self._storage.get_session(session_key)
+        if node is None:
+            raise KeyError(f"Session not found: {session_key}")
+        await self._archive_session_identity(node)
+        await self._storage.invalidate_context_states(
+            node.session_key,
+            reason="session_reset",
+        )
+        node.session_id = str(uuid.uuid4())
+        node.updated_at = _now_ms()
+        node.input_tokens = 0
+        node.output_tokens = 0
+        node.total_tokens = 0
+        node.total_tokens_fresh = False
+        node.estimated_cost_usd = 0.0
+        node.total_cost_usd = 0.0
+        node.billed_cost_usd = 0.0
+        node.estimated_cost_component_usd = 0.0
+        node.cost_source = "none"
+        node.missing_cost_entries = 0
+        node.cache_read = 0
+        node.cache_write = 0
+        node.context_tokens = None
+        node.compaction_count = 0
+        await self._storage.upsert_session(node)
+        return node
 
     async def resume(self, session_key: str) -> SessionNode:
         """Load an existing session; touch updated_at."""
@@ -856,18 +904,13 @@ class SessionManager:
         event_body_hash = checkpoint_event_hash(
             "\n".join(serialize_checkpoint_event(event) for event in events)
         )
-        failure_key = (
-            f"checkpoint:{session_key}:{resolved_turn_id}:"
-            f"{event_body_hash}"
-        )
+        failure_key = f"checkpoint:{session_key}:{resolved_turn_id}:{event_body_hash}"
         try:
             if workspace is None:
                 raise RuntimeError("checkpoint workspace_dir is not configured")
             result = await asyncio.to_thread(append_checkpoint_events, workspace, events)
         except Exception as exc:
-            failure_key = (
-                f"{failure_key}:failed:{checkpoint_event_hash(str(exc))[:16]}"
-            )
+            failure_key = f"{failure_key}:failed:{checkpoint_event_hash(str(exc))[:16]}"
             receipt = MemoryDurableReceipt(
                 session_key=session_key,
                 session_id=node.session_id,
@@ -898,9 +941,7 @@ class SessionManager:
             coverage_turn_id=coverage_turn_id,
             coverage_hash=coverage_hash,
             coverage_entry_count=coverage_entry_count,
-            idempotency_key=(
-                f"checkpoint:{session_key}:{resolved_turn_id}:{result.content_hash}"
-            ),
+            idempotency_key=(f"checkpoint:{session_key}:{resolved_turn_id}:{result.content_hash}"),
             status="checkpoint_saved",
             attempt_count=1,
         )
@@ -1146,9 +1187,7 @@ class SessionManager:
                 removed_count=result.removed_count,
                 kept_count=len(kept_entries),
                 chunk_count=result.chunks_processed,
-                flush_receipt_status=_compaction_flush_status_for_persistence(
-                    flush_receipt_status
-                ),
+                flush_receipt_status=_compaction_flush_status_for_persistence(flush_receipt_status),
                 covered_through_id=max((entry.id or 0) for entry in removed_entries)
                 if removed_entries
                 else 0,
@@ -1237,9 +1276,7 @@ class SessionManager:
                 critical_carry_forward=coverage.critical_carry_forward,
                 removed_count=len(removed_entries),
                 kept_count=len(kept_entries),
-                flush_receipt_status=_compaction_flush_status_for_persistence(
-                    flush_receipt_status
-                ),
+                flush_receipt_status=_compaction_flush_status_for_persistence(flush_receipt_status),
                 covered_through_id=max((entry.id or 0) for entry in removed_entries)
                 if removed_entries
                 else 0,

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -5,6 +5,7 @@ import base64
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -280,6 +281,115 @@ def test_channel_stream_policy_prefers_adapter_stream_updates() -> None:
     assert policy.mode == "adapter_stream"
     assert policy.relay_stream is True
     assert policy.typing_keepalive is False
+
+
+# ── Channel /new "fresh session" pointer (New Chat parity) ────────────────
+
+
+def _write_principal() -> Any:
+    from agentos.gateway.auth import Principal as GatewayPrincipal
+
+    return GatewayPrincipal(
+        role="operator",
+        scopes=frozenset({"operator.read", "operator.write"}),
+        is_owner=False,
+        authenticated=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_channel_new_command_sets_pointer_and_does_not_reset() -> None:
+    """`/new` must mint a fresh key + point the chat at it (non-destructive).
+
+    Regression for "Reset aborted: flush service is unavailable": channel /new
+    previously routed to destructive sessions.reset. It must now never call the
+    dispatcher at all — it only sets a per-chat pointer to a fresh session key.
+    """
+    from agentos.gateway.channel_dispatch import ChannelSessionPointers
+
+    base_key = "agent:main:telegram:direct:42"
+    pointers = ChannelSessionPointers()
+    msg = IncomingMessage(sender_id="42", channel_id="42", content="/new")
+    route_envelope = build_channel_route_envelope(
+        msg,
+        session_key=base_key,
+        session_prefix="telegram",
+        agent_id="main",
+    )
+
+    class ExplodingDispatcher:
+        async def dispatch(self, req_id, method, params, ctx):  # pragma: no cover
+            raise AssertionError("dispatcher must not be called for /new fresh-key flow")
+
+    reply = await _dispatch_channel_slash_command(
+        route_envelope=route_envelope,
+        msg=msg,
+        session_manager=object(),
+        session_key=base_key,
+        session_prefix="telegram",
+        rpc_dispatcher=ExplodingDispatcher(),
+        context_factory=lambda _envelope: SimpleNamespace(principal=_write_principal()),
+        session_pointers=pointers,
+        base_session_key=base_key,
+    )
+
+    assert reply is not None
+    assert reply.content == "Started a new chat session."
+    assert reply.metadata["denied"] is False
+    # A fresh key was minted and the chat now points at it.
+    new_key = reply.metadata["session_key"]
+    assert new_key != base_key
+    assert new_key.startswith(base_key + ":new:")
+    assert pointers.resolve(base_key) == new_key
+
+
+@pytest.mark.asyncio
+async def test_channel_new_command_without_pointer_falls_back_to_reset() -> None:
+    """Without a pointer map, /new retains the legacy destructive reset path."""
+    msg = IncomingMessage(sender_id="42", channel_id="42", content="/new")
+    base_key = "agent:main:telegram:direct:42"
+    route_envelope = build_channel_route_envelope(
+        msg,
+        session_key=base_key,
+        session_prefix="telegram",
+        agent_id="main",
+    )
+    calls: list[tuple[str, dict]] = []
+
+    class FakeDispatcher:
+        async def dispatch(self, req_id, method, params, ctx):
+            calls.append((method, params))
+            return make_ok_res(req_id, {"reset": True, "key": params.get("key")})
+
+    class FakeSessionManager:
+        async def get_or_create(self, session_key, agent_id="main", **fields):
+            return SimpleNamespace(session_key=session_key, session_id="sid"), True
+
+    reply = await _dispatch_channel_slash_command(
+        route_envelope=route_envelope,
+        msg=msg,
+        session_manager=FakeSessionManager(),
+        session_key=base_key,
+        session_prefix="telegram",
+        rpc_dispatcher=FakeDispatcher(),
+        context_factory=lambda _envelope: SimpleNamespace(principal=_write_principal()),
+        session_pointers=None,
+        base_session_key=base_key,
+    )
+
+    assert reply is not None
+    assert calls == [("sessions.reset", {"key": base_key})]
+
+
+def test_channel_session_pointers_resolve_and_set() -> None:
+    from agentos.gateway.channel_dispatch import ChannelSessionPointers
+
+    pointers = ChannelSessionPointers()
+    base = "agent:main:telegram:direct:7"
+    # No pointer → resolve returns base unchanged.
+    assert pointers.resolve(base) == base
+    pointers.set(base, "agent:main:telegram:direct:7:new:abcd1234")
+    assert pointers.resolve(base) == "agent:main:telegram:direct:7:new:abcd1234"
 
 
 def test_channel_stream_policy_uses_typing_placeholder_without_stream_editing() -> None:
@@ -805,10 +915,7 @@ def test_channel_artifact_fallback_uses_only_channel_safe_absolute_links() -> No
                 "signed_download_url": "https://gateway.example/artifacts/art-2?sig=short",
             }
         ]
-    ) == [
-        "Generated file: signed.txt -> "
-        "https://gateway.example/artifacts/art-2?sig=short"
-    ]
+    ) == ["Generated file: signed.txt -> https://gateway.example/artifacts/art-2?sig=short"]
 
     assert _artifact_fallback_lines(
         [

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -112,8 +112,7 @@ class FakeStorage:
     ) -> dict[str, list[SimpleNamespace]]:
         self.list_agent_tasks_for_sessions_calls.append(tuple(session_keys))
         return {
-            key: list(self._agent_tasks.get(key, []))[:limit_per_session]
-            for key in session_keys
+            key: list(self._agent_tasks.get(key, []))[:limit_per_session] for key in session_keys
         }
 
     async def list_memory_durable_receipts(
@@ -139,16 +138,10 @@ class FakeStorage:
             rows = [row for row in rows if getattr(row, "status", None) == status]
         if coverage_turn_id is not None:
             rows = [
-                row
-                for row in rows
-                if getattr(row, "coverage_turn_id", None) == coverage_turn_id
+                row for row in rows if getattr(row, "coverage_turn_id", None) == coverage_turn_id
             ]
         if coverage_hash is not None:
-            rows = [
-                row
-                for row in rows
-                if getattr(row, "coverage_hash", None) == coverage_hash
-            ]
+            rows = [row for row in rows if getattr(row, "coverage_hash", None) == coverage_hash]
         if coverage_entry_count is not None:
             rows = [
                 row
@@ -156,11 +149,7 @@ class FakeStorage:
                 if getattr(row, "coverage_entry_count", None) == coverage_entry_count
             ]
         if idempotency_key is not None:
-            rows = [
-                row
-                for row in rows
-                if getattr(row, "idempotency_key", None) == idempotency_key
-            ]
+            rows = [row for row in rows if getattr(row, "idempotency_key", None) == idempotency_key]
         return rows[:limit]
 
 
@@ -177,6 +166,7 @@ class FakeSessionManager:
         self.compact_summary = "summary for compacted context"
         self.compact_summary_source = "fallback"
         self.transcript: list[Any] = []
+        self.archive_only_rotations: list[str] = []
 
     async def append_message(self, key: str, role: str = "user", content: str = "") -> Any:
         self.created_messages.append((key, role, content))
@@ -277,6 +267,15 @@ class FakeSessionManager:
         session.session_id = f"{old_id}-rotated"
         return session, True
 
+    async def rotate_session_id_archive_only(self, session_key: str):
+        session = await self._storage.get_session(session_key)
+        if session is None:
+            raise KeyError(f"Session not found: {session_key}")
+        self.archive_only_rotations.append(session_key)
+        old_id = session.session_id
+        session.session_id = f"{old_id}-archived"
+        return session
+
 
 class SlowCompactionSessionManager(FakeSessionManager):
     def __init__(self, sessions: list[FakeSession] | None = None):
@@ -284,9 +283,7 @@ class SlowCompactionSessionManager(FakeSessionManager):
         self.started = asyncio.Event()
         self.release = asyncio.Event()
 
-    async def compact(
-        self, session_key: str, context_window_tokens: int, config=None
-    ) -> str:
+    async def compact(self, session_key: str, context_window_tokens: int, config=None) -> str:
         self.started.set()
         await self.release.wait()
         return await super().compact(session_key, context_window_tokens, config)
@@ -712,9 +709,7 @@ class TestSessionsList:
         assert row["run_status"] == "running"
 
     @pytest.mark.asyncio
-    async def test_list_prefers_running_active_task_over_newer_queued_task(
-        self, dispatcher
-    ):
+    async def test_list_prefers_running_active_task_over_newer_queued_task(self, dispatcher):
         session = FakeSession(session_key="agent:main:webchat:running-priority")
         manager = FakeSessionManager([session])
         manager._storage._agent_tasks[session.session_key] = [
@@ -842,17 +837,13 @@ class TestSessionsSend:
         assert manager.removed_messages == []
 
     @pytest.mark.asyncio
-    async def test_send_passes_persisted_user_message_id_to_task_runtime(
-        self, dispatcher, session
-    ):
+    async def test_send_passes_persisted_user_message_id_to_task_runtime(self, dispatcher, session):
         class RecordingTaskRuntime:
             def __init__(self) -> None:
                 self.enqueue_calls: list[dict[str, Any]] = []
 
             async def enqueue(self, envelope, message: str, **kwargs: Any):
-                self.enqueue_calls.append(
-                    {"envelope": envelope, "message": message, **kwargs}
-                )
+                self.enqueue_calls.append({"envelope": envelope, "message": message, **kwargs})
                 return SimpleNamespace(
                     task_id="task-1",
                     session_key=envelope.session_key,
@@ -872,22 +863,18 @@ class TestSessionsSend:
 
         assert res.ok is True
         assert runtime.enqueue_calls[0]["persisted_user_message_id"] == "msg-1"
-        assert runtime.enqueue_calls[0]["envelope"].metadata.get(
-            "persisted_user_message_id"
-        ) is None
+        assert (
+            runtime.enqueue_calls[0]["envelope"].metadata.get("persisted_user_message_id") is None
+        )
 
     @pytest.mark.asyncio
-    async def test_send_marks_empty_transcript_as_fresh_user_session(
-        self, dispatcher, session
-    ):
+    async def test_send_marks_empty_transcript_as_fresh_user_session(self, dispatcher, session):
         class RecordingTaskRuntime:
             def __init__(self) -> None:
                 self.enqueue_calls: list[dict[str, Any]] = []
 
             async def enqueue(self, envelope, message: str, **kwargs: Any):
-                self.enqueue_calls.append(
-                    {"envelope": envelope, "message": message, **kwargs}
-                )
+                self.enqueue_calls.append({"envelope": envelope, "message": message, **kwargs})
                 return SimpleNamespace(
                     task_id="task-1",
                     session_key=envelope.session_key,
@@ -918,9 +905,7 @@ class TestSessionsSend:
                 self.enqueue_calls: list[dict[str, Any]] = []
 
             async def enqueue(self, envelope, message: str, **kwargs: Any):
-                self.enqueue_calls.append(
-                    {"envelope": envelope, "message": message, **kwargs}
-                )
+                self.enqueue_calls.append({"envelope": envelope, "message": message, **kwargs})
                 return SimpleNamespace(
                     task_id="task-1",
                     session_key=envelope.session_key,
@@ -969,17 +954,13 @@ class TestSessionsSend:
         assert res.ok is True
         assert runner.run_calls[0]["fresh_user_session"] is True
 
-    def test_send_prefers_agent_encoded_in_session_key_for_routing(
-        self, dispatcher
-    ):
+    def test_send_prefers_agent_encoded_in_session_key_for_routing(self, dispatcher):
         class RecordingTaskRuntime:
             def __init__(self) -> None:
                 self.enqueue_calls: list[dict[str, Any]] = []
 
             async def enqueue(self, envelope, message: str, **kwargs: Any):
-                self.enqueue_calls.append(
-                    {"envelope": envelope, "message": message, **kwargs}
-                )
+                self.enqueue_calls.append({"envelope": envelope, "message": message, **kwargs})
                 return SimpleNamespace(
                     task_id="task-1",
                     session_key=envelope.session_key,
@@ -1235,9 +1216,7 @@ class TestSessionsSend:
         provenance = web_runner.run_calls[0]["input_provenance"]
         assert provenance["kind"] == "webchat_clip"
         assert provenance["surface"] == "test"
-        assert provenance["input_normalization"]["guard_action"] == (
-            "generated_text_attachment"
-        )
+        assert provenance["input_normalization"]["guard_action"] == ("generated_text_attachment")
         assert provenance["input_normalization"]["original_chars"] == len(raw)
         assert provenance["input_normalization"]["generated_attachment_count"] == 1
         assert provenance["input_normalization"]["material_estimated_tokens"] == (
@@ -1344,9 +1323,7 @@ class TestSessionsSend:
         assert persisted["attachments"][0]["name"].startswith("webchat-paste-")
 
         provenance = web_runner.run_calls[0]["input_provenance"]
-        assert provenance["input_normalization"]["guard_action"] == (
-            "generated_text_attachment"
-        )
+        assert provenance["input_normalization"]["guard_action"] == ("generated_text_attachment")
         assert provenance["input_normalization"]["original_chars"] == len(raw)
         assert provenance["input_normalization"]["generated_attachment_count"] == 1
         assert provenance["input_normalization"]["material_estimated_tokens"] == (
@@ -1386,9 +1363,7 @@ class TestSessionsSend:
         assert cli_runner.run_calls[0]["message"] == raw
         assert cli_runner.run_calls[0]["semantic_message"] == raw
         assert cli_runner.run_calls[0]["attachments"] == []
-        assert "input_normalization" not in cli_runner.run_calls[0][
-            "input_provenance"
-        ]
+        assert "input_normalization" not in cli_runner.run_calls[0]["input_provenance"]
 
     @pytest.mark.asyncio
     async def test_chat_send_large_web_paste_uses_sessions_guard(
@@ -1433,9 +1408,7 @@ class TestSessionsSend:
         assert len(chat_runner.run_calls[0]["attachments"]) == 2
         assert chat_runner.run_calls[0]["attachments"][0]["kind"] == "attachment_ref"
         assert "data" not in chat_runner.run_calls[0]["attachments"][0]
-        assert chat_runner.run_calls[0]["attachments"][0]["name"].startswith(
-            "webchat-paste-"
-        )
+        assert chat_runner.run_calls[0]["attachments"][0]["name"].startswith("webchat-paste-")
         assert chat_runner.run_calls[0]["attachments"][1]["name"] == "note.txt"
         persisted = json.loads(chat_manager.created_messages[0][2])
         assert persisted["text"] == placeholder
@@ -1508,9 +1481,7 @@ class TestSessionsSend:
         provenance = chat_runner.run_calls[0]["input_provenance"]
         assert provenance["kind"] == "web_message"
         assert provenance["source"] == "WebChat"
-        assert provenance["input_normalization"]["guard_action"] == (
-            "generated_text_attachment"
-        )
+        assert provenance["input_normalization"]["guard_action"] == ("generated_text_attachment")
         assert provenance["input_normalization"]["original_chars"] == len(raw)
         assert provenance["input_normalization"]["material_estimated_tokens"] == (
             estimate_text_tokens(raw)
@@ -1573,9 +1544,7 @@ class TestSessionsSend:
         )
         assert material_path.read_text(encoding="utf-8") == raw
         provenance = chat_runner.run_calls[0]["input_provenance"]
-        assert provenance["input_normalization"]["guard_action"] == (
-            "generated_text_attachment"
-        )
+        assert provenance["input_normalization"]["guard_action"] == ("generated_text_attachment")
         assert provenance["input_normalization"]["original_chars"] == len(raw)
         assert provenance["input_normalization"]["material_estimated_tokens"] == (
             estimate_text_tokens(raw)
@@ -1767,9 +1736,7 @@ class TestSessionsSend:
             {
                 "key": session.session_key,
                 "message": "hi",
-                "attachments": [
-                    {"type": "application/x-shellscript", "data": "QQ=="}
-                ],
+                "attachments": [{"type": "application/x-shellscript", "data": "QQ=="}],
             },
             ctx_with_sessions,
         )
@@ -1836,9 +1803,7 @@ class TestSessionsAbort:
                 source: str | None = None,
                 reason: str | None = None,
             ) -> int:
-                self.calls.append(
-                    {"session_key": session_key, "source": source, "reason": reason}
-                )
+                self.calls.append({"session_key": session_key, "source": source, "reason": reason})
                 return 1
 
         runtime = Runtime()
@@ -1993,9 +1958,7 @@ class TestSessionsReset:
         )
         ctx = make_ctx(session_manager=manager, flush_service=flush_service)
 
-        res = await dispatcher.dispatch(
-            "r1", "sessions.reset", {"key": session.session_key}, ctx
-        )
+        res = await dispatcher.dispatch("r1", "sessions.reset", {"key": session.session_key}, ctx)
 
         assert res.ok is True
         assert res.payload["flush_receipt"]["result_status"] == "parse_failed_archived"
@@ -2042,9 +2005,7 @@ class TestSessionsReset:
         )
         ctx = make_ctx(session_manager=manager, flush_service=flush_service)
 
-        res = await dispatcher.dispatch(
-            "r1", "sessions.reset", {"key": session.session_key}, ctx
-        )
+        res = await dispatcher.dispatch("r1", "sessions.reset", {"key": session.session_key}, ctx)
 
         assert res.ok is False
         assert res.error.code == "flush_disk_error"
@@ -2063,9 +2024,7 @@ class TestSessionsReset:
         )
         ctx = make_ctx(session_manager=manager, flush_service=None)
 
-        res = await dispatcher.dispatch(
-            "r1", "sessions.reset", {"key": session.session_key}, ctx
-        )
+        res = await dispatcher.dispatch("r1", "sessions.reset", {"key": session.session_key}, ctx)
 
         assert res.ok is True
         assert manager.applied_intents == [(session.session_key, "reset_same_key")]
@@ -2113,6 +2072,31 @@ class TestSessionsReset:
         )
         assert res.ok is False
         assert res.error.code == "NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_reset_without_flush_service_archives_instead_of_failing(
+        self, dispatcher, session
+    ):
+        # Regression: previously a non-empty transcript with no flush service and
+        # no covering checkpoint raised flush_unavailable. Now it must succeed via
+        # the non-destructive archive-then-rotate path (no transcript deleted).
+        manager = FakeSessionManager([session])
+        manager.transcript = [SimpleNamespace(id=1, content="message to preserve")]
+        ctx = make_ctx(session_manager=manager, flush_service=None)
+        before = session.session_id
+
+        res = await dispatcher.dispatch("r1", "sessions.reset", {"key": session.session_key}, ctx)
+
+        assert res.ok is True
+        assert res.payload["reset"] is True
+        assert res.payload["reset_mode"] == "archive_only"
+        assert res.payload["message_count"] == 1
+        # Non-destructive: the destructive apply_intent rotation was NOT used.
+        assert manager.applied_intents == []
+        assert manager.archive_only_rotations == [session.session_key]
+        # session_id rotated so the session reads empty going forward.
+        assert res.payload["previous_session_id"] == before
+        assert res.payload["session_id"] != before
 
 
 class TestSessionsDelete:
@@ -2183,15 +2167,11 @@ class TestSessionsTruncate:
 
         assert res.ok is True
         assert res.payload["mode"] == "truncate"
-        assert ctx_with_sessions.session_manager.truncate_calls == [
-            (session.session_key, 20)
-        ]
+        assert ctx_with_sessions.session_manager.truncate_calls == [(session.session_key, 20)]
         assert ctx_with_sessions.session_manager.compact_calls == []
 
     @pytest.mark.asyncio
-    async def test_truncate_refuses_degraded_flush_receipt(
-        self, dispatcher, session
-    ):
+    async def test_truncate_refuses_degraded_flush_receipt(self, dispatcher, session):
         manager = FakeSessionManager([session])
         manager.transcript = [SimpleNamespace(content="message to preserve")]
         flush_service = SimpleNamespace(
@@ -2351,9 +2331,7 @@ class TestSessionsTruncate:
         assert manager.truncate_calls == [(session.session_key, 1)]
 
     @pytest.mark.asyncio
-    async def test_truncate_refuses_orphaned_checkpoint_receipt(
-        self, dispatcher, session
-    ):
+    async def test_truncate_refuses_orphaned_checkpoint_receipt(self, dispatcher, session):
         manager = FakeSessionManager([session])
         manager.transcript = [SimpleNamespace(content="message to preserve")]
         manager._storage.memory_durable_receipts.append(
@@ -2718,9 +2696,7 @@ class TestSessionsContextCompact:
         assert res.payload["flush_receipt_status"] == "degraded_forensic"
 
     @pytest.mark.asyncio
-    async def test_context_compact_block_mode_allows_checkpoint_receipt(
-        self, dispatcher, session
-    ):
+    async def test_context_compact_block_mode_allows_checkpoint_receipt(self, dispatcher, session):
         manager = FakeSessionManager([session])
         manager.transcript = [SimpleNamespace(id=1, content="message to preserve")]
         manager._storage.memory_durable_receipts.append(
@@ -2867,9 +2843,7 @@ class TestSessionsContextCompact:
         assert manager.compact_calls == []
 
     @pytest.mark.asyncio
-    async def test_context_compact_persists_noop_flush_receipt_status(
-        self, dispatcher, session
-    ):
+    async def test_context_compact_persists_noop_flush_receipt_status(self, dispatcher, session):
         manager = FakeSessionManager([session])
         manager.transcript = [SimpleNamespace(content="message to preserve")]
         flush_service = SimpleNamespace(
@@ -2923,9 +2897,7 @@ class TestSessionsContextCompact:
         )
 
     @pytest.mark.asyncio
-    async def test_context_compact_passes_provider_config_without_flush_receipt(
-        self, dispatcher
-    ):
+    async def test_context_compact_passes_provider_config_without_flush_receipt(self, dispatcher):
         session = FakeSession(session_key="agent:main:abc123", model="session/model")
         manager = FakeSessionManager([session])
         selector = _FakeProviderSelector()
@@ -3143,14 +3115,10 @@ class TestSessionsMessagesSubscribe:
 
         assert res.ok is True
         assert res.payload["replayed_count"] == 1
-        assert conn.events == [
-            ("session.event.task_group.done", done, {"replayed": True})
-        ]
+        assert conn.events == [("session.event.task_group.done", done, {"replayed": True})]
 
     @pytest.mark.asyncio
-    async def test_messages_subscribe_reports_persisted_task_state_and_replay_gap(
-        self, dispatcher
-    ):
+    async def test_messages_subscribe_reports_persisted_task_state_and_replay_gap(self, dispatcher):
         key = "agent:main:webchat:restarted"
         session = FakeSession(session_key=key)
         manager = FakeSessionManager([session])


### PR DESCRIPTION
## Summary

Fixes the intermittent error `Reset aborted: flush service is unavailable and the transcript is non-empty` on `/new` and `/reset` across WebUI and Telegram.

## Root cause

- `sessions.reset` failed closed with `flush_unavailable` whenever the flush service was disabled (the default) and no durable checkpoint receipt covered the transcript, intermittently breaking `/new` and `/reset`.
- Channel session keys were pure functions of the chat id, so channel `/new` had no way to start a fresh session without destructively resetting the existing one — it needed a per-chat pointer.

## Changes

- **session**: add non-destructive `rotate_session_id_archive_only()`; `_archive_session_identity()` now returns whether archiving succeeded.
- **gateway**: `sessions.reset` flush gate falls back to archive-then-rotate (`reset_mode: "archive_only"`) instead of raising `flush_unavailable`; destructive rotation only when a checkpoint receipt covers the transcript.
- **channels**: new `ChannelSessionPointers` per-chat current-session map; channel `/new` mints a fresh session key and points the chat at it (WebUI "New Chat" parity), leaving the old session untouched.

## Tests

- Regression coverage in `tests/test_gateway/test_rpc_sessions.py` and `tests/test_gateway/test_channel_dispatch_realtime.py`.

## Quality gate

- `ruff check src tests` — clean
- `mypy src/agentos` — Success (583 files)
- `pytest -q` — 6238 passed
- `uv build --wheel` — OK