### PR TITLE
fix(skills): give every surface one answer about a skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   user's home directory in front of the model on every turn. Removing it, with
   the raised budget above, is what lets a stock install list every skill with
   its description.
+- A skill that appears in a skills directory while the gateway is running is
+  now picked up on the next turn instead of at the next restart. The cache was
+  only cleared through AgentOS's own install paths, but the directories are
+  shared: `agentos skills install` runs in a separate process, and
+  `~/.agents/skills` is written to by other agents on the same machine. A skill
+  from either was on disk, absent from `skills.list`, absent from the prompt,
+  and unmentioned in any log. The cache is now validated against the same
+  file manifest the on-disk snapshot already used, which costs one stat sweep —
+  measured at 0.6 ms for 65 skills — on each load.
+- `~/.agents/skills` and `<project>/.agents/skills` are honoured when they are
+  created after startup. Both resolved once at boot and a missing one collapsed
+  to "no such layer", so the first cross-agent install on a machine stayed
+  invisible until a restart. The managed directory was already exempt for this
+  exact reason; these two now match it.
 - The guidance above the skills list no longer argues against using it. It
   opened with "Skills are optional task playbooks" and told the model to load
   one "only when a listed entry clearly matches" — while the same block, in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   user's home directory in front of the model on every turn. Removing it, with
   the raised budget above, is what lets a stock install list every skill with
   its description.
+- Upgrading lifts an existing `skills.max_skills_prompt_chars = 8000` to the new
+  default. The key is materialised into every saved `config.toml`, so raising the
+  default alone would have reached new installs only, and 8000 is exactly the
+  value that cannot fit the shipped skills' descriptions. The rewrite runs with
+  the config migrations on the next gateway start, takes the usual timestamped
+  backup, and touches only that exact old default — a budget someone chose is
+  left alone.
 - A skill that appears in a skills directory while the gateway is running is
   now picked up on the next turn instead of at the next restart. The cache was
   only cleared through AgentOS's own install paths, but the directories are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   user's home directory in front of the model on every turn. Removing it, with
   the raised budget above, is what lets a stock install list every skill with
   its description.
+- The guidance above the skills list no longer argues against using it. It
+  opened with "Skills are optional task playbooks" and told the model to load
+  one "only when a listed entry clearly matches" — while the same block, in the
+  compact mode a stock install always fell into, listed nothing but names. A
+  bare name matches nothing clearly, so the instruction could not be followed
+  and the honest reading was "skip it". The two failure modes are not
+  symmetric: loading a skill that turned out to be unnecessary costs a little
+  context, and skipping one that carried the right endpoints, commands, or
+  conventions produces a confidently wrong answer. The block now says so, asks
+  the model to load on partial relevance, and — when only names are listed —
+  states plainly that a name is not enough to rule a skill out.
 - When the skills block does overflow its budget, the skills it drops are no
   longer chosen by load order, which always landed the cut on the skills an
   operator had installed. The cut now follows layer precedence, so `extra` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   partner's hub. Publishers are allowlisted **inside AgentOS**: a `SKILL.md` or
   a hub catalog can only *select* a recognized publisher by id, never describe
   one. A third-party skill that writes a partner's name, URL, and logo into its
-  own frontmatter renders as an ordinary unbranded skill. Publisher is
-  independent of provenance — one says whose name is on a skill, the other
-  where the text came from and under what licence.
+  own frontmatter renders as an ordinary unbranded skill. Selecting an id is
+  restricted too: only a skill shipping inside the release may name its own
+  publisher, and an installed one is branded by the hub catalog row it came
+  from, so a directory dropped into a skills path can never appear as a
+  partner. Publisher is independent of provenance — one says whose name is on a
+  skill, the other where the text came from and under what licence.
 - `agentos skills list --json` gained `publisher` and `acquisition`, built by
   the same code the gateway and the Web UI use. It deliberately has no
   `availability` key: that depends on a chat session's tool surface, which a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   explanation is one sentence naming what to do, and it never contains a
   filesystem path. Ready and offered were previously the same green dot, which
   is why a perfectly installed skill could sit there being silently withheld.
+  Five of the six answer from the installed set alone, so the Skills page shows
+  them before you send anything; only the relevance-filtering one needs a
+  message to rank against and stays in the decision log.
+- With `[tools] enabled = false`, skills that require a tool are now reported as
+  withheld rather than available. The Skills page previously answered against
+  everything the install could offer while chat answered against a turn with no
+  tools at all — the same skill, two answers.
 - How a skill was acquired — `shipped` with AgentOS, installed from a `hub`, or
   a `local` directory you added — is now a fact AgentOS records and reports,
   alongside the source, identifier, version, and install time for hub installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,7 +177,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   its description.
 - When the skills block does overflow its budget, the skills it drops are no
   longer chosen by load order, which always landed the cut on the skills an
-  operator had installed. Shipped skills are sacrificed first now. The drop is
+  operator had installed. The cut now follows layer precedence, so `extra` and
+  then `bundled` skills go before the ones in a writable skills path. The drop is
   also reported instead of being silent: a `skills_filter.budget_truncated`
   warning naming the dropped skills, and a `prompt_budget` reason on each
   affected skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,58 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   behind the approval queue and hidden by default, `env_set`. There is no
   reveal tool: a model that can read back stored credentials is one prompt
   injection away from exfiltrating them.
