### PR TITLE
feat(cli): agentos context — make per-request overhead and the tool-profile lever visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   paid for once per session rather than once per turn. Only names are emitted,
   never paths. Turn it off with `[prompt] env_probe_enabled = false`.
 
+- `agentos context` shows what every provider request carries before the
+  conversation starts. Tool schemas dominate that overhead — about 7,300 tokens
+  on a stock install, charged on every call in every turn — and nothing
+  surfaced the number, so the only way to learn it was to write a script
+  against the registry. The command breaks the cost down, lists the largest
+  schemas, and prices each `[tools] profile` against the current one.
+
+- `[tools] profile` is now documented. It already narrowed the tool surface
+  sharply — `coding` costs 77% less than `full`, `messaging` 92% less — but it
+  appeared in no example config, no doc page and no operator guide, so the
+  largest available lever on per-request cost was undiscoverable. Because a
+  profile is fixed for the session, narrowing it does not disturb the prompt
+  cache.
+
 ### Changed
 
 - `edit_file` no longer fails on text that differs from the file only in

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -393,6 +393,21 @@ thinking_level = "medium"
 # calls. When false, AgentOS sends no tool definitions and executes no tools.
 enabled = true
 
+# Base allowlist. Tool schemas are the fixed overhead on every provider call in
+# every turn — on a stock install roughly 7,300 tokens — so this is usually the
+# largest thing you can change. Run `agentos context` to see the current cost
+# and what each profile would cost on your install.
+#
+#   full         every registered tool (default)
+#   coding       filesystem, runtime, sessions, memory
+#   messaging    message + session inspection
+#   memory_only  memory tools only
+#   minimal      session_status only
+#
+# The set is fixed for the session, so narrowing it does not disturb the prompt
+# cache. `allow` / `also_allow` / `deny` refine it further.
+# profile = "coding"
+
 [agent_token_saving]
 # Project fresh tool results with the built-in tokenjuice reducer before they
 # are fed back into the model. Raw tool responses remain available through the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,7 @@ agentos <command> --help
 | `agentos sandbox` | Inspect or change default sandbox posture. |
 | `agentos cron` | Manage scheduled AgentOS runs. |
 | `agentos cost` | Inspect usage and estimated cost. |
+| `agentos context` | Show the fixed per-request context cost and what each tool profile would cost. |
 | `agentos diagnostics` | Enable or disable runtime diagnostics logging. |
 | `agentos replay` | Replay a recorded turn from the decision log. |
 | `agentos migrate` | Import state from external agent runtimes. |
@@ -521,12 +522,21 @@ Read:
 ## Cost, Diagnostics, and Replay
 
 ```sh
+agentos context
+agentos context --json
 agentos cost
 agentos diagnostics status
 agentos diagnostics on
 agentos diagnostics off
 agentos replay --session <session-key> --turn <turn-id>
 ```
+
+`agentos context` answers a different question from `agentos cost`: not what a
+session spent, but what every request carries before the conversation starts.
+Tool schemas dominate it — around 7,300 tokens on a stock install, charged on
+every call in every turn — and the command prices each `[tools] profile` against
+the current one so the trade is visible before you make it. A profile is fixed
+for the session, so narrowing it does not disturb the prompt cache.
 
 Use diagnostics and replay when you need to understand why a turn behaved a
 certain way.

