### PR TITLE
fix(cron): stop a vanished origin chat from failing every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A cron job no longer fails forever once the chat it was created from is
+  replaced. The web UI stamps `originSessionKey` onto every reminder job while
+  forcing its target to `isolated`, and reminder is the default payload kind for
+  a new job — so jobs that never asked to be bound to a session still carried
+  one. At fire time the delivery chain mirrors the result into that session, and
+  the mirror called `append_message`, which raises `KeyError: Session not found`
+  for a session that no longer exists. That surfaced as `forward_failed`, and
+  because `best_effort` defaults to off — and its checkbox is only rendered for
+  channel and webhook delivery, never for the `none` mode this path runs under —
+  the run was marked failed with no way to opt out. Both webchat paths are
+  covered: the `none`-mode mirror above, and the `mode=ORIGIN` +
+  `channel=webchat` config the cron tool synthesises from the live ToolContext
+  whenever the agent schedules something mid-conversation — neither destination
+  was picked by the operator, so neither should fail a run that already
+  succeeded in its own isolated session. They now report a distinct
+  `origin_gone` delivery status. The gateway forwarder looks the session up
+  before appending and returns `False` when it is gone; forwarders returning
+  `None` keep the previous "delivered" contract, and genuine channel delivery
+  failures still fail the run. Channel-created jobs (telegram, discord, slack)
+  were never affected: their delivery resolves to the chat, which outlives any
+  session.
+
 ## [2026.8.3] - 2026-08-03
 
 ### Changed

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -469,6 +469,34 @@ def _ensure_configured_agent_workspaces(
         )
 
 
+async def mirror_cron_result_to_session(
+    session_manager: Any,
+    origin_session_key: str,
+    text: str,
+    provenance: dict,
+) -> Any | None:
+    """Append a cron result to the session the job was created from.
+
+    Returns the transcript entry, or ``None`` when there is nothing to mirror
+    into — no session manager, or the origin session no longer exists.
+
+    The existence check is the point: ``append_message`` raises ``KeyError``
+    for a missing session, and a cron job routinely outlives the chat it was
+    created from (the web UI stamps ``originSessionKey`` onto every reminder).
+    Without it, replacing that chat made the job fail on every subsequent run.
+    """
+    if session_manager is None:
+        return None
+    if await session_manager.get_session(origin_session_key) is None:
+        return None
+    return await session_manager.append_message(
+        origin_session_key,
+        role="assistant",
+        content=text,
+        provenance=provenance,
+    )
+
+
 def _state_path(config: GatewayConfig, filename: str) -> Path:
     state_root = Path(config.state_dir or default_agentos_home() / "state")
     return state_root / filename
@@ -2067,20 +2095,25 @@ async def start_gateway_server(
             origin_session_key: str,
             text: str,
             provenance: dict,
-        ) -> None:
-            if svc.session_manager is None:
-                return
+        ) -> bool:
+            """Mirror a cron result into the originating session's transcript.
 
-            entry = await svc.session_manager.append_message(
+            Returns ``False`` when the origin session no longer exists so the
+            delivery chain can treat it as "nothing to mirror" instead of a
+            failed run. See :func:`mirror_cron_result_to_session`.
+            """
+            entry = await mirror_cron_result_to_session(
+                svc.session_manager,
                 origin_session_key,
-                role="assistant",
-                content=text,
-                provenance=provenance,
+                text,
+                provenance,
             )
+            if entry is None:
+                return False
 
             _sub_mgr = subscription_manager
             if _sub_mgr is None:
-                return
+                return True
 
             payload = build_cron_result_payload(origin_session_key, text, entry)
 