+- "Is the agent actually being offered this skill?" is now a question with an
+  answer. Every skill row from the gateway, and every line the agent's own
+  skill listing prints, carries whether the skill is offered and — when it is
+  not — which of six reasons applies: model invocation is disabled in its
+  manifest, a requirement is missing, a tool it needs is not enabled in this
+  session, a native tool supersedes it as a fallback, relevance filtering
+  skipped it for this message, or the injected skills block was full. The
+  explanation is one sentence naming what to do, and it never contains a
+  filesystem path. Ready and offered were previously the same green dot, which
+  is why a perfectly installed skill could sit there being silently withheld.
+- How a skill was acquired — `shipped` with AgentOS, installed from a `hub`, or
+  a `local` directory you added — is now a fact AgentOS records and reports,
+  alongside the source, identifier, version, and install time for hub installs.
+  It is derived from the install record rather than guessed from which
+  directory the files sit in, so moving a skill does not change the story of
+  where it came from.
+- The same record answers whether Update and Remove will actually work. A
+  hub-installed skill whose files no longer sit where the lockfile recorded
+  them keeps Update — an update re-fetches by identifier — and loses Remove,
+  because AgentOS will not delete files it cannot prove it owns. The Web UI
+  says so instead of offering a button that fails.
+- Skills can name a publisher, so a partner's skills carry that partner's
+  identity whether they shipped with AgentOS or you installed them from that
+  partner's hub. Publishers are allowlisted **inside AgentOS**: a `SKILL.md` or
+  a hub catalog can only *select* a recognized publisher by id, never describe
+  one. A third-party skill that writes a partner's name, URL, and logo into its
+  own frontmatter renders as an ordinary unbranded skill. Publisher is
+  independent of provenance — one says whose name is on a skill, the other
+  where the text came from and under what licence.
+- `agentos skills list --json` gained `publisher` and `acquisition`, built by
+  the same code the gateway and the Web UI use. It deliberately has no
+  `availability` key: that depends on a chat session's tool surface, which a
+  CLI process does not have, and an absent key means "not computed" rather than
+  "not offered".
+
+### Changed
+
+- The Skills screen's Installed tab now groups cards by where a skill came
+  from — **Partners**, **Shipped with AgentOS**, **Installed from a hub**,
+  **Your local skills** — instead of by which directory holds the files. The
+  storage layer is still shown, as a chip on each card, because it decides
+  which skill wins a name collision; it no longer decides the heading. If you
+  navigated by the old `Bundled` / `Managed` headings, the cards under them are
+  now under `Shipped with AgentOS` and `Installed from a hub`.
+- `skills.max_skills_prompt_chars` now defaults to **24000**, up from 8000. The
+  bundled skill set renders to about 16k characters with descriptions, so the
+  old default silently forced every default install past the budget and into
+  name-only mode — the model had never seen a skill description on a stock
+  install. Raise it further if you install many skills; lower it if you run a
+  model with a small context window, where the whole-request ceiling can be
+  smaller than this budget. See
+  [configuration.md](docs/configuration.md#skill-prompt-budget).
 
 ### Security
 
@@ -113,6 +165,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/reset` in the standalone chat TUI works again on sessions with a non-empty
   transcript. It had been gated on a flush service that is never constructed,
   so it aborted every time; `/compact` printed a matching false warning.
+- The skills block no longer writes an absolute filesystem path for every
+  skill into the system prompt. Nothing read it — skills are looked up by name,
+  and the skill-reading tool explicitly tells the model not to go looking on
+  disk — while it accounted for roughly two thirds of the block and put the
+  user's home directory in front of the model on every turn. Removing it, with
+  the raised budget above, is what lets a stock install list every skill with
+  its description.
+- When the skills block does overflow its budget, the skills it drops are no
+  longer chosen by load order, which always landed the cut on the skills an
+  operator had installed. Shipped skills are sacrificed first now. The drop is
+  also reported instead of being silent: a `skills_filter.budget_truncated`
+  warning naming the dropped skills, and a `prompt_budget` reason on each
+  affected skill.
+- The skill count and skill-id list in turn metadata and the
+  `skills_filter.applied` log counted skills that the budget had already thrown
+  away, so the one place that could have revealed the problem asserted
+  everything was fine.
+- Setting an environment variable or installing a missing binary now takes
+  effect for the agent without a gateway restart, which is what the
+  Environment feature promised. The chat path built one eligibility cache at
+  import time and remembered a *negative* lookup for the life of the process,
+  while every other surface rebuilt its own per call — so the Skills screen
+  reported a skill as ready while the agent refused to be given it, forever.
+- Browsing or searching a skill hub now also shows skills you already installed
+  from that source, including ones its catalog does not list. A skill installed
+  from a GitHub URL used to vanish from the page it was installed on, because
+  an empty browse never returned a row for it.
+- The Installed marker in the community list no longer goes stale after a
+  removal, and no longer fires on a catalog entry whose *name* happens to match
+  an unrelated skill's install *identifier*. Names are matched against
+  installed names and identifiers against installed identifiers.
+- Installing a skill while a search is open no longer loses the row when the
+  search is cleared, and the skill dialog no longer unmounts itself when the
+  list underneath it changes.
+- A failed hub search reports the failure instead of rendering as "no skills
+  match your query", and results the hub matched on a tag are no longer
+  discarded by a second client-side filter that could not see the tag.
 
 ## [2026.7.26] - 2026-07-26
 

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -219,7 +219,11 @@ interval = 10            # user turns between reviews; 0 disables
 # skill gating still runs for visibility, platform, and tool availability.
 filter_enabled = false
 filter_top_k = 5
-max_skills_prompt_chars = 8000
+# Character budget for the injected skills block. Above it the block falls
+# back to names only, then starts dropping skills (lowest-precedence layer
+# first). The bundled set renders ~16k with descriptions, so the default
+# leaves room for installed skills before either fallback kicks in.
+max_skills_prompt_chars = 24000
 # injection_mode = "system"  # "system", "user_context", or "user_message"
 
 # The default lexical strategy is dependency-free. "semantic" and "hybrid"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -411,12 +411,35 @@ Read:
 
 ```sh
 agentos skills list
+agentos skills list --json
 agentos skills search pdf
 agentos skills view pdf-toolkit
 agentos skills install <skill-name>
 agentos skills update --all
 agentos skills uninstall <skill-name>
 ```
+
+The `skills list` table is unchanged: name, layer, eligible, description.
+`--json` carries more, and now reports the same facts the Web UI shows for the
+same skill instead of a separate, thinner answer:
+
+| Key | What it says |
+| --- | --- |
+| `layer` | where the files are — `bundled`, `managed`, `personal`, `project`, `workspace`, `extra` |
+| `acquisition` | how the skill got there: `kind` is `shipped`, `hub`, or `local`, plus `source_id`, `identifier`, `version`, `installed_at`, `source_trust`, `scan_verdict`, and the `removable` / `updatable` booleans |
+| `publisher` | `{id, name, url, logo}`, all empty strings when the skill is unbranded. Only publishers on an allowlist inside AgentOS resolve to a name; a skill cannot brand itself by writing one into its manifest |
+| `provenance` | unchanged, and independent of `publisher` — where the text came from and under what licence |
+
+`acquisition.removable` is the honest answer to "can `agentos skills uninstall`
+remove this", not a restatement of the layer: a hub install whose recorded path
+no longer matches the configured `skills.managed_dir` reports `false`, while
+`updatable` stays `true` because an update re-fetches by identifier.
+
+There is deliberately **no `availability` key** in CLI output. Whether the
+agent is currently being offered a skill depends on a chat session's tool
+surface, which a CLI process does not have; the gateway's `skills.list` and the
+Web UI answer that instead. An absent key means "not computed", not "not
+offered".
 
 Read:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,35 @@ agentos config set skills.config.wiki.path /srv/wiki
 When the agent opens the skill, the values currently in effect are appended to
 what it reads, so it does not have to ask or go looking.
 
+## Skill Prompt Budget
+
+Every eligible skill is listed for the agent in a block appended to the system
+prompt. `[skills].max_skills_prompt_chars` caps how large that block may get:
+
+```toml
+[skills]
+max_skills_prompt_chars = 24000
+```
+
+The budget is spent in three stages. Under it, each skill is listed with its
+description. Over it, the block falls back to names only. Over it even then,
+skills are dropped, lowest-precedence layer first, so `bundled` skills are
+sacrificed before anything you installed. A drop is logged as
+`skills_filter.budget_truncated` with the names, and the affected skills report
+a `prompt_budget` reason on the Skills screen.
+
+The default of 24000 is sized so a default install lists every bundled skill
+*with* its description and still has room for skills you add. Lower it only if
+you are running a model with a small context window: the whole-request ceiling
+on a model below roughly 64k tokens can be smaller than this budget, in which
+case the skills block alone would not fit.
+
+```sh
+agentos config get skills.max_skills_prompt_chars
+agentos config set skills.max_skills_prompt_chars 32000
+agentos gateway restart
+```
+
 ## First-Run Wizard
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,8 +130,9 @@ max_skills_prompt_chars = 24000
 
 The budget is spent in three stages. Under it, each skill is listed with its
 description. Over it, the block falls back to names only. Over it even then,
-skills are dropped, lowest-precedence layer first, so `bundled` skills are
-sacrificed before anything you installed. A drop is logged as
+skills are dropped, lowest-precedence layer first — `extra` (the directories
+you listed in `skills.extra_dirs`), then `bundled`, and only then `managed`,
+`personal`, `project`, `workspace`. A drop is logged as
 `skills_filter.budget_truncated` with the names, and the affected skills report
 a `prompt_budget` reason on the Skills screen.
 

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -228,9 +228,10 @@ it. Guessing from the layer or from "it says ready" is what makes this hard.
    ```
 
    The gateway also logs `skills_filter.budget_truncated` with the names it
-   dropped and the budget it hit. Truncation sacrifices `bundled` skills before
-   anything you installed, so the symptom is usually shipped skills quietly
-   disappearing while your own survive.
+   dropped and the budget it hit. Truncation goes lowest-precedence layer
+   first — `extra` directories, then `bundled` — so the symptom is usually
+   shipped skills quietly disappearing while what you installed into
+   `managed`, `personal`, `project`, or `workspace` survives.
 
 5. **`not_retrieved`.** Only reachable when `skills.filter_enabled = true`,
    which is off by default. Raise `skills.filter_top_k` or reword the request;

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -73,9 +73,16 @@ because an update re-fetches by identifier into the current managed directory.
 **Publisher** is allowlisted inside AgentOS. A skill manifest can only *select*
 a recognized publisher by id; it can never *describe* one. A third-party skill
 that writes a partner's name, URL, and logo into its own frontmatter renders as
-an ordinary unbranded skill, because none of those fields are read. This is why
-a partner's skills sit under one heading whether they shipped with AgentOS or
-you installed them from that partner's hub.
+an ordinary unbranded skill, because none of those fields are read.
+
+Selecting an id is also restricted by where the skill lives. Only a `bundled`
+manifest — one that ships inside the release — may name its own publisher; a
+directory you (or anything else) drop into a writable skills path gets no brand
+from its own frontmatter, so a look-alike cannot sit in the Partners group. An
+installed partner skill is branded by the hub catalog row that installed it,
+recorded in the lockfile, not by its own text. This is why a partner's skills
+sit under one heading whether they shipped with AgentOS or you installed them
+from that partner's hub.
 
 **Layer** is only about file location and name-collision precedence (later
 overrides earlier): `extra` (config dirs) → `bundled` (shipped) → `managed`

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -46,6 +46,72 @@ Some skills may be ineligible when optional dependencies are missing or when the
 skill is intentionally demo-only. `skills list` is the source of truth for your
 current install.
 
+## How a Skill Is Described
+
+Four separate facts describe an installed skill. They are easy to confuse, and
+using one to answer another is the usual cause of a confusing Skills screen.
+
+| Fact | Question it answers | Values |
+| --- | --- | --- |
+| Acquisition | How did it get here? | `shipped`, `hub`, `local` |
+| Publisher | Whose name is on it? | An allowlisted partner, or nothing |
+| Layer | Where are the files? | `extra`, `bundled`, `managed`, `personal`, `project`, `workspace` |
+| Availability | Is the agent being offered it right now? | offered, or a reason |
+
+**Acquisition** is what the Web UI groups by, and what `agentos skills list
+--json` reports under `acquisition`. A `shipped` skill came with AgentOS. A
+`hub` skill was fetched by `agentos skills install` and has a lockfile entry
+recording its source, identifier, version, and install time. A `local` skill is
+a directory you put in a skills folder yourself.
+
+The same block carries `removable` and `updatable`. These are answers, not
+guesses from the layer: if a hub-installed skill's recorded path no longer
+matches the configured `skills.managed_dir`, `removable` is `false` — AgentOS
+will not delete files it cannot prove it owns — while `updatable` stays `true`,
+because an update re-fetches by identifier into the current managed directory.
+
+**Publisher** is allowlisted inside AgentOS. A skill manifest can only *select*
+a recognized publisher by id; it can never *describe* one. A third-party skill
+that writes a partner's name, URL, and logo into its own frontmatter renders as
+an ordinary unbranded skill, because none of those fields are read. This is why
+a partner's skills sit under one heading whether they shipped with AgentOS or
+you installed them from that partner's hub.
+
+**Layer** is only about file location and name-collision precedence (later
+overrides earlier): `extra` (config dirs) → `bundled` (shipped) → `managed`
+(`~/.agentos/skills`, where installs land) → `personal` (`~/.agents/skills`) →
+`project` (`<workspace>/.agents/skills`) → `workspace` (`<workspace>/skills`).
+It is shown as a detail on each card and it decides which skills are sacrificed
+first if the prompt budget is exceeded, but it does not tell you where a skill
+came from.
+
+Provenance (`origin`, `license`, `upstream_url`) is separate from all four: it
+records where the *text* came from and under what licence. A skill can be
+AgentOS-original text published by a partner, or upstream text with no
+publisher at all.
+
+## Whether the Agent Is Offered a Skill
+
+Installed, eligible, and offered are three different states. A skill can be
+installed and fully eligible and still not reach the agent on a given turn.
+
+The gateway reports this as `availability` on every skill row, and the agent's
+own skill listing prints a `[not offered]` line with the same explanation:
+
+| Reason | Meaning | What to do |
+| --- | --- | --- |
+| offered | the agent has it | — |
+| `model_invocation_disabled` | the manifest opts out of model invocation | nothing; run it yourself |
+| `ineligible` | a required binary, environment variable, or OS is missing | the detail names what is missing |
+| `tool_gate` | its required tools are not enabled in this session | enable the tools |
+| `fallback_superseded` | it is a fallback for a tool the session already has natively | nothing; the native tool is better |
+| `not_retrieved` | relevance filtering is on and this message did not match | raise `skills.filter_top_k`, or reword |
+| `prompt_budget` | ready, but the skills block is full | raise `skills.max_skills_prompt_chars` |
+
+`agentos skills list --json` does not carry `availability`. A CLI process has
+no chat session and no tool surface, so it cannot answer honestly; an absent
+key means "not computed", never "not offered".
+
 ## Install, Update, and Remove Skills
 
 Install a managed skill:
@@ -122,7 +188,8 @@ matches their description and triggers.
 
 ## Troubleshooting
 
-If a skill is not selected:
+If a skill is not used, start by finding out whether the agent was ever offered
+it. Guessing from the layer or from "it says ready" is what makes this hard.
 
 1. Confirm it appears in the installed catalog:
 
@@ -130,16 +197,47 @@ If a skill is not selected:
    agentos skills list
    ```
 
-2. Inspect its description and eligibility:
+2. Open the skill on the Skills screen, or ask the agent to list its skills.
+   Either surface names the reason it is being withheld. Match it below.
+
+3. **"Needs setup" / `ineligible`.** The reason names the missing binary or
+   environment variable. Install the binary, or set the variable:
 
    ```sh
-   agentos skills view <skill-name>
+   agentos env set <NAME> --stdin
    ```
 
-3. Ask for the outcome in normal language. Skill names can help, but user
-   intent should still be clear.
+   The value applies to the running gateway — no restart — and the skill
+   becomes eligible on the next turn.
 
-4. If optional dependencies are missing, install or update the skill and retry.
+4. **"Skills section is full" / `prompt_budget`.** The skill is ready and was
+   dropped only because the injected skills block hit its character budget.
+   Raise it:
+
+   ```sh
+   agentos config get skills.max_skills_prompt_chars     # default 24000
+   agentos config set skills.max_skills_prompt_chars 32000
+   agentos gateway restart
+   ```
+
+   The gateway also logs `skills_filter.budget_truncated` with the names it
+   dropped and the budget it hit. Truncation sacrifices `bundled` skills before
+   anything you installed, so the symptom is usually shipped skills quietly
+   disappearing while your own survive.
+
+5. **`not_retrieved`.** Only reachable when `skills.filter_enabled = true`,
+   which is off by default. Raise `skills.filter_top_k` or reword the request;
+   the answer depends on the wording of that one message.
+
+6. **`tool_gate` or `fallback_superseded`.** These are about the session's
+   tools, not the skill. The first means a tool the skill needs is not enabled;
+   the second means AgentOS already has a native tool that does the job better.
+
+7. **`model_invocation_disabled`.** Working as declared. The skill opted out of
+   model invocation and is for you to run, not the agent.
+
+8. If none of the above applies, ask for the outcome in normal language. Skill
+   names can help, but user intent should still be clear.
 
 ---
 

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -92,6 +92,16 @@ It is shown as a detail on each card and it decides which skills are sacrificed
 first if the prompt budget is exceeded, but it does not tell you where a skill
 came from.
 
+The two `.agents/skills` layers are shared with other agents on the machine —
+Codex, Cursor, and anything else following that convention install there too.
+AgentOS treats them as ordinary layers: a skill another tool writes appears on
+the next turn, and one it removes stops being offered, without a restart and
+without going through `agentos skills`. The directories are also honoured when
+they do not exist yet, so the first cross-agent install on a fresh machine does
+not need one either. Note the precedence that follows from the order above: a
+skill in `.agents/skills` overrides a bundled or hub-installed skill of the same
+name.
+
 Provenance (`origin`, `license`, `upstream_url`) is separate from all four: it
 records where the *text* came from and under what licence. A skill can be
 AgentOS-original text published by a partner, or upstream text with no

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -115,6 +115,13 @@ own skill listing prints a `[not offered]` line with the same explanation:
 | `not_retrieved` | relevance filtering is on and this message did not match | raise `skills.filter_top_k`, or reword |
 | `prompt_budget` | ready, but the skills block is full | raise `skills.max_skills_prompt_chars` |
 
+Every reason above appears in a `skills.list` row except `not_retrieved`.
+Retrieval ranks skills against the wording of one message, so there is no query
+to answer it with outside a turn — it reaches the decision log, never the Skills
+page. The other six, `prompt_budget` included, are answerable from the installed
+set plus the configured budget, so the page can show them before you send
+anything.
+
 `agentos skills list --json` does not carry `availability`. A CLI process has
 no chat session and no tool surface, so it cannot answer honestly; an absent
 key means "not computed", never "not offered".

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -255,7 +255,9 @@ heading whether they shipped with AgentOS or you installed them from that
 partner's hub. Partner identity comes from an allowlist inside AgentOS: a skill
 manifest can only select a recognized publisher by id, so a third-party skill
 cannot borrow a partner's name, link, or logo by writing them into its own
-frontmatter.
+frontmatter. Only a skill that ships with the release may select an id at all —
+an installed one is branded by the hub catalog row it came from — so dropping a
+directory into a skills path cannot put a card in the Partners group.
 
 The storage layer (`bundled`, `managed`, `personal`, …) is still shown, as a
 chip on each card, because it decides which skill wins a name collision. It no

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -71,7 +71,7 @@ non-root mounts such as `/console/` work without rebuilding. Root, `/api`, and
 | Chat | Run and resume chat sessions, inspect tool activity, publish artifacts, and use manual compact controls. |
 | Overview / Health | See readiness, provider state, memory state, sandbox posture, and recovery hints. |
 | Channels | Inspect configured channel adapter status and jump to Agent setup for configuration changes. |
-| Skills | Browse available skills. |
+| Skills | Browse installed skills grouped by where they came from, see whether the agent is actually being offered each one, and install more from a hub. |
 | Sessions | Inspect durable conversations and operational state. |
 | Agents | Manage durable agent entries. |
 | Usage | Inspect token and estimated-cost rollups. |
@@ -232,6 +232,61 @@ provider authorization flow and loads its tools without requiring a gateway
 restart. Agentic trading involves significant risk. Review the server's access
 and action permissions before authorizing it.
 
+## Skills
+
+Open **Skills** to see what is installed and what the agent can actually reach:
+
+```text
+http://127.0.0.1:18791/control/skills
+```
+
+The **Installed** tab groups cards by where a skill came from, not by which
+directory holds it:
+
+| Group | Contains |
+| --- | --- |
+| Partners | Skills published by an AgentOS partner |
+| Shipped with AgentOS | Skills that ship with the release |
+| Installed from a hub | Skills you installed with `agentos skills install` or from this screen |
+| Your local skills | Skill directories you added yourself |
+
+Partners wins over the other three, so a partner's skills stay under one
+heading whether they shipped with AgentOS or you installed them from that
+partner's hub. Partner identity comes from an allowlist inside AgentOS: a skill
+manifest can only select a recognized publisher by id, so a third-party skill
+cannot borrow a partner's name, link, or logo by writing them into its own
+frontmatter.
+
+The storage layer (`bundled`, `managed`, `personal`, …) is still shown, as a
+chip on each card, because it decides which skill wins a name collision. It no
+longer decides what heading the card sits under.
+
+**Update** and **Remove** follow what the install record actually supports
+rather than the layer. A hub-installed skill whose files no longer sit where
+the lockfile recorded them keeps Update — an update re-fetches by identifier —
+but loses Remove, and the dialog says why instead of offering a button that
+would fail.
+
+### Ready is not the same as offered
+
+A card's status dot answers "is this skill set up". A second, separate label
+answers "is the agent being offered it right now", and a skill can be fully
+ready and still withheld. When it is, the card and its dialog say which of
+these applies: the manifest disables model invocation, a requirement is
+missing, a tool it needs is not enabled in this session, a native tool
+supersedes it, relevance filtering skipped it for that message, or the injected
+skills block hit its character budget. Nothing is shown when the skill is
+offered — the absence of a label is the normal case.
+
+### Community tab
+
+Browsing and searching a hub also surfaces skills you have already installed
+from that source, including ones the catalog does not list — a skill installed
+straight from a GitHub URL appears alongside catalog rows rather than vanishing
+from the page it was installed on. Installed rows are marked and appear after
+catalog results. Installing or removing a skill updates the Installed marker
+immediately, without a page reload.
+
 ## Environment
 
 Open **Settings > Environment** to manage the variables in
@@ -257,8 +312,9 @@ that tool's own rotation.
 Values are masked. **Reveal** asks for confirmation, is rate limited, writes an
 audit line, and hides the value again after thirty seconds. Setting a variable
 applies it to the running gateway, so a skill that was ineligible becomes
-eligible immediately; provider keys additionally need a restart, and the screen
-says so when that is the case.
+eligible immediately — on this screen, on the Skills screen, and for the agent
+itself on its next turn. Provider keys additionally need a restart, and the
+screen says so when that is the case.
 
 Two things the screen deliberately makes visible:
 

--- a/frontend/src/views/skills/SkillsPage.test.tsx
+++ b/frontend/src/views/skills/SkillsPage.test.tsx
@@ -50,7 +50,15 @@ const READY_MANAGED = {
   name: 'trader',
   description: 'Trades things',
   layer: 'managed',
-  acquisition: { kind: 'hub', source_id: 'clawhub', removable: true, updatable: true },
+  acquisition: {
+    kind: 'hub',
+    source_id: 'clawhub',
+    identifier: 'uniswap-swap',
+    removable: true,
+    updatable: true,
+  },
+  publisher: { id: '', name: '', url: '', logo: '' },
+  availability: { offered: true, reason: '', detail: '' },
   status: 'ready',
   emoji: '📈',
 }
@@ -58,10 +66,62 @@ const NEEDS_BUNDLED = {
   name: 'weather',
   description: 'Weather lookups',
   layer: 'bundled',
-  acquisition: { kind: 'shipped' },
+  acquisition: { kind: 'shipped', removable: false, updatable: false },
+  publisher: { id: '', name: '', url: '', logo: '' },
+  availability: {
+    offered: false,
+    reason: 'ineligible',
+    detail: 'Installed, but not offered to the agent: the binary curl is not on PATH.',
+  },
   status: 'needs_setup',
   missing_bins: ['curl'],
   install: [{ id: 'brew-curl', kind: 'brew', label: 'Install curl', bins: ['curl'] }],
+}
+// A hub install the gateway will not offer to remove: `skills.uninstall` only
+// deletes from the configured managed dir, and this one is recorded elsewhere.
+const STRANDED_HUB = {
+  name: 'stranded',
+  description: 'Installed from a hub AgentOS can no longer delete from.',
+  layer: 'managed',
+  acquisition: {
+    kind: 'hub',
+    source_id: 'clawhub',
+    identifier: 'stranded-skill',
+    removable: false,
+    updatable: true,
+  },
+  status: 'ready',
+}
+// Hand-copied into the managed directory: same `layer`, no lockfile entry, so
+// neither affordance applies. Grouping and buttons must follow acquisition.
+const LOCAL_IN_MANAGED = {
+  name: 'handrolled',
+  description: 'Copied in by hand',
+  layer: 'managed',
+  acquisition: { kind: 'local', removable: false, updatable: false },
+  status: 'ready',
+}
+const BANKR_HUB_SKILL = {
+  name: 'bankr-swaps',
+  description: 'Swap tokens through Bankr.',
+  layer: 'managed',
+  acquisition: { kind: 'hub', source_id: 'bankr', identifier: 'bankr-swaps', removable: true },
+  publisher: { id: 'bankr', name: 'Bankr', url: 'https://bankr.bot', logo: '' },
+  status: 'ready',
+}
+// Ready, eligible, and still never reaching the model.
+const WITHHELD_SKILL = {
+  name: 'quiet',
+  description: 'The agent is never told about this one.',
+  layer: 'bundled',
+  acquisition: { kind: 'shipped' },
+  status: 'ready',
+  eligible: true,
+  availability: {
+    offered: false,
+    reason: 'model_invocation_disabled',
+    detail: 'This skill declares disable_model_invocation, so the agent is never offered it.',
+  },
 }
 const CATALOG_ITEM = {
   name: 'Uniswap',
@@ -131,6 +191,16 @@ const ROBINHOOD_UNDECLARED = {
   status: 'not_declared',
 }
 
+// A catalog row the empty-query browse does NOT return — the case where the
+// installed row used to vanish the moment the search was cleared.
+const SEARCH_ONLY_ITEM = {
+  name: 'Ledger Watch',
+  identifier: 'ledger-watch',
+  provider: 'Ledger',
+  source: 'clawhub',
+  description: 'Watch a ledger address.',
+}
+
 function wireRpc(
   opts: {
     skills?: unknown[]
@@ -138,6 +208,12 @@ function wireRpc(
     listPromise?: Promise<unknown>
     listReject?: boolean
     searchResults?: unknown[]
+    /**
+     * The catalog's own answer to a query. The mock used to return the same
+     * rows for every call, which is exactly why a list that swaps on the query
+     * text could break without a test noticing.
+     */
+    search?: (query: string, source: string) => unknown[] | Promise<{ results: unknown[] }>
     installResponse?: Record<string, unknown>
     uninstallResponse?: Record<string, unknown>
     updateResponse?: Record<string, unknown>
@@ -145,7 +221,8 @@ function wireRpc(
   } = {},
 ) {
   let listIndex = 0
-  mockRpc.call.mockImplementation((method: string) => {
+  mockRpc.call.mockImplementation((method: string, params?: unknown) => {
+    const p = (params ?? {}) as { query?: string; source?: string }
     switch (method) {
       case 'skills.list':
         if (opts.listPromise) return opts.listPromise
@@ -157,8 +234,27 @@ function wireRpc(
         return opts.listReject
           ? Promise.reject(new Error('list down'))
           : Promise.resolve({ skills: opts.skills ?? [READY_MANAGED, NEEDS_BUNDLED] })
-      case 'skills.search':
-        return Promise.resolve({ results: opts.searchResults ?? [CATALOG_ITEM] })
+      case 'skills.search': {
+        const query = (p.query ?? '').trim()
+        const source = p.source ?? ''
+        if (opts.search) {
+          const answer = opts.search(query, source)
+          return Array.isArray(answer) ? Promise.resolve({ results: answer }) : answer
+        }
+        const all = (opts.searchResults ?? [CATALOG_ITEM]) as Record<string, unknown>[]
+        const scoped = source ? all.filter((r) => r.source === source) : all
+        const q = query.toLowerCase()
+        const results = q
+          ? scoped.filter((r) =>
+              [r.name, r.description, r.provider].some((f) =>
+                String(f ?? '')
+                  .toLowerCase()
+                  .includes(q),
+              ),
+            )
+          : scoped
+        return Promise.resolve({ results })
+      }
       case 'skills.install':
         return Promise.resolve(opts.installResponse ?? { success: true, name: 'uniswap-swap' })
       case 'skills.uninstall':
@@ -173,16 +269,26 @@ function wireRpc(
   })
 }
 
-function renderPage() {
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderPage(client: QueryClient = makeClient()) {
   return render(
     <MemoryRouter>
-      <QueryClientProvider
-        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
-      >
+      <QueryClientProvider client={client}>
         <SkillsPage />
       </QueryClientProvider>
     </MemoryRouter>,
   )
+}
+
+/** The <details> block whose heading is `label`, i.e. one Installed group. */
+function groupNamed(label: string): HTMLElement {
+  const heading = screen.getByRole('heading', { name: label })
+  const block = heading.closest('details')
+  expect(block).not.toBeNull()
+  return block as HTMLElement
 }
 
 const callsFor = (m: string) => mockRpc.call.mock.calls.filter(([x]) => x === m)
@@ -468,7 +574,9 @@ describe('SkillsPage', () => {
     expect(readyCard.closest('.sk-grid')).toHaveClass('sk-grid--registry')
     expect(within(readyCard).getByRole('presentation')).toHaveAttribute('src', robinhoodSymbolUrl)
     expect(within(readyCard).getByText('Robinhood')).toBeInTheDocument()
-    expect(within(readyCard).getByText('bundled')).toBeInTheDocument()
+    // The source label is the row's real acquisition now, not a hardcoded
+    // 'bundled' — a partner hub install lands in this same tab.
+    expect(within(readyCard).getByText('shipped')).toBeInTheDocument()
     expect(within(readyCard).getByText('Ready')).toBeInTheDocument()
     expect(within(tradingCard).getByText('No manifest')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^Install$/i })).not.toBeInTheDocument()
@@ -630,6 +738,173 @@ describe('SkillsPage', () => {
     // Title + language render as their own labelled spans in the heading.
     expect(within(dialog).getByText('Quote a swap')).toBeInTheDocument()
     expect(within(dialog).getByText('python')).toBeInTheDocument()
+  })
+
+  // ── #130: the Installed tab groups on provenance, not on the layer ───────
+  it('groups the Installed tab into Partners / Shipped / Hub / Local', async () => {
+    wireRpc({
+      skills: [READY_MANAGED, NEEDS_BUNDLED, LOCAL_IN_MANAGED, BANKR_HUB_SKILL, ROBINHOOD_READY],
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+
+    expect(screen.getAllByRole('heading').map((h) => h.textContent)).toEqual(
+      expect.arrayContaining([
+        'Partners',
+        'Shipped with AgentOS',
+        'Installed from a hub',
+        'Your local skills',
+      ]),
+    )
+    // The issue's stated criterion: Bankr and Robinhood under ONE heading,
+    // even though one is a hub install and the other ships with AgentOS.
+    const partners = groupNamed('Partners')
+    expect(within(partners).getByLabelText('Skill bankr-swaps')).toBeInTheDocument()
+    expect(within(partners).getByLabelText('Skill robinhood-rwa-addresses')).toBeInTheDocument()
+
+    expect(
+      within(groupNamed('Installed from a hub')).getByLabelText('Skill trader'),
+    ).toBeInTheDocument()
+    expect(
+      within(groupNamed('Shipped with AgentOS')).getByLabelText('Skill weather'),
+    ).toBeInTheDocument()
+    // layer 'managed' with no lockfile entry is a local skill, not a hub one.
+    expect(
+      within(groupNamed('Your local skills')).getByLabelText('Skill handrolled'),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the layer visible as a per-card detail chip', async () => {
+    wireRpc({ skills: [READY_MANAGED] })
+    renderPage()
+    const card = await screen.findByLabelText('Skill trader')
+    expect(within(card).getByText('Managed')).toBeInTheDocument()
+  })
+
+  // ── #130: Update/Remove come off the payload, not off the layer ──────────
+  it('a managed-layer skill with no lockfile entry offers neither Update nor Remove', async () => {
+    wireRpc({ skills: [LOCAL_IN_MANAGED] })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill handrolled')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Skill handrolled'))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).queryByRole('button', { name: /^Update$/i })).not.toBeInTheDocument()
+    expect(within(dialog).queryByRole('button', { name: /^Remove$/i })).not.toBeInTheDocument()
+  })
+
+  it('a hub skill AgentOS cannot delete explains itself instead of offering a dead Remove', async () => {
+    wireRpc({ skills: [STRANDED_HUB] })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill stranded')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Skill stranded'))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByRole('button', { name: /^Update$/i })).toBeInTheDocument()
+    expect(within(dialog).queryByRole('button', { name: /^Remove$/i })).not.toBeInTheDocument()
+    expect(within(dialog).getByText(/cannot remove this skill/i)).toBeInTheDocument()
+  })
+
+  // ── #130 core: installed, ready, and still not reaching the agent ────────
+  it('a skill the agent is never offered says so on the card and why in the dialog', async () => {
+    wireRpc({ skills: [WITHHELD_SKILL, READY_MANAGED] })
+    renderPage()
+    const card = await screen.findByLabelText('Skill quiet')
+    // The status is untouched — this is a third state, not a failed one.
+    expect(within(card).getByText('Ready')).toBeInTheDocument()
+    expect(within(card).getByText('Not offered — agent cannot invoke')).toBeInTheDocument()
+    // A skill that IS offered carries no such chip.
+    expect(
+      within(screen.getByLabelText('Skill trader')).queryByText(/Not offered/),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(card)
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Agent availability')).toBeInTheDocument()
+    expect(within(dialog).getByText(WITHHELD_SKILL.availability.detail)).toBeInTheDocument()
+  })
+
+  // ── #130 symptom 2: the Community list stops swapping ────────────────────
+  it('a row installed while searching survives the search being cleared', async () => {
+    wireRpc({
+      search: (query) => (query ? [SEARCH_ONLY_ITEM] : [CATALOG_ITEM]),
+      installResponse: { success: true, name: 'ledger-watch' },
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('tab', { name: /^Community$/i }))
+    const input = await screen.findByLabelText('Search community skills')
+
+    fireEvent.change(input, { target: { value: 'ledger' } })
+    const card = await screen.findByLabelText('Catalog skill Ledger Watch')
+    fireEvent.click(within(card).getByRole('button', { name: /^Install$/i }))
+    await waitFor(() => expect(toast.success).toHaveBeenCalled())
+
+    fireEvent.change(input, { target: { value: '' } })
+    // The browse list is back…
+    await screen.findByLabelText('Catalog skill Uniswap')
+    // …and the row the browse itself never returned is still on it, installed.
+    const stillThere = screen.getByLabelText('Catalog skill Ledger Watch')
+    expect(within(stillThere).getByText('Installed')).toBeInTheDocument()
+  })
+
+  it('clearing the search does not unmount an open catalog dialog', async () => {
+    wireRpc({ search: (query) => (query ? [SEARCH_ONLY_ITEM] : [CATALOG_ITEM]) })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('tab', { name: /^Community$/i }))
+    const input = await screen.findByLabelText('Search community skills')
+
+    fireEvent.change(input, { target: { value: 'ledger' } })
+    const card = await screen.findByLabelText('Catalog skill Ledger Watch')
+    fireEvent.click(within(card).getByRole('button', { name: 'View details for Ledger Watch' }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: '' } })
+    await screen.findByLabelText('Catalog skill Uniswap')
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Ledger Watch')).toBeInTheDocument()
+  })
+
+  it('uninstalling refreshes the catalog so the Installed chip is not stale', async () => {
+    let removed = false
+    wireRpc({
+      skills: [READY_MANAGED],
+      search: () => [{ ...CATALOG_ITEM, installed: !removed }],
+    })
+    const client = makeClient()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    renderPage(client)
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Community$/i }))
+    const before = await screen.findByLabelText('Catalog skill Uniswap')
+    expect(within(before).getByText('Installed')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Installed' }))
+    fireEvent.click(await screen.findByLabelText('Skill trader'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Remove$/i }))
+    // The gateway has dropped the lockfile entry the chip is derived from.
+    removed = true
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ['skills.search'] }))
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Community$/i }))
+    const after = await screen.findByLabelText('Catalog skill Uniswap')
+    await waitFor(() =>
+      expect(within(after).getByRole('button', { name: /^Install$/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('a failed live search shows the error instead of an empty catalog', async () => {
+    wireRpc({
+      search: (query) => (query ? Promise.reject(new Error('search down')) : [CATALOG_ITEM]),
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('tab', { name: /^Community$/i }))
+    const input = await screen.findByLabelText('Search community skills')
+
+    fireEvent.change(input, { target: { value: 'zzz' } })
+    expect(await screen.findByText(/Failed to load: Error: search down/)).toBeInTheDocument()
+    expect(screen.queryByText('No skills match zzz.')).not.toBeInTheDocument()
   })
 
   it('sets the document title', async () => {

--- a/frontend/src/views/skills/SkillsPage.test.tsx
+++ b/frontend/src/views/skills/SkillsPage.test.tsx
@@ -50,6 +50,7 @@ const READY_MANAGED = {
   name: 'trader',
   description: 'Trades things',
   layer: 'managed',
+  acquisition: { kind: 'hub', source_id: 'clawhub', removable: true, updatable: true },
   status: 'ready',
   emoji: '📈',
 }
@@ -57,6 +58,7 @@ const NEEDS_BUNDLED = {
   name: 'weather',
   description: 'Weather lookups',
   layer: 'bundled',
+  acquisition: { kind: 'shipped' },
   status: 'needs_setup',
   missing_bins: ['curl'],
   install: [{ id: 'brew-curl', kind: 'brew', label: 'Install curl', bins: ['curl'] }],
@@ -109,10 +111,14 @@ const REQ_BUNDLED = {
   },
 }
 
+// Partner identity comes from the server-side publisher allowlist, never from
+// the `robinhood-` name prefix — the client no longer reads the name at all.
 const ROBINHOOD_READY = {
   name: 'robinhood-rwa-addresses',
   description: 'Look up tokenized-stock contract addresses.',
   layer: 'bundled',
+  acquisition: { kind: 'shipped' },
+  publisher: { id: 'robinhood', name: 'Robinhood', url: 'https://robinhood.com', logo: '' },
   status: 'ready',
 }
 
@@ -120,6 +126,8 @@ const ROBINHOOD_UNDECLARED = {
   name: 'robinhood-agentic-trading',
   description: 'Operate Robinhood Agentic Trading through the Robinhood Trading MCP.',
   layer: 'bundled',
+  acquisition: { kind: 'shipped' },
+  publisher: { id: 'robinhood', name: 'Robinhood', url: 'https://robinhood.com', logo: '' },
   status: 'not_declared',
 }
 
@@ -190,16 +198,16 @@ describe('SkillsPage', () => {
     vi.useRealTimers()
   })
 
-  it('calls skills.list after waitForConnection and renders installed cards grouped by layer', async () => {
+  it('calls skills.list after waitForConnection and groups installed cards by provenance', async () => {
     wireRpc()
     renderPage()
     await waitFor(() => expect(mockRpc.call).toHaveBeenCalledWith('skills.list', {}))
     expect(mockRpc.waitForConnection).toHaveBeenCalled()
     await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
     expect(screen.getByLabelText('Skill weather')).toBeInTheDocument()
-    // Layer groups (bundled before managed)
-    expect(screen.getByText('Bundled')).toBeInTheDocument()
-    expect(screen.getByText('Managed')).toBeInTheDocument()
+    // Provenance groups: shipped before hub (SKILL_GROUP_ORDER), not layers.
+    expect(screen.getByText('Shipped with AgentOS')).toBeInTheDocument()
+    expect(screen.getByText('Installed from a hub')).toBeInTheDocument()
   })
 
   it('renders the status metric pills from the payload', async () => {

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -45,6 +45,8 @@ import {
   skillAvailabilityLabel,
   skillAvailabilityTitle,
   skillAvailabilityTone,
+  skillCanRemove,
+  skillCanUpdate,
   skillDotClass,
   skillDotTitle,
   skillStats,
@@ -1540,11 +1542,8 @@ function SkillDialog({
 }) {
   const titleId = useId()
   const status = skillStatus(skill)
-  // What an operator may do comes off the payload, not off the layer: a hub
-  // install stays removable when `skills.managed_dir` moves, and a hand-copied
-  // directory inside the managed dir was never removable in the first place.
-  const canUpdate = skill.acquisition?.updatable === true
-  const canRemove = skill.acquisition?.removable === true
+  const canUpdate = skillCanUpdate(skill)
+  const canRemove = skillCanRemove(skill)
   const removeBlocked = skill.acquisition?.kind === 'hub' && !canRemove
   const availabilityDetail =
     skillAvailabilityTone(skill) === 'not-offered' ? skillAvailabilityTitle(skill) : ''

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -512,10 +512,12 @@ export function SkillsPage() {
   const invalidateRegistry = () => queryClient.invalidateQueries({ queryKey: ['skills.search'] })
 
   // Flip the Installed chip on every cached catalog list before the refetch
-  // lands, so it never lags a network round trip behind the button.
+  // lands, so it never lags a network round trip behind the button. Lists that
+  // hold no data yet are left alone: writing `[]` into a query that is still
+  // in flight would resolve it to a "no results" state until the fetch lands.
   const markCached = (identifier: string, name: string, installed: boolean) =>
     queryClient.setQueriesData<RegistryItem[]>({ queryKey: ['skills.search'] }, (old) =>
-      markInstalled(old ?? [], identifier, name, installed),
+      old ? markInstalled(old, identifier, name, installed) : old,
     )
 
   const setBusy = (key: string, on: boolean) =>

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -29,7 +29,7 @@ import {
   filterRegistry,
   filterSkills,
   firstUpdateResult,
-  groupSkillsByLayer,
+  groupSkills,
   initials,
   installAction,
   installSource,
@@ -38,13 +38,13 @@ import {
   layerLabel,
   registryEmptyMessage,
   registryKey,
-  robinhoodEmptyMessage,
-  robinhoodSkills,
+  partnerEmptyMessage,
   safeUrl,
   skillDotClass,
   skillDotTitle,
   skillStats,
   skillStatus,
+  skillsByPublisher,
   stillMissingCount,
   type DepsInstallResult,
   type RawSkill,
@@ -545,8 +545,8 @@ export function SkillsPage() {
   const allSkills = skillsQuery.data ?? []
   const stats = skillStats(allSkills)
   const filtered = filterSkills(allSkills, filterText, statusFilter)
-  const groups = groupSkillsByLayer(filtered)
-  const rhSkills = robinhoodSkills(allSkills)
+  const groups = groupSkills(filtered)
+  const rhSkills = skillsByPublisher(allSkills, 'robinhood')
 
   const runInstall = (item: RegistryItem, force: boolean) =>
     installMutation.mutate({
@@ -948,7 +948,7 @@ function InstalledPanel({
 }: {
   loading: boolean
   error: string
-  groups: ReturnType<typeof groupSkillsByLayer>
+  groups: ReturnType<typeof groupSkills>
   empty: boolean
   emptyMessage: string
   onOpen: (name: string) => void
@@ -974,12 +974,12 @@ function InstalledPanel({
       className="sk-panel"
     >
       {groups.map((g) => (
-        <details key={g.layer} className="sk-group" open>
+        <details key={g.key} className="sk-group" open>
           <summary className="sk-group__head">
             <ChevronDownIcon className="sk-group__caret" aria-hidden="true" />
             <span className="sk-group__label">{g.label}</span>
             <span className="sk-group__count">{g.skills.length}</span>
-            <span className="sk-group__meta">{layerHelp(g.layer)}</span>
+            <span className="sk-group__meta">{g.help}</span>
           </summary>
           <div className="sk-grid">
             <AnimatePresence initial={false}>
@@ -1119,7 +1119,9 @@ function RobinhoodPanel({
         ) : loading ? (
           <SkillsSkeleton label="Loading Robinhood skills" />
         ) : filtered.length === 0 ? (
-          <div className="sk-registry__hint">{robinhoodEmptyMessage(query, statusFilter)}</div>
+          <div className="sk-registry__hint">
+            {partnerEmptyMessage('Robinhood', query, statusFilter)}
+          </div>
         ) : (
           <div className="sk-grid sk-grid--registry">
             <AnimatePresence initial={false}>

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -36,10 +36,15 @@ import {
   installedEmptyMessage,
   layerHelp,
   layerLabel,
+  markInstalled,
+  mergeRegistryRows,
   registryEmptyMessage,
   registryKey,
   partnerEmptyMessage,
   safeUrl,
+  skillAvailabilityLabel,
+  skillAvailabilityTitle,
+  skillAvailabilityTone,
   skillDotClass,
   skillDotTitle,
   skillStats,
@@ -66,9 +71,57 @@ const TAB_ORDER: Tab[] = SHOW_BANKR
   ? ['installed', 'bankr', 'robinhood', 'community']
   : ['installed', 'robinhood', 'community']
 
+// The bundled brand artwork stays a client-side asset: a local import is not
+// something a SKILL.md could carry. Membership, however, is the payload's call —
+// `publisher.id` is resolved against a server-side allowlist.
 const PARTNER_BRANDS: Record<PartnerBrand, { label: string; asset: string }> = {
   bankr: { label: 'Bankr', asset: bankrSymbolUrl },
   robinhood: { label: 'Robinhood', asset: robinhoodSymbolUrl },
+}
+
+/**
+ * The short provenance label on a card: where the skill actually came from,
+ * rather than which directory it happens to load from. A hub install shows the
+ * hub it came from, which is the same string the catalog card prints.
+ */
+function acquisitionSourceLabel(skill: RawSkill): string {
+  const acq = skill.acquisition
+  if (acq?.kind === 'hub') return acq.source_id || 'hub'
+  if (acq?.kind === 'shipped') return 'shipped'
+  if (acq?.kind === 'local') return 'local'
+  // Pre-#130 gateway: fall back to the location layer rather than claim one.
+  return layerLabel(skill.layer).toLowerCase()
+}
+
+/**
+ * `skills.uninstall` deletes `<managed_dir>/<name>` and nothing else, so the
+ * gateway reports `removable: false` when the recorded install sits somewhere
+ * else (a re-pointed `skills.managed_dir`, or none configured). Its reason
+ * string names filesystem paths and is deliberately kept off the wire, so say
+ * what the operator has to do instead of rendering a button that half-succeeds.
+ */
+const REMOVE_BLOCKED_NOTE =
+  'AgentOS cannot remove this skill: the configured managed skills directory does not hold it. Check skills.managed_dir, or delete the files by hand.'
+
+/**
+ * The "installed, but the agent is not being offered it" chip.
+ *
+ * Renders nothing when the skill IS offered (the status chip already says the
+ * skill is fine) and nothing when availability was not computed — an absent
+ * block means unknown, never not-offered. The reason is spelled out in text so
+ * the state does not depend on the dot colour alone.
+ */
+function AvailabilityChip({ skill, className }: { skill: RawSkill; className?: string }) {
+  if (skillAvailabilityTone(skill) !== 'not-offered') return null
+  return (
+    <span
+      className={`sk-chip sk-chip--withheld${className ? ' ' + className : ''}`}
+      title={skillAvailabilityTitle(skill)}
+    >
+      <span className="sk-chip__dot" aria-hidden="true" />
+      {skillAvailabilityLabel(skill)}
+    </span>
+  )
 }
 
 interface SkillsListResponse {
@@ -168,6 +221,14 @@ function SkillCard({ skill, onOpen }: { skill: RawSkill; onOpen: () => void }) {
         </span>
       </div>
       <p className="sk-card__desc">{desc}</p>
+      {/* The Installed tab groups on provenance now, so the loading layer moves
+          to the card — precedence still has to be debuggable at a glance. */}
+      <span className="sk-card__meta">
+        <span className="sk-chip sk-chip--layer" title={layerHelp(skill.layer)}>
+          {layerLabel(skill.layer)}
+        </span>
+        <AvailabilityChip skill={skill} />
+      </span>
       <span className="sk-card__foot" aria-hidden="true">
         View details
         <ChevronRightIcon />
@@ -227,7 +288,16 @@ function RegistryCard({
   )
 }
 
-function PartnerSkillCard({ skill, onOpen }: { skill: RawSkill; onOpen: () => void }) {
+function PartnerSkillCard({
+  brand,
+  skill,
+  onOpen,
+}: {
+  brand: PartnerBrand
+  skill: RawSkill
+  onOpen: () => void
+}) {
+  const label = PARTNER_BRANDS[brand].label
   const status = skillStatus(skill)
   const statusLabel =
     status === 'ready' ? 'Ready' : status === 'needs_setup' ? 'Setup required' : 'No manifest'
@@ -239,7 +309,7 @@ function PartnerSkillCard({ skill, onOpen }: { skill: RawSkill; onOpen: () => vo
         : 'sk-chip--unverified'
 
   return (
-    <article className="sk-rcard sk-rcard--partner" aria-label={`Robinhood skill ${skill.name}`}>
+    <article className="sk-rcard sk-rcard--partner" aria-label={`${label} skill ${skill.name}`}>
       <button
         type="button"
         className="sk-rcard__details"
@@ -247,16 +317,19 @@ function PartnerSkillCard({ skill, onOpen }: { skill: RawSkill; onOpen: () => vo
         onClick={onOpen}
       >
         <div className="sk-rcard__head">
-          <PartnerLogo brand="robinhood" className="sk-rcard__logo" decorative />
+          <PartnerLogo brand={brand} className="sk-rcard__logo" decorative />
           <div className="sk-rcard__titles">
             <span className="sk-rcard__name">{skill.name}</span>
-            <span className="sk-rcard__provider">Robinhood</span>
+            <span className="sk-rcard__provider">{label}</span>
           </div>
         </div>
         <span className="sk-rcard__desc">{skill.description || 'Open details'}</span>
       </button>
       <div className="sk-rcard__foot">
-        <span className="sk-rcard__src sk-mono">bundled</span>
+        {/* Not every partner skill ships with AgentOS — a partner hub install
+            reaches this same tab, so the label comes off the payload. */}
+        <span className="sk-rcard__src sk-mono">{acquisitionSourceLabel(skill)}</span>
+        <AvailabilityChip skill={skill} />
         <span className={`sk-chip ${statusClass}`} title={skillDotTitle(skill)}>
           {status === 'ready' ? <CheckIcon aria-hidden="true" /> : null}
           {status === 'needs_setup' ? <TriangleAlertIcon aria-hidden="true" /> : null}
@@ -316,7 +389,10 @@ function InstallButton({
 type Dialog =
   | { kind: 'none' }
   | { kind: 'skill'; name: string }
-  | { kind: 'registry'; group: RegistryGroup; key: string }
+  // The row is captured on open, not only its key: the list under the dialog is
+  // a query result that changes when the search text does, and looking the row
+  // up again is what used to unmount an open dialog on a cleared query.
+  | { kind: 'registry'; group: RegistryGroup; key: string; item: RegistryItem }
 
 export function SkillsPage() {
   const rpc = useRpc()
@@ -346,6 +422,13 @@ export function SkillsPage() {
   // Force-armed identifiers (skills.js:34) + per-item busy keys.
   const [forceArmed, setForceArmed] = useState<Set<string>>(new Set())
   const [busyKeys, setBusyKeys] = useState<Set<string>>(new Set())
+
+  // Catalog rows installed during this session. The gateway now synthesizes a
+  // row for an install no catalog lists, so a refetch alone brings it back —
+  // but only once the refetch lands. Merging locally keeps the row on screen
+  // from the same tick the install succeeds, and the server's richer row wins
+  // as soon as it arrives (mergeRegistryRows lets `base` win a collision).
+  const [sessionInstalls, setSessionInstalls] = useState<RegistryItem[]>([])
 
   useEffect(() => {
     document.title = 'Skills - AgentOS Control'
@@ -426,6 +509,14 @@ export function SkillsPage() {
   })
 
   const invalidateSkills = () => queryClient.invalidateQueries({ queryKey: ['skills'] })
+  const invalidateRegistry = () => queryClient.invalidateQueries({ queryKey: ['skills.search'] })
+
+  // Flip the Installed chip on every cached catalog list before the refetch
+  // lands, so it never lags a network round trip behind the button.
+  const markCached = (identifier: string, name: string, installed: boolean) =>
+    queryClient.setQueriesData<RegistryItem[]>({ queryKey: ['skills.search'] }, (old) =>
+      markInstalled(old ?? [], identifier, name, installed),
+    )
 
   const setBusy = (key: string, on: boolean) =>
     setBusyKeys((prev) => {
@@ -447,16 +538,33 @@ export function SkillsPage() {
   // skills.js:926-977 — install. Per-item busy; a "dangerous" scan verdict
   // arms an explicit force-install override (not an error).
   const installMutation = useMutation({
-    mutationFn: (vars: { identifier: string; source: string; force: boolean }) =>
-      rpc.call<InstallResponse>('skills.install', vars),
+    // `item` never reaches the wire — it is the catalog row to keep on screen
+    // while the refetch is out. A GitHub install has none, and the gateway's
+    // synthesized row covers it on the next fetch.
+    mutationFn: (vars: {
+      identifier: string
+      source: string
+      force: boolean
+      item?: RegistryItem
+    }) =>
+      rpc.call<InstallResponse>('skills.install', {
+        identifier: vars.identifier,
+        source: vars.source,
+        force: vars.force,
+      }),
     onMutate: (vars) => setBusy(vars.identifier, true),
     onSettled: (_d, _e, vars) => setBusy(vars.identifier, false),
     onSuccess: (res, vars) => {
       if (res?.success) {
         armForce(vars.identifier, false)
         toast.success('Installed ' + (res.name || vars.identifier), { id: 'skills-install' })
+        if (vars.item) {
+          const row = { ...vars.item, installed: true }
+          setSessionInstalls((prev) => mergeRegistryRows([row], prev))
+        }
+        markCached(vars.identifier, res.name || '', true)
         void invalidateSkills()
-        void queryClient.invalidateQueries({ queryKey: ['skills.search'] })
+        void invalidateRegistry()
         return
       }
       const blocked = res?.scan_verdict === 'dangerous'
@@ -480,14 +588,26 @@ export function SkillsPage() {
 
   // skills.js:979-991 — uninstall (managed skills only). Per-item busy.
   const uninstallMutation = useMutation({
-    mutationFn: (name: string) => rpc.call<MutationResponse>('skills.uninstall', { name }),
-    onMutate: (name) => setBusy('uninstall:' + name, true),
-    onSettled: (_d, _e, name) => setBusy('uninstall:' + name, false),
-    onSuccess: (res, name) => {
+    // `identifier` is the lockfile identifier the catalog row is keyed by; it
+    // is not sent, it is what lets the Installed chip be un-flipped.
+    mutationFn: (vars: { name: string; identifier: string }) =>
+      rpc.call<MutationResponse>('skills.uninstall', { name: vars.name }),
+    onMutate: (vars) => setBusy('uninstall:' + vars.name, true),
+    onSettled: (_d, _e, vars) => setBusy('uninstall:' + vars.name, false),
+    onSuccess: (res, vars) => {
+      const name = vars.name
       if (res?.success) {
         toast.success('Removed ' + name, { id: 'skills-uninstall' })
         setDialog({ kind: 'none' })
+        setSessionInstalls((prev) =>
+          prev.filter((r) => r.name !== name && registryKey(r) !== vars.identifier),
+        )
+        markCached(vars.identifier, name, false)
         void invalidateSkills()
+        // The catalog's "Installed" chip is derived from the same lockfile the
+        // removal just edited, so it is stale until this refetch — install has
+        // always invalidated it; removal never did.
+        void invalidateRegistry()
       } else {
         toast.error(res?.message || 'Uninstall failed', { id: 'skills-uninstall-err' })
       }
@@ -553,7 +673,60 @@ export function SkillsPage() {
       identifier: registryKey(item),
       source: installSource(item),
       force,
+      item,
     })
+
+  // ── Catalog lists ─────────────────────────────────────────────────────────
+  // A live query answers a question the snapshot cannot (the snapshot is only
+  // each source's first page), so it still supersedes the snapshot as the base
+  // list. What is new is that the browse list is a MERGE, not a swap: a row
+  // installed while searching survives the search being cleared.
+  const bankrRows = useMemo(
+    () =>
+      mergeRegistryRows(
+        bankrSnapshot.data ?? [],
+        sessionInstalls.filter((r) => r.source === 'bankr'),
+      ),
+    [bankrSnapshot.data, sessionInstalls],
+  )
+
+  const communityLive = communityQuery ? communitySearch.data : undefined
+  const communityBrowse = useMemo(
+    () =>
+      mergeRegistryRows(communitySnapshot.data ?? [], communityFilter(sessionInstalls, SHOW_BANKR)),
+    [communitySnapshot.data, sessionInstalls],
+  )
+  const communityRows = communityLive ?? communityBrowse
+
+  // The rows on screen are the server's own answer only once the committed
+  // query has caught up with the input and the response has landed; until then
+  // the client text pass still narrows the stale list optimistically.
+  const communityServerFiltered = Boolean(communityLive) && communityText.trim() === communityQuery
+
+  // A failed live search used to fall through to the snapshot's error state,
+  // which is empty — so a search that errored rendered as "no results".
+  const communityError =
+    communityQuery && communitySearch.isError
+      ? String(communitySearch.error)
+      : communitySnapshot.isError
+        ? String(communitySnapshot.error)
+        : ''
+
+  /**
+   * The row behind an open registry dialog. Prefers the live lists so the
+   * Installed chip inside the dialog stays current, and falls back to the row
+   * captured when the dialog opened — clearing the search swaps the list out
+   * from under it, and the dialog must not vanish because of that.
+   */
+  const registryItemFor = (d: Extract<Dialog, { kind: 'registry' }>): RegistryItem => {
+    const pools =
+      d.group === 'bankr' ? [bankrRows] : [communityRows, communityBrowse, communitySearch.data]
+    for (const pool of pools) {
+      const hit = (pool ?? []).find((r) => registryKey(r) === d.key)
+      if (hit) return hit
+    }
+    return d.item
+  }
 
   const refresh = () => {
     if (tab === 'bankr') void bankrSnapshot.refetch()
@@ -681,7 +854,7 @@ export function SkillsPage() {
       {SHOW_BANKR && tab === 'bankr' ? (
         <RegistryPanel
           group="bankr"
-          snapshot={bankrSnapshot.data ?? []}
+          snapshot={bankrRows}
           loading={bankrSnapshot.isLoading}
           error={bankrSnapshot.isError ? String(bankrSnapshot.error) : ''}
           query={bankrQuery}
@@ -690,7 +863,9 @@ export function SkillsPage() {
           onCategory={setBankrCat}
           forceArmed={forceArmed}
           busyKeys={busyKeys}
-          onOpen={(key) => setDialog({ kind: 'registry', group: 'bankr', key })}
+          onOpen={(item) =>
+            setDialog({ kind: 'registry', group: 'bankr', key: registryKey(item), item })
+          }
           onInstall={runInstall}
         />
       ) : null}
@@ -758,22 +933,20 @@ export function SkillsPage() {
           </section>
           <RegistryPanel
             group="community"
-            // A live query supersedes the snapshot as the base list.
-            snapshot={
-              communityQuery && communitySearch.data
-                ? communitySearch.data
-                : (communitySnapshot.data ?? [])
-            }
-            chipSnapshot={communitySnapshot.data ?? []}
+            snapshot={communityRows}
+            chipSnapshot={communityBrowse}
+            serverFiltered={communityServerFiltered}
             loading={communityQuery ? communitySearch.isLoading : communitySnapshot.isLoading}
-            error={communitySnapshot.isError ? String(communitySnapshot.error) : ''}
+            error={communityError}
             query={communityText}
             onQuery={setCommunityText}
             category={communityCat}
             onCategory={setCommunityCat}
             forceArmed={forceArmed}
             busyKeys={busyKeys}
-            onOpen={(key) => setDialog({ kind: 'registry', group: 'community', key })}
+            onOpen={(item) =>
+              setDialog({ kind: 'registry', group: 'community', key: registryKey(item), item })
+            }
             onInstall={runInstall}
           />
         </>
@@ -790,7 +963,12 @@ export function SkillsPage() {
                   busyKeys={busyKeys}
                   onClose={() => setDialog({ kind: 'none' })}
                   onUpdate={() => updateMutation.mutate(skill.name!)}
-                  onRemove={() => uninstallMutation.mutate(skill.name!)}
+                  onRemove={() =>
+                    uninstallMutation.mutate({
+                      name: skill.name!,
+                      identifier: skill.acquisition?.identifier || '',
+                    })
+                  }
                   onInstallDeps={(installId) =>
                     depsMutation.mutate({ name: skill.name!, installId })
                   }
@@ -829,14 +1007,7 @@ export function SkillsPage() {
 
         {dialog.kind === 'registry'
           ? (() => {
-              const base =
-                dialog.group === 'bankr'
-                  ? (bankrSnapshot.data ?? [])
-                  : communityQuery && communitySearch.data
-                    ? communitySearch.data
-                    : (communitySnapshot.data ?? [])
-              const item = base.find((r) => registryKey(r) === dialog.key)
-              if (!item) return null
+              const item = registryItemFor(dialog)
               return (
                 <RegistryDialog
                   item={item}
@@ -977,7 +1148,7 @@ function InstalledPanel({
         <details key={g.key} className="sk-group" open>
           <summary className="sk-group__head">
             <ChevronDownIcon className="sk-group__caret" aria-hidden="true" />
-            <span className="sk-group__label">{g.label}</span>
+            <h2 className="sk-group__label">{g.label}</h2>
             <span className="sk-group__count">{g.skills.length}</span>
             <span className="sk-group__meta">{g.help}</span>
           </summary>
@@ -1127,7 +1298,11 @@ function RobinhoodPanel({
             <AnimatePresence initial={false}>
               {filtered.map((skill) => (
                 <MotionListItem key={skill.name}>
-                  <PartnerSkillCard skill={skill} onOpen={() => onOpen(skill.name!)} />
+                  <PartnerSkillCard
+                    brand="robinhood"
+                    skill={skill}
+                    onOpen={() => onOpen(skill.name!)}
+                  />
                 </MotionListItem>
               ))}
             </AnimatePresence>
@@ -1142,6 +1317,7 @@ function RegistryPanel({
   group,
   snapshot,
   chipSnapshot,
+  serverFiltered,
   loading,
   error,
   query,
@@ -1156,6 +1332,7 @@ function RegistryPanel({
   group: RegistryGroup
   snapshot: RegistryItem[]
   chipSnapshot?: RegistryItem[]
+  serverFiltered?: boolean
   loading: boolean
   error: string
   query: string
@@ -1164,7 +1341,7 @@ function RegistryPanel({
   onCategory: (c: string) => void
   forceArmed: Set<string>
   busyKeys: Set<string>
-  onOpen: (key: string) => void
+  onOpen: (item: RegistryItem) => void
   onInstall: (item: RegistryItem, force: boolean) => void
 }) {
   // skills.js:567 — chips derive from the FULL snapshot only.
@@ -1172,10 +1349,13 @@ function RegistryPanel({
     () => categoryChips(chipSnapshot ?? snapshot, category),
     [chipSnapshot, snapshot, category],
   )
-  // skills.js:610-620 — apply category then text filter.
+  // skills.js:610-620 — apply category then text filter. The text pass is
+  // skipped once these rows ARE the server's answer to the query: the server
+  // also matches on tags, which never reach the client, so re-filtering there
+  // can only drop real hits.
   const items = useMemo(
-    () => filterRegistry(snapshot, category, query),
-    [snapshot, category, query],
+    () => filterRegistry(snapshot, category, query, { serverFiltered }),
+    [snapshot, category, query, serverFiltered],
   )
 
   return (
@@ -1253,7 +1433,7 @@ function RegistryPanel({
                     item={r}
                     forceArmed={forceArmed}
                     busy={busyKeys.has(registryKey(r))}
-                    onOpen={() => onOpen(registryKey(r))}
+                    onOpen={() => onOpen(r)}
                     onInstall={(force) => onInstall(r, force)}
                   />
                 </MotionListItem>
@@ -1358,7 +1538,14 @@ function SkillDialog({
 }) {
   const titleId = useId()
   const status = skillStatus(skill)
-  const isManaged = skill.layer === 'managed'
+  // What an operator may do comes off the payload, not off the layer: a hub
+  // install stays removable when `skills.managed_dir` moves, and a hand-copied
+  // directory inside the managed dir was never removable in the first place.
+  const canUpdate = skill.acquisition?.updatable === true
+  const canRemove = skill.acquisition?.removable === true
+  const removeBlocked = skill.acquisition?.kind === 'hub' && !canRemove
+  const availabilityDetail =
+    skillAvailabilityTone(skill) === 'not-offered' ? skillAvailabilityTitle(skill) : ''
   const hasMissingBins = (skill.missing_bins || []).length > 0
   const installs = hasMissingBins ? skill.install || [] : []
   const homepage = safeUrl(skill.homepage)
@@ -1397,6 +1584,7 @@ function SkillDialog({
             ) : (
               <span className="sk-chip sk-chip--warn">needs deps</span>
             )}
+            <AvailabilityChip skill={skill} />
           </div>
         </div>
         <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label="Close">
@@ -1405,6 +1593,15 @@ function SkillDialog({
       </header>
       <section className="sk-dialog__body">
         <p className="sk-dialog__desc">{skill.description || ''}</p>
+        {/* Installed and even "ready" is not the same as reaching the agent.
+            This section is the answer to "I installed it, why can the agent
+            still not find it?" — the gateway writes the prose. */}
+        {availabilityDetail ? (
+          <div className="sk-dialog__section sk-dialog__withheld">
+            <div className="sk-dialog__section-title">Agent availability</div>
+            <p className="sk-dialog__desc">{availabilityDetail}</p>
+          </div>
+        ) : null}
         <RequirementsSection requirements={skill.requirements} />
         {hasMissing ? (
           <div className="sk-dialog__section">
@@ -1480,30 +1677,32 @@ function SkillDialog({
         ) : null}
       </section>
       <footer className="sk-dialog__foot">
-        {skill.file_path ? (
+        {removeBlocked ? (
+          <small className="sk-dim sk-dialog__note">{REMOVE_BLOCKED_NOTE}</small>
+        ) : skill.file_path ? (
           <small className="sk-dim sk-dialog__path">{skill.file_path}</small>
         ) : null}
-        {isManaged ? (
-          <>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={updateBusy}
-              onClick={onUpdate}
-            >
-              {updateBusy ? 'Updating…' : 'Update'}
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              disabled={removeBusy}
-              onClick={onRemove}
-            >
-              {removeBusy ? 'Removing…' : 'Remove'}
-            </Button>
-          </>
+        {canUpdate ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={updateBusy}
+            onClick={onUpdate}
+          >
+            {updateBusy ? 'Updating…' : 'Update'}
+          </Button>
+        ) : null}
+        {canRemove ? (
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            disabled={removeBusy}
+            onClick={onRemove}
+          >
+            {removeBusy ? 'Removing…' : 'Remove'}
+          </Button>
         ) : null}
       </footer>
     </ModalShell>

--- a/frontend/src/views/skills/logic.test.ts
+++ b/frontend/src/views/skills/logic.test.ts
@@ -26,6 +26,8 @@ import {
   skillAvailabilityTone,
   skillDotClass,
   skillDotTitle,
+  skillCanRemove,
+  skillCanUpdate,
   skillGroupKey,
   skillPublisherId,
   skillRank,
@@ -274,6 +276,38 @@ describe('skillPublisherId / isPartnerSkill / skillsByPublisher', () => {
     expect(skillsByPublisher(list, 'bankr').map((s) => s.name)).toEqual(['bankr-swap'])
     // An empty id never selects the unbranded rows.
     expect(skillsByPublisher(list, '')).toEqual([])
+  })
+})
+
+describe('skillCanUpdate / skillCanRemove', () => {
+  it('reads the affordance off acquisition, not the layer', () => {
+    const movedHubInstall = acquired('hub', { layer: 'workspace' })
+    movedHubInstall.acquisition!.updatable = true
+    movedHubInstall.acquisition!.removable = true
+    expect(skillCanUpdate(movedHubInstall)).toBe(true)
+    expect(skillCanRemove(movedHubInstall)).toBe(true)
+
+    // A hand-copied directory sitting in the managed dir was never removable.
+    const handCopied = acquired('local', { layer: 'managed' })
+    expect(skillCanUpdate(handCopied)).toBe(false)
+    expect(skillCanRemove(handCopied)).toBe(false)
+  })
+
+  it('a hub install whose files moved is updatable but not removable', () => {
+    const diverged = acquired('hub')
+    diverged.acquisition!.updatable = true
+    diverged.acquisition!.removable = false
+    expect(skillCanUpdate(diverged)).toBe(true)
+    expect(skillCanRemove(diverged)).toBe(false)
+  })
+
+  it('falls back to layer when a pre-#130 gateway sends no acquisition', () => {
+    // Reading the flags directly would be `undefined === true` -> false, which
+    // hides both buttons on a stale bundle instead of degrading to the old gate.
+    expect(skillCanUpdate(skill({ layer: 'managed' }))).toBe(true)
+    expect(skillCanRemove(skill({ layer: 'managed' }))).toBe(true)
+    expect(skillCanUpdate(skill({ layer: 'bundled' }))).toBe(false)
+    expect(skillCanRemove(skill({ layer: 'bundled' }))).toBe(false)
   })
 })
 

--- a/frontend/src/views/skills/logic.test.ts
+++ b/frontend/src/views/skills/logic.test.ts
@@ -7,25 +7,31 @@ import {
   filterRegistry,
   filterSkills,
   firstUpdateResult,
-  groupSkillsByLayer,
+  groupSkills,
   initials,
   installAction,
   installSource,
   installedEmptyMessage,
-  isRobinhoodSkill,
+  isPartnerSkill,
   layerHelp,
   layerLabel,
   markInstalled,
+  mergeRegistryRows,
+  partnerEmptyMessage,
   registryEmptyMessage,
   registryKey,
-  robinhoodEmptyMessage,
-  robinhoodSkills,
   safeUrl,
+  skillAvailabilityLabel,
+  skillAvailabilityTitle,
+  skillAvailabilityTone,
   skillDotClass,
   skillDotTitle,
+  skillGroupKey,
+  skillPublisherId,
   skillRank,
   skillStats,
   skillStatus,
+  skillsByPublisher,
   stillMissingCount,
   type RawSkill,
   type RegistryItem,
@@ -91,7 +97,10 @@ describe('installedEmptyMessage', () => {
   })
 })
 
-describe('skillRank / groupSkillsByLayer', () => {
+const acquired = (kind: string, o: Partial<RawSkill> = {}): RawSkill =>
+  skill({ acquisition: { kind }, ...o })
+
+describe('skillRank / skillGroupKey / groupSkills', () => {
   it('ranks ready < not_declared < needs_setup', () => {
     expect(skillRank(skill({ status: 'ready' }))).toBe(0)
     expect(skillRank(skill({ status: 'not_declared' }))).toBe(1)
@@ -99,25 +108,65 @@ describe('skillRank / groupSkillsByLayer', () => {
     expect(skillRank(skill({ status: 'weird' }))).toBe(2)
   })
 
-  it('buckets by layer in LAYER_ORDER, sorts ready-first then name, drops empties', () => {
+  it('maps acquisition.kind to a group key', () => {
+    expect(skillGroupKey(acquired('shipped'))).toBe('shipped')
+    expect(skillGroupKey(acquired('hub'))).toBe('hub')
+    expect(skillGroupKey(acquired('local'))).toBe('local')
+  })
+
+  it('partners wins over acquisition, whichever kind it is', () => {
+    const shipped = acquired('shipped', { publisher: { id: 'robinhood', name: 'Robinhood' } })
+    const hub = acquired('hub', { publisher: { id: 'bankr', name: 'Bankr' } })
+    expect(skillGroupKey(shipped)).toBe('partners')
+    expect(skillGroupKey(hub)).toBe('partners')
+  })
+
+  it('falls back to layer when a pre-#130 gateway sends no acquisition', () => {
+    expect(skillGroupKey(skill({ layer: 'bundled' }))).toBe('shipped')
+    expect(skillGroupKey(skill({ layer: 'managed' }))).toBe('hub')
+    expect(skillGroupKey(skill({ layer: 'project' }))).toBe('local')
+    expect(skillGroupKey(skill({}))).toBe('local')
+  })
+
+  it('groups partners → shipped → hub → local, ready-first then name, dropping empties', () => {
     const list = [
-      skill({ name: 'z-ready', layer: 'managed', status: 'ready' }),
-      skill({ name: 'a-needs', layer: 'managed', status: 'needs_setup' }),
-      skill({ name: 'm-decl', layer: 'managed', status: 'not_declared' }),
-      skill({ name: 'b', layer: 'bundled', status: 'ready' }),
-      skill({ name: 'x', status: 'ready' }), // no layer → extra
+      acquired('hub', { name: 'z-ready', status: 'ready' }),
+      acquired('hub', { name: 'a-needs', status: 'needs_setup' }),
+      acquired('hub', { name: 'm-decl', status: 'not_declared' }),
+      acquired('shipped', { name: 'b', status: 'ready' }),
+      // A partner skill that ships with AgentOS and one installed from a hub
+      // land under the SAME heading — the issue's acceptance criterion.
+      acquired('shipped', { name: 'rh', publisher: { id: 'robinhood' }, status: 'ready' }),
+      acquired('hub', { name: 'bankr-swap', publisher: { id: 'bankr' }, status: 'ready' }),
     ]
-    const groups = groupSkillsByLayer(list)
-    // bundled before managed before extra (LAYER_ORDER)
-    expect(groups.map((g) => g.layer)).toEqual(['bundled', 'managed', 'extra'])
-    // managed: ready(0) then not_declared(1) then needs_setup(2)
-    const managed = groups.find((g) => g.layer === 'managed')!
-    expect(managed.skills.map((s) => s.name)).toEqual(['z-ready', 'm-decl', 'a-needs'])
-    expect(managed.label).toBe('Managed')
+    const groups = groupSkills(list)
+    expect(groups.map((g) => g.key)).toEqual(['partners', 'shipped', 'hub'])
+    expect(groups[0]!.label).toBe('Partners')
+    expect(groups[0]!.skills.map((s) => s.name)).toEqual(['bankr-swap', 'rh'])
+    expect(groups[0]!.help).toContain('partner')
+    const hub = groups.find((g) => g.key === 'hub')!
+    expect(hub.skills.map((s) => s.name)).toEqual(['z-ready', 'm-decl', 'a-needs'])
+    expect(hub.label).toBe('Installed from a hub')
+  })
+
+  it('emits every non-empty group in order', () => {
+    const groups = groupSkills([
+      acquired('local', { name: 'l' }),
+      acquired('hub', { name: 'h' }),
+      acquired('shipped', { name: 's' }),
+      acquired('shipped', { name: 'p', publisher: { id: 'bankr' } }),
+    ])
+    expect(groups.map((g) => g.key)).toEqual(['partners', 'shipped', 'hub', 'local'])
+    expect(groups.map((g) => g.label)).toEqual([
+      'Partners',
+      'Shipped with AgentOS',
+      'Installed from a hub',
+      'Your local skills',
+    ])
   })
 
   it('returns [] for no skills', () => {
-    expect(groupSkillsByLayer([])).toEqual([])
+    expect(groupSkills([])).toEqual([])
   })
 })
 
@@ -141,39 +190,104 @@ describe('skillStatus / skillDotClass / skillDotTitle', () => {
   })
 })
 
-describe('isRobinhoodSkill / robinhoodSkills', () => {
-  it('only bundled skills named robinhood* or homepaged robinhood.com qualify', () => {
-    expect(isRobinhoodSkill(skill({ layer: 'bundled', name: 'robinhood-stocks' }))).toBe(true)
-    expect(
-      isRobinhoodSkill(skill({ layer: 'bundled', name: 'x', homepage: 'https://robinhood.com/x' })),
-    ).toBe(true)
-    // not bundled → excluded even if named robinhood
-    expect(isRobinhoodSkill(skill({ layer: 'managed', name: 'robinhood-fake' }))).toBe(false)
-    // bundled but unrelated → excluded
-    expect(isRobinhoodSkill(skill({ layer: 'bundled', name: 'weather' }))).toBe(false)
+describe('skillAvailability*', () => {
+  it('treats an absent availability block as unknown, never as not-offered', () => {
+    expect(skillAvailabilityTone(skill({}))).toBe('unknown')
+    // `agentos skills list --json` omits the key entirely.
+    expect(skillAvailabilityTone(skill({ status: 'ready', eligible: true }))).toBe('unknown')
+    expect(skillAvailabilityLabel(skill({}))).toBe('')
   })
 
-  it('robinhoodSkills filters + sorts by name', () => {
-    const list = [
-      skill({ layer: 'bundled', name: 'robinhood-z' }),
-      skill({ layer: 'bundled', name: 'robinhood-a' }),
-      skill({ layer: 'managed', name: 'robinhood-nope' }),
-    ]
-    expect(robinhoodSkills(list).map((s) => s.name)).toEqual(['robinhood-a', 'robinhood-z'])
+  it('separates offered from ready — a ready skill can still be withheld', () => {
+    const withheld = skill({
+      status: 'ready',
+      eligible: true,
+      availability: { offered: false, reason: 'model_invocation_disabled', detail: '' },
+    })
+    // The status derivations are untouched: it is still "ready".
+    expect(skillDotClass(withheld)).toBe('is-ready')
+    expect(skillAvailabilityTone(withheld)).toBe('not-offered')
+    expect(skillAvailabilityLabel(withheld)).toBe('Not offered — agent cannot invoke')
+  })
+
+  it('labels each withheld reason and falls back for an unknown one', () => {
+    const withReason = (reason: string) =>
+      skillAvailabilityLabel(skill({ availability: { offered: false, reason } }))
+    expect(withReason('ineligible')).toBe('Not offered — needs setup')
+    expect(withReason('tool_gate')).toBe('Not offered — missing tools')
+    expect(withReason('prompt_budget')).toBe('Not offered — prompt too long')
+    expect(withReason('some_future_reason')).toBe('Not offered to the agent')
+    expect(withReason('')).toBe('Not offered to the agent')
+  })
+
+  it('offered rows read as offered with an empty reason', () => {
+    const offered = skill({ availability: { offered: true, reason: '', detail: '' } })
+    expect(skillAvailabilityTone(offered)).toBe('offered')
+    expect(skillAvailabilityLabel(offered)).toBe('Offered to the agent')
+    expect(skillAvailabilityTitle(offered)).toBe('Offered to the agent')
+  })
+
+  it('the tooltip prefers the server detail prose', () => {
+    const s = skill({
+      availability: { offered: false, reason: 'ineligible', detail: 'Set LEDGER_API_KEY.' },
+    })
+    expect(skillAvailabilityTitle(s)).toBe('Set LEDGER_API_KEY.')
   })
 })
 
-describe('robinhoodEmptyMessage', () => {
+describe('skillPublisherId / isPartnerSkill / skillsByPublisher', () => {
+  it('trusts publisher.id and nothing else', () => {
+    expect(skillPublisherId(skill({ publisher: { id: 'Robinhood' } }))).toBe('robinhood')
+    expect(skillPublisherId(skill({ publisher: { id: ' bankr ' } }))).toBe('bankr')
+    expect(skillPublisherId(skill({}))).toBe('')
+    expect(skillPublisherId(skill({ publisher: { id: '', name: 'Robinhood' } }))).toBe('')
+  })
+
+  it('a robinhood-* name with no publisher is NOT a partner skill', () => {
+    // The old heuristic read the name and the homepage; the allowlist that
+    // replaced it lives server-side, and the client must not re-derive a brand.
+    const impostor = skill({
+      layer: 'bundled',
+      name: 'robinhood-stocks',
+      homepage: 'https://robinhood.com/x',
+    })
+    expect(isPartnerSkill(impostor)).toBe(false)
+    expect(skillsByPublisher([impostor], 'robinhood')).toEqual([])
+    expect(skillGroupKey(impostor)).toBe('shipped')
+  })
+
+  it('an unbranded publisher block reads as unbranded', () => {
+    // The server flattens an unrecognized id to an all-empty publisher.
+    expect(isPartnerSkill(skill({ publisher: { id: '', name: '', url: '', logo: '' } }))).toBe(
+      false,
+    )
+  })
+
+  it('selects one publisher and sorts by name', () => {
+    const list = [
+      skill({ name: 'rh-z', publisher: { id: 'robinhood' } }),
+      skill({ name: 'rh-a', publisher: { id: 'robinhood' } }),
+      skill({ name: 'bankr-swap', publisher: { id: 'bankr' } }),
+      skill({ name: 'robinhood-impostor' }),
+    ]
+    expect(skillsByPublisher(list, 'robinhood').map((s) => s.name)).toEqual(['rh-a', 'rh-z'])
+    expect(skillsByPublisher(list, 'bankr').map((s) => s.name)).toEqual(['bankr-swap'])
+    // An empty id never selects the unbranded rows.
+    expect(skillsByPublisher(list, '')).toEqual([])
+  })
+})
+
+describe('partnerEmptyMessage', () => {
   it('explains query, status, and default empty states', () => {
-    expect(robinhoodEmptyMessage('rwa', 'all')).toBe('No Robinhood skills match rwa.')
-    expect(robinhoodEmptyMessage('', 'ready')).toBe('No Robinhood skills are ready.')
-    expect(robinhoodEmptyMessage('', 'needs-setup')).toBe(
-      'No Robinhood skills currently need setup.',
+    expect(partnerEmptyMessage('Robinhood', 'rwa', 'all')).toBe('No Robinhood skills match rwa.')
+    expect(partnerEmptyMessage('Robinhood', '', 'ready')).toBe('No Robinhood skills are ready.')
+    expect(partnerEmptyMessage('Bankr', '', 'needs-setup')).toBe(
+      'No Bankr skills currently need setup.',
     )
-    expect(robinhoodEmptyMessage('', 'not-declared')).toBe(
-      'No Robinhood skills without a manifest.',
+    expect(partnerEmptyMessage('Bankr', '', 'not-declared')).toBe(
+      'No Bankr skills without a manifest.',
     )
-    expect(robinhoodEmptyMessage('', 'all')).toContain('Robinhood skills are on the way')
+    expect(partnerEmptyMessage('Robinhood', '', 'all')).toContain('Robinhood skills are on the way')
   })
 })
 
@@ -234,6 +348,56 @@ describe('filterRegistry', () => {
   it('combines category and text', () => {
     expect(filterRegistry(rows, 'trading', 'buy').map((r) => r.name)).toEqual(['Buy'])
     expect(filterRegistry(rows, 'defi', 'buy')).toEqual([])
+  })
+
+  it('also matches category, which the server matches and the client used not to', () => {
+    expect(filterRegistry(rows, 'all', 'defi').map((r) => r.name)).toEqual(['Swap'])
+  })
+
+  it('skips the text pass for rows that ARE the server answer', () => {
+    // The server matches over tags too, and tags are not on the wire — so a
+    // legitimate hit like this one has nothing the client can match on.
+    const serverHit = [item({ name: 'Swap', description: 'DEX', category: 'defi' })]
+    expect(filterRegistry(serverHit, 'all', 'perpetuals')).toEqual([])
+    expect(filterRegistry(serverHit, 'all', 'perpetuals', { serverFiltered: true })).toHaveLength(1)
+  })
+
+  it('still applies the category chip to server-filtered rows', () => {
+    expect(filterRegistry(rows, 'defi', 'anything', { serverFiltered: true }).map((r) => r.name)) //
+      .toEqual(['Swap'])
+  })
+})
+
+describe('mergeRegistryRows', () => {
+  it('unions by registryKey with base winning and extras appended', () => {
+    const base = [item({ identifier: 'id1', name: 'a', installed: false, description: 'rich' })]
+    const extra = [
+      item({ identifier: 'id1', name: 'a', installed: true }),
+      item({ identifier: 'id2', name: 'b', installed: true }),
+    ]
+    const merged = mergeRegistryRows(base, extra)
+    expect(merged.map((r) => r.identifier)).toEqual(['id1', 'id2'])
+    // base wins the collision, keeping its catalog metadata
+    expect(merged[0]!.description).toBe('rich')
+    expect(merged[0]!.installed).toBe(false)
+  })
+
+  it('dedupes on name when a row has no identifier', () => {
+    const merged = mergeRegistryRows([item({ name: 'a' })], [item({ name: 'a', installed: true })])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.installed).toBeUndefined()
+  })
+
+  it('drops unkeyable extras and never mutates the inputs', () => {
+    const base = [item({ name: 'a' })]
+    const extra = [item({ description: 'no key' })]
+    expect(mergeRegistryRows(base, extra)).toHaveLength(1)
+    expect(base).toHaveLength(1)
+  })
+
+  it('handles empty inputs', () => {
+    expect(mergeRegistryRows([], [])).toEqual([])
+    expect(mergeRegistryRows([], [item({ name: 'a' })]).map((r) => r.name)).toEqual(['a'])
   })
 })
 

--- a/frontend/src/views/skills/logic.ts
+++ b/frontend/src/views/skills/logic.ts
@@ -291,6 +291,28 @@ export function skillGroupKey(skill: RawSkill): SkillGroupKey {
   return 'local'
 }
 
+/**
+ * Whether an operator may update / remove a skill.
+ *
+ * What an operator may do comes off `acquisition`, not off the layer: a hub
+ * install stays removable when `skills.managed_dir` moves, and a hand-copied
+ * directory inside the managed dir was never removable in the first place.
+ *
+ * A row from a pre-#130 gateway carries no `acquisition` at all. Reading the
+ * flags directly would then be `undefined === true` → `false`, silently hiding
+ * both buttons rather than degrading — so fall back to the layer test these
+ * buttons used before, exactly as `skillGroupKey` does.
+ */
+export function skillCanUpdate(skill: RawSkill): boolean {
+  if (skill.acquisition) return skill.acquisition.updatable === true
+  return skill.layer === 'managed'
+}
+
+export function skillCanRemove(skill: RawSkill): boolean {
+  if (skill.acquisition) return skill.acquisition.removable === true
+  return skill.layer === 'managed'
+}
+
 export interface SkillGroup {
   key: SkillGroupKey
   label: string

--- a/frontend/src/views/skills/logic.ts
+++ b/frontend/src/views/skills/logic.ts
@@ -648,12 +648,12 @@ export function safeUrl(url?: string): string {
  * than mutating, but preserves the legacy match semantics.
  *
  * Kept, not deleted: this is the optimistic half of the install/uninstall
- * round trip. It belongs in `installMutation.onSuccess` /
- * `uninstallMutation.onSuccess` in SkillsPage.tsx, applied over the cached
+ * round trip. It is applied from `installMutation.onSuccess` /
+ * `uninstallMutation.onSuccess` in SkillsPage.tsx over the cached
  * `['skills.search', …]` data before the invalidation refetch lands, so the
  * Installed chip flips on the same tick instead of after a network round trip.
- * (The uninstall path must also invalidate `['skills.search']`, which it
- * currently does not — the chip otherwise stays stale after a removal.)
+ * Both paths then invalidate `['skills.search']` so the server's own answer
+ * replaces the optimistic one.
  */
 export function markInstalled(
   list: RegistryItem[],

--- a/frontend/src/views/skills/logic.ts
+++ b/frontend/src/views/skills/logic.ts
@@ -25,7 +25,61 @@ export interface RawSkill {
   missing_env_detail?: MissingEnvDetail[]
   install?: SkillInstallOption[]
   requirements?: SkillRequirements
+  /** Allowlisted brand, or all-empty. Absent only on a pre-#130 gateway. */
+  publisher?: SkillPublisher
+  /** How the skill got here and what an operator may do to it. */
+  acquisition?: SkillAcquisition
+  /** Whether the agent is actually being offered the skill. Absent from the CLI. */
+  availability?: SkillAvailability
   [key: string]: unknown
+}
+
+/**
+ * The publisher block from a skill row. The server resolves it against a
+ * server-side allowlist (`src/agentos/skills/publishers.py`), so `id` is the
+ * ONLY trustworthy "is this a partner skill" signal — a SKILL.md cannot mint a
+ * brand by writing one into its frontmatter, and the client must never infer a
+ * partner from a name prefix or a homepage host.
+ */
+export interface SkillPublisher {
+  id?: string
+  name?: string
+  url?: string
+  logo?: string
+}
+
+/** Where a skill came from. Always present on a current gateway. */
+export type SkillAcquisitionKind = 'shipped' | 'hub' | 'local'
+
+export interface SkillAcquisition {
+  kind?: SkillAcquisitionKind | string
+  source_id?: string
+  identifier?: string
+  version?: string
+  installed_at?: string
+  source_trust?: string
+  scan_verdict?: string
+  /** Gates the Remove button. */
+  removable?: boolean
+  /** Gates the Update button. */
+  updatable?: boolean
+}
+
+/** Why the agent is not being offered an installed, eligible skill. */
+export type SkillAvailabilityReason =
+  | ''
+  | 'model_invocation_disabled'
+  | 'ineligible'
+  | 'tool_gate'
+  | 'fallback_superseded'
+  | 'not_retrieved'
+  | 'prompt_budget'
+
+export interface SkillAvailability {
+  offered?: boolean
+  reason?: SkillAvailabilityReason | string
+  /** Tooltip prose; never carries a filesystem path. */
+  detail?: string
 }
 
 export interface MissingEnvDetail {
@@ -80,14 +134,10 @@ export type StatusFilter = 'all' | 'ready' | 'needs-setup' | 'not-declared'
 
 // ── Constants (skills.js:36-58) ──────────────────────────────────────────────
 
-export const LAYER_ORDER = [
-  'workspace',
-  'bundled',
-  'managed',
-  'personal',
-  'project',
-  'extra',
-] as const
+// `layer` is a location, not a provenance: it says which directory a SKILL.md
+// was loaded from. It is still shown as a per-card detail chip, but it no
+// longer groups the Installed tab (see SKILL_GROUP_ORDER below) — grouping on
+// it split the same partner's skills across two headings.
 
 export const LAYER_LABEL: Record<string, string> = {
   workspace: 'Workspace',
@@ -190,7 +240,7 @@ export function installedEmptyMessage(filterText: string, statusFilter: StatusFi
   return 'No skills installed.'
 }
 
-// ── Layer grouping + ready-first sort (skills.js:407-442) ─────────────────────
+// ── Provenance grouping + ready-first sort (skills.js:407-442) ────────────────
 
 /** skills.js:407-411 — sort rank: ready(0) < not_declared(1) < needs_setup(2). */
 export function skillRank(s: RawSkill): number {
@@ -199,37 +249,86 @@ export function skillRank(s: RawSkill): number {
   return 2
 }
 
+/** The Installed tab's headings, in the order they render. */
+export type SkillGroupKey = 'partners' | 'shipped' | 'hub' | 'local'
+
+export const SKILL_GROUP_ORDER: readonly SkillGroupKey[] = [
+  'partners',
+  'shipped',
+  'hub',
+  'local',
+] as const
+
+export const SKILL_GROUP_LABEL: Record<SkillGroupKey, string> = {
+  partners: 'Partners',
+  shipped: 'Shipped with AgentOS',
+  hub: 'Installed from a hub',
+  local: 'Your local skills',
+}
+
+export const SKILL_GROUP_HELP: Record<SkillGroupKey, string> = {
+  partners: 'Skills published by an AgentOS partner.',
+  shipped: 'Skills that ship with AgentOS.',
+  hub: 'Skills you installed from a skill hub.',
+  local: 'Skills you added yourself, from a local skill directory.',
+}
+
+/**
+ * The single group a skill belongs to. Partners wins over provenance so a
+ * partner's skills sit under one heading whether they shipped with AgentOS or
+ * were installed from that partner's hub — grouping on `layer` split them.
+ *
+ * A row from a pre-#130 gateway carries no `acquisition`; fall back to the
+ * location layer so an older gateway still renders something sane rather than
+ * filing every skill under "Shipped with AgentOS".
+ */
+export function skillGroupKey(skill: RawSkill): SkillGroupKey {
+  if (isPartnerSkill(skill)) return 'partners'
+  const kind = skill.acquisition?.kind
+  if (kind === 'shipped' || kind === 'hub' || kind === 'local') return kind
+  if (skill.layer === 'bundled') return 'shipped'
+  if (skill.layer === 'managed') return 'hub'
+  return 'local'
+}
+
 export interface SkillGroup {
-  layer: string
+  key: SkillGroupKey
   label: string
   help: string
   skills: RawSkill[]
 }
 
-/**
- * skills.js:413-442 — bucket the filtered skills by layer, sort each bucket
- * ready-first then name-asc, and emit groups in LAYER_ORDER (skipping empties).
- * An unknown layer buckets under 'extra' (legacy `s.layer || 'extra'`).
- */
-export function groupSkillsByLayer(skills: RawSkill[]): SkillGroup[] {
-  const groups: Record<string, RawSkill[]> = {}
-  skills.forEach((s) => {
-    const l = s.layer || 'extra'
-    ;(groups[l] = groups[l] || []).push(s)
+/** Sort a bucket ready-first (skills.js:407-411) then name-asc. */
+function sortByReady(list: RawSkill[]): RawSkill[] {
+  return list.sort((a, b) => {
+    const ra = skillRank(a)
+    const rb = skillRank(b)
+    if (ra !== rb) return ra - rb
+    return (a.name || '').localeCompare(b.name || '')
   })
-  const sortByReady = (list: RawSkill[]) =>
-    list.sort((a, b) => {
-      const ra = skillRank(a)
-      const rb = skillRank(b)
-      if (ra !== rb) return ra - rb
-      return (a.name || '').localeCompare(b.name || '')
-    })
-  Object.values(groups).forEach(sortByReady)
+}
+
+/**
+ * skills.js:413-442, regrouped — bucket the filtered skills by provenance,
+ * sort each bucket ready-first then name-asc, and emit groups in
+ * SKILL_GROUP_ORDER (skipping empties). A skill lands in exactly one group.
+ */
+export function groupSkills(skills: RawSkill[]): SkillGroup[] {
+  const groups: Partial<Record<SkillGroupKey, RawSkill[]>> = {}
+  skills.forEach((s) => {
+    const k = skillGroupKey(s)
+    ;(groups[k] = groups[k] || []).push(s)
+  })
   const out: SkillGroup[] = []
-  LAYER_ORDER.forEach((layer) => {
-    const list = groups[layer]
+  SKILL_GROUP_ORDER.forEach((key) => {
+    const list = groups[key]
     if (!list || list.length === 0) return
-    out.push({ layer, label: layerLabel(layer), help: layerHelp(layer), skills: list })
+    out.push({
+      key,
+      label: SKILL_GROUP_LABEL[key],
+      help: SKILL_GROUP_HELP[key],
+      skills: sortByReady(list),
+    })
   })
   return out
 }
@@ -257,32 +356,92 @@ export function skillDotTitle(skill: RawSkill): string {
   return skill.status_detail || (skill.eligible ? 'Ready' : 'Needs setup')
 }
 
-// ── Robinhood partner grouping (skills.js:469-497) ────────────────────────────
+// ── Availability: installed and eligible, but is it offered? ──────────────────
 
 /**
- * skills.js:469-477 — partner grouping is a brand surface: only BUNDLED skills
- * whose name starts with `robinhood` or whose homepage mentions robinhood.com
- * qualify (a user-installed community skill can't wear the partner banner).
+ * The card's third state. `status` answers "can this skill run"; availability
+ * answers "is the agent even being told about it" — a skill can be perfectly
+ * ready and still never reach the model (model invocation disabled, a missing
+ * tool, the prompt budget). 'unknown' is what an absent block means: the CLI
+ * never computes availability, and treating that as not-offered would be a
+ * fabricated verdict.
  */
-export function isRobinhoodSkill(skill: RawSkill): boolean {
-  if (skill.layer !== 'bundled') return false
-  const name = (skill.name || '').toLowerCase()
-  const home = (skill.homepage || '').toLowerCase()
-  return name.startsWith('robinhood') || home.includes('robinhood.com')
+export type SkillAvailabilityTone = 'offered' | 'not-offered' | 'unknown'
+
+export function skillAvailabilityTone(skill: RawSkill): SkillAvailabilityTone {
+  const offered = skill.availability?.offered
+  if (typeof offered !== 'boolean') return 'unknown'
+  return offered ? 'offered' : 'not-offered'
 }
 
-/** skills.js:484-486 — the installed Robinhood-family skills, name-sorted. */
-export function robinhoodSkills(skills: RawSkill[]): RawSkill[] {
-  return skills.filter(isRobinhoodSkill).sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+/** Short labels per withheld reason, for the card chip. */
+export const AVAILABILITY_REASON_LABEL: Record<string, string> = {
+  model_invocation_disabled: 'Not offered — agent cannot invoke',
+  ineligible: 'Not offered — needs setup',
+  tool_gate: 'Not offered — missing tools',
+  fallback_superseded: 'Not offered — superseded',
+  not_retrieved: 'Not offered — not retrieved',
+  prompt_budget: 'Not offered — prompt too long',
 }
 
-export function robinhoodEmptyMessage(filterText: string, statusFilter: StatusFilter): string {
-  const query = filterText.trim()
-  if (query) return `No Robinhood skills match ${query}.`
-  if (statusFilter === 'ready') return 'No Robinhood skills are ready.'
-  if (statusFilter === 'needs-setup') return 'No Robinhood skills currently need setup.'
-  if (statusFilter === 'not-declared') return 'No Robinhood skills without a manifest.'
-  return 'Robinhood skills are on the way. No Robinhood skills are installed yet.'
+/** The chip label; '' when availability was not computed (nothing to show). */
+export function skillAvailabilityLabel(skill: RawSkill): string {
+  const tone = skillAvailabilityTone(skill)
+  if (tone === 'unknown') return ''
+  if (tone === 'offered') return 'Offered to the agent'
+  const reason = String(skill.availability?.reason || '')
+  return AVAILABILITY_REASON_LABEL[reason] || 'Not offered to the agent'
+}
+
+/** The chip tooltip: the server's prose when it wrote any, else the label. */
+export function skillAvailabilityTitle(skill: RawSkill): string {
+  return skill.availability?.detail || skillAvailabilityLabel(skill)
+}
+
+// ── Partner (publisher) selection ─────────────────────────────────────────────
+
+/**
+ * The skill's brand slug, or '' for an ordinary skill.
+ *
+ * This is the ONLY partner signal the client honours. The old heuristic read
+ * the skill's own name and homepage and leaned on `layer === 'bundled'` to stop
+ * a community skill wearing the banner; that guard now lives server-side, where
+ * `publisher.id` is resolved against an allowlist before it reaches the wire.
+ * Re-deriving a brand from a name here would reopen exactly the hole the
+ * allowlist closes, so nothing below looks at `name` or `homepage`.
+ */
+export function skillPublisherId(skill: RawSkill): string {
+  return String(skill.publisher?.id || '')
+    .trim()
+    .toLowerCase()
+}
+
+/** True when the row carries any allowlisted brand. */
+export function isPartnerSkill(skill: RawSkill): boolean {
+  return skillPublisherId(skill) !== ''
+}
+
+/** The installed skills of one partner, name-sorted (skills.js:484-486). */
+export function skillsByPublisher(skills: RawSkill[], publisherId: string): RawSkill[] {
+  const want = (publisherId || '').trim().toLowerCase()
+  if (!want) return []
+  return skills
+    .filter((s) => skillPublisherId(s) === want)
+    .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+}
+
+/** The empty-state prose for a partner tab, e.g. `partnerEmptyMessage('Robinhood', …)`. */
+export function partnerEmptyMessage(
+  brand: string,
+  filterText: string,
+  statusFilter: StatusFilter,
+): string {
+  const query = (filterText || '').trim()
+  if (query) return `No ${brand} skills match ${query}.`
+  if (statusFilter === 'ready') return `No ${brand} skills are ready.`
+  if (statusFilter === 'needs-setup') return `No ${brand} skills currently need setup.`
+  if (statusFilter === 'not-declared') return `No ${brand} skills without a manifest.`
+  return `${brand} skills are on the way. No ${brand} skills are installed yet.`
 }
 
 // ── Registry (community / bankr) derivations ──────────────────────────────────
@@ -331,26 +490,49 @@ export function categoryChips(snapshot: RegistryItem[], activeCat: string): Cate
   }))
 }
 
+export interface RegistryFilterOptions {
+  /**
+   * True when `items` IS the server's answer to `query`. The text pass is then
+   * skipped entirely and only the category chip narrows the list.
+   *
+   * The server matches over name, provider, category, description and **tags**
+   * (`skills/hub/bankr.py:_matches`), and tags are not on the wire — so no
+   * client matcher can ever reproduce it, and re-filtering a server result can
+   * only throw away legitimate hits. The text pass survives for the debounce
+   * window, where it narrows a stale list optimistically while the request is
+   * still out; dropping a row there is harmless because the answer replaces it.
+   */
+  serverFiltered?: boolean
+}
+
 /**
  * skills.js:610-620 — apply the category filter then the case-insensitive text
- * filter (name / provider / description) to a registry list. `query` is trimmed
- * + lowercased here (legacy trims/lowercases inline).
+ * filter to a registry list. `query` is trimmed + lowercased here (legacy
+ * trims/lowercases inline).
+ *
+ * The text pass also matches `category`, which the server matches and the
+ * original client matcher did not; that is as close to the server as the
+ * payload allows. Pass `{ serverFiltered: true }` once the rows on screen are
+ * the server's own answer.
  */
 export function filterRegistry(
   items: RegistryItem[],
   category: string,
   query: string,
+  options: RegistryFilterOptions = {},
 ): RegistryItem[] {
   let out = items
   const cat = category || 'all'
   if (cat !== 'all') out = out.filter((r) => (r.category || 'other') === cat)
+  if (options.serverFiltered) return out
   const q = (query || '').trim().toLowerCase()
   if (q) {
     out = out.filter(
       (r) =>
         (r.name || '').toLowerCase().includes(q) ||
         (r.provider || '').toLowerCase().includes(q) ||
-        (r.description || '').toLowerCase().includes(q),
+        (r.description || '').toLowerCase().includes(q) ||
+        (r.category || '').toLowerCase().includes(q),
     )
   }
   return out
@@ -368,6 +550,32 @@ export function registryEmptyMessage(group: 'bankr' | 'community', query: string
 /** skills.js:662,715,283 — the stable identifier key for a registry row. */
 export function registryKey(r: RegistryItem): string {
   return r.identifier || r.name || ''
+}
+
+/**
+ * Union two registry lists by `registryKey`, `base` winning on a collision.
+ *
+ * The gateway now synthesizes a row for an install no catalog lists, so a
+ * refetch alone is enough to make it appear — but only once the refetch lands.
+ * Merging the just-installed row in locally shows it on the same tick, and the
+ * server's richer row replaces it on the next fetch because `base` (the query
+ * result) wins. `extra` rows are appended for the same reason the server
+ * appends its synthesized ones: they carry no relevance score and must not push
+ * ranked catalog rows off the top of the grid.
+ *
+ * A row with no identifier and no name cannot be keyed, deduped or installed,
+ * so it is dropped rather than appended blind.
+ */
+export function mergeRegistryRows(base: RegistryItem[], extra: RegistryItem[]): RegistryItem[] {
+  const seen = new Set(base.map(registryKey).filter(Boolean))
+  const out = [...base]
+  extra.forEach((r) => {
+    const key = registryKey(r)
+    if (!key || seen.has(key)) return
+    seen.add(key)
+    out.push(r)
+  })
+  return out
 }
 
 // ── Install-action state (skills.js:633-641) ──────────────────────────────────
@@ -435,9 +643,17 @@ export function safeUrl(url?: string): string {
 }
 
 /**
- * skills.js:911-924 — flip `installed` in-place on rows matching by identifier
- * or name across the cached registry lists. Returns a NEW array (React-friendly)
- * rather than mutating, but preserves the legacy match semantics.
+ * skills.js:911-924 — flip `installed` on rows matching by identifier or name
+ * across a cached registry list. Returns a NEW array (React-friendly) rather
+ * than mutating, but preserves the legacy match semantics.
+ *
+ * Kept, not deleted: this is the optimistic half of the install/uninstall
+ * round trip. It belongs in `installMutation.onSuccess` /
+ * `uninstallMutation.onSuccess` in SkillsPage.tsx, applied over the cached
+ * `['skills.search', …]` data before the invalidation refetch lands, so the
+ * Installed chip flips on the same tick instead of after a network round trip.
+ * (The uninstall path must also invalidate `['skills.search']`, which it
+ * currently does not — the chip otherwise stays stale after a removal.)
  */
 export function markInstalled(
   list: RegistryItem[],

--- a/frontend/src/views/skills/skills.css
+++ b/frontend/src/views/skills/skills.css
@@ -192,9 +192,13 @@
 .sk-group:not([open]) .sk-group__caret {
   transform: rotate(-90deg);
 }
+/* A real <h2>: the provenance groups are the Installed tab's document
+   structure, so a screen reader can jump between them. */
 .sk-group__label {
+  margin: 0;
   font-family: var(--font-mono);
   font-size: 0.75rem;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--foreground);
@@ -271,6 +275,14 @@
      read as muted glyphs, not stickers. */
   filter: grayscale(1) brightness(1.1) contrast(0.9);
   opacity: 0.75;
+}
+/* Per-card provenance detail: the loading layer, plus the withheld-from-agent
+   state when there is one. */
+.sk-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
 }
 .sk-card__desc {
   font-size: 0.75rem;
@@ -478,6 +490,31 @@
 .sk-chip--unverified {
   color: var(--dim);
 }
+.sk-chip--layer {
+  text-transform: none;
+  letter-spacing: 0.04em;
+}
+/* Installed, possibly even ready, but the agent is not being offered it. A
+   distinct tone from "needs setup" because the fix is a different one — and
+   the chip always carries the reason as text, never colour alone. */
+.sk-chip--withheld {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  --tone: var(--primary);
+  color: var(--tone);
+  border-color: color-mix(in srgb, var(--tone) 40%, var(--border));
+  background: color-mix(in srgb, var(--tone) 8%, transparent);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+.sk-chip__dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  border-radius: var(--radius-pill);
+  background: currentColor;
+}
 
 /* ── Modal / dialog ─────────────────────────────────────────────────────── */
 .sk-modal__overlay {
@@ -654,6 +691,17 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* Replaces the path in the footer when an affordance is withheld: why there is
+   no Remove button, instead of a button that half-succeeds. */
+.sk-dialog__note {
+  flex: 1;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+}
+.sk-dialog__withheld {
+  border-left: 2px solid color-mix(in srgb, var(--primary) 45%, var(--border));
+  padding-left: 10px;
 }
 
 /* ── Skills library UX refresh ────────────────────────────────────────────

--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -95,11 +95,27 @@ def _emit_skill_mutation_result(
 
 
 def _load_skill_rows() -> list[dict[str, Any]]:
+    """Build the offline ``skills list`` rows from the shared inventory.
+
+    This runs without a gateway, so it re-derives the layer directories, but the
+    facts it reports — eligibility, acquisition, publisher — come from
+    :func:`~agentos.skills.inventory.build_skill_inventory`, the same builder the
+    RPC surfaces use. That is the point: the CLI and the Web UI used to answer
+    "where did this skill come from" differently for the same skill.
+
+    ``availability`` is the one block this surface omits. It is a question about
+    a chat session's tool surface, and a CLI process has none; a fabricated
+    verdict here would be worse than an absent key.
+    """
     import os
     from pathlib import Path
 
     from agentos.gateway.config import GatewayConfig
-    from agentos.skills.eligibility import EligibilityContext, check_eligibility
+    from agentos.skills.inventory import (
+        acquisition_payload,
+        build_skill_inventory,
+        publisher_payload,
+    )
     from agentos.skills.loader import SkillLoader
     from agentos.skills.paths import resolve_skill_layer_dirs
 
@@ -121,15 +137,18 @@ def _load_skill_rows() -> list[dict[str, Any]]:
         project_agents_dir=layer_dirs.project_agents_dir,
         extra_dirs=layer_dirs.extra_dirs,
     )
-    ctx = EligibilityContext.auto()
+    inventory = build_skill_inventory(loader, config=config)
     rows: list[dict[str, Any]] = []
-    for skill in sorted(loader.get_user_invocable(), key=lambda x: x.name):
+    for row in sorted(inventory, key=lambda r: r.spec.name):
+        skill = row.spec
+        if not skill.user_invocable:
+            continue
         provenance = getattr(skill, "provenance", None)
         rows.append(
             {
                 "name": skill.name,
                 "layer": skill.layer.value,
-                "eligible": check_eligibility(skill, ctx),
+                "eligible": row.eligibility.eligible,
                 "description": skill.description,
                 "always": skill.always,
                 "triggers": list(skill.triggers),
@@ -145,6 +164,12 @@ def _load_skill_rows() -> list[dict[str, Any]]:
                     "upstreamUrl": provenance.upstream_url if provenance else "",
                     "maintainedBy": provenance.maintained_by if provenance else "AgentOS",
                 },
+                # Emitted verbatim from the shared serializers, snake_case keys
+                # and all, so a CLI row and an RPC row can be diffed field for
+                # field. The camelCase keys above predate this and keep their
+                # names — the payload is strictly additive.
+                "publisher": publisher_payload(row.publisher),
+                "acquisition": acquisition_payload(row.acquisition),
             }
         )
     return rows

--- a/src/agentos/engine/steps/skills_filter.py
+++ b/src/agentos/engine/steps/skills_filter.py
@@ -8,9 +8,9 @@ from typing import Any, cast
 import structlog
 
 from agentos.engine.pipeline import TurnContext
-from agentos.skills.eligibility import EligibilityContext, check_eligibility
+from agentos.skills.availability import gate_skills, plan_injection, retrieval_availability
+from agentos.skills.eligibility import EligibilityContext
 from agentos.skills.retrieval import HybridRetriever, Strategy
-from agentos.skills.types import SkillSpec
 
 log = structlog.get_logger(__name__)
 
@@ -64,26 +64,6 @@ def _get_retriever(skills_cfg: Any) -> HybridRetriever:
         return _retriever
 
 
-def _deterministic_gate(
-    skills: list[SkillSpec],
-    available_tools: set[str],
-    elig_ctx: EligibilityContext,
-) -> list[SkillSpec]:
-    """Pure-Python gate: eligibility, requires_tools, fallback, visibility."""
-    gated: list[SkillSpec] = []
-    for s in skills:
-        if s.disable_model_invocation:
-            continue
-        if not check_eligibility(s, elig_ctx):
-            continue
-        if s.requires_tools and not all(t in available_tools for t in s.requires_tools):
-            continue
-        if s.fallback_for_toolsets and any(t in available_tools for t in s.fallback_for_toolsets):
-            continue
-        gated.append(s)
-    return gated
-
-
 async def filter_skills(ctx: TurnContext) -> TurnContext:
     """Gate, optionally filter, and inject skills into the system prompt."""
     skill_loader = ctx.metadata.get("skill_loader")
@@ -95,6 +75,7 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
         ctx.metadata["filtered_skill_ids"] = []
         ctx.metadata["skill_count"] = 0
         ctx.metadata["skills_prompt_chars"] = 0
+        ctx.metadata["skill_availability"] = {}
         log.debug("skills_filter.skipped", reason="memory_only")
         return ctx
 
@@ -103,8 +84,11 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
         return ctx
 
     # ── deterministic gate (no LLM, pure Python) ──
+    # gate_skills / plan_injection are shared with the RPC surface that answers
+    # "why is this skill not offered?" — the engine must not compute the gate
+    # its own way, or the two answers drift.
     available_tools = {t.name for t in ctx.tool_defs} if ctx.tool_defs else set()
-    gated = _deterministic_gate(all_skills, available_tools, _eligibility_context())
+    gated, availability = gate_skills(all_skills, available_tools, _eligibility_context())
 
     # ── always skills bypass filter, guaranteed visibility ──
     pinned = [s for s in gated if s.always]
@@ -126,14 +110,15 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
         # HybridRetriever — see agentos.skills.retrieval.HybridRetriever.
         retriever = _get_retriever(skills_cfg)
         filtered = retriever.retrieve(filterable, semantic_message, top_k=top_k)
+        retrieved = {s.name for s in filtered}
+        availability.update(
+            retrieval_availability([s for s in filterable if s.name not in retrieved], top_k)
+        )
     else:
         filtered = filterable
 
     final = pinned + filtered
 
-    from agentos.skills.injector import SkillInjector
-
-    injector = SkillInjector()
     # tuple[1] is the uncached suffix slot: may already carry the
     # per-turn recalled-memory block produced upstream by
     # TurnRunner._assemble_prompt. Append instead of overwriting so that
@@ -143,18 +128,15 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
     else:
         base, suffix = ctx.system_prompt
 
-    dropped: list[str] = []
-    if injection_mode == "user_message":
-        skills_prompt = injector.inject_compact("", final)
-    else:
-        # "system" and "user_context" both budget-select full vs compact.
-        skills_prompt, dropped = injector.inject_skills("", final, max_chars=max_chars)
+    plan = plan_injection(final, max_chars, injection_mode)
+    skills_prompt, dropped = plan.prompt, plan.dropped
+    availability.update(plan.availability)
 
     # Everything below describes what actually reached the prompt, not the
     # pre-truncation list: a metadata count that includes skills the budget
     # threw away is how this stayed invisible.
     dropped_names = set(dropped)
-    injected = [s for s in final if not s.disable_model_invocation and s.name not in dropped_names]
+    injected = plan.offered
 
     # Publish the injected skill-ID list so the pipeline wrapper can
     # surface it in the decision log's PipelineStepRecord. Non-mutating
@@ -172,6 +154,9 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
     ctx.metadata["skills_prompt_chars"] = len(skills_prompt)
     ctx.metadata["skills_injection_mode"] = injection_mode
     ctx.metadata["skills_dropped_for_budget"] = dropped
+    # One entry per loaded skill: offered, or the reason it is not. Same map the
+    # RPC surface builds from the same two functions.
+    ctx.metadata["skill_availability"] = availability
 
     if dropped:
         log.warning(

--- a/src/agentos/engine/steps/skills_filter.py
+++ b/src/agentos/engine/steps/skills_filter.py
@@ -10,6 +10,7 @@ import structlog
 from agentos.engine.pipeline import TurnContext
 from agentos.skills.availability import gate_skills, plan_injection, retrieval_availability
 from agentos.skills.eligibility import EligibilityContext
+from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
 from agentos.skills.retrieval import HybridRetriever, Strategy
 
 log = structlog.get_logger(__name__)
@@ -96,7 +97,7 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
 
     skills_cfg = getattr(ctx.config, "skills", None) if ctx.config else None
     filter_enabled = getattr(skills_cfg, "filter_enabled", False) if skills_cfg else False
-    max_chars = getattr(skills_cfg, "max_skills_prompt_chars", 8000)
+    max_chars = getattr(skills_cfg, "max_skills_prompt_chars", DEFAULT_MAX_SKILLS_PROMPT_CHARS)
     injection_mode = getattr(skills_cfg, "injection_mode", "system")
     semantic_message = getattr(ctx, "semantic_message", None)
     if semantic_message is None:

--- a/src/agentos/engine/steps/skills_filter.py
+++ b/src/agentos/engine/steps/skills_filter.py
@@ -16,7 +16,17 @@ log = structlog.get_logger(__name__)
 
 _retriever: HybridRetriever | None = None
 _retriever_lock = threading.Lock()
-_elig_ctx = EligibilityContext.auto()
+
+
+def _eligibility_context() -> EligibilityContext:
+    """Build a fresh eligibility context for this turn.
+
+    A process-wide context cached negative `shutil.which()` and env lookups
+    forever: installing a missing binary or setting a credential never took
+    effect until restart, while every RPC surface builds its own context per
+    call and so reported the skill as ready. ~15 `which()` calls per turn is
+    cheap next to that divergence."""
+    return EligibilityContext.auto()
 
 
 def _get_retriever(skills_cfg: Any) -> HybridRetriever:
@@ -57,13 +67,14 @@ def _get_retriever(skills_cfg: Any) -> HybridRetriever:
 def _deterministic_gate(
     skills: list[SkillSpec],
     available_tools: set[str],
+    elig_ctx: EligibilityContext,
 ) -> list[SkillSpec]:
     """Pure-Python gate: eligibility, requires_tools, fallback, visibility."""
     gated: list[SkillSpec] = []
     for s in skills:
         if s.disable_model_invocation:
             continue
-        if not check_eligibility(s, _elig_ctx):
+        if not check_eligibility(s, elig_ctx):
             continue
         if s.requires_tools and not all(t in available_tools for t in s.requires_tools):
             continue
@@ -93,7 +104,7 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
 
     # ── deterministic gate (no LLM, pure Python) ──
     available_tools = {t.name for t in ctx.tool_defs} if ctx.tool_defs else set()
-    gated = _deterministic_gate(all_skills, available_tools)
+    gated = _deterministic_gate(all_skills, available_tools, _eligibility_context())
 
     # ── always skills bypass filter, guaranteed visibility ──
     pinned = [s for s in gated if s.always]
@@ -120,18 +131,6 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
 
     final = pinned + filtered
 
-    # Publish the post-filter skill-ID list so the pipeline wrapper can
-    # surface it in the decision log's PipelineStepRecord. Non-mutating
-    # additive read for callers that don't consume the metadata.
-    try:
-        ctx.metadata["filtered_skill_ids"] = [
-            getattr(s, "id", None) or getattr(s, "name", None)
-            for s in filtered
-            if getattr(s, "id", None) or getattr(s, "name", None)
-        ]
-    except Exception:  # pragma: no cover — metadata is best-effort
-        ctx.metadata["filtered_skill_ids"] = []
-
     from agentos.skills.injector import SkillInjector
 
     injector = SkillInjector()
@@ -144,15 +143,43 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
     else:
         base, suffix = ctx.system_prompt
 
+    dropped: list[str] = []
     if injection_mode == "user_message":
         skills_prompt = injector.inject_compact("", final)
-    elif injection_mode == "user_context":
-        skills_prompt = injector.inject_skills("", final, max_chars=max_chars)
     else:
-        skills_prompt = injector.inject_skills("", final, max_chars=max_chars)
-    ctx.metadata["skill_count"] = len(final)
+        # "system" and "user_context" both budget-select full vs compact.
+        skills_prompt, dropped = injector.inject_skills("", final, max_chars=max_chars)
+
+    # Everything below describes what actually reached the prompt, not the
+    # pre-truncation list: a metadata count that includes skills the budget
+    # threw away is how this stayed invisible.
+    dropped_names = set(dropped)
+    injected = [s for s in final if not s.disable_model_invocation and s.name not in dropped_names]
+
+    # Publish the injected skill-ID list so the pipeline wrapper can
+    # surface it in the decision log's PipelineStepRecord. Non-mutating
+    # additive read for callers that don't consume the metadata.
+    try:
+        ctx.metadata["filtered_skill_ids"] = [
+            getattr(s, "id", None) or getattr(s, "name", None)
+            for s in filtered
+            if (getattr(s, "id", None) or getattr(s, "name", None)) and s.name not in dropped_names
+        ]
+    except Exception:  # pragma: no cover — metadata is best-effort
+        ctx.metadata["filtered_skill_ids"] = []
+
+    ctx.metadata["skill_count"] = len(injected)
     ctx.metadata["skills_prompt_chars"] = len(skills_prompt)
     ctx.metadata["skills_injection_mode"] = injection_mode
+    ctx.metadata["skills_dropped_for_budget"] = dropped
+
+    if dropped:
+        log.warning(
+            "skills_filter.budget_truncated",
+            dropped=dropped,
+            budget=max_chars,
+            kept=len(injected),
+        )
 
     # Surface the actual skill IDs the retriever picked. Without this,
     # operators can see a query passed through (total → filtered count)
@@ -170,7 +197,7 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
         total=len(all_skills),
         gated=len(gated),
         pinned=len(pinned),
-        filtered=len(final),
+        filtered=len(injected),
         mode=injection_mode,
         strategy=getattr(skills_cfg, "filter_strategy", "lexical") if filter_enabled else "off",
         query_preview=(

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -129,7 +129,10 @@ class SkillsConfig(BaseSettings):
     managed_dir: str | None = None
     allow_bundled: bool = True
     extra_dirs: list[str] = Field(default_factory=list)
-    max_skills_prompt_chars: int = 8000
+    # The bundled set renders ~16k with descriptions; 8000 silently forced
+    # every default install into name-only mode, then truncation. Keep enough
+    # headroom that installed skills also fit before either fallback kicks in.
+    max_skills_prompt_chars: int = 24000
     filter_enabled: bool = False
     filter_top_k: int = 5
     # "system" = full system prompt (default)

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -35,6 +35,7 @@ from agentos.router_tiers import (
     normalize_tier_mapping,
 )
 from agentos.sandbox.config import SandboxSettings
+from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
 
 
 class ContextOverflowPolicy(StrEnum):
@@ -132,7 +133,7 @@ class SkillsConfig(BaseSettings):
     # The bundled set renders ~16k with descriptions; 8000 silently forced
     # every default install into name-only mode, then truncation. Keep enough
     # headroom that installed skills also fit before either fallback kicks in.
-    max_skills_prompt_chars: int = 24000
+    max_skills_prompt_chars: int = DEFAULT_MAX_SKILLS_PROMPT_CHARS
     filter_enabled: bool = False
     filter_top_k: int = 5
     # "system" = full system prompt (default)

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -18,6 +18,7 @@ import tomli_w
 
 from agentos.paths import default_agentos_home
 from agentos.router_strategies import PILOT_STRATEGY_ID, V4_STRATEGY_ID
+from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
 
 DEPRECATED_MEMORY_FIELDS: frozenset[str] = frozenset(
     {
@@ -100,6 +101,11 @@ LEGACY_OPENROUTER_MODEL_IDS: dict[str, str] = {
     "anthropic/claude-opus-4.7": "anthropic/claude-opus-4.8",
     "moonshotai/kimi-k2.6": "minimax/minimax-m3",
 }
+
+#: The skills-block budget every config written before 2026-07 carries. Only
+#: this exact value is refreshed to the current default — see the migration at
+#: the end of :func:`migrate_config_payload`.
+LEGACY_MAX_SKILLS_PROMPT_CHARS = 8000
 
 OPENROUTER_PROVIDER_ID = "openrouter"
 
@@ -550,6 +556,22 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
                     "agent_token_saving.tool_result_compression_* was removed; "
                     "tokenjuice projection is now the built-in tool-result path"
                 )
+
+    # 2026-07: the skills-block budget default rose from 8000 to 24000 once the
+    # block stopped emitting a filesystem path per skill. 8000 could not fit the
+    # descriptions for the shipped set, so every install that saved a config was
+    # pinned to a name-only skill list — the raised default alone would never
+    # have reached them. Refresh only the exact old default, the same rule the
+    # legacy model ids use: a value someone chose deliberately is left alone.
+    skills_section = builder.payload.get("skills")
+    if isinstance(skills_section, dict):
+        current_budget = skills_section.get("max_skills_prompt_chars")
+        if current_budget == LEGACY_MAX_SKILLS_PROMPT_CHARS:
+            skills_section["max_skills_prompt_chars"] = DEFAULT_MAX_SKILLS_PROMPT_CHARS
+            builder.changes.append(
+                f"skills.max_skills_prompt_chars: {LEGACY_MAX_SKILLS_PROMPT_CHARS} -> "
+                f"{DEFAULT_MAX_SKILLS_PROMPT_CHARS}"
+            )
 
     return builder.result()
 

--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_AND_NODE
 from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.skills.availability import SkillAvailability
 from agentos.skills.eligibility import (
     EligibilityContext,
     EligibilityReport,
@@ -22,7 +23,18 @@ from agentos.skills.hub.defaults import (
     installed_skill_names,
 )
 from agentos.skills.hub.deps import install_deps
+from agentos.skills.hub.lockfile import LockEntry, Lockfile, default_lockfile_path
+from agentos.skills.inventory import (
+    SkillRow,
+    acquisition_payload,
+    availability_payload,
+    build_skill_inventory,
+    publisher_payload,
+)
 from agentos.skills.loader import SkillLoader
+from agentos.skills.publishers import resolve_publisher
+from agentos.skills.types import SkillAcquisition, SkillPublisher
+from agentos.tools.registry import get_default_registry
 
 _d = get_dispatcher()
 
@@ -49,6 +61,27 @@ def _get_loader(ctx: RpcContext) -> SkillLoader | None:
 def _loader_managed_dir(ctx: RpcContext) -> Path | None:
     loader = _get_loader(ctx)
     return getattr(loader, "managed_dir", None) if loader is not None else None
+
+
+def _available_tool_names(ctx: RpcContext) -> set[str]:
+    """Return the tool surface availability is answered against.
+
+    Same resolution order as ``rpc_tools``: the connection's registry when it
+    has one, else the process-wide default the gateway registers builtins into.
+    A per-turn profile can still narrow this, so the answer is "what this
+    install can offer the agent", which is the question an Installed row asks —
+    not "what that one turn saw".
+    """
+    registry = getattr(ctx, "tool_registry", None) or get_default_registry()
+    return set(registry.list_names())
+
+
+def _inventory(ctx: RpcContext) -> list[SkillRow]:
+    """Build the one row set every skills RPC renders from."""
+    loader = _get_loader(ctx)
+    if loader is None:
+        return []
+    return build_skill_inventory(loader, available_tools=_available_tool_names(ctx))
 
 
 def _status_from_report(report: EligibilityReport) -> str:
@@ -154,6 +187,9 @@ def _skill_to_dict(
     *,
     skill_index: dict[str, Any] | None = None,
     eligibility_ctx: EligibilityContext | None = None,
+    acquisition: SkillAcquisition | None = None,
+    publisher: SkillPublisher | None = None,
+    availability: SkillAvailability | None = None,
 ) -> dict[str, Any]:
     """Convert a SkillSpec to a dict with eligibility diagnostics.
 
@@ -163,6 +199,13 @@ def _skill_to_dict(
     OS filter (skill-level ``metadata.os`` + per-install ``os``), and keeps the
     wire payload narrow (no ``os`` field per entry).
     Passing an empty ``os_name`` disables per-entry filtering (backward compat).
+
+    ``acquisition``/``publisher``/``availability`` come from
+    :func:`~agentos.skills.inventory.build_skill_inventory`. The first two have
+    empty defaults, so they are always on the wire. ``availability`` has no
+    honest default — it needs a tool surface — so the key is omitted when it was
+    not computed rather than carrying a made-up verdict. Every RPC handler here
+    passes one, so it is always present on a real row.
     """
     meta = getattr(spec, "metadata", None)
     install_entries: list[dict[str, Any]] = []
@@ -209,6 +252,10 @@ def _skill_to_dict(
         "upstream_url": provenance.upstream_url if provenance else "",
         "maintained_by": provenance.maintained_by if provenance else "AgentOS",
     }
+    d["publisher"] = publisher_payload(publisher)
+    d["acquisition"] = acquisition_payload(acquisition)
+    if availability is not None:
+        d["availability"] = availability_payload(availability)
     d["declared"] = report.declared
     d["status"] = _status_from_report(report)
     d["status_detail"] = _status_detail(spec, report)
@@ -224,51 +271,53 @@ def _skill_to_dict(
     return d
 
 
+def _row_to_dict(
+    row: SkillRow,
+    os_name: str,
+    skill_index: dict[str, Any],
+    eligibility_ctx: EligibilityContext | None,
+) -> dict[str, Any]:
+    """Render one inventory row as the wire payload."""
+    return _skill_to_dict(
+        row.spec,
+        row.eligibility,
+        os_name,
+        skill_index=skill_index,
+        eligibility_ctx=eligibility_ctx,
+        acquisition=row.acquisition,
+        publisher=row.publisher,
+        availability=row.availability,
+    )
+
+
+def _rows_payload(rows: list[SkillRow], *, index_from: list[SkillRow] | None = None) -> list[dict]:
+    """Render rows, resolving cross-skill lookups against ``index_from``.
+
+    ``skills.list`` hides non-user-invocable skills but must still index every
+    loaded skill, so the rendered set and the index are separate arguments.
+    """
+    ctx_eligible = EligibilityContext.auto()
+    skill_index = {row.spec.name: row.spec for row in (index_from if index_from else rows)}
+    return [_row_to_dict(row, ctx_eligible.os_name, skill_index, ctx_eligible) for row in rows]
+
+
 @_d.method("skills.status")
 async def _handle_skills_status(params: dict | None, ctx: RpcContext) -> list[dict[str, Any]]:
-    """Return all skills with their eligibility status."""
-    loader = _get_loader(ctx)
-    if loader is None:
-        return []
+    """Return all skills with their eligibility status.
 
-    ctx_eligible = EligibilityContext.auto()
-    skills = loader.load_all()
-    skill_index = {skill.name: skill for skill in skills}
-    return [
-        _skill_to_dict(
-            skill,
-            diagnose_eligibility(skill, ctx_eligible),
-            ctx_eligible.os_name,
-            skill_index=skill_index,
-            eligibility_ctx=ctx_eligible,
-        )
-        for skill in skills
-    ]
+    A published alias of ``skills.list`` with no known caller. It is kept
+    because removing a published method is a breaking change, but it shares the
+    one row builder so it can no longer drift into a second answer.
+    """
+    return _rows_payload(_inventory(ctx))
 
 
 @_d.method("skills.list", CONTROL_AND_CHANNEL)
 async def _handle_skills_list(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """List installed skills."""
-    loader = _get_loader(ctx)
-    if loader is None:
-        return {"skills": []}
-
-    ctx_eligible = EligibilityContext.auto()
-    all_skills = loader.load_all()
-    skill_index = {skill.name: skill for skill in all_skills}
-    skills = [skill for skill in all_skills if skill.user_invocable]
-    return {
-        "skills": [
-            _skill_to_dict(
-                skill,
-                diagnose_eligibility(skill, ctx_eligible),
-                ctx_eligible.os_name,
-                skill_index=skill_index,
-                eligibility_ctx=ctx_eligible,
-            )
-            for skill in skills
-        ]
-    }
+    all_rows = _inventory(ctx)
+    rows = [row for row in all_rows if row.spec.user_invocable]
+    return {"skills": _rows_payload(rows, index_from=all_rows)}
 
 
 @_d.method("skills.bins", CONTROL_AND_NODE)
@@ -303,23 +352,15 @@ async def _handle_skills_get(params: dict | None, ctx: RpcContext) -> dict[str, 
     if loader is None:
         raise KeyError("No skill loader available")
 
-    skills = loader.load_all()
-    skill_index = {item.name: item for item in skills}
-    skill = skill_index.get(params["name"])
-    if skill is None:
+    all_rows = _inventory(ctx)
+    row = next((item for item in all_rows if item.spec.name == params["name"]), None)
+    if row is None:
         raise KeyError(f"Skill not found: {params['name']}")
 
-    ctx_eligible = EligibilityContext.auto()
-    result = _skill_to_dict(
-        skill,
-        diagnose_eligibility(skill, ctx_eligible),
-        ctx_eligible.os_name,
-        skill_index=skill_index,
-        eligibility_ctx=ctx_eligible,
-    )
-    result["content"] = skill.content
-    result["file_path"] = skill.file_path
-    result["base_dir"] = skill.base_dir
+    result = _rows_payload([row], index_from=all_rows)[0]
+    result["content"] = row.spec.content
+    result["file_path"] = row.spec.file_path
+    result["base_dir"] = row.spec.base_dir
     return result
 
 
@@ -332,6 +373,79 @@ def _installed_names() -> set[str]:
     set (treat everything as not-yet-installed).
     """
     return installed_skill_names()
+
+
+def _installed_lock_entries() -> dict[str, LockEntry]:
+    """Return the lockfile's installed entries, keyed by installed skill name."""
+    return Lockfile.load(default_lockfile_path()).installed
+
+
+def _synthesized_installed_rows(
+    results: list[Any],
+    *,
+    source_id: str | None,
+    query: str,
+    loader: SkillLoader | None,
+) -> list[dict[str, Any]]:
+    """Rows for lockfile installs the catalog did not return.
+
+    A browse (empty query) hits a source's catalog, and a catalog is free not to
+    list something the user already installed — a GitHub install by URL is never
+    in any catalog, and Bankr's browse omits rows it has retired. The Community
+    tab then shows no trace of a skill the user installed minutes ago, which
+    reads as the install having been lost. The lockfile already knows every
+    field a card needs, so this is a local join, not another network call.
+
+    Synthesized rows are appended: they carry no relevance score and no catalog
+    metadata, so putting them first would push richer rows off the top of the
+    grid, and they are the least urgent thing on the page — they are already
+    installed.
+    """
+    seen_identifiers = {r.identifier for r in results if getattr(r, "identifier", "")}
+    seen_names = {r.name for r in results if getattr(r, "name", "")}
+    needle = query.strip().lower()
+
+    rows: list[dict[str, Any]] = []
+    for name, entry in sorted(_installed_lock_entries().items()):
+        # Browsing one source must not surface another source's installs.
+        if source_id is not None and entry.source != source_id:
+            continue
+        if name in seen_names or (entry.identifier and entry.identifier in seen_identifiers):
+            continue
+
+        spec = loader.get_by_name(name) if loader is not None else None
+        description = getattr(spec, "description", "") if spec is not None else ""
+        if needle and needle not in name.lower() and needle not in description.lower():
+            continue
+
+        meta = getattr(spec, "metadata", None)
+        # The lockfile's ``publisher_name`` is the raw string a catalog claimed;
+        # only the allowlisted record is ever rendered as a brand.
+        publisher = resolve_publisher(entry.publisher_id)
+        rows.append(
+            {
+                "name": name,
+                "description": description,
+                "version": entry.version,
+                "author": "",
+                "source": entry.source,
+                "trust_level": entry.source_trust,
+                "identifier": entry.identifier,
+                "provider": publisher.name,
+                "logo": publisher.logo,
+                "emoji": meta.emoji if meta else "",
+                # No catalog metadata means no category. Left empty so the row
+                # joins the existing "other" bucket the browse UI already has,
+                # rather than inventing a chip that would appear on catalogs
+                # which currently show no chips at all.
+                "category": "",
+                "setup": [],
+                "demo": {},
+                "homepage": entry.upstream_url,
+                "installed": True,
+            }
+        )
+    return rows
 
 
 @_d.method("skills.search")
@@ -358,35 +472,47 @@ async def _handle_skills_search(params: dict | None, ctx: RpcContext) -> dict[st
     if source_id is not None and not isinstance(source_id, str):
         source_id = None
     results = await router.search(query, limit=limit, source_id=source_id)
-    # Match a browse result to a lockfile install by BOTH name and identifier.
-    # Lockfile keys are the installer's name (SKILL.md frontmatter), which may
-    # be neither the ``displayName`` a source returns as ``SkillMeta.name`` nor
-    # the catalog slug — e.g. Bankr's ``bankr-token-scam-analysis`` slug
-    # installs under the name ``token-scam-analysis``. The lockfile entry's
-    # identifier (the source URL) is the reliable join key across a reload.
-    installed = _installed_names() | installed_skill_identifiers()
-    return {
-        "results": [
-            {
-                "name": r.name,
-                "description": r.description,
-                "version": r.version,
-                "author": r.author,
-                "source": r.source_id,
-                "trust_level": r.trust_level,
-                "identifier": r.identifier,
-                "provider": r.provider,
-                "logo": r.logo,
-                "emoji": r.emoji,
-                "category": r.category,
-                "setup": r.setup,
-                "demo": r.demo,
-                "homepage": r.homepage,
-                "installed": r.identifier in installed or r.name in installed,
-            }
-            for r in results
-        ]
-    }
+    # Match a browse result to a lockfile install by name against names and by
+    # identifier against identifiers — never across the two. Lockfile keys are
+    # the installer's name (SKILL.md frontmatter), which may be neither the
+    # ``displayName`` a source returns as ``SkillMeta.name`` nor the catalog
+    # slug — e.g. Bankr's ``bankr-token-scam-analysis`` slug installs under the
+    # name ``token-scam-analysis``. The identifier (the source URL) is the
+    # reliable join key across a reload; comparing a name against the pooled
+    # union of both would flag a catalog row whose name happens to equal some
+    # other skill's identifier.
+    installed_names = _installed_names()
+    installed_identifiers = installed_skill_identifiers()
+    rows = [
+        {
+            "name": r.name,
+            "description": r.description,
+            "version": r.version,
+            "author": r.author,
+            "source": r.source_id,
+            "trust_level": r.trust_level,
+            "identifier": r.identifier,
+            "provider": r.provider,
+            "logo": r.logo,
+            "emoji": r.emoji,
+            "category": r.category,
+            "setup": r.setup,
+            "demo": r.demo,
+            "homepage": r.homepage,
+            "installed": (bool(r.identifier) and r.identifier in installed_identifiers)
+            or r.name in installed_names,
+        }
+        for r in results
+    ]
+    rows.extend(
+        _synthesized_installed_rows(
+            results,
+            source_id=source_id,
+            query=query if isinstance(query, str) else "",
+            loader=_get_loader(ctx),
+        )
+    )
+    return {"results": rows}
 
 
 def _invalidate_loader(ctx: RpcContext) -> None:

--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -71,7 +71,15 @@ def _available_tool_names(ctx: RpcContext) -> set[str]:
     A per-turn profile can still narrow this, so the answer is "what this
     install can offer the agent", which is the question an Installed row asks —
     not "what that one turn saw".
+
+    The exception is ``tools.enabled = false``, which narrows every turn to no
+    tools at all. Reporting the full registry there would show a
+    ``requires_tools`` skill as available on the Skills page while chat withholds
+    it — the disagreement this whole change exists to remove.
     """
+    tools_cfg = getattr(getattr(ctx, "config", None), "tools", None)
+    if tools_cfg is not None and not getattr(tools_cfg, "enabled", True):
+        return set()
     registry = getattr(ctx, "tool_registry", None) or get_default_registry()
     return set(registry.list_names())
 
@@ -81,7 +89,11 @@ def _inventory(ctx: RpcContext) -> list[SkillRow]:
     loader = _get_loader(ctx)
     if loader is None:
         return []
-    return build_skill_inventory(loader, available_tools=_available_tool_names(ctx))
+    return build_skill_inventory(
+        loader,
+        config=getattr(ctx, "config", None),
+        available_tools=_available_tool_names(ctx),
+    )
 
 
 def _status_from_report(report: EligibilityReport) -> str:

--- a/src/agentos/skills/availability.py
+++ b/src/agentos/skills/availability.py
@@ -1,0 +1,251 @@
+"""Why a skill is — or is not — offered to the agent right now.
+
+The engine used to answer this question only by side effect: a skill either
+appeared in the injected prompt or vanished, with nothing recording which of
+the five gates dropped it. This module owns both halves of the decision as
+pure functions so the same code answers it twice — once for the turn that
+builds the prompt, once for a UI asking before any turn has run.
+
+Nothing here reads process state or mutates its inputs; given the same skills,
+tools and eligibility context it returns the same answer every time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+from agentos.skills.eligibility import (
+    EligibilityContext,
+    EligibilityReport,
+    check_eligibility,
+    diagnose_eligibility,
+)
+from agentos.skills.injector import SkillInjector
+from agentos.skills.types import SkillSpec
+
+#: Reason codes. "" is reserved for an offered skill.
+REASON_MODEL_INVOCATION_DISABLED = "model_invocation_disabled"
+REASON_INELIGIBLE = "ineligible"
+REASON_TOOL_GATE = "tool_gate"
+REASON_FALLBACK_SUPERSEDED = "fallback_superseded"
+REASON_NOT_RETRIEVED = "not_retrieved"
+REASON_PROMPT_BUDGET = "prompt_budget"
+
+
+@dataclass(frozen=True)
+class SkillAvailability:
+    """Whether the agent is being offered this skill, and why not if it isn't.
+
+    ``detail`` is written for a person reading a tooltip, so it never carries a
+    filesystem path — the operator cannot act on one, and the injected prompt
+    already leaked home directories once.
+    """
+
+    offered: bool
+    reason: str = ""
+    detail: str = ""
+
+
+class InjectionPlan(NamedTuple):
+    """What ``plan_injection`` decided: the offered skills, why the rest are
+    missing, and the prompt those decisions produce.
+
+    The prompt is part of the result rather than something a caller re-renders:
+    once the budget forces a truncation, re-running the injector over the kept
+    subset can pick a *different* mode (that subset may now fit in full), so a
+    second render is not guaranteed to reproduce the first.
+    """
+
+    offered: list[SkillSpec]
+    availability: dict[str, SkillAvailability]
+    prompt: str
+    #: Names the budget cut, in the order the injector sacrificed them.
+    dropped: list[str]
+
+
+_OFFERED = SkillAvailability(offered=True)
+
+
+def _quote(names: list[str]) -> str:
+    return ", ".join(f"`{n}`" for n in names)
+
+
+def _plural(names: list[str], singular: str, plural: str) -> str:
+    return singular if len(names) == 1 else plural
+
+
+def _ineligible_detail(spec: SkillSpec, report: EligibilityReport) -> str:
+    """Turn a structured eligibility report into one sentence an operator can act on."""
+    clauses: list[str] = []
+
+    if report.disabled:
+        clauses.append("it is switched off for this workspace")
+
+    if report.wrong_os:
+        wanted = ", ".join(spec.metadata.os) if spec.metadata and spec.metadata.os else "another OS"
+        clauses.append(f"it runs on {wanted} only")
+
+    if report.missing_bins:
+        verb = _plural(report.missing_bins, "is", "are")
+        noun = _plural(report.missing_bins, "command", "commands")
+        clauses.append(f"the {noun} {_quote(report.missing_bins)} {verb} not on PATH")
+
+    if report.missing_env_detail:
+        described = [
+            f"`{var.name}` ({var.description})" if var.description else f"`{var.name}`"
+            for var in report.missing_env_detail
+        ]
+        noun = _plural(described, "variable", "variables")
+        verb = _plural(described, "is", "are")
+        clauses.append(f"the environment {noun} {', '.join(described)} {verb} not set")
+    elif report.missing_env:
+        noun = _plural(report.missing_env, "variable", "variables")
+        verb = _plural(report.missing_env, "is", "are")
+        clauses.append(f"the environment {noun} {_quote(report.missing_env)} {verb} not set")
+
+    if not clauses:
+        # check_eligibility said no but no category matched — report whatever
+        # the diagnosis collected rather than an empty sentence.
+        clauses.append(
+            "; ".join(report.reasons) if report.reasons else "its requirements are unmet"
+        )
+
+    detail = f"Installed, but not offered to the agent: {'; '.join(clauses)}."
+    if report.install_hints:
+        detail += f" Try: {report.install_hints[0].command}"
+    return detail
+
+
+def gate_skills(
+    skills: list[SkillSpec],
+    available_tools: set[str],
+    elig_ctx: EligibilityContext,
+) -> tuple[list[SkillSpec], dict[str, SkillAvailability]]:
+    """Pure-Python gate: visibility, eligibility, requires_tools, fallback.
+
+    Returns the skills that survived plus an availability entry for *every*
+    input skill. Survivors are marked offered here provisionally — retrieval and
+    the prompt budget still run downstream and may override the entry.
+    """
+    gated: list[SkillSpec] = []
+    availability: dict[str, SkillAvailability] = {}
+
+    for s in skills:
+        if s.disable_model_invocation:
+            availability[s.name] = SkillAvailability(
+                offered=False,
+                reason=REASON_MODEL_INVOCATION_DISABLED,
+                detail=(
+                    "Installed, but its manifest sets disable-model-invocation, so the "
+                    "agent is never offered it. You can still run it yourself."
+                ),
+            )
+            continue
+
+        if not check_eligibility(s, elig_ctx):
+            availability[s.name] = SkillAvailability(
+                offered=False,
+                reason=REASON_INELIGIBLE,
+                detail=_ineligible_detail(s, diagnose_eligibility(s, elig_ctx)),
+            )
+            continue
+
+        if s.requires_tools and not all(t in available_tools for t in s.requires_tools):
+            missing = [t for t in s.requires_tools if t not in available_tools]
+            noun = _plural(missing, "tool", "tools")
+            verb = _plural(missing, "is", "are")
+            availability[s.name] = SkillAvailability(
+                offered=False,
+                reason=REASON_TOOL_GATE,
+                detail=(
+                    f"Installed and ready, but not offered to the agent: it needs the "
+                    f"{noun} {_quote(missing)}, which {verb} not enabled in this session."
+                ),
+            )
+            continue
+
+        if s.fallback_for_toolsets and any(t in available_tools for t in s.fallback_for_toolsets):
+            covered = [t for t in s.fallback_for_toolsets if t in available_tools]
+            noun = _plural(covered, "tool", "tools")
+            availability[s.name] = SkillAvailability(
+                offered=False,
+                reason=REASON_FALLBACK_SUPERSEDED,
+                detail=(
+                    f"Not offered to the agent: it is a fallback for the {noun} "
+                    f"{_quote(covered)}, which this session already has natively."
+                ),
+            )
+            continue
+
+        availability[s.name] = _OFFERED
+        gated.append(s)
+
+    return gated, availability
+
+
+def plan_injection(
+    gated: list[SkillSpec],
+    max_chars: int,
+    injection_mode: str = "system",
+) -> InjectionPlan:
+    """Render the skills block and report which skills the budget cut.
+
+    ``injection_mode="user_message"`` renders compact unconditionally and so has
+    no budget to exceed; "system" and "user_context" both budget-select between
+    full and compact and may truncate.
+    """
+    injector = SkillInjector()
+    dropped: list[str]
+
+    if injection_mode == "user_message":
+        prompt, dropped = injector.inject_compact("", gated), []
+    else:
+        prompt, dropped = injector.inject_skills("", gated, max_chars=max_chars)
+
+    dropped_names = set(dropped)
+    offered = [s for s in gated if not s.disable_model_invocation and s.name not in dropped_names]
+
+    availability: dict[str, SkillAvailability] = {}
+    detail = (
+        f"Installed and ready, but not offered to the agent: the skills section is full "
+        f"({max_chars} characters). {len(dropped)} "
+        f"{_plural(dropped, 'skill is', 'skills are')} being dropped."
+    )
+    for s in gated:
+        if s.name in dropped_names:
+            availability[s.name] = SkillAvailability(
+                offered=False,
+                reason=REASON_PROMPT_BUDGET,
+                detail=detail,
+            )
+        elif not s.disable_model_invocation:
+            availability[s.name] = _OFFERED
+
+    return InjectionPlan(
+        offered=offered,
+        availability=availability,
+        prompt=prompt,
+        dropped=dropped,
+    )
+
+
+def retrieval_availability(
+    skipped: list[SkillSpec],
+    top_k: int,
+) -> dict[str, SkillAvailability]:
+    """Explain skills that relevance filtering left out of this turn.
+
+    Only reachable when ``skills.filter_enabled`` is on (it defaults to off), and
+    the answer depends on the message being answered — hence the detail says so
+    rather than presenting it as a standing property of the skill.
+    """
+    detail = (
+        f"Installed and ready, but not offered for this message: relevance filtering is on "
+        f"and kept only the {top_k} closest matches, which did not include this skill. "
+        "A differently worded message can bring it back."
+    )
+    return {
+        s.name: SkillAvailability(offered=False, reason=REASON_NOT_RETRIEVED, detail=detail)
+        for s in skipped
+    }

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -370,9 +370,10 @@ Full reference: `docs/http-api.md` (https://useagentos.dev/docs/http-api).
   - `prompt_budget` → the skills block is full. Raise
     `agentos config set skills.max_skills_prompt_chars <n>` (default 24000)
     and restart the gateway. The gateway also logs
-    `skills_filter.budget_truncated` with the dropped names. Truncation
-    sacrifices `bundled` skills first, so this shows up as shipped skills
-    disappearing while installed ones survive.
+    `skills_filter.budget_truncated` with the dropped names. Truncation goes
+    lowest-precedence layer first (`extra`, then `bundled`), so this shows up
+    as shipped skills disappearing while `managed`/`personal`/`project`/
+    `workspace` ones survive.
   - `not_retrieved` → only possible with `skills.filter_enabled = true`
     (off by default); raise `filter_top_k` or reword the request.
   - `tool_gate` / `fallback_superseded` → about the session's tool surface,

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -277,9 +277,11 @@ while `updatable` stays true, because an update re-fetches by identifier.
 **Publisher — whose name is on it.** `agentos skills list --json` reports
 `publisher` as `{id, name, url, logo}`, empty strings when unbranded.
 The id is *allowlisted server-side*: a `SKILL.md` or a hub catalog can only
-select from the recognized set, never describe a publisher of its own. Treat
-a non-empty `publisher.id` as the only signal of a partner skill; never infer
-one from a name or a homepage URL.
+select from the recognized set, never describe a publisher of its own. Only a
+`bundled` manifest may select an id for itself; an installed skill is branded
+by the hub catalog row it came from, so a directory added by hand is always
+unbranded. Treat a non-empty `publisher.id` as the only signal of a partner
+skill; never infer one from a name or a homepage URL.
 
 Provenance (`origin`, `license`, `upstream_url`) is a fourth, independent
 fact — where the text came from and under what licence. A skill can be

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -303,6 +303,10 @@ with `reason` one of:
 | `not_retrieved` | `skills.filter_enabled` is on and this message did not match |
 | `prompt_budget` | it is ready, but the skills block hit `max_skills_prompt_chars` |
 
+All of these reach a `skills.list` row except `not_retrieved`, which ranks
+against one message's wording and so only exists inside a turn. Do not tell an
+operator to look for it on the Skills page — read it from the decision log.
+
 `agentos skills list --json` omits `availability` entirely: a CLI process has
 no chat session and no tool surface, so it cannot answer. An absent key means
 "not computed", never "not offered".

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -163,7 +163,7 @@ Main `agentos.toml` sections (full commented reference:
 | top-level | `workspace_dir`, `state_dir`, logging, `search_provider`/`search_api_key`, timeouts |
 | `[llm]` | `provider`, `model`, `api_key`, `base_url`, `proxy`, `[llm.provider_routing]` |
 | `[agentos_router]` | router on/off, `strategy` (`pilot-v1`), tier settings under `[agentos_router.tiers.c0..c3]` |
-| `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode` |
+| `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode`, `max_skills_prompt_chars` (default 24000) |
 | `[tools]` | model-visible tools and policy; `enabled = false` runs providers in plain-text mode |
 | `[memory]` | memory source and embedding model, `[memory.nudge]` (periodic memory review) |
 | `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |
@@ -255,10 +255,55 @@ agentos skills update
 agentos skills uninstall <name>
 ```
 
-Skill layers (later overrides earlier): `extra` (config dirs) → `bundled`
-(shipped) → `managed` (`~/.agentos/skills`, where installs land) →
-`personal` (`~/.agents/skills`) → `project` (`<workspace>/.agents/skills`)
-→ `workspace` (`<workspace>/skills`).
+Three separate facts describe a skill; do not use one to answer another.
+
+**Layer — where the files are.** Name-collision precedence, later overrides
+earlier: `extra` (config dirs) → `bundled` (shipped) → `managed`
+(`~/.agentos/skills`, where installs land) → `personal` (`~/.agents/skills`)
+→ `project` (`<workspace>/.agents/skills`) → `workspace`
+(`<workspace>/skills`). Layer is also the tiebreak when the prompt budget
+forces a cut: shipped skills go first, an operator's own skills go last.
+
+**Acquisition — how it got there.** `shipped` (ships with the wheel),
+`hub` (fetched by `agentos skills install`, has a lockfile entry), or `local`
+(a directory someone put there). `agentos skills list --json` reports it under
+`acquisition`, together with `source_id`, `identifier`, `version`,
+`installed_at`, and two booleans: `removable` and `updatable`. Trust those
+booleans rather than inferring from the layer — a hub install whose recorded
+path no longer matches the configured `skills.managed_dir` reports
+`removable: false` (AgentOS will not delete files it cannot prove it owns)
+while `updatable` stays true, because an update re-fetches by identifier.
+
+**Publisher — whose name is on it.** `agentos skills list --json` reports
+`publisher` as `{id, name, url, logo}`, empty strings when unbranded.
+The id is *allowlisted server-side*: a `SKILL.md` or a hub catalog can only
+select from the recognized set, never describe a publisher of its own. Treat
+a non-empty `publisher.id` as the only signal of a partner skill; never infer
+one from a name or a homepage URL.
+
+Provenance (`origin`, `license`, `upstream_url`) is a fourth, independent
+fact — where the text came from and under what licence. A skill can be
+AgentOS-original text published by a partner, or upstream text with no
+publisher at all.
+
+**Availability — whether the agent is being offered it right now.** This is
+not the same as installed or eligible. `skills.list` over the gateway, and the
+agent's own `skill_list` tool, report `availability: {offered, reason, detail}`
+with `reason` one of:
+
+| `reason` | Means |
+| --- | --- |
+| `""` | offered (`offered: true`) |
+| `model_invocation_disabled` | the manifest sets `disable-model-invocation`; only a person can run it |
+| `ineligible` | a required binary, env var, or OS is missing |
+| `tool_gate` | its `requires_tools` are not enabled in this session |
+| `fallback_superseded` | it is a fallback for a tool the session already has natively |
+| `not_retrieved` | `skills.filter_enabled` is on and this message did not match |
+| `prompt_budget` | it is ready, but the skills block hit `max_skills_prompt_chars` |
+
+`agentos skills list --json` omits `availability` entirely: a CLI process has
+no chat session and no tool surface, so it cannot answer. An absent key means
+"not computed", never "not offered".
 
 **One-shot automation:**
 
@@ -313,9 +358,29 @@ Full reference: `docs/http-api.md` (https://useagentos.dev/docs/http-api).
   public-bind recipe above.
 - **Provider/model errors** → `agentos providers status`,
   `agentos models list`, then `agentos providers configure …`.
-- **Skill missing from prompt** → `agentos skills list` (check layer and
-  enablement), then `[skills]` filter settings (`filter_top_k`,
-  `filter_strategy`).
+- **Skill missing from prompt** → do not guess from the layer. Ask the
+  surface that knows: the `availability.reason` on a `skills.list` row, or the
+  `[not offered] …` line the agent's own `skill_list` prints. Then act on the
+  reason:
+  - `ineligible` → the detail names the missing binary or variable;
+    `agentos env set <NAME> --stdin` applies to the running gateway, no
+    restart, and the skill becomes eligible on the next turn.
+  - `prompt_budget` → the skills block is full. Raise
+    `agentos config set skills.max_skills_prompt_chars <n>` (default 24000)
+    and restart the gateway. The gateway also logs
+    `skills_filter.budget_truncated` with the dropped names. Truncation
+    sacrifices `bundled` skills first, so this shows up as shipped skills
+    disappearing while installed ones survive.
+  - `not_retrieved` → only possible with `skills.filter_enabled = true`
+    (off by default); raise `filter_top_k` or reword the request.
+  - `tool_gate` / `fallback_superseded` → about the session's tool surface,
+    not the skill; check `[tools]`.
+  - `model_invocation_disabled` → working as declared; the skill is for a
+    person to run, not the agent.
+- **Skill shows "ready" in the Web UI but the agent will not use it** →
+  that is `availability`, not `eligible`. A skill can be perfectly installed
+  and still be withheld for any of the reasons above; the Skills screen labels
+  it on the card.
 - **Deep debugging** → `agentos diagnostics on`, reproduce, then
   `agentos replay` on the recorded turn.
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -264,6 +264,14 @@ earlier: `extra` (config dirs) → `bundled` (shipped) → `managed`
 (`<workspace>/skills`). Layer is also the tiebreak when the prompt budget
 forces a cut: shipped skills go first, an operator's own skills go last.
 
+The `.agents/skills` layers are shared with other agents (Codex, Cursor, and
+anything else using that convention). Skills they add or remove take effect on
+the next turn — the loader re-checks the directories rather than trusting a
+cache — so do not tell an operator to restart the gateway to pick one up, and
+do not assume `agentos skills install` is the only way a skill got there. A
+`.agents/skills` skill also outranks a bundled or hub-installed one of the
+same name.
+
 **Acquisition — how it got there.** `shipped` (ships with the wheel),
 `hub` (fetched by `agentos skills install`, has a lockfile entry), or `local`
 (a directory someone put there). `agentos skills list --json` reports it under

--- a/src/agentos/skills/bundled/robinhood-agentic-trading/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-agentic-trading/SKILL.md
@@ -5,6 +5,8 @@ provenance:
   origin: agentos-original
   license: MIT
   maintained_by: AgentOS
+publisher:
+  id: robinhood
 ---
 
 # Robinhood Agentic Trading

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -6,6 +6,8 @@ provenance:
   origin: agentos-original
   license: MIT
   maintained_by: AgentOS
+publisher:
+  id: robinhood
 metadata:
   {
     "agentos":

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -29,7 +29,7 @@ from collections.abc import Sequence
 import structlog
 
 from agentos.env import trust_env as _trust_env
-from agentos.skills.hub.github import GitHubSource, _frontmatter_field
+from agentos.skills.hub.github import GitHubSource, _frontmatter_field, _parse_identifier
 from agentos.skills.hub.source import SkillBundle, SkillMeta, SkillSource
 
 log = structlog.get_logger(__name__)
@@ -141,10 +141,35 @@ class BankrSource(SkillSource):
         results = [m for m in metas if _matches(m, query)]
         return results[:limit]
 
+    def _is_allowlisted(self, identifier: str) -> bool:
+        """Return True when ``identifier`` names an allowlisted skill in this repo.
+
+        ``inspect``/``fetch`` delegate to :class:`GitHubSource`, which will
+        download any repository it is pointed at. The delegation has to be
+        gated: a hub install records its publisher from the *source* it came
+        through, so an unchecked delegate lets
+        ``skills.install(identifier="…/attacker/skill", source="bankr")``
+        install arbitrary code and have it render under Bankr's name. The
+        allowlist is the boundary this source already declares — enforce it on
+        the install path too, not only when listing the catalog.
+        """
+        ref = _parse_identifier(identifier)
+        if ref is None:
+            return False
+        if ref.repo_full.lower() != self._repo.lower():
+            return False
+        return ref.skill_dir.strip("/") in self._allowlist
+
     async def inspect(self, identifier: str) -> SkillMeta | None:
+        if not self._is_allowlisted(identifier):
+            log.warning("bankr.identifier_rejected", op="inspect")
+            return None
         return await self._github.inspect(identifier)
 
     async def fetch(self, identifier: str) -> SkillBundle | None:
+        if not self._is_allowlisted(identifier):
+            log.warning("bankr.identifier_rejected", op="fetch")
+            return None
         return await self._github.fetch(identifier)
 
     async def _load_catalog(self) -> list[SkillMeta]:

--- a/src/agentos/skills/hub/defaults.py
+++ b/src/agentos/skills/hub/defaults.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from agentos.paths import default_agentos_home
 from agentos.skills.hub.bankr import BankrSource
 from agentos.skills.hub.clawhub import ClawHubSource
 from agentos.skills.hub.github import GitHubSource
 from agentos.skills.hub.installer import SkillInstaller
-from agentos.skills.hub.lockfile import Lockfile
+from agentos.skills.hub.lockfile import Lockfile, default_lockfile_path
 from agentos.skills.hub.router import SourceRouter
 from agentos.skills.hub.source import SkillSource
 
@@ -44,8 +43,7 @@ def build_default_skill_installer(*, managed_dir: Path | None = None) -> SkillIn
 def installed_skill_names() -> set[str]:
     """Return skill names recorded as Community installs in the lockfile."""
 
-    lockfile_path = default_agentos_home() / "skills-lock.json"
-    return set(Lockfile.load(lockfile_path).installed.keys())
+    return set(Lockfile.load(default_lockfile_path()).installed.keys())
 
 
 def installed_skill_identifiers() -> set[str]:
@@ -58,9 +56,8 @@ def installed_skill_identifiers() -> set[str]:
     by name keeps its "installed" badge correct across a page reload.
     """
 
-    lockfile_path = default_agentos_home() / "skills-lock.json"
     return {
         entry.identifier
-        for entry in Lockfile.load(lockfile_path).installed.values()
+        for entry in Lockfile.load(default_lockfile_path()).installed.values()
         if entry.identifier
     }

--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -184,6 +184,10 @@ class SkillInstaller:
             LockEntry(
                 source=source_id,
                 identifier=identifier,
+                # The field has existed since the lockfile did and was never
+                # written, so every install reported an empty version — now
+                # that `acquisition.version` is on the wire, that is visible.
+                version=bundle_meta.version if bundle_meta else "",
                 installed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 path=str(install_dir),
                 sha256=sha,

--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -11,15 +11,23 @@ from pathlib import Path
 import structlog
 
 from agentos.paths import default_agentos_home
-from agentos.skills.hub.lockfile import LockEntry, Lockfile, compute_sha256
+from agentos.skills.hub.lockfile import (
+    LockEntry,
+    Lockfile,
+    compute_sha256,
+    default_lockfile_path,
+)
 from agentos.skills.hub.router import SourceRouter
 from agentos.skills.hub.scanner import ScanResult, scan_skill_bundle
+from agentos.skills.hub.source import SkillMeta
 from agentos.skills.paths import default_managed_skills_dir
 
 log = structlog.get_logger(__name__)
 
 # Path traversal protection: only allow safe skill names
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$")
+
+_SLUG_SEPARATORS_RE = re.compile(r"[^a-z0-9]+")
 
 
 def _default_managed_dir() -> Path:
@@ -31,7 +39,21 @@ def _default_quarantine_dir() -> Path:
 
 
 def _default_lockfile() -> Path:
-    return default_agentos_home() / "skills-lock.json"
+    return default_lockfile_path()
+
+
+def _publisher_slug(meta: SkillMeta | None, source_id: str) -> str:
+    """Return the publisher slug to record for a hub install.
+
+    A hub-installed skill has no ``publisher:`` block in its frontmatter — the
+    catalog row that installed it is the only thing that knew the brand. Prefer
+    the row's ``provider`` and fall back to the source itself, so a Bankr skill
+    with no declared provider still shows as published by Bankr.
+
+    This is only a *selector*; the allowlist decides whether it means anything.
+    """
+    raw = (meta.provider if meta else "") or source_id
+    return _SLUG_SEPARATORS_RE.sub("-", raw.strip().lower()).strip("-")
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:
@@ -167,6 +189,8 @@ class SkillInstaller:
                 sha256=sha,
                 license=bundle_meta.license if bundle_meta else "",
                 upstream_url=bundle_meta.homepage if bundle_meta else "",
+                publisher_id=_publisher_slug(bundle_meta, source_id),
+                publisher_name=bundle_meta.provider if bundle_meta else "",
                 source_trust=bundle_meta.trust_level if bundle_meta else "",
                 scan_verdict=scan_result.verdict,
                 scan_strategy=scan_result.strategy,

--- a/src/agentos/skills/hub/lockfile.py
+++ b/src/agentos/skills/hub/lockfile.py
@@ -7,6 +7,17 @@ import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from agentos.paths import default_agentos_home
+
+
+def default_lockfile_path() -> Path:
+    """Return the shared skills lockfile path.
+
+    Installer, CLI, and the Installed inventory must read the same file; each
+    of them deriving it separately is how they drift apart.
+    """
+    return default_agentos_home() / "skills-lock.json"
+
 
 @dataclass
 class LockEntry:
@@ -20,6 +31,16 @@ class LockEntry:
     sha256: str = ""
     license: str = ""
     upstream_url: str = ""
+    #: Publisher slug the installing catalog row claimed. A *selector*, not a
+    #: description: it is looked up in the server-side allowlist
+    #: (:func:`agentos.skills.publishers.resolve_publisher`) before anything is
+    #: displayed, so a hub cannot mint brand identity by naming itself here any
+    #: more than a ``SKILL.md`` can.
+    publisher_id: str = ""
+    #: Raw ``provider`` string from the catalog row, kept for diagnostics —
+    #: it tells an operator which brand an *unrecognized* publisher claimed to
+    #: be. Never rendered as branding; only :attr:`publisher_id` is resolved.
+    publisher_name: str = ""
     source_trust: str = ""
     scan_verdict: str = ""
     scan_strategy: str = ""
@@ -40,6 +61,8 @@ class Lockfile:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             lf = Lockfile(version=data.get("version", 1))
+            # Every LockEntry field must be listed here or it is silently
+            # dropped on load, however faithfully install-time wrote it.
             known_fields = {
                 "source",
                 "identifier",
@@ -49,6 +72,8 @@ class Lockfile:
                 "sha256",
                 "license",
                 "upstream_url",
+                "publisher_id",
+                "publisher_name",
                 "source_trust",
                 "scan_verdict",
                 "scan_strategy",

--- a/src/agentos/skills/injector.py
+++ b/src/agentos/skills/injector.py
@@ -11,8 +11,9 @@ from agentos.skills.types import SkillLayer, SkillSpec
 #: what silently forced default installs into name-only mode.
 DEFAULT_MAX_SKILLS_PROMPT_CHARS = 24_000
 
-# Highest precedence first. When the budget forces a cut, shipped skills are
-# sacrificed before the ones an operator installed on purpose.
+# Highest precedence first — the same order that decides a name collision. When
+# the budget forces a cut it lands on the tail, so a skill in a writable skills
+# path outlives a shipped one, and `extra` (read-only config dirs) goes first.
 _LAYER_PRECEDENCE: dict[SkillLayer, int] = {
     SkillLayer.WORKSPACE: 0,
     SkillLayer.PROJECT: 1,

--- a/src/agentos/skills/injector.py
+++ b/src/agentos/skills/injector.py
@@ -44,17 +44,25 @@ class SkillInjector:
 
         lines = [
             "\n\n## Skills",
-            "Skills are optional task playbooks. Use them only when a listed entry "
-            "clearly matches the user's current request.",
+            "Skills are task playbooks written for this install. They carry the "
+            "endpoints, commands, conventions, and known pitfalls that a "
+            "general-purpose approach misses.",
             "Skill names are identifiers for `skill_view`; they are not callable tools.",
-            "Review <available_skills> before answering.",
-            'When one entry is clearly relevant, call skill_view(name="<skill_name>") '
-            "to load that skill's instructions, then use only the tools available "
-            "in this session.",
+            "Read <available_skills> before answering. When an entry relates to the "
+            'request — even partially — call skill_view(name="<skill_name>") to load '
+            "its instructions and follow them, then use only the tools available in "
+            "this session.",
+            # Bias deliberately toward loading. The two failure modes are not
+            # symmetric: loading a skill you did not need wastes a little context,
+            # while skipping one that encoded the right steps produces a confidently
+            # wrong answer. A skill also encodes how the user wants the task done
+            # here, which is not something the model can infer from the request.
+            "Lean toward loading. Load a skill even for a task you already know how "
+            "to do — it defines how that task should be done in this install.",
         ]
         lines.extend(
             [
-                "When no entry is relevant, answer without loading a skill.",
+                "Answer without a skill only when no entry relates to the request.",
                 "",
                 "<available_skills>",
             ]
@@ -74,10 +82,16 @@ class SkillInjector:
             return system_prompt
 
         lines = [
-            "\n\nSkills are optional task playbooks for specific request types.",
+            "\n\nSkills are task playbooks written for this install. Only their names "
+            "are listed below — each one's description and instructions live inside it.",
             "Skill names are identifiers for `skill_view`; they are not callable tools.",
-            'Call skill_view(name="<skill_name>") only when the current request '
-            "matches a listed entry.",
+            # Compact mode strips the descriptions, so the model has nothing to judge
+            # relevance against but a name. Telling it to load "only on a clear match"
+            # would then be an instruction it cannot follow: no name clearly matches
+            # anything. Ask it to open plausible entries instead of guessing.
+            "A name alone is not enough to rule a skill out, so call skill_view(name="
+            '"<skill_name>") on any entry that plausibly relates to the request before '
+            "concluding it does not apply.",
         ]
         lines.extend(["", "<available_skills>"])
         for s in visible:

--- a/src/agentos/skills/injector.py
+++ b/src/agentos/skills/injector.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from agentos.skills.types import SkillLayer, SkillSpec
 
+#: Character budget for the injected skills block when nothing configures one.
+#: Kept here rather than at each call site: the same number is the default for
+#: ``skills.max_skills_prompt_chars`` and the fallback the turn pipeline uses
+#: when a turn arrives without a skills config, and those two drifting apart is
+#: what silently forced default installs into name-only mode.
+DEFAULT_MAX_SKILLS_PROMPT_CHARS = 24_000
+
 # Highest precedence first. When the budget forces a cut, shipped skills are
 # sacrificed before the ones an operator installed on purpose.
 _LAYER_PRECEDENCE: dict[SkillLayer, int] = {
@@ -83,7 +90,7 @@ class SkillInjector:
         self,
         system_prompt: str,
         skills: list[SkillSpec],
-        max_chars: int = 30_000,
+        max_chars: int = DEFAULT_MAX_SKILLS_PROMPT_CHARS,
     ) -> tuple[str, list[str]]:
         """Auto-select full/compact mode based on token budget.
 

--- a/src/agentos/skills/injector.py
+++ b/src/agentos/skills/injector.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
-from agentos.skills.types import SkillSpec
+from agentos.skills.types import SkillLayer, SkillSpec
+
+# Highest precedence first. When the budget forces a cut, shipped skills are
+# sacrificed before the ones an operator installed on purpose.
+_LAYER_PRECEDENCE: dict[SkillLayer, int] = {
+    SkillLayer.WORKSPACE: 0,
+    SkillLayer.PROJECT: 1,
+    SkillLayer.PERSONAL: 2,
+    SkillLayer.MANAGED: 3,
+    SkillLayer.BUNDLED: 4,
+    SkillLayer.EXTRA: 5,
+}
+_UNKNOWN_LAYER_RANK = len(_LAYER_PRECEDENCE)
 
 
 def _escape_xml(s: str) -> str:
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def _skill_location(skill: SkillSpec) -> str:
-    if skill.file_path:
-        return skill.file_path
-    if skill.path is not None:
-        return str(skill.path)
-    return ""
+def _layer_rank(skill: SkillSpec) -> int:
+    return _LAYER_PRECEDENCE.get(skill.layer, _UNKNOWN_LAYER_RANK)
 
 
 class SkillInjector:
@@ -44,12 +52,9 @@ class SkillInjector:
             ]
         )
         for s in visible:
-            lines.append('  <skill>')
+            lines.append("  <skill>")
             lines.append(f"    <name>{_escape_xml(s.name)}</name>")
             lines.append(f"    <description>{_escape_xml(s.description)}</description>")
-            location = _skill_location(s)
-            if location:
-                lines.append(f"    <location>{_escape_xml(location)}</location>")
             lines.append("  </skill>")
         lines.append("</available_skills>")
         return system_prompt + "\n".join(lines)
@@ -68,11 +73,8 @@ class SkillInjector:
         ]
         lines.extend(["", "<available_skills>"])
         for s in visible:
-            lines.append('  <skill>')
+            lines.append("  <skill>")
             lines.append(f"    <name>{_escape_xml(s.name)}</name>")
-            location = _skill_location(s)
-            if location:
-                lines.append(f"    <location>{_escape_xml(location)}</location>")
             lines.append("  </skill>")
         lines.append("</available_skills>")
         return system_prompt + "\n".join(lines)
@@ -82,25 +84,32 @@ class SkillInjector:
         system_prompt: str,
         skills: list[SkillSpec],
         max_chars: int = 30_000,
-    ) -> str:
-        """Auto-select full/compact mode based on token budget."""
+    ) -> tuple[str, list[str]]:
+        """Auto-select full/compact mode based on token budget.
+
+        Returns the prompt plus the names of any skills the budget forced out,
+        so callers can log and surface a silent capability loss.
+        """
         if not skills:
-            return system_prompt
+            return system_prompt, []
 
         full = self.inject_full(system_prompt, skills)
         if len(full) - len(system_prompt) <= max_chars:
-            return full
+            return full, []
 
         compact = self.inject_compact(system_prompt, skills)
         if len(compact) - len(system_prompt) <= max_chars:
-            return compact
+            return compact, []
 
-        # Budget exceeded even in compact — truncate skills
+        # Budget exceeded even in compact — truncate skills. Sort by layer
+        # precedence first (stable, so within-layer order is untouched) so the
+        # cut lands on bundled skills instead of whatever the operator installed.
         visible = [s for s in skills if not s.disable_model_invocation]
-        lo, hi = 0, len(visible)
+        ordered = sorted(visible, key=_layer_rank)
+        lo, hi = 0, len(ordered)
         while lo < hi:
             mid = (lo + hi + 1) // 2
-            test = self.inject_compact(system_prompt, visible[:mid])
+            test = self.inject_compact(system_prompt, ordered[:mid])
             if len(test) - len(system_prompt) <= max_chars:
                 lo = mid
             else:
@@ -108,4 +117,6 @@ class SkillInjector:
         # If the safety header itself exceeds an extremely small budget, keep
         # one compact skill entry rather than dropping the whole skills section.
         # Losing the guard makes skill names more likely to be mistaken for tools.
-        return self.inject_compact(system_prompt, visible[: max(lo, 1)])
+        kept = max(lo, 1)
+        dropped = [s.name for s in ordered[kept:]]
+        return self.inject_compact(system_prompt, ordered[:kept]), dropped

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -163,12 +163,14 @@ def _managed_dir(loader: SkillLoader, config: Any | None) -> Path | None:
 
 
 def _derive_publisher(spec: SkillSpec, entry: LockEntry | None) -> SkillPublisher:
-    """Return the brand for a row: declared in frontmatter, else from the hub.
+    """Return the brand for a row: declared by a bundled manifest, else the hub's.
 
-    A hub install has no ``publisher:`` block of its own — the catalog row that
-    installed it is the only thing that knew the brand — so the lockfile carries
-    the slug forward. Either way it is a selector: the allowlist supplies every
-    displayed field, so neither a manifest nor a hub can invent a brand.
+    Only a bundled ``SKILL.md`` may name its own publisher (see
+    :mod:`agentos.skills.publishers`), so ``spec.publisher`` is already empty for
+    anything an operator or a hub put on disk. A hub install gets its brand from
+    the catalog row that installed it, which the lockfile carries forward. Either
+    way the declaration is only a selector: the allowlist supplies every displayed
+    field, so neither a manifest nor a hub can invent a brand.
     """
     if spec.publisher.id:
         return spec.publisher

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -171,11 +171,17 @@ def _derive_publisher(spec: SkillSpec, entry: LockEntry | None) -> SkillPublishe
     the catalog row that installed it, which the lockfile carries forward. Either
     way the declaration is only a selector: the allowlist supplies every displayed
     field, so neither a manifest nor a hub can invent a brand.
+
+    ``entry.source`` is the fallback selector because that is exactly what
+    install time falls back to (``installer._publisher_slug``). Without it every
+    lockfile written before ``publisher_id`` existed — i.e. every partner skill
+    already installed on an upgrading machine — would lose its brand and drop
+    out of the Partners group until it was reinstalled.
     """
     if spec.publisher.id:
         return spec.publisher
-    if entry is not None and entry.publisher_id:
-        return resolve_publisher(entry.publisher_id)
+    if entry is not None:
+        return resolve_publisher(entry.publisher_id or entry.source)
     return SkillPublisher()
 
 

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -35,7 +35,13 @@ from agentos.skills.types import (
     SkillSpec,
 )
 
-__all__ = ["SkillRow", "build_skill_inventory"]
+__all__ = [
+    "SkillRow",
+    "acquisition_payload",
+    "availability_payload",
+    "build_skill_inventory",
+    "publisher_payload",
+]
 
 
 @dataclass(frozen=True)
@@ -102,6 +108,50 @@ def build_skill_inventory(
             )
         )
     return rows
+
+
+def publisher_payload(publisher: SkillPublisher | None) -> dict[str, Any]:
+    """Serialize an allowlisted publisher; all-empty when a skill has none.
+
+    Lives here rather than beside any one surface: the gateway, the CLI, and the
+    agent's own ``skill_list`` all emit these three blocks, and a second copy of
+    the key names is exactly how they drifted apart before. Always present, so a
+    consumer reads ``row["publisher"]["id"]`` without a guard and tests one
+    thing — an empty ``id`` means unbranded.
+    """
+    p = publisher or SkillPublisher()
+    return {"id": p.id, "name": p.name, "url": p.url, "logo": p.logo}
+
+
+def acquisition_payload(acquisition: SkillAcquisition | None) -> dict[str, Any]:
+    """Serialize how a skill was acquired and what an operator may do to it.
+
+    :attr:`SkillAcquisition.detail` is deliberately left off the wire: it names
+    filesystem paths, and this payload reaches the agent's ``skill_list`` as
+    well as the Web UI. A surface that wants to explain a withheld affordance
+    reads it off the row.
+    """
+    a = acquisition or SkillAcquisition()
+    return {
+        "kind": str(a.kind),
+        "source_id": a.source_id,
+        "identifier": a.identifier,
+        "version": a.version,
+        "installed_at": a.installed_at,
+        "source_trust": a.source_trust,
+        "scan_verdict": a.scan_verdict,
+        "removable": a.removable,
+        "updatable": a.updatable,
+    }
+
+
+def availability_payload(availability: SkillAvailability) -> dict[str, Any]:
+    """Serialize whether the agent is being offered a skill, and why not."""
+    return {
+        "offered": availability.offered,
+        "reason": availability.reason,
+        "detail": availability.detail,
+    }
 
 
 def _managed_dir(loader: SkillLoader, config: Any | None) -> Path | None:

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -18,13 +18,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from agentos.skills.availability import SkillAvailability, gate_skills
+from agentos.skills.availability import SkillAvailability, gate_skills, plan_injection
 from agentos.skills.eligibility import (
     EligibilityContext,
     EligibilityReport,
     diagnose_eligibility,
 )
 from agentos.skills.hub.lockfile import LockEntry, Lockfile, default_lockfile_path
+from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
 from agentos.skills.loader import SkillLoader
 from agentos.skills.publishers import resolve_publisher
 from agentos.skills.types import (
@@ -71,8 +72,9 @@ def build_skill_inventory(
     Args:
         loader: Supplies the skills and the managed directory the acquisition
             guard checks recorded install paths against.
-        config: Optional gateway config, consulted only for
-            ``skills.managed_dir`` when the loader carries no managed directory.
+        config: Optional gateway config, consulted for ``skills.managed_dir``
+            when the loader carries no managed directory, and for the prompt
+            budget the availability answer is measured against.
         lockfile_path: Override for the shared lockfile; defaults to
             :func:`~agentos.skills.hub.lockfile.default_lockfile_path`.
         available_tools: Tool names this session can offer. Supplying it fills
@@ -88,12 +90,25 @@ def build_skill_inventory(
     # but built here rather than at import time, so a credential added since the
     # process started is seen on the next call.
     elig_ctx = EligibilityContext.auto()
-    # The turn pipeline runs the same gate, so a row and the prompt agree on
-    # which skills the agent is being offered. The budget and retrieval gates
-    # are turn-specific and deliberately not run here.
-    availability = (
-        gate_skills(skills, available_tools, elig_ctx)[1] if available_tools is not None else {}
-    )
+    # The turn pipeline runs the same gates, so a row and the prompt agree on
+    # which skills the agent is being offered.
+    availability: dict[str, SkillAvailability] = {}
+    if available_tools is not None:
+        gated, availability = gate_skills(skills, available_tools, elig_ctx)
+        # The budget gate is *not* turn-specific: it depends only on the gated
+        # set and the configured budget, both of which are known here. Running
+        # it is what lets a row say "installed and ready, but the skills block
+        # is full" instead of claiming the agent has a skill it is never
+        # offered — the half of the answer a Skills page could not give before.
+        # Retrieval is the one genuinely per-turn gate and stays out: it ranks
+        # against the user's message, so there is no query to answer it with.
+        skills_cfg = getattr(config, "skills", None) if config is not None else None
+        plan = plan_injection(
+            gated,
+            getattr(skills_cfg, "max_skills_prompt_chars", DEFAULT_MAX_SKILLS_PROMPT_CHARS),
+            getattr(skills_cfg, "injection_mode", "system"),
+        )
+        availability = {**availability, **plan.availability}
 
     rows: list[SkillRow] = []
     for spec in skills:
@@ -177,10 +192,15 @@ def _derive_publisher(spec: SkillSpec, entry: LockEntry | None) -> SkillPublishe
     lockfile written before ``publisher_id`` existed — i.e. every partner skill
     already installed on an upgrading machine — would lose its brand and drop
     out of the Partners group until it was reinstalled.
+
+    A shipped skill never consults the lockfile: nothing can be installed into
+    the packaged bundled directory, so an entry under that name belongs to a
+    different, since-removed install and must not lend its brand across the
+    collision. See :func:`_derive_acquisition`, which drops the same entry.
     """
     if spec.publisher.id:
         return spec.publisher
-    if entry is not None:
+    if entry is not None and spec.layer != SkillLayer.BUNDLED:
         return resolve_publisher(entry.publisher_id or entry.source)
     return SkillPublisher()
 
@@ -195,8 +215,15 @@ def _derive_acquisition(
     The lockfile wins over the layer: a hub install stays a hub install even
     when an operator has pointed ``skills.managed_dir`` somewhere else and the
     loader now reads it from a different layer.
+
+    The one exception is ``BUNDLED``. That directory is ``skills/bundled`` inside
+    the installed package (:func:`~agentos.skills.paths.default_bundled_skills_dir`)
+    and is not configurable, so nothing can ever be installed into it. A lockfile
+    entry whose name matches a shipped skill is therefore a collision with some
+    *other*, since-removed install — honoring it would show a shipped skill as
+    hub-acquired, with a source label and a Remove button that cannot apply.
     """
-    if entry is None:
+    if entry is None or spec.layer == SkillLayer.BUNDLED:
         shipped = spec.layer == SkillLayer.BUNDLED
         return SkillAcquisition(kind=AcquisitionKind.SHIPPED if shipped else AcquisitionKind.LOCAL)
 

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -1,0 +1,195 @@
+"""One inventory builder for every "what skills does this install have" surface.
+
+``skills.list``, ``skills.status``, ``skills.get``, the ``skill_list`` tool, and
+``agentos skills list`` each used to assemble their own answer, which is why they
+disagreed: only one of them read the lockfile, so a hub-installed skill looked
+like an ordinary local directory everywhere else. This module derives the whole
+row once — eligibility, acquisition, publisher — and every surface renders the
+same facts.
+
+Nothing here is cached. Acquisition depends on the lockfile, which changes
+without any ``SKILL.md`` mtime changing, so the skill snapshot deliberately does
+not carry it; see :class:`~agentos.skills.types.SkillAcquisition`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agentos.skills.availability import SkillAvailability, gate_skills
+from agentos.skills.eligibility import (
+    EligibilityContext,
+    EligibilityReport,
+    diagnose_eligibility,
+)
+from agentos.skills.hub.lockfile import LockEntry, Lockfile, default_lockfile_path
+from agentos.skills.loader import SkillLoader
+from agentos.skills.publishers import resolve_publisher
+from agentos.skills.types import (
+    AcquisitionKind,
+    SkillAcquisition,
+    SkillLayer,
+    SkillPublisher,
+    SkillSpec,
+)
+
+__all__ = ["SkillRow", "build_skill_inventory"]
+
+
+@dataclass(frozen=True)
+class SkillRow:
+    """A loaded skill plus everything a surface needs to render it."""
+
+    spec: SkillSpec
+    eligibility: EligibilityReport
+    acquisition: SkillAcquisition
+    publisher: SkillPublisher
+    #: Whether the agent would be offered this skill, from
+    #: :func:`~agentos.skills.availability.gate_skills`. ``None`` when the
+    #: caller supplied no tool set: two of the gates read one, and guessing an
+    #: empty set would report every tool-gated skill as unavailable.
+    availability: SkillAvailability | None = None
+
+
+def build_skill_inventory(
+    loader: SkillLoader,
+    *,
+    config: Any | None = None,
+    lockfile_path: Path | None = None,
+    available_tools: set[str] | None = None,
+) -> list[SkillRow]:
+    """Return one row per loaded skill, in loader precedence order.
+
+    Args:
+        loader: Supplies the skills and the managed directory the acquisition
+            guard checks recorded install paths against.
+        config: Optional gateway config, consulted only for
+            ``skills.managed_dir`` when the loader carries no managed directory.
+        lockfile_path: Override for the shared lockfile; defaults to
+            :func:`~agentos.skills.hub.lockfile.default_lockfile_path`.
+        available_tools: Tool names this session can offer. Supplying it fills
+            :attr:`SkillRow.availability`; omitting it leaves that ``None``,
+            because the tool-gate and fallback gates cannot be answered
+            without one.
+    """
+    skills = loader.load_all()
+    lock_path = lockfile_path if lockfile_path is not None else default_lockfile_path()
+    lockfile = Lockfile.load(lock_path)
+    managed_dir = _managed_dir(loader, config)
+    # One context for the whole sweep — it caches binary lookups across skills —
+    # but built here rather than at import time, so a credential added since the
+    # process started is seen on the next call.
+    elig_ctx = EligibilityContext.auto()
+    # The turn pipeline runs the same gate, so a row and the prompt agree on
+    # which skills the agent is being offered. The budget and retrieval gates
+    # are turn-specific and deliberately not run here.
+    availability = (
+        gate_skills(skills, available_tools, elig_ctx)[1] if available_tools is not None else {}
+    )
+
+    rows: list[SkillRow] = []
+    for spec in skills:
+        entry = lockfile.get(spec.name)
+        rows.append(
+            SkillRow(
+                spec=spec,
+                eligibility=diagnose_eligibility(spec, elig_ctx),
+                acquisition=_derive_acquisition(spec, entry, managed_dir),
+                publisher=_derive_publisher(spec, entry),
+                availability=availability.get(spec.name),
+            )
+        )
+    return rows
+
+
+def _managed_dir(loader: SkillLoader, config: Any | None) -> Path | None:
+    """Return the directory ``skills.uninstall`` would actually delete from."""
+    if loader.managed_dir is not None:
+        return loader.managed_dir
+    configured = getattr(getattr(config, "skills", None), "managed_dir", None)
+    return Path(configured).expanduser() if configured else None
+
+
+def _derive_publisher(spec: SkillSpec, entry: LockEntry | None) -> SkillPublisher:
+    """Return the brand for a row: declared in frontmatter, else from the hub.
+
+    A hub install has no ``publisher:`` block of its own — the catalog row that
+    installed it is the only thing that knew the brand — so the lockfile carries
+    the slug forward. Either way it is a selector: the allowlist supplies every
+    displayed field, so neither a manifest nor a hub can invent a brand.
+    """
+    if spec.publisher.id:
+        return spec.publisher
+    if entry is not None and entry.publisher_id:
+        return resolve_publisher(entry.publisher_id)
+    return SkillPublisher()
+
+
+def _derive_acquisition(
+    spec: SkillSpec,
+    entry: LockEntry | None,
+    managed_dir: Path | None,
+) -> SkillAcquisition:
+    """Classify how a skill got here, and what an operator may do to it.
+
+    The lockfile wins over the layer: a hub install stays a hub install even
+    when an operator has pointed ``skills.managed_dir`` somewhere else and the
+    loader now reads it from a different layer.
+    """
+    if entry is None:
+        shipped = spec.layer == SkillLayer.BUNDLED
+        return SkillAcquisition(kind=AcquisitionKind.SHIPPED if shipped else AcquisitionKind.LOCAL)
+
+    removable, detail = _removability(spec.name, entry, managed_dir)
+    return SkillAcquisition(
+        kind=AcquisitionKind.HUB,
+        source_id=entry.source,
+        identifier=entry.identifier,
+        version=entry.version,
+        installed_at=entry.installed_at,
+        source_trust=entry.source_trust,
+        scan_verdict=entry.scan_verdict,
+        removable=removable,
+        # An update re-fetches by identifier and writes into the *current*
+        # managed dir, so it still works when the recorded path has diverged.
+        updatable=bool(entry.identifier),
+        detail=detail,
+    )
+
+
+def _removability(name: str, entry: LockEntry, managed_dir: Path | None) -> tuple[bool, str]:
+    """Return whether ``skills.uninstall`` can act, and why not when it cannot.
+
+    ``SkillInstaller.uninstall`` deletes ``<managed_dir>/<name>`` and nothing
+    else. The lockfile path, however, is resolved from the state root while the
+    managed directory is config-overridable, so the two can point at different
+    places — and then an Uninstall button removes the lockfile entry while
+    leaving the files on disk. Report the mismatch instead of offering an
+    action that will half-succeed.
+    """
+    if managed_dir is None:
+        return False, "No managed skills directory is configured, so this cannot be uninstalled."
+
+    target = managed_dir / name
+    recorded = Path(entry.path).expanduser() if entry.path else target
+    if not _same_path(recorded, target):
+        return False, (
+            f"Recorded at {recorded}, which is outside the configured managed "
+            f"skills directory ({managed_dir}). Uninstalling would drop the lockfile "
+            "entry without removing those files."
+        )
+    if not target.exists():
+        return False, (
+            f"Nothing left at {target} — the directory was removed outside AgentOS. "
+            "The lockfile entry is stale."
+        )
+    return True, ""
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:  # pragma: no cover - resolve() only raises on exotic filesystems
+        return False

--- a/src/agentos/skills/loader.py
+++ b/src/agentos/skills/loader.py
@@ -10,11 +10,13 @@ import structlog
 import yaml
 
 from agentos.paths import default_agentos_home
+from agentos.skills.publishers import resolve_publisher
 from agentos.skills.types import (
     SkillInstallSpec,
     SkillLayer,
     SkillPlatformMeta,
     SkillProvenance,
+    SkillPublisher,
     SkillRequires,
     SkillSpec,
 )
@@ -29,7 +31,10 @@ MAX_SKILLS_PER_SOURCE = 200  # per layer cap
 # 9: requires_env carries declared descriptions/URLs instead of bare names,
 #    and config_vars was added. A version-8 snapshot would parse without error
 #    and silently strip both.
-_SNAPSHOT_SCHEMA_VERSION = 9
+# 10: publisher was added. A version-9 snapshot parses cleanly and would restore
+#    every skill without a publisher, so partner skills would silently lose
+#    their brand grouping until something else invalidated the cache.
+_SNAPSHOT_SCHEMA_VERSION = 10
 
 
 def _string_list(value: object) -> list[str]:
@@ -166,6 +171,16 @@ def _resolve_provenance(frontmatter: dict) -> SkillProvenance:
     )
 
 
+def _resolve_skill_publisher(frontmatter: dict) -> SkillPublisher:
+    """Extract the publisher a top-level ``publisher:`` block selects.
+
+    The frontmatter only picks an id; :func:`resolve_publisher` supplies the
+    displayed fields from the allowlist, so a skill cannot claim a brand that
+    is not its own. No block at all means no publisher.
+    """
+    return resolve_publisher(frontmatter.get("publisher"))
+
+
 def _snapshot_provenance(raw: object) -> SkillProvenance:
     if not isinstance(raw, dict):
         return SkillProvenance()
@@ -175,17 +190,6 @@ def _snapshot_provenance(raw: object) -> SkillProvenance:
         upstream_url=str(raw.get("upstream_url") or ""),
         maintained_by=str(raw.get("maintained_by") or "AgentOS"),
     )
-
-
-# Layer ordering: low precedence → high precedence
-_LAYER_ORDER = [
-    SkillLayer.EXTRA,
-    SkillLayer.BUNDLED,
-    SkillLayer.MANAGED,
-    SkillLayer.PERSONAL,
-    SkillLayer.PROJECT,
-    SkillLayer.WORKSPACE,
-]
 
 
 class SkillLoader:
@@ -227,6 +231,11 @@ class SkillLoader:
         self._cached = None
 
     def _get_layer_dirs(self) -> list[tuple[Path, SkillLayer]]:
+        """Return the layer directories in low → high precedence order.
+
+        This order is the precedence: ``load_all()`` walks it and lets each
+        later layer overwrite a same-named skill from an earlier one.
+        """
         layer_dirs: list[tuple[Path, SkillLayer]] = []
         for d in self._extra_dirs:
             layer_dirs.append((d, SkillLayer.EXTRA))
@@ -285,6 +294,12 @@ class SkillLoader:
                         "license": s.provenance.license,
                         "upstream_url": s.provenance.upstream_url,
                         "maintained_by": s.provenance.maintained_by,
+                    },
+                    "publisher": {
+                        "id": s.publisher.id,
+                        "name": s.publisher.name,
+                        "url": s.publisher.url,
+                        "logo": s.publisher.logo,
                     },
                     "metadata": {
                         "os": s.metadata.os if s.metadata else [],
@@ -415,6 +430,10 @@ class SkillLoader:
                     homepage=s.get("homepage", ""),
                     metadata=meta,
                     provenance=_snapshot_provenance(s.get("provenance")),
+                    # Re-resolved rather than trusted: the cache is a writable
+                    # file on disk, so it gets the same allowlist check the
+                    # manifest got.
+                    publisher=resolve_publisher(s.get("publisher")),
                     requires_tools=s.get("requires_tools", []),
                     fallback_for_toolsets=s.get("fallback_for_toolsets", []),
                 )
@@ -516,6 +535,7 @@ class SkillLoader:
             # Platform metadata fields
             metadata = _resolve_metadata(frontmatter)
             provenance = _resolve_provenance(frontmatter)
+            publisher = _resolve_skill_publisher(frontmatter)
             # metadata.always overrides top-level always if set
             if metadata and metadata.always is not None:
                 always = metadata.always
@@ -547,6 +567,7 @@ class SkillLoader:
                 path=skill_dir,
                 metadata=metadata,
                 provenance=provenance,
+                publisher=publisher,
                 user_invocable=user_invocable,
                 disable_model_invocation=disable_model_invocation,
                 homepage=homepage,

--- a/src/agentos/skills/loader.py
+++ b/src/agentos/skills/loader.py
@@ -216,6 +216,9 @@ class SkillLoader:
             snapshot_path or default_agentos_home() / "cache" / "skills_snapshot.json"
         )
         self._cached: list[SkillSpec] | None = None
+        #: Manifest the in-memory cache was built from. Compared on every
+        #: ``load_all()`` so a write nobody told us about still lands.
+        self._cached_manifest: dict[str, dict[str, float | int]] | None = None
 
     @property
     def workspace_dir(self) -> Path | None:
@@ -230,6 +233,7 @@ class SkillLoader:
     def invalidate_cache(self) -> None:
         """Clear cached skills so next load_all() re-scans from disk."""
         self._cached = None
+        self._cached_manifest = None
 
     def _get_layer_dirs(self) -> list[tuple[Path, SkillLayer]]:
         """Return the layer directories in low → high precedence order.
@@ -353,8 +357,14 @@ class SkillLoader:
         self._snapshot_path.parent.mkdir(parents=True, exist_ok=True)
         self._snapshot_path.write_text(json.dumps(data), encoding="utf-8")
 
-    def load_snapshot(self) -> list[SkillSpec] | None:
-        """Load from snapshot if manifest matches. Returns None on miss."""
+    def load_snapshot(
+        self, manifest: dict[str, dict[str, float | int]] | None = None
+    ) -> list[SkillSpec] | None:
+        """Load from snapshot if manifest matches. Returns None on miss.
+
+        ``manifest`` lets a caller that has already stat-ed the layer dirs pass
+        the result in rather than pay for a second sweep.
+        """
         import json
 
         if not self._snapshot_path.exists():
@@ -367,7 +377,7 @@ class SkillLoader:
         if data.get("version") != _SNAPSHOT_SCHEMA_VERSION:
             return None
         saved_manifest = data.get("manifest", {})
-        current_manifest = self._build_manifest()
+        current_manifest = manifest if manifest is not None else self._build_manifest()
         if saved_manifest != current_manifest:
             return None
 
@@ -446,14 +456,24 @@ class SkillLoader:
         """Load all skills with layer precedence (high overrides low).
 
         Tries snapshot cache first for fast cold starts.
+
+        The in-memory cache is validated against the on-disk manifest rather
+        than trusted outright. ``invalidate_cache()`` is only reached through
+        AgentOS's own install/update/remove paths, but the skill directories are
+        not exclusively ours: ``agentos skills install`` runs in a separate
+        process, and ``.agents/skills`` is shared with every other agent on the
+        machine. A skill written by any of them used to stay invisible to a
+        running gateway until it restarted, with nothing said about it.
         """
-        if self._cached is not None:
+        manifest = self._build_manifest()
+        if self._cached is not None and self._cached_manifest == manifest:
             return list(self._cached)
 
         # Try snapshot cache
-        cached = self.load_snapshot()
+        cached = self.load_snapshot(manifest)
         if cached is not None:
             self._cached = cached
+            self._cached_manifest = manifest
             return list(cached)
 
         # Full scan: load in low→high order; higher layers override by name
@@ -477,6 +497,10 @@ class SkillLoader:
 
         skills = list(merged.values())
         self._cached = list(skills)
+        # Set before save_snapshot(), which calls back into load_all(): with the
+        # manifest already recorded that call is a cache hit rather than a
+        # second full scan.
+        self._cached_manifest = manifest
 
         # Save snapshot for next cold start
         try:

--- a/src/agentos/skills/loader.py
+++ b/src/agentos/skills/loader.py
@@ -10,7 +10,7 @@ import structlog
 import yaml
 
 from agentos.paths import default_agentos_home
-from agentos.skills.publishers import resolve_publisher
+from agentos.skills.publishers import resolve_declared_publisher
 from agentos.skills.types import (
     SkillInstallSpec,
     SkillLayer,
@@ -171,14 +171,15 @@ def _resolve_provenance(frontmatter: dict) -> SkillProvenance:
     )
 
 
-def _resolve_skill_publisher(frontmatter: dict) -> SkillPublisher:
+def _resolve_skill_publisher(frontmatter: dict, layer: SkillLayer) -> SkillPublisher:
     """Extract the publisher a top-level ``publisher:`` block selects.
 
-    The frontmatter only picks an id; :func:`resolve_publisher` supplies the
-    displayed fields from the allowlist, so a skill cannot claim a brand that
-    is not its own. No block at all means no publisher.
+    The frontmatter only picks an id; the allowlist supplies the displayed
+    fields, and only a bundled manifest may pick one at all, so a directory
+    dropped into a writable skills path cannot claim a partner's brand. No block
+    at all means no publisher.
     """
-    return resolve_publisher(frontmatter.get("publisher"))
+    return resolve_declared_publisher(frontmatter.get("publisher"), layer)
 
 
 def _snapshot_provenance(raw: object) -> SkillProvenance:
@@ -414,11 +415,12 @@ class SkillLoader:
                     config_vars=raw_meta.get("config_vars", []),
                 )
 
+            layer = SkillLayer(s.get("layer", "bundled"))
             skills.append(
                 SkillSpec(
                     name=s["name"],
                     description=s.get("description", ""),
-                    layer=SkillLayer(s.get("layer", "bundled")),
+                    layer=layer,
                     always=s.get("always", False),
                     triggers=s.get("triggers", []),
                     content=s.get("content", ""),
@@ -431,9 +433,9 @@ class SkillLoader:
                     metadata=meta,
                     provenance=_snapshot_provenance(s.get("provenance")),
                     # Re-resolved rather than trusted: the cache is a writable
-                    # file on disk, so it gets the same allowlist check the
-                    # manifest got.
-                    publisher=resolve_publisher(s.get("publisher")),
+                    # file on disk, so it gets the same allowlist *and* layer
+                    # check the manifest got.
+                    publisher=resolve_declared_publisher(s.get("publisher"), layer),
                     requires_tools=s.get("requires_tools", []),
                     fallback_for_toolsets=s.get("fallback_for_toolsets", []),
                 )
@@ -535,7 +537,7 @@ class SkillLoader:
             # Platform metadata fields
             metadata = _resolve_metadata(frontmatter)
             provenance = _resolve_provenance(frontmatter)
-            publisher = _resolve_skill_publisher(frontmatter)
+            publisher = _resolve_skill_publisher(frontmatter, layer)
             # metadata.always overrides top-level always if set
             if metadata and metadata.always is not None:
                 always = metadata.always

--- a/src/agentos/skills/paths.py
+++ b/src/agentos/skills/paths.py
@@ -92,9 +92,7 @@ def resolve_skill_layer_dirs(
         extra_dirs: Low-precedence EXTRA dirs (config.skills.extra_dirs).
     """
     bundled_candidate = default_bundled_skills_dir()
-    bundled_dir = (
-        bundled_candidate if allow_bundled and bundled_candidate.is_dir() else None
-    )
+    bundled_dir = bundled_candidate if allow_bundled and bundled_candidate.is_dir() else None
 
     # Explicit override wins and is preserved as-is — a user-configured
     # path may not exist yet (skill_create mkdirs it on demand). The
@@ -110,12 +108,17 @@ def resolve_skill_layer_dirs(
 
     managed_dir = resolve_managed_skills_dir(managed_override)
 
-    personal_agents = Path.home() / ".agents" / "skills"
-    personal_agents_dir = personal_agents if personal_agents.is_dir() else None
+    # Returned whether or not they exist yet, for the same reason the managed
+    # directory is: these resolve once at boot, and collapsing a missing one to
+    # None removed the whole layer until the next restart. `.agents/skills` is a
+    # cross-agent directory — other tools create and populate it while AgentOS is
+    # already running — so "absent at boot" is a normal state, not a permanent
+    # one. `load_all()` and `_build_manifest()` both skip a path that is not
+    # there, so naming a directory that does not exist yet costs nothing.
+    personal_agents_dir = Path.home() / ".agents" / "skills"
 
     project_root = workspace_root if workspace_root is not None else Path.cwd()
-    project_agents = project_root / ".agents" / "skills"
-    project_agents_dir = project_agents if project_agents.is_dir() else None
+    project_agents_dir = project_root / ".agents" / "skills"
 
     return SkillLayerDirs(
         bundled_dir=bundled_dir,

--- a/src/agentos/skills/publishers.py
+++ b/src/agentos/skills/publishers.py
@@ -10,11 +10,20 @@ So the frontmatter only *selects* a publisher; it never *describes* one. The
 declared id is looked up in :data:`RECOGNIZED_PUBLISHERS`, and the allowlisted
 record supplies every displayed field. An id that is not on the list resolves to
 an empty publisher, which renders as an ordinary unbranded skill.
+
+The allowlist alone is not enough, because it makes the *ids* forgeable instead
+of the fields: any directory an operator drops into a skills path could declare
+``publisher: {id: robinhood}`` and sit in the Partners group. So a manifest may
+only select a publisher for itself when it ships inside the wheel — see
+:func:`resolve_declared_publisher`. Every other skill gets its brand from the
+hub catalog row that installed it, recorded in the lockfile
+(``LockEntry.publisher_id``), which is why an installed partner skill such as
+Bankr still shows its brand while a look-alike on disk does not.
 """
 
 from __future__ import annotations
 
-from agentos.skills.types import SkillPublisher
+from agentos.skills.types import SkillLayer, SkillPublisher
 
 #: Publishers allowed to appear as a brand. Keyed by the stable slug a skill
 #: declares in ``publisher.id``. Names match the labels the Skills UI already
@@ -37,6 +46,14 @@ RECOGNIZED_PUBLISHERS: dict[str, SkillPublisher] = {
 }
 
 
+#: Layers whose ``SKILL.md`` may name its own publisher. Only ``bundled`` skills
+#: ship inside the wheel, so their frontmatter is ours and was reviewed with the
+#: rest of the release. Anything reachable from a writable skills directory —
+#: managed, personal, project, workspace, extra — is operator- or hub-supplied
+#: text that must not be able to mint a brand for itself.
+SELF_DECLARING_LAYERS: frozenset[SkillLayer] = frozenset({SkillLayer.BUNDLED})
+
+
 def resolve_publisher(raw: object) -> SkillPublisher:
     """Return the allowlisted publisher a manifest selected, or an empty one.
 
@@ -54,3 +71,16 @@ def resolve_publisher(raw: object) -> SkillPublisher:
         return SkillPublisher()
 
     return RECOGNIZED_PUBLISHERS.get(declared_id.strip().lower(), SkillPublisher())
+
+
+def resolve_declared_publisher(raw: object, layer: SkillLayer) -> SkillPublisher:
+    """Resolve a publisher a *manifest* declared, honouring the layer it sits in.
+
+    Use this for anything read out of a ``SKILL.md`` (or out of the snapshot
+    cache, which is a writable file mirroring one). :func:`resolve_publisher` is
+    for ids that arrived over a trusted channel instead — today that is the hub
+    lockfile, whose slug comes from the catalog row rather than the skill text.
+    """
+    if layer not in SELF_DECLARING_LAYERS:
+        return SkillPublisher()
+    return resolve_publisher(raw)

--- a/src/agentos/skills/publishers.py
+++ b/src/agentos/skills/publishers.py
@@ -1,0 +1,56 @@
+"""Allowlist of publishers that may carry brand identity on a skill card.
+
+A ``SKILL.md`` is a plain text file that anyone can write and any hub can serve.
+If the publisher block in its frontmatter were trusted verbatim, a third-party
+skill could ship ``publisher: {id: robinhood, name: Robinhood}`` and inherit a
+partner's name, link, and logo in the Skills UI — a phishing surface, not a
+metadata feature.
+
+So the frontmatter only *selects* a publisher; it never *describes* one. The
+declared id is looked up in :data:`RECOGNIZED_PUBLISHERS`, and the allowlisted
+record supplies every displayed field. An id that is not on the list resolves to
+an empty publisher, which renders as an ordinary unbranded skill.
+"""
+
+from __future__ import annotations
+
+from agentos.skills.types import SkillPublisher
+
+#: Publishers allowed to appear as a brand. Keyed by the stable slug a skill
+#: declares in ``publisher.id``. Names match the labels the Skills UI already
+#: uses (``PARTNER_BRANDS`` in ``frontend/src/views/skills/SkillsPage.tsx``);
+#: ``logo`` stays empty for partners whose mark the client ships as a bundled
+#: asset, so no prompt or page has to fetch a remote image to render a card.
+RECOGNIZED_PUBLISHERS: dict[str, SkillPublisher] = {
+    "robinhood": SkillPublisher(
+        id="robinhood",
+        name="Robinhood",
+        url="https://robinhood.com",
+        logo="",
+    ),
+    "bankr": SkillPublisher(
+        id="bankr",
+        name="Bankr",
+        url="https://github.com/BankrBot/skills",
+        logo="",
+    ),
+}
+
+
+def resolve_publisher(raw: object) -> SkillPublisher:
+    """Return the allowlisted publisher a manifest selected, or an empty one.
+
+    ``raw`` is whatever the frontmatter declared — a mapping, a bare id string,
+    or junk. Only the ``id`` is read from it; name, url, and logo always come
+    from :data:`RECOGNIZED_PUBLISHERS` so a skill cannot mint its own branding.
+    """
+    if isinstance(raw, SkillPublisher):
+        declared_id = raw.id
+    elif isinstance(raw, dict):
+        declared_id = str(raw.get("id", "") or "")
+    elif isinstance(raw, str):
+        declared_id = raw
+    else:
+        return SkillPublisher()
+
+    return RECOGNIZED_PUBLISHERS.get(declared_id.strip().lower(), SkillPublisher())

--- a/src/agentos/skills/types.py
+++ b/src/agentos/skills/types.py
@@ -212,6 +212,27 @@ class SkillProvenance:
     maintained_by: str = "AgentOS"
 
 
+@dataclass(frozen=True)
+class SkillPublisher:
+    """Who stands behind a skill, for the surfaces that show a brand.
+
+    Deliberately separate from :class:`SkillProvenance`. Provenance answers
+    "where did this text come from and under what licence"; a publisher answers
+    "whose name is on it". A skill can be AgentOS-original text published by a
+    partner, or upstream text with no publisher at all.
+
+    Only ids on the server-side allowlist in :mod:`agentos.skills.publishers`
+    resolve to a populated record — see that module for why.
+    """
+
+    #: Stable slug, e.g. ``robinhood``, ``bankr``.
+    id: str = ""
+    name: str = ""
+    url: str = ""
+    #: ``https`` URL, or ``""`` to fall back to initials / a bundled mark.
+    logo: str = ""
+
+
 @dataclass
 class SkillSpec:
     """Parsed skill metadata and content."""
@@ -227,6 +248,7 @@ class SkillSpec:
     # Platform metadata
     metadata: SkillPlatformMeta | None = None
     provenance: SkillProvenance = field(default_factory=SkillProvenance)
+    publisher: SkillPublisher = field(default_factory=SkillPublisher)
     user_invocable: bool = True
     disable_model_invocation: bool = False
     homepage: str = ""

--- a/src/agentos/skills/types.py
+++ b/src/agentos/skills/types.py
@@ -233,6 +233,54 @@ class SkillPublisher:
     logo: str = ""
 
 
+class AcquisitionKind(StrEnum):
+    """How an installed skill came to exist on this machine."""
+
+    #: In-tree, ships with the wheel.
+    SHIPPED = "shipped"
+    #: Fetched by :class:`~agentos.skills.hub.installer.SkillInstaller`; has a
+    #: lockfile entry.
+    HUB = "hub"
+    #: An operator-owned directory.
+    LOCAL = "local"
+
+
+@dataclass(frozen=True)
+class SkillAcquisition:
+    """Where an install came from, as opposed to where its files sit.
+
+    :class:`SkillLayer` answers "which directory did the loader read this from",
+    which is a precedence question. Acquisition answers "did an operator install
+    this, and can they act on it" — the question every Installed-tab affordance
+    actually asks. The two agree for most skills and diverge for the ones that
+    matter: a hub install dropped into a custom managed directory is still a hub
+    install, and a hand-copied directory inside the managed dir is not.
+
+    Deliberately **not** a field on :class:`SkillSpec` and **not** serialized
+    into the skill snapshot: it is derived from the lockfile, which changes
+    without any ``SKILL.md`` mtime changing, so caching it would make the
+    snapshot go stale in a way the manifest check cannot detect.
+    """
+
+    kind: AcquisitionKind = AcquisitionKind.LOCAL
+    #: Hub source that served it — ``clawhub`` | ``bankr`` | ``github`` | ``""``.
+    source_id: str = ""
+    #: Lockfile identifier — the join key back to a catalog row.
+    identifier: str = ""
+    version: str = ""
+    installed_at: str = ""
+    source_trust: str = ""
+    scan_verdict: str = ""
+    #: ``skills.uninstall`` can act on it.
+    removable: bool = False
+    #: ``skills.update`` can act on it.
+    updatable: bool = False
+    #: Human-readable explanation when an affordance is withheld, e.g. the
+    #: recorded install path no longer lives under the configured managed
+    #: directory. Empty when there is nothing to explain.
+    detail: str = ""
+
+
 @dataclass
 class SkillSpec:
     """Parsed skill metadata and content."""

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -17,6 +17,7 @@ import structlog
 from agentos.skills.hub.defaults import (
     build_default_skill_installer,
     get_default_skill_router,
+    installed_skill_identifiers,
     installed_skill_names,
 )
 from agentos.skills.types import SkillInstallSpec, SkillLayer
@@ -144,9 +145,17 @@ def _find_install_spec(skill_name: str, install_id: str) -> SkillInstallSpec:
     raise ToolError(f"Install spec not found for skill '{skill_name}': {install_id}")
 
 
-def _community_result_to_dict(row: Any, installed: set[str]) -> dict[str, Any]:
+def _community_result_to_dict(
+    row: Any,
+    installed: set[str],
+    installed_identifiers: set[str] | None = None,
+) -> dict[str, Any]:
+    # Names are matched against installed names and identifiers against
+    # installed identifiers — never across the two, which would flag a catalog
+    # row whose name happens to equal a different skill's identifier.
     identifier = getattr(row, "identifier", "") or getattr(row, "name", "")
     name = getattr(row, "name", "")
+    identifiers = installed_identifiers if installed_identifiers is not None else installed
     return {
         "name": name,
         "description": getattr(row, "description", ""),
@@ -158,7 +167,7 @@ def _community_result_to_dict(row: Any, installed: set[str]) -> dict[str, Any]:
         "provider": getattr(row, "provider", ""),
         "category": getattr(row, "category", ""),
         "homepage": getattr(row, "homepage", ""),
-        "installed": identifier in installed or name in installed,
+        "installed": identifier in identifiers or name in installed,
     }
 
 
@@ -306,17 +315,36 @@ def create_skill_tools(loader: SkillLoader) -> None:
     async def skill_list() -> str:
         if _loader is None:
             return "No skill loader available."
-        skills = _loader.load_all()
-        if not skills:
+
+        from agentos.skills.availability import REASON_INELIGIBLE
+        from agentos.skills.inventory import build_skill_inventory
+        from agentos.tools.registry import get_default_registry
+
+        # Same builder the gateway and the CLI render from, so the agent can no
+        # longer believe something about a skill that the Skills page denies.
+        rows = build_skill_inventory(
+            _loader,
+            available_tools=set(get_default_registry().list_names()),
+        )
+        if not rows:
             return "No skills installed."
 
-        from agentos.skills.eligibility import EligibilityContext, diagnose_eligibility
-
-        ctx = EligibilityContext.auto()
-        lines = [f"Available skills ({len(skills)}):"]
-        for s in sorted(skills, key=lambda x: x.name):
-            report = diagnose_eligibility(s, ctx)
+        lines = [f"Available skills ({len(rows)}):"]
+        for row in sorted(rows, key=lambda r: r.spec.name):
+            s = row.spec
+            report = row.eligibility
             lines.append(f"  - {s.name}: {s.description}")
+            availability = row.availability
+            if (
+                availability is not None
+                and not availability.offered
+                # Ineligibility already has a richer rendering below; the
+                # reasons worth adding are the ones nothing else reports —
+                # model invocation switched off, a missing tool, a native
+                # tool superseding a fallback skill.
+                and availability.reason != REASON_INELIGIBLE
+            ):
+                lines.append(f"      [not offered] {availability.detail}")
             if not report.eligible:
                 missing = []
                 for b in report.missing_bins:
@@ -437,12 +465,15 @@ def create_skill_tools(loader: SkillLoader) -> None:
         router = get_default_skill_router()
         results = await router.search(clean_query, limit=result_limit, source_id=source_id)
         installed = installed_skill_names()
+        identifiers = installed_skill_identifiers()
         return json.dumps(
             {
                 "status": "ok",
                 "query": clean_query,
                 "source": source_id or "all",
-                "results": [_community_result_to_dict(row, installed) for row in results],
+                "results": [
+                    _community_result_to_dict(row, installed, identifiers) for row in results
+                ],
             }
         )
 

--- a/tests/test_gateway/test_config_migration_skills_budget.py
+++ b/tests/test_gateway/test_config_migration_skills_budget.py
@@ -1,0 +1,69 @@
+"""The raised skills-block budget has to reach installs that already have a config.
+
+``max_skills_prompt_chars`` is materialised into every saved ``config.toml``, so
+lifting the default alone would leave every existing install pinned to the old
+value — and that value cannot fit the shipped skills' descriptions, which is the
+whole reason it was raised.
+"""
+
+from __future__ import annotations
+
+from agentos.gateway.config_migration import (
+    LEGACY_MAX_SKILLS_PROMPT_CHARS,
+    migrate_config_payload,
+)
+from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
+
+
+def test_a_config_carrying_the_old_default_is_lifted() -> None:
+    result = migrate_config_payload(
+        {"skills": {"max_skills_prompt_chars": LEGACY_MAX_SKILLS_PROMPT_CHARS}}
+    )
+
+    assert result.payload["skills"]["max_skills_prompt_chars"] == DEFAULT_MAX_SKILLS_PROMPT_CHARS
+    assert any("max_skills_prompt_chars" in change for change in result.changes)
+
+
+def test_a_deliberately_chosen_budget_is_left_alone() -> None:
+    """Only the exact old default is refreshed — the same rule the model ids use."""
+    for chosen in (4000, 12000, 40000):
+        result = migrate_config_payload({"skills": {"max_skills_prompt_chars": chosen}})
+
+        assert result.payload["skills"]["max_skills_prompt_chars"] == chosen
+        assert not any("max_skills_prompt_chars" in change for change in result.changes)
+
+
+def test_a_config_without_the_key_is_untouched() -> None:
+    """An unset key already resolves to the current default; do not materialise it."""
+    result = migrate_config_payload({"skills": {"filter_enabled": False}})
+
+    assert "max_skills_prompt_chars" not in result.payload["skills"]
+    assert not any("max_skills_prompt_chars" in change for change in result.changes)
+
+
+def test_a_config_with_no_skills_section_survives() -> None:
+    result = migrate_config_payload({"llm": {"provider": "openrouter"}})
+
+    assert "skills" not in result.payload
+
+
+def test_the_lifted_value_fits_the_shipped_skills_in_full_mode() -> None:
+    """Pin the point of the migration, not just the number.
+
+    A future default that still cannot fit the shipped set would make this
+    migration cosmetic; assert the value it lifts to actually buys descriptions.
+    """
+    from pathlib import Path
+
+    from agentos.skills.injector import SkillInjector
+    from agentos.skills.loader import SkillLoader
+
+    bundled = Path(__file__).resolve().parents[2] / "src" / "agentos" / "skills" / "bundled"
+    loader = SkillLoader(bundled_dir=bundled, snapshot_path=Path("/nonexistent/snapshot.json"))
+    visible = [s for s in loader.load_all() if not s.disable_model_invocation]
+
+    rendered = SkillInjector().inject_full("", visible)
+
+    assert len(rendered) <= DEFAULT_MAX_SKILLS_PROMPT_CHARS
+    assert len(rendered) > LEGACY_MAX_SKILLS_PROMPT_CHARS, "otherwise the lift was unnecessary"
+    assert "<description>" in rendered

--- a/tests/test_gateway/test_rpc_skills_install_visibility.py
+++ b/tests/test_gateway/test_rpc_skills_install_visibility.py
@@ -72,6 +72,48 @@ def test_rpc_skill_install_uses_loader_managed_dir_and_list_sees_skill(
         row = next(skill for skill in listed["skills"] if skill["name"] == "plotter")
         assert row["layer"] == "managed"
         assert row["description"] == "Installed from chat"
+        # Appearing in skills.list is not the thing the user asked for. The
+        # skill was installed from chat so the agent could use it, and every
+        # gate between "loaded" and "in the prompt" is a place it can be
+        # dropped silently. Assert it is actually being offered.
+        assert row["availability"] == {"offered": True, "reason": "", "detail": ""}
+
+    asyncio.run(run())
+
+
+def test_a_skill_the_agent_is_never_offered_says_so_on_its_row(
+    tmp_path: Path,
+) -> None:
+    """``disable_model_invocation`` is invisible in every other field.
+
+    Without an availability reason the Skills page shows a green "ready" chip on
+    a skill the agent is structurally never given, and the user's only evidence
+    is the agent claiming not to have it."""
+
+    async def run() -> None:
+        managed_dir = tmp_path / "managed"
+        skill_dir = managed_dir / "receipts"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: receipts\n"
+            "description: Print receipts.\n"
+            "disable-model-invocation: true\n"
+            "---\n"
+            "Body.\n",
+            encoding="utf-8",
+        )
+        loader = SkillLoader(managed_dir=managed_dir, snapshot_path=tmp_path / "snapshot.json")
+        ctx = RpcContext(conn_id="test", skill_loader=loader)
+
+        listed = await rpc_skills._handle_skills_list(None, ctx)
+        row = next(skill for skill in listed["skills"] if skill["name"] == "receipts")
+
+        assert row["eligible"] is True
+        assert row["status"] == "not_declared"
+        assert row["availability"]["offered"] is False
+        assert row["availability"]["reason"] == "model_invocation_disabled"
+        assert "You can still run it yourself." in row["availability"]["detail"]
 
     asyncio.run(run())
 

--- a/tests/test_gateway/test_rpc_skills_search_payload.py
+++ b/tests/test_gateway/test_rpc_skills_search_payload.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from agentos.gateway import rpc_skills
+from agentos.skills.hub.lockfile import LockEntry
 from agentos.skills.hub.source import SkillMeta
 
 
@@ -17,8 +18,15 @@ class _StubRouter:
 
 
 class _Ctx:
-    def __init__(self, router: _StubRouter) -> None:
+    def __init__(self, router: _StubRouter, skill_loader=None) -> None:
         self._skill_router = router
+        self.skill_loader = skill_loader
+
+
+def _no_lockfile(monkeypatch) -> None:
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: set())
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    monkeypatch.setattr(rpc_skills, "_installed_lock_entries", dict)
 
 
 @pytest.mark.asyncio
@@ -26,8 +34,7 @@ async def test_skills_search_payload_carries_catalog_fields(monkeypatch) -> None
     """The browse UI reads provider/logo/category/setup/demo/homepage off every
     result row — dropping any of them silently breaks the registry cards and
     the detail dialog."""
-    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: set())
-    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    _no_lockfile(monkeypatch)
     meta = SkillMeta(
         name="alchemy",
         source_id="bankr",
@@ -64,10 +71,12 @@ async def test_skills_search_marks_installed_by_identifier(monkeypatch) -> None:
     # Lockfile records only the installed *name*, which does not match the
     # browse card's name; the identifier is what lines up.
     monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"token-scam-analysis"})
+    identifier = "https://github.com/BankrBot/skills/tree/main/bankr-token-scam-analysis"
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: {identifier})
     monkeypatch.setattr(
         rpc_skills,
-        "installed_skill_identifiers",
-        lambda: {"https://github.com/BankrBot/skills/tree/main/bankr-token-scam-analysis"},
+        "_installed_lock_entries",
+        lambda: {"token-scam-analysis": LockEntry(source="bankr", identifier=identifier)},
     )
     meta = SkillMeta(
         name="bankr-token-scam-analysis",
@@ -85,8 +94,7 @@ async def test_skills_search_marks_installed_by_identifier(monkeypatch) -> None:
 async def test_skills_search_limit_accommodates_full_catalog_browse(monkeypatch) -> None:
     """Browse requests whole catalogs (Bankr is ~100 skills); a cap sized for
     paged search results would silently truncate them."""
-    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: set())
-    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    _no_lockfile(monkeypatch)
     metas = [SkillMeta(name=f"skill-{i:03d}", source_id="bankr") for i in range(150)]
     router = _StubRouter(metas)
 
@@ -94,3 +102,177 @@ async def test_skills_search_limit_accommodates_full_catalog_browse(monkeypatch)
 
     assert router.calls[0]["limit"] == 200
     assert len(res["results"]) == 150
+
+
+# ── Installed skills the catalog does not return ────────────────────────────
+
+
+class _StubLoader:
+    """Just enough loader for the synthesized-row description lookup."""
+
+    def __init__(self, specs: dict) -> None:
+        self._specs = specs
+
+    def get_by_name(self, name: str):
+        return self._specs.get(name)
+
+
+class _StubSpec:
+    def __init__(self, description: str, emoji: str = "") -> None:
+        self.description = description
+        self.metadata = type("_Meta", (), {"emoji": emoji})()
+
+
+def _lock_entry(**kwargs) -> LockEntry:
+    defaults = {
+        "source": "bankr",
+        "identifier": "https://github.com/BankrBot/skills/tree/main/ledger-watch",
+        "version": "1.2.0",
+        "installed_at": "2026-01-01T00:00:00Z",
+        "upstream_url": "https://github.com/BankrBot/skills",
+        "source_trust": "trusted",
+        "publisher_id": "bankr",
+    }
+    defaults.update(kwargs)
+    return LockEntry(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_browse_surfaces_an_install_the_catalog_did_not_return(monkeypatch) -> None:
+    """Symptom 2: a skill installed minutes ago vanishes from Community.
+
+    An empty-query browse asks a source for its catalog, and a catalog is free
+    not to list something the user has installed — a GitHub install by URL is in
+    no catalog at all. Without this join the row simply is not there after a
+    reload, which reads as the install having been lost."""
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"ledger-watch"})
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    monkeypatch.setattr(
+        rpc_skills, "_installed_lock_entries", lambda: {"ledger-watch": _lock_entry()}
+    )
+    router = _StubRouter([SkillMeta(name="alchemy", source_id="bankr", identifier="alchemy-id")])
+    loader = _StubLoader({"ledger-watch": _StubSpec("Watch a ledger address.", emoji="👁")})
+
+    res = await rpc_skills._handle_skills_search({"query": ""}, _Ctx(router, loader))
+
+    names = [row["name"] for row in res["results"]]
+    # Appended, not prepended: a synthesized row has no relevance score and no
+    # catalog metadata, so it must not displace richer rows at the top.
+    assert names == ["alchemy", "ledger-watch"]
+    row = res["results"][1]
+    assert row["installed"] is True
+    assert row["source"] == "bankr"
+    assert row["identifier"] == "https://github.com/BankrBot/skills/tree/main/ledger-watch"
+    assert row["version"] == "1.2.0"
+    assert row["trust_level"] == "trusted"
+    assert row["homepage"] == "https://github.com/BankrBot/skills"
+    assert row["description"] == "Watch a ledger address."
+    assert row["emoji"] == "👁"
+    # Only the allowlisted record supplies a brand.
+    assert row["provider"] == "Bankr"
+    # No catalog metadata means no category: the row joins the existing "other"
+    # bucket rather than inventing a chip on catalogs that show none today.
+    assert row["category"] == ""
+    assert set(row) == set(res["results"][0])
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognized_publisher_cannot_brand_a_synthesized_row(monkeypatch) -> None:
+    """The lockfile is a writable file on disk; it is a selector, not a source
+    of brand identity."""
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"ledger-watch"})
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    monkeypatch.setattr(
+        rpc_skills,
+        "_installed_lock_entries",
+        lambda: {
+            "ledger-watch": _lock_entry(publisher_id="acme-capital", publisher_name="Robinhood")
+        },
+    )
+    router = _StubRouter([])
+
+    res = await rpc_skills._handle_skills_search({"query": ""}, _Ctx(router))
+
+    assert res["results"][0]["provider"] == ""
+    assert res["results"][0]["logo"] == ""
+
+
+@pytest.mark.asyncio
+async def test_browsing_one_source_does_not_surface_another_sources_installs(monkeypatch) -> None:
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"ledger-watch"})
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    monkeypatch.setattr(
+        rpc_skills, "_installed_lock_entries", lambda: {"ledger-watch": _lock_entry()}
+    )
+    router = _StubRouter([])
+
+    clawhub = await rpc_skills._handle_skills_search(
+        {"query": "", "source": "clawhub"}, _Ctx(router)
+    )
+    bankr = await rpc_skills._handle_skills_search({"query": "", "source": "bankr"}, _Ctx(router))
+
+    assert clawhub["results"] == []
+    assert [row["name"] for row in bankr["results"]] == ["ledger-watch"]
+
+
+@pytest.mark.asyncio
+async def test_a_keyword_search_only_synthesizes_installs_that_match(monkeypatch) -> None:
+    """Browse must not hide installs; a keyword search must still be a search."""
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"ledger-watch"})
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: set())
+    monkeypatch.setattr(
+        rpc_skills, "_installed_lock_entries", lambda: {"ledger-watch": _lock_entry()}
+    )
+    router = _StubRouter([])
+    loader = _StubLoader({"ledger-watch": _StubSpec("Watch a ledger address.")})
+
+    miss = await rpc_skills._handle_skills_search({"query": "photo"}, _Ctx(router, loader))
+    by_name = await rpc_skills._handle_skills_search({"query": "LEDGER"}, _Ctx(router, loader))
+    by_description = await rpc_skills._handle_skills_search(
+        {"query": "address"}, _Ctx(router, loader)
+    )
+
+    assert miss["results"] == []
+    assert [row["name"] for row in by_name["results"]] == ["ledger-watch"]
+    assert [row["name"] for row in by_description["results"]] == ["ledger-watch"]
+
+
+@pytest.mark.asyncio
+async def test_a_catalog_row_is_never_duplicated_by_a_synthesized_row(monkeypatch) -> None:
+    """Dedupe on identifier, so a slug/name mismatch does not double the card."""
+    identifier = "https://github.com/BankrBot/skills/tree/main/ledger-watch"
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"ledger-watch"})
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: {identifier})
+    monkeypatch.setattr(
+        rpc_skills, "_installed_lock_entries", lambda: {"ledger-watch": _lock_entry()}
+    )
+    router = _StubRouter(
+        [SkillMeta(name="bankr-ledger-watch", source_id="bankr", identifier=identifier)]
+    )
+
+    res = await rpc_skills._handle_skills_search({"query": ""}, _Ctx(router))
+
+    assert [row["name"] for row in res["results"]] == ["bankr-ledger-watch"]
+    assert res["results"][0]["installed"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_name_colliding_with_another_skills_identifier_is_not_installed(
+    monkeypatch,
+) -> None:
+    """The installed chip joins names to names and identifiers to identifiers.
+
+    Pooling both into one set makes a catalog row named ``x`` show as installed
+    because some unrelated skill was installed from an identifier spelled ``x``."""
+    monkeypatch.setattr(rpc_skills, "_installed_names", lambda: {"token-scam-analysis"})
+    monkeypatch.setattr(rpc_skills, "installed_skill_identifiers", lambda: {"alchemy"})
+    monkeypatch.setattr(
+        rpc_skills,
+        "_installed_lock_entries",
+        lambda: {"token-scam-analysis": _lock_entry(source="clawhub", identifier="alchemy")},
+    )
+    router = _StubRouter([SkillMeta(name="alchemy", source_id="bankr", identifier="alchemy-id")])
+
+    res = await rpc_skills._handle_skills_search({"query": "", "source": "bankr"}, _Ctx(router))
+
+    assert res["results"][0]["installed"] is False

--- a/tests/test_skills_availability.py
+++ b/tests/test_skills_availability.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps.skills_filter import filter_skills
+from agentos.skills.availability import (
+    REASON_FALLBACK_SUPERSEDED,
+    REASON_INELIGIBLE,
+    REASON_MODEL_INVOCATION_DISABLED,
+    REASON_NOT_RETRIEVED,
+    REASON_PROMPT_BUDGET,
+    REASON_TOOL_GATE,
+    SkillAvailability,
+    gate_skills,
+    plan_injection,
+)
+from agentos.skills.eligibility import EligibilityContext
+from agentos.skills.loader import SkillLoader
+from agentos.skills.types import (
+    SkillEnvVar,
+    SkillInstallSpec,
+    SkillLayer,
+    SkillPlatformMeta,
+    SkillRequires,
+    SkillSpec,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
+
+# A stand-in install root. Absolute on purpose: this is exactly the shape of
+# string that must never reach a detail sentence.
+FAKE_BASE = "/opt/example/agentos/skills"
+
+
+def _skill(
+    name: str,
+    *,
+    layer: SkillLayer = SkillLayer.BUNDLED,
+    description: str = "Use when exercising availability.",
+    disable_model_invocation: bool = False,
+    always: bool = False,
+    requires_tools: list[str] | None = None,
+    fallback_for_toolsets: list[str] | None = None,
+    metadata: SkillPlatformMeta | None = None,
+    triggers: list[str] | None = None,
+) -> SkillSpec:
+    base_dir = f"{FAKE_BASE}/{name}"
+    return SkillSpec(
+        name=name,
+        description=description,
+        layer=layer,
+        always=always,
+        triggers=triggers or [],
+        content=f"# {name}",
+        path=Path(base_dir),
+        base_dir=base_dir,
+        file_path=f"{base_dir}/SKILL.md",
+        disable_model_invocation=disable_model_invocation,
+        requires_tools=requires_tools or [],
+        fallback_for_toolsets=fallback_for_toolsets or [],
+        metadata=metadata,
+    )
+
+
+def _empty_ctx() -> EligibilityContext:
+    """An eligibility context that answers from its caches, never the host."""
+    return EligibilityContext(os_name="linux")
+
+
+# ── reason coverage ─────────────────────────────────────────────────────────
+
+
+def test_model_invocation_disabled_is_reported_with_a_detail() -> None:
+    skill = _skill("hidden", disable_model_invocation=True)
+
+    gated, availability = gate_skills([skill], set(), _empty_ctx())
+
+    assert gated == []
+    assert availability["hidden"].offered is False
+    assert availability["hidden"].reason == REASON_MODEL_INVOCATION_DISABLED
+    assert "disable-model-invocation" in availability["hidden"].detail
+
+
+def test_ineligible_detail_names_the_missing_binary_and_the_install_command() -> None:
+    skill = _skill(
+        "mailer",
+        metadata=SkillPlatformMeta(
+            requires=SkillRequires(bins=["himalaya"]),
+            install=[SkillInstallSpec(id="himalaya", kind="brew", bins=["himalaya"])],
+        ),
+    )
+    ctx = EligibilityContext(os_name="linux", has_bin_cache={"himalaya": False})
+
+    _, availability = gate_skills([skill], set(), ctx)
+
+    detail = availability["mailer"].detail
+    assert availability["mailer"].reason == REASON_INELIGIBLE
+    assert "himalaya" in detail
+    assert "not on PATH" in detail
+    assert "brew install himalaya" in detail
+
+
+def test_ineligible_detail_explains_what_a_missing_variable_is_for() -> None:
+    skill = _skill(
+        "trader",
+        metadata=SkillPlatformMeta(
+            requires=SkillRequires(
+                env=[SkillEnvVar(name="EXAMPLE_API_KEY", description="Example broker API key")]
+            )
+        ),
+    )
+    ctx = EligibilityContext(os_name="linux", env_cache={"EXAMPLE_API_KEY": None})
+
+    _, availability = gate_skills([skill], set(), ctx)
+
+    detail = availability["trader"].detail
+    assert availability["trader"].reason == REASON_INELIGIBLE
+    assert "EXAMPLE_API_KEY" in detail
+    assert "Example broker API key" in detail
+    assert "not set" in detail
+
+
+def test_wrong_os_says_which_platform_the_skill_wants() -> None:
+    skill = _skill("mac-only", metadata=SkillPlatformMeta(os=["darwin"]))
+
+    _, availability = gate_skills([skill], set(), EligibilityContext(os_name="linux"))
+
+    assert availability["mac-only"].reason == REASON_INELIGIBLE
+    assert "darwin" in availability["mac-only"].detail
+
+
+def test_tool_gate_lists_only_the_tools_this_session_is_missing() -> None:
+    skill = _skill("browser", requires_tools=["browser_open", "exec_command"])
+
+    gated, availability = gate_skills([skill], {"exec_command"}, _empty_ctx())
+
+    assert gated == []
+    assert availability["browser"].reason == REASON_TOOL_GATE
+    assert "browser_open" in availability["browser"].detail
+    assert "exec_command" not in availability["browser"].detail
+
+
+def test_fallback_superseded_names_the_native_tool_that_won() -> None:
+    skill = _skill("http-fetch", fallback_for_toolsets=["web_fetch"])
+
+    gated, availability = gate_skills([skill], {"web_fetch"}, _empty_ctx())
+
+    assert gated == []
+    assert availability["http-fetch"].reason == REASON_FALLBACK_SUPERSEDED
+    assert "web_fetch" in availability["http-fetch"].detail
+
+
+def test_prompt_budget_is_reported_instead_of_ineligible() -> None:
+    skills = [_skill(f"bundled-{i}") for i in range(30)]
+
+    gated, gate_availability = gate_skills(skills, set(), _empty_ctx())
+    plan = plan_injection(gated, max_chars=400, injection_mode="system")
+
+    assert plan.dropped
+    for name in plan.dropped:
+        assert gate_availability[name] == SkillAvailability(offered=True)
+        assert plan.availability[name].reason == REASON_PROMPT_BUDGET
+        assert "skills section is full (400 characters)" in plan.availability[name].detail
+    assert {s.name for s in plan.offered}.isdisjoint(plan.dropped)
+
+
+def test_every_reason_value_carries_a_non_empty_detail() -> None:
+    skills = [
+        _skill("hidden", disable_model_invocation=True),
+        _skill("mac-only", metadata=SkillPlatformMeta(os=["darwin"])),
+        _skill("browser", requires_tools=["browser_open"]),
+        _skill("http-fetch", fallback_for_toolsets=["web_fetch"]),
+        *(_skill(f"bundled-{i}") for i in range(30)),
+    ]
+
+    gated, availability = gate_skills(skills, {"web_fetch"}, _empty_ctx())
+    plan = plan_injection(gated, max_chars=400, injection_mode="system")
+    availability.update(plan.availability)
+
+    seen = {a.reason for a in availability.values() if not a.offered}
+    assert seen == {
+        REASON_MODEL_INVOCATION_DISABLED,
+        REASON_INELIGIBLE,
+        REASON_TOOL_GATE,
+        REASON_FALLBACK_SUPERSEDED,
+        REASON_PROMPT_BUDGET,
+    }
+    for name, entry in availability.items():
+        if entry.offered:
+            assert entry.reason == ""
+        else:
+            assert entry.detail.strip(), name
+
+
+def test_no_detail_string_leaks_a_filesystem_path() -> None:
+    skills = [
+        _skill("hidden", disable_model_invocation=True),
+        _skill("mac-only", metadata=SkillPlatformMeta(os=["darwin"])),
+        _skill("browser", requires_tools=["browser_open"]),
+        _skill("http-fetch", fallback_for_toolsets=["web_fetch"]),
+        _skill(
+            "mailer",
+            metadata=SkillPlatformMeta(
+                requires=SkillRequires(bins=["himalaya"]),
+                install=[SkillInstallSpec(id="himalaya", kind="brew", bins=["himalaya"])],
+            ),
+        ),
+        *(_skill(f"bundled-{i}") for i in range(30)),
+    ]
+    ctx = EligibilityContext(os_name="linux", has_bin_cache={"himalaya": False})
+
+    _, availability = gate_skills(skills, {"web_fetch"}, ctx)
+    gated, _ = gate_skills(skills, {"web_fetch"}, ctx)
+    availability.update(plan_injection(gated, max_chars=400).availability)
+
+    for name, entry in availability.items():
+        assert FAKE_BASE not in entry.detail, name
+        assert "SKILL.md" not in entry.detail, name
+        # No absolute POSIX path and no Windows drive path.
+        assert not re.search(r"(?<![\w`])/[\w.]+/", entry.detail), name
+        assert not re.search(r"[A-Za-z]:\\\\", entry.detail), name
+
+
+# ── the property the design rests on ────────────────────────────────────────
+
+
+def _turn_ctx(loader: SkillLoader, skills_config: object, tools: set[str]) -> TurnContext:
+    return TurnContext(
+        message="please help with anything",
+        session_key="agent:main:webchat:default",
+        config=SimpleNamespace(
+            tools=SimpleNamespace(profile="standard"),
+            skills=skills_config,
+        ),
+        provider=None,
+        model="test-model",
+        tool_defs=[SimpleNamespace(name=name) for name in sorted(tools)],
+        system_prompt="base",
+        metadata={"skill_loader": loader},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_chars", [300, 100_000])
+async def test_standalone_recomputation_matches_the_engine_offered_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    max_chars: int,
+) -> None:
+    """The RPC answers before any turn has run, so it must recompute the same set.
+
+    Both budgets are exercised: one that truncates and one that does not.
+    """
+    import agentos.engine.steps.skills_filter as skills_filter_step
+
+    monkeypatch.setattr(
+        skills_filter_step, "_eligibility_context", lambda: EligibilityContext(os_name="linux")
+    )
+    managed = tmp_path / "managed"
+    for i in range(4):
+        skill_dir = managed / f"community-skill-{i}"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: community-skill-{i}\n"
+            "description: Use when testing installed skills.\n---\n\n# s\n",
+            encoding="utf-8",
+        )
+    loader = SkillLoader(
+        bundled_dir=BUNDLED,
+        managed_dir=managed,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    tools = {"cron", "exec_command", "memory_get", "memory_save", "memory_search", "process"}
+    skills_config = SimpleNamespace(
+        filter_enabled=False,
+        max_skills_prompt_chars=max_chars,
+        injection_mode="system",
+    )
+
+    ctx = await filter_skills(_turn_ctx(loader, skills_config, tools))
+
+    # Standalone path — no turn, no shared state, same inputs.
+    gated, availability = gate_skills(loader.load_all(), tools, EligibilityContext(os_name="linux"))
+    plan = plan_injection(gated, max_chars, "system")
+    availability.update(plan.availability)
+
+    engine_offered = {
+        name for name, entry in ctx.metadata["skill_availability"].items() if entry.offered
+    }
+    standalone_offered = {name for name, entry in availability.items() if entry.offered}
+
+    assert standalone_offered == engine_offered
+    assert standalone_offered == {s.name for s in plan.offered}
+    assert plan.prompt == ctx.system_prompt[1]
+    assert len(standalone_offered) == ctx.metadata["skill_count"]
+
+
+# ── engine wiring ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_engine_publishes_a_budget_reason_for_every_dropped_skill(
+    tmp_path: Path,
+) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    skills_config = SimpleNamespace(
+        filter_enabled=False,
+        max_skills_prompt_chars=300,
+        injection_mode="system",
+    )
+
+    ctx = await filter_skills(_turn_ctx(loader, skills_config, {"exec_command"}))
+
+    availability = ctx.metadata["skill_availability"]
+    dropped = ctx.metadata["skills_dropped_for_budget"]
+    assert dropped
+    for name in dropped:
+        assert availability[name].reason == REASON_PROMPT_BUDGET
+    offered = {name for name, entry in availability.items() if entry.offered}
+    assert offered.isdisjoint(dropped)
+    assert len(offered) == ctx.metadata["skill_count"]
+
+
+@pytest.mark.asyncio
+async def test_retrieval_misses_are_reported_as_query_dependent(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    for name, description, triggers in (
+        ("weather-local", "Fetch weather forecasts.", "[weather, forecast]"),
+        ("github-local", "Inspect GitHub pull requests.", "[github, pull request]"),
+    ):
+        skill_dir = workspace / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {description}\ntriggers: {triggers}\n"
+            f"---\n\n# {name}\n",
+            encoding="utf-8",
+        )
+    loader = SkillLoader(workspace_dir=workspace, snapshot_path=tmp_path / "snapshot.json")
+    skills_config = SimpleNamespace(
+        filter_enabled=True,
+        filter_top_k=1,
+        filter_strategy="lexical",
+        filter_lexical_top_n=20,
+        filter_semantic_top_n=20,
+        filter_rrf_k=60,
+        filter_embedding_model="BAAI/bge-small-zh-v1.5",
+        max_skills_prompt_chars=100_000,
+        injection_mode="system",
+    )
+    turn = _turn_ctx(loader, skills_config, {"exec_command"})
+    turn.message = "please check the weather forecast"
+
+    ctx = await filter_skills(turn)
+
+    availability = ctx.metadata["skill_availability"]
+    assert availability["weather-local"].offered is True
+    missed = availability["github-local"]
+    assert missed.offered is False
+    assert missed.reason == REASON_NOT_RETRIEVED
+    # Query-dependent, not a standing property of the skill — say so.
+    assert "this message" in missed.detail
+    assert "worded" in missed.detail

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -132,13 +132,14 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
     class MockBinCache(dict):
         def __contains__(self, key: object) -> bool:
             return True
