### PR TITLE
feat(memory): periodic memory-review nudge

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -200,6 +200,19 @@ source = "workspace"
 # embedder_base_url = "http://localhost:11434"
 # vector_store_path = ""  # empty -> <agent state dir>/mem0
 
+[memory.nudge]
+# Periodic memory review. Every `interval` user turns, once the reply is
+# already delivered, a short background turn re-reads the conversation and
+# saves anything durable it finds. Without it MEMORY.md tends to stay empty:
+# saving is never the most urgent thing in any single turn.
+#
+# Skipped for cron/heartbeat/subagent turns, and for any turn where the agent
+# already wrote to memory on its own.
+enabled = true
+interval = 10            # user turns between reviews; 0 disables
+# max_iterations = 6     # ceiling on the review turn's own tool loop
+# timeout_seconds = 90.0
+
 [memory.dream]
 # Dream consolidation is safety-first by default. Background scheduling and
 # curated MEMORY.md writes require explicit opt-in.

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -554,6 +554,11 @@ def _normalize_capture_kind(value: str) -> str:
 # the thing the nudge would ask for, so it resets the counter instead.
 _MEMORY_WRITE_TOOL_NAMES: Final[frozenset[str]] = frozenset({"memory", "memory_save"})
 
+# Cap on retained nudge counters. Far above any realistic concurrent-session
+# count, low enough that the dict cannot grow without bound in a gateway that
+# runs for weeks.
+_MAX_NUDGE_COUNTERS: Final[int] = 2048
+
 # Prompt for the periodic memory review. Adapted from hermes-agent
 # (MIT, © 2025 Nous Research). Two properties matter and are easy to lose:
 # it names what is worth keeping (durable facts about the user, not task
@@ -1902,6 +1907,7 @@ class TurnRunner:
             self._memory_nudge_counters[key] = 0
             return False
 
+        self._evict_nudge_counters_if_needed()
         interval = int(getattr(nudge_cfg, "interval", 0))
         prior = self._memory_nudge_counters.get(key)
         if prior is None:
@@ -1936,8 +1942,27 @@ class TurnRunner:
         return max(0, prior_user_turns - 1) % interval
 
     def forget_memory_nudge_counter(self, session_key: str) -> None:
-        """Drop nudge counters for *session_key* so they do not outlive it."""
+        """Drop nudge counters for *session_key* so they do not outlive it.
+
+        Sessions have no teardown hook reaching this far, so this is a
+        courtesy for callers that do know a session ended; the size cap in
+        ``_note_turn_for_memory_nudge`` is what actually bounds the dict.
+        """
         for key in [k for k in self._memory_nudge_counters if k[1] == session_key]:
