### PR TITLE
feat(skills): install Bankr skills published from bankr.bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Bankr skills published from bankr.bot — the ones that live under an author's
+  wallet address instead of in the `BankrBot/skills` repository — can now be
+  browsed and installed like any other hub skill, starting with
+  `stock-premium-lp-manager`. They arrive as JSON with the body inline, so the
+  `SKILL.md` is synthesized from the payload rather than downloaded from a
+  repository, and the skill is credited to its author rather than inheriting
+  Bankr's brand. As with the repository half, only allowlisted skills can be
+  installed through the Bankr source, so it cannot be used to pull an arbitrary
+  author's skill and record it as having come from Bankr's hub.
+
 ## [2026.7.28] - 2026-07-28
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -415,6 +415,7 @@ agentos skills list --json
 agentos skills search pdf
 agentos skills view pdf-toolkit
 agentos skills install <skill-name>
+agentos skills install <skill-url> --source bankr
 agentos skills update --all
 agentos skills uninstall <skill-name>
 ```

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -46,6 +46,27 @@ Some skills may be ineligible when optional dependencies are missing or when the
 skill is intentionally demo-only. `skills list` is the source of truth for your
 current install.
 
+### Where Search Results Come From
+
+`skills search` fans out to every configured source and merges the results. The
+Bankr source covers both places Bankr publishes: skills in the
+[BankrBot/skills](https://github.com/BankrBot/skills) repository, and skills
+published from bankr.bot, which live under their author's wallet address
+(`https://bankr.bot/skills/<wallet>/<slug>`) and are served with their body
+inline rather than as a repository directory. Both install the same way:
+
+```sh
+agentos skills install https://bankr.bot/skills/<wallet>/<slug> --source bankr
+```
+
+Each half carries a fixed allowlist, because neither has an index that can be
+crawled without tripping a rate limit — and because the source a skill arrives
+through is recorded as its provenance, so it must not be able to pull an
+arbitrary repository or another author's skill under Bankr's name. A skill
+published from a wallet is credited to its author, not to Bankr: it lists the
+author's handle and resolves to no recognized publisher, so it renders unbranded
+rather than sitting in the Partners group.
+
 ## How a Skill Is Described
 
 Four separate facts describe an installed skill. They are easy to confuse, and

