### PR TITLE
fix(cron): stop a script job's output from vanishing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -538,8 +538,8 @@ agentos cron status <job-id>
 agentos cron runs <job-id>
 ```
 
-`--job-kind` picks what fires: `reminder` (delivers `--text` verbatim, no model),
-`script` (runs a file, no model), `agent_turn` (the agent runs `--text` as a
+`--job-kind` picks what fires: `reminder` (delivers `--text` verbatim, no LLM),
+`script` (runs a file, no LLM), `agent_turn` (the agent runs `--text` as a
 prompt), or `system_event`. It defaults to `auto`, which is `reminder` for normal
 targets — so the example above repeats that sentence hourly rather than
 summarizing anything. Add `--job-kind agent_turn` to have the agent do the work.
@@ -563,12 +563,32 @@ Secrets are masked in the output, and the gateway token is withheld from the
 child process. The bundled `cron-watchers` skill ships scripts for RSS, JSON
 endpoints, and GitHub repos that already follow this contract.
 
+#### Seeing what the script did
+
+A job scheduled from the CLI has no conversation attached, so "delivered
+verbatim" has nowhere to deliver to: the stdout lands on the run record and the
+chat stays empty. `--session-key` names the chat the job reports into — the run
+itself stays isolated, only the output is mirrored there:
+
+```sh
+agentos sessions list                       # copy the key of the chat you want
+agentos cron add --every 5m --script watch-memory.sh --name memory-watchdog \
+  --session-key 'agent:main:webchat:<id>'
+```
+
+Either way `agentos cron runs <job-id>` shows each run's `Output` and
+`Delivery` columns; `--json` prints the output untruncated. A `Delivery` of
+`fwd:no_session_target` is the scheduler saying the script printed something
+that reached no conversation — add `--session-key`. Jobs created from the Web UI
+or from a chat already carry their originating session, so their output shows up
+in that chat without any extra flag.
+
 Add `--script` to an `--job-kind agent_turn` job instead and it becomes a
 pre-run collector: its stdout is handed to the agent as context, and a tick
-where it prints nothing skips the turn entirely — no model call at all. See
+where it prints nothing skips the turn entirely — no LLM call at all. See
 [`scheduling.md`](scheduling.md).
 
-No model runs, so no tokens are spent — but nothing reviews the script before it
+No LLM runs, so no tokens are spent — but nothing reviews the script before it
 executes either. It runs on this host as you, unattended, so treat
 `~/.agentos/scripts/` as trusted as your shell profile. Only an interactive CLI
 or Web caller can create one; the in-agent `cron` tool refuses `job_kind='script'`

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -94,7 +94,7 @@ the work.
 ## Run a Script Instead of a Model
 
 A `script` job is the watchdog shape — poll something on a timer, deliver a line
-when it matters, stay quiet otherwise — with no model in the loop:
+when it matters, stay quiet otherwise — with no LLM in the loop:
 
 ```sh
 mkdir -p ~/.agentos/scripts
@@ -150,7 +150,7 @@ process, which is what lets a watcher call a model API of its own. Set
 `AGENTOS_STRIP_PROVIDER_ENV=1` to withhold those too.
 
 **What you are accepting.** The script runs on this host as you, on schedule,
-with nobody watching and no approval prompt — there is no model deciding what to
+with nobody watching and no approval prompt — there is no LLM deciding what to
 run, but also nothing reviewing it. Treat `~/.agentos/scripts/` as trusted as
 your shell profile, and remember that anything with write access to that
 directory can schedule itself. For that reason a script job can only be created
@@ -181,7 +181,7 @@ Per tick:
 - **stdout** → prepended to the prompt as `## Script output`, then the turn runs
   with your `--text` after it.
 - **no stdout** (or a `{"wakeAgent": false}` final line) → the turn is skipped
-  entirely. No model call, no session, no transcript line, no delivery. This is
+  entirely. No LLM call, no session, no transcript line, no delivery. This is
   what makes the pattern cheap: the agent only wakes on ticks with news.
 - **non-zero exit** → the error is prepended as `## Script error` and the turn
   runs anyway, so the agent can tell the user the collector broke.
@@ -255,6 +255,31 @@ Run a job immediately:
 ```sh
 agentos cron run <job-id> --yes
 ```
+
+`cron runs` shows each run's `Output` (the reply, or a script job's stdout) and
+`Delivery` (where that output went). Use `--json` for untruncated output.
+
+### Asking the agent what a job did
+
+The in-agent `cron` tool reads the same history through `action="runs"`, so you
+can ask in chat — "what did the memory watchdog report today?" — and the model
+answers from the recorded runs instead of guessing what the schedule produced:
+
+```json
+{"action": "runs", "job_id": "<job-id>", "limit": 5}
+```
+
+It returns each run's `started_at`, `success`, `output`, and `delivery`, plus
+`error` on a failure. `limit` defaults to 5 and is clamped to 20, and output
+longer than 2000 characters comes back with `output_truncated: true` — the full
+text is always available from `agentos cron runs <job-id> --json`. The action is
+scoped to the caller's own profile, the same boundary `remove` and `run` use.
+
+A script job's stdout can contain whatever the script fetched (an RSS item, an
+API response), and `action="runs"` puts that text in the model's context. That
+is the same content a delivered job already mirrors into the chat, but a job
+that reports nowhere is now readable too, so treat script output as untrusted
+input the same way you would any fetched content.
 
 ## Update or Remove Jobs
 

--- a/frontend/src/views/cron/CronPage.test.tsx
+++ b/frontend/src/views/cron/CronPage.test.tsx
@@ -371,6 +371,30 @@ describe('CronPage', () => {
     )
   })
 
