### PR TITLE
fix(webui): standardize Agent Setup labels

### DIFF
--- a/docs/features/memory.md
+++ b/docs/features/memory.md
@@ -231,7 +231,7 @@ line- or entry-limited:
   lower-priority block after it) is dropped whole rather than sliced
   mid-block — memory is checked first, then user.
 
-All three limits can also be adjusted from the gateway web UI: **Agent setup →
+All three limits can also be adjusted from the gateway web UI: **Agent Setup →
 Guided → Capabilities → Memory settings**. The card exposes friendly labels for
 each budget and warns when the combined limits would exceed the injection
 limit. Changes save through `config.patch` and apply immediately — no gateway
@@ -406,13 +406,13 @@ embedder_base_url = "http://localhost:11434"
 vector_store_path = ""  # empty -> <agent state dir>/mem0
 ```
 
-The same keys are editable from **Agent setup**: Guided mode's **Memory
+The same keys are editable from **Agent Setup**: Guided mode's **Memory
 settings** card (the *Memory provider* selector) and Advanced mode's **Memory**
 section.
 
 **Restart required.** The provider manager is built once at gateway boot, so
 changing `memory.provider.name` — or any `memory.provider.mem0.*` setting —
-only takes effect after a gateway restart. Both Agent setup modes surface a
+only takes effect after a gateway restart. Both Agent Setup modes surface a
 restart hint when you save these keys.
 
 **Privacy.** With the default stack, everything (LLM, embeddings, vector

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -70,21 +70,21 @@ non-root mounts such as `/console/` work without rebuilding. Root, `/api`, and
 | --- | --- |
 | Chat | Run and resume chat sessions, inspect tool activity, publish artifacts, and use manual compact controls. |
 | Overview / Health | See readiness, provider state, memory state, sandbox posture, and recovery hints. |
-| Channels | Inspect configured channel adapter status and jump to Agent setup for configuration changes. |
+| Channels | Inspect configured channel adapter status and jump to Agent Setup for configuration changes. |
 | Skills | Browse installed skills grouped by where they came from, see whether the agent is actually being offered each one, and install more from a hub. |
 | Sessions | Inspect durable conversations and operational state. |
 | Agents | Manage durable agent entries. |
 | Usage | Inspect token and estimated-cost rollups. |
 | Cron | View and manage scheduled runs. |
 | MCP Servers | Add local or remote MCP servers, connect tools live, and complete OAuth authorization. |
-| Agent setup | Configure the agent through Guided capability setup or the complete Advanced Form/YAML editor. |
+| Agent Setup | Configure the agent through Guided capability setup or the complete Advanced Form/YAML editor. |
 | Environment | Set, replace, and remove the environment variables skills and providers read. |
 | Logs | Inspect runtime logs and diagnostics. |
 | Approvals | Respond to sensitive tool-call approval requests. |
 
 ## Agent Setup
 
-Open **Settings > Agent setup**, or go directly to:
+Open **Settings > Agent Setup**, or go directly to:
 
 ```text
 http://127.0.0.1:18791/control/settings
@@ -110,7 +110,7 @@ implemented, not when the snapshot call fails or returns an invalid payload.
 
 Existing bookmarks remain valid: `/control/setup` opens Guided mode and
 `/control/config` opens Advanced mode. Both are compatibility paths into the
-same Agent setup workspace, not separate sidebar destinations. Guided and
+same Agent Setup workspace, not separate sidebar destinations. Guided and
 Advanced stay mounted while you switch between them so in-progress drafts are
 not discarded merely by changing modes.
 
@@ -138,7 +138,7 @@ reason instead of reporting the change as fully live.
 
 An external edit to the active config file is fail-closed. In that state,
 `config.snapshot` returns `revision: null`, `diskDiverged: true`, and
-`writeBlocked: true`; Agent setup shows **Out of sync** and disables both Guided
+`writeBlocked: true`; Agent Setup shows **Out of sync** and disables both Guided
 and Advanced writes. Reload or restart the gateway with that file before
 editing again. Refreshing only the browser cannot reconcile a stale running
 configuration.

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -464,24 +464,24 @@ describe('app shell chrome', () => {
       'Agents',
       'Usage',
       'Cron',
-      'Agent setup',
+      'Agent Setup',
       'Environment',
       'Logs',
       'Approvals',
     ])
   })
 
