### PR TITLE
feat(web-ui): add a Use button on Skills that pre-fills the chat composer

### DIFF
--- a/frontend/src/views/chat/ChatPage.test.tsx
+++ b/frontend/src/views/chat/ChatPage.test.tsx
@@ -974,6 +974,27 @@ describe('ChatPage', () => {
     })
   })
 
+  // The Skills screen's "Use" button navigates here with the lead-in already
+  // written. It is a draft, not a submission — the operator still types the
+  // actual request underneath it.
+  it('prefills the composer from ?prompt= without sending', async () => {
+    mockRpc = makeRpc()
+    renderPage('/chat?prompt=use%20skill%20xlsx%0A')
+
+    const ta = screen.getByRole('textbox', { name: 'Message' }) as HTMLTextAreaElement
+    await waitFor(() => expect(ta.value).toBe('use skill xlsx\n'))
+    expect(ta).toHaveFocus()
+    expect(mockRpc.call.mock.calls.filter(([m]) => m === 'chat.send').length).toBe(0)
+  })
+
+  it('strips ?prompt= once consumed so a reload does not re-inject it', async () => {
+    mockRpc = makeRpc()
+    renderPage('/chat?prompt=use%20skill%20xlsx%0A')
+
+    await waitFor(() => expect(probe.search).toContain('session='))
+    expect(probe.search).not.toContain('prompt=')
+  })
+
   it('switching sessions via the chip updates the URL ?session= (chat.js:1176/1809)', async () => {
     mockRpc = makeRpc()
     renderPage()

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -17,6 +17,7 @@ import {
   exportMarkdownDocument,
   hasPendingAttachmentWork,
   readAgentFromUrl,
+  readPromptFromUrl,
   readSessionFromUrl,
   webchatSessionKey,
   type ExportMessage,
@@ -134,6 +135,12 @@ export function ChatPage() {
     resolveInitialSessionKey('?' + searchParams.toString()),
   )
 
+  // `?prompt=` — a one-shot composer prefill written by the Skills screen's
+  // "Use" button. Captured from the mount-time URL (not tracked as state) so the
+  // later `persistSession` rewrite that strips the param cannot re-trigger it,
+  // and drained exactly once by the effect below.
+  const initialPromptRef = useRef(readPromptFromUrl('?' + searchParams.toString()) ?? '')
+
   // chat.js:1167-1180 `_persistSession` — mirror the canonical key into
   // localStorage + the URL `?session=` (dropping `?agent=`) so a reload / shared
   // link reopens the same session. Kept as a ref-free callback; the URL write
@@ -150,6 +157,10 @@ export function ChatPage() {
           const next = new URLSearchParams(prev)
           next.set('session', key)
           next.delete('agent')
+          // `?prompt=` is a one-shot composer prefill (Skills → "Use"). It is
+          // consumed on mount, so it must not survive into the persisted URL —
+          // otherwise a reload or a shared link re-injects the same text.
+          next.delete('prompt')
           return next
         },
         { replace: true },
@@ -198,6 +209,19 @@ export function ChatPage() {
   }, [])
   const regenerateMessage = useCallback((text: string) => {
     regenerateMessageRef.current(text)
+  }, [])
+
+  // Drain the `?prompt=` prefill into the composer once the handle is attached
+  // (refs are set before effects run). Same write path as `editMessage` above:
+  // `setValue` focuses with the caret at the end, and the mirror keeps the slash
+  // menu in sync. It never sends — the user still types their request and hits
+  // Enter, which is the whole point of the "use skill <name>" lead-in.
+  useEffect(() => {
+    const text = initialPromptRef.current
+    if (!text) return
+    initialPromptRef.current = ''
+    composerHandleRef.current?.setValue(text)
+    setComposerValue(text)
   }, [])
 
   const {

--- a/frontend/src/views/chat/logic.test.ts
+++ b/frontend/src/views/chat/logic.test.ts
@@ -28,6 +28,7 @@ import {
   normalizeSlashCommand,
   pageDumpMarkerScore,
   parseSlashInput,
+  readPromptFromUrl,
   readSessionFromUrl,
   replayGapShouldWarn,
   renderMessageAttachmentHtml,
@@ -51,6 +52,7 @@ import {
   displayRoleLabel,
   enqueuePending,
   exportMarkdownDocument,
+  MAX_URL_PROMPT_LENGTH,
   popAllPendingIntoComposer,
   popPendingTail,
   type PendingAttachment,
@@ -121,6 +123,30 @@ describe('readSessionFromUrl', () => {
   })
   it('returns null when session is absent but other params exist', () => {
     expect(readSessionFromUrl('?agent=main')).toBeNull()
+  })
+})
+
+// The Skills screen's "Use" button hands the composer a prefill through
+// `?prompt=`. Unlike the session/agent params this text is shown to the user,
+// so the reader sanitises it.
+describe('readPromptFromUrl', () => {
+  it('decodes the prompt, newline included', () => {
+    expect(readPromptFromUrl('?prompt=use%20skill%20xlsx%0A')).toBe('use skill xlsx\n')
+  })
+  it('returns null when the param is absent, empty, or the search is bare', () => {
+    expect(readPromptFromUrl('?session=agent%3Amain')).toBeNull()
+    expect(readPromptFromUrl('?prompt=')).toBeNull()
+    expect(readPromptFromUrl('')).toBeNull()
+  })
+  it('drops control characters but keeps the newline', () => {
+    expect(readPromptFromUrl('?prompt=a%00b%1Bc%7Fd%0De%0Af')).toBe('abcde\nf')
+  })
+  it('returns null when nothing survives sanitising', () => {
+    expect(readPromptFromUrl('?prompt=%00%1B')).toBeNull()
+  })
+  it('truncates an oversized prompt instead of dumping it into the composer', () => {
+    const long = 'x'.repeat(MAX_URL_PROMPT_LENGTH + 500)
+    expect(readPromptFromUrl('?prompt=' + long)).toHaveLength(MAX_URL_PROMPT_LENGTH)
   })
 })
 

--- a/frontend/src/views/chat/logic.ts
+++ b/frontend/src/views/chat/logic.ts
@@ -315,6 +315,34 @@ export function readAgentFromUrl(search: string): string | null {
 }
 
 /**
+ * The longest `?prompt=` we will accept. A prefill is meant to be a one-line
+ * lead-in ("use skill foo"), not a payload — anything past this is a malformed
+ * or hostile link, so we truncate rather than dump it into the composer.
+ */
+export const MAX_URL_PROMPT_LENGTH = 2000
+
+/**
+ * Read `?prompt=` from a search string — the composer prefill used by the
+ * Skills screen's "Use" button (`navigate('/chat?prompt=use skill <name>\n')`).
+ * Unlike `?session=` / `?agent=` this lands in user-editable text, so it is
+ * sanitised: control characters other than newline are dropped (a stray `\r`
+ * or ANSI escape has no business in a textarea) and the result is capped at
+ * `MAX_URL_PROMPT_LENGTH`. Returns `null` when absent, unparseable, or empty
+ * after sanitising, so the caller's "no prefill" branch is a single falsy test.
+ */
+export function readPromptFromUrl(search: string): string | null {
+  try {
+    const raw = new URLSearchParams(search).get('prompt')
+    if (!raw) return null
+    // Keep \n (\u000A); drop every other C0 control plus DEL.
+    const clean = raw.replace(/[\u0000-\u0009\u000B-\u001F\u007F]/g, '')
+    return clean.slice(0, MAX_URL_PROMPT_LENGTH) || null
+  } catch {
+    return null
+  }
+}
+
+/**
  * The stable transcript id for a message (chat.js:3086-3090). Legacy reads the
  * raw `transcript_id` field and coerces via `Number`, returning the number when
  * finite else `null`. We return the finite value stringified (the brief's

--- a/frontend/src/views/skills/SkillsPage.test.tsx
+++ b/frontend/src/views/skills/SkillsPage.test.tsx
@@ -17,6 +17,12 @@ vi.mock('sonner', () => ({
   },
 }))
 
+const navigateSpy = vi.fn()
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return { ...actual, useNavigate: () => navigateSpy }
+})
+
 type Handler = (...args: unknown[]) => void
 function makeRpc() {
   const listeners = new Map<string, Set<Handler>>()
@@ -365,6 +371,7 @@ const callsFor = (m: string) => mockRpc.call.mock.calls.filter(([x]) => x === m)
 describe('SkillsPage', () => {
   beforeEach(() => {
     mockRpc = makeRpc()
+    navigateSpy.mockClear()
     vi.mocked(toast.success).mockClear()
     vi.mocked(toast.error).mockClear()
     vi.mocked(toast.info).mockClear()
@@ -626,6 +633,55 @@ describe('SkillsPage', () => {
         force: true,
       }),
     )
+  })
+
+  // ── "Use" → chat with the composer prefilled ─────────────────────────────
+  // Naming the skill up front (`use skill <name>`) is the documented way to
+  // pin the agent to it; the card just saves the operator from retyping it.
+  it('the card Use button routes to chat with the skill prompt prefilled', async () => {
+    wireRpc()
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+
+    const card = screen.getByLabelText('Skill trader').closest('article') as HTMLElement
+    fireEvent.click(within(card).getByRole('button', { name: /^Use$/i }))
+
+    expect(navigateSpy).toHaveBeenCalledWith('/chat?prompt=use%20skill%20trader%0A')
+  })
+
+  it('Use does not also open the skill dialog', async () => {
+    wireRpc()
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+
+    const card = screen.getByLabelText('Skill trader').closest('article') as HTMLElement
+    fireEvent.click(within(card).getByRole('button', { name: /^Use$/i }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('the card body still opens the details dialog next to the Use button', async () => {
+    wireRpc()
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill trader')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Skill trader'))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(navigateSpy).not.toHaveBeenCalled()
+  })
+
+  it('Use in chat closes the dialog before routing', async () => {
+    wireRpc()
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Skill weather')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Skill weather'))
+
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Use in chat$/i }))
+
+    expect(navigateSpy).toHaveBeenCalledWith('/chat?prompt=use%20skill%20weather%0A')
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   })
 
   // ── Update / Uninstall from the installed-skill dialog ───────────────────

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -1,5 +1,6 @@
 import './skills.css'
-import { useEffect, useId, useMemo, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
 import {
@@ -52,6 +53,7 @@ import {
   skillAvailabilityTone,
   skillCanRemove,
   skillCanUpdate,
+  skillChatPromptPath,
   skillDotClass,
   skillDotTitle,
   skillGroupKey,
@@ -358,40 +360,69 @@ function OriginChip({ skill }: { skill: RawSkill }) {
   )
 }
 
-function SkillCard({ skill, onOpen }: { skill: RawSkill; onOpen: () => void }) {
+function SkillCard({
+  skill,
+  onOpen,
+  onUse,
+}: {
+  skill: RawSkill
+  onOpen: () => void
+  onUse: () => void
+}) {
   const desc = skill.description || ''
   const statusLabel = SKILL_BUCKET_LABEL[skillBucket(skill)]
+  // The card used to be one big <button>. "Use" is a second action, and a
+  // button cannot nest inside a button, so the shell splits the same way
+  // RegistryCard/PartnerSkillCard already do: an <article> wrapper, a details
+  // button covering the body, and an action row. The `Skill <name>` label stays
+  // on the details button so it remains the one thing that opens the dialog.
   return (
-    <button
-      type="button"
-      className="sk-card"
-      onClick={onOpen}
-      aria-label={`Skill ${skill.name}`}
-      title={skill.name + (desc ? ': ' + desc : '')}
-    >
-      <div className="sk-card__head">
-        <SkillIcon skill={skill} iconClass="sk-card__icon" brandClass="sk-card__brand" />
-        <span className="sk-card__name">{skill.name}</span>
-        <span className={`sk-card__status ${skillDotClass(skill)}`} title={skillDotTitle(skill)}>
-          <span className="sk-card__dot" aria-hidden="true" />
-          {statusLabel}
+    <article className="sk-card">
+      <button
+        type="button"
+        className="sk-card__details"
+        onClick={onOpen}
+        aria-label={`Skill ${skill.name}`}
+        title={skill.name + (desc ? ': ' + desc : '')}
+      >
+        <div className="sk-card__head">
+          <SkillIcon skill={skill} iconClass="sk-card__icon" brandClass="sk-card__brand" />
+          <span className="sk-card__name">{skill.name}</span>
+          <span className={`sk-card__status ${skillDotClass(skill)}`} title={skillDotTitle(skill)}>
+            <span className="sk-card__dot" aria-hidden="true" />
+            {statusLabel}
+          </span>
+        </div>
+        <p className="sk-card__desc">{desc}</p>
+        {/* The Installed tab groups on provenance now, so the loading layer moves
+            to the card — precedence still has to be debuggable at a glance. */}
+        <span className="sk-card__meta">
+          <span className="sk-chip sk-chip--layer" title={layerHelp(skill.layer)}>
+            {layerLabel(skill.layer)}
+          </span>
+          <OriginChip skill={skill} />
+          <AvailabilityChip skill={skill} />
         </span>
+      </button>
+      <div className="sk-card__foot">
+        {/* Still clickable, still out of the a11y tree: the details button above
+            already carries the accessible name, so a second focusable "View
+            details" here would only duplicate it. */}
+        <button
+          type="button"
+          className="sk-card__foot-link"
+          onClick={onOpen}
+          tabIndex={-1}
+          aria-hidden="true"
+        >
+          View details
+          <ChevronRightIcon />
+        </button>
+        <Button type="button" variant="outline" size="sm" onClick={onUse}>
+          Use
+        </Button>
       </div>
-      <p className="sk-card__desc">{desc}</p>
-      {/* The Installed tab groups on provenance now, so the loading layer moves
-          to the card — precedence still has to be debuggable at a glance. */}
-      <span className="sk-card__meta">
-        <span className="sk-chip sk-chip--layer" title={layerHelp(skill.layer)}>
-          {layerLabel(skill.layer)}
-        </span>
-        <OriginChip skill={skill} />
-        <AvailabilityChip skill={skill} />
-      </span>
-      <span className="sk-card__foot" aria-hidden="true">
-        View details
-        <ChevronRightIcon />
-      </span>
-    </button>
+    </article>
   )
 }
 
