### PR TITLE
fix(skills): make the skills block something the model can act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Native support for Capminal Skills (`Capminal/agent-skills`) in the Skills hub: browse, inspect, and install allowlisted Capminal skills with publisher branding.
 
+### Fixed
+
+- The agent could not tell which of its installed skills applied to a request,
+  and answered from general knowledge instead. Four separate causes, each of
+  which alone was enough to produce that:
+
+  - The prompt budget was a cliff. One skill over it and *every* description in
+    the block was dropped for a name-only list — a 27k render fell to 3.5k
+    against a 24k budget, so 20k of the configured allowance bought nothing and
+    the model had never seen a single description. Descriptions are now
+    shortened to the longest length that fits (the widest, not the first that
+    works: 451 chars where a fixed step would have settled for 320), and skills
+    are only dropped once even a names-only list overruns. A default install
+    was unaffected; the cliff was reached by installing skills, which is
+    backwards.
+  - Names-only mode told the model to call `skill_view` on every entry that
+    might be relevant — up to one call per skill, which no model will do — and
+    never mentioned `skill_list`, which returns every description in one call.
+    It now points at `skill_list`, and only when the session actually has it.
+  - With prompt caching on (the default), the block was delivered as a *user*
+    message headed "not a user request … use it only when it is relevant",
+    contradicting its own "read this before answering" from the weakest
+    position in the request. When the skill list is the same every turn
+    (relevance filtering off, the default) it now belongs to the cacheable
+    system prompt instead, which is also where it is cheapest.
+  - Scheduled (cron) turns received the block but not `skill_view` or
+    `skill_list`, so following it was impossible. Both tools — read-only — are
+    now on the cron allowlist.
+
+- A skills block that quietly lost its descriptions was indistinguishable from
+  an operator uninstalling skills: nothing was reported as dropped and the
+  character count simply fell. Each turn now records `skills_render_mode` and
+  `skills_description_max_chars` in the decision log, and any render below
+  `full` is logged as `skills_filter.budget_degraded` with what to change.
+
 ## [2026.7.29] - 2026-07-29
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,19 +128,42 @@ prompt. `[skills].max_skills_prompt_chars` caps how large that block may get:
 max_skills_prompt_chars = 24000
 ```
 
-The budget is spent in three stages. Under it, each skill is listed with its
-description. Over it, the block falls back to names only. Over it even then,
-skills are dropped, lowest-precedence layer first — `extra` (the directories
-you listed in `skills.extra_dirs`), then `bundled`, and only then `managed`,
-`personal`, `project`, `workspace`. A drop is logged as
+The budget degrades one step at a time, so overrunning it by one skill costs a
+little description text rather than every description in the block:
+
+| Step | `skills_render_mode` | What the agent sees |
+| --- | --- | --- |
+| Fits | `full` | Every skill, full description |
+| Over | `full_truncated` | Every skill, descriptions shortened to the longest length that fits (floor 120 chars) |
+| Over even at 120 | `compact` | Names only, plus a pointer to `skill_list` |
+| Still over | `compact_truncated` | Fewer names |
+
+The shortened length is the widest one that fits, not a fixed step, so the block
+spends the budget you gave it rather than settling well under it. The agent is
+told the descriptions are shortened and where to read the full text.
+
+Only the last step drops skills, and it drops the lowest-precedence layer first
+— `extra` (the directories you listed in `skills.extra_dirs`), then `bundled`,
+and only then `managed`, `personal`, `project`, `workspace`. A drop is logged as
 `skills_filter.budget_truncated` with the names, and the affected skills report
-a `prompt_budget` reason on the Skills screen.
+a `prompt_budget` reason on the Skills screen. Any step below `full` is logged
+as `skills_filter.budget_degraded` and recorded per turn as
+`skills_render_mode` in the decision log, because a block that quietly lost its
+descriptions used to be indistinguishable from one with fewer skills in it.
 
 The default of 24000 is sized so a default install lists every bundled skill
-*with* its description and still has room for skills you add. Lower it only if
-you are running a model with a small context window: the whole-request ceiling
-on a model below roughly 64k tokens can be smaller than this budget, in which
-case the skills block alone would not fit.
+*with* its description and still has room for roughly 17 skills you add — past
+that, descriptions start being shortened. If `skills_render_mode` is not `full`
+and you have context to spare, raise the budget; the alternative is
+`skills.filter_enabled`, which injects only the skills relevant to each message
+and so needs far less room. Lower it only if you are running a model with a
+small context window: the whole-request ceiling on a model below roughly 64k
+tokens can be smaller than this budget, in which case the skills block alone
+would not fit.
+
+With `filter_enabled = false` the list is identical on every turn, so it is
+injected as part of the cacheable system prompt. With filtering on it is re-picked
+per message and is kept out of the cached prefix instead.
 
 ```sh
 agentos config get skills.max_skills_prompt_chars

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -271,18 +271,34 @@ it. Guessing from the layer or from "it says ready" is what makes this hard.
    shipped skills quietly disappearing while what you installed into
    `managed`, `personal`, `project`, or `workspace` survives.
 
-5. **`not_retrieved`.** Only reachable when `skills.filter_enabled = true`,
+5. **The agent ignores skills, but nothing reports `prompt_budget`.** The block
+   fits, so no skill was dropped — but the budget was tight enough that the
+   descriptions were shortened, or replaced by names alone. A name is rarely
+   enough for the model to tell that a skill applies, so the symptom is an agent
+   that answers from general knowledge with every skill still listed as offered.
+   Check the render mode:
+
+   ```sh
+   grep skills_render_mode ~/.agentos/logs/decisions-*.jsonl | tail -1
+   ```
+
+   Anything other than `full` means the budget cost the model description text,
+   and the gateway logged `skills_filter.budget_degraded` when it happened.
+   Raise `skills.max_skills_prompt_chars`, or turn on `skills.filter_enabled` so
+   only the skills relevant to each message are injected.
+
+6. **`not_retrieved`.** Only reachable when `skills.filter_enabled = true`,
    which is off by default. Raise `skills.filter_top_k` or reword the request;
    the answer depends on the wording of that one message.
 
-6. **`tool_gate` or `fallback_superseded`.** These are about the session's
+7. **`tool_gate` or `fallback_superseded`.** These are about the session's
    tools, not the skill. The first means a tool the skill needs is not enabled;
    the second means AgentOS already has a native tool that does the job better.
 
-7. **`model_invocation_disabled`.** Working as declared. The skill opted out of
+8. **`model_invocation_disabled`.** Working as declared. The skill opted out of
    model invocation and is for you to run, not the agent.
 