+            self._memory_nudge_counters.pop(key, None)
+
+    def _evict_nudge_counters_if_needed(self) -> None:
+        """Keep the counter dict bounded in a long-lived gateway process.
+
+        Nothing notifies this runner when a session ends, so without a cap
+        the dict grows once per session for the life of the process. Losing a
+        counter only costs a re-seed from the transcript on that session's
+        next turn, so evicting the oldest half is cheap; insertion order
+        approximates least-recently-started.
+        """
+        if len(self._memory_nudge_counters) <= _MAX_NUDGE_COUNTERS:
+            return
+        for key in list(self._memory_nudge_counters)[: _MAX_NUDGE_COUNTERS // 2]:
             self._memory_nudge_counters.pop(key, None)
 
     async def _run_memory_nudge_review(

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -90,6 +90,7 @@ from agentos.engine.turn_runner.harness import (
     _TurnRunnerExtraContextAdapter,
     _TurnRunnerHistoryLoaderAdapter,
     _TurnRunnerMemoryFingerprintAdapter,
+    _TurnRunnerMemoryNudgeAdapter,
     _TurnRunnerMemorySnapshotAdapter,
     _TurnRunnerMemorySnapshotRefreshAdapter,
     _TurnRunnerMemorySyncNotifyAdapter,
@@ -547,6 +548,30 @@ def _compute_comprehensive_turn_savings(
 
 def _normalize_capture_kind(value: str) -> str:
     return value.strip().lower().replace("-", "_").replace(".", "_").replace(":", "_")
+
+
+# Curated-memory write tools. A turn that calls one of these has already done
+# the thing the nudge would ask for, so it resets the counter instead.
+_MEMORY_WRITE_TOOL_NAMES: Final[frozenset[str]] = frozenset({"memory", "memory_save"})
+
+# Prompt for the periodic memory review. Adapted from hermes-agent
+# (MIT, © 2025 Nous Research). Two properties matter and are easy to lose:
+# it names what is worth keeping (durable facts about the user, not task
+# chatter), and it gives an explicit way to decline, so a review with nothing
+# to save stops instead of inventing an entry to justify the call.
+_MEMORY_REVIEW_PROMPT: Final[str] = (
+    "Review the conversation above and consider saving to memory.\n\n"
+    "Focus on:\n"
+    "1. Has the user revealed durable things about themselves — their role, "
+    "preferences, working style, or context that will still matter in a "
+    "later session?\n"
+    "2. Has the user stated expectations about how you should work — "
+    "conventions to follow, things to avoid, corrections they had to repeat?\n\n"
+    "Save anything that stands out with the memory tool, consolidating "
+    "existing entries rather than duplicating them. Skip anything one-off, "
+    "already saved, or specific to the current task.\n\n"
+    "If nothing is worth saving, reply exactly 'Nothing to save.' and stop."
+)
 
 
 # Boot-path initialization of the safety baseline. All four submodules
@@ -1250,9 +1275,7 @@ def _render_preview_only_attachment_text(
         else "read_full: material path unavailable."
     )
     truncation = (
-        f"\n\n[attachment preview truncated: {len(decoded)} chars total]"
-        if truncated
-        else ""
+        f"\n\n[attachment preview truncated: {len(decoded)} chars total]" if truncated else ""
     )
     return (
         "[large text attachment materialized]\n"
@@ -1451,6 +1474,8 @@ class TurnRunner:
         # Captured on first prompt assembly so bootstrap-source edits do not
         # churn the cacheable prefix mid-session.
         self._bootstrap_snapshots: dict[tuple[str, str, str], BootstrapSnapshot] = {}
+        # User turns since the last memory review, keyed (agent_id, session_key).
+        self._memory_nudge_counters: dict[tuple[str, str], int] = {}
         self._compaction_failures: dict[str, _CompactionFailureState] = {}
         self._turn_compaction_attempted_sessions: set[str] = set()
         self._turn_compacted_sessions: set[str] = set()
@@ -1529,6 +1554,7 @@ class TurnRunner:
             turn_memory_capture=_TurnRunnerTurnMemoryCaptureAdapter(self),
             session_totals=_TurnRunnerSessionTotalsAdapter(self),
             turn_error_persist=_TurnRunnerTurnErrorPersistAdapter(self),
+            memory_nudge=_TurnRunnerMemoryNudgeAdapter(self),
         )
 
     @property
@@ -1793,6 +1819,184 @@ class TurnRunner:
                 ],
             )
             provider_manager.queue_prefetch_all(runtime_message, session_id=session_id)
+
+    def _memory_nudge_config(self) -> Any | None:
+        memory_cfg = getattr(self._config, "memory", None)
+        return getattr(memory_cfg, "nudge", None) if memory_cfg is not None else None
+
+    def _memory_nudge_allowed(
+        self,
+        *,
+        nudge_cfg: Any | None,
+        no_memory_capture: bool,
+        input_mode: str,
+        run_kind: str | None,
+    ) -> bool:
+        """Whether this turn may advance the nudge counter.
+
+        Deliberately stricter than turn capture: only real user turns count.
+        Machine traffic (cron, heartbeat, subagent, and the review turn
+        itself) says nothing durable about the user, and letting it advance
+        the counter would fire reviews over transcripts that are pure harness.
+        """
+        if nudge_cfg is None or not getattr(nudge_cfg, "enabled", False):
+            return False
+        if int(getattr(nudge_cfg, "interval", 0)) <= 0:
+            return False
+        if no_memory_capture or input_mode != "user":
+            return False
+        return not self._capture_filter_matches(
+            run_kind, getattr(nudge_cfg, "excluded_run_kinds", [])
+        )
+
+    @staticmethod
+    def _turn_used_memory_tool(turn_segments: Any) -> bool:
+        """True when the model called a curated-memory tool this turn.
+
+        A model that curates unprompted does not need to be nudged, so a
+        self-directed write resets the counter the same way a review would.
+        """
+        for segment in turn_segments or []:
+            if not isinstance(segment, dict):
+                continue
+            name = segment.get("name") or segment.get("tool") or segment.get("tool_name")
+            if isinstance(name, str) and name in _MEMORY_WRITE_TOOL_NAMES:
+                return True
+        return False
+
+    def _note_turn_for_memory_nudge(
+        self,
+        *,
+        agent_id: str,
+        session_key: str,
+        input_mode: str,
+        run_kind: str,
+        no_memory_capture: bool,
+        turn_segments: Any,
+        prior_user_turns: int | None = None,
+    ) -> bool:
+        """Advance the nudge counter; return True when a review is due.
+
+        The counter is held in memory rather than recomputed from history on
+        every turn, because the history window caps: its length plateaus in
+        exactly the long sessions the nudge exists for.
+
+        In-memory state alone is not enough, though. A TurnRunner is rebuilt
+        on every CLI invocation, and the gateway evicts idle agents, so a
+        fresh runner starts at zero and a session that spans processes would
+        never reach the interval -- the nudge would silently never fire. When
+        no counter exists yet, *prior_user_turns* seeds it from the persisted
+        transcript so the count survives the process that made it.
+        """
+        nudge_cfg = self._memory_nudge_config()
+        if not self._memory_nudge_allowed(
+            nudge_cfg=nudge_cfg,
+            no_memory_capture=no_memory_capture,
+            input_mode=input_mode,
+            run_kind=run_kind,
+        ):
+            return False
+
+        key = (agent_id, session_key)
+        if self._turn_used_memory_tool(turn_segments):
+            self._memory_nudge_counters[key] = 0
+            return False
+
+        interval = int(getattr(nudge_cfg, "interval", 0))
+        prior = self._memory_nudge_counters.get(key)
+        if prior is None:
+            prior = self._hydrate_nudge_counter(
+                interval=interval, prior_user_turns=prior_user_turns
+            )
+        count = prior + 1
+        if count < interval:
+            self._memory_nudge_counters[key] = count
+            return False
+        self._memory_nudge_counters[key] = 0
+        return True
+
+    @staticmethod
+    def _hydrate_nudge_counter(
+        *,
+        interval: int,
+        prior_user_turns: int | None,
+    ) -> int:
+        """Seed a missing counter from the number of user turns already stored.
+
+        Modular arithmetic recovers the session's phase: 27 prior turns at an
+        interval of 10 means 7 turns into the current cycle, so the next
+        review is 3 turns away. This is an approximation -- a self-directed
+        memory write earlier in the session shifted the real phase off the
+        multiple -- but the cost of being wrong is nudging a few turns early
+        or late, against the alternative of never nudging at all.
+        """
+        if interval <= 0 or not prior_user_turns or prior_user_turns <= 0:
+            return 0
+        # The current turn is counted by the caller, so exclude it here.
+        return max(0, prior_user_turns - 1) % interval
+
+    def forget_memory_nudge_counter(self, session_key: str) -> None:
+        """Drop nudge counters for *session_key* so they do not outlive it."""
+        for key in [k for k in self._memory_nudge_counters if k[1] == session_key]:
+            self._memory_nudge_counters.pop(key, None)
+
+    async def _run_memory_nudge_review(
+        self,
+        *,
+        agent_id: str,
+        session_key: str,
+    ) -> None:
+        """Run one background review turn asking the agent to curate memory.
+
+        Runs as its own turn against the same session, so the review sees the
+        conversation it is reviewing. `input_mode="system_event"` plus the
+        `memory_nudge` run kind keep it out of turn capture and out of its own
+        counter, so a review can never trigger another review.
+        """
+        nudge_cfg = self._memory_nudge_config()
+        if nudge_cfg is None:
+            return
+        timeout = float(getattr(nudge_cfg, "timeout_seconds", 90.0))
+
+        async def _drive() -> None:
+            # run() is an async generator; the review has no consumer for its
+            # events, so drain it to completion and discard them.
+            tool_context = ToolContext(
+                agent_id=agent_id,
+                session_key=session_key,
+                workspace_dir=str(self._resolve_memory_source_dir(agent_id)),
+                source_kind="memory_nudge",
+            )
+            async for _event in self.run(
+                message=_MEMORY_REVIEW_PROMPT,
+                session_key=session_key,
+                tool_context=tool_context,
+                agent_id=agent_id,
+                input_mode="system_event",
+                run_kind="memory_nudge",
+                no_memory_capture=True,
+                persist_input=False,
+                max_iterations=int(getattr(nudge_cfg, "max_iterations", 6)),
+                input_provenance={"kind": "memory_nudge"},
+            ):
+                pass
+
+        try:
+            await asyncio.wait_for(_drive(), timeout=timeout)
+        except TimeoutError:
+            log.warning(
+                "memory_nudge.review_timeout",
+                agent_id=agent_id,
+                session_key=session_key,
+                timeout_seconds=timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 — a failed review must not fail the turn
+            log.warning(
+                "memory_nudge.review_failed",
+                agent_id=agent_id,
+                session_key=session_key,
+                error=str(exc),
+            )
 
     @staticmethod
     def _capture_filter_matches(value: str | None, excluded_values: Any) -> bool:
@@ -2257,9 +2461,7 @@ class TurnRunner:
                 agentos_router_tier=pa_out.agentos_router_tier,
             )
             if tool_context is not None:
-                tool_context.router_control_config = getattr(
-                    self._config, "agentos_router", None
-                )
+                tool_context.router_control_config = getattr(self._config, "agentos_router", None)
                 tool_context.router_control_hold_store = self._router_control_hold_store
                 tool_context.router_control_replay_depth = router_control_replay_depth
                 tool_context.router_control_turn_hold_applied = bool(
@@ -3962,8 +4164,7 @@ class TurnRunner:
 
         router_cfg = getattr(self._config, "agentos_router", None)
         router_timeout = float(
-            getattr(router_cfg, "routing_timeout_seconds", None)
-            or DEFAULT_ROUTING_TIMEOUT_SECONDS
+            getattr(router_cfg, "routing_timeout_seconds", None) or DEFAULT_ROUTING_TIMEOUT_SECONDS
         )
 
         def _copy_router_turn(turn: TurnContext) -> TurnContext:
@@ -4426,9 +4627,7 @@ class TurnRunner:
                 skill_count=prompt_report.skill_count if prompt_report else 0,
                 skills_prompt_chars=prompt_report.skills_prompt_chars if prompt_report else 0,
                 memory_md_present=prompt_report.memory_md_present if prompt_report else False,
-                daily_notes_omitted=(
-                    prompt_report.daily_notes_omitted if prompt_report else False
-                ),
+                daily_notes_omitted=(prompt_report.daily_notes_omitted if prompt_report else False),
                 daily_notes_count_before_omit=(
                     prompt_report.daily_notes_count_before_omit if prompt_report else 0
                 ),
@@ -4650,10 +4849,7 @@ class TurnRunner:
                 deterministic_receipt_safe=checkpoint_saved and not requires_safe_receipt,
                 required=self._pre_compaction_flush_enabled(),
             )
-            if (
-                requires_safe_receipt
-                and not memory_status.allows_destructive_compaction
-            ):
+            if requires_safe_receipt and not memory_status.allows_destructive_compaction:
                 log.warning(
                     "t3_upgrade_compaction.skipped",
                     session_key=session_key,
@@ -4930,10 +5126,7 @@ class TurnRunner:
                 deterministic_receipt_safe=checkpoint_saved and not requires_safe_receipt,
                 required=self._pre_compaction_flush_enabled(),
             )
-            if (
-                requires_safe_receipt
-                and not memory_status.allows_destructive_compaction
-            ):
+            if requires_safe_receipt and not memory_status.allows_destructive_compaction:
                 log.warning(
                     "preflight_compaction.skipped",
                     session_key=session_key,
@@ -5064,9 +5257,7 @@ class TurnRunner:
             )
             return
         if not result:
-            skip_reason = str(
-                getattr(compaction_result, "skip_reason", None) or "empty_summary"
-            )
+            skip_reason = str(getattr(compaction_result, "skip_reason", None) or "empty_summary")
             if skip_reason == "stale_preimage":
                 notify_compaction(
                     session_key,
@@ -5525,11 +5716,7 @@ class TurnRunner:
         kept_entries = [self._emergency_replay_entry(raw) for raw in result.kept_entries]
         if not kept_entries or len(kept_entries) >= len(transcript):
             return False
-        summary = (
-            "Emergency request-scoped compaction\n"
-            f"Reason: {reason}\n\n"
-            f"{result.summary}"
-        )
+        summary = f"Emergency request-scoped compaction\nReason: {reason}\n\n{result.summary}"
         self._emergency_compaction_overrides[session_key] = _EmergencyCompactionOverride(
             summary=summary,
             kept_entries=kept_entries,
@@ -5706,9 +5893,7 @@ class TurnRunner:
                 )
             )
             replay_compaction_id = (
-                replayed_compaction_ids[0]
-                if replayed_compaction_ids
-                else new_compaction_id()
+                replayed_compaction_ids[0] if replayed_compaction_ids else new_compaction_id()
             )
             notify_compaction(
                 session_key,
@@ -5905,10 +6090,7 @@ class TurnRunner:
                 wrapped = _render_file_context_block(filename, media_type, extracted_pdf_text)
                 attachment_blocks.append(ContentBlockText(text=wrapped))
             elif media_type in _ENGINE_TEXT_FAMILY_MIMES:
-                if (
-                    is_attachment_ref(att)
-                    and att.get("_provider_inline_policy") == "preview_only"
-                ):
+                if is_attachment_ref(att) and att.get("_provider_inline_policy") == "preview_only":
                     decoded_text = _render_preview_only_attachment_text(
                         att,
                         filename=filename,

--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -12,6 +12,7 @@ the stage boundaries are ready to sequence.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from typing import TYPE_CHECKING, Any, cast
 
@@ -59,6 +60,7 @@ from agentos.engine.turn_runner.stream_consumer_stage import (
 )
 from agentos.engine.turn_runner.turn_finalizer_stage import (
     CostRollupResult,
+    MemoryNudgePort,
     SessionTotalsPort,
     TranscriptAppendPort,
     TurnErrorPersistPort,
@@ -80,6 +82,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Input stage adapters
 # ---------------------------------------------------------------------------
+
 
 class _TurnRunnerExtraContextAdapter(ExtraContextResolver):
     """Bind ``TurnRunner``'s two static extra-context helpers as a Protocol.
@@ -108,6 +111,7 @@ class _TurnRunnerExtraContextAdapter(ExtraContextResolver):
 # Provider/tools stage adapters
 # ---------------------------------------------------------------------------
 
+
 class _TurnRunnerProviderResolverAdapter(ProviderResolverPort):
     """Bind ``TurnRunner._resolve_provider`` as a Protocol-shaped port."""
 
@@ -117,10 +121,9 @@ class _TurnRunnerProviderResolverAdapter(ProviderResolverPort):
     def resolve_provider(self) -> tuple[Any | None, Any | None]:
         return self._runner._resolve_provider()
 
-class _TurnRunnerToolBuilderAdapter(ToolBuilderPort):
-    """Bind ``TurnRunner._build_tools`` and the two ``ToolContext`` mutators.
 
-        """
+class _TurnRunnerToolBuilderAdapter(ToolBuilderPort):
+    """Bind ``TurnRunner._build_tools`` and the two ``ToolContext`` mutators."""
 
     def __init__(self, runner: TurnRunner) -> None:
         self._runner = runner
@@ -152,6 +155,7 @@ class _TurnRunnerToolBuilderAdapter(ToolBuilderPort):
 # Prompt assembler stage adapters
 # ---------------------------------------------------------------------------
 
+
 class _TurnRunnerPromptAssemblerAdapter(PromptAssemblerPort):
     """Bind ``TurnRunner._assemble_prompt`` as a Protocol-shaped port."""
 
@@ -181,10 +185,9 @@ class _TurnRunnerPromptAssemblerAdapter(PromptAssemblerPort):
             fresh_user_session=fresh_user_session,
         )
 
-class _TurnRunnerPipelineExecutionAdapter(PipelineExecutionPort):
-    """Bind ``TurnRunner._run_pipeline`` and unpack ``RunPipelineRequest``.
 
-        """
+class _TurnRunnerPipelineExecutionAdapter(PipelineExecutionPort):
+    """Bind ``TurnRunner._run_pipeline`` and unpack ``RunPipelineRequest``."""
 
     def __init__(self, runner: TurnRunner) -> None:
         self._runner = runner
@@ -211,6 +214,7 @@ class _TurnRunnerPipelineExecutionAdapter(PipelineExecutionPort):
             normalization_metadata=request.normalization_metadata,
         )
 
+
 class _TurnRunnerRouterContextAdapter(RouterContextPort):
     """Bind ``TurnRunner._router_previous_assistant_context``."""
 
@@ -228,6 +232,7 @@ class _TurnRunnerRouterContextAdapter(RouterContextPort):
             exclude_last_user=exclude_last_user,
         )
 
+
 class _TurnRunnerPromptConfigResolverAdapter(PromptConfigResolverPort):
     """Bind ``TurnRunner._resolve_prompt_config``."""
 
@@ -239,6 +244,7 @@ class _TurnRunnerPromptConfigResolverAdapter(PromptConfigResolverPort):
         turn: Any,
     ) -> tuple[str, list[Any] | None, str | None]:
         return self._runner._resolve_prompt_config(turn)
+
 
 class _PromptReportBuilderAdapter(PromptReportBuilderPort):
     """Pure shim around the module-level ``build_prompt_report`` helper.
@@ -272,6 +278,7 @@ class _PromptReportBuilderAdapter(PromptReportBuilderPort):
             tool_profile=tool_profile,
         )
 
+
 class _TurnRunnerSessionIdResolverAdapter(SessionIdResolverPort):
     """Bind ``TurnRunner._resolve_session_id_for_log``."""
 
@@ -283,6 +290,7 @@ class _TurnRunnerSessionIdResolverAdapter(SessionIdResolverPort):
         session_key: str,
     ) -> str | None:
         return await self._runner._resolve_session_id_for_log(session_key)
+
 
 class _TurnRunnerMemoryFingerprintAdapter(MemoryFingerprintPort):
     """Bind ``TurnRunner._config.memory_mode_fingerprint`` defensively.
@@ -310,6 +318,7 @@ class _TurnRunnerMemoryFingerprintAdapter(MemoryFingerprintPort):
 # ---------------------------------------------------------------------------
 # Agent bootstrap stage adapters
 # ---------------------------------------------------------------------------
+
 
 class _TurnRunnerTimeoutBudgetAdapter(TimeoutBudgetPort):
     """Bind the five ``TurnRunner._resolve_agent_*`` helpers as a single port.
@@ -356,9 +365,7 @@ class _TurnRunnerTimeoutBudgetAdapter(TimeoutBudgetPort):
             iteration_timeout=self._runner._resolve_agent_iteration_timeout(
                 session_key, iteration_timeout
             ),
-            tool_timeout=self._runner._resolve_agent_tool_timeout(
-                session_key, tool_timeout
-            ),
+            tool_timeout=self._runner._resolve_agent_tool_timeout(session_key, tool_timeout),
             request_timeout=self._runner._resolve_agent_request_timeout(
                 session_key, request_timeout
             ),
@@ -366,6 +373,7 @@ class _TurnRunnerTimeoutBudgetAdapter(TimeoutBudgetPort):
                 session_key, max_provider_retries
             ),
         )
+
 
 class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
     """Bind ``TurnRunner._model_catalog`` lookups with a None-fallback.
@@ -386,9 +394,7 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
             max_tokens = runner._model_catalog.resolve_max_tokens(
                 model_id, user_override=user_max_tokens, provider_name=provider_name
             )
-            context_window = runner._model_catalog.resolve_context_window(
-                model_id, provider_name
-            )
+            context_window = runner._model_catalog.resolve_context_window(model_id, provider_name)
             base_url = getattr(llm_cfg, "base_url", "")
             capabilities = runner._model_catalog.get_capabilities(
                 model_id, provider_name=provider_name, base_url=base_url
@@ -402,6 +408,7 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
             context_window=context_window,
             capabilities=capabilities,
         )
+
 
 class _TurnRunnerAgentConfigBuilderAdapter(AgentConfigBuilderPort):
     """Bind the five ``TurnRunner`` helpers AgentConfig assembly needs.
@@ -430,32 +437,22 @@ class _TurnRunnerAgentConfigBuilderAdapter(AgentConfigBuilderPort):
         runner = self._runner
         mem_cfg = getattr(runner._config, "memory", None) if runner._config else None
         agent_token_cfg = (
-            getattr(runner._config, "agent_token_saving", None)
-            if runner._config
-            else None
+            getattr(runner._config, "agent_token_saving", None) if runner._config else None
         )
         thinking = runner._resolve_turn_thinking(turn)
         return _AgentConfigAuxiliaries(
             thinking=thinking,
             flush_workspace_dir=str(runner._resolve_memory_source_dir(agent_id)),
-            tool_result_store_dir=str(
-                media_root_from_config(runner._config) / "tool-results"
-            ),
+            tool_result_store_dir=str(media_root_from_config(runner._config) / "tool-results"),
             tool_result_store_session_id=session_id_for_log or session_key,
             flush_enabled=getattr(mem_cfg, "flush_enabled", False),
             flush_timeout_seconds=getattr(mem_cfg, "flush_timeout_seconds", 15.0),
             flush_background_timeout_seconds=getattr(
                 mem_cfg, "flush_background_timeout_seconds", 120.0
             ),
-            flush_backoff_initial_seconds=getattr(
-                mem_cfg, "flush_backoff_initial_seconds", 30.0
-            ),
-            flush_backoff_max_seconds=getattr(
-                mem_cfg, "flush_backoff_max_seconds", 300.0
-            ),
-            flush_archive_max_bytes=getattr(
-                mem_cfg, "flush_archive_max_bytes", 800_000
-            ),
+            flush_backoff_initial_seconds=getattr(mem_cfg, "flush_backoff_initial_seconds", 30.0),
+            flush_backoff_max_seconds=getattr(mem_cfg, "flush_backoff_max_seconds", 300.0),
+            flush_archive_max_bytes=getattr(mem_cfg, "flush_archive_max_bytes", 800_000),
             flush_compaction_requires_safe_receipt=getattr(
                 mem_cfg,
                 "flush_compaction_requires_safe_receipt",
@@ -488,6 +485,7 @@ class _TurnRunnerAgentConfigBuilderAdapter(AgentConfigBuilderPort):
             ),
         )
 
+
 class _TurnRunnerMemorySnapshotAdapter(MemorySnapshotPort):
     """Bind the per-agent memory warm + per-(agent_id, session_key) snapshot capture.
 
@@ -516,9 +514,7 @@ class _TurnRunnerMemorySnapshotAdapter(MemorySnapshotPort):
 
         runner = self._runner
         sync_manager = (
-            runner._memory_sync_managers.get(agent_id)
-            if runner._memory_sync_managers
-            else None
+            runner._memory_sync_managers.get(agent_id) if runner._memory_sync_managers else None
         )
         if sync_manager is not None:
             await sync_manager.warm_session(session_key)
@@ -535,6 +531,7 @@ class _TurnRunnerMemorySnapshotAdapter(MemorySnapshotPort):
             sync_manager=sync_manager,
             private_memory_allowed=private_memory_allowed,
         )
+
 
 class _TurnRunnerAgentFactoryAdapter(AgentFactoryPort):
     """Bind the typed ``Agent(...)`` constructor.
@@ -580,6 +577,7 @@ class _TurnRunnerAgentFactoryAdapter(AgentFactoryPort):
 # Compaction/history stage adapters
 # ---------------------------------------------------------------------------
 
+
 class _TurnRunnerT3UpgradeCompactionAdapter(T3UpgradeCompactionPort):
     """Bind ``TurnRunner._maybe_compact_on_t3_upgrade`` as a Protocol port.
 
@@ -609,6 +607,7 @@ class _TurnRunnerT3UpgradeCompactionAdapter(T3UpgradeCompactionPort):
             compaction_model=compaction_model,
         )
 
+
 class _TurnRunnerPreflightCompactionAdapter(PreflightCompactionPort):
     """Bind ``TurnRunner._maybe_preflight_compact`` as a Protocol port.
 
@@ -633,6 +632,7 @@ class _TurnRunnerPreflightCompactionAdapter(PreflightCompactionPort):
             compaction_provider=compaction_provider,
             compaction_model=compaction_model,
         )
