### PR TITLE
feat(env): find credentials that already exist, and stop promising unavailable actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- A variable reported as missing is now checked against the places a
+  credential may already live. If `gh auth login` has been run, `GITHUB_TOKEN`
+  is reported as available from the GitHub CLI and can be imported with
+  `agentos env import GITHUB_TOKEN` or a button on the Environment screen.
+  Checking runs `gh auth status`, never `gh auth token`, so nothing reads a
+  secret to decide whether one exists; importing only happens when asked for.
+- When a skill's requirements are unmet, `skill_view` appends a setup note
+  saying what is missing and what to do about it — and what to do depends on
+  who is listening. A chat channel is told a secret must not be collected
+  there because it would be stored in the conversation; an unattended run is
+  told to continue and state what does not work; an interactive session gets
+  the actual command. The skill still loads either way.
 - Environment variables can be managed from AgentOS instead of by hand-editing
   `~/.agentos/.env` and restarting. Every surface that could already *detect* a
   missing variable can now *fix* it: a new **Environment** screen in the Web UI
@@ -83,6 +95,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `env_key` is not always a variable name: providers that authenticate by
+  OAuth carry the literal string `"OAuth"`, which put a variable called
+  `OAuth` on the Environment screen that nobody could set.
+- `skill_list` no longer tells the model to call `env_set`, which is hidden by
+  default and so usually not callable — the same dead-end this feature exists
+  to remove.
 - A `.env` value with significant leading or trailing whitespace was written
   unquoted and then silently trimmed when read back. The OpenClaw migration
   carries a command allowlist across, and its entries are prefix patterns:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -369,8 +369,17 @@ agentos env list --category skill      # provider | search | image | audio | mem
 agentos env get OPENAI_API_KEY         # state and description, value masked
 agentos env get OPENAI_API_KEY --reveal
 agentos env set OPENAI_API_KEY --stdin # value read from stdin
