### PR TITLE
perf(memory): stop reading daily notes that are always discarded

### DIFF
--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -1610,7 +1610,7 @@ class TurnRunner:
         ws = self._resolve_memory_source_dir(agent_id)
         new_snap = MemorySnapshot(
             memory_md=self._load_memory_md(ws),
-            daily_notes=self._load_daily_notes(ws),
+            daily_notes={},  # dropped before injection; see the omit block below
         )
         for key in list(self._memory_snapshots):
             if key[0] == agent_id:
@@ -3832,7 +3832,7 @@ class TurnRunner:
             memory_text = snap.memory_md
             daily = snap.daily_notes
         else:
-            daily = self._load_daily_notes(memory_source_dir)
+            daily = {}
             memory_text = self._load_memory_md(memory_source_dir)
         # The curated store now owns MEMORY.md / USER.md injection via the
         # ``## Memory`` block (usage header + sanitization). Drop the raw
@@ -3867,15 +3867,23 @@ class TurnRunner:
                     memory_text = (
                         f"{memory_text}\n\n{static_block}" if memory_text else static_block
                     )
+        # Daily notes are not auto-injected, and are no longer read from disk
+        # either: every load was immediately discarded here, so the directory
+        # scan and file reads bought nothing.
+        #
+        # `daily_notes_omitted` reports the POLICY, not a count. Deriving it
+        # from "how many did we drop" would flip it to False now that nothing
+        # is loaded, and the decision log would go quiet about a policy that
+        # is still in force -- the reader could no longer tell "notes were
+        # suppressed" from "this workspace has no notes". The count is 0
+        # because none were read, which is what the separate counter says.
         daily_notes_count_before_omit = len(daily)
-        daily_notes_omitted = daily_notes_count_before_omit > 0
-        if daily_notes_omitted:
-            daily = {}
+        daily_notes_omitted = True
+        daily = {}
         if prompt_metadata is not None:
             prompt_metadata["daily_notes_omitted"] = daily_notes_omitted
             prompt_metadata["daily_notes_count_before_omit"] = daily_notes_count_before_omit
-            if daily_notes_omitted:
-                prompt_metadata["daily_notes_policy_reason"] = "auto_injection_disabled"
+            prompt_metadata["daily_notes_policy_reason"] = "auto_injection_disabled"
             if fresh_user_session:
                 prompt_metadata["daily_notes_fresh_session_omitted"] = True
             prompt_metadata["memory_md_present"] = memory_text is not None
@@ -4153,16 +4161,6 @@ class TurnRunner:
             joined_len = candidate_len
 
         return "\n\n".join(included)
