### PR TITLE
fix(cli): install the published release on agentos upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   documents skills at length — the material sat under bold labels, which
   `parse_sections` does not index. The six operation groups under **Common
   operations** are real headings now, so each can be read on its own.
+- `agentos upgrade` shipped a stale React control UI on any install laid down
+  from a local checkout. `scripts/install_source.sh` installs the directory
+  itself, so uv's tool receipt records a *directory* requirement; `uv tool
+  upgrade` then re-resolved that requirement and rebuilt the wheel from the
+  working tree. The wheel bundles `src/agentos/gateway/static/dist/**`, but
+  nothing in the upgrade path runs `npm run build` — so every upgrade
+  re-packaged whatever browser bundle happened to be on disk. Python code moved
+  forward, the web UI did not. `agentos upgrade` now installs the published
+  release (`uv tool install --force --python <running> "use-agent-os[recommended]"`
+  / `pipx install --force …`), whose wheel carries a control UI built and
+  verified in CI. Installing a checkout stays with `scripts/install_source.sh`,
+  the only path that rebuilds the bundle first; the command names it when it
+  detects a checkout-backed install.
+- `agentos upgrade` printed upgrade commands with the extras silently removed —
+  Rich parsed the `[recommended]` in `use-agent-os[recommended]` as a markup
+  tag and dropped it, so copying the printed command produced an install
+  missing the ONNX embedding models and the pilot router.
 
 ## [2026.8.2.post1] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -247,10 +247,17 @@ the #1 documented upgrade regret):
 agentos upgrade
 ```
 
-On a `uv tool` or `pipx` install this runs the matching upgrade command for
-you, then restarts the managed gateway and **verifies** the running gateway
-reports the new version before printing `Gateway: restarted and verified
+On a `uv tool` or `pipx` install this installs the published PyPI release of
+`use-agent-os[recommended]` for you (`uv tool install --force --python
+<running> …`), then restarts the managed gateway and **verifies** the running
+gateway reports the new version before printing `Gateway: restarted and verified
 (<version>)`. It prints the `old → new` versions on success.
+
+`agentos upgrade` always installs the release, never a local checkout — the PyPI
+wheel ships a control UI built in CI, while reinstalling a checkout would
+re-package whatever browser bundle happens to be on disk. If you installed from
+source, run `bash scripts/install_source.sh` again instead; it rebuilds the
+control UI first. The command says so when it detects a checkout-backed install.
 
 Flags:
 
@@ -262,8 +269,8 @@ Flags:
 | `--timeout <s>` | Upgrade-subprocess timeout (default 600s). On timeout the tool's process group is killed and recovery guidance is printed — never a half-state. |
 | `--json` | Machine-readable output. |
 
-For a plain-`pip` or editable / source install, `agentos upgrade` will **not**
-fake it — it prints the exact manual command and exits non-zero. Run it
+For a plain-`pip`, editable, or unclassifiable install, `agentos upgrade` will
+**not** fake it — it prints the exact manual command and exits non-zero. Run it
 yourself:
 
 ```sh

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,10 +205,15 @@ Useful automation flags:
 ## Upgrade
 
 `agentos upgrade` is the primary upgrade path. It detects how AgentOS was
-installed, upgrades it, and — by default — restarts the managed gateway and
+installed, installs the **published PyPI release** of
+`use-agent-os[recommended]`, and — by default — restarts the managed gateway and
 **verifies** the running gateway reports the new version before declaring
 success (a "successful" upgrade that leaves the daemon on old code is the
 common upgrade regret).
+
+It always targets the release, never a local checkout. To install a checkout,
+run `bash scripts/install_source.sh` — that script is the only path that
+rebuilds the React control UI (`npm ci && npm run build`) before installing.
 
 ```sh
 agentos upgrade                 # upgrade, restart the gateway, verify
@@ -229,16 +234,35 @@ agentos upgrade --timeout 900   # bound the upgrade subprocess (default 600s)
 
 Per install method:
 
-- **uv tool / pipx** — delegated automatically (`uv tool upgrade use-agent-os
-  --reinstall` / `pipx upgrade use-agent-os --force`), resolving the tool to an
-  absolute path over a hardened PATH. Both rebuild the managed venv rather than
-  bumping it in place — `--reinstall` (uv, implies `--refresh`) and `--force`
-  (pipx) self-heal a stale cache or an orphaned interpreter (e.g. after the base
-  Python moves) that would otherwise force a manual reinstall. Extras recorded
-  in the tool receipt are preserved.
-- **pip / editable / source checkout** — not faked: prints the exact manual
-  command (e.g. `python -m pip install --upgrade "use-agent-os"`) and exits
-  with a distinct code.
+- **uv tool** — delegated automatically as `uv tool install --force --python
+  <running major.minor> "use-agent-os[recommended]"`, resolving `uv` to an
+  absolute path over a hardened PATH. `install` rather than `upgrade` is
+  load-bearing: `uv tool upgrade` takes only a bare tool name and re-resolves
+  whatever uv's receipt recorded, so an install laid down from a checkout
+  (`install_source.sh` passes `.`) keeps rebuilding the wheel from the working
+  tree — re-packaging whatever `src/agentos/gateway/static/dist/` is on disk,
+  because nothing in the upgrade path runs `npm run build`. `--force` is
+  required so an already-installed tool is genuinely rebuilt instead of
+  no-op'ing, and it also self-heals a stale cache or an orphaned interpreter
+  (e.g. after the base Python moves). `--python` pins the rebuilt venv to the
+  interpreter already in use, so a forced reinstall never moves a 3.13 install
+  onto another version.
+- **pipx** — the same shape: `pipx install --force "use-agent-os[recommended]"`.
+- **pip / editable / unknown** — not faked: prints the exact manual command
+  (e.g. `python -m pip install --upgrade "use-agent-os[recommended]"`) and exits
+  with a distinct code. The editable hint points at
+  `git pull && bash scripts/install_source.sh`, since an editable install serves
+  the control UI straight out of the checkout.
+
+Extras are always `[recommended]` — the same profile `install_source.sh`
+installs by default. Without them the ONNX embedding models and the pilot router
+degrade silently at runtime.
+
+When the current install was built from a local directory (detected via PEP 610
+`direct_url.json`), the command prints a note naming that directory and
+`scripts/install_source.sh` before proceeding. It is informational only: it
+never prompts, blocks, or changes the exit code. `--json` reports the same as
+`sourceDirectory` (`null` for a release install).
 
 Exit codes: **0** success (upgraded + verified, or `--check`/`--dry-run`);
 **3** this install method needs a manual command (printed); **1** the upgrade

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -185,18 +185,24 @@ agentos gateway restart
 
 ## Upgrade
 
-Upgrade a `uv tool` install to the latest release, then restart the
-gateway so it runs the new code:
+Upgrade to the latest release. `agentos upgrade` also restarts the
+gateway and verifies it reports the new version, so it is preferred
+over calling `uv tool` yourself:
 
 ```sh
-uv tool upgrade use-agent-os
-agentos gateway restart
+agentos upgrade
 ```
 
-The upgrade keeps the extras from the original install, and your
-configuration and data in `~/.agentos/` are not touched. To check
-the installed version, run `uv tool list`. For source installs, see
-the [README upgrade section](../README.md#upgrade).
+It installs the published release of `use-agent-os[recommended]` — the
+same extras profile `install_source.sh` uses — pinned to the Python
+version already running AgentOS. Your configuration and data in
+`~/.agentos/` are not touched. To check the installed version, run
+`uv tool list`.
+
+`agentos upgrade` never installs from a local checkout: only
+`bash scripts/install_source.sh` rebuilds the React control UI before
+installing. If you installed from source, re-run that script. See the
+[README upgrade section](../README.md#upgrade).
 
 ## Next Steps
 

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -17,14 +17,23 @@ module:
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sys
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
 DIST_NAME = "use-agent-os"
+
+# The extras profile every managed upgrade installs. Mirrors install_source.sh's
+# default (`--profile recommended`), so the two install paths agree on what a
+# complete AgentOS is: without it the ONNX embedding models and the pilot router
+# silently degrade.
+UPGRADE_EXTRAS = "recommended"
 
 # Standard login-shell locations that a GUI-launched or daemon-inherited
 # environment frequently drops. Appended (not prepended) so an operator's own
@@ -81,6 +90,74 @@ def _looks_editable(pkg_dir: Path) -> bool:
         return False
     # ``src/agentos`` layout is the tell-tale of this repo's editable install.
     return pkg_dir.parent.name == "src" or (pkg_dir.parent / "pyproject.toml").exists()
+
+
+def runtime_python_tag() -> str:
+    """``major.minor`` of the interpreter currently running the CLI.
+
+    The upgrade pins the rebuilt tool venv to this version so ``--force`` can
+    never silently move a 3.13 install back onto whatever interpreter uv would
+    have picked by default.
+    """
+
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def _direct_url_payload(dist: str) -> dict[str, object] | None:
+    """Parsed PEP 610 ``direct_url.json`` for ``dist``, or ``None``."""
+
+    import importlib.metadata
+
+    try:
+        raw = importlib.metadata.distribution(dist).read_text("direct_url.json")
+    except Exception:  # noqa: BLE001 - missing/unreadable metadata is just "not a direct URL"
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def installed_from_directory(
+    dist: str = DIST_NAME,
+    *,
+    package_dir: Path | None = None,
+) -> Path | None:
+    """Local directory this install was BUILT FROM, per PEP 610, else ``None``.
+
+    Purely informational: ``agentos upgrade`` always installs the published
+    release, and uses this only to tell a source installer where the door back
+    to their checkout is. It must therefore never raise — every failure mode
+    degrades to ``None``.
+
+    Only ``dir_info`` counts. ``archive_info`` (a local ``.whl``/``.tar.gz``) and
+    ``vcs_info`` (a ``git+https://`` install, whose clone is a uv cache artifact)
+    are not checkouts the operator edits, so neither is reported.
+    """
+
+    payload = _direct_url_payload(dist)
+    if payload is not None and isinstance(payload.get("dir_info"), dict):
+        url = payload.get("url")
+        if isinstance(url, str) and url.startswith("file:"):
+            # url2pathname handles percent-encoding and Windows drive letters;
+            # slicing the URL would corrupt both.
+            path = urllib.parse.urlparse(url).path
+            try:
+                return Path(urllib.request.url2pathname(path))
+            except (OSError, ValueError):
+                return None
+        return None
+
+    # An editable install laid down without usable metadata (``uv sync`` in the
+    # tree, ``pip install -e`` on older tooling) still has the ``src/agentos``
+    # tell that _looks_editable keys on.
+    pkg_dir = package_dir if package_dir is not None else _package_location()
+    if pkg_dir.parent.name == "src" and len(pkg_dir.parents) > 1:
+        return pkg_dir.parents[1]
+    return None
 
 
 def _under(path: Path, *needles: str) -> bool:
@@ -216,84 +293,98 @@ def build_upgrade_plan(
     method: InstallMethod | None = None,
     env: dict[str, str] | None = None,
     dist: str = DIST_NAME,
+    python_tag: str | None = None,
 ) -> UpgradePlan:
     """Build the :class:`UpgradePlan` for the running install."""
 
     resolved_method = method if method is not None else detect_install_method()
+    python = python_tag if python_tag is not None else runtime_python_tag()
+    spec = f"{dist}[{UPGRADE_EXTRAS}]"
 
     if resolved_method is InstallMethod.UV_TOOL:
-        # ``--reinstall`` (which implies ``--refresh``) is what makes ``upgrade``
-        # a safe, self-healing operation rather than a fragile in-place bump. A
-        # plain ``uv tool upgrade`` no-ops or fails when the tool venv is in a
-        # broken state — a stale PyPI cache, or an orphaned interpreter after the
-        # base Python moved (e.g. a Homebrew bump). Both leave operators forced
-        # to hand-run ``uv tool install … --force``. ``--reinstall`` rebuilds the
-        # venv from scratch and bypasses the cache, matching install.sh's
-        # ``--force`` posture, while ``upgrade`` (not ``install``) preserves the
-        # extras recorded in uv's tool receipt — ``uv tool upgrade`` takes only a
-        # bare tool NAME and rejects a ``dist[extra]`` spec.
+        # ``install`` rather than ``upgrade``, and this is the whole point of the
+        # command: ``uv tool upgrade`` takes only a bare tool NAME and re-resolves
+        # whatever uv's receipt recorded. When AgentOS was installed from a local
+        # checkout (install_source.sh passes ``.``), that receipt is a DIRECTORY,
+        # so ``upgrade`` rebuilds the wheel from the working tree and never
+        # touches PyPI — silently re-packaging whatever
+        # ``src/agentos/gateway/static/dist/`` happens to be on disk, because
+        # nothing here runs ``npm run build``. ``uv tool install <dist>[extras]``
+        # moves the install onto the published release, whose wheel carries a
+        # CI-built Control UI (pypi-publish.yml builds and verify-archive's it).
+        #
+        # ``--force`` is required: without it uv no-ops on an already-installed
+        # tool, which is the same silent-no-op class of bug. ``--python`` pins the
+        # rebuilt venv to the interpreter already in use so the forced reinstall
+        # cannot move a 3.13 install onto another version.
         uv = resolve_tool("uv", env)
+        uv_argv = ["tool", "install", "--force", "--python", python, spec]
+        uv_hint = f'uv tool install --force --python {python} "{spec}"'
         if uv is not None:
             return UpgradePlan(
                 method=resolved_method,
                 delegated=True,
                 tool=uv,
-                command=[uv, "tool", "upgrade", dist, "--reinstall"],
-                manual_hint=f"uv tool upgrade {dist} --reinstall",
+                command=[uv, *uv_argv],
+                manual_hint=uv_hint,
             )
         return UpgradePlan(
             method=resolved_method,
             delegated=False,
             tool=None,
-            command=["uv", "tool", "upgrade", dist, "--reinstall"],
-            manual_hint=f"uv tool upgrade {dist} --reinstall",
+            command=["uv", *uv_argv],
+            manual_hint=uv_hint,
         )
 
     if resolved_method is InstallMethod.PIPX:
-        # ``--force`` is pipx's counterpart to uv's ``--reinstall``: it rebuilds
-        # the managed venv instead of no-op'ing or failing when it is in a broken
-        # state (stale wheel, orphaned interpreter after the base Python moved).
-        # ``pipx upgrade`` (not ``pipx reinstall``) is the right verb — ``upgrade
-        # --force`` still moves to the newest version, whereas ``reinstall`` only
-        # re-lays-down the currently pinned version. Extras are preserved by pipx
-        # across the forced upgrade.
+        # Same reasoning as uv: ``pipx upgrade`` re-resolves the recorded spec, so
+        # a pipx install laid down from a local path keeps rebuilding from that
+        # path. ``pipx install --force <dist>[extras]`` rebuilds the managed venv
+        # from the published release instead.
         pipx = resolve_tool("pipx", env)
+        pipx_argv = ["install", "--force", spec]
+        pipx_hint = f'pipx install --force "{spec}"'
         if pipx is not None:
             return UpgradePlan(
                 method=resolved_method,
                 delegated=True,
                 tool=pipx,
-                command=[pipx, "upgrade", dist, "--force"],
-                manual_hint=f"pipx upgrade {dist} --force",
+                command=[pipx, *pipx_argv],
+                manual_hint=pipx_hint,
             )
         return UpgradePlan(
             method=resolved_method,
             delegated=False,
             tool=None,
-            command=["pipx", "upgrade", dist, "--force"],
-            manual_hint=f"pipx upgrade {dist} --force",
+            command=["pipx", *pipx_argv],
+            manual_hint=pipx_hint,
         )
 
     if resolved_method is InstallMethod.EDITABLE:
+        # An editable install serves the Control UI straight out of the checkout,
+        # so the reinstall that matters is the source one — and only
+        # install_source.sh rebuilds the browser bundle before installing.
         return UpgradePlan(
             method=resolved_method,
             delegated=False,
             tool=None,
             command=["git", "pull"],
             manual_hint=(
-                "editable / source checkout — pull the repo and reinstall: git pull && uv sync"
+                "editable / source checkout — pull and reinstall from the checkout: "
+                "git pull && bash scripts/install_source.sh"
             ),
         )
 
     if resolved_method is InstallMethod.PIP:
-        # A genuine site-packages install: pip is the right upgrade tool.
-        pip_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", dist]
+        # A genuine site-packages install: pip is the right upgrade tool. The
+        # extras must be spelled out — pip drops any that are not in the spec.
+        pip_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", spec]
         return UpgradePlan(
             method=resolved_method,
             delegated=False,
             tool=None,
             command=pip_cmd,
-            manual_hint=f"{sys.executable} -m pip install --upgrade {dist}",
+            manual_hint=f'{sys.executable} -m pip install --upgrade "{spec}"',
         )
 
     # UNKNOWN: we could not classify the install, so a blind ``python -m pip``
@@ -303,10 +394,11 @@ def build_upgrade_plan(
         method=resolved_method,
         delegated=False,
         tool=None,
-        command=[sys.executable, "-m", "pip", "install", "--upgrade", dist],
+        command=[sys.executable, "-m", "pip", "install", "--upgrade", spec],
         manual_hint=(
             "could not detect the install method — reinstall/upgrade with your "
-            f"original installer, e.g.:\n    uv tool install {dist}\n    "
-            f"pipx install {dist}\n    {sys.executable} -m pip install --upgrade {dist}"
+            f'original installer, e.g.:\n    uv tool install --force "{spec}"\n    '
+            f'pipx install --force "{spec}"\n    '
+            f'{sys.executable} -m pip install --upgrade "{spec}"'
         ),
     )

--- a/src/agentos/cli/upgrade_cmd.py
+++ b/src/agentos/cli/upgrade_cmd.py
@@ -21,12 +21,17 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 import typer
 
 from agentos import __version__
-from agentos.cli.install_method import build_upgrade_plan, hardened_path_env
-from agentos.cli.ui import console
+from agentos.cli.install_method import (
+    build_upgrade_plan,
+    hardened_path_env,
+    installed_from_directory,
+)
+from agentos.cli.ui import console, markup_escape
 
 # Default upgrade-subprocess timeout (seconds). Overridable via --timeout.
 _DEFAULT_TIMEOUT_S = 600.0
@@ -192,6 +197,25 @@ def _restart_and_verify(
     return False
 
 
+def _emit_source_install_notice(source_dir: Path) -> None:
+    """Tell a source installer that this command installs the RELEASE instead.
+
+    ``agentos upgrade`` deliberately does not build from a checkout — only
+    ``scripts/install_source.sh`` rebuilds the Control UI before installing. A
+    source installer who is not told that would find their local code replaced
+    with no idea how to get it back, so name the way back explicitly. Purely
+    informational: it never blocks, prompts, or changes the exit code.
+    """
+
+    path = markup_escape(str(source_dir))
+    console.print(
+        f"[dim]This install was built from {path}.\n"
+        "'agentos upgrade' installs the published PyPI release instead.\n"
+        f"To install that checkout again: cd {path} && "
+        "bash scripts/install_source.sh[/dim]"
+    )
+
+
 def _emit_no_restart_warning(new_version: str) -> None:
     old = __version__
     print(
@@ -217,11 +241,15 @@ def upgrade_command(
     config_path: str | None = typer.Option(None, "--config", help="Override config path."),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
-    """Upgrade AgentOS and restart the managed gateway to match.
+    """Upgrade AgentOS to the published release and restart the gateway to match.
 
     Detects the install method (uv-tool / pipx / pip / editable) and delegates
-    to the right upgrade command. Config migrations (with an automatic
-    timestamped backup) run at gateway start.
+    to the right installer, always targeting the PyPI release of
+    ``use-agent-os[recommended]`` — including when the current install was built
+    from a local checkout. To install a checkout instead, run
+    ``bash scripts/install_source.sh``, which rebuilds the Control UI first.
+    Config migrations (with an automatic timestamped backup) run at gateway
+    start.
     """
 
     from agentos.cli.output import print_json
@@ -259,9 +287,13 @@ def upgrade_command(
 
     # Non-delegated installs: print the exact manual command, exit 3.
     if not plan.delegated:
+        # The hint carries a ``dist[extras]`` spec, whose brackets Rich would
+        # otherwise eat as markup — printing a command that silently drops the
+        # extras is exactly the failure this whole change is about.
         message = (
             f"AgentOS was installed via {plan.method.value}; automatic upgrade is not "
-            f"available for this method.\nRun this to upgrade:\n    {plan.manual_hint}"
+            f"available for this method.\nRun this to upgrade:\n    "
+            f"{markup_escape(plan.manual_hint)}"
         )
         if json_output:
             print_json(
@@ -275,6 +307,10 @@ def upgrade_command(
             console.print(message)
         raise typer.Exit(3)
 
+    # This command always installs the published release. When the current
+    # install was built from a local checkout, say so before touching anything.
+    source_dir = installed_from_directory()
+
     # --dry-run: print what would run, touch nothing.
     if dry_run:
         printable = " ".join(plan.command)
@@ -285,10 +321,13 @@ def upgrade_command(
                     "command": plan.command,
                     "wouldRestart": not no_restart,
                     "dryRun": True,
+                    "sourceDirectory": str(source_dir) if source_dir else None,
                 }
             )
         else:
-            console.print(f"Would run: {printable}")
+            if source_dir is not None:
+                _emit_source_install_notice(source_dir)
+            console.print(f"Would run: {markup_escape(printable)}")
             console.print(
                 "Would then restart and verify the managed gateway."
                 if not no_restart
@@ -297,24 +336,26 @@ def upgrade_command(
         raise typer.Exit(0)
 
     # Execute the delegated upgrade under a bounded timeout.
+    if source_dir is not None:
+        _emit_source_install_notice(source_dir)
     console.print(f"Upgrading use-agent-os via {plan.method.value}…")
     result = _run_upgrade_subprocess(plan.command, env=env, timeout=timeout)
     if result.stdout.strip():
-        console.print(result.stdout.strip())
+        console.print(markup_escape(result.stdout.strip()))
 
     if result.timed_out:
         console.print(
             f"[red]Upgrade timed out after {timeout:.0f}s and was terminated.[/red]\n"
             "The upgrade tool was killed (process group), so no half-finished child "
             "is left running.\nRecovery: re-run 'agentos upgrade' (optionally with a "
-            f"larger --timeout), or run '{plan.manual_hint}' manually.",
+            f"larger --timeout), or run '{markup_escape(plan.manual_hint)}' manually.",
         )
         raise typer.Exit(1)
 
     if not result.ok:
         console.print(
             f"[red]Upgrade failed (exit {result.returncode}).[/red]\n"
-            f"{result.stderr.strip()}"
+            f"{markup_escape(result.stderr.strip())}"
         )
         raise typer.Exit(1)
 
@@ -336,6 +377,7 @@ def upgrade_command(
                     "new": new_version,
                     "restarted": False,
                     "gatewayVersionApplied": False,
+                    "sourceDirectory": str(source_dir) if source_dir else None,
                 }
             )
         raise typer.Exit(0)
@@ -352,6 +394,7 @@ def upgrade_command(
                 "new": new_version,
                 "restarted": True,
                 "verified": verified,
+                "sourceDirectory": str(source_dir) if source_dir else None,
             }
         )
     if not verified:

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -228,12 +228,18 @@ agentos upgrade --no-restart   # upgrade only; gateway keeps running OLD code
 ```
 
 `agentos upgrade` is the primary path: it detects the install method and
-delegates (`uv tool upgrade` / `pipx upgrade`), then by default restarts the
-managed gateway and verifies it reports the new version before declaring
-success. For pip / editable / source installs it prints the exact manual
-command and exits non-zero (**exit 3**) rather than faking it; a failed or
-unverifiable upgrade is **exit 1**. Flags: `--timeout` (subprocess bound,
-default 600s; kills the process group on timeout), `--config`, `--json`.
+installs the **published PyPI release** of `use-agent-os[recommended]` (`uv tool
+install --force --python <running> …` / `pipx install --force …`), then by
+default restarts the managed gateway and verifies it reports the new version
+before declaring success. It never installs from a local checkout — even when
+the current install came from one — because only `bash scripts/install_source.sh`
+rebuilds the React control UI before installing, and a PyPI wheel already ships
+a CI-built one. A checkout-backed install gets an informational note naming that
+directory and the script; it never blocks. For pip / editable / unknown installs
+it prints the exact manual command and exits non-zero (**exit 3**) rather than
+faking it; a failed or unverifiable upgrade is **exit 1**. Flags: `--timeout`
+(subprocess bound, default 600s; kills the process group on timeout),
+`--config`, `--json` (adds `sourceDirectory`).
 
 Commands that reach the gateway compare CLI and gateway versions: a gateway
 **older** than the CLI warns (post-upgrade, before restart); a gateway

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -197,12 +198,38 @@ def test_resolve_tool_falls_back_to_which(monkeypatch: pytest.MonkeyPatch) -> No
     assert "/base" in seen["path"] or "\\base" in seen["path"]
 
 
-def test_build_plan_uv_tool_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_plan_uv_tool_installs_the_published_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ``install``, not ``upgrade``: ``uv tool upgrade`` takes a bare NAME and
+    # re-resolves uv's receipt, so an install laid down from a local checkout
+    # would keep rebuilding from the working tree and re-package its stale
+    # Control UI bundle instead of fetching the CI-built wheel.
     monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: "/abs/uv")
-    plan = im.build_upgrade_plan(method=InstallMethod.UV_TOOL)
+    plan = im.build_upgrade_plan(method=InstallMethod.UV_TOOL, python_tag="3.12")
     assert plan.delegated is True
     assert plan.tool == "/abs/uv"
-    assert plan.command == ["/abs/uv", "tool", "upgrade", "use-agent-os", "--reinstall"]
+    assert plan.command == [
+        "/abs/uv",
+        "tool",
+        "install",
+        "--force",
+        "--python",
+        "3.12",
+        "use-agent-os[recommended]",
+    ]
+
+
+def test_build_plan_pins_the_running_python(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A forced reinstall must not silently move the tool venv onto another
+    # interpreter, so the pin follows whatever is running the CLI.
+    monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: "/abs/uv")
+    pinned = im.build_upgrade_plan(method=InstallMethod.UV_TOOL, python_tag="3.13")
+    assert pinned.command[pinned.command.index("--python") + 1] == "3.13"
+
+    default = im.build_upgrade_plan(method=InstallMethod.UV_TOOL)
+    assert default.command[default.command.index("--python") + 1] == im.runtime_python_tag()
+    assert im.runtime_python_tag() == f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
 def test_build_plan_uv_tool_missing_uv_not_delegated(
@@ -212,26 +239,31 @@ def test_build_plan_uv_tool_missing_uv_not_delegated(
     plan = im.build_upgrade_plan(method=InstallMethod.UV_TOOL)
     assert plan.delegated is False
     assert plan.tool is None
-    assert "uv tool upgrade" in plan.manual_hint
+    assert "uv tool install --force" in plan.manual_hint
+    assert "use-agent-os[recommended]" in plan.manual_hint
 
 
 def test_build_plan_pipx_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: "/abs/pipx")
     plan = im.build_upgrade_plan(method=InstallMethod.PIPX)
     assert plan.delegated is True
-    assert plan.command == ["/abs/pipx", "upgrade", "use-agent-os", "--force"]
+    assert plan.command == ["/abs/pipx", "install", "--force", "use-agent-os[recommended]"]
 
 
 def test_build_plan_pip_never_delegates() -> None:
     plan = im.build_upgrade_plan(method=InstallMethod.PIP)
     assert plan.delegated is False
-    assert "pip install --upgrade use-agent-os" in plan.manual_hint
+    assert "pip install --upgrade" in plan.manual_hint
+    assert "use-agent-os[recommended]" in plan.manual_hint
 
 
-def test_build_plan_editable_never_delegates() -> None:
+def test_build_plan_editable_points_at_the_source_installer() -> None:
+    # An editable install serves the Control UI out of the checkout, and only
+    # install_source.sh rebuilds that bundle before installing.
     plan = im.build_upgrade_plan(method=InstallMethod.EDITABLE)
     assert plan.delegated is False
     assert "git pull" in plan.manual_hint
+    assert "scripts/install_source.sh" in plan.manual_hint
 
 
 def test_build_plan_unknown_lists_all_installers() -> None:
@@ -239,6 +271,112 @@ def test_build_plan_unknown_lists_all_installers() -> None:
     # no pip); list all three installers instead.
     plan = im.build_upgrade_plan(method=InstallMethod.UNKNOWN)
     assert plan.delegated is False
-    assert "uv tool install use-agent-os" in plan.manual_hint
-    assert "pipx install use-agent-os" in plan.manual_hint
-    assert "pip install --upgrade use-agent-os" in plan.manual_hint
+    assert "uv tool install --force" in plan.manual_hint
+    assert "pipx install --force" in plan.manual_hint
+    assert "pip install --upgrade" in plan.manual_hint
+    assert plan.manual_hint.count("use-agent-os[recommended]") == 3
+
+
+def test_every_delegated_plan_carries_the_recommended_extras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Dropping the extras is silent: the ONNX embedding models and the pilot
+    # router degrade at runtime, not at install time.
+    monkeypatch.setattr(im, "resolve_tool", lambda tool, env=None: f"/abs/{tool}")
+    for method in (InstallMethod.UV_TOOL, InstallMethod.PIPX):
+        plan = im.build_upgrade_plan(method=method)
+        assert plan.delegated is True
+        assert plan.command[-1] == "use-agent-os[recommended]"
+
+
+# --- installed_from_directory (PEP 610) ------------------------------------
+
+
+def _direct_url(monkeypatch: pytest.MonkeyPatch, payload: str | None) -> None:
+    parsed = json.loads(payload) if payload else None
+    monkeypatch.setattr(im, "_direct_url_payload", lambda dist: parsed)
+
+
+def test_installed_from_directory_reads_a_file_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _direct_url(
+        monkeypatch,
+        '{"url": "file:///w/checkouts/agent-os", "dir_info": {"editable": false}}',
+    )
+    assert im.installed_from_directory() == Path("/w/checkouts/agent-os")
+
+
+def test_installed_from_directory_decodes_percent_escapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Slicing the URL instead of url2pathname would leave the %20 in the path.
+    _direct_url(monkeypatch, '{"url": "file:///tmp/a%20b/repo", "dir_info": {}}')
+    assert im.installed_from_directory() == Path("/tmp/a b/repo")
+
+
+def test_installed_from_directory_reports_editable_checkouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _direct_url(monkeypatch, '{"url": "file:///w/agent-os", "dir_info": {"editable": true}}')
+    assert im.installed_from_directory() == Path("/w/agent-os")
+
+
+@pytest.mark.parametrize(
+    ("payload", "why"),
+    [
+        ('{"url": "file:///tmp/x.whl", "archive_info": {}}', "a local wheel is not a checkout"),
+        (
+            '{"url": "git+https://example.com/a.git", "vcs_info": {"vcs": "git"}}',
+            "uv's VCS clone is a cache artifact, not an editable tree",
+        ),
+        ('{"url": "https://pypi.org/x.whl", "dir_info": {}}', "not a file:// URL"),
+        ("{}", "no direct-URL kind at all"),
+    ],
+)
+def test_installed_from_directory_rejects_non_checkouts(
+    monkeypatch: pytest.MonkeyPatch, payload: str, why: str
+) -> None:
+    _direct_url(monkeypatch, payload)
+    # site-packages layout: the editable fallback must not fire either.
+    pkg_dir = Path("/venv/lib/python3.12/site-packages/agentos")
+    assert im.installed_from_directory(package_dir=pkg_dir) is None, why
+
+
+def test_installed_from_directory_falls_back_to_the_src_layout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # An editable install laid down without usable metadata still has the
+    # ``src/agentos`` tell that _looks_editable keys on.
+    _direct_url(monkeypatch, None)
+    assert im.installed_from_directory(package_dir=tmp_path / "src" / "agentos") == tmp_path
+
+
+def test_installed_from_directory_handles_a_shallow_package_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The src-layout fallback indexes parents[1]; a root-level path must not
+    # blow up a command whose real job is upgrading.
+    _direct_url(monkeypatch, None)
+    assert im.installed_from_directory(package_dir=Path("/agentos")) is None
+
+
+def test_direct_url_payload_swallows_unreadable_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.metadata
+
+    def _raise(dist: str) -> None:
+        raise importlib.metadata.PackageNotFoundError(dist)
+
+    monkeypatch.setattr(importlib.metadata, "distribution", _raise)
+    assert im._direct_url_payload("use-agent-os") is None
+
+
+def test_direct_url_payload_swallows_malformed_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    class _Dist:
+        def read_text(self, name: str) -> str:
+            return "{not json"
+
+    monkeypatch.setattr(importlib.metadata, "distribution", lambda dist: _Dist())
+    assert im._direct_url_payload("use-agent-os") is None

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -12,6 +14,18 @@ from agentos.cli import upgrade_cmd
 from agentos.cli.install_method import InstallMethod, UpgradePlan
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _no_source_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Quarantine the PEP 610 probe from the developer's own machine.
+
+    A maintainer's checkout really is installed from a directory, so without
+    this the source-install notice would fire in every test and its text would
+    embed a machine-dependent path. Tests that want the notice opt in.
+    """
+
+    monkeypatch.setattr(upgrade_cmd, "installed_from_directory", lambda *a, **k: None)
 
 
 def _app() -> typer.Typer:
@@ -30,8 +44,16 @@ def _delegated_plan() -> UpgradePlan:
         method=InstallMethod.UV_TOOL,
         delegated=True,
         tool="/abs/uv",
-        command=["/abs/uv", "tool", "upgrade", "use-agent-os", "--reinstall"],
-        manual_hint="uv tool upgrade use-agent-os --reinstall",
+        command=[
+            "/abs/uv",
+            "tool",
+            "install",
+            "--force",
+            "--python",
+            "3.12",
+            "use-agent-os[recommended]",
+        ],
+        manual_hint='uv tool install --force --python 3.12 "use-agent-os[recommended]"',
     )
 
 
@@ -49,6 +71,15 @@ def _ok_run(*_: Any, **__: Any) -> upgrade_cmd.UpgradeRunResult:
     return upgrade_cmd.UpgradeRunResult(
         ok=True, timed_out=False, returncode=0, stdout="upgraded", stderr=""
     )
+
+
+def _json_payload(stdout: str) -> dict[str, Any]:
+    """The `--json` object, which progress prose may precede on stdout."""
+
+    start = stdout.index("{")
+    payload = json.loads(stdout[start:])
+    assert isinstance(payload, dict)
+    return payload
 
 
 # --- --check ---------------------------------------------------------------
@@ -104,8 +135,90 @@ def test_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     result = runner.invoke(_app(), ["upgrade", "--dry-run"])
     assert result.exit_code == 0
-    assert "Would run: /abs/uv tool upgrade use-agent-os --reinstall" in result.stdout
+    assert (
+        "Would run: /abs/uv tool install --force --python 3.12 use-agent-os[recommended]"
+        in result.stdout
+    )
     assert ran["run"] is False
+
+
+# --- source-install notice (PEP 610 directory install) ---------------------
+
+
+def test_source_install_notice_names_the_way_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A checkout-backed install is exactly the case this command replaces, so
+    # it must say so and name install_source.sh — but never block.
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(
+        upgrade_cmd, "installed_from_directory", lambda *a, **k: Path("/w/agent-os")
+    )
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "9.9.9")
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: True)
+
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 0
+    assert "/w/agent-os" in result.stdout
+    assert "scripts/install_source.sh" in result.stdout
+    assert "Upgraded" in result.stdout
+
+
+def test_no_source_install_notice_for_a_release_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "9.9.9")
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: True)
+
+    result = runner.invoke(_app(), ["upgrade"])
+    assert result.exit_code == 0
+    assert "install_source.sh" not in result.stdout
+
+
+def test_dry_run_reports_the_source_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    ran = {"run": False}
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(
+        upgrade_cmd, "installed_from_directory", lambda *a, **k: Path("/w/agent-os")
+    )
+    monkeypatch.setattr(
+        upgrade_cmd, "_run_upgrade_subprocess", lambda *a, **k: ran.__setitem__("run", True)
+    )
+
+    result = runner.invoke(_app(), ["upgrade", "--dry-run", "--json"])
+    assert result.exit_code == 0
+    assert _json_payload(result.stdout)["sourceDirectory"] == "/w/agent-os"
+    assert ran["run"] is False
+
+
+def test_success_json_reports_the_source_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(
+        upgrade_cmd, "installed_from_directory", lambda *a, **k: Path("/w/agent-os")
+    )
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "9.9.9")
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: True)
+
+    result = runner.invoke(_app(), ["upgrade", "--json"])
+    assert result.exit_code == 0
+    payload = _json_payload(result.stdout)
+    assert payload["sourceDirectory"] == "/w/agent-os"
+    assert payload["new"] == "9.9.9"
+
+
+def test_release_install_json_reports_null_source_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
+    monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "9.9.9")
+    monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: True)
+
+    result = runner.invoke(_app(), ["upgrade", "--json"])
+    assert result.exit_code == 0
+    assert _json_payload(result.stdout)["sourceDirectory"] is None
 
 
 # --- successful delegate + restart+verify ----------------------------------

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -15,6 +15,12 @@ from agentos.cli.install_method import InstallMethod, UpgradePlan
 
 runner = CliRunner()
 
+# A fake checkout root. Assert against SOURCE_DIR_TEXT, never the literal, so the
+# expectation matches what the command actually prints: Path renders this as
+# "\w\agent-os" on Windows and "/w/agent-os" elsewhere.
+SOURCE_DIR = Path("/w/agent-os")
+SOURCE_DIR_TEXT = str(SOURCE_DIR)
+
 
 @pytest.fixture(autouse=True)
 def _no_source_install(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -149,16 +155,14 @@ def test_source_install_notice_names_the_way_back(monkeypatch: pytest.MonkeyPatc
     # A checkout-backed install is exactly the case this command replaces, so
     # it must say so and name install_source.sh — but never block.
     monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
-    monkeypatch.setattr(
-        upgrade_cmd, "installed_from_directory", lambda *a, **k: Path("/w/agent-os")
-    )
+    monkeypatch.setattr(upgrade_cmd, "installed_from_directory", lambda *a, **k: SOURCE_DIR)
     monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
     monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "9.9.9")
     monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: True)
 
     result = runner.invoke(_app(), ["upgrade"])
     assert result.exit_code == 0
-    assert "/w/agent-os" in result.stdout
+    assert SOURCE_DIR_TEXT in result.stdout
     assert "scripts/install_source.sh" in result.stdout
     assert "Upgraded" in result.stdout
 
@@ -179,24 +183,20 @@ def test_no_source_install_notice_for_a_release_install(
 def test_dry_run_reports_the_source_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     ran = {"run": False}
     monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
-    monkeypatch.setattr(
-        upgrade_cmd, "installed_from_directory", lambda *a, **k: Path("/w/agent-os")
-    )
+    monkeypatch.setattr(upgrade_cmd, "installed_from_directory", lambda *a, **k: SOURCE_DIR)
     monkeypatch.setattr(
         upgrade_cmd, "_run_upgrade_subprocess", lambda *a, **k: ran.__setitem__("run", True)
     )
 
     result = runner.invoke(_app(), ["upgrade", "--dry-run", "--json"])
     assert result.exit_code == 0
-    assert _json_payload(result.stdout)["sourceDirectory"] == "/w/agent-os"
+    assert _json_payload(result.stdout)["sourceDirectory"] == SOURCE_DIR_TEXT
     assert ran["run"] is False
 
 
 def test_success_json_reports_the_source_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(upgrade_cmd, "build_upgrade_plan", _delegated_plan)
-    monkeypatch.setattr(
-        upgrade_cmd, "installed_from_directory", lambda *a, **k: Path("/w/agent-os")
-    )
+    monkeypatch.setattr(upgrade_cmd, "installed_from_directory", lambda *a, **k: SOURCE_DIR)
     monkeypatch.setattr(upgrade_cmd, "_run_upgrade_subprocess", _ok_run)
     monkeypatch.setattr(upgrade_cmd, "_installed_version_via", lambda *a, **k: "9.9.9")
     monkeypatch.setattr(upgrade_cmd, "_restart_and_verify", lambda **k: True)
@@ -204,7 +204,7 @@ def test_success_json_reports_the_source_directory(monkeypatch: pytest.MonkeyPat
     result = runner.invoke(_app(), ["upgrade", "--json"])
     assert result.exit_code == 0
     payload = _json_payload(result.stdout)
-    assert payload["sourceDirectory"] == "/w/agent-os"
+    assert payload["sourceDirectory"] == SOURCE_DIR_TEXT
     assert payload["new"] == "9.9.9"
 
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -19,6 +19,31 @@ def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:
     assert "--force --reinstall-package use-agent-os" in sh
 
 
+def test_cli_upgrade_targets_the_release_not_the_checkout() -> None:
+    """`agentos upgrade` and install_source.sh must stay deliberately different.
+
+    They diverged silently once already: install_source.sh builds the Control UI
+    and installs the checkout, while `agentos upgrade` delegated to `uv tool
+    upgrade`, which re-resolved uv's DIRECTORY receipt and re-packaged whatever
+    stale `static/dist/` was on disk. Upgrade now installs the published wheel
+    (whose UI is built in CI); the checkout path stays with the shell script.
+    """
+
+    from agentos.cli.install_method import InstallMethod, build_upgrade_plan
+
+    sh = SOURCE_SH.read_text(encoding="utf-8")
+    assert 'install_target=".' in sh, "install_source.sh must install the local checkout"
+
+    plan = build_upgrade_plan(
+        method=InstallMethod.UV_TOOL,
+        env={"PATH": "/usr/bin"},
+        python_tag="3.12",
+    )
+    assert plan.command[-1] == "use-agent-os[recommended]"
+    assert "." not in plan.command, "upgrade must never install a local path"
+    assert "upgrade" not in plan.command, "`uv tool upgrade` re-resolves the receipt"
+
+
 def test_source_installers_build_control_ui_before_python_package_install() -> None:
     ps1 = SOURCE_PS1.read_text(encoding="utf-8")
     sh = SOURCE_SH.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #199
Refs #200

## The bug

`scripts/install_source.sh` updates the React control UI; `agentos upgrade` does not. Python code moves forward, the web UI stays frozen at the last `install_source.sh` run.

`install_source.sh:243` installs the checkout itself (`uv tool install … "."`), so uv's tool receipt records a **directory** requirement. `uv tool upgrade` takes only a bare tool name and re-resolves that receipt, so `agentos upgrade` rebuilt the wheel from the working tree and never contacted PyPI. The wheel bundles `src/agentos/gateway/static/dist/**` (`pyproject.toml:113-115`), but nothing in the upgrade path runs `npm run build` — so every upgrade faithfully re-packaged whatever browser bundle was already on disk.

Measured on an affected machine: a dist built **Aug 2 02:37** was re-shipped byte-for-byte by an upgrade on **Aug 3 00:04**.

## The fix

`agentos upgrade` now installs the published release:

```
uv tool install --force --python <running major.minor> "use-agent-os[recommended]"
pipx install --force "use-agent-os[recommended]"
```

A PyPI wheel always carries a control UI that `pypi-publish.yml:101-108` builds with Node 22 and then `verify-archive`s fail-closed, so the frontend travels with the package.

Three details are load-bearing:

- **`install`, not `upgrade`** — `uv tool upgrade` re-resolves the receipt, which is the entire bug. Only `uv tool install <dist>[extras]` can move a directory-backed install onto the registry.
- **`--force`** — without it uv no-ops on an already-installed tool, which is the same silent-no-op class of failure. It also self-heals a stale cache or an orphaned interpreter after the base Python moves.
- **`--python <running>`** — pins the rebuilt venv to the interpreter already in use, so a forced reinstall never drags a 3.13 install onto another version.

Extras are always `[recommended]`, matching `install_source.sh`'s default profile. Dropping them degrades the ONNX embedding models and the pilot router silently, at runtime rather than at install time.

Installing a checkout stays with `scripts/install_source.sh` — the only path that rebuilds the browser bundle first. When PEP 610 metadata shows the current install came from a local directory, `upgrade` prints a note naming that directory and the script. It never prompts, blocks, or changes the exit code; `--json` reports it as `sourceDirectory`.

## Secondary fix

Rich parsed the `[recommended]` in `use-agent-os[recommended]` as a markup tag and **dropped it**, so `agentos upgrade --dry-run` printed a command that, copied and run, produced an install missing those extras. Every interpolated command, hint, and subprocess echo is now escaped via the repo's existing `markup_escape`.

## Behaviour change

Users who installed via `./scripts/install_source.sh` and then run `agentos upgrade` will move onto the published release. This is intended — it is the fix — it is announced by the new notice, and it is reversible with one command:

```sh
bash scripts/install_source.sh
```

`agentos upgrade --check` also becomes coherent: it already queried PyPI, while the old upgrade path could never install what it reported.

## Not changed

`detect_install_method`, `resolve_tool`, `hardened_path_env`, the `--timeout` process-group kill, the post-upgrade restart-and-verify, exit codes (0 / 1 / 3), `pypi_client`, `version_utils`, and both install scripts. The `PIP`/`EDITABLE`/`UNKNOWN` branches still refuse to fake it and exit 3 — their printed hints now carry the extras, and the editable hint points at `git pull && bash scripts/install_source.sh` instead of the previous `uv sync`, which omitted the UI rebuild that is the whole bug.

## Verification

Against the real installed layout on a checkout-backed machine:

```
detected method   : uv-tool
python tag        : 3.12
source directory  : /…/agent-os
command           : /opt/homebrew/…/uv tool install --force --python 3.12 use-agent-os[recommended]
```

Gate:

| Step | Result |
| --- | --- |
| `uv run ruff check src tests` | pass |
| `uv run mypy src/agentos --show-error-codes` | pass, 589 files |
| `uv run pytest -q` | 7017 passed, 27 skipped |
| `uv build --wheel` | pass |

New coverage: the uv/pipx argv and the `[recommended]` spec on every delegated plan; the `--python` pin following the running interpreter; the PEP 610 matrix (`dir_info` accepted; `archive_info`, `vcs_info`, non-`file://` URLs, malformed JSON and missing metadata all rejected; percent-encoded paths decoded via `url2pathname`); the src-layout fallback for editable installs without metadata; the source-install notice and its absence on a release install; `sourceDirectory` in dry-run, success and `--no-restart` JSON.

`tests/test_install_scripts.py` gains a drift guard asserting `agentos upgrade` never installs a local path and never uses `uv tool upgrade`, so the CLI and the shell installer cannot silently converge again — their divergence is what produced this bug.

An autouse fixture in `tests/test_cli/test_upgrade_cmd.py` quarantines the PEP 610 probe, since a maintainer's checkout really is a directory install and would otherwise make the notice fire in every test with a machine-dependent path.

## Docs

`docs/cli.md`, `src/agentos/skills/bundled/agentos/SKILL.md`, `README.md`, `docs/quickstart.md`, `CHANGELOG.md`. `docs/quickstart.md` previously recommended raw `uv tool upgrade use-agent-os` and claimed the upgrade kept the original extras — both now wrong. `docs/web-ui.md` has no upgrade text and needed no edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)