-  it('keeps legacy setup and config deep links on the single Agent setup nav item', () => {
+  it('keeps legacy setup and config deep links on the single Agent Setup nav item', () => {
     stubMatchMedia(false)
     const setup = renderShellAt('/setup')
-    expect(screen.getByRole('link', { name: 'Agent setup' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Agent Setup' })).toHaveAttribute(
       'aria-current',
       'page',
     )
     setup.unmount()
 
     renderShellAt('/config')
-    expect(screen.getByRole('link', { name: 'Agent setup' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Agent Setup' })).toHaveAttribute(
       'aria-current',
       'page',
     )

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -71,7 +71,7 @@ const NAV_GROUPS: ReadonlyArray<{
   {
     label: 'Settings',
     items: [
-      { path: 'settings', title: 'Agent setup', icon: Settings2 },
+      { path: 'settings', title: 'Agent Setup', icon: Settings2 },
       { path: 'env', title: 'Environment', icon: KeyRound },
       { path: 'logs', title: 'Logs', icon: ScrollText },
       { path: 'approvals', title: 'Approvals', icon: ShieldCheck },

--- a/frontend/src/views/settings/SettingsPage.test.tsx
+++ b/frontend/src/views/settings/SettingsPage.test.tsx
@@ -93,7 +93,7 @@ describe('SettingsPage', () => {
     renderPage('/setup')
 
     expect(screen.getByText('Control · Settings')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Agent settings' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Agent Setup' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Refresh agent state' })).toHaveTextContent('Refresh')
     expect(screen.getByRole('tab', { name: /Guided/ })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByRole('tabpanel', { name: /Guided/ })).toBeVisible()

--- a/frontend/src/views/settings/SettingsPage.tsx
+++ b/frontend/src/views/settings/SettingsPage.tsx
@@ -44,7 +44,7 @@ export function SettingsPage() {
   }
 
   useEffect(() => {
-    document.title = 'Agent Settings - AgentOS Control'
+    document.title = 'Agent Setup - AgentOS Control'
   }, [])
 
   useEffect(() => {

--- a/frontend/src/views/settings/SettingsPage.tsx
+++ b/frontend/src/views/settings/SettingsPage.tsx
@@ -136,7 +136,7 @@ export function SettingsPage() {
       <header className="settings-stage__header">
         <div className="settings-stage__title-block">
           <span className="t-label">Control · Settings</span>
-          <h1 className="t-display">Agent settings</h1>
+          <h1 className="t-display">Agent Setup</h1>
           <p className="settings-stage__subtitle">
             Choose the model, routing, and tools this agent can use.
           </p>

--- a/tests/functional/test_webui_browser_e2e.py
+++ b/tests/functional/test_webui_browser_e2e.py
@@ -245,13 +245,13 @@ def test_react_control_deep_link_loads_public_settings_surface(
             playwright_node_modules,
             target_url=f"http://127.0.0.1:{port}/control/settings",
             expected_base="/control",
-            heading="Agent settings",
+            heading="Agent Setup",
         )
     finally:
         _stop_process(server)
 
     _assert_clean_react_surface(payload)
-    assert payload["title"] == "Agent Settings - AgentOS Control"
+    assert payload["title"] == "Agent Setup - AgentOS Control"
     assert payload["baseHref"] == "/control/static/dist/"
     assert payload["bootstrap"]["status"] == 200
     assert payload["bootstrap"]["body"]["base_path"] == "/control"


### PR DESCRIPTION
Fixes #123

## Summary

- Standardize the settings route, sidebar item, page heading, browser tab title, and documentation on `Agent Setup`.
- Update the frontend and opt-in browser assertions to protect the shared label.
- Rebase the branch onto the current `main` while retaining the new Environment navigation item.

The label lived as separate string literals across the route, navigation, page, browser metadata, tests, and documentation, which allowed its wording and capitalization to drift. Users now see one consistent name throughout the Control UI and supporting docs.

Third-party origin: none.

## Tests

- `.venv/bin/python scripts/build_control_ui.py build` — passed
- `npm --prefix frontend run check` — passed (80 files, 1,588 tests)
- Opt-in Web UI browser E2E — passed (2 tests)
- `.venv/bin/ruff check src tests` — passed
- `.venv/bin/mypy src/agentos --show-error-codes` — passed (576 source files)
- `uv build --wheel` — passed
- Full Python suite — 6,565 passed and 30 skipped; 12 failures and 3 errors are unrelated local checkout/environment failures involving unhydrated Git LFS ONNX pointers, sandbox-only networking/Seatbelt checks, and nested packaging tests that expect `uv` on the global `PATH`