+
 
 class _TurnRunnerHistoryLoaderAdapter(HistoryLoaderPort):
     """Bind ``TurnRunner._load_history`` as a Protocol port.
@@ -659,6 +659,7 @@ class _TurnRunnerHistoryLoaderAdapter(HistoryLoaderPort):
             trim_last_user=trim_last_user,
         )
 
+
 class _RequestContextPrependAdapter(RequestContextPrependPort):
     """Pure shim around the module-level ``_prepend_request_context_prompt``.
 
@@ -680,6 +681,7 @@ class _RequestContextPrependAdapter(RequestContextPrependPort):
 # ---------------------------------------------------------------------------
 # Stream consumer stage adapters
 # ---------------------------------------------------------------------------
+
 
 class _TurnRunnerAgentRunAdapter(AgentRunPort):
     """Bind ``agent.run_turn(turn_input, extra_messages=..., **kwargs)``.
@@ -710,6 +712,7 @@ class _TurnRunnerAgentRunAdapter(AgentRunPort):
             extra_messages=extra_messages,
             **kwargs,
         )
+
 
 class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
     """Bind ``SessionManager.persist_compaction_result`` + ``notify_compaction``.
@@ -776,6 +779,7 @@ class _TurnRunnerCompactionPersistAdapter(CompactionPersistPort):
             ),
         )
 
