### PR TITLE
fix(tools): survive formatting drift in edit_file and malformed MCP schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `edit_file` no longer fails on text that differs from the file only in
+  formatting. It still tries an exact match first, then falls back through a
+  chain of increasingly permissive strategies — indentation, whitespace runs,
+  unescaped `\n` literals, smart quotes, and finally block similarity — and
+  names the strategy that matched in its result. Text that appears more than
+  once is still rejected rather than guessed, now with the line numbers of
+  every match, and a failed edit reports the closest regions it found.
+
+### Fixed
+
+- Tool schemas from MCP servers went to the provider exactly as the server
+  emitted them, so one malformed tool could fail the whole request and take
+  every other tool down with it. Schemas are now normalized once at discovery:
+  `$ref` into `$defs` is inlined, `anyOf`/`oneOf` unions that exist only to
+  permit `null` collapse to their concrete branch, `"type": ["string", "null"]`
+  becomes `"string"`, objects without `properties` gain an empty one, and
+  values that are not schemas at all are dropped along with any `required`
+  entry naming them.
+
 ## [2026.7.31] - 2026-07-31
 
 ### Changed

--- a/src/agentos/mcp/discovery.py
+++ b/src/agentos/mcp/discovery.py
@@ -6,10 +6,15 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any
 
+import structlog
+
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef
 from agentos.tools.registry import ToolRegistry
+from agentos.tools.schema_sanitize import sanitize_input_schema
 from agentos.tools.types import ToolSpec
+
+log = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -95,8 +100,12 @@ def _make_tool_handler(
     timeout_seconds: float,
 ) -> None:
     """Register a single MCP tool into the registry with an mcp_ prefix."""
-    # Extract properties and required from input_schema
-    schema = tool_def.input_schema
+    # The server's schema goes out verbatim in every provider request, so it is
+    # normalized once here rather than per turn. A shape one backend tolerates
+    # can make another reject the whole call, tools and all.
+    schema, fixes = sanitize_input_schema(tool_def.input_schema)
+    if fixes:
+        log.info("mcp.schema_sanitized", tool=tool_name, fixes=fixes)
     properties: dict[str, Any] = schema.get("properties", {})
     required: list[str] = schema.get("required", [])
 

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -13,12 +13,22 @@ import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
+import structlog
+
 from agentos.identity.workspace import BOOTSTRAP_FILENAMES
 from agentos.sandbox.integration import get_runtime, sandboxed
+from agentos.tools.fuzzy_match import (
+    AmbiguousMatchError,
+    FuzzyMatchError,
+    FuzzyMatchResult,
+    fuzzy_find_and_replace,
+)
 from agentos.tools.path_policy import reject_foreign_host_path
 from agentos.tools.registry import tool
 from agentos.tools.types import ToolError, WorkspaceAccessError, current_tool_context
 from agentos.tools.write_tracking import record_workspace_file_write
+
+log = structlog.get_logger(__name__)
 
 _SPREADSHEET_EXTENSIONS = {".csv", ".tsv", ".xlsx"}
 _OFFICE_BINARY_EXTENSIONS = {".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"}
@@ -772,9 +782,35 @@ async def write_file(path: str, content: str, approval_id: str | None = None) ->
     return f"Written {len(content)} bytes to {p}"
 
 