--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -333,7 +333,8 @@ def skills_install(
         "--source",
         "-s",
         help=(
-            "Source (clawhub, github). GitHub accepts owner/repo, owner/repo:path, or GitHub URLs."
+            "Source (clawhub, github, bankr). GitHub accepts owner/repo, owner/repo:path, "
+            "or GitHub URLs. Bankr accepts a BankrBot/skills URL or a bankr.bot skill URL."
         ),
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Force install (skip security block)"),

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -249,6 +249,7 @@ agentos skills list                    # installed, per layer
 agentos skills search <query>
 agentos skills install <name>                    # from ClawHub (default source)
 agentos skills install owner/repo:path -s github # from a GitHub repo/URL
+agentos skills install <bankr-skill-url> -s bankr # from Bankr (repo or bankr.bot URL)
 agentos skills tap add owner/repo      # register a GitHub repo as a skill source
 agentos skills tap list
 agentos skills update

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -16,6 +16,14 @@ their ``catalog.json`` + ``SKILL.md`` directly and never calls the git-tree API.
 Only skills whose ``catalog.json`` declares ``install.type == "bankr"`` (i.e.
 they live in the repo and install directly) are listed. ``external`` skills —
 whose install runs a third-party command — are skipped.
+
+Bankr also hosts skills that never land in that repository: anyone can publish
+one from bankr.bot, where it lives under the author's wallet address and is
+served as JSON by ``api.bankr.bot/public/skills/<wallet>/<slug>`` — body and all.
+Those are carried by a second allowlist, ``_ALLOWED_USER_SKILLS``, and take a
+separate load/fetch path: there is no repository to clone and no
+``catalog.json``, so the SKILL.md is synthesized from the API payload instead of
+being downloaded through :class:`GitHubSource`.
 """
 
 from __future__ import annotations
@@ -25,6 +33,8 @@ import json
 import re
 import time
 from collections.abc import Sequence
+from dataclasses import dataclass
+from urllib.parse import unquote, urlparse
 
 import structlog
 
@@ -40,6 +50,24 @@ _DEFAULT_REF = "main"
 # and every skill's catalog.json + SKILL.md (~100 skills) trips GitHub's rate
 # limit (429); since the slugs are fixed we fetch just these directly.
 _ALLOWED_SLUGS: tuple[str, ...] = ("bankr", "bankr-token-scam-analysis")
+# Bankr-hosted skills published from bankr.bot rather than into the repository,
+# as ``<wallet>/<slug>``. Same reasoning as the repo allowlist — the registry has
+# no public index, so the entries are named here rather than crawled.
+_ALLOWED_USER_SKILLS: tuple[str, ...] = (
+    "0xd4fd8d6f0f64f3d0ba015b645ca8f8c13355c24a/stock-premium-lp-manager",
+)
+_USER_API_BASE = "https://api.bankr.bot/public/skills"
+_USER_PAGE_BASE = "https://bankr.bot/skills"
+_USER_HOSTS = {"bankr.bot", "www.bankr.bot"}
+_WALLET_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+# Mirrors the installer's safe-name rule, so an allowlisted slug can always be
+# used as the installed directory name.
+_USER_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+# The registry body is community-controlled; cap what we will turn into a
+# SKILL.md so a hostile payload cannot blow up a browse response or an install.
+_MAX_USER_CONTENT_CHARS = 256 * 1024
+_MAX_USER_DESCRIPTION_CHARS = 2000
+_MAX_USER_TAGS = 20
 # Brand avatar for Bankr cards. The catalogs ship ``logo: null`` and store their
 # emoji in SKILL.md frontmatter (in formats the browse layer can't reliably
 # parse), so browse cards fall back to this shared brand mark instead of a bare
@@ -84,13 +112,93 @@ _CATEGORY_KEYWORDS: list[tuple[str, frozenset[str]]] = [
 ]
 
 
-def _infer_category(slug: str, provider: str) -> str:
-    """Return a coarse category for browse filters, or "other" when unknown."""
-    tokens = set(_TOKEN_RE.findall(f"{slug} {provider}".lower()))
+def _infer_category(slug: str, provider: str, tags: Sequence[str] = ()) -> str:
+    """Return a coarse category for browse filters, or "other" when unknown.
+
+    ``tags`` is only carried by user-published skills — the repo catalogs have
+    none — and is folded into the same token set, so a skill whose slug says
+    nothing useful ("stock-premium-lp-manager") still lands in a real bucket.
+    """
+    haystack = " ".join([slug, provider, *tags]).lower()
+    tokens = set(_TOKEN_RE.findall(haystack))
     for category, keywords in _CATEGORY_KEYWORDS:
         if tokens & keywords:
             return category
     return "other"
+
+
+@dataclass(frozen=True)
+class _UserSkillRef:
+    """A skill published on bankr.bot, addressed by author wallet + slug."""
+
+    wallet: str
+    slug: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.wallet.lower()}/{self.slug.lower()}"
+
+    @property
+    def api_url(self) -> str:
+        return f"{_USER_API_BASE}/{self.wallet}/{self.slug}"
+
+    @property
+    def page_url(self) -> str:
+        return f"{_USER_PAGE_BASE}/{self.wallet}/{self.slug}"
+
+
+def _parse_user_identifier(identifier: str) -> _UserSkillRef | None:
+    """Parse a bankr.bot skill URL (or a bare ``<wallet>/<slug>``).
+
+    Returns ``None`` for anything that is not shaped like a Bankr user skill,
+    including a wallet that is not a 40-hex address or a slug that could not be
+    used as a directory name — those are rejected here rather than at install
+    time, so a malformed identifier never reaches the network.
+    """
+    raw = identifier.strip()
+    if raw.startswith("bankr.bot/") or raw.startswith("www.bankr.bot/"):
+        raw = "https://" + raw
+
+    if raw.startswith(("http://", "https://")):
+        parsed = urlparse(raw)
+        if parsed.netloc.lower() not in _USER_HOSTS:
+            return None
+        parts = [unquote(part) for part in parsed.path.split("/") if part]
+        if len(parts) != 3 or parts[0] != "skills":
+            return None
+        wallet, slug = parts[1], parts[2]
+    else:
+        parts = raw.split("/")
+        if len(parts) != 2:
+            return None
+        wallet, slug = parts
+
+    if not _WALLET_RE.match(wallet) or not _USER_SLUG_RE.match(slug):
+        return None
+    return _UserSkillRef(wallet=wallet, slug=slug)
+
+
+def _user_skill_markdown(name: str, description: str, tags: Sequence[str], content: str) -> str:
+    """Return SKILL.md text for a registry payload that ships only a body.
+
+    The public API keeps name/description/tags beside the markdown, but every
+    consumer downstream (installer, loader, scanner) expects one file with
+    frontmatter — so synthesize it. A body that already carries its own block is
+    returned unchanged rather than nested inside a second one.
+    """
+    import yaml
+
+    body = content.lstrip("\n")
+    if body.startswith("---") and body.find("\n---", 3) != -1:
+        return body
+
+    front = yaml.safe_dump(
+        {"name": name, "description": description, "tags": list(tags)},
+        sort_keys=False,
+        allow_unicode=True,
+        width=4096,
+    )
+    return f"---\n{front}---\n\n{body}"
 
 
 def _matches(meta: SkillMeta, query: str) -> bool:
@@ -113,11 +221,19 @@ class BankrSource(SkillSource):
         repo: str = _DEFAULT_REPO,
         ref: str = _DEFAULT_REF,
         allowlist: Sequence[str] = _ALLOWED_SLUGS,
+        user_allowlist: Sequence[str] = _ALLOWED_USER_SKILLS,
     ) -> None:
         self._github = GitHubSource(token=token)
         self._repo = repo
         self._ref = ref
         self._allowlist = tuple(allowlist)
+        # Malformed entries are dropped at construction rather than surviving as
+        # strings that can never match — an allowlist that silently accepts a
+        # typo is worse than one that is short.
+        self._user_refs = tuple(
+            ref_ for ref_ in (_parse_user_identifier(entry) for entry in user_allowlist) if ref_
+        )
+        self._user_keys = frozenset(ref_.key for ref_ in self._user_refs)
         self._raw_base = f"https://raw.githubusercontent.com/{repo}/{ref}"
         self._cache_metas: list[SkillMeta] | None = None
         self._cache_at = 0.0
@@ -160,13 +276,37 @@ class BankrSource(SkillSource):
             return False
         return ref.skill_dir.strip("/") in self._allowlist
 
+    def _allowlisted_user_ref(self, identifier: str) -> _UserSkillRef | None:
+        """Return the user-skill this identifier names, when it is allowlisted.
+
+        Same boundary as :meth:`_is_allowlisted`, for the registry half of the
+        source: bankr.bot serves every published skill from one host, so without
+        this gate ``skills.install(source="bankr")`` could pull any author's
+        skill and record it as having come through Bankr's hub.
+        """
+        ref = _parse_user_identifier(identifier)
+        if ref is None or ref.key not in self._user_keys:
+            return None
+        return ref
+
     async def inspect(self, identifier: str) -> SkillMeta | None:
+        user_ref = self._allowlisted_user_ref(identifier)
+        if user_ref is not None:
+            loaded = await self._load_user_skill(user_ref)
+            return loaded[0] if loaded else None
         if not self._is_allowlisted(identifier):
             log.warning("bankr.identifier_rejected", op="inspect")
             return None
         return await self._github.inspect(identifier)
 
     async def fetch(self, identifier: str) -> SkillBundle | None:
+        user_ref = self._allowlisted_user_ref(identifier)
+        if user_ref is not None:
+            loaded = await self._load_user_skill(user_ref)
+            if loaded is None:
+                return None
+            meta, skill_md = loaded
+            return SkillBundle(name=user_ref.slug, files={"SKILL.md": skill_md}, meta=meta)
         if not self._is_allowlisted(identifier):
             log.warning("bankr.identifier_rejected", op="fetch")
             return None
@@ -202,7 +342,7 @@ class BankrSource(SkillSource):
         """
         import httpx
 
-        if not self._allowlist:
+        if not self._allowlist and not self._user_refs:
             return []
 
         try:
@@ -213,7 +353,15 @@ class BankrSource(SkillSource):
                     async with sem:
                         return await self._load_catalog_entry(client, slug)
 
-                loaded = await asyncio.gather(*(_load_one(s) for s in self._allowlist))
+                async def _load_user(ref: _UserSkillRef) -> SkillMeta | None:
+                    async with sem:
+                        loaded = await self._load_user_entry(client, ref)
+                        return loaded[0] if loaded else None
+
+                loaded = await asyncio.gather(
+                    *(_load_one(s) for s in self._allowlist),
+                    *(_load_user(r) for r in self._user_refs),
+                )
         except Exception as exc:
             log.warning("bankr.fetch_failed", error=str(exc))
             return None
@@ -256,6 +404,81 @@ class BankrSource(SkillSource):
         skill_md_url = f"{self._raw_base}/{slug}/SKILL.md"
         meta.description = await self._load_description(client, slug, skill_md_url, headers)
         return meta
+
+    async def _load_user_skill(self, ref: _UserSkillRef) -> tuple[SkillMeta, str] | None:
+        """Load one bankr.bot skill on its own client (inspect/fetch entry point)."""
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(timeout=15, trust_env=_trust_env()) as client:
+                return await self._load_user_entry(client, ref)
+        except Exception as exc:
+            log.warning("bankr.user_fetch_failed", slug=ref.slug, error=str(exc))
+            return None
+
+    async def _load_user_entry(self, client, ref: _UserSkillRef) -> tuple[SkillMeta, str] | None:
+        """Fetch one registry payload and return its (meta, SKILL.md) pair.
+
+        Deliberately unauthenticated: the public endpoint needs no credentials,
+        and the GitHub token this source carries for the repo half has no
+        business being sent to a different host.
+        """
+        try:
+            resp = await client.get(ref.api_url)
+            resp.raise_for_status()
+            payload = json.loads(resp.content)
+        except Exception as exc:
+            log.warning("bankr.user_skill_failed", slug=ref.slug, error=str(exc))
+            return None
+        return self._user_document(ref, payload)
+
+    def _user_document(self, ref: _UserSkillRef, payload: object) -> tuple[SkillMeta, str] | None:
+        """Build (meta, SKILL.md) from a registry payload, or ``None`` if unusable."""
+        if not isinstance(payload, dict) or payload.get("success") is False:
+            return None
+        skill = payload.get("skill")
+        if not isinstance(skill, dict):
+            return None
+
+        content = skill.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return None
+        if len(content) > _MAX_USER_CONTENT_CHARS:
+            log.warning("bankr.user_skill_oversized", slug=ref.slug, chars=len(content))
+            return None
+
+        description = str(skill.get("description") or "")[:_MAX_USER_DESCRIPTION_CHARS]
+        raw_tags = skill.get("tags")
+        tags = (
+            [str(tag)[:64] for tag in raw_tags[:_MAX_USER_TAGS]]
+            if isinstance(raw_tags, list)
+            else []
+        )
+        raw_author = skill.get("author")
+        author = raw_author if isinstance(raw_author, dict) else {}
+        # The author, not Bankr: a wallet-published skill is community work that
+        # happens to be distributed through Bankr's registry, so it lists its
+        # author and resolves to no recognized publisher (see
+        # ``agentos.skills.publishers``) rather than inheriting Bankr's brand.
+        provider = str(author.get("handle") or author.get("displayName") or "")
+
+        meta = SkillMeta(
+            name=ref.slug,
+            description=description,
+            source_id=self.source_id,
+            trust_level=self.trust_level,
+            identifier=ref.page_url,
+            homepage=ref.page_url,
+            provider=provider,
+            # Author avatars are served from a third-party CDN the console's CSP
+            # does not allow (``img-src 'self' … raw.githubusercontent.com``), so
+            # cards use the Bankr brand mark instead of a broken image.
+            logo="",
+            emoji=_BANKR_EMOJI,
+            category=_infer_category(ref.slug, provider, tags),
+            tags=tags,
+        )
+        return meta, _user_skill_markdown(ref.slug, description, tags, content)
 
     async def _load_description(self, client, slug: str, url: str, headers: dict) -> str:
         """Fetch SKILL.md and read its frontmatter description. Empty on error."""

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -5,12 +5,19 @@ from typing import Any
 
 import pytest
 
-from agentos.skills.hub.bankr import _ALLOWED_SLUGS, BankrSource
+from agentos.skills.hub.bankr import _ALLOWED_SLUGS, _ALLOWED_USER_SKILLS, BankrSource
 
 # The fake catalog exercises the filtering paths (installable / external /
 # malformed). We hand BankrSource this slug set via ``allowlist=`` so the source
 # fetches exactly these directly — no repo tree crawl.
 _FIXTURE_SLUGS = ("alchemy", "bankr", "extern", "broken")
+
+# A skill published on bankr.bot rather than into BankrBot/skills: addressed by
+# author wallet, served as JSON with the body inline.
+_USER_WALLET = "0x" + "ab" * 20
+_USER_SLUG = "range-lp-manager"
+_USER_IDENT = f"https://bankr.bot/skills/{_USER_WALLET}/{_USER_SLUG}"
+_USER_API_PREFIX = f"https://api.bankr.bot/public/skills/{_USER_WALLET}/"
 
 
 def _catalog(slug: str, *, install_type: str = "bankr", logo: str | None = None) -> bytes:
@@ -26,6 +33,27 @@ def _catalog(slug: str, *, install_type: str = "bankr", logo: str | None = None)
             "install": {"type": install_type, "repoPath": slug},
         }
     ).encode("utf-8")
