### PR TITLE
fix(memory): write turn captures atomically

### DIFF
--- a/src/agentos/memory/archive.py
+++ b/src/agentos/memory/archive.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from agentos.memory.atomic_write import fsync_directory
+
 
 @dataclass(frozen=True)
 class RawArchiveWriteResult:
@@ -31,24 +33,6 @@ def _validate_sha256_hex(value: str) -> str:
     if not re.fullmatch(r"[0-9a-fA-F]{64}", normalized):
         raise ValueError("content_hash must be a 64-character SHA-256 hex string")
     return normalized.lower()
-
-
-def _fsync_directory(path: Path) -> None:
-    flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        flags |= os.O_DIRECTORY
-
-    try:
-        fd = os.open(path, flags)
-    except OSError:
-        return
-
-    try:
-        os.fsync(fd)
-    except OSError:
-        return
-    finally:
-        os.close(fd)
 
 
 def raw_fallback_relative_path(
@@ -106,7 +90,7 @@ def write_raw_fallback_archive(
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp_name, target)
-        _fsync_directory(target.parent)
+        fsync_directory(target.parent)
     except Exception:
         try:
             os.unlink(tmp_name)

--- a/src/agentos/memory/atomic_write.py
+++ b/src/agentos/memory/atomic_write.py
@@ -1,0 +1,70 @@
+"""Durable file writes for memory state.
+
+``Path.write_text`` opens with ``"w"``, which truncates the file *before* the
+new content is written. If the process dies in that window -- SIGKILL, OOM,
+container stop, power loss -- the old content is already gone and the new
+content never landed. For a file that is rewritten wholesale on every turn,
+that window is hit on every turn.
+
+Writing to a temporary file in the same directory and renaming it into place
+removes the window: the rename is atomic, so a reader sees either the old
+file or the new one, never a truncated one.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def fsync_directory(path: Path) -> None:
+    """Flush *path*'s directory entry so a rename survives a power loss.
+
+    Best-effort: a filesystem that refuses the open or the fsync (some
+    network mounts) is not a reason to fail the write that already landed.
+    """
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return
+
+    try:
+        os.fsync(fd)
+    except OSError:
+        return
+    finally:
+        os.close(fd)
+
+
+def atomic_write_text(target: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Write *content* to *target* so the file is never observed truncated.
+
+    The temporary file is created in the target's own directory, because
+    ``os.replace`` is only atomic within a single filesystem. On failure the
+    temporary file is removed and the original is left exactly as it was.
+    """
+    encoded = content.encode(encoding)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:  # pragma: no cover - already gone
+            pass
+        raise
+    fsync_directory(target.parent)

--- a/src/agentos/memory/turn_capture.py
+++ b/src/agentos/memory/turn_capture.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from agentos.engine.steps.inject_time_prefix import TIME_PREFIX_RE
+from agentos.memory.atomic_write import atomic_write_text
 
 _SESSION_SLUG_RE = re.compile(r"[^a-z0-9]+")
 _TRUNCATION_SUFFIX = "\n... (truncated)"
@@ -176,9 +177,7 @@ class TurnCaptureService:
 
             previous_content = abs_path.read_text(encoding="utf-8") if abs_path.exists() else None
             existing = (
-                previous_content
-                if previous_content is not None
-                else self._file_header(session_key)
+                previous_content if previous_content is not None else self._file_header(session_key)
             )
             new_content = existing.rstrip() + "\n\n" + entry + "\n"
             if (
@@ -214,9 +213,7 @@ class TurnCaptureService:
             else ""
         )
         cleaned_assistant = (
-            _truncate(assistant_text.strip(), max_chars)
-            if self._capture_assistant()
-            else ""
+            _truncate(assistant_text.strip(), max_chars) if self._capture_assistant() else ""
         )
         if not cleaned_user and not cleaned_assistant:
             return None
@@ -236,10 +233,17 @@ class TurnCaptureService:
         abs_path.parent.mkdir(parents=True, exist_ok=True)
         had_existing = previous_content is not None
         try:
-            abs_path.write_text(new_content, encoding="utf-8")
+            # The whole day file is rewritten on every capture, so a plain
+            # write_text would truncate it before the new content lands --
+            # a crash in that window loses the entire day's captures for this
+            # session. Rename-into-place has no such window.
+            atomic_write_text(abs_path, new_content)
         except Exception:
+            # Reached only when the write itself failed, in which case the
+            # original is still intact; this restores the pre-roll state for
+            # the rollover case, where the target is a fresh part file.
             if had_existing and previous_content is not None:
-                abs_path.write_text(previous_content, encoding="utf-8")
+                atomic_write_text(abs_path, previous_content)
             elif abs_path.exists():
                 abs_path.unlink()
             raise

--- a/tests/test_memory_atomic_write.py
+++ b/tests/test_memory_atomic_write.py
@@ -1,0 +1,135 @@
+"""Memory state files must never be observed truncated.
+
+``Path.write_text`` opens with ``"w"``, which truncates before the new
+content lands. For turn capture that window is hit on every turn, and the
+file being rewritten is the whole day's captures for a session -- so a crash
+in the window costs the day, not the turn.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.memory.atomic_write import atomic_write_text
+from agentos.memory.turn_capture import TurnCaptureService
+
+
+def test_content_lands(tmp_path: Path):
+    target = tmp_path / "note.md"
+    atomic_write_text(target, "hello")
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+def test_overwrite_replaces_content(tmp_path: Path):
+    target = tmp_path / "note.md"
+    target.write_text("old and much longer", encoding="utf-8")
+    atomic_write_text(target, "new")
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_the_original_is_never_truncated_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The decisive property: a failure mid-write leaves the old file intact.
+
+    A plain write_text would have already emptied it by this point.
+    """
+    target = tmp_path / "note.md"
+    target.write_text("important existing content", encoding="utf-8")
+
+    def die(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", die)
+    with pytest.raises(OSError):
+        atomic_write_text(target, "replacement")
+
+    assert target.read_text(encoding="utf-8") == "important existing content"
+
+
+def test_failed_write_leaves_no_temp_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    target = tmp_path / "note.md"
+    target.write_text("existing", encoding="utf-8")
+
+    monkeypatch.setattr(os, "replace", lambda *_a, **_k: (_ for _ in ()).throw(OSError("nope")))
+    with pytest.raises(OSError):
+        atomic_write_text(target, "replacement")
+
+    assert [p.name for p in tmp_path.iterdir()] == ["note.md"]
+
+
+def test_parent_directories_are_created(tmp_path: Path):
+    target = tmp_path / "deep" / "nested" / "note.md"
+    atomic_write_text(target, "content")
+    assert target.read_text(encoding="utf-8") == "content"
+
+
+def test_unicode_survives_the_round_trip(tmp_path: Path):
+    target = tmp_path / "note.md"
+    atomic_write_text(target, "§ tiếng Việt 中文 🎯")
+    assert target.read_text(encoding="utf-8") == "§ tiếng Việt 中文 🎯"
+
+
+# -- turn capture uses it -------------------------------------------------
+
+
+def _service(tmp_path: Path) -> TurnCaptureService:
+    return TurnCaptureService(
+        workspace_dir=tmp_path,
+        turns_dir=tmp_path / "turns",
+        memory_config=SimpleNamespace(
+            auto_capture_enabled=True,
+            capture_mode="turn_pair",
+            capture_user=True,
+            capture_assistant=False,
+            capture_max_chars=2000,
+            capture_roll_max_chars=50_000,
+        ),
+    )
+
+
+async def test_capture_writes_the_turn(tmp_path: Path):
+    rel = await _service(tmp_path).capture_turn(
+        session_key="s1",
+        session_id="id1",
+        user_text="first message",
+        assistant_text="",
+        captured_at=datetime(2026, 7, 26, tzinfo=UTC),
+    )
+    assert rel is not None
+    assert "first message" in (tmp_path / rel).read_text(encoding="utf-8")
+
+
+async def test_a_failed_capture_does_not_destroy_the_day(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The whole day file is rewritten each turn; a failure must not empty it."""
+    service = _service(tmp_path)
+    when = datetime(2026, 7, 26, tzinfo=UTC)
+    rel = await service.capture_turn(
+        session_key="s1",
+        session_id="id1",
+        user_text="turn one",
+        assistant_text="",
+        captured_at=when,
+    )
+    assert rel is not None
+    path = tmp_path / rel
+    before = path.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(os, "replace", lambda *_a, **_k: (_ for _ in ()).throw(OSError("io")))
+    with pytest.raises(OSError):
+        await service.capture_turn(
+            session_key="s1",
+            session_id="id1",
+            user_text="turn two",
+            assistant_text="",
+            captured_at=when,
+        )
+    monkeypatch.undo()
+
+    assert path.read_text(encoding="utf-8") == before
+    assert "turn one" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
`TurnCaptureService` rewrote the day file with `Path.write_text`, which opens with `"w"` — truncate first, then write.

The file being rewritten is **the whole day's captures for that session**: it is appended to on every turn and allowed to grow to `capture_roll_max_chars` (50 KB default). So the truncate window is entered on every single turn, and anything that kills the process inside it — SIGKILL, OOM, container stop, power loss — leaves a zero-length file. The day's captures are gone, not just the turn's.

Reproduced: 10,000 chars of captures, truncate-before-write, **0 bytes left**.

## Why the existing rollback does not cover it

```python
try:
    abs_path.write_text(new_content, encoding="utf-8")
except Exception:
    if had_existing and previous_content is not None:
        abs_path.write_text(previous_content, encoding="utf-8")
```

It only fires when `write_text` *raises*, and it recovers with another non-atomic `write_text` that can fail the same way. Process death never reaches the `except` at all — and that is the case that actually loses the file.

## The fix

`archive.py`, in the same package, already did this correctly: mkstemp → fsync → `os.replace` → fsync directory. Rather than copy it, both now share `memory/atomic_write.py`, and `archive.py` drops its private `_fsync_directory` in favour of the shared one.

Rename-into-place has no truncate window: a reader sees either the old file or the new one.

## Tests

`tests/test_memory_atomic_write.py` — 8 tests. The decisive one drives a real capture, fails the rename, and asserts the previous day's content is still there byte-for-byte. Reverting to `write_text` turns it red.

Full suite: 6357 passed, 27 skipped. ruff and mypy clean.

## Not included

The same audit flagged two more write-path issues I am handling separately rather than bundling: `curated_migration.py` writes MEMORY.md non-atomically during the one-time migration, and `TurnCaptureService` has no lock around its read-modify-write (two concurrent turns on one session can drop a capture). Both are real; neither belongs in this diff.