### PR TITLE
fix(memory): treat USER.md as a memory source for write notifications

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -108,7 +108,12 @@ def _memory_source_rel_path(path: Path) -> str | None:
         except ValueError:
             continue
 
-        if rel.parts in {("MEMORY.md",), ("memory.md",)}:
+        # USER.md is a curated store in its own right -- CuratedMemoryStore
+        # loads, sanitizes, and injects it alongside MEMORY.md. Editing it
+        # through a filesystem tool must refresh the frozen snapshot the same
+        # way, or the change stays invisible to the model until the session
+        # ends. (It is also a bootstrap file, so it notifies both paths.)
+        if rel.parts in {("MEMORY.md",), ("memory.md",), ("USER.md",)}:
             return rel.as_posix()
         if len(rel.parts) >= 2 and rel.parts[0] == "memory" and rel.suffix == ".md":
             return rel.as_posix()

--- a/tests/test_memory_user_md_notify.py
+++ b/tests/test_memory_user_md_notify.py
@@ -1,0 +1,95 @@
+"""USER.md is a curated memory store, not just a bootstrap file.
+
+``CuratedMemoryStore`` loads, sanitizes, and injects USER.md alongside
+MEMORY.md, and the periodic memory review writes user-profile facts there by
+preference. But the filesystem tools only classified it as a bootstrap file,
+so editing it never refreshed the frozen memory snapshot -- the change stayed
+invisible to the model for the rest of the session.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem
+
+
+def _rel(path: Path) -> str | None:
+    return filesystem._memory_source_rel_path(path)
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(filesystem, "_memory_roots", lambda: [tmp_path.resolve()])
+    return tmp_path
+
+
+def test_user_md_is_a_memory_source(workspace: Path):
+    """The regression this file exists for."""
+    assert _rel(workspace / "USER.md") == "USER.md"
+
+
+def test_memory_md_still_is(workspace: Path):
+    assert _rel(workspace / "MEMORY.md") == "MEMORY.md"
+
+
+def test_legacy_lowercase_memory_md_still_is(workspace: Path):
+    """Kept deliberately: runtime.py still falls back to reading memory.md."""
+    assert _rel(workspace / "memory.md") == "memory.md"
+
+
+def test_daily_notes_still_are(workspace: Path):
+    assert _rel(workspace / "memory" / "2026-07-26.md") == "memory/2026-07-26.md"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("SOUL.md", id="soul"),
+        pytest.param("IDENTITY.md", id="identity"),
+        pytest.param("AGENTS.md", id="agents"),
+        pytest.param("notes.md", id="stray_markdown"),
+        pytest.param("USER.txt", id="wrong_extension"),
+    ],
+)
+def test_other_root_files_are_not_memory_sources(workspace: Path, name: str):
+    """Widening for USER.md must not sweep in every root-level file."""
+    assert _rel(workspace / name) is None
+
+
+def test_paths_outside_the_workspace_are_ignored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(filesystem, "_memory_roots", lambda: [(tmp_path / "ws").resolve()])
+    assert _rel(tmp_path / "elsewhere" / "USER.md") is None
+
+
+@pytest.mark.asyncio
+async def test_writing_user_md_notifies_the_memory_path(tmp_path: Path):
+    """End to end through write_file: the memory callback must fire.
+
+    Without it the snapshot keeps serving the stale USER block, so a profile
+    fact the agent just saved is absent from the very next prompt.
+    """
+    from agentos.tools.types import ToolContext, current_tool_context
+
+    memory_calls: list[tuple[str, str]] = []
+    bootstrap_calls: list[tuple[str, str]] = []
+    token = current_tool_context.set(
+        ToolContext(
+            agent_id="main",
+            workspace_dir=str(tmp_path),
+            memory_source_dir=str(tmp_path),
+            on_memory_source_write=lambda a, p: memory_calls.append((a, p)),
+            on_bootstrap_source_write=lambda a, p: bootstrap_calls.append((a, p)),
+        )
+    )
+    write_file = filesystem.write_file.__wrapped__.__wrapped__  # type: ignore[attr-defined]
+    try:
+        await write_file("USER.md", "Name: Example User\n")
+    finally:
+        current_tool_context.reset(token)
+
+    assert ("main", "USER.md") in memory_calls
+    # Still a bootstrap file too -- both snapshots must be invalidated.
+    assert ("main", "USER.md") in bootstrap_calls


### PR DESCRIPTION
`USER.md` is a curated memory store in its own right. `CuratedMemoryStore` resolves it alongside `MEMORY.md` (`_path_for`), loads it, sanitizes it, and puts it in the frozen snapshot that enters the system prompt. The periodic memory review added in #108 writes user-profile facts there *by preference* — name, timezone, working style — which is the correct target for that kind of fact.

But the filesystem tools classified `USER.md` only as a bootstrap file. Editing it through `write_file` or `patch` fired `on_bootstrap_source_write` and never `on_memory_source_write`, so `refresh_memory_snapshot` did not run and `sync_manager.mark_dirty()` was not called.

## The effect

A stale snapshot, silently. A profile fact written mid-session does not reach the model until the session ends, or until some unrelated memory write happens to trigger a refresh.

The default configuration is the affected one: `memory.source = "workspace"` puts `USER.md` at the workspace root — exactly where the predicate missed it.

## The fix

`USER.md` now matches the memory-source predicate as well. It remains a bootstrap file, so both snapshots are invalidated; the two paths are independent and both are needed.

## Scope

Deliberately limited to the filesystem write-notification predicate, **not** `source_paths.is_memory_source_path`.

That shared predicate also gates what the sync manager indexes and what `memory_get` / `rpc_memory` may read. Widening it would put `USER.md` into the memory index and expose it over RPC — a larger decision than fixing snapshot invalidation, and not required for it. Worth taking separately if wanted.

## Tests

`tests/test_memory_user_md_notify.py` — 11 tests, including negative cases (`SOUL.md`, `IDENTITY.md`, `AGENTS.md`, stray markdown, wrong extension) so the widening does not sweep in every root-level file, plus an end-to-end check through `write_file` asserting both callbacks fire.

Verified they catch the regression: reverting the predicate turns 2 of them red. The pre-existing `test_bootstrap_write_notifications.py` still passes unchanged — its assertions use `in`, so they never pinned the old exclusion.

Full suite: 6341 passed, 27 skipped. ruff and mypy clean.