### PR TITLE
fix(router): price and size every tier default from a real table entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Shipped Pilot Router tier defaults resolved against static tables that had no
+  entry for them, and both tables fail open without logging: pricing falls
+  through a `startswith` scan to whatever shorter prefix matches first (or a
+  generic $3/$15), the catalog falls through an exact-key miss to a generic
+  200K context / 16K output. `glm-4.7-flashx` was estimating at the generic
+  default, and seven ids — including `anthropic/claude-opus-5`, the OpenRouter
+  c3 default, whose bare spelling was listed at 1M/128K — were sizing turns
+  against generic limits. Every tier default now carries an explicit entry in
+  both tables, enforced by a test that walks all router tier profiles.
+- OpenCAP cost estimates silently used a different gateway's rate sheet after a
+  single failed boot fetch. The price cache was seeded exactly once, only when
+  the configured provider was OpenCAP, and never refreshed — so one timeout
+  meant every estimate for the life of the process came from the shared static
+  table, which carries Bankr rates running 3-5x below OpenCAP's own. The cache
+  now refreshes on a TTL and refetches when it is cold, mirroring the existing
+  OpenRouter live-pricing path, with a shorter negative cache so an unreachable
+  catalog costs one bounded attempt rather than one per lookup. When an
+  estimate does fall back to the static table it is logged once per model, so a
+  substituted number is no longer indistinguishable from a catalog-backed one.
+  Set `AGENTOS_OPENCAP_LIVE_PRICING=0` to disable the refresh.
 - Asked to install a bundled skill that was only unconfigured, the agent
   searched a community hub instead. A skill declaring `requires` is dropped
   from the prompt until its binary and variables are present, so from inside a

--- a/src/agentos/engine/pricing.py
+++ b/src/agentos/engine/pricing.py
@@ -14,6 +14,7 @@ import structlog
 
 from agentos.env import trust_env as _trust_env
 from agentos.provider.openrouter_attribution import openrouter_app_headers
+from agentos.provider.registry import get_provider_spec
 from agentos.secrets import clean_header_secret
 
 log = structlog.get_logger(__name__)
@@ -146,6 +147,13 @@ _LIVE_PRICE_CACHE: dict[str, PriceEntry] = {}
 _LIVE_PRICE_FETCHED_AT: dict[str, float] = {}
 _LIVE_PRICE_MISS_AT: dict[str, float] = {}
 _OPENCAP_PRICE_CACHE: dict[str, PriceEntry] = {}
+# OpenCAP publishes one catalog covering every model, so a single pair of
+# timestamps replaces the per-key dicts the OpenRouter path needs.
+_OPENCAP_FETCHED_AT = 0.0
+_OPENCAP_MISS_AT = 0.0
+# Model IDs already reported as falling back to the shared static table. The
+# warning is worth emitting once per model, not once per turn.
+_OPENCAP_FALLBACK_LOGGED: set[str] = set()
 
 
 def _lookup_price_override(model_id: str) -> PriceEntry | None:
@@ -165,6 +173,11 @@ def _model_price_from_entry(entry: PriceEntry) -> ModelPrice:
 
 def _live_pricing_enabled() -> bool:
     raw = os.environ.get("AGENTOS_OPENROUTER_LIVE_PRICING", "1").strip().lower()
+    return raw not in {"0", "false", "off", "no"}
+
+
+def _opencap_live_pricing_enabled() -> bool:
+    raw = os.environ.get("AGENTOS_OPENCAP_LIVE_PRICING", "1").strip().lower()
     return raw not in {"0", "false", "off", "no"}
 
 
@@ -228,9 +241,12 @@ def _store_opencap_prices(prices: dict[str, PriceEntry]) -> int:
     """Atomically replace the OpenCAP pricing cache with validated entries."""
     if not prices:
         return 0
+    global _OPENCAP_FETCHED_AT, _OPENCAP_MISS_AT
     with _PRICE_LOCK:
         _OPENCAP_PRICE_CACHE.clear()
         _OPENCAP_PRICE_CACHE.update(prices)
