### PR TITLE
feat(senior-unilp-manager): add create-pool to initialize hook-less v4 pools

### DIFF
--- a/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: senior-unilp-manager
-description: "Query and manage Uniswap V4 liquidity on Base (8453) and Robinhood Chain (4663). Use when the user asks how much liquidity a token has, wants a pool's reserves or market-cap bands, asks who launched a token or whether its LP is locked, wants to inspect an LP position or a wallet's positions, or wants to mint, increase, decrease, collect fees from, or burn a V4 position. NOT for: Uniswap v2/v3 positions, token swaps, or price quotes."
+description: "Query and manage Uniswap V4 liquidity on Base (8453) and Robinhood Chain (4663). Use when the user asks how much liquidity a token has, wants a pool's reserves or market-cap bands, asks who launched a token or whether its LP is locked, wants to inspect an LP position or a wallet's positions, or wants to mint, increase, decrease, collect fees from, or burn a V4 position, or wants to create (initialize) a new hook-less V4 pool. NOT for: Uniswap v2/v3 positions, token swaps, or price quotes."
 homepage: https://docs.uniswap.org/contracts/v4/overview
 triggers: [uniswap v4, liquidity position, "check LP", pool id, collect fees, robinhood chain]
 provenance:
@@ -370,11 +370,48 @@ and on Robinhood Chain that is normally a Doppler pool; the hook-less pools that
 for the same token are frequently dust with punitive fee tiers. Compare `TVL` before
 switching pools, and prefer the one `pools` marks as recommended (§1).
 
-**Targeting the pool.** `mint` takes a `--pool <poolId>` that must already exist — this skill
-**never creates a pool**; there is no `initialize` path in it. Find one first with
-`pools --token <addr> --no-hook` (§1). On Base the PoolKey behind that id still has to be
-recovered, so pass `--token <addr>`, or spell the key out with
+**Targeting the pool.** `mint` takes a `--pool <poolId>` that must already exist. Find one
+first with `pools --token <addr> --no-hook` (§1); if none exists at the tier you want, open
+one with `create-pool` (§8b). On Base the PoolKey behind that id still has to be recovered,
+so pass `--token <addr>`, or spell the key out with
 `--currency0 --currency1 --fee --tick-spacing` (§2) — those flags work here too.
+
+## 8b. Create a pool
+
+```bash
+python3 "$S"/lp_write.py create-pool --token0 <addr|native> --token1 <addr> \
+  --fee 3000 --tick-spacing 60 (--tick <t> | --price <n>) [--allow-odd-tier]
+```
+
+Only reach for this when `pools --token <addr>` genuinely found nothing usable. Opening a
+second pool for a token that already has one splits its liquidity and leaves yours as the
+shallow side.
+
+**The starting price cannot be changed, ever.** A pool is initialized once. If the tick you
+pick is off the real market, the first swap or mint against it is an arbitrage at your
+expense — and the only fix is to open a different pool. Treat the price line in the table as
+the thing the user is approving, not the fee tier.
+
+- `--price <n>` is **currency1 per one whole currency0**, decimals already handled, i.e. the
+  same direction the table prints. The two tokens are sorted into PoolKey order for you, so
+  which one you typed as `--token0` does not decide anything — read the printed
+  `currency0`/`currency1` rows and check the price is the right way up. Both directions are
+  printed for exactly this reason.
+- `--price` lands on the nearest tick (the 1.0001 grid, ~1 bp), so the effective price in the
+  table is what gets initialized, not the number typed. `--tick <t>` sets it exactly. The
+  initial tick does **not** have to be a multiple of `tickSpacing` — only position boundaries
+  do — so nothing is snapped here.
+- `hooks` is fixed at the zero address. There is no `--hooks` flag: initializing a hooked pool
+  runs that hook's `beforeInitialize`/`afterInitialize`, which is out of scope for this skill.
+- `--fee`/`--tick-spacing` off the conventional tiers (100/1, 500/10, 3000/60, 10000/200) are
+  refused unless you pass `--allow-odd-tier`, because `pools` only searches those tiers and
+  you would not find the pool again afterwards. A dynamic fee (`0x800000`) is refused
+  outright — it requires a hook.
+
+The transaction moves no tokens and needs no approvals, so there is nothing to `approve`
+first; it still goes through the same dry-run → `PLAN_HASH` → `--broadcast --confirm` gate as
+everything else. It prints the `poolId`, which is what `mint` then takes. If the pool already
+exists the command says so, prints its current tick, and exits without planning anything.
 
 ## 9. Increase / decrease / collect / burn
 
