### PR TITLE
fix(cron): reject a bad delivery target, and say why one failed

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -242,6 +242,21 @@ agentos cron add \
 Prefer `--webhook-token-env` or `--webhook-token-file` over inline tokens so
 secrets do not land in shell history.
 
+### Naming a channel recipient
+
+Channel delivery is configured from the Web UI or the RPC API, and its
+**Recipient** is the id the *provider* uses — a Telegram chat id
+(`1245463966`, negative for a group) or `@username`, a Slack channel id. It is
+not an AgentOS session key: `agent:main:telegram:direct:1245463966` names a
+conversation inside AgentOS, and Telegram answers `chat not found` for it.
+
+Both are visible in the UI and the two are easy to confuse, so a save that
+carries a session key is rejected outright, and the gateway asks the channel
+whether the chat exists before storing it. Where the recipients are known —
+Telegram, whose pairing store lists every chat the bot may talk to — the Web UI
+offers them as a dropdown, with an `Enter manually…` escape hatch for a group
+chat that is not in `group_chat_ids`.
+
 ## Inspect and Run Jobs
 
 ```sh

--- a/frontend/src/views/cron/CronPage.tsx
+++ b/frontend/src/views/cron/CronPage.tsx
@@ -44,6 +44,7 @@ import {
   shortCronId,
   sortJobs,
   type CronDot,
+  type DeliveryTargetMap,
   type RawJob,
   type RawRun,
   type SaveBuild,
@@ -111,6 +112,10 @@ interface CronListResult {
 }
 interface CronRunsResult {
   runs?: RawRun[]
+}
+/** channels.deliveryTargets — recipients we can offer per channel. */
+interface DeliveryTargetsResult {
+  targets?: DeliveryTargetMap
 }
 
 // dot state → --tone bucket (status color ONLY via --tone; never hardcoded).
@@ -531,6 +536,18 @@ export function CronPage() {
     refetchOnWindowFocus: false,
   })
 
+  // Recipients the gateway can name for us, so the delivery form offers a
+  // choice instead of asking someone to remember a chat id. A failure here is
+  // not worth a toast: the form falls back to its text input.
+  const deliveryTargetsQuery = useQuery<DeliveryTargetsResult>({
+    queryKey: ['cron', 'deliveryTargets'],
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      return rpc.call<DeliveryTargetsResult>('channels.deliveryTargets', {})
+    },
+    refetchOnWindowFocus: false,
+  })
+
   // cron.js:346 — load-failure toast (stable id so repeats dedupe).
   useEffect(() => {
     if (jobsQuery.isError) {
@@ -877,6 +894,7 @@ export function CronPage() {
           template={panel.kind === 'create' ? panel.template : null}
           activeSessionKey={readActiveSessionKey()}
           saving={saveMutation.isPending}
+          deliveryTargets={deliveryTargetsQuery.data?.targets}
           onCancel={() => setPanel({ kind: 'closed' })}
           onSubmit={(build) => saveMutation.mutate(build)}
         />

--- a/frontend/src/views/cron/CronPanel.test.tsx
+++ b/frontend/src/views/cron/CronPanel.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { CronPanel } from './CronPanel'
+import type { DeliveryTargetMap } from './logic'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+const TARGETS: DeliveryTargetMap = {
+  telegram: [
+    { id: '1245463966', label: 'AndreaPN | 404AI Labs (@andreapn_dackielabs)', kind: 'dm' },
+    { id: '-1001234567890', label: '-1001234567890', kind: 'group' },
+  ],
+}
+
+function renderPanel(deliveryTargets: DeliveryTargetMap = TARGETS) {
+  return render(
+    <CronPanel
+      job={null}
+      template={null}
+      activeSessionKey="agent:main:webchat:abc"
+      saving={false}
+      deliveryTargets={deliveryTargets}
+      onCancel={() => undefined}
+      onSubmit={() => undefined}
+    />,
+  )
+}
+
+/** Open Advanced delivery, pick "Announce to channel", and name the channel. */
+function openAnnounceFor(channel: string) {
+  fireEvent.click(screen.getByText('Advanced delivery & wake'))
+  fireEvent.change(screen.getByLabelText('Delivery mode'), { target: { value: 'announce' } })
+  fireEvent.change(screen.getByLabelText('Channel'), { target: { value: channel } })
+}
+
+describe('CronPanel recipient field', () => {
+  it('offers the paired chats for a channel we know', () => {
+    // The bug this replaces: a free-text box accepted a session key, and the
+    // job only failed at delivery time, ten minutes later.
+    renderPanel()
+    openAnnounceFor('telegram')
+
+    const recipient = screen.getByLabelText('Recipient')
+    expect(recipient.tagName).toBe('SELECT')
+    expect(
+      within(recipient).getByRole('option', {
+        name: 'AndreaPN | 404AI Labs (@andreapn_dackielabs)',
+      }),
+    ).toHaveValue('1245463966')
+  })
+
+  it('selecting a chat puts its id — not its label — in the form', () => {
+    renderPanel()
+    openAnnounceFor('telegram')
+
+    fireEvent.change(screen.getByLabelText('Recipient'), { target: { value: '1245463966' } })
+
+    expect(screen.getByLabelText('Recipient')).toHaveValue('1245463966')
+  })
+
+  it('keeps a way to type an id the list does not have', () => {
+    // A group chat that is not in group_chat_ids must still be reachable.
+    renderPanel()
+    openAnnounceFor('telegram')
+
+    fireEvent.change(screen.getByLabelText('Recipient'), { target: { value: '__manual__' } })
+
+    const manual = screen.getByLabelText('Recipient')
+    expect(manual.tagName).toBe('INPUT')
+    fireEvent.change(manual, { target: { value: '-1009999' } })
+    expect(screen.getByLabelText('Recipient')).toHaveValue('-1009999')
+  })
+
+  it('falls back to a text box for a channel with no known recipients', () => {
+    renderPanel()
+    openAnnounceFor('slack')
+
+    expect(screen.getByLabelText('Recipient').tagName).toBe('INPUT')
+  })
+
+  it('falls back to a text box when the gateway reported no targets at all', () => {
+    renderPanel({})
+    openAnnounceFor('telegram')
+
+    expect(screen.getByLabelText('Recipient').tagName).toBe('INPUT')
+  })
+})

--- a/frontend/src/views/cron/CronPanel.tsx
+++ b/frontend/src/views/cron/CronPanel.tsx
@@ -11,7 +11,10 @@ import {
   parseCron,
   resolveTarget,
   seedForm,
+  targetsForChannel,
   type CronForm,
+  type DeliveryTarget,
+  type DeliveryTargetMap,
   type DeliveryMode,
   type FailureDestMode,
   type PayloadKind,
@@ -121,11 +124,78 @@ function CronExplain({ expr }: { expr: string }) {
   )
 }
 
+/** Sentinel option value: "the recipient I want is not in this list". */
+const MANUAL_RECIPIENT = '__manual__'
+
+/**
+ * The delivery recipient — a picker when the channel's chats are known, a text
+ * box otherwise.
+ *
+ * A free-text box here is what let a *session* key
+ * (`agent:main:telegram:direct:1245463966`) be saved as a Telegram chat id; the
+ * job then failed at delivery time with nothing but "delivery failed" to show
+ * for it. Where the pairing store knows the real chats, offer those instead of
+ * asking someone to remember an id.
+ */
+function RecipientField({
+  value,
+  targets,
+  placeholder,
+  onChange,
+}: {
+  value: string
+  targets: DeliveryTarget[]
+  placeholder: string
+  onChange: (next: string) => void
+}) {
+  // An id that is not in the list — a group chat outside `group_chat_ids`, or a
+  // job saved before this field existed — has to stay editable.
+  const [manual, setManual] = useState(() => !!value && !targets.some((t) => t.id === value))
+  const asPicker = targets.length > 0 && !manual
+
+  return (
+    <label className="cron-field">
+      <span className="t-label">Recipient</span>
+      {asPicker ? (
+        <select
+          className="cron-input"
+          value={value}
+          onChange={(e) => {
+            if (e.target.value === MANUAL_RECIPIENT) {
+              setManual(true)
+              onChange('')
+              return
+            }
+            onChange(e.target.value)
+          }}
+        >
+          <option value="">Select a chat…</option>
+          {targets.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.label}
+            </option>
+          ))}
+          <option value={MANUAL_RECIPIENT}>Enter manually…</option>
+        </select>
+      ) : (
+        <input
+          className="cron-input"
+          type="text"
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )}
+    </label>
+  )
+}
+
 export function CronPanel({
   job,
   template,
   activeSessionKey,
   saving,
+  deliveryTargets,
   onCancel,
   onSubmit,
 }: {
@@ -133,6 +203,8 @@ export function CronPanel({
   template: Partial<RawJob> | null
   activeSessionKey: string
   saving: boolean
+  /** Known recipients per channel; absent channels keep the free-text input. */
+  deliveryTargets?: DeliveryTargetMap
   onCancel: () => void
   onSubmit: (build: Extract<SaveBuild, { ok: true }>) => void
 }) {
@@ -498,16 +570,12 @@ export function CronPanel({
                       onChange={(e) => set('deliveryChannel', e.target.value)}
                     />
                   </label>
-                  <label className="cron-field">
-                    <span className="t-label">Recipient</span>
-                    <input
-                      className="cron-input"
-                      type="text"
-                      placeholder="C-team-alerts"
-                      value={form.deliveryTo}
-                      onChange={(e) => set('deliveryTo', e.target.value)}
-                    />
-                  </label>
+                  <RecipientField
+                    value={form.deliveryTo}
+                    targets={targetsForChannel(deliveryTargets, form.deliveryChannel)}
+                    placeholder="C-team-alerts"
+                    onChange={(next) => set('deliveryTo', next)}
+                  />
                   <label className="cron-field">
                     <span className="t-label">Account id</span>
                     <input
@@ -586,16 +654,12 @@ export function CronPanel({
                           onChange={(e) => set('fdChannel', e.target.value)}
                         />
                       </label>
-                      <label className="cron-field">
-                        <span className="t-label">Recipient</span>
-                        <input
-                          className="cron-input"
-                          type="text"
-                          placeholder="C-ops-alerts"
-                          value={form.fdTo}
-                          onChange={(e) => set('fdTo', e.target.value)}
-                        />
-                      </label>
+                      <RecipientField
+                        value={form.fdTo}
+                        targets={targetsForChannel(deliveryTargets, form.fdChannel)}
+                        placeholder="C-ops-alerts"
+                        onChange={(next) => set('fdTo', next)}
+                      />
                       <label className="cron-field">
                         <span className="t-label">Account id</span>
                         <input

--- a/frontend/src/views/cron/logic.ts
+++ b/frontend/src/views/cron/logic.ts
@@ -66,6 +66,32 @@ export interface RawDelivery {
   [key: string]: unknown
 }
 
+/** One recipient a channel can be pointed at, from `channels.deliveryTargets`. */
+export interface DeliveryTarget {
+  /** The value that goes on the wire as `channelId` — a Telegram chat id, say. */
+  id: string
+  /** What a human recognises: a display name, a username, or the id itself. */
+  label: string
+  kind: string
+}
+
+/**
+ * Known recipients keyed by channel name. A channel is absent when the gateway
+ * has no way to enumerate its chats — the caller must then let the operator
+ * type an id rather than imply the list is exhaustive.
+ */
+export type DeliveryTargetMap = Record<string, DeliveryTarget[]>
+
+/** The recipients on offer for `channel`, or none when we cannot enumerate them. */
+export function targetsForChannel(
+  targets: DeliveryTargetMap | undefined,
+  channel: string,
+): DeliveryTarget[] {
+  const key = (channel || '').trim().toLowerCase()
+  if (!key || !targets) return []
+  return targets[key] ?? []
+}
+
 /** A raw run-history row from cron.runs (all fields optional; snake or camel). */
 export interface RawRun {
   started_at?: string | number

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -58,6 +58,15 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
 _DEFAULT_TIMEOUT_S = 30.0
 _POLL_TIMEOUT_HEADROOM_S = 5.0
 _CONNECT_RETRY_DELAYS_S = (0.25, 0.5)
+#: ``TelegramApiError`` covers both "Telegram answered no" and "we never reached
+#: Telegram". These substrings mark the second kind, which is not a verdict on
+#: whatever was asked about — see :meth:`TelegramChannel.probe_target`.
+_TRANSPORT_FAILURE_MARKERS = (
+    "connection failed",
+    "request failed",
+    "returned invalid JSON",
+    "returned an invalid response",
+)
 _DEDUPE_SIZE = 4096
 _ALLOWED_UPDATES = ("message", "edited_message", "channel_post", "edited_channel_post")
 
@@ -827,6 +836,32 @@ class TelegramChannel:
         if (thread_id := inbound.metadata.get("thread_id")) is not None:
             metadata["thread_id"] = thread_id
         return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)
+
+    async def probe_target(self, target: str) -> tuple[bool, str]:
+        """Whether ``getChat`` can see *target*, and why not when it cannot.
+
+        Callers that are about to *store* a chat id use this to fail early —
+        cron does, at save time, because otherwise a mistyped recipient is only
+        discovered by a scheduled run hours later.
+
+        A transport failure is re-raised rather than answered ``False``: the bot
+        being unable to reach Telegram is not evidence about the chat id, and
+        the caller is the one that knows whether to treat "don't know" as fatal.
+        """
+        chat_id = (target or "").strip()
+        if not chat_id:
+            return True, ""
+        try:
+            await self._api("getChat", {"chat_id": chat_id})
+        except TelegramApiError as exc:
+            message = str(exc)
+            if any(marker in message for marker in _TRANSPORT_FAILURE_MARKERS):
+                raise
+            # "Telegram getChat failed: Bad Request: chat not found" reads better
+            # as just the part Telegram said.
+            _, _, detail = message.partition(": ")
+            return False, detail or message
+        return True, ""
 
     async def send_typing(
         self,

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -880,6 +880,80 @@ def _remove_debug_file_handlers(root: logging.Logger) -> None:
                 agentos_logger.setLevel(previous_level)
 
 
+#: structlog's own processor chain, saved before the tee is spliced in so
+#: turning file logging off puts it back exactly as it was.
+_structlog_processors_before_tee: list[Any] | None = None
+
+_STRUCTLOG_LEVELS = {
+    "critical": logging.CRITICAL,
+    "exception": logging.ERROR,
+    "error": logging.ERROR,
+    "warn": logging.WARNING,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}
+
+
+def _tee_structlog_to_stdlib(logger: Any, method_name: str, event_dict: dict) -> dict:
+    """Copy a structlog event into stdlib logging, then leave it untouched.
+
+    structlog prints to stderr through its own ``PrintLogger``, which never
+    reaches the stdlib handlers — so the file handler below saw only half the
+    gateway's logs. The half it missed included every ``delivery.*`` warning,
+    which is exactly what you go looking for after a cron run reports "delivery
+    failed".
+
+    Runs as the *last* processor before the renderer, so ``exc_info`` has
+    already been rendered into ``exception`` and the tee copies the traceback
+    rather than re-deriving it.
+
+    Events land under ``agentos.events`` rather than the emitting module:
+    structlog's ``PrintLogger`` does not carry a name, and this codebase already
+    namespaces its event keys (``delivery.channel_failed``), so recovering the
+    module would cost a callsite walk to say what the event already says.
+    """
+    name = str(event_dict.get("logger") or "agentos.events")
+    level = _STRUCTLOG_LEVELS.get(method_name, logging.INFO)
+    target = logging.getLogger(name)
+    if target.isEnabledFor(level):
+        event = str(event_dict.get("event", ""))
+        pairs = " ".join(
+            f"{key}={value}"
+            for key, value in event_dict.items()
+            if key not in ("event", "logger", "level", "timestamp", "exception")
+        )
+        exception = event_dict.get("exception")
+        message = " ".join(part for part in (event, pairs) if part)
+        if exception:
+            message = f"{message}\n{exception}"
+        target.log(level, message)
+    return event_dict
+
+
+def _install_structlog_tee() -> None:
+    """Splice :func:`_tee_structlog_to_stdlib` in ahead of structlog's renderer."""
+    global _structlog_processors_before_tee
+    import structlog
+
+    processors = list(structlog.get_config()["processors"])
+    if _tee_structlog_to_stdlib in processors:
+        return
+    _structlog_processors_before_tee = processors
+    spliced = [*processors[:-1], _tee_structlog_to_stdlib, processors[-1]]
+    structlog.configure(processors=spliced)
+
+
+def _remove_structlog_tee() -> None:
+    global _structlog_processors_before_tee
+    if _structlog_processors_before_tee is None:
+        return
+    import structlog
+
+    structlog.configure(processors=_structlog_processors_before_tee)
+    _structlog_processors_before_tee = None
+
+
 def _setup_file_logging(config: GatewayConfig | None = None) -> None:
     """Configure structlog + stdlib logging to write to a debug.log file."""
     config = config or GatewayConfig()
@@ -890,6 +964,7 @@ def _setup_file_logging(config: GatewayConfig | None = None) -> None:
     if enabled is None:
         enabled = config.log_file_enabled
     if not enabled:
+        _remove_structlog_tee()
         return
 
     log_dir = Path(os.environ.get("AGENTOS_LOG_DIR", str(default_agentos_home() / "logs")))
@@ -916,6 +991,7 @@ def _setup_file_logging(config: GatewayConfig | None = None) -> None:
 
     root.addHandler(file_handler)
     agentos_logger.setLevel(log_level)
+    _install_structlog_tee()
 
 
 @dataclass

--- a/src/agentos/gateway/rpc_channels.py
+++ b/src/agentos/gateway/rpc_channels.py
@@ -190,6 +190,47 @@ async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[
     return {"channels": channels}
 
 
+def _telegram_delivery_targets(row: dict[str, Any]) -> list[dict[str, str]]:
+    """Recipients a Telegram channel can be pointed at, from its access snapshot."""
+    targets: list[dict[str, str]] = []
+    for user in row.get("paired") or []:
+        chat_id = str(user.get("chat_id") or user.get("sender_id") or "").strip()
+        if not chat_id:
+            continue
+        display = str(user.get("display_name") or "").strip()
+        username = str(user.get("username") or "").strip().lstrip("@")
+        if display and username:
+            label = f"{display} (@{username})"
+        else:
+            label = display or (f"@{username}" if username else chat_id)
+        targets.append({"id": chat_id, "label": label, "kind": "dm"})
+    for group_id in row.get("group_chat_ids") or []:
+        chat_id = str(group_id).strip()
+        if chat_id:
+            targets.append({"id": chat_id, "label": chat_id, "kind": "group"})
+    return targets
+
+
+@_d.method("channels.deliveryTargets")
+async def _handle_channels_delivery_targets(
+    params: dict | None,
+    ctx: RpcContext,
+) -> dict[str, Any]:
+    """Recipients that can be offered as a choice, keyed by channel name.
+
+    Only channels whose recipients are actually known appear — today that means
+    Telegram, which has a pairing store. A caller finding its channel absent
+    should ask the operator to type the id rather than pretend the list is
+    exhaustive.
+    """
+    targets: dict[str, list[dict[str, str]]] = {}
+    for row in _telegram_pairing_rows(ctx):
+        rows = _telegram_delivery_targets(row)
+        if rows:
+            targets[str(row.get("name") or "")] = rows
+    return {"targets": targets}
+
+
 @_d.method("channels.pairing.list")
 async def _handle_channels_pairing_list(
     params: dict | None,

--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import shlex
 from dataclasses import asdict
 from typing import Any, TypeGuard
 
 from agentos.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
 from agentos.permissions import cron_tool_policy_elevated, normalize_cron_elevated
+from agentos.scheduler.delivery_targets import validate_channel_target
 from agentos.scheduler.payloads import (
     AGENT_TURN_KIND,
     REMINDER_KIND,
@@ -472,6 +474,65 @@ def _ensure_delivery_supported(
         )
 
 
+#: How long a save waits for a channel adapter to confirm a recipient exists.
+#: Generous, because the answer is worth having; bounded, because a slow
+#: provider must not hold up the form.
+_TARGET_PROBE_TIMEOUT_SECONDS = 10.0
+
+
+def _delivery_target_pairs(delivery_raw: Any) -> list[tuple[str, str]]:
+    """The (channel, recipient) pairs a delivery block asks us to send to.
+
+    Both the primary target and the failure destination, since a typo in the
+    failure route is discovered at the worst possible moment otherwise.
+    """
+    if not isinstance(delivery_raw, dict):
+        return []
+    pairs: list[tuple[str, str]] = []
+    for block in (delivery_raw, delivery_raw.get("failureDestination")):
+        if not isinstance(block, dict):
+            continue
+        channel = str(block.get("channelName") or block.get("channel") or "")
+        target = str(block.get("channelId") or block.get("to") or "")
+        if target:
+            pairs.append((channel, target))
+    return pairs
+
+
+async def _probe_channel_target(ctx: RpcContext, channel_name: str, target: str) -> None:
+    """Ask the adapter whether *target* is a chat it can actually reach.
+
+    Only a definite "no" raises. An adapter without the capability, one that is
+    offline, one that errors, and one that is simply slow all leave the save
+    alone — none of them is evidence that the recipient is wrong.
+    """
+    manager = getattr(ctx, "channel_manager", None)
+    if manager is None or not channel_name:
+        return
+    try:
+        adapter = manager.get(channel_name)
+    except Exception:  # noqa: BLE001 - an unknown channel is not a bad recipient
+        return
+    probe = getattr(adapter, "probe_target", None)
+    if not callable(probe):
+        return
+    try:
+        ok, reason = await asyncio.wait_for(probe(target), timeout=_TARGET_PROBE_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001 - timeout, transport error, offline bot: see docstring
+        return
+    if not ok:
+        raise ValueError(
+            f'{channel_name} cannot deliver to "{target}": {reason or "unknown reason"}'
+        )
+
+
+async def _ensure_delivery_targets_valid(ctx: RpcContext, delivery_raw: Any) -> None:
+    """Reject a recipient the channel cannot use, before the job is stored."""
+    for channel_name, target in _delivery_target_pairs(delivery_raw):
+        validate_channel_target(channel_name, target)
+        await _probe_channel_target(ctx, channel_name, target)
+
+
 def _originating_reply_target(ctx: RpcContext) -> ReplyTargetSnapshot | None:
     envelope = getattr(ctx, "originating_envelope", None)
     target = getattr(envelope, "reply_target", None)
@@ -618,6 +679,7 @@ async def _handle_cron_add(params: dict | None, ctx: RpcContext) -> dict[str, An
     origin_session_key = _resolve_origin_session_key(params, session_target)
     delivery_raw = params.get("delivery")
     _ensure_delivery_supported(session_target=session_target, delivery_raw=delivery_raw)
+    await _ensure_delivery_targets_valid(ctx, delivery_raw)
     scheduler = _require_scheduler(ctx)
 
     # Webhook delivery bypasses session-based channel inference entirely.
@@ -914,6 +976,7 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         delivery_raw = params.get("delivery")
         effective_target = patch.get("session_target", current_job.session_target)
         _ensure_delivery_supported(session_target=effective_target, delivery_raw=delivery_raw)
+        await _ensure_delivery_targets_valid(ctx, delivery_raw)
         if isinstance(delivery_raw, dict) and delivery_raw.get("mode") == "none":
             patch["delivery"] = DeliveryConfig()
         elif _is_webhook_delivery(delivery_raw):

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -74,6 +74,33 @@ ORIGIN_SESSION_GONE = "origin_gone"
 NO_SESSION_TARGET = "no_session_target"
 
 
+class ChannelStatus(str):
+    """A channel-delivery status that can carry the reason behind it.
+
+    A plain ``str`` subclass so every existing ``== "delivery_failed"`` keeps
+    working, while the one thing an operator actually needs — *why* Telegram
+    refused — survives the trip to the run record instead of living only in a
+    log line nobody reads.
+    """
+
+    detail: str
+
+    def __new__(cls, value: str, detail: str = "") -> ChannelStatus:
+        status = super().__new__(cls, value)
+        status.detail = detail
+        return status
+
+
+def _failed(detail: str) -> ChannelStatus:
+    """``delivery_failed``, with the reason attached."""
+    return ChannelStatus("delivery_failed", detail)
+
+
+def status_detail(status: object) -> str:
+    """The reason carried by *status*, if it carries one."""
+    return str(getattr(status, "detail", "") or "")
+
+
 @dataclass
 class DeliveryReport:
     """Result of the delivery pipeline."""
@@ -81,6 +108,8 @@ class DeliveryReport:
     channel_status: str = "skipped"  # "delivered" | "delivery_failed" | "skipped" | "origin_gone"
     ws_status: str = "skipped"  # "delivered" | "no_subscribers" | "skipped"
     session_status: str = "skipped"  # "delivered" | "forward_failed" | "skipped" | "origin_gone"
+    #: Why channel delivery failed, when it did. Empty otherwise.
+    channel_detail: str = ""
 
 
 class DeliveryChain:
@@ -205,7 +234,21 @@ class DeliveryChain:
         )
 
         report = DeliveryReport()
-        report.channel_status = ch_result if isinstance(ch_result, str) else "delivery_failed"
+        if isinstance(ch_result, str):
+            report.channel_status = ch_result
+            report.channel_detail = status_detail(ch_result)
+        else:
+            # An exception escaped the channel leg entirely — gather turned it
+            # into a value. Without this the run would report "delivery failed"
+            # with no trace of what raised, anywhere.
+            report.channel_status = "delivery_failed"
+            report.channel_detail = f"{type(ch_result).__name__}: {ch_result}"
+            log.warning(
+                "delivery.channel_raised",
+                job_id=job.id,
+                error_type=type(ch_result).__name__,
+                error=str(ch_result),
+            )
         report.ws_status = ws_result if isinstance(ws_result, str) else "skipped"
         report.session_status = fwd_result if isinstance(fwd_result, str) else "forward_failed"
         return report
@@ -324,11 +367,11 @@ class DeliveryChain:
         """
         text = strip_reply_directives(text) or ""
         if not self._session_forwarder:
-            return "delivery_failed"
+            return _failed("no session forwarder is wired into the scheduler")
         if not text or not text.strip():
-            return "delivery_failed"
+            return _failed("nothing to mirror: the output was empty")
         if not target_session_key:
-            return "delivery_failed"
+            return _failed("no session to mirror into")
         try:
             forwarded = await self._session_forwarder(
                 origin_session_key=target_session_key,
@@ -346,7 +389,7 @@ class DeliveryChain:
                 origin_session_key=target_session_key,
                 exc_info=True,
             )
-            return "delivery_failed"
+            return _failed(f"forwarding into {target_session_key} raised")
         # ``False`` means the origin webchat session is gone. This target was
         # *inferred* from the ambient turn, not chosen by the operator: the cron
         # tool synthesises ``mode=ORIGIN`` + ``channel=webchat`` from the live
@@ -386,7 +429,7 @@ class DeliveryChain:
                 job_id=job_id,
                 channel=channel_name,
             )
-            return "delivery_failed"
+            return _failed(f"no adapter is registered for channel {channel_name!r}")
         try:
             from agentos.channels.types import OutgoingMessage
 
@@ -408,9 +451,11 @@ class DeliveryChain:
             await asyncio.wait_for(adapter.send(msg), timeout=30.0)
             log.info("delivery.channel_sent", job_id=job_id, channel=channel_name)
             return "delivered"
-        except Exception:
+        except Exception as exc:
             log.warning("delivery.channel_failed", job_id=job_id, exc_info=True)
-            return "delivery_failed"
+            # The provider's own words ("Bad Request: chat not found") are what
+            # make the run record actionable, so they go on the report too.
+            return _failed(str(exc) or type(exc).__name__)
 
     async def _post_to_webhook(
         self,
@@ -425,12 +470,12 @@ class DeliveryChain:
         text = strip_reply_directives(text) or ""
         if not url:
             log.warning("delivery.webhook_url_missing", job_id=job_id)
-            return "delivery_failed"
+            return _failed("no webhook URL is configured")
         try:
             validate_webhook_url(url)
         except ValueError as exc:
             log.warning("delivery.webhook_url_invalid", job_id=job_id, reason=str(exc))
-            return "delivery_failed"
+            return _failed(f"invalid webhook URL: {exc}")
 
         import httpx
 
@@ -449,9 +494,9 @@ class DeliveryChain:
                 response.raise_for_status()
             log.info("delivery.webhook_sent", job_id=job_id)
             return "delivered"
-        except Exception:
+        except Exception as exc:
             log.warning("delivery.webhook_failed", job_id=job_id, exc_info=True)
-            return "delivery_failed"
+            return _failed(str(exc) or type(exc).__name__)
 
     async def _deliver_webhook(self, job: CronJob, text: str) -> str:
         """Primary webhook delivery — POST to ``delivery.webhook_url``."""

--- a/src/agentos/scheduler/delivery_targets.py
+++ b/src/agentos/scheduler/delivery_targets.py
@@ -1,0 +1,55 @@
+"""What a cron job's delivery recipient is allowed to look like.
+
+A ``channelId`` reaches the adapter untouched — Telegram, for instance, puts it
+straight into ``sendMessage``'s ``chat_id``. A wrong value is therefore not
+caught until the job next fires, ten minutes or a day later, and all the
+operator sees then is "delivery failed". These checks move that discovery to the
+moment the job is saved.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Prefixes of AgentOS *session* keys. A session key names a conversation
+#: inside AgentOS; a channel id names a chat on the provider's side. They are
+#: routinely confused because both are visible in the UI, and the session key is
+#: the one that happens to be selectable text.
+#:
+#: Matched as prefixes rather than by counting colons on purpose: a genuine MS
+#: Teams conversation id looks like ``19:meeting_NGY3@thread.v2``.
+_SESSION_KEY_PREFIXES = ("agent:", "cron:", "webchat:", "session:")
+
+_TELEGRAM_CHAT_ID = re.compile(r"^-?\d+$")
+_TELEGRAM_USERNAME = re.compile(r"^@[A-Za-z0-9_]{3,}$")
+
+
+def _suggest_from_session_key(value: str) -> str:
+    """The trailing segment of a session key — usually the id that was meant."""
+    return value.rsplit(":", 1)[-1].strip()
+
+
+def validate_channel_target(channel_name: str, channel_id: str) -> None:
+    """Raise ``ValueError`` when *channel_id* cannot be a *channel_name* recipient.
+
+    An empty target is legal: delivery falls back to the channel's configured
+    default chat.
+    """
+    target = (channel_id or "").strip()
+    if not target:
+        return
+
+    if target.startswith(_SESSION_KEY_PREFIXES):
+        suggestion = _suggest_from_session_key(target)
+        hint = f" — use {suggestion}" if suggestion and suggestion != target else ""
+        raise ValueError(
+            f'delivery target "{target}" is a session key, not a '
+            f"{channel_name or 'channel'} chat id{hint}"
+        )
+
+    if (channel_name or "").strip().lower() == "telegram":
+        if not (_TELEGRAM_CHAT_ID.match(target) or _TELEGRAM_USERNAME.match(target)):
+            raise ValueError(
+                f'delivery target "{target}" is not a telegram chat id — '
+                "pass the numeric chat id (negative for groups) or @username"
+            )

--- a/src/agentos/scheduler/handlers.py
+++ b/src/agentos/scheduler/handlers.py
@@ -108,7 +108,13 @@ def _required_delivery_error(job: CronJob, report: Any) -> str | None:
     channel_status = getattr(report, "channel_status", "skipped")
     session_status = getattr(report, "session_status", "skipped")
     if channel_status == "delivery_failed":
-        return f"Cron job '{job.name}' delivery failed"
+        # This string is the whole of what `agentos cron runs` shows for a failed
+        # run, so it has to name the destination and the reason. "delivery
+        # failed" alone sent an operator digging through gateway logs for a
+        # Telegram "chat not found".
+        where = job.delivery.channel_name or "the configured destination"
+        reason = getattr(report, "channel_detail", "") or "no reason reported"
+        return f"Cron job '{job.name}' delivery to {where} failed: {reason}"
     if (
         mode in {DeliveryMode.CHANNEL, DeliveryMode.ORIGIN, DeliveryMode.WEBHOOK}
         and channel_status == "skipped"

--- a/tests/test_channels/test_telegram_probe_target.py
+++ b/tests/test_channels/test_telegram_probe_target.py
@@ -1,0 +1,81 @@
+"""``probe_target`` lets a caller check a chat id before committing to it.
+
+Cron uses it at save time: a recipient Telegram cannot reach is worth knowing
+about while the operator is still looking at the form.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.channels.telegram import TelegramApiError, TelegramChannel, TelegramChannelConfig
+
+
+def _channel() -> TelegramChannel:
+    return TelegramChannel(TelegramChannelConfig(token="token"))
+
+
+@pytest.mark.asyncio
+async def test_probe_confirms_a_chat_the_bot_can_see() -> None:
+    channel = _channel()
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        calls.append((method, payload))
+        return {"id": 1245463966, "type": "private"}
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    ok, reason = await channel.probe_target("1245463966")
+
+    assert (ok, reason) == (True, "")
+    assert calls == [("getChat", {"chat_id": "1245463966"})]
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_the_reason_telegram_gave() -> None:
+    channel = _channel()
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        raise TelegramApiError("Telegram getChat failed: Bad Request: chat not found")
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    ok, reason = await channel.probe_target("agent:main:telegram:direct:1245463966")
+
+    assert ok is False
+    assert "chat not found" in reason
+
+
+@pytest.mark.asyncio
+async def test_a_transport_failure_is_not_a_verdict_on_the_chat() -> None:
+    # The bot being unable to reach Telegram says nothing about the chat id, so
+    # the probe raises rather than answering "no" — the caller decides.
+    channel = _channel()
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        raise TelegramApiError("Telegram getChat connection failed")
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    with pytest.raises(TelegramApiError):
+        await channel.probe_target("1245463966")
+
+
+@pytest.mark.asyncio
+async def test_probe_without_a_target_is_not_an_answer() -> None:
+    channel = _channel()
+    calls: list[str] = []
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        calls.append(method)
+        return {}
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+
+    ok, reason = await channel.probe_target("   ")
+
+    assert (ok, reason) == (True, "")
+    assert calls == []

--- a/tests/test_gateway/test_rpc_channels_delivery_targets.py
+++ b/tests/test_gateway/test_rpc_channels_delivery_targets.py
@@ -1,0 +1,121 @@
+"""``channels.deliveryTargets`` — the recipients we can name without guessing.
+
+The cron form uses this to offer a dropdown instead of a free-text box. A
+channel that is absent from the map is the signal that the caller has to ask
+the operator to type the id.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_channels import _handle_channels_delivery_targets
+
+
+class _FakeAdapter:
+    def __init__(self, snapshot: dict) -> None:
+        self._snapshot = snapshot
+
+    def access_snapshot(self) -> dict:
+        return self._snapshot
+
+
+class _FakeChannelManager:
+    def __init__(self, adapters: dict) -> None:
+        self._adapters = adapters
+
+    def get(self, name):
+        return self._adapters.get(name)
+
+
+def _ctx(channels: list[dict], adapters: dict) -> RpcContext:
+    ctx = RpcContext(conn_id="test")
+    ctx.config = SimpleNamespace(channels=SimpleNamespace(channels=list(channels)))
+    ctx.channel_manager = _FakeChannelManager(adapters)
+    return ctx
+
+
+PAIRED = {
+    "pending": [],
+    "paired": [
+        {
+            "sender_id": "1245463966",
+            "chat_id": "1245463966",
+            "display_name": "AndreaPN | 404AI Labs",
+            "username": "andreapn_dackielabs",
+        }
+    ],
+    "locked_until": 0.0,
+    "groups_enabled": True,
+    "group_chat_ids": ["-1001234567890"],
+    "group_mention_required": True,
+}
+
+
+def test_paired_users_become_dm_targets_labelled_for_a_human() -> None:
+    ctx = _ctx(
+        [{"name": "telegram", "type": "telegram", "enabled": True}],
+        {"telegram": _FakeAdapter(PAIRED)},
+    )
+    result = asyncio.run(_handle_channels_delivery_targets(None, ctx))
+
+    dms = [t for t in result["targets"]["telegram"] if t["kind"] == "dm"]
+    assert dms == [
+        {
+            "id": "1245463966",
+            "label": "AndreaPN | 404AI Labs (@andreapn_dackielabs)",
+            "kind": "dm",
+        }
+    ]
+
+
+def test_configured_group_chats_are_offered_too() -> None:
+    ctx = _ctx(
+        [{"name": "telegram", "type": "telegram", "enabled": True}],
+        {"telegram": _FakeAdapter(PAIRED)},
+    )
+    result = asyncio.run(_handle_channels_delivery_targets(None, ctx))
+
+    groups = [t for t in result["targets"]["telegram"] if t["kind"] == "group"]
+    assert groups == [{"id": "-1001234567890", "label": "-1001234567890", "kind": "group"}]
+
+
+def test_a_channel_we_know_nothing_about_is_absent() -> None:
+    # Slack has no pairing store, so the caller must keep its free-text input.
+    ctx = _ctx(
+        [
+            {"name": "telegram", "type": "telegram", "enabled": True},
+            {"name": "slack", "type": "slack", "enabled": True},
+        ],
+        {"telegram": _FakeAdapter(PAIRED)},
+    )
+    result = asyncio.run(_handle_channels_delivery_targets(None, ctx))
+
+    assert "slack" not in result["targets"]
+    assert "telegram" in result["targets"]
+
+
+def test_a_telegram_channel_with_nobody_paired_is_absent() -> None:
+    empty = {**PAIRED, "paired": [], "group_chat_ids": []}
+    ctx = _ctx(
+        [{"name": "telegram", "type": "telegram", "enabled": True}],
+        {"telegram": _FakeAdapter(empty)},
+    )
+    result = asyncio.run(_handle_channels_delivery_targets(None, ctx))
+
+    assert result["targets"] == {}
+
+
+def test_a_paired_user_without_a_username_falls_back_to_the_display_name() -> None:
+    snapshot = {
+        **PAIRED,
+        "paired": [{"chat_id": "42", "display_name": "Someone", "username": ""}],
+        "group_chat_ids": [],
+    }
+    ctx = _ctx(
+        [{"name": "telegram", "type": "telegram", "enabled": True}],
+        {"telegram": _FakeAdapter(snapshot)},
+    )
+    result = asyncio.run(_handle_channels_delivery_targets(None, ctx))
+
+    assert result["targets"]["telegram"] == [{"id": "42", "label": "Someone", "kind": "dm"}]

--- a/tests/test_gateway/test_rpc_cron_current_session.py
+++ b/tests/test_gateway/test_rpc_cron_current_session.py
@@ -860,7 +860,9 @@ async def test_static_reminder_delivery_failure_fails_job_by_default() -> None:
         DeliveryChain(channel_manager_ref=lambda: _FakeChannelManager())
     )
 
-    with pytest.raises(RuntimeError, match="delivery failed"):
+    # The message is what `agentos cron runs` shows for the failed run, so it
+    # names the destination and the adapter's own reason, not just "failed".
+    with pytest.raises(RuntimeError, match="delivery to feishu failed: channel down"):
         await handler(job)
 
 
@@ -1028,7 +1030,7 @@ async def test_agent_run_delivery_failure_fails_job_by_default() -> None:
         session_manager_ref=lambda: session_manager,
     )
 
-    with pytest.raises(RuntimeError, match="delivery failed"):
+    with pytest.raises(RuntimeError, match="delivery to feishu failed: channel down"):
         await handler(job)
 
 

--- a/tests/test_gateway/test_rpc_cron_delivery_target.py
+++ b/tests/test_gateway/test_rpc_cron_delivery_target.py
@@ -1,0 +1,247 @@
+"""cron.add / cron.update refuse a delivery target the channel cannot use.
+
+Both the shape check and the optional adapter probe run at save time, so an
+operator learns about a bad recipient while they are looking at the form —
+not from a run that fails ten minutes later.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.gateway import rpc_cron
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_cron import _handle_cron_add, _handle_cron_update
+from agentos.scheduler.types import (
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    SessionTarget,
+)
+
+SESSION_KEY = "agent:main:telegram:direct:1245463966"
+
+
+class _FakeScheduler:
+    def __init__(self, job: CronJob | None = None) -> None:
+        self.added: dict | None = None
+        self.updated: dict | None = None
+        self.job = job
+
+    async def add_job(self, **kwargs) -> CronJob:
+        self.added = kwargs
+        return CronJob(
+            id="job-1",
+            name=kwargs["name"],
+            cron_expr=kwargs.get("schedule_value") or "",
+            schedule_raw=kwargs.get("schedule_value") or "",
+            handler_key=kwargs["handler_key"],
+            payload=kwargs["payload"],
+            session_target=kwargs["session_target"],
+            session_key=kwargs["session_key"],
+            origin_session_key=kwargs["origin_session_key"],
+            delivery=kwargs.get("delivery") or DeliveryConfig(),
+        )
+
+    async def update_job(self, job_id, **patch) -> CronJob:
+        self.updated = patch
+        assert self.job is not None
+        for key, value in patch.items():
+            setattr(self.job, key, value)
+        return self.job
+
+    async def get_job(self, job_id) -> CronJob | None:
+        return self.job if self.job and self.job.id == job_id else None
+
+
+class _FakeChannelManager:
+    def __init__(self, adapter=None) -> None:
+        self._adapter = adapter
+
+    def get(self, name):
+        return self._adapter
+
+
+def _existing_job() -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="watchdog",
+        cron_expr="600",
+        schedule_raw="600",
+        handler_key="script_run",
+        payload={"kind": "script", "script": "tick.sh"},
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="telegram",
+            channel_id="1245463966",
+        ),
+    )
+
+
+def _add_params(channel_id: str, **extra) -> dict:
+    params = {
+        "name": "watchdog",
+        "expression": "*/10 * * * *",
+        "text": "tick",
+        "sessionTarget": "isolated",
+        "delivery": {"mode": "channel", "channelName": "telegram", "channelId": channel_id},
+    }
+    params["delivery"].update(extra)
+    return params
+
+
+def test_add_rejects_a_session_key_as_the_channel_id() -> None:
+    scheduler = _FakeScheduler()
+    with pytest.raises(ValueError) as excinfo:
+        asyncio.run(
+            _handle_cron_add(
+                _add_params(SESSION_KEY),
+                RpcContext(conn_id="test", cron_scheduler=scheduler),
+            )
+        )
+    assert "session key" in str(excinfo.value)
+    assert "1245463966" in str(excinfo.value)
+    assert scheduler.added is None
+
+
+def test_add_rejects_a_non_numeric_telegram_target() -> None:
+    scheduler = _FakeScheduler()
+    with pytest.raises(ValueError):
+        asyncio.run(
+            _handle_cron_add(
+                _add_params("C-team-alerts"),
+                RpcContext(conn_id="test", cron_scheduler=scheduler),
+            )
+        )
+    assert scheduler.added is None
+
+
+def test_add_accepts_a_real_chat_id() -> None:
+    scheduler = _FakeScheduler()
+    asyncio.run(
+        _handle_cron_add(
+            _add_params("1245463966"),
+            RpcContext(conn_id="test", cron_scheduler=scheduler),
+        )
+    )
+    assert scheduler.added is not None
+
+
+def test_add_validates_the_failure_destination_too() -> None:
+    scheduler = _FakeScheduler()
+    with pytest.raises(ValueError):
+        asyncio.run(
+            _handle_cron_add(
+                _add_params(
+                    "1245463966",
+                    failureDestination={
+                        "mode": "channel",
+                        "channelName": "telegram",
+                        "channelId": SESSION_KEY,
+                    },
+                ),
+                RpcContext(conn_id="test", cron_scheduler=scheduler),
+            )
+        )
+    assert scheduler.added is None
+
+
+def test_update_rejects_a_session_key_as_the_channel_id() -> None:
+    scheduler = _FakeScheduler(_existing_job())
+    with pytest.raises(ValueError) as excinfo:
+        asyncio.run(
+            _handle_cron_update(
+                {
+                    "id": "job-1",
+                    "delivery": {
+                        "mode": "channel",
+                        "channelName": "telegram",
+                        "channelId": SESSION_KEY,
+                    },
+                },
+                RpcContext(conn_id="test", cron_scheduler=scheduler),
+            )
+        )
+    assert "session key" in str(excinfo.value)
+    assert scheduler.updated is None
+
+
+def test_update_keeps_a_valid_target() -> None:
+    scheduler = _FakeScheduler(_existing_job())
+    asyncio.run(
+        _handle_cron_update(
+            {
+                "id": "job-1",
+                "delivery": {
+                    "mode": "channel",
+                    "channelName": "telegram",
+                    "channelId": "-1001234567890",
+                },
+            },
+            RpcContext(conn_id="test", cron_scheduler=scheduler),
+        )
+    )
+    assert scheduler.updated is not None
+    assert scheduler.updated["delivery"].channel_id == "-1001234567890"
+
+
+# ── adapter probe ───────────────────────────────────────────────────────────
+
+
+def test_probe_blocks_a_chat_the_adapter_says_does_not_exist() -> None:
+    async def probe_target(target: str):
+        return False, "chat not found"
+
+    scheduler = _FakeScheduler()
+    ctx = RpcContext(conn_id="test", cron_scheduler=scheduler)
+    ctx.channel_manager = _FakeChannelManager(SimpleNamespace(probe_target=probe_target))
+    with pytest.raises(ValueError) as excinfo:
+        asyncio.run(_handle_cron_add(_add_params("999"), ctx))
+    assert "chat not found" in str(excinfo.value)
+    assert scheduler.added is None
+
+
+def test_probe_that_confirms_the_chat_lets_the_save_through() -> None:
+    async def probe_target(target: str):
+        return True, ""
+
+    scheduler = _FakeScheduler()
+    ctx = RpcContext(conn_id="test", cron_scheduler=scheduler)
+    ctx.channel_manager = _FakeChannelManager(SimpleNamespace(probe_target=probe_target))
+    asyncio.run(_handle_cron_add(_add_params("1245463966"), ctx))
+    assert scheduler.added is not None
+
+
+def test_an_adapter_without_a_probe_does_not_block_the_save() -> None:
+    scheduler = _FakeScheduler()
+    ctx = RpcContext(conn_id="test", cron_scheduler=scheduler)
+    ctx.channel_manager = _FakeChannelManager(SimpleNamespace())
+    asyncio.run(_handle_cron_add(_add_params("1245463966"), ctx))
+    assert scheduler.added is not None
+
+
+def test_a_probe_that_raises_does_not_block_the_save() -> None:
+    # The bot being offline is not evidence that the chat id is wrong.
+    async def probe_target(target: str):
+        raise RuntimeError("telegram unreachable")
+
+    scheduler = _FakeScheduler()
+    ctx = RpcContext(conn_id="test", cron_scheduler=scheduler)
+    ctx.channel_manager = _FakeChannelManager(SimpleNamespace(probe_target=probe_target))
+    asyncio.run(_handle_cron_add(_add_params("1245463966"), ctx))
+    assert scheduler.added is not None
+
+
+def test_a_probe_that_hangs_does_not_block_the_save(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def probe_target(target: str):
+        await asyncio.sleep(60)
+        return False, "never gets here"
+
+    monkeypatch.setattr(rpc_cron, "_TARGET_PROBE_TIMEOUT_SECONDS", 0.01)
+    scheduler = _FakeScheduler()
+    ctx = RpcContext(conn_id="test", cron_scheduler=scheduler)
+    ctx.channel_manager = _FakeChannelManager(SimpleNamespace(probe_target=probe_target))
+    asyncio.run(_handle_cron_add(_add_params("1245463966"), ctx))
+    assert scheduler.added is not None

--- a/tests/test_gateway/test_structlog_reaches_debug_log.py
+++ b/tests/test_gateway/test_structlog_reaches_debug_log.py
@@ -1,0 +1,85 @@
+"""structlog events belong in debug.log too.
+
+Half of this codebase logs through ``logging.getLogger`` (scheduler jobs, the
+reaper) and half through ``structlog`` (delivery, handlers, channels). Only the
+first half reached ``~/.agentos/logs/debug.log``, so a cron run could fail with
+"delivery failed" in the file while the reason — a structlog warning carrying
+Telegram's "chat not found" — existed nowhere but the terminal the gateway
+happened to be started in.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import structlog
+
+from agentos.gateway.boot import _setup_file_logging
+from agentos.gateway.config import GatewayConfig
+
+
+def _remove_debug_handlers() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if getattr(handler, "_agentos_debug_file_handler", False):
+            root.removeHandler(handler)
+            handler.close()
+
+
+def _enable_file_logging(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("AGENTOS_LOG_LEVEL", "DEBUG")
+    # structlog's own level filter is process-global and another test may have
+    # raised it; pin it here so this file tests the tee, not the ambient config.
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG))
+    _setup_file_logging(GatewayConfig(log_level="DEBUG"))
+
+
+def test_a_structlog_warning_lands_in_the_debug_log(tmp_path, monkeypatch) -> None:
+    original = structlog.get_config()
+    try:
+        _enable_file_logging(tmp_path, monkeypatch)
+
+        structlog.get_logger("agentos.scheduler.delivery").warning(
+            "delivery.channel_failed",
+            job_id="job-1",
+            error="Bad Request: chat not found",
+        )
+
+        contents = (tmp_path / "debug.log").read_text()
+        assert "delivery.channel_failed" in contents
+        assert "chat not found" in contents
+        assert "job-1" in contents
+    finally:
+        _remove_debug_handlers()
+        structlog.configure(**original)
+
+
+def test_the_level_is_preserved_so_filters_still_work(tmp_path, monkeypatch) -> None:
+    original = structlog.get_config()
+    try:
+        _enable_file_logging(tmp_path, monkeypatch)
+
+        structlog.get_logger("agentos.test").warning("something.wrong")
+        structlog.get_logger("agentos.test").info("something.fine")
+
+        contents = (tmp_path / "debug.log").read_text()
+        assert "[WARNING]" in contents.split("something.wrong")[0].splitlines()[-1]
+        assert "[INFO]" in contents.split("something.fine")[0].splitlines()[-1]
+    finally:
+        _remove_debug_handlers()
+        structlog.configure(**original)
+
+
+def test_turning_file_logging_off_restores_the_previous_structlog_config(
+    tmp_path, monkeypatch
+) -> None:
+    original = structlog.get_config()
+    try:
+        _enable_file_logging(tmp_path, monkeypatch)
+        _setup_file_logging(GatewayConfig(log_file_enabled=False))
+
+        assert structlog.get_config()["processors"] == original["processors"]
+    finally:
+        _remove_debug_handlers()
+        structlog.configure(**original)

--- a/tests/test_scheduler/test_delivery_failure_reason.py
+++ b/tests/test_scheduler/test_delivery_failure_reason.py
@@ -1,0 +1,109 @@
+"""A failed delivery has to say *why* on the run record.
+
+The run that prompted this failed with exactly one line — "Cron job '<name>'
+delivery failed" — while the reason (Telegram's `chat not found`) existed only
+as a log line in the gateway's stdout. Whoever reads `agentos cron runs` next
+gets the reason too.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.scheduler.delivery import DeliveryChain
+from agentos.scheduler.handlers import _required_delivery_error
+from agentos.scheduler.payloads import make_script_payload
+from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+
+
+class _FailingAdapter:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def send(self, message: Any) -> None:
+        raise self._error
+
+
+class _FakeChannelManager:
+    def __init__(self, adapter: Any) -> None:
+        self._adapter = adapter
+
+    def get(self, name: str) -> Any:
+        return self._adapter
+
+
+def _telegram_job() -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="watch-memory",
+        handler_key="script_run",
+        payload=make_script_payload("watch-memory.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="telegram",
+            channel_id="1245463966",
+        ),
+    )
+
+
+async def _deliver_with(adapter: Any) -> Any:
+    chain = DeliveryChain(channel_manager_ref=lambda: _FakeChannelManager(adapter))
+    return await chain.deliver(
+        _telegram_job(),
+        result_text="3 alerts pending",
+        success=True,
+        summary="3 alerts pending",
+        session_key="cron:job-1:run:deadbeef",
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_adapters_error_is_carried_on_the_report() -> None:
+    report = await _deliver_with(_FailingAdapter(RuntimeError("Bad Request: chat not found")))
+
+    assert report.channel_status == "delivery_failed"
+    assert "chat not found" in report.channel_detail
+
+
+@pytest.mark.asyncio
+async def test_the_run_error_names_the_reason_not_just_the_job() -> None:
+    report = await _deliver_with(_FailingAdapter(RuntimeError("Bad Request: chat not found")))
+
+    error = _required_delivery_error(_telegram_job(), report)
+
+    assert error is not None
+    assert "watch-memory" in error
+    assert "telegram" in error
+    assert "chat not found" in error
+
+
+@pytest.mark.asyncio
+async def test_a_missing_adapter_says_so() -> None:
+    chain = DeliveryChain(channel_manager_ref=lambda: _FakeChannelManager(None))
+    report = await chain.deliver(
+        _telegram_job(),
+        result_text="3 alerts pending",
+        success=True,
+        summary="3 alerts pending",
+        session_key="cron:job-1:run:deadbeef",
+    )
+
+    assert report.channel_status == "delivery_failed"
+    assert "no adapter" in report.channel_detail
+    assert "no adapter" in str(_required_delivery_error(_telegram_job(), report))
+
+
+@pytest.mark.asyncio
+async def test_a_successful_delivery_carries_no_reason() -> None:
+    class _OkAdapter:
+        async def send(self, message: Any) -> None:
+            return None
+
+    report = await _deliver_with(_OkAdapter())
+
+    assert report.channel_status == "delivered"
+    assert report.channel_detail == ""
+    assert _required_delivery_error(_telegram_job(), report) is None

--- a/tests/test_scheduler/test_delivery_targets.py
+++ b/tests/test_scheduler/test_delivery_targets.py
@@ -1,0 +1,70 @@
+"""Shape checks for a cron job's delivery recipient.
+
+The bug behind these: a session key (``agent:main:telegram:direct:1245463966``)
+was accepted as a Telegram ``channelId``. Telegram answers "chat not found" for
+it, so the job only failed ten minutes later, at delivery time.
+"""
+
+import pytest
+
+from agentos.scheduler.delivery_targets import validate_channel_target
+
+SESSION_KEY = "agent:main:telegram:direct:1245463966"
+
+
+@pytest.mark.parametrize(
+    "channel",
+    ["telegram", "slack", "discord", "msteams", "unknown-channel"],
+)
+def test_session_keys_are_rejected_for_every_channel(channel: str) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        validate_channel_target(channel, SESSION_KEY)
+    assert "session key" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "agent:main:telegram:direct:1245463966",
+        "cron:6b23bfa7:run:deadbeef",
+        "webchat:abc123",
+        "session:main",
+    ],
+)
+def test_every_session_key_prefix_is_rejected(key: str) -> None:
+    with pytest.raises(ValueError):
+        validate_channel_target("slack", key)
+
+
+def test_rejection_suggests_the_id_that_would_have_worked() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        validate_channel_target("telegram", SESSION_KEY)
+    assert "1245463966" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("target", ["1245463966", "-1001234567890", "@andreapn", "  42  "])
+def test_telegram_accepts_chat_ids_and_usernames(target: str) -> None:
+    validate_channel_target("telegram", target)
+
+
+@pytest.mark.parametrize("target", ["C-team-alerts", "not a chat", "12ab", "@", "+1245463966"])
+def test_telegram_rejects_anything_that_is_not_a_chat_id(target: str) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        validate_channel_target("telegram", target)
+    assert "chat id" in str(excinfo.value)
+
+
+def test_other_channels_keep_their_own_id_shapes() -> None:
+    # Slack channel ids, a Discord snowflake, and an MS Teams conversation id —
+    # the last one has colons, which is why the guard is a prefix whitelist and
+    # not a colon count.
+    validate_channel_target("slack", "C0123ABCDEF")
+    validate_channel_target("slack", "#team-alerts")
+    validate_channel_target("discord", "1103283746372617")
+    validate_channel_target("msteams", "19:meeting_NGY3@thread.v2")
+
+
+def test_empty_target_is_left_alone() -> None:
+    # Delivery falls back to the channel's configured default chat.
+    validate_channel_target("telegram", "")
+    validate_channel_target("slack", "   ")


### PR DESCRIPTION
Closes #232.

## The failure this comes from

A script cron job was repointed at Telegram from the Web UI. The value on hand was the AgentOS *session* key `agent:main:telegram:direct:1245463966`; the Recipient field was free text; nothing objected. Ten minutes later the run failed with one line — `delivery failed` — while the reason (Telegram's `chat not found`) existed only in the terminal the gateway happened to be started in.

Three fixes, in the order the investigation found them.

## 1. Reject the target at save time

`scheduler/delivery_targets.py` — `validate_channel_target(channel, id)`:

- refuses an id beginning with a session-key prefix (`agent:`, `cron:`, `webchat:`, `session:`) for **any** channel, and suggests the id that would have worked: *`"agent:main:telegram:direct:1245463966" is a session key, not a telegram chat id — use 1245463966`*;
- requires an integer (negative allowed, for groups) or `@username` for Telegram;
- leaves an empty target alone — delivery falls back to the channel default.

The guard is a prefix whitelist rather than a colon count on purpose: a genuine MS Teams conversation id looks like `19:meeting_NGY3@thread.v2`.

`cron.add` and `cron.update` apply it to the primary delivery **and** the failure destination, then ask the adapter itself through the new `TelegramChannel.probe_target` (`getChat`). Only a definite negative blocks the save — a missing capability, a disconnected bot, a timeout, or any transport error leaves it alone, because none of those is evidence about the chat id. `probe_target` re-raises transport failures rather than answering `False` for the same reason.

## 2. Offer the chats we already know

New `channels.deliveryTargets` RPC returns, per channel, the recipients the gateway can actually name — for Telegram, every paired DM (labelled `Display Name (@username)`) and every configured group chat. A channel with no pairing store is simply absent from the map.

The Web UI renders **Recipient** as a dropdown when the selected channel has known targets, with a trailing `Enter manually…` option that restores the text input for a group chat outside `group_chat_ids`. Primary delivery and the failure destination share the component. Slack, Discord and MS Teams are unchanged — enumerating their conversations means calling their APIs, which is separate work.

## 3. Put the reason where it will be read

`DeliveryReport.channel_detail` carries why channel delivery failed. `ChannelStatus` is a `str` subclass so all ~20 existing `== "delivery_failed"` comparisons keep working while the reason rides along. The run error becomes:

```
Cron job 'Ratchet tick …' delivery to telegram failed: Bad Request: chat not found
```

An exception escaping the channel leg entirely used to vanish into `asyncio.gather(return_exceptions=True)` and produce a bare `delivery_failed` with no trace anywhere; it now reports its type and message and logs `delivery.channel_raised`.

## 4. structlog reaches debug.log

Half this codebase logs through `logging.getLogger` (scheduler jobs, reaper) and half through `structlog` (delivery, handlers, channels). Only the first half reached `~/.agentos/logs/debug.log`, so the file held the bare traceback and none of the `delivery.*` warnings explaining it. `_setup_file_logging` now splices a tee processor ahead of structlog's renderer while file logging is on, and restores the previous processor chain when it is turned off. It runs last so `exc_info` is already rendered — tracebacks land in the file too.

## Tests

- `tests/test_scheduler/test_delivery_targets.py` — shape validation per channel, session-key prefixes, the suggestion, MS Teams colons, empty target.
- `tests/test_gateway/test_rpc_cron_delivery_target.py` — `cron.add`/`cron.update` reject a session key and a malformed Telegram id, in primary delivery and in the failure destination; the probe blocks a definite negative and is ignored when absent, raising, or hanging.
- `tests/test_channels/test_telegram_probe_target.py` — `getChat` confirms, reports Telegram's own reason, re-raises transport failures.
- `tests/test_gateway/test_rpc_channels_delivery_targets.py` — target shape, group chats, channels with nothing to offer.
- `tests/test_scheduler/test_delivery_failure_reason.py` — the adapter's error reaches the report and the run error.
- `tests/test_gateway/test_structlog_reaches_debug_log.py` — a structlog warning lands in `debug.log` at the right level; the processor chain is restored on teardown.
- `docs/scheduling.md` gains a "Naming a channel recipient" section.

Gate: `ruff` clean, `mypy` clean over 591 files, **7284 backend tests pass**, `npm run check` passes 1669 frontend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)