+  it('expands a run to show script stdout the cell had to clip', async () => {
+    // A script job's stdout is its only trace, and it is routinely multi-line
+    // and wider than the cell — the preview must not be the only copy on screen.
+    const stdout = 'checked 4 pools\nunilp-3 below floor\n' + 'detail '.repeat(40)
+    wireRpc({ runs: [{ started_at: Date.now(), status: 'ok', duration_ms: 8, summary: stdout }] })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Daily standup' }))
+
+    const toggle = await screen.findByRole('button', { name: /checked 4 pools/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    // Queried by node, not by text: the stdout is deliberately whitespace-heavy
+    // and testing-library's text matcher collapses whitespace.
+    expect(document.querySelector('.cron-runs__output')).toBeNull()
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(document.querySelector('.cron-runs__output')?.textContent).toBe(stdout)
+
+    fireEvent.click(toggle)
+    expect(document.querySelector('.cron-runs__output')).toBeNull()
+  })
+
   it('deleting requires confirmation then calls cron.remove and invalidates', async () => {
     wireRpc()
     renderPage()

--- a/frontend/src/views/cron/CronPage.tsx
+++ b/frontend/src/views/cron/CronPage.tsx
@@ -1,5 +1,5 @@
 import './cron.css'
-import { useEffect, useId, useState } from 'react'
+import { Fragment, useEffect, useId, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
@@ -163,6 +163,9 @@ function RunsDrawer({
   })
 
   const runs = runsQuery.data ?? []
+  // A script job's output is its only trace — the row preview is one clipped
+  // line, so the full text has to be reachable without leaving the page.
+  const [expanded, setExpanded] = useState<number | null>(null)
 
   return (
     <div className="cron-detail panel" aria-label={`Run history for ${jobName}`}>
@@ -197,39 +200,63 @@ function RunsDrawer({
                 <th>Status</th>
                 <th>Duration</th>
                 <th>Delivery</th>
-                <th>Reply</th>
+                <th>Output</th>
                 <th />
               </tr>
             </thead>
             <tbody>
               {runs.map((r, i) => {
                 const row = runRow(r, relTime)
+                const isOpen = expanded === i
                 return (
-                  <tr key={i}>
-                    <td className="cron-mono">{row.timeLabel}</td>
-                    <td>
-                      <span className={`cron-status ${row.statusOk ? 'tone-ok' : 'tone-danger'}`}>
-                        {row.status}
-                      </span>
-                    </td>
-                    <td className="cron-mono">{row.duration}</td>
-                    <td>{row.delivery}</td>
-                    <td className="cron-runs__reply">{row.reply}</td>
-                    <td>
-                      {row.sessionKey ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() =>
-                            navigate('/chat?session=' + encodeURIComponent(row.sessionKey))
-                          }
-                        >
-                          → Chat
-                        </Button>
-                      ) : null}
-                    </td>
-                  </tr>
+                  <Fragment key={i}>
+                    <tr>
+                      <td className="cron-mono">{row.timeLabel}</td>
+                      <td>
+                        <span className={`cron-status ${row.statusOk ? 'tone-ok' : 'tone-danger'}`}>
+                          {row.status}
+                        </span>
+                      </td>
+                      <td className="cron-mono">{row.duration}</td>
+                      <td>{row.delivery}</td>
+                      <td className="cron-runs__reply">
+                        {row.replyFull ? (
+                          <button
+                            type="button"
+                            className="cron-runs__reply-toggle"
+                            aria-expanded={isOpen}
+                            title={isOpen ? 'Hide full output' : 'Show full output'}
+                            onClick={() => setExpanded(isOpen ? null : i)}
+                          >
+                            {row.reply}
+                          </button>
+                        ) : (
+                          row.reply
+                        )}
+                      </td>
+                      <td>
+                        {row.sessionKey ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              navigate('/chat?session=' + encodeURIComponent(row.sessionKey))
+                            }
+                          >
+                            → Chat
+                          </Button>
+                        ) : null}
+                      </td>
+                    </tr>
+                    {isOpen ? (
+                      <tr className="cron-runs__output-row">
+                        <td colSpan={6}>
+                          <pre className="cron-runs__output">{row.replyFull}</pre>
+                        </td>
+                      </tr>
+                    ) : null}
+                  </Fragment>
                 )
               })}
             </tbody>

--- a/frontend/src/views/cron/CronPanel.tsx
+++ b/frontend/src/views/cron/CronPanel.tsx
@@ -38,8 +38,8 @@ const SCHEDULE_TYPES: Array<{ value: ScheduleKind; label: string }> = [
 
 // cron.js:130-134 — job mode options.
 const JOB_MODES: Array<{ value: PayloadKind; label: string }> = [
-  { value: 'reminder', label: 'Static Reminder (no model)' },
-  { value: 'script', label: 'Script (no model)' },
+  { value: 'reminder', label: 'Static Reminder (no LLM)' },
+  { value: 'script', label: 'Script (no LLM)' },
   { value: 'agent_turn', label: 'Background Agent Task (choose session)' },
   { value: 'system_event', label: 'System Event (Main)' },
 ]

--- a/frontend/src/views/cron/cron.css
+++ b/frontend/src/views/cron/cron.css
@@ -311,10 +311,43 @@
   font-size: 0.7rem;
 }
 .cron-runs__reply {
-  max-width: 24ch;
+  max-width: 32ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* The preview doubles as the disclosure control for the full output. */
+.cron-runs__reply-toggle {
+  all: unset;
+  cursor: pointer;
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-decoration: underline dotted;
+  text-underline-offset: 0.2em;
+}
+.cron-runs__reply-toggle:hover,
+.cron-runs__reply-toggle:focus-visible {
+  color: var(--foreground);
+}
+.cron-runs__output-row > td {
+  padding-top: 0;
+}
+.cron-runs__output {
+  margin: 0;
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--muted);
+  color: var(--foreground);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* Empty state — dashed, tokenized. */

--- a/frontend/src/views/cron/logic.test.ts
+++ b/frontend/src/views/cron/logic.test.ts
@@ -223,6 +223,7 @@ describe('runRow', () => {
       duration: '42ms',
       delivery: 'ch: slack, ws: sent',
       reply: 'done',
+      replyFull: 'done',
       sessionKey: 'k',
     })
   })
@@ -232,10 +233,22 @@ describe('runRow', () => {
       statusOk: false,
       duration: '—',
       reply: '—',
+      replyFull: '',
       timeLabel: '—',
       sessionKey: '',
     })
     expect(runRow({}, rel)).toMatchObject({ status: 'unknown', delivery: '—' })
+  })
+  it('flattens multi-line script stdout for the cell but keeps it whole', () => {
+    // A script job's stdout is the whole result, and it is routinely multi-line
+    // and longer than the cell — the preview must not be the only copy.
+    const stdout = 'line one\nline two\n' + 'x'.repeat(200)
+    const row = runRow({ status: 'ok', summary: stdout }, rel)
+
+    expect(row.reply).not.toContain('\n')
+    expect(row.reply.startsWith('line one line two')).toBe(true)
+    expect(row.reply).toHaveLength(120)
+    expect(row.replyFull).toBe(stdout)
   })
 })
 

--- a/frontend/src/views/cron/logic.ts
+++ b/frontend/src/views/cron/logic.ts
@@ -256,6 +256,8 @@ export interface RunRow {
   duration: string
   delivery: string
   reply: string
+  /** Untruncated output, for the expanded view. Empty when there was none. */
+  replyFull: string
   sessionKey: string
 }
 
@@ -274,13 +276,17 @@ export function runRow(run: RawRun, relTime: (ts: string | number) => string): R
         : '—'
   const status = run.status || 'unknown'
   const summary = run.summary ? String(run.summary) : ''
+  // A script job's stdout *is* its result and is routinely multi-line, so the
+  // cell keeps a flattened preview while the full text stays reachable.
+  const preview = summary.split('\n').join(' ').trim()
   return {
     timeLabel: run.started_at != null ? relTime(run.started_at) : '—',
     status,
     statusOk: status === 'ok',
     duration: run.duration_ms != null ? run.duration_ms + 'ms' : '—',
     delivery,
-    reply: summary ? summary.substring(0, 120) : '—',
+    reply: preview ? preview.substring(0, 120) : '—',
+    replyFull: summary,
     sessionKey: run.sessionKey ? String(run.sessionKey) : '',
   }
 }

--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -448,6 +448,24 @@ def _render_mapping(payload: dict[str, Any], *, title: str) -> None:
     console.print(table)
 
 
+_RUN_OUTPUT_WIDTH = 60
+
+
+def _run_output_cell(summary: Any) -> str:
+    """One-line preview of a run's output for the runs table.
+
+    A script job's stdout *is* its result, and it is routinely multi-line, so it
+    is flattened and clipped here rather than allowed to break the table. The
+    untruncated text stays available through ``--json``.
+    """
+    text = " ".join(str(summary or "").split())
+    if not text:
+        return ""
+    if len(text) <= _RUN_OUTPUT_WIDTH:
+        return text
+    return text[: _RUN_OUTPUT_WIDTH - 1] + "…"
+
+
 def _render_runs(rows: list[dict[str, Any]]) -> None:
     if not rows:
         typer.echo("No cron runs.")
