### PR TITLE
fix(memory): restore hermes durability guards in curated store

### DIFF
--- a/src/agentos/memory/curated.py
+++ b/src/agentos/memory/curated.py
@@ -14,7 +14,9 @@ via atomic replace, so concurrent agent sessions never clobber each other.
 
 from __future__ import annotations
 
+import errno
 import os
+import shutil
 import tempfile
 import time
 from collections.abc import Iterator
@@ -38,11 +40,68 @@ ENTRY_DELIMITER = "\n§\n"
 # fragile replace/add can't loop the turn to budget exhaustion.
 _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
+# Sentinel returned by _reload_target when the memory file exists but could
+# not be read (transient lock, permission change, I/O error, corrupt UTF-8).
+# It is deliberately NOT a valid .bak path string: every write path checks for
+# it by identity before touching disk. Treating an unreadable file as "empty"
+# and then flushing would silently erase every stored entry.
+_READ_FAILED = "\x00__read_failed__"
+
+# How long a consolidation-failure streak stays "current". The store is cached
+# per workspace for the whole process, so failures must expire on their own --
+# otherwise three failures spread across three unrelated turns would latch the
+# tool into its terminal error state permanently. Comfortably longer than any
+# single turn's retry loop, far shorter than a session.
+_CONSOLIDATION_FAILURE_WINDOW_S = 300.0
+
 
 def _scan(content: str) -> str | None:
     from agentos.tools.builtin.memory_tools import _scan_memory_content
 
     return _scan_memory_content(content)
+
+
+def _atomic_replace(tmp_path: str | Path, target: Path) -> None:
+    """Move *tmp_path* onto *target* atomically, preserving symlinks.
+
+    A plain ``os.replace`` swaps the SYMLINK itself for a regular file, which
+    silently detaches deployments that symlink MEMORY.md / USER.md into a
+    dotfiles repo or a managed profile package. Resolving the link first makes
+    the rename land on the real file so the symlink survives.
+
+    ``EXDEV`` (tmp and target on different filesystems) and ``EBUSY`` (target
+    is a bind mount or held open) cannot be renamed across; fall back to a
+    copy + fsync so those deployments still get a durable write instead of an
+    exception. The copy is not atomic, but the alternative is no write at all.
+    """
+    target_str = str(target)
+    real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
+    tmp_str = str(tmp_path)
+    try:
+        os.replace(tmp_str, real_path)
+        return
+    except OSError as exc:
+        if exc.errno not in (errno.EXDEV, errno.EBUSY):
+            raise
+        log.debug(
+            "curated_memory_atomic_replace_fallback",
+            tmp=tmp_str,
+            target=real_path,
+            errno=errno.errorcode.get(exc.errno, exc.errno),
+        )
+    shutil.copyfile(tmp_str, real_path)
+    try:
+        fd = os.open(real_path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError:  # pragma: no cover - best effort durability
+        pass
+    try:
+        os.unlink(tmp_str)
+    except OSError:  # pragma: no cover
+        pass
 
 
 class CuratedMemoryStore:
@@ -60,6 +119,7 @@ class CuratedMemoryStore:
         self.memory_entries: list[str] = []
         self.user_entries: list[str] = []
         self._consolidation_failures = 0
+        self._first_failure_at = 0.0
         # Frozen snapshot for system-prompt injection -- set once per
         # load_from_disk() call and never mutated by mid-session writes.
         self._snapshot: dict[str, str] = {}
@@ -93,7 +153,14 @@ class CuratedMemoryStore:
         }
 
     def reset_consolidation_failures(self) -> None:
+        """Clear the consolidation-failure streak.
+
+        Callers that know a turn boundary was crossed can call this to reset
+        immediately; otherwise the streak expires on its own after
+        ``_CONSOLIDATION_FAILURE_WINDOW_S`` (see ``_consolidation_failure``).
+        """
         self._consolidation_failures = 0
+        self._first_failure_at = 0.0
 
     # -- public state -----------------------------------------------------
 
