### PR TITLE
fix(cron): keep full run output and stop dead "→ Chat" links

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -536,6 +536,7 @@ agentos cron list
 agentos cron add --every 1h --text "Summarize important updates" --name hourly-summary
 agentos cron status <job-id>
 agentos cron runs <job-id>
+agentos cron output <job-id>
 ```
 
 `--job-kind` picks what fires: `reminder` (delivers `--text` verbatim, no LLM),
@@ -577,7 +578,10 @@ agentos cron add --every 5m --script watch-memory.sh --name memory-watchdog \
 ```
 
 Either way `agentos cron runs <job-id>` shows each run's `Output` and
-`Delivery` columns; `--json` prints the output untruncated. A `Delivery` of
+`Delivery` columns. The `Output` column is a 500-character preview, so the whole
+list stays small no matter how much a job prints; `agentos cron output <job-id>`
+prints one run's output in full (the most recent run, or `--run <run-id>` for an
+older one — run ids come from `agentos cron runs --json`). A `Delivery` of
 `fwd:no_session_target` is the scheduler saying the script printed something
 that reached no conversation — add `--session-key`. Jobs created from the Web UI
 or from a chat already carry their originating session, so their output shows up

--- a/frontend/src/views/cron/CronPage.test.tsx
+++ b/frontend/src/views/cron/CronPage.test.tsx
@@ -100,6 +100,8 @@ function wireRpc(
     removePending?: boolean
     createPending?: boolean
     runs?: unknown[]
+    runOutput?: string
+    runOutputReject?: boolean
   } = {},
 ) {
   mockRpc.call.mockImplementation((method: string) => {
@@ -124,6 +126,10 @@ function wireRpc(
         return opts.runsReject
           ? Promise.reject(new Error('runs down'))
           : Promise.resolve(opts.runs ?? RUNS)
+      case 'cron.runOutput':
+        return opts.runOutputReject
+          ? Promise.reject(new Error('output down'))
+          : Promise.resolve({ output: opts.runOutput ?? '' })
       case 'cron.remove':
         if (opts.removePending) return new Promise(() => undefined)
         return opts.removeReject ? Promise.reject(new Error('remove failed')) : Promise.resolve({})
@@ -371,6 +377,45 @@ describe('CronPage', () => {
     )
   })
 
+  it('hides the Chat button for a run whose session was never created', async () => {
+    // Script jobs never open a session, and isolated agent sessions are reaped
+    // after 24h — the key alone used to send you to "Could not load chat history."
+    wireRpc({
+      runs: [
+        {
+          started_at: Date.now(),
+          status: 'ok',
+          summary: 'script ran',
+          sessionKey: 'cron:job-rem:run:deadbeef',
+          chatAvailable: false,
+        },
+        {
+          started_at: Date.now() - 60_000,
+          status: 'ok',
+          summary: 'agent turn',
+          sessionKey: 'cron:job-rem:run:cafe1234',
+          chatAvailable: true,
+        },
+      ],
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Daily standup' }))
+
+    await screen.findByText('script ran')
+    expect(screen.getAllByRole('button', { name: '→ Chat' })).toHaveLength(1)
+  })
+
+  it('keeps the Chat button when the gateway does not report availability', async () => {
+    // An older gateway omits the field; hiding every button would be a regression.
+    wireRpc({ runs: [{ started_at: Date.now(), status: 'ok', summary: 'x', sessionKey: 'k' }] })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Daily standup' }))
+
+    expect(await screen.findByRole('button', { name: '→ Chat' })).toBeInTheDocument()
+  })
+
   it('expands a run to show script stdout the cell had to clip', async () => {
     // A script job's stdout is its only trace, and it is routinely multi-line
     // and wider than the cell — the preview must not be the only copy on screen.
@@ -393,6 +438,58 @@ describe('CronPage', () => {
 
     fireEvent.click(toggle)
     expect(document.querySelector('.cron-runs__output')).toBeNull()
+  })
+
+  it('expanding a run fetches the full output the list row only previewed', async () => {
+    // cron.runs sends a 500-char preview so a 20-row list stays small; the rest
+    // of the output — which is the whole point of opening the row — arrives here.
+    const preview = 'checked 4 pools'
+    const full = preview + '\n' + 'x'.repeat(4000) + '\n}'
+    wireRpc({
+      runs: [
+        {
+          id: 'run-9',
+          started_at: Date.now(),
+          status: 'ok',
+          duration_ms: 8,
+          summary: preview,
+          summaryTruncated: true,
+        },
+      ],
+      runOutput: full,
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Daily standup' }))
+
+    const toggle = await screen.findByRole('button', { name: /checked 4 pools/ })
+    fireEvent.click(toggle)
+
+    await waitFor(() =>
+      expect(mockRpc.call).toHaveBeenCalledWith('cron.runOutput', {
+        id: 'job-rem',
+        runId: 'run-9',
+      }),
+    )
+    await waitFor(() =>
+      expect(document.querySelector('.cron-runs__output')?.textContent).toBe(full),
+    )
+  })
+
+  it('falls back to the preview when the full output cannot be fetched', async () => {
+    const preview = 'checked 4 pools'
+    wireRpc({
+      runs: [{ id: 'run-9', started_at: Date.now(), status: 'ok', summary: preview }],
+      runOutputReject: true,
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Daily standup' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /checked 4 pools/ }))
+
+    expect(await screen.findByText(/Failed to load full output/)).toBeInTheDocument()
+    expect(document.querySelector('.cron-runs__output')?.textContent).toBe(preview)
   })
 
   it('deleting requires confirmation then calls cron.remove and invalidates', async () => {

--- a/frontend/src/views/cron/CronPage.tsx
+++ b/frontend/src/views/cron/CronPage.tsx
@@ -112,6 +112,10 @@ interface CronListResult {
 interface CronRunsResult {
   runs?: RawRun[]
 }
+/** cron.runOutput — the full stored output for a single run. */
+interface CronRunOutput {
+  output?: string
+}
 
 // dot state → --tone bucket (status color ONLY via --tone; never hardcoded).
 function dotTone(state: CronDot): string {
@@ -166,6 +170,19 @@ function RunsDrawer({
   // A script job's output is its only trace — the row preview is one clipped
   // line, so the full text has to be reachable without leaving the page.
   const [expanded, setExpanded] = useState<number | null>(null)
+
+  // cron.runs sends previews so a 20-row list stays small; the full output is
+  // fetched for the one run that is open, and cached per run id.
+  const openRunId = expanded != null ? (runs[expanded]?.id ?? '') : ''
+  const outputQuery = useQuery<CronRunOutput>({
+    queryKey: ['cron', 'runOutput', jobId, openRunId],
+    enabled: Boolean(openRunId),
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      return rpc.call<CronRunOutput>('cron.runOutput', { id: jobId, runId: openRunId })
+    },
+    refetchOnWindowFocus: false,
+  })
 
   return (
     <div className="cron-detail panel" aria-label={`Run history for ${jobName}`}>
@@ -235,7 +252,7 @@ function RunsDrawer({
                         )}
                       </td>
                       <td>
-                        {row.sessionKey ? (
+                        {row.sessionKey && row.chatAvailable ? (
                           <Button
                             type="button"
                             variant="ghost"
@@ -252,7 +269,16 @@ function RunsDrawer({
                     {isOpen ? (
                       <tr className="cron-runs__output-row">
                         <td colSpan={6}>
-                          <pre className="cron-runs__output">{row.replyFull}</pre>
+                          <pre className="cron-runs__output">
+                            {outputQuery.data?.output ?? row.replyFull}
+                          </pre>
+                          {outputQuery.isLoading ? (
+                            <p className="cron-muted">Loading full output…</p>
+                          ) : outputQuery.isError ? (
+                            <p className="cron-muted">
+                              Failed to load full output — showing preview.
+                            </p>
+                          ) : null}
                         </td>
                       </tr>
                     ) : null}

--- a/frontend/src/views/cron/cron.css
+++ b/frontend/src/views/cron/cron.css
@@ -337,7 +337,9 @@
 }
 .cron-runs__output {
   margin: 0;
-  max-height: 18rem;
+  /* Script output is routinely hundreds of lines — give it most of the viewport
+     before falling back to the scrollbar. */
+  max-height: min(60vh, 32rem);
   overflow: auto;
   padding: 0.6rem 0.75rem;
   border: 1px solid var(--border);

--- a/frontend/src/views/cron/logic.test.ts
+++ b/frontend/src/views/cron/logic.test.ts
@@ -224,7 +224,24 @@ describe('runRow', () => {
       delivery: 'ch: slack, ws: sent',
       reply: 'done',
       replyFull: 'done',
+      runId: '',
+      truncated: false,
       sessionKey: 'k',
+      chatAvailable: true,
+    })
+  })
+  it('treats chatAvailable as opt-out so an older gateway keeps its Chat buttons', () => {
+    // A script job's session is never created; the server says so explicitly.
+    expect(runRow({ sessionKey: 'cron:j:run:ab', chatAvailable: false }, rel).chatAvailable).toBe(
+      false,
+    )
+    // Field absent — we cannot know, so do not hide what used to work.
+    expect(runRow({ sessionKey: 'cron:j:run:ab' }, rel).chatAvailable).toBe(true)
+  })
+  it('carries the run id and truncation flag through for the lazy output fetch', () => {
+    expect(runRow({ id: 'run-9', summary: 'head…', summaryTruncated: true }, rel)).toMatchObject({
+      runId: 'run-9',
+      truncated: true,
     })
   })
   it('falls back for a string / absent deliveryStatus and missing fields', () => {

--- a/frontend/src/views/cron/logic.ts
+++ b/frontend/src/views/cron/logic.ts
@@ -68,11 +68,16 @@ export interface RawDelivery {
 
 /** A raw run-history row from cron.runs (all fields optional; snake or camel). */
 export interface RawRun {
+  id?: string
   started_at?: string | number
   status?: string
   duration_ms?: number | null
+  /** Preview only — cron.runs caps this. Full text comes from cron.runOutput. */
   summary?: string
+  summaryTruncated?: boolean
   sessionKey?: string
+  /** Whether sessionKey names a session that still exists and can be opened. */
+  chatAvailable?: boolean
   deliveryStatus?: unknown
   delivery_status?: unknown
   [key: string]: unknown
@@ -256,9 +261,22 @@ export interface RunRow {
   duration: string
   delivery: string
   reply: string
-  /** Untruncated output, for the expanded view. Empty when there was none. */
+  /**
+   * The preview text, shown in the expanded view until (or unless) the full
+   * output arrives from cron.runOutput. Empty when there was no output.
+   */
   replyFull: string
+  /** Run id used to fetch the full output; empty for rows the server sent without one. */
+  runId: string
+  /** True when the server preview is only part of the stored output. */
+  truncated: boolean
   sessionKey: string
+  /**
+   * Whether a chat transcript actually exists for this run. Script jobs never
+   * create a session and isolated agent sessions are reaped, so the key alone
+   * does not mean there is anything to open.
+   */
+  chatAvailable: boolean
 }
 
 /**
@@ -287,7 +305,12 @@ export function runRow(run: RawRun, relTime: (ts: string | number) => string): R
     delivery,
     reply: preview ? preview.substring(0, 120) : '—',
     replyFull: summary,
+    runId: run.id ? String(run.id) : '',
+    truncated: Boolean(run.summaryTruncated),
     sessionKey: run.sessionKey ? String(run.sessionKey) : '',
+    // Absent means an older gateway that cannot tell us — keep the previous
+    // behaviour there rather than hiding the button everywhere.
+    chatAvailable: run.chatAvailable !== false,
   }
 }
 

--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -1162,3 +1162,37 @@ def cron_runs(
         print_json(payload)
         return
     _render_runs(_job_rows(payload))
+
+
+@cron_app.command("output")
+def cron_output(
+    job_id: str = typer.Argument(..., help="Cron job id"),
+    run: str = typer.Option("", "--run", "-r", help="Run id (default: the most recent run)"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Print the full output of one run.
+
+    'cron runs' shows a short preview per row; this prints the whole thing for a
+    single run — which for a script job is its entire stdout.
+    """
+
+    async def _run(client):
+        params = {"id": job_id}
+        if run:
+            params["runId"] = run
+        return await client.call("cron.runOutput", params)
+
+    payload = run_gateway_sync(_run, json_output=json_output)
+    if json_output:
+        print_json(payload)
+        return
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if error:
+            console.print(f"[red]error:[/red] {error}")
+        output = payload.get("output")
+        if output:
+            # Raw script stdout — JSON brackets must not be read as rich markup.
+            console.print(output, markup=False, highlight=False)
+        else:
+            console.print("[dim](no output)[/dim]")

--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -65,6 +65,17 @@ def _is_webchat_session_key(key: str) -> bool:
     )
 
 
+def _is_cron_session_key(key: str) -> bool:
+    """Cron run keys — ``cron:<job>:run:<hex>`` (isolated) or ``cron:<job>``.
+
+    These routinely name a session that does not exist: ``script_run`` jobs never
+    create one, and isolated per-run sessions are reaped after 24h. Opening one
+    should read as an empty transcript, not a failed request.
+    """
+    parts = str(key or "").split(":")
+    return len(parts) >= 2 and parts[0] == "cron" and bool(parts[1])
+
+
 def _empty_chat_history_payload(limit: int) -> dict[str, Any]:
     return {
         "messages": [],
@@ -472,7 +483,9 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
             include_canonical=include_canonical,
         )
     except KeyError:
-        if _is_webchat_session_key(session_key):
+        # A whitelist, not a blanket swallow — a typo'd agent key should still
+        # surface as an error rather than silently render an empty chat.
+        if _is_webchat_session_key(session_key) or _is_cron_session_key(session_key):
             return _empty_chat_history_payload(limit)
         raise
     page_entries, has_more = _chat_history_page(

--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -30,12 +30,14 @@ from agentos.scheduler.schedule_normalizer import (
 )
 from agentos.scheduler.scripts import normalize_script_value, validate_script_path
 from agentos.scheduler.types import (
+    CRON_SUMMARY_PREVIEW_CHARS,
     DeliveryConfig,
     DeliveryMode,
     FailureDestination,
     ReplyTargetSnapshot,
     ScheduleKind,
     SessionTarget,
+    preview_summary,
 )
 from agentos.tools.policy_config import normalize_tool_profile
 
@@ -996,6 +998,28 @@ async def _handle_cron_run(params: dict | None, ctx: RpcContext) -> dict[str, An
     return _manual_run_to_wire(result)
 
 
+async def _live_session_keys(ctx: RpcContext, keys: list[str]) -> set[str]:
+    """Of *keys*, the ones a chat transcript can actually be opened for.
+
+    A run always carries a session key, but that key is only a label unless a
+    handler created the session: ``script_run`` never touches the session manager
+    at all, and isolated ``agent_run`` sessions are reaped after 24h. Probing here
+    is what lets the UI hide a "→ Chat" button that would only lead to an error.
+    """
+    manager = getattr(ctx, "session_manager", None)
+    getter = getattr(manager, "get_session", None)
+    if not callable(getter):
+        return set()
+    live: set[str] = set()
+    for key in dict.fromkeys(keys):  # de-dup, order irrelevant
+        try:
+            if await getter(key) is not None:
+                live.add(key)
+        except Exception:  # noqa: BLE001 - run history must render regardless
+            continue
+    return live
+
+
 @_d.method("cron.runs")
 async def _handle_cron_runs(params: dict | None, ctx: RpcContext) -> list[dict]:
     if not isinstance(params, dict):
@@ -1008,6 +1032,7 @@ async def _handle_cron_runs(params: dict | None, ctx: RpcContext) -> list[dict]:
     if scheduler is None:
         return []
     runs = await scheduler.get_runs(job_id, limit=limit)
+    live_keys = await _live_session_keys(ctx, [r.session_key for r in runs if r.session_key])
     return [
         {
             "id": r.id,
@@ -1021,12 +1046,41 @@ async def _handle_cron_runs(params: dict | None, ctx: RpcContext) -> list[dict]:
                 else None
             ),
             "error": r.error,
-            "summary": r.summary,
+            # Rows carry a preview only — a script job's stdout can be large and
+            # this list is 10-20 rows wide. cron.runOutput fetches the full text
+            # for the one run the caller opens.
+            "summary": preview_summary(r.summary),
+            "summaryTruncated": bool(r.summary and len(r.summary) > CRON_SUMMARY_PREVIEW_CHARS),
             "sessionKey": r.session_key or None,
+            # False when the session was never created (script jobs) or has been
+            # reaped — the caller should not offer to open a chat that 404s.
+            "chatAvailable": bool(r.session_key) and r.session_key in live_keys,
             "deliveryStatus": r.delivery_status or None,
         }
         for r in runs
     ]
+
+
+@_d.method("cron.runOutput")
+async def _handle_cron_run_output(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    """Full stored output for a single run. Omit ``runId`` for the latest run."""
+    if not isinstance(params, dict):
+        raise ValueError("params.id is required")
+    job_id = params.get("id") or params.get("job_id")
+    if not job_id:
+        raise ValueError("params.id is required")
+    run_id = params.get("runId") or params.get("run_id") or None
+    scheduler = _require_scheduler(ctx)
+    run = await scheduler.get_run(job_id, run_id)
+    if run is None:
+        raise KeyError(f"Cron run not found: {run_id or 'latest'}")
+    return {
+        "runId": run.id,
+        "jobId": run.job_id,
+        "success": run.success,
+        "error": run.error,
+        "output": run.summary or "",
+    }
 
 
 @_d.method("cron.subscribe")

--- a/src/agentos/scheduler/engine.py
+++ b/src/agentos/scheduler/engine.py
@@ -240,6 +240,10 @@ class SchedulerEngine:
         """Return recent execution records for a job."""
         return await self._ops.get_runs(job_id, limit)
 
+    async def get_run(self, job_id: str, run_id: str | None = None) -> JobExecution | None:
+        """Return one execution record — the latest when *run_id* is omitted."""
+        return await self._ops.get_run(job_id, run_id)
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------

--- a/src/agentos/scheduler/handlers.py
+++ b/src/agentos/scheduler/handlers.py
@@ -33,6 +33,8 @@ from agentos.scheduler.types import (
     DeliveryMode,
     HandlerResult,
     SessionTarget,
+    clamp_run_output,
+    preview_summary,
 )
 from agentos.session.keys import build_main_key
 from agentos.session.terminal_reply import (
@@ -352,7 +354,7 @@ def make_agent_run_handler(
                     )
                     error_message = f"Cron job '{job.name}' timed out after {timeout_value}s"
                     result_text = error_message
-                    summary = result_text[:500]
+                    summary = clamp_run_output(result_text)
                 else:
                     success = getattr(record, "status", None) == AgentTaskStatus.SUCCEEDED
                     if success:
@@ -370,7 +372,7 @@ def make_agent_run_handler(
                         if is_context_payload_too_large(record):
                             error_message = build_terminal_reply(record)
                         result_text = error_message or ""
-                    summary = result_text[:500] if result_text else error_message
+                    summary = clamp_run_output(result_text) if result_text else error_message
             else:
                 assert turn_runner is not None
                 tool_context = _build_cron_tool_context(
@@ -419,7 +421,7 @@ def make_agent_run_handler(
                 result_text = "".join(collected_text)
                 if not success and not result_text:
                     result_text = error_message or ""
-                summary = result_text[:500] if result_text else error_message
+                summary = clamp_run_output(result_text) if result_text else error_message
         except Exception as exc:
             _, error_message = sanitize_agent_error(
                 {
@@ -431,7 +433,7 @@ def make_agent_run_handler(
                 fallback_error_message=str(exc) or "Agent error",
             )
             result_text = f"Cron job '{job.name}' failed: {error_message}"
-            summary = result_text[:500]
+            summary = clamp_run_output(result_text)
             success = False
 
         result_text = strip_reply_directives(result_text) or ""
@@ -442,7 +444,7 @@ def make_agent_run_handler(
             job,
             result_text=result_text,
             success=success,
-            summary=summary,
+            summary=preview_summary(summary),
             session_key=session_key,
             route_envelope=build_reply_rendezvous_envelope(job, session_key),
         )
@@ -486,7 +488,7 @@ def make_static_message_handler(delivery_chain: DeliveryChain) -> Callable:
             job,
             result_text=text,
             success=True,
-            summary=text[:500],
+            summary=preview_summary(text),
             session_key=session_key,
             route_envelope=build_reply_rendezvous_envelope(job, session_key),
         )
@@ -494,7 +496,7 @@ def make_static_message_handler(delivery_chain: DeliveryChain) -> Callable:
         if delivery_error:
             raise RuntimeError(delivery_error)
         return HandlerResult(
-            summary=text[:500],
+            summary=clamp_run_output(text),
             session_key=session_key,
             delivery_status=(
                 f"{report.channel_status}|ws:{report.ws_status}|fwd:{report.session_status}"
@@ -545,7 +547,7 @@ def make_script_run_handler(delivery_chain: DeliveryChain) -> Callable:
                 job,
                 result_text=alert,
                 success=False,
-                summary=alert[:500],
+                summary=preview_summary(alert),
                 session_key=session_key,
                 route_envelope=build_reply_rendezvous_envelope(job, session_key),
             )
@@ -564,7 +566,7 @@ def make_script_run_handler(delivery_chain: DeliveryChain) -> Callable:
             job,
             result_text=output,
             success=True,
-            summary=output[:500],
+            summary=preview_summary(output),
             session_key=session_key,
             route_envelope=build_reply_rendezvous_envelope(job, session_key),
         )
@@ -572,7 +574,7 @@ def make_script_run_handler(delivery_chain: DeliveryChain) -> Callable:
         if delivery_error:
             raise RuntimeError(delivery_error)
         return HandlerResult(
-            summary=output[:500],
+            summary=clamp_run_output(output),
             session_key=session_key,
             delivery_status=(
                 f"{report.channel_status}|ws:{report.ws_status}|fwd:{report.session_status}"

--- a/src/agentos/scheduler/jobs.py
+++ b/src/agentos/scheduler/jobs.py
@@ -10,7 +10,15 @@ from zoneinfo import ZoneInfo
 
 from .parser import parse_cron
 from .persistence import JobStore
-from .types import CronJob, HandlerResult, JobExecution, JobStatus, ScheduleKind, clear_reservation
+from .types import (
+    CronJob,
+    HandlerResult,
+    JobExecution,
+    JobStatus,
+    ScheduleKind,
+    clamp_run_output,
+    clear_reservation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -137,16 +145,16 @@ async def execute_with_timeout(job: CronJob, handler: HandlerFn) -> JobExecution
             result = await asyncio.wait_for(task, timeout=job.timeout_seconds)
         execution.success = True
         if isinstance(result, HandlerResult):
-            execution.summary = result.summary[:500] if result.summary else None
+            execution.summary = clamp_run_output(result.summary)
             execution.session_key = result.session_key
             execution.delivery_status = result.delivery_status
         elif isinstance(result, tuple) and len(result) >= 2:
-            execution.summary = result[0][:500] if isinstance(result[0], str) else None
+            execution.summary = clamp_run_output(result[0]) if isinstance(result[0], str) else None
             execution.session_key = result[1] or ""
             if len(result) >= 3:
                 execution.delivery_status = result[2] or ""
         elif isinstance(result, str):
-            execution.summary = result[:500]
+            execution.summary = clamp_run_output(result)
         else:
             execution.summary = None
     except TimeoutError:

--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -442,3 +442,7 @@ class SchedulerOps:
     async def get_runs(self, job_id: str, limit: int = 20) -> list[JobExecution]:
         """Return recent execution records for a job."""
         return await self._store.list_executions(job_id, limit)
+
+    async def get_run(self, job_id: str, run_id: str | None = None) -> JobExecution | None:
+        """Return one execution record — the latest when *run_id* is omitted."""
+        return await self._store.get_execution(job_id, run_id)

--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -191,6 +191,28 @@ def _row_to_job(row: aiosqlite.Row) -> CronJob:
     )
 
 
+def _row_to_execution(row: aiosqlite.Row) -> JobExecution:
+    """Map a ``scheduler_runs`` row, tolerating columns older DBs may lack."""
+
+    def _get(key: str, default: object = None) -> object:
+        try:
+            return row[key]
+        except (IndexError, KeyError):
+            return default
+
+    return JobExecution(
+        id=row["id"],
+        job_id=row["job_id"],
+        started_at=datetime.fromisoformat(row["started_at"]),
+        finished_at=(datetime.fromisoformat(row["finished_at"]) if row["finished_at"] else None),
+        success=bool(row["success"]),
+        error=row["error"],
+        summary=_get("summary"),  # type: ignore[arg-type]
+        session_key=_get("session_key", ""),  # type: ignore[arg-type]
+        delivery_status=_get("delivery_status", ""),  # type: ignore[arg-type]
+    )
+
+
 def _parse_wake_mode(raw: object) -> CronWakeMode:
     value = getattr(raw, "value", raw)
     normalized = value.strip().lower() if isinstance(value, str) else ""
@@ -834,29 +856,23 @@ class JobStore:
             (job_id, limit),
         ) as cur:
             rows = await cur.fetchall()
+            return [_row_to_execution(r) for r in rows]
 
-            def _safe_get(row, key, default=None):
-                try:
-                    return row[key]
-                except (IndexError, KeyError):
-                    return default
+    async def get_execution(self, job_id: str, run_id: str | None = None) -> JobExecution | None:
+        """One run record, scoped to its job. Without *run_id*, the most recent run.
 
-            return [
-                JobExecution(
-                    id=r["id"],
-                    job_id=r["job_id"],
-                    started_at=datetime.fromisoformat(r["started_at"]),
-                    finished_at=(
-                        datetime.fromisoformat(r["finished_at"]) if r["finished_at"] else None
-                    ),
-                    success=bool(r["success"]),
-                    error=r["error"],
-                    summary=_safe_get(r, "summary"),
-                    session_key=_safe_get(r, "session_key", ""),
-                    delivery_status=_safe_get(r, "delivery_status", ""),
-                )
-                for r in rows
-            ]
+        The run-history drawer shows a preview per row and fetches the full output
+        only for the row someone opens, so this reads one record at a time.
+        """
+        if run_id:
+            query = "SELECT * FROM scheduler_runs WHERE job_id = ? AND id = ?"
+            params: tuple[str, ...] = (job_id, run_id)
+        else:
+            query = "SELECT * FROM scheduler_runs WHERE job_id = ? ORDER BY started_at DESC LIMIT 1"
+            params = (job_id,)
+        async with self._db().execute(query, params) as cur:
+            row = await cur.fetchone()
+            return _row_to_execution(row) if row is not None else None
 
     async def prune_runs(self, max_age_days: int = 30, max_per_job: int = 100) -> int:
         """Delete old execution records. Returns total rows deleted."""

--- a/src/agentos/scheduler/reaper.py
+++ b/src/agentos/scheduler/reaper.py
@@ -19,6 +19,8 @@ class SessionReaper:
 
     DEFAULT_RETENTION_SECONDS = 86400  # 24 hours
     MIN_REAP_INTERVAL = 300  # 5 minutes
+    PAGE_SIZE = 500
+    MAX_PAGES = 200  # backstop, so a pathological store cannot spin forever
 
     def __init__(self, session_store, retention_seconds: int = DEFAULT_RETENTION_SECONDS) -> None:
         self._session_store = session_store
@@ -40,15 +42,26 @@ class SessionReaper:
 
         cutoff_ms = int((time.time() - self._retention) * 1000)
 
-        sessions = await self._session_store.list_sessions()
         to_delete: list[str] = []
-
-        for session in sessions:
-            key = getattr(session, "session_key", None) or getattr(session, "key", None)
-            updated_at = getattr(session, "updated_at", None)
-            if key and updated_at is not None:
-                if _is_isolated_cron_session(key) and updated_at < cutoff_ms:
-                    to_delete.append(key)
+        # list_sessions defaults to the 100 most recently updated sessions, which
+        # is precisely the set that is *not* expired — so the whole store has to
+        # be walked. Collect first, delete after: deleting mid-sweep would shift
+        # the offsets of the pages still to come.
+        for page in range(self.MAX_PAGES):
+            sessions = await self._session_store.list_sessions(
+                limit=self.PAGE_SIZE,
+                offset=page * self.PAGE_SIZE,
+            )
+            for session in sessions:
+                key = getattr(session, "session_key", None) or getattr(session, "key", None)
+                updated_at = getattr(session, "updated_at", None)
+                if key and updated_at is not None:
+                    if _is_isolated_cron_session(key) and updated_at < cutoff_ms:
+                        to_delete.append(key)
+            if len(sessions) < self.PAGE_SIZE:
+                break
+        else:
+            logger.warning("reaper.page_cap_reached pages=%d", self.MAX_PAGES)
 
         for key in to_delete:
             await self._session_store.delete_session(key)

--- a/src/agentos/scheduler/types.py
+++ b/src/agentos/scheduler/types.py
@@ -106,6 +106,28 @@ class DeliveryConfig:
     failure_destination: FailureDestination | None = None
 
 
+# Two different things used to share one 500-char cap, which meant a script job's
+# stdout was destroyed at write time and the run-history drawer could never show it.
+# They are separated now: what goes out over WS/webhook stays small, what goes into
+# the run record keeps the whole output (up to a sanity ceiling).
+CRON_SUMMARY_PREVIEW_CHARS = 500
+CRON_RUN_OUTPUT_MAX_CHARS = 200_000
+
+
+def clamp_run_output(text: str | None) -> str | None:
+    """Cap output stored on a run record — generous, only a runaway-script backstop."""
+    if not text:
+        return text
+    return text[:CRON_RUN_OUTPUT_MAX_CHARS]
+
+
+def preview_summary(text: str | None) -> str | None:
+    """Short preview for delivery payloads (WS broadcast, webhook POST, list rows)."""
+    if not text:
+        return text
+    return text[:CRON_SUMMARY_PREVIEW_CHARS]
+
+
 @dataclass
 class HandlerResult:
     """Typed return from cron job handlers."""

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -397,11 +397,13 @@ agentos cron add --every 5m --script watch-memory.sh --name memory-watchdog
 # only reaches the run record. --session-key names the chat it reports into
 # (the run stays isolated). Web UI / in-chat jobs already carry their session.
 agentos cron add --every 5m --script watch-memory.sh --session-key "$KEY"
-# 'runs' shows each run's Output + Delivery; --json prints output untruncated.
+# 'runs' shows each run's Output + Delivery; Output is a 500-char preview.
+# 'output' prints one run in full — latest by default, or --run <run-id>.
 # Delivery 'fwd:no_session_target' == printed something, reached no chat.
 # In chat, the cron tool reads the same history via action="runs" — use it to
 # answer "what did that job do?" instead of guessing from the schedule.
 agentos cron runs <id> [--json]
+agentos cron output <id> [--run <run-id>] [--json]
 # --script on an agent_turn is a pre-run collector instead: its stdout becomes
 # the turn's context, and a tick that prints nothing skips the turn (no tokens).
 agentos cron add --every 10m --job-kind agent_turn --script watch_rss.py \

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -194,6 +194,33 @@ async def test_chat_history_returns_empty_for_missing_webchat_session(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "session_key",
+    [
+        # Isolated per-run key: script jobs never create the session at all, and
+        # agent-turn ones are reaped after 24h. Run history links here either way.
+        "cron:6b23bfa7-8344-4c07-80f0-2a1c6dbf13d6:run:ddad09c4",
+        # SessionTarget.SESSION shares one key across runs.
+        "cron:6b23bfa7-8344-4c07-80f0-2a1c6dbf13d6",
+    ],
+)
+async def test_chat_history_returns_empty_for_missing_cron_session(session_key: str) -> None:
+    mgr = _FakeSessionManager(
+        [],
+        canonical_exception=KeyError(f"Session not found: {session_key}"),
+        transcript_exception=KeyError(f"Session not found: {session_key}"),
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": session_key, "limit": 2},
+        RpcContext(conn_id="test", session_manager=mgr),
+    )
+
+    assert result["messages"] == []
+    assert result["history_scope"] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_chat_history_keeps_not_found_for_missing_non_webchat_session() -> None:
     session_key = "agent:main:cli:new123"
     mgr = _FakeSessionManager(

--- a/tests/test_gateway/test_rpc_cron_chat_available.py
+++ b/tests/test_gateway/test_rpc_cron_chat_available.py
@@ -1,0 +1,99 @@
+"""A run's session key does not mean a chat transcript exists.
+
+``_resolve_session_key`` mints ``cron:<job>:run:<hex>`` for every run and writes it
+onto the run record, but only ``agent_run`` ever creates the session — and even
+those are reaped after 24h. Run history used to offer a "→ Chat" button for all of
+them, which landed on "Could not load chat history."
+
+``cron.runs`` now probes the session store so the caller can tell the difference.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _handle_cron_runs
+from agentos.scheduler.types import JobExecution
+
+SCRIPT_RUN = "cron:job-1:run:deadbeef"  # script job — session never created
+AGENT_RUN = "cron:job-1:run:cafe1234"  # agent turn — session exists
+
+
+class _FakeScheduler:
+    def __init__(self, runs: list[JobExecution]) -> None:
+        self._runs = runs
+
+    async def get_runs(self, job_id: str, limit: int = 20) -> list[JobExecution]:
+        return self._runs[:limit]
+
+
+class _FakeSessionManager:
+    """Only ``AGENT_RUN`` resolves, mirroring a store where the rest were reaped."""
+
+    def __init__(self, *, live: set[str], explode: bool = False) -> None:
+        self._live = live
+        self._explode = explode
+        self.lookups: list[str] = []
+
+    async def get_session(self, session_key: str) -> Any:
+        self.lookups.append(session_key)
+        if self._explode:
+            raise RuntimeError("session store unavailable")
+        return object() if session_key in self._live else None
+
+
+def _ctx(scheduler: Any, session_manager: Any = None) -> RpcContext:
+    ctx = RpcContext(conn_id="test", session_manager=session_manager)
+    ctx.cron_scheduler = scheduler  # type: ignore[attr-defined]
+    return ctx
+
+
+def _runs() -> list[JobExecution]:
+    return [
+        JobExecution(id="r1", job_id="job-1", success=True, session_key=AGENT_RUN),
+        JobExecution(id="r2", job_id="job-1", success=True, session_key=SCRIPT_RUN),
+        JobExecution(id="r3", job_id="job-1", success=True, session_key=None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chat_available_only_where_the_session_exists() -> None:
+    mgr = _FakeSessionManager(live={AGENT_RUN})
+
+    rows = await _handle_cron_runs({"id": "job-1"}, _ctx(_FakeScheduler(_runs()), mgr))
+
+    assert [r["chatAvailable"] for r in rows] == [True, False, False]
+    # The key is still sent — the caller needs it to build the URL.
+    assert rows[1]["sessionKey"] == SCRIPT_RUN
+
+
+@pytest.mark.asyncio
+async def test_repeated_session_keys_are_probed_once() -> None:
+    shared = "cron:job-1"
+    runs = [JobExecution(id=f"r{i}", job_id="job-1", session_key=shared) for i in range(5)]
+    mgr = _FakeSessionManager(live={shared})
+
+    rows = await _handle_cron_runs({"id": "job-1"}, _ctx(_FakeScheduler(runs), mgr))
+
+    assert all(r["chatAvailable"] for r in rows)
+    assert mgr.lookups == [shared]
+
+
+@pytest.mark.asyncio
+async def test_no_session_manager_means_nothing_is_offered() -> None:
+    rows = await _handle_cron_runs({"id": "job-1"}, _ctx(_FakeScheduler(_runs()), None))
+
+    assert [r["chatAvailable"] for r in rows] == [False, False, False]
+
+
+@pytest.mark.asyncio
+async def test_a_failing_lookup_does_not_take_down_run_history() -> None:
+    mgr = _FakeSessionManager(live={AGENT_RUN}, explode=True)
+
+    rows = await _handle_cron_runs({"id": "job-1"}, _ctx(_FakeScheduler(_runs()), mgr))
+
+    assert len(rows) == 3
+    assert [r["chatAvailable"] for r in rows] == [False, False, False]

--- a/tests/test_scheduler/test_run_output_retention.py
+++ b/tests/test_scheduler/test_run_output_retention.py
@@ -1,0 +1,235 @@
+"""A run record keeps the whole output; only what goes *out* stays short.
+
+One 500-character cap used to serve two unrelated jobs: trimming the WS/webhook
+payload, and writing the run record. The second use destroyed the output at write
+time, so the run-history drawer could never show more than half a screen of a
+script's stdout no matter how it scrolled.
+
+They are separate now:
+
+* ``preview_summary`` — WS broadcast, webhook POST, ``cron.runs`` list rows;
+* ``clamp_run_output`` — the stored record, capped only as a runaway backstop.
+
+``cron.runOutput`` then fetches the full text for the single run someone opens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentos.gateway.rpc_cron import _handle_cron_run_output, _handle_cron_runs
+from agentos.scheduler.handlers import make_script_run_handler
+from agentos.scheduler.jobs import execute_with_timeout
+from agentos.scheduler.payloads import make_script_payload
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import (
+    CRON_RUN_OUTPUT_MAX_CHARS,
+    CRON_SUMMARY_PREVIEW_CHARS,
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    HandlerResult,
+    JobExecution,
+    SessionTarget,
+    clamp_run_output,
+    preview_summary,
+)
+
+LONG_OUTPUT = "line of json output\n" * 400  # ~8 KB, well past the old cap
+
+
+def _script_job() -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="ratchet-tick",
+        handler_key="script_run",
+        payload=make_script_payload("ratchet.py"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(mode=DeliveryMode.NONE),
+    )
+
+
+class _RecordingChain:
+    """Captures what the delivery chain was handed, which must stay small."""
+
+    def __init__(self) -> None:
+        self.delivered: list[dict[str, Any]] = []
+
+    async def notify_start(self, job: CronJob, text: str) -> None:
+        return None
+
+    async def deliver(self, job: CronJob, **kwargs: Any) -> Any:
+        self.delivered.append(kwargs)
+        from agentos.scheduler.delivery import DeliveryReport
+
+        return DeliveryReport(
+            channel_status="skipped",
+            ws_status="skipped",
+            session_status="skipped",
+        )
+
+
+class _FakeScheduler:
+    def __init__(self, runs: list[JobExecution]) -> None:
+        self.runs = runs
+
+    async def get_runs(self, job_id: str, limit: int = 20) -> list[JobExecution]:
+        return self.runs[:limit]
+
+    async def get_run(self, job_id: str, run_id: str | None = None) -> JobExecution | None:
+        if run_id is None:
+            return self.runs[0] if self.runs else None
+        return next((r for r in self.runs if r.id == run_id), None)
+
+
+def _ctx(scheduler: Any) -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(cron_scheduler=scheduler)
+
+
+# ── the helpers themselves ──────────────────────────────────────────────────
+
+
+def test_preview_is_short_and_stored_output_is_not() -> None:
+    assert len(preview_summary(LONG_OUTPUT) or "") == CRON_SUMMARY_PREVIEW_CHARS
+    assert clamp_run_output(LONG_OUTPUT) == LONG_OUTPUT
+
+
+def test_stored_output_still_has_a_runaway_backstop() -> None:
+    runaway = "x" * (CRON_RUN_OUTPUT_MAX_CHARS + 5_000)
+    assert len(clamp_run_output(runaway) or "") == CRON_RUN_OUTPUT_MAX_CHARS
+
+
+@pytest.mark.parametrize("empty", ["", None])
+def test_helpers_pass_empty_values_through(empty: str | None) -> None:
+    assert preview_summary(empty) == empty
+    assert clamp_run_output(empty) == empty
+
+
+# ── the handler: full text on the record, preview on the wire ───────────────
+
+
+async def test_script_handler_keeps_full_output_but_delivers_a_preview(monkeypatch) -> None:
+    chain = _RecordingChain()
+    monkeypatch.setattr(
+        "agentos.scheduler.handlers.run_job_script",
+        _fake_run_script(True, LONG_OUTPUT),
+    )
+
+    result = await make_script_run_handler(chain)(_script_job())
+
+    assert result.summary == LONG_OUTPUT
+    assert len(chain.delivered) == 1
+    delivered = chain.delivered[0]["summary"]
+    assert len(delivered) == CRON_SUMMARY_PREVIEW_CHARS
+    # The WS broadcast and webhook POST both carry this value — it must not grow.
+    assert LONG_OUTPUT.startswith(delivered)
+
+
+async def test_execute_with_timeout_no_longer_trims_the_record() -> None:
+    async def handler(job: CronJob) -> HandlerResult:
+        return HandlerResult(summary=LONG_OUTPUT, session_key="s", delivery_status="skipped")
+
+    execution = await execute_with_timeout(_script_job(), handler)
+
+    assert execution.summary == LONG_OUTPUT
+
+
+def _fake_run_script(ok: bool, output: str):
+    async def _run(script: str, **kwargs: Any) -> tuple[bool, str]:
+        return ok, output
+
+    return _run
+
+
+# ── persistence: one run at a time ──────────────────────────────────────────
+
+
+async def test_get_execution_reads_back_the_full_output(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    try:
+        run = JobExecution(job_id="job-1", success=True, summary=LONG_OUTPUT)
+        await store.save_execution(run)
+
+        by_id = await store.get_execution("job-1", run.id)
+        assert by_id is not None
+        assert by_id.summary == LONG_OUTPUT
+
+        latest = await store.get_execution("job-1")
+        assert latest is not None and latest.id == run.id
+
+        # Scoped to the job, so a run id alone cannot reach another job's output.
+        assert await store.get_execution("other-job", run.id) is None
+        assert await store.get_execution("job-1", "no-such-run") is None
+    finally:
+        await store.close()
+
+
+async def test_get_execution_returns_none_for_a_job_that_never_ran(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    try:
+        assert await store.get_execution("job-1") is None
+    finally:
+        await store.close()
+
+
+# ── RPC surface ─────────────────────────────────────────────────────────────
+
+
+async def test_cron_runs_rows_carry_a_preview_and_say_it_is_one() -> None:
+    scheduler = _FakeScheduler([JobExecution(id="r1", job_id="job-1", summary=LONG_OUTPUT)])
+
+    rows = await _handle_cron_runs({"id": "job-1"}, _ctx(scheduler))
+
+    assert len(rows[0]["summary"]) == CRON_SUMMARY_PREVIEW_CHARS
+    assert rows[0]["summaryTruncated"] is True
+    assert rows[0]["id"] == "r1"
+
+
+async def test_a_short_run_is_not_marked_truncated() -> None:
+    scheduler = _FakeScheduler([JobExecution(id="r1", job_id="job-1", summary="all quiet")])
+
+    rows = await _handle_cron_runs({"id": "job-1"}, _ctx(scheduler))
+
+    assert rows[0]["summary"] == "all quiet"
+    assert rows[0]["summaryTruncated"] is False
+
+
+async def test_cron_run_output_returns_the_whole_thing() -> None:
+    scheduler = _FakeScheduler([JobExecution(id="r1", job_id="job-1", summary=LONG_OUTPUT)])
+
+    payload = await _handle_cron_run_output({"id": "job-1", "runId": "r1"}, _ctx(scheduler))
+
+    assert payload["output"] == LONG_OUTPUT
+    assert payload["runId"] == "r1"
+
+
+async def test_cron_run_output_defaults_to_the_latest_run() -> None:
+    scheduler = _FakeScheduler(
+        [
+            JobExecution(id="r2", job_id="job-1", summary="newest"),
+            JobExecution(id="r1", job_id="job-1", summary="older"),
+        ]
+    )
+
+    payload = await _handle_cron_run_output({"id": "job-1"}, _ctx(scheduler))
+
+    assert payload["output"] == "newest"
+
+
+async def test_cron_run_output_rejects_an_unknown_run() -> None:
+    scheduler = _FakeScheduler([])
+
+    with pytest.raises(KeyError):
+        await _handle_cron_run_output({"id": "job-1", "runId": "nope"}, _ctx(scheduler))
+
+
+async def test_cron_run_output_requires_a_job_id() -> None:
+    with pytest.raises(ValueError):
+        await _handle_cron_run_output({}, _ctx(_FakeScheduler([])))

--- a/tests/test_scheduler/test_session_reaper_pagination.py
+++ b/tests/test_scheduler/test_session_reaper_pagination.py
@@ -1,0 +1,96 @@
+"""The reaper has to walk the whole session store, not just its first page.
+
+``SessionStorage.list_sessions`` defaults to ``limit=100, ORDER BY updated_at
+DESC``. The reaper used to call it with no arguments, so it only ever saw the 100
+*most recently updated* sessions — exactly the ones that are not expired. Past a
+hundred sessions it silently stopped reaping anything.
+
+These run against the real ``SessionStorage`` rather than a fake: a fake with a
+permissive ``list_sessions(**kwargs)`` would have passed the whole time.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agentos.scheduler.reaper import SessionReaper
+from agentos.session.models import SessionNode
+from agentos.session.storage import SessionStorage
+
+DAY_MS = 86_400_000
+
+
+@pytest.fixture
+async def storage():
+    store = SessionStorage(":memory:")
+    await store.connect()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+def _node(key: str, updated_at: int) -> SessionNode:
+    return SessionNode(
+        session_key=key,
+        session_id=key.replace(":", "-"),
+        agent_id="main",
+        created_at=updated_at,
+        updated_at=updated_at,
+    )
+
+
+async def _keys(store: SessionStorage) -> set[str]:
+    return {s.session_key for s in await store.list_sessions(limit=10_000)}
+
+
+async def test_expired_cron_session_is_reaped_from_beyond_the_first_page(storage) -> None:
+    now_ms = int(time.time() * 1000)
+
+    # 150 fresh sessions, all newer than the expired one, so DESC ordering pushes
+    # the stale cron session onto the second page.
+    for i in range(150):
+        await storage.upsert_session(_node(f"agent:main:webchat:s{i:03d}", now_ms - i))
+    stale = "cron:job-1:run:deadbeef"
+    await storage.upsert_session(_node(stale, now_ms - 3 * DAY_MS))
+
+    assert len(await storage.list_sessions()) == 100, "guard: default page is still 100"
+
+    await SessionReaper(storage)._do_reap()
+
+    remaining = await _keys(storage)
+    assert stale not in remaining
+    assert len(remaining) == 150
+
+
+async def test_reaper_leaves_fresh_and_non_cron_sessions_alone(storage) -> None:
+    now_ms = int(time.time() * 1000)
+    fresh_cron = "cron:job-1:run:aaaa1111"
+    old_agent = "agent:main:webchat:ancient"
+    # Three parts, so SessionTarget.SESSION keys are out of the reaper's reach.
+    old_shared_cron = "cron:job-1"
+
+    await storage.upsert_session(_node(fresh_cron, now_ms - 60_000))
+    await storage.upsert_session(_node(old_agent, now_ms - 30 * DAY_MS))
+    await storage.upsert_session(_node(old_shared_cron, now_ms - 30 * DAY_MS))
+
+    await SessionReaper(storage)._do_reap()
+
+    assert await _keys(storage) == {fresh_cron, old_agent, old_shared_cron}
+
+
+async def test_reaper_sweeps_every_page(storage) -> None:
+    now_ms = int(time.time() * 1000)
+    # Force more than one page at the real PAGE_SIZE without inserting 500 rows.
+    reaper = SessionReaper(storage)
+    reaper.PAGE_SIZE = 10
+
+    stale = [f"cron:job-1:run:{i:08x}" for i in range(25)]
+    for i, key in enumerate(stale):
+        await storage.upsert_session(_node(key, now_ms - 3 * DAY_MS - i))
+
+    await reaper._do_reap()
+
+    assert await _keys(storage) == set()


### PR DESCRIPTION
Closes #230.

## What changed

**Stop truncating a run's output on the way in.** `clamp_run_output()` replaces the scattered `[:500]` slices in `handlers.py` and `jobs.py`, so a script job's whole stdout reaches `scheduler_runs.summary`. `preview_summary()` is what the delivery layer and the run list see — the clamp now happens at the read boundary, not the write.

**Read one run in full.** New `cron.runOutput` RPC, backed by `JobStore.get_execution()` (one row, scoped to its job; latest run when `runId` is omitted). Exposed as `agentos cron output <job-id> [--run <run-id>]`, printed with `markup=False` so JSON brackets in stdout are not read as rich markup. The Web UI's expanded row fetches it lazily, caches per run id, and falls back to the row preview with a visible note when the fetch fails.

**Hide "→ Chat" when there is no chat.** `cron.runs` now probes the session manager and reports `chatAvailable` per run; the button renders only when it is true. Absent field is treated as `true` so an older gateway keeps its current behaviour. `chat.history` returns an empty transcript for a missing `cron:*` key rather than raising — a whitelist, so a typo'd agent key still surfaces as an error.

**Page the reaper's scan.** `list_sessions()` defaults to the 100 most recently updated sessions, which is exactly the set that has *not* expired, so isolated cron sessions were never reaped on a store with more than 100 sessions. The sweep now pages at 500 with a 200-page backstop, collecting first and deleting after so deletions do not shift the offsets of pages still to come.

**Output panel height** goes from `18rem` to `min(60vh, 32rem)`.

## Tests

- `tests/test_scheduler/test_run_output_retention.py` — full output survives storage; the list preview is clamped.
- `tests/test_scheduler/test_session_reaper_pagination.py` — expired sessions past the first page are reaped.
- `tests/test_gateway/test_rpc_cron_chat_available.py` — `chatAvailable` false for a reaped/never-created session.
- `tests/test_gateway/test_rpc_chat_history.py` — missing cron session reads as an empty transcript.
- `CronPage.test.tsx` / `logic.test.ts` — lazy full-output fetch, fetch-failure fallback, and the `chatAvailable` opt-out.

Gate: `ruff` clean, `mypy` clean over 590 files, 1482 backend tests in `tests/test_scheduler` + `tests/test_gateway` pass, `npm run check` passes 1670 frontend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)