### PR TITLE
test(memory): pin the memory ↔ session import cycle

### DIFF
--- a/src/agentos/session/compaction_lifecycle.py
+++ b/src/agentos/session/compaction_lifecycle.py
@@ -466,6 +466,10 @@ def compaction_memory_status(
 
 
 def pre_compaction_flush_enabled(config: Any) -> bool:
+    # Function-local on purpose: agentos.memory.flush_status imports from this
+    # module at module scope, so hoisting this to the top of the file closes an
+    # import cycle and raises ImportError on `import agentos.memory.*`. The
+    # cycle is real, not theoretical -- see tests/test_memory_session_import.py.
     from agentos.memory.flush_config import is_session_flush_enabled
 
     if not is_session_flush_enabled():

--- a/tests/test_memory_session_import.py
+++ b/tests/test_memory_session_import.py
@@ -1,0 +1,85 @@
+"""`agentos.memory` and `agentos.session` import each other.
+
+`memory/flush_status.py` imports from `session/compaction_lifecycle` at module
+scope. `compaction_lifecycle.pre_compaction_flush_enabled` imports back from
+`memory/flush_config`, but from *inside the function body* -- which is the only
+reason the cycle does not close at import time.
+
+Nothing marked that as load-bearing, so a routine "move imports to the top"
+cleanup would break `import agentos.memory.*` outright. These tests make the
+constraint executable, and the failure legible when someone trips it.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+_LIFECYCLE = _SRC / "agentos" / "session" / "compaction_lifecycle.py"
+
+
+def _run(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(_SRC.parent),
+    )
+
+
+def test_memory_imports_cleanly():
+    assert _run("import agentos.memory.flush_status").returncode == 0
+
+
+def test_session_imports_cleanly():
+    assert _run("import agentos.session.compaction_lifecycle").returncode == 0
+
+
+def test_either_import_order_works():
+    """Whichever package a caller reaches first must succeed."""
+    assert (
+        _run(
+            "import agentos.session.compaction_lifecycle; import agentos.memory.flush_status"
+        ).returncode
+        == 0
+    )
+    assert (
+        _run(
+            "import agentos.memory.flush_status; import agentos.session.compaction_lifecycle"
+        ).returncode
+        == 0
+    )
+
+
+def test_the_flush_config_import_stays_inside_the_function():
+    """The invariant itself: hoisting this import closes the cycle.
+
+    Asserted structurally rather than by string match, so reformatting or
+    renaming around it does not produce a false pass.
+    """
+    tree = ast.parse(_LIFECYCLE.read_text(encoding="utf-8"))
+
+    module_level_memory_imports = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module
+        and node.module.startswith("agentos.memory")
+    ]
+    assert not module_level_memory_imports, (
+        "agentos.memory imported at module scope in compaction_lifecycle.py -- "
+        "this closes the memory <-> session import cycle. Keep it function-local."
+    )
+
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "pre_compaction_flush_enabled"
+    )
+    assert any(
+        isinstance(node, ast.ImportFrom) and node.module == "agentos.memory.flush_config"
+        for node in ast.walk(function)
+    ), "pre_compaction_flush_enabled no longer imports flush_config locally"


### PR DESCRIPTION
`memory/flush_status.py` imports from `session/compaction_lifecycle` at module scope. `compaction_lifecycle.pre_compaction_flush_enabled` imports back from `memory/flush_config` — but from *inside the function body*, which is the only reason the cycle does not close at import time.

Nothing marked that as load-bearing. A routine "move imports to the top" cleanup would break `import agentos.memory.*` outright.

Verified rather than assumed: hoisting the import raises `ImportError` immediately.

## What this adds

- A comment at the import saying why it is where it is, and pointing at the test.
- Tests that make the constraint executable: both import orders succeed, and a **structural** assertion (AST, not string match, so reformatting cannot produce a false pass) that no `agentos.memory` import sits at module scope and that the local one is still present.

Hoisting turns the last test red with a message naming the cause, so whoever trips it finds out why in the failure rather than in a stack trace.

## Deliberately not restructuring

`flush_config.py` imports only `os`, so the cycle could genuinely be broken by relocating it to a neutral module — a better end state than a documented workaround.

I left that out: it moves a module two packages depend on, which deserves its own change rather than being folded into a comment fix. This PR makes the current state safe to live with in the meantime.

Full suite: 6361 passed, 27 skipped. ruff and mypy clean.