@@ -598,7 +635,7 @@ different branches at every layer, and a hook can answer differently on each.
 ## Verifying a change
 
 ```bash
-python3 {baseDir}/scripts/selftest.py     # 695 offline assertions, no network
+python3 {baseDir}/scripts/selftest.py     # 716 offline assertions, no network
 ```
 
 Covers the keccak / EIP-55 / ABI-codec primitives, secp256k1 signing, TickMath, the AGENTOS

--- a/src/agentos/skills/bundled/senior-unilp-manager/assets/v4-reference.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/assets/v4-reference.md
@@ -37,6 +37,12 @@ Encoded by `scripts/unilp/v4_actions.py`.
 | `0x13` | CLEAR_OR_TAKE | take if above a threshold, otherwise forfeit dust |
 | `0x14` | SWEEP | refund a leftover currency balance to a recipient |
 
+There is **no INITIALIZE_POOL action byte**. Creating a pool is
+`PositionManager.initializePool(PoolKey, uint160 sqrtPriceX96)` — a plain function call
+(selector `0xf7020405`), outside `modifyLiquidities` entirely, which forwards to
+`PoolManager.initialize`. `lp_write.py create-pool` is that call; it takes no `unlockData`
+and no deadline.
+
 ## Parameter layouts
 
 ```
@@ -368,6 +374,9 @@ Read-only, Uniswap v4 only, by design:
 - **No Uniswap v3 positions.** Clanker v3.1 and Doppler's v3 initializers still deploy v3
   pools; those fall back to the balance-only `--include-v3` report, which reads raw pool
   balances (including uncollected fees) and cannot read v3 NFT positions.
+- **No hooked pool creation.** `create-pool` opens hook-less pools only; a hook address in
+  the PoolKey would make `initialize` call that hook's `beforeInitialize`/`afterInitialize`,
+  and deploying a hook (which has to be mined for its flag bits) is out of scope entirely.
 
 Sources: [Clanker](https://clanker.world/docs/references/deployed-contracts#base-8453) ·
 [Liquid](https://app.liquidprotocol.org/docs#contracts) ·

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/lp_write.py
@@ -7,6 +7,8 @@ echoing that hash back, so the transaction that gets signed is provably the one 
 human approved.
 
     python3 scripts/lp_write.py approve  --token <addr>
+    python3 scripts/lp_write.py create-pool --token0 <addr> --token1 <addr> --fee 3000 \\
+                                         --tick-spacing 60 --price <n>
     python3 scripts/lp_write.py mint     --pool <poolId> --tick-lower <t> --tick-upper <t> \\
                                          --amount1 <n>
     python3 scripts/lp_write.py increase --token-id <id> --amount1 <n>
@@ -75,6 +77,7 @@ from unilp.v4_actions import (  # noqa: E402
     describe_actions,
     encode_unlock_data,
     is_native_currency,
+    pool_key_tuple,
 )
 from unilp.v4_math import (  # noqa: E402
     get_amounts_for_liquidity,
@@ -84,21 +87,29 @@ from unilp.v4_math import (  # noqa: E402
     get_sqrt_ratio_at_tick,
     range_status,
     snap_tick,
+    tick_at_price,
+    token_price_in_quote_at_tick,
 )
 from unilp.v4_pool import (  # noqa: E402
     NATIVE,
+    VANILLA_FEE_TIERS,
     compute_pool_id,
     decode_hook_flags,
     decode_position_info,
     format_fee,
     format_hook_flags,
+    is_dynamic_fee,
     normalize_pool_key,
+    sort_currencies,
 )
 
 USAGE = """
 senior-unilp-manager — Uniswap V4 LP writes (DRY RUN unless --broadcast --confirm <HASH>)
 
   approve  --token <addr> [--amount max] [--expiration-days 30]
+  create-pool --token0 <addr|native> --token1 <addr> --fee <n> --tick-spacing <n>
+           (--tick <t> | --price <currency1 per currency0>) [--allow-odd-tier]
+           hook-less pools only; the starting price can never be changed afterwards
   mint     --pool <poolId> (--tick-lower <t> --tick-upper <t>)
            (--amount0 <n> | --amount1 <n> | --liquidity <raw>)
            [--slippage-bps 100] [--recipient <addr>] [--allow-hooked]
@@ -124,6 +135,11 @@ DEFAULT_SLIPPAGE_BPS = 100
 DEFAULT_DEADLINE_SECS = 1200
 MAX_UINT160 = 2**160 - 1
 MAX_UINT256 = 2**256 - 1
+# 100% in hundredths of a bip, and the int16 ceiling the PoolManager enforces on
+# tickSpacing. Both are validated locally so create-pool fails with a sentence rather
+# than an unnamed custom-error selector out of the simulation.
+MAX_STATIC_FEE = 1_000_000
+MAX_TICK_SPACING = 32_767
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +289,29 @@ def load_pool_state(client, chain: dict, pool_id: str, pool_key: dict) -> dict:
         "lpFee": int(lp_fee),
         "activeLiquidity": int(liquidity["result"]),
     }
+
+
+def pool_is_initialized(client, chain: dict, pool_id: str) -> bool:
+    """Does this poolId exist yet?
+
+    An uninitialized pool is a zeroed mapping entry rather than a revert, so getSlot0
+    succeeds and returns sqrtPriceX96 = 0 — the same test ``lp_read.py`` uses to filter
+    derived pool candidates. Kept separate from :func:`load_pool_state`, which would
+    otherwise have to invent a meaning for a zero price.
+    """
+    slot0 = client.multicall([
+        {"address": chain["stateView"], "abi": STATE_VIEW_ABI,
+         "functionName": "getSlot0", "args": [pool_id]},
+    ], allow_failure=False)[0]
+    return int(slot0["result"][0]) != 0
+
+
+def _currency_arg(args: dict, name: str) -> str:
+    """A PoolKey currency from the CLI: an address, or ``native``/``eth`` for ETH."""
+    value = str(require_arg(args, name, "token address, or 'native' for ETH")).strip()
+    if value.lower() in ("native", "eth", "0", "0x0"):
+        return NATIVE
+    return checksum_address(value)
 
 
 def load_position_for_write(client, chain: dict, token_id: int) -> dict:
@@ -662,6 +701,146 @@ def _token_map(info0: dict, info1: dict) -> dict:
     return {info0["address"].lower(): info0, info1["address"].lower(): info1}
 
 
+def cmd_create_pool(client, chain: dict, args: dict, signer: dict) -> dict | None:
+    """Initialize a hook-less v4 pool. Moves no tokens; fixes the starting price forever.
+
+    ``initializePool`` is a plain PositionManager function, not a ``modifyLiquidities``
+    action — there is no INITIALIZE_POOL byte in the Actions enum. That keeps the target
+    address the same as every other write here, so nothing about ``run_plan`` changes.
+    """
+    token_a = _currency_arg(args, "token0")
+    token_b = _currency_arg(args, "token1")
+    if token_a.lower() == token_b.lower():
+        raise RuntimeError("--token0 and --token1 are the same currency")
+    currency0, currency1 = sort_currencies(token_a, token_b)
+
+    fee = int(require_arg(args, "fee", "fee in hundredths of a bip, e.g. 3000 for 0.30%"))
+    tick_spacing = int(require_arg(args, "tick-spacing"))
+    if is_dynamic_fee(fee):
+        raise RuntimeError(
+            f"fee {fee} sets the dynamic-fee flag (0x800000). A dynamic-fee pool has to be "
+            "driven by a hook, and this command only opens hook-less pools."
+        )
+    if not 0 <= fee <= MAX_STATIC_FEE:
+        raise RuntimeError(f"--fee must be between 0 and {MAX_STATIC_FEE} (= 100%), got {fee}")
+    if not 1 <= tick_spacing <= MAX_TICK_SPACING:
+        raise RuntimeError(f"--tick-spacing must be between 1 and {MAX_TICK_SPACING}, "
+                           f"got {tick_spacing}")
+    # A pool opened off the conventional tiers is invisible to `lp_read.py pools`, which
+    # derives hook-less candidates from VANILLA_FEE_TIERS only. Creating a pool you cannot
+    # then find again is a bad enough trap to be opt-in.
+    odd_tier = (fee, tick_spacing) not in VANILLA_FEE_TIERS
+    if odd_tier and not args.get("allow-odd-tier"):
+        tiers = ", ".join(f"{f}/{s}" for f, s in VANILLA_FEE_TIERS)
+        raise RuntimeError(
+            f"fee {fee} with tickSpacing {tick_spacing} is not one of the conventional tiers "
+            f"({tiers}).\n"
+            "  v4 allows it, but `lp_read.py pools` only searches those tiers, so the pool "
+            "would not show up\n"
+            "  in discovery afterwards. Re-run with --allow-odd-tier if that is deliberate."
+        )
+
+    pool_key = normalize_pool_key({
+        "currency0": currency0, "currency1": currency1, "fee": fee,
+        "tickSpacing": tick_spacing, "hooks": NATIVE,
+    })
+    pool_id = compute_pool_id(pool_key)
+    info0 = token_info(client, chain, currency0)
+    info1 = token_info(client, chain, currency1)
+
+    # --- starting price ------------------------------------------------------
+    # v4 does not require the initial tick to sit on the tickSpacing grid — only position
+    # boundaries do — so neither branch snaps. --price still lands on the 1.0001^n grid,
+    # which is why the effective price is echoed back before anything is signed.
+    # `is not None` would not do: parse_args turns a valueless `--tick` into True, and
+    # int(True) is 1 — a silently wrong starting price is exactly the failure to avoid.
+    has_tick = args.get("tick") not in (None, True)
+    has_price = args.get("price") not in (None, True)
+    if has_tick == has_price:
+        raise RuntimeError("give exactly one of --tick <t> or --price <currency1 per currency0>")
+    if has_tick:
+        tick = int(args["tick"])
+        price_source = "--tick"
+    else:
+        tick = tick_at_price(float(args["price"]), info0["decimals"], info1["decimals"])
+        price_source = f"--price {args['price']}"
+    sqrt_price_x96 = get_sqrt_ratio_at_tick(tick)
+
+    price_1_per_0 = token_price_in_quote_at_tick(tick, False, info0["decimals"],
+                                                 info1["decimals"])
+    price_0_per_1 = token_price_in_quote_at_tick(tick, True, info0["decimals"],
+                                                 info1["decimals"])
+
+    if pool_is_initialized(client, chain, pool_id):
+        state = load_pool_state(client, chain, pool_id, pool_key)
+        print(heading(f"pool already exists on {chain['name']}"))
+        print(render_kv([
+            ["poolId", pool_id],
+            ["pair", f"{info0['symbol']}/{info1['symbol']}"],
+            ["fee", format_fee(pool_key["fee"], state["lpFee"])],
+            ["tickSpacing", str(tick_spacing)],
+            ["current tick", str(state["tick"])],
+        ]))
+        print("\n  Nothing to do — a pool can only be initialized once. To add liquidity:")
+        print(f"    python3 scripts/lp_read.py pool --id {pool_id}   (read it first)")
+        print(f"    python3 scripts/lp_write.py mint --pool {pool_id} --tick-lower <t> "
+              "--tick-upper <t> --amount1 <n>")
+        return None
+
+    data = encode_function_data(POSITION_MANAGER_ABI, "initializePool",
+                               [pool_key_tuple(pool_key), sqrt_price_x96])
+
+    rows = [
+        ["signer", signer["address"] + ("  (simulate-only, --from)"
+                                        if signer["simulateOnly"] else "")],
+        ["poolId", pool_id],
+        ["currency0", f"{info0['symbol']}  {currency0}"],
+        ["currency1", f"{info1['symbol']}  {currency1}"],
+        ["fee", format_fee(fee) + ("  (NON-STANDARD TIER)" if odd_tier else "")],
+        ["tickSpacing", str(tick_spacing)],
+        ["hooks", "none (0x0) — fixed, this command never opens a hooked pool"],
+        ["start tick", f"{tick}  (from {price_source})"],
+        ["sqrtPriceX96", str(sqrt_price_x96)],
+        ["start price", f"1 {info0['symbol']} = {price_1_per_0:.10g} {info1['symbol']}"],
+        ["", f"1 {info1['symbol']} = {price_0_per_1:.10g} {info0['symbol']}"],
+        ["moves", "no tokens — initialize only; liquidity comes later via mint"],
+    ]
+
+    # Printed ahead of the table rather than after it because run_plan owns everything from
+    # the heading down. It reads as an instruction for how to look at the rows below.
+    print("\n  READ THE START PRICE BELOW. A pool is initialized once and its starting tick "
+          "can never\n  be changed; if it is off the real market, the first swap or mint "
+          "against it is an\n  arbitrage at your expense, and the only remedy is a different "
+          "pool.")
+
+    def revalidate() -> None:
+        # Somebody else can initialize the same PoolKey between the dry run and the
+        # broadcast — the tx would revert, but failing here says why.
+        if pool_is_initialized(client, chain, pool_id):
+            raise RuntimeError(
+                f"pool {pool_id} was initialized by someone else since the plan was made. "
+                "Re-run to read its current price."
+            )
+
+    return run_plan(client, chain, args, signer, {
+        "title": f"create pool {info0['symbol']}/{info1['symbol']} on {chain['name']}",
+        "rows": rows,
+        "tokenMap": _token_map(info0, info1),
+        "hashFields": {
+            "chainId": chain["chainId"], "to": chain["positionManager"], "cmd": "create-pool",
+            "currency0": currency0, "currency1": currency1, "fee": fee,
+            "tickSpacing": tick_spacing, "hooks": pool_key["hooks"], "poolId": pool_id,
+            "tick": tick, "sqrtPriceX96": Big(sqrt_price_x96),
+            "signer": signer["address"],
+        },
+        # No unlockData and no deadline in the calldata, so there is nothing to rebuild at
+        # send time and deadlineSecs is deliberately absent from the hash above.
+        "data": data,
+        "value": 0,
+        "revalidate": revalidate,
+    })
+
+
 def cmd_mint(client, chain: dict, args: dict, signer: dict, *,
              authorization: MandateAuthorization | None = None) -> dict | None:
     pool_id = require_arg(args, "pool", "poolId")
@@ -1026,6 +1205,7 @@ def cmd_address(args: dict) -> None:
 
 COMMANDS = {
     "approve": cmd_approve,
+    "create-pool": cmd_create_pool,
     "mint": cmd_mint,
     "increase": cmd_increase,
     "decrease": cmd_decrease,

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/selftest.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/selftest.py
@@ -885,11 +885,17 @@ _POOL = "0xdb2c20421239d46bb30a7a73029b7f9b7f166489bfb972057d33cbd7249413a5f"
 _POOL_ALT = "0x1299aa8c4ea0db5b8453757ed129ed8e916561925926a161cb89842e3987401a"
 _TOKEN = "0x4200000000000000000000000000000000000006"
 _TOKEN_ALT = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+_TOKEN_THIRD = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 _ME = "0x7de10Fec3dBC1267446d00a1F3ccFcb7F4176412"
 _THEM = "0x000000000000000000000000000000000000dEaD"
 
 _BASELINE = {
     "approve": {"token": _TOKEN, "amount": "1", "expiration-days": "30"},
+    # 3000/60 is a conventional tier, so --allow-odd-tier is inert here; it is set so the
+    # fee and tick-spacing mutations below do not trip the odd-tier refusal instead of
+    # producing a plan. The refusal itself is tested separately in tier6.
+    "create-pool": {"token0": _TOKEN, "token1": _TOKEN_ALT, "fee": "3000",
+                    "tick-spacing": "60", "tick": "0", "allow-odd-tier": True},
     "mint": {"pool": _POOL, "tick-lower": "-600", "tick-upper": "600",
              "liquidity": "1000000", "slippage-bps": "100", "recipient": _ME,
              "max-tick-drift": "60", "deadline-secs": "1200"},
@@ -908,6 +914,11 @@ _MUTATIONS = [
     ("approve", "token", _TOKEN_ALT),
     ("approve", "amount", "2"),
     ("approve", "expiration-days", "3650"),
+    ("create-pool", "token0", _TOKEN_THIRD),
+    ("create-pool", "token1", _TOKEN_THIRD),
+    ("create-pool", "fee", "500"),
+    ("create-pool", "tick-spacing", "10"),
+    ("create-pool", "tick", "600"),
     ("mint", "pool", _POOL_ALT),
     ("mint", "tick-lower", "-1200"),
     ("mint", "tick-upper", "1200"),
@@ -940,6 +951,9 @@ _MUTATIONS = [
 _HASH_FIELDS = {
     "approve": ["amount", "chainId", "cmd", "expirationDays", "needErc20", "needPermit2",
                 "signer", "token"],
+    # No deadlineSecs: initializePool carries no deadline, so nothing binds one.
+    "create-pool": ["chainId", "cmd", "currency0", "currency1", "fee", "hooks", "poolId",
+                    "signer", "sqrtPriceX96", "tick", "tickSpacing", "to"],
     "mint": ["amount0Max", "amount1Max", "chainId", "cmd", "deadlineSecs", "liquidity",
              "maxTickDrift", "poolId", "recipient", "signer", "tickLower", "tickUpper",
              "to"],
@@ -1014,7 +1028,10 @@ def _plan_of(lp_write, chain: dict, command: str, args: dict, *,
     stubs = {"pool_key_for_id": stub_pool_key, "load_pool_state": stub_state,
              "load_position_for_write": stub_position, "token_info": stub_token_info,
              "check_allowances": stub_allowances, "plan_hash": recording_plan_hash,
-             "run_plan": stub_run_plan}
+             "run_plan": stub_run_plan,
+             # create-pool returns early (and never hashes) against a live pool, so the
+             # planning path is the one where this reads False.
+             "pool_is_initialized": lambda client, chn, pool_id: False}
     saved = {name: getattr(lp_write, name) for name in stubs}
     signer = {"address": _ME, "privateKey": None, "simulateOnly": True}
     try:
@@ -1077,6 +1094,61 @@ def tier6(g: dict, r: Results) -> None:
             "unused" in (_row(plans["increase"]["rows"], "recipient") or ""), True)
     r.check("mint shows the tick-drift bound it hashes",
             "60" in (_row(plans["mint"]["rows"], "max tick drift") or ""), True)
+
+    # --- create-pool -------------------------------------------------------
+    # The starting price is the one parameter of this command that cannot be undone, so
+    # the two ways of expressing it must agree exactly and both must reach the hash.
+    def _create(**overrides):
+        return _plan_of(lp_write, chain, "create-pool",
+                        dict(_BASELINE["create-pool"], **overrides))
+
+    # Pinned selector: the ABI fragment is hand-written, so a typo in a parameter type
+    # would still encode cleanly and only fail on chain. 0xf7020405 is
+    # initializePool((address,address,uint24,int24,address),uint160).
+    from unilp.abi_codec import encode_function_data as _efd
+    from unilp.abi_defs import POSITION_MANAGER_ABI as _PM_ABI
+    _key = {"currency0": lp_write.NATIVE, "currency1": _TOKEN, "fee": 3000,
+            "tickSpacing": 60, "hooks": lp_write.NATIVE}
+    _data = _efd(_PM_ABI, "initializePool", [lp_write.pool_key_tuple(_key), 1 << 96])
+    r.check("initializePool encodes to the known selector", _data[:10], "0xf7020405")
+    r.check("initializePool calldata is 4 + 6 words", len(_data), 2 + 8 + 6 * 64)
+
+    base = plans["create-pool"]
+    r.check("create-pool hashes the sqrtPriceX96 it will send",
+            int(base["fields"]["sqrtPriceX96"]), 1 << 96)
+    r.check("create-pool pins hooks to the zero address",
+            base["fields"]["hooks"], lp_write.NATIVE)
+    r.check("create-pool sorts the currencies into PoolKey order",
+            (base["fields"]["currency0"].lower() < base["fields"]["currency1"].lower()), True)
+    swapped = _create(token0=_TOKEN_ALT, token1=_TOKEN)
+    r.check("create-pool ignores the order the two tokens were typed in",
+            swapped["hash"], base["hash"])
+
+    # --price 1.0 on two 18-decimal tokens is tick 0, i.e. the same plan as --tick 0.
+    by_price = _plan_of(lp_write, chain, "create-pool",
+                        {k: v for k, v in dict(_BASELINE["create-pool"],
+                                               price="1").items() if k != "tick"})
+    r.check("create-pool --price and the equivalent --tick produce one plan",
+            by_price["hash"], base["hash"])
+
+    def _refuses(**overrides):
+        try:
+            _create(**overrides)
+        except Exception:  # noqa: BLE001 — the message differs per guard; refusal is the check
+            return True
+        return False
+
+    r.check("create-pool refuses a non-standard tier without --allow-odd-tier",
+            _refuses(fee="3000", **{"tick-spacing": "10", "allow-odd-tier": None}), True)
+    r.check("create-pool refuses a dynamic fee (needs a hook)",
+            _refuses(fee=str(0x800000)), True)
+    r.check("create-pool refuses tickSpacing 0", _refuses(**{"tick-spacing": "0"}), True)
+    r.check("create-pool refuses a fee above 100%", _refuses(fee="1000001"), True)
+    r.check("create-pool refuses the same token twice", _refuses(token1=_TOKEN), True)
+    r.check("create-pool refuses both --tick and --price", _refuses(price="1"), True)
+    r.check("create-pool refuses neither --tick nor --price",
+            _refuses(tick=None, price=None), True)
+    r.check("create-pool refuses a valueless --tick", _refuses(tick=True), True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/abi_defs.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/abi_defs.py
@@ -106,6 +106,15 @@ POSITION_MANAGER_ABI = [
     {"type": "function", "name": "modifyLiquidities", "stateMutability": "payable",
      "inputs": [{"name": "unlockData", "type": "bytes"}, {"name": "deadline", "type": "uint256"}],
      "outputs": []},
+    # Creating a pool is a plain function call, not a modifyLiquidities action: there is
+    # no INITIALIZE_POOL byte in the Actions enum. PositionManager forwards to
+    # PoolManager.initialize, which is why the skill still never targets PoolManager.
+    {"type": "function", "name": "initializePool", "stateMutability": "payable",
+     "inputs": [
+         {"name": "key", "type": "tuple", "components": POOL_KEY_COMPONENTS},
+         {"name": "sqrtPriceX96", "type": "uint160"},
+     ],
+     "outputs": [{"name": "tick", "type": "int24"}]},
     {"type": "event", "name": "Transfer",
      "inputs": [
          {"name": "from", "type": "address", "indexed": True},

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/v4_math.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/v4_math.py
@@ -394,6 +394,30 @@ def mcap_band_for_range(
     }
 
 
+def tick_at_price(price_1_per_0: float, decimals0: int, decimals1: int) -> int:
+    """The tick at which one whole currency0 costs ``price_1_per_0`` whole currency1.
+
+    Inverse of ``token_price_in_quote_at_tick(tick, False, ...)``. Only used to turn a
+    human-typed ``--price`` into a candidate tick, which the caller then snaps to the
+    pool's tickSpacing and shows back before anything is signed — the exact
+    :func:`get_sqrt_ratio_at_tick` of that snapped tick is what reaches the calldata,
+    so this float never lands in a transaction.
+    """
+    price = float(price_1_per_0)
+    if not price > 0:
+        raise ValueError("tick_at_price: price must be positive")
+    raw = price * 10 ** (int(decimals1) - int(decimals0))
+    tick = math.log(raw) / math.log(1.0001)
+    if not math.isfinite(tick):
+        raise ValueError(f"tick_at_price: non-finite tick for price {price_1_per_0}")
+    if tick < MIN_TICK or tick > MAX_TICK:
+        raise ValueError(
+            f"tick_at_price: price {price_1_per_0} is outside the representable range "
+            f"(tick {js_round(tick)}, limits {MIN_TICK}..{MAX_TICK})"
+        )
+    return js_round(tick)
+
+
 def tick_at_mcap(
     mcap_usd: float,
     token_is_currency1: bool,


### PR DESCRIPTION
Closes #226

## What

Adds `create-pool` to `lp_write.py`, so the skill can open the pool a position needs instead of requiring one to already exist:

```bash
python3 scripts/lp_write.py create-pool --token0 <addr|native> --token1 <addr> \
  --fee 3000 --tick-spacing 60 (--tick <t> | --price <n>) [--allow-odd-tier]
