### PR TITLE
test(pricing): verify router tier defaults have pricing metadata

### DIFF
--- a/src/agentos/provider/model_catalog.py
+++ b/src/agentos/provider/model_catalog.py
@@ -63,6 +63,7 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "qwen3.7-max": (32_768, 256_000),
     "qwen3.7-plus": (32_768, 256_000),
     "claude-opus-5": (128_000, 1_000_000),
+    "anthropic/claude-opus-5": (128_000, 1_000_000),
     "claude-opus-4.8": (128_000, 1_000_000),
     "claude-sonnet-5": (64_000, 1_000_000),
     "claude-sonnet-4.6": (64_000, 1_000_000),

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -3,16 +3,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from agentos.gateway.config import (
-    _bankr_tiers,
-    _opencap_tiers,
-    _openrouter_tiers,
-)
-from agentos.engine.pricing import _PRICING_TABLE
-from agentos.provider.model_catalog import _STATIC_FALLBACK
-
 from agentos.engine import pricing
 from agentos.engine.pricing import (
+    _PRICING_TABLE,
     PriceEntry,
     PricingCache,
     _parse_opencap_prices,
@@ -22,6 +15,12 @@ from agentos.engine.pricing import (
     seed_live_price_cache_for_tests,
     seed_opencap_price_cache,
 )
+from agentos.gateway.config import (
+    _bankr_tiers,
+    _opencap_tiers,
+    _openrouter_tiers,
+)
+from agentos.provider.model_catalog import _STATIC_FALLBACK
 
 
 @pytest.fixture(autouse=True)
@@ -405,20 +404,3 @@ def test_tier_defaults_have_explicit_price_and_catalog_entries() -> None:
     assert not missing_catalog, (
         f"Missing catalog entries: {sorted(missing_catalog)}"
     )
-
-def test_tier_defaults_have_explicit_price_and_catalog_entries():
-    from agentos.gateway.config import _bankr_tiers
-    from agentos.engine.pricing import _PRICING_TABLE
-    from agentos.provider.model_catalog import _STATIC_FALLBACK
-
-    tier_models = {
-        cfg["model"]
-        for name, cfg in _bankr_tiers().items()
-        if name != "image_model"
-    }
-
-    pricing_models = {model for model, _ in _PRICING_TABLE}
-
-    for model in tier_models:
-        assert model in pricing_models, model
-        assert model in _STATIC_FALLBACK, model

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -3,6 +3,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from agentos.gateway.config import (
+    _bankr_tiers,
+    _opencap_tiers,
+    _openrouter_tiers,
+)
+from agentos.engine.pricing import _PRICING_TABLE
+from agentos.provider.model_catalog import _STATIC_FALLBACK
+
 from agentos.engine import pricing
 from agentos.engine.pricing import (
     PriceEntry,
@@ -372,3 +380,45 @@ def test_direct_openai_zhipu_kimi_and_minimax_prices_do_not_fall_back_to_default
 
     assert price.input_per_m == pytest.approx(input_per_m)
     assert price.output_per_m == pytest.approx(output_per_m)
+
+def test_tier_defaults_have_explicit_price_and_catalog_entries() -> None:
+    pricing_ids = {prefix.lower() for prefix, _ in _PRICING_TABLE}
+    catalog_ids = {model_id.lower() for model_id in _STATIC_FALLBACK}
+
+    tier_models = set()
+
+    for tier_set in (
+        _bankr_tiers(),
+        _opencap_tiers(),
+        _openrouter_tiers(),
+    ):
+        for config in tier_set.values():
+            tier_models.add(config["model"].lower())
+
+    missing_pricing = tier_models - pricing_ids
+    missing_catalog = tier_models - catalog_ids
+
+    assert not missing_pricing, (
+        f"Missing pricing entries: {sorted(missing_pricing)}"
+    )
+
+    assert not missing_catalog, (
+        f"Missing catalog entries: {sorted(missing_catalog)}"
+    )
+
+def test_tier_defaults_have_explicit_price_and_catalog_entries():
+    from agentos.gateway.config import _bankr_tiers
+    from agentos.engine.pricing import _PRICING_TABLE
+    from agentos.provider.model_catalog import _STATIC_FALLBACK
+
+    tier_models = {
+        cfg["model"]
+        for name, cfg in _bankr_tiers().items()
+        if name != "image_model"
+    }
+
+    pricing_models = {model for model, _ in _PRICING_TABLE}
+
+    for model in tier_models:
+        assert model in pricing_models, model
+        assert model in _STATIC_FALLBACK, model


### PR DESCRIPTION
## Summary

Adds a test to verify that all router tier default models have corresponding pricing and catalog metadata entries.

## Changes

- add `test_tier_defaults_have_explicit_price_and_catalog_entries`
- validate that all models from `_bankr_tiers`, `_opencap_tiers`, and `_openrouter_tiers` exist in `_PRICING_TABLE`
- validate that all tier models exist in `_STATIC_FALLBACK`

## Testing

```bash
python -m pytest tests/test_engine/test_pricing.py

closes #140 