### PR TITLE
feat(provider): one accounted path for side-task LLM calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `[auxiliary]` configures the model for work AgentOS runs on its own behalf
+  rather than as part of a turn — analysing an attached document, describing an
+  image. Empty values reuse `[llm]`, so an install that never sets it is
+  unchanged; point it at something cheap when those tasks do not need your main
+  model. Per-task overrides live in `[auxiliary.tasks.<task>]` (`document` and
+  `vision` today), because a text-only model cannot describe an image.
+
 ### Changed
 
 - `edit_file` no longer fails on text that differs from the file only in
@@ -26,6 +35,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   becomes `"string"`, objects without `properties` gain an empty one, and
   values that are not schemas at all are dropped along with any `required`
   entry naming them.
+
+- Side-task LLM calls spent tokens that nothing recorded. Analysing a document
+  and describing an image each built their own provider client, so the cost
+  appeared on the provider bill but never in `agentos cost`. Those calls now run
+  through one auxiliary client that bills the session that triggered them and
+  additionally records them under an `aux:<task>` scope, keeping runtime cost
+  separable from turn cost. Two copies of the provider-to-credential mapping in
+  `tools/builtin/media.py` collapse into one — the document path had only ever
+  read the environment, so it ignored a key configured in `[llm]` for the same
+  provider and now finds it.
+
+- A side task with no reachable API key sent the request anyway and failed on
+  `Illegal header value b'Bearer '`, which named neither the provider nor the
+  variable to set. It now fails before the request with both. Local backends
+  such as Ollama, which authenticate by reachability rather than by key, are
+  unaffected.
 
 ## [2026.7.31] - 2026-07-31
 

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -407,6 +407,24 @@ enabled = true
 # model = ""            # None = use session model
 # timeout_seconds = 30.0
 
+[auxiliary]
+# The model for work AgentOS does on its own behalf rather than as part of a
+# turn: analysing an attached document, describing an image. These calls are
+# billed to the session but tracked separately, so `agentos cost` can show what
+# the agent spent answering versus what the runtime spent on its own.
+#
+# Leave empty to reuse the [llm] provider and model. Point it at something
+# cheap if these tasks do not need your main model.
+# provider = ""
+# model = ""
+# timeout_seconds = 120.0
+
+# Per-task overrides. Tasks in use: "document" (analysing an attached file) and
+# "vision" (describing an image). A task with a capability requirement wants its
+# own entry — vision needs a model that can actually see an image.
+# [auxiliary.tasks.vision]
+# model = "openai/gpt-4o-mini"
+
 [sandbox]
 # Per-command ephemeral sandbox + security grading.
 #

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -594,6 +594,37 @@ embedding support.
 
 Read: [`features/memory.md`](features/memory.md)
 