-8. If none of the above applies, ask for the outcome in normal language. Skill
+9. If none of the above applies, ask for the outcome in normal language. Skill
    names can help, but user intent should still be clear.
 
 ---

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -4702,6 +4702,10 @@ class TurnRunner:
                 tools_schema_chars=prompt_report.tools_schema_chars if prompt_report else 0,
                 skill_count=prompt_report.skill_count if prompt_report else 0,
                 skills_prompt_chars=prompt_report.skills_prompt_chars if prompt_report else 0,
+                skills_render_mode=(prompt_report.skills_render_mode if prompt_report else None),
+                skills_description_max_chars=(
+                    prompt_report.skills_description_max_chars if prompt_report else None
+                ),
                 memory_md_present=prompt_report.memory_md_present if prompt_report else False,
                 daily_notes_omitted=(prompt_report.daily_notes_omitted if prompt_report else False),
                 daily_notes_count_before_omit=(

--- a/src/agentos/engine/steps/skills_filter.py
+++ b/src/agentos/engine/steps/skills_filter.py
@@ -10,7 +10,7 @@ import structlog
 from agentos.engine.pipeline import TurnContext
 from agentos.skills.availability import gate_skills, plan_injection, retrieval_availability
 from agentos.skills.eligibility import EligibilityContext
-from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
+from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS, RENDER_MODE_FULL
 from agentos.skills.retrieval import HybridRetriever, Strategy
 
 log = structlog.get_logger(__name__)
@@ -129,7 +129,15 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
     else:
         base, suffix = ctx.system_prompt
 
-    plan = plan_injection(final, max_chars, injection_mode)
+    plan = plan_injection(
+        final,
+        max_chars,
+        injection_mode,
+        # Which route back to the descriptions the block advertises has to match
+        # the live tool surface: cron agents run under an allowlist, so pointing
+        # them at a tool they do not have is worse than saying nothing.
+        skill_list_tool="skill_list" in available_tools,
+    )
     skills_prompt, dropped = plan.prompt, plan.dropped
     availability.update(plan.availability)
 
@@ -155,6 +163,12 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
     ctx.metadata["skills_prompt_chars"] = len(skills_prompt)
     ctx.metadata["skills_injection_mode"] = injection_mode
     ctx.metadata["skills_dropped_for_budget"] = dropped
+    # How the block was rendered, not just how big it came out. A budget that
+    # silently threw away every description reported an empty `dropped` list and
+    # a smaller char count — indistinguishable from the operator uninstalling
+    # skills, which is how it went unnoticed across every turn of an install.
+    ctx.metadata["skills_render_mode"] = plan.mode
+    ctx.metadata["skills_description_max_chars"] = plan.description_max_chars
     # One entry per loaded skill: offered, or the reason it is not. Same map the
     # RPC surface builds from the same two functions.
     ctx.metadata["skill_availability"] = availability
@@ -165,6 +179,18 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
             dropped=dropped,
             budget=max_chars,
             kept=len(injected),
+        )
+    elif plan.mode != RENDER_MODE_FULL and injection_mode != "user_message":
+        # "user_message" renders compact by configuration, not under budget
+        # pressure, so the same warning there would be noise on every turn and
+        # its advice — raise the budget — would not change anything.
+        log.warning(
+            "skills_filter.budget_degraded",
+            mode=plan.mode,
+            description_max_chars=plan.description_max_chars,
+            budget=max_chars,
+            skills=len(injected),
+            hint="raise skills.max_skills_prompt_chars or enable skills.filter_enabled",
         )
 
     # Surface the actual skill IDs the retriever picked. Without this,
@@ -197,7 +223,25 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
 
     if skills_prompt and injection_mode == "user_context":
         ctx.metadata["skills_context_prompt"] = skills_prompt
+    elif skills_prompt and not filter_enabled:
+        # The block belongs in the cacheable base, not the dynamic suffix.
+        # Downstream, an enabled prompt cache splits a (base, dynamic) prompt by
+        # sending base as the system message and the dynamic half as a *user*
+        # message headed "not a user request ... use it only when it is
+        # relevant" — which is the weakest position in the request and directly
+        # contradicts the block's own "read this before answering". Skills are
+        # instructions, so they have to stay system-role.
+        #
+        # Putting them in the cached half is also the cheaper choice: with
+        # relevance filtering off the list is the same on every turn, so paying
+        # to re-send it uncached bought nothing. It only busts the cached prefix
+        # when the offered set genuinely changes — an install, a removal, or a
+        # skill becoming eligible.
+        ctx.system_prompt = (f"{base}{skills_prompt}", suffix) if suffix else base + skills_prompt
     elif skills_prompt:
+        # Relevance filtering re-picks the list from the message, so it varies
+        # per turn and would bust the cached prefix every time. Keep it in the
+        # dynamic slot.
         combined_suffix = f"{suffix}\n\n{skills_prompt}" if suffix else skills_prompt
         ctx.system_prompt = (base, combined_suffix)
     # else: leave ctx.system_prompt unchanged — preserves any upstream tuple

--- a/src/agentos/observability/decision_log.py
+++ b/src/agentos/observability/decision_log.py
@@ -135,6 +135,10 @@ class DecisionEntry:
     tools_schema_chars: int = 0
     skill_count: int = 0
     skills_prompt_chars: int = 0
+    #: How the skills block was rendered — see injector.RENDER_MODE_*.
+    skills_render_mode: str | None = None
+    #: The cap descriptions were shortened to, when they were.
+    skills_description_max_chars: int | None = None
     memory_md_present: bool = False
     daily_notes_omitted: bool = False
     daily_notes_count_before_omit: int = 0

--- a/src/agentos/observability/prompt_report.py
+++ b/src/agentos/observability/prompt_report.py
@@ -36,6 +36,13 @@ class PromptReport:
     tools_schema_chars: int = 0
     skill_count: int = 0
     skills_prompt_chars: int = 0
+    #: How the skills block was rendered — see injector.RENDER_MODE_*. Anything
+    #: other than "full" means the budget cost the model description text.
+    skills_render_mode: str | None = None
+    #: The cap descriptions were shortened to, when they were. The mode alone
+    #: cannot tell a healthy trim (451 chars — still a sentence) from a severe
+    #: one (120), and those call for different responses.
+    skills_description_max_chars: int | None = None
     memory_md_present: bool = False
     daily_notes_omitted: bool = False
     daily_notes_count_before_omit: int = 0
