### PR TITLE
fix(skills): stop a hub install from silently replacing a bundled skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   operator installs the CLI and supplies their own key. Gated out of the model
   prompt until then, exactly like `senior-unilp-manager`.
 
+### Fixed
+
+- Asked to install a bundled skill that was only unconfigured, the agent
+  searched a community hub instead. A skill declaring `requires` is dropped
+  from the prompt until its binary and variables are present, so from inside a
+  turn an installed-but-unconfigured skill is indistinguishable from one that
+  was never installed — and a same-named catalog row installs into the managed
+  layer, which outranks bundled and would have silently replaced the shipped
+  skill for every session. Three changes close that path: the installer now
+  refuses a first install that would shadow a bundled skill (overridable with
+  `force`, and never blocking a reinstall or `agentos skills update` of an
+  existing one); `skill_search_community` answers with an `installed_match`
+  block, carrying what the local skill is missing and how to fix it, ahead of
+  the catalog results; and the `agentos` skill documents both rules.
+- `skill_view(name="agentos", section="Skills")` failed even though the skill
+  documents skills at length — the material sat under bold labels, which
+  `parse_sections` does not index. The six operation groups under **Common
+  operations** are real headings now, so each can be read on its own.
+
 ## [2026.8.2.post1] - 2026-08-02
 
 ### Fixed

--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -337,7 +337,12 @@ def skills_install(
             "or GitHub URLs. Bankr accepts a BankrBot/skills URL or a bankr.bot skill URL."
         ),
     ),