--- a/src/agentos/cli/context_cmd.py
+++ b/src/agentos/cli/context_cmd.py
@@ -1,0 +1,134 @@
+"""Show what the fixed part of every provider request costs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+from rich.table import Table
+
+from agentos.cli.output import print_json
+from agentos.cli.ui import ACCENT_HEADER, console
+
+if TYPE_CHECKING:
+    from agentos.engine.context_breakdown import ContextBreakdown
+
+app = typer.Typer(help="Inspect the fixed per-request context cost.")
+
+_PROFILE_ORDER = ("full", "coding", "messaging", "memory_only", "minimal")
+
+
+def _measure() -> ContextBreakdown:
+    from agentos.engine.context_breakdown import build_breakdown, tokens_from_chars
+    from agentos.tools.policy_config import profile_allowlist
+    from agentos.tools.registry import get_default_registry
+    from agentos.tools.types import ToolContext
+
+    registry = get_default_registry()
+    available = frozenset(registry.list_names())
+
+    def cost_for(allowed: set[str] | None) -> tuple[int, int]:
+        ctx = ToolContext(allowed_tools=allowed)
+        definitions = registry.to_tool_definitions(ctx)
+        from agentos.engine.context_breakdown import tool_payload_chars
+
+        chars = sum(tool_payload_chars(d) for d in definitions)
+        return len(definitions), tokens_from_chars(chars)
+
+    profiles: dict[str, tuple[int, int]] = {}
+    for name in _PROFILE_ORDER:
+        try:
+            allowed = profile_allowlist(name, available)
+        except ValueError:
+            continue
+        profiles[name] = cost_for(allowed)
+
+    definitions = registry.to_tool_definitions(ToolContext())
+    return build_breakdown(tools=definitions, profiles=profiles)
+
+
+@app.callback(invoke_without_command=True)
+def context(
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    top: int = typer.Option(10, "--top", help="How many of the largest tools to list"),
+) -> None:
+    """Show the fixed per-request cost and what each tool profile would cost.
+
+    This is the overhead every provider call carries before a single word of
+    conversation: tool schemas above all. It is charged on every call in every
+    turn, so it is usually the largest thing an operator can actually change.
+    """
+
+    breakdown = _measure()
+
+    if json_output:
+        print_json(breakdown.to_dict())
+        return
+
+    console.print()
+    console.print("[bold]Fixed per-request cost[/bold]", style=ACCENT_HEADER)
+    section_table = Table(show_header=True, header_style=ACCENT_HEADER)
+    section_table.add_column("Section")
+    section_table.add_column("Items", justify="right")
+    section_table.add_column("Chars", justify="right")
+    section_table.add_column("~Tokens", justify="right")
+    for section in breakdown.sections:
+        section_table.add_row(
+            section.name,
+            str(section.items or ""),
+            f"{section.chars:,}",
+            f"{section.tokens:,}",
+        )
+    console.print(section_table)
+
+    largest = breakdown.largest_tools(top)
+    if largest:
+        console.print()
+        console.print(f"[bold]Largest {len(largest)} tool schemas[/bold]", style=ACCENT_HEADER)
+        tool_table = Table(show_header=True, header_style=ACCENT_HEADER)
+        tool_table.add_column("Tool")
+        tool_table.add_column("Chars", justify="right")
+        tool_table.add_column("~Tokens", justify="right")
+        for tool in largest:
+            tool_table.add_row(tool.name, f"{tool.chars:,}", f"{tool.tokens:,}")
+        console.print(tool_table)
+
+    profiles = breakdown.profiles
+    if profiles:
+        baseline = profiles.get("full", (0, 0))[1]
+        console.print()
+        # Escaped: rich would read a bare [tools] as a style tag and drop it.
+        console.print(r"[bold]What \[tools] profile would cost[/bold]", style=ACCENT_HEADER)
+        profile_table = Table(show_header=True, header_style=ACCENT_HEADER)
+        profile_table.add_column("Profile")
+        profile_table.add_column("Tools", justify="right")
+        profile_table.add_column("~Tokens", justify="right")
+        profile_table.add_column("Saved", justify="right")
+        deferred = False
+        for name in _PROFILE_ORDER:
+            if name not in profiles:
+                continue
+            count, tokens = profiles[name]
+            if count == 0:
+                # Not a 100% saving — the profile's tools simply are not in the
+                # base registry. Memory tools, for one, register per agent at
+                # boot. Reporting a saving here would be a lie.
+                deferred = True
+                profile_table.add_row(name, "0*", "—", "—")
+                continue
+            saved = f"{(baseline - tokens) / baseline:.0%}" if baseline else "—"
+            profile_table.add_row(name, str(count), f"{tokens:,}", saved)
+        console.print(profile_table)
+        console.print()
+        console.print(
+            r"Set one in agentos.toml under \[tools] profile. The set is fixed for the "
+            "session, so narrowing it does not disturb the prompt cache.",
+            style="dim",
+        )
+        if deferred:
+            console.print(
+                "* resolves to no tools in the base registry; those tools register "
+                "per agent at runtime.",
+                style="dim",
+            )
+    console.print()

--- a/src/agentos/cli/main.py
+++ b/src/agentos/cli/main.py
@@ -62,6 +62,7 @@ from agentos.cli.agent_cmd import run_agent_command  # noqa: E402
 from agentos.cli.agents_cmd import agents_app  # noqa: E402
 from agentos.cli.channels_cmd import channels_app  # noqa: E402
 from agentos.cli.config_cmd import app as config_app  # noqa: E402
+from agentos.cli.context_cmd import app as context_app  # noqa: E402
 from agentos.cli.cost_cmd import app as cost_app  # noqa: E402
 from agentos.cli.cron_cmd import cron_app  # noqa: E402
 from agentos.cli.diagnostics_cmd import diagnostics_app  # noqa: E402
@@ -93,6 +94,7 @@ app = typer.Typer(
 app.add_typer(channels_app, name="channels")
 app.add_typer(agents_app, name="agents")
 app.add_typer(config_app, name="config")
+app.add_typer(context_app, name="context")
 app.add_typer(cost_app, name="cost")
 app.add_typer(diagnostics_app, name="diagnostics")
 app.add_typer(env_app, name="env")

--- a/src/agentos/engine/context_breakdown.py
+++ b/src/agentos/engine/context_breakdown.py
@@ -1,0 +1,162 @@
+"""Where the request budget actually goes, before a turn is ever run.
+
+Every provider request carries fixed overhead the operator never sees: the
+tool schemas, the system prompt, the skills block. On a stock install the tool
+schemas alone are around 7,000 tokens, paid on every call in every turn — and
+nothing surfaced that number, so the only way to learn it was to write a script
+against the registry.
+
+This module answers it directly, and prices the lever that changes it. The
+`[tools] profile` key already narrows the tool surface sharply, but an operator
+cannot weigh a lever whose cost they cannot see.
+
+Estimates use the same ~4-chars-per-token rule as the rest of the runtime
+(`engine.tool_token_estimate`). It is deliberately a rough count: the point is
+the relative weight of each section, which is stable across tokenizers, not a
+billing-grade figure.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentos.provider.types import ToolDefinition
+
+# Mirrors agentos.engine.tool_token_estimate.estimate_tokens, which takes the
+# text itself. Only character counts are carried here, so the rule is applied
+# to the count directly rather than rebuilding the text to measure it again.
+_CHARS_PER_TOKEN = 4
+
+
+def tokens_from_chars(chars: int) -> int:
+    return max(0, chars // _CHARS_PER_TOKEN)
+
+
+@dataclass(frozen=True)
+class SectionCost:
+    """One named contributor to the per-request payload."""
+
+    name: str
+    chars: int
+    items: int = 0
+
+    @property
+    def tokens(self) -> int:
+        return tokens_from_chars(self.chars)
+
+
+@dataclass(frozen=True)
+class ToolCost:
+    name: str
+    chars: int
+
+    @property
+    def tokens(self) -> int:
+        return tokens_from_chars(self.chars)
+
+
+@dataclass(frozen=True)
+class ContextBreakdown:
+    """The fixed cost of a request, split by what produced it."""
+
+    sections: tuple[SectionCost, ...] = ()
+    tools: tuple[ToolCost, ...] = ()
+    profiles: dict[str, tuple[int, int]] = field(default_factory=dict)
+    """profile name -> (tool count, estimated tokens)."""
+
+    @property
+    def total_chars(self) -> int:
+        return sum(section.chars for section in self.sections)
+
+    @property
+    def total_tokens(self) -> int:
+        return tokens_from_chars(self.total_chars)
+
+    def largest_tools(self, limit: int = 10) -> tuple[ToolCost, ...]:
+        return tuple(sorted(self.tools, key=lambda t: t.chars, reverse=True)[:limit])
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_chars": self.total_chars,
+            "total_tokens": self.total_tokens,
+            "sections": [
+                {
+                    "name": section.name,
+                    "chars": section.chars,
+                    "tokens": section.tokens,
+                    "items": section.items,
+                }
+                for section in self.sections
+            ],
+            "largest_tools": [
+                {"name": tool.name, "chars": tool.chars, "tokens": tool.tokens}
+                for tool in self.largest_tools()
+            ],
+            "profiles": {
+                name: {"tools": count, "tokens": tokens}
+                for name, (count, tokens) in self.profiles.items()
+            },
+        }
+
+
+def tool_payload_chars(tool: ToolDefinition) -> int:
+    """Serialized size of one tool as it reaches the provider."""
+
+    try:
+        payload = {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema.model_dump(exclude_none=True),
+        }
+        return len(json.dumps(payload, ensure_ascii=False))
+    except (TypeError, ValueError):
+        return len(str(tool.name)) + len(str(tool.description))
+
+
+def measure_tools(tools: list[ToolDefinition]) -> tuple[SectionCost, tuple[ToolCost, ...]]:
+    per_tool = tuple(ToolCost(name=tool.name, chars=tool_payload_chars(tool)) for tool in tools)
+    total = sum(tool.chars for tool in per_tool)
+    return SectionCost(name="tools", chars=total, items=len(per_tool)), per_tool
+
+
+def build_breakdown(
+    *,
+    tools: list[ToolDefinition] | None = None,
+    system_prompt: str | tuple[str, str] | None = None,
+    extra_sections: dict[str, str] | None = None,
+    profiles: dict[str, tuple[int, int]] | None = None,
+) -> ContextBreakdown:
+    """Measure the fixed parts of a request.
+
+    Messages are deliberately excluded: they are the conversation, and their
+    size is the user's, not something an operator can configure away.
+    """
+
+    sections: list[SectionCost] = []
+    per_tool: tuple[ToolCost, ...] = ()
+
+    if tools:
+        tool_section, per_tool = measure_tools(tools)
+        sections.append(tool_section)
+
+    if system_prompt:
+        if isinstance(system_prompt, str):
+            base, suffix = system_prompt, ""
+        else:
+            base, suffix = system_prompt
+        if base:
+            sections.append(SectionCost(name="system prompt (cached)", chars=len(base)))
+        if suffix:
+            sections.append(SectionCost(name="system prompt (per-turn)", chars=len(suffix)))
+
+    for name, text in (extra_sections or {}).items():
+        if text:
+            sections.append(SectionCost(name=name, chars=len(text)))
+
+    return ContextBreakdown(
+        sections=tuple(sections),
+        tools=per_tool,
+        profiles=dict(profiles or {}),
+    )

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -176,7 +176,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[llm]` | `provider`, `model`, `api_key`, `base_url`, `proxy`, `[llm.provider_routing]` |
 | `[agentos_router]` | router on/off, `strategy` (`pilot-v1`), tier settings under `[agentos_router.tiers.c0..c3]` |
 | `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode`, `max_skills_prompt_chars` (default 24000), `max_skill_view_chars` (default 10000, 0 disables) |
-| `[tools]` | model-visible tools and policy; `enabled = false` runs providers in plain-text mode |
+| `[tools]` | model-visible tools and policy; `enabled = false` runs providers in plain-text mode; `profile` (`full` \| `coding` \| `messaging` \| `memory_only` \| `minimal`) sets the base allowlist — `agentos context` prices each one |
 | `[memory]` | memory source and embedding model, `[memory.nudge]` (periodic memory review) |
 | `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |
 | `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`) |

