### PR TITLE
docs(config): separate model selection from plain-text mode settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,15 +119,17 @@ Read: [`providers-and-models.md`](providers-and-models.md)
 ### Ollama plain-text mode
 
 AgentOS supports Ollama native tool calls. For a local model that does not
-reliably implement Ollama's tool-call protocol, configure your local model separately, then configure plain-text mode.
+reliably implement Ollama's tool-call protocol, select the model separately,
+then enable plain-text mode.
 
-First, check your installed local Ollama models with `ollama list` and configure your provider (keeping model configuration independent):
+Check which models are installed with `ollama list`, then configure the
+provider and model:
 
 ```bash
 agentos configure provider --provider ollama --model <your-local-model>
 ```
 
-Then, configure the plain-text settings in your `agentos.toml` to disable tools and the router:
+Then disable model-visible tools and the router in `agentos.toml`:
 
 ```toml
 [tools]
@@ -137,10 +139,13 @@ enabled = false
 enabled = false
 ```
 
+Optional settings, such as `base_url` (for non-standard hostnames/ports,
+e.g. `http://10.0.0.42:11434`), go under `[llm]`.
+
 `tools.enabled = false` is a hard plain-text mode: no tool definitions are sent
-to the provider and no tool handler is exposed for the turn. Keep a positive
-`agent_max_iterations` when enabling tools on smaller local models so malformed
-or repetitive tool calls terminate predictably.
+to the provider and no tool handler is exposed for the turn. When tools are
+disabled, any local routing is bypassed; standard single-model fallback rules
+apply.
 
 ## Router Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,17 +119,17 @@ Read: [`providers-and-models.md`](providers-and-models.md)
 ### Ollama plain-text mode
 
 AgentOS supports Ollama native tool calls. For a local model that does not
-reliably implement Ollama's tool-call protocol, disable model-visible tools and
-route directly to the configured model:
+reliably implement Ollama's tool-call protocol, configure your local model separately, then configure plain-text mode.
+
+First, check your installed local Ollama models with `ollama list` and configure your provider (keeping model configuration independent):
+
+```bash
+agentos configure provider --provider ollama --model <your-local-model>
+```
+
+Then, configure the plain-text settings in your `agentos.toml` to disable tools and the router:
 
 ```toml
-agent_max_iterations = 8
-
-[llm]
-provider = "ollama"
-model = "qwen2.5:7b"
-base_url = "http://localhost:11434"
-
 [tools]
 enabled = false
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,16 +120,16 @@ Read: [`providers-and-models.md`](providers-and-models.md)
 
 AgentOS supports Ollama native tool calls. For a local model that does not
 reliably implement Ollama's tool-call protocol, select the model separately,
-then enable plain-text mode.
+then turn on plain-text mode.
 
 Check which models are installed with `ollama list`, then configure the
 provider and model:
 
-```bash
+```sh
 agentos configure provider --provider ollama --model <your-local-model>
 ```
 
-Then disable model-visible tools and the router in `agentos.toml`:
+Then disable model-visible tools and the router in agentos.toml:
 
 ```toml
 [tools]
@@ -139,13 +139,14 @@ enabled = false
 enabled = false
 ```
 
-Optional settings, such as `base_url` (for non-standard hostnames/ports,
-e.g. `http://10.0.0.42:11434`), go under `[llm]`.
+For a remote or non-default host, set `base_url` under `[llm]` (e.g.
+`http://10.0.0.42:11434`).
 
-`tools.enabled = false` is a hard plain-text mode: no tool definitions are sent
-to the provider and no tool handler is exposed for the turn. When tools are
-disabled, any local routing is bypassed; standard single-model fallback rules
-apply.
+`tools.enabled = false` is a hard plain-text mode: no tool definitions
+are sent to the provider and no tool handler is exposed for the turn.
+When you do enable tools on smaller local models, keep a positive
+`agent_max_iterations` so malformed or repetitive tool calls terminate
+predictably.
 
 ## Router Configuration
 


### PR DESCRIPTION

Fixes the Ollama plain-text example in docs/configuration.md, which hardcoded model = "qwen2.5:7b" and agent_max_iterations = 8. Copying the snippet could overwrite a user's configured model or point at a model that is not installed locally, and the tool-loop cap is irrelevant while tools are disabled.

Model selection is now a separate step (ollama list + agentos configure provider), and the TOML block shows only the settings plain-text mode requires.

Closes #58