+
         def __getitem__(self, key: str) -> bool:
             return True
 
     monkeypatch.setattr(
         skills_filter_step,
-        "_elig_ctx",
-        EligibilityContext(
+        "_eligibility_context",
+        lambda: EligibilityContext(
             os_name="linux",
             has_bin_cache=MockBinCache(),
         ),

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -313,6 +313,49 @@ async def test_fetch_and_inspect_delegate_to_github(monkeypatch) -> None:
     assert calls == {"fetch": ident, "inspect": ident}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        # A different repository entirely — the laundering case.
+        "https://github.com/attacker/skills/tree/main/bankr",
+        # The right repo, but a slug that is not published by Bankr.
+        "https://github.com/BankrBot/skills/tree/main/not-a-bankr-skill",
+        # The repo root, with no skill directory at all.
+        "https://github.com/BankrBot/skills",
+        # Not a GitHub reference in the first place.
+        "not-an-identifier",
+    ],
+)
+async def test_install_path_refuses_identifiers_outside_the_allowlist(
+    monkeypatch, identifier: str
+) -> None:
+    """A non-Bankr identifier must not be installable *through* the Bankr source.
+
+    A hub install records its publisher from the source it came through, so an
+    ungated delegate would let an arbitrary GitHub skill be installed with
+    ``source="bankr"`` and then render under Bankr's name and link in the
+    Partners group.
+    """
+    calls: list[str] = []
+
+    async def _fake_fetch(self: Any, ident: str) -> str:
+        calls.append(ident)
+        return "bundle"
+
+    from agentos.skills.hub.github import GitHubSource
+
+    monkeypatch.setattr(GitHubSource, "fetch", _fake_fetch)
+    monkeypatch.setattr(GitHubSource, "inspect", _fake_fetch)
+
+    src = BankrSource()
+
+    assert await src.fetch(identifier) is None
+    assert await src.inspect(identifier) is None
+    # The delegate is never reached — nothing is downloaded.
+    assert calls == []
+
+
 def test_default_router_exposes_bankr_source(monkeypatch) -> None:
     from agentos.skills.hub import defaults
 