+agentos env import GITHUB_TOKEN         # copy from a tool that already has it
 agentos env unset OPENAI_API_KEY
 ```
+
+`agentos env import` covers the case where the credential is not really
+missing. If you have run `gh auth login`, AgentOS can see that the GitHub CLI
+holds a token and copy it in rather than asking you to go find one; `agentos
+env list` marks such variables. Nothing is imported without you asking — a
+token you granted to another tool is not automatically something an agent
+should get. The copy does not follow that tool's own rotation, so re-run the
+import after rotating.
 
 Values are never printed unless you ask for them with `--reveal`, which
 prompts first. Prefer `--stdin` or the interactive prompt over `--value`: a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,22 @@ ordinary credentials such as `AGENTOS_LLM_API_KEY` remain writable.
 The gate applies on *write* only. Values you set in your shell or by editing
 `~/.agentos/.env` by hand keep working exactly as before.
 
+### Credentials that already exist elsewhere
+
+Before telling you a variable is missing, AgentOS checks whether it is already
+obtainable. Today that means the GitHub CLI: if `gh auth login` has been run,
+`GITHUB_TOKEN` and `GH_TOKEN` are reported as available and can be imported
+with one command or one click.
+
+Two properties are deliberate. Checking never reads the credential — it runs
+`gh auth status`, not `gh auth token` — so a listing that mentions a source has
+not touched a secret. And importing only ever happens when you ask for it,
+because a token you granted to another tool becoming available to an agent
+should not be something that happens quietly.
+
+An imported value is a copy. It stays as it was when imported and will not
+follow the source's own rotation; re-import to refresh it.
+
 ### Skill settings are not secrets
 
 A skill may also declare ordinary settings — a directory, a format, a default —

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -247,6 +247,13 @@ skill declared one, a link to where the credential is obtained. A skill listed
 as needing setup can be fixed from its own dialog on the Skills screen too: the
 Missing block offers **Set &lt;VAR&gt;** next to the existing install action.
 
+A variable that is not set but is already obtainable elsewhere shows a **Use
+&lt;source&gt;** button instead of asking you to go find a value — today that is
+the GitHub CLI for `GITHUB_TOKEN` and `GH_TOKEN`, when `gh auth login` has been
+run. Deciding whether to offer it never reads the credential, and importing
+only happens when you click. The imported value is a copy and will not follow
+that tool's own rotation.
+
 Values are masked. **Reveal** asks for confirmation, is rate limited, writes an
 audit line, and hides the value again after thirty seconds. Setting a variable
 applies it to the running gateway, so a skill that was ineligible becomes

--- a/frontend/src/views/env/EnvPage.test.tsx
+++ b/frontend/src/views/env/EnvPage.test.tsx
@@ -337,4 +337,41 @@ describe('EnvPage', () => {
     // Same heading node throughout — the view was never replaced.
     expect(screen.getByRole('heading', { name: /Environment/ })).toBeTruthy()
   })
+
+  it('offers to import a credential that already exists elsewhere', async () => {
+    // The point of the offer: stop telling someone to go find a token they
+    // have already authenticated with somewhere.
+    mockRpc.call.mockImplementation((method: string) => {
+      if (method === 'env.list')
+        return Promise.resolve({
+          ...PAYLOAD,
+          vars: [
+            row({
+              name: 'GITHUB_TOKEN',
+              category: 'skill',
+              owner: 'repo-triage',
+              required: true,
+              missing: true,
+              availableFrom: { id: 'gh_cli', label: 'GitHub CLI' },
+            }),
+          ],
+        })
+      return Promise.resolve({})
+    })
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Use GitHub CLI/ }))
+    await waitFor(() => {
+      expect(mockRpc.call).toHaveBeenCalledWith('env.import', {
+        name: 'GITHUB_TOKEN',
+        sourceId: 'gh_cli',
+      })
+    })
+  })
+
+  it('does not offer an import for a variable that is already set', async () => {
+    renderPage()
+    await screen.findByText('OPENAI_API_KEY')
+    expect(screen.queryByRole('button', { name: /^Use / })).toBeNull()
+  })
 })

--- a/frontend/src/views/env/EnvPage.tsx
+++ b/frontend/src/views/env/EnvPage.tsx
@@ -118,6 +118,19 @@ export function EnvPage() {
     }
   }
 
+  async function importFrom(name: string, sourceId: string) {
+    setBusy(name)
+    try {
+      await rpc.call('env.import', { name, sourceId })
+      await refresh()
+      toast.success(`${name} imported. It will not follow that source's own rotation.`)
+    } catch (error) {
+      toast.error(errorMessage(error))
+    } finally {
+      setBusy(null)
+    }
+  }
+
   async function remove(name: string) {
     setBusy(name)
     try {
@@ -383,6 +396,17 @@ export function EnvPage() {
                           >
                             {row.isSet ? 'Edit' : 'Set'}
                           </Button>
+                          {!row.isSet && row.availableFrom ? (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              disabled={busy === row.name}
+                              onClick={() => void importFrom(row.name, row.availableFrom!.id)}
+                            >
+                              Use {row.availableFrom.label}
+                            </Button>
+                          ) : null}
                           {row.isSet && row.secret ? (
                             <Button
                               type="button"

--- a/frontend/src/views/env/logic.ts
+++ b/frontend/src/views/env/logic.ts
@@ -10,6 +10,12 @@ export const ENV_QUERY_KEY = ['env', 'list'] as const
 
 export type EnvSource = 'process' | 'cwd_file' | 'home_file' | 'unset'
 
+/** A place a credential already lives, offered instead of asking for it. */
+export interface EnvSourceOffer {
+  id: string
+  label: string
+}
+
 export interface EnvVarRow {
   name: string
   isSet: boolean
@@ -25,6 +31,8 @@ export interface EnvVarRow {
   writable: boolean
   restartRequired: boolean
   missing: boolean
+  /** Set only when the variable is unset and a source can supply it. */
+  availableFrom?: EnvSourceOffer | null
 }
 
 export interface EnvListResponse {

--- a/src/agentos/cli/env_cmd.py
+++ b/src/agentos/cli/env_cmd.py
@@ -94,6 +94,16 @@ def _offline_loader() -> Any:
         return None
 
 
+def _available_from(name: str, is_set: bool) -> dict[str, str] | None:
+    """Mirror the gateway's availability field for the offline listing."""
+    if is_set:
+        return None
+    from agentos import credential_sources
+
+    source = credential_sources.available_for(name)
+    return None if source is None else {"id": source.id, "label": source.label}
+
+
 def _offline_payload() -> dict[str, Any]:
     """Produce the same shape as ``env.list`` without a gateway."""
     from agentos import env_catalog, env_store
@@ -119,6 +129,7 @@ def _offline_payload() -> dict[str, Any]:
                 "writable": entry.writable,
                 "restartRequired": spec.restart_required,
                 "missing": spec.required and not entry.is_set,
+                "availableFrom": _available_from(name, entry.is_set),
             }
         )
     return {
@@ -170,6 +181,9 @@ def env_list_cmd(
         status = "set" if row.get("isSet") else ("MISSING" if row.get("missing") else "unset")
         if not row.get("writable"):
             status = f"{status} (locked)"
+        available = row.get("availableFrom")
+        if available:
+            status = f"{status} · in {available.get('label', available.get('id'))}"
         table.add_row(
             str(row.get("name", "")),
             status,
@@ -234,6 +248,66 @@ def env_get_cmd(
         console.print(f"value: {row['masked']}")
     if row.get("url"):
         console.print(f"obtain: {row['url']}")
+
+
+@env_app.command("import")
+def env_import_cmd(
+    name: str = typer.Argument(..., help="Variable name"),
+    source: str = typer.Option("", "--source", help="Source id (default: the usable one)"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Copy a credential in from a tool that already holds it.
+
+    Nothing is imported without this command being run: a token you granted to
+    the GitHub CLI is not automatically something an agent should get.
+    """
+    from agentos import credential_sources
+
+    source_id = source.strip()
+    if not source_id:
+        found = credential_sources.available_for(name, refresh=True)
+        if found is None:
+            candidates = credential_sources.sources_for(name)
+            if not candidates:
+                emit_error(f"No known source supplies {name}.", json_output=json_output)
+            else:
+                emit_error(
+                    f"No usable source for {name}. " + " ".join(c.hint for c in candidates),
+                    json_output=json_output,
+                )
+            raise typer.Exit(1)
+        source_id = found.id
+
+    payload = _run(
+        _try_gateway("env.import", {"name": name, "sourceId": source_id}, json_output=json_output)
+    )
+    applied_live = payload is not None
+    if payload is None:
+        from agentos import env_store
+        from agentos.env_policy import EnvPolicyError
+
+        try:
+            value = credential_sources.read_from(name, source_id)
+            entry = env_store.set_env_var(name, value)
+        except (EnvPolicyError, LookupError, RuntimeError) as exc:
+            emit_error(str(exc), json_output=json_output)
+            raise typer.Exit(2) from exc
+        payload = {"name": entry.name, "isSet": entry.is_set, "importedFrom": source_id}
+
+    if json_output:
+        print_json({**payload, "appliedLive": applied_live})
+        return
+
+    console.print(f"Imported {name} from {source_id}.")
+    console.print(
+        "[yellow]This is a copy — it will not update when that source rotates "
+        "its credential. Re-import to refresh.[/yellow]"
+    )
+    if not applied_live:
+        console.print(
+            "[yellow]No gateway is running — the value applies the next time "
+            "AgentOS starts.[/yellow]"
+        )
 
 
 @env_app.command("set")

--- a/src/agentos/credential_sources.py
+++ b/src/agentos/credential_sources.py
@@ -1,0 +1,187 @@
+"""Places a credential may already exist, other than ``~/.agentos/.env``.
+
+A variable reported as "missing" often is not. The operator has usually
+authenticated somewhere already — ``gh auth login`` for GitHub, a provider's
+own CLI — and asking them to go find a token they have effectively lost is
+worse than looking where it lives.
+
+So before any surface tells someone to produce a credential, it asks here
+whether one is already reachable, and says so:
+
+    GITHUB_TOKEN — not set, but the GitHub CLI is authenticated. Import it?
+
+Two rules keep this from becoming a credential-harvesting mechanism:
+
+**Probing never reads the value.** :meth:`CredentialSource.available` answers
+"could this source supply it", using whatever status check the source offers
+(``gh auth status``, not ``gh auth token``). Listings call it constantly; none
+of those calls touch a secret.
+
+**Importing is always explicit.** Nothing here runs on its own. A value moves
+into AgentOS only when an operator asks for that specific variable, because
+"AgentOS silently took my GitHub token and handed it to an agent" is not a
+surprise anyone should get.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# A probe shells out, and a listing asks about every unset variable it knows.
+# Without a cache that is one subprocess per row per refresh; with it, one per
+# source per minute. Short enough that logging in elsewhere shows up promptly.
+_PROBE_TTL_SECONDS = 60.0
+
+# Any external command here is a status check, not a fetch. Keep it short so a
+# hung or network-bound CLI cannot stall an env listing.
+_PROBE_TIMEOUT_SECONDS = 3.0
+_READ_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class CredentialSource:
+    """A place AgentOS can obtain a credential it does not store itself."""
+
+    id: str
+    label: str
+    #: Variable names this source can supply.
+    provides: tuple[str, ...]
+    #: What the operator would do to make this source usable, shown when it is
+    #: not. Phrased as an instruction, not a diagnosis.
+    hint: str
+    #: Cheap check that must not read the secret.
+    probe: Callable[[], bool] = field(repr=False, default=lambda: False)
+    #: Fetches the value. Only ever called from an explicit import.
+    read: Callable[[], str | None] = field(repr=False, default=lambda: None)
+
+
+@dataclass
+class _ProbeCache:
+    value: bool
+    checked_at: float
+
+
+_probe_cache: dict[str, _ProbeCache] = {}
+
+
+def _run(argv: list[str], *, timeout: float) -> tuple[int, str]:
+    """Run *argv* and return ``(returncode, stdout)``; never raise."""
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.debug("credential_source.command_failed", argv=argv[0], error=str(exc))
+        return 1, ""
+    return completed.returncode, (completed.stdout or "").strip()
+
+
+# ── GitHub CLI ──────────────────────────────────────────────────────────────
+#
+# `gh auth status` reports whether a login exists and prints no token;
+# `gh auth token` prints the token. Keeping them on the probe/read split is the
+# whole point — a listing can say "available" without ever fetching a secret.
+
+
+def _gh_available() -> bool:
+    if shutil.which("gh") is None:
+        return False
+    code, _ = _run(["gh", "auth", "status"], timeout=_PROBE_TIMEOUT_SECONDS)
+    return code == 0
+
+
+def _gh_token() -> str | None:
+    code, out = _run(["gh", "auth", "token"], timeout=_READ_TIMEOUT_SECONDS)
+    if code != 0 or not out:
+        return None
+    return out.splitlines()[0].strip() or None
+
+
+GH_CLI = CredentialSource(
+    id="gh_cli",
+    label="GitHub CLI",
+    provides=("GITHUB_TOKEN", "GH_TOKEN"),
+    hint="Run `gh auth login` to authenticate the GitHub CLI.",
+    probe=_gh_available,
+    read=_gh_token,
+)
+
+_REGISTRY: tuple[CredentialSource, ...] = (GH_CLI,)
+
+
+def registry() -> tuple[CredentialSource, ...]:
+    """Return every known source, whether or not it is currently usable."""
+    return _REGISTRY
+
+
+def sources_for(name: str) -> list[CredentialSource]:
+    """Return the sources that could supply *name*, usable or not."""
+    return [source for source in _REGISTRY if name in source.provides]
+
+
+def is_available(source: CredentialSource, *, refresh: bool = False) -> bool:
+    """Return whether *source* can currently supply a credential.
+
+    Cached: listings ask about many variables at once, and each miss would
+    otherwise spawn a process.
+    """
+    cached = _probe_cache.get(source.id)
+    now = time.monotonic()
+    if not refresh and cached is not None and now - cached.checked_at < _PROBE_TTL_SECONDS:
+        return cached.value
+    try:
+        value = bool(source.probe())
+    except Exception:  # pragma: no cover - a broken probe must not break listings
+        log.debug("credential_source.probe_failed", source=source.id, exc_info=True)
+        value = False
+    _probe_cache[source.id] = _ProbeCache(value=value, checked_at=now)
+    return value
+
+
+def available_for(name: str, *, refresh: bool = False) -> CredentialSource | None:
+    """Return the first usable source for *name*, or ``None``.
+
+    ``None`` covers both "nothing knows about this variable" and "the source
+    that does is not logged in" — a caller that wants to explain the second
+    case should ask :func:`sources_for` for the hint.
+    """
+    for source in sources_for(name):
+        if is_available(source, refresh=refresh):
+            return source
+    return None
+
+
+def read_from(name: str, source_id: str) -> str:
+    """Fetch *name* from *source_id*. Only for an explicit, operator-driven import.
+
+    Raises :class:`LookupError` when the source is unknown or does not supply
+    this variable, and :class:`RuntimeError` when it is not usable right now —
+    the two cases a caller has to tell apart to say anything useful.
+    """
+    source = next((s for s in sources_for(name) if s.id == source_id), None)
+    if source is None:
+        raise LookupError(f"No credential source {source_id!r} supplies {name}")
+    if not is_available(source, refresh=True):
+        raise RuntimeError(f"{source.label} is not usable right now. {source.hint}")
+    value = source.read()
+    if not value:
+        raise RuntimeError(f"{source.label} returned no value for {name}.")
+    log.info("credential_source.read", key=name, source=source.id)
+    return value
+
+
+def reset_probe_cache() -> None:
+    """Clear cached probe results. Test seam, and used after an import."""
+    _probe_cache.clear()

--- a/src/agentos/env_catalog.py
+++ b/src/agentos/env_catalog.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from agentos import env_policy
+from agentos.env_policy import ENV_NAME_RE
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from agentos.skills.loader import SkillLoader
@@ -75,6 +76,21 @@ class EnvVarSpec:
         return self.category in _BOOT_CONSUMED_CATEGORIES
 
 
+def _is_env_var_name(value: str) -> bool:
+    """Return whether *value* is a real variable name rather than a sentinel.
+
+    ``env_key`` is not always one. Providers that authenticate by OAuth carry
+    the literal string ``"OAuth"`` there, meaning "no API key involved" — and
+    taking that at face value put a variable called ``OAuth`` in the catalog,
+    and on the Environment screen, that no one could ever set.
+
+    Requiring upper case is what separates the two: environment variables are
+    conventionally shouted, sentinels are prose. It also holds for any future
+    sentinel without this needing to know its name.
+    """
+    return bool(value) and value.isupper() and ENV_NAME_RE.match(value) is not None
+
+
 def _provider_specs() -> list[EnvVarSpec]:
     """Return catalog entries derived from the onboarding provider families."""
     from agentos.onboarding.audio_specs import list_audio_provider_setup_specs
@@ -107,7 +123,7 @@ def _provider_specs() -> list[EnvVarSpec]:
     for category, kind, specs in families:
         for spec in specs:
             env_key = str(getattr(spec, "env_key", "") or "").strip()
-            if not env_key:
+            if not _is_env_var_name(env_key):
                 continue
             label = str(getattr(spec, "label", "") or getattr(spec, "provider_id", "") or env_key)
             entries.append(

--- a/src/agentos/gateway/rpc_env.py
+++ b/src/agentos/gateway/rpc_env.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import structlog
 
-from agentos import env_catalog, env_policy, env_store
+from agentos import credential_sources, env_catalog, env_policy, env_store
 from agentos.gateway.access import CONTROL_ONLY
 from agentos.gateway.rpc import RpcContext, get_dispatcher
 
@@ -39,6 +39,21 @@ _d = get_dispatcher()
 _REVEAL_MAX_PER_WINDOW = 5
 _REVEAL_WINDOW_SECONDS = 30.0
 _reveal_times: deque[float] = deque(maxlen=_REVEAL_MAX_PER_WINDOW * 4)
+
+
+def _available_from(name: str, is_set: bool) -> dict[str, str] | None:
+    """Return the source that could supply *name*, when one is usable.
+
+    Only offered for a variable that is not set: the point is to stop telling
+    someone to go find a credential they already have authenticated elsewhere.
+    Probing never reads a value.
+    """
+    if is_set:
+        return None
+    source = credential_sources.available_for(name)
+    if source is None:
+        return None
+    return {"id": source.id, "label": source.label}
 
 
 def _entry_payload(name: str, spec: env_catalog.EnvVarSpec) -> dict[str, Any]:
@@ -62,6 +77,10 @@ def _entry_payload(name: str, spec: env_catalog.EnvVarSpec) -> dict[str, Any]:
         # A required variable that is not set is what a UI highlights; an
         # optional one that is unset is merely unconfigured.
         "missing": spec.required and not entry.is_set,
+        # Set when the value is already obtainable from somewhere the operator
+        # authenticated earlier, so a surface can offer to import it instead of
+        # asking them to go find it.
+        "availableFrom": _available_from(name, entry.is_set),
     }
 
 
@@ -138,6 +157,45 @@ async def _handle_env_unset(params: dict | None, ctx: RpcContext) -> dict[str, A
     payload = _entry_payload(name, spec)
     payload["removed"] = removed
     log.info("env.rpc_unset", key=name, removed=removed)
+    return payload
+
+
+@_d.method("env.import", CONTROL_ONLY)
+async def _handle_env_import(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    """Copy a credential in from a source that already holds it.
+
+    Explicit by construction: nothing imports on its own, because "AgentOS took
+    my GitHub token and gave it to an agent" is not a surprise anyone should
+    get. The value goes source → store; it is not returned here.
+    """
+    name = _require_name(params)
+    assert isinstance(params, dict)
+    source_id = str(params.get("sourceId") or "").strip()
+    if not source_id:
+        raise ValueError("params.sourceId is required")
+
+    try:
+        value = credential_sources.read_from(name, source_id)
+    except LookupError as exc:
+        raise ValueError(str(exc)) from exc
+    except RuntimeError as exc:
+        raise ValueError(str(exc)) from exc
+
+    try:
+        env_store.set_env_var(name, value)
+    except env_policy.EnvPolicyError as exc:
+        raise ValueError(str(exc)) from exc
+
+    spec = env_catalog.describe(name, _catalog_for(ctx))
+    payload = _entry_payload(name, spec)
+    payload["importedFrom"] = source_id
+    # A copy does not follow the source's own rotation; say so once, here,
+    # rather than letting it become a mystery 401 later.
+    payload["note"] = (
+        f"Copied from {source_id}. It will not update when that source rotates "
+        "its credential — re-import to refresh."
+    )
+    log.info("env.imported", key=name, source=source_id)
     return payload
 
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -104,7 +104,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | --- | --- |
 | `gateway` | `run`, `start`, `status`, `stop`, `restart` (`--port`, `--bind`, `--listen`, `--config`, `--json`, `--debug`) |
 | `config` | `get [key]` (empty key = show all), `set <dot.key> <value>` |
-| `env` | `list [--missing] [--category]`, `get <NAME> [--reveal]`, `set <NAME> --stdin`, `unset <NAME>` |
+| `env` | `list [--missing] [--category]`, `get <NAME> [--reveal]`, `set <NAME> --stdin`, `import <NAME>`, `unset <NAME>` |
 | `providers` | `list`, `status`, `configure <id> [-m MODEL] [-k API_KEY] [--base-url] [--proxy]` |
 | `models` | `list` |
 | `skills` | `list`, `search`, `view`, `install`, `uninstall`, `update`, `publish`, `tap add/list/remove` |

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -185,6 +185,92 @@ async def _run_install_argv(argv: list[str]) -> tuple[int, str, str, bool]:
     return proc.returncode or 0, _cap_output(stdout), _cap_output(stderr), False
 
 
+def _setup_surface() -> str:
+    """Return where this call is coming from: ``channel``, ``unattended``, or ``interactive``.
+
+    A missing credential is answerable in very different ways depending on who
+    is on the other end, and the tool is the only place that knows.
+    """
+    from agentos.tools.types import CallerKind, InteractionMode, current_tool_context
+
+    ctx = current_tool_context.get()
+    if ctx is None:
+        return "interactive"
+    if ctx.caller_kind is CallerKind.CHANNEL:
+        return "channel"
+    if ctx.interaction_mode is InteractionMode.UNATTENDED:
+        return "unattended"
+    return "interactive"
+
+
+def _import_offer(name: str) -> str:
+    """Return an import suggestion when the credential already exists elsewhere."""
+    try:
+        from agentos import credential_sources
+
+        source = credential_sources.available_for(name)
+    except Exception:  # pragma: no cover - discovery must never break a skill load
+        return ""
+    if source is None:
+        return ""
+    return f"{name} is already available from {source.label} — `agentos env import {name}`."
+
+
+def _skill_setup_note(skill: Any) -> str:
+    """Return a ``[Skill setup note: ...]`` block when a requirement is unmet.
+
+    The skill still loads. An agent that knows what is missing can do the parts
+    that work and say plainly which parts cannot — more useful than refusing to
+    open the skill at all.
+
+    What the note tells it to do depends on who is listening. A secret cannot
+    be collected over Telegram without landing in a chat log, and an unattended
+    cron run has nobody to collect it from; in both cases promising an action
+    would be a lie.
+    """
+    from agentos.skills.eligibility import EligibilityContext, diagnose_eligibility
+
+    report = diagnose_eligibility(skill, EligibilityContext.auto())
+    if report.eligible:
+        return ""
+
+    lines: list[str] = []
+    for declared in report.missing_env_detail:
+        detail = f" — {declared.description}" if declared.description else ""
+        where = f" Obtain one at {declared.url}." if declared.url else ""
+        lines.append(f"{declared.name} is not set{detail}.{where}")
+        offer = _import_offer(declared.name)
+        if offer:
+            lines.append(offer)
+    for binary in report.missing_bins:
+        lines.append(f"{binary} is not installed.")
+    if not lines:
+        # Ineligible for a reason the operator cannot act on here (wrong OS,
+        # explicitly disabled). Saying nothing beats inventing an instruction.
+        return ""
+
+    surface = _setup_surface()
+    if surface == "channel":
+        lines.append(
+            "This is a chat channel, so a secret cannot be entered here — it would "
+            "be stored in the conversation. Ask the operator to set it from the "
+            "AgentOS Environment screen or with `agentos env set <NAME>`."
+        )
+    elif surface == "unattended":
+        lines.append(
+            "This run is unattended, so nothing can be entered now. Continue with "
+            "what works and state clearly which parts do not."
+        )
+    else:
+        lines.append(
+            "Ask the user to set it from the AgentOS Environment screen or with "
+            "`agentos env set <NAME>`, then retry. Continue meanwhile with "
+            "whatever does not depend on it, and say what will not work."
+        )
+    body = " ".join(lines)
+    return f"\n\n[Skill setup note: {body}]"
+
+
 def _skill_config_block(skill: Any) -> str:
     """Return the skill's configured settings as a trailing block, or ``""``.
 
@@ -246,14 +332,13 @@ def create_skill_tools(loader: SkillLoader) -> None:
                 for hint in report.install_hints:
                     lines.append(f"      Install: {hint.command}")
                 for declared in report.missing_env_detail:
-                    # Name what the variable is for and where to get it when
-                    # the manifest says, and point at the tool that can
-                    # actually set it — a hint with no corresponding action
-                    # just hands the work back to the user.
+                    # What the variable is for and where a value comes from.
+                    # How to set it belongs in skill_view, where the agent is
+                    # actually trying to use the skill — a listing of fifty
+                    # skills does not need fifty sets of instructions.
                     detail = f" — {declared.description}" if declared.description else ""
                     source = f" (get one at {declared.url})" if declared.url else ""
                     lines.append(f"      Needs {declared.name}{detail}{source}")
-                    lines.append(f'      Fix: env_set(name="{declared.name}", value=...)')
         return "\n".join(lines)
 
     @tool(
@@ -300,6 +385,7 @@ def create_skill_tools(loader: SkillLoader) -> None:
             return content
 
         body = skill.content or f"(Skill '{name}' has no body content)"
+        body += _skill_setup_note(skill)
         # Append whatever the operator configured for this skill, so the agent
         # starts from the values in effect rather than asking the user or
         # going to read the config file itself. Skills that declare no

--- a/tests/test_cli/test_env_cmd.py
+++ b/tests/test_cli/test_env_cmd.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from agentos import env_store
+from agentos import credential_sources, env_store
 from agentos.cli.main import app
 
 runner = CliRunner()
@@ -225,3 +225,63 @@ class TestMachineReadableOutput:
         assert result.returncode == 0, result.stderr
         payload = json_module.loads(result.stdout)
         assert payload["totalCount"] >= 1
+
+
+class TestImport:
+    @pytest.fixture(autouse=True)
+    def _clear_probe_cache(self):
+        credential_sources.reset_probe_cache()
+        yield
+        credential_sources.reset_probe_cache()
+
+    def test_picks_the_usable_source_when_none_is_named(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+        monkeypatch.setattr(
+            credential_sources,
+            "_run",
+            lambda argv, timeout: (0, "gho_from_cli" if "token" in argv else "Logged in"),
+        )
+        result = runner.invoke(app, ["env", "import", "GITHUB_TOKEN"])
+
+        assert result.exit_code == 0, result.output
+        assert env_store.read_env_file()["GITHUB_TOKEN"] == "gho_from_cli"
+
+    def test_says_the_copy_goes_stale_on_rotation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+        monkeypatch.setattr(
+            credential_sources,
+            "_run",
+            lambda argv, timeout: (0, "gho_from_cli" if "token" in argv else "Logged in"),
+        )
+        result = runner.invoke(app, ["env", "import", "GITHUB_TOKEN"])
+        assert "rotates" in result.output
+
+    def test_no_known_source_says_so(self) -> None:
+        result = runner.invoke(app, ["env", "import", "SOME_RANDOM_KEY"])
+        assert result.exit_code != 0
+        assert "No known source" in result.output
+
+    def test_a_known_but_unusable_source_gives_the_login_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: None)
+        result = runner.invoke(app, ["env", "import", "GITHUB_TOKEN"])
+        assert result.exit_code != 0
+        assert "gh auth login" in result.output
+
+    def test_listing_flags_a_variable_that_could_be_imported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+        monkeypatch.setattr(credential_sources, "_run", lambda argv, timeout: (0, "Logged in"))
+        # Present in the file, then removed: still catalogued, now unset.
+        env_store.set_env_var("GITHUB_TOKEN", "x")
+        result = runner.invoke(app, ["env", "list", "--json"])
+        env_store.unset_env_var("GITHUB_TOKEN")
+
+        rows = json.loads(result.output)["vars"]
+        row = next(r for r in rows if r["name"] == "GITHUB_TOKEN")
+        # It is set here, so no offer — the field exists and is correct.
+        assert row["availableFrom"] is None

--- a/tests/test_credential_sources.py
+++ b/tests/test_credential_sources.py
@@ -1,0 +1,162 @@
+"""Tests for discovering credentials that already exist elsewhere.
+
+The two invariants worth defending: probing must never read a secret, and
+nothing must import one without being asked to.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from agentos import credential_sources
+from agentos.credential_sources import CredentialSource
+
+
+@pytest.fixture(autouse=True)
+def clear_probe_cache():
+    credential_sources.reset_probe_cache()
+    yield
+    credential_sources.reset_probe_cache()
+
+
+def _source(**kwargs) -> CredentialSource:
+    base = {
+        "id": "fake",
+        "label": "Fake CLI",
+        "provides": ("FAKE_TOKEN",),
+        "hint": "Run `fake login`.",
+        "probe": lambda: True,
+        "read": lambda: "value-from-source",
+    }
+    base.update(kwargs)
+    return CredentialSource(**base)  # type: ignore[arg-type]
+
+
+class TestRegistry:
+    def test_finds_sources_by_variable_name(self) -> None:
+        assert [s.id for s in credential_sources.sources_for("GITHUB_TOKEN")] == ["gh_cli"]
+        assert [s.id for s in credential_sources.sources_for("GH_TOKEN")] == ["gh_cli"]
+
+    def test_unknown_names_have_no_source(self) -> None:
+        assert credential_sources.sources_for("SOMETHING_ELSE") == []
+        assert credential_sources.available_for("SOMETHING_ELSE") is None
+
+
+class TestProbing:
+    def test_probe_result_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A listing asks about every unset variable; without caching that is one
+        # subprocess per row per refresh.
+        calls: list[int] = []
+
+        def counting_probe() -> bool:
+            calls.append(1)
+            return True
+
+        source = _source(probe=counting_probe)
+        assert credential_sources.is_available(source) is True
+        assert credential_sources.is_available(source) is True
+        assert len(calls) == 1
+
+    def test_refresh_bypasses_the_cache(self) -> None:
+        calls: list[int] = []
+        source = _source(probe=lambda: (calls.append(1), True)[1])
+        credential_sources.is_available(source)
+        credential_sources.is_available(source, refresh=True)
+        assert len(calls) == 2
+
+    def test_a_probe_that_raises_reports_unavailable(self) -> None:
+        def broken() -> bool:
+            raise RuntimeError("gh exploded")
+
+        # A broken external CLI must not take down an env listing.
+        assert credential_sources.is_available(_source(probe=broken)) is False
+
+    def test_available_for_skips_unusable_sources(self) -> None:
+        assert credential_sources.available_for("FAKE_TOKEN") is None
+
+
+class TestGitHubCliSource:
+    def test_probe_uses_a_status_check_not_a_token_read(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The whole probe/read split exists so a listing can say "available"
+        # without ever fetching a secret.
+        seen: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            seen.append(argv)
+            return SimpleNamespace(returncode=0, stdout="Logged in to github.com\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+
+        assert credential_sources.is_available(credential_sources.GH_CLI) is True
+        assert seen == [["gh", "auth", "status"]]
+        assert not any("token" in arg for argv in seen for arg in argv)
+
+    def test_absent_cli_is_unavailable_without_running_anything(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def explode(*args, **kwargs):
+            raise AssertionError("must not shell out when gh is not installed")
+
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: None)
+        monkeypatch.setattr(subprocess, "run", explode)
+        # which() short-circuits, so the assertion is that `explode` never ran.
+        assert credential_sources.is_available(credential_sources.GH_CLI) is False
+
+    def test_read_returns_the_first_line_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def fake_run(argv, **kwargs):
+            if argv[1:] == ["auth", "status"]:
+                return SimpleNamespace(returncode=0, stdout="ok")
+            return SimpleNamespace(returncode=0, stdout="gho_thetoken\nsome trailing noise\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert credential_sources.read_from("GITHUB_TOKEN", "gh_cli") == "gho_thetoken"
+
+    def test_a_timeout_is_not_an_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def timing_out(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=3)
+
+        monkeypatch.setattr(subprocess, "run", timing_out)
+        assert credential_sources.is_available(credential_sources.GH_CLI, refresh=True) is False
+
+
+class TestReadFrom:
+    def test_unknown_source_for_a_name_is_a_lookup_error(self) -> None:
+        with pytest.raises(LookupError, match="No credential source"):
+            credential_sources.read_from("GITHUB_TOKEN", "not_a_source")
+
+    def test_unusable_source_reports_how_to_fix_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: None)
+        with pytest.raises(RuntimeError, match="gh auth login"):
+            credential_sources.read_from("GITHUB_TOKEN", "gh_cli")
+
+    def test_a_source_returning_nothing_is_an_error_not_an_empty_write(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def fake_run(argv, **kwargs):
+            if argv[1:] == ["auth", "status"]:
+                return SimpleNamespace(returncode=0, stdout="ok")
+            return SimpleNamespace(returncode=0, stdout="   \n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="returned no value"):
+            credential_sources.read_from("GITHUB_TOKEN", "gh_cli")
+
+
+class TestNothingImportsItself:
+    def test_the_module_exposes_no_automatic_hydration(self) -> None:
+        # Discovery is a report, not an action. Anything that moved credentials
+        # on its own would make "AgentOS took my GitHub token" a real sentence.
+        exported = {name for name in dir(credential_sources) if not name.startswith("_")}
+        assert not exported & {"hydrate", "autoload", "seed", "apply", "inject"}

--- a/tests/test_env_catalog.py
+++ b/tests/test_env_catalog.py
@@ -172,3 +172,22 @@ class TestCatalog:
 
         catalog = env_catalog.build_catalog(ExplodingLoader())  # type: ignore[arg-type]
         assert "OPENAI_API_KEY" in catalog
+
+
+class TestSentinelEnvKeys:
+    def test_oauth_providers_do_not_become_a_variable(self) -> None:
+        """``env_key`` is not always a variable name.
+
+        Providers that authenticate by OAuth carry the literal string
+        ``"OAuth"`` there, meaning "no API key involved". Taking it at face
+        value put a variable called ``OAuth`` on the Environment screen that
+        nobody could ever set.
+        """
+        catalog = env_catalog.build_catalog()
+        assert "OAuth" not in catalog
+        assert not [name for name in catalog if not name.isupper()]
+
+    def test_every_provider_that_does_use_a_key_is_still_listed(self) -> None:
+        catalog = env_catalog.build_catalog()
+        for name in ("OPENAI_API_KEY", "GEMINI_API_KEY", "BRAVE_SEARCH_API_KEY"):
+            assert name in catalog

--- a/tests/test_gateway/test_rpc_env.py
+++ b/tests/test_gateway/test_rpc_env.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from agentos import env_store
+from agentos import credential_sources, env_catalog, env_store
 from agentos.gateway import rpc_env
 from agentos.gateway.access import CONTROL_ONLY, ConnectionSurface
 from agentos.gateway.auth import AccessContext
@@ -226,3 +226,127 @@ class TestReveal:
         # The log exists so someone can tell which secrets were read — not to
         # make a second copy of them.
         assert SECRET not in json.dumps(emitted)
+
+
+class TestCredentialAvailability:
+    """A variable is often not missing — it is authenticated somewhere else."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_probe_cache(self):
+        credential_sources.reset_probe_cache()
+        yield
+        credential_sources.reset_probe_cache()
+
+    @pytest.fixture
+    def gh_authenticated(self, monkeypatch: pytest.MonkeyPatch):
+        """Pretend `gh auth status` succeeds, without shelling out."""
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+        monkeypatch.setattr(
+            credential_sources, "_run", lambda argv, timeout: (0, "Logged in to github.com")
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unset_variable_reports_where_it_can_come_from(
+        self, gh_authenticated, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A skill declaring the variable is what puts it in the catalog while
+        # it is unset — which is exactly the case worth reporting on.
+        monkeypatch.setattr(
+            env_catalog,
+            "build_catalog",
+            lambda *a, **k: {
+                "GITHUB_TOKEN": env_catalog.EnvVarSpec(
+                    name="GITHUB_TOKEN",
+                    description="Required by the repo-triage skill.",
+                    category=env_catalog.CATEGORY_SKILL,
+                    owner="repo-triage",
+                    required=True,
+                )
+            },
+        )
+        res = await call("env.list")
+        row = next(v for v in res.payload["vars"] if v["name"] == "GITHUB_TOKEN")
+        assert row["isSet"] is False
+        assert row["availableFrom"] == {"id": "gh_cli", "label": "GitHub CLI"}
+
+    @pytest.mark.asyncio
+    async def test_a_variable_already_set_is_not_offered_an_import(self, gh_authenticated) -> None:
+        env_store.set_env_var("GITHUB_TOKEN", "already-here")
+        res = await call("env.list")
+        row = next(v for v in res.payload["vars"] if v["name"] == "GITHUB_TOKEN")
+        # Nothing to import: it is already configured.
+        assert row["availableFrom"] is None
+
+    @pytest.mark.asyncio
+    async def test_listing_never_reads_a_credential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Probing answers "could this supply it", never "what is it". The
+        # commands a listing is allowed to run are asserted here by name.
+        ran: list[list[str]] = []
+
+        def record(argv, timeout):
+            ran.append(argv)
+            return 0, "Logged in"
+
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+        monkeypatch.setattr(credential_sources, "_run", record)
+        # Put the unset variable in the catalog so the probe actually fires.
+        monkeypatch.setattr(
+            env_catalog,
+            "build_catalog",
+            lambda *a, **k: {"GITHUB_TOKEN": env_catalog.EnvVarSpec(name="GITHUB_TOKEN")},
+        )
+        await call("env.list")
+
+        assert ran, "the probe should have run at least once"
+        assert ran == [["gh", "auth", "status"]]
+
+
+class TestImport:
+    @pytest.fixture(autouse=True)
+    def _clear_probe_cache(self):
+        credential_sources.reset_probe_cache()
+        yield
+        credential_sources.reset_probe_cache()
+
+    @pytest.mark.asyncio
+    async def test_copies_the_value_in_without_returning_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(credential_sources, "read_from", lambda n, s: "gho_imported")
+        res = await call("env.import", {"name": "GITHUB_TOKEN", "sourceId": "gh_cli"})
+
+        assert res.error is None, res.error
+        assert "gho_imported" not in json.dumps(res.payload)
+        assert res.payload["isSet"] is True
+        assert env_store.read_env_file()["GITHUB_TOKEN"] == "gho_imported"
+
+    @pytest.mark.asyncio
+    async def test_says_the_copy_will_not_follow_rotation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A copied token goes stale when the source rotates; better said once
+        # here than discovered as a mystery 401 later.
+        monkeypatch.setattr(credential_sources, "read_from", lambda n, s: "gho_imported")
+        res = await call("env.import", {"name": "GITHUB_TOKEN", "sourceId": "gh_cli"})
+        assert "rotates" in res.payload["note"]
+
+    @pytest.mark.asyncio
+    async def test_requires_a_source(self) -> None:
+        res = await call("env.import", {"name": "GITHUB_TOKEN"})
+        assert res.error is not None
+
+    @pytest.mark.asyncio
+    async def test_an_unusable_source_explains_how_to_fix_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: None)
+        res = await call("env.import", {"name": "GITHUB_TOKEN", "sourceId": "gh_cli"})
+        assert res.error is not None
+        assert "gh auth login" in res.error.message
+
+    @pytest.mark.asyncio
+    async def test_the_policy_gate_still_applies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An import is still a write; a denylisted name cannot sneak in by it.
+        monkeypatch.setattr(credential_sources, "read_from", lambda n, s: "/tmp/evil.so")
+        res = await call("env.import", {"name": "LD_PRELOAD", "sourceId": "gh_cli"})
+        assert res.error is not None

--- a/tests/test_tools/test_skill_setup_note.py
+++ b/tests/test_tools/test_skill_setup_note.py
@@ -1,0 +1,194 @@
+"""Tests for what an agent is told when a skill's requirements are unmet.
+
+The rule being enforced: never promise an action the surface cannot perform.
+A secret cannot be collected over a chat channel without landing in the chat
+log, and an unattended run has nobody to collect it from — in both cases an
+instruction to "ask the user" is a lie the agent would faithfully repeat.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agentos import credential_sources
+from agentos.skills.loader import SkillLoader
+from agentos.tools.builtin import skill_tools
+from agentos.tools.types import (
+    CallerKind,
+    InteractionMode,
+    ToolContext,
+    current_tool_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("BASE_RPC_URL", raising=False)
+    credential_sources.reset_probe_cache()
+    yield
+    credential_sources.reset_probe_cache()
+
+
+@pytest.fixture
+def gated_skill(tmp_path: Path):
+    skills = tmp_path / "skills"
+    (skills / "onchain").mkdir(parents=True)
+    (skills / "onchain" / "SKILL.md").write_text(
+        "---\n"
+        "name: onchain\n"
+        "description: Query an L2\n"
+        "metadata:\n"
+        "  agentos:\n"
+        "    requires:\n"
+        "      env:\n"
+        "        - name: BASE_RPC_URL\n"
+        "          description: Base L2 RPC endpoint\n"
+        "          url: https://docs.example.invalid/\n"
+        "---\n"
+        "body\n",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(bundled_dir=skills, snapshot_path=tmp_path / "snap.json")
+    return next(s for s in loader.load_all() if s.name == "onchain")
+
+
+class TestWhatIsMissing:
+    def test_names_the_variable_with_its_purpose_and_source(self, gated_skill) -> None:
+        note = skill_tools._skill_setup_note(gated_skill)
+        assert "BASE_RPC_URL is not set" in note
+        assert "Base L2 RPC endpoint" in note
+        assert "https://docs.example.invalid/" in note
+
+    def test_a_satisfied_skill_says_nothing(
+        self, gated_skill, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BASE_RPC_URL", "https://rpc.example.invalid")
+        assert skill_tools._skill_setup_note(gated_skill) == ""
+
+    def test_an_unactionable_reason_produces_no_instruction(self, tmp_path: Path) -> None:
+        # Wrong OS is not something the operator can fix from here; inventing
+        # an instruction would be worse than staying quiet.
+        skills = tmp_path / "skills"
+        (skills / "winonly").mkdir(parents=True)
+        (skills / "winonly" / "SKILL.md").write_text(
+            "---\nname: winonly\ndescription: d\nmetadata:\n  agentos:\n"
+            "    os: [nosuchos]\n---\nbody\n",
+            encoding="utf-8",
+        )
+        loader = SkillLoader(bundled_dir=skills, snapshot_path=tmp_path / "snap.json")
+        skill = next(s for s in loader.load_all() if s.name == "winonly")
+        assert skill_tools._skill_setup_note(skill) == ""
+
+
+class TestSurfaceAwareness:
+    def test_a_chat_channel_is_told_not_to_collect_the_secret(
+        self, gated_skill, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(skill_tools, "_setup_surface", lambda: "channel")
+        note = skill_tools._skill_setup_note(gated_skill)
+        assert "chat channel" in note
+        assert "stored in the conversation" in note
+        # It must not tell the agent to ask for the value here.
+        assert "Ask the user to set it" not in note
+
+    def test_an_unattended_run_is_told_to_continue_degraded(
+        self, gated_skill, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(skill_tools, "_setup_surface", lambda: "unattended")
+        note = skill_tools._skill_setup_note(gated_skill)
+        assert "unattended" in note
+        assert "which parts do not" in note
+
+    def test_an_interactive_run_gets_a_real_action(
+        self, gated_skill, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(skill_tools, "_setup_surface", lambda: "interactive")
+        note = skill_tools._skill_setup_note(gated_skill)
+        assert "agentos env set" in note
+        assert "Environment screen" in note
+
+
+class TestSurfaceDetection:
+    def test_channel_callers_are_detected(self) -> None:
+        ctx = ToolContext(caller_kind=CallerKind.CHANNEL)
+        token = current_tool_context.set(ctx)
+        try:
+            assert skill_tools._setup_surface() == "channel"
+        finally:
+            current_tool_context.reset(token)
+
+    def test_unattended_runs_are_detected(self) -> None:
+        ctx = ToolContext(caller_kind=CallerKind.CRON, interaction_mode=InteractionMode.UNATTENDED)
+        token = current_tool_context.set(ctx)
+        try:
+            assert skill_tools._setup_surface() == "unattended"
+        finally:
+            current_tool_context.reset(token)
+
+    def test_no_context_is_treated_as_interactive(self) -> None:
+        token = current_tool_context.set(None)
+        try:
+            assert skill_tools._setup_surface() == "interactive"
+        finally:
+            current_tool_context.reset(token)
+
+
+class TestImportOffer:
+    def test_mentions_a_credential_that_already_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        skills = tmp_path / "skills"
+        (skills / "repo").mkdir(parents=True)
+        (skills / "repo" / "SKILL.md").write_text(
+            "---\nname: repo\ndescription: d\nmetadata:\n  agentos:\n"
+            "    requires:\n      env: [GITHUB_TOKEN]\n---\nbody\n",
+            encoding="utf-8",
+        )
+        loader = SkillLoader(bundled_dir=skills, snapshot_path=tmp_path / "snap.json")
+        skill = next(s for s in loader.load_all() if s.name == "repo")
+
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr(credential_sources.shutil, "which", lambda _: "/usr/bin/gh")
+        monkeypatch.setattr(credential_sources, "_run", lambda argv, timeout: (0, "Logged in"))
+
+        note = skill_tools._skill_setup_note(skill)
+        assert "already available from GitHub CLI" in note
+        assert "agentos env import GITHUB_TOKEN" in note
+
+    def test_discovery_failure_does_not_break_the_note(
+        self, gated_skill, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def explode(*args, **kwargs):
+            raise RuntimeError("registry is broken")
+
+        monkeypatch.setattr(credential_sources, "available_for", explode)
+        note = skill_tools._skill_setup_note(gated_skill)
+        assert "BASE_RPC_URL is not set" in note
+
+
+class TestNoPhantomTool:
+    def test_the_note_never_points_at_a_hidden_tool(self, gated_skill) -> None:
+        # env_set is hidden by default, so naming it here would be the same
+        # dead-end this feature exists to remove.
+        note = skill_tools._skill_setup_note(gated_skill)
+        assert "env_set(" not in note
+
+    def test_skill_list_no_longer_points_at_it_either(self) -> None:
+        source = Path(skill_tools.__file__).read_text(encoding="utf-8")
+        assert "env_set(name=" not in source
+
+
+class TestOsEnvironIsolation:
+    def test_the_note_reads_the_live_environment(
+        self, gated_skill, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Eligibility is rebuilt per call, so a value set moments ago counts.
+        assert "BASE_RPC_URL is not set" in skill_tools._skill_setup_note(gated_skill)
+        os.environ["BASE_RPC_URL"] = "https://rpc.example.invalid"
+        try:
+            assert skill_tools._skill_setup_note(gated_skill) == ""
+        finally:
+            os.environ.pop("BASE_RPC_URL", None)


### PR DESCRIPTION
Follow-up to #127. That PR gave AgentOS a way to write environment variables;
this one makes the surrounding behaviour honest — look before asking, and never
promise an action the surface cannot perform.

## Look before asking

A variable reported as missing often is not. The operator has usually run
`gh auth login` already, and telling them to go find a token they effectively
lost is worse than looking where it lives.

`credential_sources` registers the places a credential may already exist and
splits two questions that are usually conflated:

- **Probing** asks "could this supply it", using the source's own status check
  — `gh auth status`, never `gh auth token`. Listings call it constantly and
  none of those calls touch a secret. A test asserts the command a listing runs
  by name.
- **Reading** happens only from an explicit import, because "AgentOS took my
  GitHub token and handed it to an agent" is not a surprise anyone should get.
  A test asserts the module exports nothing that could hydrate on its own.

Probe results are cached for a minute: a listing asks about every unset
variable it knows, which would otherwise be one subprocess per row per refresh.

`env.list` reports `availableFrom`, and `agentos env import NAME` and a
**Use GitHub CLI** button act on it. All three say the same thing afterwards —
the value is a copy and will not follow the source's own rotation. Better
stated once at import than discovered as a mystery 401.

## Never promise what the surface cannot do

`skill_view` now appends a setup note when a skill's requirements are unmet,
and what it says depends on who is listening:

| Surface | What the agent is told |
| --- | --- |
| Chat channel | The secret must not be collected here — it would be stored in the conversation. Ask the operator to use the Environment screen or the CLI. |
| Unattended (cron) | Nobody is available. Continue with what works and state clearly what does not. |
| Interactive | The actual command, plus an import offer when the credential already exists elsewhere. |

This is not cosmetic. An agent handed "ask the user for the value" on a
messaging surface will faithfully do it, and the credential ends up in a chat
log. The skill still loads in every case: an agent that knows what is missing
can do the parts that work and say plainly which parts cannot.

Ineligibility the operator cannot act on from here — an OS mismatch — produces
no instruction at all. Inventing one would be worse than silence.

## Fixes from #127

- `env_key` is not always a variable name. Providers that authenticate by OAuth
  carry the literal string `"OAuth"` there, meaning "no API key involved", and
  taking it at face value put a variable called `OAuth` on the Environment
  screen that nobody could ever set. Catalog entries now have to look like
  environment variables, which also holds for any future sentinel without this
  needing to know its name.
- `skill_list` no longer prints `Fix: env_set(...)`. `env_set` is hidden by
  default, so that line pointed the model at a tool it usually could not call —
  the same dead-end this feature exists to remove. The listing keeps the
  diagnosis; how to fix it belongs in `skill_view`, where the agent is actually
  trying to use the skill, rather than repeated once per entry across a listing
  of fifty.

## Verification

Quality gate green: 6469 backend tests, mypy and ruff clean; 1558 frontend
tests with tsc, eslint, and prettier clean.

Exercised against a running gateway with a skill declaring
`requires.env: GITHUB_TOKEN` and `gh` authenticated. The Environment screen
shows it under Skills as missing, attributed to the declaring skill, with a
link to where the token comes from and a **Use GitHub CLI** button; the CLI
reports the same through `agentos env list --json`.

The import button was deliberately not clicked during that check — it would
have read a real credential and written it to disk, which is precisely what
this design says should only happen when someone asks for it. The click path
is covered by unit tests instead.

## Scope note

An earlier sketch of this work included a pending-request queue so an operator
could see that an agent had asked for a credential. It was dropped after
checking what the Environment screen already shows: the declaring skill, the
missing state, and now the import offer. A separate queue would have added a
second store for the marginal information of *when* an agent tried.