@@ -554,6 +585,7 @@ type Dialog =
 export function SkillsPage() {
   const rpc = useRpc()
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
 
   const [tab, setTab] = useState<Tab>('installed')
   const [filterText, setFilterText] = useState('')
@@ -565,6 +597,18 @@ export function SkillsPage() {
   const [envPrompt, setEnvPrompt] = useState<{ skill: string; name: string } | null>(null)
   const [envValue, setEnvValue] = useState('')
   const [envSaving, setEnvSaving] = useState(false)
+
+  // "Use" hands the skill name to chat as a composer prefill rather than running
+  // anything here — the same cross-screen hop AgentsPage/SessionsPage make with
+  // `?agent=` / `?session=`. Closing the dialog first keeps the modal from
+  // lingering over the chat view during the route change.
+  const openSkillInChat = useCallback(
+    (name: string) => {
+      setDialog({ kind: 'none' })
+      navigate(skillChatPromptPath(name))
+    },
+    [navigate],
+  )
 
   // Registry (bankr/community) query text + debounced community query.
   const [bankrQuery, setBankrQuery] = useState('')
@@ -1056,6 +1100,7 @@ export function SkillsPage() {
           empty={filtered.length === 0}
           emptyMessage={installedEmptyMessage(filterText, statusFilter)}
           onOpen={(name) => setDialog({ kind: 'skill', name })}
+          onUse={openSkillInChat}
         />
       ) : null}
 
@@ -1200,6 +1245,7 @@ export function SkillsPage() {
                     depsMutation.mutate({ name: skill.name!, installId })
                   }
                   onSetEnv={(name) => setEnvPrompt({ skill: skill.name!, name })}
+                  onUse={() => openSkillInChat(skill.name!)}
                 />
               )
             })()