+
 class _TurnRunnerMemorySnapshotRefreshAdapter(MemorySnapshotRefreshPort):
     """Refresh ``runner._memory_snapshots[(agent_id, session_key)]`` after compaction.
 
@@ -803,6 +807,7 @@ class _TurnRunnerMemorySnapshotRefreshAdapter(MemorySnapshotRefreshPort):
                 memory_md=runner._load_memory_md(workspace),
                 daily_notes=runner._load_daily_notes(workspace),
             )
+
 
 class _TurnRunnerSystemPromptRefreshAdapter(SystemPromptRefreshPort):
     """Rebuild + apply the cacheable system-prompt base after compaction.
@@ -832,10 +837,9 @@ class _TurnRunnerSystemPromptRefreshAdapter(SystemPromptRefreshPort):
             session_key=session_key,
             bootstrap_context_mode=bootstrap_context_mode,
         )
-        refreshed_prompt = (
-            assembled[0] if isinstance(assembled, tuple) else assembled
-        )
+        refreshed_prompt = assembled[0] if isinstance(assembled, tuple) else assembled
         agent.refresh_system_prompt(refreshed_prompt)
+
 
 class _TurnRunnerMemorySyncNotifyAdapter(MemorySyncNotifyPort):
     """Notify ``sync_manager.notify_message(byte_count)`` post-stream.
@@ -859,6 +863,7 @@ class _TurnRunnerMemorySyncNotifyAdapter(MemorySyncNotifyPort):
 # ---------------------------------------------------------------------------
 # Attachment stage adapters
 # ---------------------------------------------------------------------------
+
 
 class _TurnRunnerAttachmentMessageBuilderAdapter(AttachmentMessageBuilderPort):
     """Bind ``TurnRunner._build_attachment_messages`` + media-root lookup.
@@ -892,6 +897,7 @@ class _TurnRunnerAttachmentMessageBuilderAdapter(AttachmentMessageBuilderPort):
 # ---------------------------------------------------------------------------
 # Turn finalizer stage adapters
 # ---------------------------------------------------------------------------
+
 
 class _TurnRunnerTranscriptAppendAdapter(TranscriptAppendPort):
     """Bind ``SessionManager.append_message`` for the assistant turn persist.
@@ -937,15 +943,15 @@ class _TurnRunnerTranscriptAppendAdapter(TranscriptAppendPort):
         }
         if reasoning_content is not None:
             append_kwargs["reasoning_content"] = reasoning_content
-        if (
-            turn_usage is not None
-            and _accepts_keyword_arg(session_manager.append_message, "turn_usage")
+        if turn_usage is not None and _accepts_keyword_arg(
+            session_manager.append_message, "turn_usage"
         ):
             append_kwargs["turn_usage"] = turn_usage
         if _accepts_keyword_arg(session_manager.append_message, "token_count"):
             append_kwargs["token_count"] = token_count
         await self._runner._append_session_message(session_key, **append_kwargs)
         return True
+
 
 class _TurnRunnerTurnMemoryCaptureAdapter(TurnMemoryCapturePort):
     """Bind ``TurnRunner._capture_turn_memory`` as a Protocol port.
@@ -982,6 +988,90 @@ class _TurnRunnerTurnMemoryCaptureAdapter(TurnMemoryCapturePort):
             run_kind=run_kind,
             no_memory_capture=no_memory_capture,
         )
+
+
+class _TurnRunnerMemoryNudgeAdapter(MemoryNudgePort):
+    """Bind the memory-nudge counter as a Protocol port.
+
+    Advances the counter and, when a review comes due, schedules it as a
+    detached task. The stage never awaits the review: the reply has already
+    been delivered, and blocking here would keep the task marked running for
+    as long as the review takes.
+
+    The task reference is held until completion so the loop cannot collect it
+    mid-flight, which would cancel the review silently.
+    """
+
+    def __init__(self, runner: TurnRunner) -> None:
+        self._runner = runner
+        self._pending: set[asyncio.Task[None]] = set()
+
+    def note_turn(
+        self,
+        *,
+        agent_id: str,
+        session_key: str,
+        input_mode: str,
+        run_kind: str,
+        no_memory_capture: bool,
+        turn_segments: Any,
+    ) -> None:
+        task = asyncio.create_task(
+            self._note_and_maybe_review(
+                agent_id=agent_id,
+                session_key=session_key,
+                input_mode=input_mode,
+                run_kind=run_kind,
+                no_memory_capture=no_memory_capture,
+                turn_segments=turn_segments,
+            )
+        )
+        self._pending.add(task)
+        task.add_done_callback(self._pending.discard)
+
+    async def _note_and_maybe_review(
+        self,
+        *,
+        agent_id: str,
+        session_key: str,
+        input_mode: str,
+        run_kind: str,
+        no_memory_capture: bool,
+        turn_segments: Any,
+    ) -> None:
+        prior_user_turns: int | None = None
+        if (agent_id, session_key) not in self._runner._memory_nudge_counters:
+            prior_user_turns = await self._count_prior_user_turns(session_key)
+        due = self._runner._note_turn_for_memory_nudge(
+            agent_id=agent_id,
+            session_key=session_key,
+            input_mode=input_mode,
+            run_kind=run_kind,
+            no_memory_capture=no_memory_capture,
+            turn_segments=turn_segments,
+            prior_user_turns=prior_user_turns,
+        )
+        if due:
+            await self._runner._run_memory_nudge_review(
+                agent_id=agent_id,
+                session_key=session_key,
+            )
+
+    async def _count_prior_user_turns(self, session_key: str) -> int | None:
+        """User messages already persisted for this session, or None if unknown.
+
+        Read once per session per process, only to seed a counter that does
+        not exist yet -- afterwards the in-memory count carries the session.
+        """
+        manager = getattr(self._runner, "_session_manager", None)
+        if manager is None:
+            return None
+        try:
+            entries = await manager.get_transcript(session_key)
+        except Exception:  # noqa: BLE001 — seeding is best-effort
+            return None
+        return sum(1 for e in entries or [] if getattr(e, "role", None) == "user")
+
 
 class _TurnRunnerSessionTotalsAdapter(SessionTotalsPort):
     """Roll up session token + cost + cache totals from a DoneEvent.
@@ -1044,9 +1134,7 @@ class _TurnRunnerSessionTotalsAdapter(SessionTotalsPort):
                     0.0,
                     done_event.cost_usd - done_event.billed_cost,
                 )
-            next_missing_entries = (
-                getattr(current_session, "missing_cost_entries", 0) or 0
-            )
+            next_missing_entries = getattr(current_session, "missing_cost_entries", 0) or 0
             if event_cost_source == "unavailable":
                 next_missing_entries += 1
             next_cost_source = rollup_cost_source(
@@ -1109,6 +1197,7 @@ class _TurnRunnerSessionTotalsAdapter(SessionTotalsPort):
             cache_write=next_cache_write,
             model_override=next_model_override,
         )
+
 
 class _TurnRunnerTurnErrorPersistAdapter(TurnErrorPersistPort):
     """Bind ``TurnRunner._persist_turn_error`` as a Protocol port.

--- a/src/agentos/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/agentos/engine/turn_runner/turn_finalizer_stage.py
@@ -90,6 +90,7 @@ def _with_unconfirmed_action_notice(final_text: str, turn_segments: list[dict]) 
 # Ports -- four narrow Protocols
 # ---------------------------------------------------------------------------
 
+
 @runtime_checkable
 class TranscriptAppendPort(Protocol):
     """Persist the assistant turn via ``SessionManager.append_message(...)``.
@@ -118,6 +119,7 @@ class TranscriptAppendPort(Protocol):
         token_count: int | None,
     ) -> bool: ...
 
+
 @runtime_checkable
 class TurnMemoryCapturePort(Protocol):
     """Wrap ``TurnRunner._capture_turn_memory(...)``.
@@ -140,6 +142,34 @@ class TurnMemoryCapturePort(Protocol):
         run_kind: str,
         no_memory_capture: bool,
     ) -> None: ...
