### PR TITLE
fix(skills-ui): style the env-var dialog input so it is visible

### DIFF
--- a/frontend/src/views/skills/skills.css
+++ b/frontend/src/views/skills/skills.css
@@ -656,6 +656,26 @@
   font-size: 0.8125rem;
   color: var(--muted-foreground);
 }
+/* Env-var value field in the "Set <VAR>" dialog. Without this the input falls
+   back to UA styling, which on the dark panel is indistinguishable from its
+   background — the field looks like it isn't there. */
+.sk-dialog__input {
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  padding: 8px 10px;
+  background: var(--input, var(--card));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--foreground);
+}
+.sk-dialog__input::placeholder {
+  color: var(--muted-foreground);
+}
+.sk-dialog__input:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+}
 .sk-dialog__section-title {
   font-family: var(--font-mono);
   font-size: 0.625rem;


### PR DESCRIPTION
Closes #179

## Problem

In the Skills page, the **Set `<VAR>`** dialog (e.g. `Set CAP_API_KEY`) renders its value field with `className="sk-dialog__input"` — but that class was never defined in `skills.css`. The input fell back to user-agent styling, which on the dark panel is indistinguishable from its background: the field looks like it isn't there at all.

## Fix

Add `.sk-dialog__input` next to the other dialog styles, matching the existing `.sk-search-input` posture already used elsewhere on this page:

- `background: var(--input, var(--card))` + `1px solid var(--border)` so the field reads as a field
- `color: var(--foreground)`, mono font, `var(--radius)`
- muted placeholder, primary-colored border on `:focus-visible`

CSS only — no component or behavior changes. The Env page's "Add a variable" dialog already had its own input styles and was not affected.

Prettier check passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