@@ -458,6 +476,8 @@ def _render_runs(rows: list[dict[str, Any]]) -> None:
     table.add_column("Finished")
     table.add_column("Status")
     table.add_column("Duration ms", justify="right")
+    table.add_column("Delivery")
+    table.add_column("Output")
     table.add_column("Error")
     for row in rows:
         table.add_row(
@@ -466,6 +486,8 @@ def _render_runs(rows: list[dict[str, Any]]) -> None:
             str(row.get("finished_at") or ""),
             str(row.get("status") or ("ok" if row.get("success") else "error")),
             str(row.get("duration_ms") or ""),
+            str(row.get("deliveryStatus") or row.get("delivery_status") or ""),
+            _run_output_cell(row.get("summary")),
             str(row.get("error") or ""),
         )
     console.print(table)
@@ -538,7 +560,7 @@ def cron_add(
         "--script",
         help=(
             "Run this script, relative to ~/.agentos/scripts/. On its own it "
-            "creates a script job: stdout is delivered verbatim and no model "
+            "creates a script job: stdout is delivered verbatim and no LLM "
             "runs. With --job-kind agent_turn it becomes a pre-run collector — "
             "the agent sees the stdout, and no output means the turn is skipped."
         ),
@@ -568,6 +590,16 @@ def cron_add(
         "isolated",
         "--session-target",
         help="Target session mode: isolated, main, current, or session",
+    ),
+    session_key: str | None = typer.Option(
+        None,
+        "--session-key",
+        help=(
+            "Chat session this job reports into. Without it a job scheduled "
+            "from the CLI has no conversation to mirror results to — which is "
+            "how a --script job ends up running with nothing to show for it. "
+            "List keys with 'agentos sessions list'."
+        ),
     ),
     timeout: float | None = typer.Option(None, "--timeout", help="Run timeout in seconds"),
     tz: str | None = typer.Option(
@@ -720,6 +752,7 @@ def cron_add(
     text = _as_optional_str(text)
     script = _as_optional_str(script)
     workdir = _as_optional_str(workdir)
+    session_key = _as_optional_str(session_key)
     script_args = _as_str_list(script_arg)
     target = _validate_session_target(session_target)
     payload_kind = _validate_job_kind(job_kind)
@@ -762,6 +795,13 @@ def cron_add(
             "--session-target current is only available from session-bound clients; "
             "use the WebUI/current chat surface or choose --session-target isolated"
         )
+    if session_key and target == "main":
+        raise typer.BadParameter(
+            "--session-key cannot be combined with --session-target main; "
+            "main-target jobs report through the heartbeat, not a chat"
+        )
+    if target == "session" and not session_key:
+        raise typer.BadParameter("--session-target session requires --session-key")
     params: dict[str, Any] = {
         **_build_schedule_param(
             expression=expression,
@@ -774,6 +814,8 @@ def cron_add(
         "payloadKind": payload_kind,
         "sessionTarget": target,
     }
+    if session_key:
+        params["sessionKey"] = session_key
     if script:
         params["script"] = script
     if workdir:

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 
 import structlog
 
+from agentos.scheduler.payloads import SCRIPT_KIND
 from agentos.scheduler.types import (
     CronJob,
     DeliveryConfig,
@@ -22,6 +23,8 @@ from agentos.scheduler.types import (
 from agentos.session.keys import parse_agent_id
 
 log = structlog.get_logger(__name__)
+
+SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
@@ -62,6 +65,14 @@ def validate_webhook_url(url: str) -> None:
 # session and never reaches these branches.
 ORIGIN_SESSION_GONE = "origin_gone"
 
+# A script job produced output but is bound to no conversation to mirror it
+# into — an isolated job scheduled without ``--session-key``. Like
+# ``ORIGIN_SESSION_GONE`` this is not a failure (the script ran, and its stdout
+# is on the run record), but it is not "skipped" either: something *was*
+# produced and had nowhere to go. Naming it separately is what makes an empty
+# chat legible in ``agentos cron runs`` instead of looking like a silent run.
+NO_SESSION_TARGET = "no_session_target"
+
 
 @dataclass
 class DeliveryReport:
@@ -88,6 +99,43 @@ class DeliveryChain:
         self._channel_manager_ref = channel_manager_ref
         self._ws_emitter = ws_emitter
         self._session_forwarder = session_forwarder
+
+    @staticmethod
+    def _is_script_job(job: CronJob) -> bool:
+        """Whether this job's output came from a script rather than a model turn.
+
+        Several skips in this chain mean "the run already wrote this into the
+        session, so mirroring it would duplicate it" — true for an agent turn,
+        which appends its own reply to the transcript it ran in. A script job
+        has no turn: nothing writes its stdout anywhere unless this chain does,
+        so those skips silently discard the output instead of deduplicating it.
+        """
+        if job.handler_key == SCRIPT_HANDLER_KEY:
+            return True
+        payload = job.payload if isinstance(job.payload, dict) else {}
+        return str(payload.get("kind", "")) == SCRIPT_KIND
+
+    @staticmethod
+    def _script_mirror_session_key(job: CronJob, session_key: str) -> str:
+        """Where a script job's stdout should be mirrored, or "" if nowhere.
+
+        The originating chat wins — that is the conversation the operator was
+        in when they scheduled the job. Failing that, an explicitly bound
+        session (``sessionTarget`` of ``session``/``current``) is a destination
+        the operator chose. An isolated job created with neither — the shape
+        ``agentos cron add --script`` produces without ``--session-key`` — has
+        no conversation to mirror into, and says so rather than pretending.
+        """
+        if job.origin_session_key:
+            return job.origin_session_key
+        target = (
+            job.session_target
+            if isinstance(job.session_target, SessionTarget)
+            else SessionTarget(job.session_target)
+        )
+        if target in (SessionTarget.SESSION, SessionTarget.CURRENT):
+            return job.session_key or session_key
+        return ""
 
     @staticmethod
     def _is_same_webchat_session_delivery(
@@ -218,6 +266,16 @@ class DeliveryChain:
             channel_id=channel_id or "",
             session_key=session_key,
         ):
+            # An agent turn ran *in* this session and already appended its reply
+            # there, so "same session" means the work is done. A script job left
+            # nothing behind — mirror its stdout or it reaches no one.
+            if self._is_script_job(job):
+                return await self._mirror_to_session(
+                    job,
+                    text,
+                    session_key=session_key,
+                    target_session_key=session_key,
+                )
             return "delivered"
         if self._is_origin_webchat_session_delivery(
             job,
@@ -242,14 +300,38 @@ class DeliveryChain:
         text: str,
         session_key: str,
     ) -> str:
+        return await self._mirror_to_session(
+            job,
+            text,
+            session_key=session_key,
+            target_session_key=job.origin_session_key,
+        )
+
+    async def _mirror_to_session(
+        self,
+        job: CronJob,
+        text: str,
+        *,
+        session_key: str,
+        target_session_key: str,
+    ) -> str:
+        """Append ``text`` to ``target_session_key``'s transcript.
+
+        Shared by the two channel-side paths that resolve to a chat rather than
+        a real channel adapter. Speaks the channel vocabulary
+        (``delivered``/``delivery_failed``/``origin_gone``) because
+        :func:`handlers._required_delivery_error` reads it as primary delivery.
+        """
         text = strip_reply_directives(text) or ""
         if not self._session_forwarder:
             return "delivery_failed"
         if not text or not text.strip():
             return "delivery_failed"
+        if not target_session_key:
+            return "delivery_failed"
         try:
             forwarded = await self._session_forwarder(
-                origin_session_key=job.origin_session_key,
+                origin_session_key=target_session_key,
                 text=text,
                 provenance={
                     "kind": "cron",
@@ -261,7 +343,7 @@ class DeliveryChain:
             log.warning(
                 "delivery.webchat_forward_failed",
                 job_id=job.id,
-                origin_session_key=job.origin_session_key,
+                origin_session_key=target_session_key,
                 exc_info=True,
             )
             return "delivery_failed"
@@ -276,7 +358,7 @@ class DeliveryChain:
             log.info(
                 "delivery.webchat_origin_session_missing",
                 job_id=job.id,
-                origin_session_key=job.origin_session_key,
+                origin_session_key=target_session_key,
             )
             return ORIGIN_SESSION_GONE
         return "delivered"
@@ -463,15 +545,31 @@ class DeliveryChain:
             return "skipped"
         if target == SessionTarget.MAIN:
             return "skipped"
-        if not job.origin_session_key:
-            return "skipped"
-        if job.origin_session_key == session_key:
-            return "skipped"
         if not text or not text.strip():
             return "skipped"
+        # A script job has no turn of its own, so neither "the run wrote this
+        # into its own session" nor "there is no origin" is a reason to drop the
+        # output — both just mean this mirror is the only writer. It still needs
+        # somewhere to write; an isolated script job bound to no chat has not.
+        if self._is_script_job(job):
+            mirror_session_key = self._script_mirror_session_key(job, session_key)
+            if not mirror_session_key:
+                log.info(
+                    "delivery.script_output_has_no_session",
+                    job_id=job.id,
+                    session_target=str(target.value),
+                    hint="bind a chat with --session-key to mirror this output",
+                )
+                return NO_SESSION_TARGET
+        else:
+            if not job.origin_session_key:
+                return "skipped"
+            if job.origin_session_key == session_key:
+                return "skipped"
+            mirror_session_key = job.origin_session_key
         try:
             forwarded = await self._session_forwarder(
-                origin_session_key=job.origin_session_key,
+                origin_session_key=mirror_session_key,
                 text=text,
                 provenance={
                     "kind": "cron",
@@ -483,7 +581,7 @@ class DeliveryChain:
             log.warning(
                 "delivery.session_forward_failed",
                 job_id=job.id,
-                origin_session_key=job.origin_session_key,
+                origin_session_key=mirror_session_key,
                 exc_info=True,
             )
             return "forward_failed"
@@ -497,7 +595,7 @@ class DeliveryChain:
             log.info(
                 "delivery.origin_session_missing",
                 job_id=job.id,
-                origin_session_key=job.origin_session_key,
+                origin_session_key=mirror_session_key,
             )
             return ORIGIN_SESSION_GONE
         return "delivered"

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -109,7 +109,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `models` | `list` |
 | `skills` | `list`, `search`, `view`, `install`, `uninstall`, `update`, `publish`, `tap add/list/remove` |
 | `sessions` | `list`, `show`, `resume`, `abort`, `delete`, `export` |
-| `cron` | `list`, `status`, `add`, `update` (both take `--job-kind`, `--script`, `--script-arg`, `--workdir`, `--elevated`, `--elevated-mode`, `--tool-policy`; the policy's `profile` must be one of `coding`/`full`/`memory_only`/`messaging`/`minimal`, or be omitted), `remove`, `run`, `runs` |
+| `cron` | `list`, `status`, `add` (also takes `--session-key`, the chat a job reports into), `update` (both take `--job-kind`, `--script`, `--script-arg`, `--workdir`, `--elevated`, `--elevated-mode`, `--tool-policy`; the policy's `profile` must be one of `coding`/`full`/`memory_only`/`messaging`/`minimal`, or be omitted), `remove`, `run`, `runs` |
 | `channels` | `list`, `status`, `types`, `describe`, `native-commands`, `add`, `remove`, `enable`, `disable`, `edit`, `restart`, `logout`, `pairing …` |
 | `memory` | `status`, `index`, `list`, `search`, `show`, `embedding-download`, `raw-fallbacks …` |
 | `sandbox` | `status`, `on`, `bypass`, `full`, `reset` |
@@ -387,12 +387,21 @@ Bounding flags: `--timeout` (wall-clock seconds), `--max-iterations`,
 agentos sessions list / show <id> / export <id> <out>
 agentos cron list / add / run <id> / runs
 # --job-kind decides what fires. Default 'auto' = reminder: --text is delivered
-# verbatim and NO model runs, so a job that should think needs agent_turn.
+# verbatim and NO LLM runs, so a job that should think needs agent_turn.
 agentos cron add --every 1h --job-kind agent_turn --text "Summarize updates"
 # script jobs run a file in ~/.agentos/scripts/ and deliver its stdout — no
 # model, no tokens. Empty stdout = silent; non-zero exit delivers the error and
 # fails the job. Relative paths only; CLI/Web callers only (never a channel).
 agentos cron add --every 5m --script watch-memory.sh --name memory-watchdog
+# ...but a job added from the CLI has no chat to deliver into, so that stdout
+# only reaches the run record. --session-key names the chat it reports into
+# (the run stays isolated). Web UI / in-chat jobs already carry their session.
+agentos cron add --every 5m --script watch-memory.sh --session-key "$KEY"
+# 'runs' shows each run's Output + Delivery; --json prints output untruncated.
+# Delivery 'fwd:no_session_target' == printed something, reached no chat.
+# In chat, the cron tool reads the same history via action="runs" — use it to
+# answer "what did that job do?" instead of guessing from the schedule.
+agentos cron runs <id> [--json]
 # --script on an agent_turn is a pre-run collector instead: its stdout becomes
 # the turn's context, and a tick that prints nothing skips the turn (no tokens).
 agentos cron add --every 10m --job-kind agent_turn --script watch_rss.py \

--- a/src/agentos/skills/bundled/cron-watchers/SKILL.md
+++ b/src/agentos/skills/bundled/cron-watchers/SKILL.md
@@ -53,7 +53,7 @@ whichever watcher you install.
 
 ## Schedule one
 
-Deliver the new items straight to the user, no model call:
+Deliver the new items straight to the user, no LLM call:
 
 ```sh
 agentos cron add --every 15m --name hn-watch --script watch_rss.py \

--- a/src/agentos/skills/bundled/cron/SKILL.md
+++ b/src/agentos/skills/bundled/cron/SKILL.md
@@ -50,7 +50,7 @@ Translation examples (do this in your own reasoning before calling the tool):
 
 ## Running a script instead of a model
 
-`job_kind="script"` runs a file on schedule and delivers its stdout — no model
+`job_kind="script"` runs a file on schedule and delivers its stdout — no LLM
 call, no tokens. The `script` must be a path relative to `~/.agentos/scripts/`;
 `script_args` is a list passed as argv (never through a shell). Empty stdout
 means the run stays silent, and a non-zero exit is delivered as a failure.

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -32,7 +32,14 @@ from agentos.tools.types import ToolError
 
 log = structlog.get_logger(__name__)
 
-_VALID_CRON_ACTIONS = ("list", "add", "remove", "run")
+_VALID_CRON_ACTIONS = ("list", "add", "remove", "run", "runs")
+
+# Run history is the only record of what a script job printed, and a watcher's
+# stdout can be arbitrarily long. These bounds keep "what did it do last night?"
+# from spending the context window on one answer.
+_CRON_RUNS_DEFAULT_LIMIT = 5
+_CRON_RUNS_MAX_LIMIT = 20
+_CRON_RUN_OUTPUT_MAX_CHARS = 2000
 
 
 _VALID_GATEWAY_ACTIONS = ("restart", "config_get", "config_set")
@@ -71,6 +78,8 @@ class _SchedulerProtocol(Protocol):
     async def remove_job(self, job_id: str) -> bool: ...
 
     async def run_job_now(self, job_id: str) -> Any: ...
+
+    async def get_runs(self, job_id: str, limit: int = 20) -> list[Any]: ...
 
 
 # Setter-injected dependencies (gateway boot calls these)
@@ -134,10 +143,43 @@ def _cron_job_agent_id(job: Any) -> str:
     return payload_agent_id(payload if isinstance(payload, dict) else None, "main")
 
 
+def _cron_run_item(run: Any) -> dict[str, Any]:
+    """Shape one execution record for the model.
+
+    ``summary`` is renamed to ``output`` because for a script job that field
+    holds the script's literal stdout, not a description of it — a name that
+    invites the model to quote it rather than paraphrase. ``delivery`` is
+    included so the model can tell "this ran and told you" from "this ran and
+    the output went nowhere", which reads identically from the job alone.
+    """
+    output = str(getattr(run, "summary", "") or "")
+    truncated = len(output) > _CRON_RUN_OUTPUT_MAX_CHARS
+    if truncated:
+        output = output[:_CRON_RUN_OUTPUT_MAX_CHARS]
+    started_at = getattr(run, "started_at", None)
+    item: dict[str, Any] = {
+        "started_at": started_at.isoformat() if started_at is not None else "",
+        "success": bool(getattr(run, "success", False)),
+        "output": output,
+        "delivery": str(getattr(run, "delivery_status", "") or ""),
+    }
+    if truncated:
+        item["output_truncated"] = True
+    error = getattr(run, "error", None)
+    if error:
+        item["error"] = str(error)
+    return item
+
+
 @tool(
     name="cron",
     description=(
-        "Create, list, remove, or trigger scheduled cron jobs. "
+        "Create, list, inspect, remove, or trigger scheduled cron jobs. "
+        "Use action=runs to answer any question about what a job actually did — "
+        "its recent runs with the output each one produced, whether it succeeded, "
+        "and where that output was delivered. For a script job the run output is "
+        "the script's stdout, and run history is the only place it is recorded, "
+        "so answer from action=runs rather than guessing what a schedule produced. "
         "Use this tool (NOT exec_command or background_process) for any recurring/timed "
         "task scheduling or reminders. Translate any natural language into the "
         "structured schedule shape yourself; the tool will not parse free-form text. "
@@ -156,7 +198,7 @@ def _cron_job_agent_id(job: Any) -> str:
     params={
         "action": {
             "type": "string",
-            "description": "Action: list, add, remove, run",
+            "description": "Action: list, add, remove, run, runs",
         },
         "schedule": {
             "type": "object",
@@ -208,7 +250,7 @@ def _cron_job_agent_id(job: Any) -> str:
                 "the model. Use agent_turn only for scheduled background tasks "
                 "that need the agent/model to work. Use system_event only for "
                 "internal main-session events. Use script to run an existing "
-                "script on schedule and deliver its stdout — no model, no tokens; "
+                "script on schedule and deliver its stdout — no LLM, no tokens; "
                 "it requires the script parameter and an interactive CLI or Web "
                 "caller."
             ),
@@ -258,7 +300,17 @@ def _cron_job_agent_id(job: Any) -> str:
         },
         "job_id": {
             "type": "string",
-            "description": "Job ID (required for remove and run)",
+            "description": "Job ID (required for remove, run, and runs)",
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                f"How many recent runs to return for action=runs "
+                f"(default {_CRON_RUNS_DEFAULT_LIMIT}, max {_CRON_RUNS_MAX_LIMIT})."
+            ),
+            "minimum": 1,
+            "maximum": _CRON_RUNS_MAX_LIMIT,
+            "default": _CRON_RUNS_DEFAULT_LIMIT,
         },
         "agent_id": {
             "type": "string",
@@ -310,15 +362,16 @@ async def cron(
     script_args: list[str] | None = None,
     workdir: str = "",
     tz: str = "",
+    limit: int = _CRON_RUNS_DEFAULT_LIMIT,
 ) -> str:
     if action not in _VALID_CRON_ACTIONS:
-        raise ToolError(f"Invalid action: {action}. Must be list|add|remove|run")
+        raise ToolError(f"Invalid action: {action}. Must be list|add|remove|run|runs")
 
     if action == "add" and schedule is None:
         raise ToolError("'schedule' required for add")
     if action == "add" and job_kind != SCRIPT_KIND and not task:
         raise ToolError("'task' required for add")
-    if action in ("remove", "run") and not job_id:
+    if action in ("remove", "run", "runs") and not job_id:
         raise ToolError(f"'job_id' required for {action}")
 
     # Dispatch to injected scheduler
@@ -394,6 +447,28 @@ async def cron(
             for j in jobs
         ]
         return json.dumps({"action": "list", "jobs": items})
+
+    if action == "runs":
+        assert job_id is not None
+        target_job = await sched.get_job(job_id)
+        if target_job is None:
+            raise ToolError(f"Job not found: {job_id}")
+        if _cron_job_agent_id(target_job) != current_agent_id:
+            raise ToolError("cron job belongs to a different profile")
+        try:
+            requested = int(limit)
+        except (TypeError, ValueError):
+            requested = _CRON_RUNS_DEFAULT_LIMIT
+        requested = max(1, min(requested, _CRON_RUNS_MAX_LIMIT))
+        runs = await sched.get_runs(job_id, limit=requested)
+        return json.dumps(
+            {
+                "action": "runs",
+                "job_id": job_id,
+                "name": target_job.name,
+                "runs": [_cron_run_item(run) for run in runs],
+            }
+        )
 
     if action == "add":
         assert schedule is not None

--- a/tests/test_cli/test_cron_cmd.py
+++ b/tests/test_cli/test_cron_cmd.py
@@ -1090,3 +1090,132 @@ def test_cron_update_no_elevated_sends_a_clearing_false(stub_gateway) -> None:
 
     _method, params = stub_gateway.calls[-1]
     assert params["elevated"] is False
+
+
+# --- script job output visibility -----------------------------------------
+#
+# A script job scheduled from the CLI had no conversation to report into, so it
+# ran every tick with nothing to show for it. --session-key names that chat, and
+# the runs table surfaces the stdout the run record was already storing.
+
+
+def _add_script_job(**overrides: Any) -> dict[str, Any]:
+    """Call cron_add for a script job, returning the RPC params."""
+    kwargs: dict[str, Any] = dict(
+        expression="*/5 * * * *",
+        text=None,
+        script="watch-memory.sh",
+        job_kind="script",
+        name=None,
+        agent=None,
+        session_target="isolated",
+        timeout=None,
+        tz=None,
+        wake=None,
+        exact=False,
+        jitter=None,
+        announce=False,
+        no_deliver=False,
+        channel=None,
+        to=None,
+        account=None,
+        best_effort_deliver=False,
+        webhook_url=None,
+        webhook_token=None,
+        webhook_token_env=None,
+        webhook_token_file=None,
+        failure_mode=None,
+        failure_channel=None,
+        failure_to=None,
+        failure_account=None,
+        failure_webhook_url=None,
+        failure_webhook_token=None,
+        failure_webhook_token_env=None,
+        failure_webhook_token_file=None,
+        elevated=None,
+        elevated_mode=None,
+        tool_policy=None,
+        json_output=False,
+    )
+    kwargs.update(overrides)
+    cron_cmd.cron_add(**kwargs)
+    return kwargs
+
+
+def test_cron_add_session_key_binds_the_reporting_chat(stub_gateway) -> None:
+    _add_script_job(session_key="agent:main:webchat:my-chat")
+
+    _method, params = stub_gateway.calls[-1]
+    assert params["sessionKey"] == "agent:main:webchat:my-chat"
+    # The run itself stays isolated; only the mirror target is bound.
+    assert params["sessionTarget"] == "isolated"
+
+
+def test_cron_add_omits_session_key_when_not_given(stub_gateway) -> None:
+    _add_script_job()
+
+    _method, params = stub_gateway.calls[-1]
+    assert "sessionKey" not in params
+
+
+def test_cron_add_rejects_session_key_with_main_target(stub_gateway) -> None:
+    # Main-target jobs report through the heartbeat, so a chat binding is a
+    # misunderstanding worth naming rather than silently dropping.
+    with pytest.raises(typer.BadParameter, match="session-key.*main"):
+        _add_script_job(
+            script=None,
+            text="daily rollup",
+            job_kind="system_event",
+            session_target="main",
+            session_key="agent:main:webchat:my-chat",
+        )
+
+
+def test_cron_add_session_target_session_requires_a_key(stub_gateway) -> None:
+    with pytest.raises(typer.BadParameter, match="requires --session-key"):
+        _add_script_job(session_target="session")
+
+
+# --- runs table output column ---------------------------------------------
+
+
+def test_run_output_cell_flattens_and_clips_script_stdout() -> None:
+    assert cron_cmd._run_output_cell("line one\nline two") == "line one line two"
+    assert cron_cmd._run_output_cell(None) == ""
+    assert cron_cmd._run_output_cell("   ") == ""
+
+    clipped = cron_cmd._run_output_cell("x" * 200)
+    assert len(clipped) == cron_cmd._RUN_OUTPUT_WIDTH
+    assert clipped.endswith("…")
+
+
+def test_render_runs_shows_the_script_output(capsys, monkeypatch) -> None:
+    # Eight columns do not fit an 80-column default, and rich wraps headers
+    # mid-word when they do not. Widen the console so the assertions describe
+    # the table rather than the terminal.
+    from rich.console import Console
+
+    monkeypatch.setattr(cron_cmd, "console", Console(width=200))
+    cron_cmd._render_runs(
+        [
+            {
+                "id": "run-1",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "finished_at": "2026-01-01T00:00:01+00:00",
+                "status": "ok",
+                "duration_ms": 1000,
+                "summary": "3 alerts pending",
+                "deliveryStatus": "skipped|ws:no_subscribers|fwd:no_session_target",
+                "error": None,
+            }
+        ]
+    )
+
+    out = capsys.readouterr().out
+    # Both new columns are present, and the stdout the run record was already
+    # storing is finally on screen. Rich wraps to the terminal width, so the
+    # cells are matched loosely rather than verbatim.
+    assert "Output" in out
+    assert "Delivery" in out
+    assert "3 alerts pending" in out
+    assert "no_session_target" in out

--- a/tests/test_scheduler/test_script_output_visibility.py
+++ b/tests/test_scheduler/test_script_output_visibility.py
@@ -1,0 +1,263 @@
+"""A script job's stdout is its only trace, so the delivery chain must not drop it.
+
+Several skips in :class:`DeliveryChain` encode "the run already wrote this into
+the session, so mirroring it would duplicate it". That holds for an agent turn,
+which appends its own reply to the transcript it ran in. A script job has no
+turn: nothing writes its stdout anywhere unless the chain does, so the very same
+skips silently discard the output instead of deduplicating it.
+
+Two shapes reached that dead end:
+
+* ``sessionTarget=current`` from webchat — ``_deliver_channel`` recognised the
+  run's session as the destination session and returned ``"delivered"`` without
+  writing, so a run reported success with nothing to show for it;
+* a job bound to a chat whose run *is* that chat — ``_forward_to_session``
+  skipped on ``origin == session_key``.
+
+A third shape genuinely has nowhere to write (``agentos cron add --script``
+with no ``--session-key``). That one is reported as ``no_session_target`` rather
+than ``skipped``, so an empty chat is legible in ``agentos cron runs``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentos.scheduler.delivery import (
+    NO_SESSION_TARGET,
+    ORIGIN_SESSION_GONE,
+    DeliveryChain,
+)
+from agentos.scheduler.handlers import _required_delivery_error
+from agentos.scheduler.payloads import make_script_payload
+from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+
+WEBCHAT_SESSION = "agent:main:webchat:live-chat"
+ISOLATED_RUN_KEY = "cron:job-1:run:deadbeef"
+
+
+class _RecordingForwarder:
+    """Stands in for the gateway forwarder, recording where output landed."""
+
+    def __init__(self, result: bool | None = True) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> bool | None:
+        self.calls.append(kwargs)
+        return self.result
+
+
+def _script_job(
+    *,
+    session_target: SessionTarget,
+    session_key: str = "",
+    origin_session_key: str = "",
+    delivery: DeliveryConfig | None = None,
+) -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="watch-memory",
+        handler_key="script_run",
+        payload=make_script_payload("watch-memory.sh"),
+        session_target=session_target,
+        session_key=session_key,
+        origin_session_key=origin_session_key,
+        delivery=delivery or DeliveryConfig(mode=DeliveryMode.NONE),
+    )
+
+
+def _agent_turn_job(**kwargs: Any) -> CronJob:
+    job = _script_job(**kwargs)
+    job.handler_key = "agent_run"
+    job.payload = {"kind": "agent_turn", "task": "summarise", "agent_id": "main"}
+    return job
+
+
+async def test_current_target_webchat_script_output_reaches_the_chat() -> None:
+    """The regression: run's session == destination session, so nothing wrote it."""
+    forwarder = _RecordingForwarder()
+    job = _script_job(
+        session_target=SessionTarget.CURRENT,
+        session_key=WEBCHAT_SESSION,
+        origin_session_key=WEBCHAT_SESSION,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.ORIGIN,
+            channel_name="webchat",
+            channel_id=f"webchat:{WEBCHAT_SESSION}",
+        ),
+    )
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="3 alerts pending",
+        success=True,
+        summary="3 alerts pending",
+        session_key=WEBCHAT_SESSION,
+    )
+
+    assert report.channel_status == "delivered"
+    assert [c["origin_session_key"] for c in forwarder.calls] == [WEBCHAT_SESSION]
+    assert forwarder.calls[0]["text"] == "3 alerts pending"
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_current_target_webchat_agent_turn_is_still_not_mirrored() -> None:
+    """The turn wrote its own reply there; mirroring would double it."""
+    forwarder = _RecordingForwarder()
+    job = _agent_turn_job(
+        session_target=SessionTarget.CURRENT,
+        session_key=WEBCHAT_SESSION,
+        origin_session_key=WEBCHAT_SESSION,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.ORIGIN,
+            channel_name="webchat",
+            channel_id=f"webchat:{WEBCHAT_SESSION}",
+        ),
+    )
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="here is your summary",
+        success=True,
+        summary="here is your summary",
+        session_key=WEBCHAT_SESSION,
+    )
+
+    assert report.channel_status == "delivered"
+    assert forwarder.calls == []
+
+
+async def test_script_output_is_mirrored_into_the_session_it_ran_in() -> None:
+    """mode=NONE twin of the above: ``origin == session_key`` skipped the write."""
+    forwarder = _RecordingForwarder()
+    job = _script_job(
+        session_target=SessionTarget.SESSION,
+        session_key=WEBCHAT_SESSION,
+        origin_session_key=WEBCHAT_SESSION,
+    )
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="disk at 91%",
+        success=True,
+        summary="disk at 91%",
+        session_key=WEBCHAT_SESSION,
+    )
+
+    assert report.session_status == "delivered"
+    assert [c["origin_session_key"] for c in forwarder.calls] == [WEBCHAT_SESSION]
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_agent_turn_in_its_own_session_is_still_skipped() -> None:
+    forwarder = _RecordingForwarder()
+    job = _agent_turn_job(
+        session_target=SessionTarget.SESSION,
+        session_key=WEBCHAT_SESSION,
+        origin_session_key=WEBCHAT_SESSION,
+    )
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="summary",
+        success=True,
+        summary="summary",
+        session_key=WEBCHAT_SESSION,
+    )
+
+    assert report.session_status == "skipped"
+    assert forwarder.calls == []
+
+
+async def test_isolated_script_job_mirrors_into_its_origin_chat() -> None:
+    """The web-UI shape: isolated run, output mirrored back to the chat."""
+    forwarder = _RecordingForwarder()
+    job = _script_job(
+        session_target=SessionTarget.ISOLATED,
+        origin_session_key=WEBCHAT_SESSION,
+    )
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="nothing unusual",
+        success=True,
+        summary="nothing unusual",
+        session_key=ISOLATED_RUN_KEY,
+    )
+
+    assert report.session_status == "delivered"
+    assert [c["origin_session_key"] for c in forwarder.calls] == [WEBCHAT_SESSION]
+
+
+async def test_isolated_script_job_with_no_chat_reports_no_session_target() -> None:
+    """``agentos cron add --script`` without ``--session-key``.
+
+    Nothing is wrong with the run — the script ran and its stdout is on the run
+    record — but the output reached no conversation, and the status has to say
+    so rather than read as an ordinary skip.
+    """
+    forwarder = _RecordingForwarder()
+    job = _script_job(session_target=SessionTarget.ISOLATED)
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="hello from a script cron job",
+        success=True,
+        summary="hello from a script cron job",
+        session_key=ISOLATED_RUN_KEY,
+    )
+
+    assert report.session_status == NO_SESSION_TARGET
+    assert forwarder.calls == []
+    # Not a failure: the job did what it was asked to do.
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_script_mirror_survives_a_vanished_chat() -> None:
+    forwarder = _RecordingForwarder(result=False)
+    job = _script_job(
+        session_target=SessionTarget.ISOLATED,
+        origin_session_key="agent:main:webchat:closed-chat",
+    )
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="nothing unusual",
+        success=True,
+        summary="nothing unusual",
+        session_key=ISOLATED_RUN_KEY,
+    )
+
+    assert report.session_status == ORIGIN_SESSION_GONE
+    assert _required_delivery_error(job, report) is None
+
+
+async def test_script_job_is_recognised_from_its_payload_alone() -> None:
+    """Rows written before ``handler_key`` was normalized still carry the kind."""
+    forwarder = _RecordingForwarder()
+    job = _script_job(
+        session_target=SessionTarget.SESSION,
+        session_key=WEBCHAT_SESSION,
+        origin_session_key=WEBCHAT_SESSION,
+    )
+    job.handler_key = ""
+    chain = DeliveryChain(session_forwarder=forwarder)
+
+    report = await chain.deliver(
+        job,
+        result_text="disk at 91%",
+        success=True,
+        summary="disk at 91%",
+        session_key=WEBCHAT_SESSION,
+    )
+
+    assert report.session_status == "delivered"
+    assert len(forwarder.calls) == 1

--- a/tests/test_tools/test_cron_tool_runs.py
+++ b/tests/test_tools/test_cron_tool_runs.py
@@ -1,0 +1,189 @@
+"""Cron tool: ``action=runs`` — what a scheduled job actually did.
+
+Without this action the model can list a job but not see a single thing any run
+produced, so "what did the watcher report last night?" had no answer it could
+look up — only one it could invent. For a ``script`` job the run record is the
+*only* place stdout is kept unless the job was bound to a chat, which makes this
+the difference between the model reading the output and guessing at it.
+
+The bounds matter as much as the data: a watcher's stdout is unbounded and the
+answer has to fit in a context window, so the limit is clamped and long output
+is truncated with a flag saying so rather than silently cut.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import agentos.tools.builtin.control as control_mod
+from agentos.scheduler.payloads import make_script_payload
+from agentos.tools.builtin.control import cron as cron_tool
+from agentos.tools.types import ToolError
+
+RUN_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+
+def _run(
+    *,
+    summary: str = "pool alpha: ok",
+    success: bool = True,
+    delivery: str = "skipped|ws:no_subscribers|fwd:delivered",
+    error: str | None = None,
+) -> Any:
+    return SimpleNamespace(
+        started_at=RUN_AT,
+        success=success,
+        summary=summary,
+        delivery_status=delivery,
+        error=error,
+    )
+
+
+class _FakeScheduler:
+    def __init__(self, runs: list[Any], *, agent_id: str = "main") -> None:
+        self._runs = runs
+        self._job = SimpleNamespace(
+            id="job-1",
+            name="memory-watchdog",
+            payload=make_script_payload("watch-memory.sh", agent_id),
+        )
+        self.get_runs_calls: list[tuple[str, int]] = []
+
+    async def get_job(self, job_id: str) -> Any | None:
+        return self._job if job_id == "job-1" else None
+
+    async def get_runs(self, job_id: str, limit: int = 20) -> list[Any]:
+        self.get_runs_calls.append((job_id, limit))
+        return self._runs[:limit]
+
+
+async def _runs(fake: _FakeScheduler, **kwargs: Any) -> dict[str, Any]:
+    control_mod.set_scheduler(fake)
+    try:
+        raw = await cron_tool(action="runs", job_id="job-1", **kwargs)
+    finally:
+        control_mod.set_scheduler(None)  # type: ignore[arg-type]
+    return json.loads(raw)
+
+
+@pytest.mark.asyncio
+async def test_runs_returns_the_output_each_run_produced() -> None:
+    fake = _FakeScheduler([_run(summary="pool beta: BELOW FLOOR")])
+
+    payload = await _runs(fake)
+
+    assert payload["action"] == "runs"
+    assert payload["job_id"] == "job-1"
+    assert payload["name"] == "memory-watchdog"
+    assert payload["runs"] == [
+        {
+            "started_at": "2026-01-02T03:04:05+00:00",
+            "success": True,
+            # Named "output", not "summary": for a script job this is literal
+            # stdout, and the name should invite quoting rather than rewording.
+            "output": "pool beta: BELOW FLOOR",
+            "delivery": "skipped|ws:no_subscribers|fwd:delivered",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runs_surfaces_delivery_so_a_silent_job_is_distinguishable() -> None:
+    """"It ran and told you" and "it ran and told no one" look identical
+    from the job alone — only the run's delivery status separates them."""
+    fake = _FakeScheduler(
+        [_run(delivery="skipped|ws:no_subscribers|fwd:no_session_target")]
+    )
+
+    payload = await _runs(fake)
+
+    assert payload["runs"][0]["delivery"].endswith("fwd:no_session_target")
+
+
+@pytest.mark.asyncio
+async def test_runs_reports_failures_with_their_error() -> None:
+    fake = _FakeScheduler(
+        [_run(summary="", success=False, error="exit status 1: no such file")]
+    )
+
+    payload = await _runs(fake)
+
+    assert payload["runs"][0]["success"] is False
+    assert payload["runs"][0]["error"] == "exit status 1: no such file"
+
+
+@pytest.mark.asyncio
+async def test_runs_omits_error_when_there_was_none() -> None:
+    fake = _FakeScheduler([_run()])
+
+    payload = await _runs(fake)
+
+    assert "error" not in payload["runs"][0]
+    assert "output_truncated" not in payload["runs"][0]
+
+
+@pytest.mark.asyncio
+async def test_long_output_is_truncated_and_says_so() -> None:
+    fake = _FakeScheduler([_run(summary="x" * 5000)])
+
+    payload = await _runs(fake)
+
+    run = payload["runs"][0]
+    assert len(run["output"]) == control_mod._CRON_RUN_OUTPUT_MAX_CHARS
+    assert run["output_truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_limit_defaults_and_is_clamped_to_the_maximum() -> None:
+    fake = _FakeScheduler([_run() for _ in range(50)])
+
+    await _runs(fake)
+    assert fake.get_runs_calls[-1] == ("job-1", control_mod._CRON_RUNS_DEFAULT_LIMIT)
+
+    await _runs(fake, limit=500)
+    assert fake.get_runs_calls[-1] == ("job-1", control_mod._CRON_RUNS_MAX_LIMIT)
+
+    await _runs(fake, limit=0)
+    assert fake.get_runs_calls[-1] == ("job-1", 1)
+
+    # A model that fills the field with a string should not crash the call.
+    await _runs(fake, limit="three")  # type: ignore[arg-type]
+    assert fake.get_runs_calls[-1] == ("job-1", control_mod._CRON_RUNS_DEFAULT_LIMIT)
+
+
+@pytest.mark.asyncio
+async def test_runs_requires_a_job_id() -> None:
+    control_mod.set_scheduler(_FakeScheduler([]))
+    try:
+        with pytest.raises(ToolError, match="'job_id' required for runs"):
+            await cron_tool(action="runs")
+    finally:
+        control_mod.set_scheduler(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_runs_rejects_an_unknown_job() -> None:
+    fake = _FakeScheduler([])
+    control_mod.set_scheduler(fake)
+    try:
+        with pytest.raises(ToolError, match="Job not found"):
+            await cron_tool(action="runs", job_id="nope")
+    finally:
+        control_mod.set_scheduler(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_runs_refuses_a_job_owned_by_another_profile() -> None:
+    """Same ownership boundary remove and run already enforce."""
+    fake = _FakeScheduler([_run()], agent_id="research")
+    control_mod.set_scheduler(fake)
+    try:
+        with pytest.raises(ToolError, match="different profile"):
+            await cron_tool(action="runs", job_id="job-1")
+    finally:
+        control_mod.set_scheduler(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## The bug

Several skips in `DeliveryChain` encode *"the run already wrote this into the session, so mirroring it would duplicate it."* That holds for an agent turn, which appends its own reply to the transcript it ran in. **A script job has no turn** — nothing writes its stdout anywhere unless the chain does, so the same skips silently discarded the output instead of deduplicating it.

Two shapes reached that dead end:

| Shape | What happened |
| --- | --- |
| `sessionTarget=current` from webchat | `_deliver_channel` returned `"delivered"` without writing a byte |
| Job bound to a chat whose run *is* that chat | `_forward_to_session` skipped on `origin == session_key` |

Both ran green. Both left an empty conversation.

A third shape genuinely has nowhere to write — `agentos cron add --script` from a CLI has no conversation attached — and reported the same indistinguishable `fwd:skipped`.

## The fix

- **Delivery** — script jobs are exempt from the "a turn already wrote this" skips, and mirror into the originating chat or an explicitly bound session.
- **`no_session_target`** — a new status for "printed something, reached no chat". Not a failure (the script ran; stdout is on the run record), but no longer indistinguishable from a quiet run.
- **`cron add --session-key`** — names the chat a job reports into, so a CLI-scheduled job has a destination at all.
- **Readable output** — `cron runs` grew `Delivery` and `Output` columns (`--json` for untruncated); the web UI run row expands to full stdout instead of clipping at 120 chars *and* 24ch of CSS.
- **`cron` tool `action="runs"`** — the model had no way to read run history, so *"what did the watcher report?"* had no answer it could look up, only one it could invent. Returns recent runs with `output` + `delivery`, bounded (limit 5, max 20, output capped at 2000 chars) so one answer cannot eat the context window.
- Renames user-facing **"no model" → "no LLM"** across the cron surfaces.

## Verification

Beyond the suite, this was exercised against a live gateway on an isolated state dir, running the **same three jobs before and after** the delivery change:

| Job | Before | After |
| --- | --- | --- |
| CLI, no `--session-key` | `fwd:skipped` | `fwd:no_session_target` |
| CLI, with `--session-key` | `fwd:delivered` | `fwd:delivered` (unchanged) |
| Bound to its own chat | `fwd:skipped` ❌ | `fwd:delivered` ✅ |

Transcript entries went 3 → 5 across the two rounds; under the old code the third job contributed nothing. Also verified: the `delivery.script_output_has_no_session` log fires only for the unbound job, the web UI run drawer expands full stdout, and cron output pushes into an open chat live over WS.

`action="runs"` was verified end-to-end with two real model turns. Asked *"what did A-no-session last produce?"*, the agent called `list` then `runs` and quoted the stdout verbatim. Asked to compare delivery between two jobs, it reported `fwd:no_session_target` vs `fwd:delivered` and concluded the first job's output reached nothing — a status string that exists nowhere but this branch, so it could only have come from actually calling the tool.

## Tests

7232 passed · ruff + mypy (590 files) clean · 137 frontend cron tests · bundle within budget.

New: `tests/test_scheduler/test_script_output_visibility.py` (8, including canaries that agent turns are still *not* mirrored twice) and `tests/test_tools/test_cron_tool_runs.py` (9).

## Note

`action="runs"` puts a script's stdout into the model's context, and a watcher script may have fetched that text from outside. It is the same content a delivered job already mirrors into the chat, but a job that reports nowhere is now readable too — `docs/scheduling.md` says to treat script output as untrusted input.