+
+
+@runtime_checkable
+class MemoryNudgePort(Protocol):
+    """Wrap ``TurnRunner.note_turn_for_memory_nudge(...)``.
+
+    Synchronous by design: the adapter only advances a counter and, when a
+    review is due, schedules it as a background task. Nothing here awaits the
+    review itself, so a slow review cannot hold the turn open.
+    """
+
+    def note_turn(
+        self,
+        *,
+        agent_id: str,
+        session_key: str,
+        input_mode: str,
+        run_kind: str,
+        no_memory_capture: bool,
+        turn_segments: Any,
+    ) -> None: ...
+
+
+class _NoopMemoryNudge:
+    """Stand-in used when no nudge port is wired. Never nudges."""
+
+    def note_turn(self, **_kwargs: Any) -> None:
+        return None
 
 
 def _turn_usage_payload(
@@ -174,6 +204,7 @@ def _turn_usage_payload(
         "total_savings_usd": float(done_event.total_savings_usd or 0.0),
     }
 
+
 @runtime_checkable
 class SessionTotalsPort(Protocol):
     """Roll up session token + cost + cache totals from a DoneEvent.
@@ -200,6 +231,7 @@ class SessionTotalsPort(Protocol):
         resolved_model: str,
     ) -> CostRollupResult | None: ...
 
+
 @runtime_checkable
 class TurnErrorPersistPort(Protocol):
     """Wrap ``TurnRunner._persist_turn_error(session_key, event)``.
@@ -217,9 +249,11 @@ class TurnErrorPersistPort(Protocol):
         event: ErrorEvent | None,
     ) -> None: ...
 
+
 # ---------------------------------------------------------------------------
 # Cost-rollup result -- exposed for equivalence-harness pinning
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class CostRollupResult:
@@ -243,9 +277,11 @@ class CostRollupResult:
     cache_write: int
     model_override: str | None
 
+
 # ---------------------------------------------------------------------------
 # Stage I/O dataclasses
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class TurnFinalizerStageInput:
@@ -285,15 +321,16 @@ class TurnFinalizerStageInput:
     heartbeat_ack_max_chars: int
     no_memory_capture: bool
 
+
 @dataclass(frozen=True)
 class TurnFinalizerStageOutput:
     """Outputs the harness applies to ``TurnContext`` after the stage runs.
 
-   Downstream consumers read ``final_text``, ``turn_segments``,
-    ``turn_artifacts``, ``error_message``, ``pending_error_event``,
-    ``done_event`` for its turn_end trace + decision entry. The
-    ``cost_rollup`` snapshot is observability-only (pinned by the
-    equivalence harness, not consumed downstream).
+    Downstream consumers read ``final_text``, ``turn_segments``,
+     ``turn_artifacts``, ``error_message``, ``pending_error_event``,
+     ``done_event`` for its turn_end trace + decision entry. The
+     ``cost_rollup`` snapshot is observability-only (pinned by the
+     equivalence harness, not consumed downstream).
     """
 
     # Heartbeat-normalized final text (the harness writes this onto
@@ -315,39 +352,41 @@ class TurnFinalizerStageOutput:
     # Did the memory capture fire?
     memory_captured: bool
 
+
 # ---------------------------------------------------------------------------
 # Outer stage class
 # ---------------------------------------------------------------------------
 
+
 class TurnFinalizerStage:
     """Persist the assistant turn, capture memory, roll up session totals.
 
-    Stable boundary: runs ONCE per turn, after StreamConsumerStage
-    exhausts (and after the harness flushes the trailing text segment),
-   . The four ports execute in the original order:
+     Stable boundary: runs ONCE per turn, after StreamConsumerStage
+     exhausts (and after the harness flushes the trailing text segment),
+    . The four ports execute in the original order:
 
-    1. Heartbeat-normalize the accumulated text.
-    2. ``TranscriptAppendPort.append_message`` (assistant turn).
-    3. ``TurnMemoryCapturePort.capture_turn`` (memory write -- wrapped
-       in log-and-continue try/except intentional).
-    4. ``TurnErrorPersistPort.persist_error`` (pending error, only if
-       ``error_message`` is truthy).
-    5. ``SessionTotalsPort.rollup`` (DoneEvent-driven session.update --
-       wrapped in log-and-continue try/except intentional).
+     1. Heartbeat-normalize the accumulated text.
+     2. ``TranscriptAppendPort.append_message`` (assistant turn).
+     3. ``TurnMemoryCapturePort.capture_turn`` (memory write -- wrapped
+        in log-and-continue try/except intentional).
+     4. ``TurnErrorPersistPort.persist_error`` (pending error, only if
+        ``error_message`` is truthy).
+     5. ``SessionTotalsPort.rollup`` (DoneEvent-driven session.update --
+        wrapped in log-and-continue try/except intentional).
 
-    The order is load-bearing: transcript persistence MUST precede
-    memory capture (memory capture reads ``final_text`` AS PERSISTED);
-    error persist MUST precede totals rollup for diagnostic ordering
-    that downstream observability relies on.
+     The order is load-bearing: transcript persistence MUST precede
+     memory capture (memory capture reads ``final_text`` AS PERSISTED);
+     error persist MUST precede totals rollup for diagnostic ordering
+     that downstream observability relies on.
 
-    Exception model: the stage does NOT wrap the ``append_message``
-    call. Any exception there propagates to the outer ``_run_turn``
-    terminal handler --. The memory-capture
-    and totals-rollup ports each have their own log-and-continue
-    try/except inside the stage body.
+     Exception model: the stage does NOT wrap the ``append_message``
+     call. Any exception there propagates to the outer ``_run_turn``
+     terminal handler --. The memory-capture
+     and totals-rollup ports each have their own log-and-continue
+     try/except inside the stage body.
 
-    No ``TurnHook.after_turn`` fan-out today; that wiring belongs in a separate
-    production hook pass.
+     No ``TurnHook.after_turn`` fan-out today; that wiring belongs in a separate
+     production hook pass.
     """
 
     name = "turn_finalizer_stage"
@@ -359,11 +398,15 @@ class TurnFinalizerStage:
         turn_memory_capture: TurnMemoryCapturePort,
         session_totals: SessionTotalsPort,
         turn_error_persist: TurnErrorPersistPort,
+        memory_nudge: MemoryNudgePort | None = None,
     ) -> None:
         self._transcript_append = transcript_append
         self._turn_memory_capture = turn_memory_capture
         self._session_totals = session_totals
         self._turn_error_persist = turn_error_persist
