### PR TITLE
fix(shell): block shell redirection bypasses under workspace lockdown

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -328,7 +328,9 @@ def _resolve_shell_write_target(raw_target: str, workdir: str | None) -> Path:
 
 def _shell_write_targets(command: str) -> list[str]:
     targets: list[str] = []
-    redirection_pattern = r"(?:^|\s)(?:\d?>{1,2}|&>{1,2})\s*(['\"]?)([^'\"\s|&;]+)\1"
+    redirection_pattern = (
+        r"(?:\d?>{1,2}|&>{1,2})\s*(['\"]?)([^'\"\s|&;]+)\1"
+    )
     targets.extend(match.group(2) for match in re.finditer(redirection_pattern, command))
     tee_pattern = r"(?:^|\s)tee(?:\s+-[A-Za-z]+)*\s+(['\"]?)([^'\"\s|&;]+)\1"
     targets.extend(match.group(2) for match in re.finditer(tee_pattern, command))

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -429,12 +429,23 @@ def test_tool_definitions_include_scratch_guidance_when_configured(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo ok > {outside}",
+        "echo ok>{outside}",
+        "cat /etc/hosts 2>{outside}",
+        "(echo ok)>{outside}",
+    ],
+)
 async def test_workspace_lockdown_blocks_obvious_outside_shell_redirection(
     tmp_path: Path,
+    command: str,
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     outside = tmp_path / "outside.txt"
+
     ctx = current_tool_context.get()
     assert ctx is not None
     ctx.interaction_mode = InteractionMode.UNATTENDED
@@ -444,7 +455,7 @@ async def test_workspace_lockdown_blocks_obvious_outside_shell_redirection(
 
     result = await shell._check_exec_approval(
         "exec_command",
-        f"echo ok > {outside}",
+        command.format(outside=outside),
         str(workspace),
         "command requires approval",
         None,


### PR DESCRIPTION
## Summary

Fix workspace-lockdown shell redirection detection to block redirections
without preceding whitespace.

Previously, commands such as:

- echo ok>/tmp/out.txt
- (echo ok)>/tmp/out.txt

bypassed `_shell_write_targets()` because the regex required whitespace
before the redirection operator.

This change removes that assumption and adds regression tests covering:

- `echo ok > file`
- `echo ok>file`
- `cat /etc/hosts 2>file`
- `(echo ok)>file`

## Testing

pytest tests/test_tools/test_shell_approval_policy.py -vv
pytest tests -k shell -vv

closes #198 