@@ -151,6 +158,16 @@ def build_prompt_report(
         tools_schema_chars=sum(entry.schema_chars for entry in tool_entries),
         skill_count=int(metadata.get("skill_count") or 0),
         skills_prompt_chars=int(metadata.get("skills_prompt_chars") or 0),
+        skills_render_mode=(
+            str(metadata["skills_render_mode"])
+            if metadata.get("skills_render_mode") is not None
+            else None
+        ),
+        skills_description_max_chars=(
+            int(metadata["skills_description_max_chars"])
+            if metadata.get("skills_description_max_chars") is not None
+            else None
+        ),
         memory_md_present=bool(metadata.get("memory_md_present", False)),
         daily_notes_omitted=bool(metadata.get("daily_notes_omitted", False)),
         daily_notes_count_before_omit=int(metadata.get("daily_notes_count_before_omit") or 0),

--- a/src/agentos/skills/availability.py
+++ b/src/agentos/skills/availability.py
@@ -21,7 +21,11 @@ from agentos.skills.eligibility import (
     check_eligibility,
     diagnose_eligibility,
 )
-from agentos.skills.injector import SkillInjector
+from agentos.skills.injector import (
+    RENDER_MODE_COMPACT,
+    RENDER_MODE_FULL,
+    SkillInjector,
+)
 from agentos.skills.types import SkillSpec
 
 #: Reason codes. "" is reserved for an offered skill.
@@ -62,6 +66,10 @@ class InjectionPlan(NamedTuple):
     prompt: str
     #: Names the budget cut, in the order the injector sacrificed them.
     dropped: list[str]
+    #: One of the ``injector.RENDER_MODE_*`` values.
+    mode: str = RENDER_MODE_FULL
+    #: Cap applied to each description, or None when they are untrimmed.
+    description_max_chars: int | None = None
 
 
 _OFFERED = SkillAvailability(offered=True)
@@ -188,20 +196,32 @@ def plan_injection(
     gated: list[SkillSpec],
     max_chars: int,
     injection_mode: str = "system",
+    *,
+    skill_list_tool: bool = False,
 ) -> InjectionPlan:
     """Render the skills block and report which skills the budget cut.
 
-    ``injection_mode="user_message"`` renders compact unconditionally and so has
-    no budget to exceed; "system" and "user_context" both budget-select between
-    full and compact and may truncate.
+    ``injection_mode="user_message"`` renders names-only unconditionally and so
+    has no budget to exceed; "system" and "user_context" both spend the budget
+    on as much description text as fits and may truncate.
+
+    ``skill_list_tool`` says whether the session actually exposes ``skill_list``.
+    It decides which route back to the descriptions the block advertises, so it
+    must reflect the live tool surface rather than being assumed.
     """
     injector = SkillInjector()
     dropped: list[str]
+    mode: str
+    description_max_chars: int | None = None
 
     if injection_mode == "user_message":
-        prompt, dropped = injector.inject_compact("", gated), []
+        prompt = injector.inject_compact("", gated, skill_list_tool=skill_list_tool)
+        dropped = []
+        mode = RENDER_MODE_COMPACT if gated else RENDER_MODE_FULL
     else:
-        prompt, dropped = injector.inject_skills("", gated, max_chars=max_chars)
+        block = injector.render("", gated, max_chars, skill_list_tool=skill_list_tool)
+        prompt, dropped = block.text, block.dropped
+        mode, description_max_chars = block.mode, block.description_max_chars
 
     dropped_names = set(dropped)
     offered = [s for s in gated if not s.disable_model_invocation and s.name not in dropped_names]
@@ -227,6 +247,8 @@ def plan_injection(
         availability=availability,
         prompt=prompt,
         dropped=dropped,
+        mode=mode,
+        description_max_chars=description_max_chars,
     )
 
 

--- a/src/agentos/skills/injector.py
+++ b/src/agentos/skills/injector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from agentos.skills.types import SkillLayer, SkillSpec
 
 #: Character budget for the injected skills block when nothing configures one.
@@ -10,6 +12,19 @@ from agentos.skills.types import SkillLayer, SkillSpec
 #: when a turn arrives without a skills config, and those two drifting apart is
 #: what silently forced default installs into name-only mode.
 DEFAULT_MAX_SKILLS_PROMPT_CHARS = 24_000
+
+#: How the block was rendered, widest first. Recorded per turn so a fall to a
+#: narrower mode is a visible fact rather than something an operator has to
+#: infer from a character count.
+RENDER_MODE_FULL = "full"
+RENDER_MODE_FULL_TRUNCATED = "full_truncated"
+RENDER_MODE_COMPACT = "compact"
+RENDER_MODE_COMPACT_TRUNCATED = "compact_truncated"
+
+#: Shortest description worth rendering. Below roughly this a description stops
+#: being a sentence and starts being a fragment, at which point names-only is
+#: the more honest render.
+MIN_DESCRIPTION_CHARS = 120
 
 # Highest precedence first — the same order that decides a name collision. When
 # the budget forces a cut it lands on the tail, so a skill in a writable skills
@@ -33,11 +48,55 @@ def _layer_rank(skill: SkillSpec) -> int:
     return _LAYER_PRECEDENCE.get(skill.layer, _UNKNOWN_LAYER_RANK)
 
 
+def _shorten(text: str, limit: int) -> str:
+    """Cut ``text`` to ``limit`` characters, preferring a word boundary."""
+    if limit <= 0 or len(text) <= limit:
+        return text
+    cut = text[: limit - 1].rstrip()
+    space = cut.rfind(" ")
+    if space >= limit // 2:
+        cut = cut[:space].rstrip()
+    return f"{cut}…"
+
+
+@dataclass(frozen=True)
+class SkillsBlock:
+    """A rendered skills block plus what rendering it cost.
+
+    ``mode`` and ``description_max_chars`` exist because the budget decision
+    used to leave no trace: ``skills_prompt_chars`` shrinking by 20k looks
+    identical to an operator uninstalling skills, and nothing recorded that
+    every description had just been dropped.
+    """
+
+    text: str
+    dropped: list[str] = field(default_factory=list)
+    mode: str = RENDER_MODE_FULL
+    description_max_chars: int | None = None
+
+    @property
+    def degraded(self) -> bool:
+        """Whether the budget cost this block descriptions or entries."""
+        return self.mode != RENDER_MODE_FULL
+
+
 class SkillInjector:
     """Injects skill content into system prompts with budget control."""
 
-    def inject_full(self, system_prompt: str, skills: list[SkillSpec]) -> str:
-        """Full mode: name + description for each skill."""
+    def inject_full(
+        self,
+        system_prompt: str,
+        skills: list[SkillSpec],
+        *,
+        description_max_chars: int | None = None,
+        skill_list_tool: bool = False,
+    ) -> str:
+        """Full mode: name + description for each skill.
+
+        ``description_max_chars`` shortens each description to fit a budget that
+        the untrimmed block overruns — still far more use to the model than the
+        name-only fallback, which is what this used to degrade to.
+        """
         visible = [s for s in skills if not s.disable_model_invocation]
         if not visible:
             return system_prompt
@@ -60,6 +119,17 @@ class SkillInjector:
             "Lean toward loading. Load a skill even for a task you already know how "
             "to do — it defines how that task should be done in this install.",
         ]