--- a/tests/test_skills_injector.py
+++ b/tests/test_skills_injector.py
@@ -74,17 +74,21 @@ def test_compact_mode_takes_over_when_descriptions_do_not_fit() -> None:
 
 
 def test_truncation_sacrifices_the_lowest_precedence_layers_first() -> None:
-    skills = [
-        *(_skill(f"bundled-{i}") for i in range(20)),
-        *(_skill(f"managed-{i}", layer=SkillLayer.MANAGED) for i in range(3)),
+    keep = [
         _skill("workspace-0", layer=SkillLayer.WORKSPACE),
+        *(_skill(f"managed-{i}", layer=SkillLayer.MANAGED) for i in range(3)),
     ]
+    skills = [*(_skill(f"bundled-{i}") for i in range(20)), *keep]
+    injector = SkillInjector()
+    # Budget derived from a real render, not a magic number: the block's guidance
+    # text is prose and does change, and a hardcoded budget silently turns this
+    # into a different test (or a passing one that proves less) when it does.
+    budget = len(injector.inject_compact("", keep))
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=600)
+    prompt, dropped = injector.inject_skills("", skills, max_chars=budget)
 
-    assert "<name>workspace-0</name>" in prompt
-    for i in range(3):
-        assert f"<name>managed-{i}</name>" in prompt
+    for spec in keep:
+        assert f"<name>{spec.name}</name>" in prompt
     assert dropped
     assert all(name.startswith("bundled-") for name in dropped)
 
