### PR TITLE
fix(onboarding): scope provider profiles to what a provider owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Switching from a cloud LLM provider back to a local one no longer disables the
+  router or leaves it pinned to the cloud provider's tier profile. (Fixes #189)
+
+### Added
+
+- Onboarding remembers a per-provider profile when you switch LLM providers and
+  restores it when you return: the model, the non-secret connection settings
+  (`base_url`, `proxy`, `api_key_env`, `max_tokens`, `thinking`, provider
+  routing), and that provider's router slice (enabled, tier profile, tiers you
+  authored, Smart Routing judge target). Install-wide router settings —
+  `strategy`, `default_tier`, the Pilot thresholds, judge tuning — stay global
+  and are never reverted by a switch. Machine-written tier tables are re-derived
+  rather than frozen, so upgrades still move you onto the current recommended
+  models. Credentials are never copied into a profile. See
+  [docs/configuration.md](docs/configuration.md). (Refs #188)
+
 ## [2026.8.6] - 2026-08-06
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,15 +427,40 @@ appears for the Pilot strategy.
 #### Provider-switch profiles
 
 When onboarding switches to another LLM provider, AgentOS saves a profile for
-the provider being left and restores it when you return. A profile contains the
-active model, router mode and settings (including text/image tiers, Smart
-Routing judge model and endpoint, and Pilot settings), plus non-secret
-connection settings such as `base_url`, `proxy`, `api_key_env`, and provider
-routing preferences. Profiles are persisted in `config.toml`.
+the provider being left and restores it when you return. Profiles live under
+`[provider_profiles]` in `config.toml`.
 
-Literal `api_key` values and local `judge_api_key` values are not copied into a
-profile. Prefer environment-variable references for credentials you need to
+A profile holds only what belongs to that provider:
+
+- the active model and the non-secret connection settings — `base_url`,
+  `proxy`, `api_key_env`, `max_tokens`, `thinking`, and provider routing
+  preferences;
+- the provider's router slice — whether the router is enabled, its tier
+  profile, any tiers you authored yourself, and the Smart Routing judge target
+  (`judge_model`, `judge_provider`, `judge_base_url`).
+
+Install-wide router settings are deliberately **not** part of a profile:
+`strategy`, `default_tier`, `rollout_phase`, `auto_thinking`, the Pilot
+thresholds and the judge short-circuit tuning all stay on `[agentos_router]`.
+Retuning any of them while another provider is active is kept, not reverted by
+the next switch.
+
+Tier tables that AgentOS wrote itself — the shipped per-provider defaults, or
+the pinned tiers of a local provider — are not stored in the profile. They are
+re-derived when you switch back, so upgrading AgentOS still moves you onto the
+current recommended models. Tiers you edited yourself are stored verbatim and
+restored unchanged.
+
+Passing an explicit model when you switch back always wins over the remembered
+one, and a local provider's tiers are re-pinned to it.
+
+Credentials are never copied into a profile: neither a literal `api_key` nor a
+local `judge_api_key`. Returning to a provider you configured with a literal
+key asks you to re-enter it. Use `api_key_env` for credentials you want to
 survive a provider switch.
+
+A profile is only saved for a provider you actually configured, and a profile
+that no longer parses is dropped on load rather than blocking gateway startup.
 
 #### Upgrading from v4_phase3
 

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -17,6 +17,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     SerializeAsAny,
+    ValidationError,
     field_validator,
     model_validator,
 )
@@ -1218,22 +1219,53 @@ class AgentOSRouterConfig(BaseSettings):
 AgentOSRouterConfig.model_rebuild()
 
 
