### PR TITLE
fix(memory): surface unreadable curated files instead of going blind

### DIFF
--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -550,6 +550,15 @@ def _normalize_capture_kind(value: str) -> str:
     return value.strip().lower().replace("-", "_").replace(".", "_").replace(":", "_")
 
 
+class MemorySourceUnreadableError(Exception):
+    """Curated memory exists on disk but could not be read this attempt.
+
+    Distinct from "there is no memory": callers must not freeze an empty
+    snapshot on this, or a transient read failure blinds the agent for the
+    rest of the session.
+    """
+
+
 # Curated-memory write tools. A turn that calls one of these has already done
 # the thing the nudge would ask for, so it resets the counter instead.
 _MEMORY_WRITE_TOOL_NAMES: Final[frozenset[str]] = frozenset({"memory", "memory_save"})
@@ -4094,6 +4103,16 @@ class TurnRunner:
             user_char_limit=user_limit,
         )
         store.load_from_disk()
+        if store.load_failed:
+            # The file exists but could not be read. Returning None here would
+            # be indistinguishable from "no memory yet", and the caller freezes
+            # that result for the whole session -- so one transient lock or
+            # permission blip would blind the agent until the session ends,
+            # silently. Raise so the snapshot is not frozen and the next turn
+            # retries the read.
+            raise MemorySourceUnreadableError(
+                f"curated memory unreadable: {sorted(store.load_failed)}"
+            )
         named_blocks = [
             (name, block)
             for name, block in (

--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -522,11 +522,21 @@ class _TurnRunnerMemorySnapshotAdapter(MemorySnapshotPort):
         private_memory_allowed = allows_private_memory_prompt_injection(session_key)
         snap_key = (agent_id, session_key)
         if private_memory_allowed and snap_key not in runner._memory_snapshots:
+            from agentos.engine.runtime import MemorySourceUnreadableError
+
             workspace = runner._resolve_memory_source_dir(agent_id)
-            runner._memory_snapshots[snap_key] = MemorySnapshot(
-                memory_md=runner._load_memory_md(workspace),
-                daily_notes=runner._load_daily_notes(workspace),
-            )
+            try:
+                memory_md = runner._load_memory_md(workspace)
+            except MemorySourceUnreadableError:
+                # Leave the snapshot unset so the next turn retries. Freezing
+                # an empty one here would blind the agent for the whole
+                # session over a transient read failure.
+                pass
+            else:
+                runner._memory_snapshots[snap_key] = MemorySnapshot(
+                    memory_md=memory_md,
+                    daily_notes=runner._load_daily_notes(workspace),
+                )
         return _MemorySnapshotResult(
             sync_manager=sync_manager,
             private_memory_allowed=private_memory_allowed,

--- a/src/agentos/memory/curated.py
+++ b/src/agentos/memory/curated.py
@@ -125,6 +125,10 @@ class CuratedMemoryStore:
         self.user_entries: list[str] = []
         self._consolidation_failures = 0
         self._first_failure_at = 0.0
+        # Targets whose last load_from_disk() could not read the file. Their
+        # in-memory entries are NOT the file's contents, so writes must refuse
+        # rather than flush emptiness over real data.
+        self.load_failed: dict[str, bool] = {}
         # Frozen snapshot for system-prompt injection -- set once per
         # load_from_disk() call and never mutated by mid-session writes.
         self._snapshot: dict[str, str] = {}
@@ -147,8 +151,30 @@ class CuratedMemoryStore:
         stable for the entire session (prefix-cache invariant holds).
         """
         self._memory_dir.mkdir(parents=True, exist_ok=True)
-        self.memory_entries = list(dict.fromkeys(self._read_file(self._path_for("memory"))))
-        self.user_entries = list(dict.fromkeys(self._read_file(self._path_for("user"))))
+
+        # An unreadable file is not an empty one. Loading it as [] would put
+        # the agent into a silent memory blackout for the whole session --
+        # the file still holds every entry on disk, but the snapshot is empty
+        # and nothing anywhere says why. Worse, the store then holds [] in
+        # memory while disk holds real entries, and `add` (which skips the
+        # drift check) would flush that emptiness back over them.
+        #
+        # Record the failure instead: writes refuse, and the caller can tell
+        # "no memory" apart from "could not read memory".
+        self.load_failed = {}
+        memory_raw = self._read_raw_checked(self._path_for("memory"))
+        user_raw = self._read_raw_checked(self._path_for("user"))
+        if memory_raw is None:
+            self.load_failed["memory"] = True
+            log.error(
+                "curated_memory_load_failed", target="memory", path=str(self._path_for("memory"))
+            )
+        if user_raw is None:
+            self.load_failed["user"] = True
+            log.error("curated_memory_load_failed", target="user", path=str(self._path_for("user")))
+
+        self.memory_entries = list(dict.fromkeys(self._parse_entries(memory_raw or "")))
+        self.user_entries = list(dict.fromkeys(self._parse_entries(user_raw or "")))
 
         sanitized_memory = self._sanitize_entries_for_snapshot(self.memory_entries, "MEMORY.md")
         sanitized_user = self._sanitize_entries_for_snapshot(self.user_entries, "USER.md")

--- a/tests/test_memory_curated_load_failure.py
+++ b/tests/test_memory_curated_load_failure.py
@@ -1,0 +1,152 @@
+"""Curated memory must not go silently blind when its files cannot be read.
+
+The write paths already refuse on an unreadable file (see
+test_memory_curated_durability). The *read* path had no equivalent: a
+transient lock or permission blip during load produced an empty snapshot,
+which the runtime then froze for the whole session. The agent ran with no
+memory at all, the file still holding every entry on disk, and nothing
+anywhere said why.
+"""
+
+from __future__ import annotations
+
+import errno
+from pathlib import Path
+
+import pytest
+
+from agentos.memory.curated import ENTRY_DELIMITER, CuratedMemoryStore
+
+
+def _seed(tmp_path: Path) -> None:
+    (tmp_path / "MEMORY.md").write_text(
+        ENTRY_DELIMITER.join(["fact one", "fact two", "fact three"]), encoding="utf-8"
+    )
+    (tmp_path / "USER.md").write_text("Name: Example User", encoding="utf-8")
+
+
+def _blocking_read(target_name: str, exc: Exception):
+    real = Path.read_text
+
+    def patched(self: Path, *a, **k):
+        if self.name == target_name:
+            raise exc
+        return real(self, *a, **k)
+
+    return patched
+
+
+def test_load_records_the_failure_instead_of_reporting_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed(tmp_path)
+    monkeypatch.setattr(
+        Path, "read_text", _blocking_read("MEMORY.md", OSError(errno.EACCES, "locked"))
+    )
+
+    store = CuratedMemoryStore(memory_dir=tmp_path)
+    store.load_from_disk()
+
+    assert store.load_failed == {"memory": True}
+
+
+def test_successful_load_records_no_failure(tmp_path: Path):
+    _seed(tmp_path)
+    store = CuratedMemoryStore(memory_dir=tmp_path)
+    store.load_from_disk()
+
+    assert store.load_failed == {}
+    assert len(store.entries_for("memory")) == 3
+
+
+def test_a_genuinely_empty_store_is_not_a_failure(tmp_path: Path):
+    """Absent files are a known state, not an unreadable one."""
+    store = CuratedMemoryStore(memory_dir=tmp_path)
+    store.load_from_disk()
+
+    assert store.load_failed == {}
+    assert store.entries_for("memory") == []
+
+
+def test_each_target_is_tracked_separately(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A readable MEMORY.md must not be penalised for an unreadable USER.md."""
+    _seed(tmp_path)
+    monkeypatch.setattr(
+        Path, "read_text", _blocking_read("USER.md", OSError(errno.EACCES, "locked"))
+    )
+
+    store = CuratedMemoryStore(memory_dir=tmp_path)
+    store.load_from_disk()
+
+    assert store.load_failed == {"user": True}
+    assert len(store.entries_for("memory")) == 3
+
+
+def test_corrupt_utf8_counts_as_unreadable(tmp_path: Path):
+    _seed(tmp_path)
+    (tmp_path / "MEMORY.md").write_bytes(b"\xff\xfe not utf-8 \xff")
+
+    store = CuratedMemoryStore(memory_dir=tmp_path)
+    store.load_from_disk()
+
+    assert store.load_failed == {"memory": True}
+
+
+def test_a_failed_load_never_flushes_emptiness_over_real_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The decisive case: load fails, the file recovers, then a write lands.
+
+    The store holds [] in memory while disk holds real entries. `add` skips
+    the drift check, so only the re-read inside the write path stands between
+    the user and losing everything.
+    """
+    _seed(tmp_path)
+    before = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+
+    monkeypatch.setattr(
+        Path, "read_text", _blocking_read("MEMORY.md", OSError(errno.EACCES, "locked"))
+    )
+    store = CuratedMemoryStore(memory_dir=tmp_path)
+    store.load_from_disk()
+    monkeypatch.undo()  # the transient condition clears
+
+    result = store.add("memory", "fact four")
+
+    assert result["success"] is True
+    text = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+    for entry in before.split(ENTRY_DELIMITER):
+        assert entry in text, "a pre-existing entry was lost"
+    assert "fact four" in text
+
+
+def test_runtime_refuses_to_freeze_a_snapshot_it_could_not_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """`_load_memory_md` must raise, not return None.
+
+    None is indistinguishable from "no memory yet", and the caller freezes
+    that for the whole session -- so returning it would blind the agent until
+    the session ends over a momentary read failure.
+    """
+    from agentos.engine.runtime import MemorySourceUnreadableError, TurnRunner
+
+    _seed(tmp_path)
+    runner = object.__new__(TurnRunner)
+    runner._config = type("C", (), {"memory": None})()
+
+    monkeypatch.setattr(
+        Path, "read_text", _blocking_read("MEMORY.md", OSError(errno.EACCES, "locked"))
+    )
+    with pytest.raises(MemorySourceUnreadableError):
+        runner._load_memory_md(tmp_path)
+
+
+def test_runtime_returns_none_when_memory_is_merely_absent(tmp_path: Path):
+    """An empty workspace is not an error -- only an unreadable one is."""
+    from agentos.engine.runtime import TurnRunner
+
+    runner = object.__new__(TurnRunner)
+    runner._config = type("C", (), {"memory": None})()
+
+    assert runner._load_memory_md(tmp_path) is None


### PR DESCRIPTION
#106 introduced `_read_raw_checked` and routed every **write** path through it, so a transient read failure could no longer flush emptiness over real entries. The **read** path was left on `_read_file`, whose own docstring admits it *"Returns [] for both empty AND unreadable"* — and that is the path deciding what the model actually sees.

## The failure

Quiet and total. `MEMORY.md` becomes briefly unreadable — a sync client's lock, a permission change, one bad byte from a partial write. `load_from_disk` yields `[]`, the snapshot is empty, and the runtime **freezes that empty snapshot for the rest of the session**. The agent runs with no memory at all, the file still holding every entry on disk, and nothing anywhere says why.

Reproduced on a real store: 630 bytes on disk, zero entries visible, zero log lines.

This is the same class #106 set out to close, on the one path it did not cover.

## The fix

- `load_from_disk` reads through `_read_raw_checked`, records which targets failed in `load_failed`, and logs at error level.
- `_load_memory_md` raises `MemorySourceUnreadableError` instead of returning `None`. `None` is indistinguishable from *"no memory yet"*, and the snapshot writer treats that as a value worth freezing — so returning it is what turns a momentary blip into a session-long blackout.
- On that error the snapshot is simply **not cached**, so the next turn retries the read rather than inheriting the failure.

## What I checked rather than assumed

The audit that found this also predicted a data-loss path: store holds `[]` in memory after a failed load, file recovers, `add` (which passes `skip_drift=True`) flushes emptiness over the real entries.

That one does **not** reproduce. `_reload_target` re-reads under the lock and returns `_READ_FAILED`, so the write path was already protected. Verified directly: failed load → file recovers → `add` preserves all prior entries and appends normally (630 → 666 bytes). Reporting it as fixed would have been wrong; the real bug is the blackout, not the overwrite.

## Tests

`tests/test_memory_curated_load_failure.py` — 8 tests covering per-target tracking, corrupt UTF-8, the absent-vs-unreadable distinction, and the write-after-failed-load case above.

Verified they catch the regression rather than passing vacuously: reverting the guard turns 3 of them red.

Full suite: 6338 passed, 27 skipped. ruff and mypy clean.