@@ -98,6 +102,9 @@ def test_dropped_names_match_what_is_missing_from_the_prompt() -> None:
     prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=700)
 
     missing = {s.name for s in skills if f"<name>{s.name}</name>" not in prompt}
+    # Without this the assertion below passes vacuously (empty == empty) the day
+    # a wider budget stops truncation firing at all.
+    assert dropped
     assert set(dropped) == missing
     assert len(dropped) == len(set(dropped))
 

--- a/tests/test_skills_injector.py
+++ b/tests/test_skills_injector.py
@@ -24,7 +24,7 @@ def _skill(
     disable_model_invocation: bool = False,
 ) -> SkillSpec:
     """A spec carrying the on-disk fields the injector used to leak."""
-    base_dir = f"/home/example/.agentos/skills/{name}"
+    base_dir = f"/opt/example/agentos/skills/{name}"
     return SkillSpec(
         name=name,
         description=description,
@@ -49,7 +49,7 @@ def test_neither_mode_emits_a_skill_location() -> None:
     for prompt in (full, compact):
         assert "<location>" not in prompt
         assert "SKILL.md" not in prompt
-        assert "/home/example" not in prompt
+        assert "/opt/example" not in prompt
 
 
 def test_full_mode_is_used_when_it_fits_the_budget() -> None:

--- a/tests/test_skills_injector.py
+++ b/tests/test_skills_injector.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps.skills_filter import filter_skills
+from agentos.gateway.config import GatewayConfig
+from agentos.skills.injector import SkillInjector
+from agentos.skills.loader import SkillLoader
+from agentos.skills.types import SkillLayer, SkillSpec
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
+
+
+def _skill(
+    name: str,
+    *,
+    layer: SkillLayer = SkillLayer.BUNDLED,
+    description: str = "Use when exercising the injector.",
+    disable_model_invocation: bool = False,
+) -> SkillSpec:
+    """A spec carrying the on-disk fields the injector used to leak."""
+    base_dir = f"/home/example/.agentos/skills/{name}"
+    return SkillSpec(
+        name=name,
+        description=description,
+        layer=layer,
+        always=False,
+        triggers=[],
+        content=f"# {name}",
+        path=Path(base_dir),
+        base_dir=base_dir,
+        file_path=f"{base_dir}/SKILL.md",
+        disable_model_invocation=disable_model_invocation,
+    )
+
+
+def test_neither_mode_emits_a_skill_location() -> None:
+    skills = [_skill("alpha"), _skill("beta")]
+    injector = SkillInjector()
+
+    full = injector.inject_full("", skills)
+    compact = injector.inject_compact("", skills)
+
+    for prompt in (full, compact):
+        assert "<location>" not in prompt
+        assert "SKILL.md" not in prompt
+        assert "/home/example" not in prompt
+
+
+def test_full_mode_is_used_when_it_fits_the_budget() -> None:
+    skills = [_skill("alpha", description="Use when alpha things happen.")]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=10_000)
+
+    assert "<description>Use when alpha things happen.</description>" in prompt
+    assert "<name>alpha</name>" in prompt
+    assert dropped == []
+
+
+def test_compact_mode_takes_over_when_descriptions_do_not_fit() -> None:
+    skills = [_skill(f"skill-{i}", description="d" * 400) for i in range(10)]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=1_000)
+
+    assert "<description>" not in prompt
+    for i in range(10):
+        assert f"<name>skill-{i}</name>" in prompt
+    assert dropped == []
+
+
+def test_truncation_sacrifices_the_lowest_precedence_layers_first() -> None:
+    skills = [
+        *(_skill(f"bundled-{i}") for i in range(20)),
+        *(_skill(f"managed-{i}", layer=SkillLayer.MANAGED) for i in range(3)),
+        _skill("workspace-0", layer=SkillLayer.WORKSPACE),
+    ]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=600)
+
+    assert "<name>workspace-0</name>" in prompt
+    for i in range(3):
+        assert f"<name>managed-{i}</name>" in prompt
+    assert dropped
+    assert all(name.startswith("bundled-") for name in dropped)
+
+
+def test_dropped_names_match_what_is_missing_from_the_prompt() -> None:
+    skills = [
+        *(_skill(f"bundled-{i}") for i in range(30)),
+        *(_skill(f"managed-{i}", layer=SkillLayer.MANAGED) for i in range(5)),
+    ]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=700)
+
+    missing = {s.name for s in skills if f"<name>{s.name}</name>" not in prompt}
+    assert set(dropped) == missing
+    assert len(dropped) == len(set(dropped))
+
+
+def test_truncation_preserves_within_layer_order() -> None:
+    skills = [_skill(f"bundled-{i:02d}") for i in range(30)]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=500)
+
+    kept = [s.name for s in skills if f"<name>{s.name}</name>" in prompt]
+    assert kept == sorted(kept)
+    assert dropped == [s.name for s in skills if s.name not in kept]
+
+
+def test_model_invisible_skills_are_never_reported_as_dropped() -> None:
+    skills = [
+        _skill("hidden", disable_model_invocation=True),
+        *(_skill(f"bundled-{i}") for i in range(20)),
+    ]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=400)
+
+    assert "<name>hidden</name>" not in prompt
+    assert "hidden" not in dropped
+
+
+def test_a_tiny_budget_still_keeps_one_skill_and_the_guard() -> None:
+    skills = [_skill(f"bundled-{i}") for i in range(5)]
+
+    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=1)
+
+    assert "they are not callable tools" in prompt
+    assert prompt.count("<name>") == 1
+    assert len(dropped) == 4
+
+
+def _ctx(loader: SkillLoader, skills_config: object) -> TurnContext:
+    tool_defs = [
+        SimpleNamespace(name=name)
+        for name in (
+            "background_process",
+            "cron",
+            "exec_command",
+            "memory_get",
+            "memory_save",
+            "memory_search",
+            "process",
+        )
+    ]
+    return TurnContext(
+        message="please help with anything",
+        session_key="agent:main:webchat:default",
+        config=SimpleNamespace(
+            tools=SimpleNamespace(profile="standard"),
+            skills=skills_config,
+        ),
+        provider=None,
+        model="test-model",
+        tool_defs=tool_defs,
+        system_prompt="base",
+        metadata={"skill_loader": loader},
+    )
+
+
+@pytest.mark.asyncio
+async def test_shipped_default_budget_keeps_every_managed_skill(tmp_path: Path) -> None:
+    """The shipped default must fit the bundled set plus installed skills.
+
+    The old 8000-char default could not hold the bundled set even in compact
+    mode, and truncation kept a bundled-first prefix — so the skills an
+    operator installed were the first thing dropped, silently.
+    """
+    managed = tmp_path / "managed"
+    installed = [f"community-skill-{i}" for i in range(6)]
+    for name in installed:
+        skill_dir = managed / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\n"
+            "description: Use when testing installed skills.\n"
+            f"---\n\n# {name}\n",
+            encoding="utf-8",
+        )
+    loader = SkillLoader(
+        bundled_dir=BUNDLED,
+        managed_dir=managed,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+
+    ctx = await filter_skills(_ctx(loader, GatewayConfig().skills))
+
+    prompt = ctx.system_prompt[1]
+    for name in installed:
+        assert f"<name>{name}</name>" in prompt
+    assert ctx.metadata["skills_dropped_for_budget"] == []
+    # Descriptions are the whole point of the budget: without them the model
+    # cannot tell which skill matches the request.
+    assert "<description>" in prompt
+
+
+@pytest.mark.asyncio
+async def test_budget_truncation_is_reported_in_metadata(tmp_path: Path) -> None:
+    managed = tmp_path / "managed"
+    skill_dir = managed / "community-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: community-skill\ndescription: Use when testing installed skills.\n---\n\n# c\n",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(
+        bundled_dir=BUNDLED,
+        managed_dir=managed,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    skills_config = SimpleNamespace(
+        filter_enabled=False,
+        max_skills_prompt_chars=300,
+        injection_mode="system",
+    )
+
+    ctx = await filter_skills(_ctx(loader, skills_config))
+
+    prompt = ctx.system_prompt[1]
+    dropped = ctx.metadata["skills_dropped_for_budget"]
+    assert dropped
+    assert "community-skill" not in dropped
+    assert "<name>community-skill</name>" in prompt
+    assert ctx.metadata["skill_count"] == prompt.count("<name>")
+    assert all(name not in ctx.metadata["filtered_skill_ids"] for name in dropped)

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -220,6 +220,46 @@ def test_a_hub_cannot_mint_a_brand_either(tmp_path: Path) -> None:
     assert rows[0].publisher == SkillPublisher()
 
 
+def test_a_partner_installed_before_publisher_ids_existed_keeps_its_brand(tmp_path: Path) -> None:
+    """An upgrading machine must not silently lose the Partners grouping.
+
+    Every lockfile written before ``publisher_id`` existed has an empty one, so
+    a Bankr skill installed on the previous release would fall out of Partners
+    and into "Installed from a hub" until it was reinstalled — the exact split
+    heading this issue set out to remove. The source is the same selector
+    install time falls back to, so it resolves to the same allowlisted record.
+    """
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "legacy-install")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "legacy-install",
+        source="bankr",
+        identifier="id",
+        path=str(install_dir),
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].publisher == BANKR
+
+
+def test_an_unrecognized_source_still_grants_no_brand(tmp_path: Path) -> None:
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "community-install")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "community-install",
+        source="clawhub",
+        identifier="id",
+        path=str(install_dir),
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].publisher == SkillPublisher()
+
+
 def test_an_installed_skill_cannot_rebrand_itself_over_the_lockfile(tmp_path: Path) -> None:
     """The catalog row that installed it is the trusted source, not its own text."""
 