@@ -128,7 +195,9 @@ class CuratedMemoryStore:
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
-            self._reload_target(target, skip_drift=True)
+            reload_signal = self._reload_target(target, skip_drift=True)
+            if reload_signal is _READ_FAILED:
+                return self._read_failed_error(self._path_for(target))
             entries = self.entries_for(target)
             limit = self._char_limit(target)
             if content in entries:
@@ -136,17 +205,19 @@ class CuratedMemoryStore:
             new_total = len(ENTRY_DELIMITER.join([*entries, content]))
             if new_total > limit:
                 current = self._char_count(target)
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
-                        f"Memory at {current:,}/{limit:,} chars. Adding this entry "
-                        f"({len(content)} chars) would exceed the limit. Consolidate now: "
-                        f"use 'replace' to merge overlapping entries or 'remove' stale "
-                        f"ones (see current_entries), then retry — all in this turn."
-                    ),
-                    "current_entries": list(entries),
-                    "usage": f"{current:,}/{limit:,}",
-                })
+                return self._consolidation_failure(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Memory at {current:,}/{limit:,} chars. Adding this entry "
+                            f"({len(content)} chars) would exceed the limit. Consolidate now: "
+                            f"use 'replace' to merge overlapping entries or 'remove' stale "
+                            f"ones (see current_entries), then retry — all in this turn."
+                        ),
+                        "current_entries": list(entries),
+                        "usage": f"{current:,}/{limit:,}",
+                    }
+                )
             entries.append(content)
             self._set_entries(target, entries)
             self._save(target)
@@ -168,19 +239,23 @@ class CuratedMemoryStore:
 
         with self._file_lock(self._path_for(target)):
             bak = self._reload_target(target, skip_drift=False)
+            if bak is _READ_FAILED:
+                return self._read_failed_error(self._path_for(target))
             if bak:
                 return self._drift_error(self._path_for(target), bak)
             entries = self.entries_for(target)
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
             if not matches:
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
-                        f"No entry matched '{old_text}'. Check current_entries and retry "
-                        f"with the exact text of the entry you want to replace."
-                    ),
-                    "current_entries": list(entries),
-                })
+                return self._consolidation_failure(
+                    {
+                        "success": False,
+                        "error": (
+                            f"No entry matched '{old_text}'. Check current_entries and retry "
+                            f"with the exact text of the entry you want to replace."
+                        ),
+                        "current_entries": list(entries),
+                    }
+                )
             if len({e for _, e in matches}) > 1:
                 return {
                     "success": False,
@@ -194,16 +269,18 @@ class CuratedMemoryStore:
             new_total = len(ENTRY_DELIMITER.join(test_entries))
             if new_total > limit:
                 current = self._char_count(target)
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
-                        f"Replacement would put memory at {new_total:,}/{limit:,} chars. "
-                        f"Shorten the new content or 'remove' stale entries first, then "
-                        f"retry — all in this turn."
-                    ),
-                    "current_entries": list(entries),
-                    "usage": f"{current:,}/{limit:,}",
-                })
+                return self._consolidation_failure(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Replacement would put memory at {new_total:,}/{limit:,} chars. "
+                            f"Shorten the new content or 'remove' stale entries first, then "
+                            f"retry — all in this turn."
+                        ),
+                        "current_entries": list(entries),
+                        "usage": f"{current:,}/{limit:,}",
+                    }
+                )
             entries[idx] = new_content
             self._set_entries(target, entries)
             self._save(target)
@@ -215,19 +292,23 @@ class CuratedMemoryStore:
             return {"success": False, "error": "old_text cannot be empty."}
         with self._file_lock(self._path_for(target)):
             bak = self._reload_target(target, skip_drift=False)