-    force: bool = typer.Option(False, "--force", "-f", help="Force install (skip security block)"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Force install (skip the security block and the bundled-shadow refusal)",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Install a skill from a Community source."""

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -194,7 +194,7 @@ otherwise export them with `agentos channels native-commands slack --request-url
 
 ## Common operations (verified recipes)
 
-**Change the model/provider (persistently):**
+### Change the model/provider (persistently)
 
 ```sh
 agentos providers configure openrouter -m anthropic/claude-sonnet-4   # provider + model in one step
@@ -203,7 +203,7 @@ agentos configure                                                     # interact
 agentos gateway restart                                               # apply to a running gateway
 ```
 
-**Gateway lifecycle:**
+### Gateway lifecycle
 
 ```sh
 agentos gateway start          # background; `run` = foreground
@@ -218,7 +218,7 @@ the installed CLI version (`cliVersion`) and the running gateway's version
 (`gatewayVersion`); a `versionMismatch` diagnostic means the gateway is running
 old code — restart it.
 
-**Upgrading AgentOS:**
+### Upgrading AgentOS
 
 ```sh
 agentos upgrade                # upgrade, then restart + verify the gateway
@@ -256,7 +256,7 @@ Unauthenticated non-loopback Control is unsupported. A reverse proxy, VPN, or
 firewall does not replace the AgentOS Control token. Behind a reverse proxy on
 another browser origin, also set `control_ui.allowed_origins`.
 
-**Skills:**
+### Skills
 
 ```sh
 agentos skills list                    # installed, per layer
@@ -269,6 +269,22 @@ agentos skills tap list
 agentos skills update
 agentos skills uninstall <name>
 ```
+
+**Before concluding a skill is missing, run `skill_list`.** A skill that
+declares `requires` is dropped from your prompt until its binary and variables
+are present, so an installed-but-unconfigured skill and a skill that was never
+installed look identical from inside a turn. `skill_list` shows both, and marks
+the first `[unavailable]` with what it is missing and the command that fixes
+it. Reporting that is the answer to "install X" when X is already here — an
+install would not have helped.
+
+**Never install a hub skill over a bundled one.** Layer precedence means the
+managed copy wins, so the built-in stops running everywhere while its files sit
+untouched on disk — nothing in the session would show the swap. The installer
+refuses this and says so; only pass `force` after the operator has confirmed
+they want the hub version instead of the shipped one. `skill_search_community`
+answers with an `installed_match` block when the query names a skill this
+machine already has, for the same reason.
 
 Three separate facts describe a skill; do not use one to answer another.
 
@@ -346,7 +362,7 @@ operator to look for it on the Skills page — read it from the decision log.
 no chat session and no tool surface, so it cannot answer. An absent key means
 "not computed", never "not offered".
 
-**One-shot automation:**
+### One-shot automation
 
 ```sh
 agentos agent -m "summarize README.md" --model gpt-5.4-mini --timeout 120
@@ -359,7 +375,7 @@ Bounding flags: `--timeout` (wall-clock seconds), `--max-iterations`,
 `--workspace-strict` (reads), `--workspace-lockdown` (writes),
 `--scratch-dir`.
 
-**Day-two operations:**
+### Day-two operations
 
 ```sh
 agentos sessions list / show <id> / export <id> <out>

--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -20,7 +20,7 @@ from agentos.skills.hub.lockfile import (
 from agentos.skills.hub.router import SourceRouter
 from agentos.skills.hub.scanner import ScanResult, scan_skill_bundle
 from agentos.skills.hub.source import SkillMeta
-from agentos.skills.paths import default_managed_skills_dir
+from agentos.skills.paths import default_bundled_skills_dir, default_managed_skills_dir
 
 log = structlog.get_logger(__name__)
 
@@ -40,6 +40,26 @@ def _default_quarantine_dir() -> Path:
 
 def _default_lockfile() -> Path:
     return default_lockfile_path()
+
+
+def bundled_skill_names() -> set[str]:
+    """Names of the skills that ship with AgentOS.
+
+    Read off disk rather than through :class:`~agentos.skills.loader.SkillLoader`
+    so the installer stays usable from the CLI, where no loader has been built.
+    Only directory names are needed — a shadow is decided by name, and the
+    loader resolves layers by name too.
+    """
+    try:
+        bundled = default_bundled_skills_dir()
+        return {
+            path.name
+            for path in bundled.iterdir()
+            if path.is_dir() and (path / "SKILL.md").is_file()
+        }
+    except OSError:  # pragma: no cover — a missing bundled dir must not block installs
+        log.debug("installer.bundled_names_unavailable", exc_info=True)
+        return set()
 
 
 def _publisher_slug(meta: SkillMeta | None, source_id: str) -> str:
@@ -115,6 +135,25 @@ class SkillInstaller:
         name = bundle.name
         if not _SAFE_NAME_RE.match(name):
             return InstallResult(success=False, name=name, message=f"Invalid skill name: {name}")
+
+        # A managed install outranks a bundled one (SkillLayer precedence), so a
+        # same-named community skill replaces the shipped one for every session
+        # without touching it on disk — nothing in the old flow said so. Refuse
+        # the *first* such install; a reinstall or update of an already-shadowing
+        # skill is not a new decision and passes through.
+        if not force and name in bundled_skill_names() and not (self._managed_dir / name).is_dir():
+            return InstallResult(
+                success=False,
+                name=name,
+                message=(
+                    f"'{name}' already ships with AgentOS. Installing this one writes to "
+                    f"the managed layer, which outranks bundled, so it would silently "
+                    f"replace the built-in skill everywhere. If the built-in shows as "
+                    f"unavailable it is missing a binary or an environment variable, not "
+                    f"an install — run 'agentos skills list' to see which. Re-run with "
+                    f"force once the user has confirmed they want this one instead."
+                ),
+            )
 
         skill_md = bundle.skill_md
         if not skill_md:

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -171,6 +171,70 @@ def _community_result_to_dict(
     }
 
 
+def _local_match(loader: SkillLoader, query: str) -> dict[str, Any] | None:
+    """What an installed skill named like ``query`` already offers, or ``None``.
+
+    A skill that declares ``requires`` disappears from the prompt until its
+    binary and variables are present, so from the model's side an unconfigured
+    bundled skill and a skill that was never installed look identical. Asked to
+    install one, it goes shopping on a hub — and a same-named catalog row
+    installs over it, because managed outranks bundled. Answering the search
+    with the local truth is what stops that, so this runs before the network
+    call and its result is emitted ahead of the results list.
+    """
+    from agentos.skills.inventory import build_skill_inventory
+    from agentos.tools.registry import get_default_registry
+
+    wanted = query.strip().casefold()
+    if not wanted:
+        return None
+    try:
+        rows = build_skill_inventory(
+            loader,
+            available_tools=set(get_default_registry().list_names()),
+        )
+    except Exception:  # pragma: no cover — a hint is never worth failing the search on
+        logger.debug("skill_search_community.local_probe_failed", exc_info=True)
+        return None
+
+    row = next((r for r in rows if r.spec.name.casefold() == wanted), None)
+    if row is None:
+        near = [r.spec.name for r in rows if wanted in r.spec.name.casefold()][:3]
+        return {"similar_installed": near} if near else None
+
+    report = row.eligibility
+    payload: dict[str, Any] = {
+        "name": row.spec.name,
+        "layer": str(row.spec.layer),
+        "eligible": report.eligible,
+    }
+    if report.eligible:
+        payload["note"] = (
+            f"'{row.spec.name}' is already installed and ready to use. Read it with "
+            f"skill_view instead of installing anything."
+        )
+        return payload
+
+    missing = [f"{b} (binary)" for b in report.missing_bins]
+    missing += [f"{e} (env var)" for e in report.missing_env]
+    if missing:
+        payload["missing"] = missing
+    if report.install_hints:
+        payload["install_hints"] = [hint.command for hint in report.install_hints]
+    if report.missing_env_detail:
+        payload["needs_env"] = [
+            {"name": d.name, "description": d.description, "url": d.url}
+            for d in report.missing_env_detail
+        ]
+    payload["note"] = (
+        f"'{row.spec.name}' is already installed at the {row.spec.layer} layer — it is "
+        f"not missing, it is unconfigured. Fix what 'missing' lists rather than "
+        f"installing a hub skill. A hub skill of the same name lands in the managed "
+        f"layer, which outranks this one, and would replace it for every session."
+    )
+    return payload
+
+
 async def _run_install_argv(argv: list[str]) -> tuple[int, str, str, bool]:
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -744,7 +808,11 @@ def create_skill_tools(loader: SkillLoader) -> None:
         name="skill_search_community",
         description=(
             "Search Community skill sources such as ClawHub. Use this when the user asks to "
-            "find, search, browse, or locate installable skills from the community marketplace."
+            "find, search, browse, or locate installable skills from the community marketplace. "
+            "A skill that needs setup is hidden from your skill list but is still installed, so "
+            "check skill_list before concluding one is missing. When the reply carries "
+            "installed_match, that skill is already on this machine: report what it needs and "
+            "stop, rather than installing a catalog row of the same name over it."
         ),
         params={
             "query": {
@@ -782,20 +850,24 @@ def create_skill_tools(loader: SkillLoader) -> None:
         source_id: str | None = str(source or "clawhub").strip() or "clawhub"
         if source_id in {"all", "*"}:
             source_id = None
+        local = _local_match(_loader, clean_query) if _loader is not None else None
         router = get_default_skill_router()
         results = await router.search(clean_query, limit=result_limit, source_id=source_id)
         installed = installed_skill_names()
         identifiers = installed_skill_identifiers()
-        return json.dumps(
-            {
-                "status": "ok",
-                "query": clean_query,
-                "source": source_id or "all",
-                "results": [
-                    _community_result_to_dict(row, installed, identifiers) for row in results
-                ],
-            }
-        )
+        payload: dict[str, Any] = {
+            "status": "ok",
+            "query": clean_query,
+            "source": source_id or "all",
+        }
+        # Ahead of the results: whatever the catalog says, the machine's own
+        # answer comes first. Browsing still works — nothing is withheld.
+        if local is not None:
+            payload["installed_match"] = local
+        payload["results"] = [
+            _community_result_to_dict(row, installed, identifiers) for row in results
+        ]
+        return json.dumps(payload)
 
     @tool(
         name="skill_install_community",
@@ -803,7 +875,8 @@ def create_skill_tools(loader: SkillLoader) -> None:
             "Install a Community skill from ClawHub or another configured source. "
             "Use only when the user clearly asked to install a specific skill identifier "
             "or chose one exact result from skill_search_community. Do not use skill_create "
-            "for Community installs."
+            "for Community installs. Installing a skill whose name matches one AgentOS "
+            "already ships is refused, because it would outrank and replace the built-in."
         ),
         params={
             "identifier": {
@@ -820,7 +893,8 @@ def create_skill_tools(loader: SkillLoader) -> None:
             "force": {
                 "type": "boolean",
                 "description": (
-                    "Override a dangerous security scan only after the user explicitly asks."
+                    "Override a dangerous security scan, or a refusal to shadow a bundled "
+                    "skill, only after the user explicitly asks."
                 ),
                 "default": False,
             },

--- a/tests/test_skills_shadow_guard.py
+++ b/tests/test_skills_shadow_guard.py
@@ -1,0 +1,211 @@
+"""A hub install must not silently replace a skill that ships with AgentOS.
+
+Managed outranks bundled, so a same-named catalog row takes over every session
+while the shipped files sit untouched on disk. Nothing in the old flow said so,
+and the way an agent reaches that state is ordinary: a bundled skill declaring
+`requires` is dropped from the prompt until it is configured, so "install X"
+for an X that is already here reads as "X is missing" and sends it shopping.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentos.skills.hub import installer as installer_module
+from agentos.skills.hub.installer import SkillInstaller
+from agentos.skills.hub.source import SkillBundle, SkillMeta
+from agentos.skills.loader import SkillLoader
+from agentos.tools.builtin import skill_tools as skill_tools_module
+
+BUNDLED_NAME = "shipped-skill"
+
+
+class FakeRouter:
+    def __init__(self, bundle: SkillBundle | None) -> None:
+        self.bundle = bundle
+        self.searched: list[str] = []
+
+    async def fetch(self, identifier: str, source_id: str) -> SkillBundle | None:
+        return self.bundle
+
+    async def inspect(self, identifier: str, source_id: str) -> SkillMeta | None:
+        return self.bundle.meta if self.bundle is not None else None
+
+    async def search(
+        self, query: str, limit: int = 10, source_id: str | None = None
+    ) -> list[SkillMeta]:
+        self.searched.append(query)
+        return [SkillMeta(name=query, description="A catalog row", identifier=query)]
+
+
+def _write_skill(root: Path, name: str, *, requires: str = "") -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    block = ""
+    if requires:
+        block = "metadata:\n  agentos:\n" + requires
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Use when testing skills.\n{block}---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _installer(tmp_path: Path, bundle_name: str) -> SkillInstaller:
+    return SkillInstaller(
+        router=FakeRouter(
+            SkillBundle(
+                name=bundle_name,
+                files={
+                    "SKILL.md": (
+                        f"---\nname: {bundle_name}\ndescription: From the hub.\n---\n\n# Hub\n"
+                    )
+                },
+            )
+        ),
+        managed_dir=tmp_path / "managed",
+        quarantine_dir=tmp_path / "quarantine",
+        lockfile_path=tmp_path / "lock.json",
+    )
+
+
+@pytest.fixture
+def bundled_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A stand-in bundled tree, so the guard is tested against known names."""
+    root = tmp_path / "bundled"
+    _write_skill(root, BUNDLED_NAME)
+    monkeypatch.setattr(installer_module, "default_bundled_skills_dir", lambda: root)
+    return root
+
+
+@pytest.mark.asyncio
+async def test_install_refuses_to_shadow_a_bundled_skill(tmp_path: Path, bundled_dir: Path) -> None:
+    result = await _installer(tmp_path, BUNDLED_NAME).install(BUNDLED_NAME, "clawhub")
+
+    assert result.success is False
+    assert not (tmp_path / "managed" / BUNDLED_NAME).exists()
+    # The message has to say what to do instead, or the agent reports a dead end.
+    assert "already ships with AgentOS" in result.message
+    assert "agentos skills list" in result.message
+    assert "force" in result.message
+
+
+@pytest.mark.asyncio
+async def test_force_installs_over_a_bundled_skill(tmp_path: Path, bundled_dir: Path) -> None:
+    result = await _installer(tmp_path, BUNDLED_NAME).install(BUNDLED_NAME, "clawhub", force=True)
+
+    assert result.success is True
+    assert (tmp_path / "managed" / BUNDLED_NAME / "SKILL.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_reinstall_of_an_existing_shadow_is_not_a_new_decision(
+    tmp_path: Path, bundled_dir: Path
+) -> None:
+    """`agentos skills update` must not start failing once a shadow exists."""
+    _write_skill(tmp_path / "managed", BUNDLED_NAME)
+
+    result = await _installer(tmp_path, BUNDLED_NAME).install(BUNDLED_NAME, "clawhub")
+
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_a_name_that_is_not_bundled_installs_normally(
+    tmp_path: Path, bundled_dir: Path
+) -> None:
+    result = await _installer(tmp_path, "community-only").install("community-only", "clawhub")
+
+    assert result.success is True
+    assert (tmp_path / "managed" / "community-only" / "SKILL.md").is_file()
+
+
+# ── skill_search_community answers with the local truth first ────────────────
+
+
+async def _search(query: str) -> dict[str, Any]:
+    from agentos.tools.registry import get_default_registry
+
+    registered = get_default_registry().get("skill_search_community")
+    assert registered is not None
+    return json.loads(await registered.handler(query=query))
+
+
+@pytest.fixture
+def searchable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[SkillLoader]:
+    bundled = tmp_path / "bundled"
+    _write_skill(
+        bundled,
+        "needs-setup",
+        requires=(
+            "    requires:\n"
+            "      bins: [definitely-not-a-real-binary]\n"
+            "      env:\n"
+            "        - name: DEMO_SKILL_TOKEN\n"
+            "          description: Token for the demo service.\n"
+            "          url: https://example.com/keys\n"
+        ),
+    )
+    _write_skill(bundled, "ready-skill")
+    monkeypatch.delenv("DEMO_SKILL_TOKEN", raising=False)
+
+    loader = SkillLoader(bundled_dir=bundled, snapshot_path=tmp_path / "snapshot.json")
+    monkeypatch.setattr(skill_tools_module, "get_default_skill_router", lambda: FakeRouter(None))
+    # create_skill_tools sets a module-level loader; tests run in random order,
+    # so put back whatever the process had.
+    previous_loader = skill_tools_module._loader
+    skill_tools_module.create_skill_tools(loader)
+    try:
+        yield loader
+    finally:
+        skill_tools_module._loader = previous_loader
+
+
+@pytest.mark.asyncio
+async def test_search_reports_an_unconfigured_bundled_skill_as_installed(
+    searchable: SkillLoader,
+) -> None:
+    payload = await _search("needs-setup")
+
+    match = payload["installed_match"]
+    assert match["name"] == "needs-setup"
+    assert match["eligible"] is False
+    assert "definitely-not-a-real-binary (binary)" in match["missing"]
+    assert "DEMO_SKILL_TOKEN (env var)" in match["missing"]
+    assert match["needs_env"][0]["url"] == "https://example.com/keys"
+    assert "already installed" in match["note"]
+    # Browsing is not withheld — the local answer just comes first.
+    assert "results" in payload
+    assert list(payload).index("installed_match") < list(payload).index("results")
+
+
+@pytest.mark.asyncio
+async def test_search_still_reports_a_ready_skill_as_installed(
+    searchable: SkillLoader,
+) -> None:
+    payload = await _search("ready-skill")
+
+    assert payload["installed_match"]["eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_for_a_partial_name_points_at_what_is_installed(
+    searchable: SkillLoader,
+) -> None:
+    """A near miss still has to reach the agent — 'gmgn' must find 'gmgn-token'."""
+    payload = await _search("needs")
+
+    assert payload["installed_match"] == {"similar_installed": ["needs-setup"]}
+
+
+@pytest.mark.asyncio
+async def test_search_for_an_unknown_name_carries_no_local_match(
+    searchable: SkillLoader,
+) -> None:
+    payload = await _search("nothing-like-this")
+
+    assert "installed_match" not in payload


### PR DESCRIPTION
Asked to install a skill that AgentOS already ships, the agent searched ClawHub instead — and would have installed a same-named catalog row over the built-in one.

The reasoning was sound from where it stood. A skill declaring `requires` is dropped from the prompt until its binary and variables are present, so inside a turn an **installed-but-unconfigured** skill and one that was **never installed** look identical. Gating meant to keep the agent from calling a skill that cannot run also hid the fact that the skill exists.

The consequence is worse than a wasted search: a community install lands in the `managed` layer, which outranks `bundled`. The shipped skill stops running everywhere while its files sit untouched on disk, and nothing in the session reports the swap.

## Three changes, one per step of that path

**The installer refuses a shadowing install.** A first install whose name matches a bundled skill is rejected with a message naming what to check instead. `force` still gets through for an operator who means it, and a reinstall or `agentos skills update` of an already-shadowing skill is not a new decision, so it passes untouched. Guarding in `SkillInstaller` rather than in the agent tool means the CLI and the Web UI get the same rule — the hole was never agent-specific.

**`skill_search_community` answers with the local truth first.** When the query names an installed skill, the reply carries an `installed_match` block ahead of the catalog results:

```json
"installed_match": {
  "name": "gmgn-token", "layer": "bundled", "eligible": false,
  "missing": ["gmgn-cli (binary)", "GMGN_API_KEY (env var)"],
  "install_hints": ["npm install -g gmgn-cli"],
  "needs_env": [{"name": "GMGN_API_KEY", "url": "https://gmgn.ai/ai"}],
  "note": "... already installed at the bundled layer — it is not missing, it is unconfigured ..."
}
```

Nothing is withheld: the catalog results still follow, so browsing works. A partial name yields `similar_installed` instead.

**The `agentos` skill documents both rules.** Its skills material was already thorough — layer precedence, `needs_setup`, availability — but sat under bold labels, which `parse_sections` does not index. So `skill_view(name="agentos", section="Skills")` failed on the skill that documents skills, which is how the original session dead-ended. The six operation groups under **Common operations** are real headings now and each can be read on its own, plus two rules that were missing: run `skill_list` before concluding a skill is absent, and never install over a bundled skill.

## Testing

New `tests/test_skills_shadow_guard.py` covers the refusal, the `force` override, the reinstall-of-an-existing-shadow path, a non-bundled name installing normally, and the four `installed_match` shapes.

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos` — clean, 589 files
- `uv run pytest -q` — 7033 passed, 27 skipped