@@ -1343,6 +1389,7 @@ function InstalledPanel({
   empty,
   emptyMessage,
   onOpen,
+  onUse,
 }: {
   loading: boolean
   error: string
@@ -1350,6 +1397,7 @@ function InstalledPanel({
   empty: boolean
   emptyMessage: string
   onOpen: (name: string) => void
+  onUse: (name: string) => void
 }) {
   if (error)
     return (
@@ -1383,7 +1431,11 @@ function InstalledPanel({
             <AnimatePresence initial={false}>
               {g.skills.map((s) => (
                 <MotionListItem key={s.name}>
-                  <SkillCard skill={s} onOpen={() => onOpen(s.name!)} />
+                  <SkillCard
+                    skill={s}
+                    onOpen={() => onOpen(s.name!)}
+                    onUse={() => onUse(s.name!)}
+                  />
                 </MotionListItem>
               ))}
             </AnimatePresence>
@@ -1760,6 +1812,7 @@ function SkillDialog({
   onRemove,
   onInstallDeps,
   onSetEnv,
+  onUse,
 }: {
   skill: RawSkill
   busyKeys: Set<string>
@@ -1768,6 +1821,7 @@ function SkillDialog({
   onRemove: () => void
   onInstallDeps: (installId: string) => void
   onSetEnv: (name: string) => void
+  onUse: () => void
 }) {
   const titleId = useId()
   const status = skillStatus(skill)
@@ -1938,6 +1992,9 @@ function SkillDialog({
         ) : skill.file_path ? (
           <small className="sk-dim sk-dialog__path">{skill.file_path}</small>
         ) : null}
+        <Button type="button" size="sm" onClick={onUse}>
+          Use in chat
+        </Button>
         {canUpdate ? (
           <Button
             type="button"

--- a/frontend/src/views/skills/logic.ts
+++ b/frontend/src/views/skills/logic.ts
@@ -314,6 +314,17 @@ export const SKILL_GROUP_ORDER: readonly SkillGroupKey[] = [
   'local',
 ] as const
 
+/**
+ * The chat URL behind a skill card's "Use" button. Naming a skill explicitly is
+ * the documented way to pin the agent to it — the prompt opens with
+ * `use skill <name>` and a newline so the user lands on a fresh line and types
+ * the actual request. ChatPage reads `?prompt=` on mount, prefills the composer
+ * and strips the param; nothing is sent automatically.
+ */
+export function skillChatPromptPath(name: string): string {
+  return '/chat?prompt=' + encodeURIComponent('use skill ' + name + '\n')
+}
+
 export const SKILL_GROUP_LABEL: Record<SkillGroupKey, string> = {
   partners: 'Partner Skills',
   crypto: 'AgentOS Crypto Skills',

--- a/frontend/src/views/skills/skills-css.test.ts
+++ b/frontend/src/views/skills/skills-css.test.ts
@@ -67,8 +67,10 @@ describe('Skills directory CSS contract', () => {
   })
 
   it('keeps the installed chip the same height as the card install action', () => {
+    // The installed-card foot shares this rule with the catalog card, so the
+    // "Use" button lines up with an Install button at the same height.
     expect(css).toMatch(
-      /\.control-surface \.sk-rcard__foot \[data-slot='button'\] \{[\s\S]*?min-height:\s*2\.25rem;/,
+      /\.control-surface \.sk-rcard__foot \[data-slot='button'\],\s*\.control-surface \.sk-card__foot \[data-slot='button'\] \{[\s\S]*?min-height:\s*2\.25rem;/,
     )
     expect(css).toMatch(
       /\.control-surface \.sk-rcard__foot \.sk-chip--card-action \{[\s\S]*?display:\s*inline-flex;[\s\S]*?min-height:\s*2\.25rem;/,

--- a/frontend/src/views/skills/skills.css
+++ b/frontend/src/views/skills/skills.css
@@ -241,11 +241,42 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--background);
-  cursor: pointer;
   min-width: 0;
 }
 .sk-card:hover {
   border-color: var(--dim);
+}
+/* The card body is the "open details" target; the foot row next to it carries
+   the Use action, so the two cannot be one button (mirrors .sk-rcard__details). */
+.sk-card__details {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+.sk-card__details:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 3px;
+}
+.sk-card__foot-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 .sk-card__head {
   display: flex;
@@ -1281,7 +1312,8 @@
 .control-surface .sk-card__foot {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  justify-content: space-between;
+  gap: 0.5rem;
   margin-top: auto;
   color: var(--dim);
   font-size: 0.6875rem;
@@ -1294,11 +1326,11 @@
   transition: transform 180ms ease;
 }
 
-.control-surface .sk-card:hover .sk-card__foot {
+.control-surface .sk-card:hover .sk-card__foot-link {
   color: var(--primary);
 }
 
-.control-surface .sk-card:hover .sk-card__foot svg {
+.control-surface .sk-card:hover .sk-card__foot-link svg {
   transform: translateX(2px);
 }
 
@@ -1484,7 +1516,8 @@
   line-clamp: 3;
 }
 
-.control-surface .sk-rcard__foot [data-slot='button'] {
+.control-surface .sk-rcard__foot [data-slot='button'],
+.control-surface .sk-card__foot [data-slot='button'] {
   min-height: 2.25rem;
 }
 


### PR DESCRIPTION
Fixes #215

## What

Adds a **Use** action to the Skills screen so the `use skill <name>` prefix is one click instead of something to remember and retype.

- `Use` button in every installed skill card footer, next to `View details`.
- `Use in chat` button in the skill detail dialog footer (closes the dialog first).

Both navigate to Chat with the composer pre-filled with `use skill <name>\n`, focused, caret at the end. **Nothing is sent** — the user types the request underneath and submits it. The current chat session is kept.

## How

The prefill travels as a one-shot `?prompt=` query param, alongside the `?agent=` and `?session=` params the app already uses for cross-screen navigation.

- `chat/logic.ts` — new `readPromptFromUrl()`, next to `readSessionFromUrl` / `readAgentFromUrl`. Because this text is shown back to the user, it drops C0 control characters other than `\n` and truncates at `MAX_URL_PROMPT_LENGTH` (2000).
- `ChatPage.tsx` — captures the prompt once on mount and deposits it via the existing `ComposerHandle.setValue` seam (already used by `editMessage`); `persistSession` now also does `next.delete('prompt')`, so a reload or a shared link does not re-inject the text. `onComposerSend` is untouched.
- `skills/logic.ts` — `skillChatPromptPath()` builds the URL for both call sites.
- `SkillsPage.tsx` — a skill card used to be a single `<button>`, so a nested action button would have been invalid HTML. `SkillCard` now follows the `RegistryCard` / `PartnerSkillCard` shape already in this file: an `<article>` wrapper, an inner `.sk-card__details` button, and an action footer row. The `Skill <name>` aria-label stays on the details button, so the card body still opens the dialog and existing selectors keep working unchanged.
- `skills.css` — `.sk-card__details` and `.sk-card__foot-link` rules, footer becomes a `space-between` row, hover moves to the foot link, and the `Use` button reuses the catalog card's `min-height: 2.25rem` so it lines up with an `Install` button.

No `Composer.tsx` change was needed. No backend, CLI surface, or config change.

## Tests

`npm --prefix frontend run check` — **80 files, 1640 tests, 0 failures**; tsc, eslint and prettier clean.

11 new tests:
- `chat/logic.test.ts` (5) — decodes `%0A`, null on absent/empty/bare search, strips control chars while keeping `\n`, truncates at the limit.
- `ChatPage.test.tsx` (2) — composer pre-filled and focused from `?prompt=` with zero `chat.send` calls; `?prompt=` stripped from the URL while `session=` survives.
- `SkillsPage.test.tsx` (4) — card `Use` navigates to the right URL; `Use` does not open the dialog; the card body still opens the dialog and does not navigate; `Use in chat` navigates and closes the dialog.

## Manual verification

Ran against a live gateway with the Vite dev server:

- `Use` buttons render where expected in every installed group, dark and light theme.
- `Use` on `bankr` → Chat with `use skill bankr` in the composer, focused, `No messages yet.`, URL keeps `?session=` and has no `?prompt=`.
- `Use in chat` on `capminal` → dialog closes, same result.
- Clicking the card body still opens the detail dialog.

One gap, stated plainly: the **≤768px layout was verified by reading the CSS, not visually** — the browser resize did not change the captured viewport. Risk is low (the grid collapses to one column and the footer holds two short items), but it was not seen with my own eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