+def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> FuzzyMatchResult:
+    """Find *old_text* in *original*, tolerating whitespace and quote drift.
+
+    Exact equality is tried first and costs nothing extra. The fallback chain
+    only runs once exact has missed, so the common case is unchanged. Both
+    failure modes keep the wording the model already knows, enriched with
+    whatever the matcher learned.
+    """
+
+    try:
+        return fuzzy_find_and_replace(original, old_text, new_text)
+    except AmbiguousMatchError as exc:
+        lines = ", ".join(str(line) for line in exc.lines)
+        raise ValueError(
+            f"old_text matches {exc.match_count} locations in {path} (lines {lines});"
+            " be more specific"
+        ) from exc
+    except FuzzyMatchError as exc:
+        detail = f" Closest match: {exc.hint}" if exc.hint else ""
+        raise ValueError(f"old_text not found in {path}.{detail}") from exc
+
+
 @tool(
     name="edit_file",
-    description="Edit a file by replacing old_text with new_text (exact string replacement).",
+    description=(
+        "Edit a file by replacing old_text with new_text. Matching tolerates"
+        " indentation, whitespace and smart-quote drift; text appearing more"
+        " than once is rejected rather than guessed."
+    ),
     params={
         "path": {"type": "string", "description": "Absolute path to the file to edit."},
         "old_text": {"type": "string", "description": "Text to find and replace."},
@@ -804,14 +840,8 @@ async def edit_file(
     loop = asyncio.get_event_loop()
     original = await loop.run_in_executor(None, p.read_text, "utf-8")
 
-    if old_text not in original:
-        raise ValueError(f"old_text not found in {path}")
-
-    count = original.count(old_text)
-    if count > 1:
-        raise ValueError(f"old_text matches {count} locations in {path}; be more specific")
-
-    updated = original.replace(old_text, new_text, 1)
+    match = _locate_edit(original, old_text, new_text, path=path)
+    updated = match.updated
 
     def _write() -> None:
         p.write_text(updated, encoding="utf-8")
@@ -819,7 +849,18 @@ async def edit_file(
     await loop.run_in_executor(None, _write)
     _notify_memory_source_write(p)
     _notify_bootstrap_source_write(p)
-    return f"Edited {p}: replaced {len(old_text)} chars with {len(new_text)} chars"
+    summary = f"replaced {len(old_text)} chars with {len(new_text)} chars"
+    if match.strategy == "exact":
+        return f"Edited {p}: {summary}"
+    # Surface the fallback: an edit that landed via similarity deserves a
+    # second look, and the operator log needs to show how often this happens.
+    log.info(
+        "tools.edit_file.fuzzy_match",
+        strategy=match.strategy,
+        path=str(p),
+        match_count=match.match_count,
+    )
+    return f"Edited {p} [match={match.strategy}]: {summary}"
 
 
 @tool(

--- a/src/agentos/tools/fuzzy_match.py
+++ b/src/agentos/tools/fuzzy_match.py
@@ -1,0 +1,625 @@
+"""Multi-strategy text matching for tool-driven file edits.
+
+``edit_file`` receives an ``old_text`` the model reproduced from memory or from
+an earlier ``read_file``. Exact string equality fails on differences that carry
+no meaning for the edit: a block the model re-indented, a tab that became
+spaces, a literal ``\\n`` it never unescaped, a smart quote carried in from
+prose. Every one of those costs a turn.
+
+This module tries a fixed chain of strategies, ordered from strict to
+permissive, and stops at the first one that finds the text. It reports which
+strategy matched, because a hit from ``context_similarity`` deserves more
+scrutiny than one from ``exact``.
+
+Three invariants make the permissive strategies safe to run by default:
+
+* **Spans are always original-coordinate.** A strategy may normalize text to
+  *find* a match, but it maps the result back to offsets in the untouched
+  ``content``, so characters outside the replaced region are never rewritten.
+* **Replacements are re-indented to the region they land in.** When a strategy
+  ignored indentation to match, the model's ``new_text`` almost never carries
+  the file's actual indentation; pasting it verbatim produces broken code.
+* **Ambiguity is an error, never a guess.** A strategy that finds more than one
+  region raises instead of silently taking the first.
+
+Everything here is pure — strings in, strings out, no filesystem access.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+# Strategy order. Strict first: a permissive strategy must never win a match a
+# stricter one could have found, or the reported strategy understates the risk.
+STRATEGIES: tuple[str, ...] = (
+    "exact",
+    "escape_normalized",
+    "unicode_normalized",
+    "trimmed_boundary",
+    "indent_agnostic",
+    "line_trimmed",
+    "whitespace_collapsed",
+    "block_anchor",
+    "context_similarity",
+)
+
+# Strategies that matched without honouring the file's indentation. A hit from
+# any of these means new_text has to be re-indented to the matched region.
+_INDENT_BLIND = frozenset(
+    {
+        "trimmed_boundary",
+        "indent_agnostic",
+        "line_trimmed",
+        "whitespace_collapsed",
+        "block_anchor",
+        "context_similarity",
+    }
+)
+
+# Similarity floors for the two strategies that match on resemblance rather
+# than on a normalization. Deliberately high: these rewrite source code, and a
+# near-miss that replaces the wrong block is worse than reporting no match.
+_BLOCK_ANCHOR_MIN_SIMILARITY = 0.70
+_CONTEXT_MIN_SIMILARITY = 0.90
+# A context_similarity winner must beat the runner-up by this margin, otherwise
+# the file has two comparable candidates and picking either one is a guess.
+_CONTEXT_MIN_MARGIN = 0.05
+# block_anchor needs a head and a tail to anchor on, plus something between.
+_BLOCK_ANCHOR_MIN_LINES = 3
+# Below this, a "closest region" is noise — every line in the file scores a few
+# percent against any pattern, and offering those as a hint misleads the model.
+_HINT_MIN_SIMILARITY = 0.40
+
+_ESCAPE_SEQUENCES = (
+    ("\\r\\n", "\n"),
+    ("\\n", "\n"),
+    ("\\r", "\r"),
+    ("\\t", "\t"),
+    ('\\"', '"'),
+    ("\\'", "'"),
+)
+
+# Characters prose editors and chat clients substitute silently.
+_UNICODE_LOOKALIKES = {
+    "“": '"',
+    "”": '"',
+    "‘": "'",
+    "’": "'",
+    "—": "--",
+    "–": "-",
+    "…": "...",
+    " ": " ",
+}
+
+_INDENT_RE = re.compile(r"^[ \t]*")
+
+
+@dataclass(frozen=True)
+class FuzzyMatchResult:
+    """Outcome of a successful match-and-replace."""
+
+    updated: str
+    match_count: int
+    strategy: str
+    spans: tuple[tuple[int, int], ...]
+
+
+class FuzzyMatchError(ValueError):
+    """No strategy located *old_text*.
+
+    ``hint`` holds the closest regions found, with line numbers, so the caller
+    can hand the model something actionable instead of "not found".
+    """
+
+    def __init__(self, message: str, *, hint: str = "") -> None:
+        super().__init__(message)
+        self.hint = hint
+
+
+class AmbiguousMatchError(FuzzyMatchError):
+    """A strategy matched several regions and the caller wanted exactly one."""
+
+    def __init__(self, message: str, *, strategy: str, match_count: int, lines: Sequence[int]):
+        super().__init__(message)
+        self.strategy = strategy
+        self.match_count = match_count
+        self.lines = tuple(lines)
+
+
+# ---------------------------------------------------------------------------
+# line/offset bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def _content_lines(content: str) -> tuple[list[str], list[int], list[int]]:
+    """Split *content* into lines plus their start and end offsets.
+
+    The end offset excludes the newline, so a caller replacing lines i..j can
+    decide for itself whether to consume the trailing newline.
+    """
+
+    lines: list[str] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    start = 0
+    for index, char in enumerate(content):
+        if char == "\n":
+            lines.append(content[start:index])
+            starts.append(start)
+            ends.append(index)
+            start = index + 1
+    lines.append(content[start:])
+    starts.append(start)
+    ends.append(len(content))
+    return lines, starts, ends
+
+
+def _split_pattern_lines(pattern: str) -> tuple[list[str], bool]:
+    """Return the pattern's lines and whether it ended on a newline."""
+
+    trailing = pattern.endswith("\n")
+    body = pattern[:-1] if trailing else pattern
+    return body.split("\n"), trailing
+
+
+def _line_number(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def _leading_indent(line: str) -> str:
+    match = _INDENT_RE.match(line)
+    return match.group(0) if match else ""
+
+
+def _first_meaningful_line(lines: Sequence[str]) -> str | None:
+    for line in lines:
+        if line.strip():
+            return line
+    return None
+
+
+# ---------------------------------------------------------------------------
+# normalization with original-coordinate maps
+# ---------------------------------------------------------------------------
+
+
+def _map_unicode(text: str) -> tuple[str, list[int], list[int]]:
+    """Fold lookalike characters, tracking where each output char came from."""
+
+    out: list[str] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    for index, char in enumerate(text):
+        replacement = _UNICODE_LOOKALIKES.get(char, char)
+        for piece in replacement:
+            out.append(piece)
+            starts.append(index)
+            ends.append(index + 1)
+    return "".join(out), starts, ends
+
+
+def _map_collapsed_whitespace(text: str) -> tuple[str, list[int], list[int]]:
+    """Collapse runs of spaces/tabs to one space, tracking source offsets.
+
+    Newlines survive untouched so line structure still means something.
+    """
+
+    out: list[str] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char in " \t":
+            run_start = index
+            while index < length and text[index] in " \t":
+                index += 1
+            out.append(" ")
+            starts.append(run_start)
+            ends.append(index)
+            continue
+        out.append(char)
+        starts.append(index)
+        ends.append(index + 1)
+        index += 1
+    return "".join(out), starts, ends
+
+
+def _find_all(haystack: str, needle: str) -> list[tuple[int, int]]:
+    """Every non-overlapping occurrence of *needle*, as (start, end) spans."""
+
+    if not needle:
+        return []
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while True:
+        found = haystack.find(needle, cursor)
+        if found < 0:
+            return spans
+        spans.append((found, found + len(needle)))
+        cursor = found + len(needle)
+
+
+def _project_spans(
+    spans: Sequence[tuple[int, int]],
+    starts: Sequence[int],
+    ends: Sequence[int],
+) -> list[tuple[int, int]]:
+    """Map spans in normalized coordinates back to the original string."""
+
+    projected: list[tuple[int, int]] = []
+    for span_start, span_end in spans:
+        if span_end <= span_start or span_end > len(starts):
+            continue
+        projected.append((starts[span_start], ends[span_end - 1]))
+    return projected
+
+
+# ---------------------------------------------------------------------------
+# line-block matching
+# ---------------------------------------------------------------------------
+
+
+def _block_span(
+    starts: Sequence[int],
+    ends: Sequence[int],
+    first: int,
+    last: int,
+    *,
+    content: str,
+    include_newline: bool,
+) -> tuple[int, int]:
+    end = ends[last]
+    if include_newline and end < len(content) and content[end] == "\n":
+        end += 1
+    return starts[first], end
+
+
+def _keyed_block_spans(
+    content: str,
+    pattern: str,
+    key: Callable[[str], str],
+) -> list[tuple[int, int]]:
+    """Match pattern lines against content lines under a per-line normalizer."""
+
+    pattern_lines, trailing_newline = _split_pattern_lines(pattern)
+    pattern_keys = [key(line) for line in pattern_lines]
+    if not any(pattern_keys):
+        # Every line normalizes to nothing — this would match whitespace
+        # anywhere in the file. Refuse rather than pick a region at random.
+        return []
+
+    lines, starts, ends = _content_lines(content)
+    window = len(pattern_keys)
+    if window > len(lines):
+        return []
+
+    line_keys = [key(line) for line in lines]
+    spans: list[tuple[int, int]] = []
+    index = 0
+    while index <= len(lines) - window:
+        if line_keys[index : index + window] == pattern_keys:
+            spans.append(
+                _block_span(
+                    starts,
+                    ends,
+                    index,
+                    index + window - 1,
+                    content=content,
+                    include_newline=trailing_newline,
+                )
+            )
+            index += window
+            continue
+        index += 1
+    return spans
+
+
+def _similarity(left: str, right: str) -> float:
+    if not left and not right:
+        return 1.0
+    return SequenceMatcher(None, left, right).ratio()
+
+
+# ---------------------------------------------------------------------------
+# strategies
+# ---------------------------------------------------------------------------
+
+
+def _strategy_exact(content: str, pattern: str) -> list[tuple[int, int]]:
+    return _find_all(content, pattern)
+
+
+def _strategy_escape_normalized(content: str, pattern: str) -> list[tuple[int, int]]:
+    unescaped = pattern
+    for literal, actual in _ESCAPE_SEQUENCES:
+        unescaped = unescaped.replace(literal, actual)
+    if unescaped == pattern:
+        return []
+    return _find_all(content, unescaped)
+
+
+def _strategy_unicode_normalized(content: str, pattern: str) -> list[tuple[int, int]]:
+    normalized_content, starts, ends = _map_unicode(content)
+    normalized_pattern, _, _ = _map_unicode(pattern)
+    if normalized_content == content and normalized_pattern == pattern:
+        return []
+    return _project_spans(_find_all(normalized_content, normalized_pattern), starts, ends)
+
+
+def _strategy_trimmed_boundary(content: str, pattern: str) -> list[tuple[int, int]]:
+    trimmed = pattern.strip()
+    if not trimmed or trimmed == pattern:
+        return []
+    return _find_all(content, trimmed)
+
+
+def _strategy_indent_agnostic(content: str, pattern: str) -> list[tuple[int, int]]:
+    return _keyed_block_spans(content, pattern, lambda line: line.lstrip(" \t").rstrip("\r"))
+
+
+def _strategy_line_trimmed(content: str, pattern: str) -> list[tuple[int, int]]:
+    return _keyed_block_spans(content, pattern, lambda line: line.strip())
+
+
+def _strategy_whitespace_collapsed(content: str, pattern: str) -> list[tuple[int, int]]:
+    normalized_content, starts, ends = _map_collapsed_whitespace(content)
+    normalized_pattern, _, _ = _map_collapsed_whitespace(pattern)
+    if normalized_content == content and normalized_pattern == pattern:
+        return []
+    return _project_spans(_find_all(normalized_content, normalized_pattern), starts, ends)
+
+
+def _strategy_block_anchor(content: str, pattern: str) -> list[tuple[int, int]]:
+    """Anchor on the first and last line, judge the middle on resemblance.
+
+    This is how a model's paraphrased middle still lands on the right block:
+    the boundaries are exact, only the interior drifted.
+    """
+
+    pattern_lines, trailing_newline = _split_pattern_lines(pattern)
+    if len(pattern_lines) < _BLOCK_ANCHOR_MIN_LINES:
+        return []
+    head = pattern_lines[0].strip()
+    tail = pattern_lines[-1].strip()
+    if not head or not tail:
+        return []
+
+    lines, starts, ends = _content_lines(content)
+    window = len(pattern_lines)
+    if window > len(lines):
+        return []
+
+    middle = "\n".join(line.strip() for line in pattern_lines[1:-1])
+    spans: list[tuple[int, int]] = []
+    for index in range(len(lines) - window + 1):
+        last = index + window - 1
+        if lines[index].strip() != head or lines[last].strip() != tail:
+            continue
+        candidate = "\n".join(line.strip() for line in lines[index + 1 : last])
+        if _similarity(candidate, middle) < _BLOCK_ANCHOR_MIN_SIMILARITY:
+            continue
+        spans.append(
+            _block_span(
+                starts,
+                ends,
+                index,
+                last,
+                content=content,
+                include_newline=trailing_newline,
+            )
+        )
+    return spans
+
+
+def _strategy_context_similarity(content: str, pattern: str) -> list[tuple[int, int]]:
+    """Last resort: the single most similar block, if it is clearly the one.
+
+    Requires both a high absolute score and a clear gap to the runner-up. Two
+    comparable candidates mean the file genuinely has two similar blocks, and
+    choosing between them is the model's job, not ours.
+    """
+
+    pattern_lines, trailing_newline = _split_pattern_lines(pattern)
+    normalized_pattern = "\n".join(line.strip() for line in pattern_lines)
+    if not normalized_pattern.strip():
+        return []
+
+    lines, starts, ends = _content_lines(content)
+    window = len(pattern_lines)
+    if window > len(lines):
+        return []
+
+    best_score = 0.0
+    best_index = -1
+    runner_up = 0.0
+    for index in range(len(lines) - window + 1):
+        candidate = "\n".join(line.strip() for line in lines[index : index + window])
+        score = _similarity(candidate, normalized_pattern)
+        if score > best_score:
+            runner_up = best_score
+            best_score = score
+            best_index = index
+        elif score > runner_up:
+            runner_up = score
+
+    if best_index < 0 or best_score < _CONTEXT_MIN_SIMILARITY:
+        return []
+    if best_score - runner_up < _CONTEXT_MIN_MARGIN:
+        return []
+    return [
+        _block_span(
+            starts,
+            ends,
+            best_index,
+            best_index + window - 1,
+            content=content,
+            include_newline=trailing_newline,
+        )
+    ]
+
+
+_STRATEGY_FUNCTIONS: dict[str, Callable[[str, str], list[tuple[int, int]]]] = {
+    "exact": _strategy_exact,
+    "escape_normalized": _strategy_escape_normalized,
+    "unicode_normalized": _strategy_unicode_normalized,
+    "trimmed_boundary": _strategy_trimmed_boundary,
+    "indent_agnostic": _strategy_indent_agnostic,
+    "line_trimmed": _strategy_line_trimmed,
+    "whitespace_collapsed": _strategy_whitespace_collapsed,
+    "block_anchor": _strategy_block_anchor,
+    "context_similarity": _strategy_context_similarity,
+}
+
+
+# ---------------------------------------------------------------------------
+# replacement
+# ---------------------------------------------------------------------------
+
+
+def _reindent(new_text: str, *, pattern_indent: str, target_indent: str) -> str:
+    """Re-hang *new_text* under the indentation of the region it replaces.
+
+    The model wrote ``new_text`` against the indentation it believed the file
+    had (``pattern_indent``). Where the file actually sits at
+    ``target_indent``, every line shifts by the difference — relative structure
+    inside the block is preserved, blank lines stay blank.
+    """
+
+    if pattern_indent == target_indent:
+        return new_text
+
+    out: list[str] = []
+    for line in new_text.split("\n"):
+        if not line.strip():
+            out.append("")
+            continue
+        if pattern_indent and line.startswith(pattern_indent):
+            out.append(target_indent + line[len(pattern_indent) :])
+        elif not pattern_indent:
+            out.append(target_indent + line)
+        else:
+            # The line is shallower than the pattern's own indent; keep whatever
+            # relative depth it has rather than inventing one.
+            out.append(target_indent + line.lstrip(" \t"))
+    return "\n".join(out)
+
+
+def _resolve_replacement(
+    content: str,
+    span: tuple[int, int],
+    old_text: str,
+    new_text: str,
+    strategy: str,
+) -> str:
+    if strategy not in _INDENT_BLIND:
+        return new_text
+
+    pattern_first = _first_meaningful_line(_split_pattern_lines(old_text)[0])
+    matched_region = content[span[0] : span[1]]
+    matched_first = _first_meaningful_line(matched_region.split("\n"))
+    if pattern_first is None or matched_first is None:
+        return new_text
+    return _reindent(
+        new_text,
+        pattern_indent=_leading_indent(pattern_first),
+        target_indent=_leading_indent(matched_first),
+    )
+
+
+def _drop_overlaps(spans: Sequence[tuple[int, int]]) -> list[tuple[int, int]]:
+    ordered = sorted(spans)
+    kept: list[tuple[int, int]] = []
+    for span in ordered:
+        if kept and span[0] < kept[-1][1]:
+            continue
+        kept.append(span)
+    return kept
+
+
+def find_closest_lines(content: str, old_text: str, *, max_results: int = 3) -> str:
+    """Describe the regions that came closest, for a failed-match hint."""
+
+    pattern_lines, _ = _split_pattern_lines(old_text)
+    normalized_pattern = "\n".join(line.strip() for line in pattern_lines)
+    lines, _, _ = _content_lines(content)
+    window = min(len(pattern_lines), len(lines))
+    if window == 0 or not normalized_pattern.strip():
+        return ""
+
+    scored: list[tuple[float, int]] = []
+    for index in range(len(lines) - window + 1):
+        candidate = "\n".join(line.strip() for line in lines[index : index + window])
+        scored.append((_similarity(candidate, normalized_pattern), index))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+
+    parts: list[str] = []
+    for score, index in scored[:max_results]:
+        if score < _HINT_MIN_SIMILARITY:
+            continue
+        preview = lines[index].strip()[:80]
+        parts.append(f"line {index + 1} ({score:.0%} similar): {preview}")
+    return "; ".join(parts)
+
+
+def fuzzy_find_and_replace(
+    content: str,
+    old_text: str,
+    new_text: str,
+    *,
+    replace_all: bool = False,
+    strategies: Sequence[str] | None = None,
+) -> FuzzyMatchResult:
+    """Locate *old_text* in *content* and replace it with *new_text*.
+
+    Tries each strategy in order and uses the first that finds anything.
+
+    Raises:
+        ValueError: *old_text* is empty.
+        AmbiguousMatchError: the winning strategy found several regions and
+            ``replace_all`` is False.
+        FuzzyMatchError: no strategy found the text.
+    """
+
+    if not old_text:
+        raise ValueError("old_text must not be empty")
+
+    chain = tuple(strategies) if strategies is not None else STRATEGIES
+    for strategy in chain:
+        matcher = _STRATEGY_FUNCTIONS.get(strategy)
+        if matcher is None:
+            continue
+        spans = _drop_overlaps(matcher(content, old_text))
+        if not spans:
+            continue
+
+        if len(spans) > 1 and not replace_all:
+            raise AmbiguousMatchError(
+                f"old_text matches {len(spans)} locations (strategy: {strategy});"
+                " be more specific",
+                strategy=strategy,
+                match_count=len(spans),
+                lines=[_line_number(content, start) for start, _ in spans],
+            )
+
+        # Right to left, so each replacement leaves earlier offsets valid.
+        updated = content
+        for span in reversed(spans):
+            replacement = _resolve_replacement(content, span, old_text, new_text, strategy)
+            updated = updated[: span[0]] + replacement + updated[span[1] :]
+
+        return FuzzyMatchResult(
+            updated=updated,
+            match_count=len(spans),
+            strategy=strategy,
+            spans=tuple(spans),
+        )
+
+    raise FuzzyMatchError(
+        "old_text not found",
+        hint=find_closest_lines(content, old_text),
+    )

--- a/src/agentos/tools/schema_sanitize.py
+++ b/src/agentos/tools/schema_sanitize.py
@@ -1,0 +1,230 @@
+"""Normalize third-party JSON Schemas into the subset every backend accepts.
+
+AgentOS's own tools declare their parameters through ``@tool(params=...)`` and
+reach the provider as a typed :class:`~agentos.provider.types.ToolInputSchema`,
+so they are well-formed by construction. MCP servers are not: their schemas
+arrive as whatever the server chose to emit, and go out unchanged in the next
+provider request. Shapes that OpenAI tolerates make other backends reject the
+*entire* call, taking every other tool down with them:
+
+* ``{"type": "object"}`` with no ``properties`` — llama.cpp's
+  ``json-schema-to-grammar`` converter cannot build a parser for it and fails
+  the request outright.
+* ``anyOf``/``oneOf`` whose only purpose is to permit ``null`` — the shape
+  Pydantic emits for every ``Optional[...]`` field. Anthropic rejects it at the
+  top of ``input_schema``.
+* ``"type": ["string", "null"]`` — many grammar converters accept only a
+  single-string ``type``.
+* ``$ref`` into ``$defs`` — routine Pydantic output, and unsupported by
+  several providers, so it has to be inlined before the request goes out.
+* A schema value that is a bare string instead of an object, from a server
+  that serialized its own types wrong.
+
+Sanitizing happens once at registration, not per request. Everything here is
+pure, idempotent, and never raises: a schema this module cannot repair is
+returned as it arrived, because a tool the model can still call beats a
+discovery that aborted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+# Deep enough for any hand-written tool schema; short enough that a
+# self-referential $defs chain cannot spin.
+_MAX_DEPTH = 12
+
+# Bookkeeping keys that mean nothing to a provider once refs are inlined.
+_DROPPED_KEYS = frozenset({"$schema", "$id", "$defs", "definitions"})
+
+# Keys whose value is itself a schema.
+_SCHEMA_VALUED_KEYS = ("items", "additionalProperties", "contains", "not")
+
+# Keys whose value is a list of schemas.
+_SCHEMA_LIST_KEYS = ("allOf", "anyOf", "oneOf", "prefixItems")
+
+
+def _is_null_schema(node: Any) -> bool:
+    return isinstance(node, Mapping) and node.get("type") == "null"
+
+
+def _collect_defs(schema: Mapping[str, Any]) -> dict[str, Any]:
+    defs: dict[str, Any] = {}
+    for container in ("$defs", "definitions"):
+        section = schema.get(container)
+        if isinstance(section, Mapping):
+            for name, value in section.items():
+                defs[f"#/{container}/{name}"] = value
+    return defs
+
+
+def _resolve_ref(ref: str, defs: Mapping[str, Any]) -> Any:
+    target = defs.get(ref)
+    return target if isinstance(target, Mapping) else None
+
+
+def _sanitize_node(
+    node: Any,
+    *,
+    defs: Mapping[str, Any],
+    depth: int,
+    seen: frozenset[str],
+    fixes: list[str],
+) -> Any:
+    """Return a cleaned copy of *node*, or ``None`` when it must be dropped."""
+
+    if depth > _MAX_DEPTH:
+        fixes.append("depth_truncated")
+        return {}
+    if isinstance(node, bool):
+        # `additionalProperties: false` is legal and meaningful — keep it.
+        return node
+    if not isinstance(node, Mapping):
+        # A bare string where a schema belongs. There is nothing to salvage.
+        return None
+
+    ref = node.get("$ref")
+    if isinstance(ref, str):
+        siblings = {key: value for key, value in node.items() if key != "$ref"}
+        target = _resolve_ref(ref, defs)
+        if target is None:
+            fixes.append("dropped_dangling_ref")
+            node = siblings
+        elif ref in seen:
+            fixes.append("cycle_truncated")
+            node = siblings
+        else:
+            fixes.append("inlined_ref")
+            merged = dict(target)
+            merged.update(siblings)
+            return _sanitize_node(
+                merged,
+                defs=defs,
+                depth=depth + 1,
+                seen=seen | {ref},
+                fixes=fixes,
+            )
+
+    for union_key in ("anyOf", "oneOf"):
+        branches = node.get(union_key)
+        if not isinstance(branches, list):
+            continue
+        non_null = [branch for branch in branches if not _is_null_schema(branch)]
+        if len(non_null) == 1 and len(non_null) < len(branches):
+            fixes.append("collapsed_nullable_union")
+            branch = non_null[0]
+            collapsed: dict[str, Any] = dict(branch) if isinstance(branch, Mapping) else {}
+            # Siblings win: a description written next to the union describes
+            # the field, not the branch it was lifted from.
+            collapsed.update({k: v for k, v in node.items() if k != union_key})
+            return _sanitize_node(
+                collapsed,
+                defs=defs,
+                depth=depth + 1,
+                seen=seen,
+                fixes=fixes,
+            )
+
+    out: dict[str, Any] = {}
+    for key, value in node.items():
+        if key in _DROPPED_KEYS:
+            continue
+
+        if key == "type" and isinstance(value, list):
+            concrete = [entry for entry in value if entry != "null"]
+            out["type"] = concrete[0] if concrete else "string"
+            fixes.append("collapsed_type_array")
+            continue
+
+        if key == "properties":
+            if not isinstance(value, Mapping):
+                fixes.append("dropped_invalid_properties")
+                continue
+            cleaned_properties: dict[str, Any] = {}
+            for name, child in value.items():
+                sanitized = _sanitize_node(
+                    child, defs=defs, depth=depth + 1, seen=seen, fixes=fixes
+                )
+                if sanitized is None:
+                    fixes.append("dropped_non_schema_property")
+                    continue
+                cleaned_properties[str(name)] = sanitized
+            out["properties"] = cleaned_properties
+            continue
+
+        if key in _SCHEMA_VALUED_KEYS:
+            sanitized = _sanitize_node(value, defs=defs, depth=depth + 1, seen=seen, fixes=fixes)
+            if sanitized is None:
+                fixes.append("dropped_non_schema_value")
+                continue
+            out[key] = sanitized
+            continue
+
+        if key in _SCHEMA_LIST_KEYS and isinstance(value, list):
+            cleaned_list: list[Any] = []
+            for child in value:
+                sanitized = _sanitize_node(
+                    child, defs=defs, depth=depth + 1, seen=seen, fixes=fixes
+                )
+                if sanitized is None:
+                    fixes.append("dropped_non_schema_value")
+                    continue
+                cleaned_list.append(sanitized)
+            if cleaned_list:
+                out[key] = cleaned_list
+            continue
+
+        out[key] = value
+
+    if out.get("type") == "object" and not isinstance(out.get("properties"), Mapping):
+        # A grammar converter has nothing to constrain without this.
+        out["properties"] = {}
+        fixes.append("added_missing_properties")
+
+    required = out.get("required")
+    if isinstance(required, list):
+        properties = out.get("properties")
+        if isinstance(properties, Mapping):
+            kept = [name for name in required if name in properties]
+            if len(kept) != len(required):
+                fixes.append("pruned_required")
+            out["required"] = kept
+
+    return out
+
+
+def sanitize_input_schema(schema: Any) -> tuple[dict[str, Any], list[str]]:
+    """Clean one tool input schema.
+
+    Returns the sanitized schema and the sorted names of the repairs applied,
+    which is empty when the schema was already fine. Callers log the names to
+    identify which server is emitting broken schemas.
+    """
+
+    if not isinstance(schema, Mapping):
+        return {"type": "object", "properties": {}}, ["replaced_non_object_schema"]
+
+    fixes: list[str] = []
+    try:
+        cleaned = _sanitize_node(
+            schema,
+            defs=_collect_defs(schema),
+            depth=0,
+            seen=frozenset(),
+            fixes=fixes,
+        )
+    except Exception:  # noqa: BLE001 — a usable tool beats a failed discovery
+        return dict(schema), ["sanitize_failed"]
+
+    if not isinstance(cleaned, dict):
+        return {"type": "object", "properties": {}}, ["replaced_non_object_schema"]
+
+    if cleaned.get("type") != "object":
+        cleaned["type"] = "object"
+        fixes.append("forced_object_root")
+    if not isinstance(cleaned.get("properties"), Mapping):
+        cleaned["properties"] = {}
+        fixes.append("added_missing_properties")
+
+    return cleaned, sorted(set(fixes))

--- a/tests/test_mcp/test_discovery_lifecycle.py
+++ b/tests/test_mcp/test_discovery_lifecycle.py
@@ -147,3 +147,84 @@ async def test_cancelled_mcp_discovery_closes_client_without_leaking(
 
     assert client.closed is True
     assert discovery.active_clients_snapshot() == ()
+
+
+@pytest.mark.asyncio
+async def test_server_schema_is_sanitized_before_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server's raw schema reaches the provider, so it is repaired on the way in."""
+
+    from agentos.mcp import discovery
+
+    config = MCPServerConfig(name="pydantic-ish", transport="stdio", command="mock-mcp")
+    client = FakeMCPClient(
+        config,
+        tools=[
+            MCPToolDef(
+                name="search",
+                description="Search things",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        # The shape Pydantic emits for every Optional[...] field.
+                        "limit": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                        "mode": {"type": ["string", "null"]},
+                        "target": {"$ref": "#/$defs/Target"},
+                        "broken": "object",
+                    },
+                    "required": ["limit", "broken"],
+                    "$defs": {
+                        "Target": {"type": "object", "properties": {"id": {"type": "string"}}}
+                    },
+                },
+            )
+        ],
+    )
+    monkeypatch.setattr(discovery, "create_client", lambda _config: client)
+
+    registry = ToolRegistry()
+    await discovery.discover_and_register(config, registry, owner="gateway")
+
+    registered = registry.get("mcp_search")
+    assert registered is not None
+    parameters = registered.spec.parameters
+
+    assert parameters["limit"] == {"type": "integer"}
+    assert parameters["mode"] == {"type": "string"}
+    assert parameters["target"] == {"type": "object", "properties": {"id": {"type": "string"}}}
+    assert "broken" not in parameters
+    # required must not name a property that no longer exists.
+    assert registered.spec.required == ["limit"]
+
+
+@pytest.mark.asyncio
+async def test_clean_server_schema_is_registered_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentos.mcp import discovery
+
+    config = MCPServerConfig(name="tidy", transport="stdio", command="mock-mcp")
+    client = FakeMCPClient(
+        config,
+        tools=[
+            MCPToolDef(
+                name="lookup",
+                description="Lookup",
+                input_schema={
+                    "type": "object",
+                    "properties": {"q": {"type": "string", "description": "Query."}},
+                    "required": ["q"],
+                },
+            )
+        ],
+    )
+    monkeypatch.setattr(discovery, "create_client", lambda _config: client)
+
+    registry = ToolRegistry()
+    await discovery.discover_and_register(config, registry, owner="gateway")
+
+    registered = registry.get("mcp_lookup")
+    assert registered is not None
+    assert registered.spec.parameters == {"q": {"type": "string", "description": "Query."}}
+    assert registered.spec.required == ["q"]

--- a/tests/test_tools/test_edit_file_fuzzy.py
+++ b/tests/test_tools/test_edit_file_fuzzy.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    """Unwrap the @tool and @sandboxed decorators to reach the implementation."""
+
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+edit_file = _original_async(fs.edit_file)
+
+
+@contextmanager
+def tool_context(workspace: Path) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_exact_edit_keeps_the_original_result_wording(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text("value = 1\n", encoding="utf-8")
+
+    with tool_context(tmp_path):
+        result = await edit_file(str(target), "value = 1", "value = 2")
+
+    # No marker on the exact path — the common case reads exactly as before.
+    assert result == f"Edited {target}: replaced 9 chars with 9 chars"
+    assert target.read_text(encoding="utf-8") == "value = 2\n"
+
+
+@pytest.mark.asyncio
+async def test_indent_drift_edits_successfully_and_names_the_strategy(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text(
+        "class A:\n    def run(self):\n        value = 1\n        return value\n",
+        encoding="utf-8",
+    )
+
+    with tool_context(tmp_path):
+        result = await edit_file(
+            str(target),
+            "    value = 1\n    return value\n",
+            "    value = 2\n    return value * 2\n",
+        )
+
+    assert "[match=indent_agnostic]" in result
+    assert target.read_text(encoding="utf-8") == (
+        "class A:\n    def run(self):\n        value = 2\n        return value * 2\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_smart_quote_drift_edits_successfully(tmp_path: Path) -> None:
+    target = tmp_path / "notes.py"
+    target.write_text("title = \u201chello\u201d\n", encoding="utf-8")
+
+    with tool_context(tmp_path):
+        result = await edit_file(str(target), 'title = "hello"', 'title = "bye"')
+
+    assert "[match=unicode_normalized]" in result
+    assert target.read_text(encoding="utf-8") == 'title = "bye"\n'
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_edit_reports_the_matching_lines(tmp_path: Path) -> None:
+    target = tmp_path / "dup.py"
+    target.write_text("x = 1\ny = 0\nx = 1\n", encoding="utf-8")
+
+    with tool_context(tmp_path):
+        with pytest.raises(ValueError) as excinfo:
+            await edit_file(str(target), "x = 1", "x = 2")
+
+    message = str(excinfo.value)
+    assert "matches 2 locations" in message
+    assert "lines 1, 3" in message
+    # A rejected edit must leave the file untouched.
+    assert target.read_text(encoding="utf-8") == "x = 1\ny = 0\nx = 1\n"
+
+
+@pytest.mark.asyncio
+async def test_missing_text_error_carries_a_closest_match_hint(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text("def calculate_total(items):\n    return 0\n", encoding="utf-8")
+
+    with tool_context(tmp_path):
+        with pytest.raises(ValueError) as excinfo:
+            await edit_file(
+                str(target),
+                "def calculate_grand_totals(a, b, c, d):\n",
+                "x",
+            )
+
+    message = str(excinfo.value)
+    assert "old_text not found" in message
+    assert "Closest match: line 1" in message
+
+
+@pytest.mark.asyncio
+async def test_missing_file_still_reports_file_not_found(tmp_path: Path) -> None:
+    with tool_context(tmp_path):
+        with pytest.raises(FileNotFoundError):
+            await edit_file(str(tmp_path / "absent.py"), "a", "b")

--- a/tests/test_tools/test_fuzzy_match.py
+++ b/tests/test_tools/test_fuzzy_match.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+
+from agentos.tools.fuzzy_match import (
+    STRATEGIES,
+    AmbiguousMatchError,
+    FuzzyMatchError,
+    find_closest_lines,
+    fuzzy_find_and_replace,
+)
+
+
+def test_exact_match_wins_before_any_fallback() -> None:
+    result = fuzzy_find_and_replace("a\nfoo\nb\n", "foo", "bar")
+
+    assert result.strategy == "exact"
+    assert result.updated == "a\nbar\nb\n"
+    assert result.match_count == 1
+
+
+def test_escape_normalized_matches_unexpanded_newline_literal() -> None:
+    result = fuzzy_find_and_replace("a = 1\nb = 2\n", "a = 1\\nb = 2", "c = 3")
+
+    assert result.strategy == "escape_normalized"
+    assert result.updated == "c = 3\n"
+
+
+def test_unicode_normalized_matches_smart_quotes() -> None:
+    result = fuzzy_find_and_replace('x = \u201chello\u201d\n', 'x = "hello"', 'x = "bye"')
+
+    assert result.strategy == "unicode_normalized"
+    assert result.updated == 'x = "bye"\n'
+
+
+def test_unicode_outside_the_replaced_span_is_preserved() -> None:
+    content = "note = \u201ckeep\u201d\nx = \u201chit\u201d\n"
+
+    result = fuzzy_find_and_replace(content, 'x = "hit"', 'x = "done"')
+
+    # The normalization exists to find the text, never to rewrite the file.
+    assert result.updated == "note = \u201ckeep\u201d\nx = \"done\"\n"
+
+
+def test_trimmed_boundary_matches_across_an_indent_change() -> None:
+    result = fuzzy_find_and_replace("if x:\n\treturn 1\n", "    return 1", "    return 9")
+
+    assert result.strategy == "trimmed_boundary"
+    # The file's own tab survives; the model's four spaces do not leak in.
+    assert result.updated == "if x:\n\treturn 9\n"
+
+
+def test_indent_agnostic_reindents_replacement_to_the_matched_region() -> None:
+    content = "class A:\n    def run(self):\n        value = 1\n        return value\n"
+
+    result = fuzzy_find_and_replace(
+        content,
+        "    value = 1\n    return value\n",
+        "    value = 2\n    return value * 2\n",
+    )
+
+    assert result.strategy == "indent_agnostic"
+    assert result.updated == (
+        "class A:\n    def run(self):\n        value = 2\n        return value * 2\n"
+    )
+
+
+def test_reindent_preserves_relative_nesting_inside_the_replacement() -> None:
+    content = "class A:\n    def m(self):\n        if x:\n            return 1\n"
+
+    result = fuzzy_find_and_replace(
+        content,
+        "if x:\n    return 1\n",
+        "if x:\n    log()\n    return 2\n",
+    )
+
+    assert result.updated == (
+        "class A:\n    def m(self):\n        if x:\n            log()\n            return 2\n"
+    )
+
+
+def test_line_trimmed_matches_trailing_whitespace_drift() -> None:
+    result = fuzzy_find_and_replace("alpha   \nbeta\n", "alpha\nbeta\n", "gamma\n")
+
+    assert result.strategy == "line_trimmed"
+    assert result.updated == "gamma\n"
+
+
+def test_whitespace_collapsed_matches_repeated_inner_spaces() -> None:
+    result = fuzzy_find_and_replace(
+        "def f():\n        return  1\n",
+        "    return   1",
+        "    return 2",
+    )
+
+    assert result.strategy == "whitespace_collapsed"
+    assert result.updated == "def f():\n        return 2\n"
+
+
+def test_block_anchor_matches_when_only_the_middle_drifted() -> None:
+    content = "def run():\n    a = 1\n    b = 2\n    return a + b\n"
+
+    result = fuzzy_find_and_replace(
+        content,
+        "def run():\n    a = 111\n    b = 222\n    return a + b\n",
+        "def run():\n    return 0\n",
+    )
+
+    assert result.strategy == "block_anchor"
+    assert result.updated == "def run():\n    return 0\n"
+
+
+def test_context_similarity_matches_a_single_near_miss() -> None:
+    content = "def calculate_total(items):\n    return 0\n"
+
+    result = fuzzy_find_and_replace(
+        content,
+        "def calculate_totals(item):\n    return 0\n",
+        "def total(items):\n    return 1\n",
+    )
+
+    assert result.strategy == "context_similarity"
+    assert result.updated == "def total(items):\n    return 1\n"
+
+
+def test_context_similarity_refuses_when_two_blocks_are_comparable() -> None:
+    content = "def f():\n    x = 1\n    return x\n\ndef g():\n    x = 1\n    return x\n"
+
+    # Two candidates score alike; choosing either one would be a guess.
+    with pytest.raises(FuzzyMatchError):
+        fuzzy_find_and_replace(content, "def h():\n    x = 1\n    return x\n", "pass\n")
+
+
+def test_ambiguous_match_reports_every_line() -> None:
+    with pytest.raises(AmbiguousMatchError) as excinfo:
+        fuzzy_find_and_replace("foo\nfoo\n", "foo", "bar")
+
+    assert excinfo.value.match_count == 2
+    assert excinfo.value.lines == (1, 2)
+    assert excinfo.value.strategy == "exact"
+
+
+def test_replace_all_accepts_multiple_matches() -> None:
+    result = fuzzy_find_and_replace("foo\nfoo\n", "foo", "bar", replace_all=True)
+
+    assert result.match_count == 2
+    assert result.updated == "bar\nbar\n"
+
+
+def test_missing_text_raises_with_a_closest_line_hint() -> None:
+    content = "def calculate_total(items):\n    return 0\n"
+
+    with pytest.raises(FuzzyMatchError) as excinfo:
+        fuzzy_find_and_replace(content, "def calculate_grand_totals(a, b, c, d):\n", "x")
+
+    assert "line 1" in excinfo.value.hint
+
+
+def test_unrelated_text_produces_no_misleading_hint() -> None:
+    with pytest.raises(FuzzyMatchError) as excinfo:
+        fuzzy_find_and_replace("alpha\nbeta\n", "zzz_nothing_like_this", "x")
+
+    assert excinfo.value.hint == ""
+
+
+def test_whitespace_only_pattern_is_refused_by_line_strategies() -> None:
+    # Every line normalizes to nothing, so a line strategy would match anywhere.
+    with pytest.raises(FuzzyMatchError):
+        fuzzy_find_and_replace("a\n    \nb\n", "\t\n\t\n", "x")
+
+
+def test_empty_old_text_is_rejected() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        fuzzy_find_and_replace("anything", "", "x")
+
+
+def test_applying_the_result_again_finds_nothing() -> None:
+    first = fuzzy_find_and_replace("a\nfoo\n", "foo", "bar")
+
+    with pytest.raises(FuzzyMatchError):
+        fuzzy_find_and_replace(first.updated, "foo", "bar")
+
+
+def test_restricting_the_chain_disables_the_fallbacks() -> None:
+    content = "class A:\n\tvalue = 1\n"
+
+    # The tab-vs-spaces drift is exactly what trimmed_boundary would absorb.
+    assert fuzzy_find_and_replace(content, "    value = 1", "    value = 2").strategy != "exact"
+    with pytest.raises(FuzzyMatchError):
+        fuzzy_find_and_replace(content, "    value = 1", "    value = 2", strategies=("exact",))
+
+
+def test_every_declared_strategy_is_runnable() -> None:
+    # Guards against a name in STRATEGIES with no implementation behind it,
+    # which would silently skip that rung of the chain.
+    for strategy in STRATEGIES:
+        with pytest.raises(FuzzyMatchError):
+            fuzzy_find_and_replace("a\nb\n", "no_such_text_anywhere", "x", strategies=(strategy,))
+
+
+def test_find_closest_lines_reports_line_numbers_and_scores() -> None:
+    content = "alpha\nbeta gamma delta\nomega\n"
+
+    hint = find_closest_lines(content, "beta gamma delta epsilon")
+
+    assert "line 2" in hint
+    assert "%" in hint

--- a/tests/test_tools/test_schema_sanitize.py
+++ b/tests/test_tools/test_schema_sanitize.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from agentos.tools.schema_sanitize import sanitize_input_schema
+
+
+def test_clean_schema_passes_through_untouched() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"path": {"type": "string", "description": "A path."}},
+        "required": ["path"],
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert fixes == []
+    assert cleaned == schema
+
+
+def test_object_without_properties_gains_an_empty_one() -> None:
+    # llama.cpp's grammar converter fails the whole request on this shape.
+    cleaned, fixes = sanitize_input_schema({"type": "object"})
+
+    assert cleaned == {"type": "object", "properties": {}}
+    assert "added_missing_properties" in fixes
+
+
+def test_nullable_union_collapses_to_the_concrete_branch() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "anyOf": [{"type": "integer"}, {"type": "null"}],
+                "description": "How many.",
+            }
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["limit"] == {"type": "integer", "description": "How many."}
+    assert "collapsed_nullable_union" in fixes
+
+
+def test_union_with_two_real_branches_is_left_alone() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"value": {"anyOf": [{"type": "integer"}, {"type": "string"}]}},
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["value"]["anyOf"] == [{"type": "integer"}, {"type": "string"}]
+    assert "collapsed_nullable_union" not in fixes
+
+
+def test_type_array_collapses_to_the_non_null_entry() -> None:
+    schema = {"type": "object", "properties": {"name": {"type": ["string", "null"]}}}
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["name"]["type"] == "string"
+    assert "collapsed_type_array" in fixes
+
+
+def test_local_ref_is_inlined_and_defs_are_dropped() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"point": {"$ref": "#/$defs/Point"}},
+        "$defs": {
+            "Point": {"type": "object", "properties": {"x": {"type": "integer"}}},
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["point"] == {
+        "type": "object",
+        "properties": {"x": {"type": "integer"}},
+    }
+    assert "$defs" not in cleaned
+    assert "inlined_ref" in fixes
+
+
+def test_ref_siblings_survive_inlining() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "point": {"$ref": "#/$defs/Point", "description": "Where."},
+        },
+        "$defs": {"Point": {"type": "object", "properties": {}}},
+    }
+
+    cleaned, _ = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["point"]["description"] == "Where."
+
+
+def test_dangling_ref_is_dropped_without_failing_the_tool() -> None:
+    schema = {"type": "object", "properties": {"thing": {"$ref": "#/$defs/Missing"}}}
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert "$ref" not in cleaned["properties"]["thing"]
+    assert "dropped_dangling_ref" in fixes
+
+
+def test_self_referential_defs_terminate() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"node": {"$ref": "#/$defs/Node"}},
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {"child": {"$ref": "#/$defs/Node"}},
+            }
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert "cycle_truncated" in fixes
+    assert cleaned["properties"]["node"]["type"] == "object"
+
+
+def test_bare_string_property_value_is_dropped() -> None:
+    schema = {"type": "object", "properties": {"broken": "object", "ok": {"type": "string"}}}
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert "broken" not in cleaned["properties"]
+    assert cleaned["properties"]["ok"] == {"type": "string"}
+    assert "dropped_non_schema_property" in fixes
+
+
+def test_required_entries_for_dropped_properties_are_pruned() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"broken": "object", "ok": {"type": "string"}},
+        "required": ["broken", "ok"],
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["required"] == ["ok"]
+    assert "pruned_required" in fixes
+
+
+def test_non_object_root_is_forced_to_an_object() -> None:
+    cleaned, fixes = sanitize_input_schema({"type": "string"})
+
+    assert cleaned["type"] == "object"
+    assert cleaned["properties"] == {}
+    assert "forced_object_root" in fixes
+
+
+def test_non_mapping_schema_is_replaced() -> None:
+    cleaned, fixes = sanitize_input_schema("object")
+
+    assert cleaned == {"type": "object", "properties": {}}
+    assert fixes == ["replaced_non_object_schema"]
+
+
+def test_additional_properties_false_is_preserved() -> None:
+    schema = {"type": "object", "properties": {}, "additionalProperties": False}
+
+    cleaned, _ = sanitize_input_schema(schema)
+
+    assert cleaned["additionalProperties"] is False
+
+
+def test_nested_properties_are_sanitized_too() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "outer": {
+                "type": "object",
+                "properties": {"inner": {"type": ["integer", "null"]}},
+            }
+        },
+    }
+
+    cleaned, fixes = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["outer"]["properties"]["inner"]["type"] == "integer"
+    assert "collapsed_type_array" in fixes
+
+
+def test_array_items_are_sanitized() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": ["string", "null"]}},
+        },
+    }
+
+    cleaned, _ = sanitize_input_schema(schema)
+
+    assert cleaned["properties"]["tags"]["items"]["type"] == "string"
+
+
+def test_sanitizing_twice_changes_nothing_further() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "limit": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            "point": {"$ref": "#/$defs/Point"},
+            "broken": "object",
+        },
+        "required": ["limit", "broken"],
+        "$defs": {"Point": {"type": "object"}},
+    }
+
+    once, first_fixes = sanitize_input_schema(schema)
+    twice, second_fixes = sanitize_input_schema(once)
+
+    assert once == twice
+    assert first_fixes != []
+    assert second_fixes == []


