### PR TITLE
feat(senior-unilp-manager): unattended ratchet mandates and wallet resolution

### DIFF
--- a/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
@@ -25,20 +25,30 @@ metadata:
           url: https://robinhood.com
           secret: false
         - name: UNIV4_LP_PRIVATE_KEY
-          description: Signing key for LP writes. Read-only commands never touch it.
+          description: Signing key for LP writes. Read-only commands use it only to derive
+            your own wallet address, and cannot sign with it.
           secret: true
 ---
 
 # Senior UniLP Manager — Uniswap V4 pools and positions
 
-Two scripts, Python 3 stdlib only, no install step.
+Three scripts, Python 3 stdlib only, no install step.
 
-**`lp_read.py` never touches a private key**; every write goes through `lp_write.py`, which
-is a dry run unless it is given both `--broadcast` and the `--confirm <PLAN_HASH>` printed by
-that same dry run.
+**`lp_read.py` can never sign**; every attended write goes through
+`lp_write.py`, which is a dry run unless it is given both `--broadcast` and the
+`--confirm <PLAN_HASH>` printed by that same dry run. `ratchet.py` is the one unattended
+path — see Part C — and it is separate precisely so that boundary is visible.
+
+`lp_read.py` reads `UNIV4_LP_PRIVATE_KEY` in exactly one place: to answer "which wallet is
+mine" when `positions` is run without `--owner`. It imports `unilp/account.py`, which holds
+curve arithmetic and address derivation and contains no `sign_digest`; `unilp/secp256k1.py`
+imports *that* and adds signing on top. The dependency only runs one way, so no argument to
+`lp_read.py` reaches a signature — and re-adding one is a circular-import error, not a code
+review question.
 
 **Part A (read) needs no confirmation. Part B (write) must never broadcast until the user has
-seen the parameter table and explicitly said yes.**
+seen the parameter table and explicitly said yes. Part C broadcasts on a schedule, under a
+mandate the user approved once, by hash.**
 
 ```bash
 # Keep the quotes — the path can contain spaces.
@@ -46,6 +56,7 @@ S="{baseDir}/scripts"
 
 python3 "$S"/lp_read.py  <command> [flags]   # default chain: robinhood
 python3 "$S"/lp_write.py <command> [flags]   # add --chain base for Base
+python3 "$S"/ratchet.py  <command> [flags]   # unattended take-profit, Part C
 ```
 
 Chain endpoints come from `RPC_ROBINHOOD_URL` and `RPC_BASE_URL`; `--rpc <url>` overrides.
@@ -149,7 +160,20 @@ in/out of range, uncollected fees, USD values. The owner line names known contra
 ## 4. A wallet's positions
 
 ```bash
-python3 "$S"/lp_read.py positions --owner <address> [--include-empty]
+python3 "$S"/lp_read.py positions [--owner <address>] [--include-empty]
+```
+
+**Never ask the user for their own address.** Leave `--owner` off and it resolves the wallet
+`UNIV4_LP_PRIVATE_KEY` derives; `--signer-env <VAR>` reads a different variable. Pass
+`--owner` only when the question is about *someone else's* wallet — that path never touches
+the key, so it works on a machine with no key configured at all.
+
+If you need the address itself rather than the positions — to show the user which wallet is
+in use, or to feed another command — `lp_write.py address` prints it. No chain, no plan,
+nothing sent:
+
+```bash
+python3 "$S"/lp_write.py address [--json]
 ```
 
 The v4 PositionManager has no enumerable index, so this scans inbound ERC-721 `Transfer` logs
@@ -268,8 +292,10 @@ transaction does changes the hash — if you find a flag that does not, that is 
 The key is read from **`UNIV4_LP_PRIVATE_KEY` in the environment and nowhere else**.
 **Never put a private key on a command line** — it would land in shell history and in the
 agent transcript, and redaction only masks `NAME=value`, not a bare hex string. Override the
-variable name with `--signer-env <VAR>`. Only the derived address is ever printed. Signing is
-pure Python and therefore **not constant-time**: use a hot LP key, not a treasury key.
+variable name with `--signer-env <VAR>`. Only the derived address is ever printed —
+`lp_write.py address` prints just that, and is the way to answer "which wallet am I using".
+Signing is pure Python and therefore **not constant-time**: use a hot LP key, not a treasury
+key.
 
 `--from <address>` is **planning mode**: simulate as any address with no key present. It can
 never broadcast. Use it to answer "would this even work" before anyone approves tokens.
@@ -305,6 +331,19 @@ here up to a higher mcap" is a range **below** the current tick and takes the to
 When it is `currency0` it is the other way round. `ticks` (§6) prints the side outright on
 its `position type` line: trust that line and pass its `--tick-lower` / `--tick-upper`
 straight through, rather than deriving the direction yourself.
+
+Written out, because "a sell sits above the price" is true for exactly half of all pools:
+
+| intent | token is | you deposit | range vs price | fills as the tick |
+|---|---|---|---|---|
+| limit **sell** the token | currency0 | currency0 (the token) | **above** | **rises** |
+| limit **sell** the token | currency1 | currency1 (the token) | **below** | **falls** |
+| limit **buy** the token | currency0 | currency1 (the quote) | **below** | **falls** |
+| limit **buy** the token | currency1 | currency0 (the quote) | **above** | **rises** |
+
+Sort order is not something the user chooses — it falls out of the two addresses. So never
+key logic on "sell" or "buy"; key it on **which currency the range takes**, which the
+geometry fixes on its own.
 
 **Hook policy: this skill mints into hook-less pools by default.** A pool whose `hooks` is not
 the zero address is refused outright unless you pass `--allow-hooked`, because a hook can
@@ -366,7 +405,163 @@ nothing, so that trace is the only way to know what a call really moves.
 a `WARNING` above 0.5% divergence. Causes and how to read a revert:
 `assets/v4-reference.md`.
 
+---
+
+# Part C — Ratchet (unattended take-profit)
+
+`ratchet.py` watches a one-sided position fill and takes profit at milestones without anyone
+watching. At each milestone it exits the whole position, keeps whatever has already
+converted, and redeploys **only the unconverted remainder** into a narrower range running
+from the current price to the original far edge.
+
+It ratchets — converted value never goes back to work, and a price retracement leaves the
+position sitting still rather than unwinding. That is the trade: a plain one-sided position
+would buy the token back if the price came down, and this deliberately gives that up.
+
+```bash
+python3 "$S"/ratchet.py arm --token-id <id> [--steps 30,60,100]
+python3 "$S"/ratchet.py arm --token-id <id> --steps 30,60,100 --confirm <MANDATE_HASH>
+python3 "$S"/ratchet.py tick --all --broadcast --json     # what cron runs
+python3 "$S"/ratchet.py status --id <m>   |   list   |   disarm --id <m>
+```
+
+**Milestones are measured against the ORIGINAL principal, not what is left.** 100k AGENTOS
+with `--steps 30,60,100` fires when 70k, then 40k, then 0 remains — three fires, then the
+mandate completes. Re-basing onto the remainder would never reach zero.
+
+**One position, one live mandate.** Re-running `arm` on a position that already has one is
+safe and idempotent: identical terms print `already armed as <id>` and change nothing, exit
+0. Differing terms (`--steps`, principal, far edge, signer) are refused — two mandates would
+each try to burn the same NFT — so `disarm` the old one first if the new terms are the ones
+you want. Do not work around this by re-labelling: `--label` is only a display string.
+
+## One transaction, and why that matters
+
+A fire is a single `modifyLiquidities` call:
+
+    DECREASE_LIQUIDITY(all) → BURN_POSITION → MINT_POSITION(remainder) → TAKE_PAIR
+
+There is **no SETTLE leg**. Deltas accumulate per currency across the unlock, and the mint
+always redeploys strictly less of the principal than the decrease just credited (and zero of
+the other currency, since the new range is one-sided), so both net deltas are still positive
+when `TAKE_PAIR` runs. Nothing is pulled from the wallet.
+
+Two consequences that a two-transaction design would not have:
+
+- **Permit2 is not involved.** An allowance that lapsed mid-mandate cannot strand anything.
+- **There is no window with loose tokens and no position.** The fire either happened or it
+  did not, and the burned NFT proves which — which is what makes unattended recovery a
+  boolean rather than a guess.
+
+## The mandate is the approval
+
+`arm` is attended and hash-confirmed, exactly like a write: it prints the full table and a
+`MANDATE_HASH` you must echo back. What the mandate then buys is the right to replay *that*
+approval against a plan proven to fall inside it. Every fire is checked against the pinned
+`chainId`, PositionManager, poolId (which is `keccak(PoolKey)`, so the hook address is pinned
+with it), tokenId, signer, recipient, slippage floors, milestone index and — for a re-arm —
+the fixed far edge plus a re-derived near edge and a zero cap on the harvested currency.
+
+`lp_write.py --broadcast` is unchanged: it still requires a `--confirm <PLAN_HASH>` a human
+echoed back, and its CLI cannot construct a mandate authorization at all.
+
+**Optional bounds, off by default:** `--max-principal-per-fire`, `--max-fee-per-gas`,
+`--expires-days`. Without them there is no ceiling on what a fire may move, so a math error
+or a manipulated pool has no brake beyond the slippage floor. Say so when arming one.
+
+## States
+
+| state | meaning | what `tick` does |
+|---|---|---|
+| `ARMED` | position live, nothing in flight | evaluate; fire if a milestone is due |
+| `FIRE_SENT` | hash and nonce on disk, outcome unknown | reconcile against the chain |
+| `COMPLETE` | final milestone fired | nothing |
+| `NEEDS_ATTENTION` | an ambiguity it refuses to resolve alone | nothing until `clear-attention` |
+| `DISARMED` / `EXPIRED` | stopped by a human / by the clock | nothing |
+
+Reconciliation is chain-first: `ownerOf` reverting means the fire landed, the nonce watermark
+separates "still pending" from "dropped", and a log scan bounded by the journalled
+`sentAtBlock` finds the replacement tokenId. If none of those give a total answer it goes to
+`NEEDS_ATTENTION` rather than retrying — a duplicate burn is harmless, a duplicate mint is
+not.
+
+**"The node did not answer" is not "the NFT is gone".** `multicall` reports a transport
+failure the same way it reports a revert, so `ownerOf` failing is only read as a burn when a
+`nextTokenId` control call in the same request came back. If both fail the tick reports
+`deferred`, changes nothing, and tries again next time — a five-minute cron meets a flaky
+RPC eventually, and halting on one would make every blip cost a manual `clear-attention`.
+
+A price gap that clears several milestones at once fires **only the deepest**; the ones it
+skipped are satisfied by the same reading and recorded as fired.
+
+### When `clear-attention` needs `--token-id`
+
+One `NEEDS_ATTENTION` cause needs more than an acknowledgement: the fire landed, the old NFT
+is burned, and neither the receipt nor the log scan could say which position replaced it.
+Find it with `lp_read.py positions` — the mandate's signer is the configured wallet, so no
+`--owner` is needed — and hand the new id back:
+
+```
+python3 <S>/ratchet.py clear-attention --id <m> --token-id <new>
+```
+
+It is checked before adoption — same pool, same signer, live liquidity, same far edge, and
+one-sided on the same side of the price — and the old position must really be burned.
+
+Do **not** disarm and arm a fresh mandate instead. `arm` reads the position it is given as a
+new original principal, so every milestone still to come is rebased onto the remainder: a
+100k mandate that has already converted 60k would re-arm as a 40k mandate and fire its next
+30% at 28k left, not at the 40k the original plan meant.
+
+## State on disk
+
+`$UNILP_STATE_DIR`, else `$AGENTOS_HOME/state/unilp`, else `~/.agentos/state/unilp`. Three
+files per mandate: the mandate JSON (mode 0600, replaced atomically), an append-only
+`.log.jsonl` write-ahead log, and a `.lock` for `flock`. Overlapping cron ticks are normal
+and the loser exits 0.
+
+The mandate file is now an **authorization artifact**. It is written 0600 and the runner
+re-hashes it to its own filename on load, which catches corruption and hand-editing. It is
+not a defence against someone who can write that directory — they can also read the dotenv
+holding the signing key, and forging a mandate is the long way round from there. Only the
+`immutable` block is covered by that hash; the mutable fields are guarded by the predicate
+re-deriving them from the chain at the gate, not by the file.
+
+Two rules the log follows, both because it is what restores an in-flight fire after a crash:
+
+* Only the **last** line may be unreadable — that is a torn write from a power cut, and the
+  record it lost had not been confirmed anyway. A bad line with good lines after it stops
+  the runner, because silently skipping it could erase the only proof a transaction was
+  signed.
+* A `tx.sent` record carries the whole in-flight fire, not just the hash. A crash between
+  that append and the mandate replace leaves the file reading `ARMED`; the next tick replays
+  the record and finds the transaction rather than planning the same milestone again.
+
+`--id` only ever accepts 32 lowercase hex characters — the shape `mandate_id` produces — and
+is validated before any path is built, so it cannot walk out of the state directory.
+
+## Wiring it to cron
+
+```
+cron(action="add", schedule={"kind": "cron", "expr": "*/5 * * * *"},
+     task="python3 <S>/ratchet.py tick --all --broadcast --json — report the result, "
+          "and raise the alarm if any state is NEEDS_ATTENTION",
+     job_kind="agent_turn", session_target="isolated")
+```
+
+`tick` does the reconcile and the fire in one process on purpose: no agent judgement sits
+between deciding and sending.
+
+## Before arming anything real
+
+Run `tick` **without** `--broadcast` first — it is a full dry run of the transaction,
+simulation trace and `PLAN_HASH` included, and sends nothing. Then rehearse one real fire by
+hand with dust, on **both** a range above the price and one below: the two directions take
+different branches at every layer, and a hook can answer differently on each.
+
 ## Error handling
+
+
 
 | Symptom | Cause / fix |
 |---|---|
@@ -388,17 +583,40 @@ a `WARNING` above 0.5% divergence. Causes and how to read a revert:
 | `--confirm mismatch` | Parameters changed after approval. Re-plan — never force it |
 | `pool moved: tick X → Y` | Drift past `--max-tick-drift` between plan and send. Re-plan |
 | USD columns show `n/a` | GeckoTerminal has not indexed the token. Amounts are still exact |
+| `tokenId … has an empty PoolKey` | The position was burned, or that id was never minted on this chain. `getPoolAndPositionInfo` is a mapping read and does not revert for a burned id, so this check is what stands in for one |
+| `range … straddles the current tick` (arm) | A ratchet needs a range entirely above or entirely below the price. Two-sided positions have no "unconverted remainder" to redeploy |
+| `mandate refuses the plan: …` | The unattended bounds check rejected the fire. Not a retry — read which bound and why |
+| `position #N is already armed as <id> … differs in: …` | A second mandate on one position would burn the same NFT twice. `disarm --id <id>` if the new terms are the ones you want. Identical terms are not an error at all — they print `already armed` and exit 0 |
+| `another tick holds the lock` | A concurrent cron tick, normal during a fire. Exits 0; nothing to do |
+| `mandate … does not hash to its own filename` | The state file was edited or truncated. Do not repair it by hand — `disarm` and arm a fresh mandate |
+| ratchet state `NEEDS_ATTENTION` | It refused to resolve an ambiguity alone. `status --id <m>` for the record, then `clear-attention --id <m>` once the position is confirmed — add `--token-id <new>` if the note says the replacement could not be identified |
+| ratchet action `deferred` | The node could not be read, so nothing was decided and nothing changed. Normal on a flaky RPC; investigate only if it repeats for hours |
+| `journal holds an unreplayed … record` | The log has an event this build does not know. Almost always a downgrade — run the version that wrote it |
+| `… line N is corrupt … not a torn tail` | The write-ahead log was damaged mid-file. `status --id <m> --json` still reads the mandate; the log needs a human before the runner will move |
+| `… is not a mandate id` | `--id` takes the 32 hex characters `list` prints, nothing else |
 
 ## Verifying a change
 
 ```bash
-python3 {baseDir}/scripts/selftest.py     # 503 offline assertions, no network
+python3 {baseDir}/scripts/selftest.py     # 695 offline assertions, no network
 ```
 
 Covers the keccak / EIP-55 / ABI-codec primitives, secp256k1 signing, TickMath, the AGENTOS
 reserve figures, market-cap bands, the three Base launchpad poolIds, every `unlockData`
 blob, and the planning helpers `--from-current` leans on. Run it after touching anything in
 `scripts/unilp/`; the live fixtures it pins are listed in its module docstring.
+
+Tier 7 covers the ratchet, and runs its assertions across all four combinations of
+{token is currency0, token is currency1} × {range above the price, range below it}, because
+a bug on one side is invisible from the other. It also pins the five independent reasons
+`lp_write.py`'s CLI cannot construct a mandate authorization; if you touch `run_plan`'s gate,
+that tier is the one that has to stay green.
+
+Its state-machine block drives every crash and network outcome a cron runner meets against
+a stub chain — a send journalled but never saved, an unreachable node, an unidentifiable
+replacement, a retry budget that has to survive on the mandate rather than on the fire.
+Those rows exist because each one was a real bug at some point; they are cheap to assert
+and close to impossible to keep right by reading the code.
 
 Deeper background — the v4 Actions table, hook permission bits, and the Clanker / Liquid /
 Doppler registry architecture: `{baseDir}/assets/v4-reference.md`.

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_read.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_read.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Read-only Uniswap V4 LP inspection.
 
-This file NEVER reads a private key and never imports a signing path — that is what
-makes it safe to allowlist wholesale. All writes live in ``lp_write.py``.
+This file NEVER signs and never imports a signing path — that is what makes it safe to
+allowlist wholesale. All writes live in ``lp_write.py``.
+
+It touches ``UNIV4_LP_PRIVATE_KEY`` in exactly one place, ``resolve_owner``, and only to
+answer "which wallet is mine" when ``positions`` is run without ``--owner``. That import
+is ``unilp.account``, which holds curve arithmetic and address derivation and has no
+``sign_digest`` in it, so no argument to this script can reach a signature.
 
     python3 scripts/lp_read.py pools     --token <addr> [--include-v3] [--all-pools]
     python3 scripts/lp_read.py pool      --id <poolId>
     python3 scripts/lp_read.py position  --token-id <id>
-    python3 scripts/lp_read.py positions --owner <addr>
+    python3 scripts/lp_read.py positions [--owner <addr>]   omit = the configured wallet
     python3 scripts/lp_read.py launcher  --token <addr>
     python3 scripts/lp_read.py ticks     --pool <poolId> --mcap-lower <usd> --mcap-upper <usd>
     python3 scripts/lp_read.py price     --tokens <a,b,...>
@@ -34,7 +39,7 @@ from unilp.abi_defs import (  # noqa: E402
     V3_FACTORY_ABI,
     V3_POOL_ABI,
 )
-from unilp.chains import resolve_chain  # noqa: E402
+from unilp.chains import ENV_SIGNER, resolve_chain, resolve_signer_address  # noqa: E402
 from unilp.fmt import (  # noqa: E402
     die,
     fmt_band,
@@ -66,6 +71,7 @@ from unilp.v4_math import (  # noqa: E402
     get_sqrt_ratio_at_tick,
     mcap_at_tick,
     mcap_band_for_range,
+    pull_off_current_tick,
     range_status,
     snap_tick,
     tick_at_mcap,
@@ -105,7 +111,10 @@ senior-unilp-manager — read-only Uniswap V4 LP inspection
             gives the PoolKey outright: no lookup at all, works for any pool on any chain.
             It is checked by recomputing the poolId. --hooks defaults to no hook.
   position  --token-id <id> [--no-fees]
-  positions --owner <addr> [--include-empty]
+  positions [--owner <addr>] [--include-empty]
+            Leave --owner off for the wallet UNIV4_LP_PRIVATE_KEY derives; --signer-env
+            <VAR> reads a different variable. The key is only ever used to derive that
+            address — this script has no signing path to reach.
   launcher  --token <addr>            which launchpad deployed it, its pool, who holds the LP
   ticks     --pool <poolId>
             (--mcap-lower <usd> --mcap-upper <usd> | --tick-lower <t> --tick-upper <t>)
@@ -183,42 +192,6 @@ def mcap_context(pool_key: dict, token: str, meta0: dict, meta1: dict, prices: d
         "tickSpacing": pool_key["tickSpacing"],
         "hasSupply": supply is not None and supply > 0,
     }
-
-
-def _pull_off_current_tick(
-    current: int, tick_lower: int, tick_upper: int, spacing: int
-) -> tuple[int, int]:
-    """Move a range that straddles ``current`` fully onto one side of it.
-
-    A band with one end at "where it trades right now" is the normal way to ask for a
-    single-sided add, but snapping outward pushes that end across the current tick and the
-    range comes back two-sided — the caller then has to guess a tick by hand. Keep whichever
-    side holds more of the band they asked for and pull the near edge past ``current``.
-
-    A range is single-sided below the current price when ``tickUpper <= current``, and above
-    it when ``tickLower > current``; that is the same boundary ``range_status`` uses.
-    """
-    if not (tick_lower <= current < tick_upper):
-        return tick_lower, tick_upper  # already one-sided, leave it alone
-
-    below = snap_tick(current, spacing, "down")
-    above = below + spacing
-    keep_below = (current - tick_lower) >= (tick_upper - current)
-
-    if keep_below and below > tick_lower:
-        return tick_lower, below
-    if not keep_below and above < tick_upper:
-        return above, tick_upper
-    # The band is thinner than one spacing on the side we wanted, so that side cannot hold a
-    # range at all. Fall back to the other one rather than returning a straddle.
-    if below > tick_lower:
-        return tick_lower, below
-    if above < tick_upper:
-        return above, tick_upper
-    raise RuntimeError(
-        f"the band is narrower than one tickSpacing ({spacing}) either side of the current "
-        f"tick {current} — widen it, or give --tick-lower/--tick-upper directly"
-    )
 
 
 def _math_kwargs(ctx: dict, **overrides) -> dict:
@@ -1052,8 +1025,27 @@ def cmd_position(client, chain: dict, args: dict) -> None:
     ]))
 
 
+def resolve_owner(args: dict) -> str:
+    """``--owner``, or the wallet the signing key derives when it is left off.
+
+    "Show my positions" should not require the user to recite their own address, and the
+    address is already implied by the key the skill is configured with. This is the one
+    place in this file that touches ``UNIV4_LP_PRIVATE_KEY``, it reads it only to derive
+    the address, and the key never enters a variable here — see
+    ``chains.resolve_signer_address`` for why that stays incapable of signing.
+    """
+    given = args.get("owner")
+    if given:
+        return str(given)
+    signer_env = args.get("signer-env") or ENV_SIGNER
+    try:
+        return resolve_signer_address(signer_env)
+    except RuntimeError as exc:
+        die(f"{exc}\n\nOr name the wallet directly: positions --owner <address>")
+
+
 def cmd_positions(client, chain: dict, args: dict) -> None:
-    owner = checksum_address(require_arg(args, "owner", "wallet address"))
+    owner = checksum_address(resolve_owner(args))
 
     # This command has no registry shortcut: finding a wallet's NFTs means scanning
     # ERC-721 Transfer logs, which a chain with a hard getLogs range cap cannot serve in
@@ -1309,7 +1301,7 @@ def cmd_ticks(client, chain: dict, args: dict) -> None:
         tick_lower = snap_tick(a, spacing, "down")
         tick_upper = snap_tick(b, spacing, "up")
         if args.get("from-current"):