--- a/tests/test_engine/test_context_breakdown.py
+++ b/tests/test_engine/test_context_breakdown.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from agentos.engine.context_breakdown import (
+    build_breakdown,
+    measure_tools,
+    tokens_from_chars,
+    tool_payload_chars,
+)
+from agentos.provider.types import ToolDefinition, ToolInputSchema
+
+
+def _tool(name: str, description: str = "", properties: dict | None = None) -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        description=description,
+        input_schema=ToolInputSchema(properties=properties or {}, required=[]),
+    )
+
+
+def test_tokens_follow_the_runtime_four_char_rule() -> None:
+    assert tokens_from_chars(0) == 0
+    assert tokens_from_chars(3) == 0
+    assert tokens_from_chars(4) == 1
+    assert tokens_from_chars(4000) == 1000
+
+
+def test_negative_char_counts_do_not_produce_negative_tokens() -> None:
+    assert tokens_from_chars(-10) == 0
+
+
+def test_tool_payload_measures_the_shape_sent_to_the_provider() -> None:
+    small = _tool("a")
+    large = _tool(
+        "b",
+        description="a much longer description",
+        properties={"path": {"type": "string", "description": "where"}},
+    )
+
+    assert tool_payload_chars(large) > tool_payload_chars(small)
+
+
+def test_a_tool_whose_schema_will_not_serialise_still_reports_a_size() -> None:
+    broken = _tool("broken", description="d", properties={"x": {"default": object()}})
+
+    # Falling back to zero would understate the payload and hide the tool.
+    assert tool_payload_chars(broken) > 0
+
+
+def test_tools_section_counts_every_tool() -> None:
+    section, per_tool = measure_tools([_tool("a"), _tool("b"), _tool("c")])
+
+    assert section.name == "tools"
+    assert section.items == 3
+    assert len(per_tool) == 3
+    assert section.chars == sum(t.chars for t in per_tool)
+
+
+def test_largest_tools_are_ranked_by_size() -> None:
+    breakdown = build_breakdown(
+        tools=[
+            _tool("tiny"),
+            _tool("huge", description="x" * 500),
+            _tool("middling", description="y" * 100),
+        ]
+    )
+
+    assert [t.name for t in breakdown.largest_tools(2)] == ["huge", "middling"]
+
+
+def test_system_prompt_is_split_into_cached_and_per_turn() -> None:
+    breakdown = build_breakdown(system_prompt=("BASE" * 100, "SUFFIX" * 10))
+
+    names = [s.name for s in breakdown.sections]
+    assert "system prompt (cached)" in names
+    assert "system prompt (per-turn)" in names
+
+
+def test_a_plain_string_prompt_reports_only_the_cached_part() -> None:
+    breakdown = build_breakdown(system_prompt="BASE" * 100)
+
+    names = [s.name for s in breakdown.sections]
+    assert names == ["system prompt (cached)"]
+
+
+def test_empty_inputs_produce_an_empty_breakdown() -> None:
+    breakdown = build_breakdown()
+
+    assert breakdown.sections == ()
+    assert breakdown.total_tokens == 0
+
+
+def test_totals_are_the_sum_of_the_sections() -> None:
+    breakdown = build_breakdown(
+        tools=[_tool("a", description="x" * 40)],
+        system_prompt="y" * 80,
+    )
+
+    assert breakdown.total_chars == sum(s.chars for s in breakdown.sections)
+    assert breakdown.total_tokens == tokens_from_chars(breakdown.total_chars)
+
+
+def test_profiles_round_trip_through_the_serialised_form() -> None:
+    breakdown = build_breakdown(
+        tools=[_tool("a")],
+        profiles={"full": (46, 7273), "coding": (14, 1648)},
+    )
+
+    payload = breakdown.to_dict()
+
+    assert payload["profiles"]["coding"] == {"tools": 14, "tokens": 1648}
+    assert payload["sections"][0]["name"] == "tools"
+    assert payload["total_tokens"] == breakdown.total_tokens


