### PR TITLE
fix(skills): stop skill_view spending a whole skill on every read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `skill_list`, so following it was impossible. Both tools — read-only — are
     now on the cron allowlist.
 
+- Asking for a skill that is not installed read as a broken tool. `skill_view`
+  answered with what *not* to do and "tell the user the skill is not installed",
+  offering no next step even when a configured hub carries the skill and the
+  tools to fetch it are in the session — so a model dressed the dead end up as a
+  failure, reporting that `skill_view` "returned error: 14", a code that exists
+  nowhere in AgentOS. It now says the lookup worked and the skill simply is not
+  here, names installed skills with similar names, and points at
+  `skill_search_community` — only when the session can actually reach it, and
+  always as an offer to install rather than an instruction to (#162).
+
 - Reading a large skill cost the whole skill. `skill_view` returned every byte
   of a SKILL.md, and unlike the system prompt a tool result is not cached, so a
   56 000-character hub skill spent ~14 000 tokens per read and again on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `skill_list`, so following it was impossible. Both tools — read-only — are
     now on the cron allowlist.
 
+- Reading a large skill cost the whole skill. `skill_view` returned every byte
+  of a SKILL.md, and unlike the system prompt a tool result is not cached, so a
+  56 000-character hub skill spent ~14 000 tokens per read and again on every
+  re-read — the shape behind reports of skill loading being slow and expensive.
+  Over `[skills].max_skill_view_chars` (new, default 10 000) it now returns the
+  skill's opening sections plus an index of the rest, read on with
+  `skill_view(name, section="<title>")`. Across the skills on a real install
+  that is 43% fewer characters, and 80–87% on the largest. Shipped skills are
+  unaffected: the largest is 21 600 characters and the median 2 400. A body with
+  no headings, or one only slightly over the ceiling where the index would cost
+  more than it saves, is still returned whole.
+
 - A skills block that quietly lost its descriptions was indistinguishable from
   an operator uninstalling skills: nothing was reported as dropped and the
   character count simply fell. Each turn now records `skills_render_mode` and

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -224,6 +224,11 @@ filter_top_k = 5
 # first). The bundled set renders ~16k with descriptions, so the default
 # leaves room for installed skills before either fallback kicks in.
 max_skills_prompt_chars = 24000
+# Ceiling on one skill_view result. Unlike the block above, a tool result is
+# not cached, so a large skill costs its tokens again on every re-read. Over
+# this, the opening sections come back with an index of the rest, which the
+# agent reads one section at a time. 0 restores whole-body reads.
+max_skill_view_chars = 10000
 # injection_mode = "system"  # "system", "user_context", or "user_message"
 
 # The default lexical strategy is dependency-free. "semantic" and "hybrid"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,29 @@ With `filter_enabled = false` the list is identical on every turn, so it is
 injected as part of the cacheable system prompt. With filtering on it is re-picked
 per message and is kept out of the cached prefix instead.
 
+## Skill Read Ceiling
+
+`[skills].max_skill_view_chars` caps one `skill_view` result:
+
+```toml
+[skills]
+max_skill_view_chars = 10000
+```
+
+This is a different budget from the one above, because a tool result is not
+cached the way the system prompt is: a large skill costs its tokens again on
+every re-read. The shipped skills are small (median 2 400 characters, largest
+21 600), so the ceiling only engages for skills installed from a hub or written
+for another agent — 56 000 characters for one, 87 000 for another, which is
+14 000 to 22 000 tokens in a single tool result.
+
+Over the ceiling, `skill_view` returns the skill's opening sections plus an
+index of the rest, and the agent reads on with
+`skill_view(name, section="<title>")` or `skill_view(name, file_path="...")`.
+Two cases are deliberately left whole: a body with no headings, because there
+would be no way to ask for the rest, and a body only slightly over the ceiling,
+where the index would cost more than it saves. Set `0` to switch it off.
+
 ```sh
 agentos config get skills.max_skills_prompt_chars
 agentos config set skills.max_skills_prompt_chars 32000

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -36,6 +36,7 @@ from agentos.router_tiers import (
 )
 from agentos.sandbox.config import SandboxSettings
 from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
+from agentos.skills.outline import DEFAULT_MAX_SKILL_VIEW_CHARS
 
 
 class ContextOverflowPolicy(StrEnum):
@@ -134,6 +135,11 @@ class SkillsConfig(BaseSettings):
     # every default install into name-only mode, then truncation. Keep enough
     # headroom that installed skills also fit before either fallback kicks in.
     max_skills_prompt_chars: int = DEFAULT_MAX_SKILLS_PROMPT_CHARS
+    # Ceiling on one skill_view body. Unlike the prompt block above, a tool
+    # result is not cached, so a 56k-character hub skill costs its ~14k tokens
+    # again on every re-read. Over this, the opening sections come back with an
+    # index of the rest. 0 disables it and restores whole-body reads.
+    max_skill_view_chars: int = DEFAULT_MAX_SKILL_VIEW_CHARS
     filter_enabled: bool = False
     filter_top_k: int = 5
     # "system" = full system prompt (default)

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -163,7 +163,7 @@ Main `agentos.toml` sections (full commented reference:
 | top-level | `workspace_dir`, `state_dir`, logging, `search_provider`/`search_api_key`, timeouts |
 | `[llm]` | `provider`, `model`, `api_key`, `base_url`, `proxy`, `[llm.provider_routing]` |
 | `[agentos_router]` | router on/off, `strategy` (`pilot-v1`), tier settings under `[agentos_router.tiers.c0..c3]` |
-| `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode`, `max_skills_prompt_chars` (default 24000) |
+| `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode`, `max_skills_prompt_chars` (default 24000), `max_skill_view_chars` (default 10000, 0 disables) |
 | `[tools]` | model-visible tools and policy; `enabled = false` runs providers in plain-text mode |
 | `[memory]` | memory source and embedding model, `[memory.nudge]` (periodic memory review) |
 | `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |

--- a/src/agentos/skills/outline.py
+++ b/src/agentos/skills/outline.py
@@ -1,0 +1,248 @@
+"""Section outline for skill bodies too large to hand back whole.
+
+``skill_view`` used to return every byte of a SKILL.md. That is fine for the
+shipped set — 37 bundled skills, median 2.4k characters — but skills installed
+from a hub or written for another agent run far larger: 56k characters for one
+hub skill, 87k for one in ``~/.agents/skills``. At roughly four characters per
+token that is 14k–22k tokens spent in a single tool result, paid again on every
+re-read, and none of it is cached the way the system prompt is.
+
+The fix is not to cut the text off. It is to return the opening sections whole
+and hand back an index of the rest, so the agent can ask for the one section it
+needs. Everything here is a pure function over the body text.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+#: Bodies at or under this are returned whole. Sized from the shipped set: the
+#: largest bundled skill is 21.6k characters and the median is 2.4k, so a 10k
+#: ceiling leaves every small skill untouched and only engages for the imported
+#: ones that motivated it.
+DEFAULT_MAX_SKILL_VIEW_CHARS = 10_000
+
+#: How far below the shallowest heading the index descends. Measured on real
+#: skills: listing every heading of a 56k-character skill costs 3.5k characters
+#: — an index nearly as expensive as the problem — while two levels costs 320 to
+#: 1100 and still names every part worth asking for.
+_OUTLINE_DEPTH = 2
+
+#: Entries the index may name before it collapses to a single level. Depth is
+#: normally cheap, but a 56k-character skill carries 95 headings two levels
+#: down, and naming them costs 3.5k characters — the problem again in a
+#: different shape. Collapsing loses no reach: ``section=`` resolves against
+#: every heading, and asking for a parent indexes its children.
+_MAX_OUTLINE_ENTRIES = 30
+
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(\S.*?)[ \t]*#*[ \t]*$")
+_FENCE_RE = re.compile(r"^[ \t]*(```+|~~~+)")
+
+
+@dataclass(frozen=True)
+class Section:
+    """One heading and everything under it, including deeper headings."""
+
+    level: int
+    title: str
+    #: Offset of the heading line in the body.
+    start: int
+    #: Offset one past the last character owned by this section.
+    end: int
+    #: Titles of the enclosing sections, outermost first.
+    ancestors: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def size(self) -> int:
+        return self.end - self.start
+
+    @property
+    def path(self) -> str:
+        """``Parent > Child`` — how the index names an ambiguous title."""
+        return " > ".join((*self.ancestors, self.title))
+
+
+def parse_sections(body: str) -> list[Section]:
+    """Split ``body`` at its markdown headings, in document order.
+
+    Fenced code is skipped: a shell transcript or a nested markdown example
+    routinely contains lines starting with ``#``, and treating those as headings
+    would invent sections that cannot be read back.
+    """
+    if not body:
+        return []
+
+    found: list[tuple[int, str, int]] = []  # (level, title, start offset)
+    offset = 0
+    fence: str | None = None  # the opening run, e.g. "```" or "````"
+    for line in body.splitlines(keepends=True):
+        stripped = line.strip()
+        fence_match = _FENCE_RE.match(line)
+        if fence_match:
+            run = fence_match.group(1)
+            if fence is None:
+                fence = run
+            elif run[0] == fence[0] and len(run) >= len(fence) and stripped == run:
+                # CommonMark: a fence closes only on the same character, at
+                # least as long, and alone on its line. Skills that document
+                # markdown nest a ``` block inside a ```` one, and closing on
+                # the inner fence would expose its headings as real sections.
+                fence = None
+            offset += len(line)
+            continue
+        if fence is None:
+            heading = _HEADING_RE.match(line)
+            if heading is not None:
+                found.append((len(heading.group(1)), heading.group(2).strip(), offset))
+        offset += len(line)
+
+    sections: list[Section] = []
+    for index, (level, title, start) in enumerate(found):
+        # A section owns everything up to the next heading at its level or
+        # shallower, so asking for a parent returns its children too.
+        end = len(body)
+        for next_level, _next_title, next_start in found[index + 1 :]:
+            if next_level <= level:
+                end = next_start
+                break
+        # Walk back for the innermost enclosing heading of each shallower
+        # level: those, outermost first, are what disambiguates a title that
+        # appears under more than one parent.
+        trimmed: list[str] = []
+        innermost = level
+        for prev_level, prev_title, _prev_start in reversed(found[:index]):
+            if prev_level < innermost:
+                trimmed.append(prev_title)
+                innermost = prev_level
+        ancestors = tuple(reversed(trimmed))
+        sections.append(
+            Section(level=level, title=title, start=start, end=end, ancestors=ancestors)
+        )
+    return sections
+
+
+def _base_level(sections: list[Section]) -> int:
+    """The heading level that actually partitions the body.
+
+    Most large skills open with a single ``# Title`` owning every byte, so the
+    shallowest level is not a partition at all — indexing it yields one entry
+    the size of the whole skill, and a head built from it is empty. Descend past
+    any level that is one all-encompassing heading.
+    """
+    if not sections:
+        return 1
+    body_len = max(s.end for s in sections)
+    level = min(s.level for s in sections)
+    while True:
+        at_level = [s for s in sections if s.level == level]
+        deeper = [s.level for s in sections if s.level > level]
+        spans_everything = len(at_level) == 1 and at_level[0].size >= body_len * 0.9
+        if spans_everything and deeper:
+            level = min(deeper)
+            continue
+        return level
+
+
+def indexable(sections: list[Section]) -> list[Section]:
+    """The sections the index names, and that ``section=`` can address."""
+    if not sections:
+        return []
+    base = _base_level(sections)
+    wide = [s for s in sections if base <= s.level <= base + _OUTLINE_DEPTH - 1]
+    if len(wide) <= _MAX_OUTLINE_ENTRIES:
+        return wide
+    return [s for s in sections if s.level == base]
+
+
+def find_section(sections: list[Section], query: str) -> Section | list[Section] | None:
+    """Resolve ``query`` to one section.
+
+    Returns the section, a list of candidates when the title is ambiguous, or
+    ``None`` when nothing matches. Matching is deliberately forgiving — the
+    agent is quoting a title back from an index, and a case or spacing
+    difference should not cost it a whole extra tool call.
+    """
+    wanted = " ".join(query.split()).casefold()
+    if not wanted:
+        return None
+
+    def norm(text: str) -> str:
+        return " ".join(text.split()).casefold()
+
+    for candidates in (
+        [s for s in sections if norm(s.path) == wanted],
+        [s for s in sections if norm(s.title) == wanted],
+        [s for s in sections if wanted in norm(s.title)],
+    ):
+        if len(candidates) == 1:
+            return candidates[0]
+        if candidates:
+            shallowest = min(s.level for s in candidates)
+            top = [s for s in candidates if s.level == shallowest]
+            return top[0] if len(top) == 1 else candidates
+    return None
+
+
+def head_sections(body: str, sections: list[Section], limit: int) -> tuple[str, int]:
+    """Return the opening of ``body`` that fits ``limit``, cut on a boundary.
+
+    Cutting mid-sentence would make the head read as the whole skill with a
+    ragged ending. Whole sections are taken instead, so the head always ends
+    where the author ended something.
+    """
+    if limit <= 0:
+        return "", 0
+    # The last heading that starts within the budget: everything before it is
+    # whole sections, and the head ends exactly where a heading begins. Every
+    # heading counts here, not just the indexed ones — the index decides what is
+    # worth naming, while the head only needs the closest clean cut to the
+    # budget, and a coarse one wastes most of it.
+    fits = [s.start for s in sections if 0 < s.start <= limit]
+    if fits:
+        cut = max(fits)
+    else:
+        # Nothing to cut on — the opening section alone overruns. Fall back to a
+        # paragraph boundary so the head at least ends on a blank line.
+        cut = body.rfind("\n\n", 0, limit)
+        cut = cut if cut > limit // 2 else limit
+    return body[:cut].rstrip(), cut
+
+
+def _human(count: int) -> str:
+    return f"{count:,}"
+
+
+def render_outline(
+    sections: list[Section],
+    *,
+    shown_through: int,
+    skill_name: str,
+) -> str:
+    """Render the index of sections, marking the ones already returned."""
+    entries = indexable(sections)
+    if not entries:
+        return ""
+    base = _base_level(sections)
+    lines = ["Sections:"]
+    for section in entries:
+        indent = "  " * (section.level - base)
+        note = " (shown above)" if section.end <= shown_through else ""
+        lines.append(f"- {indent}{section.title} — {_human(section.size)} chars{note}")
+    lines.append("")
+    lines.append(
+        f'Read one with skill_view(name="{skill_name}", section="<title>"). '
+        "Ask for a parent to get its subsections with it."
+    )
+    return "\n".join(lines)
+
+
+def render_linked_files(paths: list[str], skill_name: str) -> str:
+    """Render the skill's supporting files, which are never inlined."""
+    if not paths:
+        return ""
+    lines = ["Linked files:"]
+    lines.extend(f"- {path}" for path in sorted(paths))
+    lines.append("")
+    lines.append(f'Read one with skill_view(name="{skill_name}", file_path="<path>").')
+    return "\n".join(lines)

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -395,7 +395,13 @@ def create_skill_tools(loader: SkillLoader) -> None:
         return DEFAULT_MAX_SKILL_VIEW_CHARS
 
     def _linked_files(skill: Any) -> list[str]:
-        """Supporting files, relative to the skill directory."""
+        """Supporting files, relative to the skill directory, POSIX-style.
+
+        Always forward slashes, including on Windows. These paths are handed to
+        the model to quote back as ``file_path``, where a backslash is an escape
+        character in the tool call's JSON, and they have to match how a SKILL.md
+        writes its own links.
+        """
         try:
             base = Path(skill.base_dir)
             from agentos.skills.resources import SkillResources
@@ -406,7 +412,7 @@ def create_skill_tools(loader: SkillLoader) -> None:
                 *resources.list_scripts(),
                 *resources.list_assets(),
             ]