+        _OPENCAP_FETCHED_AT = time.monotonic()
+        _OPENCAP_MISS_AT = 0.0
     log.info("pricing.opencap_refreshed", models=len(prices))
     return len(prices)
 
@@ -240,8 +256,55 @@ def seed_opencap_price_cache(data: dict[str, Any]) -> int:
     return _store_opencap_prices(_parse_opencap_prices(data))
 
 
+def _fetch_opencap_catalog_sync() -> dict[str, Any] | None:
+    """Fetch OpenCAP's public catalog, returning None when it is unreachable."""
+    url = get_provider_spec("opencap").model_catalog_url
+    if not url:
+        return None
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT, trust_env=_trust_env()) as client:
+            resp = client.get(url, headers={"Accept": "application/json"})
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception as exc:
+        log.debug("pricing.opencap_fetch_failed", error=str(exc))
+        return None
+    if not isinstance(payload, dict):
+        log.debug("pricing.opencap_fetch_failed", error="catalog response is not an object")
+        return None
+    return cast(dict[str, Any], payload)
+
+
+def _refresh_opencap_prices_if_needed() -> None:
+    """Refresh the OpenCAP price cache when it is empty or past its TTL.
+
+    The cache used to be seeded exactly once at boot, so a single timeout left
+    every OpenCAP estimate on the shared static table — another gateway's rate
+    sheet — for the life of the process. This mirrors the OpenRouter live path:
+    a TTL on success and a shorter negative cache on failure, so an unreachable
+    catalog costs one bounded attempt rather than one per lookup.
+    """
+    global _OPENCAP_FETCHED_AT, _OPENCAP_MISS_AT
+    if not _opencap_live_pricing_enabled():
+        return
+    now = time.monotonic()
+    with _PRICE_LOCK:
+        if _OPENCAP_PRICE_CACHE and now - _OPENCAP_FETCHED_AT <= _CACHE_TTL:
+            return
+        if _OPENCAP_MISS_AT and now - _OPENCAP_MISS_AT <= _LIVE_PRICE_MISS_TTL:
+            return
+
+    data = _fetch_opencap_catalog_sync()
+    prices = _parse_opencap_prices(data) if data is not None else {}
+    if prices:
+        _store_opencap_prices(prices)
+        return
+    with _PRICE_LOCK:
+        _OPENCAP_MISS_AT = time.monotonic()
+
+
 def _lookup_opencap_price(model_id: str) -> PriceEntry | None:
-    """Return a boot-seeded OpenCAP price without performing outbound I/O."""
+    """Return a cached OpenCAP price without performing outbound I/O."""
     key = str(model_id or "").strip().lower()
     if not key:
         return None