+
+
+def _user_payload(
+    *,
+    content: str = "# Range LP\n\nPlace and rebalance concentrated liquidity.\n",
+    **overrides: Any,
+) -> bytes:
+    skill: dict[str, Any] = {
+        "slug": _USER_SLUG,
+        "name": _USER_SLUG,
+        "description": "Manage range liquidity — premium aware.",
+        "tags": ["defi", "liquidity"],
+        "content": content,
+        "author": {
+            "walletAddress": _USER_WALLET,
+            "displayName": "Jane Doe",
+            "handle": "@janedoe",
+        },
+    }
+    skill.update(overrides)
+    return json.dumps({"success": True, "skill": skill}).encode("utf-8")
 
 
 class _Response:
@@ -102,7 +130,8 @@ def _reset_client_counters() -> None:
 
 
 def _source() -> BankrSource:
-    return BankrSource(allowlist=_FIXTURE_SLUGS)
+    """Repo-half source: the registry allowlist is exercised separately below."""
+    return BankrSource(allowlist=_FIXTURE_SLUGS, user_allowlist=())
 
 
 @pytest.mark.asyncio
@@ -258,7 +287,7 @@ async def test_all_entries_failing_returns_empty_without_raising(monkeypatch) ->
 
 
 class _DefaultAllowlistClient(_AsyncClient):