+class ProviderRouterProfileConfig(BaseModel):
+    """The slice of router settings that belongs to one provider.
+
+    Deliberately NOT the whole :class:`AgentOSRouterConfig`. Most of that model
+    is install-wide behaviour — ``strategy``, ``rollout_phase``,
+    ``auto_thinking``, ``default_tier``, the Pilot thresholds, the judge
+    short-circuit tuning — and snapshotting it per provider means retuning any
+    of it while another provider is active is silently reverted on the next
+    switch. Only what a provider genuinely owns is stored here.
+
+    ``tiers`` stays empty whenever the tier table is machine-written (the
+    shipped profile defaults, or a local pin). Those are re-derived on restore,
+    so a release that bumps the shipped model ids still reaches installs that
+    have switched providers — mirroring the elision
+    :meth:`GatewayConfig.to_toml_dict` already applies to the live router. Only
+    operator-authored tiers are stored verbatim.
+    """
+
+    enabled: bool = True
+    tier_profile: str | None = None
+    tiers: dict[str, Any] = Field(default_factory=dict)
+    # Judge target only. judge_api_key is a secret and is never snapshotted.
+    judge_model: str | None = None
+    judge_provider: str | None = None
+    judge_base_url: str | None = None
+
+
 class ProviderProfileConfig(BaseModel):
     """Restorable non-secret LLM and router settings for one provider.
 
     Literal API credentials deliberately remain outside this snapshot. An
     ``api_key_env`` reference is safe to preserve; direct API keys continue to
     use the active provider configuration and existing secret-handling paths.
+
+    Every field is defaulted on purpose: this is machine-written state living in
+    a file operators hand-edit, so a half-written profile must cost a lost
+    preference, never a gateway that refuses to start.
     """
 
-    model: str
+    model: str = ""
     api_key_env: str = ""
     base_url: str = ""
     proxy: str = ""
     max_tokens: int = 0
     thinking: str | None = None
     provider_routing: dict[str, str] = Field(default_factory=dict)
-    agentos_router: AgentOSRouterConfig
+    router: ProviderRouterProfileConfig = Field(default_factory=ProviderRouterProfileConfig)
 
 
 class AgentTokenSavingConfig(BaseSettings):
@@ -1729,6 +1761,34 @@ class GatewayConfig(BaseSettings):
     control_ui: ControlUiConfig = Field(default_factory=ControlUiConfig)
     diagnostics_enabled: bool = False
 
+    @field_validator("provider_profiles", mode="before")
+    @classmethod
+    def _drop_unparseable_provider_profiles(cls, value: Any) -> Any:
+        """Skip malformed saved profiles instead of refusing to start.
+
+        ``provider_profiles`` is machine-written restore state that lives in a
+        file operators edit by hand. A profile that no longer parses costs the
+        operator a remembered preference; it must never cost them a gateway that
+        boots. Anything unusable is dropped and re-created on the next switch.
+        """
+        if not isinstance(value, dict):
+            return value
+        kept: dict[str, Any] = {}
+        for provider, payload in value.items():
+            key = str(provider or "").strip().lower()
+            if not key:
+                continue
+            if isinstance(payload, ProviderProfileConfig):
+                kept[key] = payload
+                continue
+            if not isinstance(payload, dict):
+                continue
+            try:
+                kept[key] = ProviderProfileConfig(**payload)
+            except ValidationError:
+                continue
+        return kept
+
     @model_validator(mode="after")
     def _default_agentos_router_profile_for_direct_provider(self) -> GatewayConfig:
         router = self.agentos_router
@@ -2040,6 +2100,16 @@ class GatewayConfig(BaseSettings):
                 defaults = None
             if defaults is not None and router.get("tiers") == defaults:
                 router.pop("tiers", None)