+        # Optional so existing constructions (tests, older wiring) keep
+        # working; a stage without it simply never nudges.
+        self._memory_nudge = memory_nudge or _NoopMemoryNudge()
 
     async def run(
         self,
@@ -418,14 +461,10 @@ class TurnFinalizerStage:
             if (
                 inp.done_event is not None
                 and inp.done_event.reasoning_content
-                and _is_deepseek_model_id(
-                    inp.done_event.model or inp.resolved_model or ""
-                )
+                and _is_deepseek_model_id(inp.done_event.model or inp.resolved_model or "")
             ):
                 reasoning_content = inp.done_event.reasoning_content
-            token_count = (
-                inp.done_event.output_tokens if inp.done_event is not None else None
-            )
+            token_count = inp.done_event.output_tokens if inp.done_event is not None else None
             transcript_appended = await self._transcript_append.append_message(
                 inp.session_key,
                 role="assistant",
@@ -455,6 +494,26 @@ class TurnFinalizerStage:
                 except Exception as exc:  # noqa: BLE001 - log-and-continue intentional
                     log.warning(
                         "turn_runner.capture_failed",
+                        session_key=inp.session_key,
+                        agent_id=inp.agent_id,
+                        error=str(exc),
+                    )
+
+                # Periodic memory review. Fire-and-forget: the reply is
+                # already on the wire, and a review must never hold the turn
+                # open -- a slow one would leave the task marked running.
+                try:
+                    self._memory_nudge.note_turn(
+                        agent_id=inp.agent_id,
+                        session_key=inp.session_key,
+                        input_mode=inp.input_mode,
+                        run_kind=inp.run_kind,
+                        no_memory_capture=inp.no_memory_capture,
+                        turn_segments=turn_segments,
+                    )
+                except Exception as exc:  # noqa: BLE001 - log-and-continue intentional
+                    log.warning(
+                        "turn_runner.memory_nudge_failed",
                         session_key=inp.session_key,
                         agent_id=inp.agent_id,
                         error=str(exc),

--- a/src/agentos/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/agentos/engine/turn_runner/turn_finalizer_stage.py
@@ -48,6 +48,15 @@ log = structlog.get_logger(__name__)
 
 _UNCONFIRMED_BACKGROUND_TOOL_NAMES = frozenset({"background_process", "process"})
 
+# Turn kinds whose reply belongs to the harness rather than the conversation.
+# Their output must not be persisted: it would show up as unexplained
+# assistant lines in the user's transcript and then be replayed as context.
+_INTERNAL_TURN_KINDS = frozenset({"memory_nudge"})
+
+
+def _is_internal_turn(run_kind: str | None) -> bool:
+    return bool(run_kind) and run_kind in _INTERNAL_TURN_KINDS
+
 
 def _unconfirmed_background_tool_names(turn_segments: list[dict]) -> list[str]:
     names: list[str] = []
@@ -448,7 +457,14 @@ class TurnFinalizerStage:
 
         # 2. Transcript append + 3. memory capture (paired -- memory
         # only fires if transcript persisted).
-        if final_text or turn_segments or inp.turn_artifacts:
+        #
+        # Internal turns are excluded: their reply is addressed to the
+        # harness, not the user. Persisting it would leave stray lines like
+        # "Nothing to save." in the conversation and, worse, feed them back
+        # as context on the next real turn.
+        if (final_text or turn_segments or inp.turn_artifacts) and not _is_internal_turn(
+            inp.run_kind
+        ):
             persisted_content = (
                 _json.dumps(
                     {"text": final_text, "artifacts": inp.turn_artifacts},

--- a/src/agentos/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/agentos/engine/turn_runner/turn_finalizer_stage.py
@@ -515,25 +515,31 @@ class TurnFinalizerStage:
                         error=str(exc),
                     )
 
-                # Periodic memory review. Fire-and-forget: the reply is
-                # already on the wire, and a review must never hold the turn
-                # open -- a slow one would leave the task marked running.
-                try:
-                    self._memory_nudge.note_turn(
-                        agent_id=inp.agent_id,
-                        session_key=inp.session_key,
-                        input_mode=inp.input_mode,
-                        run_kind=inp.run_kind,
-                        no_memory_capture=inp.no_memory_capture,
-                        turn_segments=turn_segments,
-                    )
-                except Exception as exc:  # noqa: BLE001 - log-and-continue intentional
-                    log.warning(
-                        "turn_runner.memory_nudge_failed",
-                        session_key=inp.session_key,
-                        agent_id=inp.agent_id,
-                        error=str(exc),
-                    )
+        # Periodic memory review. Deliberately outside the transcript-append
+        # branch: how many turns the user has taken is independent of whether
+        # this deployment persists transcripts, and nesting it there meant the
+        # counter never advanced wherever append returns False (no session
+        # manager wired), so the nudge silently never fired.
+        #
+        # Fire-and-forget: the reply is already on the wire, and a review must
+        # never hold the turn open -- a slow one would leave the task marked
+        # running for its whole duration.
+        try:
+            self._memory_nudge.note_turn(
+                agent_id=inp.agent_id,
+                session_key=inp.session_key,
+                input_mode=inp.input_mode,
+                run_kind=inp.run_kind,
+                no_memory_capture=inp.no_memory_capture,
+                turn_segments=turn_segments,
+            )
+        except Exception as exc:  # noqa: BLE001 - log-and-continue intentional
+            log.warning(
+                "turn_runner.memory_nudge_failed",
+                session_key=inp.session_key,
+                agent_id=inp.agent_id,
+                error=str(exc),
+            )
 
         # 4. Error persist (only when error_message is truthy; the
         # adapter folds the session-manager-None guard, and the helper

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -116,9 +116,7 @@ class ControlUiConfig(BaseSettings):
             or re.fullmatch(r"[A-Za-z0-9._~-]+", segment) is None
             for segment in segments
         ):
-            raise ValueError(
-                "control_ui.base_path must contain only safe URL path segments"
-            )
+            raise ValueError("control_ui.base_path must contain only safe URL path segments")
         if base_path in {"/api", "/ws"} or base_path.startswith(("/api/", "/ws/")):
             raise ValueError("control_ui.base_path cannot overlap gateway API or WebSocket routes")
         return base_path
@@ -218,9 +216,7 @@ class TaskRuntimeConfig(BaseModel):
             PendingOverflowPolicy(value)
         except ValueError as exc:
             valid = ", ".join(member.value for member in PendingOverflowPolicy)
-            raise ValueError(
-                f"pending_overflow_policy must be one of {{{valid}}}"
-            ) from exc
+            raise ValueError(f"pending_overflow_policy must be one of {{{valid}}}") from exc
         return value
 
     @field_validator("pending_overflow_policy_per_channel")
@@ -234,8 +230,7 @@ class TaskRuntimeConfig(BaseModel):
                 PendingOverflowPolicy(policy)
             except ValueError as exc:
                 raise ValueError(
-                    f"pending_overflow_policy_per_channel[{channel!r}] "
-                    f"must be one of {{{valid}}}"
+                    f"pending_overflow_policy_per_channel[{channel!r}] must be one of {{{valid}}}"
                 ) from exc
         return value
 
@@ -403,6 +398,43 @@ class DreamConfig(BaseModel):
     evidence_negative_recurrence_threshold: int = Field(default=2, ge=1)
     evidence_curated_writes_enabled: bool = True
     evidence_quarantine_enabled: bool = True
+
+
+class MemoryNudgeConfig(BaseModel):
+    """Periodic memory-review nudge.
+
+    Curated memory only fills up when something asks the agent to write to it.
+    Left alone, an agent will happily run for hundreds of turns with an empty
+    MEMORY.md, because saving is never the most urgent thing in any single
+    turn. The nudge closes that gap: every N user turns, once the reply is
+    already on the wire, a short background turn re-reads the conversation and
+    saves anything durable it finds.
+
+    It runs after the response so it never competes with the user's task for
+    model attention, and it is skipped entirely when the model already wrote
+    to memory on its own -- an agent that curates unprompted needs no nudge.
+
+    Adapted from hermes-agent's memory nudge (MIT, © 2025 Nous Research).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    # User turns between reviews. 0 disables the nudge entirely.
+    interval: int = Field(default=10, ge=0)
+    # Ceiling on the review turn's own tool loop. The review has one job --
+    # read the transcript, decide, maybe call `memory` -- so it should never
+    # need a long loop; a low cap bounds the cost of a confused review.
+    max_iterations: int = Field(default=6, ge=1)
+    # Give up on a review that outlives its usefulness rather than letting it
+    # trail the session.
+    timeout_seconds: float = Field(default=90.0, gt=0)
+    # Turn kinds that must never trigger a review. Cron/heartbeat/subagent
+    # turns are machine traffic: their transcripts say nothing durable about
+    # the user, and reviewing them would write the harness into memory.
+    excluded_run_kinds: list[str] = Field(
+        default_factory=lambda: ["memory_nudge", "cron", "heartbeat", "subagent", "recall"]
+    )
 
 
 class SafetyConfig(BaseModel):
@@ -597,6 +629,9 @@ class MemoryConfig(BaseSettings):
 
     # Dream consolidation
     dream: DreamConfig = Field(default_factory=DreamConfig)
+
+    # Periodic memory-review nudge
+    nudge: MemoryNudgeConfig = Field(default_factory=MemoryNudgeConfig)
 
     # Curated memory (hermes-style bounded entry stores). Char budgets for the
     # always-injected MEMORY.md / USER.md files. Chars, not tokens — char
@@ -838,8 +873,7 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
                 "provider": "dashscope",
                 "model": "qwen3.6-flash",
                 "description": (
-                    "DashScope fast route: Qwen3.6 Flash for simple text tasks; "
-                    "pending live smoke."
+                    "DashScope fast route: Qwen3.6 Flash for simple text tasks; pending live smoke."
                 ),
                 "supports_image": False,
             },
@@ -992,8 +1026,7 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
                 "provider": "moonshot",
                 "model": "kimi-k2.5",
                 "description": (
-                    "Moonshot balanced route: Kimi K2.5 for normal multimodal "
-                    "agent work."
+                    "Moonshot balanced route: Kimi K2.5 for normal multimodal agent work."
                 ),
                 "supports_image": True,
                 "thinking_level": "medium",
@@ -1012,8 +1045,7 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
                 "provider": "moonshot",
                 "model": "kimi-k2.6",
                 "description": (
-                    "Moonshot highest route: Kimi K2.6 for the hardest long-horizon "
-                    "agent work."
+                    "Moonshot highest route: Kimi K2.6 for the hardest long-horizon agent work."
                 ),
                 "supports_image": True,
                 "thinking_level": "high",
@@ -1161,9 +1193,7 @@ class AgentOSRouterConfig(BaseSettings):
         normalized = LEGACY_STRATEGY_ALIASES.get(normalized, normalized)
         if not is_known_strategy(normalized):
             allowed = ", ".join(repr(s) for s in sorted(known_strategy_ids()))
-            raise ValueError(
-                f"agentos_router.strategy must be one of {allowed}; got {value!r}"
-            )
+            raise ValueError(f"agentos_router.strategy must be one of {allowed}; got {value!r}")
         return normalized
 
     @model_validator(mode="before")
@@ -1176,9 +1206,7 @@ class AgentOSRouterConfig(BaseSettings):
             "upgrade_to_c3_compaction_enabled" not in values
             and "upgrade_to_t3_compaction_enabled" in values
         ):
-            values["upgrade_to_c3_compaction_enabled"] = values[
-                "upgrade_to_t3_compaction_enabled"
-            ]
+            values["upgrade_to_c3_compaction_enabled"] = values["upgrade_to_t3_compaction_enabled"]
         if "default_tier" in values:
             values["default_tier"] = normalize_text_tier(values.get("default_tier")) or values.get(
                 "default_tier"
@@ -1346,9 +1374,7 @@ class AudioElevenLabsProviderConfig(BaseModel):
 
 
 class AudioProvidersConfig(BaseModel):
-    elevenlabs: AudioElevenLabsProviderConfig = Field(
-        default_factory=AudioElevenLabsProviderConfig
-    )
+    elevenlabs: AudioElevenLabsProviderConfig = Field(default_factory=AudioElevenLabsProviderConfig)
 
 
 class AudioTTSConfig(BaseModel):
@@ -1479,9 +1505,7 @@ class TelegramChannelEntry(ConfiguredChannelEntry):
             if not self.webhook_url:
                 raise ValueError("webhook_url is required for telegram webhook mode")
             if not self.webhook_secret_token:
-                raise ValueError(
-                    "webhook_secret_token is required for telegram webhook mode"
-                )
+                raise ValueError("webhook_secret_token is required for telegram webhook mode")
         return self
 
 
@@ -1681,6 +1705,7 @@ class GatewayConfig(BaseSettings):
     # Component enable flags
     control_ui: ControlUiConfig = Field(default_factory=ControlUiConfig)
     diagnostics_enabled: bool = False
+
     @model_validator(mode="after")
     def _default_agentos_router_profile_for_direct_provider(self) -> GatewayConfig:
         router = self.agentos_router
@@ -1755,8 +1780,7 @@ class GatewayConfig(BaseSettings):
         import logging
 
         logging.getLogger(__name__).warning(
-            "agentos_router.judge_provider_cross_provider_reset "
-            "judge_provider=%s llm_provider=%s",
+            "agentos_router.judge_provider_cross_provider_reset judge_provider=%s llm_provider=%s",
             judge_provider,
             provider,
         )
@@ -1957,6 +1981,7 @@ class GatewayConfig(BaseSettings):
             "capture_roll_max_chars": str(self.memory.capture_roll_max_chars),
             "dream_enabled": str(self.memory.dream.enabled).lower(),
         }
+
     _runtime_secret_paths: set[str] = PrivateAttr(default_factory=set)
 
     def to_toml_dict(self) -> dict[str, Any]:

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -153,7 +153,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[agentos_router]` | router on/off, `strategy` (`pilot-v1`), tier settings under `[agentos_router.tiers.c0..c3]` |
 | `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode` |
 | `[tools]` | model-visible tools and policy; `enabled = false` runs providers in plain-text mode |
-| `[memory]` | memory source and embedding model, `[memory.dream]` |
+| `[memory]` | memory source and embedding model, `[memory.nudge]` (periodic memory review), `[memory.dream]` |
 | `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |
 | `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`) |
 | `[auth]` | gateway admission: `mode` (`none` on loopback or `token`), `token` |

--- a/tests/test_memory_nudge.py
+++ b/tests/test_memory_nudge.py
@@ -41,6 +41,7 @@ class _Runner:
     _turn_used_memory_tool = staticmethod(TurnRunner._turn_used_memory_tool)
     _capture_filter_matches = staticmethod(TurnRunner._capture_filter_matches)
     _hydrate_nudge_counter = staticmethod(TurnRunner._hydrate_nudge_counter)
+    _evict_nudge_counters_if_needed = TurnRunner._evict_nudge_counters_if_needed
     _note_turn_for_memory_nudge = TurnRunner._note_turn_for_memory_nudge
     forget_memory_nudge_counter = TurnRunner.forget_memory_nudge_counter
 
@@ -202,6 +203,31 @@ def test_forgetting_resets_progress_for_that_session():
     _note(r, session_key="a")
     r.forget_memory_nudge_counter("a")
     assert _note(r, session_key="a") is False
+
+
+def test_counter_dict_stays_bounded():
+    """Nothing tells the runner a session ended, so the dict must self-bound.
+
+    A gateway running for weeks would otherwise retain one entry per session
+    it ever saw.
+    """
+    from agentos.engine.runtime import _MAX_NUDGE_COUNTERS
+
+    r = _Runner(MemoryNudgeConfig(interval=1000))
+    for i in range(_MAX_NUDGE_COUNTERS + 100):
+        _note(r, session_key=f"s{i}")
+    assert len(r._memory_nudge_counters) <= _MAX_NUDGE_COUNTERS
+
+
+def test_eviction_keeps_the_most_recent_sessions():
+    """Evicting the oldest half costs a re-seed, never a wrong count."""
+    from agentos.engine.runtime import _MAX_NUDGE_COUNTERS
+
+    r = _Runner(MemoryNudgeConfig(interval=1000))
+    for i in range(_MAX_NUDGE_COUNTERS + 1):
+        _note(r, session_key=f"s{i}")
+    newest = f"s{_MAX_NUDGE_COUNTERS}"
+    assert ("main", newest) in r._memory_nudge_counters
 
 
 # -- hydration across processes --------------------------------------------

--- a/tests/test_memory_nudge.py
+++ b/tests/test_memory_nudge.py
@@ -275,6 +275,36 @@ def test_hydration_ignores_nonsense_counts():
     assert _note(r, prior_user_turns=-5) is False
 
 
+# -- the review must not pollute the conversation --------------------------
+
+
+def test_review_turns_are_classified_internal():
+    """The review's reply is addressed to the harness, not the user.
+
+    Persisting it would leave stray "Nothing to save." lines in the
+    transcript and then replay them as context on the next real turn.
+    """
+    from agentos.engine.turn_runner.turn_finalizer_stage import _is_internal_turn
+
+    assert _is_internal_turn("memory_nudge") is True
+
+
+@pytest.mark.parametrize("run_kind", ["default", "cron_turn", "subagent", "heartbeat", ""])
+def test_ordinary_turns_are_still_persisted(run_kind: str):
+    """Only the nudge is internal -- everything else keeps its transcript."""
+    from agentos.engine.turn_runner.turn_finalizer_stage import _is_internal_turn
+
+    assert _is_internal_turn(run_kind) is False
+
+
+def test_review_prompt_is_not_persisted_as_user_input():
+    """persist_input=False keeps the harness prompt out of the transcript."""
+    import inspect
+
+    src = inspect.getsource(TurnRunner._run_memory_nudge_review)
+    assert "persist_input=False" in src
+
+
 # -- prompt ----------------------------------------------------------------
 
 

--- a/tests/test_memory_nudge.py
+++ b/tests/test_memory_nudge.py
@@ -297,6 +297,67 @@ def test_ordinary_turns_are_still_persisted(run_kind: str):
     assert _is_internal_turn(run_kind) is False
 
 
+async def test_nudge_counts_even_when_the_transcript_is_not_persisted():
+    """`append_message` returns False wherever no session manager is wired.
+
+    Nesting the nudge under that result meant the counter never advanced and
+    the review silently never fired in those deployments -- which is exactly
+    what CLI runs do.
+    """
+    from agentos.engine.turn_runner.turn_finalizer_stage import (
+        TurnFinalizerStage,
+        TurnFinalizerStageInput,
+    )
+
+    noted: list[str] = []
+
+    class _NoTranscript:
+        async def append_message(self, *_a: Any, **_k: Any) -> bool:
+            return False  # no session manager wired
+
+    class _Capture:
+        async def capture_turn(self, **_k: Any) -> None:
+            raise AssertionError("capture must stay paired with the transcript")
+
+    class _Nudge:
+        def note_turn(self, *, run_kind: str, **_k: Any) -> None:
+            noted.append(run_kind)
+
+    class _Noop:
+        async def persist_error(self, **_k: Any) -> None: ...
+        async def roll_up(self, **_k: Any) -> Any:
+            return None
+
+    stage = TurnFinalizerStage(
+        transcript_append=_NoTranscript(),
+        turn_memory_capture=_Capture(),
+        session_totals=_Noop(),
+        turn_error_persist=_Noop(),
+        memory_nudge=_Nudge(),
+    )
+    await stage.run(
+        TurnFinalizerStageInput(
+            final_text_parts=["hello"],
+            turn_segments=[],
+            turn_artifacts=[],
+            error_message=None,
+            pending_error_event=None,
+            done_event=None,
+            runtime_message="hi",
+            input_mode="user",
+            input_provenance=None,
+            resolved_model="m",
+            agent_id="main",
+            session_key="s1",
+            tool_context=None,
+            run_kind="default",
+            heartbeat_ack_max_chars=300,
+            no_memory_capture=False,
+        )
+    )
+    assert noted == ["default"]
+
+
 def test_review_prompt_is_not_persisted_as_user_input():
     """persist_input=False keeps the harness prompt out of the transcript."""
     import inspect

--- a/tests/test_memory_nudge.py
+++ b/tests/test_memory_nudge.py
@@ -1,0 +1,260 @@
+"""Periodic memory-review nudge.
+
+Curated memory only fills up when something asks the agent to write to it, so
+the nudge is what turns "the agent *can* save memories" into "the agent
+*does*". These tests pin the counter's arithmetic and, more importantly, the
+cases where it must stay quiet: machine traffic, self-directed writes, and
+reviews reviewing themselves.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.engine.runtime import TurnRunner
+from agentos.gateway.config import MemoryNudgeConfig
+
+
+class _Cfg:
+    """Minimal stand-in for the memory config block."""
+
+    def __init__(self, nudge: MemoryNudgeConfig | None) -> None:
+        self.nudge = nudge
+
+
+class _Runner:
+    """TurnRunner counter surface, unbound from the full runtime.
+
+    The nudge methods only touch `_config` and `_memory_nudge_counters`, so
+    binding them onto a bare object exercises the real implementations
+    without standing up a gateway.
+    """
+
+    def __init__(self, nudge: MemoryNudgeConfig | None) -> None:
+        self._config = type("C", (), {"memory": _Cfg(nudge)})()
+        self._memory_nudge_counters: dict[tuple[str, str], int] = {}
+
+    _memory_nudge_config = TurnRunner._memory_nudge_config
+    _memory_nudge_allowed = TurnRunner._memory_nudge_allowed
+    _turn_used_memory_tool = staticmethod(TurnRunner._turn_used_memory_tool)
+    _capture_filter_matches = staticmethod(TurnRunner._capture_filter_matches)
+    _hydrate_nudge_counter = staticmethod(TurnRunner._hydrate_nudge_counter)
+    _note_turn_for_memory_nudge = TurnRunner._note_turn_for_memory_nudge
+    forget_memory_nudge_counter = TurnRunner.forget_memory_nudge_counter
+
+
+def _note(runner: _Runner, **overrides: Any) -> bool:
+    kwargs: dict[str, Any] = {
+        "agent_id": "main",
+        "session_key": "s1",
+        "input_mode": "user",
+        "run_kind": "default",
+        "no_memory_capture": False,
+        "turn_segments": [],
+        "prior_user_turns": None,
+    }
+    kwargs.update(overrides)
+    return runner._note_turn_for_memory_nudge(**kwargs)
+
+
+# -- counter arithmetic ----------------------------------------------------
+
+
+def test_fires_on_the_interval_turn_and_not_before():
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    assert [_note(r) for _ in range(3)] == [False, False, True]
+
+
+def test_counter_restarts_after_firing():
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    fired = [_note(r) for _ in range(9)]
+    assert fired == [False, False, True] * 3
+
+
+def test_interval_one_fires_every_turn():
+    r = _Runner(MemoryNudgeConfig(interval=1))
+    assert all(_note(r) for _ in range(4))
+
+
+def test_sessions_count_independently():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    assert _note(r, session_key="a") is False
+    assert _note(r, session_key="b") is False
+    assert _note(r, session_key="a") is True
+    assert _note(r, session_key="b") is True
+
+
+def test_agents_count_independently():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    assert _note(r, agent_id="main") is False
+    assert _note(r, agent_id="ops") is False
+    assert _note(r, agent_id="main") is True
+
+
+# -- disabled paths --------------------------------------------------------
+
+
+def test_disabled_never_fires():
+    r = _Runner(MemoryNudgeConfig(enabled=False, interval=1))
+    assert not any(_note(r) for _ in range(5))
+
+
+def test_zero_interval_disables():
+    r = _Runner(MemoryNudgeConfig(interval=0))
+    assert not any(_note(r) for _ in range(5))
+
+
+def test_missing_config_never_fires():
+    r = _Runner(None)
+    assert not any(_note(r) for _ in range(5))
+
+
+# -- traffic that must not advance the counter -----------------------------
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"input_mode": "system_event"}, id="system_event"),
+        pytest.param({"no_memory_capture": True}, id="no_memory_capture"),
+        pytest.param({"run_kind": "memory_nudge"}, id="the_review_itself"),
+        pytest.param({"run_kind": "cron_turn"}, id="cron"),
+        pytest.param({"run_kind": "heartbeat"}, id="heartbeat"),
+        pytest.param({"run_kind": "subagent"}, id="subagent"),
+    ],
+)
+def test_machine_traffic_never_fires(overrides: dict[str, Any]):
+    """Machine turns say nothing durable about the user.
+
+    Reviewing them would write the harness itself into memory.
+    """
+    r = _Runner(MemoryNudgeConfig(interval=1))
+    assert not any(_note(r, **overrides) for _ in range(5))
+
+
+def test_excluded_traffic_does_not_even_advance_the_counter():
+    """Skipping must not merely suppress the fire -- it must not count.
+
+    Otherwise a burst of cron turns silently consumes the user's interval and
+    the next real turn nudges early.
+    """
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    for _ in range(10):
+        _note(r, run_kind="cron_turn")
+    assert [_note(r) for _ in range(3)] == [False, False, True]
+
+
+def test_review_cannot_trigger_another_review():
+    """The nudge's own run_kind is excluded, so reviews cannot recurse."""
+    r = _Runner(MemoryNudgeConfig(interval=1))
+    assert _note(r, run_kind="memory_nudge") is False
+    assert r._memory_nudge_counters == {}
+
+
+# -- self-directed writes reset the counter --------------------------------
+
+
+@pytest.mark.parametrize("tool_name", ["memory", "memory_save"])
+def test_agent_writing_memory_itself_resets_the_counter(tool_name: str):
+    """An agent that curates unprompted does not need to be nudged."""
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    _note(r)
+    _note(r)
+    assert _note(r, turn_segments=[{"type": "tool_result", "name": tool_name}]) is False
+    # Counter restarted: the next fire is a full interval away.
+    assert [_note(r) for _ in range(3)] == [False, False, True]
+
+
+def test_unrelated_tool_calls_do_not_reset():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    _note(r)
+    assert _note(r, turn_segments=[{"type": "tool_result", "name": "shell"}]) is True
+
+
+def test_memory_search_is_not_a_write():
+    """Reading memory is not curating it, so it must not reset the counter."""
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    _note(r)
+    assert _note(r, turn_segments=[{"type": "tool_result", "name": "memory_search"}]) is True
+
+
+def test_malformed_segments_are_ignored():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    _note(r)
+    assert _note(r, turn_segments=["not a dict", None, {}, {"name": None}]) is True
+
+
+# -- eviction --------------------------------------------------------------
+
+
+def test_forgetting_a_session_drops_its_counter():
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    _note(r, session_key="a")
+    _note(r, session_key="b")
+    r.forget_memory_nudge_counter("a")
+    assert [k[1] for k in r._memory_nudge_counters] == ["b"]
+
+
+def test_forgetting_resets_progress_for_that_session():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    _note(r, session_key="a")
+    r.forget_memory_nudge_counter("a")
+    assert _note(r, session_key="a") is False
+
+
+# -- hydration across processes --------------------------------------------
+
+
+def test_counter_seeds_from_persisted_turns():
+    """A rebuilt runner must not restart the session's count from zero.
+
+    Every CLI invocation builds a fresh TurnRunner and the gateway evicts
+    idle agents, so without seeding, a session spread across processes would
+    never reach the interval and the nudge would never fire at all.
+    """
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    # 5 stored turns: 4 completed before this one, so phase is 4 % 3 == 1.
+    # This turn makes 2 -> one more to go, instead of restarting at 1.
+    assert _note(r, prior_user_turns=5) is False
+    assert _note(r) is True
+
+
+def test_hydration_can_fire_immediately_when_the_session_is_already_due():
+    r = _Runner(MemoryNudgeConfig(interval=3))
+    # 3 prior turns means 2 complete cycles' worth of phase -> due now.
+    assert _note(r, prior_user_turns=3) is True
+
+
+def test_hydration_only_seeds_once():
+    """After seeding, the live counter owns the session."""
+    r = _Runner(MemoryNudgeConfig(interval=5))
+    _note(r, prior_user_turns=4)  # seed 3, this turn -> 4
+    # A later turn reporting a wildly different count must not re-seed.
+    assert _note(r, prior_user_turns=999) is True  # 5 == interval
+    assert r._memory_nudge_counters[("main", "s1")] == 0
+
+
+def test_unknown_prior_turns_starts_from_zero():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    assert _note(r, prior_user_turns=None) is False
+    assert _note(r) is True
+
+
+def test_hydration_ignores_nonsense_counts():
+    r = _Runner(MemoryNudgeConfig(interval=2))
+    assert _note(r, prior_user_turns=0) is False
+    r.forget_memory_nudge_counter("s1")
+    assert _note(r, prior_user_turns=-5) is False
+
+
+# -- prompt ----------------------------------------------------------------
+
+
+def test_review_prompt_offers_an_explicit_way_to_decline():
+    """Without a stated opt-out a review invents an entry to justify itself."""
+    from agentos.engine.runtime import _MEMORY_REVIEW_PROMPT
+
+    assert "Nothing to save." in _MEMORY_REVIEW_PROMPT
+    assert "memory tool" in _MEMORY_REVIEW_PROMPT


