### PR TITLE
fix(memory): stop the degraded list growing once per failed metric

### DIFF
--- a/src/agentos/memory/manager.py
+++ b/src/agentos/memory/manager.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -45,13 +45,19 @@ class MemoryDegradation:
     component: str
     operation: str
     error: str
+    count: int = 1
 
-    def as_dict(self) -> dict[str, str]:
-        return {
+    def as_dict(self) -> dict[str, str | int]:
+        payload: dict[str, str | int] = {
             "component": self.component,
             "operation": self.operation,
             "error": self.error,
         }
+        # Only surfaced once it has actually recurred, so a one-off failure
+        # reads exactly as it did before.
+        if self.count > 1:
+            payload["count"] = self.count
+        return payload
 
 
 # Filenames written by ``_raw_dump_fallback`` historically lived in the canonical
@@ -302,10 +308,25 @@ class MemoryManager:
         operation: str,
         error: Exception,
     ) -> None:
+        # Collapse repeats instead of appending. `status()` records up to five
+        # degradations per call, so a broken store under a health poller would
+        # otherwise grow this list by five entries every poll -- and `status()`
+        # serializes the whole list into every response. Within a day of 30s
+        # polling that is ~14k entries, and the operator reads thousands of
+        # copies of one error rather than "this component is down".
+        message = str(error)
+        for index, existing in enumerate(self.degraded):
+            if (
+                existing.component == component
+                and existing.operation == operation
+                and existing.error == message
+            ):
+                self.degraded[index] = replace(existing, count=existing.count + 1)
+                return
         degradation = MemoryDegradation(
             component=component,
             operation=operation,
-            error=str(error),
+            error=message,
         )
         self.degraded.append(degradation)
         log.warning(

--- a/tests/test_memory_degraded_bounded.py
+++ b/tests/test_memory_degraded_bounded.py
@@ -1,0 +1,102 @@
+"""`MemoryManager.degraded` must not grow once per failed metric.
+
+`status()` records up to five degradations per call and serializes the whole
+list into its response. Under a health poller against a broken store that
+means the list -- and every status payload -- grows without bound, and the
+operator ends up reading thousands of copies of one error instead of "this
+component is down".
+"""
+
+from __future__ import annotations
+
+from agentos.memory.manager import MemoryDegradation, MemoryManager
+
+
+def _manager() -> MemoryManager:
+    """A manager with only the fields the degradation path touches."""
+    manager = object.__new__(MemoryManager)
+    object.__setattr__(manager, "agent_id", "main")
+    object.__setattr__(manager, "degraded", [])
+    return manager
+
+
+def _record(
+    manager: MemoryManager, *, component="store", operation="file_count", error="db locked"
+):
+    manager._record_degradation(component=component, operation=operation, error=RuntimeError(error))
+
+
+def test_a_single_failure_is_recorded():
+    m = _manager()
+    _record(m)
+    assert len(m.degraded) == 1
+    assert m.degraded[0].as_dict() == {
+        "component": "store",
+        "operation": "file_count",
+        "error": "db locked",
+    }
+
+
+def test_repeats_collapse_instead_of_appending():
+    """The regression this file exists for."""
+    m = _manager()
+    for _ in range(500):
+        _record(m)
+    assert len(m.degraded) == 1
+
+
+def test_a_repeat_reports_how_many_times_it_happened():
+    """Collapsing must not hide that the failure is ongoing."""
+    m = _manager()
+    for _ in range(7):
+        _record(m)
+    assert m.degraded[0].as_dict()["count"] == 7
+
+
+def test_a_one_off_failure_carries_no_count():
+    """Unchanged shape for the common case, so existing readers still work."""
+    m = _manager()
+    _record(m)
+    assert "count" not in m.degraded[0].as_dict()
+
+
+def test_distinct_failures_stay_distinct():
+    """Collapsing must not merge unrelated problems into one entry."""
+    m = _manager()
+    _record(m, component="store", operation="file_count")
+    _record(m, component="store", operation="chunk_count")
+    _record(m, component="curated", operation="status")
+    assert len(m.degraded) == 3
+
+
+def test_the_same_operation_failing_differently_stays_distinct():
+    """A changed error message is new information, not a repeat."""
+    m = _manager()
+    _record(m, error="db locked")
+    _record(m, error="disk full")
+    assert len(m.degraded) == 2
+
+
+def test_a_full_status_poll_cycle_stays_bounded():
+    """Five metrics per poll is the real shape of the growth."""
+    m = _manager()
+    metrics = [
+        ("store", "file_count"),
+        ("store", "chunk_count"),
+        ("store", "total_size"),
+        ("store", "source_counts"),
+        ("curated", "status"),
+    ]
+    for _ in range(2880):  # a day of 30s polls
+        for component, operation in metrics:
+            _record(m, component=component, operation=operation)
+
+    assert len(m.degraded) == len(metrics)
+    assert all(d.as_dict()["count"] == 2880 for d in m.degraded)
+
+
+def test_degradation_equality_ignores_nothing_unexpected():
+    """count participates in the dataclass, so replace() produces a new value."""
+    a = MemoryDegradation(component="store", operation="x", error="e")
+    assert a.count == 1
+    assert a.as_dict() == {"component": "store", "operation": "x", "error": "e"}


### PR DESCRIPTION
`MemoryManager.degraded` only ever grew — `_record_degradation` appends, nothing evicts or dedupes.

That compounds badly because `status()` both **writes** to the list (up to five degradations per call: four store metrics plus curated) and **serializes the whole list** into its own response.

Under a health poller against a broken store: every poll adds five entries, and every poll returns all of them. A day of 30s polling is ~14,400 entries in one list, re-serialized into each status payload. The operator ends up reading thousands of copies of one error instead of *"this component is down"*, and the payload keeps getting more expensive to produce.

## The fix

Repeats collapse on `(component, operation, error)` with a count.

- A **one-off failure serializes exactly as before** — `count` only appears once it exceeds 1 — so existing readers are unaffected.
- A **changed error message stays a separate entry**, since a different failure usually is new information rather than a repeat.
- Collapsing does not hide an ongoing problem: the count is what tells the operator it is still happening.

This is the unbounded-collection shape fixed for the nudge counter in #108, in a collection that fills far faster (per status poll, not per session) and that is sent to clients.

## Tests

`tests/test_memory_degraded_bounded.py` — 8 tests, including a full day-of-polling cycle (2,880 polls × 5 metrics) asserting the list stays at five entries with `count == 2880` on each.

Verified they catch the regression: reverting the dedupe turns 3 of them red.

Full suite: 6357 passed, 27 skipped. ruff and mypy clean.