### PR TITLE
fix(memory): make the MEMORY.md migration non-destructive

### DIFF
--- a/src/agentos/memory/curated_migration.py
+++ b/src/agentos/memory/curated_migration.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import structlog
 
+from agentos.memory.atomic_write import atomic_write_text
 from agentos.memory.curated import ENTRY_DELIMITER
 
 log = structlog.get_logger(__name__)
@@ -159,7 +160,13 @@ def migrate_freeform_memory_md(
     if overflow:
         _append_overflow(memory_dir, overflow, today or date.today().isoformat())
 
-    memory_path.write_text(ENTRY_DELIMITER.join(kept), encoding="utf-8")
+    # Atomic: this is the one moment MEMORY.md is restructured, and `kept` --
+    # the ~80% the user is meant to retain -- exists nowhere else. The overflow
+    # archive written just above holds only the discarded remainder. A plain
+    # write_text truncates first, so a crash mid-write would destroy the
+    # user's primary memory file with nothing to recover it from, and the
+    # migration is one-time and content-idempotent, so no retry brings it back.
+    atomic_write_text(memory_path, ENTRY_DELIMITER.join(kept))
     log.info(
         "memory_md_migrated",
         kept=len(kept),
@@ -178,6 +185,13 @@ def _append_overflow(memory_dir: Path, overflow: list[str], today: str) -> None:
     if archive_path.is_file():
         try:
             existing = archive_path.read_text(encoding="utf-8").rstrip() + "\n\n"
-        except OSError:
-            existing = ""
-    archive_path.write_text(existing + header + body, encoding="utf-8")
+        except OSError as exc:
+            # Unreadable is not empty. Falling back to "" here would rewrite
+            # the archive with only this batch, discarding every previously
+            # migrated overflow entry -- the same class of loss guarded
+            # against on the curated write paths. Refuse instead: the caller
+            # has not yet touched MEMORY.md, so nothing is lost by stopping.
+            raise OSError(
+                f"refusing to overwrite unreadable overflow archive {archive_path}"
+            ) from exc
+    atomic_write_text(archive_path, existing + header + body)

--- a/tests/test_memory_migration_durability.py
+++ b/tests/test_memory_migration_durability.py
@@ -1,0 +1,129 @@
+"""The one-time MEMORY.md migration must not be able to destroy the file.
+
+The migration is the single moment MEMORY.md is restructured, and the kept
+entries -- the ~80% the user retains -- exist nowhere else at that point: the
+overflow archive holds only the discarded remainder. It is also one-time and
+content-idempotent, so a failure that truncates the file has no retry that
+brings it back.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from agentos.memory.curated import ENTRY_DELIMITER
+from agentos.memory.curated_migration import migrate_freeform_memory_md
+
+_FREEFORM = """# Notes
+
+- prefers concise answers
+- uses uv and ruff
+
+Some longer paragraph worth keeping across sessions.
+"""
+
+
+def test_migration_still_works(tmp_path: Path):
+    (tmp_path / "MEMORY.md").write_text(_FREEFORM, encoding="utf-8")
+
+    assert migrate_freeform_memory_md(tmp_path, 4000, today="2026-07-26") is True
+
+    text = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+    assert ENTRY_DELIMITER in text
+    assert "prefers concise answers" in text
+
+
+def test_a_failed_write_leaves_the_original_intact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The decisive case: crash-equivalent failure must not truncate MEMORY.md.
+
+    A plain write_text would already have emptied it before failing.
+    """
+    path = tmp_path / "MEMORY.md"
+    path.write_text(_FREEFORM, encoding="utf-8")
+
+    monkeypatch.setattr(
+        os, "replace", lambda *_a, **_k: (_ for _ in ()).throw(OSError(errno.EIO, "io"))
+    )
+    with pytest.raises(OSError):
+        migrate_freeform_memory_md(tmp_path, 4000, today="2026-07-26")
+    monkeypatch.undo()
+
+    assert path.read_text(encoding="utf-8") == _FREEFORM
+
+
+def test_a_failed_write_leaves_no_temp_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    path = tmp_path / "MEMORY.md"
+    path.write_text(_FREEFORM, encoding="utf-8")
+
+    monkeypatch.setattr(
+        os, "replace", lambda *_a, **_k: (_ for _ in ()).throw(OSError(errno.EIO, "io"))
+    )
+    with pytest.raises(OSError):
+        migrate_freeform_memory_md(tmp_path, 4000, today="2026-07-26")
+    monkeypatch.undo()
+
+    assert [p.name for p in tmp_path.iterdir() if p.is_file()] == ["MEMORY.md"]
+
+
+# -- overflow archive ------------------------------------------------------
+
+
+def _overflow_workspace(tmp_path: Path) -> Path:
+    """A file large enough that migration must archive part of it."""
+    entries = "\n\n".join(f"- durable fact number {i} worth keeping" for i in range(60))
+    (tmp_path / "MEMORY.md").write_text(f"# Notes\n\n{entries}\n", encoding="utf-8")
+    return tmp_path / "memory" / "archive" / "memory-overflow.md"
+
+
+def test_overflow_is_archived(tmp_path: Path):
+    archive = _overflow_workspace(tmp_path)
+    assert migrate_freeform_memory_md(tmp_path, 500, today="2026-07-26") is True
+    assert archive.is_file()
+    assert "durable fact number" in archive.read_text(encoding="utf-8")
+
+
+def test_an_unreadable_archive_aborts_rather_than_overwriting_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Unreadable is not empty.
+
+    Falling back to "" would rewrite the archive with only this batch,
+    discarding every overflow entry migrated previously.
+    """
+    archive = _overflow_workspace(tmp_path)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.write_text("## Migrated earlier\n\nan older overflow entry\n", encoding="utf-8")
+    before = archive.read_text(encoding="utf-8")
+    memory_before = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+
+    real_read = Path.read_text
+
+    def blocked(self: Path, *a, **k):
+        if self.name == "memory-overflow.md":
+            raise OSError(errno.EACCES, "locked")
+        return real_read(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", blocked)
+    with pytest.raises(OSError):
+        migrate_freeform_memory_md(tmp_path, 500, today="2026-07-26")
+    monkeypatch.undo()
+
+    assert archive.read_text(encoding="utf-8") == before
+    # MEMORY.md is written after the archive, so aborting costs nothing.
+    assert (tmp_path / "MEMORY.md").read_text(encoding="utf-8") == memory_before
+
+
+def test_a_readable_archive_is_appended_to_not_replaced(tmp_path: Path):
+    archive = _overflow_workspace(tmp_path)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.write_text("## Migrated earlier\n\nan older overflow entry\n", encoding="utf-8")
+
+    assert migrate_freeform_memory_md(tmp_path, 500, today="2026-07-26") is True
+
+    text = archive.read_text(encoding="utf-8")
+    assert "an older overflow entry" in text
+    assert "durable fact number" in text


### PR DESCRIPTION
Two write-path defects in the one-time free-form → curated migration.

## MEMORY.md was rewritten non-atomically

`memory_path.write_text(...)` truncates before the new content lands, and the **ordering makes it worse than a generic non-atomic write**:

```python
if overflow:
    _append_overflow(...)          # discarded 20% is archived first
memory_path.write_text(...)        # then MEMORY.md is overwritten
```

A crash during that write destroys MEMORY.md while `kept` — the ~80% the user is meant to *retain* — has never been written anywhere else. The archive holds only the remainder that was being thrown away.

And there is no second chance: the migration is one-time and content-idempotent, so nothing re-runs to rebuild it. This is the single moment the file is restructured.

Now routed through `atomic_write_text` (added in #112).

## The overflow archive treated unreadable as empty

```python
try:
    existing = archive_path.read_text(...)
except OSError:
    existing = ""                  # then the archive is rewritten with only this batch
```

A locked or unreadable archive silently drops **every overflow entry migrated previously**. Same class of loss guarded against on the curated write paths in #106 and on the read path in #109 — this was the remaining instance.

It now refuses. Two things make aborting the right response rather than a new failure mode:

- MEMORY.md is written *after* the archive, so nothing has been touched yet when we stop.
- The caller already wraps the migration in `except OSError: pass`, so a refusal means "skip migration this boot" and it retries next time — which is exactly what you want while a file is temporarily locked.

## Tests

`tests/test_memory_migration_durability.py` — 6 tests covering both defects, plus the happy paths (migration still migrates, overflow still archives, a readable archive is appended to rather than replaced) so the guards cannot pass by simply disabling migration.

Verified they catch the regressions: reverting either fix turns 3 of them red. The existing `test_memory_curated_migration.py` is unchanged and still passes.

Full suite: 6363 passed, 27 skipped. ruff and mypy clean.