-            tick_lower, tick_upper = _pull_off_current_tick(
+            tick_lower, tick_upper = pull_off_current_tick(
                 pool["tick"], tick_lower, tick_upper, spacing
             )
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
@@ -37,7 +37,12 @@ from unilp.abi_defs import (  # noqa: E402
     POSITION_MANAGER_ABI,
     STATE_VIEW_ABI,
 )
-from unilp.chains import ENV_SIGNER, resolve_chain, resolve_private_key  # noqa: E402
+from unilp.chains import (  # noqa: E402
+    ENV_SIGNER,
+    resolve_chain,
+    resolve_private_key,
+    resolve_signer_address,
+)
 from unilp.fmt import (  # noqa: E402
     die,
     fmt_units,
@@ -103,6 +108,7 @@ senior-unilp-manager — Uniswap V4 LP writes (DRY RUN unless --broadcast --conf
            [--recipient <addr>]
   collect  --token-id <id> [--recipient <addr>]
   burn     --token-id <id> [--slippage-bps 100] [--recipient <addr>]
+  address  [--json]        print the wallet UNIV4_LP_PRIVATE_KEY derives; no chain, no send
 
 Safety:  --broadcast --confirm <PLAN_HASH>   both required to send
          --from <addr>            simulate only, no key needed
@@ -153,6 +159,52 @@ def plan_hash(fields: dict) -> str:
         separators=(",", ":"),
     )
     return keccak256(to_hex(canonical.encode("utf-8")))[2:10]
+
+
+# ---------------------------------------------------------------------------
+# Mandate authorization — the ONLY way a broadcast happens without a human hash
+# ---------------------------------------------------------------------------
+
+_ARGV_ENTRY = False
+"""True once :func:`main` has run, i.e. this process is the interactive CLI.
+
+A CLI process may never construct a :class:`MandateAuthorization`. That is not a policy
+check that a future refactor could forget — it makes the two modes disjoint by construction.
+"""
+
+
+class MandateAuthorization:
+    """A programmatic stand-in for the ``--confirm <PLAN_HASH>`` a human echoes back.
+
+    ``run_plan`` normally refuses to broadcast unless the caller passes back the exact hash
+    printed by the dry run they just showed a human. An unattended runner has nobody to echo
+    it, so it supplies one of these instead: the human approved a *mandate* once, and this
+    object carries the predicate that decides whether the plan in hand falls inside it.
+
+    Reachability from ``lp_write.py``'s own CLI is blocked five independent ways —
+    keyword-only parameter, ``main()`` never passes one, an ``isinstance`` gate that fails
+    closed, the ``_ARGV_ENTRY`` guard below, and the pre-existing "``--broadcast`` requires
+    ``--confirm``" check in ``main``. ``lp_write.py --broadcast`` still needs a human hash.
+    """
+
+    __slots__ = ("mandate_id", "fire_id", "_predicate")
+
+    def __init__(self, *, mandate_id: str, fire_id: str, predicate) -> None:
+        if _ARGV_ENTRY:
+            raise RuntimeError(
+                "lp_write.py's CLI can never construct a MandateAuthorization; --broadcast "
+                "requires --confirm <PLAN_HASH> echoed back by a human"
+            )
+        if not callable(predicate):
+            raise TypeError("MandateAuthorization predicate must be callable")
+        self.mandate_id = str(mandate_id)
+        self.fire_id = str(fire_id)
+        self._predicate = predicate
+
+    def authorize(self, client, chain: dict, args: dict, signer: dict, ctx: dict,
+                  hash_value: str) -> None:
+        """Raise unless every bound holds. Returning normally means "send it"."""
+        self._predicate(client, chain, args, signer, ctx, hash_value)
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +288,16 @@ def load_position_for_write(client, chain: dict, token_id: int) -> dict:
         raise RuntimeError(f"tokenId {token_id} does not exist on {chain['name']}")
     raw_key, info = pool_and_info["result"]
     pool_key = normalize_pool_key(raw_key)
+    # getPoolAndPositionInfo is a mapping read, so a BURNED tokenId comes back with status
+    # "success" and an all-zero PoolKey rather than reverting. Without this check the caller
+    # goes on to compute_pool_id(zeros) and builds a plan against a pool that cannot exist,
+    # failing later with an unrelated revert instead of saying the position is gone.
+    if (pool_key["currency0"] == NATIVE and pool_key["currency1"] == NATIVE
+            and int(pool_key["fee"]) == 0 and int(pool_key["tickSpacing"]) == 0):
+        raise RuntimeError(
+            f"tokenId {token_id} has an empty PoolKey on {chain['name']} — the position was "
+            "burned, or that id was never minted here"
+        )
     return {
         "tokenId": int(token_id),
         "poolKey": pool_key,
@@ -298,8 +360,13 @@ def allowance_problem(row: dict, needed: int, now_secs: int) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def run_plan(client, chain: dict, args: dict, signer: dict, ctx: dict):
-    """Simulate, print, gate on the confirmed hash, then (only then) broadcast."""
+def run_plan(client, chain: dict, args: dict, signer: dict, ctx: dict, *,
+             authorization: MandateAuthorization | None = None):
+    """Simulate, print, gate on the confirmed hash, then (only then) broadcast.
+
+    ``authorization`` replaces the human hash echo for an unattended mandate run; see
+    :class:`MandateAuthorization`. It is keyword-only and unreachable from this file's CLI.
+    """
     hash_value = plan_hash(ctx["hashFields"])
     token_map = ctx.get("tokenMap") or {}
 
@@ -375,7 +442,19 @@ def run_plan(client, chain: dict, args: dict, signer: dict, ctx: dict):
         return None
     # Confirm is checked before anything else about the signer: a stale hash means the
     # plan the human approved is not the plan in hand, and that is the worse failure.
-    if args.get("confirm") != hash_value:
+    if authorization is not None:
+        if not isinstance(authorization, MandateAuthorization):
+            raise RuntimeError(
+                "authorization must be a MandateAuthorization; refusing to broadcast on a "
+                f"{type(authorization).__name__}"
+            )
+        if args.get("confirm"):
+            raise RuntimeError(
+                "--confirm and a mandate authorization are mutually exclusive: one of them "
+                "is stale, and guessing which would defeat both"
+            )
+        authorization.authorize(client, chain, args, signer, ctx, hash_value)
+    elif args.get("confirm") != hash_value:
         raise RuntimeError(
             f'--confirm mismatch: got "{args.get("confirm") or "(none)"}", plan is '
             f'"{hash_value}".\n'
@@ -397,19 +476,26 @@ def run_plan(client, chain: dict, args: dict, signer: dict, ctx: dict):
     data = ctx["rebuildData"](deadline) if ctx.get("rebuildData") else ctx["data"]
 
     return _send(client, chain, args, signer, chain["positionManager"], data,
-                 ctx.get("value", 0))
+                 ctx.get("value", 0), on_sent=ctx.get("onSent"))
 
 
 def _send(client, chain: dict, args: dict, signer: dict, to: str, data: str,
-          value: int = 0, label: str = "") -> dict:
-    """Build, sign, broadcast and wait. Shared by run_plan and the approve legs."""
+          value: int = 0, label: str = "", on_sent=None) -> dict:
+    """Build, sign, broadcast and wait. Shared by run_plan and the approve legs.
+
+    ``on_sent`` is passed straight through to :func:`send_transaction` so an unattended
+    caller can persist the hash and nonce before the broadcast leaves the process.
+    """
+    max_fee_cap = args.get("max-fee-per-gas")
     tx = prepare_transaction(
         client, chain, signer["address"], to, data, value,
         gas_multiplier=float(args.get("gas-multiplier") or DEFAULT_GAS_MULTIPLIER),
+        max_fee_cap=int(str(max_fee_cap).replace("_", "")) if max_fee_cap else None,
     )
     prefix = f"  {label} " if label else "\n  "
     tx_hash = send_transaction(client, chain, tx, signer["privateKey"],
-                               on_hash=lambda h: print(f"{prefix}sent: {h}"))
+                               on_hash=lambda h: print(f"{prefix}sent: {h}"),
+                               on_sent=on_sent)
     receipt = wait_for_receipt(client, tx_hash)
     status = receipt_status(receipt)
     print(f"  status: {status}  block: {int(receipt['blockNumber'], 16)}  "
@@ -576,7 +662,8 @@ def _token_map(info0: dict, info1: dict) -> dict:
     return {info0["address"].lower(): info0, info1["address"].lower(): info1}
 
 
-def cmd_mint(client, chain: dict, args: dict, signer: dict) -> None:
+def cmd_mint(client, chain: dict, args: dict, signer: dict, *,
+             authorization: MandateAuthorization | None = None) -> dict | None:
     pool_id = require_arg(args, "pool", "poolId")
     pool_key = pool_key_for_id(client, chain, pool_id, args)
     if not pool_key:
@@ -672,7 +759,7 @@ def cmd_mint(client, chain: dict, args: dict, signer: dict) -> None:
                 f"(drift {drift} > {max_drift}). Re-plan."
             )
 
-    run_plan(client, chain, args, signer, {
+    return run_plan(client, chain, args, signer, {
         "title": "mint position",
         "rows": rows,
         "tokenMap": _token_map(info0, info1),
@@ -692,7 +779,7 @@ def cmd_mint(client, chain: dict, args: dict, signer: dict) -> None:
         },
         "rebuildData": lambda d: encode_call(plan, d),
         "revalidate": revalidate,
-    })
+    }, authorization=authorization)
 
 
 def cmd_increase(client, chain: dict, args: dict, signer: dict) -> None:
@@ -869,7 +956,8 @@ def cmd_collect(client, chain: dict, args: dict, signer: dict) -> None:
     })
 
 
-def cmd_burn(client, chain: dict, args: dict, signer: dict) -> None:
+def cmd_burn(client, chain: dict, args: dict, signer: dict, *,
+             authorization: MandateAuthorization | None = None) -> dict | None:
     token_id = int(require_arg(args, "token-id"))
     pos = load_position_for_write(client, chain, token_id)
     hook_gate(pos["poolKey"], args)
@@ -890,7 +978,7 @@ def cmd_burn(client, chain: dict, args: dict, signer: dict) -> None:
                            amount0_min, amount1_min, recipient)
     deadline = int(client.get_block()["timestamp"], 16) + deadline_offset(args)
 