### PR DESCRIPTION
Two independent tool-layer reliability fixes. Both are failures happening today,
not missing features, and neither changes the CLI surface or adds a config key.

## `edit_file` required exact string equality

The model reproduces `old_text` from memory or from an earlier `read_file`, and
that reproduction routinely drifts in ways that carry no meaning for the edit: a
re-indented block, a tab that became spaces, an unexpanded `\n` literal, a smart
quote carried in from prose. Every one of those raised `old_text not found` and
cost a turn to retry.

Exact equality is still tried first and costs nothing extra. Only once it misses
does a chain of increasingly permissive strategies run, and the matched strategy
is reported in the tool result (`Edited /path [match=indent_agnostic]: …`) and
logged, so an edit that landed on similarity is visible rather than silent.

Three properties keep the permissive end of the chain safe to run by default:

- **Spans stay in original coordinates.** A strategy may normalize text to
  *find* a match, but maps the result back to offsets in the untouched content,
  so characters outside the replaced region are never rewritten — a smart quote
  on a line the edit did not touch survives.
- **Replacements are re-indented to the region they land in.** Without this, a
  strategy that ignored indentation to match would paste the model's
  indentation into the file and break the code it just edited. Relative nesting
  inside the replacement is preserved; a file indented with tabs keeps its tabs.
