### PR TITLE
feat(setup): convert router tier provider and model fields to pickers…

### DIFF
--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -52,7 +52,7 @@ function renderAt(path: string) {
 describe('routes', () => {
   it('renders a real lazily loaded registered view', async () => {
     renderAt('/sessions')
-    expect(await screen.findByRole('heading', { name: 'Sessions' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Sessions' }, { timeout: 5000 })).toBeInTheDocument()
   })
 
   it('registers every major view as a route-object lazy module', () => {

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -52,7 +52,9 @@ function renderAt(path: string) {
 describe('routes', () => {
   it('renders a real lazily loaded registered view', async () => {
     renderAt('/sessions')
-    expect(await screen.findByRole('heading', { name: 'Sessions' }, { timeout: 5000 })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', { name: 'Sessions' }, { timeout: 5000 }),
+    ).toBeInTheDocument()
   })
 
   it('registers every major view as a route-object lazy module', () => {

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -52,9 +52,7 @@ function renderAt(path: string) {
 describe('routes', () => {
   it('renders a real lazily loaded registered view', async () => {
     renderAt('/sessions')
-    expect(
-      await screen.findByRole('heading', { name: 'Sessions' }, { timeout: 5000 }),
-    ).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Sessions' })).toBeInTheDocument()
   })
 
   it('registers every major view as a route-object lazy module', () => {

--- a/frontend/src/views/setup/RouterSection.test.tsx
+++ b/frontend/src/views/setup/RouterSection.test.tsx
@@ -1,7 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
 import { RouterSection } from './RouterSection'
 import type { Catalog } from './logic'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
 
 const STATUS = {
   hasConfig: true,
@@ -36,7 +41,37 @@ function catalogWithTiers(tiers: Record<string, Record<string, unknown>>): Catal
   }
 }
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const MOCK_MODELS = [
+  { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
+  { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
+  { id: 'gpt-image-1', name: 'GPT Image 1', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'vision'] },
+  { id: 'claude-3-opus', name: 'Claude 3 Opus', provider: 'anthropic', contextWindow: 200000, capabilities: ['chat'] },
+]
+
+const mockRpc = {
+  waitForConnection: vi.fn().mockResolvedValue(undefined),
+  call: vi.fn((method) => {
+    if (method === 'models.list') {
+      return Promise.resolve(MOCK_MODELS)
+    }
+    return Promise.resolve({})
+  }),
+}
+
+vi.mock('@/app/providers', () => ({
+  useRpc: () => mockRpc,
+}))
+
 function renderSection(catalog: Catalog, onSave = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
   const props = {
     catalog,
     status: STATUS,
@@ -46,11 +81,19 @@ function renderSection(catalog: Catalog, onSave = vi.fn()) {
     onNext: vi.fn(),
     saving: false,
   }
-  const result = render(<RouterSection {...props} />)
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <RouterSection {...props} />
+    </QueryClientProvider>,
+  )
   return {
     ...result,
     rerenderCatalog: (nextCatalog: Catalog) =>
-      result.rerender(<RouterSection {...props} catalog={nextCatalog} />),
+      result.rerender(
+        <QueryClientProvider client={queryClient}>
+          <RouterSection {...props} catalog={nextCatalog} />
+        </QueryClientProvider>,
+      ),
   }
 }
 
@@ -124,5 +167,81 @@ describe('RouterSection', () => {
 
     expect(screen.getByLabelText('image_model supports image')).toBeChecked()
     expect(screen.getByLabelText('image_model supports image')).toBeDisabled()
+  })
+
+  it('updates datalist options when provider changes and filters image_model for vision capability', async () => {
+    const catalog = catalogWithTiers({
+      c0: { provider: 'openai', model: 'gpt-4o-mini' },
+      image_model: { provider: 'openai', model: 'gpt-image-1' },
+    })
+    catalog.providers = [
+      { providerId: 'openai', label: 'OpenAI', runtimeSupported: true },
+      { providerId: 'anthropic', label: 'Anthropic', runtimeSupported: true },
+    ]
+
+    renderSection(catalog)
+
+    const c0ProviderSelect = screen.getByLabelText('c0 provider')
+    expect(c0ProviderSelect).toHaveValue('openai')
+
+    // Wait for the datalist options to be loaded from the RPC call
+    await waitFor(() => {
+      const c0Datalist = document.getElementById('datalist-c0') as HTMLDataListElement
+      expect(c0Datalist).toBeInTheDocument()
+      const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+      expect(c0Options).toContain('gpt-4o')
+    })
+
+    const c0Datalist = document.getElementById('datalist-c0') as HTMLDataListElement
+    let c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+    expect(c0Options).toContain('gpt-4o-mini')
+    expect(c0Options).toContain('gpt-image-1')
+    expect(c0Options).not.toContain('claude-3-opus')
+
+    fireEvent.change(c0ProviderSelect, { target: { value: 'anthropic' } })
+    expect(c0ProviderSelect).toHaveValue('anthropic')
+
+    // Wait for options to update for the new provider
+    await waitFor(() => {
+      const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+      expect(c0Options).toContain('claude-3-opus')
+    })
+
+    c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+    expect(c0Options).not.toContain('gpt-4o')
+
+    const imageDatalist = document.getElementById('datalist-image_model') as HTMLDataListElement
+    expect(imageDatalist).toBeInTheDocument()
+    const imageOptions = Array.from(imageDatalist.options).map((opt) => opt.value)
+    expect(imageOptions).toContain('gpt-image-1')
+    expect(imageOptions).not.toContain('gpt-4o')
+    expect(imageOptions).not.toContain('gpt-4o-mini')
+  })
+
+  it('warns on unknown model ID on save', async () => {
+    const onSave = vi.fn()
+    const catalog = catalogWithTiers({
+      c0: { provider: 'openai', model: 'unknown-model-id-123' },
+    })
+    catalog.providers = [
+      { providerId: 'openai', label: 'OpenAI', runtimeSupported: true },
+    ]
+
+    renderSection(catalog, onSave)
+
+    // Wait for the query to populate allModels so that validation runs on a loaded list
+    await waitFor(() => {
+      const c0Datalist = document.getElementById('datalist-c0') as HTMLDataListElement
+      expect(c0Datalist).toBeInTheDocument()
+      expect(c0Datalist.options.length).toBeGreaterThan(0)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Warning: Model ID not in catalog: unknown-model-id-123'),
+      expect.any(Object),
+    )
+    expect(onSave).toHaveBeenCalled()
   })
 })

--- a/frontend/src/views/setup/RouterSection.test.tsx
+++ b/frontend/src/views/setup/RouterSection.test.tsx
@@ -44,10 +44,34 @@ function catalogWithTiers(tiers: Record<string, Record<string, unknown>>): Catal
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const MOCK_MODELS = [
-  { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
-  { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
-  { id: 'gpt-image-1', name: 'GPT Image 1', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'vision'] },
-  { id: 'claude-3-opus', name: 'Claude 3 Opus', provider: 'anthropic', contextWindow: 200000, capabilities: ['chat'] },
+  {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    capabilities: ['chat', 'tools'],
+  },
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o Mini',
+    provider: 'openai',
+    contextWindow: 128000,
+    capabilities: ['chat', 'tools'],
+  },
+  {
+    id: 'gpt-image-1',
+    name: 'GPT Image 1',
+    provider: 'openai',
+    contextWindow: 128000,
+    capabilities: ['chat', 'vision'],
+  },
+  {
+    id: 'claude-3-opus',
+    name: 'Claude 3 Opus',
+    provider: 'anthropic',
+    contextWindow: 200000,
+    capabilities: ['chat'],
+  },
 ]
 
 const mockRpc = {
@@ -223,9 +247,7 @@ describe('RouterSection', () => {
     const catalog = catalogWithTiers({
       c0: { provider: 'openai', model: 'unknown-model-id-123' },
     })
-    catalog.providers = [
-      { providerId: 'openai', label: 'OpenAI', runtimeSupported: true },
-    ]
+    catalog.providers = [{ providerId: 'openai', label: 'OpenAI', runtimeSupported: true }]
 
     renderSection(catalog, onSave)
 

--- a/frontend/src/views/setup/RouterSection.test.tsx
+++ b/frontend/src/views/setup/RouterSection.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { toast } from 'sonner'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterSection } from './RouterSection'
 import type { Catalog } from './logic'
 
@@ -24,24 +25,27 @@ function catalogWithTiers(tiers: Record<string, Record<string, unknown>>): Catal
       defaultTier: 'c1',
       profiles: [
         {
-          // Keep the production gateway profile shape, including fields the
-          // editor does not consume.
           profileId: 'openai',
           providerId: 'openai',
           label: 'OpenAI',
+          tiers,
+        },
+        {
+          profileId: 'anthropic',
+          providerId: 'anthropic',
+          label: 'Anthropic',
           tiers,
         },
       ],
       judge: {
         profiles: {
           openai: { autoModel: 'gpt-4o-mini', models: ['gpt-4o-mini', 'gpt-4o'] },
+          anthropic: { autoModel: 'claude-3-opus', models: ['claude-3-opus'] },
         },
       },
     },
   }
 }
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const MOCK_MODELS = [
   {
@@ -72,13 +76,22 @@ const MOCK_MODELS = [
     contextWindow: 200000,
     capabilities: ['chat'],
   },
+  {
+    id: 'claude-image-1',
+    name: 'Claude Image 1',
+    provider: 'anthropic',
+    contextWindow: 200000,
+    capabilities: ['chat', 'vision'],
+  },
 ]
+
+let mockModelsResponse: unknown = MOCK_MODELS
 
 const mockRpc = {
   waitForConnection: vi.fn().mockResolvedValue(undefined),
   call: vi.fn((method) => {
     if (method === 'models.list') {
-      return Promise.resolve(MOCK_MODELS)
+      return Promise.resolve(mockModelsResponse)
     }
     return Promise.resolve({})
   }),
@@ -88,7 +101,7 @@ vi.mock('@/app/providers', () => ({
   useRpc: () => mockRpc,
 }))
 
-function renderSection(catalog: Catalog, onSave = vi.fn()) {
+function renderSection(catalog: Catalog, onSave = vi.fn(), config = CONFIG, draftProvider = '') {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -99,7 +112,8 @@ function renderSection(catalog: Catalog, onSave = vi.fn()) {
   const props = {
     catalog,
     status: STATUS,
-    config: CONFIG,
+    config,
+    draftProvider,
     onSave,
     onBack: vi.fn(),
     onNext: vi.fn(),
@@ -118,10 +132,20 @@ function renderSection(catalog: Catalog, onSave = vi.fn()) {
           <RouterSection {...props} catalog={nextCatalog} />
         </QueryClientProvider>,
       ),
+    rerenderWithConfig: (nextConfig: typeof CONFIG) =>
+      result.rerender(
+        <QueryClientProvider client={queryClient}>
+          <RouterSection {...props} config={nextConfig} />
+        </QueryClientProvider>,
+      ),
   }
 }
 
 describe('RouterSection', () => {
+  afterEach(() => {
+    mockModelsResponse = MOCK_MODELS
+  })
+
   it('seeds tiers that appear in a later partial-catalog update without crashing', () => {
     const partialCatalog = catalogWithTiers({
       c0: { provider: 'openai', model: 'gpt-4o-mini' },
@@ -129,7 +153,7 @@ describe('RouterSection', () => {
     const view = renderSection(partialCatalog)
 
     expect(screen.getByLabelText('c0 model')).toHaveValue('gpt-4o-mini')
-    expect(screen.queryByLabelText('c1 provider')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('c1 model')).not.toBeInTheDocument()
 
     view.rerenderCatalog(
       catalogWithTiers({
@@ -139,7 +163,6 @@ describe('RouterSection', () => {
       }),
     )
 
-    expect(screen.getByLabelText('c1 provider')).toHaveValue('openai')
     expect(screen.getByLabelText('c1 model')).toHaveValue('gpt-4o')
     expect(screen.getByLabelText('image_model model')).toHaveValue('gpt-image-1')
   })
@@ -203,43 +226,52 @@ describe('RouterSection', () => {
       { providerId: 'anthropic', label: 'Anthropic', runtimeSupported: true },
     ]
 
-    renderSection(catalog)
+    const config = {
+      llm: { provider: 'openai', model: 'gpt-4o' },
+      agentos_router: { enabled: true, strategy: 'pilot-v1', default_tier: 'c1' },
+    }
 
-    const c0ProviderSelect = screen.getByLabelText('c0 provider')
-    expect(c0ProviderSelect).toHaveValue('openai')
+    const { rerenderWithConfig } = renderSection(catalog, vi.fn(), config)
 
     // Wait for the datalist options to be loaded from the RPC call
     await waitFor(() => {
       const c0Datalist = document.getElementById('datalist-c0') as HTMLDataListElement
       expect(c0Datalist).toBeInTheDocument()
       const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
-      expect(c0Options).toContain('gpt-4o')
+      expect(c0Options).toContain('gpt-image-1')
     })
 
     const c0Datalist = document.getElementById('datalist-c0') as HTMLDataListElement
-    let c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+    const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+    expect(c0Options).toContain('gpt-4o')
     expect(c0Options).toContain('gpt-4o-mini')
-    expect(c0Options).toContain('gpt-image-1')
     expect(c0Options).not.toContain('claude-3-opus')
 
-    fireEvent.change(c0ProviderSelect, { target: { value: 'anthropic' } })
-    expect(c0ProviderSelect).toHaveValue('anthropic')
-
-    // Wait for options to update for the new provider
-    await waitFor(() => {
-      const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
-      expect(c0Options).toContain('claude-3-opus')
-    })
-
-    c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
-    expect(c0Options).not.toContain('gpt-4o')
-
+    // Verify image model capability filtering for OpenAI initially
     const imageDatalist = document.getElementById('datalist-image_model') as HTMLDataListElement
     expect(imageDatalist).toBeInTheDocument()
     const imageOptions = Array.from(imageDatalist.options).map((opt) => opt.value)
     expect(imageOptions).toContain('gpt-image-1')
     expect(imageOptions).not.toContain('gpt-4o')
     expect(imageOptions).not.toContain('gpt-4o-mini')
+
+    // Change configuration provider
+    const nextConfig = {
+      ...config,
+      llm: { provider: 'anthropic', model: 'claude-3-opus' },
+    }
+    rerenderWithConfig(nextConfig)
+
+    // Wait for options to update for the new provider, including the image model capability filter
+    await waitFor(() => {
+      const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+      expect(c0Options).toContain('claude-3-opus')
+
+      const imgDatalist = document.getElementById('datalist-image_model') as HTMLDataListElement
+      const imgOptions = Array.from(imgDatalist.options).map((opt) => opt.value)
+      expect(imgOptions).toContain('claude-image-1')
+      expect(imgOptions).not.toContain('claude-3-opus')
+    })
   })
 
   it('warns on unknown model ID on save', async () => {
@@ -264,6 +296,56 @@ describe('RouterSection', () => {
       expect.stringContaining('Warning: Model ID not in catalog: unknown-model-id-123'),
       expect.any(Object),
     )
+    expect(onSave).toHaveBeenCalled()
+  })
+
+  it('falls back to offline catalog judge profiles models when models.list returns empty', async () => {
+    // Override RPC mock to return empty array
+    mockModelsResponse = []
+
+    const catalog = catalogWithTiers({
+      c0: { provider: 'openai', model: 'gpt-4o' },
+    })
+    catalog.routerProfiles!.judge = {
+      profiles: {
+        openai: { autoModel: 'gpt-4o-mini', models: ['gpt-4o-mini', 'gpt-4o-offline'] },
+      },
+    }
+
+    renderSection(catalog)
+
+    await waitFor(() => {
+      const c0Datalist = document.getElementById('datalist-c0') as HTMLDataListElement
+      expect(c0Datalist).toBeInTheDocument()
+      const c0Options = Array.from(c0Datalist.options).map((opt) => opt.value)
+      expect(c0Options).toContain('gpt-4o-offline')
+    })
+  })
+
+  it('shows warning when both models.list and offline catalog are empty (cannot validate model)', async () => {
+    // Override RPC mock to return empty array
+    mockModelsResponse = []
+
+    const onSave = vi.fn()
+    const catalog = catalogWithTiers({
+      c0: { provider: 'openai', model: 'any-model' },
+    })
+    catalog.routerProfiles!.judge = {
+      profiles: {
+        openai: { autoModel: null, models: [] },
+      },
+    }
+
+    renderSection(catalog, onSave)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Warning: Could not validate model ID'),
+        expect.any(Object),
+      )
+    })
     expect(onSave).toHaveBeenCalled()
   })
 })

--- a/frontend/src/views/setup/RouterSection.tsx
+++ b/frontend/src/views/setup/RouterSection.tsx
@@ -70,10 +70,6 @@ export function RouterSection({
 }) {
   const router = config.agentos_router || {}
   const rpc = useRpc()
-  const providers = useMemo(
-    () => (catalog.providers || []).filter((p) => p.runtimeSupported),
-    [catalog.providers],
-  )
 
   const modelsQuery = useQuery<ModelSpec[]>({
     queryKey: ['setup', 'models'],
@@ -152,21 +148,45 @@ export function RouterSection({
     if (!canSave) return
 
     const unknownModels: string[] = []
-    if (allModels.length > 0) {
-      visibleTiers.forEach(([name, tier]) => {
-        const row = rowFor(name, tier)
-        if (row.model) {
-          const match = allModels.find((m) => m.provider === row.provider && m.id === row.model)
+    const unvalidatedTiers: string[] = []
+
+    visibleTiers.forEach(([name, tier]) => {
+      const row = rowFor(name, tier)
+      if (row.model) {
+        // Enforce the active provider when validating
+        const rowProvider = provider
+        const hasRpcModels = allModels.some((m) => m.provider === rowProvider)
+
+        if (hasRpcModels) {
+          const match = allModels.find((m) => m.provider === rowProvider && m.id === row.model)
           if (!match) {
             unknownModels.push(row.model)
           }
+        } else {
+          // Fall back to offline catalog judge profiles models
+          const judgeProfile = judgeProfiles[rowProvider] || {}
+          const fallbackModels = Array.isArray(judgeProfile.models) ? judgeProfile.models : []
+          if (fallbackModels.length > 0) {
+            if (!fallbackModels.includes(row.model)) {
+              unknownModels.push(row.model)
+            }
+          } else {
+            unvalidatedTiers.push(`${name} (${row.model})`)
+          }
         }
-      })
-    }
+      }
+    })
+
     if (unknownModels.length > 0) {
       toast.warning(
         `Warning: Model ID${unknownModels.length > 1 ? 's' : ''} not in catalog: ${unknownModels.join(', ')}`,
         { id: 'setup-router-warning' },
+      )
+    }
+    if (unvalidatedTiers.length > 0) {
+      toast.warning(
+        `Warning: Could not validate model ID${unvalidatedTiers.length > 1 ? 's' : ''} against catalog: ${unvalidatedTiers.join(', ')}`,
+        { id: 'setup-router-unvalidated-warning' },
       )
     }
 
@@ -176,7 +196,14 @@ export function RouterSection({
       defaultTier,
       judgeModel,
       pilotThresholdRaw: pilotThreshold,
-      tiers: visibleTiers.map(([name, tier]) => ({ tier: name, ...rowFor(name, tier) })),
+      tiers: visibleTiers.map(([name, tier]) => {
+        const row = rowFor(name, tier)
+        return {
+          tier: name,
+          ...row,
+          provider: provider, // Enforce active provider on save
+        }
+      }),
     })
     onSave(params)
   }
@@ -272,13 +299,23 @@ export function RouterSection({
             const isImageModel = name === 'image_model'
             const supportsImage = isImageModel || row.supportsImage
             const listId = `datalist-${name}`
-            const filteredModels = allModels.filter((m) => {
-              if (m.provider !== row.provider) return false
-              if (isImageModel) {
-                return m.capabilities?.includes('vision')
-              }
-              return true
-            })
+
+            let filteredModels = allModels.filter((m) => m.provider === provider)
+            if (filteredModels.length === 0) {
+              const judgeProfile = judgeProfiles[provider] || {}
+              const fallbackModels = Array.isArray(judgeProfile.models) ? judgeProfile.models : []
+              filteredModels = fallbackModels.map((modelId) => ({
+                id: modelId,
+                name: modelId,
+                provider: provider,
+                contextWindow: 0,
+                capabilities: isImageModel ? ['vision'] : ['chat'],
+              }))
+            }
+            if (isImageModel) {
+              filteredModels = filteredModels.filter((m) => m.capabilities?.includes('vision'))
+            }
+
             return (
               <div className="setup-tier-table__row" role="row" key={name}>
                 <div className="setup-tier-table__cell setup-tier-table__cell--tier" role="cell">
@@ -291,25 +328,7 @@ export function RouterSection({
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">
                     Provider
                   </span>
-                  <SetupSelect
-                    aria-label={`${name} provider`}
-                    value={row.provider}
-                    onChange={(e) => setRow(name, tier, { provider: e.target.value })}
-                  >
-                    <option value="" disabled>
-                      Choose a provider
-                    </option>
-                    {providers.map((p) => (
-                      <option key={p.providerId} value={p.providerId}>
-                        {p.label || p.providerId}
-                      </option>
-                    ))}
-                    {row.provider && !providers.some((p) => p.providerId === row.provider) && (
-                      <option key={row.provider} value={row.provider}>
-                        {row.provider}
-                      </option>
-                    )}
-                  </SetupSelect>
+                  <code className="setup-provider-chip">{provider}</code>
                 </div>
                 <div className="setup-tier-table__cell setup-tier-table__cell--model" role="cell">
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">
@@ -320,8 +339,17 @@ export function RouterSection({
                     value={row.model}
                     list={listId}
                     autoComplete="off"
+                    title={row.model}
                     onChange={(e) => setRow(name, tier, { model: e.target.value })}
                   />
+                  {filteredModels.length === 0 && (
+                    <small
+                      className="setup-hint"
+                      style={{ display: 'block', marginTop: '0.25rem' }}
+                    >
+                      No catalog models for {provider} — type an ID.
+                    </small>
+                  )}
                   <datalist id={listId}>
                     {filteredModels.map((m) => {
                       const ctxText =

--- a/frontend/src/views/setup/RouterSection.tsx
+++ b/frontend/src/views/setup/RouterSection.tsx
@@ -156,9 +156,7 @@ export function RouterSection({
       visibleTiers.forEach(([name, tier]) => {
         const row = rowFor(name, tier)
         if (row.model) {
-          const match = allModels.find(
-            (m) => m.provider === row.provider && m.id === row.model,
-          )
+          const match = allModels.find((m) => m.provider === row.provider && m.id === row.model)
           if (!match) {
             unknownModels.push(row.model)
           }
@@ -168,7 +166,7 @@ export function RouterSection({
     if (unknownModels.length > 0) {
       toast.warning(
         `Warning: Model ID${unknownModels.length > 1 ? 's' : ''} not in catalog: ${unknownModels.join(', ')}`,
-        { id: 'setup-router-warning' }
+        { id: 'setup-router-warning' },
       )
     }
 

--- a/frontend/src/views/setup/RouterSection.tsx
+++ b/frontend/src/views/setup/RouterSection.tsx
@@ -3,6 +3,9 @@
 // editable tier table. Save via onboarding.router.configure, gated on the
 // provider being saved (effective === configured).
 import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useRpc } from '@/app/providers'
 import { Button } from '@/components/ui/button'
 import { PanelHead, SetupCheckbox, SetupSelect } from './parts'
 import {
@@ -24,6 +27,18 @@ import {
 } from './logic'
 
 const THINKING_LEVELS = ['', 'off', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh']
+
+interface ModelSpec {
+  id: string
+  name: string
+  provider: string
+  contextWindow: number
+  capabilities: string[]
+  pricing?: {
+    inputPer1k: number
+    outputPer1k: number
+  }
+}
 
 interface TierRowState {
   provider: string
@@ -54,6 +69,23 @@ export function RouterSection({
   saving: boolean
 }) {
   const router = config.agentos_router || {}
+  const rpc = useRpc()
+  const providers = useMemo(
+    () => (catalog.providers || []).filter((p) => p.runtimeSupported),
+    [catalog.providers],
+  )
+
+  const modelsQuery = useQuery<ModelSpec[]>({
+    queryKey: ['setup', 'models'],
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      const data = await rpc.call<unknown>('models.list', {})
+      return (data as ModelSpec[]) ?? []
+    },
+    refetchOnWindowFocus: false,
+  })
+  const allModels = Array.isArray(modelsQuery.data) ? modelsQuery.data : []
+
   const provider = effectiveProviderFn(status, config, draftProvider)
   const configured = configuredProviderFn(status, config)
   const canSave = Boolean(provider && provider === configured)
@@ -118,6 +150,28 @@ export function RouterSection({
 
   const collectAndSave = () => {
     if (!canSave) return
+
+    const unknownModels: string[] = []
+    if (allModels.length > 0) {
+      visibleTiers.forEach(([name, tier]) => {
+        const row = rowFor(name, tier)
+        if (row.model) {
+          const match = allModels.find(
+            (m) => m.provider === row.provider && m.id === row.model,
+          )
+          if (!match) {
+            unknownModels.push(row.model)
+          }
+        }
+      })
+    }
+    if (unknownModels.length > 0) {
+      toast.warning(
+        `Warning: Model ID${unknownModels.length > 1 ? 's' : ''} not in catalog: ${unknownModels.join(', ')}`,
+        { id: 'setup-router-warning' }
+      )
+    }
+
     const judgeModel = resolveJudgeModelParam(judge, judgeLoaded, judgeIsLocal)
     const params = buildRouterConfigureParams({
       sel: mode,
@@ -219,6 +273,14 @@ export function RouterSection({
             const row = rowFor(name, tier)
             const isImageModel = name === 'image_model'
             const supportsImage = isImageModel || row.supportsImage
+            const listId = `datalist-${name}`
+            const filteredModels = allModels.filter((m) => {
+              if (m.provider !== row.provider) return false
+              if (isImageModel) {
+                return m.capabilities?.includes('vision')
+              }
+              return true
+            })
             return (
               <div className="setup-tier-table__row" role="row" key={name}>
                 <div className="setup-tier-table__cell setup-tier-table__cell--tier" role="cell">
@@ -231,11 +293,25 @@ export function RouterSection({
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">
                     Provider
                   </span>
-                  <input
+                  <SetupSelect
                     aria-label={`${name} provider`}
                     value={row.provider}
                     onChange={(e) => setRow(name, tier, { provider: e.target.value })}
-                  />
+                  >
+                    <option value="" disabled>
+                      Choose a provider
+                    </option>
+                    {providers.map((p) => (
+                      <option key={p.providerId} value={p.providerId}>
+                        {p.label || p.providerId}
+                      </option>
+                    ))}
+                    {row.provider && !providers.some((p) => p.providerId === row.provider) && (
+                      <option key={row.provider} value={row.provider}>
+                        {row.provider}
+                      </option>
+                    )}
+                  </SetupSelect>
                 </div>
                 <div className="setup-tier-table__cell setup-tier-table__cell--model" role="cell">
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">
@@ -244,8 +320,34 @@ export function RouterSection({
                   <input
                     aria-label={`${name} model`}
                     value={row.model}
+                    list={listId}
+                    autoComplete="off"
                     onChange={(e) => setRow(name, tier, { model: e.target.value })}
                   />
+                  <datalist id={listId}>
+                    {filteredModels.map((m) => {
+                      const ctxText =
+                        Number(m.contextWindow) > 0
+                          ? `${Math.round(Number(m.contextWindow) / 1000)}k ctx`
+                          : ''
+                      const input1M = m.pricing ? (Number(m.pricing.inputPer1k) || 0) * 1000 : 0
+                      const output1M = m.pricing ? (Number(m.pricing.outputPer1k) || 0) * 1000 : 0
+                      const pricingText =
+                        input1M || output1M
+                          ? `$${input1M.toFixed(2)}/$${output1M.toFixed(2)} per 1M`
+                          : ''
+                      const labelParts = [ctxText, pricingText].filter(Boolean)
+                      const optionLabel =
+                        labelParts.length > 0
+                          ? `${m.name || m.id} (${labelParts.join(' · ')})`
+                          : m.name || m.id
+                      return (
+                        <option key={m.id} value={m.id}>
+                          {optionLabel}
+                        </option>
+                      )
+                    })}
+                  </datalist>
                 </div>
                 <div className="setup-tier-table__cell" role="cell">
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -134,6 +134,12 @@ const CONFIG = {
   memory: { curated_memory_char_limit: 4000, curated_user_char_limit: 2000, inject_limit: 6400 },
 }
 
+const MOCK_MODELS = [
+  { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
+  { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
+  { id: 'dall-e', name: 'Dall-E', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'vision'] },
+]
+
 function statusFor(overrides: Record<string, unknown> = {}) {
   return {
     needsOnboarding: false,
@@ -158,6 +164,7 @@ function wireCalls(status: Record<string, unknown> = statusFor()) {
     if (method === 'onboarding.status') return Promise.resolve(status)
     if (method === 'config.get') return Promise.resolve(CONFIG)
     if (method === 'doctor.memory.status') return Promise.resolve(null)
+    if (method === 'models.list') return Promise.resolve(MOCK_MODELS)
     return Promise.resolve({})
   })
 }

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -135,9 +135,27 @@ const CONFIG = {
 }
 
 const MOCK_MODELS = [
-  { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
-  { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'tools'] },
-  { id: 'dall-e', name: 'Dall-E', provider: 'openai', contextWindow: 128000, capabilities: ['chat', 'vision'] },
+  {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    capabilities: ['chat', 'tools'],
+  },
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o Mini',
+    provider: 'openai',
+    contextWindow: 128000,
+    capabilities: ['chat', 'tools'],
+  },
+  {
+    id: 'dall-e',
+    name: 'Dall-E',
+    provider: 'openai',
+    contextWindow: 128000,
+    capabilities: ['chat', 'vision'],
+  },
 ]
 
 function statusFor(overrides: Record<string, unknown> = {}) {

--- a/frontend/src/views/setup/setup.css
+++ b/frontend/src/views/setup/setup.css
@@ -564,7 +564,7 @@
 .setup-tier-table__row {
   display: grid;
   grid-template-columns:
-    4.5rem minmax(7rem, 0.85fr) minmax(10rem, 1.45fr) minmax(7rem, 0.75fr)
+    4.5rem minmax(5.5rem, 0.6fr) minmax(14rem, 2fr) minmax(7rem, 0.75fr)
     5rem;
   gap: 0.5rem;
   align-items: center;


### PR DESCRIPTION


### Description:
This PR replaces the manual free-text inputs for **Provider** and **Model** in the **Router Tiers** setup panel with interactive select dropdowns and comboboxes.

* **Provider Dropdown**: Converts the provider input to a `<SetupSelect>` populated from the configured catalog providers.
* **Model Combobox**: Replaces the model input with a native HTML5 combobox (`<input list={...} />` + `<datalist>`) dynamically populated from the `models.list` RPC call.
* **Smart Filtering**:
  * Suggesions are filtered to match the selected provider in each tier row.
  * The `image_model` row automatically filters suggestions to only include models with `vision` capabilities.
* **Richer Metadata**: Options in the suggestion picker display context window (e.g. `128k ctx`) and input/output token pricing per 1M (e.g. `$1.50/$3.00 per 1M`).
* **Validation Warning**: Warns the operator on save (via `toast.warning`) if a typed model ID is not in the catalog (warn-only, does not block save).
* **Unit Tests**: Includes new unit test coverage in `RouterSection.test.tsx` verifying these features, and updates mock setups to pass the entire test suite.

Closes #142