-    run_plan(client, chain, args, signer, {
+    return run_plan(client, chain, args, signer, {
         "title": f"burn position #{token_id} (full exit)",
         "tokenMap": _token_map(info0, info1),
         "rows": [
@@ -916,7 +1004,24 @@ def cmd_burn(client, chain: dict, args: dict, signer: dict) -> None:
         "data": encode_call(plan, deadline),
         "value": 0,
         "rebuildData": lambda d: encode_call(plan, d),
-    })
+    }, authorization=authorization)
+
+
+def cmd_address(args: dict) -> None:
+    """Print the wallet ``UNIV4_LP_PRIVATE_KEY`` derives. No chain, no plan, no send.
+
+    Kept here rather than in ``lp_read.py`` because this is the script that already holds
+    the key, so nothing about the read/write boundary moves to add it. ``lp_read.py
+    positions`` resolves the same address on its own; this command is for the times you
+    want the address itself — to check which wallet is configured, or to hand to another
+    tool. The key is never printed.
+    """
+    signer_env = args.get("signer-env") or ENV_SIGNER
+    address = resolve_signer_address(signer_env)
+    if args.get("json"):
+        print(json.dumps({"address": address, "signerEnv": signer_env}, indent=2))
+    else:
+        print(address)
 
 
 COMMANDS = {
@@ -930,11 +1035,22 @@ COMMANDS = {
 
 
 def main() -> None:
+    # From here on this process is the interactive CLI, and MandateAuthorization refuses to
+    # be constructed. The unattended runner imports this module and never calls main().
+    global _ARGV_ENTRY
+    _ARGV_ENTRY = True
+
     args = parse_args(sys.argv[1:])
     command = args["_"][0] if args["_"] else None
     if not command or args.get("help") or args.get("h"):
         print(USAGE)
         sys.exit(0 if command else 1)
+    # Answered before a chain or an RpcClient is built: this command reads one env var and
+    # does arithmetic, so it must not fail because an RPC endpoint is unset or unreachable.
+    if command == "address":
+        cmd_address(args)
+        return
+
     if args.get("broadcast") and not args.get("confirm"):
         raise RuntimeError("--broadcast requires --confirm <PLAN_HASH>. Run the dry run "
                            "first and show the plan to the user.")

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/ratchet.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/ratchet.py
@@ -1,0 +1,1515 @@
+#!/usr/bin/env python3
+"""Unattended take-profit for a one-sided Uniswap V4 position.
+
+A one-sided position is a limit order that fills gradually. This runner watches one fill and,
+at each milestone, exits the whole position, keeps what has already converted, and redeploys
+only the unconverted remainder into a narrower range running from the current price to the
+original far edge. It ratchets: converted value never goes back to work, and a price
+retracement leaves the position sitting still rather than unwinding.
+
+    arm    --token-id <id> [--steps 30,60,100]      plan a mandate, then --confirm it
+    tick   [--id <m>|--all] [--broadcast]           reconcile and fire; what cron runs
+    status --id <m>      list      disarm --id <m>      clear-attention --id <m>
+
+Why this is a separate entrypoint. ``lp_read.py`` never imports a signing path, which is what
+makes it safe to allowlist wholesale. ``lp_write.py`` is the attended path and still refuses
+to broadcast without a PLAN_HASH a human echoed back. This file is the third thing: it reads,
+it writes, and it runs with nobody watching. Keeping it separate puts that boundary somewhere
+a reviewer can see it.
+
+The authorization it uses is narrow by construction — see ``lp_write.MandateAuthorization``.
+Arming is still an attended, hash-confirmed act; what the mandate buys is the right to replay
+*that* approval against a plan proven to fall inside it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import lp_write  # noqa: E402
+from unilp.chains import resolve_chain  # noqa: E402
+from unilp.fmt import (  # noqa: E402
+    die,
+    fmt_units,
+    heading,
+    parse_args,
+    render_kv,
+    require_arg,
+    short_id,
+)
+from unilp.journal import (  # noqa: E402
+    SCHEMA_VERSION,
+    MandateStore,
+    canonical_json,
+    mandate_id,
+    state_root,
+)
+from unilp.ratchet_math import (  # noqa: E402
+    CURRENCY0,
+    RangeExhaustedError,
+    due_milestone,
+    far_edge_tick,
+    fills_as_tick_rises,
+    milestone_thresholds,
+    parse_steps,
+    principal_for_range,
+    rearm_range,
+    remaining_principal,
+    tick_for_remaining,
+)
+from unilp.reconcile import (  # noqa: E402
+    AMBIGUOUS,
+    LANDED,
+    NOT_SENT,
+    PENDING,
+    UNAVAILABLE,
+    find_minted_token_id,
+    position_truth,
+    reconcile,
+)
+from unilp.rpc import RpcClient  # noqa: E402
+from unilp.simulate import net_transfers  # noqa: E402
+from unilp.v4_actions import build_ratchet_plan, describe_actions  # noqa: E402
+from unilp.v4_math import (  # noqa: E402
+    get_amounts_for_liquidity,
+    get_liquidity_for_amount0,
+    get_liquidity_for_amount1,
+    get_sqrt_ratio_at_tick,
+    raw_price_at_tick,
+)
+from unilp.v4_pool import compute_pool_id, format_hook_flags  # noqa: E402
+
+USAGE = """
+senior-unilp-manager — ratchet: unattended take-profit on a one-sided position
+
+  arm     --token-id <id> [--steps 30,60,100] [--slippage-bps 100] [--allow-hooked]
+          [--label <name>] [--max-tick-drift <n>] [--deadline-secs 1200]
+          [--max-principal-per-fire <human>] [--max-fee-per-gas <wei>] [--expires-days <n>]
+          Dry run prints the mandate table and a MANDATE_HASH; re-run with
+          --confirm <MANDATE_HASH> to arm it.
+  tick    [--id <m> | --all] [--broadcast] [--json]
+          Reconcile against the chain and fire any milestone that is due. Without
+          --broadcast this is a full dry run of the transaction, and sends nothing.
+  status  --id <m> [--json]
+  list    [--json]
+  disarm  --id <m>
+  clear-attention --id <m> [--token-id <new>]
+          Acknowledge a NEEDS_ATTENTION mandate and re-arm it. Pass --token-id when a
+          fire landed but the runner could not work out which position replaced the
+          old one; it is validated against the mandate's pool, signer and far edge
+          before being adopted.
+
+Global: --chain <key|id>  (default robinhood)   --rpc <url>   --signer-env <VAR>
+        --from <addr>     plan-only, no key, can never broadcast
+
+Milestones are measured against the ORIGINAL principal: 100k with --steps 30,60,100 fires
+when 70k, then 40k, then 0 is left. Three fires, then the mandate completes.
+"""
+
+STATE_ARMED = "ARMED"
+STATE_FIRE_SENT = "FIRE_SENT"
+STATE_COMPLETE = "COMPLETE"
+STATE_NEEDS_ATTENTION = "NEEDS_ATTENTION"
+STATE_DISARMED = "DISARMED"
+STATE_EXPIRED = "EXPIRED"
+
+TERMINAL_STATES = {STATE_COMPLETE, STATE_DISARMED, STATE_EXPIRED, STATE_NEEDS_ATTENTION}
+
+# A tick skips NEEDS_ATTENTION, but an arm must not: that mandate is waiting for a human and
+# still owns its position. The two sets are deliberately different, not an oversight.
+FINISHED_STATES = {STATE_COMPLETE, STATE_DISARMED, STATE_EXPIRED}
+
+# What makes two mandates the same *instruction*. Everything else in ``immutable`` is either
+# a measurement taken at arm time — ``originalPrincipalRaw`` is read off the chain and moves
+# with the price — or a display string. Counting those as terms would mean an honest re-run
+# of the same setup could never be recognised as one.
+POLICY_FIELDS: tuple[str, ...] = (
+    "chainId",
+    "positionManager",
+    "poolId",
+    "signer",
+    "principal",
+    "farEdgeTick",
+    "stepsBps",
+)
+
+DEFAULT_MAX_ATTEMPTS = 5
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _big(value) -> int:
+    """Read back an integer the journal may have stored as a string."""
+    return int(str(value))
+
+
+def _token_map(info0: dict, info1: dict) -> dict:
+    return {info0["address"].lower(): info0, info1["address"].lower(): info1}
+
+
+def _principal_info(mandate: dict, info0: dict, info1: dict) -> tuple[dict, dict]:
+    """``(principal, harvested)`` token info, in that order."""
+    if mandate["immutable"]["principal"] == CURRENCY0:
+        return info0, info1
+    return info1, info0
+
+
+def _emit(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, default=str))
+
+
+def _client(chain: dict, args: dict) -> RpcClient:
+    return RpcClient(chain, args.get("rpc"))
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+# Events whose loss cannot cause the runner to act wrongly, because the state they carry is
+# re-derived from the chain on the next tick. Listing them out rather than defaulting to
+# "ignore" means a future event type cannot be added and silently skipped by the replay.
+REPLAY_IGNORED = {
+    "armed", "plan.built", "plan.rejected", "tick.noop", "tick.dryrun",
+    "milestone.reached", "reconcile.adopted", "complete", "needs_attention",
+}
+
+
+def replay_tail(mandate: dict, records: list[dict]) -> dict:
+    """Re-apply journalled records the mandate file never got to see.
+
+    Every side effect appends its outcome and fsyncs *before* the mandate file is replaced,
+    so a crash in that window leaves the log ahead of the view. Most of those records need
+    no replay: the state they describe — a fire that landed, a milestone that came due — is
+    re-derived from the chain a moment later, and re-deriving is more trustworthy than
+    replaying anyway.
+
+    ``tx.sent`` is the exception, and it is the one that matters. Lose it and the mandate
+    reads ``ARMED`` with no fire in flight, so the next tick plans that same milestone again
+    and broadcasts a second transaction. The single-transaction design keeps that from
+    duplicating anything — both transactions burn the *same* NFT, so whichever loses reverts
+    — but the survivor is then a transaction the mandate has no record of, and the recovery
+    scan starts from the wrong block and lands in ``NEEDS_ATTENTION``. Cheaper to not lose
+    the record.
+    """
+    for record in records:
+        event = record.get("event")
+        if event == "tx.sent":
+            mandate["state"] = STATE_FIRE_SENT
+            mandate["currentFire"] = record.get("currentFire") or mandate.get("currentFire")
+            if record.get("milestonesFired") is not None:
+                mandate["milestonesFired"] = int(record["milestonesFired"])
+        elif event == "tx.dropped":
+            # Ordering matters: a tail of [tx.sent, tx.dropped] must end at ARMED.
+            mandate["state"] = STATE_ARMED
+            mandate["currentFire"] = None
+            if record.get("attempt") is not None:
+                mandate["attempt"] = int(record["attempt"])
+        elif event == "expired":
+            mandate["state"] = STATE_EXPIRED
+        elif event == "disarmed":
+            # The one an operator would notice: a disarm that crashed before the replace
+            # would otherwise leave a mandate live that they were told was off.
+            mandate["state"] = STATE_DISARMED
+        elif event == "state.changed" and record.get("to"):
+            mandate["state"] = str(record["to"])
+            mandate["currentFire"] = None
+        elif event not in REPLAY_IGNORED:
+            raise RuntimeError(
+                f"journal holds an unreplayed {event!r} record the runner does not know how "
+                "to interpret. Refusing to run on a state it cannot reconstruct."
+            )
+    return mandate
+
+
+# ---------------------------------------------------------------------------
+# arm
+# ---------------------------------------------------------------------------
+
+
+def build_mandate(client, chain: dict, args: dict, signer: dict) -> dict:
+    token_id = int(require_arg(args, "token-id", "the position NFT to ratchet"))
+    position = lp_write.load_position_for_write(client, chain, token_id)
+    pool_key = position["poolKey"]
+    lp_write.hook_gate(pool_key, args)
+
+    if position["owner"] and position["owner"].lower() != signer["address"].lower():
+        raise RuntimeError(
+            f"position #{token_id} is owned by {position['owner']}, not {signer['address']}. "
+            "A mandate can only manage a position its own signer holds."
+        )
+    if position["liquidity"] <= 0:
+        raise RuntimeError(f"position #{token_id} holds no liquidity — nothing to ratchet")
+
+    pool = lp_write.load_pool_state(client, chain, position["poolId"], pool_key)
+    principal = principal_for_range(pool["tick"], position["tickLower"],
+                                    position["tickUpper"])
+    far_edge = far_edge_tick(position["tickLower"], position["tickUpper"], principal)
+    original = remaining_principal(pool["sqrtPriceX96"], position["tickLower"],
+                                   position["tickUpper"], position["liquidity"], principal)
+    if original <= 0:
+        raise RuntimeError(
+            "the position holds none of its principal currency already — it is fully "
+            "converted, so there is nothing for a ratchet to do"
+        )
+
+    steps = parse_steps(args.get("steps"))
+    thresholds = milestone_thresholds(original, steps)
+
+    expires_days = args.get("expires-days")
+    max_per_fire = args.get("max-principal-per-fire")
+    info0 = lp_write.token_info(client, chain, pool_key["currency0"])
+    info1 = lp_write.token_info(client, chain, pool_key["currency1"])
+    principal_info = info0 if principal == CURRENCY0 else info1
+
+    immutable = {
+        "schemaVersion": SCHEMA_VERSION,
+        "chainId": chain["chainId"],
+        "chainKey": chain["key"],
+        "positionManager": chain["positionManager"],
+        # poolId IS keccak(PoolKey), so pinning it pins the currencies, the fee, the tick
+        # spacing and — the one that matters for an unattended run — the hook address.
+        "poolId": position["poolId"],
+        "poolKey": pool_key,
+        "signer": signer["address"],
+        "originalTokenId": token_id,
+        "principal": principal,
+        "farEdgeTick": far_edge,
+        "originalTickLower": position["tickLower"],
+        "originalTickUpper": position["tickUpper"],
+        "originalPrincipalRaw": str(original),
+        "stepsBps": steps,
+        "label": args.get("label") or "",
+    }
+
+    return {
+        "immutable": immutable,
+        "bounds": {
+            "maxSlippageBps": int(args.get("slippage-bps") or lp_write.DEFAULT_SLIPPAGE_BPS),
+            "maxDeadlineSecs": lp_write.deadline_offset(args),
+            "maxTickDrift": int(args.get("max-tick-drift") or pool_key["tickSpacing"]),
+            "allowHooked": bool(args.get("allow-hooked")),
+            "maxAttempts": int(args.get("max-attempts") or DEFAULT_MAX_ATTEMPTS),
+            "maxPrincipalRawPerFire": (
+                str(lp_write.parse_amount(max_per_fire, principal_info["decimals"]))
+                if max_per_fire else None
+            ),
+            "maxFeePerGasWei": (
+                str(int(str(args["max-fee-per-gas"]).replace("_", "")))
+                if args.get("max-fee-per-gas") else None
+            ),
+            "expiresAt": _now() + int(float(expires_days) * 86_400) if expires_days else None,
+        },
+        "state": STATE_ARMED,
+        "tokenId": token_id,
+        "tickLower": position["tickLower"],
+        "tickUpper": position["tickUpper"],
+        "liquidity": str(position["liquidity"]),
+        "thresholds": [str(t) for t in thresholds],
+        "milestonesFired": 0,
+        "currentFire": None,
+        "realized": {"amount0": "0", "amount1": "0"},
+        "lastSeq": 0,
+        "createdAt": _now(),
+        "history": [],
+    }
+
+
+def find_position_conflict(root, chain_key: str, ident: str, immutable: dict) -> dict | None:
+    """A live mandate already driving this position, or ``None``.
+
+    ``mandate_id`` hashes ``label`` along with the terms, so arming one position twice under
+    two names yields two ids, two files and two mandates that each intend to burn the same
+    NFT. ``store.exists()`` cannot see that — the ids differ by construction — so uniqueness
+    per position has to be a scan. It is cheap: arming is rare and human-supervised.
+
+    A mandate that no longer hashes to its own filename raises out of here rather than being
+    skipped. That file might BE the duplicate, and what an arm authorizes is unattended
+    broadcasts; refusing to proceed past an unreadable one is the only honest option.
+    """
+    root = Path(root)
+    token_id = int(immutable["originalTokenId"])
+    for other in MandateStore.list_ids(root, str(chain_key)):
+        if other == ident:
+            continue
+        mandate = MandateStore(root, str(chain_key), other).load()
+        if not mandate or mandate.get("state") in FINISHED_STATES:
+            continue
+        # The CURRENT tokenId, not the original: a mandate rolls forward onto the position
+        # each fire mints, and that new one is just as taken as the one it started with.
+        if int(mandate.get("tokenId", -1)) != token_id:
+            continue
+        theirs = mandate.get("immutable") or {}
+        differs = [name for name in POLICY_FIELDS
+                   if canonical_json(theirs.get(name)) != canonical_json(immutable.get(name))]
+        return {
+            "id": other,
+            "state": mandate.get("state"),
+            "sameTerms": not differs,
+            "differs": differs,
+            "milestonesFired": int(mandate.get("milestonesFired") or 0),
+            "label": theirs.get("label") or "",
+        }
+    return None
+
+
+def pending_remint_mandates(root, chain_key: str, signer: str, pool_id: str) -> list[str]:
+    """Mandates halted because a landed fire's replacement position was never identified.
+
+    The one duplicate :func:`find_position_conflict` structurally cannot catch: such a
+    mandate still names the tokenId that was burned, so arming the position it actually
+    minted collides with nothing. Arming it would restart the milestone schedule against a
+    remainder, which is the mistake the halt note warns about — hence a warning here, not a
+    refusal, since a second position in the same pool is perfectly legitimate.
+    """
+    root = Path(root)
+    found = []
+    for other in MandateStore.list_ids(root, str(chain_key)):
+        mandate = MandateStore(root, str(chain_key), other).load()
+        if not mandate or mandate.get("state") != STATE_NEEDS_ATTENTION:
+            continue
+        imm = mandate.get("immutable") or {}
+        if str(imm.get("signer") or "").lower() != str(signer).lower():
+            continue
+        if str(imm.get("poolId") or "").lower() != str(pool_id).lower():
+            continue
+        history = mandate.get("history") or []
+        if history and history[-1].get("newTokenId") is None:
+            found.append(other)
+    return sorted(found)
+
+
+def cmd_arm(client, chain: dict, args: dict, signer: dict) -> None:
+    mandate = build_mandate(client, chain, args, signer)
+    imm = mandate["immutable"]
+    ident = mandate_id(imm)
+
+    # Before the table, not after --confirm: a duplicate is not something the operator should
+    # find out about only once they have read a screenful and typed the hash back.
+    conflict = find_position_conflict(state_root(), chain["key"], ident, imm)
+    if conflict is not None:
+        if not conflict["sameTerms"]:
+            raise RuntimeError(
+                f"position #{imm['originalTokenId']} is already armed as {conflict['id']} "
+                f"[{conflict['state']}], and this arm differs in: "
+                f"{', '.join(conflict['differs'])}. Both mandates would burn the same NFT. "
+                f"`disarm --id {conflict['id']}` first if these are the terms you want."
+            )
+        label = f"  ({conflict['label']})" if conflict["label"] else ""
+        print(f"\n  Position #{imm['originalTokenId']} is already armed as "
+              f"{conflict['id']}{label}  [{conflict['state']}, "
+              f"{conflict['milestonesFired']} of {len(imm['stepsBps'])} milestones fired].")
+        print("  Identical terms — nothing created, nothing changed. Re-running the same "
+              "setup is not an error.")
+        print(f"  `status --id {conflict['id']}` to inspect it, "
+              f"`disarm --id {conflict['id']}` to replace it.")
+        return
+
+    pool = lp_write.load_pool_state(client, chain, imm["poolId"], imm["poolKey"])
+    info0 = lp_write.token_info(client, chain, imm["poolKey"]["currency0"])
+    info1 = lp_write.token_info(client, chain, imm["poolKey"]["currency1"])
+    principal_info, harvest_info = _principal_info(mandate, info0, info1)
+    principal = imm["principal"]
+    original = _big(imm["originalPrincipalRaw"])
+
+    known = {k.lower() for k in (chain.get("knownQuotes") or [])}
+    if principal_info["address"].lower() in known:
+        intent = f"limit BUY {harvest_info['symbol']} with {principal_info['symbol']}"
+    elif harvest_info["address"].lower() in known:
+        intent = f"limit SELL {principal_info['symbol']} for {harvest_info['symbol']}"
+    else:
+        intent = (f"selling {principal_info['symbol']} for {harvest_info['symbol']} "
+                  "(neither side is a known quote — the label is a guess, the geometry is not)")
+
+    rows = [
+        ["mandate", ident + (f"  ({imm['label']})" if imm["label"] else "")],
+        ["signer", signer["address"] + ("  (plan-only, --from)" if signer["simulateOnly"]
+                                        else "")],
+        ["position", f"#{imm['originalTokenId']}  ticks {imm['originalTickLower']} → "
+                     f"{imm['originalTickUpper']}"],
+        ["pool", f"{short_id(imm['poolId'])}  {info0['symbol']}/{info1['symbol']}"],
+        ["hooks", "none" if imm["poolKey"]["hooks"] == lp_write.NATIVE
+                  else f"{imm['poolKey']['hooks']} "
+                       f"{format_hook_flags(imm['poolKey']['hooks'])}"],
+        ["reading", intent],
+        ["token0", f"{info0['symbol']}  {info0['address']}"],
+        ["token1", f"{info1['symbol']}  {info1['address']}"],
+        ["principal", f"{principal} = {principal_info['symbol']}  "
+                      "(the side that is redeployed each fire)"],
+        ["harvested", f"{harvest_info['symbol']}  (stays in the wallet as realized profit)"],
+        ["far edge", f"tick {imm['farEdgeTick']}  "
+                     f"({'tickUpper' if principal == CURRENCY0 else 'tickLower'})"],
+        ["fills as tick", "RISES" if fills_as_tick_rises(principal) else "FALLS"],
+        ["current tick", str(pool["tick"])],
+        ["original principal", f"{fmt_units(original, principal_info['decimals'])} "
+                               f"{principal_info['symbol']}"],
+    ]
+
+    for index, (step, threshold) in enumerate(zip(imm["stepsBps"], mandate["thresholds"])):
+        target = _big(threshold)
+        trigger = tick_for_remaining(mandate["tickLower"], mandate["tickUpper"],
+                                     _big(mandate["liquidity"]), target, principal)
+        note = "exit only, no re-arm" if index == len(imm["stepsBps"]) - 1 else "re-arm"
+        rows.append([
+            f"milestone {step / 100:g}%",
+            f"fires when ≤ {fmt_units(target, principal_info['decimals'])} "
+            f"{principal_info['symbol']} is left  →  tick {trigger}  "
+            f"(price {raw_price_at_tick(trigger):.6g})  [{note}]",
+        ])
+
+    bounds = mandate["bounds"]
+    rows.extend([
+        ["slippage", f"{bounds['maxSlippageBps']} bps"],
+        ["max tick drift", str(bounds["maxTickDrift"])],
+        ["hooked pool", "allowed" if bounds["allowHooked"] else "refused"],
+        ["max principal / fire", "unlimited" if not bounds["maxPrincipalRawPerFire"]
+         else f"{fmt_units(_big(bounds['maxPrincipalRawPerFire']), principal_info['decimals'])}"
+              f" {principal_info['symbol']}"],
+        ["max fee per gas", bounds["maxFeePerGasWei"] or "unlimited"],
+        ["expires", "never" if not bounds["expiresAt"]
+         else time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(bounds["expiresAt"]))],
+        ["state dir", str(state_root() / "ratchet" / chain["key"])],
+    ])
+
+    print(heading(f"ratchet mandate on {chain['name']}"))
+    print(render_kv(rows))
+    print("\n  Once armed, `tick --broadcast` may send these transactions with nobody "
+          "watching.")
+    print("  It is bound to this exact tokenId, pool, hook and signer, and to the "
+          "milestones above.")
+
+    stranded = pending_remint_mandates(state_root(), chain["key"], signer["address"],
+                                       imm["poolId"])
+    if stranded:
+        print(f"\n  WARNING: mandate(s) {', '.join(stranded)} landed a fire in this pool but "
+              "never identified the position it minted.")
+        print(f"  If #{imm['originalTokenId']} is that position, arming it here restarts the "
+              "milestone schedule against what is left of the principal.")
+        print("  Hand it back instead:  clear-attention --id <m> --token-id "
+              f"{imm['originalTokenId']}")
+
+    print(f"\n  MANDATE_HASH: {ident}")
+
+    if args.get("confirm") != ident:
+        if args.get("confirm"):
+            raise RuntimeError(
+                f'--confirm mismatch: got "{args["confirm"]}", this mandate is "{ident}". '
+                "The parameters changed since it was shown; re-read the table above."
+            )
+        print("\n  DRY RUN — nothing armed.")
+        print(f"  To arm, re-run the identical command with:  --confirm {ident}")
+        return
+    if signer["simulateOnly"]:
+        raise RuntimeError("--from is plan-only; drop it and set the signing key to arm")
+
+    store = MandateStore(state_root(), chain["key"], ident)
+    with store.lock() as acquired:
+        if not acquired:
+            raise RuntimeError(f"another process holds mandate {ident}")
+        if store.exists():
+            raise RuntimeError(
+                f"mandate {ident} already exists — `status --id {ident}` to inspect it, "
+                f"`disarm --id {ident}` to replace it"
+            )
+        store.append({"event": "armed", "state": STATE_ARMED,
+                      "tokenId": mandate["tokenId"],
+                      "thresholds": mandate["thresholds"]})
+        mandate["lastSeq"] = store.last_seq()
+        store.save(mandate)
+    print("\n  ARMED. Wire it to cron with:  ratchet.py tick --all --broadcast --json")
+
+
+# ---------------------------------------------------------------------------
+# Planning a fire
+# ---------------------------------------------------------------------------
+
+
+def plan_fire(client, chain: dict, mandate: dict, milestone_index: int) -> dict:
+    """Everything the fire needs, computed from fresh chain state.
+
+    Returns a dict with the plan, the amounts, and the re-arm decision. Raises on anything
+    that means the mandate should stop rather than send.
+    """
+    imm = mandate["immutable"]
+    principal = imm["principal"]
+    bps = int(mandate["bounds"]["maxSlippageBps"])
+
+    position = lp_write.load_position_for_write(client, chain, mandate["tokenId"])
+    if position["poolId"] != imm["poolId"]:
+        raise RuntimeError(
+            f"position #{mandate['tokenId']} now reports pool {position['poolId']}, "
+            f"the mandate is pinned to {imm['poolId']}"
+        )
+    lp_write.hook_gate(position["poolKey"], {"allow-hooked": mandate["bounds"]["allowHooked"]})
+    if position["liquidity"] <= 0:
+        raise RuntimeError("position holds no liquidity")
+
+    pool = lp_write.load_pool_state(client, chain, imm["poolId"], position["poolKey"])
+    sqrt_lower = get_sqrt_ratio_at_tick(position["tickLower"])
+    sqrt_upper = get_sqrt_ratio_at_tick(position["tickUpper"])
+    exiting = get_amounts_for_liquidity(pool["sqrtPriceX96"], sqrt_lower, sqrt_upper,
+                                        position["liquidity"])
+    amount0_min = lp_write.with_slippage_down(exiting["amount0"], bps)
+    amount1_min = lp_write.with_slippage_down(exiting["amount1"], bps)
+
+    remainder = exiting["amount0"] if principal == CURRENCY0 else exiting["amount1"]
+    cap = mandate["bounds"].get("maxPrincipalRawPerFire")
+    if cap and remainder > _big(cap):
+        raise RuntimeError(
+            f"the fire would redeploy {remainder} of the principal, over the "
+            f"{_big(cap)} per-fire bound"
+        )
+
+    final = milestone_index >= len(imm["stepsBps"]) - 1
+    remint = None
+    new_lower = new_upper = None
+    required = {"amount0": 0, "amount1": 0}
+
+    if not final:
+        try:
+            new_lower, new_upper = rearm_range(pool["tick"], imm["farEdgeTick"],
+                                               position["poolKey"]["tickSpacing"], principal)
+            # Haircut first, size second. The mint is funded by the delta the decrease just
+            # credited inside the same unlock, so redeploying the full remainder would put
+            # the net delta one rounding step underwater and TAKE_PAIR would revert.
+            budget = lp_write.with_slippage_down(remainder, bps)
+            sqrt_new_lower = get_sqrt_ratio_at_tick(new_lower)
+            sqrt_new_upper = get_sqrt_ratio_at_tick(new_upper)
+            liquidity_new = (
+                get_liquidity_for_amount0(sqrt_new_lower, sqrt_new_upper, budget)
+                if principal == CURRENCY0
+                else get_liquidity_for_amount1(sqrt_new_lower, sqrt_new_upper, budget)
+            )
+            if liquidity_new <= 0:
+                raise RangeExhaustedError(
+                    "the remainder is too small to make a position in the re-armed range"
+                )
+            required = get_amounts_for_liquidity(pool["sqrtPriceX96"], sqrt_new_lower,
+                                                 sqrt_new_upper, liquidity_new, True)
+            other = required["amount1"] if principal == CURRENCY0 else required["amount0"]
+            if other != 0:
+                raise RuntimeError(
+                    f"re-armed range {new_lower} → {new_upper} is not one-sided at tick "
+                    f"{pool['tick']}: it would also need {other} of the harvested currency. "
+                    "Refusing to send."
+                )
+            need = required["amount0"] if principal == CURRENCY0 else required["amount1"]
+            if need > remainder:
+                raise RuntimeError(
+                    f"re-mint would need {need} but the exit only frees {remainder}"
+                )
+            remint = {
+                "tickLower": new_lower,
+                "tickUpper": new_upper,
+                "liquidity": liquidity_new,
+                "amount0Max": (lp_write.with_slippage_up(required["amount0"], bps)
+                               if required["amount0"] else 0),
+                "amount1Max": (lp_write.with_slippage_up(required["amount1"], bps)
+                               if required["amount1"] else 0),
+            }
+        except RangeExhaustedError:
+            # The price ran past the far edge, or what is left cannot fill a tickSpacing.
+            # Either way there is nothing to re-arm, so this fire is the last one.
+            final = True
+            remint = None
+
+    plan = build_ratchet_plan(
+        position["poolKey"], mandate["tokenId"], position["liquidity"],
+        amount0_min, amount1_min, imm["signer"], remint,
+    )
+
+    return {
+        "position": position,
+        "pool": pool,
+        "plan": plan,
+        "exiting": exiting,
+        "required": required,
+        "remainder": remainder,
+        "amount0Min": amount0_min,
+        "amount1Min": amount1_min,
+        "remint": remint,
+        "final": final,
+        "newLower": new_lower,
+        "newUpper": new_upper,
+    }
+
+
+def hash_fields(chain: dict, mandate: dict, fire: dict, milestone_index: int,
+                deadline_secs: int) -> dict:
+    remint = fire["remint"]
+    return {
+        "chainId": chain["chainId"],
+        "to": chain["positionManager"],
+        "cmd": "ratchet",
+        "mandateId": mandate_id(mandate["immutable"]),
+        "milestone": int(milestone_index),
+        "tokenId": lp_write.Big(mandate["tokenId"]),
+        "liquidity": lp_write.Big(fire["position"]["liquidity"]),
+        "amount0Min": lp_write.Big(fire["amount0Min"]),
+        "amount1Min": lp_write.Big(fire["amount1Min"]),
+        "remintTickLower": remint["tickLower"] if remint else None,
+        "remintTickUpper": remint["tickUpper"] if remint else None,
+        "remintLiquidity": lp_write.Big(remint["liquidity"]) if remint else None,
+        "remintAmount0Max": lp_write.Big(remint["amount0Max"]) if remint else None,
+        "remintAmount1Max": lp_write.Big(remint["amount1Max"]) if remint else None,
+        "recipient": mandate["immutable"]["signer"],
+        "deadlineSecs": int(deadline_secs),
+        "signer": mandate["immutable"]["signer"],
+    }
+
+
+def make_predicate(chain: dict, mandate: dict, milestone_index: int):
+    """The bounds check that stands in for a human echoing back the PLAN_HASH.
+
+    It runs at the gate inside ``run_plan``, after the simulation and before the send, and
+    checks ``ctx["hashFields"]`` — the same dict the hash was computed from. Selftest tier 6
+    pins that this dict covers every calldata-affecting parameter, which makes checking the
+    fields strictly stronger than comparing the digest string.
+    """
+    imm = mandate["immutable"]
+    bounds = mandate["bounds"]
+
+    def check(client, chain_arg, args, signer, ctx, hash_value):
+        fields = ctx["hashFields"]
+
+        def want(key, expected):
+            if fields.get(key) != expected:
+                raise RuntimeError(
+                    f"mandate refuses the plan: {key} is {fields.get(key)!r}, "
+                    f"expected {expected!r}"
+                )
+
+        want("cmd", "ratchet")
+        want("chainId", imm["chainId"])
+        want("to", imm["positionManager"])
+        want("mandateId", mandate_id(imm))
+        want("milestone", int(milestone_index))
+        want("recipient", imm["signer"])
+        want("signer", imm["signer"])
+        if int(fields["tokenId"]) != int(mandate["tokenId"]):
+            raise RuntimeError("mandate refuses the plan: tokenId is not the pinned position")
+        if signer["address"].lower() != imm["signer"].lower():
+            raise RuntimeError(
+                f"mandate refuses the plan: signing key derives {signer['address']}, the "
+                f"mandate was armed by {imm['signer']}"
+            )
+        if signer["simulateOnly"]:
+            raise RuntimeError("mandate refuses the plan: plan-only signer cannot broadcast")
+        if int(fields["deadlineSecs"]) > int(bounds["maxDeadlineSecs"]):
+            raise RuntimeError("mandate refuses the plan: deadline is longer than approved")
+        if milestone_index < int(mandate["milestonesFired"]):
+            raise RuntimeError(
+                f"mandate refuses the plan: milestone {milestone_index} already fired"
+            )
+        if bounds.get("expiresAt") and _now() > int(bounds["expiresAt"]):
+            raise RuntimeError("mandate refuses the plan: the mandate has expired")
+
+        # Re-read the chain rather than trusting the planner that ran moments ago.
+        position = lp_write.load_position_for_write(client, chain_arg, mandate["tokenId"])
+        if position["poolId"] != imm["poolId"]:
+            raise RuntimeError("mandate refuses the plan: the position changed pool")
+        if compute_pool_id(position["poolKey"]) != imm["poolId"]:
+            raise RuntimeError("mandate refuses the plan: PoolKey no longer hashes to poolId")
+        lp_write.hook_gate(position["poolKey"], {"allow-hooked": bounds["allowHooked"]})
+        if int(fields["liquidity"]) != int(position["liquidity"]):
+            raise RuntimeError(
+                "mandate refuses the plan: it does not remove the position's full liquidity"
+            )
+
+        pool = lp_write.load_pool_state(client, chain_arg, imm["poolId"], position["poolKey"])
+        exiting = get_amounts_for_liquidity(
+            pool["sqrtPriceX96"], get_sqrt_ratio_at_tick(position["tickLower"]),
+            get_sqrt_ratio_at_tick(position["tickUpper"]), position["liquidity"],
+        )
+        floor0 = lp_write.with_slippage_down(exiting["amount0"], bounds["maxSlippageBps"])
+        floor1 = lp_write.with_slippage_down(exiting["amount1"], bounds["maxSlippageBps"])
+        if int(fields["amount0Min"]) < floor0 or int(fields["amount1Min"]) < floor1:
+            raise RuntimeError(
+                "mandate refuses the plan: slippage floors are looser than approved"
+            )
+
+        if fields["remintTickLower"] is None:
+            return  # exit-only fire; nothing further to bind
+
+        principal = imm["principal"]
+        # The far edge never moves; only the near edge tracks the price.
+        if principal == CURRENCY0:
+            want("remintTickUpper", imm["farEdgeTick"])
+        else:
+            want("remintTickLower", imm["farEdgeTick"])
+
+        fresh_lower, fresh_upper = rearm_range(
+            pool["tick"], imm["farEdgeTick"], position["poolKey"]["tickSpacing"], principal
+        )
+        drift = int(bounds["maxTickDrift"])
+        near_planned = (int(fields["remintTickLower"]) if principal == CURRENCY0
+                        else int(fields["remintTickUpper"]))
+        near_fresh = fresh_lower if principal == CURRENCY0 else fresh_upper
+        if abs(near_fresh - near_planned) > drift:
+            raise RuntimeError(
+                f"mandate refuses the plan: the pool moved, re-arm edge would now be "
+                f"{near_fresh} not {near_planned} (drift > {drift})"
+            )
+        # The direction that actually breaks the add: for a currency0 re-arm the price
+        # rising past the planned lower tick turns the range two-sided and the mint reverts.
+        # Drift the other way is harmless, so this is asserted one-sided rather than by
+        # tightening maxTickDrift, which would abort on the harmless direction too.
+        if principal == CURRENCY0 and pool["tick"] >= near_planned:
+            raise RuntimeError(
+                f"mandate refuses the plan: tick {pool['tick']} has reached the re-arm "
+                f"lower edge {near_planned}; the range would not be one-sided"
+            )
+        if principal != CURRENCY0 and pool["tick"] < near_planned:
+            raise RuntimeError(
+                f"mandate refuses the plan: tick {pool['tick']} is below the re-arm "
+                f"upper edge {near_planned}; the range would not be one-sided"
+            )
+
+        # The cheapest possible proof that the re-mint really is one-sided.
+        other_max = (fields["remintAmount1Max"] if principal == CURRENCY0
+                     else fields["remintAmount0Max"])
+        if int(other_max) != 0:
+            raise RuntimeError(
+                "mandate refuses the plan: the re-mint would spend the harvested currency"
+            )
+
+        # Everything above binds the *shape* of the re-mint. This binds its size, which is
+        # the invariant the whole design rests on: the mint is funded entirely by the delta
+        # the decrease just credited inside the same unlock, and that is what lets the plan
+        # omit a SETTLE leg. Recomputed here from the liquidity actually in the calldata
+        # rather than taken from the planner, because reproducing the planner's arithmetic
+        # is precisely what a gate is for.
+        remint_liquidity = int(fields["remintLiquidity"])
+        if remint_liquidity <= 0:
+            raise RuntimeError("mandate refuses the plan: the re-mint carries no liquidity")
+        need = get_amounts_for_liquidity(
+            pool["sqrtPriceX96"],
+            get_sqrt_ratio_at_tick(int(fields["remintTickLower"])),
+            get_sqrt_ratio_at_tick(int(fields["remintTickUpper"])),
+            remint_liquidity, True,
+        )
+        need_principal = need["amount0"] if principal == CURRENCY0 else need["amount1"]
+        need_other = need["amount1"] if principal == CURRENCY0 else need["amount0"]
+        free_principal = (exiting["amount0"] if principal == CURRENCY0
+                          else exiting["amount1"])
+        if need_other != 0:
+            # Unreachable while the directional assertion above holds — a range that needs
+            # the harvested currency is one that contains the current price, which that
+            # check already refused. Kept as a tripwire, derived from amounts rather than
+            # from a tick comparison, so that loosening the check above fails loudly here
+            # instead of quietly letting a two-sided mint through. No test can isolate it
+            # without first disabling its neighbour.
+            raise RuntimeError(
+                f"mandate refuses the plan: at tick {pool['tick']} that liquidity would "
+                f"also need {need_other} of the harvested currency — the range is not "
+                "one-sided any more"
+            )
+        if need_principal > free_principal:
+            raise RuntimeError(
+                f"mandate refuses the plan: the re-mint needs {need_principal} of the "
+                f"principal but the exit only frees {free_principal}"
+            )
+        principal_max = (fields["remintAmount0Max"] if principal == CURRENCY0
+                         else fields["remintAmount1Max"])
+        if int(principal_max) > free_principal:
+            raise RuntimeError(
+                f"mandate refuses the plan: it authorizes spending up to {principal_max} "
+                f"on the re-mint, more than the {free_principal} the exit frees"
+            )
+
+    return check
+
+
+# ---------------------------------------------------------------------------
+# tick
+# ---------------------------------------------------------------------------
+
+
+def fire_rows(chain: dict, mandate: dict, fire: dict, info0: dict, info1: dict,
+              milestone_index: int) -> list:
+    imm = mandate["immutable"]
+    principal_info, harvest_info = _principal_info(mandate, info0, info1)
+    step = imm["stepsBps"][milestone_index] / 100
+    return [
+        ["mandate", mandate_id(imm) + (f"  ({imm['label']})" if imm["label"] else "")],
+        ["milestone", f"{step:g}%  ({milestone_index + 1} of {len(imm['stepsBps'])})"],
+        ["position", f"#{mandate['tokenId']}  ticks {fire['position']['tickLower']} → "
+                     f"{fire['position']['tickUpper']}"],
+        ["current tick", str(fire["pool"]["tick"])],
+        ["exiting", f"{fmt_units(fire['exiting']['amount0'], info0['decimals'])} "
+                    f"{info0['symbol']} + "
+                    f"{fmt_units(fire['exiting']['amount1'], info1['decimals'])} "
+                    f"{info1['symbol']} + fees"],
+        ["principal left", f"{fmt_units(fire['remainder'], principal_info['decimals'])} "
+                           f"{principal_info['symbol']}"],
+        ["re-arm", "none — final milestone, the position is closed for good"
+                   if fire["final"] else
+                   f"{fmt_units(fire['required']['amount0'] or fire['required']['amount1'], principal_info['decimals'])} "  # noqa: E501
+                   f"{principal_info['symbol']} into ticks {fire['newLower']} → "
+                   f"{fire['newUpper']}"],
+        ["harvested to wallet", f"{harvest_info['symbol']} (plus fees in both currencies)"],
+        ["recipient", imm["signer"]],
+        ["actions", describe_actions(fire["plan"]["actions"])],
+        ["authorized by", "mandate (unattended) — no PLAN_HASH echo"],
+    ]
+
+
+def run_fire(client, chain: dict, args: dict, signer: dict, store: MandateStore,
+             mandate: dict, milestone_index: int, broadcast: bool) -> dict:
+    """Plan, journal, and (when broadcasting) send one milestone's transaction."""
+    imm = mandate["immutable"]
+    fire = plan_fire(client, chain, mandate, milestone_index)
+    info0 = lp_write.token_info(client, chain, imm["poolKey"]["currency0"])
+    info1 = lp_write.token_info(client, chain, imm["poolKey"]["currency1"])
+
+    deadline_secs = int(mandate["bounds"]["maxDeadlineSecs"])
+    block = client.get_block()
+    deadline = int(block["timestamp"], 16) + deadline_secs
+    fields = hash_fields(chain, mandate, fire, milestone_index, deadline_secs)
+    plan_hash_value = lp_write.plan_hash(fields)
+    fire_id = f"{mandate_id(imm)}:{milestone_index}:{mandate.get('attempt', 0)}"
+
+    principal_info, harvest_info = _principal_info(mandate, info0, info1)
+    principal_delta = fire["remainder"] - (
+        fire["required"]["amount0"] if imm["principal"] == CURRENCY0
+        else fire["required"]["amount1"]
+    )
+    harvested = (fire["exiting"]["amount1"] if imm["principal"] == CURRENCY0
+                 else fire["exiting"]["amount0"])
+
+    store.append({
+        "event": "plan.built", "fireId": fire_id, "milestone": milestone_index,
+        "planHash": plan_hash_value, "tick": fire["pool"]["tick"],
+        "remainderRaw": str(fire["remainder"]), "final": fire["final"],
+        "remintTickLower": fire["newLower"], "remintTickUpper": fire["newUpper"],
+    })
+
+    write_args = dict(args)
+    write_args["deadline-secs"] = deadline_secs
+    write_args["broadcast"] = bool(broadcast)
+    write_args.pop("confirm", None)
+    if mandate["bounds"].get("maxFeePerGasWei"):
+        write_args["max-fee-per-gas"] = mandate["bounds"]["maxFeePerGasWei"]
+
+    sent_record: dict = {}
+
+    def on_sent(info: dict) -> None:
+        # Durability point: the hash and nonce reach the disk before the broadcast leaves
+        # this process. A crash here is recoverable; a broadcast with nothing written is not.
+        sent_record.update(info)
+        current = {
+            "fireId": fire_id, "milestone": milestone_index,
+            "attempt": int(mandate.get("attempt", 0)),
+            "planHash": plan_hash_value, "final": fire["final"],
+            "plannedTick": fire["pool"]["tick"],
+            "plannedRemainderRaw": str(fire["remainder"]),
+            "remintTickLower": fire["newLower"], "remintTickUpper": fire["newUpper"],
+            "tx": {k: (str(v) if isinstance(v, int) and abs(v) > 2**53 else v)
+                   for k, v in info.items()},
+        }
+        mandate["state"] = STATE_FIRE_SENT
+        mandate["currentFire"] = current
+        # The whole fire record goes into the log line, not just the hash. This record has
+        # to be able to rebuild `currentFire` on its own: if the crash lands between here
+        # and the save below, it is the only surviving evidence that anything was signed,
+        # and `replay_tail` has nothing else to work from.
+        mandate["lastSeq"] = store.append({
+            "event": "tx.sent", "fireId": fire_id, "from": STATE_ARMED,
+            "to": STATE_FIRE_SENT, "currentFire": current,
+            "milestonesFired": int(mandate["milestonesFired"]), **info,
+        })
+        store.save(mandate)
+
+    ctx = {
+        "title": f"ratchet fire — milestone {imm['stepsBps'][milestone_index] / 100:g}% "
+                 f"on position #{mandate['tokenId']}",
+        "tokenMap": _token_map(info0, info1),
+        "rows": fire_rows(chain, mandate, fire, info0, info1, milestone_index),
+        "hashFields": fields,
+        "data": lp_write.encode_call(fire["plan"], deadline),
+        "value": fire["plan"]["value"],
+        "expected": {
+            principal_info["address"].lower(): {"amount": principal_delta, "mode": "atLeast"},
+            harvest_info["address"].lower(): {"amount": harvested, "mode": "atLeast"},
+        },
+        "rebuildData": lambda d: lp_write.encode_call(fire["plan"], d),
+        "onSent": on_sent,
+    }
+
+    authorization = None
+    if broadcast:
+        authorization = lp_write.MandateAuthorization(
+            mandate_id=mandate_id(imm), fire_id=fire_id,
+            predicate=make_predicate(chain, mandate, milestone_index),
+        )
+
+    receipt = lp_write.run_plan(client, chain, write_args, signer, ctx,
+                                authorization=authorization)
+    return {"fire": fire, "receipt": receipt, "fireId": fire_id,
+            "planHash": plan_hash_value, "sent": sent_record,
+            "info0": info0, "info1": info1}
+
+
+def adopt_landed_fire(client, chain: dict, store: MandateStore, mandate: dict,
+                      receipt: dict | None, new_token_id: int | None = None) -> str:
+    """Move a mandate forward after its fire is known to be on chain.
+
+    ``new_token_id`` is the escape hatch for the one case the oracles cannot close: the fire
+    landed, but neither the receipt nor the log scan could name the replacement position.
+    ``clear-attention --token-id`` supplies it, having validated it first — that path is
+    attended, so a human is the oracle. Everything downstream of the identification is the
+    same code either way, which is the point of threading it through here rather than
+    reimplementing the accounting in the command.
+    """
+    imm = mandate["immutable"]
+    current = mandate.get("currentFire") or {}
+    final = bool(current.get("final"))
+    old_token_id = int(mandate["tokenId"])
+
+    if not final and new_token_id is None:
+        if receipt:
+            minted = net_transfers(receipt.get("logs") or [], imm["signer"])["mintedNfts"]
+            candidates = [int(n["id"]) for n in minted if int(n["id"]) != old_token_id]
+            if len(candidates) == 1:
+                new_token_id = candidates[0]
+        if new_token_id is None:
+            # Oracle C. Deliberately gives up rather than guessing: a duplicate mint would
+            # deploy the remainder twice, which no amount of convenience is worth.
+            sent = current.get("tx") or {}
+            from_block = sent.get("sentAtBlock")
+            if from_block is not None:
+                new_token_id = find_minted_token_id(
+                    client, chain, imm["signer"], int(from_block), exclude={old_token_id}
+                )
+        if new_token_id is None:
+            mandate["state"] = STATE_NEEDS_ATTENTION
+            mandate["note"] = (
+                "the fire landed but the replacement position could not be identified. "
+                "Find the new tokenId with `lp_read.py positions --owner <signer>`, then "
+                "`clear-attention --id <m> --token-id <new>` to hand it back. Do not arm a "
+                "fresh mandate instead: arm would treat the remainder as a new original "
+                "principal and rebase every milestone still to come."
+            )
+            mandate["lastSeq"] = store.append({
+                "event": "needs_attention", "reason": "remint tokenId unknown",
+                "fireId": current.get("fireId"),
+            })
+            store.save(mandate)
+            return STATE_NEEDS_ATTENTION
+
+    fired_through = int(current.get("milestone", mandate["milestonesFired"]))
+    mandate["milestonesFired"] = fired_through + 1
+    mandate["attempt"] = 0  # a landed fire clears the retry budget for the next milestone
+    mandate["history"] = (mandate.get("history") or []) + [{
+        "fireId": current.get("fireId"),
+        "milestone": current.get("milestone"),
+        "planHash": current.get("planHash"),
+        "txHash": (current.get("tx") or {}).get("hash"),
+        "oldTokenId": old_token_id,
+        "newTokenId": new_token_id,
+        "at": _now(),
+    }]
+    mandate["currentFire"] = None
+
+    if final or new_token_id is None:
+        mandate["state"] = STATE_COMPLETE
+        mandate["tokenId"] = old_token_id
+        mandate["liquidity"] = "0"
+        mandate["lastSeq"] = store.append({
+            "event": "complete", "fireId": current.get("fireId"),
+            "milestonesFired": mandate["milestonesFired"],
+        })
+        store.save(mandate)
+        return STATE_COMPLETE
+
+    position = lp_write.load_position_for_write(client, chain, new_token_id)
+    mandate["tokenId"] = new_token_id
+    mandate["tickLower"] = position["tickLower"]
+    mandate["tickUpper"] = position["tickUpper"]
+    mandate["liquidity"] = str(position["liquidity"])
+    mandate["state"] = STATE_ARMED
+    mandate["lastSeq"] = store.append({
+        "event": "reconcile.adopted", "fireId": current.get("fireId"),
+        "newTokenId": new_token_id, "ticks": [position["tickLower"], position["tickUpper"]],
+        "liquidity": str(position["liquidity"]), "to": STATE_ARMED,
+    })
+    store.save(mandate)
+    return STATE_ARMED
+
+
+def tick_one(client, chain: dict, args: dict, signer: dict, ident: str,
+             broadcast: bool) -> dict:
+    """One mandate, one tick. Never raises for an expected condition — reports it."""
+    store = MandateStore(state_root(), chain["key"], ident)
+    result = {"mandateId": ident}
+
+    with store.lock() as acquired:
+        if not acquired:
+            # Overlapping cron ticks are normal during a fire that is waiting on a receipt.
+            return {**result, "action": "skipped", "reason": "another tick holds the lock"}
+
+        mandate = store.load()
+        if mandate is None:
+            return {**result, "action": "missing", "reason": "no such mandate"}
+
+        # The log is the write-ahead record; the mandate file is the view. If the view is
+        # behind, a crash landed between the outcome record and the replace.
+        behind = store.tail(int(mandate.get("lastSeq") or 0))
+        if behind:
+            result["replayed"] = [r.get("event") for r in behind]
+            mandate = replay_tail(mandate, behind)
+            mandate["lastSeq"] = store.last_seq()
+            store.save(mandate)
+
+        state = mandate.get("state")
+        result["state"] = state
+        if state in TERMINAL_STATES:
+            return {**result, "action": "noop", "reason": f"state is {state}",
+                    "note": mandate.get("note")}
+
+        expires_at = mandate["bounds"].get("expiresAt")
+        if expires_at and _now() > int(expires_at) and state == STATE_ARMED:
+            mandate["state"] = STATE_EXPIRED
+            mandate["lastSeq"] = store.append({"event": "expired"})
+            store.save(mandate)
+            return {**result, "action": "expired", "state": STATE_EXPIRED}
+
+        # --- reconcile an in-flight fire ---------------------------------
+        if state == STATE_FIRE_SENT:
+            current = mandate.get("currentFire") or {}
+            verdict = reconcile(client, chain, mandate["immutable"]["signer"],
+                                int(mandate["tokenId"]), current.get("tx"))
+            result["truth"] = verdict["truth"]
+            result["reason"] = verdict["reason"]
+
+            if verdict["truth"] == PENDING:
+                return {**result, "action": "waiting"}
+            if verdict["truth"] == UNAVAILABLE:
+                # The node did not answer, so nothing was learned and nothing changes. Left
+                # deliberately as a plain retry rather than NEEDS_ATTENTION: a five-minute
+                # cron will meet a flaky RPC sooner or later, and halting on one would mean
+                # every blip costs a manual `clear-attention`.
+                store.append({"event": "tick.noop", "reason": verdict["reason"]})
+                return {**result, "action": "deferred"}
+            if verdict["truth"] == AMBIGUOUS:
+                mandate["state"] = STATE_NEEDS_ATTENTION
+                mandate["note"] = verdict["reason"]
+                mandate["lastSeq"] = store.append({"event": "needs_attention",
+                                                   "reason": verdict["reason"]})
+                store.save(mandate)
+                return {**result, "action": "halted", "state": STATE_NEEDS_ATTENTION}
+            if verdict["truth"] == LANDED:
+                receipt = None
+                tx_hash = (current.get("tx") or {}).get("hash")
+                if tx_hash:
+                    # _send raises before returning the receipt when a transaction reverts,
+                    # so re-fetch it by the hash the journal already holds.
+                    receipt = client.get_receipt(tx_hash)
+                new_state = adopt_landed_fire(client, chain, store, mandate, receipt)
+                result["state"] = new_state
+                # Kept as its own field, not as `action`: the tick carries on to re-evaluate
+                # and would otherwise overwrite this with "noop", hiding a completed fire
+                # from whoever reads the cron summary.
+                result["adopted"] = True
+                result["action"] = "adopted"
+                result["tokenId"] = mandate["tokenId"]
+                if new_state != STATE_ARMED:
+                    return result
+                state = STATE_ARMED
+            elif verdict["truth"] == NOT_SENT:
+                # The counter lives on the mandate, not on currentFire: currentFire is
+                # cleared on every retry, so counting there would reset to zero each round
+                # and maxAttempts would never be reached.
+                attempt = int(mandate.get("attempt", 0)) + 1
+                if attempt > int(mandate["bounds"]["maxAttempts"]):
+                    mandate["state"] = STATE_NEEDS_ATTENTION
+                    mandate["note"] = (f"{attempt - 1} attempts all failed to land: "
+                                       f"{verdict['reason']}")
+                    mandate["lastSeq"] = store.append({"event": "needs_attention",
+                                                       "reason": mandate["note"]})
+                    store.save(mandate)
+                    return {**result, "action": "halted", "state": STATE_NEEDS_ATTENTION}
+                mandate["state"] = STATE_ARMED
+                mandate["attempt"] = attempt
+                mandate["currentFire"] = None
+                mandate["lastSeq"] = store.append({
+                    "event": "tx.dropped", "reason": verdict["reason"], "attempt": attempt,
+                })
+                store.save(mandate)
+                result["attempt"] = attempt
+                # Report where the mandate ended up, not where it started; `result["state"]`
+                # was seeded from the entry state and the tick carries on from here.
+                result["state"] = STATE_ARMED
+                state = STATE_ARMED
+
+        # --- is a milestone due? -----------------------------------------
+        imm = mandate["immutable"]
+        try:
+            position = lp_write.load_position_for_write(client, chain,
+                                                        int(mandate["tokenId"]))
+        except RuntimeError as exc:
+            mandate["state"] = STATE_NEEDS_ATTENTION
+            mandate["note"] = str(exc)
+            mandate["lastSeq"] = store.append({"event": "needs_attention",
+                                               "reason": str(exc)})
+            store.save(mandate)
+            return {**result, "action": "halted", "state": STATE_NEEDS_ATTENTION,
+                    "reason": str(exc)}
+
+        pool = lp_write.load_pool_state(client, chain, imm["poolId"], position["poolKey"])
+        remaining = remaining_principal(pool["sqrtPriceX96"], position["tickLower"],
+                                        position["tickUpper"], position["liquidity"],
+                                        imm["principal"])
+        thresholds = [_big(t) for t in mandate["thresholds"]]
+        due = due_milestone(thresholds, int(mandate["milestonesFired"]), remaining)
+
+        result.update({
+            "tick": pool["tick"], "tokenId": mandate["tokenId"],
+            "remainingRaw": str(remaining),
+            "milestonesFired": mandate["milestonesFired"],
+            "nextThresholdRaw": (str(thresholds[mandate["milestonesFired"]])
+                                 if mandate["milestonesFired"] < len(thresholds) else None),
+        })
+
+        if due is None:
+            store.append({"event": "tick.noop", "tick": pool["tick"],
+                          "remainingRaw": str(remaining)})
+            return {**result, "action": "noop", "reason": "no milestone due"}
+
+        # A gap that clears several levels fires only the deepest; the ones it skipped are
+        # satisfied by the same reading, so they are recorded as fired rather than replayed.
+        result["milestone"] = due
+        result["skipped"] = list(range(int(mandate["milestonesFired"]), due))
+        mandate["milestonesFired"] = due
+        store.append({"event": "milestone.reached", "milestone": due,
+                      "skipped": result["skipped"], "tick": pool["tick"],
+                      "remainingRaw": str(remaining)})
+
+        try:
+            outcome = run_fire(client, chain, args, signer, store, mandate, due, broadcast)
+        except SystemExit as exc:
+            # run_plan exits 2 when the simulation reverts, and cmd_* do the same on missing
+            # approvals. For a runner those are retryable conditions, not process death.
+            reason = f"simulation refused the fire (exit {exc.code})"
+            mandate["lastSeq"] = store.append({"event": "plan.rejected", "reason": reason,
+                                               "milestone": due})
+            store.save(mandate)
+            return {**result, "action": "rejected", "reason": reason}
+        except RuntimeError as exc:
+            mandate["lastSeq"] = store.append({"event": "plan.rejected", "reason": str(exc),
+                                               "milestone": due})
+            store.save(mandate)
+            return {**result, "action": "rejected", "reason": str(exc)}
+
+        result["planHash"] = outcome["planHash"]
+        if not broadcast:
+            store.append({"event": "tick.dryrun", "milestone": due,
+                          "planHash": outcome["planHash"]})
+            return {**result, "action": "dry-run"}
+
+        result["txHash"] = (outcome["sent"] or {}).get("hash")
+        new_state = adopt_landed_fire(client, chain, store, mandate, outcome["receipt"])
+        result["state"] = new_state
+        result["tokenId"] = mandate["tokenId"]
+        return {**result, "action": "fired"}
+
+
+def cmd_tick(client, chain: dict, args: dict, signer: dict) -> None:
+    broadcast = bool(args.get("broadcast"))
+    if args.get("all"):
+        idents = MandateStore.list_ids(state_root(), chain["key"])
+    else:
+        idents = [require_arg(args, "id", "mandate id, or use --all")]
+
+    results = []
+    for ident in idents:
+        try:
+            if args.get("json"):
+                # Keep the machine-readable channel clean: the human-facing plan table and
+                # simulation trace still go to the log, just not to stdout.
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    outcome = tick_one(client, chain, args, signer, ident, broadcast)
+                outcome["output"] = buffer.getvalue()
+            else:
+                outcome = tick_one(client, chain, args, signer, ident, broadcast)
+        except Exception as exc:  # noqa: BLE001 — one bad mandate must not stop the others
+            outcome = {"mandateId": ident, "action": "error", "reason": str(exc)}
+        results.append(outcome)
+
+    if args.get("json"):
+        _emit({"chain": chain["key"], "broadcast": broadcast, "results": results})
+        return
+
+    if not idents:
+        print(f"\nNo ratchet mandates on {chain['name']}.")
+        return
+    print(heading(f"ratchet tick on {chain['name']}"
+                  f"{'' if broadcast else '  (DRY RUN — nothing sent)'}"))
+    for outcome in results:
+        rows = [
+            ["mandate", outcome["mandateId"]],
+            ["action", outcome.get("action", "?")],
+            ["state", outcome.get("state", "?")],
+            ["detail", outcome.get("reason") or outcome.get("note") or ""],
+        ]
+        if outcome.get("adopted"):
+            rows.insert(2, ["adopted", f"a landed fire was reconciled; position is now "
+                                       f"#{outcome.get('tokenId')}"])
+        if outcome.get("txHash"):
+            rows.insert(2, ["tx", outcome["txHash"]])
+        print(render_kv(rows))
+        if outcome.get("action") in ("halted", "error"):
+            print("  ^ needs a human. `status --id <id>` for the full record.")
+
+
+# ---------------------------------------------------------------------------
+# status / list / disarm
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(client, chain: dict, args: dict, signer: dict) -> None:
+    idents = MandateStore.list_ids(state_root(), chain["key"])
+    rows = []
+    for ident in idents:
+        store = MandateStore(state_root(), chain["key"], ident)
+        try:
+            mandate = store.load()
+        except RuntimeError as exc:
+            rows.append({"mandateId": ident, "state": "UNREADABLE", "note": str(exc)})
+            continue
+        if mandate is None:
+            continue
+        imm = mandate["immutable"]
+        rows.append({
+            "mandateId": ident,
+            "label": imm.get("label") or "",
+            "state": mandate["state"],
+            "tokenId": mandate["tokenId"],
+            "principal": imm["principal"],
+            "milestonesFired": mandate["milestonesFired"],
+            "steps": imm["stepsBps"],
+        })
+
+    if args.get("json"):
+        _emit({"chain": chain["key"], "mandates": rows})
+        return
+    if not rows:
+        print(f"\nNo ratchet mandates on {chain['name']}.")
+        print(f"State dir: {state_root() / 'ratchet' / chain['key']}")
+        return
+    print(heading(f"ratchet mandates on {chain['name']}"))
+    for row in rows:
+        print(render_kv([[key, str(value)] for key, value in row.items()]))
+
+
+def cmd_status(client, chain: dict, args: dict, signer: dict) -> None:
+    ident = require_arg(args, "id", "mandate id")
+    store = MandateStore(state_root(), chain["key"], ident)
+    mandate = store.load()
+    if mandate is None:
+        raise RuntimeError(f"no mandate {ident} on {chain['name']}")
+
+    if args.get("json"):
+        _emit({"mandate": mandate, "log": store.records()})
+        return
+
+    imm = mandate["immutable"]
+    info0 = lp_write.token_info(client, chain, imm["poolKey"]["currency0"])
+    info1 = lp_write.token_info(client, chain, imm["poolKey"]["currency1"])
+    principal_info, harvest_info = _principal_info(mandate, info0, info1)
+
+    print(heading(f"ratchet mandate {ident} on {chain['name']}"))
+    print(render_kv([
+        ["label", imm.get("label") or "(none)"],
+        ["state", mandate["state"]],
+        ["note", mandate.get("note") or ""],
+        ["position", f"#{mandate['tokenId']}  ticks {mandate['tickLower']} → "
+                     f"{mandate['tickUpper']}"],
+        ["principal", f"{imm['principal']} = {principal_info['symbol']}"],
+        ["harvested", harvest_info["symbol"]],
+        ["far edge", str(imm["farEdgeTick"])],
+        ["original principal",
+         f"{fmt_units(_big(imm['originalPrincipalRaw']), principal_info['decimals'])} "
+         f"{principal_info['symbol']}"],
+        ["milestones", f"{mandate['milestonesFired']} of {len(imm['stepsBps'])} fired"],
+        ["thresholds", ", ".join(
+            fmt_units(_big(t), principal_info["decimals"]) for t in mandate["thresholds"])],
+        ["in flight", json.dumps(mandate.get("currentFire")) if mandate.get("currentFire")
+         else "none"],
+        ["log", str(store.log_path)],
+    ]))
+    history = mandate.get("history") or []
+    if history:
+        print(heading("fires"))
+        for entry in history:
+            print(render_kv([[key, str(value)] for key, value in entry.items()]))
+
+
+def cmd_disarm(client, chain: dict, args: dict, signer: dict) -> None:
+    ident = require_arg(args, "id", "mandate id")
+    store = MandateStore(state_root(), chain["key"], ident)
+    with store.lock() as acquired:
+        if not acquired:
+            raise RuntimeError(f"mandate {ident} is being ticked right now — try again")
+        mandate = store.load()
+        if mandate is None:
+            raise RuntimeError(f"no mandate {ident} on {chain['name']}")
+        if mandate["state"] == STATE_FIRE_SENT:
+            raise RuntimeError(
+                f"mandate {ident} has a transaction in flight. Run `tick --id {ident}` "
+                "until it settles, then disarm — disarming now would lose the only record "
+                "of that hash."
+            )
+        mandate["state"] = STATE_DISARMED
+        mandate["lastSeq"] = store.append({"event": "disarmed"})
+        store.save(mandate)
+    print(f"\nMandate {ident} disarmed. It will no longer fire.")
+    print(f"Files kept for the record: {store.path}")
+
+
+def check_replacement(client, chain: dict, mandate: dict, token_id: int) -> dict:
+    """Everything that must hold before a mandate is pointed at a different position.
+
+    An operator naming the replacement is standing in for an oracle that could not decide,
+    so their answer gets checked the way the oracle's would have been. The mandate's whole
+    authorization rests on the geometry being what it was armed against: same pool, same
+    signer, same far edge, same side of the price. Any of those wrong and the milestones
+    still to come would be measured against something else entirely.
+    """
+    imm = mandate["immutable"]
+    position = lp_write.load_position_for_write(client, chain, int(token_id))
+    if position["poolId"] != imm["poolId"] or compute_pool_id(position["poolKey"]) != \
+            imm["poolId"]:
+        raise RuntimeError(
+            f"position #{token_id} is in pool {position['poolId']}, the mandate is pinned "
+            f"to {imm['poolId']}"
+        )
+    if position["owner"] and position["owner"].lower() != imm["signer"].lower():
+        raise RuntimeError(
+            f"position #{token_id} is owned by {position['owner']}, not the mandate signer "
+            f"{imm['signer']}"
+        )
+    if position["liquidity"] <= 0:
+        raise RuntimeError(f"position #{token_id} holds no liquidity")
+
+    pool = lp_write.load_pool_state(client, chain, imm["poolId"], position["poolKey"])
+    principal = principal_for_range(pool["tick"], position["tickLower"],
+                                    position["tickUpper"])
+    if principal != imm["principal"]:
+        raise RuntimeError(
+            f"position #{token_id} is one-sided in {principal}, but the mandate ratchets "
+            f"{imm['principal']} — it sits on the wrong side of the price"
+        )
+    edge = far_edge_tick(position["tickLower"], position["tickUpper"], principal)
+    if edge != int(imm["farEdgeTick"]):
+        raise RuntimeError(
+            f"position #{token_id} runs to tick {edge}; the mandate's far edge is "
+            f"{imm['farEdgeTick']}. A ratchet re-arm never moves that edge, so this is not "
+            "the position the fire created."
+        )
+    return position
+
+
+def cmd_clear_attention(client, chain: dict, args: dict, signer: dict) -> None:
+    ident = require_arg(args, "id", "mandate id")
+    replacement = args.get("token-id")
+    store = MandateStore(state_root(), chain["key"], ident)
+    with store.lock() as acquired:
+        if not acquired:
+            raise RuntimeError(f"mandate {ident} is being ticked right now — try again")
+        mandate = store.load()
+        if mandate is None:
+            raise RuntimeError(f"no mandate {ident} on {chain['name']}")
+        if mandate["state"] != STATE_NEEDS_ATTENTION:
+            raise RuntimeError(f"mandate {ident} is {mandate['state']}, not "
+                               f"{STATE_NEEDS_ATTENTION}")
+
+        if replacement is not None:
+            # Finishing an adoption the oracles could not. The old position must really be
+            # gone — if it is still alive the fire did not land, and adopting would credit a
+            # milestone that never fired and abandon a position the mandate still owns.
+            new_token_id = int(replacement)
+            if new_token_id == int(mandate["tokenId"]):
+                raise RuntimeError(
+                    "--token-id names the position the mandate already holds; drop the flag "
+                    "to simply resume against it"
+                )
+            truth = position_truth(client, chain, int(mandate["tokenId"]),
+                                   mandate["immutable"]["signer"])
+            if truth.get("unreachable"):
+                raise RuntimeError("could not read the old position from the node — retry")
+            if not truth["burned"]:
+                raise RuntimeError(
+                    f"position #{mandate['tokenId']} is still alive, so no fire landed and "
+                    "there is nothing to adopt. Re-run `tick` and let it reconcile."
+                )
+            check_replacement(client, chain, mandate, new_token_id)
+            mandate["note"] = ""
+            mandate["attempt"] = 0
+            new_state = adopt_landed_fire(client, chain, store, mandate, None,
+                                          new_token_id=new_token_id)
+            print(f"\nMandate {ident} adopted position #{mandate['tokenId']} "
+                  f"and is now {new_state}.")
+            return
+
+        position = lp_write.load_position_for_write(client, chain, int(mandate["tokenId"]))
+        if position["liquidity"] <= 0:
+            raise RuntimeError(
+                f"position #{mandate['tokenId']} holds no liquidity; this mandate cannot be "
+                "resumed. Disarm it and arm a fresh one against the current position."
+            )
+        mandate["tickLower"] = position["tickLower"]
+        mandate["tickUpper"] = position["tickUpper"]
+        mandate["liquidity"] = str(position["liquidity"])
+        mandate["state"] = STATE_ARMED
+        mandate["currentFire"] = None
+        mandate["attempt"] = 0
+        mandate["note"] = ""
+        mandate["lastSeq"] = store.append({"event": "state.changed", "to": STATE_ARMED,
+                                           "reason": "cleared by operator"})
+        store.save(mandate)
+    print(f"\nMandate {ident} is armed again against position #{mandate['tokenId']}.")
+
+
+COMMANDS = {
+    "arm": cmd_arm,
+    "tick": cmd_tick,
+    "status": cmd_status,
+    "list": cmd_list,
+    "disarm": cmd_disarm,
+    "clear-attention": cmd_clear_attention,
+}
+
+
+def main() -> None:
+    args = parse_args(sys.argv[1:])
+    command = args["_"][0] if args["_"] else None
+    if not command or args.get("help") or args.get("h"):
+        print(USAGE)
+        sys.exit(0 if command else 1)
+    handler = COMMANDS.get(command)
+    if handler is None:
+        raise RuntimeError(f'unknown command "{command}"\n{USAGE}')
+
+    chain = resolve_chain(args.get("chain"))
+    client = _client(chain, args)
+    signer = lp_write.resolve_signer(args)
+    handler(client, chain, args, signer)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001
+        die(exc)

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/selftest.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/selftest.py
@@ -403,6 +403,36 @@ def tier2(g: dict, r: Results) -> None:
     s = g["signing"]
     account = account_from_private_key(s["private_key"])
     r.check("derived signer address", account["address"], s["expected_address"])
+
+    # Derivation lives in `account`, signing in `secp256k1`. lp_read.py imports the first
+    # so `positions` can resolve your own wallet, and the split is what keeps that from
+    # making a read-only script able to move funds. Pin both halves: the same address comes
+    # out of the derivation-only module, and that module has no way to sign.
+    from unilp import account as account_mod
+
+    r.check("account module derives the same address",
+            account_mod.account_from_private_key(s["private_key"])["address"],
+            s["expected_address"])
+    r.check("account module exposes no signing entry point",
+            sorted(n for n in dir(account_mod) if "sign" in n.lower()), [])
+
+    # Read the imports out of the syntax tree, not out of the text: the docstring names
+    # secp256k1 to explain the split, and a grep would score that as a dependency.
+    import ast
+
+    imported = set()
+    for node in ast.walk(ast.parse(Path(account_mod.__file__).read_text(encoding="utf-8"))):
+        if isinstance(node, ast.ImportFrom):
+            # `from . import secp256k1` parses with module=None and the module name in
+            # names — reading only `node.module` would score that as importing nothing.
+            if node.module:
+                imported.add(node.module)
+            else:
+                imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+    r.check("account module imports nothing that can sign",
+            sorted(imported - {"__future__"}), ["hexutil", "keccak"])
     signature = sign_digest(s["private_key"], s["digest"])
     r.check("RFC-6979 signature is deterministic", signature["hex"], s["signature"])
     r.check("ecrecover round-trips to the signer",
@@ -718,7 +748,7 @@ def tier5(g: dict, r: Results) -> None:
         r.skip("tier5/planning", "lp_read or unilp.prices not importable")
         return
 
-    pull = lp_read._pull_off_current_tick
+    pull = lp_read.pull_off_current_tick
 
     # The live case this was written for: AGENTOS at tick 209056, band asked for as
     # "from here up to $200K mcap", snapped outward to 206400..209200 — one spacing past
@@ -806,6 +836,33 @@ def tier5(g: dict, r: Results) -> None:
     r.check("unindexed message names the network", "robinhood" in unknown, True)
     r.check("unindexed message is not the rate-limit one",
             "rate-limiting" in unknown, False)
+
+    # `positions` with no --owner means "mine". The address comes from the signing key,
+    # which is the only thing this file ever reads it for.
+    from unilp.account import account_from_private_key
+
+    key = "0x" + "11" * 32
+    # Derived here rather than written out: tier 2 already pins the arithmetic against the
+    # golden vectors, so what this needs to prove is only that the wiring reaches it.
+    expected = account_from_private_key(key)["address"]
+    was_env = dict(os.environ)
+    try:
+        os.environ["UNIV4_LP_PRIVATE_KEY"] = key
+        r.check("positions with no --owner resolves the configured wallet",
+                lp_read.resolve_owner({}), expected)
+        r.check("an explicit --owner still wins",
+                lp_read.resolve_owner({"owner": "0x" + "ab" * 20}), "0x" + "ab" * 20)
+        os.environ["OTHER_KEY"] = "0x" + "22" * 32
+        r.check("--signer-env picks a different variable",
+                lp_read.resolve_owner({"signer-env": "OTHER_KEY"}) != expected, True)
+        # An explicit owner must not need the key at all — asking about someone else's
+        # wallet is the ordinary case and cannot depend on this machine being configured.
+        os.environ.pop("UNIV4_LP_PRIVATE_KEY")
+        r.check("an explicit --owner never touches the key",
+                lp_read.resolve_owner({"owner": "0x" + "cd" * 20}), "0x" + "cd" * 20)
+    finally:
+        os.environ.clear()
+        os.environ.update(was_env)
 
 
 # ---------------------------------------------------------------------------
@@ -949,8 +1006,9 @@ def _plan_of(lp_write, chain: dict, command: str, args: dict, *,
         captured["fields"] = dict(fields)
         return real_plan_hash(fields)
 
-    def stub_run_plan(client, chn, a, signer, ctx):
+    def stub_run_plan(client, chn, a, signer, ctx, *, authorization=None):
         captured["rows"] = ctx["rows"]
+        captured["authorization"] = authorization
         return lp_write.plan_hash(ctx["hashFields"])
 
     stubs = {"pool_key_for_id": stub_pool_key, "load_pool_state": stub_state,
@@ -1023,6 +1081,1089 @@ def tier6(g: dict, r: Results) -> None:
 
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Tier 7 — ratchet
+# ---------------------------------------------------------------------------
+
+# Two token addresses whose sort order is known, so a fixture can put the SAME token on
+# either side of the pair. That is the whole point of this tier: "the token is currency1"
+# is not an exotic case, it is half of all pools, and it inverts which way the price has to
+# move for a limit sell to fill.
+_LOW = "0x1111111111111111111111111111111111111111"
+_HIGH = "0x2222222222222222222222222222222222222222"
+
+
+def _ratchet_fixture(principal_side: str, spacing: int = 60):
+    """A position that was armed one-sided and has since been partly filled.
+
+    The two ticks are the whole point. At ARM time the range is entirely on one side of the
+    price, which is what makes it a limit order. By the time a milestone fires the price has
+    moved *into* the range, so the position holds both currencies — and the principal is no
+    longer derivable from the live geometry, which is why the mandate pins it at arm time.
+
+    currency0 principal -> the range sits ABOVE the price and fills as the tick rises.
+    currency1 principal -> the range sits BELOW and fills as the tick falls.
+    """
+    if principal_side == "currency0":
+        tick_lower, tick_upper, armed_at, current = 600, 3000, 500, 1200
+    else:
+        tick_lower, tick_upper, armed_at, current = -3000, -600, -500, -1200
+    return {"tickLower": tick_lower, "tickUpper": tick_upper, "tick": current,
+            "armedAt": armed_at, "tickSpacing": spacing}
+
+
+def _ratchet_env(lp_write, ratchet, chain, fixture, principal_side, quote_side,
+                 liquidity=10**20, owner=None):
+    """Stub the chain out from under ratchet.plan_fire and hand back the restore hook."""
+    from unilp.v4_math import get_sqrt_ratio_at_tick
+
+    owner = owner or _ME
+    pool_key = {"currency0": _LOW, "currency1": _HIGH, "fee": 3000,
+                "tickSpacing": fixture["tickSpacing"], "hooks": lp_write.NATIVE}
+    from unilp.v4_pool import compute_pool_id
+    pool_id = compute_pool_id(pool_key)
+
+    state = {
+        "poolId": pool_id, "poolKey": pool_key,
+        "sqrtPriceX96": get_sqrt_ratio_at_tick(fixture["tick"]),
+        "tick": fixture["tick"], "lpFee": 3000, "activeLiquidity": liquidity,
+    }
+    position = {
+        "tokenId": 7, "poolKey": pool_key, "poolId": pool_id,
+        "tickLower": fixture["tickLower"], "tickUpper": fixture["tickUpper"],
+        "hasSubscriber": False, "liquidity": liquidity, "owner": owner,
+    }
+
+    def stub_position(client, chn, token_id):
+        return dict(position, tokenId=int(token_id))
+
+    def stub_state(client, chn, pid, key):
+        return dict(state, poolId=pid, poolKey=key)
+
+    def stub_token_info(client, chn, address):
+        return {"address": address, "symbol": "T0" if address == _LOW else "T1",
+                "decimals": 18, "isNative": False}
+
+    stubs = {"load_position_for_write": stub_position, "load_pool_state": stub_state,
+             "token_info": stub_token_info}
+    saved = {name: getattr(lp_write, name) for name in stubs}
+    for name, fn in stubs.items():
+        setattr(lp_write, name, fn)
+
+    chain = dict(chain, knownQuotes={(_HIGH if quote_side == "currency1" else _LOW).lower():
+                                     "QUOTE"})
+
+    def restore():
+        for name, fn in saved.items():
+            setattr(lp_write, name, fn)
+
+    return {"chain": chain, "poolKey": pool_key, "poolId": pool_id, "position": position,
+            "state": state, "armedAt": fixture["armedAt"], "restore": restore}
+
+
+def _ratchet_mandate(ratchet, env, principal_side, steps=(3000, 6000, 10_000)):
+    from unilp.ratchet_math import (
+        far_edge_tick,
+        milestone_thresholds,
+        principal_for_range,
+        remaining_principal,
+    )
+    from unilp.v4_math import get_sqrt_ratio_at_tick
+
+    position = env["position"]
+    # Derived from the geometry AS ARMED — outside the range — exactly as cmd_arm does.
+    principal = principal_for_range(env["armedAt"], position["tickLower"],
+                                    position["tickUpper"])
+    assert principal == principal_side, (principal, principal_side)
+    original = remaining_principal(get_sqrt_ratio_at_tick(env["armedAt"]),
+                                   position["tickLower"], position["tickUpper"],
+                                   position["liquidity"], principal)
+    immutable = {
+        "schemaVersion": 1, "chainId": env["chain"]["chainId"], "chainKey": "test",
+        "positionManager": env["chain"]["positionManager"], "poolId": env["poolId"],
+        "poolKey": env["poolKey"], "signer": _ME, "originalTokenId": 7,
+        "principal": principal,
+        "farEdgeTick": far_edge_tick(position["tickLower"], position["tickUpper"], principal),
+        "originalTickLower": position["tickLower"],
+        "originalTickUpper": position["tickUpper"],
+        "originalPrincipalRaw": str(original), "stepsBps": list(steps), "label": "",
+    }
+    return {
+        "immutable": immutable,
+        "bounds": {"maxSlippageBps": 100, "maxDeadlineSecs": 1200, "maxTickDrift": 600,
+                   "allowHooked": False, "maxAttempts": 5,
+                   "maxPrincipalRawPerFire": None, "maxFeePerGasWei": None,
+                   "expiresAt": None},
+        "state": "ARMED", "tokenId": 7,
+        "tickLower": position["tickLower"], "tickUpper": position["tickUpper"],
+        "liquidity": str(position["liquidity"]),
+        "thresholds": [str(t) for t in milestone_thresholds(original, list(steps))],
+        "milestonesFired": 0, "currentFire": None,
+        "realized": {"amount0": "0", "amount1": "0"}, "lastSeq": 0, "history": [],
+    }
+
+
+def _tier7_math(r) -> None:
+    from unilp.ratchet_math import (
+        CURRENCY0,
+        CURRENCY1,
+        RangeExhaustedError,
+        due_milestone,
+        far_edge_tick,
+        fills_as_tick_rises,
+        milestone_thresholds,
+        parse_steps,
+        principal_for_range,
+        rearm_range,
+        remaining_principal,
+        sqrt_price_for_remaining,
+    )
+    from unilp.v4_math import get_sqrt_ratio_at_tick, pull_off_current_tick
+
+    r.check("steps parse to bps", parse_steps("30,60,100"), [3000, 6000, 10_000])
+    r.check("steps dedupe and sort", parse_steps("60, 30 ,60"), [3000, 6000])
+    r.check("thresholds are absolute against the original principal",
+            milestone_thresholds(100_000, [3000, 6000, 10_000]), [70_000, 40_000, 0])
+
+    # The matrix. Every assertion below runs once per geometry, and each geometry is
+    # exercised with the quote on either side so the sell/buy LABEL cannot leak into the
+    # geometry. A case that only ever tested "token is currency0" would pass while half of
+    # all real pools silently ratcheted the wrong way.
+    for principal, tick_lower, tick_upper, current in (
+        (CURRENCY0, 600, 3000, 1200),
+        (CURRENCY1, -3000, -600, -1200),
+    ):
+        label = f"[{principal}]"
+        # Geometry -> principal, with no reference to which token is "the" token.
+        outside = tick_lower - 1 if principal == CURRENCY0 else tick_upper
+        r.check(f"{label} principal derives from geometry alone",
+                principal_for_range(outside, tick_lower, tick_upper), principal)
+        r.check(f"{label} far edge is the end the price travels to",
+                far_edge_tick(tick_lower, tick_upper, principal),
+                tick_upper if principal == CURRENCY0 else tick_lower)
+        r.check(f"{label} fill direction", fills_as_tick_rises(principal),
+                principal == CURRENCY0)
+
+        liquidity = 10**20
+        unfilled = get_sqrt_ratio_at_tick(tick_lower if principal == CURRENCY0
+                                          else tick_upper)
+        filled = get_sqrt_ratio_at_tick(tick_upper if principal == CURRENCY0
+                                        else tick_lower)
+        original = remaining_principal(unfilled, tick_lower, tick_upper, liquidity,
+                                       principal)
+        r.check(f"{label} unfilled position is 100% principal", original > 0, True)
+        r.check(f"{label} fully crossed position holds no principal",
+                remaining_principal(filled, tick_lower, tick_upper, liquidity, principal), 0)
+        r.check(f"{label} the other currency is untouched while unfilled",
+                remaining_principal(unfilled, tick_lower, tick_upper, liquidity,
+                                    CURRENCY1 if principal == CURRENCY0 else CURRENCY0), 0)
+
+        # The inverse must land back on the amount it was asked for. One wei of slack:
+        # both directions truncate, and the runtime decision is made on the amount anyway.
+        for target in milestone_thresholds(original, [3000, 6000, 10_000]) + [original]:
+            sqrt_at = sqrt_price_for_remaining(tick_lower, tick_upper, liquidity, target,
+                                               principal)
+            back = remaining_principal(sqrt_at, tick_lower, tick_upper, liquidity, principal)
+            r.check(f"{label} remaining<->price round-trips at {target}",
+                    abs(back - target) <= 1, True)
+
+        # Re-arm travels the right way and stays one-sided on the SAME side.
+        new_lower, new_upper = rearm_range(current, far_edge_tick(tick_lower, tick_upper,
+                                                                  principal), 60, principal)
+        r.check(f"{label} re-arm keeps the far edge fixed",
+                new_upper if principal == CURRENCY0 else new_lower,
+                tick_upper if principal == CURRENCY0 else tick_lower)
+        r.check(f"{label} re-arm is still one-sided on the same currency",
+                principal_for_range(current, new_lower, new_upper), principal)
+        r.check(f"{label} re-arm narrows towards the price",
+                (new_lower > tick_lower) if principal == CURRENCY0
+                else (new_upper < tick_upper), True)
+
+        # Past the far edge there is nothing to re-arm — that IS the final milestone.
+        past = tick_upper if principal == CURRENCY0 else tick_lower
+        threw = False
+        try:
+            rearm_range(past, far_edge_tick(tick_lower, tick_upper, principal), 60, principal)
+        except RangeExhaustedError:
+            threw = True
+        r.check(f"{label} a fully crossed range reports exhausted", threw, True)
+
+    # The one-tick asymmetry, stated as its own case in both directions because
+    # range_status is strict on one edge and not on the other.
+    r.check("currency0 re-arm clears a tick sitting exactly on a spacing boundary",
+            rearm_range(1200, 3000, 60, CURRENCY0)[0] > 1200, True)
+    r.check("currency1 re-arm may land exactly on the current tick",
+            rearm_range(-1200, -3000, 60, CURRENCY1)[1], -1200)
+
+    # A forced side never falls back to the other one; an unforced call is unchanged.
+    r.check("forced pull-off matches the heuristic when they agree",
+            pull_off_current_tick(209056, 206400, 209200, 200, "currency1"),
+            pull_off_current_tick(209056, 206400, 209200, 200))
+    threw = False
+    try:
+        pull_off_current_tick(209190, 209010, 209300, 200, "currency1")
+    except RuntimeError:
+        threw = True
+    r.check("forced pull-off refuses rather than flipping sides", threw, True)
+    r.check("unforced pull-off still falls back to the other side",
+            pull_off_current_tick(209190, 209010, 209300, 200), (209200, 209300))
+
+    # A gap that clears two levels fires the deeper one only.
+    thresholds = [70, 40, 0]
+    r.check("no milestone before the first threshold", due_milestone(thresholds, 0, 71), None)
+    r.check("first milestone at its threshold", due_milestone(thresholds, 0, 70), 0)
+    r.check("a two-level gap fires the deeper level", due_milestone(thresholds, 0, 35), 1)
+    r.check("a full crossing fires the last level", due_milestone(thresholds, 0, 0), 2)
+    r.check("levels already fired never re-fire", due_milestone(thresholds, 3, 0), None)
+
+
+def _tier7_plan(r) -> None:
+    import lp_write
+    import ratchet
+    from unilp.chains import resolve_chain
+    from unilp.v4_actions import ACTIONS
+
+    base = resolve_chain("base")
+    for principal in ("currency0", "currency1"):
+        for quote in ("currency0", "currency1"):
+            label = f"[{principal}/quote={quote}]"
+            fixture = _ratchet_fixture(principal)
+            env = _ratchet_env(lp_write, ratchet, base, fixture, principal, quote)
+            try:
+                mandate = _ratchet_mandate(ratchet, env, principal)
+                client = _StubClient()
+                fire = ratchet.plan_fire(client, env["chain"], mandate, 0)
+
+                actions = fire["plan"]["actions"]
+                r.check(f"{label} a re-arming fire is decrease+burn+mint+take", actions,
+                        [ACTIONS["DECREASE_LIQUIDITY"], ACTIONS["BURN_POSITION"],
+                         ACTIONS["MINT_POSITION"], ACTIONS["TAKE_PAIR"]])
+                r.check(f"{label} the fire carries no SETTLE leg",
+                        any(a in (ACTIONS["SETTLE"], ACTIONS["SETTLE_ALL"],
+                                  ACTIONS["SETTLE_PAIR"]) for a in actions), False)
+                r.check(f"{label} the fire sends no value", fire["plan"]["value"], 0)
+                r.check(f"{label} the fire is not the final one", fire["final"], False)
+
+                remint = fire["remint"]
+                other_max = (remint["amount1Max"] if principal == "currency0"
+                             else remint["amount0Max"])
+                own_max = (remint["amount0Max"] if principal == "currency0"
+                           else remint["amount1Max"])
+                r.check(f"{label} the re-mint spends none of the harvested currency",
+                        other_max, 0)
+                r.check(f"{label} the re-mint spends the principal", own_max > 0, True)
+                r.check(f"{label} the re-mint keeps the pinned far edge",
+                        remint["tickUpper"] if principal == "currency0"
+                        else remint["tickLower"],
+                        mandate["immutable"]["farEdgeTick"])
+                need = (fire["required"]["amount0"] if principal == "currency0"
+                        else fire["required"]["amount1"])
+                r.check(f"{label} the re-mint costs less than the exit frees",
+                        need < fire["remainder"], True)
+
+                # The final milestone must not re-arm, whatever the geometry.
+                last = len(mandate["immutable"]["stepsBps"]) - 1
+                final_fire = ratchet.plan_fire(client, env["chain"], mandate, last)
+                r.check(f"{label} the final milestone exits without re-arming",
+                        final_fire["remint"], None)
+                r.check(f"{label} the final fire is decrease+burn+take",
+                        final_fire["plan"]["actions"],
+                        [ACTIONS["DECREASE_LIQUIDITY"], ACTIONS["BURN_POSITION"],
+                         ACTIONS["TAKE_PAIR"]])
+            finally:
+                env["restore"]()
+
+
+def _tier7_predicate(r) -> None:
+    import lp_write
+    import ratchet
+    from unilp.chains import resolve_chain
+
+    base = resolve_chain("base")
+    for principal in ("currency0", "currency1"):
+        fixture = _ratchet_fixture(principal)
+        env = _ratchet_env(lp_write, ratchet, base, fixture, principal, "currency1")
+        try:
+            mandate = _ratchet_mandate(ratchet, env, principal)
+            client = _StubClient()
+            fire = ratchet.plan_fire(client, env["chain"], mandate, 0)
+            fields = ratchet.hash_fields(env["chain"], mandate, fire, 0, 1200)
+            check = ratchet.make_predicate(env["chain"], mandate, 0)
+            signer = {"address": _ME, "privateKey": "0x00", "simulateOnly": False}
+
+            def run(mutation=None, sgn=None, milestone=0):
+                mutated = dict(fields, **(mutation or {}))
+                fn = check if milestone == 0 else ratchet.make_predicate(
+                    env["chain"], mandate, milestone)
+                fn(client, env["chain"], {}, sgn or signer,
+                   {"hashFields": mutated}, "deadbeef")
+
+            def refuses(name, **kwargs):
+                try:
+                    run(**kwargs)
+                except RuntimeError:
+                    r.check(f"[{principal}] predicate refuses {name}", True, True)
+                    return
+                r.check(f"[{principal}] predicate refuses {name}", False, True)
+
+            run()
+            r.check(f"[{principal}] predicate accepts its own plan", True, True)
+
+            refuses("a different tokenId", mutation={"tokenId": lp_write.Big(9)})
+            refuses("a different recipient", mutation={"recipient": _TOKEN})
+            refuses("a partial exit", mutation={"liquidity": lp_write.Big(1)})
+            refuses("a looser slippage floor", mutation={"amount0Min": lp_write.Big(0),
+                                                         "amount1Min": lp_write.Big(0)})
+            refuses("a longer deadline", mutation={"deadlineSecs": 99_999})
+            refuses("a foreign command", mutation={"cmd": "burn"})
+            refuses("a plan-only signer",
+                    sgn={"address": _ME, "privateKey": None, "simulateOnly": True})
+            refuses("a signer that is not the one that armed it",
+                    sgn={"address": _TOKEN, "privateKey": "0x00", "simulateOnly": False})
+            moved = "remintTickUpper" if principal == "currency0" else "remintTickLower"
+            refuses("a moved far edge", mutation={moved: fields[moved] + 60})
+            other = ("remintAmount1Max" if principal == "currency0"
+                     else "remintAmount0Max")
+            refuses("a re-mint that spends the harvested currency",
+                    mutation={other: lp_write.Big(1)})
+
+            # The shape of the re-mint is bound above; this binds its SIZE. The plan omits a
+            # SETTLE leg only because the mint is funded entirely by the delta the decrease
+            # credits in the same unlock, so liquidity that needs more principal than the
+            # exit frees would send a transaction that cannot do anything but revert.
+            mine = ("remintAmount0Max" if principal == "currency0"
+                    else "remintAmount1Max")
+            refuses("a re-mint sized past what the exit frees",
+                    mutation={"remintLiquidity": lp_write.Big(
+                        int(fields["remintLiquidity"]) * 4)})
+            refuses("an empty re-mint",
+                    mutation={"remintLiquidity": lp_write.Big(0)})
+            refuses("a principal allowance larger than the exit frees",
+                    mutation={mine: lp_write.Big(2**120)})
+
+            # An already-fired milestone can never be replayed.
+            mandate["milestonesFired"] = 2
+            refuses("a milestone that already fired")
+            mandate["milestonesFired"] = 0
+        finally:
+            env["restore"]()
+
+
+def _tier7_authorization(r) -> None:
+    import lp_write
+
+    r.check("importing the runner does not put lp_write in CLI mode",
+            lp_write._ARGV_ENTRY, False)
+    r.check("run_plan takes authorization keyword-only",
+            "authorization" in lp_write.run_plan.__code__.co_varnames
+            and lp_write.run_plan.__code__.co_kwonlyargcount >= 1, True)
+
+    made = lp_write.MandateAuthorization(mandate_id="m", fire_id="f",
+                                         predicate=lambda *a: None)
+    r.check("the runner can construct an authorization",
+            isinstance(made, lp_write.MandateAuthorization), True)
+
+    saved = lp_write._ARGV_ENTRY
+    try:
+        lp_write._ARGV_ENTRY = True
+        threw = False
+        try:
+            lp_write.MandateAuthorization(mandate_id="m", fire_id="f",
+                                          predicate=lambda *a: None)
+        except RuntimeError:
+            threw = True
+        r.check("a CLI process cannot construct an authorization at all", threw, True)
+    finally:
+        lp_write._ARGV_ENTRY = saved
+
+    # A non-MandateAuthorization must fail closed rather than being trusted, and a hash
+    # echo must never be combined with a mandate.
+    calls = {"n": 0}
+
+    def stub_simulate(client, call):
+        calls["n"] += 1
+        return {"ok": True, "method": "eth_call", "logs": [], "gasUsed": None, "revert": None}
+
+    real_simulate = lp_write.simulate_call
+    lp_write.simulate_call = stub_simulate
+    chain = {"positionManager": _TOKEN, "chainId": 1}
+    ctx = {"title": "t", "rows": [["k", "v"]], "hashFields": {"a": 1}, "data": "0x",
+           "value": 0}
+    signer = {"address": _ME, "privateKey": "0x00", "simulateOnly": False}
+
+    def refused(args, **kwargs) -> bool:
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                lp_write.run_plan(_StubClient(), chain, args, signer, dict(ctx), **kwargs)
+        except RuntimeError:
+            return True
+        return False
+
+    try:
+        r.check("run_plan refuses a dict posing as an authorization",
+                refused({"broadcast": True}, authorization={"mandate": "x"}), True)
+        r.check("run_plan refuses a string posing as an authorization",
+                refused({"broadcast": True}, authorization="yes"), True)
+        r.check("run_plan refuses a hash echo combined with a mandate",
+                refused({"broadcast": True, "confirm": "abc"}, authorization=made), True)
+        # And the ordinary attended path is untouched: no authorization, wrong hash, refuse.
+        r.check("the attended path still requires the right PLAN_HASH",
+                refused({"broadcast": True, "confirm": "not-the-hash"}), True)
+    finally:
+        lp_write.simulate_call = real_simulate
+
+
+def _tier7_journal(r) -> None:
+    import shutil
+    import tempfile
+
+    from unilp.journal import MandateStore, mandate_id
+
+    root = Path(tempfile.mkdtemp(prefix="unilp-selftest-"))
+    try:
+        immutable = {"chainId": 4663, "tokenId": 7, "poolId": "0xfeed"}
+        ident = mandate_id(immutable)
+        r.check("mandate ids are 16 bytes, not the 4 of a PLAN_HASH", len(ident), 32)
+
+        store = MandateStore(root, "test", ident)
+        with store.lock() as acquired:
+            r.check("an idle mandate locks", acquired, True)
+            store.save({"immutable": immutable, "state": "ARMED",
+                        "liquidity": 2**100, "lastSeq": 0})
+            r.check("the file is owner-only", oct(store.path.stat().st_mode & 0o777), "0o600")
+            loaded = store.load()
+            r.check("integers past 2**53 survive as strings",
+                    loaded["liquidity"], str(2**100))
+
+            store.append({"event": "plan.built"})
+            seq = store.append({"event": "tx.sent"})
+            r.check("the log assigns increasing sequence numbers", seq, 2)
+            # A crash between the outcome record and the mandate replace leaves the view
+            # behind the log; the tail is what tells the next tick to catch up.
+            r.check("the tail exposes records the mandate has not absorbed",
+                    [rec["event"] for rec in store.tail(loaded["lastSeq"])],
+                    ["plan.built", "tx.sent"])
+
+            # A second lock on the SAME file object is re-entrant within a process, so the
+            # meaningful check is that the lock target is not the file that gets replaced —
+            # os.replace would otherwise orphan the inode the lock is held on.
+            r.check("the lock is not the file that gets atomically replaced",
+                    store.lock_path != store.path, True)
+
+        tampered = store.path.read_text().replace('"tokenId": 7', '"tokenId": 8')
+        store.path.write_text(tampered)
+        threw = False
+        try:
+            store.load()
+        except RuntimeError:
+            threw = True
+        r.check("a mandate that no longer hashes to its filename is refused", threw, True)
+
+        # `--id` arrives straight from argv, and every path in this class is built by
+        # interpolating it. Rejecting anything that is not the shape `mandate_id` emits
+        # keeps `status`, `disarm` and especially `delete` inside the state directory.
+        for hostile in ("../../../etc/passwd", "..", "a/b", "", "ABCDEF" * 5 + "AB"):
+            refused = False
+            try:
+                MandateStore(root, "test", hostile)
+            except RuntimeError:
+                refused = True
+            r.check(f"a mandate id of {hostile!r} is refused before any path is built",
+                    refused, True)
+
+        # Only the LAST journal line may be unreadable — that is a torn write from a power
+        # cut, and the record it lost had not been confirmed anyway. A bad line with good
+        # lines after it is damage of a different kind, and since the tail of this log is
+        # what restores an in-flight fire, quietly skipping it could erase the only proof a
+        # transaction was signed.
+        good = MandateStore(root, "test", mandate_id({"chainId": 1}))
+        good.append({"event": "tx.sent"})
+        good.log_path.write_text(good.log_path.read_text() + '{"event": "tx.se\n')
+        r.check("a torn final line is tolerated",
+                [rec["event"] for rec in good.records()], ["tx.sent"])
+        good.append({"event": "tick.noop"})
+        threw = False
+        try:
+            good.records()
+        except RuntimeError:
+            threw = True
+        r.check("a corrupt line with records after it stops the runner", threw, True)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+class _RatchetChain:
+    """A chain that remembers whether the fire landed, for the recovery branches."""
+
+    def __init__(self, chain, pool_key, pool_id, me, tick=1400):
+        self.chain, self.pool_key, self.pool_id, self.me = chain, pool_key, pool_id, me
+        self.tick = tick
+        self.burned: set = set()
+        self.nonce = 0
+        self.receipts: dict = {}
+        self.logs: list = []
+        self.in_mempool = None
+        # Flipped on to model an unreachable node: `rpc.multicall` reports a transport
+        # failure the same way it reports a revert, so the reconciler must not read one as
+        # the other. Everything in the batch fails together, which is what makes the
+        # liveness control call able to tell them apart.
+        self.rpc_down = False
+        # tokenId -> (tickLower, tickUpper); anything unlisted is the original range.
+        self.ranges: dict = {}
+
+    # -- RpcClient surface -------------------------------------------------
+    def get_block(self, block="latest"):
+        return {"timestamp": hex(1_800_000_000)}
+
+    def block_number(self):
+        return 1000
+
+    def transaction_count(self, address, block="pending"):
+        return self.nonce
+
+    def get_receipt(self, tx_hash):
+        return self.receipts.get(tx_hash)
+
+    def request(self, method, params=None):
+        return self.in_mempool
+
+    def get_logs(self, params):
+        return self.logs
+
+    def multicall(self, calls, allow_failure=True, **kwargs):
+        if self.rpc_down:
+            return [{"status": "failure", "result": None,
+                     "error": "call failed on its own"} for _ in calls]
+        out = []
+        for call in calls:
+            name = call["functionName"]
+            args = call.get("args") or []
+            token_id = int(args[0]) if args else None
+            if name == "ownerOf":
+                out.append({"status": "failure", "result": None} if token_id in self.burned
+                           else {"status": "success", "result": self.me})
+            elif name == "getPositionLiquidity":
+                out.append({"status": "success",
+                            "result": 0 if token_id in self.burned else 10**20})
+            elif name == "nextTokenId":
+                out.append({"status": "success", "result": 9999})
+            else:
+                out.append({"status": "success", "result": 0})
+        return out
+
+    # -- loaders -----------------------------------------------------------
+    def position(self, client, chn, token_id):
+        if int(token_id) in self.burned:
+            raise RuntimeError(f"tokenId {token_id} has an empty PoolKey — burned")
+        lower, upper = self.ranges.get(int(token_id), (600, 3000))
+        return {"tokenId": int(token_id), "poolKey": self.pool_key, "poolId": self.pool_id,
+                "tickLower": lower, "tickUpper": upper, "hasSubscriber": False,
+                "liquidity": 10**20, "owner": self.me}
+
+    def state(self, client, chn, pool_id, key):
+        from unilp.v4_math import get_sqrt_ratio_at_tick
+        return {"poolId": pool_id, "poolKey": key, "tick": self.tick,
+                "sqrtPriceX96": get_sqrt_ratio_at_tick(self.tick), "lpFee": 3000,
+                "activeLiquidity": 10**20}
+
+    def erc721_log(self, token_id):
+        return {"address": self.chain["positionManager"],
+                "topics": [_TOPIC_ERC721, "0x" + "0" * 64,
+                           "0x" + "0" * 24 + self.me[2:].lower(),
+                           "0x" + f"{token_id:064x}"],
+                "data": "0x"}
+
+
+_TOPIC_ERC721 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+
+def _tier7_state_machine(r) -> None:
+    """The FIRE_SENT recovery table, driven for real against a stub chain.
+
+    Every row here is a crash or a network outcome that a cron-driven runner will meet, and
+    getting one wrong either strands funds or sends a duplicate. They are cheap to assert and
+    impossible to reason about reliably by reading the code.
+    """
+    import shutil
+    import tempfile
+
+    import lp_write
+    import ratchet
+    from unilp.chains import resolve_chain
+    from unilp.journal import MandateStore, mandate_id
+    from unilp.v4_pool import compute_pool_id
+
+    chain = resolve_chain("base")
+    pool_key = {"currency0": _LOW, "currency1": _HIGH, "fee": 3000, "tickSpacing": 60,
+                "hooks": lp_write.NATIVE}
+    pool_id = compute_pool_id(pool_key)
+    world = _RatchetChain(chain, pool_key, pool_id, _ME)
+
+    immutable = {
+        "schemaVersion": 1, "chainId": chain["chainId"], "chainKey": "base",
+        "positionManager": chain["positionManager"], "poolId": pool_id, "poolKey": pool_key,
+        "signer": _ME, "originalTokenId": 7, "principal": "currency0", "farEdgeTick": 3000,
+        "originalTickLower": 600, "originalTickUpper": 3000,
+        "originalPrincipalRaw": "10973255779209930436",
+        "stepsBps": [3000, 6000, 10_000], "label": "",
+    }
+    ident = mandate_id(immutable)
+    fire = {"fireId": f"{ident}:0:0", "milestone": 0, "planHash": "abcd1234", "final": False,
+            "plannedTick": 1400, "plannedRemainderRaw": "7168265174372228876",
+            "remintTickLower": 1440, "remintTickUpper": 3000,
+            "tx": {"hash": "0xfire", "nonce": 0, "sentAtBlock": 900}}
+
+    root = Path(tempfile.mkdtemp(prefix="unilp-ratchet-"))
+    saved_env = os.environ.get("UNILP_STATE_DIR")
+    os.environ["UNILP_STATE_DIR"] = str(root)
+    saved = {name: getattr(lp_write, name)
+             for name in ("load_position_for_write", "load_pool_state", "token_info",
+                          "simulate_call")}
+    lp_write.load_position_for_write = world.position
+    lp_write.load_pool_state = world.state
+    lp_write.token_info = lambda c, ch, a: {"address": a, "symbol": "T", "decimals": 18,
+                                            "isNative": False}
+    lp_write.simulate_call = lambda c, call: {"ok": True, "method": "eth_simulateV1",
+                                              "logs": [], "gasUsed": 1, "revert": None}
+    signer = {"address": _ME, "privateKey": "0x" + "11" * 32, "simulateOnly": False}
+
+    def seed(state, current_fire, max_attempts=2):
+        world.burned, world.nonce = set(), 0
+        world.receipts, world.logs, world.in_mempool = {}, [], None
+        world.rpc_down, world.ranges = False, {}
+        store = MandateStore(root, "base", ident)
+        store.delete()
+        mandate = {
+            "immutable": immutable,
+            "bounds": {"maxSlippageBps": 100, "maxDeadlineSecs": 1200, "maxTickDrift": 600,
+                       "allowHooked": False, "maxAttempts": max_attempts,
+                       "maxPrincipalRawPerFire": None, "maxFeePerGasWei": None,
+                       "expiresAt": None},
+            "state": state, "tokenId": 7, "tickLower": 600, "tickUpper": 3000,
+            "liquidity": str(10**20),
+            "thresholds": ["7681279045446951305", "4389302311683972174", "0"],
+            "milestonesFired": 0, "currentFire": current_fire,
+            "realized": {"amount0": "0", "amount1": "0"}, "lastSeq": 0, "history": [],
+        }
+        with store.lock() as ok:
+            assert ok
+            store.save(mandate)
+        return store
+
+    def tick():
+        with contextlib.redirect_stdout(io.StringIO()):
+            return ratchet.tick_one(world, chain, {}, signer, ident, False)
+
+    try:
+        seed("FIRE_SENT", dict(fire))
+        world.in_mempool = {"hash": "0xfire"}
+        out = tick()
+        r.check("a pending fire is left alone", (out["action"], out["state"]),
+                ("waiting", "FIRE_SENT"))
+
+        seed("FIRE_SENT", dict(fire))
+        out = tick()
+        r.check("a dropped fire is retried", out["truth"], "not-sent")
+
+        seed("FIRE_SENT", dict(fire))
+        world.nonce = 1
+        out = tick()
+        r.check("a consumed nonce with the NFT intact is a revert, not a landing",
+                out["truth"], "not-sent")
+
+        # The retry budget has to survive on the MANDATE, not on currentFire. Each round
+        # below re-enters FIRE_SENT with a currentFire that carries no attempt count — the
+        # state a crash between the send and the journal write leaves behind. A runner that
+        # counts on currentFire reads zero every round and retries for ever.
+        store = seed("FIRE_SENT", dict(fire), max_attempts=2)
+        seen = []
+        for _ in range(4):
+            out = tick()
+            seen.append((out.get("attempt"), out["state"]))
+            if out["state"] == "NEEDS_ATTENTION":
+                break
+            mandate = store.load()
+            mandate["state"] = "FIRE_SENT"
+            mandate["currentFire"] = dict(fire)
+            with store.lock() as ok:
+                assert ok
+                store.save(mandate)
+        r.check("repeated drops accumulate towards maxAttempts", seen,
+                [(1, "ARMED"), (2, "ARMED"), (None, "NEEDS_ATTENTION")])
+
+        seed("FIRE_SENT", dict(fire))
+        world.burned = {7}
+        world.receipts["0xfire"] = {"status": "0x1", "blockNumber": "0x1", "gasUsed": "0x1",
+                                    "logs": [world.erc721_log(101)]}
+        out = tick()
+        r.check("a burned NFT plus a receipt adopts the replacement",
+                (out["state"], out["tokenId"]), ("ARMED", 101))
+
+        seed("FIRE_SENT", dict(fire))
+        world.burned = {7}
+        world.logs = [world.erc721_log(202)]
+        out = tick()
+        r.check("with no receipt the bounded log scan finds the replacement",
+                (out["state"], out["tokenId"]), ("ARMED", 202))
+
+        seed("FIRE_SENT", dict(fire))
+        world.burned = {7}
+        out = tick()
+        r.check("an unidentifiable replacement escalates instead of re-minting",
+                out["state"], "NEEDS_ATTENTION")
+
+        seed("FIRE_SENT", dict(fire, final=True, milestone=2))
+        world.burned = {7}
+        out = tick()
+        r.check("the final milestone completes without re-arming", out["state"], "COMPLETE")
+
+        seed("COMPLETE", None)
+        out = tick()
+        r.check("a terminal mandate does no chain work", out["action"], "noop")
+
+        seed("ARMED", None)
+        world.burned = {7}
+        out = tick()
+        r.check("a position that vanished escalates", out["state"], "NEEDS_ATTENTION")
+
+        # --- the write-ahead log actually leads the mandate file -------------
+        # A crash between `on_sent`'s journal write and the mandate replace leaves the file
+        # reading ARMED with nothing in flight. Detecting that the log is ahead is not
+        # enough; the runner has to put the fire back, or it plans the same milestone again
+        # and broadcasts a second transaction for it.
+        store = seed("ARMED", None)
+        store.append({"event": "tx.sent", "fireId": fire["fireId"], "currentFire": dict(fire),
+                      "milestonesFired": 0, **fire["tx"]})
+        world.in_mempool = {"hash": "0xfire"}
+        out = tick()
+        r.check("a journalled send the mandate file never saw is replayed, not re-sent",
+                (out["state"], out["action"]), ("FIRE_SENT", "waiting"))
+        r.check("and the replay is reported", out.get("replayed"), ["tx.sent"])
+
+        # Order matters within the tail: the same fire sent and then dropped ends ARMED.
+        store = seed("ARMED", None)
+        store.append({"event": "tx.sent", "fireId": fire["fireId"], "currentFire": dict(fire),
+                      "milestonesFired": 0, **fire["tx"]})
+        store.append({"event": "tx.dropped", "reason": "dropped", "attempt": 1})
+        world.in_mempool = {"hash": "0xfire"}
+        out = tick()
+        r.check("a sent-then-dropped tail replays in order", out["state"], "ARMED")
+
+        # An event the runner has no rule for must stop it rather than be skipped: a future
+        # record type that carries state would otherwise be silently dropped on recovery.
+        store = seed("ARMED", None)
+        store.append({"event": "some.future.record"})
+        threw = False
+        try:
+            tick()
+        except RuntimeError:
+            threw = True
+        r.check("an unknown journal record halts instead of being ignored", threw, True)
+
+        # --- an unreachable node is not a burned NFT -------------------------
+        # `rpc.multicall` reports a transport failure exactly as it reports a revert. Read
+        # naively that says "the NFT is gone", which this runner treats as proof the fire
+        # landed — and on the final milestone would retire a mandate whose position is still
+        # alive and still filling.
+        seed("FIRE_SENT", dict(fire, final=True, milestone=2))
+        world.rpc_down = True
+        out = tick()
+        r.check("an unreachable node defers instead of reading a burn",
+                (out["truth"], out["action"], out["state"]),
+                ("unavailable", "deferred", "FIRE_SENT"))
+        r.check("and a deferred tick is not a halt that needs an operator",
+                out["state"] == "NEEDS_ATTENTION", False)
+
+        # --- clear-attention can finish an adoption the oracles could not ----
+        seed("FIRE_SENT", dict(fire))
+        world.burned = {7}
+        out = tick()
+        r.check("the setup lands in NEEDS_ATTENTION", out["state"], "NEEDS_ATTENTION")
+
+        world.ranges = {101: (1440, 3000)}
+        with contextlib.redirect_stdout(io.StringIO()):
+            ratchet.cmd_clear_attention(world, chain, {"id": ident, "token-id": "101"}, signer)
+        mandate = MandateStore(root, "base", ident).load()
+        r.check("an operator-supplied replacement is adopted with the milestone credited",
+                (mandate["state"], mandate["tokenId"], mandate["milestonesFired"]),
+                ("ARMED", 101, 1))
+        r.check("and the fire is recorded in the history",
+                mandate["history"][0]["newTokenId"], 101)
+
+        # The operator is standing in for an oracle, so their answer is checked like one.
+        for label, ranges, burn, expect in (
+            ("a replacement on the wrong far edge", {101: (1440, 2400)}, {7}, True),
+            ("a replacement that straddles the price", {101: (600, 3000)}, {7}, True),
+            ("an adoption while the old position is still alive", {101: (1440, 3000)},
+             set(), True),
+        ):
+            seed("FIRE_SENT", dict(fire))
+            world.burned = {7}
+            with contextlib.redirect_stdout(io.StringIO()):
+                tick()
+            world.burned, world.ranges = burn, ranges
+            refused = False
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    ratchet.cmd_clear_attention(world, chain,
+                                                {"id": ident, "token-id": "101"}, signer)
+            except RuntimeError:
+                refused = True
+            r.check(f"{label} is refused", refused, expect)
+
+        # And the happy path: price inside the range, milestone due, full dry run.
+        seed("ARMED", None)
+        out = tick()
+        r.check("a due milestone plans a fire", (out["action"], out["milestone"]),
+                ("dry-run", 0))
+        world.tick = 500
+        seed("ARMED", None)
+        out = tick()
+        r.check("no milestone before the price gets there", out["action"], "noop")
+        world.tick = 1400
+    finally:
+        for name, fn in saved.items():
+            setattr(lp_write, name, fn)
+        if saved_env is None:
+            os.environ.pop("UNILP_STATE_DIR", None)
+        else:
+            os.environ["UNILP_STATE_DIR"] = saved_env
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _tier7_duplicate_arm(r) -> None:
+    """One position, one live mandate — enforced by scanning, not by the id hash.
+
+    ``mandate_id`` hashes ``label`` along with everything else, so arming the same position
+    twice under two names produces two ids, two files, and two mandates that each intend to
+    burn the same NFT. The ``store.exists()`` check cannot see that: the ids differ. This is
+    the check that can.
+    """
+    import shutil
+    import tempfile
+
+    import ratchet
+    from unilp.journal import MandateStore, mandate_id
+
+    base = {
+        "schemaVersion": 1, "chainId": 8453, "chainKey": "base",
+        "positionManager": "0x" + "aa" * 20, "poolId": "0x" + "bb" * 32,
+        "poolKey": {"currency0": _LOW, "currency1": _HIGH, "fee": 3000, "tickSpacing": 60,
+                    "hooks": "0x" + "00" * 20},
+        "signer": _ME, "originalTokenId": 7, "principal": "currency0", "farEdgeTick": 3000,
+        "originalTickLower": 600, "originalTickUpper": 3000,
+        "originalPrincipalRaw": "1000", "stepsBps": [3000, 6000, 10_000], "label": "",
+    }
+
+    root = Path(tempfile.mkdtemp(prefix="unilp-dup-"))
+
+    def seed(immutable, state="ARMED", token_id=7, fired=0, history=None):
+        ident = mandate_id(immutable)
+        store = MandateStore(root, "base", ident)
+        with store.lock() as ok:
+            assert ok
+            store.save({"immutable": immutable, "bounds": {}, "state": state,
+                        "tokenId": token_id, "tickLower": 600, "tickUpper": 3000,
+                        "liquidity": "1", "thresholds": ["700", "400", "0"],
+                        "milestonesFired": fired, "currentFire": None,
+                        "realized": {"amount0": "0", "amount1": "0"}, "lastSeq": 0,
+                        "history": history or []})
+        return ident
+
+    def conflict(immutable):
+        return ratchet.find_position_conflict(root, "base", mandate_id(immutable), immutable)
+
+    try:
+        first = seed(base)
+
+        r.check("an unrelated position is not a conflict",
+                conflict({**base, "originalTokenId": 9}), None)
+        r.check("the mandate does not conflict with itself", conflict(base), None)
+
+        # The exact shape of the bug: same position, same terms, different label.
+        renamed = {**base, "label": "AGENTOS-7"}
+        found = conflict(renamed)
+        r.check("a second label on the same position IS a conflict",
+                None if found is None else found["id"], first)
+        # `sameTerms` is what makes a re-run idempotent instead of an error, so it has to be
+        # right in both directions.
+        r.check("identical terms are recognised as identical",
+                None if found is None else found["sameTerms"], True)
+
+        # A measurement, not a policy: principal is read off the chain at arm time and moves
+        # with the price. If it counted as a term, no re-run would ever be idempotent.
+        r.check("a re-measured principal does not make the terms differ",
+                (conflict({**base, "label": "x", "originalPrincipalRaw": "999"}) or {})
+                .get("sameTerms"), True)
+
+        for field, value in (("stepsBps", [5000, 10_000]), ("farEdgeTick", 2400),
+                             ("principal", "currency1"), ("signer", "0x" + "cc" * 20)):
+            differing = conflict({**base, "label": "x", field: value})
+            r.check(f"a different {field} is a conflict but NOT the same terms",
+                    None if differing is None else (differing["sameTerms"],
+                                                    differing["differs"]),
+                    (False, [field]))
+
+        # After a fire the mandate rolls onto the position it just minted. That one is taken
+        # too, and it is not the id in `immutable` — comparing against `originalTokenId`
+        # would leave every post-fire position free to be armed a second time.
+        MandateStore(root, "base", first).delete()
+        seed(base, token_id=9)
+        r.check("the position a fire rolled onto is taken",
+                (conflict({**base, "label": "x", "originalTokenId": 9}) or {}).get("id"),
+                mandate_id(base))
+        r.check("and the burned one it started from is not",
+                conflict({**base, "label": "x"}), None)
+        MandateStore(root, "base", mandate_id(base)).delete()
+        first = seed(base)
+
+        # Finished mandates are history. Blocking on them would make a position unusable
+        # forever after its first ratchet completes.
+        for dead in ("COMPLETE", "DISARMED", "EXPIRED"):
+            MandateStore(root, "base", first).delete()
+            seed(base, state=dead)
+            r.check(f"a {dead} mandate does not block a fresh arm", conflict(renamed), None)
+
+        # NEEDS_ATTENTION is the one non-running state that must still block: it is waiting
+        # for a human, and arming over it is exactly the mistake its note warns against.
+        MandateStore(root, "base", mandate_id(base)).delete()
+        seed(base, state="NEEDS_ATTENTION")
+        r.check("a NEEDS_ATTENTION mandate still blocks",
+                (conflict(renamed) or {}).get("state"), "NEEDS_ATTENTION")
+
+        # A mandate whose fire landed but whose replacement id is unknown is the one case
+        # where the conflict cannot be seen by tokenId — it still names the burned one.
+        MandateStore(root, "base", mandate_id(base)).delete()
+        seed(base, state="NEEDS_ATTENTION", fired=1,
+             history=[{"fireId": "x", "milestone": 0, "newTokenId": None}])
+        r.check("an unidentified re-mint is flagged when arming any other position",
+                ratchet.pending_remint_mandates(root, "base", _ME, base["poolId"]),
+                [mandate_id(base)])
+        MandateStore(root, "base", mandate_id(base)).delete()
+        seed(base, state="ARMED")
+        r.check("a healthy mandate is not flagged as a pending re-mint",
+                ratchet.pending_remint_mandates(root, "base", _ME, base["poolId"]), [])
+
+        # Failing closed here is deliberate: a mandate that no longer hashes to its filename
+        # might BE the duplicate, and arming past it would authorize unattended sends.
+        (root / "ratchet" / "base" / f"{mandate_id(base)}.json").write_text(
+            '{"immutable": {"tampered": true}}', encoding="utf-8")
+        try:
+            conflict(renamed)
+            r.check("a corrupted sibling stops the arm", "no error", "RuntimeError")
+        except RuntimeError as exc:
+            r.check("a corrupted sibling stops the arm", "does not hash" in str(exc), True)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _tier7_arm_is_idempotent(r) -> None:
+    """The wiring, driven through ``cmd_arm`` itself.
+
+    The check above proves the detector answers correctly; this proves ``arm`` asks it. They
+    are separate failures — a correct detector nobody calls is exactly the shape of duplicate
+    that reached the live state directory.
+    """
+    import shutil
+    import tempfile
+
+    import lp_write
+    import ratchet
+    from unilp.chains import resolve_chain
+    from unilp.journal import MandateStore
+    from unilp.v4_pool import compute_pool_id
+
+    chain = resolve_chain("base")
+    pool_key = {"currency0": _LOW, "currency1": _HIGH, "fee": 3000, "tickSpacing": 60,
+                "hooks": lp_write.NATIVE}
+    # Tick 300 with the stub's 600 → 3000 range: entirely above the price, so `arm` accepts
+    # it and the principal is currency0. Anything straddling is refused before this test
+    # reaches what it is here to check.
+    world = _RatchetChain(chain, pool_key, compute_pool_id(pool_key), _ME, tick=300)
+
+    root = Path(tempfile.mkdtemp(prefix="unilp-arm-"))
+    saved_env = os.environ.get("UNILP_STATE_DIR")
+    os.environ["UNILP_STATE_DIR"] = str(root)
+    saved = {name: getattr(lp_write, name)
+             for name in ("load_position_for_write", "load_pool_state", "token_info")}
+    lp_write.load_position_for_write = world.position
+    lp_write.load_pool_state = world.state
+    lp_write.token_info = lambda c, ch, a: {"address": a, "symbol": "T", "decimals": 18,
+                                            "isNative": False}
+    signer = {"address": _ME, "privateKey": "0x" + "11" * 32, "simulateOnly": False}
+
+    def arm(args):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            ratchet.cmd_arm(world, chain, args, signer)
+        return out.getvalue()
+
+    def ids():
+        return MandateStore.list_ids(root, "base")
+
+    try:
+        base_args = {"token-id": "7", "steps": "30,60,100"}
+        shown = arm(dict(base_args))
+        ident = shown.rsplit("MANDATE_HASH: ", 1)[1].split()[0]
+        r.check("a dry run arms nothing", ids(), [])
+        arm({**base_args, "confirm": ident})
+        r.check("confirming writes exactly one mandate", ids(), [ident])
+
+        # The exact sequence that produced two files on the live machine.
+        again = arm({**base_args, "label": "AGENTOS-7"})
+        r.check("re-arming the same position under a new label creates nothing", ids(),
+                [ident])
+        r.check("and says so instead of failing", "already armed as" in again, True)
+        r.check("naming the mandate that already holds it", ident in again, True)
+
+        # A --confirm on the duplicate must not slip past either: same answer, same file.
+        arm({**base_args, "label": "AGENTOS-7", "confirm": "0" * 32})
+        r.check("even with --confirm, the duplicate is not written", ids(), [ident])
+
+        # Different terms are a different matter — that is an operator error, not a re-run.
+        try:
+            arm({**base_args, "steps": "50,100", "label": "other"})
+            r.check("differing terms are refused", "no error", "RuntimeError")
+        except RuntimeError as exc:
+            r.check("differing terms are refused",
+                    ("already armed" in str(exc), "stepsBps" in str(exc)), (True, True))
+        r.check("and still write nothing", ids(), [ident])
+
+        # Disarm is the documented way out, so it has to actually clear the way.
+        with contextlib.redirect_stdout(io.StringIO()):
+            ratchet.cmd_disarm(world, chain, {"id": ident}, signer)
+        replaced = arm({**base_args, "steps": "50,100", "label": "other"})
+        r.check("after disarm the position can be armed on new terms",
+                "MANDATE_HASH" in replaced, True)
+    finally:
+        for name, fn in saved.items():
+            setattr(lp_write, name, fn)
+        if saved_env is None:
+            os.environ.pop("UNILP_STATE_DIR", None)
+        else:
+            os.environ["UNILP_STATE_DIR"] = saved_env
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def tier7(g: dict, r: Results) -> None:
+    try:
+        import lp_write  # noqa: F401
+        import ratchet  # noqa: F401
+        from unilp import journal, ratchet_math  # noqa: F401
+    except ImportError as exc:
+        r.skip("tier7/ratchet", f"ratchet modules not importable ({exc})")
+        return
+
+    _tier7_math(r)
+    _tier7_plan(r)
+    _tier7_predicate(r)
+    _tier7_authorization(r)
+    _tier7_journal(r)
+    _tier7_state_machine(r)
+    _tier7_duplicate_arm(r)
+    _tier7_arm_is_idempotent(r)
+
+
 TIERS = (
     ("Tier 0 — primitives (keccak, EIP-55, fixed point, JS arithmetic)", tier0),
     ("Tier 1 — ABI codec (encode/decode, unlockData, logs)", tier1),
@@ -1031,6 +2172,7 @@ TIERS = (
     ("Tier 4 — domain layer (PositionInfo, hooks, ranges, display)", tier4),
     ("Tier 5 — planning ergonomics (tick pull-off, price cache, messages)", tier5),
     ("Tier 6 — PLAN_HASH covers every calldata-affecting flag", tier6),
+    ("Tier 7 — ratchet: both sides, both currencies, and the mandate gate", tier7),
 )
 
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/account.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/account.py
@@ -1,0 +1,154 @@
+"""secp256k1 curve arithmetic and address derivation — everything except signing.
+
+This module exists to be *importable by the read-only path*. ``lp_read.py`` needs one
+thing from the key material — "which wallet is mine" — and that answer is a public one:
+an address is derived from a private key by a one-way function, and nothing here can
+produce a signature.
+
+The split is the whole point. ``secp256k1.py`` imports this module and adds RFC 6979 and
+``sign_digest`` on top; a caller that imports *this* module gets no path to a signature no
+matter what it passes. So ``lp_read.py`` resolving your own address does not make it
+capable of moving funds, and that stays true by construction rather than by review.
+
+The non-constant-time caveat from ``secp256k1.py`` applies here too: pure-Python
+big-integer arithmetic leaks timing. It is the same hot-wallet mitigation — and scalar
+multiplication by a private key happens here, in ``public_key``, whichever module is
+doing the importing.
+"""
+
+from __future__ import annotations
+
+from .hexutil import checksum_address, strip0x
+from .keccak import keccak256
+
+# Curve parameters (SEC 2, secp256k1). a = 0, b = 7.
+P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+GX = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798
+GY = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8
+G = (GX, GY)
+HALF_N = N // 2
+
+
+# ---------------------------------------------------------------------------
+# Curve arithmetic, in Jacobian coordinates
+# ---------------------------------------------------------------------------
+#
+# Affine addition needs a modular inverse per step; at 256 doublings that dominates the
+# runtime. Jacobian coordinates defer all of it to a single inverse at the end.
+# The point at infinity is any triple with y == 0.
+
+
+def _jacobian_double(point: tuple[int, int, int]) -> tuple[int, int, int]:
+    x, y, z = point
+    if not y:
+        return (0, 0, 0)
+    ysq = (y * y) % P
+    s = (4 * x * ysq) % P
+    m = (3 * x * x) % P  # + a*z^4, and a == 0 on this curve
+    nx = (m * m - 2 * s) % P
+    ny = (m * (s - nx) - 8 * ysq * ysq) % P
+    nz = (2 * y * z) % P
+    return (nx, ny, nz)
+
+
+def _jacobian_add(p: tuple[int, int, int], q: tuple[int, int, int]) -> tuple[int, int, int]:
+    if not p[1]:
+        return q
+    if not q[1]:
+        return p
+    u1 = (p[0] * q[2] * q[2]) % P
+    u2 = (q[0] * p[2] * p[2]) % P
+    s1 = (p[1] * q[2] * q[2] * q[2]) % P
+    s2 = (q[1] * p[2] * p[2] * p[2]) % P
+    if u1 == u2:
+        # Same x: either the same point (double it) or a point and its negation (infinity).
+        return _jacobian_double(p) if s1 == s2 else (0, 0, 1)
+    h = u2 - u1
+    r = s2 - s1
+    h2 = (h * h) % P
+    h3 = (h * h2) % P
+    u1h2 = (u1 * h2) % P
+    nx = (r * r - h3 - 2 * u1h2) % P
+    ny = (r * (u1h2 - nx) - s1 * h3) % P
+    nz = (h * p[2] * q[2]) % P
+    return (nx, ny, nz)
+
+
+def _jacobian_multiply(point: tuple[int, int, int], scalar: int) -> tuple[int, int, int]:
+    if point[1] == 0 or scalar == 0:
+        return (0, 0, 1)
+    if scalar == 1:
+        return point
+    if scalar < 0 or scalar >= N:
+        return _jacobian_multiply(point, scalar % N)
+    half = _jacobian_multiply(point, scalar // 2)
+    if scalar % 2 == 0:
+        return _jacobian_double(half)
+    return _jacobian_add(_jacobian_double(half), point)
+
+
+def _to_affine(point: tuple[int, int, int]) -> tuple[int, int] | None:
+    x, y, z = point
+    if z == 0 or y == 0:
+        return None
+    inv = pow(z, -1, P)
+    inv2 = (inv * inv) % P
+    return ((x * inv2) % P, (y * inv2 % P) * inv % P)
+
+
+def multiply(point: tuple[int, int], scalar: int) -> tuple[int, int] | None:
+    """Scalar multiplication on the curve. ``None`` is the point at infinity."""
+    return _to_affine(_jacobian_multiply((point[0], point[1], 1), scalar))
+
+
+def add(a: tuple[int, int], b: tuple[int, int]) -> tuple[int, int] | None:
+    """Point addition. ``None`` is the point at infinity."""
+    return _to_affine(_jacobian_add((a[0], a[1], 1), (b[0], b[1], 1)))
+
+
+# ---------------------------------------------------------------------------
+# Keys and addresses
+# ---------------------------------------------------------------------------
+
+
+def normalize_private_key(private_key: str | bytes | int) -> int:
+    """Parse a key in any accepted shape and range-check it.
+
+    ``0`` and anything at or above the group order are not valid scalars; a node would
+    accept the resulting signature and it would recover to the wrong address.
+    """
+    if isinstance(private_key, int):
+        value = private_key
+    elif isinstance(private_key, (bytes, bytearray)):
+        value = int.from_bytes(private_key, "big")
+    else:
+        text = strip0x(private_key.strip().strip('"').strip("'"))
+        if len(text) != 64:
+            raise ValueError("private key must be 32 bytes")
+        value = int(text, 16)
+    if not 1 <= value < N:
+        raise ValueError("private key out of range for secp256k1")
+    return value
+
+
+def public_key(private_key: str | bytes | int) -> tuple[int, int]:
+    point = multiply(G, normalize_private_key(private_key))
+    if point is None:  # Unreachable for an in-range scalar; a guard, not a branch.
+        raise ValueError("private key produced the point at infinity")
+    return point
+
+
+def address_from_public_key(point: tuple[int, int]) -> str:
+    """Last 20 bytes of keccak over the 64-byte uncompressed key, EIP-55 checksummed."""
+    body = point[0].to_bytes(32, "big") + point[1].to_bytes(32, "big")
+    return checksum_address("0x" + strip0x(keccak256(body))[24:])
+
+
+def account_from_private_key(private_key: str | bytes | int) -> dict:
+    """The signer identity. Deliberately does not carry the key in the returned dict."""
+    point = public_key(private_key)
+    return {
+        "address": address_from_public_key(point),
+        "publicKey": "0x" + point[0].to_bytes(32, "big").hex() + point[1].to_bytes(32, "big").hex(),
+    }

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/chains.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/chains.py
@@ -186,3 +186,19 @@ def resolve_private_key(signer_env: str = ENV_SIGNER) -> str:
     if len(key) != 66:
         raise RuntimeError(f"{signer_env} is not a 32-byte hex private key")
     return key
+
+
+def resolve_signer_address(signer_env: str = ENV_SIGNER) -> str:
+    """The wallet address the signing key derives — the answer to "which wallet is mine".
+
+    Imports from ``account`` rather than ``secp256k1`` on purpose. An address is public
+    information derived one-way from the key, so answering this question does not need a
+    signing path anywhere in reach, and ``lp_read.py`` can therefore call it without
+    becoming able to move funds. The distinction is structural: ``account`` has no
+    ``sign_digest`` in it.
+
+    The key itself never leaves this function.
+    """
+    from .account import account_from_private_key
+
+    return account_from_private_key(resolve_private_key(signer_env))["address"]

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/journal.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/journal.py
@@ -1,0 +1,273 @@
+"""Durable mandate state for the ratchet runner.
+
+Three files per mandate, and the split between them is load-bearing:
+
+``<id>.json``       the mandate — a materialized view, replaced atomically
+``<id>.log.jsonl``  the write-ahead log — append-only, never replaced
+``<id>.lock``       flock target — never replaced, never read
+
+The ordering rule for every side effect is: append the *intent* record and fsync, do the
+thing, append the *outcome* record and fsync, then replace the mandate. A crash before the
+replace leaves ``log.lastSeq > mandate.lastSeq``, which :meth:`MandateStore.load` detects
+and repairs by replaying the tail. A crash anywhere else is resolved against the chain, not
+against these files — they record what we *tried*, and only the chain knows what happened.
+
+**This is state, not cache.** It deliberately does not live under ``~/.cache`` like
+``prices.py``: a cache cleaner deleting a half-fired mandate is a fund-loss bug, whereas
+deleting a stale price is free.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from .chains import load_env
+from .hexutil import to_hex
+from .keccak import keccak256
+
+SCHEMA_VERSION = 1
+
+# How long a `claim` is considered fresh when reporting status. Purely cosmetic — flock is
+# what actually prevents two runners colliding, and the OS releases it when a process dies.
+CLAIM_TTL_SECS = 900
+
+# A mandate id is exactly what `mandate_id` produces and nothing else.
+MANDATE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def state_root() -> Path:
+    """Where mandates live. Mirrors ``chains.load_env``'s resolution order."""
+    load_env()
+    configured = os.environ.get("UNILP_STATE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    home = os.environ.get("AGENTOS_HOME")
+    if home:
+        return Path(home).expanduser() / "state" / "unilp"
+    return Path.home() / ".agentos" / "state" / "unilp"
+
+
+def canonical_json(payload) -> str:
+    """Stable serialisation for hashing. Sorted keys, no whitespace."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def mandate_id(immutable: dict) -> str:
+    """16 bytes of keccak over the fields that define *which* mandate this is.
+
+    Not ``plan_hash``: that truncates to 4 bytes, which is the right size for a human to
+    read back off a terminal but far too small to serve as an identity — and this value
+    names a file that authorizes unattended broadcasts.
+    """
+    digest = keccak256(to_hex(canonical_json(immutable).encode("utf-8")))
+    return digest[2:34]
+
+
+def jsonable(value):
+    """Recursively stringify ints that would lose precision in a JSON number.
+
+    ``lp_write.Big`` is an ``int`` subclass, so ``json.dumps`` emits it as a bare number and
+    a 128-bit liquidity value silently rounds for anything reading the file with a JS-style
+    parser. Everything above 2**53 becomes a string, matching ``lp_read``'s convention.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return str(value) if abs(value) > 2**53 else int(value)
+    if isinstance(value, dict):
+        return {key: jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [jsonable(item) for item in value]
+    return value
+
+
+class MandateStore:
+    """One mandate's files, with the locking and durability rules applied."""
+
+    def __init__(self, root: Path, chain_key: str, ident: str) -> None:
+        # Validate BEFORE any path is built, not after. `--id` reaches here straight from
+        # argv, and `Path / "../../x"` is a perfectly ordinary path that `unlink` will
+        # happily follow out of the state directory. Pinning the shape to what `mandate_id`
+        # emits removes the whole class rather than filtering for `..`.
+        if not MANDATE_ID_RE.match(str(ident)):
+            raise RuntimeError(
+                f"{ident!r} is not a mandate id — expected 32 lowercase hex characters. "
+                "Run `list` to see the ids that exist."
+            )
+        self.dir = Path(root) / "ratchet" / str(chain_key)
+        self.id = str(ident)
+        self.path = self.dir / f"{self.id}.json"
+        self.log_path = self.dir / f"{self.id}.log.jsonl"
+        # The lock lives on its own file because `save` calls os.replace, which swaps the
+        # inode. A flock held on the mandate file itself would guard an inode that no longer
+        # exists, and a second runner would acquire the "same" lock immediately.
+        self.lock_path = self.dir / f"{self.id}.lock"
+
+    # -- discovery ---------------------------------------------------------
+
+    @classmethod
+    def list_ids(cls, root: Path, chain_key: str) -> list[str]:
+        directory = Path(root) / "ratchet" / str(chain_key)
+        if not directory.is_dir():
+            return []
+        # Anything else in here is not ours — a stray file must not turn `tick --all` into
+        # a crash that stops the mandates behind it from being serviced.
+        return sorted(p.stem for p in directory.glob("*.json") if MANDATE_ID_RE.match(p.stem))
+
+    # -- locking -----------------------------------------------------------
+
+    @contextmanager
+    def lock(self, blocking: bool = False):
+        """Exclusive advisory lock for the whole tick, receipt wait included.
+
+        Overlapping cron ticks are expected and are not an error: the loser exits quietly.
+        Yields True when acquired, False when another runner holds it.
+        """
+        self.dir.mkdir(parents=True, exist_ok=True)
+        handle = os.open(self.lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        acquired = False
+        try:
+            flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+            try:
+                fcntl.flock(handle, flags)
+                acquired = True
+            except OSError:
+                acquired = False
+            yield acquired
+        finally:
+            if acquired:
+                fcntl.flock(handle, fcntl.LOCK_UN)
+            os.close(handle)
+
+    # -- mandate -----------------------------------------------------------
+
+    def exists(self) -> bool:
+        return self.path.is_file()
+
+    def load(self) -> dict | None:
+        try:
+            with self.path.open(encoding="utf-8") as handle:
+                mandate = json.load(handle)
+        except FileNotFoundError:
+            return None
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(
+                f"mandate {self.path} is unreadable ({exc}). Refusing to guess its state — "
+                "inspect the file and the .log.jsonl beside it."
+            ) from exc
+        if not isinstance(mandate, dict):
+            raise RuntimeError(f"mandate {self.path} is not an object")
+
+        # The identity must survive a round trip through the file. This catches truncation
+        # and hand-editing; it is not a defence against someone who can write this
+        # directory, since that person can also read the dotenv holding the signing key.
+        expected = mandate_id(mandate.get("immutable") or {})
+        if expected != self.id:
+            raise RuntimeError(
+                f"mandate {self.path} does not hash to its own filename (recomputed "
+                f"{expected}). The file was edited or corrupted."
+            )
+        return mandate
+
+    def save(self, mandate: dict) -> None:
+        """Atomic replace, with the fsyncs ``prices.py`` can afford to skip and this cannot."""
+        self.dir.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(jsonable(mandate), indent=2, sort_keys=True)
+        handle = tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=self.dir, delete=False
+        )
+        try:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        finally:
+            handle.close()
+        temporary = Path(handle.name)
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, self.path)
+        # Fsync the directory too, or the rename itself can be lost on a power cut.
+        directory = os.open(self.dir, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        except OSError:
+            pass
+        finally:
+            os.close(directory)
+
+    def delete(self) -> None:
+        for path in (self.path, self.log_path, self.lock_path):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+    # -- audit log ---------------------------------------------------------
+
+    def append(self, record: dict) -> int:
+        """Append one record and fsync. Returns the sequence number assigned."""
+        self.dir.mkdir(parents=True, exist_ok=True)
+        seq = self.last_seq() + 1
+        entry = dict(record)
+        entry["seq"] = seq
+        entry.setdefault("ts", int(time.time()))
+        entry.setdefault("mandateId", self.id)
+        line = json.dumps(jsonable(entry), sort_keys=True) + "\n"
+        # O_APPEND makes a single write atomic against other appenders, so a concurrent
+        # runner that slipped past the lock still cannot interleave half a record.
+        handle = os.open(self.log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(handle, line.encode("utf-8"))
+            os.fsync(handle)
+        finally:
+            os.close(handle)
+        return seq
+
+    def records(self) -> list[dict]:
+        """Every journalled record, in order.
+
+        Only the **final** line may be unreadable. A torn last line is what a power cut
+        during the closing ``os.write`` looks like, and the record it lost is by definition
+        the one whose side effect had not been confirmed yet — the recovery path handles
+        that against the chain. A bad line anywhere *else* is different in kind: appends are
+        sequential, so a later line exists only because that one was already complete. Its
+        damage came from something other than a crash, and since the tail of this file is
+        what restores in-flight state after a crash, silently dropping it could erase the
+        only record that a transaction was signed. That one stops the runner.
+        """
+        try:
+            text = self.log_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return []
+        lines = text.splitlines()
+        out = []
+        for index, raw in enumerate(lines):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except ValueError as exc:
+                if index == len(lines) - 1:
+                    break  # torn final line from a power cut; everything before it stands
+                raise RuntimeError(
+                    f"{self.log_path} line {index + 1} is corrupt ({exc}). This is not a "
+                    "torn tail — records after it parsed. Refusing to run on a journal "
+                    "that may be missing a send record; inspect it by hand."
+                ) from exc
+            if isinstance(parsed, dict):
+                out.append(parsed)
+        return out
+
+    def last_seq(self) -> int:
+        records = self.records()
+        return max((int(r.get("seq") or 0) for r in records), default=0)
+
+    def tail(self, since_seq: int) -> list[dict]:
+        return [r for r in self.records() if int(r.get("seq") or 0) > int(since_seq)]

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/ratchet_math.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/ratchet_math.py
@@ -1,0 +1,243 @@
+"""Ratchet math — how far a one-sided position has filled, and the price that fills it more.
+
+A one-sided v4 position is a limit order that fills gradually. This module answers the two
+questions the ratchet runner needs:
+
+* **How much of the principal is left?** — the runtime source of truth, recomputed from
+  ``getSlot0`` every tick.
+* **At what price will only ``A`` be left?** — the closed-form inverse, used at ``arm`` time
+  to show a human the exact tick each milestone will fire at.
+
+Because the second is a closed form, the ratchet never needs a price history, a sampler, or
+a scheduler that remembers anything: one ``getSlot0`` per tick is the whole data requirement.
+
+## The two directions, and why they are named after a currency
+
+In v4, price ``P = currency1 / currency0``. A range entirely **above** the current price
+holds 100% ``currency0``; entirely **below**, 100% ``currency1``. Which one is a "limit sell"
+depends on whether the token being sold sorted low or high, which the user does not control:
+
+    intent       token is      principal    range vs price   fills as tick
+    limit sell   currency0     currency0    above            rises
+    limit sell   currency1     currency1    below            falls
+    limit buy    currency0     currency1    below            falls
+    limit buy    currency1     currency0    above            rises
+
+So "sell" and "buy" are labels, not code paths. Everything here keys off **which currency is
+the principal**, which the geometry fixes completely — see :func:`principal_for_range`. That
+collapses four user-visible cases into two branches and makes the token0/token1 asymmetry
+impossible to get wrong by forgetting a case.
+"""
+
+from __future__ import annotations
+
+from .v4_math import (
+    Q96,
+    get_amounts_for_liquidity_at_ticks,
+    get_sqrt_ratio_at_tick,
+    get_tick_at_sqrt_ratio,
+    pull_off_current_tick,
+    range_status,
+)
+
+CURRENCY0 = "currency0"
+CURRENCY1 = "currency1"
+
+
+class RangeExhaustedError(RuntimeError):
+    """The band between the current price and the far edge cannot hold a range any more.
+
+    Not an error condition for the ratchet: it is exactly how the final milestone announces
+    itself. The caller exits the position without re-arming.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Which side are we on
+# ---------------------------------------------------------------------------
+
+
+def principal_for_range(tick: int, tick_lower: int, tick_upper: int) -> str:
+    """The currency a one-sided range holds, derived from geometry alone.
+
+    Mind the vocabulary clash: ``range_status`` reports where the **current tick** sits
+    relative to the range, so ``"below"`` means the tick is below the range — i.e. the range
+    is *above* the price — i.e. the principal is ``currency0``. That inversion is the single
+    most reliable way to get this backwards, so it is resolved here, once.
+    """
+    status = range_status(int(tick), int(tick_lower), int(tick_upper))
+    if status == "below":
+        return CURRENCY0
+    if status == "above":
+        return CURRENCY1
+    raise RuntimeError(
+        f"range {tick_lower} → {tick_upper} straddles the current tick {tick}, so it is "
+        "two-sided and cannot be ratcheted. Arm a range that is entirely above or entirely "
+        "below the current price."
+    )
+
+
+def far_edge_tick(tick_lower: int, tick_upper: int, principal: str) -> int:
+    """The end of the range the price is travelling towards — the edge that never moves."""
+    return int(tick_upper) if principal == CURRENCY0 else int(tick_lower)
+
+
+def fills_as_tick_rises(principal: str) -> bool:
+    return principal == CURRENCY0
+
+
+# ---------------------------------------------------------------------------
+# Fill progress
+# ---------------------------------------------------------------------------
+
+
+def remaining_principal(
+    sqrt_price_x96: int, tick_lower: int, tick_upper: int, liquidity: int, principal: str
+) -> int:
+    """How much of the principal currency the position still holds at this price.
+
+    Rounds down (``get_amounts_for_liquidity`` default), which is correct here: this is what
+    would be RECEIVED, not what must be paid.
+    """
+    amounts = get_amounts_for_liquidity_at_ticks(
+        int(sqrt_price_x96), int(tick_lower), int(tick_upper), int(liquidity)
+    )
+    return amounts["amount0"] if principal == CURRENCY0 else amounts["amount1"]
+
+
+def sqrt_price_for_remaining(
+    tick_lower: int, tick_upper: int, liquidity: int, target: int, principal: str
+) -> int:
+    """Inverse of :func:`remaining_principal`: the sqrt price at which ``target`` is left.
+
+    currency0 — ``A = L·Q96·(sb − s)/(s·sb)``  ⟹  ``s = L·Q96·sb / (A·sb + L·Q96)``
+    currency1 — ``A = L·(s − sa)/Q96``          ⟹  ``s = sa + A·Q96/L``
+
+    Both are exact rearrangements of ``get_amount{0,1}_delta``. Integer division truncates,
+    so the result can sit one wei of sqrt price early; that is irrelevant because triggering
+    is decided on the recomputed amount, never on this value. It exists to be shown to a
+    human at ``arm`` time.
+    """
+    sqrt_lower = get_sqrt_ratio_at_tick(int(tick_lower))
+    sqrt_upper = get_sqrt_ratio_at_tick(int(tick_upper))
+    amount = int(target)
+    liq = int(liquidity)
+    if liq <= 0:
+        raise ValueError("sqrt_price_for_remaining: liquidity must be > 0")
+    if amount < 0:
+        raise ValueError("sqrt_price_for_remaining: target must be >= 0")
+
+    if principal == CURRENCY0:
+        numerator = liq * Q96 * sqrt_upper
+        denominator = amount * sqrt_upper + liq * Q96
+        result = numerator // denominator
+    else:
+        result = sqrt_lower + (amount * Q96) // liq
+    return min(max(result, sqrt_lower), sqrt_upper)
+
+
+def tick_for_remaining(
+    tick_lower: int, tick_upper: int, liquidity: int, target: int, principal: str
+) -> int:
+    """:func:`sqrt_price_for_remaining` as a tick, for the ``arm`` approval table."""
+    return get_tick_at_sqrt_ratio(
+        sqrt_price_for_remaining(tick_lower, tick_upper, liquidity, target, principal)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Milestones
+# ---------------------------------------------------------------------------
+
+
+def parse_steps(raw: str | None) -> list[int]:
+    """``"30,60,100"`` -> ``[3000, 6000, 10000]`` basis points, sorted and deduplicated."""
+    text = (raw or "30,60,100").strip()
+    steps: list[int] = []
+    for chunk in text.split(","):
+        piece = chunk.strip()
+        if not piece:
+            continue
+        value = float(piece)
+        if not 0 < value <= 100:
+            raise RuntimeError(f"--steps entries must be in (0, 100], got {piece}")
+        bps = int(round(value * 100))
+        if bps not in steps:
+            steps.append(bps)
+    if not steps:
+        raise RuntimeError("--steps is empty")
+    steps.sort()
+    return steps
+
+
+def milestone_thresholds(original_principal: int, steps_bps: list[int]) -> list[int]:
+    """Absolute "principal still held" levels, measured against the ORIGINAL principal.
+
+    100k with steps 30/60/100 gives 70k / 40k / 0 — fixed numbers that do not move when a
+    fire re-arms the remainder. Rebasing onto the remainder instead would never converge to
+    zero and would need a separate stop condition.
+    """
+    original = int(original_principal)
+    return [original * (10_000 - int(bps)) // 10_000 for bps in steps_bps]
+
+
+def due_milestone(thresholds: list[int], fired: int, remaining: int) -> int | None:
+    """Index of the DEEPEST milestone now due, or ``None``.
+
+    ``fired`` is how many milestones have already gone off, so indices below it are history.
+    Returning the deepest — rather than the next — is what stops a price gap that clears two
+    levels at once from running two burn/mint cycles back to back. Every level it skipped is
+    already satisfied by the same reading, so the caller marks them fired together.
+    """
+    due: int | None = None
+    for index in range(int(fired), len(thresholds)):
+        if int(remaining) <= thresholds[index]:
+            due = index
+    return due
+
+
+# ---------------------------------------------------------------------------
+# Re-arming
+# ---------------------------------------------------------------------------
+
+
+def rearm_range(
+    current_tick: int, far_edge: int, tick_spacing: int, principal: str
+) -> tuple[int, int]:
+    """The range the unconverted remainder is redeployed into: current price → far edge.
+
+    Delegates the edge handling to :func:`pull_off_current_tick` with the side forced, so
+    the one-tick asymmetry between the two directions is decided in exactly one place:
+    ``currency0`` needs ``current < tickLower`` (strict), ``currency1`` needs
+    ``current >= tickUpper`` (not strict).
+
+    Raises :class:`RangeExhaustedError` when the price has reached or passed the far edge, which
+    is the final milestone.
+    """
+    current = int(current_tick)
+    edge = int(far_edge)
+    spacing = int(tick_spacing)
+
+    if principal == CURRENCY0:
+        if current >= edge:
+            raise RangeExhaustedError(
+                f"price is at tick {current}, at or past the far edge {edge} — the position "
+                "is fully converted, nothing left to re-arm"
+            )
+        band = (current, edge)
+    else:
+        if edge > current:
+            raise RangeExhaustedError(
+                f"price is at tick {current}, at or past the far edge {edge} — the position "
+                "is fully converted, nothing left to re-arm"
+            )
+        # pull_off_current_tick only acts on a band that straddles `current`, and for this
+        # direction it only ever moves the UPPER edge down to snap_down(current). So
+        # `current + 1` is a placeholder that satisfies the straddle test and can never
+        # appear in the result.
+        band = (edge, current + 1)
+
+    try:
+        return pull_off_current_tick(current, band[0], band[1], spacing, principal)
+    except RuntimeError as exc:  # no room for one tickSpacing on the side we must use
+        raise RangeExhaustedError(str(exc)) from exc

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/reconcile.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/reconcile.py
@@ -1,0 +1,215 @@
+"""Answering "did the fire land?" from the chain, never from our own notes.
+
+The mandate file records what the runner *tried*. Only the chain knows what happened, and
+after a crash those two can disagree in half a dozen ways. Three oracles resolve it, in
+priority order — the first that gives a total answer wins.
+
+The single-transaction fire shape is what makes this tractable. Because DECREASE, BURN and
+MINT all live in one unlock, the whole fire either happened or it did not, and **the burned
+NFT is the proof**: an ``ownerOf`` that reverts cannot mean anything else. That turns the
+hard question into a boolean, and reduces the receipt to a source of *details* rather than
+the thing that decides.
+
+One rule is worth stating on its own, because getting it wrong costs money rather than time:
+**never blind-retry a mint on ambiguous evidence.** A duplicate burn is impossible — the NFT
+is already gone and the second attempt reverts harmlessly. A duplicate mint is not: it would
+deploy the remainder twice. When Oracle C cannot run, the answer is "ask a human", not
+"probably fine".
+"""
+
+from __future__ import annotations
+
+from .abi_defs import POSITION_MANAGER_ABI, TOPIC_ERC721_TRANSFER
+from .hexutil import pad, to_hex
+
+# Sentinels for `truth`
+LANDED = "landed"          # the fire is on chain
+NOT_SENT = "not-sent"      # definitively never mined; safe to rebuild and send again
+PENDING = "pending"        # still in the mempool; do nothing this tick
+AMBIGUOUS = "ambiguous"    # the chain answered, and the answer needs a human
+UNAVAILABLE = "unavailable"  # the chain did not answer; nothing was decided, retry next tick
+
+# The distinction between the last two is worth keeping sharp. AMBIGUOUS is a fact about the
+# position — someone transferred it, someone drained it — and it should stop the mandate
+# until a human looks. UNAVAILABLE is a fact about the node, and a five-minute cron will hit
+# one eventually; halting on it would mean every RPC blip needs a manual `clear-attention`.
+# Both are equally fail-closed at the moment they occur: neither ever sends anything.
+
+ZERO_TOPIC = "0x" + "0" * 64
+
+
+# ---------------------------------------------------------------------------
+# Oracle A — the position itself
+# ---------------------------------------------------------------------------
+
+
+def position_truth(client, chain: dict, token_id: int, expected_owner: str) -> dict:
+    """Is the old position still there?
+
+    Uses ``ownerOf``, which reverts on a burned id. It deliberately does **not** use
+    ``getPoolAndPositionInfo``: that is a mapping read and returns ``success`` with an
+    all-zero PoolKey for a burned token, so it cannot distinguish "gone" from "alive".
+
+    **The control call is not optional.** ``RpcClient.multicall`` reports a transport
+    failure — node down, HTTP 500, timeout — as ``status: "failure"`` on the individual
+    call, exactly like a contract revert (``rpc.py`` bisects a failed chunk and labels a
+    lone survivor "call failed on its own"). Read naively, an RPC hiccup would therefore
+    say "the NFT is burned", which this module treats as proof the fire landed. On the
+    final milestone that would retire a mandate whose position is still alive and still
+    filling. ``nextTokenId`` rides along in the same request as a liveness witness: if it
+    came back, the node is up, multicall3 works, and the PositionManager has code, so the
+    only remaining explanation for a failed ``ownerOf`` is a real revert. If it did not
+    come back, we learned nothing and say so.
+    """
+    owner_call, liquidity_call, control_call = client.multicall([
+        {"address": chain["positionManager"], "abi": POSITION_MANAGER_ABI,
+         "functionName": "ownerOf", "args": [int(token_id)]},
+        {"address": chain["positionManager"], "abi": POSITION_MANAGER_ABI,
+         "functionName": "getPositionLiquidity", "args": [int(token_id)]},
+        {"address": chain["positionManager"], "abi": POSITION_MANAGER_ABI,
+         "functionName": "nextTokenId", "args": []},
+    ])
+
+    if owner_call["status"] != "success":
+        if control_call["status"] != "success":
+            return {"alive": None, "burned": False, "unreachable": True, "owner": None,
+                    "liquidity": 0,
+                    "anomaly": "could not read the position: ownerOf and the nextTokenId "
+                               "control call both failed, so the node — not the token — is "
+                               "what is missing"}
+        return {"alive": False, "burned": True, "unreachable": False, "owner": None,
+                "liquidity": 0}
+
+    owner = owner_call["result"]
+    liquidity = int(liquidity_call["result"]) if liquidity_call["status"] == "success" else 0
+    base = {"alive": True, "burned": False, "unreachable": False, "owner": owner}
+    if str(owner).lower() != str(expected_owner).lower():
+        return {**base, "liquidity": liquidity,
+                "anomaly": f"position is owned by {owner}, not the mandate signer "
+                           f"{expected_owner} — it was transferred out from under us"}
+    if liquidity <= 0:
+        return {**base, "liquidity": 0,
+                "anomaly": "position still exists but holds no liquidity — it was drained "
+                           "outside this mandate"}
+    return {**base, "liquidity": liquidity}
+
+
+# ---------------------------------------------------------------------------
+# Oracle B — the nonce watermark
+# ---------------------------------------------------------------------------
+
+
+def nonce_truth(client, signer: str, tx_hash: str, nonce: int) -> dict:
+    """Has our nonce been consumed, and is our transaction still in the mempool?
+
+    ``latest`` rather than ``pending``: we want the mined watermark, not one that counts
+    our own queued transaction and would always say "consumed".
+    """
+    mined_count = client.transaction_count(signer, "latest")
+    consumed = mined_count > int(nonce)
+
+    in_mempool = None
+    if not consumed:
+        try:
+            in_mempool = client.request("eth_getTransactionByHash", [tx_hash]) is not None
+        except Exception:  # noqa: BLE001 — an RPC hiccup must not look like "dropped"
+            in_mempool = None
+
+    return {"consumed": consumed, "inMempool": in_mempool, "minedCount": mined_count}
+
+
+# ---------------------------------------------------------------------------
+# Oracle C — a bounded log scan for the replacement NFT
+# ---------------------------------------------------------------------------
+
+
+def find_minted_token_id(client, chain: dict, recipient: str, from_block: int,
+                         exclude: set[int] | None = None) -> int | None:
+    """The tokenId minted to ``recipient`` since ``from_block``, if exactly one exists.
+
+    ``from_block`` comes from the journal, written before the send, which is what keeps this
+    to a handful of blocks. Without it the scan would start at genesis and Base would simply
+    refuse.
+
+    Returns ``None`` when nothing matched *or* when several did — two candidates is not a
+    reason to pick one, it is a reason to stop.
+    """
+    latest = client.block_number()
+    start = max(int(from_block), 0)
+    step = int((chain.get("logScan") or {}).get("chunkBlocks") or 9_000)
+    skip = exclude or set()
+
+    found: list[int] = []
+    cursor = start
+    while cursor <= latest:
+        window_end = min(cursor + step - 1, latest)
+        logs = client.get_logs({
+            "address": chain["positionManager"],
+            "topics": [TOPIC_ERC721_TRANSFER, ZERO_TOPIC, pad(str(recipient).lower(), size=32)],
+            "fromBlock": to_hex(cursor),
+            "toBlock": to_hex(window_end),
+        })
+        for log in logs:
+            token_id = int(log["topics"][3], 16)
+            if token_id not in skip and token_id not in found:
+                found.append(token_id)
+        cursor = window_end + 1
+
+    if len(found) == 1:
+        return found[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The combined verdict
+# ---------------------------------------------------------------------------
+
+
+def reconcile(client, chain: dict, signer: str, token_id: int, sent: dict | None) -> dict:
+    """What really happened to the in-flight fire on ``token_id``.
+
+    ``sent`` is the journalled ``{"hash", "nonce", "sentAtBlock"}``, or ``None`` when no
+    transaction was ever signed.
+
+    Returns ``{"truth", "reason", "position", "nonce"}``.
+    """
+    position = position_truth(client, chain, token_id, signer)
+
+    if position.get("unreachable"):
+        # Not knowing is its own answer, and the safe one: every other branch below acts.
+        return {"truth": UNAVAILABLE, "reason": position["anomaly"],
+                "position": position, "nonce": None}
+
+    if position["burned"]:
+        return {"truth": LANDED, "reason": "the position NFT is burned, which only this "
+                                           "mandate's transaction could have done",
+                "position": position, "nonce": None}
+
+    if position.get("anomaly"):
+        return {"truth": AMBIGUOUS, "reason": position["anomaly"],
+                "position": position, "nonce": None}
+
+    # The position is alive and ours, so the fire did not land. The only question left is
+    # whether the transaction is still coming.
+    if not sent or not sent.get("hash"):
+        return {"truth": NOT_SENT, "reason": "no transaction was ever signed",
+                "position": position, "nonce": None}
+
+    nonce = nonce_truth(client, signer, sent["hash"], sent["nonce"])
+    if nonce["consumed"]:
+        # Nonce spent but the NFT is still alive: our transaction reverted, or a manual
+        # replacement took the slot. Either way nothing changed on chain, so re-planning is
+        # safe — the burn cannot be duplicated.
+        return {"truth": NOT_SENT,
+                "reason": "nonce was consumed but the position is untouched — the "
+                          "transaction reverted or was replaced",
+                "position": position, "nonce": nonce}
+    if nonce["inMempool"]:
+        return {"truth": PENDING, "reason": "still in the mempool",
+                "position": position, "nonce": nonce}
+    if nonce["inMempool"] is None:
+        return {"truth": UNAVAILABLE,
+                "reason": "could not ask the node whether the transaction is still pending",
+                "position": position, "nonce": nonce}
+    return {"truth": NOT_SENT, "reason": "dropped from the mempool and never mined",
+            "position": position, "nonce": nonce}

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/secp256k1.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/secp256k1.py
@@ -8,6 +8,11 @@ transaction is allowed anywhere near the network. That check costs ~12 ms and re
 entire class of "wrong v, wrong s normalisation, wrong sighash" bugs, which lose money
 silently.
 
+The first of those three lives in ``account.py``, not here, and is re-exported below.
+That is not tidying: it lets ``lp_read.py`` answer "which wallet is mine" by importing a
+module that has no ``sign_digest`` in it at all. Everything a caller needs to *sign* is
+in this file, so importing the derivation half cannot reach it.
+
 Caveat that must stay visible: pure-Python big-integer arithmetic is **not constant time**.
 A local attacker who can measure this process precisely could in principle learn something
 about the key. Python has no fix for that. The mitigation is operational — this is a
@@ -19,140 +24,43 @@ from __future__ import annotations
 import hashlib
 import hmac
 
-from .hexutil import checksum_address, strip0x, to_bytes
-from .keccak import keccak256
+from .account import (
+    GX,
+    GY,
+    HALF_N,
+    G,
+    N,
+    P,
+    _jacobian_add,
+    _jacobian_multiply,
+    _to_affine,
+    account_from_private_key,
+    add,
+    address_from_public_key,
+    multiply,
+    normalize_private_key,
+    public_key,
+)
+from .hexutil import to_bytes
 
-# Curve parameters (SEC 2, secp256k1). a = 0, b = 7.
-P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
-N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
-GX = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798
-GY = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8
-G = (GX, GY)
-HALF_N = N // 2
-
-
-# ---------------------------------------------------------------------------
-# Curve arithmetic, in Jacobian coordinates
-# ---------------------------------------------------------------------------
-#
-# Affine addition needs a modular inverse per step; at 256 doublings that dominates the
-# runtime. Jacobian coordinates defer all of it to a single inverse at the end.
-# The point at infinity is any triple with y == 0.
-
-
-def _jacobian_double(point: tuple[int, int, int]) -> tuple[int, int, int]:
-    x, y, z = point
-    if not y:
-        return (0, 0, 0)
-    ysq = (y * y) % P
-    s = (4 * x * ysq) % P
-    m = (3 * x * x) % P  # + a*z^4, and a == 0 on this curve
-    nx = (m * m - 2 * s) % P
-    ny = (m * (s - nx) - 8 * ysq * ysq) % P
-    nz = (2 * y * z) % P
-    return (nx, ny, nz)
-
-
-def _jacobian_add(p: tuple[int, int, int], q: tuple[int, int, int]) -> tuple[int, int, int]:
-    if not p[1]:
-        return q
-    if not q[1]:
-        return p
-    u1 = (p[0] * q[2] * q[2]) % P
-    u2 = (q[0] * p[2] * p[2]) % P
-    s1 = (p[1] * q[2] * q[2] * q[2]) % P
-    s2 = (q[1] * p[2] * p[2] * p[2]) % P
-    if u1 == u2:
-        # Same x: either the same point (double it) or a point and its negation (infinity).
-        return _jacobian_double(p) if s1 == s2 else (0, 0, 1)
-    h = u2 - u1
-    r = s2 - s1
-    h2 = (h * h) % P
-    h3 = (h * h2) % P
-    u1h2 = (u1 * h2) % P
-    nx = (r * r - h3 - 2 * u1h2) % P
-    ny = (r * (u1h2 - nx) - s1 * h3) % P
-    nz = (h * p[2] * q[2]) % P
-    return (nx, ny, nz)
-
-
-def _jacobian_multiply(point: tuple[int, int, int], scalar: int) -> tuple[int, int, int]:
-    if point[1] == 0 or scalar == 0:
-        return (0, 0, 1)
-    if scalar == 1:
-        return point
-    if scalar < 0 or scalar >= N:
-        return _jacobian_multiply(point, scalar % N)
-    half = _jacobian_multiply(point, scalar // 2)
-    if scalar % 2 == 0:
-        return _jacobian_double(half)
-    return _jacobian_add(_jacobian_double(half), point)
-
-
-def _to_affine(point: tuple[int, int, int]) -> tuple[int, int] | None:
-    x, y, z = point
-    if z == 0 or y == 0:
-        return None
-    inv = pow(z, -1, P)
-    inv2 = (inv * inv) % P
-    return ((x * inv2) % P, (y * inv2 % P) * inv % P)
-
-
-def multiply(point: tuple[int, int], scalar: int) -> tuple[int, int] | None:
-    """Scalar multiplication on the curve. ``None`` is the point at infinity."""
-    return _to_affine(_jacobian_multiply((point[0], point[1], 1), scalar))
-
-
-def add(a: tuple[int, int], b: tuple[int, int]) -> tuple[int, int] | None:
-    """Point addition. ``None`` is the point at infinity."""
-    return _to_affine(_jacobian_add((a[0], a[1], 1), (b[0], b[1], 1)))
-
-
-# ---------------------------------------------------------------------------
-# Keys and addresses
-# ---------------------------------------------------------------------------
-
-
-def normalize_private_key(private_key: str | bytes | int) -> int:
-    """Parse a key in any accepted shape and range-check it.
-
-    ``0`` and anything at or above the group order are not valid scalars; a node would
-    accept the resulting signature and it would recover to the wrong address.
-    """
-    if isinstance(private_key, int):
-        value = private_key
-    elif isinstance(private_key, (bytes, bytearray)):
-        value = int.from_bytes(private_key, "big")
-    else:
-        text = strip0x(private_key.strip().strip('"').strip("'"))
-        if len(text) != 64:
-            raise ValueError("private key must be 32 bytes")
-        value = int(text, 16)
-    if not 1 <= value < N:
-        raise ValueError("private key out of range for secp256k1")
-    return value
-
-
-def public_key(private_key: str | bytes | int) -> tuple[int, int]:
-    point = multiply(G, normalize_private_key(private_key))
-    if point is None:  # Unreachable for an in-range scalar; a guard, not a branch.
-        raise ValueError("private key produced the point at infinity")
-    return point
-
-
-def address_from_public_key(point: tuple[int, int]) -> str:
-    """Last 20 bytes of keccak over the 64-byte uncompressed key, EIP-55 checksummed."""
-    body = point[0].to_bytes(32, "big") + point[1].to_bytes(32, "big")
-    return checksum_address("0x" + strip0x(keccak256(body))[24:])
-
-
-def account_from_private_key(private_key: str | bytes | int) -> dict:
-    """The signer identity. Deliberately does not carry the key in the returned dict."""
-    point = public_key(private_key)
-    return {
-        "address": address_from_public_key(point),
-        "publicKey": "0x" + point[0].to_bytes(32, "big").hex() + point[1].to_bytes(32, "big").hex(),
-    }
+# Re-exported so `from .secp256k1 import ...` keeps working for every existing caller —
+# and so the golden vectors in selftest.py go on testing these through this module.
+__all__ = [
+    "G",
+    "GX",
+    "GY",
+    "HALF_N",
+    "N",
+    "P",
+    "account_from_private_key",
+    "add",
+    "address_from_public_key",
+    "ecrecover",
+    "multiply",
+    "normalize_private_key",
+    "public_key",
+    "sign_digest",
+]
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/tx.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/tx.py
@@ -185,9 +185,23 @@ def estimate_gas(client, tx: dict, multiplier: float = DEFAULT_GAS_MULTIPLIER) -
 
 def prepare_transaction(client, chain: dict, signer: str, to: str, data: str,
                         value: int = 0, gas_multiplier: float = DEFAULT_GAS_MULTIPLIER,
-                        priority_fee: int | None = None) -> dict:
-    """Everything needed to sign, read from the chain in one place."""
+                        priority_fee: int | None = None,
+                        max_fee_cap: int | None = None) -> dict:
+    """Everything needed to sign, read from the chain in one place.
+
+    ``max_fee_cap`` refuses the send outright when the suggested ``maxFeePerGas`` exceeds
+    it, rather than silently clamping — a clamped fee just produces a transaction that sits
+    in the mempool and gets dropped, which for an unattended runner is a slower way to fail.
+    Off by default; gas price is deliberately excluded from PLAN_HASH, so an interactive
+    user approved the plan without seeing it either way.
+    """
     fees = suggest_fees(client, priority_fee)
+    if max_fee_cap is not None and fees["maxFeePerGas"] > int(max_fee_cap):
+        raise RuntimeError(
+            f"refusing to send: maxFeePerGas would be {fees['maxFeePerGas']} wei, over the "
+            f"{int(max_fee_cap)} wei cap (base fee {fees['baseFeePerGas']}). Wait for gas to "
+            "fall, or raise the cap."
+        )
     tx = {
         "type": "eip1559",
         "chainId": chain["chainId"],
@@ -204,12 +218,18 @@ def prepare_transaction(client, chain: dict, signer: str, to: str, data: str,
 
 
 def send_transaction(client, chain: dict, tx: dict, private_key: str,
-                     on_hash=None) -> str:
+                     on_hash=None, on_sent=None) -> str:
     """Sign and broadcast. Returns the hash; does not wait.
 
     The chain id is re-read from the node rather than trusted from the config: signing
     for 8453 and sending to 4663 produces a transaction that is either rejected or —
     worse, if the same key has funds on both — replayable.
+
+    ``on_sent`` is the durability hook: it fires after signing and before broadcast with
+    everything needed to find this transaction again, so a journal can fsync first. A crash
+    between that fsync and the broadcast is recoverable (nothing was sent); a broadcast with
+    nothing on disk would not be. ``on_hash`` is the older display-only callback and still
+    fires, after ``on_sent``.
     """
     live_chain_id = client.chain_id()
     if live_chain_id != int(tx["chainId"]):
@@ -223,6 +243,23 @@ def send_transaction(client, chain: dict, tx: dict, private_key: str,
         raise RuntimeError(
             f"refusing to send: the key derives {signed['from']}, plan says {tx['from']}"
         )
+
+    if on_sent:
+        # The head is read BEFORE broadcasting on purpose. A recovery log scan bounded by a
+        # block number taken afterwards could start past the block the transaction landed
+        # in, and would then conclude it never happened.
+        try:
+            sent_at_block = client.block_number()
+        except Exception:  # noqa: BLE001 — a missing bound only widens the recovery scan
+            sent_at_block = None
+        on_sent({
+            "hash": signed["hash"],
+            "nonce": int(tx["nonce"]),
+            "sentAtBlock": sent_at_block,
+            "maxFeePerGas": int(tx.get("maxFeePerGas") or 0),
+            "maxPriorityFeePerGas": int(tx.get("maxPriorityFeePerGas") or 0),
+            "gas": int(tx.get("gas") or 0),
+        })
 
     # Print the hash before the send, not after: if the node accepts the transaction and
     # the connection then drops, the hash is the only way to find it again.

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/v4_actions.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/v4_actions.py
@@ -191,3 +191,58 @@ def build_burn_plan(pool_key: dict, token_id: int, liquidity: int, amount0_min: 
     actions.append(ACTIONS["TAKE_PAIR"])
     params.append(encode_take_pair(pool_key["currency0"], pool_key["currency1"], recipient))
     return {"actions": actions, "params": params, "value": 0}
+
+
+def build_ratchet_plan(pool_key: dict, token_id: int, liquidity: int, amount0_min: int,
+                       amount1_min: int, recipient: str, remint: dict | None = None,
+                       hook_data: str = "0x") -> dict:
+    """Exit a one-sided position and redeploy its unconverted remainder, in ONE unlock.
+
+    ``DECREASE(all) → BURN → [MINT] → TAKE_PAIR``. The mint is omitted on the final
+    milestone, where nothing is left to redeploy; then this is exactly ``build_burn_plan``.
+
+    **There is deliberately no SETTLE leg.** Deltas accumulate per currency across the whole
+    unlock, and the mint always redeploys strictly less of the principal than the decrease
+    just credited (and zero of the other currency, because the new range is one-sided). Both
+    net deltas are therefore still positive when TAKE_PAIR runs, so nothing is owed and
+    nothing is pulled from the wallet.
+
+    Two consequences worth stating, because they are the reason this shape was chosen over
+    two separate transactions:
+
+    * Permit2 never enters the picture. An allowance that lapsed mid-mandate cannot strand
+      the position, because no allowance is used.
+    * There is no window in which the tokens are loose in the wallet with no position. The
+      fire either happened or it did not, and the burned NFT proves which.
+
+    ``remint`` is ``{"tickLower", "tickUpper", "liquidity", "amount0Max", "amount1Max"}``.
+    For a one-sided redeploy exactly one of the two maxima is non-zero; passing both is
+    accepted here but rejected upstream, where the side is known.
+    """
+    actions: list[int] = []
+    params: list[str] = []
+
+    if int(liquidity) > 0:
+        actions.append(ACTIONS["DECREASE_LIQUIDITY"])
+        params.append(
+            encode_decrease_liquidity(token_id, liquidity, amount0_min, amount1_min, hook_data)
+        )
+    actions.append(ACTIONS["BURN_POSITION"])
+    params.append(encode_burn_position(token_id, 0, 0, hook_data))
+
+    if remint is not None:
+        if int(remint["liquidity"]) <= 0:
+            raise ValueError("build_ratchet_plan: remint liquidity must be > 0")
+        actions.append(ACTIONS["MINT_POSITION"])
+        params.append(encode_mint_position(
+            pool_key, remint["tickLower"], remint["tickUpper"], remint["liquidity"],
+            remint["amount0Max"], remint["amount1Max"], recipient, hook_data,
+        ))
+
+    actions.append(ACTIONS["TAKE_PAIR"])
+    params.append(encode_take_pair(pool_key["currency0"], pool_key["currency1"], recipient))
+
+    # msg.value stays 0 even when currency0 is native ETH: the mint is funded from the
+    # in-flight delta, not from the wallet, so there is nothing to send and nothing for a
+    # SWEEP to refund. build_mint_plan's native branch would be actively wrong here.
+    return {"actions": actions, "params": params, "value": 0}

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/v4_math.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/v4_math.py
@@ -242,6 +242,79 @@ def snap_tick(tick: int, tick_spacing: int, mode: str = "nearest") -> int:
     return min(max(snapped, min_usable_tick(spacing)), max_usable_tick(spacing))
 
 
+def pull_off_current_tick(
+    current: int, tick_lower: int, tick_upper: int, spacing: int,
+    force_principal: str | None = None,
+) -> tuple[int, int]:
+    """Move a range that straddles ``current`` fully onto one side of it.
+
+    A band with one end at "where it trades right now" is the normal way to ask for a
+    single-sided add, but snapping outward pushes that end across the current tick and the
+    range comes back two-sided — the caller then has to guess a tick by hand. Keep whichever
+    side holds more of the band they asked for and pull the near edge past ``current``.
+
+    A range is single-sided below the current price when ``tickUpper <= current``, and above
+    it when ``tickLower > current``; that is the same boundary ``range_status`` uses.
+
+    ``force_principal`` names the currency the resulting range must take, and is how the
+    ratchet asks for a specific side instead of the "bigger half" heuristic:
+
+    * ``"currency0"`` — the range must sit entirely ABOVE the current price. Note this edge
+      is **strict** (``range_status`` needs ``current < tickLower``), which is why the near
+      edge is ``snap_down(current) + spacing`` and never ``current`` itself.
+    * ``"currency1"`` — entirely BELOW. That edge is **non-strict** (``current >=
+      tickUpper``), so landing exactly on ``current`` is fine.
+
+    Naming the side by its currency rather than by "above"/"below" is deliberate: this
+    module already uses "below" for *the current tick relative to the range*, which is the
+    opposite of "the range below the price", and mixing the two is how the sell/buy
+    directions get silently swapped.
+
+    Raises when the side that was asked for cannot hold a range at least one spacing wide.
+    A forced side never falls back to the other one — for the ratchet that situation means
+    "this is the final milestone", and quietly flipping sides would re-arm backwards.
+    """
+    if force_principal not in (None, "currency0", "currency1"):
+        raise ValueError(f'force_principal must be "currency0", "currency1" or None, '
+                         f"got {force_principal!r}")
+    if not (tick_lower <= current < tick_upper):
+        return tick_lower, tick_upper  # already one-sided, leave it alone
+
+    below = snap_tick(current, spacing, "down")
+    above = below + spacing
+
+    if force_principal == "currency0":
+        if above < tick_upper:
+            return above, tick_upper
+        raise RuntimeError(
+            f"no room for a currency0-only range above the current tick {current}: the band "
+            f"ends at {tick_upper}, less than one tickSpacing ({spacing}) away"
+        )
+    if force_principal == "currency1":
+        if below > tick_lower:
+            return tick_lower, below
+        raise RuntimeError(
+            f"no room for a currency1-only range below the current tick {current}: the band "
+            f"starts at {tick_lower}, less than one tickSpacing ({spacing}) away"
+        )
+
+    keep_below = (current - tick_lower) >= (tick_upper - current)
+    if keep_below and below > tick_lower:
+        return tick_lower, below
+    if not keep_below and above < tick_upper:
+        return above, tick_upper
+    # The band is thinner than one spacing on the side we wanted, so that side cannot hold a
+    # range at all. Fall back to the other one rather than returning a straddle.
+    if below > tick_lower:
+        return tick_lower, below
+    if above < tick_upper:
+        return above, tick_upper
+    raise RuntimeError(
+        f"the band is narrower than one tickSpacing ({spacing}) either side of the current "
+        f"tick {current} — widen it, or give --tick-lower/--tick-upper directly"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Price / market cap — the display path, floats allowed from here down
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #212

One commit, because the three parts interleave inside the same files
(`lp_write.py`, `selftest.py`, `SKILL.md`) and do not split into clean diffs.

## 1. Ratchet

`ratchet.py` — `arm`, `tick`, `status`, `list`, `disarm`, `clear-attention`.
Plus `unilp/journal.py` (durable state), `unilp/ratchet_math.py` (milestones and
their inverse), `unilp/reconcile.py` (three chain oracles).

**A fire is a single `modifyLiquidities`:**

    DECREASE_LIQUIDITY(all) -> BURN_POSITION -> MINT_POSITION(remainder) -> TAKE_PAIR

No SETTLE leg. The mint redeploys strictly less of the principal than the
decrease just credited, and zero of the other currency, so both net deltas are
still positive when `TAKE_PAIR` runs. Nothing is pulled from the wallet.

Two failure modes disappear rather than being handled:

- **Permit2 is never involved.** An allowance that lapsed mid-mandate cannot
  strand anything.
- **There is no window with loose tokens and no position.** The fire either
  landed or it did not, and the burned NFT proves which — which is what makes
  unattended recovery a lookup instead of a guess.

**Authorization.** `MandateAuthorization` is keyword-only, is never passed by
`main()`, is `isinstance`-checked at the gate, and refuses to construct at all
once `_ARGV_ENTRY` is set. Four independent reasons the CLI cannot build one;
`lp_write.py --broadcast` still requires a human-echoed `--confirm <PLAN_HASH>`.

Each fire is re-checked against the pinned chainId, PositionManager, poolId
(which is `keccak(PoolKey)`, so the hook address is pinned with it), tokenId,
signer, recipient, slippage floors, milestone index, the fixed far edge, a
re-derived near edge, and a zero cap on the harvested currency.

**State** lives under `$AGENTOS_HOME/state/unilp`, not the price cache — a cache
sweeper deleting a mandate mid-flight is a money bug. Write-ahead log plus a
materialized view, fsynced, 0600, with `flock` on a **separate** file because
`os.replace` swaps the inode out from under a lock held on the mandate itself.

**Both currency orderings.** `principal_is_currency0 == (range_status ==
"below")` collapses four cases to two code paths, and the one-tick asymmetry
between the directions (`tick < tickLower` strict, `tick >= tickUpper` not) is
decided in one place.

## 2. Wallet resolution

`unilp/secp256k1.py` is split. `unilp/account.py` holds the curve arithmetic and
address derivation and imports nothing that can sign; `secp256k1.py` imports it
and layers RFC 6979 on top. The dependency runs one way only, so `lp_read.py`
can answer "which wallet is mine" while having no path to a signature.
Reintroducing signing into `account.py` is a circular import, not a review
comment.

- `lp_read.py positions` resolves the owner from `UNIV4_LP_PRIVATE_KEY` when
  `--owner` is omitted; `--owner` still works for anyone else's wallet.
- `lp_write.py address` prints the derived address, before any chain or RPC
  client is built.

The documented invariant is **reworded, not quietly broken**: `lp_read.py` can
never sign, and it touches the key in exactly one function.

## 3. One live mandate per position

`mandate_id` hashes `label` with the terms, so arming one position twice under
two names produced two ids, two files, and two mandates each intending to burn
the same NFT. This happened on a live position. The existing `store.exists()`
check cannot see it — the ids differ by construction — so uniqueness is a scan.

- **Identical terms make `arm` idempotent**: print `already armed as <id>`, exit
  0. The way this arose was a setup step run twice, and an error there just
  invites a workaround.
- **Differing terms are refused**, naming the field.
- Compared against the mandate's **current** tokenId, since a fire rolls it onto
  the position it mints, and excluding `originalPrincipalRaw`, which is a
  measurement that moves with the price rather than a term.

## Verification

```
python3 scripts/selftest.py   # 695 assertions, no network
uv run ruff check .           # clean
uv run pytest tests/ -q       # 7071 passed, 27 skipped
```

The unattended paths are driven against a stub chain, not asserted by reading:
every `FIRE_SENT` recovery branch, the four principal/side combinations, and
`arm` itself. Six mutations were run against the duplicate-arm checks and all
six were caught — including one that only the end-to-end `cmd_arm` test catches,
which is the shape of the bug that reached the live state directory in the first
place: a correct check nobody calls.

## Not done, and required before this is used

The combined unlock has **never been sent on chain**. The AGENTOS pool on
Robinhood has a hook, and a hook can take delta in `afterRemoveLiquidity` or
`afterAddLiquidity` in a way that makes `TAKE_PAIR` revert. SKILL.md marks the
dust rehearsal — one range above the price and one below, since they go through
different code at every layer — as required before the first broadcast, with the
two-transaction fallback documented behind it.

The optional value bounds (`--max-principal-per-fire`, `--max-fee-per-gas`,
`--expires-days`) default to **off**. Without them a fire has no ceiling beyond
the slippage floor and the identity checks. That is a deliberate choice, and
SKILL.md says so where someone arming a mandate will read it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