- **Ambiguity raises instead of guessing.** Text matching more than once is
  rejected, now naming every line. The two similarity-based strategies
  additionally require a clear margin over the runner-up, so a file containing
  two comparable blocks reports both rather than picking one.

A failed edit now also reports the closest regions it found, with line numbers,
instead of only "not found".

## MCP tool schemas reached the provider unchecked

A server's `inputSchema` went into `ToolSpec` unchanged and out again in every
provider request. AgentOS's own tools are well-formed by construction — they
declare parameters through `@tool` and reach the provider as a typed
`ToolInputSchema` — so discovery is the only ingress for foreign schemas, and
nothing was checking it.

The failure is not scoped to the offending tool: a rejected schema fails the
whole request, taking every other tool with it. Pydantic-backed servers emit
`$ref` into `$defs` for nested models and an `anyOf`/null union for every
`Optional` field, which several providers do not support and Anthropic rejects
outright at the top of `input_schema`. An object without `properties` makes
llama.cpp's grammar converter abort. A server that serialized its own types
wrong sends a bare string where a schema belongs.

Schemas are now normalized once at registration rather than per request: local
refs are inlined, null-only unions collapse to their concrete branch, type
arrays lose their null entry, objects gain the empty `properties` a grammar
converter needs, and non-schema values are dropped along with any `required`
entry naming them. The pass is idempotent, depth-capped against
self-referential `$defs`, and never raises — a schema it cannot repair is
returned as it arrived, because a tool the model can still call beats a
discovery that aborted. Repairs are logged with the tool name so a server
emitting broken schemas can be identified.

## Notes on scope

- **No config key.** `[tools]` values reach the tool layer through
  `ToolContext`, so a kill switch would mean touching `ToolsConfig`, the policy
  chain, `ToolContext`, the config view and docs — more surface than the change
  itself. The safety here is structural rather than tunable, and every fallback
  names its strategy in the result and the log, so a bad match is diagnosable
  without one.
- **No defensive pass in `ToolRegistry.register`.** It has exactly two callers:
  the `@tool` decorator (clean by construction) and MCP discovery (now
  sanitized). A third guard would run per turn in `to_tool_definitions` for a
  case that does not exist.

## Verification

`ruff` and `mypy` (580 files) clean; `uv build --wheel` succeeds; full suite
**6686 passed, 27 skipped, 0 failed**.

47 tests added: 22 unit tests over the strategy chain (one per strategy, plus
re-indent, unicode preservation, ambiguity, hint quality, idempotency), 6
through `edit_file` itself, 17 over the sanitizer (one per malformed shape,
plus idempotency and the cycle guard), and 2 through MCP discovery covering a
dirty schema and a clean one.