@@ -341,6 +381,23 @@ async def test_install_falls_back_to_the_source_when_no_provider_is_declared(
     entry = Lockfile.load(tmp_path / "lock.json").get("demo")
     assert entry is not None
     assert entry.publisher_id == "bankr"
+
+
+@pytest.mark.asyncio
+async def test_install_records_the_version_the_row_advertises(tmp_path: Path) -> None:
+    """``acquisition.version`` is on the wire, so it has to be written."""
+    meta = SkillMeta(name="demo", source_id="clawhub", version="2.1.0")
+    await _stub_installer(tmp_path, meta).install("demo", "clawhub")
+
+    entry = Lockfile.load(tmp_path / "lock.json").get("demo")
+    assert entry is not None
+    assert entry.version == "2.1.0"
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, managed_dir=tmp_path / "managed"),
+        lockfile_path=tmp_path / "lock.json",
+    )
+    assert rows[0].acquisition.version == "2.1.0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -220,7 +220,9 @@ def test_a_hub_cannot_mint_a_brand_either(tmp_path: Path) -> None:
     assert rows[0].publisher == SkillPublisher()
 
 
-def test_a_declared_publisher_wins_over_the_lockfile(tmp_path: Path) -> None:
+def test_an_installed_skill_cannot_rebrand_itself_over_the_lockfile(tmp_path: Path) -> None:
+    """The catalog row that installed it is the trusted source, not its own text."""
+
     managed = tmp_path / "managed"
     install_dir = _write_skill(managed, "declared", "publisher:\n  id: robinhood\n")
     lock = _lockfile(
@@ -232,6 +234,19 @@ def test_a_declared_publisher_wins_over_the_lockfile(tmp_path: Path) -> None:
     )
 
     rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].spec.publisher == SkillPublisher()
