### PR TITLE
docs(contributing): document issue and PR workflow rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,23 @@
 name: Bug report
 description: Report a reproducible AgentOS defect
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["type: bug", "status: needs triage"]
 body:
   - type: markdown
     attributes:
       value: |
         Do not include credentials, provider tokens, account identifiers, local paths, or vulnerability details. Use SECURITY.md for suspected vulnerabilities.
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Duplicate check
+      options:
+        - label: I searched the existing open and closed issues and this is not a duplicate.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        A maintainer will add the matching `area:` and `priority:` labels after triage. Comment on the issue if you want to work on it and you will be assigned; see CONTRIBUTING.md for the full issue and pull request workflow.
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,12 +1,23 @@
 name: Documentation issue
 description: Report missing, confusing, or outdated AgentOS documentation
 title: "[Docs]: "
-labels: ["documentation"]
+labels: ["type: documentation", "status: needs triage"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for improving AgentOS's docs. Do not include credentials, provider tokens, private transcripts, account identifiers, or sensitive local paths.
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Duplicate check
+      options:
+        - label: I searched the existing open and closed issues and this is not a duplicate.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        A maintainer will add the matching `area:` and `priority:` labels after triage. Comment on the issue if you want to work on it and you will be assigned; see CONTRIBUTING.md for the full issue and pull request workflow.
   - type: input
     id: page
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,19 @@
 name: Feature request
 description: Propose a focused AgentOS improvement
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["type: enhancement", "status: needs triage"]
 body:
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Duplicate check
+      options:
+        - label: I searched the existing open and closed issues and this is not a duplicate.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        A maintainer will add the matching `area:` and `priority:` labels after triage. Comment on the issue if you want to work on it and you will be assigned; see CONTRIBUTING.md for the full issue and pull request workflow.
   - type: textarea
     id: problem
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,12 @@
+## Linked issue
+
+Fixes #
+
+<!-- Use `Refs #123` instead if this only covers part of the issue. -->
+
+- [ ] This pull request fully resolves the linked issue, or the description
+      says what remains.
+
 ## Summary
 
 What does this change and why?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,12 @@ Docs live in `docs/` (`docs/README.md` is the index); helper scripts in `scripts
   `feat(provider)!: …`, `fix(gateway): …`, `docs(...)`, `chore(...)`,
   `refactor(...)`. Use `!` for breaking changes.
 - Commit or push **only when asked**. If on `main`, branch first.
-- PRs go against `main`; reference issues with `Fixes #123` / `Refs #123`.
-  Preserve co-authorship with `Co-authored-by:` trailers on squash/rebase.
+- PRs go against `main` and **must** link their issue: `Fixes #123` /
+  `Closes #123` when the PR fully resolves it, `Refs #123` when it does not.
+  Open an issue first if none exists. Preserve co-authorship with
+  `Co-authored-by:` trailers on squash/rebase.
+- Issue labeling, claiming, assignment, and the 3-day unassignment policy live
+  in [`CONTRIBUTING.md`](CONTRIBUTING.md) — follow it before starting work.
 - This repo is **public** — never commit secrets, tokens, real provider
   transcripts, local paths, or scratch/editor artifacts. `.gitignore` is
   hardened and `tests/test_public_release_hygiene.py` guards it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,40 @@
 Thanks for improving AgentOS. Keep pull requests small, focused, and covered
 by tests that outside contributors can run without private access.
 
+## Issues
+
+Before opening a new issue, search the existing open and closed issues. If one
+already covers your report, comment there instead of opening a duplicate.
+
+Open an issue before opening a pull request for a bug fix or a new feature.
+Maintainers confirm the change is needed and can assign the issue to you.
+
+Give every issue the labels that match it: one `type:` label, the relevant
+`area:` label, and a `priority:` label when you can judge it. List the labels
+this repository defines with `gh label list` (or the Labels page on GitHub)
+and pick from those rather than inventing new ones.
+
+To claim an issue, comment on it. A maintainer will assign it to you and add
+`status: claimed`. Check the assignee before you start work — do not fix an
+issue that is already assigned to someone else, because it duplicates their
+effort.
+
+If an assigned contributor posts no progress within three days, maintainers
+may unassign the issue so someone else can take it over.
+
 ## Pull Requests
 
-Open pull requests against `main`. Reference related issues in the
-description with GitHub keywords (`Fixes #123`, `Refs #123`) when one exists.
+Open pull requests against `main`. Every pull request must link its issue in
+the description with a GitHub keyword: `Fixes #123` or `Closes #123` when the
+pull request fully resolves the issue, or `Refs #123` when it does not.
+
+A pull request that closes an issue should solve that issue completely. If it
+covers only part of the issue, use `Refs #123` and say in the description what
+still remains.
+
+You do not have to wait to be assigned. Opening a pull request that links the
+issue is enough to claim the work — just check the assignee first so you do not
+duplicate someone else's effort.
 
 When a squash or rebase collapses commits from several people, keep the final
 commit attributable with `Co-authored-by:` trailers for every contributor


### PR DESCRIPTION
## Linked issue

Fixes #202

- [x] This pull request fully resolves the linked issue.

## Summary

Writes down the contributor issue/PR workflow that until now was only announced to builders, and fixes the label defect found while auditing.

**`CONTRIBUTING.md`** — new `## Issues` section: search before filing, open an issue before a PR, label every issue from the set this repo defines (`gh label list`), comment to claim, do not take an issue assigned to someone else, and maintainers may unassign after three days without progress. The `## Pull Requests` section now requires an issue link (`Fixes`/`Closes`, or `Refs` for partial work) instead of the old conditional *"when one exists"*, states that a PR closing an issue should fully resolve it, and makes explicit that waiting to be assigned is not required.

**`.github/pull_request_template.md`** — adds a `## Linked issue` field and a checkbox confirming the PR fully resolves it.

**`.github/ISSUE_TEMPLATE/*.yml`** — adds a required duplicate-search checkbox and a triage/labeling note to all three forms.

**`.github/ISSUE_TEMPLATE/*.yml` label fix** — the forms declared `bug`, `enhancement`, and `documentation`, none of which exist in this repository; the real labels are `type: bug`, `type: enhancement`, and `type: documentation`. Since `config.yml` sets `blank_issues_enabled: false`, these forms are the only intake path, so new issues were arriving with no label at all. Corrected, and `status: needs triage` added so triage state is visible from the moment an issue is filed.

**`AGENTS.md`** — mirrors the PR rule for agents and points at `CONTRIBUTING.md` for the issue policy rather than duplicating it.

The three-day unassignment remains a written policy applied by maintainers. No stale-bot workflow is added.

## Tests

Documentation and template only; no Python or frontend source is touched.

- `uv run python -c "import yaml,glob; ..."` over `.github/ISSUE_TEMPLATE/*.yml` — all four files parse; a malformed form would break issue creation silently on GitHub.
- `gh label list` — confirmed `type: bug`, `type: enhancement`, `type: documentation`, and `status: needs triage` all exist, and that the previous `bug`/`enhancement`/`documentation` names do not.
- `uv run pytest tests/test_public_release_hygiene.py -q` — 15 passed.
- `uv run ruff check src tests` — all checks passed.
- `uv run mypy src/agentos --show-error-codes` — success, no issues in 589 source files.
- `uv run pytest -q` — 7052 passed, 27 skipped, 21 snapshots passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)