### PR DESCRIPTION
Curated memory only fills up when something asks the agent to write to it. Left alone, an agent runs for hundreds of turns with an empty `MEMORY.md` — saving is never the most urgent thing in any single turn. #106 and #107 made memory *writable*; nothing made it *written*.

This adds the nudge, modelled on hermes-agent: every N user turns, once the reply is already on the wire, a short background turn re-reads the conversation and saves anything durable it finds. Default interval 10, enabled.

## Placement

Runs **after** the response so it never competes with the user's task for model attention, and **fire-and-forget** so a slow review cannot hold the turn open — awaiting it would leave the task marked running for as long as the review takes.

## What must not trigger a review

- **Machine traffic** (cron, heartbeat, subagent, recall). Those transcripts say nothing durable about the user; reviewing them writes the harness into memory.
- **The review turn itself**, so reviews cannot recurse.
- **Turns where the agent already wrote to memory.** An agent that curates unprompted needs no nudge, so a self-directed `memory` / `memory_save` call resets the counter.

Excluded turns do not advance the counter *at all*, rather than merely being suppressed. Otherwise a burst of cron turns silently consumes the user's interval and the next real turn nudges early.

## Counter placement, and why it needs seeding

The counter is held per `(agent_id, session_key)` rather than derived from history length, because the history window caps — its length plateaus in exactly the long sessions the nudge exists for.