+            if bak is _READ_FAILED:
+                return self._read_failed_error(self._path_for(target))
             if bak:
                 return self._drift_error(self._path_for(target), bak)
             entries = self.entries_for(target)
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
             if not matches:
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
-                        f"No entry matched '{old_text}'. Check current_entries and retry "
-                        f"with the exact text of the entry you want to remove."
-                    ),
-                    "current_entries": list(entries),
-                })
+                return self._consolidation_failure(
+                    {
+                        "success": False,
+                        "error": (
+                            f"No entry matched '{old_text}'. Check current_entries and retry "
+                            f"with the exact text of the entry you want to remove."
+                        ),
+                        "current_entries": list(entries),
+                    }
+                )
             if len({e for _, e in matches}) > 1:
                 return {
                     "success": False,
@@ -267,6 +348,8 @@ class CuratedMemoryStore:
 
         with self._file_lock(self._path_for(target)):
             bak = self._reload_target(target, skip_drift=False)
+            if bak is _READ_FAILED:
+                return self._read_failed_error(self._path_for(target))
             if bak:
                 return self._drift_error(self._path_for(target), bak)
 
@@ -298,9 +381,7 @@ class CuratedMemoryStore:
                         )
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
-                        return self._batch_error(
-                            target, f"{pos}: no entry matched '{old_text}'."
-                        )
+                        return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
                     if len({working[j] for j in matches}) > 1:
                         return self._batch_error(
                             target,
@@ -314,9 +395,7 @@ class CuratedMemoryStore:
                         return self._batch_error(target, f"{pos}: old_text is required.")
                     matches = [j for j, e in enumerate(working) if old_text in e]
                     if not matches:
-                        return self._batch_error(
-                            target, f"{pos}: no entry matched '{old_text}'."
-                        )
+                        return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
                     if len({working[j] for j in matches}) > 1:
                         return self._batch_error(
                             target,
@@ -334,17 +413,19 @@ class CuratedMemoryStore:
             new_total = len(ENTRY_DELIMITER.join(working)) if working else 0
             if new_total > limit:
                 current = self._char_count(target)
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
-                        f"After applying all {len(operations)} operations, memory would be "
-                        f"at {new_total:,}/{limit:,} chars -- over the limit. Remove or "
-                        f"shorten more entries in the same batch (see current_entries "
-                        f"below), then retry."
-                    ),
-                    "current_entries": list(self.entries_for(target)),
-                    "usage": f"{current:,}/{limit:,}",
-                })
+                return self._consolidation_failure(
+                    {
+                        "success": False,
+                        "error": (
+                            f"After applying all {len(operations)} operations, memory would be "
+                            f"at {new_total:,}/{limit:,} chars -- over the limit. Remove or "
+                            f"shorten more entries in the same batch (see current_entries "
+                            f"below), then retry."
+                        ),
+                        "current_entries": list(self.entries_for(target)),
+                        "usage": f"{current:,}/{limit:,}",
+                    }
+                )
 
             # Commit.
             self._set_entries(target, working)
@@ -356,12 +437,14 @@ class CuratedMemoryStore:
         """Build a batch-abort error that reports live (uncommitted) state."""
         current = self._char_count(target)
         limit = self._char_limit(target)
-        return self._consolidation_failure({
-            "success": False,
-            "error": message + " No operations were applied (batch is all-or-nothing).",
-            "current_entries": list(self.entries_for(target)),
-            "usage": f"{current:,}/{limit:,}",
-        })
+        return self._consolidation_failure(
+            {
+                "success": False,
+                "error": message + " No operations were applied (batch is all-or-nothing).",
+                "current_entries": list(self.entries_for(target)),
+                "usage": f"{current:,}/{limit:,}",
+            }
+        )
 
     # -- internals ---------------------------------------------------------
 
@@ -399,9 +482,7 @@ class CuratedMemoryStore:
                 continue
             threat = _scan(entry)
             if threat:
-                log.warning(
-                    "memory_entry_blocked_at_load", filename=filename, threat=threat
-                )
+                log.warning("memory_entry_blocked_at_load", filename=filename, threat=threat)
                 sanitized.append(
                     f"[BLOCKED: {filename} entry contained threat pattern(s): "
                     f"{threat}. Removed from system prompt; use the memory "
@@ -433,24 +514,37 @@ class CuratedMemoryStore:
         """Re-read entries from disk into in-memory state.
 
         Called under the file lock to get the latest state before mutating.
-        Returns the backup path if external drift was detected (the on-disk
-        file contains content that wouldn't round-trip through our
-        parser/serializer, OR an entry larger than the store's char limit).
-        When drift is detected the caller must abort the mutation — flushing
-        would discard the un-roundtrippable content. Returns None on clean
-        reload.
+        Reads the file EXACTLY ONCE and feeds those bytes to both the drift
+        check and the parse, so no external writer can slip between the two
+        (a second read would reopen the TOCTOU window this closes).
+
+        Returns:
+          - ``_READ_FAILED`` when the file could not be read at all. In-memory
+            state is left untouched and the caller MUST abort the mutation.
+          - the ``.bak`` path string when external drift was detected.
+          - ``None`` on a clean reload.
 
         When *skip_drift* is True the round-trip / entry-size check is
         bypassed. Used by ``add``, which appends without rewriting, so
         existing content is never clobbered.
         """
-        bak = None if skip_drift else self._detect_external_drift(target)
-        fresh = list(dict.fromkeys(self._read_file(self._path_for(target))))
+        path = self._path_for(target)
+        raw = self._read_raw_checked(path)
+        if raw is None:
+            # Unreadable != empty. Leave in-memory entries alone so a caller
+            # that ignores this signal still cannot flush [] over real data.
+            return _READ_FAILED
+        bak = None if skip_drift else self._detect_external_drift(target, raw)
+        fresh = list(dict.fromkeys(self._parse_entries(raw)))
         self._set_entries(target, fresh)
         return bak
 
-    def _detect_external_drift(self, target: str) -> str | None:
+    def _detect_external_drift(self, target: str, raw: str) -> str | None:
         """Return a backup-path string if on-disk content shows external drift.
+
+        *raw* is the already-read file content -- callers pass the same bytes
+        they will parse, so this check and the parse can never disagree about
+        what is on disk.
 
         The memory file is supposed to be a list of small entries the store
         wrote, joined by §. Detect drift via two signals:
@@ -471,12 +565,6 @@ class CuratedMemoryStore:
         backed up; returns None when the file looks tool-shaped.
         """
         path = self._path_for(target)
-        if not path.exists():
-            return None
-        try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError:
-            return None
         if not raw.strip():
             return None
 
@@ -504,6 +592,32 @@ class CuratedMemoryStore:
     def _save(self, target: str) -> None:
         self._memory_dir.mkdir(parents=True, exist_ok=True)
         self._write_file(self._path_for(target), self.entries_for(target))
+
+    @staticmethod
+    def _read_failed_error(path: Path) -> dict[str, Any]:
+        """Build the error returned when the memory file could not be read.
+
+        Refusing the write is the whole point: the alternative is to treat an
+        unreadable file as an empty one and flush, which deletes every entry
+        the store already held. The write is dropped, disk is untouched, and
+        the model is told to move on rather than retry into the same error.
+        """
+        return {
+            "success": False,
+            "done": True,
+            "error": (
+                f"Refusing to write {path.name}: the existing file could not be "
+                f"read (locked by another process, permission change, I/O error, "
+                f"or invalid UTF-8). Writing now would overwrite its current "
+                f"contents with an empty store and lose every saved entry. "
+                f"Memory is unchanged — continue with your reply; the fact can "
+                f"be saved in a later turn."
+            ),
+            "remediation": (
+                f"Check that {path} is readable (permissions, encoding) and that "
+                f"no other process is holding it open, then retry."
+            ),
+        }
 
     @staticmethod
     def _drift_error(path: Path, bak_path: str) -> dict[str, Any]:
@@ -536,6 +650,23 @@ class CuratedMemoryStore:
         }
 
     def _consolidation_failure(self, response: dict[str, Any]) -> dict[str, Any]:
