### PR TITLE
fix(webui): stabilize skill card layout

### DIFF
--- a/frontend/src/views/skills/SkillsPage.test.tsx
+++ b/frontend/src/views/skills/SkillsPage.test.tsx
@@ -486,6 +486,16 @@ describe('SkillsPage', () => {
     await waitFor(() => expect(callsFor('skills.list').length).toBeGreaterThanOrEqual(2))
   })
 
+  it('renders an installed catalog chip in the same card-action slot as Install', async () => {
+    wireRpc({ searchResults: [{ ...CATALOG_ITEM, installed: true }] })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Community$/i }))
+    const card = await screen.findByLabelText('Catalog skill Uniswap')
+    expect(within(card).getByText('Installed')).toHaveClass('sk-chip--card-action')
+  })
+
   it('a dangerous scan verdict arms a force install instead of erroring', async () => {
     wireRpc({
       installResponse: {

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -366,7 +366,7 @@ function InstallButton({
 }) {
   if (action === 'installed')
     return (
-      <span className={`sk-chip sk-chip--ok${large ? ' sk-chip--lg' : ''}`}>
+      <span className={`sk-chip sk-chip--ok${large ? ' sk-chip--lg' : ' sk-chip--card-action'}`}>
         <CheckIcon aria-hidden="true" />
         Installed
       </span>

--- a/frontend/src/views/skills/skills-css.test.ts
+++ b/frontend/src/views/skills/skills-css.test.ts
@@ -38,6 +38,7 @@ describe('Skills directory CSS contract', () => {
   })
 
   it('prevents skill cards from overflowing grid tracks when skill names are long', () => {
+    expect(css).toMatch(/\.sk-grid > \* \{[\s\S]*?min-width:\s*0;/)
     expect(css).toMatch(/\.sk-card \{[\s\S]*?min-width:\s*0;/)
     expect(css).toMatch(/\.sk-card__head \{[\s\S]*?min-width:\s*0;/)
     expect(css).toMatch(
@@ -54,5 +55,14 @@ describe('Skills directory CSS contract', () => {
       /\.sk-chip--lg \{[\s\S]*?font-size: 0\.6875rem;[\s\S]*?min-height: 2\.25rem;/,
     )
     expect(css).not.toMatch(/\.control-surface \.sk-chip \{/)
+  })
+
+  it('keeps the installed chip the same height as the card install action', () => {
+    expect(css).toMatch(
+      /\.control-surface \.sk-rcard__foot \[data-slot='button'\] \{[\s\S]*?min-height:\s*2\.25rem;/,
+    )
+    expect(css).toMatch(
+      /\.control-surface \.sk-rcard__foot \.sk-chip--card-action \{[\s\S]*?display:\s*inline-flex;[\s\S]*?min-height:\s*2\.25rem;/,
+    )
   })
 })

--- a/frontend/src/views/skills/skills.css
+++ b/frontend/src/views/skills/skills.css
@@ -224,6 +224,11 @@
   gap: 10px;
   padding: 0 12px 14px;
 }
+/* MotionListItem is the grid child, not the card itself. Let the wrapper
+   shrink so a long skill title cannot widen its track at browser zoom. */
+.sk-grid > * {
+  min-width: 0;
+}
 .sk-grid--registry {
   padding: 0;
 }
@@ -1331,6 +1336,14 @@
   min-height: 2.25rem;
 }
 
+/* The installed state is a non-interactive chip, but it occupies the same
+   card-footer action slot as an Install button. Match that button's height. */
+.control-surface .sk-rcard__foot .sk-chip--card-action {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  padding-inline: 0.75rem;
+}
 .control-surface .sk-github-install {
   display: grid;
   grid-template-columns: minmax(15rem, 0.8fr) minmax(20rem, 1.2fr);


### PR DESCRIPTION
## Summary

- allow animated skill-card grid items to shrink at browser zoom, preventing track overflow
- give the non-interactive `Installed` chip the same card-footer height as `Install`
- add focused component and CSS regression coverage

## Scope

Bug 4 is already covered by the current Robinhood catalog implementation: it shares the catalog-card shell and derives its acquisition/status labels from the payload. This PR intentionally leaves bug 3 to its existing dedicated PR.

## Verification

- `npm run check` (80 files, 1,600 tests)
- `npm run build` (bundle budget passes)

Refs #161