-    """Serves only the two real default slugs."""
+    """Serves the real default slugs plus the default registry skill."""
 
     catalogs = {
         "bankr": _catalog("bankr", logo=None),
@@ -271,20 +300,34 @@ class _DefaultAllowlistClient(_AsyncClient):
         ),
     }
 
+    async def get(self, url: str, **kwargs: Any) -> _Response:
+        if url.startswith("https://api.bankr.bot/public/skills/"):
+            slug = url.rsplit("/", 1)[-1]
+            return _Response(content=_user_payload(slug=slug, name=slug))
+        return await super().get(url, **kwargs)
+
 
 @pytest.mark.asyncio
-async def test_default_allowlist_loads_only_two_skills(monkeypatch) -> None:
+async def test_default_allowlist_loads_the_shipped_repo_and_registry_skills(monkeypatch) -> None:
     import httpx
 
     monkeypatch.setattr(httpx, "AsyncClient", _DefaultAllowlistClient)
 
-    # Default (no allowlist arg) → exactly the two Bankr slugs, nothing else.
+    # Defaults (no allowlist args) → exactly these, nothing else.
     assert _ALLOWED_SLUGS == ("bankr", "bankr-token-scam-analysis")
+    assert _ALLOWED_USER_SKILLS == (
+        "0xd4fd8d6f0f64f3d0ba015b645ca8f8c13355c24a/stock-premium-lp-manager",
+    )
 
     results = await BankrSource().search("")
 