In-memory alone is not enough. A `TurnRunner` is rebuilt on every CLI invocation and the gateway evicts idle agents, so a fresh runner starting at zero means a session spread across processes never reaches the interval and the nudge silently never fires. I hit this while testing: two consecutive turns both reported a count of 1.

A missing counter is therefore seeded from the persisted user-turn count, once per session per process. Modular arithmetic recovers the phase: 27 prior turns at interval 10 means 7 into the cycle, so the next review is 3 away. It is an approximation — an earlier self-directed write shifted the real phase — but the cost of being wrong is nudging a few turns early or late, against never nudging at all.

## Prompt

Keeps two properties from upstream that are easy to lose: it names what is worth keeping (durable facts about the user, not task chatter), and it gives an explicit way to decline, so a review with nothing to save stops instead of inventing an entry to justify the call.

## Config

`[memory.nudge]` with `enabled`, `interval` (0 disables), `max_iterations`, `timeout_seconds`, `excluded_run_kinds`. Documented in `agentos.toml.example` and the bundled skill's config table.

## Tests

`tests/test_memory_nudge.py` — 29 tests over the arithmetic, every exclusion path, hydration, and eviction. Verified they catch regressions rather than passing vacuously: removing the run-kind exclusion turns 6 of them red.

Also exercised end-to-end in a same-process multi-turn session (the shape of `agentos chat` and the gateway): 6 turns at interval 2 scheduled exactly 3 reviews, firing on turns 2, 4, and 6; 9 cron turns scheduled none.

Full suite: 6320 passed, 27 skipped. ruff and mypy clean.

## One caveat for review

These files pick up pre-existing `ruff format` churn — the tree was not fully formatted before this branch, so `ruff format` on the touched files reflows unrelated lines. Confirmed present on a clean checkout, not introduced here. Happy to split it out if you would rather have the reformat as its own commit.