-
-    def _load_daily_notes(self, workspace_dir: Any) -> dict[str, str]:
-        from agentos.identity.workspace import load_daily_notes
-
-        memory_cfg = getattr(self._config, "memory", None)
-        return load_daily_notes(
-            str(workspace_dir),
-            per_note_max_chars=getattr(memory_cfg, "daily_note_max_chars", 4000),
-            total_max_chars=getattr(memory_cfg, "daily_notes_total_max_chars", 8000),
-        )
 
     async def _run_pipeline(
         self,

--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -535,7 +535,11 @@ class _TurnRunnerMemorySnapshotAdapter(MemorySnapshotPort):
             else:
                 runner._memory_snapshots[snap_key] = MemorySnapshot(
                     memory_md=memory_md,
-                    daily_notes=runner._load_daily_notes(workspace),
+                    # Daily notes are dropped unconditionally before injection
+                    # (see the omit block in runtime.py). Reading them here
+                    # only to discard them there cost a directory scan plus
+                    # file reads on every session start.
+                    daily_notes={},
                 )
         return _MemorySnapshotResult(
             sync_manager=sync_manager,
@@ -815,7 +819,7 @@ class _TurnRunnerMemorySnapshotRefreshAdapter(MemorySnapshotRefreshPort):
         if private_memory_allowed:
             runner._memory_snapshots[(agent_id, session_key)] = MemorySnapshot(
                 memory_md=runner._load_memory_md(workspace),
-                daily_notes=runner._load_daily_notes(workspace),
+                daily_notes={},  # dropped before injection; see runtime.py
             )
 
 

--- a/tests/test_engine/test_bootstrap_snapshot_invalidation.py
+++ b/tests/test_engine/test_bootstrap_snapshot_invalidation.py
@@ -145,7 +145,6 @@ def test_fresh_user_session_omits_live_daily_notes_from_dynamic_context(tmp_path
             tools=SimpleNamespace(profile=None),
         ),
     )
-    runner._load_daily_notes = lambda _workspace_dir: {"2026-05-31.md": "stale Labubu context"}
     metadata: dict[str, object] = {}
 
     assembled = runner._assemble_prompt(
@@ -160,7 +159,9 @@ def test_fresh_user_session_omits_live_daily_notes_from_dynamic_context(tmp_path
     assert "## Recent Notes" not in dynamic
     assert "stale Labubu context" not in dynamic
     assert metadata["daily_notes_fresh_session_omitted"] is True
-    assert metadata["daily_notes_count_before_omit"] == 1
+    # 0, not 1: daily notes are no longer read from disk at all, so nothing
+    # is loaded to be counted. The omit flag still reports the policy.
+    assert metadata["daily_notes_count_before_omit"] == 0
 
 
 def test_fresh_user_session_omits_snapshot_daily_notes_from_dynamic_context(tmp_path) -> None:
@@ -192,6 +193,9 @@ def test_fresh_user_session_omits_snapshot_daily_notes_from_dynamic_context(tmp_
     assert "snapshot daily context" not in dynamic
     assert "stable memory" in full_prompt
     assert metadata["daily_notes_fresh_session_omitted"] is True
+    # 1 here, unlike the load-path tests below: this snapshot was populated
+    # directly, so the notes exist in memory and must still be dropped. A
+    # snapshot captured before this change can still carry them.
     assert metadata["daily_notes_count_before_omit"] == 1
 
 
@@ -205,7 +209,6 @@ def test_non_fresh_user_session_omits_live_daily_notes_from_dynamic_context(tmp_
             tools=SimpleNamespace(profile=None),
         ),
     )
-    runner._load_daily_notes = lambda _workspace_dir: {"2026-05-31.md": "daily context"}
     metadata: dict[str, object] = {}
 
     assembled = runner._assemble_prompt(
@@ -220,7 +223,9 @@ def test_non_fresh_user_session_omits_live_daily_notes_from_dynamic_context(tmp_
     assert "daily context" not in dynamic
     assert metadata["daily_notes_omitted"] is True
     assert metadata["daily_notes_policy_reason"] == "auto_injection_disabled"
-    assert metadata["daily_notes_count_before_omit"] == 1
+    # 0, not 1: daily notes are no longer read from disk at all, so nothing
+    # is loaded to be counted. The omit flag still reports the policy.
+    assert metadata["daily_notes_count_before_omit"] == 0
 
 
 def test_daily_notes_auto_omit_preserves_memory_md(tmp_path) -> None:
@@ -234,7 +239,6 @@ def test_daily_notes_auto_omit_preserves_memory_md(tmp_path) -> None:
             tools=SimpleNamespace(profile=None),
         ),
     )
-    runner._load_daily_notes = lambda _workspace_dir: {"2026-05-31.md": "daily context"}
     metadata: dict[str, object] = {}
 
     assembled = runner._assemble_prompt(
@@ -350,7 +354,4 @@ def test_full_and_unattended_bootstrap_snapshots_use_distinct_keys(tmp_path) -> 
     full_snapshot = runner._bootstrap_snapshots[("main", session_key, "full")]
     unattended_snapshot = runner._bootstrap_snapshots[("main", session_key, "unattended")]
     assert "BOOTSTRAP.md" in full_snapshot.workspace_files
-    assert (
-        "BOOTSTRAP.md"
-        not in unattended_snapshot.workspace_files
-    )
+    assert "BOOTSTRAP.md" not in unattended_snapshot.workspace_files

--- a/tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py
+++ b/tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py
@@ -321,14 +321,10 @@ def _patch_memory_helpers(runner):
     def _load_memory_md(self, workspace_dir, max_chars=None):  # noqa: ARG001, ARG002
         return None
 
-    def _load_daily_notes(self, workspace_dir):  # noqa: ARG001, ARG002
-        return {}
-
     runner._resolve_memory_source_dir = _resolve_memory_source_dir.__get__(
         runner, TurnRunner
     )
     runner._load_memory_md = _load_memory_md.__get__(runner, TurnRunner)
-    runner._load_daily_notes = _load_daily_notes.__get__(runner, TurnRunner)
 
 
 def _patch_post_slice_probe(runner):


### PR DESCRIPTION
Daily notes are not auto-injected — `runtime.py` drops them unconditionally right before assembling the prompt. But every snapshot build still loaded them first: a directory scan plus up to `daily_notes_total_max_chars` of file reads (8 KB default), on session start, after every compaction, and on every memory write that triggers a snapshot refresh. The result was thrown away each time.

## The change

The three load sites pass `{}` directly.

`_load_daily_notes` had no remaining callers afterwards, so it is removed rather than left as a method that looks wired but is not — the same shape as the uncalled helpers fixed in #106 and #108. `identity.workspace.load_daily_notes` is untouched.

## Telemetry stays honest

`daily_notes_omitted` now reports the **policy** rather than being derived from how many notes were dropped.

Deriving it would flip it to `False` now that nothing is read, and the decision log would go quiet about a policy that is still in force — a reader could no longer distinguish *"notes were suppressed"* from *"this workspace has no notes"*. The count reports `0`, which is accurate: none were read.

This is the same reasoning as #109 — a system that silently stops reporting is worse than one that reports a boring truth.

## On the test expectations

Two load-path tests move from `count == 1` to `count == 0`, because the loader they mocked no longer runs.

One test keeps asserting `count == 1`, and should: it populates a snapshot **directly**, so the notes exist in memory and must still be dropped. A snapshot captured before this change can still carry them, and that path has to keep working.

Full suite: 6341 passed, 27 skipped. ruff and mypy clean.

## Not included

Removing the `## Recent Notes` render block and the two config keys (`daily_note_max_chars`, `daily_notes_total_max_chars`). Those are reachable if daily-note injection is ever re-enabled, and deleting them is a product decision rather than a dead-code cleanup.