-    assert {r.name for r in results} == {"bankr", "bankr-token-scam-analysis"}
-    # Two skills → two catalog.json + two SKILL.md fetches, and no tree crawl.
+    assert {r.name for r in results} == {
+        "bankr",
+        "bankr-token-scam-analysis",
+        "stock-premium-lp-manager",
+    }
+    # Two repo skills → two catalog.json + two SKILL.md fetches, no tree crawl.
+    # The registry skill needs neither: its payload carries the body inline.
     assert _DefaultAllowlistClient.catalog_calls == 2
     assert _DefaultAllowlistClient.skill_md_calls == 2
 
@@ -354,6 +397,227 @@ async def test_install_path_refuses_identifiers_outside_the_allowlist(
     assert await src.inspect(identifier) is None
     # The delegate is never reached — nothing is downloaded.
     assert calls == []
+
+
+# ── Registry half: skills published on bankr.bot, not into BankrBot/skills ───
+
+
+class _UserSkillClient(_AsyncClient):
+    """Serves the public registry endpoint; repo URLs fall through to the base."""
+
+    payload = _user_payload()
+    user_calls = 0
+    last_kwargs: dict[str, Any] = {}
+
+    async def get(self, url: str, **kwargs: Any) -> _Response:
+        if url.startswith("https://api.bankr.bot/public/skills/"):
+            type(self).user_calls += 1
+            type(self).last_kwargs = kwargs
+            if url != _USER_API_PREFIX + _USER_SLUG:
+                return _Response(status_code=404)
+            return _Response(content=self.payload)
+        return await super().get(url, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _reset_user_counters() -> None:
+    _UserSkillClient.user_calls = 0
+    _UserSkillClient.last_kwargs = {}
+    _UserSkillClient.payload = _user_payload()
+
+
+def _user_source() -> BankrSource:
+    return BankrSource(
+        token="github-token",
+        allowlist=(),
+        user_allowlist=(f"{_USER_WALLET}/{_USER_SLUG}",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_registry_skill_is_listed_with_author_tags_and_page_identifier(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+
+    results = await _user_source().search("")
+
+    assert len(results) == 1
+    meta = results[0]
+    assert meta.name == _USER_SLUG
+    assert meta.source_id == "bankr"
+    assert meta.trust_level == "community"
+    assert meta.description == "Manage range liquidity — premium aware."
+    assert meta.tags == ["defi", "liquidity"]
+    # The author is credited, not Bankr — a wallet-published skill must not
+    # resolve to the Bankr publisher record.
+    assert meta.provider == "@janedoe"
+    # No catalog.json to declare a category, so the tags supply one.
+    assert meta.category == "defi"
+    assert meta.identifier == _USER_IDENT
+    assert meta.homepage == _USER_IDENT
+    # No avatar URL: the console's CSP would block the author's CDN image.
+    assert meta.logo == ""
+    assert meta.emoji == "📺"
+
+
+@pytest.mark.asyncio
+async def test_registry_skill_is_searchable_by_tag_and_author(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+
+    src = _user_source()
+
+    assert [r.name for r in await src.search("liquidity")] == [_USER_SLUG]
+    assert [r.name for r in await src.search("janedoe")] == [_USER_SLUG]
+    assert await src.search("nothing-matches-this") == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_registry_skill_synthesizes_skill_md_frontmatter(monkeypatch) -> None:
+    import httpx
+    import yaml
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+
+    async def _unreachable(self: Any, identifier: str) -> Any:
+        raise AssertionError("registry skills must not be fetched through GitHub")
+
+    from agentos.skills.hub.github import GitHubSource
+
+    monkeypatch.setattr(GitHubSource, "fetch", _unreachable)
+
+    bundle = await _user_source().fetch(_USER_IDENT)
+
+    assert bundle is not None
+    assert bundle.name == _USER_SLUG
+    assert set(bundle.files) == {"SKILL.md"}
+    md = bundle.skill_md
+    assert md is not None and md.startswith("---\n")
+
+    front_text, _, body = md[4:].partition("\n---\n")
+    front = yaml.safe_load(front_text)
+    assert front["name"] == _USER_SLUG
+    assert front["description"] == "Manage range liquidity — premium aware."
+    assert front["tags"] == ["defi", "liquidity"]
+    # The body the registry served is preserved verbatim underneath.
+    assert body.strip().startswith("# Range LP")
+    assert "concentrated liquidity" in body
+    assert bundle.meta is not None and bundle.meta.identifier == _USER_IDENT
+
+
+@pytest.mark.asyncio
+async def test_registry_fetch_does_not_send_the_github_token(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+
+    await _user_source().fetch(_USER_IDENT)
+
+    # api.bankr.bot is a different host than the repo half authenticates
+    # against — the GitHub token has no business being sent there.
+    assert _UserSkillClient.user_calls == 1
+    assert not _UserSkillClient.last_kwargs.get("headers")
+
+
+@pytest.mark.asyncio
+async def test_inspect_registry_skill_returns_meta_without_github(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+
+    async def _unreachable(self: Any, identifier: str) -> Any:
+        raise AssertionError("registry skills must not be inspected through GitHub")
+
+    from agentos.skills.hub.github import GitHubSource
+
+    monkeypatch.setattr(GitHubSource, "inspect", _unreachable)
+
+    meta = await _user_source().inspect(_USER_IDENT)
+
+    assert meta is not None
+    assert meta.name == _USER_SLUG
+    assert meta.identifier == _USER_IDENT
+
+
+@pytest.mark.asyncio
+async def test_body_that_already_has_frontmatter_is_not_nested(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+    authored = "---\nname: authored\ndescription: Written by hand\n---\n\n# Authored\n"
+    _UserSkillClient.payload = _user_payload(content=authored)
+
+    bundle = await _user_source().fetch(_USER_IDENT)
+
+    assert bundle is not None
+    assert bundle.skill_md == authored
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(b"{ not json", id="malformed-json"),
+        pytest.param(json.dumps({"success": False}).encode(), id="unsuccessful"),
+        pytest.param(json.dumps({"success": True}).encode(), id="no-skill-object"),
+        pytest.param(_user_payload(content=""), id="empty-body"),
+        pytest.param(_user_payload(content="x" * (256 * 1024 + 1)), id="oversized-body"),
+    ],
+)
+async def test_unusable_registry_payloads_are_dropped(monkeypatch, payload: bytes) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+    _UserSkillClient.payload = payload
+
+    src = _user_source()
+
+    assert await src.search("") == []
+    assert await src.fetch(_USER_IDENT) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        # Another author's skill on the same host — the laundering case.
+        f"https://bankr.bot/skills/{'0x' + 'cd' * 20}/{_USER_SLUG}",
+        # The allowlisted author, but a skill they did not get listed for.
+        f"https://bankr.bot/skills/{_USER_WALLET}/some-other-skill",
+        # A look-alike host.
+        f"https://bankr.bot.evil.example/skills/{_USER_WALLET}/{_USER_SLUG}",
+        # Path traversal in the slug, and a wallet that is not an address.
+        f"https://bankr.bot/skills/{_USER_WALLET}/../../etc/passwd",
+        f"https://bankr.bot/skills/not-a-wallet/{_USER_SLUG}",
+    ],
+)
+async def test_registry_install_path_refuses_identifiers_outside_the_allowlist(
+    monkeypatch, identifier: str
+) -> None:
+    """bankr.bot serves every published skill from one host, so the source must
+    gate on the exact wallet/slug pair — otherwise any author's skill could be
+    installed with ``source="bankr"`` and inherit the hub's provenance."""
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _UserSkillClient)
+
+    src = _user_source()
+
+    assert await src.fetch(identifier) is None
+    assert await src.inspect(identifier) is None
+    # Rejected before the network, not after.
+    assert _UserSkillClient.user_calls == 0
+
+
+def test_malformed_user_allowlist_entries_are_dropped_at_construction() -> None:
+    src = BankrSource(
+        allowlist=(),
+        user_allowlist=("not-a-wallet/slug", "0xzz/bad", f"{_USER_WALLET}/{_USER_SLUG}"),
+    )
+
+    assert [ref.key for ref in src._user_refs] == [f"{_USER_WALLET}/{_USER_SLUG}"]
 
 
 def test_default_router_exposes_bankr_source(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #149.

## What was in the way

`stock-premium-lp-manager` is not in `BankrBot/skills` — the repository the Bankr source reads. It is published from bankr.bot, where a skill lives under its author's wallet address and is served by `api.bankr.bot/public/skills/<wallet>/<slug>` as JSON with the body inline. There is no repository to clone and no `catalog.json`, so adding the slug to `_ALLOWED_SLUGS` just 404s and the skill is dropped silently; the install path rejects it too, because the identifier does not resolve to the allowlisted repo.

## What this does

Carries those skills on a second allowlist (`_ALLOWED_USER_SKILLS`, as `<wallet>/<slug>`) with their own load path:

- **Browse** — the catalog load fans out to both halves on one client, so a registry skill appears in the Bankr tab beside the repository ones. Its tags feed both search matching and the category inference, so a slug that says nothing useful still lands in a real bucket (`stock-premium-lp-manager` → `defi`).
- **Install** — the `SKILL.md` is synthesized from the payload: frontmatter from the JSON fields, body verbatim. A body that already ships its own frontmatter is passed through rather than nested inside a second block. Everything downstream (quarantine, scan, lockfile, loader) is unchanged.
- **Identifier** — the page URL the user actually has: `https://bankr.bot/skills/<wallet>/<slug>`.

## Boundaries

- **The install gate is the point.** bankr.bot serves every published skill from one host, so an ungated source would let `skills.install(identifier=…, source="bankr")` pull any author's skill and record it as having come through Bankr's hub. `fetch`/`inspect` match the exact wallet/slug pair before any network call — same reasoning as the existing repo-side gate, and covered by the same style of test (other wallet, unlisted slug, look-alike host, traversal in the slug, non-address wallet).
- **No brand inheritance.** A wallet-published skill is credited to its author (`@handle`) and resolves to no recognized publisher, so it renders as an ordinary unbranded skill rather than sitting in the Partners group next to Bankr's own.
- **No token leak.** The registry request is unauthenticated; the GitHub token the repo half carries is never sent to `api.bankr.bot`.
- **No CSP widening.** Author avatars live on a third-party CDN that `img-src 'self' data: https://raw.githubusercontent.com` does not allow, so cards keep the Bankr brand mark instead of rendering a broken image.
- **Bounded payloads.** Body, description, and tag count are capped — this is community-controlled text on a browse path.

## Verification

- `uv run pytest -q` — 6603 passed, 27 skipped.
- 15 new tests in `tests/test_skills_hub_bankr.py` (listing, tag/author search, frontmatter synthesis, pass-through of an authored block, unusable payloads, the allowlist gate, no-token assertion). All offline.
- Checked against the live endpoint and through a real install into temp dirs: fetch → scan (`safe`) → install → lockfile, with `publisher_id` resolving to nothing recognized as intended.

Docs: `docs/features/skills.md` gains a short section on where search results come from; `docs/cli.md`, the bundled `agentos` skill, and the `--source` help text now mention `bankr` and the URL forms it accepts. Changelog entry under `[Unreleased]`.