+        """Count a failed consolidation and cut the model off after N in a row.
+
+        The budget is scoped to a WINDOW rather than a literal turn: this
+        store is cached per workspace for the life of the process, so a plain
+        counter would accumulate failures across unrelated turns and then
+        refuse every future write forever -- the tool would go permanently
+        dead with no way back. Any failure older than the window is stale
+        evidence about a turn that already ended, so the count restarts.
+
+        A successful write also resets it (see ``_success``).
+        """
+        now = time.monotonic()
+        if now - self._first_failure_at > _CONSOLIDATION_FAILURE_WINDOW_S:
+            self._consolidation_failures = 0
+            self._first_failure_at = now
+        if self._consolidation_failures == 0:
+            self._first_failure_at = now
         self._consolidation_failures += 1
         if self._consolidation_failures <= _MAX_CONSOLIDATION_FAILURES_PER_TURN:
             return response
@@ -550,7 +681,17 @@ class CuratedMemoryStore:
         }
 
     def _success(self, target: str, message: str | None = None) -> dict[str, Any]:
+        """Build the terminal success response for a committed write.
+
+        Deliberately does NOT echo the entries list. Handing the model the
+        full store right after a successful write invites it to spot "one
+        more thing to fix" and re-issue the same operations -- observed as a
+        correct batch on call 1 followed by several redundant repeats. The
+        entries only appear on the error paths, where the model genuinely
+        needs them to decide what to consolidate.
+        """
         self._consolidation_failures = 0
+        self._first_failure_at = 0.0
         entries = self.entries_for(target)
         current = self._char_count(target)
         limit = self._char_limit(target)
@@ -561,7 +702,6 @@ class CuratedMemoryStore:
             "target": target,
             "usage": f"{pct}% — {current:,}/{limit:,} chars",
             "entry_count": len(entries),
-            "current_entries": list(entries),
         }
         if message:
             resp["message"] = message
@@ -592,13 +732,36 @@ class CuratedMemoryStore:
             fd.close()
 
     @staticmethod
-    def _read_file(path: Path) -> list[str]:
+    def _read_raw_checked(path: Path) -> str | None:
+        """Return the file's raw text, or ``None`` when the read FAILED.
+
+        ``None`` means "we could not determine the current contents" -- it is
+        NOT the same as "the file is empty". Callers must refuse to write on
+        ``None``: treating an unreadable file as ``[]`` and then flushing
+        would erase every existing entry (see ``_read_failed_error``).
+
+        A genuinely absent or empty file returns ``""``, which is a known
+        state and safe to write against.
+        """
         if not path.exists():
-            return []
+            return ""
         try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError:
-            return []
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    @classmethod
+    def _read_file(cls, path: Path) -> list[str]:
+        """Parse *path* into entries. Returns [] for both empty AND unreadable.
+
+        Prefer ``_read_raw_checked`` + ``_parse_entries`` on any write path so
+        an unreadable file can be distinguished from an empty one.
+        """
+        raw = cls._read_raw_checked(path)
+        return cls._parse_entries(raw or "")
+
+    @staticmethod
+    def _parse_entries(raw: str) -> list[str]:
         if not raw.strip():
             return []
         return [e for e in (part.strip() for part in raw.split(ENTRY_DELIMITER)) if e]
@@ -606,15 +769,13 @@ class CuratedMemoryStore:
     @staticmethod
     def _write_file(path: Path, entries: list[str]) -> None:
         content = ENTRY_DELIMITER.join(entries) if entries else ""
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(path.parent), suffix=".tmp", prefix=".mem_"
-        )
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".mem_")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(content)
                 f.flush()
                 os.fsync(f.fileno())
-            os.replace(tmp_path, path)
+            _atomic_replace(tmp_path, path)
         except BaseException:
             try:
                 os.unlink(tmp_path)