+        if description_max_chars is not None:
+            # Say so, or a clipped description reads as the whole description and
+            # the model rules out a skill on half a sentence.
+            lines.append(
+                "The descriptions below are shortened to fit. They are enough to "
+                "judge relevance, not to work from — skill_view returns the full text."
+            )
+            if skill_list_tool:
+                lines.append(
+                    "`skill_list` returns every skill's untrimmed description in one call."
+                )
         lines.extend(
             [
                 "Answer without a skill only when no entry relates to the request.",
@@ -68,14 +138,23 @@ class SkillInjector:
             ]
         )
         for s in visible:
+            description = s.description
+            if description_max_chars is not None:
+                description = _shorten(description, description_max_chars)
             lines.append("  <skill>")
             lines.append(f"    <name>{_escape_xml(s.name)}</name>")
-            lines.append(f"    <description>{_escape_xml(s.description)}</description>")
+            lines.append(f"    <description>{_escape_xml(description)}</description>")
             lines.append("  </skill>")
         lines.append("</available_skills>")
         return system_prompt + "\n".join(lines)
 
-    def inject_compact(self, system_prompt: str, skills: list[SkillSpec]) -> str:
+    def inject_compact(
+        self,
+        system_prompt: str,
+        skills: list[SkillSpec],
+        *,
+        skill_list_tool: bool = False,
+    ) -> str:
         """Compact mode: name only (saves tokens). Use skill_view to read full content."""
         visible = [s for s in skills if not s.disable_model_invocation]
         if not visible:
@@ -85,14 +164,25 @@ class SkillInjector:
             "\n\nSkills are task playbooks written for this install. Only their names "
             "are listed below — each one's description and instructions live inside it.",
             "Skill names are identifiers for `skill_view`; they are not callable tools.",
-            # Compact mode strips the descriptions, so the model has nothing to judge
-            # relevance against but a name. Telling it to load "only on a clear match"
-            # would then be an instruction it cannot follow: no name clearly matches
-            # anything. Ask it to open plausible entries instead of guessing.
-            "A name alone is not enough to rule a skill out, so call skill_view(name="
-            '"<skill_name>") on any entry that plausibly relates to the request before '
-            "concluding it does not apply.",
         ]
+        # Compact mode strips the descriptions, so the model has nothing to judge
+        # relevance against but a name. Telling it to load "only on a clear match"
+        # would then be an instruction it cannot follow: no name clearly matches
+        # anything. Point at whichever route back to the descriptions exists —
+        # asking for a skill_view per plausible name is a route the model will not
+        # take once the list is dozens of entries long.
+        if skill_list_tool:
+            lines.append(
+                "A name alone is not enough to rule a skill out. Call `skill_list` "
+                "first — one call returns every skill's description — then "
+                'skill_view(name="<skill_name>") to load the one that matches.'
+            )
+        else:
+            lines.append(
+                "A name alone is not enough to rule a skill out, so call skill_view(name="
+                '"<skill_name>") on any entry that plausibly relates to the request before '
+                "concluding it does not apply."
+            )
         lines.extend(["", "<available_skills>"])
         for s in visible:
             lines.append("  <skill>")
@@ -101,37 +191,80 @@ class SkillInjector:
         lines.append("</available_skills>")
         return system_prompt + "\n".join(lines)
 
