### PR TITLE
docs(config): separate model selection from plain-text mode settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,17 +215,19 @@ for the canonical setup, model catalog, routing, and pricing behavior.
 ### Ollama plain-text mode
 
 AgentOS supports Ollama native tool calls. For a local model that does not
-reliably implement Ollama's tool-call protocol, disable model-visible tools and
-route directly to the configured model:
+reliably implement Ollama's tool-call protocol, select the model separately,
+then turn on plain-text mode.
+
+Check which models are installed with `ollama list`, then configure the
+provider and model:
+
+```sh
+agentos configure provider --provider ollama --model <your-local-model>
+```
+
+Then disable model-visible tools and the router in `agentos.toml`:
 
 ```toml
-agent_max_iterations = 8
-
-[llm]
-provider = "ollama"
-model = "qwen2.5:7b"
-base_url = "http://localhost:11434"
-
 [tools]
 enabled = false
 
@@ -233,10 +235,13 @@ enabled = false
 enabled = false
 ```
 
+For a remote or non-default host, set `base_url` under `[llm]` (e.g.
+`http://10.0.0.42:11434`).
+
 `tools.enabled = false` is a hard plain-text mode: no tool definitions are sent
-to the provider and no tool handler is exposed for the turn. Keep a positive
-`agent_max_iterations` when enabling tools on smaller local models so malformed
-or repetitive tool calls terminate predictably.
+to the provider and no tool handler is exposed for the turn. When you do enable
+tools on smaller local models, keep a positive `agent_max_iterations` so
+malformed or repetitive tool calls terminate predictably.
 
 ## Router Configuration
 


### PR DESCRIPTION
## Summary

The Ollama plain-text example in `docs/configuration.md` hardcoded `model = "qwen2.5:7b"` and `agent_max_iterations = 8`. Copying the snippet could overwrite a user's configured model or point at a model that is not installed locally, and the tool-loop cap is irrelevant while tools are disabled.

Model selection is now a separate step (`ollama list` + `agentos configure provider`), and the TOML block shows only the settings plain-text mode requires.

## Changes

- Point users at `ollama list` and `agentos configure provider --provider ollama --model <your-local-model>` to pick an installed model.
- Reduce the TOML snippet to just `[tools].enabled = false` and `[agentos_router].enabled = false`.
- Mention `base_url` under `[llm]` as an optional note for remote/non-default hosts instead of baking `http://localhost:11434` into the copy-paste block.
- Reword the `agent_max_iterations` guidance so it reads as advice for when tools *are* enabled.

Docs-only change; no code or CLI surface touched.

Closes #58

Supersedes #105 (closed) — same change, rebased on current `main`, with `agentos.toml` backticked to match the docs convention. Original authorship credited via `Co-authored-by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)