+## Auxiliary Model
+
+Not every provider call belongs to a turn. Analysing a document the user
+attached and describing an image are work AgentOS initiates on its own behalf.
+These run against the `[auxiliary]` model rather than the agent's:
+
+```toml
+[auxiliary]
+provider = ""            # empty = reuse [llm]
+model = ""               # empty = reuse [llm]
+timeout_seconds = 120.0
+
+[auxiliary.tasks.vision]
+model = "openai/gpt-4o-mini"
+```
+
+Point it at something cheap when these tasks do not need your main model. Tasks
+currently in use are `document` and `vision`; a task with a capability
+requirement wants its own entry, since a text-only model cannot describe an
+image.
+
+Resolution runs highest-first: `AGENTOS_<TASK>_MODEL` (for example
+`AGENTOS_VISION_MODEL`), then `[auxiliary.tasks.<task>]`, then a
+capability-aware default such as the router's image-capable tier, then
+`[auxiliary]`, then `AGENTOS_LLM_MODEL`, then `[llm]`. An install that sets
+none of this keeps using the `[llm]` model exactly as before.
+
+These calls are billed to the session that triggered them and are additionally
+tracked under an `aux:<task>` scope, so `agentos cost` can separate what the
+agent spent answering from what the runtime spent on its own.
+
 ## Sandbox and Permissions
 
 Inspect or change posture:

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1668,6 +1668,18 @@ async def build_services(
     if usage_tracker is None:
         usage_tracker = _UsageTracker(default_provider_id=config.llm.provider)
 
+    # ── Auxiliary LLM client (needs the tracker above to bill side tasks) ──
+    try:
+        from agentos.provider.auxiliary import configure_auxiliary
+
+        configure_auxiliary(
+            config.auxiliary,
+            llm_config=config.llm,
+            usage_tracker=usage_tracker,
+        )
+    except Exception as e:
+        log.warning("build_services.auxiliary_config_failed", error=str(e))
+
     # ── Search provider (brave > duckduckgo fallback) ───────────────
     try:
         import agentos.search.providers.brave  # noqa: F401 — registers provider

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1235,6 +1235,32 @@ class CompactionLlmConfig(BaseSettings):
     enabled: bool = True
 
 
+class AuxiliaryTaskConfig(BaseModel):
+    """Per-task override for a side-task LLM call."""
+
+    provider: str = ""
+    model: str = ""
+
+
+class AuxiliaryConfig(BaseSettings):
+    """Model used for work AgentOS initiates itself, not for the agent's turn.
+
+    Document analysis and image description run here today. Empty values fall
+    back to the configured ``[llm]`` section, so an install that never sets
+    this keeps working exactly as before.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AGENTOS_AUXILIARY_",
+        env_nested_delimiter="__",
+    )
+
+    provider: str = ""
+    model: str = ""
+    timeout_seconds: float = 120.0
+    tasks: dict[str, AuxiliaryTaskConfig] = Field(default_factory=dict)
+
+
 class MCPServerEntry(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="AGENTOS_MCP_SERVER_")
 
@@ -1666,6 +1692,7 @@ class GatewayConfig(BaseSettings):
     agentos_router: AgentOSRouterConfig = Field(default_factory=AgentOSRouterConfig)
     agent_token_saving: AgentTokenSavingConfig = Field(default_factory=AgentTokenSavingConfig)
     compaction: CompactionLlmConfig = Field(default_factory=CompactionLlmConfig)
+    auxiliary: AuxiliaryConfig = Field(default_factory=AuxiliaryConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
     image_generation: ImageGenerationConfig = Field(default_factory=ImageGenerationConfig)

--- a/src/agentos/gateway/config_commit.py
+++ b/src/agentos/gateway/config_commit.py
@@ -323,6 +323,7 @@ def sync_provider_selector(ctx: RpcContext, config: Any) -> None:
 
 
 def sync_media(config: Any) -> None:
+    from agentos.provider.auxiliary import configure_auxiliary
     from agentos.tools.builtin.media import configure_audio, configure_image_generation
 
     configure_image_generation(
@@ -331,6 +332,10 @@ def sync_media(config: Any) -> None:
         agentos_router_config=getattr(config, "agentos_router", None),
     )
     configure_audio(getattr(config, "audio", None))
+    configure_auxiliary(
+        getattr(config, "auxiliary", None),
+        llm_config=getattr(config, "llm", None),
+    )
 
 
 def sync_search(config: Any) -> None:

--- a/src/agentos/provider/auxiliary.py
+++ b/src/agentos/provider/auxiliary.py
@@ -1,0 +1,449 @@
+"""One path for the LLM calls AgentOS makes on its own behalf.
+
+Not every provider call belongs to a turn. Analysing a PDF the user attached,
+describing an image, and — as the harness grows — summarising a transcript or
+reviewing what a turn produced are all work AgentOS initiates itself. They are
+not the agent's conversation and must not be charged to its prompt cache.
+
+Before this module each of those calls carried its own copy of the plumbing:
+which model to use, where the key lives, what a failure means. The copies drift
+— `tools/builtin/media.py` had two provider-to-credential mappings side by side,
+one that consulted the configured `[llm]` section and one that only read the
+environment — and none of them recorded what they spent, so side-task tokens
+were invisible in `agentos cost` while still appearing on the bill.
+
+What this owns:
+
+* **Model resolution**, in one documented order, so a task can be pointed at a
+  cheaper model without touching the code that calls it.
+* **Credentials**, resolved once from the configured provider and then the
+  environment, rather than per call site.
+* **Accounting.** Every call is recorded under the scope ``aux:<task>``, so its
+  cost lands in the session total *and* stays separable from turn cost.
+* **Failure shape.** Errors arrive classified through the same taxonomy the
+  turn loop uses, so a caller decides to degrade or raise on real information.
+
+What this deliberately does not do: re-enter ``TurnRunner``, touch the session
+transcript, or reuse message history carrying cache breakpoints. A side task
+that broke the main prompt cache would cost more than it saves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+
+from agentos.provider.failures import ProviderFailureKind, classify_provider_error
+from agentos.provider.selector import ProviderConfig, build_provider
+from agentos.provider.types import ChatConfig, Message
+
+log = structlog.get_logger(__name__)
+
+# Small, cheap, widely available. Only used when nothing else is configured.
+DEFAULT_AUXILIARY_MODEL = "openai/gpt-4o-mini"
+DEFAULT_AUXILIARY_TIMEOUT_SECONDS = 120.0
+
+_OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+@dataclass(frozen=True)
+class AuxResult:
+    """What an auxiliary call produced, and what it cost."""
+
+    text: str
+    provider: str
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+class AuxiliaryError(RuntimeError):
+    """An auxiliary call failed.
+
+    ``kind`` carries the same classification the turn loop uses, so a caller
+    can tell "no credentials configured" from "the provider is rate limiting"
+    without parsing a message.
+    """
+
+    def __init__(self, message: str, *, task: str, kind: ProviderFailureKind | None = None) -> None:
+        super().__init__(message)
+        self.task = task
+        self.kind = kind
+
+
+@dataclass
+class _Resolution:
+    provider: str
+    model: str
+    source: str
+
+
+def _config_value(config: Any | None, key: str, default: Any = "") -> Any:
+    if config is None:
+        return default
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _env_scope(task: str) -> tuple[str, str]:
+    """Read the ``AGENTOS_<TASK>_*`` override pair for a task.
+
+    These predate this module — `AGENTOS_VISION_MODEL` and friends are how
+    operators pin a side-task model today — so they stay the highest-priority
+    source rather than being quietly demoted below the new config section.
+
+    ``LLM`` is excluded: ``AGENTOS_LLM_MODEL`` is the general model setting the
+    turn loop reads too, not a side-task override. Treating it as one would let
+    it outrank ``[auxiliary].model`` and defeat the whole point of the section,
+    so it is consulted further down instead.
+    """
+
+    scope = task.strip().upper()
+    if not scope or scope == "LLM":
+        return "", ""
+    return (
+        str(os.environ.get(f"AGENTOS_{scope}_PROVIDER", "") or "").strip(),
+        str(os.environ.get(f"AGENTOS_{scope}_MODEL", "") or "").strip(),
+    )
+
+
+@dataclass
+class AuxiliaryClient:
+    """Runs side-task LLM calls against a resolved, accounted provider."""
+
+    config: Any | None = None
+    llm_config: Any | None = None
+    usage_tracker: Any | None = None
+    provider_factory: Any = field(default=build_provider)
+
+    # -- resolution ---------------------------------------------------------
+
+    def _task_config(self, task: str) -> Any | None:
+        tasks = _config_value(self.config, "tasks", None)
+        if isinstance(tasks, Mapping):
+            return tasks.get(task)
+        return _config_value(tasks, task, None)
+
+    def _resolve_target(
+        self,
+        task: str,
+        *,
+        preferred_provider: str = "",
+        preferred_model: str = "",
+        default_model: str = "",
+    ) -> _Resolution:
+        """Pick the provider and model for *task*.
+
+        Order, highest first:
+
+        1. ``AGENTOS_<TASK>_PROVIDER`` / ``AGENTOS_<TASK>_MODEL``
+        2. ``[auxiliary.tasks.<task>]``
+        3. the caller's hint — a capability-aware choice such as the router's
+           image-capable tier, which has to outrank a generic default because a
+           text model cannot do the job
+        4. ``[auxiliary]``
+        5. ``AGENTOS_LLM_PROVIDER`` / ``AGENTOS_LLM_MODEL``
+        6. the configured ``[llm]`` section
+        7. the caller's ``default_model``, then :data:`DEFAULT_AUXILIARY_MODEL`
+        """
+
+        task_cfg = self._task_config(task)
+        env_provider, env_model = _env_scope(task)
+
+        provider_candidates = (
+            (env_provider, "env_scope"),
+            (str(_config_value(task_cfg, "provider", "") or "").strip(), "auxiliary_task"),
+            (str(preferred_provider or "").strip(), "caller_hint"),
+            (str(_config_value(self.config, "provider", "") or "").strip(), "auxiliary"),
+            (str(os.environ.get("AGENTOS_LLM_PROVIDER", "") or "").strip(), "env_llm"),
+            (str(_config_value(self.llm_config, "provider", "") or "").strip(), "llm_config"),
+        )
+        model_candidates = (
+            (env_model, "env_scope"),
+            (str(_config_value(task_cfg, "model", "") or "").strip(), "auxiliary_task"),
+            (str(preferred_model or "").strip(), "caller_hint"),
+            (str(_config_value(self.config, "model", "") or "").strip(), "auxiliary"),
+            (str(os.environ.get("AGENTOS_LLM_MODEL", "") or "").strip(), "env_llm"),
+            (str(_config_value(self.llm_config, "model", "") or "").strip(), "llm_config"),
+            (str(default_model or "").strip(), "caller_default"),
+        )
+
+        provider = next((value for value, _ in provider_candidates if value), "openrouter")
+        model = next((value for value, _ in model_candidates if value), DEFAULT_AUXILIARY_MODEL)
+        source = next((name for value, name in model_candidates if value), "builtin_default")
+        return _Resolution(provider=provider.lower(), model=model, source=source)
+
+    def _credentials(self, provider: str) -> tuple[str, str, str, dict[str, str]]:
+        """Find the key, base URL, proxy and routing for *provider*.
+
+        The configured ``[llm]`` section wins when it describes this same
+        provider — an operator who set a key there meant it — and the
+        environment fills whatever is left.
+        """
+
+        configured = str(_config_value(self.llm_config, "provider", "") or "").strip().lower()
+        use_configured = bool(configured) and configured == provider
+
+        api_key = str(_config_value(self.llm_config, "api_key", "") or "") if use_configured else ""
+        if use_configured and not api_key:
+            api_key_env = str(_config_value(self.llm_config, "api_key_env", "") or "")
+            if api_key_env:
+                api_key = os.environ.get(api_key_env, "")
+        base_url = (
+            str(_config_value(self.llm_config, "base_url", "") or "") if use_configured else ""
+        )
+        proxy = str(_config_value(self.llm_config, "proxy", "") or "") if use_configured else ""
+        routing = _config_value(self.llm_config, "provider_routing", {}) if use_configured else {}
+        if not isinstance(routing, dict):
+            routing = {}
+
+        if provider == "anthropic":
+            api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+            base_url = base_url or os.environ.get("ANTHROPIC_BASE_URL", "")
+        elif provider == "openrouter":
+            api_key = (
+                api_key
+                or os.environ.get("OPENROUTER_API_KEY", "")
+                or os.environ.get("OPENAI_API_KEY", "")
+            )
+            base_url = base_url or os.environ.get(
+                "OPENROUTER_BASE_URL", _OPENROUTER_DEFAULT_BASE_URL
+            )
+        else:
+            api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+            base_url = base_url or os.environ.get("OPENAI_BASE_URL", "")
+
+        return api_key, base_url, proxy or os.environ.get("AGENTOS_LLM_PROXY", ""), routing
+
+    def provider_config(
+        self,
+        task: str,
+        *,
+        preferred_provider: str = "",
+        preferred_model: str = "",
+        default_model: str = "",
+    ) -> ProviderConfig:
+        """Resolve *task* to a fully populated provider config."""
+
+        target = self._resolve_target(
+            task,
+            preferred_provider=preferred_provider,
+            preferred_model=preferred_model,
+            default_model=default_model,
+        )
+        api_key, base_url, proxy, routing = self._credentials(target.provider)
+        return ProviderConfig(
+            provider=target.provider,
+            model=target.model,
+            api_key=api_key,
+            base_url=base_url,
+            proxy=proxy,
+            provider_routing=routing,
+        )
+
+    # -- execution ----------------------------------------------------------
+
+    def _timeout(self, override: float | None) -> float:
+        if override is not None and override > 0:
+            return float(override)
+        configured = _config_value(self.config, "timeout_seconds", 0.0)
+        try:
+            value = float(configured or 0.0)
+        except (TypeError, ValueError):
+            value = 0.0
+        return value if value > 0 else DEFAULT_AUXILIARY_TIMEOUT_SECONDS
+
+    def _require_credentials(self, task: str, cfg: ProviderConfig) -> None:
+        """Fail early, and legibly, when no key is reachable.
+
+        Otherwise the request goes out with an empty bearer token and the
+        provider answers with a transport complaint about a malformed header
+        — ``Illegal header value b'Bearer '`` — which tells the operator
+        nothing about what to fix. Local backends are exempt: they
+        authenticate by reachability, not by key.
+
+        Only the real builder is guarded. A caller that injected its own
+        factory has taken over how the client is authenticated, and holding it
+        to this rule would reject doubles that need no credentials at all.
+        """
+
+        if cfg.api_key or self.provider_factory is not build_provider:
+            return
+        try:
+            from agentos.provider.registry import get_provider_spec
+
+            spec = get_provider_spec(cfg.provider)
+        except Exception:  # noqa: BLE001 — an unknown provider fails later, with its own message
+            return
+        if "api_key" not in spec.required_fields:
+            return
+        hint = f" Set {spec.env_key}." if spec.env_key else ""
+        raise AuxiliaryError(
+            f"auxiliary task {task!r} has no API key for provider {cfg.provider!r}.{hint}",
+            task=task,
+            kind=ProviderFailureKind.AUTH_INVALID,
+        )
+
+    def _record(self, task: str, session_key: str | None, done: Any, model: str) -> None:
+        tracker = self.usage_tracker
+        if tracker is None or not session_key:
+            return
+        from agentos.engine.usage import usage_scope
+
+        try:
+            with usage_scope(f"aux:{task}"):
+                tracker.add(
+                    session_key,
+                    int(getattr(done, "input_tokens", 0) or 0),
+                    int(getattr(done, "output_tokens", 0) or 0),
+                    model_id=str(getattr(done, "model", "") or model),
+                    cache_read_tokens=int(getattr(done, "cached_tokens", 0) or 0),
+                    cache_write_tokens=int(getattr(done, "cache_write_tokens", 0) or 0),
+                    billed_cost=float(getattr(done, "billed_cost", 0.0) or 0.0),
+                )
+        except Exception as exc:  # noqa: BLE001 — accounting must not fail the call
+            log.warning("auxiliary.usage_record_failed", task=task, error=str(exc))
+
+    async def complete(
+        self,
+        *,
+        task: str,
+        messages: list[Message],
+        preferred_provider: str = "",
+        preferred_model: str = "",
+        default_model: str = "",
+        chat_config: ChatConfig | None = None,
+        timeout: float | None = None,
+        session_key: str | None = None,
+    ) -> AuxResult:
+        """Run one side-task completion and return the assembled text.
+
+        Raises:
+            AuxiliaryError: the provider could not be built, the stream failed,
+                or the call exceeded its timeout.
+        """
+
+        cfg = self.provider_config(
+            task,
+            preferred_provider=preferred_provider,
+            preferred_model=preferred_model,
+            default_model=default_model,
+        )
+        self._require_credentials(task, cfg)
+        try:
+            provider = self.provider_factory(
+                provider=cfg.provider,
+                model=cfg.model,
+                api_key=cfg.api_key,
+                base_url=cfg.base_url,
+            )
+        except Exception as exc:
+            raise AuxiliaryError(
+                f"auxiliary task {task!r} could not build provider {cfg.provider!r}: {exc}",
+                task=task,
+                kind=ProviderFailureKind.AUTH_INVALID,
+            ) from exc
+
+        budget = self._timeout(timeout)
+        try:
+            result = await asyncio.wait_for(
+                self._drain(task, provider, messages, chat_config, cfg, session_key),
+                timeout=budget,
+            )
+        except TimeoutError as exc:
+            raise AuxiliaryError(
+                f"auxiliary task {task!r} timed out after {budget:g}s",
+                task=task,
+                # A timeout is transient by nature; the taxonomy already routes
+                # TRANSPORT_TRANSIENT to a retry rather than a config failure.
+                kind=ProviderFailureKind.TRANSPORT_TRANSIENT,
+            ) from exc
+
+        log.debug(
+            "auxiliary.completed",
+            task=task,
+            provider=cfg.provider,
+            model=cfg.model,
+            output_tokens=result.output_tokens,
+        )
+        return result
+
+    async def _drain(
+        self,
+        task: str,
+        provider: Any,
+        messages: list[Message],
+        chat_config: ChatConfig | None,
+        cfg: ProviderConfig,
+        session_key: str | None,
+    ) -> AuxResult:
+        parts: list[str] = []
+        input_tokens = 0
+        output_tokens = 0
+
+        async for event in provider.chat(messages=messages, config=chat_config):
+            kind = getattr(event, "kind", "")
+            if kind == "error":
+                code = str(getattr(event, "code", "") or "provider_error")
+                message = str(getattr(event, "message", "") or "provider stream failed")
+                raise AuxiliaryError(
+                    f"auxiliary task {task!r} failed ({code}): {message}",
+                    task=task,
+                    kind=classify_provider_error(cfg.provider, None, code, message),
+                )
+            if kind == "done":
+                input_tokens = int(getattr(event, "input_tokens", 0) or 0)
+                output_tokens = int(getattr(event, "output_tokens", 0) or 0)
+                self._record(task, session_key, event, cfg.model)
+                continue
+            text = getattr(event, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+                continue
+            delta = getattr(event, "delta", None)
+            if isinstance(delta, str):
+                parts.append(delta)
+
+        return AuxResult(
+            text="".join(parts),
+            provider=cfg.provider,
+            model=cfg.model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+
+_client = AuxiliaryClient()
+
+
+def configure_auxiliary(
+    config: Any | None,
+    *,
+    llm_config: Any | None = None,
+    usage_tracker: Any | None = None,
+) -> None:
+    """Point the shared client at the live configuration.
+
+    Called from gateway boot and again on every config commit, mirroring how
+    the media, search and image-generation surfaces are wired.
+    """
+
+    global _client
+    _client = AuxiliaryClient(
+        config=config,
+        llm_config=llm_config,
+        usage_tracker=usage_tracker if usage_tracker is not None else _client.usage_tracker,
+    )
+
+
+def get_auxiliary_client() -> AuxiliaryClient:
+    """Return the shared client. Usable before configuration — it falls back
+    to the environment, which is what an unconfigured install has anyway."""
+
+    return _client

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -184,6 +184,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[control_ui]` | `allowed_origins` for reverse-proxy setups |
 | `[updates]` | `notify` (default true) — the once-per-24h "new release available" notice |
 | `[channels]` | messaging channels (`[[channels.channels]]` entries) |
+| `[auxiliary]` | model for work AgentOS runs itself, not the agent's turn (document analysis, image description): `provider`, `model`, `timeout_seconds`, `[auxiliary.tasks.<task>]`. Empty = reuse `[llm]` |
 | `[compaction]`, `[agent_token_saving]`, `[task_runtime]` | context compaction, tool-result projection, concurrency |
 
 Slack native commands auto-sync when a Slack channel entry provides `app_id`,

--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -66,6 +66,9 @@ _PDF_RENDER_SCALE = 2.0
 _PDF_TEXT_LIMIT = 50_000
 _MAX_REDIRECTS = 5
 _VISION_ANALYSIS_TIMEOUT_SECONDS = 180.0
+# Used only when neither [auxiliary] nor [llm] names a model: small, cheap, and
+# able to read an image, which the document and vision paths both need.
+_DEFAULT_AUXILIARY_MEDIA_MODEL = "openai/gpt-4o-mini"
 _image_generation_config: Any | None = None
 _audio_config: Any | None = None
 _media_llm_config: Any | None = None
@@ -349,33 +352,17 @@ def _mime_to_ext(content_type: str) -> str:
     return mapping.get(ct, "")
 
 
-async def _complete_from_stream(provider: Any, messages: list, config: Any = None) -> str:
-    """Consume a chat() stream and return the assembled text response."""
-    text_parts: list[str] = []
-    async for event in provider.chat(messages=messages, config=config):
-        if hasattr(event, "text"):
-            text_parts.append(event.text)
-        elif hasattr(event, "delta") and isinstance(event.delta, str):
-            text_parts.append(event.delta)
-        elif getattr(event, "kind", None) == "error":
-            code = getattr(event, "code", "") or "provider_error"
-            message = getattr(event, "message", "") or "Provider stream failed"
-            raise RuntimeError(f"Provider stream error ({code}): {message}")
-    return "".join(text_parts)
+def _aux_session_key() -> str | None:
+    ctx = current_tool_context.get()
+    return getattr(ctx, "session_key", None) if ctx is not None else None
 
 
 async def _call_vision_provider(b64_data: str, media_type: str, prompt: str) -> str:
-    """Send image to provider vision API. Raises if provider not available."""
-    try:
-        from agentos.provider.selector import ModelSelector, SelectorConfig
-        from agentos.provider.types import ContentBlockImage, ContentBlockText, Message
+    """Send image to the auxiliary vision model. Raises if it is unavailable."""
+    from agentos.provider.auxiliary import AuxiliaryError, get_auxiliary_client
+    from agentos.provider.types import ContentBlockImage, ContentBlockText, Message
 
-        cfg = _resolve_vision_provider_config(default_model="openai/gpt-4o-mini")
-        selector = ModelSelector(SelectorConfig(primary=cfg))
-        provider = selector.resolve()
-    except Exception as exc:
-        raise RuntimeError(f"Provider not available: {exc}") from exc
-
+    hint_provider, hint_model = _vision_model_hint()
     vision_message = Message(
         role="user",
         content=[
@@ -383,7 +370,18 @@ async def _call_vision_provider(b64_data: str, media_type: str, prompt: str) -> 
             ContentBlockText(text=prompt),
         ],
     )
-    return await _complete_from_stream(provider, [vision_message])
+    try:
+        result = await get_auxiliary_client().complete(
+            task="vision",
+            messages=[vision_message],
+            preferred_provider=hint_provider,
+            preferred_model=hint_model,
+            default_model=_DEFAULT_AUXILIARY_MEDIA_MODEL,
+            session_key=_aux_session_key(),
+        )
+    except AuxiliaryError as exc:
+        raise RuntimeError(f"Provider not available: {exc}") from exc
+    return result.text
 
 
 # ---------------------------------------------------------------------------
@@ -758,16 +756,18 @@ def _parse_page_range(pages: str, total: int) -> list[int]:
 
 
 async def _call_llm_with_text(text: str, prompt: str) -> str:
-    """Send extracted text to LLM with analysis prompt. Graceful fallback."""
+    """Send extracted text to the auxiliary model. Graceful fallback."""
     try:
-        from agentos.provider.selector import ModelSelector, SelectorConfig
+        from agentos.provider.auxiliary import get_auxiliary_client
         from agentos.provider.types import Message
 
-        cfg = _resolve_provider_config("LLM", default_model="openai/gpt-4o-mini")
-        selector = ModelSelector(SelectorConfig(primary=cfg))
-        provider = selector.resolve()
-        message = Message(role="user", content=f"{prompt}\n\n---\n{text}")
-        return await _complete_from_stream(provider, [message])
+        result = await get_auxiliary_client().complete(
+            task="document",
+            messages=[Message(role="user", content=f"{prompt}\n\n---\n{text}")],
+            default_model=_DEFAULT_AUXILIARY_MEDIA_MODEL,
+            session_key=_aux_session_key(),
+        )
+        return result.text
     except Exception:
         return f"[LLM analysis not available] Extracted text ({len(text)} chars) ready."
 
@@ -802,92 +802,42 @@ def _configured_image_tier(router_config: Any | None) -> Any | None:
     return None
 
 
-def _configured_provider_config(provider_name: str, model: str):
-    from agentos.provider.selector import ProviderConfig
+def _vision_model_hint() -> tuple[str, str]:
+    """The image-capable tier the router already knows about, if any.
 
-    provider_name = str(provider_name or "").strip().lower() or "openrouter"
-    llm_provider = str(_config_value(_media_llm_config, "provider", "") or "").strip().lower()
-    use_llm_config = provider_name == llm_provider
+    Offered to the auxiliary client as a hint rather than a decision. It is
+    withheld when the operator pinned the vision scope through the
+    environment, so an explicit ``AGENTOS_VISION_*`` still outranks anything
+    derived — the same precedence this had before resolution moved out.
+    """
 
-    api_key = str(_config_value(_media_llm_config, "api_key", "") or "") if use_llm_config else ""
-    if use_llm_config and not api_key:
-        api_key_env = str(_config_value(_media_llm_config, "api_key_env", "") or "")
-        if api_key_env:
-            api_key = os.environ.get(api_key_env, "")
-
-    base_url = str(_config_value(_media_llm_config, "base_url", "") or "") if use_llm_config else ""
-    proxy = str(_config_value(_media_llm_config, "proxy", "") or "") if use_llm_config else ""
-    provider_routing = (
-        _config_value(_media_llm_config, "provider_routing", {}) if use_llm_config else {}
+    if _has_explicit_scope_override("VISION"):
+        return "", ""
+    tier = _configured_image_tier(_media_agentos_router_config)
+    model = str(_config_value(tier, "model", "") or "")
+    if tier is None or not model:
+        return "", ""
+    provider = str(
+        _config_value(tier, "provider", _config_value(_media_llm_config, "provider", "")) or ""
     )
-    if not isinstance(provider_routing, dict):
-        provider_routing = {}
-
-    if provider_name == "anthropic":
-        api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-        base_url = base_url or os.environ.get("ANTHROPIC_BASE_URL", "")
-    elif provider_name == "openrouter":
-        api_key = api_key or os.environ.get("OPENROUTER_API_KEY", "") or os.environ.get(
-            "OPENAI_API_KEY", ""
-        )
-        base_url = base_url or os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-    else:
-        api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
-        base_url = base_url or os.environ.get("OPENAI_BASE_URL", "")
-
-    return ProviderConfig(
-        provider=provider_name,
-        model=model,
-        api_key=api_key,
-        base_url=base_url,
-        proxy=proxy or os.environ.get("AGENTOS_LLM_PROXY", ""),
-        provider_routing=provider_routing,
-    )
+    return provider, model
 
 
 def _resolve_vision_provider_config(*, default_model: str):
-    if not _has_explicit_scope_override("VISION"):
-        tier = _configured_image_tier(_media_agentos_router_config)
-        model = str(_config_value(tier, "model", "") or "")
-        if tier is not None and model:
-            provider_name = str(
-                _config_value(tier, "provider", _config_value(_media_llm_config, "provider", ""))
-                or "openrouter"
-            )
-            return _configured_provider_config(provider_name, model)
-    return _resolve_provider_config("VISION", default_model=default_model)
+    """Resolve the vision provider, credentials included.
 
+    Kept as a named seam because the resolution it performs is what the vision
+    path depends on; the work itself now lives in the auxiliary client.
+    """
 
-def _resolve_provider_config(scope: str, *, default_model: str):
-    from agentos.provider.selector import ProviderConfig
+    from agentos.provider.auxiliary import get_auxiliary_client
 
-    provider_name = (
-        os.environ.get(f"AGENTOS_{scope}_PROVIDER")
-        or os.environ.get("AGENTOS_LLM_PROVIDER")
-        or "openrouter"
-    )
-    model = (
-        os.environ.get(f"AGENTOS_{scope}_MODEL")
-        or os.environ.get("AGENTOS_LLM_MODEL")
-        or default_model
-    )
-
-    if provider_name == "anthropic":
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-        base_url = os.environ.get("ANTHROPIC_BASE_URL", "")
-    elif provider_name == "openrouter":
-        api_key = os.environ.get("OPENROUTER_API_KEY", "") or os.environ.get("OPENAI_API_KEY", "")
-        base_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-    else:
-        api_key = os.environ.get("OPENAI_API_KEY", "")
-        base_url = os.environ.get("OPENAI_BASE_URL", "")
-
-    return ProviderConfig(
-        provider=provider_name,
-        model=model,
-        api_key=api_key,
-        base_url=base_url,
-        proxy=os.environ.get("AGENTOS_LLM_PROXY", ""),
+    hint_provider, hint_model = _vision_model_hint()
+    return get_auxiliary_client().provider_config(
+        "vision",
+        preferred_provider=hint_provider,
+        preferred_model=hint_model,
+        default_model=default_model,
     )
 
 

--- a/tests/test_provider_auxiliary.py
+++ b/tests/test_provider_auxiliary.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.provider.auxiliary import (
+    DEFAULT_AUXILIARY_MODEL,
+    AuxiliaryClient,
+    AuxiliaryError,
+    configure_auxiliary,
+    get_auxiliary_client,
+)
+from agentos.provider.failures import ProviderFailureKind
+from agentos.provider.types import DoneEvent, ErrorEvent, Message
+
+_ENV_KEYS = (
+    "AGENTOS_VISION_PROVIDER",
+    "AGENTOS_VISION_MODEL",
+    "AGENTOS_LLM_PROVIDER",
+    "AGENTOS_LLM_MODEL",
+    "AGENTOS_LLM_PROXY",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _ENV_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _config(**kwargs: object) -> SimpleNamespace:
+    kwargs.setdefault("provider", "")
+    kwargs.setdefault("model", "")
+    kwargs.setdefault("timeout_seconds", 0.0)
+    kwargs.setdefault("tasks", {})
+    return SimpleNamespace(**kwargs)
+
+
+def _stream(*events: object):
+    class _Provider:
+        async def chat(self, *, messages, config=None, tools=None):
+            for event in events:
+                yield event
+
+    def factory(**_kwargs: object) -> _Provider:
+        return _Provider()
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# model resolution
+# ---------------------------------------------------------------------------
+
+
+def test_falls_back_to_the_builtin_model_when_nothing_is_configured() -> None:
+    cfg = AuxiliaryClient().provider_config("llm")
+
+    assert cfg.provider == "openrouter"
+    assert cfg.model == DEFAULT_AUXILIARY_MODEL
+
+
+def test_caller_default_beats_the_builtin_model() -> None:
+    cfg = AuxiliaryClient().provider_config("llm", default_model="vendor/tiny")
+
+    assert cfg.model == "vendor/tiny"
+
+
+def test_llm_section_beats_the_caller_default() -> None:
+    client = AuxiliaryClient(llm_config=SimpleNamespace(provider="openai", model="gpt-x"))
+
+    cfg = client.provider_config("llm", default_model="vendor/tiny")
+
+    assert cfg.provider == "openai"
+    assert cfg.model == "gpt-x"
+
+
+def test_auxiliary_section_beats_the_llm_section() -> None:
+    client = AuxiliaryClient(
+        config=_config(provider="anthropic", model="cheap-1"),
+        llm_config=SimpleNamespace(provider="openai", model="gpt-x"),
+    )
+
+    cfg = client.provider_config("llm")
+
+    assert cfg.provider == "anthropic"
+    assert cfg.model == "cheap-1"
+
+
+def test_caller_hint_beats_the_generic_auxiliary_model() -> None:
+    # The hint is capability-aware — a router tier that can actually see an
+    # image — so a generic text model configured for all side tasks must not
+    # silently take vision's place.
+    client = AuxiliaryClient(config=_config(model="text-only-1"))
+
+    cfg = client.provider_config(
+        "vision", preferred_provider="openrouter", preferred_model="sees-1"
+    )
+
+    assert cfg.model == "sees-1"
+
+
+def test_per_task_config_beats_the_caller_hint() -> None:
+    client = AuxiliaryClient(
+        config=_config(tasks={"vision": SimpleNamespace(provider="", model="pinned-1")})
+    )
+
+    cfg = client.provider_config("vision", preferred_model="sees-1")
+
+    assert cfg.model == "pinned-1"
+
+
+def test_task_scoped_env_beats_every_configured_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_VISION_MODEL", "env-pinned-1")
+    monkeypatch.setenv("AGENTOS_VISION_PROVIDER", "anthropic")
+    client = AuxiliaryClient(
+        config=_config(
+            model="cheap-1", tasks={"vision": SimpleNamespace(provider="", model="pinned-1")}
+        ),
+        llm_config=SimpleNamespace(provider="openai", model="gpt-x"),
+    )
+
+    cfg = client.provider_config("vision", preferred_model="sees-1")
+
+    assert cfg.provider == "anthropic"
+    assert cfg.model == "env-pinned-1"
+
+
+def test_generic_llm_env_sits_below_the_auxiliary_section(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_LLM_MODEL", "env-generic-1")
+    client = AuxiliaryClient(config=_config(model="cheap-1"))
+
+    assert client.provider_config("llm").model == "cheap-1"
+    assert AuxiliaryClient().provider_config("llm").model == "env-generic-1"
+
+
+# ---------------------------------------------------------------------------
+# credentials
+# ---------------------------------------------------------------------------
+
+
+def test_configured_llm_credentials_are_used_for_the_same_provider() -> None:
+    client = AuxiliaryClient(
+        llm_config=SimpleNamespace(
+            provider="openrouter",
+            model="gpt-x",
+            api_key="sk-configured",
+            base_url="https://router.example/v1",
+            proxy="http://proxy.example",
+            provider_routing={"gpt-x": "upstream"},
+        )
+    )
+
+    cfg = client.provider_config("llm")
+
+    assert cfg.api_key == "sk-configured"
+    assert cfg.base_url == "https://router.example/v1"
+    assert cfg.proxy == "http://proxy.example"
+    assert cfg.provider_routing == {"gpt-x": "upstream"}
+
+
+def test_configured_credentials_are_not_reused_for_a_different_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    client = AuxiliaryClient(
+        config=_config(provider="anthropic"),
+        llm_config=SimpleNamespace(provider="openrouter", api_key="sk-openrouter"),
+    )
+
+    cfg = client.provider_config("llm")
+
+    # An OpenRouter key must never be sent to Anthropic.
+    assert cfg.api_key == "sk-ant-env"
+
+
+def test_api_key_env_indirection_is_followed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_VENDOR_KEY", "sk-from-env-name")
+    client = AuxiliaryClient(
+        llm_config=SimpleNamespace(provider="openrouter", api_key="", api_key_env="MY_VENDOR_KEY")
+    )
+
+    assert client.provider_config("llm").api_key == "sk-from-env-name"
+
+
+def test_openrouter_falls_back_to_the_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+
+    cfg = AuxiliaryClient().provider_config("llm")
+
+    assert cfg.provider == "openrouter"
+    assert cfg.api_key == "sk-openai"
+    assert cfg.base_url == "https://openrouter.ai/api/v1"
+
+
+# ---------------------------------------------------------------------------
+# execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_deltas_are_assembled_into_one_result() -> None:
+    client = AuxiliaryClient(
+        provider_factory=_stream(
+            SimpleNamespace(kind="text_delta", text="hel"),
+            SimpleNamespace(kind="text_delta", text="lo"),
+            DoneEvent(input_tokens=11, output_tokens=3),
+        )
+    )
+
+    result = await client.complete(task="llm", messages=[Message(role="user", content="hi")])
+
+    assert result.text == "hello"
+    assert result.input_tokens == 11
+    assert result.output_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_stream_error_raises_classified_rather_than_returning_empty_text() -> None:
+    client = AuxiliaryClient(
+        provider_factory=_stream(ErrorEvent(message="slow down", code="rate_limit_exceeded"))
+    )
+
+    with pytest.raises(AuxiliaryError) as excinfo:
+        await client.complete(task="llm", messages=[Message(role="user", content="hi")])
+
+    assert excinfo.value.task == "llm"
+    assert excinfo.value.kind == ProviderFailureKind.RATE_LIMITED
+
+
+@pytest.mark.asyncio
+async def test_provider_build_failure_is_reported_as_an_auxiliary_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-present")
+
+    def broken_factory(**_kwargs: object):
+        raise RuntimeError("backend exploded")
+
+    client = AuxiliaryClient(provider_factory=broken_factory)
+
+    with pytest.raises(AuxiliaryError) as excinfo:
+        await client.complete(task="vision", messages=[Message(role="user", content="hi")])
+
+    assert excinfo.value.kind == ProviderFailureKind.AUTH_INVALID
+    assert "backend exploded" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_a_missing_api_key_names_the_provider_and_the_variable_to_set() -> None:
+    # Without this guard the request goes out with an empty bearer token and
+    # the provider answers "Illegal header value b'Bearer '", which tells an
+    # operator nothing about what to fix.
+    # No factory is injected, so the real builder — and therefore the guard —
+    # is in play. It fires before anything reaches the network.
+    client = AuxiliaryClient()
+
+    with pytest.raises(AuxiliaryError) as excinfo:
+        await client.complete(task="document", messages=[Message(role="user", content="hi")])
+
+    message = str(excinfo.value)
+    assert excinfo.value.kind == ProviderFailureKind.AUTH_INVALID
+    assert "openrouter" in message
+    assert "OPENROUTER_API_KEY" in message
+
+
+def test_a_local_backend_needs_no_api_key() -> None:
+    # Ollama authenticates by reachability; demanding a key would break it.
+    client = AuxiliaryClient(config=_config(provider="ollama", model="llama3"))
+
+    cfg = client.provider_config("document")
+
+    assert cfg.provider == "ollama"
+    assert not cfg.api_key
+    client._require_credentials("document", cfg)  # must not raise
+
+
+def test_an_injected_factory_is_trusted_to_handle_its_own_auth() -> None:
+    client = AuxiliaryClient(provider_factory=lambda **_kwargs: object())
+
+    cfg = client.provider_config("document")
+
+    assert not cfg.api_key
+    client._require_credentials("document", cfg)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_a_hanging_provider_is_cut_off_by_the_timeout() -> None:
+    import asyncio
+
+    class _Hanging:
+        async def chat(self, *, messages, config=None, tools=None):
+            await asyncio.sleep(30)
+            yield DoneEvent()
+
+    client = AuxiliaryClient(provider_factory=lambda **_kwargs: _Hanging())
+
+    with pytest.raises(AuxiliaryError) as excinfo:
+        await client.complete(
+            task="llm",
+            messages=[Message(role="user", content="hi")],
+            timeout=0.05,
+        )
+
+    assert excinfo.value.kind == ProviderFailureKind.TRANSPORT_TRANSIENT
+
+
+# ---------------------------------------------------------------------------
+# accounting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_usage_is_billed_to_the_session_and_kept_separable() -> None:
+    from agentos.engine.usage import UsageTracker
+
+    tracker = UsageTracker()
+    client = AuxiliaryClient(
+        usage_tracker=tracker,
+        provider_factory=_stream(
+            SimpleNamespace(kind="text_delta", text="ok"),
+            DoneEvent(input_tokens=100, output_tokens=20, model="vendor/small"),
+        ),
+    )
+
+    await client.complete(
+        task="vision",
+        messages=[Message(role="user", content="hi")],
+        session_key="session-1",
+    )
+
+    session = tracker.get("session-1")
+    assert session is not None
+    assert session.input_tokens == 100
+    assert session.output_tokens == 20
+    # The same tokens are also recorded under a scope, so turn cost and
+    # side-task cost stay tellable apart.
+    assert ("session-1", "aux:vision") in tracker._scopes
+
+
+@pytest.mark.asyncio
+async def test_a_call_without_a_session_records_nothing_and_still_succeeds() -> None:
+    from agentos.engine.usage import UsageTracker
+
+    tracker = UsageTracker()
+    client = AuxiliaryClient(
+        usage_tracker=tracker,
+        provider_factory=_stream(
+            SimpleNamespace(kind="text_delta", text="ok"),
+            DoneEvent(input_tokens=5, output_tokens=1),
+        ),
+    )
+
+    result = await client.complete(task="llm", messages=[Message(role="user", content="hi")])
+
+    assert result.text == "ok"
+    assert tracker.get("") is None
+
+
+@pytest.mark.asyncio
+async def test_a_failing_tracker_does_not_fail_the_call() -> None:
+    class _Broken:
+        def add(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError("tracker exploded")
+
+    client = AuxiliaryClient(
+        usage_tracker=_Broken(),
+        provider_factory=_stream(
+            SimpleNamespace(kind="text_delta", text="ok"),
+            DoneEvent(input_tokens=1, output_tokens=1),
+        ),
+    )
+
+    result = await client.complete(
+        task="llm",
+        messages=[Message(role="user", content="hi")],
+        session_key="session-1",
+    )
+
+    assert result.text == "ok"
+
+
+# ---------------------------------------------------------------------------
+# wiring
+# ---------------------------------------------------------------------------
+
+
+def test_configure_replaces_the_shared_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agentos.provider import auxiliary
+
+    original = auxiliary._client
+    try:
+        configure_auxiliary(
+            _config(model="configured-1"),
+            llm_config=SimpleNamespace(provider="openai"),
+        )
+        assert get_auxiliary_client().provider_config("llm").model == "configured-1"
+    finally:
+        auxiliary._client = original
+
+
+def test_configure_keeps_a_tracker_wired_by_an_earlier_call() -> None:
+    from agentos.engine.usage import UsageTracker
+    from agentos.provider import auxiliary
+
+    original = auxiliary._client
+    tracker = UsageTracker()
+    try:
+        configure_auxiliary(_config(), usage_tracker=tracker)
+        # A later config commit carries no tracker; it must not drop the one
+        # boot already supplied or side-task cost stops being recorded.
+        configure_auxiliary(_config(model="after-commit"))
+        assert get_auxiliary_client().usage_tracker is tracker
+    finally:
+        auxiliary._client = original

--- a/tests/test_provider_image_generation.py
+++ b/tests/test_provider_image_generation.py
@@ -31,6 +31,25 @@ def _clear_vision_provider_env(monkeypatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
+def _use_auxiliary(monkeypatch, *, llm_config=None, config=None, factory=None):
+    """Point the shared auxiliary client at test doubles.
+
+    The vision and document paths resolve and run their provider through this
+    client, so a test intercepts it by replacing its provider factory rather
+    than whatever the client uses internally.
+    """
+
+    from agentos.provider import auxiliary
+
+    client = auxiliary.AuxiliaryClient(
+        config=config,
+        llm_config=llm_config,
+        provider_factory=factory if factory is not None else auxiliary.build_provider,
+    )
+    monkeypatch.setattr(auxiliary, "_client", client)
+    return client
+
+
 @pytest.mark.asyncio
 async def test_openrouter_image_provider_adds_app_attribution_headers(monkeypatch) -> None:
     captured: dict[str, object] = {}
@@ -309,6 +328,7 @@ def test_vision_provider_uses_configured_router_image_tier(monkeypatch) -> None:
         llm_config=llm_config,
         agentos_router_config=router_config,
     )
+    _use_auxiliary(monkeypatch, llm_config=llm_config)
     try:
         cfg = media._resolve_vision_provider_config(default_model="openai/gpt-4o-mini")
     finally:
@@ -411,14 +431,12 @@ async def test_image_tool_uses_configured_router_vision_provider_for_local_file(
             captured["messages"] = messages
             yield SimpleNamespace(text="a generated image")
 
-    class FakeSelector:
-        def __init__(self, selector_config):
-            captured["primary"] = selector_config.primary
+    def fake_factory(*, provider, model, api_key="", base_url="", **_kwargs):
+        captured["provider"] = provider
+        captured["model"] = model
+        return FakeProvider()
 
-        def resolve(self):
-            return FakeProvider()
-
-    monkeypatch.setattr("agentos.provider.selector.ModelSelector", FakeSelector)
+    _use_auxiliary(monkeypatch, llm_config=llm_config, factory=fake_factory)
 
     try:
         result = await media.image(str(png_path), prompt="Describe this image")
@@ -428,7 +446,7 @@ async def test_image_tool_uses_configured_router_vision_provider_for_local_file(
     payload = json.loads(result)
     assert payload["description"] == "a generated image"
     assert payload["model"] == "provider"
-    assert captured["primary"].model == "moonshotai/kimi-k2.6"
+    assert captured["model"] == "moonshotai/kimi-k2.6"
     messages = captured["messages"]
     assert isinstance(messages, list)
     message = messages[0]
@@ -455,14 +473,7 @@ async def test_vision_provider_sends_provider_native_multimodal_message(monkeypa
             captured["config"] = config
             yield SimpleNamespace(text="described")
 
-    class FakeSelector:
-        def __init__(self, selector_config):
-            captured["primary"] = selector_config.primary
-
-        def resolve(self):
-            return FakeProvider()
-
-    monkeypatch.setattr("agentos.provider.selector.ModelSelector", FakeSelector)
+    _use_auxiliary(monkeypatch, factory=lambda **_kwargs: FakeProvider())
 
     result = await media._call_vision_provider(
         b64_data="aW1hZ2UtYnl0ZXM=",
@@ -497,16 +508,11 @@ async def test_vision_provider_error_event_is_not_empty_success(monkeypatch) -> 
         async def chat(self, *, messages, config=None):
             yield ErrorEvent(message="Request timed out", code="timeout")
 
-    class FakeSelector:
-        def __init__(self, selector_config):
-            return None
+    _use_auxiliary(monkeypatch, factory=lambda **_kwargs: FakeProvider())
 
-        def resolve(self):
-            return FakeProvider()
-
-    monkeypatch.setattr("agentos.provider.selector.ModelSelector", FakeSelector)
-
-    with pytest.raises(RuntimeError, match="Provider stream error.*timeout"):
+    # An error event must surface as a failure, never as an empty description.
+    # The message now names the failing task as well as the provider code.
+    with pytest.raises(RuntimeError, match="vision.*timeout"):
         await media._call_vision_provider(
             b64_data="aW1hZ2UtYnl0ZXM=",
             media_type="image/png",
@@ -529,14 +535,7 @@ async def test_text_media_llm_uses_provider_native_message(monkeypatch) -> None:
             captured["config"] = config
             yield SimpleNamespace(text="analyzed")
 
-    class FakeSelector:
-        def __init__(self, selector_config):
-            captured["primary"] = selector_config.primary
-
-        def resolve(self):
-            return FakeProvider()
-
-    monkeypatch.setattr("agentos.provider.selector.ModelSelector", FakeSelector)
+    _use_auxiliary(monkeypatch, factory=lambda **_kwargs: FakeProvider())
 
     result = await media._call_llm_with_text("Extracted text", "Analyze this")
 


### PR DESCRIPTION
Not every provider call belongs to a turn. Analysing a PDF the user attached and
describing an image are work AgentOS initiates on its own behalf, and as the
harness grows — transcript summaries, post-turn review — there will be more of
them. Each one currently carries its own copy of the plumbing.

## What was wrong

`tools/builtin/media.py` held **two provider-to-credential mappings side by
side**: one that consulted the configured `[llm]` section and one that only read
the environment. The document path used the environment-only copy, so a key
configured in `[llm]` for that same provider was ignored — on an install pointed
at a non-default provider it silently addressed OpenRouter instead of the
configured one.

Neither recorded what it spent. Side-task tokens were invisible in
`agentos cost` while still arriving on the bill.

## What this adds

`AuxiliaryClient` owns the four things every such call needs — model resolution,
credentials, accounting, and a classified failure — and nothing else. It
deliberately does **not** re-enter `TurnRunner`, touch the transcript, or reuse
history carrying cache breakpoints: a side task that broke the main prompt cache
would cost more than it saves.

**Resolution** runs highest-first: `AGENTOS_<TASK>_MODEL`,
`[auxiliary.tasks.<task>]`, a capability-aware caller hint, `[auxiliary]`,
`AGENTOS_LLM_MODEL`, `[llm]`, then a built-in default.

Two ordering decisions are load-bearing:

- The **caller hint sits above the generic `[auxiliary]` model**. The hint comes
  from a capability-aware source — the router's image-capable tier — and a text
  model configured for all side tasks must not silently take vision's place.
- **`AGENTOS_LLM_*` is excluded from the task-scoped lookup.** It is the general
  model setting the turn loop reads too, not a side-task override. Treating it
  as one would let it outrank `[auxiliary].model` and defeat the section's whole
  purpose. (A test caught this: the task was originally named `llm`, so
  `_env_scope` read `AGENTOS_LLM_MODEL` and won. The task is now `document`, and
  the `LLM` scope is refused explicitly so a future task cannot re-enter the trap.)

**Accounting**: usage is billed to the session that triggered the call and
additionally recorded under an `aux:<task>` scope, so runtime cost stays
separable from turn cost. A tracker that raises is logged and ignored —
accounting must never fail the call it is measuring. The scope is readable via
`UsageTracker.get_scope`; rendering it in `agentos cost` is left for the
insights work.

**Credentials**: a call with no reachable key used to reach the network and come
back with `Illegal header value b'Bearer '`, naming neither the provider nor the
variable to set. It now fails before the request with both, using the provider
registry's own `required_fields` so local backends that authenticate by
reachability (Ollama, LM Studio, vLLM) stay exempt. Only the real builder is
guarded; a caller that injected its own factory has taken over authentication.

## Scope

Only `media.py` is migrated. `agentos_router/llm_judge.py` and the compaction
summariser keep their own paths — `llm_judge` guards an orphaned-worker
invariant with `assert timeout < budget` and is on the hot path of every turn,
so it deserves its own change with its own tests.

`[auxiliary]` is entirely optional. Empty values reuse `[llm]`, so an install
that never sets it behaves exactly as before.

## Verification

`ruff` and `mypy` (581 files) clean; `uv build --wheel` succeeds; full suite
**6777 passed, 27 skipped, 0 failed**. 24 tests cover the client (resolution
order per source, credential selection, stream assembly, classified failures,
timeout, accounting, the missing-key guard and its exemptions).

The two pre-existing `_resolve_vision_provider_config` tests keep their original
assertions and now exercise the migrated path, so they double as regression
tests for the move.

Also run against a live provider through the web console. The `image` tool on a
local PNG produced:

```
auxiliary.completed  task=vision  provider=opencap  model=minimax-m3  output_tokens=89
```

— resolving to the configured provider rather than the old environment-only
default — and a `document` call recorded `aux:document in=185 out=44` into both
the session total and the scope bucket.
