### PR TITLE
feature: add keyboard shortcut for the new chat button

### DIFF
--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -280,7 +280,9 @@ describe('app shell chrome', () => {
     expect(nav).not.toContainElement(action)
     expect(document.querySelector('.chat-composer')).not.toContainElement(action)
     expect(screen.getAllByRole('button', { name: 'New chat' })).toHaveLength(1)
-    expect(action).toHaveAttribute('title', 'New chat')
+    // The tooltip carries a platform-dependent shortcut hint (⌘⇧O vs
+    // Ctrl+Shift+O), so match the stable prefix instead of the literal string.
+    expect(action.getAttribute('title')).toMatch(/^New chat/)
     expect(action.querySelector('svg')).not.toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse navigation' }))

--- a/frontend/src/views/chat/ChatPage.test.tsx
+++ b/frontend/src/views/chat/ChatPage.test.tsx
@@ -1044,6 +1044,155 @@ describe('ChatPage', () => {
     expect(mockRpc.call.mock.calls.filter(([method]) => method === 'chat.abort')).toHaveLength(0)
   })
 
+  describe.each([
+    ['Windows/Linux', { ctrlKey: true }],
+    ['macOS', { metaKey: true }],
+  ])('New chat shortcut (%s)', (_, modifier) => {
+    it('starts a new chat from the keyboard', async () => {
+      mockRpc = makeRpc()
+      renderPage()
+  
+      const composer = screen.getByRole('textbox', { name: 'Message' })
+      composer.focus()
+  
+      fireEvent.keyDown(document, {
+        ...modifier,
+        shiftKey: true,
+        code: 'KeyO',
+      })
+  
+      await waitFor(() => {
+        const sessions = mockRpc.call.mock.calls
+          .filter(([method]) => method === 'sessions.messages.subscribe')
+          .map(([, params]) => (params as { key: string }).key)
+  
+        expect(
+          sessions.some(
+            key =>
+              key.startsWith('agent:main:webchat:') &&
+              key !== 'agent:main:webchat:default',
+          ),
+        ).toBe(true)
+      })
+  
+      expect(composer).toHaveFocus()
+    })
+  })
+
+  it('prevents browser default for Cmd/Ctrl+Shift+O shortcut', () => {
+    mockRpc = makeRpc()
+    renderPage()
+  
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      shiftKey: true,
+      code: 'KeyO',
+    })
+  
+    const preventDefault = vi.spyOn(event, 'preventDefault')
+  
+    document.dispatchEvent(event)
+  
+    expect(preventDefault).toHaveBeenCalled()
+  })
+  
+  it('ignores new chat shortcut when event is already prevented', () => {
+    mockRpc = makeRpc()
+  
+    document.addEventListener(
+      'keydown',
+      event => {
+        if (event.code === 'KeyO') {
+          event.preventDefault()
+        }
+      },
+      { once: true },
+    )
+  
+    renderPage()
+  
+    const before = mockRpc.call.mock.calls.length
+  
+    fireEvent.keyDown(document, {
+      ctrlKey: true,
+      shiftKey: true,
+      code: 'KeyO',
+    })
+  
+    expect(mockRpc.call.mock.calls.length).toBe(before)
+  })
+  
+  it('does not start new chat when a modal is open', () => {
+    mockRpc = makeRpc()
+    renderPage()
+  
+    const before = mockRpc.call.mock.calls.length
+  
+    const modal = document.createElement('div')
+    modal.className = 'modal-backdrop'
+  
+    document.body.appendChild(modal)
+  
+    fireEvent.keyDown(document, {
+      ctrlKey: true,
+      shiftKey: true,
+      code: 'KeyO',
+    })
+  
+    expect(mockRpc.call.mock.calls.length).toBe(before)
+  
+    modal.remove()
+  })
+  
+  it('shows the keyboard shortcut in the New chat tooltip', () => {
+    mockRpc = makeRpc()
+    renderPage()
+  
+    const button = screen.getByRole('button', {
+      name: 'New chat',
+    })
+  
+    expect(button).toHaveAttribute(
+      'title',
+      expect.stringMatching(/⌘⇧O|Ctrl\+Shift\+O/),
+    )
+  })
+
+  it('starts a new chat while composer is focused', async () => {
+    mockRpc = makeRpc()
+    renderPage()
+  
+    const composer = screen.getByRole('textbox', {
+      name: 'Message',
+    })
+  
+    composer.focus()
+  
+    fireEvent.keyDown(composer, {
+      ctrlKey: true,
+      shiftKey: true,
+      code: 'KeyO',
+    })
+  
+    await waitFor(() => {
+      const subscriptions = mockRpc.call.mock.calls
+        .filter(([method]) => method === 'sessions.messages.subscribe')
+        .map(([, params]) => (params as { key: string }).key)
+  
+      expect(
+        subscriptions.some(
+          key =>
+            key.startsWith('agent:main:webchat:') &&
+            key !== 'agent:main:webchat:default',
+        ),
+      ).toBe(true)
+    })
+  
+    expect(composer).toHaveFocus()
+  })
+
   it('closes Chat actions on Tab and preserves deterministic focus', async () => {
     mockRpc = makeRpc()
     renderPage()

--- a/frontend/src/views/chat/ChatPage.test.tsx
+++ b/frontend/src/views/chat/ChatPage.test.tsx
@@ -1051,30 +1051,28 @@ describe('ChatPage', () => {
     it('starts a new chat from the keyboard', async () => {
       mockRpc = makeRpc()
       renderPage()
-  
+
       const composer = screen.getByRole('textbox', { name: 'Message' })
       composer.focus()
-  
+
       fireEvent.keyDown(document, {
         ...modifier,
         shiftKey: true,
         code: 'KeyO',
       })
-  
+
       await waitFor(() => {
         const sessions = mockRpc.call.mock.calls
           .filter(([method]) => method === 'sessions.messages.subscribe')
           .map(([, params]) => (params as { key: string }).key)
-  
+
         expect(
           sessions.some(
-            key =>
-              key.startsWith('agent:main:webchat:') &&
-              key !== 'agent:main:webchat:default',
+            (key) => key.startsWith('agent:main:webchat:') && key !== 'agent:main:webchat:default',
           ),
         ).toBe(true)
       })
-  
+
       expect(composer).toHaveFocus()
     })
   })
@@ -1082,7 +1080,7 @@ describe('ChatPage', () => {
   it('prevents browser default for Cmd/Ctrl+Shift+O shortcut', () => {
     mockRpc = makeRpc()
     renderPage()
-  
+
     const event = new KeyboardEvent('keydown', {
       bubbles: true,
       cancelable: true,
@@ -1090,106 +1088,101 @@ describe('ChatPage', () => {
       shiftKey: true,
       code: 'KeyO',
     })
-  
+
     const preventDefault = vi.spyOn(event, 'preventDefault')
-  
+
     document.dispatchEvent(event)
-  
+
     expect(preventDefault).toHaveBeenCalled()
   })
-  
+
   it('ignores new chat shortcut when event is already prevented', () => {
     mockRpc = makeRpc()
-  
+
     document.addEventListener(
       'keydown',
-      event => {
+      (event) => {
         if (event.code === 'KeyO') {
           event.preventDefault()
         }
       },
       { once: true },
     )
-  
+
     renderPage()
-  
+
     const before = mockRpc.call.mock.calls.length
-  
+
     fireEvent.keyDown(document, {
       ctrlKey: true,
       shiftKey: true,
       code: 'KeyO',
     })
-  
+
     expect(mockRpc.call.mock.calls.length).toBe(before)
   })
-  
+
   it('does not start new chat when a modal is open', () => {
     mockRpc = makeRpc()
     renderPage()
-  
+
     const before = mockRpc.call.mock.calls.length
-  
+
     const modal = document.createElement('div')
     modal.className = 'modal-backdrop'
-  
+
     document.body.appendChild(modal)
-  
+
     fireEvent.keyDown(document, {
       ctrlKey: true,
       shiftKey: true,
       code: 'KeyO',
     })
-  
+
     expect(mockRpc.call.mock.calls.length).toBe(before)
-  
+
     modal.remove()
   })
-  
+
   it('shows the keyboard shortcut in the New chat tooltip', () => {
     mockRpc = makeRpc()
     renderPage()
-  
+
     const button = screen.getByRole('button', {
       name: 'New chat',
     })
-  
-    expect(button).toHaveAttribute(
-      'title',
-      expect.stringMatching(/⌘⇧O|Ctrl\+Shift\+O/),
-    )
+
+    expect(button).toHaveAttribute('title', expect.stringMatching(/⌘⇧O|Ctrl\+Shift\+O/))
   })
 
   it('starts a new chat while composer is focused', async () => {
     mockRpc = makeRpc()
     renderPage()
-  
+
     const composer = screen.getByRole('textbox', {
       name: 'Message',
     })
-  
+
     composer.focus()
-  
+
     fireEvent.keyDown(composer, {
       ctrlKey: true,
       shiftKey: true,
       code: 'KeyO',
     })
-  
+
     await waitFor(() => {
       const subscriptions = mockRpc.call.mock.calls
         .filter(([method]) => method === 'sessions.messages.subscribe')
         .map(([, params]) => (params as { key: string }).key)
-  
+
       expect(
         subscriptions.some(
-          key =>
-            key.startsWith('agent:main:webchat:') &&
-            key !== 'agent:main:webchat:default',
+          (key) => key.startsWith('agent:main:webchat:') && key !== 'agent:main:webchat:default',
         ),
       ).toBe(true)
     })
-  
+
     expect(composer).toHaveFocus()
   })
 

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -524,6 +524,8 @@ export function ChatPage() {
     toast.info('Exported as Markdown')
   }, [containerRef, sessionKey])
 
+  const shortcutHint = /mac/i.test(navigator.userAgent) ? '⌘⇧O' : 'Ctrl+Shift+O'
+
   // chat.js:2518-2539 `_onDocKeydown` — document-level keyboard shortcuts.
   // Cmd/Ctrl+Shift+O mirrors the New chat button from anywhere in the app,
   // while Escape keeps the legacy priority chain:
@@ -536,22 +538,18 @@ export function ChatPage() {
   useEffect(() => {
     const onDocKeydown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return
-
+      const isNewChatShortcut = (e.metaKey || e.ctrlKey) && e.shiftKey && e.code === 'KeyO'
+      const isEscape = e.key === 'Escape'
+      if (!isNewChatShortcut && !isEscape) return
       const hasOverlay = !!document.querySelector(
         '.modal-backdrop, .chat-session-popover, .chat-session-actions-menu',
       )
-      const isNewChatShortcut =
-        (e.metaKey || e.ctrlKey) &&
-        e.shiftKey &&
-        e.code === 'KeyO'
+      if (hasOverlay) return
       if (isNewChatShortcut) {
-        if (hasOverlay) return
         e.preventDefault()
         startNewChat()
         return
       }
-      if (e.key !== 'Escape') return
-      if (hasOverlay) return
       const target = e.target as HTMLElement | null
       const isEditable =
         !!target &&
@@ -580,7 +578,7 @@ export function ChatPage() {
         <button
           type="button"
           className="chat-new-button"
-          title="New chat (⌘⇧O)"
+          title={`New chat (${shortcutHint})`}
           aria-label="New chat"
           onClick={startNewChat}
         >

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -524,32 +524,41 @@ export function ChatPage() {
     toast.info('Exported as Markdown')
   }, [containerRef, sessionKey])
 
-  // chat.js:2518-2539 `_onDocKeydown` — the from-anywhere ESC priority chain:
-  //   1. streaming        → abort the turn (which recovers pending).
+  // chat.js:2518-2539 `_onDocKeydown` — document-level keyboard shortcuts.
+  // Cmd/Ctrl+Shift+O mirrors the New chat button from anywhere in the app,
+  // while Escape keeps the legacy priority chain:
+  //   1. streaming         → abort the turn (which recovers pending).
   //   2. pending non-empty → recover the whole queue into the composer.
-  // Visible overlays own their ESC, as do other editable targets (an ESC inside
-  // a different input is theirs). The composer's
-  // own ESC (Composer.tsx) handles the focused-composer case + the clear rung; a
-  // guard here skips when the composer is the target so it isn't double-handled.
+  // Visible overlays own their shortcuts, and Escape inside other editable
+  // targets remains handled by those elements. Unlike Escape, the New chat
+  // shortcut intentionally works even when focus is inside the composer or
+  // another editable field.
   useEffect(() => {
     const onDocKeydown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
       if (e.defaultPrevented) return
-      // A visible overlay's own dismiss handler takes priority (chat.js:8583-8588).
-      if (
-        document.querySelector('.modal-backdrop, .chat-session-popover, .chat-session-actions-menu')
+
+      const hasOverlay = !!document.querySelector(
+        '.modal-backdrop, .chat-session-popover, .chat-session-actions-menu',
       )
+      const isNewChatShortcut =
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        e.code === 'KeyO'
+      if (isNewChatShortcut) {
+        if (hasOverlay) return
+        e.preventDefault()
+        startNewChat()
         return
+      }
+      if (e.key !== 'Escape') return
+      if (hasOverlay) return
       const target = e.target as HTMLElement | null
       const isEditable =
         !!target &&
         (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
-      // An ESC inside ANY editable (incl. the composer) is handled by that
-      // element's own handler — the composer runs the full chain there.
       if (isEditable) return
       if (busy) {
         e.preventDefault()
-        // chat.js:8448 — the stop path also recovers pending into the composer.
         abortAndRecover('webui_escape')
         return
       }
@@ -560,7 +569,7 @@ export function ChatPage() {
     }
     document.addEventListener('keydown', onDocKeydown)
     return () => document.removeEventListener('keydown', onDocKeydown)
-  }, [busy, abortAndRecover, pending])
+  }, [busy, abortAndRecover, pending, startNewChat])
 
   return (
     <div className="chat-stage" onDrop={onDrop} onDragOver={onDragOver} onPaste={onPaste}>
@@ -571,7 +580,7 @@ export function ChatPage() {
         <button
           type="button"
           className="chat-new-button"
-          title="New chat"
+          title="New chat (⌘⇧O)"
           aria-label="New chat"
           onClick={startNewChat}
         >


### PR DESCRIPTION
Closes #120 

## Summary

Added a keyboard shortcut for starting a new chat in the WebUI.

This change allows users to trigger the same action as the "New chat" button using:
- Cmd + Shift + O on macOS
- Ctrl + Shift + O on Windows/Linux

The shortcut reuses the existing `startNewChat` flow so both the button and keyboard shortcut share the same behavior. It also prevents the browser default shortcut, works while the composer is focused, ignores already handled events, and avoids triggering when a modal/popover is active.

Updated the New chat button tooltip to display the available shortcut for better discoverability.

## Tests

Verified with the following command:

```bash
npm run test -- ChatPage.test.tsx