### PR TITLE
fix(web-ui): keep cron cards inside their grid track and surface the cron ID

### DIFF
--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,20 @@
+// Copy with a non-secure-context fallback, mirroring the shared CommandLine
+// copy contract (clipboard API, else a hidden-textarea execCommand). Legacy
+// sessions used a bare navigator.clipboard call with no fallback, so this is a
+// deliberate uplift (recorded as ported(uplift) in the parity matrix) that lets
+// the copy work when the page isn't served from a secure context.
+export function copyWithFallback(text: string): Promise<void> {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    return navigator.clipboard.writeText(text)
+  }
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.setAttribute('readonly', '')
+  ta.style.position = 'fixed'
+  ta.style.left = '-9999px'
+  document.body.appendChild(ta)
+  ta.select()
+  const ok = document.execCommand('copy')
+  document.body.removeChild(ta)
+  return ok ? Promise.resolve() : Promise.reject(new Error('Copy command failed'))
+}

--- a/frontend/src/views/cron/CronPage.test.tsx
+++ b/frontend/src/views/cron/CronPage.test.tsx
@@ -182,6 +182,44 @@ describe('CronPage', () => {
     expect(screen.getByText('Health check')).toBeInTheDocument()
   })
 
+  it('shows the cron id on the card, shortened but recoverable in full', async () => {
+    const uuid = '3f9a2b1c-77d0-4e21-9c33-8a1b2c3d9d4e'
+    wireRpc({ jobs: [{ ...REMINDER_JOB, id: uuid }] })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    const card = screen.getByLabelText('Cron job Daily standup')
+    expect(within(card).getByText('Cron ID')).toBeInTheDocument()
+    // Shortened for the card, full value on the row's title for hover/copy.
+    expect(within(card).getByText('3f9a2b1c…9d4e')).toBeInTheDocument()
+    expect(within(card).getByTitle(uuid)).toBeInTheDocument()
+  })
+
+  it('copies the full cron id and toasts on success', async () => {
+    const uuid = '3f9a2b1c-77d0-4e21-9c33-8a1b2c3d9d4e'
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    wireRpc({ jobs: [{ ...REMINDER_JOB, id: uuid }] })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    const card = screen.getByLabelText('Cron job Daily standup')
+    fireEvent.click(within(card).getByRole('button', { name: `Copy cron ID ${uuid}` }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(uuid))
+    expect(toast.success).toHaveBeenCalledWith('Copied cron ID', expect.anything())
+  })
+
+  it('warns when copying the cron id fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.assign(navigator, { clipboard: { writeText } })
+    wireRpc({ jobs: [REMINDER_JOB] })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    const card = screen.getByLabelText('Cron job Daily standup')
+    fireEvent.click(within(card).getByRole('button', { name: 'Copy cron ID job-rem' }))
+    await waitFor(() =>
+      expect(toast.warning).toHaveBeenCalledWith('Copy failed: denied', expect.anything()),
+    )
+  })
+
   it('shows the elevated badge on the card, without opening the editor', async () => {
     wireRpc({ jobs: [{ ...AGENT_JOB, elevated: 'bypass' }] })
     renderPage()

--- a/frontend/src/views/cron/CronPage.tsx
+++ b/frontend/src/views/cron/CronPage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CalendarClockIcon,
+  CopyIcon,
   PencilIcon,
   PlusIcon,
   RefreshCwIcon,
@@ -18,6 +19,7 @@ import {
 import { toast } from 'sonner'
 import { ModalShell } from '@/components/ModalShell'
 import { Button } from '@/components/ui/button'
+import { copyWithFallback } from '@/lib/clipboard'
 import { MotionListItem } from '@/lib/motion'
 import { useRpc } from '@/app/providers'
 import { relTime } from '@/views/overview/logic'
@@ -39,6 +41,7 @@ import {
   nextRunAbs,
   nextRunText,
   runRow,
+  shortCronId,
   sortJobs,
   type CronDot,
   type RawJob,
@@ -247,6 +250,7 @@ function JobCard({
   onRun,
   onEdit,
   onDelete,
+  onCopyId,
 }: {
   job: RawJob
   busy: boolean
@@ -256,6 +260,7 @@ function JobCard({
   onRun: (id: string) => void
   onEdit: (job: RawJob) => void
   onDelete: (job: RawJob) => void
+  onCopyId: (id: string) => void
 }) {
   const id = String(job.id ?? '')
   const name = String(job.name || job.id || '')
@@ -312,14 +317,36 @@ function JobCard({
       </div>
 
       <dl className="cron-card__meta">
+        {id ? (
+          <div className="cron-card__id">
+            <dt className="t-label">Cron ID</dt>
+            <dd className="t-data cron-mono" title={id}>
+              <span className="cron-card__id-value">{shortCronId(id)}</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                title="Copy cron ID"
+                aria-label={`Copy cron ID ${id}`}
+                onClick={() => onCopyId(id)}
+              >
+                <CopyIcon />
+              </Button>
+            </dd>
+          </div>
+        ) : null}
         <div>
           <dt className="t-label">Target</dt>
-          <dd className="t-data">{target}</dd>
+          <dd className="t-data" title={target}>
+            {target}
+          </dd>
         </div>
         {createdFrom ? (
           <div>
             <dt className="t-label">Created from</dt>
-            <dd className="t-data cron-mono">{createdFrom}</dd>
+            <dd className="t-data cron-mono" title={createdFrom}>
+              {createdFrom}
+            </dd>
           </div>
         ) : null}
         <div>
@@ -589,6 +616,18 @@ export function CronPage() {
     },
   })
 
+  // The job id is the handle every `agentos cron …` command takes, so the card
+  // exposes it with a one-click copy rather than making you go find it.
+  async function copyId(id: string) {
+    try {
+      await copyWithFallback(id)
+      toast.success('Copied cron ID', { id: 'cron-copy-ok', duration: 1600 })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.warning('Copy failed: ' + message, { id: 'cron-copy-err', duration: 2500 })
+    }
+  }
+
   const jobs = jobsQuery.data ?? []
   const busy = toggleMutation.isPending || runMutation.isPending || removeMutation.isPending
 
@@ -762,7 +801,7 @@ export function CronPage() {
           <div className="cron-cards">
             <AnimatePresence initial={false}>
               {visible.map((job, i) => (
-                <MotionListItem key={String(job.id ?? i)}>
+                <MotionListItem key={String(job.id ?? i)} className="cron-cards__item">
                   <JobCard
                     job={job}
                     busy={busy}
@@ -772,6 +811,7 @@ export function CronPage() {
                     onRun={(id) => runMutation.mutate(id)}
                     onEdit={(j) => setPanel({ kind: 'edit', job: j })}
                     onDelete={(j) => setPendingDelete(j)}
+                    onCopyId={(id) => void copyId(id)}
                   />
                 </MotionListItem>
               ))}

--- a/frontend/src/views/cron/cron-css.test.ts
+++ b/frontend/src/views/cron/cron-css.test.ts
@@ -24,6 +24,21 @@ describe('Cron scheduling workspace CSS contract', () => {
     )
   })
 
+  it('keeps unbreakable session keys inside the card grid track', () => {
+    // Every box between the grid track and the text must be able to shrink,
+    // otherwise a colon-separated session key sets the card's min-content width.
+    expect(css).toMatch(/\.cron-cards > \*,[\s\S]*?\.cron-cards__item \{[\s\S]*?min-width: 0;/)
+    expect(css).toMatch(/\.cron-card__meta > div \{[\s\S]*?min-width: 0;/)
+    expect(css).toMatch(/\.cron-card__meta dd \{[\s\S]*?min-width: 0;/)
+    expect(css).toMatch(/\.cron-card__meta dd \{[\s\S]*?text-overflow: ellipsis;/)
+    expect(css).toMatch(/\.cron-card__message dd \{[\s\S]*?overflow-wrap: anywhere;/)
+  })
+
+  it('lays the cron id row out as value plus copy affordance', () => {
+    expect(css).toMatch(/\.cron-card__id dd \{[\s\S]*?justify-content: flex-end;/)
+    expect(css).toMatch(/\.cron-card__id-value \{[\s\S]*?text-overflow: ellipsis;/)
+  })
+
   it('contains small-screen controls and disables decorative motion', () => {
     expect(css).toMatch(
       /@media \(max-width: 900px\)[\s\S]*?\.cron-search-wrap,[\s\S]*?\.control-surface \.cron-search \{[\s\S]*?width: 100%;/,

--- a/frontend/src/views/cron/cron.css
+++ b/frontend/src/views/cron/cron.css
@@ -107,6 +107,14 @@
   grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
   gap: 1rem;
 }
+/* Session keys have no break opportunity (a colon is not one, per UAX-14), so a
+   grid item sized by its content min-width grows past its track and the card
+   spills over its neighbour. Every box between the track and the text has to be
+   allowed to shrink. */
+.cron-cards > *,
+.cron-cards__item {
+  min-width: 0;
+}
 
 /* Job card — a .panel with a --tone status gutter. */
 .cron-card {
@@ -171,6 +179,7 @@
   flex-wrap: wrap;
   align-items: baseline;
   gap: 0.5rem;
+  min-width: 0;
 }
 .cron-expr {
   font-family: var(--font-mono, ui-monospace, monospace);
@@ -194,17 +203,42 @@
   gap: 0.75rem;
   border-bottom: 1px solid var(--border);
   padding-bottom: 0.35rem;
+  min-width: 0;
 }
 .cron-card__meta dt {
   color: var(--muted-foreground);
+  flex: none;
 }
 .cron-card__meta dd {
   margin: 0;
   text-align: right;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
+/* The prompt is prose (and may carry a contract address), so it wraps instead of
+   truncating — `anywhere` keeps an unbroken 0x… hash from widening the card. */
 .cron-card__message dd {
   text-align: left;
   color: var(--muted-foreground);
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+/* Cron ID reads as value + copy affordance on one line. */
+.cron-card__id dd {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+.cron-card__id-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cron-card__id dd > button {
+  flex: none;
 }
 .cron-card__abs {
   color: var(--muted-foreground);

--- a/frontend/src/views/cron/logic.test.ts
+++ b/frontend/src/views/cron/logic.test.ts
@@ -14,6 +14,7 @@ import {
   jobKindClass,
   jobKindLabel,
   jobSchedule,
+  shortCronId,
   jobTarget,
   nextRunAbs,
   nextRuns,
@@ -60,6 +61,15 @@ describe('jobCreatedFrom', () => {
     expect(jobCreatedFrom({ createdFrom: 'agent:main:telegram:1' })).toBe('agent:main:telegram:1')
     expect(jobCreatedFrom({ creator_session_key: 'agent:main:slack:2' })).toBe('agent:main:slack:2')
     expect(jobCreatedFrom({})).toBe('')
+  })
+})
+
+describe('shortCronId', () => {
+  it('elides the middle of a uuid but leaves short ids alone', () => {
+    expect(shortCronId('3f9a2b1c-77d0-4e21-9c33-8a1b2c3d9d4e')).toBe('3f9a2b1c…9d4e')
+    expect(shortCronId('job-rem')).toBe('job-rem')
+    expect(shortCronId('0123456789abcdef')).toBe('0123456789abcdef')
+    expect(shortCronId('')).toBe('')
   })
 })
 

--- a/frontend/src/views/cron/logic.ts
+++ b/frontend/src/views/cron/logic.ts
@@ -114,6 +114,12 @@ export function jobCreatedFrom(job: RawJob): string {
   )
 }
 
+/** UUIDs are unreadable at card width; show head+tail, copy the full value. */
+export function shortCronId(id: string): string {
+  const s = String(id || '')
+  return s.length > 16 ? `${s.slice(0, 8)}…${s.slice(-4)}` : s
+}
+
 /** cron.js:618 — the schedule expression display (expression|schedule|—). */
 export function jobSchedule(job: RawJob): string {
   return String(job.expression || job.schedule || '—')

--- a/frontend/src/views/sessions/SessionsPage.tsx
+++ b/frontend/src/views/sessions/SessionsPage.tsx
@@ -15,6 +15,7 @@ import {
   Trash2Icon,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { copyWithFallback } from '@/lib/clipboard'
 import { listItemVariants, SUBTLE_EASE } from '@/lib/motion'
 import { ModalShell } from '@/components/ModalShell'
 import { Button } from '@/components/ui/button'
@@ -52,27 +53,6 @@ interface RpcError {
 }
 
 const PAGE_SIZES = [10, 25, 50, 100]
-
-// Copy with a non-secure-context fallback, mirroring the shared CommandLine
-// copy contract (clipboard API, else a hidden-textarea execCommand). Legacy
-// sessions used a bare navigator.clipboard call with no fallback, so this is a
-// deliberate uplift (recorded as ported(uplift) in the parity matrix) that lets
-// the copy work when the page isn't served from a secure context.
-function copyWithFallback(text: string): Promise<void> {
-  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-    return navigator.clipboard.writeText(text)
-  }
-  const ta = document.createElement('textarea')
-  ta.value = text
-  ta.setAttribute('readonly', '')
-  ta.style.position = 'fixed'
-  ta.style.left = '-9999px'
-  document.body.appendChild(ta)
-  ta.select()
-  const ok = document.execCommand('copy')
-  document.body.removeChild(ta)
-  return ok ? Promise.resolve() : Promise.reject(new Error('Copy command failed'))
-}
 
 // ── Reusable destructive confirmation (alertdialog) ──────────────────────────
 function ConfirmDialog({


### PR DESCRIPTION
Fixes #217

## Problem

On the Schedules screen, a card whose `CREATED FROM` or `TARGET` is a long session key rendered **wider than its grid track** and overlapped the neighbouring column.

A session key has no break opportunity (a colon is not one, per UAX-14), so its min-content width equals its full rendered width. Three boxes between the grid track and the text were all unable to shrink:

| Box | Where | Why |
| --- | --- | --- |
| `MotionListItem` | `CronPage.tsx:765` | unclassed grid item, `min-width: auto` |
| `.cron-card__meta > div` | `cron.css:191` | grid item of the `<dl>`, same |
| `.cron-card__meta dd` | `cron.css:201` | flex item, same |

The existing `overflow: hidden` on the card clipped *inside* the card, but the card box itself had already been widened — so the spill happened at the grid level.

## Changes

- **Overflow containment** — `min-width: 0` on all three boxes plus `text-overflow: ellipsis` on the value. Truncation is CSS-only, so the full string stays in the DOM and on `title` (hoverable, and existing assertions keep passing).
- **Prompt wraps instead of truncating** — `overflow-wrap: anywhere`, so a prompt carrying `CA:0x6eda83fc…` no longer widens the card.
- **New `CRON ID` row** — first meta row, shortened head+tail (`6c1fd340…17a8`) with a copy button for the full UUID. The cron ID is the handle every `agentos cron …` command takes but was previously CLI-only.
- **Shared clipboard helper** — `copyWithFallback` (clipboard API, else hidden-textarea `execCommand`) moves out of `SessionsPage.tsx` into `lib/clipboard.ts`; both screens now import it. `CommandLine.tsx` / `SessionChip.tsx` keep their own copies — out of scope here.

## Verification

- `npm run check` (tsc + eslint + prettier + vitest) — **1646 tests pass across 80 files**.
- New tests: CSS contract assertions in `cron-css.test.ts`, the `CRON ID` row and both copy paths (success + failure) in `CronPage.test.tsx`, and `shortCronId` in `logic.test.ts`.
- Ran the dev server against a live gateway and confirmed at 3-column width that `CREATED FROM` truncates to `agent:main:telegram:direct:124546396…` inside its card with no overlap, and that the `CRON ID` row renders correctly.

**Not verified in-browser:** narrow (1–2 column) widths and an actual click of the copy button — the browser extension disconnected mid-check. Copy behaviour is covered by unit tests on both paths, and the CSS fix is width-independent, but neither was confirmed by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)