### PR TITLE
feat(telegram): add streaming message support

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -829,6 +829,17 @@ class TelegramChannel:
             metadata["thread_id"] = thread_id
         return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)
 
+    def streaming_reply_kwargs(self, inbound: IncomingMessage) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "channel_id": inbound.channel_id,
+        }
+
+        thread_id = inbound.metadata.get("thread_id")
+        if thread_id is not None:
+            kwargs["thread_id"] = thread_id
+
+        return kwargs
+
     async def send_typing(
         self,
         channel_id: str | None = None,

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -916,14 +916,24 @@ class TelegramChannel:
                 )
 
                 msg = result.get("result", result)
-                message_ref = f"{target}:{msg['message_id']}"
+                message_id = msg.get("message_id")
+                if message_id is None:
+                    raise RuntimeError("telegram send_streaming missing message_id")
+
+                message_ref = f"{target}|{message_id}"
             else:
                 await self.edit(message_ref, text)
+
+        if message_ref is None:
+            return ChannelSendResult.unsupported(
+                capability=ChannelCapabilities.STREAMING,
+                reason="empty stream",
+            )
 
         return ChannelSendResult.sent(
             capability=ChannelCapabilities.STREAMING,
             target_id=str(target),
-            provider_message_id=message_ref or "",
+            provider_message_id=message_ref,
         )
 
     async def send_file(

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -119,6 +119,7 @@ class TelegramChannel:
     pairing_store: ChannelPairingStore = field(default_factory=ChannelPairingStore)
 
     supports_slash_commands: bool = True
+    supports_streaming: bool = True
     typing_keepalive_interval_s: ClassVar[float] = 4.0
     policy: ChannelAccessPolicy = field(
         default_factory=lambda: ChannelAccessPolicy(
@@ -863,6 +864,56 @@ class TelegramChannel:
             payload.pop("parse_mode", None)
             result = await self._api("sendMessage", payload)
         return result if isinstance(result, dict) else {"result": result}
+
+    async def send_streaming(
+        self,
+        chunks,
+        *,
+        channel_id: str | None = None,
+        thread_id: str | None = None,
+        **_: object,
+    ) -> ChannelSendResult:
+        """
+        Stream partial responses by repeatedly editing a Telegram message.
+        """
+
+        target = channel_id or self.config.default_chat_id
+        if not target:
+            return ChannelSendResult.unsupported(
+                capability=ChannelCapabilities.STREAMING,
+                reason="no chat target",
+            )
+
+        text = ""
+        message_ref: str | None = None
+
+        async for chunk in chunks:
+            if not chunk:
+                continue
+
+            text += chunk
+
+            if message_ref is None:
+                result = await self.send(
+                    OutgoingMessage(
+                        content=text,
+                        metadata={
+                            "chat_id": target,
+                            "thread_id": thread_id,
+                        },
+                    )
+                )
+
+                msg = result.get("result", result)
+                message_ref = f"{target}:{msg['message_id']}"
+            else:
+                await self.edit(message_ref, text)
+
+        return ChannelSendResult.sent(
+            capability=ChannelCapabilities.STREAMING,
+            target_id=str(target),
+            provider_message_id=message_ref or "",
+        )
 
     async def send_file(
         self,

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -36,6 +36,7 @@ from agentos.channels.contract import (
 from agentos.channels.types import Attachment, ChannelHealth, IncomingMessage, OutgoingMessage
 from agentos.engine.native_commands import telegram_bot_commands
 from agentos.env import trust_env as _trust_env
+from agentos.channels._util import StreamThrottle
 
 log = structlog.get_logger(__name__)
 
@@ -889,40 +890,48 @@ class TelegramChannel:
         """
 
         target = channel_id or self.config.default_chat_id
+        throttle = StreamThrottle(interval_s=1.0)
+        message_ref: str | None = None
         if not target:
             return ChannelSendResult.unsupported(
                 capability=ChannelCapabilities.STREAMING,
                 reason="no chat target",
             )
 
-        text = ""
-        message_ref: str | None = None
+        async def _post(text: str) -> None:
+            nonlocal message_ref
+
+            result = await self.send(
+                OutgoingMessage(
+                    content=text,
+                    metadata={
+                        "chat_id": target,
+                        "thread_id": thread_id,
+                    },
+                )
+            )
+
+            msg = result.get("result", result)
+
+            message_id = msg.get("message_id")
+            if message_id is None:
+                raise RuntimeError("telegram send_streaming missing message_id")
+
+            message_ref = f"{target}|{message_id}"
+
+
+        async def _edit(text: str) -> None:
+            if message_ref is None:
+                return
+
+            await self.edit(message_ref, text)
+
 
         async for chunk in chunks:
-            if not chunk:
-                continue
+            throttle.add(chunk)
+            await throttle.maybe_flush(post=_post, edit=_edit)
 
-            text += chunk
-
-            if message_ref is None:
-                result = await self.send(
-                    OutgoingMessage(
-                        content=text,
-                        metadata={
-                            "chat_id": target,
-                            "thread_id": thread_id,
-                        },
-                    )
-                )
-
-                msg = result.get("result", result)
-                message_id = msg.get("message_id")
-                if message_id is None:
-                    raise RuntimeError("telegram send_streaming missing message_id")
-
-                message_ref = f"{target}|{message_id}"
-            else:
-                await self.edit(message_ref, text)
+        await throttle.force_flush(post=_post, edit=_edit)
 
         if message_ref is None:
             return ChannelSendResult.unsupported(

--- a/tests/test_channels/test_telegram_typing.py
+++ b/tests/test_channels/test_telegram_typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any
 
@@ -135,7 +136,6 @@ async def test_telegram_keepalive_uses_inbound_chat_topic_and_adapter_cadence(
     assert sleep_intervals == []
     assert sleep_started.is_set() is False
 
-from collections.abc import AsyncIterator
 @pytest.mark.asyncio
 async def test_telegram_keepalive_treats_api_failure_as_best_effort(
     monkeypatch: pytest.MonkeyPatch,
@@ -200,12 +200,14 @@ async def test_send_streaming_posts_then_edits() -> None:
     assert calls[0][1]["chat_id"] == "-100111"
     assert calls[0][1]["message_thread_id"] == 5
 
-    assert calls[-1][0] == "editMessageText"
-    assert calls[-1][1]["chat_id"] == "-100111"
-    assert calls[-1][1]["message_id"] == 42
+    edit_call = next(call for call in calls if call[0] == "editMessageText")
+
+    assert edit_call[1]["chat_id"] == "-100111"
+    assert edit_call[1]["message_id"] == 42
 
 def test_telegram_streaming_reply_kwargs_preserve_thread() -> None:
     inbound = IncomingMessage(
+        sender_id="user-1",
         content="hello",
         channel_id="-100777",
         metadata={"thread_id": "5"},

--- a/tests/test_channels/test_telegram_typing.py
+++ b/tests/test_channels/test_telegram_typing.py
@@ -135,7 +135,7 @@ async def test_telegram_keepalive_uses_inbound_chat_topic_and_adapter_cadence(
     assert sleep_intervals == []
     assert sleep_started.is_set() is False
 
-
+from collections.abc import AsyncIterator
 @pytest.mark.asyncio
 async def test_telegram_keepalive_treats_api_failure_as_best_effort(
     monkeypatch: pytest.MonkeyPatch,
@@ -162,3 +162,60 @@ async def test_telegram_keepalive_treats_api_failure_as_best_effort(
     assert attempts == 0
     assert sleep_intervals == []
     assert sleep_started.is_set() is False
+
+@pytest.mark.asyncio
+async def test_send_streaming_posts_then_edits() -> None:
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_api(method: str, payload: dict) -> dict:
+        calls.append((method, payload))
+
+        if method == "sendMessage":
+            return {"message_id": 42}
+
+        return {"ok": True}
+
+    channel = TelegramChannel(
+        TelegramChannelConfig(
+            token="test-token",
+            default_chat_id="-100111",
+        )
+    )
+
+    channel._api = fake_api  # type: ignore[method-assign]
+
+    async def chunks() -> AsyncIterator[str]:
+        yield "Hello "
+        yield "world"
+
+    result = await channel.send_streaming(
+        chunks(),
+        channel_id="-100111",
+        thread_id="5",
+    )
+
+    assert result.provider_message_id == "-100111|42"
+
+    assert calls[0][0] == "sendMessage"
+    assert calls[0][1]["chat_id"] == "-100111"
+    assert calls[0][1]["message_thread_id"] == 5
+
+    assert calls[-1][0] == "editMessageText"
+    assert calls[-1][1]["chat_id"] == "-100111"
+    assert calls[-1][1]["message_id"] == 42
+
+def test_telegram_streaming_reply_kwargs_preserve_thread() -> None:
+    inbound = IncomingMessage(
+        content="hello",
+        channel_id="-100777",
+        metadata={"thread_id": "5"},
+    )
+
+    channel = TelegramChannel(
+        TelegramChannelConfig(token="test-token")
+    )
+
+    assert channel.streaming_reply_kwargs(inbound) == {
+        "channel_id": "-100777",
+        "thread_id": "5",
+    }

--- a/tests/test_channels/test_telegram_typing.py
+++ b/tests/test_channels/test_telegram_typing.py
@@ -102,9 +102,9 @@ def test_telegram_typing_capability_selects_keepalive_policy() -> None:
 
     assert channel.capability_profile.typing_indicator is True
     assert ChannelCapabilities.TYPING_INDICATOR in channel.capabilities
-    assert policy.mode == "typing_final"
-    assert policy.relay_stream is False
-    assert policy.typing_keepalive is True
+    assert policy.mode == "adapter_stream"
+    assert policy.relay_stream is True
+    assert policy.typing_keepalive is False
     assert 0 < channel.typing_keepalive_interval_s < 5
 
 
@@ -128,25 +128,12 @@ async def test_telegram_keepalive_uses_inbound_chat_topic_and_adapter_cadence(
         metadata={"is_group": True, "thread_id": "777"},
     )
 
-    task = channel_dispatch._start_typing_keepalive(channel, inbound)  # noqa: SLF001
+    task = channel_dispatch._start_typing_keepalive(channel, inbound)
 
-    assert task is not None
-    await asyncio.wait_for(sleep_started.wait(), timeout=1)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    assert api_calls == [
-        (
-            "sendChatAction",
-            {
-                "chat_id": "-100123",
-                "action": "typing",
-                "message_thread_id": 777,
-            },
-        )
-    ]
-    assert sleep_intervals == [4.0]
+    assert task is None
+    assert api_calls == []
+    assert sleep_intervals == []
+    assert sleep_started.is_set() is False
 
 
 @pytest.mark.asyncio
@@ -169,14 +156,9 @@ async def test_telegram_keepalive_treats_api_failure_as_best_effort(
         content="hello",
     )
 
-    task = channel_dispatch._start_typing_keepalive(channel, inbound)  # noqa: SLF001
+    task = channel_dispatch._start_typing_keepalive(channel, inbound)
 
-    assert task is not None
-    await asyncio.wait_for(sleep_started.wait(), timeout=1)
-    assert task.done() is False
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    assert attempts == 1
-    assert sleep_intervals == [4.0]
+    assert task is None
+    assert attempts == 0
+    assert sleep_intervals == []
+    assert sleep_started.is_set() is False


### PR DESCRIPTION
## Summary

Update Telegram typing tests to reflect the current streaming behavior.

### Changes

- Update `test_telegram_typing_capability_selects_keepalive_policy` to expect the `adapter_stream` policy.
- Remove assumptions that Telegram uses the `typing_final` keepalive strategy.
- Remove assertions that expect `_start_typing_keepalive()` to create a background task.
- Remove assertions that expect `sendChatAction` calls when streaming is enabled.
- Align Telegram channel tests with the current `ChannelStreamPolicy` behavior.

## Testing

```bash
uv run pytest tests/test_channels/test_telegram_typing.py -q
uv run pytest -k "telegram and not pilot" -q
```

Closes #141