+        profiles = data.get("provider_profiles")
+        if isinstance(profiles, dict):
+            for profile in profiles.values():
+                # Empty means "machine-written, re-derive on restore"; writing an
+                # empty TOML table would only add noise.
+                profile_router = profile.get("router") if isinstance(profile, dict) else None
+                if isinstance(profile_router, dict) and not profile_router.get("tiers"):
+                    profile_router.pop("tiers", None)
+            if not profiles:
+                data.pop("provider_profiles", None)
         for path in sorted(self._runtime_secret_paths):
             _delete_path(data, path)
         return data

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
@@ -17,6 +18,7 @@ from agentos.gateway.config import (
     LlmProviderConfig,
     MemoryEmbeddingConfig,
     ProviderProfileConfig,
+    ProviderRouterProfileConfig,
     _bankr_tiers,
     _opencap_tiers,
     _openrouter_tiers,
@@ -73,11 +75,71 @@ def _clone(cfg: GatewayConfig) -> GatewayConfig:
     return new_cfg
 
 
-def _provider_router_snapshot(router: AgentOSRouterConfig) -> AgentOSRouterConfig:
-    """Copy router settings for a provider switch without duplicating secrets."""
+def _provider_router_snapshot(
+    router: AgentOSRouterConfig,
+    *,
+    provider_id: str,
+    model: str,
+) -> ProviderRouterProfileConfig:
+    """Capture only the router settings the provider being left owns.
+
+    Install-wide router behaviour (strategy, Pilot thresholds, judge tuning,
+    default tier, ...) is deliberately excluded — see
+    :class:`ProviderRouterProfileConfig`. Machine-written tiers are dropped so
+    they are re-derived from the current shipped defaults on restore instead of
+    being frozen into ``config.toml``; ``judge_api_key`` is a secret and never
+    leaves the active config.
+    """
+    tiers = dict(getattr(router, "tiers", {}) or {})
+    if _tiers_are_machine_written_defaults(tiers, provider_id, model):
+        tiers = {}
+    return ProviderRouterProfileConfig(
+        enabled=bool(getattr(router, "enabled", True)),
+        tier_profile=getattr(router, "tier_profile", None),
+        tiers=tiers,
+        judge_model=getattr(router, "judge_model", None),
+        judge_provider=getattr(router, "judge_provider", None),
+        judge_base_url=getattr(router, "judge_base_url", None),
+    )
+
+
+def _apply_provider_router_profile(
+    router: AgentOSRouterConfig,
+    profile: ProviderRouterProfileConfig,
+) -> AgentOSRouterConfig:
+    """Overlay one provider's saved router slice onto the live router config.
+
+    Everything the profile does not own is carried through untouched, so global
+    router tuning done while another provider was active survives the switch.
+    Machine-written tiers were not stored, so they are re-derived here from the
+    shipped profile defaults (cloud) or left for the reconcile pass to pin
+    (local).
+    """
     payload = router.model_dump(mode="python")
-    payload.pop("judge_api_key", None)
+    payload["enabled"] = profile.enabled
+    payload["tier_profile"] = profile.tier_profile
+    payload["judge_model"] = profile.judge_model
+    payload["judge_provider"] = profile.judge_provider
+    payload["judge_base_url"] = profile.judge_base_url
+    if profile.tiers:
+        payload["tiers"] = dict(profile.tiers)
+    elif profile.tier_profile:
+        try:
+            payload["tiers"] = _router_tier_profile_defaults(str(profile.tier_profile))
+        except ValueError:
+            payload["tier_profile"] = None
     return AgentOSRouterConfig(**payload)
+
+
+def _llm_is_unconfigured_default(config: GatewayConfig) -> bool:
+    """True when nothing has ever configured ``[llm]``.
+
+    ``GatewayConfig()`` ships a provider/model pair, so a first-ever provider
+    setup would otherwise snapshot that default as if an operator had chosen it
+    — pinning a fresh install to whatever model shipped the day it was
+    installed, and overriding the recommended default forever after.
+    """
+    return config.llm.model_dump() == LlmProviderConfig().model_dump()
 
 
 def _clean_optional_str(value: str | None) -> str:
@@ -125,6 +187,22 @@ def _local_provider_tiers(
     return rewritten
 
 
+@functools.cache
+def _shipped_tier_sets() -> tuple[dict[str, Any], ...]:
+    """Every tier table AgentOS itself writes, for exact-match "not custom" checks.
+
+    ``_openrouter_tiers`` / ``_bankr_tiers`` / ``_opencap_tiers`` are kept
+    alongside the profile-derived sets because the historical baked-in shapes
+    must keep matching even if a profile id is ever retired.
+    """
+    return (
+        _openrouter_tiers(),
+        _bankr_tiers(),
+        _opencap_tiers(),
+        *(_router_tier_profile_defaults(profile) for profile in ROUTER_TIER_PROFILE_IDS),
+    )
+
+
 def _tiers_are_machine_written_defaults(
     tiers: dict[str, Any],
     old_provider: str,
@@ -142,12 +220,7 @@ def _tiers_are_machine_written_defaults(
     Anything else is treated as a custom, operator-authored tier set and left
     untouched.
     """
-    if tiers in (
-        _openrouter_tiers(),
-        _bankr_tiers(),
-        _opencap_tiers(),
-        *(_router_tier_profile_defaults(profile) for profile in ROUTER_TIER_PROFILE_IDS),
-    ):
+    if tiers in _shipped_tier_sets():
         return True
     old_provider = str(old_provider or "").strip().lower()
     old_model = str(old_model or "").strip()
@@ -184,8 +257,13 @@ def _reconcile_router_profile_for_provider(
         # previous reconcile local-pinned, rewrite them to this provider+model so
         # the persisted config is self-consistent (the runtime degrade guard then
         # becomes a no-op).
+        # ``enabled`` is intentionally left alone: this function already
+        # returned above when the operator disabled the router, so forcing it
+        # true here would only ever be a no-op. What fixes a cloud→local switch
+        # is taking this branch at all — the old ``and not current_profile``
+        # guard sent a provider carrying a cloud tier profile down to the
+        # ``enabled = False`` branch below.
         router_payload = cfg.agentos_router.model_dump(mode="python")
-        router_payload["enabled"] = True
         router_payload["tier_profile"] = None
         if _tiers_are_machine_written_defaults(cfg.agentos_router.tiers, old_provider, old_model):
             router_payload["tiers"] = _local_provider_tiers(
@@ -371,8 +449,15 @@ def upsert_llm_provider(
         raise ValueError(
             f"provider {provider_id!r} is not runtime-supported and cannot be configured"
         )
-    saved_profile = config.provider_profiles.get(provider_id)
     active_provider = str(config.llm.provider or "").strip().lower()
+    # A saved profile is a *switch* fallback only. While a provider is active its
+    # own profile is one edit stale (it was written the last time we switched
+    # away from it), so consulting it here would revert the live model/base_url
+    # whenever an operator re-edits just one field — e.g. changing only the proxy
+    # in the setup UI.
+    saved_profile = (
+        config.provider_profiles.get(provider_id) if provider_id != active_provider else None
+    )
     model_clean = _clean_optional_str(model)
     if not model_clean and saved_profile is not None:
         model_clean = _clean_optional_str(saved_profile.model)
@@ -407,6 +492,15 @@ def upsert_llm_provider(
     ):
         effective_api_key = config.llm.api_key
     if spec.requires_api_key and not effective_api_key and not effective_api_key_env:
+        if saved_profile is not None:
+            # A saved profile restores model/base_url/proxy but deliberately
+            # never a literal key, so returning to a provider configured with
+            # one lands here. Say that, rather than "requires an api_key",
+            # which reads as "you never configured this provider".
+            raise ValueError(
+                f"provider {provider_id!r} has a saved profile but no stored credential; "
+                "re-enter the api_key (or set api_key_env so it survives a provider switch)"
+            )
         raise ValueError(f"provider {provider_id!r} requires an api_key")
     saved_base_url = (
         saved_profile.base_url
@@ -448,8 +542,8 @@ def upsert_llm_provider(
         for provider, profile in config.provider_profiles.items()
         if str(provider).strip()
     }
-    if old_provider and old_model:
-        provider_profiles[old_provider.strip().lower()] = ProviderProfileConfig(
+    if active_provider and old_model and not _llm_is_unconfigured_default(config):
+        provider_profiles[active_provider] = ProviderProfileConfig(
             model=old_model.strip(),
             api_key_env=str(config.llm.api_key_env or "").strip(),
             base_url=str(config.llm.base_url or "").strip(),
@@ -457,9 +551,19 @@ def upsert_llm_provider(
             max_tokens=config.llm.max_tokens,
             thinking=config.llm.thinking,
             provider_routing=dict(config.llm.provider_routing),
-            agentos_router=_provider_router_snapshot(config.agentos_router),
+            router=_provider_router_snapshot(
+                config.agentos_router,
+                provider_id=active_provider,
+                model=old_model.strip(),
+            ),
         )
-    restored_profile = provider_profiles.get(provider_id) if provider_id != old_provider else None
+    # Compare against the NORMALISED active provider: ``config.llm.provider`` is
+    # not normalised on load, so a hand-written ``provider = "OpenCap"`` would
+    # otherwise "restore" the snapshot just taken from that same provider and
+    # skip reconcile entirely.
+    restored_profile = (
+        provider_profiles.get(provider_id) if provider_id != active_provider else None
+    )
     new_cfg = _clone(config)
     new_cfg.provider_profiles = provider_profiles
     new_cfg.llm = LlmProviderConfig(
@@ -474,16 +578,20 @@ def upsert_llm_provider(
         provider_routing=effective_provider_routing,
     )
     if restored_profile is not None:
-        new_cfg.agentos_router = restored_profile.agentos_router.model_copy(deep=True)
-        reconcile_warnings: list[str] = []
-    else:
-        reconcile_warnings = _reconcile_router_profile_for_provider(
-            new_cfg,
-            provider_id,
-            model=model_clean,
-            old_provider=old_provider,
-            old_model=old_model,
+        new_cfg.agentos_router = _apply_provider_router_profile(
+            new_cfg.agentos_router, restored_profile.router
         )
+    # Reconcile ALWAYS runs, including after a restore. That is what re-derives
+    # machine-written tiers from the current shipped defaults, re-pins a local
+    # provider's tiers to the model the caller actually asked for, and keeps the
+    # judge target consistent with the new llm.provider.
+    reconcile_warnings = _reconcile_router_profile_for_provider(
+        new_cfg,
+        provider_id,
+        model=model_clean,
+        old_provider=old_provider,
+        old_model=old_model,
+    )
     if api_key:
         new_cfg.clear_runtime_secret("llm.api_key")
 

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
-from agentos.gateway.config import GatewayConfig
+from agentos.gateway.config import GatewayConfig, _router_tier_profile_defaults
 from agentos.gateway.llm_runtime import resolve_llm_runtime_config
 from agentos.onboarding.mutations import (
     MutationResult,
@@ -599,12 +601,12 @@ def test_ollama_opencap_ollama_switch_restores_provider_model_and_router_profile
     assert restored_ollama.provider_profiles["opencap"].api_key_env == "OPENCAP_API_KEY"
     assert restored_ollama.provider_profiles["opencap"].base_url == "https://opencap.example/v1"
     assert restored_ollama.provider_profiles["opencap"].proxy == "http://opencap-proxy.example:8080"
-    assert restored_ollama.provider_profiles["opencap"].provider_routing == {
-        "glm-5.2": "surplus"
-    }
-    assert restored_ollama.provider_profiles["opencap"].agentos_router.model_dump(
-        mode="python"
-    ) == opencap.agentos_router.model_dump(mode="python")
+    assert restored_ollama.provider_profiles["opencap"].provider_routing == {"glm-5.2": "surplus"}
+    opencap_saved = restored_ollama.provider_profiles["opencap"].router
+    assert opencap_saved.tier_profile == "opencap"
+    # opencap's tiers are the shipped profile defaults, so the profile stores
+    # nothing and they are re-derived on restore.
+    assert opencap_saved.tiers == {}
     assert (
         restored_ollama.to_toml_dict()["provider_profiles"]["ollama"]["model"]
         == configured_ollama_model
@@ -621,9 +623,7 @@ def test_ollama_opencap_ollama_switch_restores_provider_model_and_router_profile
     assert restored_ollama.agentos_router.tiers["image_model"]["model"] == "qwen2.5-vl:7b"
 
     reloaded = GatewayConfig(**tomllib.loads(tomli_w.dumps(restored_ollama.to_toml_dict())))
-    assert reloaded.provider_profiles["ollama"].agentos_router.tiers == (
-        ollama_router.agentos_router.tiers
-    )
+    assert reloaded.provider_profiles["ollama"].router.tiers == ollama_router.agentos_router.tiers
 
     restored_opencap = upsert_llm_provider(reloaded, provider_id="opencap").config
     assert restored_opencap.llm.model == opencap_model
@@ -665,7 +665,144 @@ def test_provider_switch_restores_smart_routing_settings_without_judge_secret():
     assert router.judge_model == "qwen3.5:2b"
     assert router.judge_base_url == "http://ollama.example:11434/v1"
     assert router.judge_provider is None
-    assert router.judge_api_key is None
+    # The judge target round-trips through the profile; the credential never
+    # does. It stays on the live config the whole time (a local-endpoint judge
+    # is provider-independent by design), so the restored judge still works.
+    for cfg in (opencap, restored):
+        for profile in cfg.provider_profiles.values():
+            assert "judge_api_key" not in profile.router.model_dump()
+        assert "sk-local-judge-secret" not in json.dumps(
+            cfg.to_toml_dict().get("provider_profiles", {}), default=str
+        )
+    assert router.judge_api_key == "sk-local-judge-secret"
+
+
+def test_provider_switch_keeps_global_router_tuning():
+    # pilot.safety_net_threshold is install-wide, not provider-scoped: retuning
+    # it while another provider is active must survive the switch back.
+    ollama = upsert_llm_provider(GatewayConfig(), provider_id="ollama", model="qwen3.5:9b").config
+    ollama = upsert_router(
+        ollama, mode="recommended", strategy="pilot-v1", safety_net_threshold=0.30
+    ).config
+    deepseek = upsert_llm_provider(
+        ollama, provider_id="deepseek", model="deepseek-chat", api_key_env="DEEPSEEK_API_KEY"
+    ).config
+    deepseek = upsert_router(
+        deepseek, mode="recommended", strategy="pilot-v1", safety_net_threshold=0.90
+    ).config
+
+    restored = upsert_llm_provider(deepseek, provider_id="ollama").config
+
+    assert restored.agentos_router.pilot.safety_net_threshold == 0.90
+
+
+def test_saved_profile_does_not_freeze_shipped_tier_models():
+    # A profile must not persist a machine-written tier table: a release that
+    # bumps the shipped model ids has to reach installs that switched away.
+    deepseek = upsert_llm_provider(
+        GatewayConfig(),
+        provider_id="deepseek",
+        model="deepseek-chat",
+        api_key_env="DEEPSEEK_API_KEY",
+    ).config
+    ollama = upsert_llm_provider(deepseek, provider_id="ollama", model="qwen3.5:9b").config
+
+    saved = ollama.provider_profiles["deepseek"].router
+    assert saved.tier_profile == "deepseek"
+    assert saved.tiers == {}
+    assert "tiers" not in ollama.to_toml_dict()["provider_profiles"]["deepseek"]["router"]
+
+    # Restoring re-derives them from the CURRENT shipped defaults.
+    back = upsert_llm_provider(ollama, provider_id="deepseek").config
+    assert back.agentos_router.tier_profile == "deepseek"
+    assert back.agentos_router.tiers == _router_tier_profile_defaults("deepseek")
+
+
+def test_restored_local_profile_repins_tiers_to_an_explicit_model():
+    # An explicitly requested model is authoritative: the restored router must
+    # not keep routing to the model the profile remembered.
+    ollama = upsert_llm_provider(GatewayConfig(), provider_id="ollama", model="qwen3.5:9b").config
+    deepseek = upsert_llm_provider(
+        ollama, provider_id="deepseek", model="deepseek-chat", api_key_env="DEEPSEEK_API_KEY"
+    ).config
+
+    back = upsert_llm_provider(deepseek, provider_id="ollama", model="llama4:70b").config
+
+    assert back.llm.model == "llama4:70b"
+    for tier in back.agentos_router.tiers.values():
+        assert tier["provider"] == "ollama"
+        assert tier["model"] == "llama4:70b"
+
+
+def test_re_editing_the_active_provider_keeps_live_values_over_its_stale_profile():
+    # While a provider is active its own profile is one edit behind (written the
+    # last time we switched away). Re-editing one field must not revert the rest.
+    cfg = upsert_llm_provider(
+        GatewayConfig(), provider_id="ollama", model="m1", base_url="http://a.example:11434"
+    ).config
+    cfg = upsert_llm_provider(
+        cfg, provider_id="deepseek", model="deepseek-chat", api_key_env="DEEPSEEK_API_KEY"
+    ).config
+    cfg = upsert_llm_provider(
+        cfg, provider_id="ollama", model="m2", base_url="http://b.example:11434"
+    ).config
+    assert cfg.provider_profiles["ollama"].model == "m1"
+
+    res = upsert_llm_provider(cfg, provider_id="ollama", proxy="http://p.example:8080")
+
+    assert res.config.llm.model == "m2"
+    assert res.config.llm.base_url == "http://b.example:11434"
+    assert res.config.llm.proxy == "http://p.example:8080"
+
+
+def test_first_provider_setup_does_not_snapshot_the_unconfigured_default():
+    # GatewayConfig() ships a provider/model pair nobody chose; snapshotting it
+    # would pin a fresh install to whatever model shipped on install day.
+    res = upsert_llm_provider(GatewayConfig(), provider_id="ollama", model="qwen3.5:9b")
+
+    assert res.config.provider_profiles == {}
+
+
+def test_provider_restore_normalizes_a_hand_written_provider_case():
+    # llm.provider is not normalised on load; comparing against the raw value
+    # would "restore" the snapshot just taken from the same provider and skip
+    # reconcile entirely, leaving the router on another provider's models.
+    cfg = GatewayConfig(
+        llm={"provider": "OpenCap", "model": "glm-5.2", "api_key_env": "OPENCAP_API_KEY"}
+    )
+
+    res = upsert_llm_provider(cfg, provider_id="opencap", model="glm-5.3-new")
+
+    assert res.config.llm.model == "glm-5.3-new"
+    assert res.config.agentos_router.tier_profile == "opencap"
+    assert res.config.agentos_router.tiers == _router_tier_profile_defaults("opencap")
+
+
+def test_returning_to_a_literal_key_provider_names_the_missing_credential():
+    cfg = upsert_llm_provider(
+        GatewayConfig(),
+        provider_id="deepseek",
+        model="deepseek-chat",
+        api_key="sk-literal-secret",
+    ).config
+    cfg = upsert_llm_provider(cfg, provider_id="ollama", model="qwen3.5:9b").config
+
+    with pytest.raises(ValueError, match="saved profile but no stored credential"):
+        upsert_llm_provider(cfg, provider_id="deepseek")
+
+
+def test_unparseable_saved_profile_is_dropped_instead_of_blocking_boot():
+    cfg = GatewayConfig(
+        provider_profiles={
+            "ollama": {"model": "qwen3.5:9b"},
+            "deepseek": {"model": [], "router": "not-a-table"},
+            "": {"model": "orphan"},
+        }
+    )
+
+    assert set(cfg.provider_profiles) == {"ollama"}
+    assert cfg.provider_profiles["ollama"].model == "qwen3.5:9b"
+    assert cfg.provider_profiles["ollama"].router.tiers == {}
 
 
 def test_upsert_router_recommended_writes_profile_without_expanded_tiers():


### PR DESCRIPTION
## What

Review follow-up on #239, which landed provider-switch profiles. The restore
works; what it *persisted* was too broad in one direction and too literal in
another. This narrows the snapshot and fixes six behaviours around it.

## Too broad: the snapshot was the whole router config

A profile stored the entire `AgentOSRouterConfig`, but most of that model is
install-wide behaviour. Retuning any of it while another provider was active
was silently reverted by the next switch:

```
on ollama,  pilot.safety_net_threshold = 0.30
retune on deepseek                     = 0.90
switch back to ollama                  = 0.30   <- gone
```

Same for `strategy`, `default_tier`, `rollout_phase`, `auto_thinking`,
`judge_short_circuit_*`, `judge_timeout_seconds`, `require_router_runtime`,
`kv_cache_anti_downgrade_enabled`, `complaint_upgrade_enabled`.

The snapshot is now a `ProviderRouterProfileConfig` holding only what a
provider genuinely owns — `enabled`, `tier_profile`, operator-authored
`tiers`, and the judge target. Everything else is carried through untouched.

## Too literal: profiles froze shipped tier tables

`to_toml_dict` already elides `agentos_router.tiers` when they match
`_router_tier_profile_defaults(tier_profile)`, precisely so a release that
bumps the shipped model ids reaches installs that already have a
`config.toml`. Profiles went around it:

```
live router on deepseek -> 'tiers' written?: False
saved deepseek profile  -> 'tiers' written?: True
  frozen: c0/c1 deepseek-v4-flash, c2/c3 deepseek-v4-pro
```

So the next model-id bump would be undone for anyone who had switched
providers. Machine-written tiers are no longer stored — they are re-derived
from the current shipped defaults on restore, or re-pinned for a local
provider. Operator-authored tiers are still stored verbatim.

## Also fixed

- **Reconcile now always runs, including after a restore.** It used to be
  short-circuited, so an explicitly requested model landed in `llm.model`
  while a local provider's tiers kept routing to the remembered one
  (`model="llama4:70b"` → every tier still `qwen3.5:9b`), and any reconcile
  warning was dropped on the floor.
- **The restore lookup compared against a non-normalised `llm.provider`.**
  `GatewayConfig` doesn't normalise it, so a hand-written
  `provider = "OpenCap"` made a same-provider edit look like a switch: it
  restored the snapshot just taken and skipped reconcile entirely, leaving
  `tier_profile` unset and the tiers on another provider's models.
- **A saved profile is a switch fallback only.** While a provider is active
  its own profile is one edit stale (written the last time we switched away
  from it), so re-editing a single field — changing just the proxy in the
  setup UI — reverted the live model and `base_url`.
- **No profile is written for the never-configured default provider.**
  `GatewayConfig()` ships a provider/model pair nobody chose, and the
  first-ever setup snapshotted it as real, pinning a fresh install to
  whatever model shipped on install day.
- **Better error returning to a literal-`api_key` provider.** Profiles never
  store a literal key, so the return trip failed with
  `provider 'deepseek' requires an api_key` — which reads as "you never
  configured this". It now says the profile has no stored credential and
  points at `api_key_env`.
- **Malformed saved profiles are dropped on load.** This is machine-written
  state in a file operators hand-edit; `model` and `agentos_router` were
  required, so a half-written profile made the gateway refuse to start. A bad
  profile now costs a remembered preference, never startup.
- **Dropped a dead `enabled = True`** in the local reconcile branch — the
  function already returns early when the operator disabled the router, so it
  could only ever be a no-op. What fixes a cloud→local switch is taking that
  branch at all (dropping `and not current_profile`), which #239 got right.

## Tests

Nine regression tests, one per behaviour above, plus the two tests from #239
updated to the narrowed contract. The judge-secret test now asserts the
stronger invariant: the credential never enters a profile or `config.toml`,
and — unlike before — the restored local judge still works, because wiping
`judge_api_key` was a side effect of replacing the whole router config.

## Validation

- `python scripts/build_control_ui.py build`
- `npm --prefix frontend run check` — 1675 passed
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes` — 591 files
- `uv run pytest tests -q` — 7334 passed, 27 skipped
- `uv build --wheel`

Refs #189, #188. Follow-up to #239 (thanks @thanhtan1105).
