### PR TITLE
fix(gateway): warn on stale control UI bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Gateway boot and `agentos doctor` now warn when the bundled React Control UI
+  is older than the frontend sources in a checkout (`gateway.control_ui.dist_stale`),
+  instead of reporting a clean bill of health while serving a stale web UI.
+  Wheel installs are unaffected. (Fixes #200)
 ## [2026.8.6] - 2026-08-06
 
 ### Added

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -52,6 +52,13 @@ license ledger. The source-install scripts perform it automatically. If a
 checkout is started without a bundle, the Control UI returns an actionable
 `503` instead of a blank page or a different interface.
 
+Gateway boot and `agentos doctor` also warn when a checkout's bundle is
+older than its frontend sources (`gateway.control_ui.dist_stale`); the
+warning is advisory and never blocks serving the existing bundle. Rebuild
+with `python scripts/build_control_ui.py build`, then restart the gateway
+to clear it. Wheel installs ship no frontend sources, so they are never
+flagged.
+
 For hot reload during frontend work, run the gateway and Vite together:
 
 ```sh

--- a/src/agentos/control_ui_check.py
+++ b/src/agentos/control_ui_check.py
@@ -1,0 +1,93 @@
+"""Detect when the bundled React Control UI is older than its frontend sources.
+
+Warn-only helper shared by gateway boot and ``agentos doctor``. The mtime
+comparison is a hint, not an oracle: ``git checkout`` / ``git pull`` rewrite
+source mtimes and can flag a legitimately fresh bundle, so callers must never
+gate readiness on this result.
+
+Must stay dependency-free (stdlib only) and must not import any ``agentos.*``
+module: the architecture import-contract test tracks edges between top-level
+*packages* only, and this module deliberately lives outside that graph.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+
+# Inputs consumed by the Vite build (sdist-only; absent in wheels).
+FRONTEND_INPUT_DIRS = ("src", "public")
+FRONTEND_INPUT_FILES = (
+    "index.html",
+    "package.json",
+    "package-lock.json",
+    "vite.config.ts",
+    "tsconfig.json",
+)
+# Directories that are built or fetched, never inputs.
+_PRUNE_DIRS = {"node_modules", "dist", ".git"}
+
+# Mirrored in agentos/gateway/control_ui.py (_DIST_DIR); the contract test
+# tests/test_health/test_control_ui_check.py asserts they stay in sync.
+DIST_REL = Path("src") / "agentos" / "gateway" / "static" / "dist" / "index.html"
+
+BUILD_CMD = "python scripts/build_control_ui.py build"
+
+
+def build_hint() -> str:
+    """Return the command that rebuilds the Control UI bundle."""
+    return BUILD_CMD
+
+
+@functools.cache
+def repo_root(root: Path | None = None) -> Path:
+    """Resolve the checkout root; ``root`` wins when given (tests)."""
+    if root is not None:
+        return root
+    return Path(__file__).resolve().parents[2]
+
+
+@functools.cache
+def frontend_input_mtime(root: Path | None = None) -> float | None:
+    """Newest mtime among tracked frontend inputs, or ``None`` for a wheel.
+
+    ``None`` means there is nothing to compare against (``frontend/`` ships
+    only in the sdist), so wheel installs must stay silent.
+    """
+    frontend = repo_root(root) / "frontend"
+    if not (frontend / "package.json").is_file():
+        return None
+    newest = 0.0
+    for input_dir in FRONTEND_INPUT_DIRS:
+        for current, dirs, files in os.walk(frontend / input_dir):
+            dirs[:] = [dirname for dirname in dirs if dirname not in _PRUNE_DIRS]
+            for filename in files:
+                try:
+                    newest = max(newest, (Path(current) / filename).stat().st_mtime)
+                except OSError:
+                    continue
+    for filename in FRONTEND_INPUT_FILES:
+        try:
+            newest = max(newest, (frontend / filename).stat().st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+@functools.cache
+def control_ui_is_stale(root: Path | None = None) -> bool | None:
+    """Whether the bundled Control UI predates the frontend sources.
+
+    Returns ``None`` when there is nothing to compare (wheel install or
+    missing bundle). Strict ``>``: equal timestamps count as fresh, which is
+    false-negative safe on filesystems with coarse mtime resolution.
+    """
+    source_mtime = frontend_input_mtime(root)
+    if source_mtime is None:
+        return None
+    try:
+        bundle_mtime = (repo_root(root) / DIST_REL).stat().st_mtime
+    except OSError:
+        return None
+    return source_mtime > bundle_mtime

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1942,13 +1942,20 @@ async def start_gateway_server(
 
     # Gateway-specific: resolve the built React Control UI (boot order 17)
     if config.control_ui.enabled:
+        from agentos.control_ui_check import build_hint, control_ui_is_stale
         from agentos.gateway.control_ui import _DIST_DIR
 
         if not (_DIST_DIR / "index.html").is_file():
             log.warning(
                 "gateway.control_ui.dist_missing",
                 path=str(_DIST_DIR),
-                hint="run `python scripts/build_control_ui.py build`",
+                hint=build_hint(),
+            )
+        elif control_ui_is_stale():
+            log.warning(
+                "gateway.control_ui.dist_stale",
+                path=str(_DIST_DIR),
+                hint=build_hint(),
             )
         log.info(
             "gateway.control_ui.resolved",

--- a/src/agentos/gateway/rpc_doctor.py
+++ b/src/agentos/gateway/rpc_doctor.py
@@ -16,6 +16,7 @@ from agentos.gateway.rpc_system import _handle_doctor_memory_status
 from agentos.gateway.rpc_tools import _handle_providers_status, _handle_search_status
 from agentos.health.evaluator import (
     evaluate_channels,
+    evaluate_control_ui,
     evaluate_image_generation,
     evaluate_logs,
     evaluate_memory,
@@ -486,6 +487,28 @@ def _memory_embedding_payload(ctx: RpcContext) -> dict[str, Any]:
     }
 
 
+def _control_ui_payload() -> dict[str, Any]:
+    from agentos.control_ui_check import (
+        DIST_REL,
+        control_ui_is_stale,
+        frontend_input_mtime,
+        repo_root,
+    )
+
+    source_mtime = frontend_input_mtime()
+    bundle_mtime: float | None = None
+    try:
+        bundle_mtime = (repo_root() / DIST_REL).stat().st_mtime
+    except OSError:
+        pass
+    return {
+        "stale": control_ui_is_stale(),
+        "sourceMtime": source_mtime,
+        "bundleMtime": bundle_mtime,
+        "wheelInstall": source_mtime is None,
+    }
+
+
 async def _evaluate_collection(
     surface: str,
     collect: Collector,
@@ -543,6 +566,11 @@ async def _handle_doctor_status(params: dict | None, ctx: RpcContext) -> dict[st
             "image_generation",
             lambda: _image_generation_payload(ctx),
             evaluate_image_generation,
+        ),
+        (
+            "control_ui",
+            lambda: _control_ui_payload(),
+            evaluate_control_ui,
         ),
     ]
 

--- a/src/agentos/health/evaluator.py
+++ b/src/agentos/health/evaluator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
+from agentos.control_ui_check import BUILD_CMD
 from agentos.health.model import FixStep, HealthFinding
 
 _LEGACY_PROVIDER_REPLACEMENTS = {
@@ -1454,5 +1455,41 @@ def evaluate_sandbox(payload: dict[str, Any]) -> list[HealthFinding]:
             title="Sandbox posture configured",
             detail=f"Sandbox posture is {posture}.",
             evidence=evidence,
+        )
+    ]
+
+
+def evaluate_control_ui(payload: dict[str, Any]) -> list[HealthFinding]:
+    """Warn when the bundled Control UI predates the frontend sources.
+
+    ``payload["stale"]`` is ``None`` for wheel installs or a missing bundle —
+    nothing to compare, so the doctor stays clean. Never gates readiness.
+    """
+    if not payload.get("stale"):
+        return []
+    return [
+        HealthFinding(
+            id="control_ui.stale",
+            severity="warn",
+            surface="control_ui",
+            title="Bundled control UI is out of date",
+            detail=(
+                "The packaged React console predates the frontend sources "
+                "in this checkout. Rebuild it so the web UI matches the "
+                "current source tree."
+            ),
+            readiness_impact="degrades",
+            evidence={
+                key: value
+                for key, value in payload.items()
+                if key not in {"stale"}
+            },
+            fix_steps=[
+                FixStep(
+                    label="Rebuild the Control UI bundle",
+                    command=BUILD_CMD,
+                    detail="Restart the gateway to clear the boot-time warning.",
+                )
+            ],
         )
     ]

--- a/tests/test_health/test_control_ui_check.py
+++ b/tests/test_health/test_control_ui_check.py
@@ -1,0 +1,116 @@
+"""Regression tests for control-UI staleness detection (issue #200)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from agentos.control_ui_check import (
+    BUILD_CMD,
+    DIST_REL,
+    control_ui_is_stale,
+    frontend_input_mtime,
+    repo_root,
+)
+from agentos.gateway.control_ui import _DIST_DIR
+from agentos.health.evaluator import evaluate_control_ui
+from agentos.health.model import build_report
+
+_BASE = 1_700_000_000
+
+
+def _utime(path: Path, offset: float) -> None:
+    os.utime(path, (_BASE + offset, _BASE + offset))
+
+
+def _make_tree(root: Path, *, frontend: bool = True, dist: bool = True) -> Path:
+    """Synthetic checkout: frontend sources (fresh) + built bundle (old)."""
+    if frontend:
+        (root / "frontend" / "src").mkdir(parents=True)
+        (root / "frontend" / "src" / "main.tsx").write_text("export const x = 1")
+        (root / "frontend" / "package.json").write_text("{}")
+        (root / "frontend" / "index.html").write_text("<html></html>")
+        _utime(root / "frontend" / "src" / "main.tsx", 100)
+        _utime(root / "frontend" / "package.json", 100)
+        _utime(root / "frontend" / "index.html", 100)
+    if dist:
+        dist_index = root / DIST_REL
+        dist_index.parent.mkdir(parents=True)
+        dist_index.write_text("<html></html>")
+        _utime(dist_index, 200)
+    return root
+
+
+def test_wheel_install_no_frontend_is_not_stale(tmp_path: Path) -> None:
+    root = _make_tree(tmp_path, frontend=False)
+    assert frontend_input_mtime(root) is None
+    assert control_ui_is_stale(root) is None
+
+
+def test_missing_bundle_is_not_stale(tmp_path: Path) -> None:
+    root = _make_tree(tmp_path, dist=False)
+    assert frontend_input_mtime(root) is not None
+    assert control_ui_is_stale(root) is None
+
+
+def test_fresh_bundle_not_stale(tmp_path: Path) -> None:
+    assert control_ui_is_stale(_make_tree(tmp_path)) is False
+
+
+def test_stale_bundle_detected(tmp_path: Path) -> None:
+    root = _make_tree(tmp_path)
+    _utime(root / "frontend" / "src" / "main.tsx", 300)
+    assert control_ui_is_stale(root) is True
+
+
+def test_prunes_node_modules_and_dist(tmp_path: Path) -> None:
+    root = _make_tree(tmp_path)
+    ignored = root / "frontend" / "src" / "node_modules" / "lib"
+    ignored.mkdir(parents=True)
+    (ignored / "index.js").write_text("x")
+    _utime(ignored / "index.js", 300)
+    assert control_ui_is_stale(root) is False
+
+
+def test_top_level_input_files_count(tmp_path: Path) -> None:
+    root = _make_tree(tmp_path)
+    _utime(root / "frontend" / "package.json", 300)
+    assert control_ui_is_stale(root) is True
+
+
+def test_equal_mtimes_not_stale(tmp_path: Path) -> None:
+    root = _make_tree(tmp_path)
+    _utime(root / "frontend" / "src" / "main.tsx", 200)
+    assert control_ui_is_stale(root) is False
+
+
+def test_dist_path_contract() -> None:
+    assert (repo_root() / DIST_REL).resolve().parent == _DIST_DIR.resolve()
+
+
+def test_evaluate_control_ui_findings() -> None:
+    assert evaluate_control_ui({"stale": None}) == []
+    assert evaluate_control_ui({"stale": False}) == []
+    findings = evaluate_control_ui(
+        {
+            "stale": True,
+            "sourceMtime": 1.0,
+            "bundleMtime": 0.5,
+            "wheelInstall": False,
+        }
+    )
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.id == "control_ui.stale"
+    assert finding.severity == "warn"
+    assert finding.readiness_impact == "degrades"
+    assert finding.fix_steps[0].command == BUILD_CMD
+    assert finding.restart_required is False
+    assert finding.evidence == {"sourceMtime": 1.0, "bundleMtime": 0.5, "wheelInstall": False}
+
+
+def test_build_report_degraded_status() -> None:
+    finding = evaluate_control_ui({"stale": True})[0]
+    report = build_report([finding])
+    assert report["status"] == "degraded"
+    assert report["ready"] is True


### PR DESCRIPTION
## What

`git pull` on a source checkout can leave the bundled React Control UI older
than the frontend sources, but nothing signals it: gateway boot only warned
when `dist/` was missing entirely, and `agentos doctor` reported a clean bill
of health while serving a stale web UI.

This adds warn-only staleness detection for the Control UI bundle, shared by
gateway boot and `agentos doctor`.

## How

A dependency-free helper (`src/agentos/control_ui_check.py`) compares the
newest mtime among tracked frontend inputs (`frontend/src/**`,
`frontend/public/**`, `index.html`, `package.json`, `package-lock.json`,
`vite.config.ts`, `tsconfig.json`, pruning `node_modules` and `dist`) against
`src/agentos/gateway/static/dist/index.html`.

Two consumers, both warn-only:

1. `gateway/boot.py` — an `elif` next to the existing `dist_missing` branch,
   logging `gateway.control_ui.dist_stale` with a build hint.
2. `agentos doctor` — a `control_ui` collector plus a `health/evaluator`
   finding at `severity="warn"`, `readiness_impact="degrades"`, with a
   `FixStep` naming the rebuild command.

Never gates readiness — mtimes are a hint, not an oracle; `git checkout` /
`git pull` rewrite source mtimes and can flag a legitimately fresh bundle.

## Wheel installs are silent

`frontend/` and `scripts/` are sdist-only, so for a PyPI install there is
nothing to compare against and `frontend_input_mtime()` returns `None` — no
warning, clean doctor.

## Validation

- `uv run pytest tests/test_health/test_control_ui_check.py -q`
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`

Fixes #200