--- a/tests/test_memory_curated_durability.py
+++ b/tests/test_memory_curated_durability.py
@@ -1,0 +1,274 @@
+"""CuratedMemoryStore durability guards — hermes parity for the write path.
+
+Each test here pins a failure mode that silently destroyed or froze curated
+memory before: an unreadable file being treated as an empty one, a drift check
+that re-read the file and raced with it, a rename that ate symlinks, a failure
+counter that never expired, and a success payload that invited the model to
+redo the write it had just made.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from agentos.memory.curated import (
+    _CONSOLIDATION_FAILURE_WINDOW_S,
+    _MAX_CONSOLIDATION_FAILURES_PER_TURN,
+    ENTRY_DELIMITER,
+    CuratedMemoryStore,
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> CuratedMemoryStore:
+    s = CuratedMemoryStore(memory_dir=tmp_path, memory_char_limit=200, user_char_limit=100)
+    s.load_from_disk()
+    return s
+
+
+# -- unreadable != empty ---------------------------------------------------
+
+
+@pytest.mark.parametrize("action", ["add", "replace", "remove", "batch"])
+def test_write_refuses_when_existing_file_is_unreadable(
+    store: CuratedMemoryStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: str
+):
+    """An unreadable MEMORY.md must abort the write, never overwrite it.
+
+    Treating a failed read as "no entries" and then flushing is what turned a
+    transient lock/permission blip into total memory loss.
+    """
+    store.add("memory", "fact A")
+    store.add("memory", "fact B")
+    original = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+
+    def boom(*_args, **_kwargs):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+
+    if action == "add":
+        result = store.add("memory", "fact C")
+    elif action == "replace":
+        result = store.replace("memory", "fact A", "fact A2")
+    elif action == "remove":
+        result = store.remove("memory", "fact A")
+    else:
+        result = store.apply_batch("memory", [{"action": "add", "content": "fact C"}])
+
+    assert result["success"] is False
+    assert "could not be read" in result["error"]
+    monkeypatch.undo()
+    # The decisive assertion: disk still holds both original entries.
+    assert (tmp_path / "MEMORY.md").read_text(encoding="utf-8") == original
+
+
+def test_write_refuses_on_corrupt_utf8(store: CuratedMemoryStore, tmp_path: Path):
+    """Invalid UTF-8 is a failed read, not an empty store."""
+    store.add("memory", "fact A")
+    (tmp_path / "MEMORY.md").write_bytes(b"\xff\xfe invalid utf-8 \xff")
+    raw_before = (tmp_path / "MEMORY.md").read_bytes()
+
+    result = store.add("memory", "fact B")
+
+    assert result["success"] is False
+    assert "could not be read" in result["error"]
+    assert (tmp_path / "MEMORY.md").read_bytes() == raw_before
+
+
+def test_read_failure_is_terminal_so_the_model_stops_retrying(
+    store: CuratedMemoryStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store.add("memory", "fact A")
+
+    def boom(*_args, **_kwargs):
+        raise OSError(errno.EIO, "io error")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    result = store.add("memory", "fact B")
+
+    assert result["done"] is True
+
+
+def test_missing_file_is_still_a_normal_write(tmp_path: Path):
+    """A genuinely absent file is a known state — writes must proceed."""
+    s = CuratedMemoryStore(memory_dir=tmp_path, memory_char_limit=200, user_char_limit=100)
+    s.load_from_disk()
+    (tmp_path / "MEMORY.md").unlink(missing_ok=True)
+
+    assert s.add("memory", "first fact")["success"] is True
+    assert "first fact" in (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+
+
+# -- drift detection reads the file exactly once ---------------------------
+
+
+def test_drift_check_and_parse_see_the_same_bytes(
+    store: CuratedMemoryStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The drift check must not re-read the file behind the parse's back.
+
+    Two reads leave a window where an external writer lands between them, so
+    the store would validate one version of the file and then write over a
+    different one.
+    """
+    store.add("memory", "fact A")
+    path = tmp_path / "MEMORY.md"
+
+    reads: list[str] = []
+    real_read_text = Path.read_text
+
+    def counting_read(self, *args, **kwargs):
+        data = real_read_text(self, *args, **kwargs)
+        if os.path.samefile(self, path) if self.exists() else False:
+            reads.append(data)
+        return data
+
+    monkeypatch.setattr(Path, "read_text", counting_read)
+    store.replace("memory", "fact A", "fact A revised")
+
+    assert len(reads) == 1, f"MEMORY.md was read {len(reads)}x during one write"
+
+
+def test_drift_still_detected_and_backed_up(store: CuratedMemoryStore, tmp_path: Path):
+    """Passing raw through must not weaken the actual drift detection."""
+    store.add("memory", "fact A")
+    path = tmp_path / "MEMORY.md"
+    path.write_text("fact A" + ENTRY_DELIMITER + "z" * 500, encoding="utf-8")
+
+    result = store.replace("memory", "fact A", "fact A revised")
+
+    assert result["success"] is False
+    assert "drift_backup" in result
+    assert Path(result["drift_backup"]).exists()
+
+
+# -- atomic replace preserves symlinks -------------------------------------
+
+
+def test_write_through_symlink_keeps_the_symlink(tmp_path: Path):
+    """Deployments symlink MEMORY.md into dotfiles; a write must not detach it."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    real_file = real_dir / "MEMORY-real.md"
+    real_file.write_text("", encoding="utf-8")
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    link = workspace / "MEMORY.md"
+    link.symlink_to(real_file)
+
+    s = CuratedMemoryStore(memory_dir=workspace, memory_char_limit=200, user_char_limit=100)
+    s.load_from_disk()
+    assert s.add("memory", "persisted fact")["success"] is True
+
+    assert link.is_symlink(), "symlink was replaced by a regular file"
+    assert "persisted fact" in real_file.read_text(encoding="utf-8")
+
+
+def test_cross_device_rename_falls_back_to_copy(
+    store: CuratedMemoryStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """EXDEV/EBUSY must degrade to copy, not raise and lose the write."""
+    calls = {"n": 0}
+    real_replace = os.replace
+
+    def flaky_replace(src, dst, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError(errno.EXDEV, "cross-device link")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+    result = store.add("memory", "durable fact")
+
+    assert result["success"] is True
+    assert "durable fact" in (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+
+
+def test_unexpected_oserror_still_propagates(
+    store: CuratedMemoryStore, monkeypatch: pytest.MonkeyPatch
+):
+    """Only EXDEV/EBUSY are recoverable — other errors must not be swallowed."""
+
+    def boom(*_args, **_kwargs):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        store.add("memory", "fact")
+
+
+# -- consolidation failure streak expires ----------------------------------
+
+
+def test_failure_streak_expires_so_memory_never_latches_dead(
+    store: CuratedMemoryStore, monkeypatch: pytest.MonkeyPatch
+):
+    """Failures from an old turn must not permanently disable memory writes.
+
+    The store is cached per workspace for the process lifetime, so without an
+    expiry the Nth failure across unrelated turns would freeze every later
+    write into the terminal error.
+    """
+    clock = {"t": 1000.0}
+    monkeypatch.setattr("agentos.memory.curated.time.monotonic", lambda: clock["t"])
+
+    store.add("memory", "x" * 150)
+    for _ in range(_MAX_CONSOLIDATION_FAILURES_PER_TURN + 2):
+        store.add("memory", "y" * 150)  # over budget -> consolidation failures
+
+    frozen = store.add("memory", "y" * 150)
+    assert frozen["done"] is True and frozen["success"] is False
+
+    # A later turn, past the window: the store must accept work again.
+    clock["t"] += _CONSOLIDATION_FAILURE_WINDOW_S + 1
+    recovered = store.add("memory", "small")
+    assert recovered["success"] is True
+
+
+def test_failure_streak_still_cuts_off_a_runaway_loop(
+    store: CuratedMemoryStore, monkeypatch: pytest.MonkeyPatch
+):
+    """Expiry must not defeat the anti-loop guard within a single turn."""
+    monkeypatch.setattr("agentos.memory.curated.time.monotonic", lambda: 1000.0)
+
+    store.add("memory", "x" * 150)
+    results = [store.add("memory", "y" * 150) for _ in range(5)]
+
+    assert results[-1]["done"] is True
+    assert "Stop retrying" in results[-1]["error"]
+
+
+def test_successful_write_clears_the_streak(store: CuratedMemoryStore):
+    store.add("memory", "x" * 150)
+    store.add("memory", "y" * 150)  # failure
+    assert store.add("memory", "ok")["success"] is True
+    assert store._consolidation_failures == 0
+
+
+# -- success payload stays terminal ----------------------------------------
+
+
+def test_success_does_not_echo_entries(store: CuratedMemoryStore):
+    """Echoing the store after a write invited redundant repeat calls."""
+    store.add("memory", "fact A")
+    result = store.add("memory", "fact B")
+
+    assert result["success"] is True
+    assert "current_entries" not in result
+    assert result["entry_count"] == 2
+    assert result["done"] is True
+
+
+def test_error_paths_still_carry_entries(store: CuratedMemoryStore):
+    """The model needs the inventory precisely when it must consolidate."""
+    store.add("memory", "x" * 150)
+    result = store.add("memory", "y" * 150)
+
+    assert result["success"] is False
+    assert result["current_entries"] == ["x" * 150]


### PR DESCRIPTION
`CuratedMemoryStore` was adapted from hermes-agent `tools/memory_tool.py` (see the module docstring and NOTICE), but the port dropped several guards the original relies on. Two of them can silently destroy or permanently freeze curated memory.

## Unreadable ≠ empty (data loss)

`_read_file` mapped `OSError` to `[]`, and `UnicodeDecodeError` was not caught at all. A transient lock, a permission change, or one corrupt byte made `_reload_target` load zero entries — and the `add()` that followed flushed a single-entry file over the entire store.

`add()` was the most exposed path: it passes `skip_drift=True`, so it had no guard whatsoever.

Reads now go through `_read_raw_checked`, which returns `None` on failure. Every write path (`add` / `replace` / `remove` / `apply_batch`) aborts with `_read_failed_error` instead of writing. Upstream hermes does the same thing via its `_READ_FAILED` sentinel.

## Consolidation streak never expired (memory latches dead)

`reset_consolidation_failures` had **no caller anywhere** in `src/` or `tests/` — hermes calls it once per turn. Meanwhile the store is cached per workspace for the lifetime of the process, so the counter was effectively per-process rather than per-turn.

The consequence: three consolidation failures spread across unrelated turns latched the tool into its terminal error state permanently, with no way back short of a restart.

The streak now expires after a 300s window. That keeps the anti-loop cutoff intact within a turn — the case the limit exists for — without the tool going dead for good. `reset_consolidation_failures` is kept for callers that do know a turn boundary was crossed.

## Drift check re-read the file (TOCTOU)

`_detect_external_drift` opened `MEMORY.md` a second time after `_reload_target` had already read it, reopening the exact TOCTOU window upstream had closed, and treated a failed second read as "no drift". The raw bytes are now read once and passed through, so the drift check and the parse can never disagree about what is on disk.

## `os.replace` ate symlinks

Writes now go through `_atomic_replace`, which resolves the link first so deployments symlinking `MEMORY.md` / `USER.md` into a dotfiles repo or managed profile package stay attached. It also falls back to copy+fsync on `EXDEV`/`EBUSY` (cross-device tmpdir, bind mount) instead of raising.

## Success response echoed the store

`current_entries` is dropped from the success payload, matching upstream: handing the model the full store immediately after a write invites redundant repeat calls. Error paths still carry it, which is where the model actually needs it to decide what to consolidate.

## Tests

Adds `tests/test_memory_curated_durability.py` (17 tests), one per guard, including that a failed read leaves the file byte-identical.

Verified the tests actually catch the regressions rather than passing vacuously: reverting just the read guard turns 5 of them red immediately.

Full gate green — 6235 passed, 27 skipped; ruff and mypy clean.