### PR DESCRIPTION
This phase was planned as Hermes-style **progressive tool disclosure**: defer
non-core tool schemas out of the payload, give the agent a `tool_search` to pull
them back in. Measuring first changed the answer, so this PR ships something
else — and the measurement is the reason.

## What the numbers said

Measured on a stock install (46 registered tools, real registry, real schemas):

| | tools | ~tokens |
|---|---|---|
| everything | 46 | **7,273** |
| `profile = "coding"` | 14 | 1,648 (**−77%**) |
| `profile = "messaging"` | 5 | 558 (**−92%**) |
| `profile = "minimal"` | 1 | 42 (−99%) |

Two things follow.

**The capability already exists.** `[tools] profile` is declared in
`ToolsConfig`, expanded by `profile_allowlist`, and honoured by the policy
chain. It cuts more than dynamic disclosure would.

**Dynamic disclosure would have cost more than it saved.** The tool set is part
of the cached prompt prefix — `engine/cache_break_monitor.py` already tracks
`tools_hash` as cache-relevant state for exactly this reason. Swapping tools in
and out mid-session invalidates that prefix. On a live session here the cached
portion was 21k–38.7k tokens; breaking it to avoid ~4k of schemas is a loss on
every pull. A profile is resolved once and fixed for the session, so it takes
the saving without touching the cache.

