### PR TITLE
fix(packaging): ship a bundled skill's assets/ markdown in the wheel

### DIFF
--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -230,6 +230,16 @@ def _is_dist_info_license_file(name: str) -> bool:
     return len(parts) >= 3 and parts[0].endswith(".dist-info") and parts[1] == "licenses"
 
 
+def _is_bundled_skill_asset(name: str) -> bool:
+    """A bundled skill's shipped data files: skills/bundled/<skill>/assets/**."""
+    parts = name.split("/")
+    return (
+        len(parts) > 5
+        and parts[:3] == ["agentos", "skills", "bundled"]
+        and parts[4] == "assets"
+    )
+
+
 def _is_allowed_runtime_markdown(path: str) -> bool:
     name = _release_name(path)
     if _is_dist_info_license_file(name):
@@ -239,6 +249,13 @@ def _is_allowed_runtime_markdown(path: str) -> bool:
     if name in ALLOWED_SKILL_REFERENCE_WHEEL_PATHS:
         return True
     if name.startswith("agentos/skills/bundled/") and name.endswith("/SKILL.md"):
+        return True
+    # assets/ is the one place a skill's documentation may live and still reach an
+    # install: the wheel excludes references/*.md wholesale, so
+    # test_skill_docs_do_not_link_to_files_the_wheel_strips tells skills to put
+    # load-bearing docs under assets/. SKILL.md links them by {baseDir}, and
+    # dropping them would ship instructions pointing at a file that is not there.
+    if _is_bundled_skill_asset(name):
         return True
     # Router model bundles ship their PROVENANCE.md: the weights are derived
     # from OpenSquilla (Apache-2.0), so their attribution must travel with them

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -289,6 +289,59 @@ def test_real_router_bundle_markdown_passes_release_guard() -> None:
     assert module.forbidden_release_wheel_entries(wheel_names) == []
 
 
+def test_release_wheel_allows_bundled_skill_assets_markdown() -> None:
+    """A skill's assets/ docs ship; references/ docs still do not.
+
+    The wheel excludes `references/*.md` wholesale, so load-bearing skill
+    documentation belongs in `assets/` and is linked from SKILL.md by
+    `{baseDir}`. Dropping it would ship instructions pointing at a file that
+    is not on disk.
+    """
+
+    module = load_script()
+    asset_doc = "agentos/skills/bundled/senior-unilp-manager/assets/v4-reference.md"
+    nested_asset_doc = "agentos/skills/bundled/demo/assets/nested/notes.md"
+    reference_doc = "agentos/skills/bundled/demo/references/notes.md"
+    top_level_doc = "agentos/skills/bundled/demo/NOTES.md"
+
+    violations = module.forbidden_release_wheel_entries(
+        (asset_doc, nested_asset_doc, reference_doc, top_level_doc)
+    )
+
+    assert asset_doc not in violations
+    assert nested_asset_doc not in violations
+    assert reference_doc in violations
+    assert top_level_doc in violations
+
+
+def test_real_bundled_skill_markdown_passes_release_guard() -> None:
+    """Guard the real bundled-skill tree, not just synthetic names.
+
+    The wheel-path guard runs against a built wheel only in the tagged release
+    job, so a new .md dropped into a bundled skill passes PR CI and fails after
+    the tag is pushed — which is how `senior-unilp-manager` broke the 2026.8.2
+    release build.
+    """
+
+    module = load_script()
+    bundled = REPO_ROOT / "src" / "agentos" / "skills" / "bundled"
+    if not bundled.is_dir():
+        pytest.skip("bundled skills not present in this checkout")
+
+    relative_paths = sorted(
+        path.relative_to(bundled).as_posix() for path in bundled.rglob("*.md")
+    )
+    wheel_names = tuple(
+        f"agentos/skills/bundled/{rel}"
+        for rel in relative_paths
+        # Mirror the pyproject wheel excludes: these never reach the wheel, so
+        # the guard is never asked about them.
+        if not rel.endswith("/THIRD_PARTY_NOTICES.md") and "/references/" not in f"/{rel}"
+    )
+
+    assert module.forbidden_release_wheel_entries(wheel_names) == []
+
+
 def test_release_wheel_allows_dist_info_license_files() -> None:
     module = load_script()
     license_md = "use_agent_os-2026.7.15.dist-info/licenses/THIRD_PARTY_NOTICES.md"


### PR DESCRIPTION
## Why

The `v2026.8.2` tag is pushed and PyPI published, but **Windows Release Assets failed**:

```
Built wheel contains forbidden release entries:
  agentos/skills/bundled/senior-unilp-manager/assets/v4-reference.md
```

`_is_allowed_runtime_markdown` allowed markdown only at `SKILL.md` plus the two force-included `pptx` references, so the new `senior-unilp-manager` skill's `assets/v4-reference.md` read as a forbidden entry.

`assets/` is exactly where that file is supposed to be. `test_skill_docs_do_not_link_to_files_the_wheel_strips` tells skills to move load-bearing documentation out of `references/` (excluded from the wheel wholesale) into `assets/`, and `SKILL.md` links it by `{baseDir}` — so stripping it would ship instructions pointing at a file that is not on disk.

## What

- Allow `agentos/skills/bundled/<skill>/assets/**` through the release wheel guard. `references/` and stray top-level skill markdown stay forbidden.
- Add a real-tree test over the bundled skills, mirroring `test_real_router_bundle_markdown_passes_release_guard`, so a new `.md` in a bundled skill fails PR CI instead of the tagged release job. That gap is why this only surfaced after the tag was pushed.

## Verification

Built the 2026.8.2 wheel locally and ran both release guards against it:

```
wheel: use_agent_os-2026.8.2-py3-none-any.whl
forbidden paths: []
text markers: []
```

`ruff check`, `mypy scripts/build_wheelhouse_zip.py`, and `pytest tests/test_scripts/test_build_wheelhouse_zip.py tests/test_packaging` (49 passed) are green.

## After merge

Re-run **Windows Release Assets** via `workflow_dispatch` from `main` with `tag: v2026.8.2` to build and upload the assets to the existing tag. PyPI already has 2026.8.2, so the version is not re-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)