### PR TITLE
docs(security): reject audit reports as PRs and state no bounty program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,20 @@ Helpful reports include:
 - Reproduction steps using placeholders instead of real credentials.
 - Expected impact and any known mitigations.
 
+## Audit Reports and Scanner Output
+
+Do not submit audit reports, scanner output, or security review documents as pull
+requests. A report pinned to a commit goes stale in the tree within weeks with
+nothing to keep it honest, and a document committed to this repository reads as
+maintainer-endorsed regardless of who wrote it.
+
+Route those findings through the private advisory link above. We triage every
+finding against `main` and reply with a per-finding verdict.
+
+There is no bug bounty or paid reward program for AgentOS, and none is planned.
+Researchers whose reports lead to a fix are credited in the release notes for that
+fix, under whichever name they prefer.
+
 ## Handling
 
 Maintainers will acknowledge valid reports, triage severity, prepare a fix on a


### PR DESCRIPTION
## Summary

Adds an "Audit Reports and Scanner Output" section to `SECURITY.md`.

Prompted by #146, where an external contributor opened a PR adding a point-in-time
`SECURITY_AUDIT.md` at the repository root. The existing policy covers where to send
vulnerability *details*, but said nothing about audit *documents*, whether a reward
program exists, or how researchers get credited — so there was no written policy to
point at when declining it.

The new section covers all three:

- Audit reports and scanner output go through the private advisory form, not a PR.
  A report pinned to a commit goes stale in the tree within weeks, and a document
  committed here reads as maintainer-endorsed regardless of who wrote it.
- There is no bug bounty or paid reward program, and none is planned. This question
  comes up in most external reports; better answered once in the policy.
- Researchers whose reports lead to a fix are credited in that fix's release notes,
  under whichever name they prefer.

Docs-only. No behavior change.

Refs #146

## Tests

```
uv run pytest tests/test_public_release_hygiene.py -q   # 15 passed
uv run ruff check src tests                             # All checks passed!
```

`test_security_policy_routes_vulnerability_reports_privately` is the guard that pins
this file's wording — it still passes, and the added text does not reintroduce the
phrase it asserts against.

The rest of the quality gate (mypy, full pytest, wheel build, frontend checks) is
unaffected — this touches a single Markdown file and no Python, TypeScript, or
packaging input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
