### PR TITLE
fix(scheduler): reject unknown cron tool profiles at write time

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -553,8 +553,11 @@ agentos cron update <job-id> --no-elevated
 
 Related flags: `--elevated-mode {bypass,full}` (default `bypass`) and
 `--tool-policy '<json>'` (`profile`, `allow`, `alsoAllow`, `deny` — can only
-narrow the cron baseline). Elevation is only accepted on agent-turn jobs;
-reminders and system events never run an agent turn with the job's tool policy.
+narrow the cron baseline). `profile` must be one of `coding`, `full`,
+`memory_only`, `messaging`, `minimal`; omit the key to inherit rather than
+inventing a name, since an unknown one is rejected when the job is written.
+Elevation is only accepted on agent-turn jobs; reminders and system events
+never run an agent turn with the job's tool policy.
 
 **What you are accepting.** Every time the job fires, with nobody watching, an
 LLM decides which shell commands run on this host as you, and they run — no

--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -29,6 +29,7 @@ from agentos.scheduler.types import (
     ScheduleKind,
     SessionTarget,
 )
+from agentos.tools.policy_config import normalize_tool_profile
 
 _d = get_dispatcher()
 
@@ -182,7 +183,15 @@ def _as_string_list(value: Any) -> list[str]:
     raise ValueError("toolPolicy list fields must be strings or arrays")
 
 
-def _normalize_tool_policy(raw: Any) -> dict[str, Any]:
+def _normalize_tool_policy(raw: Any, *, strict: bool = False) -> dict[str, Any]:
+    """Shape a tool policy for storage (``strict``) or for display.
+
+    Only the write direction rejects an unknown ``profile``. Rows carrying one
+    already exist — that is what this validation was added to stop — and the
+    read direction has to render them, or ``cron list`` would die on the bad job
+    and leave no way to find the id and delete it.
+    """
+
     if raw is None:
         return {}
     if not isinstance(raw, dict):
@@ -190,7 +199,10 @@ def _normalize_tool_policy(raw: Any) -> dict[str, Any]:
     result: dict[str, Any] = {}
     if "profile" in raw:
         profile = raw.get("profile")
-        result["profile"] = None if profile is None else str(profile)
+        if strict:
+            result["profile"] = normalize_tool_profile(profile)
+        else:
+            result["profile"] = None if profile is None else str(profile)
     for key in ("allow", "deny"):
         if key in raw:
             result[key] = _as_string_list(raw.get(key))
@@ -214,7 +226,9 @@ def _tool_policy_from_params(params: dict[str, Any]) -> dict[str, Any]:
 
     policy: dict[str, Any] = {}
     if "toolPolicy" in params or "tool_policy" in params:
-        policy = _normalize_tool_policy(params.get("toolPolicy", params.get("tool_policy")))
+        policy = _normalize_tool_policy(
+            params.get("toolPolicy", params.get("tool_policy")), strict=True
+        )
     if "elevated" in params:
         mode = normalize_cron_elevated(params.get("elevated"))
         if mode is None:

--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from agentos.permissions import normalize_cron_elevated
 from agentos.session.keys import normalize_agent_id
+from agentos.tools.policy_config import normalize_tool_profile
 
 from .delivery import validate_webhook_url
 from .jobs import _next_run
@@ -32,11 +33,16 @@ def _normalized_tool_policy(
     *,
     handler_key: str,
 ) -> dict[str, Any]:
-    """Canonicalise ``tool_policy["elevated"]`` and gate it to agent turns.
+    """Canonicalise ``tool_policy["profile"]`` and ``["elevated"]``, and gate
+    elevation to agent turns.
 
     This runs here, not only at the RPC boundary, because the ``cron`` builtin
     tool hands its ``tool_policy`` argument straight to ``add`` — validating
     only on the wire would leave that path open.
+
+    ``profile`` is checked for the same reason it is checked at all: the name is
+    otherwise resolved for the first time inside the run, so an unknown one
+    creates a job that stores cleanly and then fails on every firing.
 
     Only ``agent_run`` jobs are allowed to carry elevation. A ``system_event``
     job may be serviced by HeartbeatLoop, which builds its own read-only