```

## Why the diff is small

`initializePool(PoolKey, uint160)` is a plain PositionManager function (selector `0xf7020405`), **not** a `modifyLiquidities` action — there is no `INITIALIZE_POOL` byte in the Actions enum. `run_plan` already hardcodes `positionManager` as its target, so the plan → simulate → `PLAN_HASH` → `--broadcast --confirm` path is untouched. The transaction carries no `unlockData`, no deadline and no token movement, so there is no `rebuildData`, no approvals preflight and no `expected` transfer map.

Not modified: `run_plan`, `_send`, `tx.py`, `rpc.py`, `ratchet.py`, `journal.py`, `reconcile.py`, `lp_read.py`, and `v4_actions.ACTIONS` (still 14 entries). The read/write firewall (`account.py` has no `sign_digest`; `secp256k1.py` imports it and adds signing) is unchanged.

## Guards

- `hooks` is pinned to `address(0)`; there is no `--hooks` flag
- a dynamic fee (`0x800000`) is refused — it requires a hook
- `fee` must be `0..1_000_000`, `tickSpacing` `1..32767`, checked locally so a bad value produces a sentence rather than an unnamed custom-error selector
- a `fee`/`tickSpacing` pair outside `VANILLA_FEE_TIERS` needs `--allow-odd-tier`, because `pools` only searches those tiers and the new pool would otherwise be invisible to discovery
- the pool is read first: if it already exists, the command prints its `poolId` and current tick and exits without planning anything
- `revalidate` re-reads slot0 immediately before sending, so a pool initialized by someone else between approval and broadcast fails with a reason instead of an opaque revert

## The starting price

This is the one parameter that can never be corrected, so the table prints `tick`, `sqrtPriceX96` and the price **in both directions**, under a banner saying it is permanent. `--price` is currency1 per whole currency0 with decimals handled; the two tokens are sorted into PoolKey order, so which one is typed as `--token0` decides nothing.

Neither branch snaps to `tickSpacing`. v4 requires grid alignment for *position boundaries*, not for the initial tick — forcing it would block initializing at the exact market price for no benefit.

## Files

| File | Change |
|---|---|
| `unilp/abi_defs.py` | `initializePool(PoolKey,uint160)` added to `POSITION_MANAGER_ABI` |
| `unilp/v4_math.py` | `tick_at_price()` for `--price` |
| `lp_write.py` | `pool_is_initialized()`, `_currency_arg()`, `cmd_create_pool()`, `COMMANDS` + `USAGE` |
| `selftest.py` | Tier 6 coverage for the new command |
| `SKILL.md`, `assets/v4-reference.md` | non-goal removed, §8b added |

## Verification

`selftest.py` goes **695 → 716** assertions. Tier 6 gains the mutation rows and the frozen hash-field set for every new flag (it fails by design if a calldata-affecting flag misses the hash), the pinned `0xf7020405` selector, and eight refusal cases. `PLAN_HASH` binds `currency0`/`currency1`/`fee`/`tickSpacing`/`hooks`/`poolId`/`tick`/`sqrtPriceX96`; `deadlineSecs` is deliberately absent because the calldata has no deadline.

```
python3 scripts/selftest.py   →  716 assertions pass
uv run ruff check .           →  All checks passed!
uv run pytest -q              →  7209 passed, 27 skipped
```

Against Base, all in `--from` simulate-only mode (nothing broadcast):

- existing ETH/USDC 500/10 pool → takes the already-initialized path, prints `poolId` + current tick, exits without planning
- fresh 4200/60 pool → simulates OK at 56302 gas, `PLAN_HASH: 667d3645`
- `--price 3000` and `--tick -196256`, with the token arguments given in either order → one identical hash, confirming sorting, decimals and the price↔tick conversion
- `--price 3001` → `ce35f3a8`, `--tick -196196` → `8fd5546a` — the hash tracks the price
- `--confirm deadbeef` → refused, nothing sent
- odd tier without `--allow-odd-tier`, and fee `0x800000` → refused with the reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)