-    def inject_skills(
+    def render(
         self,
         system_prompt: str,
         skills: list[SkillSpec],
         max_chars: int = DEFAULT_MAX_SKILLS_PROMPT_CHARS,
-    ) -> tuple[str, list[str]]:
-        """Auto-select full/compact mode based on token budget.
+        *,
+        skill_list_tool: bool = False,
+    ) -> SkillsBlock:
+        """Render the widest skills block that fits ``max_chars``.
 
-        Returns the prompt plus the names of any skills the budget forced out,
-        so callers can log and surface a silent capability loss.
+        Four steps, each narrower than the last: untrimmed descriptions, then
+        descriptions shortened to the longest length that fits, then names only,
+        then fewer names. Only the last loses a skill, so overrunning the budget
+        by one entry costs a little description text rather than every
+        description in the block.
         """
         if not skills:
-            return system_prompt, []
+            return SkillsBlock(text=system_prompt)
 
-        full = self.inject_full(system_prompt, skills)
-        if len(full) - len(system_prompt) <= max_chars:
-            return full, []
+        def spend(text: str) -> int:
+            return len(text) - len(system_prompt)
 
-        compact = self.inject_compact(system_prompt, skills)
+        untrimmed = self.inject_full(system_prompt, skills, skill_list_tool=skill_list_tool)
+        if spend(untrimmed) <= max_chars:
+            return SkillsBlock(text=untrimmed)
+
+        # Widest cap that fits, not the first rung of a fixed ladder: the budget
+        # is what the operator agreed to spend, and settling for 320 chars where
+        # 451 also fitted (measured on a 58-skill install) leaves description
+        # text unbought and clips a dozen skills that did not need clipping.
+        # Rendered length is monotonic in the cap — a wider cap can only lengthen
+        # a description — so bisect it.
+        #
+        # The search stops one short of the longest description, so a cap that
+        # would clip nothing is never chosen: it is the `untrimmed` render plus a
+        # "descriptions are shortened" line that would not be true.
+        visible = [s for s in skills if not s.disable_model_invocation]
+        longest = max((len(s.description) for s in visible), default=0)
+        lo, hi = MIN_DESCRIPTION_CHARS, longest - 1
+        best: tuple[int, str] | None = None
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            candidate = self.inject_full(
+                system_prompt,
+                skills,
+                description_max_chars=mid,
+                skill_list_tool=skill_list_tool,
+            )
+            if spend(candidate) <= max_chars:
+                best = (mid, candidate)
+                lo = mid + 1
+            else:
+                hi = mid - 1
+        if best is not None:
+            return SkillsBlock(
+                text=best[1],
+                mode=RENDER_MODE_FULL_TRUNCATED,
+                description_max_chars=best[0],
+            )
+
+        compact = self.inject_compact(system_prompt, skills, skill_list_tool=skill_list_tool)
         if len(compact) - len(system_prompt) <= max_chars:
-            return compact, []
+            return SkillsBlock(text=compact, mode=RENDER_MODE_COMPACT)
 
         # Budget exceeded even in compact — truncate skills. Sort by layer
         # precedence first (stable, so within-layer order is untouched) so the
         # cut lands on bundled skills instead of whatever the operator installed.
-        visible = [s for s in skills if not s.disable_model_invocation]
         ordered = sorted(visible, key=_layer_rank)
         lo, hi = 0, len(ordered)
         while lo < hi:
             mid = (lo + hi + 1) // 2
-            test = self.inject_compact(system_prompt, ordered[:mid])
+            test = self.inject_compact(
+                system_prompt, ordered[:mid], skill_list_tool=skill_list_tool
+            )
             if len(test) - len(system_prompt) <= max_chars:
                 lo = mid
             else:
@@ -140,5 +273,10 @@ class SkillInjector:
         # one compact skill entry rather than dropping the whole skills section.
         # Losing the guard makes skill names more likely to be mistaken for tools.
         kept = max(lo, 1)
-        dropped = [s.name for s in ordered[kept:]]
-        return self.inject_compact(system_prompt, ordered[:kept]), dropped
+        return SkillsBlock(
+            text=self.inject_compact(
+                system_prompt, ordered[:kept], skill_list_tool=skill_list_tool
+            ),
+            dropped=[s.name for s in ordered[kept:]],
+            mode=RENDER_MODE_COMPACT_TRUNCATED,
+        )

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -107,6 +107,11 @@ def build_skill_inventory(
             gated,
             getattr(skills_cfg, "max_skills_prompt_chars", DEFAULT_MAX_SKILLS_PROMPT_CHARS),
             getattr(skills_cfg, "injection_mode", "system"),
+            # Derived from the same tool set the gate just used. Guessing it
+            # would change the block's header length, which moves the point a
+            # tight budget truncates at — and then a row here and the prompt the
+            # engine builds would disagree about which skills are offered.
+            skill_list_tool="skill_list" in available_tools,
         )
         availability = {**availability, **plan.availability}
 

--- a/src/agentos/tools/types.py
+++ b/src/agentos/tools/types.py
@@ -120,6 +120,12 @@ CRON_AGENT_ALLOW: frozenset[str] = frozenset(
         "session_status",
         "sessions_history",
         "sessions_list",
+        # A cron turn gets the same skills block as any other, telling it to call
+        # skill_view. Leaving both tools off this allowlist made that block an
+        # instruction the agent could not carry out: it could see the names and
+        # never open one. Both are read-only.
+        "skill_list",
+        "skill_view",
         "web_fetch",
         "web_search",
     }

--- a/tests/test_engine/test_cron_tool_policy.py
+++ b/tests/test_engine/test_cron_tool_policy.py
@@ -50,3 +50,34 @@ def test_cron_tool_policy_uses_runtime_registry_names_and_respects_hard_denies()
     assert "read_file" in names
     assert "exec_command" not in names
     assert "web_fetch" not in names
+
+
+def test_a_cron_agent_can_open_the_skills_it_is_shown() -> None:
+    """The skills block is injected on cron turns too, and it says "call skill_view".
+
+    Both skill tools were missing from the allowlist, so that block described a
+    move the agent could not make: it saw the names and could never read one.
+    """
+    registry = ToolRegistry()
+    for name in ("skill_list", "skill_view", "write_file"):
+        registry.register(_spec(name), _handler)
+    runner = TurnRunner(
+        provider_selector=None,
+        tool_registry=registry,
+        session_manager=object(),
+        config=object(),
+    )
+    ctx = ToolContext(
+        caller_kind=CallerKind.CRON,
+        interaction_mode=InteractionMode.UNATTENDED,
+        session_key="cron:job:run:1",
+        allowed_tools=set(CRON_AGENT_ALLOW),
+        denied_tools=set(CRON_AGENT_DENY),
+    )
+
+    tool_defs, _handler_fn = runner._build_tools(ctx)
+    names = {tool.name for tool in tool_defs}
+
+    assert {"skill_list", "skill_view"} <= names
+    # Read-only only: reading a skill must not widen a cron turn's write surface.
+    assert "write_file" not in names

--- a/tests/test_skills_availability.py
+++ b/tests/test_skills_availability.py
@@ -287,7 +287,7 @@ async def test_standalone_recomputation_matches_the_engine_offered_set(
 
     # Standalone path — no turn, no shared state, same inputs.
     gated, availability = gate_skills(loader.load_all(), tools, EligibilityContext(os_name="linux"))
-    plan = plan_injection(gated, max_chars, "system")
+    plan = plan_injection(gated, max_chars, "system", skill_list_tool="skill_list" in tools)
     availability.update(plan.availability)
 
     engine_offered = {
@@ -297,7 +297,10 @@ async def test_standalone_recomputation_matches_the_engine_offered_set(
 
     assert standalone_offered == engine_offered
     assert standalone_offered == {s.name for s in plan.offered}
-    assert plan.prompt == ctx.system_prompt[1]
+    # Byte-for-byte, and appended to the base prompt: with relevance filtering
+    # off the block is part of the cacheable system message, not the dynamic
+    # suffix the prompt cache ships as a user message.
+    assert ctx.system_prompt == "base" + plan.prompt
     assert len(standalone_offered) == ctx.metadata["skill_count"]
 
 

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -106,6 +106,17 @@ def _ctx(
     )
 
 
+def _injected(ctx: TurnContext) -> str:
+    """Everything the pipeline put in the system prompt, whichever slot it used.
+
+    Which slot the skills block lands in is its own contract (see
+    ``test_skills_injector``); tests that only ask "was this skill listed"
+    should not have to care.
+    """
+    prompt = ctx.system_prompt
+    return prompt if isinstance(prompt, str) else "\n\n".join(prompt)
+
+
 def test_bundled_directory_only_contains_retained_default_skills() -> None:
     bundled_names = {
         path.name for path in BUNDLED.iterdir() if path.is_dir() and (path / "SKILL.md").is_file()
@@ -148,7 +159,7 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
 
     ctx = await filter_skills(_ctx(loader))
 
-    prompt = ctx.system_prompt[1]
+    prompt = _injected(ctx)
     for name in PROMPT_DEFAULTS_WITHOUT_AUDIO_TOOLS:
         assert f"<name>{name}</name>" in prompt
     for name in AUDIO_DEFAULTS:
@@ -180,7 +191,7 @@ async def test_allowlist_does_not_hide_managed_or_workspace_skills(
 
     ctx = await filter_skills(_ctx(loader))
 
-    assert "<name>custom-community</name>" in ctx.system_prompt[1]
+    assert "<name>custom-community</name>" in _injected(ctx)
 
 
 @pytest.mark.asyncio
@@ -287,7 +298,7 @@ async def test_disable_model_invocation_hides_from_prompt_but_not_loader(
 
     assert skill is not None
     assert skill.content == "# Hidden"
-    assert "<name>hidden-skill</name>" not in ctx.system_prompt[1]
+    assert "<name>hidden-skill</name>" not in _injected(ctx)
 
 
 def test_retained_default_skills_are_parseable_and_not_disabled(tmp_path: Path) -> None:

--- a/tests/test_skills_injector.py
+++ b/tests/test_skills_injector.py
@@ -8,7 +8,13 @@ import pytest
 from agentos.engine.pipeline import TurnContext
 from agentos.engine.steps.skills_filter import filter_skills
 from agentos.gateway.config import GatewayConfig
-from agentos.skills.injector import SkillInjector
+from agentos.skills.injector import (
+    RENDER_MODE_COMPACT,
+    RENDER_MODE_COMPACT_TRUNCATED,
+    RENDER_MODE_FULL,
+    RENDER_MODE_FULL_TRUNCATED,
+    SkillInjector,
+)
 from agentos.skills.loader import SkillLoader
 from agentos.skills.types import SkillLayer, SkillSpec
 
@@ -55,7 +61,8 @@ def test_neither_mode_emits_a_skill_location() -> None:
 def test_full_mode_is_used_when_it_fits_the_budget() -> None:
     skills = [_skill("alpha", description="Use when alpha things happen.")]
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=10_000)
+    block = SkillInjector().render("", skills, max_chars=10_000)
+    prompt, dropped = block.text, block.dropped
 
     assert "<description>Use when alpha things happen.</description>" in prompt
     assert "<name>alpha</name>" in prompt
@@ -65,7 +72,8 @@ def test_full_mode_is_used_when_it_fits_the_budget() -> None:
 def test_compact_mode_takes_over_when_descriptions_do_not_fit() -> None:
     skills = [_skill(f"skill-{i}", description="d" * 400) for i in range(10)]
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=1_000)
+    block = SkillInjector().render("", skills, max_chars=1_000)
+    prompt, dropped = block.text, block.dropped
 
     assert "<description>" not in prompt
     for i in range(10):
@@ -85,7 +93,8 @@ def test_truncation_sacrifices_the_lowest_precedence_layers_first() -> None:
     # into a different test (or a passing one that proves less) when it does.
     budget = len(injector.inject_compact("", keep))
 
-    prompt, dropped = injector.inject_skills("", skills, max_chars=budget)
+    block = injector.render("", skills, max_chars=budget)
+    prompt, dropped = block.text, block.dropped
 
     for spec in keep:
         assert f"<name>{spec.name}</name>" in prompt
@@ -99,7 +108,8 @@ def test_dropped_names_match_what_is_missing_from_the_prompt() -> None:
         *(_skill(f"managed-{i}", layer=SkillLayer.MANAGED) for i in range(5)),
     ]
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=700)
+    block = SkillInjector().render("", skills, max_chars=700)
+    prompt, dropped = block.text, block.dropped
 
     missing = {s.name for s in skills if f"<name>{s.name}</name>" not in prompt}
     # Without this the assertion below passes vacuously (empty == empty) the day
@@ -112,7 +122,8 @@ def test_dropped_names_match_what_is_missing_from_the_prompt() -> None:
 def test_truncation_preserves_within_layer_order() -> None:
     skills = [_skill(f"bundled-{i:02d}") for i in range(30)]
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=500)
+    block = SkillInjector().render("", skills, max_chars=500)
+    prompt, dropped = block.text, block.dropped
 
     kept = [s.name for s in skills if f"<name>{s.name}</name>" in prompt]
     assert kept == sorted(kept)
@@ -125,7 +136,8 @@ def test_model_invisible_skills_are_never_reported_as_dropped() -> None:
         *(_skill(f"bundled-{i}") for i in range(20)),
     ]
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=400)
+    block = SkillInjector().render("", skills, max_chars=400)
+    prompt, dropped = block.text, block.dropped
 
     assert "<name>hidden</name>" not in prompt
     assert "hidden" not in dropped
@@ -134,11 +146,135 @@ def test_model_invisible_skills_are_never_reported_as_dropped() -> None:
 def test_a_tiny_budget_still_keeps_one_skill_and_the_guard() -> None:
     skills = [_skill(f"bundled-{i}") for i in range(5)]
 
-    prompt, dropped = SkillInjector().inject_skills("", skills, max_chars=1)
+    block = SkillInjector().render("", skills, max_chars=1)
+    prompt, dropped = block.text, block.dropped
 
     assert "they are not callable tools" in prompt
     assert prompt.count("<name>") == 1
     assert len(dropped) == 4
+
+
+def test_the_budget_costs_description_text_before_it_costs_descriptions() -> None:
+    """One skill over budget used to drop every description in the block.
+
+    Full mode overran by 3k of a 24k budget and the whole block fell to
+    name-only — 3.5k rendered against a 24k allowance, so 20k of the operator's
+    budget bought nothing and the model never saw a single description.
+    """
+    skills = [_skill(f"skill-{i}", description="word " * 100) for i in range(20)]
+    injector = SkillInjector()
+    untrimmed = injector.inject_full("", skills)
+    # A budget just under what untrimmed descriptions need.
+    budget = len(untrimmed) - 500
+
+    block = injector.render("", skills, max_chars=budget)
+
+    assert block.mode == RENDER_MODE_FULL_TRUNCATED
+    assert block.description_max_chars is not None
+    assert block.dropped == []
+    # Every skill still listed, and still with description text to judge on.
+    for i in range(20):
+        assert f"<name>skill-{i}</name>" in block.text
+    assert block.text.count("<description>") == 20
+    assert len(block.text) <= budget
+    # And the shortening is disclosed, so a clipped sentence is not read as the
+    # whole description.
+    assert "shortened to fit" in block.text
+
+
+def test_the_widest_description_cap_that_fits_is_the_one_used() -> None:
+    """The budget is what the operator agreed to spend, so spend it.
+
+    A fixed ladder of caps settles for the first rung that fits — 320 chars
+    where 451 also fitted, on a real install — and every skill between those two
+    lengths is clipped for nothing.
+    """
+    skills = [
+        _skill(f"skill-{i}", description="Use when " + "word " * (20 + i * 4)) for i in range(25)
+    ]
+    injector = SkillInjector()
+    budget = len(injector.inject_full("", skills)) - 2_000
+
+    block = injector.render("", skills, max_chars=budget)
+    cap = block.description_max_chars
+
+    assert block.mode == RENDER_MODE_FULL_TRUNCATED
+    assert cap is not None
+    assert len(block.text) <= budget
+    # Nothing wider fits: the cap is the ceiling, not the first rung under it.
+    assert len(injector.inject_full("", skills, description_max_chars=cap + 1)) > budget
+
+
+def test_a_cap_that_would_clip_nothing_is_never_chosen() -> None:
+    """Such a cap is the untrimmed block plus a claim that is not true of it.
+
+    It also renders *larger* than untrimmed — the disclosure costs ~150 chars
+    and saves none — so choosing one both misinforms the model and wastes budget.
+    """
+    skills = [_skill(f"skill-{i}", description="Use when " + "word " * 80) for i in range(20)]
+    injector = SkillInjector()
+
+    for budget in range(len(injector.inject_full("", skills)) - 1, 0, -900):
+        block = injector.render("", skills, max_chars=budget)
+        if block.mode != RENDER_MODE_FULL_TRUNCATED:
+            continue
+        # Shortening was claimed, so shortening must have happened.
+        assert "shortened to fit" in block.text
+        assert "…" in block.text
+        assert len(block.text) <= budget
+
+
+def test_a_render_that_fits_untrimmed_says_nothing_about_shortening() -> None:
+    skills = [_skill("alpha", description="Use when alpha things happen.")]
+
+    block = SkillInjector().render("", skills, max_chars=10_000)
+
+    assert block.mode == RENDER_MODE_FULL
+    assert block.description_max_chars is None
+    assert block.degraded is False
+    assert "shortened to fit" not in block.text
+
+
+def test_compact_mode_points_at_skill_list_when_the_session_has_it() -> None:
+    """Name-only mode has to name a route back to the descriptions.
+
+    Asking for a skill_view per plausible name is not a route the model will
+    take once the list is dozens of entries long, and skill_list answers the
+    same question in one call — but the block never mentioned it existed.
+    """
+    skills = [_skill(f"skill-{i}") for i in range(40)]
+    injector = SkillInjector()
+
+    with_list = injector.inject_compact("", skills, skill_list_tool=True)
+    without_list = injector.inject_compact("", skills, skill_list_tool=False)
+
+    assert "`skill_list`" in with_list
+    # Never advertise a tool the session does not expose.
+    assert "skill_list" not in without_list
+    assert "skill_view" in without_list
+
+
+def test_render_modes_are_reported_for_every_degradation_step() -> None:
+    skills = [_skill(f"skill-{i}", description="word " * 100) for i in range(30)]
+    injector = SkillInjector()
+    # Budgets derived from real renders rather than hardcoded: the block's
+    # guidance is prose and changes, and a magic number quietly stops testing
+    # the step it was chosen for when it does.
+    untrimmed = len(injector.inject_full("", skills))
+    narrowest = len(injector.inject_full("", skills, description_max_chars=120))
+    names_only = len(injector.inject_compact("", skills))
+
+    assert injector.render("", skills, max_chars=untrimmed).mode == RENDER_MODE_FULL
+    assert injector.render("", skills, max_chars=untrimmed - 1).mode == RENDER_MODE_FULL_TRUNCATED
+    assert injector.render("", skills, max_chars=narrowest - 1).mode == RENDER_MODE_COMPACT
+    truncated = injector.render("", skills, max_chars=names_only - 1)
+    assert truncated.mode == RENDER_MODE_COMPACT_TRUNCATED
+    assert truncated.dropped
+
+
+def _injected(ctx: TurnContext) -> str:
+    prompt = ctx.system_prompt
+    return prompt if isinstance(prompt, str) else "\n\n".join(prompt)
 
 
 def _ctx(loader: SkillLoader, skills_config: object) -> TurnContext:
@@ -196,13 +332,14 @@ async def test_shipped_default_budget_keeps_every_managed_skill(tmp_path: Path) 
 
     ctx = await filter_skills(_ctx(loader, GatewayConfig().skills))
 
-    prompt = ctx.system_prompt[1]
+    prompt = _injected(ctx)
     for name in installed:
         assert f"<name>{name}</name>" in prompt
     assert ctx.metadata["skills_dropped_for_budget"] == []
     # Descriptions are the whole point of the budget: without them the model
     # cannot tell which skill matches the request.
     assert "<description>" in prompt
+    assert ctx.metadata["skills_render_mode"] == RENDER_MODE_FULL
 
 
 @pytest.mark.asyncio
@@ -227,10 +364,95 @@ async def test_budget_truncation_is_reported_in_metadata(tmp_path: Path) -> None
 
     ctx = await filter_skills(_ctx(loader, skills_config))
 
-    prompt = ctx.system_prompt[1]
+    prompt = _injected(ctx)
     dropped = ctx.metadata["skills_dropped_for_budget"]
     assert dropped
     assert "community-skill" not in dropped
     assert "<name>community-skill</name>" in prompt
     assert ctx.metadata["skill_count"] == prompt.count("<name>")
     assert all(name not in ctx.metadata["filtered_skill_ids"] for name in dropped)
+
+
+@pytest.mark.asyncio
+async def test_a_stable_skill_list_lands_in_the_cached_system_prompt(tmp_path: Path) -> None:
+    """The block is instructions, so it has to stay in the system message.
+
+    It used to go into the dynamic suffix, which an enabled prompt cache splits
+    off and delivers as a *user* message headed "not a user request ... use it
+    only when it is relevant" — contradicting the block's own "read this before
+    answering", from the weakest position in the request. With relevance
+    filtering off the list is identical on every turn, so the cacheable half is
+    also where it belongs on cost.
+    """
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    skills_config = SimpleNamespace(
+        filter_enabled=False,
+        max_skills_prompt_chars=100_000,
+        injection_mode="system",
+    )
+
+    ctx = await filter_skills(_ctx(loader, skills_config))
+
+    # str, not (base, dynamic): nothing for the cache split to peel off.
+    assert isinstance(ctx.system_prompt, str)
+    assert ctx.system_prompt.startswith("base")
+    assert "<available_skills>" in ctx.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_a_stable_list_joins_the_base_and_leaves_the_recall_suffix_alone(
+    tmp_path: Path,
+) -> None:
+    """Appending to the base must not eat an upstream dynamic block."""
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    skills_config = SimpleNamespace(
+        filter_enabled=False,
+        max_skills_prompt_chars=100_000,
+        injection_mode="system",
+    )
+    ctx = _ctx(loader, skills_config)
+    ctx.system_prompt = ("base", "RECALLED MEMORY BLOCK")
+
+    ctx = await filter_skills(ctx)
+
+    assert isinstance(ctx.system_prompt, tuple)
+    base, dynamic = ctx.system_prompt
+    assert base.startswith("base")
+    assert "<available_skills>" in base
+    assert dynamic == "RECALLED MEMORY BLOCK"
+
+
+@pytest.mark.asyncio
+async def test_a_per_message_skill_list_stays_out_of_the_cached_prefix(tmp_path: Path) -> None:
+    """Relevance filtering re-picks the list per message, so caching it churns."""
+    workspace = tmp_path / "workspace"
+    for name in ("weather-local", "github-local"):
+        skill_dir = workspace / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Use when testing {name}.\n---\n\n# {name}\n",
+            encoding="utf-8",
+        )
+    loader = SkillLoader(workspace_dir=workspace, snapshot_path=tmp_path / "snapshot.json")
+    skills_config = SimpleNamespace(
+        filter_enabled=True,
+        filter_top_k=1,
+        filter_strategy="lexical",
+        filter_lexical_top_n=20,
+        filter_semantic_top_n=20,
+        filter_rrf_k=60,
+        filter_embedding_model="BAAI/bge-small-zh-v1.5",
+        max_skills_prompt_chars=100_000,
+        injection_mode="system",
+    )
+
+    ctx = _ctx(loader, skills_config)
+    # Retrieval ranks against the message, so it needs one that actually matches.
+    ctx.message = "please check the weather forecast"
+
+    ctx = await filter_skills(ctx)
+
+    assert ctx.metadata["skill_count"] == 1
+    assert isinstance(ctx.system_prompt, tuple)
+    assert ctx.system_prompt[0] == "base"
+    assert "<available_skills>" in ctx.system_prompt[1]


### PR DESCRIPTION
An install with skills added could not get the agent to use them. It answered
from general knowledge while the Skills page reported every skill as offered,
so there was nothing to act on.

Reproduced against a real 58-skill install (37 bundled, 26 in
`~/.agents/skills`, 2 hub-installed, 1 project). Its decision log shows the
same `skills_prompt_chars` on every turn since the log begins:

| Date | Skills | `skills_prompt_chars` |
| --- | --- | --- |
| Jul 13–27 | 51–57 | 7 876 – 7 973 |
| Jul 28 (after #132 removed `<location>`) | 57 | 3 466 |

3 466 characters for 57 skills is a name-only list against a 24 000-character
budget. That install has never had a single skill description in its prompt.

## Four causes, each sufficient on its own

**The budget was a cliff.** One skill over it and *every* description was
dropped for names only — the untrimmed render is 27 084 chars, so a 24 000
budget produced 3 473, leaving 20 000 of the configured allowance buying
nothing. Descriptions are now shortened instead, to the widest length that
fits rather than the first step that works: **451 chars, clipping 17 of 58**,
where a fixed ladder settles for 320 and clips 29. Rendered length is
monotonic in the cap, so the search bisects it, and it stops one short of the
longest description — a cap that clips nothing is the untrimmed render plus a
"descriptions are shortened" line that is not true of it, and comes out
*larger* (27 288 > 27 084). Skills are dropped only once even names-only
overruns.

A default install was never affected: 33 gated bundled skills render in 15 833
chars and fit. The cliff is reached by **installing** skills — about 17 of
them — which is backwards.

**Names-only mode described a move no model makes.** It asked for a
`skill_view` call on every entry that might be relevant; at 57 opaque names
that is 57 calls. `skill_list`, which returns every description in one call,
was never mentioned. It now points there, and only when the session exposes
the tool.

**The block never reached the system prompt.** With `prompt_cache` on — the
default — `_resolve_prompt_config` splits a `(base, dynamic)` prompt and ships
the dynamic half as a **user** message headed *"not a user request … use it
only when it is relevant"*, which contradicts the block's own "read
`<available_skills>` before answering" from the weakest position in the
request. `filter_skills` was appending the block to that dynamic half. Skills
are instructions, so when the offered set is identical every turn (relevance
filtering off, the default) the block now belongs to the cacheable base. That
is also the cheaper half: a list that never changes was being re-sent uncached
every turn. With filtering on it genuinely varies per message and stays out of
the cached prefix.

**Cron turns could not open what they were shown.** `CRON_AGENT_ALLOW` is an
allowlist and omitted both `skill_view` and `skill_list`, while the block was
still injected telling the agent to call `skill_view`. Both are read-only and
are now on it.

## And it was invisible

A block that quietly lost every description reported an empty dropped list and
a smaller character count — indistinguishable from an operator uninstalling
skills, which is how this survived every turn of an install. Each turn now
records `skills_render_mode` and `skills_description_max_chars`; the mode alone
cannot separate a healthy trim at 451 chars from a severe one at 120. Any
render below `full` logs `skills_filter.budget_degraded` with what to change.

`skill_list_tool` is threaded through `build_skill_inventory` too: a different
header length moves the point a tight budget truncates at, and the Skills page
and the prompt must not disagree about which skills are offered — the
invariant #132 established.

`inject_skills` is dropped. Nothing called it once `plan_injection` moved to
`render()`, and its shape — text and dropped names but no mode — is what let
the degradation go unreported.

## Result on that install

| | Before | After |
| --- | --- | --- |
| Render mode | names only | `full_truncated`, cap 451 |
| Block size | 3 473 / 24 000 | 23 975 / 24 000 |
| Descriptions the model sees | 0 / 57 | 57 / 57 |
| Delivered as | user message | system message |
| Skills dropped | 0 | 0 |

Cost: the block is now the size it was configured to be, and it sits at
position 0 of the request, byte-identical across turns while the offered set
holds — inside the `cache_control` block for models with explicit caching, and
a stable prefix for the rest. Previously the smaller block was re-sent
uncached at the tail of every turn.

## Deliberately not in this PR

- No skills paragraph in `system_prompt.j2`: redundant once the block is in the
  system message, and it would grow every install's cached prefix.
- No per-layer description caps (full text for installed skills, clipped for
  bundled). A uniform bisected cap already leaves 41 of 58 untouched, and "why
  is this one complete and that one clipped" is hard to reason about for a
  second-order gain.
- No UI state for a degraded render: the skill *is* offered, so it is not an
  availability reason. It is in the log and the decision log.

## Tests

`tests/test_skills_injector.py` — the budget costs description text before it
costs descriptions; the chosen cap is the widest that fits (asserted by
proving `cap + 1` does not); a cap that clips nothing is never chosen; every
degradation step reports its mode; names-only points at `skill_list` and never
advertises a tool the session lacks; the block lands in the system slot when
the list is stable, does not eat an upstream recall suffix, and stays in the
dynamic slot when filtering is on.
`tests/test_engine/test_cron_tool_policy.py` — a cron agent can open the skills
it is shown, without gaining write tools.

Gate: `ruff` clean · `mypy` clean (577 files) · `pytest` 6616 passed, 27
skipped · `uv build --wheel` OK.

Refs #158, which reports skill loading as slow and difficult. A names-only
block asking for one `skill_view` per plausible name is a plausible cause of
that fan-out, though the slowness itself is not verified here.