@@ -45,6 +51,8 @@ def _normalized_tool_policy(
     """
 
     policy = dict(tool_policy or {})
+    if "profile" in policy:
+        policy["profile"] = normalize_tool_profile(policy["profile"])
     if "elevated" not in policy:
         return policy
     mode = normalize_cron_elevated(policy["elevated"])

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -109,7 +109,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `models` | `list` |
 | `skills` | `list`, `search`, `view`, `install`, `uninstall`, `update`, `publish`, `tap add/list/remove` |
 | `sessions` | `list`, `show`, `resume`, `abort`, `delete`, `export` |
-| `cron` | `list`, `status`, `add`, `update` (both take `--elevated`, `--elevated-mode`, `--tool-policy`), `remove`, `run`, `runs` |
+| `cron` | `list`, `status`, `add`, `update` (both take `--elevated`, `--elevated-mode`, `--tool-policy`; the policy's `profile` must be one of `coding`/`full`/`memory_only`/`messaging`/`minimal`, or be omitted), `remove`, `run`, `runs` |
 | `channels` | `list`, `status`, `types`, `describe`, `native-commands`, `add`, `remove`, `enable`, `disable`, `edit`, `restart`, `logout`, `pairing …` |
 | `memory` | `status`, `index`, `list`, `search`, `show`, `embedding-download`, `raw-fallbacks …` |
 | `sandbox` | `status`, `on`, `bypass`, `full`, `reset` |

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -245,7 +245,9 @@ def _cron_job_agent_id(job: Any) -> str:
             "type": "object",
             "description": (
                 "Optional per-job cron tool policy with profile, allow, also_allow, and "
-                "deny. May also carry elevated: 'bypass' to let the job run shell-based "
+                "deny. profile must be one of: coding, full, memory_only, messaging, "
+                "minimal — omit it to inherit the caller's tools rather than guessing a "
+                "name. May also carry elevated: 'bypass' to let the job run shell-based "
                 "skills unattended, which only an interactive CLI or Web caller may set."
             ),
         },

--- a/src/agentos/tools/policy_config.py
+++ b/src/agentos/tools/policy_config.py
@@ -112,6 +112,33 @@ _TOOL_PROFILES: Mapping[str, frozenset[str] | None] = {
 _SENDER_SCOPED_TOOL_GROUPS: frozenset[str] = frozenset({"channel:perm"})
 _SENDER_SCOPED_TOOL_NAMES: frozenset[str] = _TOOL_GROUPS["channel:perm"]
 
+KNOWN_TOOL_PROFILES: tuple[str, ...] = tuple(sorted(_TOOL_PROFILES))
+
+
+def normalize_tool_profile(value: object) -> str | None:
+    """Canonicalise a profile name, or raise naming the ones that exist.
+
+    ``profile_allowlist`` resolves the name during a *run*. That is the right
+    place to fail closed but the wrong place to fail first: a caller who typos a
+    profile when scheduling work gets a job that stores fine and then dies on
+    every firing, with the error going to the run record instead of to them.
+    This is the write-boundary half, and it is deliberately shaped like
+    ``normalize_cron_elevated`` — canonicalise, or raise listing the valid set.
+
+    ``None`` and the empty string mean "no profile", which is how every layer
+    below spells "inherit whatever the caller already had".
+    """
+
+    if value is None:
+        return None
+    key = str(value).strip().lower()
+    if not key:
+        return None
+    if key not in _TOOL_PROFILES:
+        allowed = ", ".join(KNOWN_TOOL_PROFILES)
+        raise ValueError(f"unknown cron tool profile: {value!r} (expected one of: {allowed})")
+    return key
+
 
 @dataclass(frozen=True)
 class ToolPolicy:

--- a/tests/test_scheduler/test_cron_tool_profile.py
+++ b/tests/test_scheduler/test_cron_tool_profile.py
@@ -1,0 +1,119 @@
+"""A cron job's tool profile is validated where it is written.
+
+``profile`` used to be the one ``tool_policy`` key nothing checked: the wire
+boundary stringified it, ops passed it through, and the store accepted it. The
+name was resolved for the first time inside the *run*, where
+``profile_allowlist`` raises on an unknown one — so a typo produced a job that
+was created successfully and then failed every single firing, forever, with an
+error the creator never saw.
+
+``elevated`` already had the right shape and these pin the same one onto
+``profile``: reject at both write boundaries, naming the valid values, and stay
+tolerant on the read path so a row written before this validation existed can
+still be listed and deleted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.gateway.rpc_cron import _tool_policy_from_params, _tool_policy_to_wire
+from agentos.scheduler.ops import SchedulerOps
+from agentos.scheduler.payloads import make_agent_turn_payload
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import ScheduleKind, SessionTarget
+
+
+async def _open_ops(tmp_path: Path) -> tuple[JobStore, SchedulerOps]:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    return store, SchedulerOps(store)
+
+
+async def _add(ops: SchedulerOps, **kwargs):
+    defaults = {
+        "name": "job",
+        "handler_key": "agent_run",
+        "payload": make_agent_turn_payload("ping"),
+        "session_target": SessionTarget.ISOLATED,
+        "schedule_kind": ScheduleKind.CRON,
+        "schedule_value": "*/5 * * * *",
+    }
+    return await ops.add(**{**defaults, **kwargs})
+
+
+async def test_ops_add_rejects_an_unknown_tool_profile(tmp_path: Path) -> None:
+    """The exact value that produced a job failing every five minutes forever."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        with pytest.raises(ValueError, match="unknown cron tool profile: 'default'"):
+            await _add(ops, tool_policy={"profile": "default", "elevated": "bypass"})
+    finally:
+        await store.close()
+
+
+async def test_the_rejection_names_the_profiles_that_do_exist(tmp_path: Path) -> None:
+    """A caller that guessed a name cannot guess a second time from 'no'."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        with pytest.raises(ValueError) as caught:
+            await _add(ops, tool_policy={"profile": "readonly"})
+        message = str(caught.value)
+        for known in ("coding", "full", "memory_only", "messaging", "minimal"):
+            assert known in message
+    finally:
+        await store.close()
+
+
+async def test_ops_add_accepts_a_known_profile_and_canonicalises_it(tmp_path: Path) -> None:
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await _add(ops, tool_policy={"profile": "  Coding  "})
+        assert job.tool_policy == {"profile": "coding"}
+    finally:
+        await store.close()
+
+
+async def test_ops_add_keeps_an_empty_profile_meaning_no_profile(tmp_path: Path) -> None:
+    """``None`` is how every other layer spells "inherit"; it must stay legal."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await _add(ops, tool_policy={"profile": None, "deny": ["web_fetch"]})
+        assert job.tool_policy == {"profile": None, "deny": ["web_fetch"]}
+    finally:
+        await store.close()
+
+
+async def test_ops_update_rejects_an_unknown_profile(tmp_path: Path) -> None:
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await _add(ops, tool_policy={"profile": "coding"})
+        with pytest.raises(ValueError, match="unknown cron tool profile"):
+            await ops.update(job.id, tool_policy={"profile": "default"})
+    finally:
+        await store.close()
+
+
+def test_the_rpc_write_path_rejects_an_unknown_profile() -> None:
+    with pytest.raises(ValueError, match="unknown cron tool profile: 'default'"):
+        _tool_policy_from_params({"toolPolicy": {"profile": "default"}})
+
+
+def test_the_rpc_write_path_accepts_a_known_profile() -> None:
+    assert _tool_policy_from_params({"toolPolicy": {"profile": "minimal"}}) == {
+        "profile": "minimal"
+    }
+
+
+def test_listing_a_job_stored_before_this_validation_does_not_raise() -> None:
+    """The read path stays total.
+
+    Rows carrying an unknown profile already exist — that is the whole reason
+    this validation was added. If rendering one raised, ``cron list`` would die
+    on the bad job and the operator could not even find the id to delete it.
+    """
+    wire = _tool_policy_to_wire({"profile": "default", "elevated": "bypass"})
+    assert wire["profile"] == "default"
+    assert wire["elevated"] == "bypass"


### PR DESCRIPTION
Fixes #211

## What changed

`normalize_tool_profile` in `policy_config.py` canonicalises a profile name or
raises listing the ones that exist. Both write boundaries call it:
`SchedulerOps._normalized_tool_policy` and `rpc_cron._tool_policy_from_params`.

It is deliberately shaped like `normalize_cron_elevated` — the codebase already
had the right pattern for exactly this, and `profile` was the field that had not
been given it.

## The read direction is left tolerant, on purpose

`_normalize_tool_policy` takes a `strict` flag and only the write path passes
it. Rows carrying a bad profile already exist — that is what this validation
was added to stop — and `cron list` has to render them.

This is not hypothetical: rendering the broken job is how its id was found so it
could be repaired. Failing closed on the read path would have left a paused job
with no supported way to identify it.

## Also

The `cron` tool schema now names the valid profiles. The model that created the
offending job had no way to know them from the schema, which is why it invented
`"default"`. `docs/cli.md` and the bundled `agentos` SKILL.md get the same list,
per the repo rule that a CLI surface change updates both.

## Verification

```
uv run ruff check .        # clean
uv run mypy src/           # no issues in 589 source files
uv run pytest tests/ -q    # 7071 passed, 27 skipped, 21 snapshots
```

`tests/test_scheduler/test_cron_tool_profile.py` covers both write boundaries,
canonicalisation (`"  Coding  "` -> `"coding"`), the empty profile meaning "no
profile", and — the one that pins the tolerance above — that listing a job
stored before this validation does not raise.

## Note for the release

The fix only takes effect for a gateway running this code. An installed build
carrying a job with a bad profile still needs the job repaired directly:

```
agentos cron update <job-id> --tool-policy '{"elevated":"bypass"}' --enabled
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
