### PR TITLE
feat(engine): warn when a turn stops on unverified code edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   profile is fixed for the session, narrowing it does not disturb the prompt
   cache.
 
+- A turn that edits code and then answers "done" without running anything is
+  now noticed. A passive ledger records which files a turn changed and whether
+  a test, build or lint command ran *after* the last change; when the model
+  stops on unverified edits the turn emits a warning naming the files and the
+  omission. Evidence gathered before an edit does not count for it. Prose,
+  data and config files are excluded — a README edit has nothing a test could
+  exercise — and messaging surfaces are exempt, since answering a person in
+  chat is not maintaining a checkout.
+
 ### Changed
 
 - `edit_file` no longer fails on text that differs from the file only in

--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -49,6 +49,10 @@ from agentos.engine.tool_result_store import (
 )
 from agentos.engine.tool_text_compat import strip_synthetic_tool_call_suffix
 from agentos.engine.tool_token_estimate import estimate_tokens as get_approx_tokens
+from agentos.engine.verification_ledger import (
+    VerificationLedger,
+    build_verification_nudge,
+)
 from agentos.execution_status import (
     mark_execution_status_truncated,
     runtime_execution_status,
@@ -485,6 +489,39 @@ class _ProviderRetryPolicy:
                 < self.provider_failure_budgets.get(failure_kind, self.max_provider_retries)
             )
         return provider_retry_attempt < self.max_provider_retries
