### PR TITLE
fix(compaction): only require a flush receipt when flush can produce one

### DIFF
--- a/src/agentos/session/compaction_lifecycle.py
+++ b/src/agentos/session/compaction_lifecycle.py
@@ -473,6 +473,19 @@ def pre_compaction_flush_enabled(config: Any) -> bool:
 
 
 def pre_compaction_flush_requires_safe_receipt(config: Any) -> bool:
+    """Whether compaction must refuse to run without a safe flush receipt.
+
+    Gated on the flush path being enabled at all, mirroring
+    ``pre_compaction_flush_enabled`` above. Without that gate, "block" demands
+    a receipt that nothing can produce: compaction is refused on every turn,
+    the context window fills, and the only signal is one warning line. The
+    user sees an agent that stops working for no visible reason.
+
+    Requiring a receipt is only meaningful when something is there to write
+    one.
+    """
+    if not pre_compaction_flush_enabled(config):
+        return False
     return flush_compaction_safety_mode(config) == "block"
 
 

--- a/tests/test_compaction_safe_receipt_gate.py
+++ b/tests/test_compaction_safe_receipt_gate.py
@@ -1,0 +1,113 @@
+"""Compaction must not demand a flush receipt nothing can produce.
+
+`flush_compaction_safety_mode = "block"` tells compaction to refuse unless a
+safe flush receipt exists. That is a reasonable demand *while the flush path
+is running*. With flush disabled -- the default, and the end state once the
+flush stack is removed -- no receipt is ever written, so "block" refuses
+compaction on every single turn.
+
+The failure is slow and quiet: the context window fills, the provider
+eventually errors, and the only clue is one warning line. So the requirement
+is gated on flush actually being enabled.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.session.compaction_lifecycle import (
+    compaction_memory_status,
+    pre_compaction_flush_enabled,
+    pre_compaction_flush_requires_safe_receipt,
+)
+
+
+def _config(
+    *,
+    mode: str | None = None,
+    legacy: bool = False,
+    flush_enabled: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        memory=SimpleNamespace(
+            flush_compaction_safety_mode=mode,
+            flush_compaction_requires_safe_receipt=legacy,
+            flush_enabled=flush_enabled,
+        )
+    )
+
+
+def _compaction_allowed(config: SimpleNamespace) -> bool:
+    """Does compaction proceed when no receipt exists (flush service absent)?"""
+    requires = pre_compaction_flush_requires_safe_receipt(config)
+    status = compaction_memory_status(
+        None,
+        deterministic_receipt_safe=not requires,
+        required=True,
+    )
+    return status.allows_destructive_compaction
+
+
+# -- the regression --------------------------------------------------------
+
+
+def test_block_mode_does_not_stall_compaction_when_flush_is_off():
+    """The decisive case: "block" with no flush path must not wedge compaction."""
+    assert _compaction_allowed(_config(mode="block")) is True
+
+
+def test_legacy_requires_safe_receipt_does_not_stall_compaction_when_flush_is_off():
+    """The legacy flag escalates to "block" internally -- same trap."""
+    assert _compaction_allowed(_config(legacy=True)) is True
+
+
+# -- the feature still works where it means something ----------------------
+
+
+def test_block_mode_is_still_enforced_when_flush_is_enabled():
+    """Gating must not quietly disable the safety mode for users relying on it."""
+    config = _config(mode="block", flush_enabled=True)
+    assert pre_compaction_flush_requires_safe_receipt(config) is True
+    assert _compaction_allowed(config) is False
+
+
+def test_the_gate_matches_pre_compaction_flush_enabled():
+    """Both predicates answer the same underlying question, so they agree."""
+    for flush_enabled in (True, False):
+        config = _config(mode="block", flush_enabled=flush_enabled)
+        assert pre_compaction_flush_requires_safe_receipt(config) == (
+            pre_compaction_flush_enabled(config)
+        )
+
+
+# -- everything else is unchanged ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param(None, id="unset"),
+        pytest.param("protect", id="protect"),
+        pytest.param("best_effort", id="best_effort"),
+        pytest.param("off", id="off"),
+    ],
+)
+def test_non_block_modes_never_required_a_receipt(mode: str | None):
+    for flush_enabled in (True, False):
+        config = _config(mode=mode, flush_enabled=flush_enabled)
+        assert pre_compaction_flush_requires_safe_receipt(config) is False
+        assert _compaction_allowed(config) is True
+
+
+def test_a_missing_memory_config_is_safe():
+    assert pre_compaction_flush_requires_safe_receipt(SimpleNamespace(memory=None)) is False
+
+
+def test_kill_switch_also_releases_the_requirement(monkeypatch: pytest.MonkeyPatch):
+    """AGENTOS_SESSION_FLUSH=0 disables flush, so the demand must lift with it."""
+    monkeypatch.setenv("AGENTOS_SESSION_FLUSH", "0")
+    config = _config(mode="block", flush_enabled=True)
+    assert pre_compaction_flush_requires_safe_receipt(config) is False
+    assert _compaction_allowed(config) is True


### PR DESCRIPTION
`flush_compaction_safety_mode = "block"` tells compaction to refuse unless a safe flush receipt exists. That is a reasonable demand *while the flush path is running*.

With flush disabled — **the default** — no receipt is ever written, so `"block"` refuses compaction on **every turn**.

The failure is slow and quiet: the context window fills, the provider eventually errors, and the only signal is one warning line (`compaction skipped, reason=unsafe_flush_receipt`). From the outside the agent just stops working, for no visible reason.

`flush_compaction_requires_safe_receipt = true` reaches the same state — it escalates to `"block"` internally (`compaction_lifecycle.py:262`).

## The fix

The requirement is gated on `pre_compaction_flush_enabled`, mirroring the predicate directly above it in the same file. Requiring a receipt only means something when something is there to write one.

Verified across the matrix rather than assumed:

| Config | Requires receipt | Compaction |
|---|---|---|
| `block`, flush off | `False` | **runs** |
| legacy flag, flush off | `False` | **runs** |
| `block`, flush **on** | `True` | blocks — feature intact |
| default | `False` | runs |

The env kill switch (`AGENTOS_SESSION_FLUSH=0`) releases it too, which is consistent: if flush is off by any means, nothing writes receipts.

## Why now

This is the sharpest edge in front of removing the flush stack. That removal makes `flush_service` permanently `None`, which means `receipt` is permanently `None` — so any user who had set either option would find compaction wedged, silently, after upgrading. Worth fixing on its own regardless of whether the removal lands.

## Tests

`tests/test_compaction_safe_receipt_gate.py` — 10 tests covering the two stall scenarios, the still-enforced case, every non-block mode, a missing memory config, and the kill switch.

Verified they catch the regression: reverting the gate turns 4 of them red.

Full suite: 6333 passed, 27 skipped. ruff and mypy clean.