-            return [str(path.relative_to(base)) for path in found]
+            return [path.relative_to(base).as_posix() for path in found]
         except Exception:  # pragma: no cover — a listing is never worth failing on
             logger.debug("skill_view.linked_files_failed", exc_info=True)
             return []

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -536,6 +536,81 @@ def create_skill_tools(loader: SkillLoader) -> None:
         )
         return "\n\n".join(part for part in (head, "---", note, outline) if part)
 
+    def _session_has_tool(tool_name: str) -> bool:
+        """Whether this session can actually call ``tool_name`` right now.
+
+        Registration is not availability: a cron turn runs under an allowlist,
+        and an operator can deny a tool. Naming one the caller cannot reach
+        turns a useful next step into an instruction it fails to follow.
+        """
+        try:
+            from agentos.tools.registry import get_default_registry
+            from agentos.tools.types import current_tool_context
+            from agentos.tools.visibility import is_tool_visible
+
+            registered = get_default_registry().get(tool_name)
+            if registered is None:
+                return False
+            return is_tool_visible(registered, current_tool_context.get())
+        except Exception:  # pragma: no cover — a hint is never worth failing on
+            logger.debug("skill_view.tool_probe_failed", tool=tool_name, exc_info=True)
+            return False
+
+    def _near_names(name: str, limit: int = 3) -> list[str]:
+        """Installed skill names close enough to ``name`` to be worth naming."""
+        if _loader is None:
+            return []
+        try:
+            import difflib
+
+            names = [s.name for s in _loader.load_all()]
+            wanted = name.strip().casefold()
+            close = difflib.get_close_matches(wanted, [n.casefold() for n in names], n=limit)
+            by_fold = {n.casefold(): n for n in names}
+            return [by_fold[c] for c in close if c in by_fold]
+        except Exception:  # pragma: no cover
+            logger.debug("skill_view.near_names_failed", exc_info=True)
+            return []
+
+    def _skill_not_found(name: str) -> str:
+        """What to say when the skill is not installed.
+
+        The old text said what *not* to do — do not go looking on disk — and
+        then to tell the user it is not installed, which is a dead end even
+        though a hub may carry the skill and the tools to fetch it are right
+        there. A model handed a dead end reports a failure instead of the next
+        step: the report behind this said `skill_view` "returned error: 14",
+        a code that exists nowhere in this codebase, invented while paraphrasing
+        the old message.
+        """
+        lines = [
+            f"Skill not found: {name}. It is not installed, so there is nothing "
+            "to read yet. Do not search host filesystem paths to recover it.",
+        ]
+        near = [n for n in _near_names(name) if n != name]
+        if near:
+            quoted = ", ".join(f"`{n}`" for n in near)
+            lines.append(f"Installed skills with similar names: {quoted}.")
+        if _session_has_tool("skill_search_community"):
+            install = (
+                " and offer to install it with skill_install_community"
+                if _session_has_tool("skill_install_community")
+                else ""
+            )
+            lines.append(
+                f"It may still be published on a configured skill hub — search with "
+                f'skill_search_community(query="{name}"){install}. Installing changes '
+                "this machine, so ask the user before doing it rather than installing "
+                "on your own."
+            )
+        lines.append(
+            "Otherwise use skill_list to see what is installed, continue with the "
+            "tools available in this session, or tell the user the skill is not "
+            "installed. Do not report this as a tool error — the lookup worked, "
+            "the skill simply is not here."
+        )
+        return " ".join(lines)
+
     @tool(
         name="skill_view",
         description=(
@@ -571,13 +646,7 @@ def create_skill_tools(loader: SkillLoader) -> None:
             return "No skill loader available."
         skill = _loader.get_by_name(name)
         if skill is None:
-            return (
-                f"Skill not found: {name}. This skill is not available in the "
-                "current skill catalog. Do not search host filesystem paths to "
-                "recover missing skills. Use skill_list to inspect available "
-                "skills, continue with available tools, or tell the user the "
-                "skill is not installed."
-            )
+            return _skill_not_found(name)
 
         if file_path:
             normalized_path = file_path.strip().lstrip("./")

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -369,9 +369,174 @@ def create_skill_tools(loader: SkillLoader) -> None:
                     lines.append(f"      Needs {declared.name}{detail}{source}")
         return "\n".join(lines)
 
+    def _view_budget() -> int:
+        """The character ceiling for one ``skill_view`` body, 0 when disabled.
+
+        Read off the gateway config the control tools already hold, the same way
+        the config block is. A missing config means the default rather than an
+        unbounded read: the ceiling exists to stop a 87k-character skill from
+        landing in one tool result, and a boot ordering detail should not be
+        what turns that off.
+        """
+        from agentos.skills.outline import DEFAULT_MAX_SKILL_VIEW_CHARS
+
+        try:
+            from agentos.tools.builtin.control import _gateway_config
+
+            configured = getattr(
+                getattr(_gateway_config, "skills", None),
+                "max_skill_view_chars",
+                None,
+            )
+            if isinstance(configured, int) and configured >= 0:
+                return configured
+        except Exception:  # pragma: no cover — never block reading a skill
+            logger.debug("skill_view.budget_lookup_failed", exc_info=True)
+        return DEFAULT_MAX_SKILL_VIEW_CHARS
+
+    def _linked_files(skill: Any) -> list[str]:
+        """Supporting files, relative to the skill directory."""
+        try:
+            base = Path(skill.base_dir)
+            from agentos.skills.resources import SkillResources
+
+            resources = SkillResources(base)
+            found = [
+                *resources.list_references(),
+                *resources.list_scripts(),
+                *resources.list_assets(),
+            ]
+            return [str(path.relative_to(base)) for path in found]
+        except Exception:  # pragma: no cover — a listing is never worth failing on
+            logger.debug("skill_view.linked_files_failed", exc_info=True)
+            return []
+
+    def _skill_body_within_budget(skill: Any, raw: str) -> str:
+        """Return the body whole, or its opening plus an index of the rest."""
+        from agentos.skills.outline import (
+            head_sections,
+            parse_sections,
+            render_linked_files,
+            render_outline,
+        )
+
+        budget = _view_budget()
+        if budget <= 0 or len(raw) <= budget:
+            return raw
+
+        sections = parse_sections(raw)
+        if not sections:
+            # Nothing to index means nothing to ask for afterwards, and a body
+            # cut off with no way back is worse than an expensive one. Hand it
+            # over whole and say so in the log.
+            logger.info(
+                "skill_view.oversized_without_headings",
+                skill=skill.name,
+                chars=len(raw),
+                budget=budget,
+            )
+            return raw
+
+        head, shown_through = head_sections(raw, sections, budget)
+        outline = render_outline(sections, shown_through=shown_through, skill_name=skill.name)
+        linked = render_linked_files(_linked_files(skill), skill.name)
+        parts = [
+            head,
+            "---",
+            (
+                f"`{skill.name}` is {len(raw):,} characters; the {shown_through:,} above are "
+                "its opening sections. The rest is indexed below — read only what the task "
+                "needs rather than the whole skill."
+            ),
+            outline,
+        ]
+        if linked:
+            parts.append(linked)
+        outlined = "\n\n".join(part for part in parts if part)
+
+        # A body only a little over the ceiling costs more to index than to
+        # send: the head is nearly the whole thing and the index is pure
+        # addition. Never hand back more than the skill.
+        if len(outlined) >= len(raw):
+            return raw
+
+        logger.debug(
+            "skill_view.outlined",
+            skill=skill.name,
+            chars=len(raw),
+            returned=len(outlined),
+            budget=budget,
+        )
+        return outlined
+
+    def _skill_section(skill: Any, raw: str, wanted: str) -> str:
+        """Return one section of a skill body, addressed by heading title."""
+        from agentos.skills.outline import (
+            Section,
+            find_section,
+            indexable,
+            parse_sections,
+            render_outline,
+        )
+
+        sections = parse_sections(raw)
+        if not sections:
+            return (
+                f"Skill '{skill.name}' has no sections to address. "
+                "Call skill_view without section to read it."
+            )
+
+        match = find_section(sections, wanted)
+        if match is None:
+            listed = ", ".join(f'"{s.path}"' for s in indexable(sections))
+            return f"No section '{wanted}' in skill '{skill.name}'. Sections: {listed}"
+        if isinstance(match, list):
+            listed = ", ".join(f'"{s.path}"' for s in match)
+            return (
+                f"'{wanted}' matches more than one section in skill '{skill.name}'. "
+                f"Ask for one by its full path: {listed}"
+            )
+
+        text = raw[match.start : match.end].rstrip()
+        budget = _view_budget()
+        if budget <= 0 or len(text) <= budget:
+            return text
+
+        # The section is itself over budget. Index its children the same way the
+        # whole body is indexed, so there is always a next step to take.
+        from agentos.skills.outline import head_sections
+
+        children = [
+            Section(
+                level=child.level,
+                title=child.title,
+                start=child.start - match.start,
+                end=child.end - match.start,
+                ancestors=child.ancestors,
+            )
+            for child in sections
+            if match.start < child.start < match.end
+        ]
+        if not children:
+            # A leaf section with no subheadings: there is nothing finer to
+            # offer, so return it whole rather than cutting it into a dead end.
+            return text
+
+        head, shown_through = head_sections(text, children, budget)
+        outline = render_outline(children, shown_through=shown_through, skill_name=skill.name)
+        note = (
+            f"Section '{match.title}' of `{skill.name}` is {len(text):,} characters; "
+            f"the {shown_through:,} above are its opening."
+        )
+        return "\n\n".join(part for part in (head, "---", note, outline) if part)
+
     @tool(
         name="skill_view",
-        description=("Read a skill's SKILL.md content by name. Optionally read a supporting file."),
+        description=(
+            "Read a skill's SKILL.md content by name. A large skill comes back as its "
+            "opening sections plus an index of the rest — pass section to read one of "
+            "those, or file_path to read a supporting file."
+        ),
         params={
             "name": {
                 "type": "string",
@@ -381,10 +546,21 @@ def create_skill_tools(loader: SkillLoader) -> None:
                 "type": "string",
                 "description": "Optional sub-file path (references/, scripts/)",
             },
+            "section": {
+                "type": "string",
+                "description": (
+                    "Optional section title, quoted from the index a large skill "
+                    'returns. Accepts "Parent > Child" when a title repeats.'
+                ),
+            },
         },
         required=["name"],
     )
-    async def skill_view(name: str, file_path: str | None = None) -> str:
+    async def skill_view(
+        name: str,
+        file_path: str | None = None,
+        section: str | None = None,
+    ) -> str:
         if _loader is None:
             return "No skill loader available."
         skill = _loader.get_by_name(name)
@@ -412,7 +588,13 @@ def create_skill_tools(loader: SkillLoader) -> None:
                 return f"File not found in skill '{name}': {file_path}"
             return content
 
-        body = skill.content or f"(Skill '{name}' has no body content)"
+        raw = skill.content or ""
+        if section:
+            return _skill_section(skill, raw, section)
+
+        body = raw or f"(Skill '{name}' has no body content)"
+        if raw:
+            body = _skill_body_within_budget(skill, raw)
         body += _skill_setup_note(skill)
         # Append whatever the operator configured for this skill, so the agent
         # starts from the values in effect rather than asking the user or

--- a/tests/test_skills_outline.py
+++ b/tests/test_skills_outline.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from agentos.skills.outline import (
+    find_section,
+    head_sections,
+    indexable,
+    parse_sections,
+    render_outline,
+)
+
+
+def _body(*lines: str) -> str:
+    return "\n".join(lines) + "\n"
+
+
+def test_headings_inside_fenced_code_are_not_sections() -> None:
+    """A skill that shows markdown or a shell transcript is full of '#' lines.
+
+    Reading those as headings invents sections that section= cannot return,
+    and moves the head's cut point into the middle of a code block.
+    """
+    body = _body(
+        "# Guide",
+        "",
+        "```sh",
+        "# install it first",
+        "brew install thing",
+        "```",
+        "",
+        "## Real section",
+        "text",
+    )
+
+    titles = [s.title for s in parse_sections(body)]
+
+    assert titles == ["Guide", "Real section"]
+
+
+def test_a_nested_fence_does_not_close_the_outer_one() -> None:
+    """Skills that document markdown wrap a ``` block inside a ```` one."""
+    body = _body(
+        "# Guide",
+        "",
+        "````markdown",
+        "```py",
+        "# not a heading",
+        "```",
+        "## also not a heading",
+        "````",
+        "",
+        "## Real section",
+    )
+
+    titles = [s.title for s in parse_sections(body)]
+
+    assert titles == ["Guide", "Real section"]
+
+
+def test_a_section_owns_its_subsections() -> None:
+    body = _body(
+        "## Parent",
+        "intro",
+        "### Child A",
+        "a",
+        "### Child B",
+        "b",
+        "## Next",
+        "n",
+    )
+
+    sections = {s.title: s for s in parse_sections(body)}
+    parent = sections["Parent"]
+
+    assert body[parent.start : parent.end].strip().endswith("b")
+    assert "## Next" not in body[parent.start : parent.end]
+
+
+def test_a_title_heading_that_owns_the_whole_body_is_not_the_index() -> None:
+    """Large skills open with one '# Title' spanning every byte.
+
+    Indexing that level yields a single entry the size of the whole skill, and
+    a head built from it is empty — which is what shipped before this test.
+    """
+    body = _body(
+        "# Bankr",
+        "intro paragraph",
+        "## Getting started",
+        "x" * 400,
+        "## Commands",
+        "y" * 400,
+        "## Troubleshooting",
+        "z" * 400,
+    )
+
+    entries = [s.title for s in indexable(parse_sections(body))]
+
+    assert entries == ["Getting started", "Commands", "Troubleshooting"]
+
+
+def test_the_head_ends_on_a_heading_and_is_not_empty() -> None:
+    body = _body(
+        "# Title",
+        "intro",
+        "## One",
+        "x" * 300,
+        "## Two",
+        "y" * 300,
+        "## Three",
+        "z" * 5_000,
+    )
+    sections = parse_sections(body)
+
+    head, shown_through = head_sections(body, sections, 1_000)
+
+    assert head.startswith("# Title")
+    assert "## One" in head
+    assert "## Three" not in head
+    assert body[shown_through:].lstrip().startswith("#")
+
+
+def test_a_deep_index_collapses_instead_of_becoming_the_problem() -> None:
+    """Two levels is cheap until a skill has ninety headings two levels down."""
+    lines = ["# Title", "intro"]
+    for parent in range(12):
+        lines += [f"## Parent {parent}", "text"]
+        for child in range(6):
+            lines += [f"### Child {parent}.{child}", "text"]
+    sections = parse_sections(_body(*lines))
+
+    entries = indexable(sections)
+
+    assert len(entries) == 12
+    assert all(s.title.startswith("Parent") for s in entries)
+    # Collapsing costs no reach — every heading is still addressable.
+    assert find_section(sections, "Child 3.2") is not None
+
+
+def test_a_section_is_found_by_title_case_and_path() -> None:
+    body = _body(
+        "## Setup",
+        "s",
+        "### Notes",
+        "under setup",
+        "## Usage",
+        "u",
+        "### Notes",
+        "under usage",
+    )
+    sections = parse_sections(body)
+
+    assert find_section(sections, "  usage  ").title == "Usage"  # type: ignore[union-attr]
+    assert find_section(sections, "Setup > Notes").ancestors == ("Setup",)  # type: ignore[union-attr]
+
+
+def test_an_ambiguous_title_returns_the_candidates_rather_than_a_guess() -> None:
+    body = _body("## Setup", "s", "### Notes", "a", "## Usage", "u", "### Notes", "b")
+    sections = parse_sections(body)
+
+    match = find_section(sections, "Notes")
+
+    assert isinstance(match, list)
+    assert {s.path for s in match} == {"Setup > Notes", "Usage > Notes"}
+
+
+def test_an_unknown_section_is_not_matched() -> None:
+    sections = parse_sections(_body("## Setup", "s"))
+
+    assert find_section(sections, "nothing like this") is None
+
+
+def test_the_index_marks_what_the_head_already_returned() -> None:
+    body = _body("# T", "i", "## One", "x" * 100, "## Two", "y" * 100)
+    sections = parse_sections(body)
+    _head, shown_through = head_sections(body, sections, 130)
+
+    rendered = render_outline(sections, shown_through=shown_through, skill_name="demo")
+
+    assert "One — " in rendered
+    assert "(shown above)" in rendered
+    assert 'skill_view(name="demo", section="<title>")' in rendered
+
+
+def test_a_body_without_headings_has_nothing_to_index() -> None:
+    assert parse_sections("just prose, no headings\n") == []
+    assert indexable([]) == []

--- a/tests/test_tools/test_skill_view_budget.py
+++ b/tests/test_tools/test_skill_view_budget.py
@@ -110,8 +110,11 @@ async def test_a_large_skill_returns_its_opening_plus_an_index(loaded: SkillLoad
     assert "Section 0" in result
     assert "Sections:" in result
     assert 'skill_view(name="big-skill", section="<title>")' in result
-    # Supporting files are named, never inlined.
+    # Supporting files are named, never inlined — and named with forward
+    # slashes on every platform, because the model quotes these back as
+    # file_path, where a backslash is a JSON escape.
     assert "references/api.md" in result
+    assert "references\\api.md" not in result
     assert "reference body" not in result
 
 

--- a/tests/test_tools/test_skill_view_budget.py
+++ b/tests/test_tools/test_skill_view_budget.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.skills.loader import SkillLoader
+from agentos.skills.outline import DEFAULT_MAX_SKILL_VIEW_CHARS
+from agentos.tools.builtin import control as control_module
+from agentos.tools.builtin import skill_tools as skill_tools_module
+from agentos.tools.registry import get_default_registry
+
+
+async def _skill_view(name: str, **kwargs: object) -> str:
+    registered = get_default_registry().get("skill_view")
+    assert registered is not None
+    return await registered.handler(name=name, **kwargs)
+
+
+def _long_skill(dir_: Path, name: str, *, sections: int, section_chars: int) -> str:
+    """A skill shaped like the ones that motivated the ceiling: one '# Title'
+    owning the body, then several '##' sections."""
+    body = [f"# {name.title()}", "", "One-line overview of what this does.", ""]
+    for index in range(sections):
+        body += [f"## Section {index}", "", "w" * section_chars, ""]
+    text = "\n".join(body)
+    skill_dir = dir_ / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Use when testing the view budget.\n---\n{text}",
+        encoding="utf-8",
+    )
+    return text
+
+
+@pytest.fixture()
+def loaded(tmp_path: Path) -> Iterator[SkillLoader]:
+    bundled = tmp_path / "bundled"
+    _long_skill(bundled, "big-skill", sections=12, section_chars=3_000)
+    _long_skill(bundled, "small-skill", sections=2, section_chars=200)
+
+    # Barely over the ceiling, with many small sections: the shape three real
+    # skills have (11.4k / 40 sections, 10.4k / 14, 10.3k / 18).
+    _long_skill(bundled, "narrow-skill", sections=40, section_chars=240)
+
+    prose = bundled / "prose-skill"
+    prose.mkdir(parents=True)
+    (prose / "SKILL.md").write_text(
+        "---\nname: prose-skill\ndescription: Use when testing headingless bodies.\n---\n"
+        + ("no headings here at all. " * 1_000),
+        encoding="utf-8",
+    )
+
+    refs = bundled / "big-skill" / "references"
+    refs.mkdir()
+    (refs / "api.md").write_text("reference body\n", encoding="utf-8")
+
+    loader = SkillLoader(
+        bundled_dir=bundled,
+        workspace_dir=tmp_path / "workspace",
+        managed_dir=tmp_path / "managed",
+        personal_agents_dir=tmp_path / "personal",
+        project_agents_dir=tmp_path / "project",
+        snapshot_path=tmp_path / "skills.snapshot.json",
+    )
+    previous_loader = skill_tools_module._loader
+    previous_config = control_module._gateway_config
+    skill_tools_module.create_skill_tools(loader)
+    try:
+        yield loader
+    finally:
+        skill_tools_module._loader = previous_loader
+        control_module._gateway_config = previous_config
+
+
+def _set_budget(value: int | None) -> None:
+    if value is None:
+        control_module._gateway_config = None
+        return
+    control_module._gateway_config = SimpleNamespace(
+        skills=SimpleNamespace(max_skill_view_chars=value)
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_small_skill_comes_back_whole(loaded: SkillLoader) -> None:
+    """The shipped set is small — median 2.4k characters — and must be untouched."""
+    _set_budget(None)
+    raw = loaded.get_by_name("small-skill").content
+
+    result = await _skill_view("small-skill")
+
+    assert result.startswith(raw)
+    assert "indexed below" not in result
+
+
+@pytest.mark.asyncio
+async def test_a_large_skill_returns_its_opening_plus_an_index(loaded: SkillLoader) -> None:
+    """A 56k hub skill cost ~14k tokens per read, and again on every re-read."""
+    _set_budget(None)
+    raw = loaded.get_by_name("big-skill").content
+
+    result = await _skill_view("big-skill")
+
+    assert len(result) < len(raw) / 2
+    # The opening is real content, not just an index.
+    assert "One-line overview" in result
+    assert "Section 0" in result
+    assert "Sections:" in result
+    assert 'skill_view(name="big-skill", section="<title>")' in result
+    # Supporting files are named, never inlined.
+    assert "references/api.md" in result
+    assert "reference body" not in result
+
+
+@pytest.mark.asyncio
+async def test_a_named_section_comes_back_whole(loaded: SkillLoader) -> None:
+    _set_budget(None)
+
+    result = await _skill_view("big-skill", section="Section 7")
+
+    assert result.startswith("## Section 7")
+    assert "Section 8" not in result
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_section_names_the_ones_that_exist(loaded: SkillLoader) -> None:
+    _set_budget(None)
+
+    result = await _skill_view("big-skill", section="nowhere")
+
+    assert "No section 'nowhere'" in result
+    assert "Section 3" in result
+
+
+@pytest.mark.asyncio
+async def test_a_body_that_would_grow_is_returned_whole(loaded: SkillLoader) -> None:
+    """Just over the ceiling, the index costs more than it saves.
+
+    The head is nearly the whole body and the index is pure addition, so
+    outlining would hand back *more* than the skill.
+    """
+    _set_budget(None)
+    raw = loaded.get_by_name("narrow-skill").content
+    assert len(raw) > DEFAULT_MAX_SKILL_VIEW_CHARS
+
+    result = await _skill_view("narrow-skill")
+
+    assert result.startswith(raw)
+    assert "Sections:" not in result
+
+
+@pytest.mark.asyncio
+async def test_a_body_with_no_headings_is_never_cut(loaded: SkillLoader) -> None:
+    """Nothing to index means no way back to the rest, and a body cut off with
+    no next step is worse than an expensive one."""
+    _set_budget(None)
+    raw = loaded.get_by_name("prose-skill").content
+    assert len(raw) > DEFAULT_MAX_SKILL_VIEW_CHARS
+
+    result = await _skill_view("prose-skill")
+
+    assert result.startswith(raw)
+
+
+@pytest.mark.asyncio
+async def test_the_ceiling_can_be_switched_off(loaded: SkillLoader) -> None:
+    _set_budget(0)
+    raw = loaded.get_by_name("big-skill").content
+
+    result = await _skill_view("big-skill")
+
+    assert result.startswith(raw)
+
+
+@pytest.mark.asyncio
+async def test_a_missing_config_still_applies_the_ceiling(loaded: SkillLoader) -> None:
+    """A boot-ordering detail must not silently restore whole-body reads."""
+    control_module._gateway_config = None
+
+    result = await _skill_view("big-skill")
+
+    assert "Sections:" in result

--- a/tests/test_tools/test_skill_view_budget.py
+++ b/tests/test_tools/test_skill_view_budget.py
@@ -186,3 +186,56 @@ async def test_a_missing_config_still_applies_the_ceiling(loaded: SkillLoader) -
     result = await _skill_view("big-skill")
 
     assert "Sections:" in result
+
+
+@pytest.mark.asyncio
+async def test_a_missing_skill_is_pointed_at_the_hub_that_may_carry_it(
+    loaded: SkillLoader,
+) -> None:
+    """A skill named in the catalog but not installed is not a failure.
+
+    The old text offered no next step beyond "tell the user", so a model asked
+    for a hub skill reported the lookup as broken — the issue behind this said
+    `skill_view` "returned error: 14", a code that exists nowhere in AgentOS.
+    """
+    _set_budget(None)
+
+    result = await _skill_view("capminal")
+
+    assert "Skill not found: capminal" in result
+    assert 'skill_search_community(query="capminal")' in result
+    # Installing touches the machine, so it is offered, never assumed.
+    assert "ask the user before" in result
+    assert "Do not report this as a tool error" in result
+
+
+@pytest.mark.asyncio
+async def test_a_near_miss_names_the_installed_skill_it_probably_meant(
+    loaded: SkillLoader,
+) -> None:
+    _set_budget(None)
+
+    result = await _skill_view("big-skil")
+
+    assert "`big-skill`" in result
+
+
+@pytest.mark.asyncio
+async def test_the_hub_is_not_suggested_to_a_session_that_cannot_reach_it(
+    loaded: SkillLoader,
+) -> None:
+    """Cron runs under an allowlist that carries neither hub tool."""
+    from agentos.tools.types import CRON_AGENT_ALLOW, CallerKind, ToolContext, current_tool_context
+
+    _set_budget(None)
+    token = current_tool_context.set(
+        ToolContext(caller_kind=CallerKind.CRON, allowed_tools=set(CRON_AGENT_ALLOW))
+    )
+    try:
+        result = await _skill_view("capminal")
+    finally:
+        current_tool_context.reset(token)
+
+    assert "skill_search_community" not in result
+    assert "skill_install_community" not in result
+    assert "skill_list" in result

--- a/tests/test_tools/test_skill_view_resources.py
+++ b/tests/test_tools/test_skill_view_resources.py
@@ -95,9 +95,12 @@ async def test_skill_view_missing_skill_uses_catalog_guidance(
     result = await _skill_view("missing-skill")
 
     assert "Skill not found: missing-skill" in result
-    assert "current skill catalog" in result
+    assert "not installed" in result
     assert "Do not search host filesystem paths" in result
     assert "skill_list" in result
+    # The lookup succeeded; only the skill is absent. Reported as a tool error,
+    # it becomes "skill_view returned error: 14" in the answer to the user.
+    assert "Do not report this as a tool error" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes two skill problems reported by users: reading a skill burns a huge number
of tokens, and asking for a skill that isn't installed looks like a crash.

## 1. `skill_view` returned the entire SKILL.md

Every call returned the whole file. That's fine for our own skills, but not for
what users install:

| Where the skill came from | count | median size | largest |
| --- | --- | --- | --- |
| bundled (ships with AgentOS) | 37 | 2,430 chars | 21,647 |
| installed from a hub | 2 | 39,258 chars | 56,209 (~14k tokens) |
| `~/.agents/skills` | 26 | 9,957 chars | 86,805 (~22k tokens) |

Tool results aren't cached, so those tokens are paid again on every re-read. One
real transcript has **18 `skill_view` calls vs 2 `skill_list` calls**, re-reading
the same 56k skill over and over.

### What changed

Above `[skills].max_skill_view_chars` (new, default 10,000), `skill_view` returns
the opening sections in full, then an index of what's left:

```
# Bankr

Execute crypto trading and DeFi operations using natural language...
## Getting an API Key
...

---

`bankr` is 56,209 characters; the 8,418 above are its opening sections.

Sections:
- Getting an API Key — 1,224 chars (shown above)
- CLI Command Reference (v0.3.x) — 8,248 chars
- Error Handling — 535 chars
  ...
Read one with skill_view(name="bankr", section="<title>").

Linked files:
- references/token-trading.md   ... (19 files)
Read one with skill_view(name="bankr", file_path="<path>").
```

The agent then calls `skill_view(name="bankr", section="Error Handling")` and gets
those 535 characters. Linked files are listed by name, never inlined. `file_path`
works exactly as before.

### Results

| Skill | Before | After | Saved |
| --- | --- | --- | --- |
| `design-taste-frontend` | 86,805 (~21.7k tok) | 11,200 (~2.8k tok) | 87% |
| `bankr` | 56,209 (~14.1k tok) | 11,394 (~2.8k tok) | 80% |
| `drawio-skill` | 35,173 (~8.8k tok) | 11,514 (~2.9k tok) | 67% |
| **all 66 skills on one install** | 612,912 (~153k tok) | 350,075 (~87k tok) | **43%** |

Bundled skills are unchanged — all of them are under the limit.

### Edge cases

Each of these was a bug in the first version, found by running it against real
installed skills instead of fixtures:

- **Most big skills start with one `# Title` that wraps the whole file.** Indexing
  the top level gives you one entry the size of the skill, and an empty head. We
  skip any level that's a single all-encompassing heading.
- **A file barely over the limit gets bigger, not smaller** — the head is almost
  everything and the index is pure overhead. Three real skills look like this. We
  never return more than the original.
- **95 headings two levels deep costs 3,536 chars of index** — same problem, new
  shape. Past 30 entries the index drops to one level. Nothing becomes
  unreachable: `section=` matches *any* heading, and asking for a parent lists its
  children.
- **The head can cut at any heading; the index only lists ones worth naming.**
  Using one list for both made the head land on a coarse boundary and waste most
  of the budget (one skill's head dropped to 1,764 chars).
- **No headings → return the whole file.** There'd be no way to ask for the rest,
  and truncating with no next step is worse than the token cost.
- **Fenced code is skipped**, including ``` inside ```` (CommonMark rules).
  Otherwise a skill that documents markdown advertises headings that `section=`
  can't return.

## 2. A skill that isn't installed looked like a tool failure (#162)

`skill_view` used to say what *not* to do, then "tell the user the skill is not
installed" — a dead end, even though a hub may have the skill and the tools to
install it are right there. Given a dead end, the model reported a failure. The
issue shows an answer claiming `skill_view` **"returned error: 14"**, a code that
doesn't exist anywhere in AgentOS. The lookup actually worked; `capminal` is a
catalog entry from `Capminal/agent-skills` that was never installed.

**Before:**
> Skill not found: capminal. This skill is not available in the current skill
> catalog. Do not search host filesystem paths to recover missing skills. Use
> skill_list to inspect available skills, continue with available tools, or tell
> the user the skill is not installed.

**After:**
> Skill not found: capminal. It is not installed, so there is nothing to read yet.
> Do not search host filesystem paths to recover it. It may still be published on
> a configured skill hub — search with `skill_search_community(query="capminal")`.
> Installing changes this machine, so ask the user before doing it rather than
> installing on your own. Otherwise use skill_list to see what is installed,
> continue with the tools available in this session, or tell the user the skill is
> not installed. **Do not report this as a tool error — the lookup worked, the
> skill simply is not here.**

Typos are handled too: `skill_view("bankrr")` → *"Installed skills with similar
names: `bankr`."*

Both hints check what the session can actually call, using the same visibility
rules that build the tool list:

| Session | Suggests |
| --- | --- |
| normal chat | `skill_search_community` |
| normal chat | not `skill_install_community` (hidden by default) |
| cron | neither — its allowlist has no hub tools |

Installing writes to the machine, so it's always phrased as something to offer
the user, never something to do unasked.

## Upgrading requires no action

Verified against a gateway booted from an isolated home with a `config.toml`
written *before* the new key existed, plus a hub skill already installed:

- Boots clean — no validation error from the missing key.
- `/api/config` on that gateway reports `skills.max_skill_view_chars = 10000`.
- Skill snapshot schema is unchanged (`_SNAPSHOT_SCHEMA_VERSION` still 10), so no
  cache to clear and no re-sync.
- `agentos upgrade` already restarts the gateway and verifies the version.
- `agentos/skills/outline.py` is in the built wheel — it's a new module, so a
  packaging miss would be an ImportError at runtime.
- Backend only, no frontend rebuild.

Set `max_skill_view_chars = 0` to go back to whole-file reads.

## Tests

`tests/test_skills_outline.py` (11) — fences (plain and nested) ignored; sections
own their subsections; a wrapper title heading isn't used as the index; head ends
on a heading and is never empty; deep index collapses without losing reach; titles
match by case and by `Parent > Child`; ambiguous titles return candidates instead
of guessing.

`tests/test_tools/test_skill_view_budget.py` (11) — small skill unchanged; large
skill returns head + index + linked filenames (never their contents); named
section returned in full; unknown section lists real ones; a file that would grow
is returned whole; no-heading file never cut; limit can be disabled; missing
config still applies the limit; missing skill points at the hub; near-miss names
the right skill; cron isn't offered tools it can't call.

Gate: `ruff` clean, `mypy` clean (578 files), `pytest` 6,638 passed / 27 skipped,
`uv build --wheel` OK.

Fixes #162.
Refs #158 — "skill loading is slow and difficult". Plausibly the same root cause
(one `skill_view` per candidate name, each returning a full file), but I haven't
reproduced their exact path, so not marked as fixed.