@@ -2111,6 +2144,8 @@ async def start_gateway_server(
                         await conn.send_event("sessions.changed", sessions_changed_payload)
                     except Exception:
                         pass
+
+            return True
 
         async def _emit_session_event(
             session_key: str,

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -52,13 +52,24 @@ def validate_webhook_url(url: str) -> None:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
 
 
+# The origin webchat session a job was born in no longer exists. Deliberately
+# distinct from both "delivered" and the failure statuses: there was nothing to
+# deliver into, and that is not the job's fault. ``_required_delivery_error``
+# fails a run on "delivery_failed", "forward_failed", and a "skipped" channel
+# under an explicit delivery mode — this status matches none of them, so the run
+# stands. Only ever produced for webchat origins, whose session *is* the
+# conversation; a real channel chat (telegram, discord, slack) outlives the
+# session and never reaches these branches.
+ORIGIN_SESSION_GONE = "origin_gone"
+
+
 @dataclass
 class DeliveryReport:
     """Result of the delivery pipeline."""
 
-    channel_status: str = "skipped"  # "delivered" | "delivery_failed" | "skipped"
+    channel_status: str = "skipped"  # "delivered" | "delivery_failed" | "skipped" | "origin_gone"
     ws_status: str = "skipped"  # "delivered" | "no_subscribers" | "skipped"
-    session_status: str = "skipped"  # "delivered" | "forward_failed" | "skipped"
+    session_status: str = "skipped"  # "delivered" | "forward_failed" | "skipped" | "origin_gone"
 
 
 class DeliveryChain:
@@ -72,7 +83,7 @@ class DeliveryChain:
         self,
         channel_manager_ref: Callable[[], Any] | None = None,
         ws_emitter: Callable[[str, str, dict], Awaitable[int]] | None = None,
-        session_forwarder: Callable[..., Awaitable[None]] | None = None,
+        session_forwarder: Callable[..., Awaitable[bool | None]] | None = None,
     ) -> None:
         self._channel_manager_ref = channel_manager_ref
         self._ws_emitter = ws_emitter
@@ -237,7 +248,7 @@ class DeliveryChain:
         if not text or not text.strip():
             return "delivery_failed"
         try:
-            await self._session_forwarder(
+            forwarded = await self._session_forwarder(
                 origin_session_key=job.origin_session_key,
                 text=text,
                 provenance={
@@ -246,7 +257,6 @@ class DeliveryChain:
                     "source_tool": f"cron:{job.id}",
                 },
             )
-            return "delivered"
         except Exception:
             log.warning(
                 "delivery.webchat_forward_failed",
@@ -255,6 +265,21 @@ class DeliveryChain:
                 exc_info=True,
             )
             return "delivery_failed"
+        # ``False`` means the origin webchat session is gone. This target was
+        # *inferred* from the ambient turn, not chosen by the operator: the cron
+        # tool synthesises ``mode=ORIGIN`` + ``channel=webchat`` from the live
+        # ToolContext (tools/builtin/control.py:424-445) whenever the agent
+        # schedules something from a webchat turn. So a vanished origin is the
+        # same "nothing to mirror into" as the mode=NONE path, not an operator
+        # misconfiguration. Forwarders returning ``None`` stay "delivered".
+        if forwarded is False:
+            log.info(
+                "delivery.webchat_origin_session_missing",
+                job_id=job.id,
+                origin_session_key=job.origin_session_key,
+            )
+            return ORIGIN_SESSION_GONE
+        return "delivered"
 
     async def _post_to_channel(
         self,
@@ -445,7 +470,7 @@ class DeliveryChain:
         if not text or not text.strip():
             return "skipped"
         try:
-            await self._session_forwarder(
+            forwarded = await self._session_forwarder(
                 origin_session_key=job.origin_session_key,
                 text=text,
                 provenance={
@@ -454,7 +479,6 @@ class DeliveryChain:
                     "source_tool": f"cron:{job.id}",
                 },
             )
-            return "delivered"
         except Exception:
             log.warning(
                 "delivery.session_forward_failed",
@@ -463,6 +487,20 @@ class DeliveryChain:
                 exc_info=True,
             )
             return "forward_failed"
+        # ``False`` means the origin session is gone — the user started a new
+        # chat after the job was created. This mirror is opportunistic (the run
+        # itself happened elsewhere and already succeeded), so a missing origin
+        # is "nothing to do", not a failed run. Reporting ``forward_failed``
+        # here made every default web-UI reminder fail once the originating
+        # chat was replaced. Forwarders returning ``None`` stay "delivered".
+        if forwarded is False:
+            log.info(
+                "delivery.origin_session_missing",
+                job_id=job.id,
+                origin_session_key=job.origin_session_key,
+            )
+            return ORIGIN_SESSION_GONE
+        return "delivered"
 
 
 def build_reply_rendezvous_envelope(job: CronJob, session_key: str) -> Any:

--- a/tests/test_scheduler/test_origin_session_missing.py
+++ b/tests/test_scheduler/test_origin_session_missing.py
@@ -1,0 +1,162 @@
+"""A cron job must not fail because the chat it was created from is gone.
+
+The web UI stamps ``originSessionKey`` onto every reminder job
+(``frontend/src/views/cron/logic.ts:1009-1011``) while forcing the target to
+ISOLATED (``logic.ts:820-827``), and reminder is the default payload kind for a
+new job (``logic.ts:692``). The session mirror is therefore configured on jobs
+the operator never asked to bind to a session — so when the originating chat is
+replaced, the mirror must degrade to a no-op rather than fail the run.
+
+``DeliveryChain`` learns the origin is gone from a ``False`` return on the
+session forwarder (``gateway/boot.py`` looks the session up before appending).
+Forwarders that return ``None`` keep the historic "delivered" contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentos.scheduler.delivery import ORIGIN_SESSION_GONE, DeliveryChain
+from agentos.scheduler.handlers import _required_delivery_error
+from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+
+STALE_ORIGIN = "agent:main:webchat:closed-chat"
+RUN_SESSION_KEY = "cron:job-1:run:deadbeef"
+
+
+def _isolated_reminder_job() -> CronJob:
+    """The shape the web UI produces for a default reminder."""
+    return CronJob(
+        id="job-1",
+        name="daily brief",
+        session_target=SessionTarget.ISOLATED,
+        session_key="",
+        origin_session_key=STALE_ORIGIN,
+        delivery=DeliveryConfig(mode=DeliveryMode.NONE),
+    )
+
+
+async def _forwarder_origin_gone(**_: Any) -> bool:
+    return False
+
+
+async def _forwarder_legacy_none(**_: Any) -> None:
+    return None
+
+
+async def _forwarder_raises(**_: Any) -> bool:
+    raise KeyError(f"Session not found: {STALE_ORIGIN}")
+
+
+async def test_missing_origin_session_does_not_fail_an_isolated_run() -> None:
+    job = _isolated_reminder_job()
+    chain = DeliveryChain(session_forwarder=_forwarder_origin_gone)
+
+    report = await chain.deliver(
+        job,
+        result_text="Here is your daily brief.",
+        success=True,
+        summary="brief",
+        session_key=RUN_SESSION_KEY,
+    )
+
+    assert report.session_status == ORIGIN_SESSION_GONE
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_forwarder_returning_none_still_counts_as_delivered() -> None:
+    """The historic contract: forwarders returned None on success."""
+    job = _isolated_reminder_job()
+    chain = DeliveryChain(session_forwarder=_forwarder_legacy_none)
+
+    report = await chain.deliver(
+        job,
+        result_text="Here is your daily brief.",
+        success=True,
+        summary="brief",
+        session_key=RUN_SESSION_KEY,
+    )
+
+    assert report.session_status == "delivered"
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_unexpected_forwarder_error_is_still_a_failure() -> None:
+    """Only a clean "origin is gone" signal is forgiven; real errors are not."""
+    job = _isolated_reminder_job()
+    chain = DeliveryChain(session_forwarder=_forwarder_raises)
+
+    report = await chain.deliver(
+        job,
+        result_text="Here is your daily brief.",
+        success=True,
+        summary="brief",
+        session_key=RUN_SESSION_KEY,
+    )
+
+    assert report.session_status == "forward_failed"
+    assert _required_delivery_error(job, report) is not None
+
+
+async def test_inferred_webchat_origin_delivery_is_also_forgiven() -> None:
+    """The second webchat path: ``mode=ORIGIN`` synthesised by the cron tool.
+
+    When the agent schedules something from a webchat turn, the cron tool builds
+    ``mode=ORIGIN`` + ``channel=webchat`` from the live ToolContext
+    (``tools/builtin/control.py:424-445``) — the operator never picked that
+    destination. So it must degrade the same way the mode=NONE mirror does,
+    rather than failing the run.
+    """
+    job = CronJob(
+        id="job-2",
+        name="agent-scheduled brief",
+        session_target=SessionTarget.ISOLATED,
+        session_key="",
+        origin_session_key=STALE_ORIGIN,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.ORIGIN,
+            channel_name="webchat",
+            channel_id=f"webchat:{STALE_ORIGIN}",
+        ),
+    )
+    chain = DeliveryChain(session_forwarder=_forwarder_origin_gone)
+
+    report = await chain.deliver(
+        job,
+        result_text="Here is your daily brief.",
+        success=True,
+        summary="brief",
+        session_key=RUN_SESSION_KEY,
+    )
+
+    assert report.channel_status == ORIGIN_SESSION_GONE
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_a_real_channel_delivery_failure_still_fails_the_run() -> None:
+    """The forgiveness must not leak into genuine channel delivery problems."""
+    job = CronJob(
+        id="job-3",
+        name="telegram brief",
+        session_target=SessionTarget.ISOLATED,
+        session_key="",
+        origin_session_key=STALE_ORIGIN,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="telegram",
+            channel_id="-1001234567890",
+        ),
+    )
+    # No channel manager wired -> the adapter cannot be reached.
+    chain = DeliveryChain(session_forwarder=_forwarder_origin_gone)
+
+    report = await chain.deliver(
+        job,
+        result_text="Here is your daily brief.",
+        success=True,
+        summary="brief",
+        session_key=RUN_SESSION_KEY,
+    )
+
+    assert report.channel_status != ORIGIN_SESSION_GONE
+    assert _required_delivery_error(job, report) is not None

--- a/tests/test_scheduler/test_origin_session_missing_integration.py
+++ b/tests/test_scheduler/test_origin_session_missing_integration.py
@@ -1,0 +1,135 @@
+"""End-to-end: a reminder job survives the chat it was created from going away.
+
+Unlike the unit tests next door, nothing here is a stand-in for the code under
+test — this drives the real ``SessionManager`` over real SQLite, the real
+``mirror_cron_result_to_session`` the gateway wires in, the real
+``DeliveryChain``, and the real reminder handler
+(``make_static_message_handler``), which is the thing that raises
+``RuntimeError`` and marks the run failed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from agentos.gateway.boot import mirror_cron_result_to_session
+from agentos.scheduler.delivery import DeliveryChain
+from agentos.scheduler.handlers import make_static_message_handler
+from agentos.scheduler.payloads import make_reminder_payload
+from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+from agentos.session.manager import SessionManager
+from agentos.session.storage import SessionStorage
+
+ORIGIN_KEY = "agent:main:webchat:the-chat-i-made-it-from"
+
+
+@pytest_asyncio.fixture
+async def session_stack():
+    """``(manager, storage)`` — deletion lives on storage, as in rpc_sessions."""
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    yield SessionManager(storage, inject_time_prefix=False), storage
+    await storage.close()
+
+
+def _reminder_job() -> CronJob:
+    """Exactly what the web UI builds for a default reminder."""
+    return CronJob(
+        id="job-e2e",
+        name="uống nước",
+        session_target=SessionTarget.ISOLATED,
+        origin_session_key=ORIGIN_KEY,
+        payload=make_reminder_payload("Nhắc: uống nước"),
+        delivery=DeliveryConfig(mode=DeliveryMode.NONE),
+    )
+
+
+def _chain_for(manager: SessionManager) -> DeliveryChain:
+    """Wire the chain the way gateway boot does."""
+
+    async def forwarder(*, origin_session_key: str, text: str, provenance: dict) -> bool:
+        entry = await mirror_cron_result_to_session(
+            manager, origin_session_key, text, provenance
+        )
+        return entry is not None
+
+    return DeliveryChain(session_forwarder=forwarder)
+
+
+@pytest.mark.asyncio
+async def test_reminder_mirrors_into_the_origin_chat_while_it_exists(session_stack) -> None:
+    manager, _ = session_stack
+    await manager.create(ORIGIN_KEY)
+    handler = make_static_message_handler(_chain_for(manager))
+
+    result = await handler(_reminder_job())
+
+    assert "fwd:delivered" in result.delivery_status
+    transcript = await manager.get_transcript(ORIGIN_KEY)
+    assert [e.content for e in transcript] == ["Nhắc: uống nước"]
+    assert transcript[0].provenance_kind == "cron"
+
+
+@pytest.mark.asyncio
+async def test_reminder_survives_the_origin_chat_being_deleted(session_stack) -> None:
+    """The regression: this used to raise RuntimeError and fail the run."""
+    manager, storage = session_stack
+    await manager.create(ORIGIN_KEY)
+    await storage.delete_session(ORIGIN_KEY)
+    handler = make_static_message_handler(_chain_for(manager))
+
+    result = await handler(_reminder_job())
+
+    assert "fwd:origin_gone" in result.delivery_status
+    assert result.summary == "Nhắc: uống nước"
+
+
+@pytest.mark.asyncio
+async def test_reminder_survives_an_origin_chat_that_never_existed(session_stack) -> None:
+    """A job restored from an older database whose session rows are long gone."""
+    manager, _ = session_stack
+    handler = make_static_message_handler(_chain_for(manager))
+
+    result = await handler(_reminder_job())
+
+    assert "fwd:origin_gone" in result.delivery_status
+
+
+@pytest.mark.asyncio
+async def test_the_pre_fix_wiring_really_did_fail_the_run(session_stack) -> None:
+    """Pins the root cause, so a regression is recognisable rather than mysterious.
+
+    This reconstructs the wiring as it shipped before the fix — appending
+    straight to the transcript with no existence check — against the real
+    SessionManager. The resulting ``KeyError: Session not found`` is what the
+    delivery chain turned into ``forward_failed``, and the reminder handler
+    into a failed run. If someone drops the lookup again, this documents the
+    exact behaviour that returns.
+    """
+    manager, storage = session_stack
+    await manager.create(ORIGIN_KEY)
+    await storage.delete_session(ORIGIN_KEY)
+
+    async def pre_fix_forwarder(*, origin_session_key: str, text: str, provenance: dict) -> None:
+        await manager.append_message(
+            origin_session_key, role="assistant", content=text, provenance=provenance
+        )
+
+    handler = make_static_message_handler(DeliveryChain(session_forwarder=pre_fix_forwarder))
+
+    with pytest.raises(RuntimeError, match="session delivery failed"):
+        await handler(_reminder_job())
+
+
+@pytest.mark.asyncio
+async def test_mirror_helper_appends_only_to_a_live_session(session_stack) -> None:
+    manager, storage = session_stack
+    await manager.create(ORIGIN_KEY)
+
+    entry = await mirror_cron_result_to_session(manager, ORIGIN_KEY, "hi", {"kind": "cron"})
+    assert entry is not None
+
+    await storage.delete_session(ORIGIN_KEY)
+    gone = await mirror_cron_result_to_session(manager, ORIGIN_KEY, "hi again", {"kind": "cron"})
+    assert gone is None


### PR DESCRIPTION
## The bug

A cron job fails on **every** run, forever, once the chat it was created from is no longer in the session store. The run itself succeeds — only the delivery mirror fails, and that failure is promoted to a failed run.

Reported as *"I use `isolated` but I still get session-ID-not-found after starting a new session."* `isolated` decides where the job **runs**; it does not decide where the result is **forwarded**. The two are independent, and the second one is what breaks.

## Why it happens by default

Nothing here requires an unusual configuration — the web UI's own defaults produce it:

| Step | Where |
|---|---|
| A new job without a template defaults to `payloadKind: 'reminder'` | `cron/logic.ts:692` |
| reminder forces `target: 'isolated', locked: true` — the operator cannot choose otherwise | `cron/logic.ts:820-827` |
| reminder unconditionally stamps `payload.originSessionKey = activeSessionKey`, with no field surfaced in the form | `cron/logic.ts:1009-1011` |

So a default reminder is bound to a session the operator never asked to bind to.

"New Chat" turns this from rare into routine: `startNewChat` (`ChatPage.tsx:322`) mints a key **client-side** via `Math.random()` — no RPC, no row. A reminder created before the first message in that chat therefore points at a session that has **never existed**.

At fire time, `_forward_to_session` clears every gate for `mode=NONE`, and the forwarder called `append_message`, which raises `KeyError: Session not found` (`session/manager.py:798`). That became `forward_failed`, and `_required_delivery_error` (`scheduler/handlers.py:95`) turned it into a failed run.

There was no way to opt out: `best_effort` defaults to `False`, and its checkbox only renders for channel and webhook delivery (`CronPanel.tsx:152`) — never for the `none` mode this path runs under.

## The fix

The mirror is opportunistic. The run already succeeded in its own isolated session, so a missing origin is "nothing to mirror", not a failure.

- `mirror_cron_result_to_session()` looks the session up before appending and returns `None` when it is gone; the gateway forwarder maps that to `False`.
- `DeliveryChain` reports a distinct `origin_gone` status rather than `forward_failed` / `delivery_failed`.
- Forwarders returning `None` keep the previous "delivered" contract, so no caller changes.

**Both** webchat paths are covered:

1. the `mode=NONE` mirror above, and
2. the `mode=ORIGIN` + `channel=webchat` config the cron tool synthesises from the live ToolContext (`tools/builtin/control.py:424-445`) when the agent schedules something mid-conversation.

Neither destination was chosen by the operator, so neither should fail a run. Genuine channel delivery failures still fail the run, and channel-created jobs (telegram, discord, slack) were never affected — their delivery resolves to the chat id, which outlives any session.

## Verification

10 new tests, including one that reconstructs the pre-fix wiring against a real `SessionManager` so a regression is recognisable rather than mysterious. Removing the fix makes the key regression test fail:

```
FAILED test_missing_origin_session_does_not_fail_an_isolated_run
```

Also verified end to end against a running gateway:

```
origin session key : agent:main:webchat:34iof0uy    exists in DB: False
success            : True
deliveryStatus     : skipped | ws:no_subscribers | fwd:origin_gone
error              : None
```

with the matching log line:

```
delivery.origin_session_missing  origin_session_key=agent:main:webchat:34iof0uy
```

and a Telegram-created job on the same gateway still delivering to its chat after `/new` (`delivered | ws:no_subscribers | fwd:skipped`), confirming no regression on the channel path.

Full suite: 7073 passed, 27 skipped. ruff and mypy clean.

## Not addressed here

The web UI still stamps `originSessionKey` onto every reminder without surfacing it (`cron/logic.ts:1009-1011`). This change makes that harmless, but the UX root cause is a separate call.