+
+
+_MUTATING_TOOL_NAMES = frozenset({"write_file", "edit_file", "apply_patch"})
+_COMMAND_TOOL_NAMES = frozenset({"exec_command", "execute_code", "background_process"})
+# Sessions whose surface is a person in a chat rather than a checkout. There is
+# usually no test command to run there, so the verification nudge is withheld.
+_MESSAGING_SESSION_MARKERS = ("telegram", "slack", "discord", "msteams", "whatsapp", "signal")
+
+
+def _mutated_paths(arguments: dict[str, Any]) -> list[str]:
+    """Pull the touched paths out of a mutating tool's arguments."""
+
+    paths: list[str] = []
+    for key in ("path", "file_path", "target"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value.strip():
+            paths.append(value.strip())
+    patch = arguments.get("patch")
+    if isinstance(patch, str):
+        # apply_patch names its files inside the patch body.
+        for line in patch.splitlines():
+            stripped = line.strip()
+            for marker in ("*** Update File:", "*** Add File:", "*** Delete File:"):
+                if stripped.startswith(marker):
+                    candidate = stripped[len(marker) :].strip()
+                    if candidate:
+                        paths.append(candidate)
+    return paths
+
+
+def _is_messaging_surface(session_key: str | None) -> bool:
+    key = str(session_key or "").casefold()
+    return any(marker in key for marker in _MESSAGING_SESSION_MARKERS)
 
 
 def _classify_provider_attempt(
@@ -1854,6 +1891,7 @@ class Agent:
         max_iterations_finalization_pending = False
         max_iterations_finalization_message: Message | None = None
         progress_watchdog = ProgressWatchdog(observe_only=True)
+        verification_ledger = VerificationLedger()
         _fallback = FallbackPolicy(
             max_retries=self.config.max_provider_retries,
             base_backoff_ms=self.config.retry_base_backoff_ms,
@@ -3141,6 +3179,22 @@ class Agent:
                 # No tool calls → we're done
                 if not tool_calls:
                     max_iterations_finalization_pending = False
+                    # The model is answering rather than acting: this is the
+                    # moment it stops, and the last chance to notice that it is
+                    # stopping on edits nothing checked.
+                    verification_decision = verification_ledger.decide(
+                        is_messaging_surface=_is_messaging_surface(self._session_key)
+                    )
+                    if verification_decision.needs_verification:
+                        nudge = build_verification_nudge(verification_decision)
+                        self._write_turn_call_log(
+                            "verification_ledger",
+                            reason=verification_decision.reason,
+                            changed_paths=list(verification_decision.changed_paths),
+                            details=verification_decision.details,
+                            guidance=nudge,
+                        )
+                        yield WarningEvent(code="unverified_code_changes", message=nudge)
                     break
 
                 tool_deadline = _loop.time() + self.config.iteration_timeout
@@ -3474,6 +3528,19 @@ class Agent:
                     None,
                 )
                 arguments_by_id = {tc.tool_use_id: tc.arguments for tc in tool_calls}
+
+                # Record what this iteration changed and whether it checked it.
+                # Order matters: a check only counts for edits made before it.
+                for result in executed_results:
+                    if result.is_error:
+                        continue
+                    arguments = arguments_by_id.get(result.tool_use_id) or {}
+                    if result.tool_name in _MUTATING_TOOL_NAMES:
+                        verification_ledger.record_mutation(_mutated_paths(arguments))
+                    elif result.tool_name in _COMMAND_TOOL_NAMES:
+                        verification_ledger.record_command(
+                            str(arguments.get("command") or arguments.get("code") or "")
+                        )
                 watchdog_decision = progress_watchdog.observe(
                     ProgressObservation(
                         iteration=iterations,

--- a/src/agentos/engine/verification_ledger.py
+++ b/src/agentos/engine/verification_ledger.py
@@ -1,0 +1,232 @@
+"""Did the turn that changed code ever check that the code still works?
+
+A turn that edits three files and then answers "done" is the most common way an
+agent is confidently wrong. Nothing in the loop notices: every tool call
+succeeded, the model produced text, the turn ended cleanly. The only thing
+missing is the one step that would have caught the mistake.
+
+This module keeps a passive ledger of two things per turn — which files were
+mutated, and whether a verification command ran *after* the last mutation — and
+answers one question at the end: is the model about to stop on unverified
+edits?
+
+It is policy only. It runs nothing, and it has no opinion on what the right
+command is; it recognises that one ran. Whether the answer becomes a log line,
+a warning, or a follow-up turn belongs to the runtime.
+
+Two exclusions keep it from crying wolf, both learned the hard way in the
+runtimes that shipped this before:
+
+* **Prose is not code.** A turn that edits only Markdown, text or data files has
+  nothing a test could exercise. Demanding verification for a README edit
+  teaches the model to ignore the nudge.
+* **Chat is not a workspace.** On a messaging surface the agent is answering a
+  person, not maintaining a checkout, and there is usually no test command to
+  run at all.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Editing one of these produces nothing a build or test suite can exercise.
+_NON_CODE_SUFFIXES = frozenset(
+    {
+        ".md",
+        ".markdown",
+        ".mdx",
+        ".rst",
+        ".txt",
+        ".log",
+        ".csv",
+        ".tsv",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".lock",
+        ".svg",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".pdf",
+    }
+)
+
+# Programs whose presence in a command means the turn checked its own work.
+_VERIFICATION_PROGRAMS = frozenset(
+    {
+        "pytest",
+        "tox",
+        "nox",
+        "unittest",
+        "mypy",
+        "ruff",
+        "flake8",
+        "pylint",
+        "black",
+        "isort",
+        "eslint",
+        "prettier",
+        "tsc",
+        "vitest",
+        "jest",
+        "mocha",
+        "playwright",
+        "cypress",
+        "cargo",
+        "go",
+        "gradle",
+        "mvn",
+        "make",
+        "cmake",
+        "ctest",
+        "bazel",
+        "rspec",
+        "phpunit",
+        "dotnet",
+        "swift",
+    }
+)
+
+# Subcommands that turn an otherwise ambiguous program into a verification run.
+_VERIFICATION_SUBCOMMANDS = frozenset({"test", "check", "lint", "build", "vet", "typecheck"})
+
+# Runners that only say what comes next; the real program is the following word.
+_RUNNER_PREFIXES = frozenset({"uv", "uvx", "npm", "npx", "pnpm", "yarn", "bun", "poetry", "pipenv"})
+
+_MAX_PATHS_IN_NUDGE = 8
+
+
+@dataclass(frozen=True)
+class VerificationDecision:
+    """Whether the turn is stopping on unverified edits, and what changed."""
+
+    needs_verification: bool
+    reason: str
+    changed_paths: tuple[str, ...] = ()
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def is_code_path(path: str) -> bool:
+    """Whether editing *path* could plausibly break something a check would catch."""
+
+    text = str(path or "").strip()
+    if not text:
+        return False
+    name = text.replace("\\", "/").rsplit("/", 1)[-1]
+    if "." not in name:
+        # No suffix at all — a Makefile, a Dockerfile, a shell script. Treat as
+        # code: these are exactly the files whose breakage is silent.
+        return True
+    suffix = name[name.rfind(".") :].casefold()
+    return suffix not in _NON_CODE_SUFFIXES
+
+
+def looks_like_verification(command: str) -> bool:
+    """Whether *command* is the turn checking its own work.
+
+    Recognition, not prescription: the point is to notice that some check ran,
+    not to decide which one should have.
+    """
+
+    text = str(command or "").strip()
+    if not text:
+        return False
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        tokens = re.split(r"\s+", text)
+
+    words = [token.rsplit("/", 1)[-1].casefold() for token in tokens if token]
+    for index, word in enumerate(words):
+        if word in _VERIFICATION_PROGRAMS:
+            if word in {"cargo", "go", "dotnet", "swift", "gradle", "mvn"}:
+                # These do many things; only some of them verify anything.
+                following = words[index + 1] if index + 1 < len(words) else ""
+                if following in _VERIFICATION_SUBCOMMANDS:
+                    return True
+                continue
+            return True
+        if word in _RUNNER_PREFIXES:
+            continue
+        if word in _VERIFICATION_SUBCOMMANDS and index > 0:
+            # `npm test`, `pnpm check`, `make lint`.
+            return True
+    return False
+
+
+class VerificationLedger:
+    """Per-turn record of mutations and the checks that followed them."""
+
+    def __init__(self) -> None:
+        self._changed: dict[str, None] = {}
+        self._verified_after_last_change = False
+
+    def record_mutation(self, paths: list[str] | tuple[str, ...]) -> None:
+        """Note files this turn changed. Any mutation invalidates prior evidence."""
+
+        added = False
+        for path in paths:
+            if is_code_path(path):
+                self._changed[str(path)] = None
+                added = True
+        if added:
+            # Evidence gathered before this edit says nothing about it.
+            self._verified_after_last_change = False
+
+    def record_command(self, command: str) -> None:
+        if looks_like_verification(command):
+            self._verified_after_last_change = True
+
+    @property
+    def changed_paths(self) -> tuple[str, ...]:
+        return tuple(self._changed)
+
+    def decide(self, *, is_messaging_surface: bool = False) -> VerificationDecision:
+        """Answer whether stopping here would leave edits unchecked."""
+
+        if not self._changed:
+            return VerificationDecision(False, "no_code_changes")
+        if self._verified_after_last_change:
+            return VerificationDecision(
+                False, "verified", changed_paths=self.changed_paths
+            )
+        if is_messaging_surface:
+            # Answering a person in a chat, not maintaining a checkout.
+            return VerificationDecision(
+                False, "messaging_surface", changed_paths=self.changed_paths
+            )
+        return VerificationDecision(
+            True,
+            "unverified_code_changes",
+            changed_paths=self.changed_paths,
+            details={"changed_count": len(self._changed)},
+        )
+
+
+def build_verification_nudge(decision: VerificationDecision) -> str:
+    """A sentence naming what changed and what was not done about it."""
+
+    if not decision.needs_verification:
+        return ""
+    paths = list(decision.changed_paths)
+    shown = paths[:_MAX_PATHS_IN_NUDGE]
+    listed = ", ".join(shown)
+    if len(paths) > len(shown):
+        listed += f", and {len(paths) - len(shown)} more"
+    return (
+        f"This turn changed {listed} and no test, build or lint command ran"
+        " afterwards. Run the check that covers the change before calling it done,"
+        " or say plainly that it is unverified."
+    )

--- a/tests/test_engine/test_verification_ledger.py
+++ b/tests/test_engine/test_verification_ledger.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import pytest
+
+from agentos.engine.verification_ledger import (
+    VerificationLedger,
+    build_verification_nudge,
+    is_code_path,
+    looks_like_verification,
+)
+
+# ---------------------------------------------------------------------------
+# what counts as code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["src/app.py", "index.ts", "main.go", "Makefile", "Dockerfile", "scripts/deploy", "a/b/c.rs"],
+)
+def test_source_files_are_code(path: str) -> None:
+    assert is_code_path(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["README.md", "docs/guide.mdx", "notes.txt", "data.csv", "config.yaml", "logo.png"],
+)
+def test_prose_and_data_files_are_not_code(path: str) -> None:
+    # Demanding a test run for a README edit teaches the model to ignore the nudge.
+    assert is_code_path(path) is False
+
+
+def test_windows_separators_are_understood() -> None:
+    assert is_code_path(r"src\app.py") is True
+    assert is_code_path(r"docs\guide.md") is False
+
+
+def test_empty_path_is_not_code() -> None:
+    assert is_code_path("") is False
+    assert is_code_path("   ") is False
+
+
+# ---------------------------------------------------------------------------
+# what counts as verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pytest -q",
+        "uv run pytest tests/",
+        "npm test",
+        "pnpm check",
+        "yarn lint",
+        "make test",
+        "cargo test",
+        "go test ./...",
+        "npx tsc --noEmit",
+        "ruff check src",
+        "uv run mypy src/agentos",
+        "/usr/local/bin/pytest",
+        "dotnet test",
+    ],
+)
+def test_verification_commands_are_recognised(command: str) -> None:
+    assert looks_like_verification(command) is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls -la",
+        "git status",
+        "cat README.md",
+        "go run main.go",
+        "cargo run",
+        "echo done",
+        "",
+    ],
+)
+def test_ordinary_commands_are_not_verification(command: str) -> None:
+    assert looks_like_verification(command) is False
+
+
+def test_a_build_counts_as_evidence_but_running_the_program_does_not() -> None:
+    # A build fails on code that does not compile, which is the most common way
+    # an edit breaks something — that is evidence. Executing the program is not:
+    # it says nothing about the paths the edit touched.
+    assert looks_like_verification("cargo build --release") is True
+    assert looks_like_verification("cargo check") is True
+    assert looks_like_verification("cargo run") is False
+    assert looks_like_verification("go run main.go") is False
+
+
+def test_an_unparseable_command_does_not_raise() -> None:
+    assert looks_like_verification("pytest 'unclosed") is True
+
+
+# ---------------------------------------------------------------------------
+# the ledger
+# ---------------------------------------------------------------------------
+
+
+def test_a_turn_that_changed_nothing_needs_nothing() -> None:
+    assert VerificationLedger().decide().needs_verification is False
+
+
+def test_editing_code_without_checking_is_flagged() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py"])
+
+    decision = ledger.decide()
+
+    assert decision.needs_verification is True
+    assert decision.reason == "unverified_code_changes"
+    assert decision.changed_paths == ("src/app.py",)
+
+
+def test_running_a_check_after_the_edit_clears_it() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py"])
+    ledger.record_command("uv run pytest -q")
+
+    assert ledger.decide().needs_verification is False
+
+
+def test_a_check_before_the_last_edit_does_not_count() -> None:
+    # Evidence gathered before an edit says nothing about that edit — this is
+    # the whole reason the ledger tracks order rather than mere presence.
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py"])
+    ledger.record_command("pytest -q")
+    ledger.record_mutation(["src/other.py"])
+
+    assert ledger.decide().needs_verification is True
+
+
+def test_editing_only_prose_is_never_flagged() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["README.md", "docs/guide.md"])
+
+    decision = ledger.decide()
+
+    assert decision.needs_verification is False
+    assert decision.reason == "no_code_changes"
+
+
+def test_a_prose_edit_after_a_verified_code_edit_does_not_reopen_it() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py"])
+    ledger.record_command("pytest -q")
+    ledger.record_mutation(["CHANGELOG.md"])
+
+    assert ledger.decide().needs_verification is False
+
+
+def test_messaging_surfaces_are_exempt() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py"])
+
+    decision = ledger.decide(is_messaging_surface=True)
+
+    assert decision.needs_verification is False
+    assert decision.reason == "messaging_surface"
+
+
+def test_the_same_file_edited_twice_is_listed_once() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py"])
+    ledger.record_mutation(["src/app.py"])
+
+    assert ledger.decide().changed_paths == ("src/app.py",)
+
+
+# ---------------------------------------------------------------------------
+# the nudge
+# ---------------------------------------------------------------------------
+
+
+def test_the_nudge_names_the_files_that_changed() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation(["src/app.py", "src/other.py"])
+
+    nudge = build_verification_nudge(ledger.decide())
+
+    assert "src/app.py" in nudge
+    assert "src/other.py" in nudge
+
+
+def test_a_long_change_list_is_summarised() -> None:
+    ledger = VerificationLedger()
+    ledger.record_mutation([f"src/f{i}.py" for i in range(20)])
+
+    nudge = build_verification_nudge(ledger.decide())
+
+    assert "and 12 more" in nudge
+    assert len(nudge) < 600
+
+
+def test_no_nudge_when_nothing_is_owed() -> None:
+    assert build_verification_nudge(VerificationLedger().decide()) == ""


### PR DESCRIPTION
A turn that edits three files and then answers "done" is the most common way an
agent is confidently wrong, and nothing in the loop noticed. Every tool call
succeeded, the model produced text, the turn ended cleanly. The only thing
missing was the step that would have caught the mistake.

## What this adds

A passive ledger records two things per turn — which files were mutated, and
whether a test/build/lint command ran **after** the last mutation — and answers
one question at the point the model stops acting and starts answering: are these
edits unchecked? If so, the turn emits a `WarningEvent` naming the files and
writes the decision to the turn call log.

**Order is the whole point.** Evidence gathered before an edit says nothing
about that edit, so any mutation invalidates prior evidence. The ledger does not
merely ask whether a check appeared somewhere in the turn.

## Two exclusions, both deliberate

A guard that fires on everything teaches the model to ignore it.

- **Prose is not code.** A turn touching only Markdown, text, data or config has
  nothing a test could exercise. Demanding verification for a README edit is how
  this feature becomes noise.
- **Chat is not a workspace.** On a messaging surface the agent is answering a
  person, not maintaining a checkout, and there is usually no test command to
  run at all.

## Recognition, not prescription

The module notices that *some* check ran and has no opinion on which one should
have. A build counts — it fails on code that does not compile, which is the most
common way an edit breaks something. Running the program does not: `cargo run`
says nothing about the paths the edit touched. Recognised runners cover Python,
JS/TS, Rust, Go, Java, .NET, C/C++ and Ruby toolchains, including `uv run …`,
`npm test`, `npx tsc` and similar wrappers.

It is **policy only** — it runs nothing. Whether the decision becomes a log
line, a warning, or a follow-up turn belongs to the runtime; today it is the
first two, matching the observe-first posture the progress watchdog already set.

## Verification

`ruff` and `mypy` (581 files) clean; full suite **6801 passed, 27 skipped, 0
failed**. 48 unit tests cover code/prose classification, command recognition
(including the build-vs-run distinction and unparseable input), the
ordering rule, the exclusions, and nudge formatting.

Verified end to end against a live provider on this install:

- Agent told to edit `calc.py` and skip all checks → turn call log records
  `"reason": "unverified_code_changes"` with the changed path named and the
  guidance rendered.
- Same edit followed by a command run → no entry, no warning.

Both directions, real model, real tool calls.

## Note for reviewers

This touches the same region of `engine/agent.py` as #175 (the tool-call
guardrail). Whichever merges second needs a small rebase there.