So the real defect was not a missing mechanism. It was that the mechanism was
**invisible**: `[tools] profile` appeared in no example config, no doc page and
no operator guide, and the cost it controls was never reported anywhere. The
only way to learn that tool schemas cost 7,273 tokens was to write a script
against the registry — which no operator will do.

## What this ships

**`agentos context`** — the fixed cost of every request, before any
conversation:

- cost by section
- the largest tool schemas by name (`cron` alone is 966 tokens, 13% of the total)
- what each `[tools] profile` would cost, measured against the current one

`--json` for machine use, `--top N` to widen the schema list.

**Documentation** for `[tools] profile` in `agentos.toml.example`, `docs/cli.md`
and the bundled self-operation skill, including the note that a profile is fixed
for the session and therefore cache-safe.

## Honesty in the output

A profile that resolves to no tools in the base registry reports `0*` with a
footnote rather than a 100% saving. `memory_only` is one: memory tools register
per agent at boot, not in the base registry, so the profile is not free — it is
unmeasurable from here, and claiming otherwise would be a lie in a table whose
whole purpose is to be trusted.

## Verification

`ruff` and `mypy` (582 files) clean; `uv build --wheel` succeeds; full suite
**6764 passed, 27 skipped, 0 failed**. 11 unit tests over the measurement
(the 4-chars-per-token rule, unserialisable schemas, ranking, cached vs per-turn
prompt split, totals, serialisation).

The command was run against this install; every figure quoted above and in the
commit message is its real output, not an estimate.