+    assert rows[0].publisher == BANKR
+
+
+def test_a_bundled_skill_keeps_the_brand_it_declares(tmp_path: Path) -> None:
+    bundled = tmp_path / "bundled"
+    _write_skill(bundled, "shipped-partner", "publisher:\n  id: robinhood\n")
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, bundled_dir=bundled),
+        lockfile_path=tmp_path / "lock.json",
+    )
 
     assert rows[0].publisher == ROBINHOOD
 

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -1,0 +1,428 @@
+"""Acquisition is derived from the lockfile, and never promises a broken action."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.skills.availability import REASON_TOOL_GATE
+from agentos.skills.hub.installer import SkillInstaller
+from agentos.skills.hub.lockfile import LockEntry, Lockfile
+from agentos.skills.hub.source import SkillBundle, SkillMeta
+from agentos.skills.inventory import SkillRow, build_skill_inventory
+from agentos.skills.loader import SkillLoader
+from agentos.skills.publishers import RECOGNIZED_PUBLISHERS
+from agentos.skills.types import AcquisitionKind, SkillPublisher
+
+BANKR = RECOGNIZED_PUBLISHERS["bankr"]
+ROBINHOOD = RECOGNIZED_PUBLISHERS["robinhood"]
+
+
+def _write_skill(root: Path, name: str, extra_frontmatter: str = "") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Synthetic skill.\n{extra_frontmatter}---\n\n# body\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _loader(tmp_path: Path, **kwargs: Path | None) -> SkillLoader:
+    """Build a loader with no snapshot cache, so every call re-reads disk."""
+    return SkillLoader(snapshot_path=tmp_path / "cache" / "snapshot.json", **kwargs)
+
+
+def _lockfile(lock_path: Path, name: str, **fields: str) -> Path:
+    lockfile = Lockfile()
+    lockfile.add(name, LockEntry(source=fields.pop("source", "bankr"), **fields))
+    lockfile.save(lock_path)
+    return lock_path
+
+
+def _row(rows: list[SkillRow], name: str) -> SkillRow:
+    return next(row for row in rows if row.spec.name == name)
+
+
+# ── Acquisition kinds ────────────────────────────────────────────────────────
+
+
+def test_a_bundled_skill_is_shipped(tmp_path: Path) -> None:
+    bundled = tmp_path / "bundled"
+    _write_skill(bundled, "shipped-one")
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, bundled_dir=bundled),
+        lockfile_path=tmp_path / "lock.json",
+    )
+
+    assert [row.spec.name for row in rows] == ["shipped-one"]
+    assert rows[0].acquisition.kind is AcquisitionKind.SHIPPED
+    assert rows[0].acquisition.removable is False
+    assert rows[0].acquisition.updatable is False
+
+
+def test_a_directory_with_no_lockfile_entry_is_local(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_skill(workspace, "hand-written")
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, workspace_dir=workspace),
+        lockfile_path=tmp_path / "lock.json",
+    )
+
+    assert rows[0].acquisition.kind is AcquisitionKind.LOCAL
+    assert rows[0].acquisition.removable is False
+
+
+def test_a_lockfile_entry_makes_it_a_hub_install(tmp_path: Path) -> None:
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "from-a-hub")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "from-a-hub",
+        source="bankr",
+        identifier="https://example.com/skills/from-a-hub",
+        installed_at="2026-01-01T00:00:00Z",
+        path=str(install_dir),
+        source_trust="community",
+        scan_verdict="clean",
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    acquisition = rows[0].acquisition
+    assert acquisition.kind is AcquisitionKind.HUB
+    assert acquisition.source_id == "bankr"
+    assert acquisition.identifier == "https://example.com/skills/from-a-hub"
+    assert acquisition.installed_at == "2026-01-01T00:00:00Z"
+    assert acquisition.source_trust == "community"
+    assert acquisition.scan_verdict == "clean"
+    assert acquisition.removable is True
+    assert acquisition.updatable is True
+    assert acquisition.detail == ""
+
+
+def test_a_hub_install_stays_hub_even_when_it_loads_from_another_layer(tmp_path: Path) -> None:
+    """The lockfile, not the layer, decides whether an operator installed it."""
+    workspace = tmp_path / "workspace"
+    install_dir = _write_skill(workspace, "relocated")
+    lock = _lockfile(tmp_path / "lock.json", "relocated", identifier="id", path=str(install_dir))
+
+    rows = build_skill_inventory(_loader(tmp_path, workspace_dir=workspace), lockfile_path=lock)
+
+    assert rows[0].acquisition.kind is AcquisitionKind.HUB
+
+
+# ── Guards: never offer an action that would half-succeed ────────────────────
+
+
+def test_a_custom_managed_dir_withholds_uninstall_and_says_why(tmp_path: Path) -> None:
+    """The lockfile path comes from the state root; the managed dir is
+    config-overridable. When they disagree, Uninstall would drop the lockfile
+    entry and leave the files behind."""
+    elsewhere = tmp_path / "elsewhere"
+    install_dir = _write_skill(elsewhere, "diverged")
+    configured = tmp_path / "configured"
+    _write_skill(configured, "diverged")
+    lock = _lockfile(tmp_path / "lock.json", "diverged", identifier="id", path=str(install_dir))
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=configured), lockfile_path=lock)
+
+    acquisition = rows[0].acquisition
+    assert acquisition.kind is AcquisitionKind.HUB
+    assert acquisition.removable is False
+    assert str(install_dir) in acquisition.detail
+    assert str(configured) in acquisition.detail
+    # Re-fetching by identifier still works, so the update affordance stays.
+    assert acquisition.updatable is True
+
+
+def test_an_orphaned_entry_does_not_claim_to_be_removable(tmp_path: Path) -> None:
+    """Someone deleted the managed copy by hand; the entry outlived its files.
+
+    The skill still loads — from a workspace copy — so it still gets a row, and
+    that row must not offer to uninstall a directory that is already gone.
+    """
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    workspace = tmp_path / "workspace"
+    _write_skill(workspace, "survivor")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "survivor",
+        identifier="id",
+        path=str(managed / "survivor"),
+    )
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, managed_dir=managed, workspace_dir=workspace),
+        lockfile_path=lock,
+    )
+
+    acquisition = _row(rows, "survivor").acquisition
+    assert acquisition.kind is AcquisitionKind.HUB
+    assert acquisition.removable is False
+    assert str(managed / "survivor") in acquisition.detail
+
+
+def test_no_managed_dir_at_all_withholds_uninstall(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_skill(workspace, "orphan")
+    lock = _lockfile(tmp_path / "lock.json", "orphan", identifier="id")
+
+    rows = build_skill_inventory(
+        SkillLoader(workspace_dir=workspace, snapshot_path=tmp_path / "snap.json"),
+        lockfile_path=lock,
+    )
+
+    assert rows[0].acquisition.removable is False
+    assert rows[0].acquisition.detail
+
+
+# ── Publisher carried through a hub install ─────────────────────────────────
+
+
+def test_a_hub_entry_supplies_the_brand_a_manifest_never_declared(tmp_path: Path) -> None:
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "branded")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "branded",
+        identifier="id",
+        path=str(install_dir),
+        publisher_id="bankr",
+        publisher_name="Bankr",
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].spec.publisher == SkillPublisher()
+    assert rows[0].publisher == BANKR
+
+
+def test_a_hub_cannot_mint_a_brand_either(tmp_path: Path) -> None:
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "impostor")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "impostor",
+        identifier="id",
+        path=str(install_dir),
+        publisher_id="acme-capital",
+        publisher_name="Robinhood",
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].publisher == SkillPublisher()
+
+
+def test_a_declared_publisher_wins_over_the_lockfile(tmp_path: Path) -> None:
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "declared", "publisher:\n  id: robinhood\n")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "declared",
+        identifier="id",
+        path=str(install_dir),
+        publisher_id="bankr",
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].publisher == ROBINHOOD
+
+
+# ── LockEntry schema ────────────────────────────────────────────────────────
+
+
+def test_lock_entry_round_trips_the_publisher_fields(tmp_path: Path) -> None:
+    path = tmp_path / "lock.json"
+    lockfile = Lockfile()
+    lockfile.add(
+        "demo",
+        LockEntry(
+            source="bankr",
+            identifier="id",
+            publisher_id="bankr",
+            publisher_name="Bankr",
+        ),
+    )
+    lockfile.save(path)
+
+    entry = Lockfile.load(path).get("demo")
+    assert entry is not None
+    assert entry.publisher_id == "bankr"
+    assert entry.publisher_name == "Bankr"
+
+
+def test_an_entry_written_before_publisher_fields_existed_still_loads(tmp_path: Path) -> None:
+    path = tmp_path / "lock.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "installed": {"demo": {"source": "clawhub", "identifier": "demo", "sha256": "abc"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    entry = Lockfile.load(path).get("demo")
+    assert entry is not None
+    assert entry.identifier == "demo"
+    assert entry.publisher_id == ""
+    assert entry.publisher_name == ""
+
+
+# ── Install writes the publisher ────────────────────────────────────────────
+
+
+class _StubRouter:
+    """Router returning one fixed bundle, so install() can be driven offline."""
+
+    def __init__(self, meta: SkillMeta | None) -> None:
+        self._meta = meta
+
+    async def fetch(self, identifier: str, source_id: str) -> SkillBundle:
+        body = "---\nname: demo\ndescription: Use when testing.\n---\n\n# Demo\n"
+        return SkillBundle(name="demo", files={"SKILL.md": body}, meta=self._meta)
+
+    async def inspect(self, identifier: str, source_id: str) -> SkillMeta | None:
+        return self._meta
+
+
+def _stub_installer(tmp_path: Path, meta: SkillMeta | None) -> SkillInstaller:
+    return SkillInstaller(
+        router=_StubRouter(meta),  # type: ignore[arg-type]
+        managed_dir=tmp_path / "managed",
+        quarantine_dir=tmp_path / "quarantine",
+        lockfile_path=tmp_path / "lock.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_records_the_catalog_provider_as_the_publisher(tmp_path: Path) -> None:
+    meta = SkillMeta(name="demo", source_id="bankr", provider="Bankr")
+    result = await _stub_installer(tmp_path, meta).install("demo", "bankr")
+
+    assert result.success
+    entry = Lockfile.load(tmp_path / "lock.json").get("demo")
+    assert entry is not None
+    assert entry.publisher_id == "bankr"
+    assert entry.publisher_name == "Bankr"
+
+
+@pytest.mark.asyncio
+async def test_install_falls_back_to_the_source_when_no_provider_is_declared(
+    tmp_path: Path,
+) -> None:
+    meta = SkillMeta(name="demo", source_id="bankr", provider="")
+    await _stub_installer(tmp_path, meta).install("demo", "bankr")
+
+    entry = Lockfile.load(tmp_path / "lock.json").get("demo")
+    assert entry is not None
+    assert entry.publisher_id == "bankr"
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognized_provider_installs_unbranded(tmp_path: Path) -> None:
+    meta = SkillMeta(name="demo", source_id="github", provider="Acme Capital")
+    await _stub_installer(tmp_path, meta).install("demo", "github")
+
+    entry = Lockfile.load(tmp_path / "lock.json").get("demo")
+    assert entry is not None
+    # The raw claim is kept for diagnostics, but it resolves to nothing.
+    assert entry.publisher_id == "acme-capital"
+    assert entry.publisher_name == "Acme Capital"
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, managed_dir=tmp_path / "managed"),
+        lockfile_path=tmp_path / "lock.json",
+    )
+    assert rows[0].publisher == SkillPublisher()
+
+
+# ── The builder itself ──────────────────────────────────────────────────────
+
+
+def test_one_row_per_loaded_skill_with_every_derived_fact(tmp_path: Path) -> None:
+    bundled = tmp_path / "bundled"
+    _write_skill(bundled, "shipped-one")
+    _write_skill(bundled, "shipped-two")
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "hub-one")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "hub-one",
+        identifier="id",
+        path=str(install_dir),
+        publisher_id="bankr",
+    )
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, bundled_dir=bundled, managed_dir=managed),
+        lockfile_path=lock,
+        available_tools=set(),
+    )
+
+    assert {row.spec.name for row in rows} == {"shipped-one", "shipped-two", "hub-one"}
+    assert all(row.eligibility.eligible for row in rows)
+    assert all(row.availability is not None and row.availability.offered for row in rows)
+    assert all(row.acquisition.kind for row in rows)
+    assert _row(rows, "shipped-one").acquisition.kind is AcquisitionKind.SHIPPED
+    assert _row(rows, "hub-one").acquisition.kind is AcquisitionKind.HUB
+    assert _row(rows, "hub-one").publisher == BANKR
+
+
+def test_availability_is_answered_only_when_a_tool_set_is_supplied(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_skill(
+        workspace,
+        "needs-tools",
+        "metadata:\n  agentos:\n    requires_tools: [web_search]\n",
+    )
+    loader = _loader(tmp_path, workspace_dir=workspace)
+    lock = tmp_path / "lock.json"
+
+    assert loader.load_all()[0].requires_tools == ["web_search"]
+    # No tool set supplied → no claim either way, rather than a guess that would
+    # report every tool-gated skill as unavailable.
+    assert build_skill_inventory(loader, lockfile_path=lock)[0].availability is None
+
+    rows = build_skill_inventory(loader, lockfile_path=lock, available_tools=set())
+    availability = rows[0].availability
+    assert availability is not None
+    assert availability.offered is False
+    assert availability.reason == REASON_TOOL_GATE
+
+    rows = build_skill_inventory(loader, lockfile_path=lock, available_tools={"web_search"})
+    availability = rows[0].availability
+    assert availability is not None
+    assert availability.offered is True
+
+
+def test_managed_dir_falls_back_to_config_when_the_loader_has_none(tmp_path: Path) -> None:
+    """CLI paths build a loader without a managed dir; the guard still needs one."""
+    managed = tmp_path / "managed"
+    install_dir = _write_skill(managed, "configured-only")
+    lock = _lockfile(
+        tmp_path / "lock.json", "configured-only", identifier="id", path=str(install_dir)
+    )
+
+    class _Skills:
+        managed_dir = str(managed)
+
+    class _Config:
+        skills = _Skills()
+
+    rows = build_skill_inventory(
+        SkillLoader(workspace_dir=managed, snapshot_path=tmp_path / "snap.json"),
+        config=_Config(),
+        lockfile_path=lock,
+    )
+
+    assert rows[0].acquisition.removable is True

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from agentos.skills.availability import REASON_TOOL_GATE
+from agentos.skills.availability import REASON_PROMPT_BUDGET, REASON_TOOL_GATE
 from agentos.skills.hub.installer import SkillInstaller
 from agentos.skills.hub.lockfile import LockEntry, Lockfile
 from agentos.skills.hub.source import SkillBundle, SkillMeta
@@ -498,3 +498,81 @@ def test_managed_dir_falls_back_to_config_when_the_loader_has_none(tmp_path: Pat
     )
 
     assert rows[0].acquisition.removable is True
+
+
+def test_a_stale_lockfile_entry_cannot_make_a_shipped_skill_look_installed(
+    tmp_path: Path,
+) -> None:
+    """A bundled skill is never a hub install, whatever the lockfile says.
+
+    The bundled directory lives inside the installed package and is not
+    configurable, so nothing can be installed into it. An entry whose name
+    collides with a shipped skill is a leftover from a different, since-removed
+    install; honoring it would render a shipped skill with a source label and a
+    Remove button that cannot apply.
+    """
+    bundled = tmp_path / "bundled"
+    _write_skill(bundled, "collides")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "collides",
+        identifier="id",
+        path=str(tmp_path / "managed" / "collides"),
+        publisher_id="bankr",
+    )
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, bundled_dir=bundled, managed_dir=tmp_path / "managed"),
+        lockfile_path=lock,
+        available_tools=set(),
+    )
+
+    acquisition = _row(rows, "collides").acquisition
+    assert acquisition.kind is AcquisitionKind.SHIPPED
+    assert acquisition.removable is False
+    assert acquisition.source_id == ""
+    # And the stale entry must not lend it a partner's brand either.
+    assert _row(rows, "collides").publisher == SkillPublisher()
+
+
+def test_a_row_reports_the_budget_that_will_drop_it(tmp_path: Path) -> None:
+    """`prompt_budget` has to be answerable without a turn.
+
+    It depends only on the installed set and the configured budget, both known
+    here — so the Skills page can say "installed, ready, but the block is full"
+    instead of implying the agent has a skill it is never offered.
+    """
+    workspace = tmp_path / "workspace"
+    for i in range(6):
+        _write_skill(workspace, f"skill-{i:02d}")
+    loader = _loader(tmp_path, workspace_dir=workspace)
+    lock = tmp_path / "lock.json"
+
+    class _Skills:
+        max_skills_prompt_chars = 120
+        injection_mode = "system"
+
+    class _Config:
+        skills = _Skills()
+
+    rows = build_skill_inventory(
+        loader, config=_Config(), lockfile_path=lock, available_tools=set()
+    )
+
+    dropped = [r for r in rows if r.availability and r.availability.reason == REASON_PROMPT_BUDGET]
+    assert dropped, "a 120-char budget cannot fit six skills"
+    assert all(r.eligibility.eligible for r in dropped), "dropped for budget, not for eligibility"
+    assert all("120" in (r.availability.detail if r.availability else "") for r in dropped)
+
+    # A budget with room reports every skill as offered.
+    class _RoomySkills:
+        max_skills_prompt_chars = 30_000
+        injection_mode = "system"
+
+    class _RoomyConfig:
+        skills = _RoomySkills()
+
+    rows = build_skill_inventory(
+        loader, config=_RoomyConfig(), lockfile_path=lock, available_tools=set()
+    )
+    assert all(r.availability is not None and r.availability.offered for r in rows)

--- a/tests/test_skills_publisher_contract.py
+++ b/tests/test_skills_publisher_contract.py
@@ -72,19 +72,81 @@ def test_declared_brand_fields_are_ignored_in_favour_of_the_allowlist() -> None:
 
 
 def test_third_party_skill_cannot_load_a_partner_brand_it_wrote_itself(tmp_path: Path) -> None:
-    root = tmp_path / "skills"
+    """A directory dropped into a writable skills path gets no brand at all."""
+
+    managed = tmp_path / "managed"
     _write_skill(
-        root,
+        managed,
         "totally-legit-trading",
         'publisher:\n  id: robinhood\n  name: "Not Robinhood"\n  url: https://example.com\n',
     )
 
-    loader = SkillLoader(bundled_dir=root, snapshot_path=tmp_path / "snapshot.json")
+    loader = SkillLoader(
+        bundled_dir=tmp_path / "bundled",
+        managed_dir=managed,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
     skill = loader.get_by_name("totally-legit-trading")
 
     assert skill is not None
-    assert skill.publisher == ROBINHOOD
+    assert skill.publisher == SkillPublisher()
     assert "example.com" not in (skill.publisher.url + skill.publisher.logo)
+
+
+def test_only_a_bundled_manifest_may_select_its_own_publisher(tmp_path: Path) -> None:
+    """The allowlist stops forged *fields*; the layer stops forged *ids*."""
+
+    bundled = tmp_path / "bundled"
+    managed = tmp_path / "managed"
+    personal = tmp_path / "personal"
+    _write_skill(bundled, "shipped-partner", "publisher:\n  id: robinhood\n")
+    _write_skill(managed, "managed-lookalike", "publisher:\n  id: robinhood\n")
+    _write_skill(personal, "personal-lookalike", "publisher:\n  id: robinhood\n")
+
+    loader = SkillLoader(
+        bundled_dir=bundled,
+        managed_dir=managed,
+        personal_agents_dir=personal,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    skills = {s.name: s for s in loader.load_all()}
+
+    assert skills["shipped-partner"].publisher == ROBINHOOD
+    assert skills["managed-lookalike"].publisher == SkillPublisher()
+    assert skills["personal-lookalike"].publisher == SkillPublisher()
+
+
+def test_the_layer_gate_survives_the_snapshot_cache(tmp_path: Path) -> None:
+    """The cache stores the layer, so a restored row gets the same answer."""
+
+    bundled = tmp_path / "bundled"
+    managed = tmp_path / "managed"
+    _write_skill(bundled, "shipped-partner", "publisher:\n  id: robinhood\n")
+    _write_skill(managed, "managed-lookalike", "publisher:\n  id: robinhood\n")
+    snapshot = tmp_path / "snapshot.json"
+
+    def load() -> dict[str, SkillPublisher]:
+        loader = SkillLoader(bundled_dir=bundled, managed_dir=managed, snapshot_path=snapshot)
+        return {s.name: s.publisher for s in loader.load_all()}
+
+    load()
+    SkillLoader(bundled_dir=bundled, managed_dir=managed, snapshot_path=snapshot).save_snapshot()
+
+    # A snapshot written before the layer gate existed still carries the brand.
+    data = json.loads(snapshot.read_text(encoding="utf-8"))
+    for entry in data["skills"]:
+        entry["publisher"] = {
+            "id": "robinhood",
+            "name": "Robinhood",
+            "url": "https://robinhood.com",
+            "logo": "",
+        }
+    snapshot.write_text(json.dumps(data), encoding="utf-8")
+
+    restored = load()
+
+    assert restored["shipped-partner"] == ROBINHOOD
+    assert restored["managed-lookalike"] == SkillPublisher()
 
 
 def test_a_tampered_snapshot_cannot_inject_a_brand(tmp_path: Path) -> None:

--- a/tests/test_skills_publisher_contract.py
+++ b/tests/test_skills_publisher_contract.py
@@ -1,0 +1,213 @@
+"""Publisher is real, allowlisted data — not a string a manifest can claim."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentos.skills.loader import SkillLoader
+from agentos.skills.publishers import RECOGNIZED_PUBLISHERS, resolve_publisher
+from agentos.skills.types import SkillPublisher
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
+
+ROBINHOOD = RECOGNIZED_PUBLISHERS["robinhood"]
+
+
+def _write_skill(root: Path, name: str, frontmatter: str) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Synthetic skill.\n{frontmatter}---\n\n# body\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+# ── Allowlist ────────────────────────────────────────────────────────────────
+
+
+def test_recognized_publishers_carry_the_labels_the_ui_shows() -> None:
+    assert RECOGNIZED_PUBLISHERS["robinhood"].name == "Robinhood"
+    assert RECOGNIZED_PUBLISHERS["bankr"].name == "Bankr"
+    for slug, publisher in RECOGNIZED_PUBLISHERS.items():
+        assert publisher.id == slug
+        assert publisher.url.startswith("https://")
+
+
+def test_unrecognized_id_resolves_to_no_publisher() -> None:
+    assert resolve_publisher({"id": "acme-capital", "name": "Acme"}) == SkillPublisher()
+
+
+def test_missing_or_malformed_declaration_resolves_to_no_publisher() -> None:
+    for raw in (None, {}, [], 7, "", {"id": ""}, {"name": "Robinhood"}):
+        assert resolve_publisher(raw) == SkillPublisher()
+
+
+def test_bare_id_string_selects_the_allowlisted_record() -> None:
+    assert resolve_publisher("robinhood") == ROBINHOOD
+    assert resolve_publisher(" Robinhood ") == ROBINHOOD
+
+
+# ── Impersonation guard ──────────────────────────────────────────────────────
+
+
+def test_declared_brand_fields_are_ignored_in_favour_of_the_allowlist() -> None:
+    """A skill selects a publisher; it never gets to describe one."""
+
+    resolved = resolve_publisher(
+        {
+            "id": "robinhood",
+            "name": "Not Robinhood",
+            "url": "https://example.com",
+            "logo": "https://example.com/logo.png",
+        }
+    )
+
+    assert resolved == ROBINHOOD
+    assert resolved.name != "Not Robinhood"
+    assert resolved.url != "https://example.com"
+    assert resolved.logo != "https://example.com/logo.png"
+
+
+def test_third_party_skill_cannot_load_a_partner_brand_it_wrote_itself(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(
+        root,
+        "totally-legit-trading",
+        'publisher:\n  id: robinhood\n  name: "Not Robinhood"\n  url: https://example.com\n',
+    )
+
+    loader = SkillLoader(bundled_dir=root, snapshot_path=tmp_path / "snapshot.json")
+    skill = loader.get_by_name("totally-legit-trading")
+
+    assert skill is not None
+    assert skill.publisher == ROBINHOOD
+    assert "example.com" not in (skill.publisher.url + skill.publisher.logo)
+
+
+def test_a_tampered_snapshot_cannot_inject_a_brand(tmp_path: Path) -> None:
+    """The cache file is writable, so it gets the same allowlist check."""
+
+    root = tmp_path / "skills"
+    _write_skill(root, "plain", "")
+    snapshot = tmp_path / "snapshot.json"
+    SkillLoader(bundled_dir=root, snapshot_path=snapshot).save_snapshot()
+
+    data = json.loads(snapshot.read_text(encoding="utf-8"))
+    data["skills"][0]["publisher"] = {
+        "id": "acme-capital",
+        "name": "Robinhood",
+        "url": "https://example.com",
+        "logo": "https://example.com/logo.png",
+    }
+    snapshot.write_text(json.dumps(data), encoding="utf-8")
+
+    restored = SkillLoader(bundled_dir=root, snapshot_path=snapshot).get_by_name("plain")
+
+    assert restored is not None
+    assert restored.publisher == SkillPublisher()
+
+
+# ── Parsing and snapshot round-trip ──────────────────────────────────────────
+
+
+def test_publisher_parses_and_survives_snapshot_roundtrip(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(root, "partner-skill", "publisher:\n  id: bankr\n")
+    snapshot = tmp_path / "snapshot.json"
+
+    loader = SkillLoader(bundled_dir=root, snapshot_path=snapshot)
+    fresh = loader.get_by_name("partner-skill")
+    assert fresh is not None
+    assert fresh.publisher == RECOGNIZED_PUBLISHERS["bankr"]
+    loader.save_snapshot()
+
+    reloaded = SkillLoader(bundled_dir=root, snapshot_path=snapshot)
+    assert reloaded.load_snapshot() is not None  # the snapshot really was used
+    from_snapshot = reloaded.get_by_name("partner-skill")
+
+    assert from_snapshot is not None
+    assert from_snapshot.publisher == RECOGNIZED_PUBLISHERS["bankr"]
+
+
+def test_a_skill_without_a_publisher_block_still_loads(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(root, "unbranded", "")
+
+    skill = SkillLoader(bundled_dir=root, snapshot_path=tmp_path / "snapshot.json").get_by_name(
+        "unbranded"
+    )
+
+    assert skill is not None
+    assert skill.publisher == SkillPublisher()
+
+
+def test_a_version_9_snapshot_is_rejected_instead_of_stripping_publisher(tmp_path: Path) -> None:
+    """A v9 cache parses cleanly, so only the version bump keeps the brand."""
+
+    root = tmp_path / "skills"
+    _write_skill(root, "partner-skill", "publisher:\n  id: robinhood\n")
+    snapshot = tmp_path / "snapshot.json"
+    SkillLoader(bundled_dir=root, snapshot_path=snapshot).save_snapshot()
+
+    data = json.loads(snapshot.read_text(encoding="utf-8"))
+    data["version"] = 9
+    for entry in data["skills"]:
+        entry.pop("publisher", None)
+    snapshot.write_text(json.dumps(data), encoding="utf-8")
+
+    stale = SkillLoader(bundled_dir=root, snapshot_path=snapshot)
+    assert stale.load_snapshot() is None
+
+    rescanned = stale.get_by_name("partner-skill")
+    assert rescanned is not None
+    assert rescanned.publisher == ROBINHOOD
+
+
+# ── Independence from provenance ─────────────────────────────────────────────
+
+
+def test_publisher_and_provenance_do_not_constrain_each_other(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(root, "brand-only", "publisher:\n  id: robinhood\n")
+    _write_skill(
+        root,
+        "provenance-only",
+        "provenance:\n  origin: clawhub-mit0\n  license: MIT-0\n",
+    )
+    loader = SkillLoader(bundled_dir=root, snapshot_path=tmp_path / "snapshot.json")
+
+    brand_only = loader.get_by_name("brand-only")
+    provenance_only = loader.get_by_name("provenance-only")
+
+    assert brand_only is not None and provenance_only is not None
+    # A publisher says nothing about where the text came from...
+    assert brand_only.publisher == ROBINHOOD
+    assert brand_only.provenance.origin == "unknown"
+    assert brand_only.provenance.license == "unknown"
+    # ...and provenance says nothing about whose name is on the card.
+    assert provenance_only.provenance.origin == "clawhub-mit0"
+    assert provenance_only.publisher == SkillPublisher()
+
+
+# ── The bundled partner skills ───────────────────────────────────────────────
+
+
+def test_bundled_robinhood_skills_declare_the_robinhood_publisher(tmp_path: Path) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    skills = {skill.name: skill for skill in loader.load_all()}
+
+    for name in ("robinhood-agentic-trading", "robinhood-rwa-addresses"):
+        assert skills[name].publisher == ROBINHOOD
+        # Publisher is additive: the notices pipeline still reads provenance.
+        assert skills[name].provenance.origin == "agentos-original"
+
+
+def test_other_bundled_skills_stay_unbranded(tmp_path: Path) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+
+    branded = {skill.name for skill in loader.load_all() if skill.publisher != SkillPublisher()}
+
+    assert branded == {"robinhood-agentic-trading", "robinhood-rwa-addresses"}

--- a/tests/test_skills_shared_dirs.py
+++ b/tests/test_skills_shared_dirs.py
@@ -1,0 +1,100 @@
+"""The skill directories are not exclusively ours.
+
+``agentos skills install`` runs in its own process, and ``.agents/skills`` is a
+cross-agent directory that Codex, Cursor, and others write into while an AgentOS
+gateway is already running. Both used to leave a skill on disk and invisible
+until the next restart, with no log and no user-visible signal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.skills.loader import SkillLoader
+from agentos.skills.paths import resolve_skill_layer_dirs
+from agentos.skills.types import SkillLayer
+
+
+def _write_skill(root: Path, name: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name} does a thing.\n---\nBody.\n",
+        encoding="utf-8",
+    )
+
+
+def test_a_skill_another_agent_writes_lands_without_an_invalidate(tmp_path: Path) -> None:
+    personal = tmp_path / "agents-skills"
+    _write_skill(personal, "already-here")
+    loader = SkillLoader(personal_agents_dir=personal, snapshot_path=tmp_path / "snapshot.json")
+
+    assert {s.name for s in loader.load_all()} == {"already-here"}
+
+    # Another agent writes into the shared directory. Nothing calls
+    # invalidate_cache() — that is only reached through AgentOS's own paths.
+    _write_skill(personal, "written-by-someone-else")
+
+    names = {s.name for s in loader.load_all()}
+    assert "written-by-someone-else" in names, "a shared-directory write must not need a restart"
+    assert names == {"already-here", "written-by-someone-else"}
+
+
+def test_a_removed_skill_stops_being_reported(tmp_path: Path) -> None:
+    personal = tmp_path / "agents-skills"
+    _write_skill(personal, "here-then-gone")
+    loader = SkillLoader(personal_agents_dir=personal, snapshot_path=tmp_path / "snapshot.json")
+    assert loader.get_by_name("here-then-gone") is not None
+
+    for path in sorted((personal / "here-then-gone").iterdir()):
+        path.unlink()
+    (personal / "here-then-gone").rmdir()
+
+    assert loader.get_by_name("here-then-gone") is None
+
+
+def test_an_edited_skill_is_re_read(tmp_path: Path) -> None:
+    personal = tmp_path / "agents-skills"
+    _write_skill(personal, "edited")
+    loader = SkillLoader(personal_agents_dir=personal, snapshot_path=tmp_path / "snapshot.json")
+    assert loader.load_all()[0].description == "edited does a thing."
+
+    (personal / "edited" / "SKILL.md").write_text(
+        "---\nname: edited\ndescription: rewritten by another agent.\n---\nBody.\n",
+        encoding="utf-8",
+    )
+
+    assert loader.load_all()[0].description == "rewritten by another agent."
+
+
+def test_agents_dirs_are_named_even_before_they_exist(tmp_path: Path, monkeypatch) -> None:
+    """A directory created after boot must not need a restart to be seen.
+
+    ``.agents/skills`` frequently does not exist yet — the first cross-agent
+    install creates it. Resolving it to None at boot dropped the whole layer.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+
+    dirs = resolve_skill_layer_dirs(allow_bundled=False, workspace_root=project)
+
+    assert dirs.personal_agents_dir == home / ".agents" / "skills"
+    assert dirs.project_agents_dir == project / ".agents" / "skills"
+    assert not dirs.personal_agents_dir.exists()
+
+    loader = SkillLoader(
+        personal_agents_dir=dirs.personal_agents_dir,
+        project_agents_dir=dirs.project_agents_dir,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    # Naming a directory that is not there costs nothing.
+    assert loader.load_all() == []
+
+    _write_skill(dirs.personal_agents_dir, "created-after-boot")
+
+    loaded = loader.load_all()
+    assert [s.name for s in loaded] == ["created-after-boot"]
+    assert loaded[0].layer is SkillLayer.PERSONAL

--- a/tests/test_skills_surface_agreement.py
+++ b/tests/test_skills_surface_agreement.py
@@ -1,0 +1,244 @@
+"""Every surface answers "what is this skill" from the one inventory builder.
+
+``skills.list``, ``skills.status``, ``skills.get``, ``agentos skills list`` and
+the agent's own ``skill_list`` each used to assemble a row by hand, and only one
+of them read the lockfile. The result was three different answers to the same
+question about the same skill on the same machine. These tests pin the join.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from agentos.cli import skills_cmd
+from agentos.gateway import rpc_skills
+from agentos.gateway.rpc import RpcContext
+from agentos.skills.loader import SkillLoader
+from agentos.tools.builtin import skill_tools as skill_tools_module
+from agentos.tools.registry import get_default_registry
+
+SKILL_NAME = "ledger-watch"
+IDENTIFIER = "https://github.com/BankrBot/skills/tree/main/ledger-watch"
+
+
+def _write_skill(managed_dir: Path) -> None:
+    skill_dir = managed_dir / SKILL_NAME
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {SKILL_NAME}\n"
+        "description: Watch a ledger address.\n"
+        "publisher:\n"
+        "  id: bankr\n"
+        "---\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+
+
+def _write_lockfile(path: Path, managed_dir: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "installed": {
+                    SKILL_NAME: {
+                        "source": "bankr",
+                        "identifier": IDENTIFIER,
+                        "version": "1.2.0",
+                        # Pinned UTC instant — never the system clock.
+                        "installed_at": "2026-01-01T00:00:00Z",
+                        "path": str(managed_dir / SKILL_NAME),
+                        "source_trust": "trusted",
+                        "scan_verdict": "safe",
+                        "publisher_id": "bankr",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def hub_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[SkillLoader]:
+    """One hub-installed skill, visible to every surface through real paths."""
+    state = tmp_path / "state"
+    managed = state / "skills"
+    _write_skill(managed)
+    _write_lockfile(state / "skills-lock.json", managed)
+
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(state))
+    monkeypatch.setenv("AGENTOS_SKILLS_MANAGED_DIR", str(managed))
+    # Keep the sweep to the one skill under test: the bundled layer is 40 more.
+    monkeypatch.setenv("AGENTOS_SKILLS_ALLOW_BUNDLED", "false")
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+
+    loader = SkillLoader(managed_dir=managed, snapshot_path=tmp_path / "snapshot.json")
+    previous_loader = skill_tools_module._loader
+    skill_tools_module.create_skill_tools(loader)
+    try:
+        yield loader
+    finally:
+        skill_tools_module._loader = previous_loader
+
+
+async def _skill_list_text() -> str:
+    registered = get_default_registry().get("skill_list")
+    assert registered is not None
+    return str(await registered.handler())
+
+
+def _row(rows: list[dict], name: str = SKILL_NAME) -> dict:
+    return next(row for row in rows if row["name"] == name)
+
+
+def test_the_gateway_surfaces_agree_on_one_skill(hub_install: SkillLoader) -> None:
+    async def run() -> None:
+        ctx = RpcContext(conn_id="test", skill_loader=hub_install)
+
+        listed = _row((await rpc_skills._handle_skills_list(None, ctx))["skills"])
+        status = _row(await rpc_skills._handle_skills_status(None, ctx))
+        got = await rpc_skills._handle_skills_get({"name": SKILL_NAME}, ctx)
+
+        # ``skills.get`` adds the body; everything else must be identical.
+        body_only = {"content", "base_dir"}
+        assert {k: v for k, v in got.items() if k not in body_only} == listed
+        assert status == listed
+
+        assert listed["publisher"] == {
+            "id": "bankr",
+            "name": "Bankr",
+            "url": "https://github.com/BankrBot/skills",
+            "logo": "",
+        }
+        assert listed["acquisition"]["kind"] == "hub"
+        assert listed["acquisition"]["source_id"] == "bankr"
+        assert listed["acquisition"]["identifier"] == IDENTIFIER
+        assert listed["acquisition"]["version"] == "1.2.0"
+        assert listed["acquisition"]["installed_at"] == "2026-01-01T00:00:00Z"
+        assert listed["acquisition"]["source_trust"] == "trusted"
+        assert listed["acquisition"]["scan_verdict"] == "safe"
+        assert listed["availability"] == {"offered": True, "reason": "", "detail": ""}
+        # ``layer`` keeps meaning location, not provenance.
+        assert listed["layer"] == "managed"
+
+    asyncio.run(run())
+
+
+def test_the_cli_and_the_agent_report_the_same_acquisition_as_the_gateway(
+    hub_install: SkillLoader,
+) -> None:
+    async def run() -> None:
+        ctx = RpcContext(conn_id="test", skill_loader=hub_install)
+        listed = _row((await rpc_skills._handle_skills_list(None, ctx))["skills"])
+
+        cli = _row(skills_cmd._load_skill_rows())
+        assert cli["publisher"] == listed["publisher"]
+        assert cli["acquisition"] == listed["acquisition"]
+        assert cli["eligible"] == listed["eligible"]
+        assert cli["description"] == listed["description"]
+        assert cli["layer"] == listed["layer"]
+        # The CLI has no chat session, so it reports no availability rather
+        # than inventing one.
+        assert "availability" not in cli
+
+        agent_text = await _skill_list_text()
+        assert f"- {SKILL_NAME}: Watch a ledger address." in agent_text
+        assert "[not offered]" not in agent_text
+
+    asyncio.run(run())
+
+
+def test_a_hub_install_is_removable_and_a_local_skill_is_not(
+    hub_install: SkillLoader,
+) -> None:
+    """Only a lockfile entry pointing at the managed dir earns Remove/Update."""
+
+    async def run() -> None:
+        assert hub_install.managed_dir is not None
+        hand_copied = hub_install.managed_dir / "hand-copied"
+        hand_copied.mkdir()
+        (hand_copied / "SKILL.md").write_text(
+            "---\nname: hand-copied\ndescription: Copied by hand.\n---\nBody.\n",
+            encoding="utf-8",
+        )
+        hub_install.invalidate_cache()
+
+        ctx = RpcContext(conn_id="test", skill_loader=hub_install)
+        rows = (await rpc_skills._handle_skills_list(None, ctx))["skills"]
+
+        hub = _row(rows)["acquisition"]
+        assert (hub["removable"], hub["updatable"]) == (True, True)
+
+        local_row = _row(rows, "hand-copied")
+        local = local_row["acquisition"]
+        assert local["kind"] == "local"
+        assert (local["removable"], local["updatable"]) == (False, False)
+        assert local_row["publisher"]["id"] == ""
+
+    asyncio.run(run())
+
+
+def test_the_agent_is_told_which_listed_skills_it_will_never_be_offered(
+    hub_install: SkillLoader,
+) -> None:
+    """``skill_list`` used to advertise skills the agent can never invoke.
+
+    It listed every loaded skill with no hint that five of the bundled ones set
+    ``disable-model-invocation``, so the agent would announce a capability, try
+    to use it, and find nothing."""
+
+    async def run() -> None:
+        assert hub_install.managed_dir is not None
+        user_only = hub_install.managed_dir / "receipts"
+        user_only.mkdir()
+        (user_only / "SKILL.md").write_text(
+            "---\n"
+            "name: receipts\n"
+            "description: Print receipts.\n"
+            "disable-model-invocation: true\n"
+            "---\n"
+            "Body.\n",
+            encoding="utf-8",
+        )
+        hub_install.invalidate_cache()
+
+        text = await _skill_list_text()
+
+        assert "  - receipts: Print receipts." in text
+        assert "[not offered]" in text
+        assert "disable-model-invocation" in text
+        # The offered skill keeps its plain one-liner.
+        assert f"  - {SKILL_NAME}: Watch a ledger address.\n" in text + "\n"
+
+    asyncio.run(run())
+
+
+def test_a_bundled_skill_is_never_removable() -> None:
+    """Shipped skills live in the wheel; offering Remove would be a dead button."""
+
+    async def run() -> None:
+        bundled = Path(__file__).resolve().parent.parent / "src" / "agentos" / "skills" / "bundled"
+        loader = SkillLoader(bundled_dir=bundled)
+        ctx = RpcContext(conn_id="test", skill_loader=loader)
+        rows = (await rpc_skills._handle_skills_list(None, ctx))["skills"]
+
+        acquisitions = [row["acquisition"] for row in rows]
+        assert acquisitions, "the bundled layer should not be empty"
+        assert {a["kind"] for a in acquisitions} == {"shipped"}
+        assert not any(a["removable"] or a["updatable"] for a in acquisitions)
+
+        # Branding reaches the wire, and only through the allowlist.
+        branded = {row["name"] for row in rows if row["publisher"]["id"]}
+        assert branded, "the bundled Robinhood skills declare a publisher"
+        assert all(name.startswith("robinhood-") for name in branded), branded
+        assert {row["publisher"]["name"] for row in rows if row["publisher"]["id"]} == {"Robinhood"}
+
+    asyncio.run(run())

--- a/tests/test_skills_surface_agreement.py
+++ b/tests/test_skills_surface_agreement.py
@@ -242,3 +242,52 @@ def test_a_bundled_skill_is_never_removable() -> None:
         assert {row["publisher"]["name"] for row in rows if row["publisher"]["id"]} == {"Robinhood"}
 
     asyncio.run(run())
+
+
+def test_disabling_tools_is_reflected_on_the_skills_page(hub_install: SkillLoader) -> None:
+    """With ``[tools] enabled = false`` the page must not claim a tool-gated skill works.
+
+    The turn narrows to no tools at all, so a ``requires_tools`` skill is
+    withheld from the agent. Answering the row against the full process registry
+    would show it as offered — the Skills-page-versus-chat disagreement this
+    change exists to remove.
+    """
+    skill_dir = hub_install.managed_dir / "needs-a-tool" if hub_install.managed_dir else None
+    assert skill_dir is not None
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: needs-a-tool\n"
+        "description: Needs a tool.\n"
+        "metadata:\n"
+        "  agentos:\n"
+        "    requires_tools: [web_search]\n"
+        "---\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+    hub_install.invalidate_cache()
+
+    class _Tools:
+        enabled = False
+
+    class _Config:
+        tools = _Tools()
+
+    async def run() -> None:
+        enabled_ctx = RpcContext(conn_id="test", skill_loader=hub_install)
+        disabled_ctx = RpcContext(conn_id="test", skill_loader=hub_install, config=_Config())
+
+        enabled = _row(
+            (await rpc_skills._handle_skills_list(None, enabled_ctx))["skills"], "needs-a-tool"
+        )
+        disabled = _row(
+            (await rpc_skills._handle_skills_list(None, disabled_ctx))["skills"], "needs-a-tool"
+        )
+
+        assert enabled["availability"]["offered"] is True
+        assert disabled["availability"]["offered"] is False
+        assert disabled["availability"]["reason"] == "tool_gate"
+        assert disabled["availability"]["detail"]
+
+    asyncio.run(run())


### PR DESCRIPTION
Closes #130.

Every symptom in the issue is `SkillLayer` being asked four different questions —
*where do the files live*, *how was this acquired*, *who published it*, and *can the
agent use it* — when it can only answer the first honestly. This splits those apart
and gives every surface one object to read.

## What the investigation actually found

Both candidates the issue listed for symptom 3 are real, and there was a third,
larger one it did not name. Measured against the real bundled set, not inferred:

| | before | after |
|---|---|---|
| `inject_full()` rendered | 20953 chars | 16589 |
| `max_skills_prompt_chars` | 8000 | 24000 |
| full mode reachable | **never** — every install ran name-only | yes |
| `<description>` in the prompt | **0** | 47 |
| absolute paths in the prompt | 35 (69% of the compact block) | 0 |
| 12 installed skills reaching the agent | 3–9, depending on path length | 12 |

Full mode never fit, so a stock install always fell through to compact — names and
absolute file paths, no descriptions. Nothing consumes those paths: `skill_view`
resolves by name, and its own not-found text tells the model not to search the
filesystem. They also put the user's home directory in front of the model on every
turn. Meanwhile the guidance above the list said skills were "optional" and to load
one "only when a listed entry clearly matches" — an instruction that cannot be
followed when the entries are bare names.

Truncation, when it fired, kept a prefix of a bundled-first list, so the cut landed
on exactly the skills an operator had installed, with no log and no signal.

Two corrections to the issue's own analysis: the Installed tab groups purely on
`layer` (`groupSkillsByLayer`), so the Robinhood name heuristic was never what put
it under "Bundled" — that heuristic feeds a separate tab, and is an independent
problem. And the Community row does not vanish because state is lost; both queries
stay cached and both refetch after an install. It vanishes because an empty-query
browse never returned it.

## What changed

**One builder.** New `skills/inventory.py` joins skills × lockfile × eligibility ×
availability. `skills.list`, `skills.status`, `skills.get`, `agentos skills list`,
and the agent's own `skill_list` all render from it; `test_skills_surface_agreement.py`
asserts byte-equality across the RPC rows. The lockfile was previously read by
exactly one surface, which is why they disagreed.

**Three new facts, all additive on the wire.** `publisher` (allowlisted server-side,
so a third-party manifest cannot claim a partner's brand), `acquisition`
(`shipped` / `hub` / `local`, derived from the lockfile, plus `removable` /
`updatable`), and `availability` (`offered` plus a reason and a human sentence).
`layer` keeps its exact meaning and is demoted to a per-card detail.

**Installed groups by publisher then acquisition**, so Bankr and Robinhood sit under
one heading. Update/Remove now read `acquisition.removable`, which also fixes a
custom `skills.managed_dir` rendering an Uninstall button that could not work.

**Browse includes installed rows** synthesised from the lockfile, so an installed
skill survives clearing the search across a reload — and every `skills.search`
consumer gets it, CLI included.

**The prompt block stops arguing against its own contents.** It now asks for a load
on partial relevance, and in compact mode says plainly that a name alone cannot rule
a skill out.

**Shared directories are treated as shared.** `~/.agents/skills` is a cross-agent
convention — other tools install there while a gateway is running. `load_all()` now
validates its cache against the file manifest instead of trusting it (one stat sweep,
0.6 ms for 65 skills), and the two `.agents/skills` layers are honoured when created
after startup. Previously either case left a skill on disk and invisible until a
restart, silently.

**Eligibility is no longer frozen at import.** The chat path built one
`EligibilityContext` at module import and cached *negative* lookups for the life of
the process, while every other surface rebuilt per call — so the Skills screen showed
"ready" while chat refused forever. This is what the environment-variable feature
already promised in its changelog.

## Acceptance criteria

- **Consistent headings** — verified in the browser: Partners contains the bundled
  Robinhood skills and a hub-installed Bankr skill together, `layer` preserved as a
  card chip.
- **Search → install → clear** — verified: with the catalog unreachable, the installed
  row still renders at empty query, proving it comes from the lockfile rather than a
  session-scoped client merge.
- **Install → ask in chat** — verified against the real pipeline: all 12 simulated
  installs reach the injected prompt with descriptions and no filesystem paths; a
  variable set after the context was first built takes effect on the next turn.

## Deliberately out of scope

`EligibilityContext.enabled_set` / `disabled_set` have never been populated by any
caller, so "has the operator opted in" is a missing concept rather than a disagreeing
one. Wiring it needs a config key and a UI control; deleting it removes public fields
from a re-exported dataclass. Neither belongs in a bug fix — left untouched.

`skills.status` has no callers but stays as a public alias; it now shares the one row
builder instead of being a second payload.

## Upgrade path

`max_skills_prompt_chars` is materialised into every saved `config.toml`, so raising
the default would have reached new installs only — and `8000` is exactly the value that
cannot fit the shipped skills' descriptions. An existing install would have stayed on a
name-only skill list with nothing saying why.

Upgrading is therefore enough on its own: the rewrite joins the config migrations that
already run on the next gateway start and take a timestamped backup. Only the exact old
default is touched, the same rule the legacy model ids follow — a budget someone chose
deliberately is left alone, and an unset key is not materialised.

## Verification

`ruff check`, `mypy src/agentos`, `pytest -q` (6596 passed), and
`npm --prefix frontend run check` (1588 passed) are green. The three tests failing
locally — two mem0, one WeasyPrint — are environmental, touch files this branch does
not modify, and pass on CI.

Each new test for the cache and directory-resolution fixes was confirmed to fail
against the previous implementation before the fix was applied.