@@ -382,11 +445,15 @@ def refresh_live_prices(
 
 
 def reset_live_price_cache_for_tests() -> None:
+    global _OPENCAP_FETCHED_AT, _OPENCAP_MISS_AT
     with _PRICE_LOCK:
         _LIVE_PRICE_CACHE.clear()
         _LIVE_PRICE_FETCHED_AT.clear()
         _LIVE_PRICE_MISS_AT.clear()
         _OPENCAP_PRICE_CACHE.clear()
+        _OPENCAP_FALLBACK_LOGGED.clear()
+        _OPENCAP_FETCHED_AT = 0.0
+        _OPENCAP_MISS_AT = 0.0
 
 
 def seed_live_price_cache_for_tests(model_id: str, price: PriceEntry) -> None:
@@ -430,6 +497,10 @@ _PRICING_TABLE: list[tuple[str, PriceEntry]] = [
     ("gpt-5.6-luna", PriceEntry(0.20, 1.25)),
     ("gpt-5.6-terra", PriceEntry(0.75, 4.50)),
     ("gpt-5.6-sol", PriceEntry(5.0, 30.0)),
+    # Zhipu GLM-4.7-FlashX, the zhipu profile c0 default. Source: published
+    # GLM-4.7-FlashX API rates, checked 2026-08-03. Must precede any shorter
+    # "glm-4.7" prefix added later: the scan below takes the first match.
+    ("glm-4.7-flashx", PriceEntry(0.07, 0.40)),
     ("glm-5.1", PriceEntry(1.40, 4.40)),
     ("glm-5", PriceEntry(0.72, 2.30)),
     ("kimi-k2.5", PriceEntry(0.3827, 1.72)),
@@ -540,6 +611,23 @@ def _lookup_static_price(model_id: str) -> PriceEntry:
     return _DEFAULT_PRICING
 
 
+def _log_opencap_static_fallback(model_id: str) -> None:
+    """Warn once per model when an OpenCAP estimate comes from the static table.
+
+    The shared table holds Bankr gateway rates for these bare IDs, which run
+    several times below OpenCAP's own. Without this the substituted number is
+    indistinguishable from a catalog-backed one.
+    """
+    key = str(model_id or "").strip().lower()
+    if not key:
+        return
+    with _PRICE_LOCK:
+        if key in _OPENCAP_FALLBACK_LOGGED:
+            return
+        _OPENCAP_FALLBACK_LOGGED.add(key)
+    log.warning("pricing.opencap_static_fallback", model=model_id)
+
+
 def _should_fetch_live_price(model_id: str) -> bool:
     model_lower = model_id.lower().strip()
     if not _live_pricing_enabled():
@@ -564,9 +652,13 @@ def lookup_price(model_id: str, provider_id: str = "") -> PriceEntry:
     if str(provider_id or "").strip().lower() == "opencap":
         # OpenCAP's public catalog is canonical for this provider. Shared bare
         # IDs intentionally bypass the Bankr/static override entries below.
+        # Refreshing first is a no-op while the cache is fresh; it only fetches
+        # when the boot seed never landed or has aged past the TTL.
+        _refresh_opencap_prices_if_needed()
         opencap_price = _lookup_opencap_price(model_id)
         if opencap_price is not None:
             return opencap_price
+        _log_opencap_static_fallback(model_id)
         return _lookup_static_price(model_id)
     override = _lookup_price_override(model_id)
     if override is not None:

--- a/src/agentos/provider/model_catalog.py
+++ b/src/agentos/provider/model_catalog.py
@@ -60,9 +60,11 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "oc-uncensored-1.0": (DEFAULT_MAX_TOKENS, 262_144),
     "glm-5.2": (131_072, 1_048_576),
     "minimax-m3": (131_072, 1_048_576),
+    "qwen3.6-flash": (65_536, 1_000_000),
     "qwen3.7-max": (32_768, 256_000),
     "qwen3.7-plus": (32_768, 256_000),
     "claude-opus-5": (128_000, 1_000_000),
+    "anthropic/claude-opus-5": (128_000, 1_000_000),
     "claude-opus-4.8": (128_000, 1_000_000),
     "claude-sonnet-5": (64_000, 1_000_000),
     "claude-sonnet-4.6": (64_000, 1_000_000),
@@ -71,6 +73,7 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "gemini-3.1-flash-lite": (65_536, 1_000_000),
     "gemini-3.5-flash": (65_536, 1_000_000),
     "gemini-3.1-pro-preview": (32_768, 1_000_000),
+    "gemini-2.5-pro": (65_536, 1_048_576),
     "grok-4.3": (128_000, 1_000_000),
     "grok-4.5": (DEFAULT_MAX_TOKENS, 500_000),
     "kimi-k2.7-code": (262_144, 262_144),
@@ -80,6 +83,15 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "gpt-5.6-luna-pro": (128_000, 1_050_000),
     "gpt-5.6-terra-pro": (128_000, 1_050_000),
     "gpt-5.6-sol-pro": (128_000, 1_050_000),
+    # Volcengine Ark Seed 2.0, the volcengine profile tier defaults. Ark serves
+    # the family with a 256K context. Published max output disagrees across
+    # sources (32K vs 128K), so the conservative value is used: boot.py fetches
+    # no live catalog for volcengine, so nothing corrects an over-ask here and
+    # too high a max_tokens fails the request outright.
+    "doubao-seed-2-0-mini-260215": (32_768, 256_000),
+    "doubao-seed-2-0-lite-260215": (32_768, 256_000),
+    "doubao-seed-2-0-pro-260215": (32_768, 256_000),
+    "doubao-seed-2-0-code-preview-260215": (32_768, 256_000),
 }
 
 # Per-provider overrides for ids whose shared _STATIC_FALLBACK entry carries a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,7 @@ _PYTEST_STATE_ROOT = Path(tempfile.gettempdir()) / f"agentos-pytest-{os.getpid()
 os.environ.setdefault("AGENTOS_STATE_DIR", str(_PYTEST_STATE_ROOT / "state"))
 os.environ.setdefault("AGENTOS_LOG_DIR", str(_PYTEST_STATE_ROOT / "logs"))
 os.environ.setdefault("AGENTOS_TURN_CALL_LOG", "0")
+# OpenCAP price lookups refresh their catalog over the network when the cache
+# is cold. Default tests must stay offline; tests that exercise the refresh
+# opt back in with monkeypatch.setenv.
+os.environ.setdefault("AGENTOS_OPENCAP_LIVE_PRICING", "0")

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -372,3 +372,164 @@ def test_direct_openai_zhipu_kimi_and_minimax_prices_do_not_fall_back_to_default
 
     assert price.input_per_m == pytest.approx(input_per_m)
     assert price.output_per_m == pytest.approx(output_per_m)
+
+
+def test_zhipu_c0_default_is_priced_instead_of_hitting_the_generic_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTOS_OPENROUTER_LIVE_PRICING", "0")
+
+    price = lookup_price("glm-4.7-flashx")
+
+    assert price.input_per_m == pytest.approx(0.07)
+    assert price.output_per_m == pytest.approx(0.40)
+    assert price != pricing._DEFAULT_PRICING
+
+
+def test_every_router_tier_default_has_explicit_price_and_catalog_entries() -> None:
+    """No shipped tier default may rely on a prefix match or a generic default.
+
+    Both tables fail open: pricing falls through a ``startswith`` scan to an
+    older model or ``_DEFAULT_PRICING``, and the catalog falls through an
+    exact-key miss to ``DEFAULT_CONTEXT_WINDOW``/``DEFAULT_MAX_TOKENS``. Neither
+    logs, so a miss only shows up as a plausible-looking wrong number.
+    """
+    from agentos.gateway.config import (
+        ROUTER_TIER_PROFILE_IDS,
+        _router_tier_profile_defaults,
+    )
+    from agentos.provider.model_catalog import _STATIC_FALLBACK
+
+    priced_ids = {prefix for prefix, _ in pricing._PRICING_TABLE}
+    catalog_ids = {model_id.lower() for model_id in _STATIC_FALLBACK}
+
+    tier_models = {
+        str(tier["model"]).lower()
+        for profile in ROUTER_TIER_PROFILE_IDS
+        for tier in _router_tier_profile_defaults(profile).values()
+        if tier.get("model")
+    }
+
+    assert tier_models, "expected at least one tier default to audit"
+    assert not tier_models - priced_ids, (
+        f"tier defaults missing an exact _PRICING_TABLE entry: "
+        f"{sorted(tier_models - priced_ids)}"
+    )
+    assert not tier_models - catalog_ids, (
+        f"tier defaults missing an exact _STATIC_FALLBACK entry: "
+        f"{sorted(tier_models - catalog_ids)}"
+    )
+
+
+def _opencap_catalog_payload() -> dict[str, object]:
+    return {
+        "data": [
+            {
+                "id": "claude-opus-5",
+                "pricing": {"input": 4.305, "output": 21.525, "cachedInput": 0.4305},
+            }
+        ]
+    }
+
+
+def test_opencap_cold_cache_refreshes_instead_of_using_another_gateways_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed boot seed must not pin OpenCAP to Bankr rates for the process."""
+    monkeypatch.setenv("AGENTOS_OPENCAP_LIVE_PRICING", "1")
+    calls: list[int] = []
+
+    def fake_fetch() -> dict[str, object]:
+        calls.append(1)
+        return _opencap_catalog_payload()
+
+    monkeypatch.setattr(pricing, "_fetch_opencap_catalog_sync", fake_fetch)
+
+    price = lookup_price("claude-opus-5", provider_id="opencap")
+
+    assert len(calls) == 1
+    assert price.input_per_m == pytest.approx(4.305)
+    assert price.output_per_m == pytest.approx(21.525)
+    # The Bankr static entry for the same bare id is ~3x lower.
+    assert lookup_price("claude-opus-5").input_per_m == pytest.approx(1.375)
+
+
+def test_opencap_cache_is_not_refetched_while_still_within_its_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTOS_OPENCAP_LIVE_PRICING", "1")
+    calls: list[int] = []
+
+    def fake_fetch() -> dict[str, object]:
+        calls.append(1)
+        return _opencap_catalog_payload()
+
+    monkeypatch.setattr(pricing, "_fetch_opencap_catalog_sync", fake_fetch)
+
+    lookup_price("claude-opus-5", provider_id="opencap")
+    lookup_price("claude-opus-5", provider_id="opencap")
+    lookup_price("claude-opus-5", provider_id="opencap")
+
+    assert len(calls) == 1
+
+
+def test_opencap_boot_seed_counts_toward_the_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTOS_OPENCAP_LIVE_PRICING", "1")
+    monkeypatch.setattr(
+        pricing,
+        "_fetch_opencap_catalog_sync",
+        lambda: pytest.fail("a fresh boot seed must not trigger a refresh"),
+    )
+
+    seed_opencap_price_cache(_opencap_catalog_payload())
+    price = lookup_price("claude-opus-5", provider_id="opencap")
+
+    assert price.input_per_m == pytest.approx(4.305)
+
+
+def test_opencap_unreachable_catalog_is_negative_cached_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTOS_OPENCAP_LIVE_PRICING", "1")
+    calls: list[int] = []
+
+    def failing_fetch() -> None:
+        calls.append(1)
+        return None
+
+    monkeypatch.setattr(pricing, "_fetch_opencap_catalog_sync", failing_fetch)
+
+    first = lookup_price("claude-opus-5", provider_id="opencap")
+    second = lookup_price("claude-opus-5", provider_id="opencap")
+
+    assert len(calls) == 1, "a failed fetch must be negative cached, not retried per lookup"
+    assert first == second == PriceEntry(1.375, 6.875)
+
+
+def test_opencap_static_fallback_is_reported_once_per_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    class RecordingLog:
+        def warning(self, event: str, **kwargs: object) -> None:
+            warnings.append((event, kwargs))
+
+        def info(self, event: str, **kwargs: object) -> None: ...
+
+        def debug(self, event: str, **kwargs: object) -> None: ...
+
+    monkeypatch.setattr(pricing, "log", RecordingLog())
+
+    lookup_price("minimax-m3", provider_id="opencap")
+    lookup_price("minimax-m3", provider_id="opencap")
+    lookup_price("glm-5.2", provider_id="opencap")
+
+    events = [
+        kwargs["model"]
+        for event, kwargs in warnings
+        if event == "pricing.opencap_static_fallback"
+    ]
+    assert events == ["minimax-m3", "glm-5.2"]

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -33,6 +33,12 @@ def test_direct_profile_static_fallbacks_cover_context_windows() -> None:
         "moonshot-v1-128k": 131_072,
         "kimi-k2.5": 262_144,
         "kimi-k2.6": 262_144,
+        "gemini-2.5-pro": 1_048_576,
+        "qwen3.6-flash": 1_000_000,
+        "doubao-seed-2-0-mini-260215": 256_000,
+        "doubao-seed-2-0-lite-260215": 256_000,
+        "doubao-seed-2-0-pro-260215": 256_000,
+        "doubao-seed-2-0-code-preview-260215": 256_000,
     }
 
     for model_id, context_window in expected_windows.items():
@@ -40,6 +46,24 @@ def test_direct_profile_static_fallbacks_cover_context_windows() -> None:
         max_tokens = catalog.resolve_max_tokens(model_id)
         assert max_tokens > 0
         assert max_tokens <= context_window
+
+
+def test_namespaced_opus_5_resolves_like_its_bare_gateway_spelling() -> None:
+    """The openrouter c3 default must not fall through to the generic limits.
+
+    ``resolve_context_window``/``resolve_max_tokens`` are exact-key lookups, so
+    a namespaced spelling with no entry silently gets DEFAULT_CONTEXT_WINDOW and
+    DEFAULT_MAX_TOKENS instead of the model's real 1M/128K windows.
+    """
+    catalog = ModelCatalog()
+
+    assert catalog.resolve_context_window("anthropic/claude-opus-5") == 1_000_000
+    assert catalog.resolve_context_window("anthropic/claude-opus-5") == (
+        catalog.resolve_context_window("claude-opus-5")
+    )
+    assert catalog.resolve_max_tokens("anthropic/claude-opus-5") == (
+        catalog.resolve_max_tokens("claude-opus-5")
+    )
 
 
 def test_openrouter_near_context_completion_window_uses_safe_default() -> None:


### PR DESCRIPTION
## Summary

Closes #139.

Both static tables behind cost estimation and token budgeting fail open, in opposite directions and without logging, so a shipped tier default missing from them yields a plausible-looking wrong number instead of an error.

### Missing table entries

Re-running the audit script from the issue against `main` today:

- **Pricing — 1 miss.** `glm-4.7-flashx` (zhipu c0 default) resolved to `_DEFAULT_PRICING` at $3.00/$15.00. Now `PriceEntry(0.07, 0.40)`.
- **Catalog — 7 misses.** `anthropic/claude-opus-5`, `gemini-2.5-pro`, `qwen3.6-flash`, and the four `doubao-seed-2-0-*-260215` ids fell through to `DEFAULT_CONTEXT_WINDOW = 200_000` / `DEFAULT_MAX_TOKENS = 16_384`.

The opus case is the bare-vs-slash divergence the issue flagged, reappearing on opus-5 after the 4.8 default was migrated forward:

```
resolve_context_window("claude-opus-5")            # 1000000
resolve_context_window("anthropic/claude-opus-5")  # 200000   <- the openrouter c3 default
```

The `anthropic/claude-opus-4.8` and `glm-4.7-flashx` pricing cases named in the issue body have partly aged out: `anthropic/claude-opus-4.8` gained its own `$5/$25` entry, and `config_migration.py` now maps both `4.7` and `4.8` straight to `claude-opus-5`. The catalog half of that same complaint is still live, on `anthropic/claude-opus-5`.

### OpenCAP prices outliving a single failed fetch

The price cache was seeded exactly once in `build_services`, only when `config.llm.provider == "opencap"`, with one 5s fetch whose failure was logged and swallowed. One timeout meant every OpenCAP estimate for the life of the process came from the shared static table — Bankr's rates for those bare ids.

Measured against the live catalog (`https://gw.capminal.ai/api/public/models`, fetched 2026-08-03), USD per 1M in/out:

| bare id | static (Bankr) | OpenCAP live | static is |
| --- | --- | --- | --- |
| `claude-opus-5` | 1.375 / 6.875 | 4.305 / 21.525 | 3.1x under |
| `gemini-3.5-flash` | 0.275 / 1.375 | 1.353 / 8.118 | 4.9x under |
| `glm-5.2` | 0.132 / 0.429 | 0.630 / 1.980 | 4.8x under |
| `grok-4.3` | 0.34375 / 0.6875 | 0.9625 / 1.925 | 2.8x under |
| `minimax-m3` | 0.0825 / 0.33 | 0.315 / 1.26 | 3.8x under |
| `claude-fable-5` | 6.27 / 31.35 | 9.46 / 47.30 | 1.5x under |
| `claude-sonnet-5` | 2.20 / 11.0 | 1.76 / 8.80 | 1.25x **over** |

The cache now refreshes on a TTL and refetches when cold, mirroring the OpenRouter live-pricing path already in this module, with a shorter negative cache so an unreachable catalog costs one bounded attempt rather than one per lookup. A successful boot seed stamps the same clock, so `build_services` still avoids a duplicate fetch on the first turn. Falling back to the static table now logs `pricing.opencap_static_fallback` once per model.

## Two deliberate deviations from the issue

**1. Lazy refresh instead of unconditional boot seeding.** The issue asks to "seed regardless of whether `config.llm.provider` happens to be `opencap` at boot". That would make every gateway start call out to `gw.capminal.ai`, including for users who never touch OpenCAP. The TTL + cold-cache refetch closes the same failure — a gateway configured for OpenCAP self-heals from a failed boot fetch on its first lookup — without the unconditional third-party call. Happy to switch if you'd rather have the literal behaviour.

**2. Conservative max output for the doubao family.** Sources disagree (32K vs 128K); context is consistently 256K. `boot.py` fetches no live catalog for volcengine, so nothing corrects an over-ask, and too high a `max_tokens` fails the request outright rather than degrading. `(32_768, 256_000)` — still a large improvement on the generic `16_384 / 200_000`.

## Blocking I/O

`lookup_price` is sync and called from inside async turn execution (`engine/usage.py`, `engine/runtime.py`). The TTL and negative cache bound the new fetch to at most one 3s stall per hour, or one per 5 minutes while OpenCAP is unreachable — the same exposure the OpenRouter path in this function already accepts. `AGENTOS_OPENCAP_LIVE_PRICING=0` disables it; `tests/conftest.py` defaults it off so the suite stays offline per AGENTS.md.

## Overlap with #198

#198 (open, `Closes #140`) adds `"anthropic/claude-opus-5": (128_000, 1_000_000)` to `_STATIC_FALLBACK`. This PR adds the identical line in the identical position, so the two should merge without conflict. #198's drift test covers the three gateway tier sets; the test here walks every profile in `ROUTER_TIER_PROFILE_IDS`, which is where the other six misses lived. If #198 lands first, its test is subsumed and can be dropped.

## Testing

Nine new tests, each verified to fail on `main` and pass here:

```
tests/test_engine/test_pricing.py
  test_zhipu_c0_default_is_priced_instead_of_hitting_the_generic_default
  test_every_router_tier_default_has_explicit_price_and_catalog_entries
  test_opencap_cold_cache_refreshes_instead_of_using_another_gateways_table
  test_opencap_cache_is_not_refetched_while_still_within_its_ttl
  test_opencap_boot_seed_counts_toward_the_ttl
  test_opencap_unreachable_catalog_is_negative_cached_and_falls_back
  test_opencap_static_fallback_is_reported_once_per_model
tests/test_provider_model_catalog.py
  test_direct_profile_static_fallbacks_cover_context_windows  (extended)
  test_namespaced_opus_5_resolves_like_its_bare_gateway_spelling
```

The existing `test_opencap_unseeded_lookup_uses_static_fallback_without_outbound_io`, which deliberately pins the no-I/O contract, passes unchanged under the conftest default.

Quality gate:

```
uv run ruff check src tests                  # pass
uv run mypy src/agentos --show-error-codes   # pass, 589 files
uv run pytest -q                             # 7059 passed, 27 skipped, 1 failed
uv build --wheel                             # pass
```

The one failure is `tests/test_memory_dream_removal.py::test_removed_modules_are_gone[agentos.memory.dream]`, reproduced on a clean stashed tree — a stale local `__pycache__` directory under `src/agentos/memory/dream/` left by the removed module, unrelated to this change.

Frontend gates not run — no `frontend/**` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
