### PR TITLE
feat(webui): one keyboard shortcut registry with a discoverable ? overlay

### DIFF
--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { routeChildren, VIEWS } from './routes'
 import { AppProviders } from './providers'
 import { AppShell, SIDEBAR_COLLAPSED_STORAGE_KEY } from './AppShell'
+import { KeyboardShortcutProvider } from '@/components/KeyboardShortcuts'
 import { useConnection } from '@/stores/connection'
 import { useApprovals } from '@/services/approval-monitor'
 import type { Bootstrap } from '@/lib/bootstrap'
@@ -650,5 +651,46 @@ describe('AppProviders effect cleanup', () => {
       </AppProviders>,
     )
     expect(() => second.unmount()).not.toThrow()
+  })
+})
+
+// #137 — the cheat-sheet has to be reachable without a keyboard. '?' is
+// deliberately inert while focus is in an editable field (the chat composer
+// autofocuses on desktop), and touch devices have no keyboard at all, so the
+// shell carries a visible entry point.
+describe('keyboard shortcuts entry point', () => {
+  function renderShellAt(path: string) {
+    const router = createMemoryRouter([{ element: <AppShell />, children: routeChildren }], {
+      initialEntries: [path],
+    })
+    return render(
+      <QueryClientProvider client={new QueryClient()}>
+        <KeyboardShortcutProvider>
+          <RouterProvider router={router} />
+        </KeyboardShortcutProvider>
+      </QueryClientProvider>,
+    )
+  }
+
+  it('opens the shortcut overlay from the sidebar', async () => {
+    renderShellAt('/overview')
+    const button = screen.getByRole('button', { name: 'Keyboard shortcuts' })
+    expect(button).toHaveAttribute('title', expect.stringContaining('?'))
+
+    fireEvent.click(button)
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Show this list')).toBeInTheDocument()
+  })
+
+  it('renders nothing rather than a dead button when no registry is mounted', () => {
+    const router = createMemoryRouter([{ element: <AppShell />, children: routeChildren }], {
+      initialEntries: ['/overview'],
+    })
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    )
+    expect(screen.queryByRole('button', { name: 'Keyboard shortcuts' })).toBeNull()
   })
 })

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -22,6 +22,7 @@ import {
   Moon,
   Network,
   KeyRound,
+  Keyboard,
   Puzzle,
   Radio,
   ScrollText,
@@ -34,6 +35,12 @@ import {
 import { Toaster } from '@/components/ui/sonner'
 import { Button } from '@/components/ui/button'
 import { AsciiField } from '@/components/AsciiField'
+import {
+  formatCombo,
+  HELP_COMBO,
+  useKeyboardShortcut,
+  useShortcutOverlay,
+} from '@/components/KeyboardShortcuts'
 import { useTheme } from '@/stores/theme'
 import { useConnection } from '@/stores/connection'
 import { useApprovals } from '@/services/approval-monitor'
@@ -137,6 +144,20 @@ export function AppShell() {
   const hasPendingApprovals = useApprovals((s) => s.pending.length > 0)
   const bootstrap = useBootstrap()
   const location = useLocation()
+  const shortcutOverlay = useShortcutOverlay()
+
+  // Documented, not dispatched: the drawer binds Escape itself (below) because
+  // it has to run while focus is inside the drawer, which the global editable
+  // guard would otherwise skip.
+  useKeyboardShortcut(
+    {
+      combo: 'escape',
+      description: 'Close the navigation drawer (mobile)',
+      category: 'Global',
+      documentationOnly: true,
+    },
+    () => {},
+  )
 
   // app.js:119-171 — mobile sidebar drawer: hamburger toggle, close on
   // nav-click / outside-click / Escape, aria-expanded + aria-hidden/inert sync.
@@ -454,6 +475,23 @@ export function AppShell() {
             </span>
             {version ? <span className="shell-sidebar__version ml-auto">v{version}</span> : null}
           </div>
+          {/* #137: the overlay needs a way in that is not a keyboard shortcut.
+              '?' is deliberately inert while focus sits in the composer (which
+              autofocuses on desktop) and on touch devices there is no keyboard
+              at all, so a discoverability feature reachable only by key would
+              not be discoverable. */}
+          {shortcutOverlay.available ? (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="shell-sidebar__shortcuts"
+              onClick={shortcutOverlay.open}
+              title={`Keyboard shortcuts (${formatCombo(HELP_COMBO)})`}
+              aria-label="Keyboard shortcuts"
+            >
+              <Keyboard className="size-4" />
+            </Button>
+          ) : null}
           <Button
             variant="ghost"
             size="icon-sm"

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { useConnection } from '@/stores/connection'
 import { initTheme } from '@/stores/theme'
 import { approvalMonitor } from '@/services/approval-monitor'
 import type { RpcState } from '@/lib/ws-rpc'
+import { KeyboardShortcutProvider } from '@/components/KeyboardShortcuts'
 
 const WS_URL_KEY = 'agentos.wsUrl'
 const WS_TOKEN_KEY = 'agentos.wsToken'
@@ -89,7 +90,9 @@ export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <BootstrapContext.Provider value={bootstrap}>
       <RpcContext.Provider value={rpc}>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        <QueryClientProvider client={queryClient}>
+          <KeyboardShortcutProvider>{children}</KeyboardShortcutProvider>
+        </QueryClientProvider>
       </RpcContext.Provider>
     </BootstrapContext.Provider>
   )

--- a/frontend/src/components/KeyboardShortcuts.css
+++ b/frontend/src/components/KeyboardShortcuts.css
@@ -1,0 +1,126 @@
+@layer components {
+  /* The shortcut cheat-sheet is a route-owned dialog, so it sits on the same
+     layer as the agents / sessions / skills / env dialogs (60) — NOT on
+     --z-critical-approval, which is reserved for the blocking approval prompt
+     and must stay above everything, this sheet included. */
+  .shortcut-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: color-mix(in srgb, var(--background) 72%, transparent);
+    backdrop-filter: blur(2px);
+  }
+
+  .shortcut-sheet {
+    width: 100%;
+    max-width: 520px;
+    max-height: calc(100dvh - 48px);
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+  }
+
+  .shortcut-sheet__head {
+    flex: none;
+  }
+
+  .shortcut-sheet__title {
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+  }
+
+  .shortcut-sheet__close {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--dim);
+    cursor: pointer;
+    transition:
+      color 150ms ease,
+      background-color 150ms ease;
+  }
+
+  .shortcut-sheet__close:hover {
+    color: var(--foreground);
+    background: var(--elevated);
+  }
+
+  .shortcut-sheet__body {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    overflow-y: auto;
+  }
+
+  .shortcut-sheet__group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .shortcut-sheet__group-title {
+    margin-bottom: 6px;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--dim);
+  }
+
+  .shortcut-sheet__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 6px 0;
+  }
+
+  .shortcut-sheet__row + .shortcut-sheet__row {
+    border-top: 1px solid var(--hairline);
+  }
+
+  .shortcut-sheet__desc {
+    min-width: 0;
+    font-size: 0.8125rem;
+    color: var(--foreground);
+  }
+
+  .shortcut-sheet__keys {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    gap: 3px;
+  }
+
+  .shortcut-sheet__kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    border: 1px solid var(--hairline);
+    border-radius: var(--radius-sm);
+    background: var(--elevated);
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 650;
+    color: var(--foreground);
+  }
+
+  .shortcut-sheet__plus {
+    font-size: 0.6875rem;
+    color: var(--dim);
+  }
+}

--- a/frontend/src/components/KeyboardShortcuts.test.tsx
+++ b/frontend/src/components/KeyboardShortcuts.test.tsx
@@ -1,0 +1,297 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ModalShell } from './ModalShell'
+import {
+  comboParts,
+  eventCombos,
+  formatCombo,
+  KeyboardShortcutProvider,
+  useKeyboardShortcut,
+  useShortcutDocs,
+  useShortcutOverlay,
+} from './KeyboardShortcuts'
+
+function setPlatform(value: string) {
+  Object.defineProperty(navigator, 'userAgent', { value, configurable: true })
+  Object.defineProperty(navigator, 'platform', { value, configurable: true })
+}
+
+const ORIGINAL_UA = navigator.userAgent
+const ORIGINAL_PLATFORM = navigator.platform
+
+afterEach(() => {
+  setPlatform(ORIGINAL_PLATFORM || ORIGINAL_UA)
+})
+
+function press(target: Element | Document, init: KeyboardEventInit) {
+  return fireEvent.keyDown(target, { bubbles: true, ...init })
+}
+
+describe('combo labels', () => {
+  it('renders the platform the viewer is actually on', () => {
+    setPlatform('Windows NT 10.0')
+    expect(formatCombo('mod+shift+o')).toBe('Ctrl+Shift+O')
+    expect(formatCombo('alt+arrowup')).toBe('Alt+↑')
+    expect(formatCombo('escape')).toBe('Esc')
+
+    setPlatform('MacIntel')
+    expect(formatCombo('mod+shift+o')).toBe('⌘⇧O')
+    expect(formatCombo('alt+arrowup')).toBe('⌥↑')
+    expect(formatCombo('escape')).toBe('Esc')
+  })
+
+  it('exposes the same labels as caps, so the overlay and call sites cannot drift', () => {
+    setPlatform('MacIntel')
+    expect(comboParts('mod+shift+o')).toEqual(['⌘', '⇧', 'O'])
+    expect(formatCombo('mod+shift+o')).toBe(comboParts('mod+shift+o').join(''))
+  })
+})
+
+describe('event → combo', () => {
+  it('treats shift as a modifier for letters but as part of a symbol', () => {
+    expect(
+      eventCombos({ key: 'O', code: 'KeyO', ctrlKey: true, shiftKey: true } as never),
+    ).toContain('mod+shift+o')
+    // '?' is Shift+/ — nobody calls it "shift question mark".
+    expect(eventCombos({ key: '?', code: 'Slash', shiftKey: true } as never)).toContain('?')
+  })
+
+  it('offers the physical key as well, so layouts that remap it still match', () => {
+    // Physical KeyO on a layout where it does not produce "o". The pre-registry
+    // handler matched on e.code for exactly this reason.
+    const combos = eventCombos({
+      key: 'R',
+      code: 'KeyO',
+      ctrlKey: true,
+      shiftKey: true,
+    } as never)
+    expect(combos).toContain('mod+shift+o')
+    expect(combos).toContain('mod+shift+r')
+  })
+
+  it('ignores a bare modifier press', () => {
+    expect(eventCombos({ key: 'Shift', code: 'ShiftLeft', shiftKey: true } as never)).toEqual([])
+  })
+})
+
+function Harness({ onFire = () => {} }: { onFire?: (name: string) => void }) {
+  useKeyboardShortcut(
+    {
+      combo: 'mod+shift+o',
+      description: 'Start a new chat',
+      category: 'Chat',
+      allowInInputs: true,
+    },
+    (e) => {
+      e.preventDefault()
+      onFire('new-chat')
+    },
+  )
+  useKeyboardShortcut(
+    { combo: 'escape', description: 'Abort the streaming turn', category: 'Chat' },
+    (e) => {
+      e.preventDefault()
+      onFire('escape')
+    },
+  )
+  useShortcutDocs('Composer', [{ combo: 'enter', description: 'Send the message' }])
+  return <textarea data-testid="composer" />
+}
+
+describe('dispatch guards', () => {
+  it('fires a document shortcut and respects allowInInputs', () => {
+    const fired: string[] = []
+    render(
+      <KeyboardShortcutProvider>
+        <Harness onFire={(n) => fired.push(n)} />
+      </KeyboardShortcutProvider>,
+    )
+    const composer = screen.getByTestId('composer')
+
+    press(document, { key: 'O', code: 'KeyO', ctrlKey: true, shiftKey: true })
+    expect(fired).toEqual(['new-chat'])
+
+    // New chat opts into editable targets; Escape does not, because the
+    // composer runs its own Escape chain.
+    press(composer, { key: 'O', code: 'KeyO', ctrlKey: true, shiftKey: true })
+    press(composer, { key: 'Escape', code: 'Escape' })
+    expect(fired).toEqual(['new-chat', 'new-chat'])
+
+    press(document, { key: 'Escape', code: 'Escape' })
+    expect(fired).toEqual(['new-chat', 'new-chat', 'escape'])
+  })
+
+  it('never dispatches a documentation-only entry', () => {
+    const fired: string[] = []
+    render(
+      <KeyboardShortcutProvider>
+        <Harness onFire={(n) => fired.push(n)} />
+      </KeyboardShortcutProvider>,
+    )
+    press(document, { key: 'Enter', code: 'Enter' })
+    expect(fired).toEqual([])
+  })
+
+  it('stands down while an overlay layer is mounted', async () => {
+    const fired: string[] = []
+    function WithDialog() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <Harness onFire={(n) => fired.push(n)} />
+          <button type="button" onClick={() => setOpen(true)}>
+            open dialog
+          </button>
+          {open ? (
+            <ModalShell
+              role="dialog"
+              labelledBy="t"
+              onClose={() => setOpen(false)}
+              overlayClassName="x"
+            >
+              <h2 id="t">A dialog</h2>
+            </ModalShell>
+          ) : null}
+        </>
+      )
+    }
+    render(
+      <KeyboardShortcutProvider>
+        <WithDialog />
+      </KeyboardShortcutProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'open dialog' }))
+    await screen.findByText('A dialog')
+
+    press(document, { key: 'O', code: 'KeyO', ctrlKey: true, shiftKey: true })
+    expect(fired).toEqual([])
+  })
+})
+
+describe('the ? overlay', () => {
+  function renderOverlayHarness() {
+    function Chrome() {
+      const overlay = useShortcutOverlay()
+      return (
+        <>
+          <Harness />
+          <button type="button" onClick={overlay.open}>
+            Keyboard shortcuts
+          </button>
+        </>
+      )
+    }
+    return render(
+      <KeyboardShortcutProvider>
+        <Chrome />
+      </KeyboardShortcutProvider>,
+    )
+  }
+
+  it('toggles in both directions from "?"', async () => {
+    renderOverlayHarness()
+    press(document, { key: '?', code: 'Slash', shiftKey: true })
+    await screen.findByText('Keyboard shortcuts', { selector: 'h2' })
+
+    // The overlay is itself a layer, so closing has to be handled before the
+    // open-guard — this is the case that silently regressed once already.
+    press(document, { key: '?', code: 'Slash', shiftKey: true })
+    await waitFor(() =>
+      expect(screen.queryByText('Keyboard shortcuts', { selector: 'h2' })).toBeNull(),
+    )
+  })
+
+  it('opens from the UI even when focus is in the composer', async () => {
+    renderOverlayHarness()
+    const composer = screen.getByTestId('composer')
+    composer.focus()
+
+    // '?' is deliberately inert here — the composer autofocuses on desktop, so
+    // this is the state a first-time operator is actually in.
+    press(composer, { key: '?', code: 'Slash', shiftKey: true })
+    expect(screen.queryByText('Keyboard shortcuts', { selector: 'h2' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keyboard shortcuts' }))
+    expect(await screen.findByText('Keyboard shortcuts', { selector: 'h2' })).toBeInTheDocument()
+  })
+
+  it('does not open on top of a dialog that is already up', async () => {
+    function WithDialog() {
+      const [open, setOpen] = useState(true)
+      return (
+        <ModalShell
+          role="dialog"
+          labelledBy="t"
+          onClose={() => setOpen(!open)}
+          overlayClassName="x"
+        >
+          <h2 id="t">A dialog</h2>
+        </ModalShell>
+      )
+    }
+    render(
+      <KeyboardShortcutProvider>
+        <WithDialog />
+      </KeyboardShortcutProvider>,
+    )
+    await screen.findByText('A dialog')
+    press(document, { key: '?', code: 'Slash', shiftKey: true })
+    expect(screen.queryByText('Keyboard shortcuts', { selector: 'h2' })).toBeNull()
+  })
+
+  it('lists every registered key, grouped, with platform-aware caps', async () => {
+    setPlatform('Windows NT 10.0')
+    renderOverlayHarness()
+    press(document, { key: '?', code: 'Slash', shiftKey: true })
+    await screen.findByText('Keyboard shortcuts', { selector: 'h2' })
+
+    const rows = Array.from(document.querySelectorAll('.shortcut-sheet__row')).map(
+      (row) => row.textContent,
+    )
+    expect(rows).toEqual([
+      'Show this list?',
+      'Start a new chatCtrl+Shift+O',
+      'Abort the streaming turnEsc',
+      'Send the messageEnter',
+    ])
+    const groups = Array.from(document.querySelectorAll('.shortcut-sheet__group-title')).map(
+      (el) => el.textContent,
+    )
+    expect(groups).toEqual(['Global', 'Chat', 'Composer'])
+  })
+
+  it('drops a shortcut from the list when its owner unmounts', async () => {
+    function Toggling() {
+      const [mounted, setMounted] = useState(true)
+      return (
+        <>
+          {mounted ? <Harness /> : null}
+          <button type="button" onClick={() => setMounted(false)}>
+            unmount
+          </button>
+        </>
+      )
+    }
+    render(
+      <KeyboardShortcutProvider>
+        <Toggling />
+      </KeyboardShortcutProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'unmount' }))
+    press(document, { key: '?', code: 'Slash', shiftKey: true })
+    await screen.findByText('Keyboard shortcuts', { selector: 'h2' })
+
+    expect(screen.queryByText('Start a new chat')).toBeNull()
+    expect(screen.getByText('Show this list')).toBeInTheDocument()
+  })
+})
+
+describe('outside a provider', () => {
+  it('renders without a registry rather than throwing', () => {
+    // Views are rendered bare in their own unit tests; a missing cheat-sheet
+    // must not take them down.
+    expect(() => render(<Harness />)).not.toThrow()
+  })
+})

--- a/frontend/src/components/KeyboardShortcuts.tsx
+++ b/frontend/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,256 @@
+// The one place that knows what keys the console binds (#137).
+//
+// Before this, key handling was ad-hoc `keydown` listeners in ChatPage,
+// Composer, SlashMenu, SessionChip and AppShell. Nothing could enumerate them,
+// so nothing could document them, and each new one re-litigated the same
+// overlay / editable-target guards.
+//
+// Shape:
+//   - components register a `ShortcutSpec` via `useKeyboardShortcut`;
+//   - the provider owns the single document listener and both guards;
+//   - the `?` overlay (loaded lazily, `ShortcutOverlay.tsx`) renders whatever is
+//     registered, with platform-aware caps from `comboParts` — the only place
+//     that maps a combo to a label;
+//   - keys whose behaviour is bound to an element rather than the document
+//     (composer, slash menu, session switcher) register `documentationOnly`, so
+//     the overlay stays honest without moving the handler.
+import React, {
+  createContext,
+  lazy,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { overlayDepth } from '@/components/overlay-layer'
+import {
+  eventCombos,
+  HELP_COMBO,
+  type RegisteredShortcut,
+  type ShortcutSpec,
+} from './shortcut-combo'
+
+export {
+  comboParts,
+  eventCombos,
+  formatCombo,
+  HELP_COMBO,
+  isMac,
+  type ShortcutSpec,
+} from './shortcut-combo'
+
+const ShortcutOverlay = lazy(() => import('./ShortcutOverlay'))
+
+type RegisterFn = (
+  id: string,
+  spec: ShortcutSpec,
+  handler: (e: KeyboardEvent) => void,
+) => () => void
+
+// Two contexts, so registering a shortcut does not re-render every other
+// registrant: `register` is stable for the life of the provider, while the list
+// changes as components mount.
+const RegisterContext = createContext<RegisterFn | null>(null)
+const HelpContext = createContext<{
+  isHelpOpen: boolean
+  setHelpOpen: (open: boolean) => void
+} | null>(null)
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  if (!el) return false
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable === true
+}
+
+export function KeyboardShortcutProvider({ children }: { children: React.ReactNode }) {
+  const [shortcuts, setShortcuts] = useState<RegisteredShortcut[]>([])
+  const [isHelpOpen, setHelpOpenState] = useState(false)
+  // Keep the sheet's chunk mounted after the first open so its exit animation
+  // can play; before that, nothing of it is downloaded at all.
+  const [overlayLoaded, setOverlayLoaded] = useState(false)
+
+  const setHelpOpen = useCallback((open: boolean) => {
+    if (open) setOverlayLoaded(true)
+    setHelpOpenState(open)
+  }, [])
+
+  // The document listener binds once; it reads the live registry and the live
+  // overlay state through refs so it never has to be torn down and re-bound.
+  const shortcutsRef = useRef<RegisteredShortcut[]>([])
+  const helpOpenRef = useRef(false)
+  useEffect(() => {
+    shortcutsRef.current = shortcuts
+  }, [shortcuts])
+  useEffect(() => {
+    helpOpenRef.current = isHelpOpen
+  }, [isHelpOpen])
+
+  const register = useCallback<RegisterFn>((id, spec, handler) => {
+    setShortcuts((prev) => [...prev, { id, spec, handler }])
+    return () => setShortcuts((prev) => prev.filter((item) => item.id !== id))
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return
+      const combos = eventCombos(e)
+      if (combos.length === 0) return
+
+      const editable = isEditableTarget(e.target)
+      const overlaid = overlayDepth() > 0
+
+      // The sheet owns '?' in both directions. Closing has to be checked first:
+      // the sheet is itself a layer, so the open-guard below can never be true
+      // while it is up.
+      if (combos.includes(HELP_COMBO)) {
+        if (helpOpenRef.current) {
+          e.preventDefault()
+          setHelpOpen(false)
+          return
+        }
+        if (!editable && !overlaid) {
+          e.preventDefault()
+          setHelpOpen(true)
+          return
+        }
+      }
+
+      const matches = shortcutsRef.current.filter(
+        (item) => !item.spec.documentationOnly && combos.includes(item.spec.combo),
+      )
+      // Most-recently registered first, so a later mount can claim a key the
+      // page below it also binds.
+      for (let i = matches.length - 1; i >= 0; i -= 1) {
+        const match = matches[i]!
+        if (overlaid && !match.spec.allowWithOverlays) continue
+        if (editable && !match.spec.allowInInputs) continue
+        match.handler(e)
+        if (e.defaultPrevented) break
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [setHelpOpen])
+
+  const help = useMemo(() => ({ isHelpOpen, setHelpOpen }), [isHelpOpen, setHelpOpen])
+  const closeHelp = useCallback(() => setHelpOpen(false), [setHelpOpen])
+
+  return (
+    <RegisterContext.Provider value={register}>
+      <HelpContext.Provider value={help}>
+        {children}
+        {overlayLoaded ? (
+          <Suspense fallback={null}>
+            <ShortcutOverlay open={isHelpOpen} shortcuts={shortcuts} onClose={closeHelp} />
+          </Suspense>
+        ) : null}
+      </HelpContext.Provider>
+    </RegisterContext.Provider>
+  )
+}
+
+/**
+ * Register a shortcut for as long as the component is mounted.
+ *
+ * Outside a provider this is a no-op rather than a throw: views are rendered
+ * bare in unit tests, and a missing cheat-sheet must not break them.
+ */
+export function useKeyboardShortcut(spec: ShortcutSpec, handler: (e: KeyboardEvent) => void): void {
+  const register = useContext(RegisterContext)
+  const id = useId()
+
+  // The handler is re-created on most renders; keep the registration stable and
+  // read the latest through a ref, so the registry churns only on mount.
+  const handlerRef = useRef(handler)
+  useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  const { combo, description, category, allowInInputs, allowWithOverlays, documentationOnly } = spec
+
+  useEffect(() => {
+    if (!register) return
+    return register(
+      id,
+      { combo, description, category, allowInInputs, allowWithOverlays, documentationOnly },
+      (e) => handlerRef.current(e),
+    )
+  }, [
+    register,
+    id,
+    combo,
+    description,
+    category,
+    allowInInputs,
+    allowWithOverlays,
+    documentationOnly,
+  ])
+}
+
+const NOOP = () => {}
+
+/**
+ * Register a fixed list of documentation-only entries in one effect.
+ *
+ * For UI that binds its keys to its own element — the composer, the slash menu,
+ * the session switcher — where the handler cannot move to the document but the
+ * overlay should still report the key.
+ *
+ * Keyed on the entries' *content*, not their identity: registering re-renders
+ * the caller, so depending on the array reference would make an inline literal
+ * re-register forever.
+ */
+export function useShortcutDocs(
+  category: string,
+  entries: ReadonlyArray<{ combo: string; description: string }>,
+): void {
+  const register = useContext(RegisterContext)
+  const id = useId()
+
+  const signature = entries.map((entry) => `${entry.combo} ${entry.description}`).join('')
+  const entriesRef = useRef(entries)
+  // Effects run in declaration order within a commit, so this lands before
+  // the registration below reads it.
+  useEffect(() => {
+    entriesRef.current = entries
+  })
+
+  useEffect(() => {
+    if (!register) return
+    const unregister = entriesRef.current.map((entry, index) =>
+      register(
+        `${id}-${index}`,
+        {
+          combo: entry.combo,
+          description: entry.description,
+          category,
+          documentationOnly: true,
+        },
+        NOOP,
+      ),
+    )
+    return () => unregister.forEach((fn) => fn())
+  }, [register, id, category, signature])
+}
+
+/**
+ * Open/close the sheet from the UI. `available` is false outside a provider, so
+ * chrome can hide its affordance instead of offering a dead button.
+ */
+export function useShortcutOverlay(): {
+  available: boolean
+  isOpen: boolean
+  open: () => void
+  close: () => void
+} {
+  const ctx = useContext(HelpContext)
+  const setHelpOpen = ctx?.setHelpOpen
+  const open = useCallback(() => setHelpOpen?.(true), [setHelpOpen])
+  const close = useCallback(() => setHelpOpen?.(false), [setHelpOpen])
+  return { available: ctx != null, isOpen: ctx?.isHelpOpen ?? false, open, close }
+}

--- a/frontend/src/components/ModalShell.tsx
+++ b/frontend/src/components/ModalShell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, useReducedMotion } from 'motion/react'
 import { SUBTLE_SPRING, overlayVariants, panelVariants } from '@/lib/motion'
+import { useOverlayLayer } from '@/components/overlay-layer'
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -54,6 +55,11 @@ export function ModalShell({
 }) {
   const panelRef = useRef<HTMLDivElement>(null)
   const reduce = useReducedMotion()
+
+  // Every tokenised dialog goes through this shell, so registering here is what
+  // lets document-level key handlers ask "is a dialog up?" without maintaining
+  // a selector list of every dialog in the app.
+  useOverlayLayer()
 
   useEffect(() => {
     const previousFocus =

--- a/frontend/src/components/ShortcutOverlay.tsx
+++ b/frontend/src/components/ShortcutOverlay.tsx
@@ -1,0 +1,81 @@
+// The `?` cheat-sheet (#137).
+//
+// Split from the registry and loaded lazily: it is the only part that needs
+// ModalShell and `motion`, and the registry provider mounts at app boot. Pulling
+// those into the eager tree moved the whole animation runtime into the initial
+// bundle (+44 KiB gzip) for a panel most sessions never open.
+import { Fragment } from 'react'
+import { AnimatePresence } from 'motion/react'
+import { X } from 'lucide-react'
+import { ModalShell } from '@/components/ModalShell'
+import { comboParts, groupByCategory, isMac, type RegisteredShortcut } from './shortcut-combo'
+import './KeyboardShortcuts.css'
+
+/**
+ * Stays mounted once the sheet has been opened, so `AnimatePresence` can play
+ * the exit as well as the enter.
+ */
+export default function ShortcutOverlay({
+  open,
+  shortcuts,
+  onClose,
+}: {
+  open: boolean
+  shortcuts: RegisteredShortcut[]
+  onClose: () => void
+}) {
+  return (
+    <AnimatePresence>
+      {open ? <Sheet shortcuts={shortcuts} onClose={onClose} /> : null}
+    </AnimatePresence>
+  )
+}
+
+function Sheet({ shortcuts, onClose }: { shortcuts: RegisteredShortcut[]; onClose: () => void }) {
+  const groups = groupByCategory(shortcuts)
+  const mac = isMac()
+
+  return (
+    <ModalShell
+      role="dialog"
+      labelledBy="shortcut-overlay-title"
+      onClose={onClose}
+      overlayClassName="shortcut-overlay"
+      className="shortcut-sheet panel"
+    >
+      <div className="panel__head shortcut-sheet__head">
+        <h2 id="shortcut-overlay-title" className="shortcut-sheet__title">
+          Keyboard shortcuts
+        </h2>
+        <button
+          type="button"
+          className="shortcut-sheet__close"
+          onClick={onClose}
+          aria-label="Close dialog"
+        >
+          <X size={18} />
+        </button>
+      </div>
+      <div className="panel__body shortcut-sheet__body">
+        {groups.map(([category, items]) => (
+          <section key={category} className="shortcut-sheet__group">
+            <h3 className="shortcut-sheet__group-title">{category}</h3>
+            {items.map((item) => (
+              <div key={item.id} className="shortcut-sheet__row">
+                <span className="shortcut-sheet__desc">{item.spec.description}</span>
+                <span className="shortcut-sheet__keys">
+                  {comboParts(item.spec.combo).map((part, idx) => (
+                    <Fragment key={`${item.id}-${idx}`}>
+                      {idx > 0 && !mac ? <span className="shortcut-sheet__plus">+</span> : null}
+                      <kbd className="shortcut-sheet__kbd">{part}</kbd>
+                    </Fragment>
+                  ))}
+                </span>
+              </div>
+            ))}
+          </section>
+        ))}
+      </div>
+    </ModalShell>
+  )
+}

--- a/frontend/src/components/keyboard-shortcuts-css.test.ts
+++ b/frontend/src/components/keyboard-shortcuts-css.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const sheetCss = readFileSync('src/components/KeyboardShortcuts.css', 'utf8')
+const promptCss = readFileSync('src/components/ApprovalPrompt.css', 'utf8')
+
+describe('shortcut overlay CSS contract', () => {
+  it('stays on the route-dialog layer, below the blocking approval prompt', () => {
+    // The approval prompt is the one surface that must never be covered; it
+    // owns --z-critical-approval alone (see approval-prompt-css.test.ts). A
+    // cheat-sheet that borrowed that token would paint over a pending approval,
+    // because it portals into <body> later.
+    expect(promptCss).toMatch(/\.approval-backdrop \{[\s\S]*?z-index: var\(--z-critical-approval\)/)
+    expect(sheetCss).not.toMatch(/z-index:\s*var\(--z-critical-approval\)/)
+    expect(sheetCss).toMatch(/\.shortcut-overlay \{[\s\S]*?z-index: 60;/)
+  })
+
+  it('sizes the sheet so a long list scrolls inside it', () => {
+    expect(sheetCss).toMatch(/\.shortcut-sheet \{[\s\S]*?max-height: calc\(100dvh - 48px\);/)
+    expect(sheetCss).toMatch(/\.shortcut-sheet__body \{[\s\S]*?overflow-y: auto;/)
+  })
+
+  it('draws keycaps from theme tokens rather than hardcoded colours', () => {
+    expect(sheetCss).toMatch(
+      /\.shortcut-sheet__kbd \{[\s\S]*?background: var\(--elevated\);[\s\S]*?color: var\(--foreground\);/,
+    )
+  })
+})

--- a/frontend/src/components/overlay-layer.ts
+++ b/frontend/src/components/overlay-layer.ts
@@ -1,0 +1,39 @@
+// One place that answers "is a modal or popover on screen right now?".
+//
+// Document-level key handlers each used to carry their own hardcoded selector
+// list ('.modal-backdrop, .chat-session-popover, .chat-session-actions-menu'),
+// so every new dialog had to remember to extend every list. They drifted: the
+// chat handler still guarded on `.modal-backdrop`, which no view renders any
+// more, and knew about none of the tokenised `*-modal__overlay` dialogs — the
+// blocking approval prompt included.
+//
+// Layers register themselves instead. `ModalShell` covers every tokenised
+// dialog (agents / sessions / skills / cron / env / mcp / channels / approvals
+// / the shortcut overlay); the chat session popover, which is not a ModalShell,
+// opts in explicitly.
+import { useEffect } from 'react'
+
+let depth = 0
+
+/** How many overlay layers are mounted right now. */
+export function overlayDepth(): number {
+  return depth
+}
+
+/**
+ * Count this component as an overlay layer while `active`.
+ *
+ * Reads are synchronous (`overlayDepth()`), so a document-level keydown handler
+ * can consult it without subscribing and re-binding.
+ */
+export function useOverlayLayer(active: boolean = true): void {
+  useEffect(() => {
+    if (!active) return
+    depth += 1
+    return () => {
+      // Clamp: a double-invoked cleanup (StrictMode) must not drive the count
+      // negative and silently disable every guard that reads it.
+      depth = Math.max(0, depth - 1)
+    }
+  }, [active])
+}

--- a/frontend/src/components/shortcut-combo.ts
+++ b/frontend/src/components/shortcut-combo.ts
@@ -1,0 +1,186 @@
+// Combos and their labels — the pure half of the shortcut registry (#137).
+//
+// Kept apart from the provider and the overlay so that the eagerly-loaded
+// shell can format a keycap (the New chat tooltip) without pulling in the
+// overlay's ModalShell / motion dependencies.
+
+export interface ShortcutSpec {
+  /**
+   * Canonical combo: lowercase, '+'-joined, modifiers first in the order
+   * mod → alt → shift. `mod` is Cmd on macOS and Ctrl elsewhere.
+   * e.g. 'mod+shift+o', 'alt+arrowup', 'escape', '?'.
+   */
+  combo: string
+  description: string
+  category: string
+  /** Fire even when focus is in an input / textarea / contenteditable. */
+  allowInInputs?: boolean
+  /** Fire even while a modal or popover layer is open. */
+  allowWithOverlays?: boolean
+  /**
+   * Documented here, handled elsewhere. The composer, slash menu and session
+   * switcher bind their keys to their own element (they need the event before
+   * it reaches the document, and they need to consume it). Registering the spec
+   * keeps the overlay complete without relocating the behaviour.
+   */
+  documentationOnly?: boolean
+}
+
+export interface RegisteredShortcut {
+  id: string
+  spec: ShortcutSpec
+  handler: (e: KeyboardEvent) => void
+}
+
+/** The combo that opens the overlay. Shift+/ on a US layout. */
+export const HELP_COMBO = '?'
+
+export const HELP_SHORTCUT: RegisteredShortcut = {
+  id: 'help-overlay',
+  spec: {
+    combo: HELP_COMBO,
+    description: 'Show this list',
+    category: 'Global',
+    documentationOnly: true,
+  },
+  handler: () => {},
+}
+
+/** Categories render in this order; anything else falls in after it. */
+export const CATEGORY_ORDER = [
+  'Global',
+  'Chat',
+  'Composer',
+  'Slash commands',
+  'Session switcher',
+  'Dialogs',
+]
+
+export function isMac(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const platform =
+    (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ||
+    navigator.platform ||
+    navigator.userAgent
+  return /mac/i.test(platform)
+}
+
+const KEY_LABELS: Record<string, string> = {
+  enter: 'Enter',
+  escape: 'Esc',
+  esc: 'Esc',
+  tab: 'Tab',
+  space: 'Space',
+  arrowup: '↑',
+  arrowdown: '↓',
+  arrowleft: '←',
+  arrowright: '→',
+  up: '↑',
+  down: '↓',
+  home: 'Home',
+  end: 'End',
+}
+
+/**
+ * A combo as the caps that should be drawn for it, on this platform. The single
+ * source of truth for shortcut labels — `formatCombo` joins these and the
+ * overlay renders one `<kbd>` per entry, so the two cannot drift. #131
+ * hardcoded '⌘⇧O' at the call site, which was wrong on Windows and Linux.
+ */
+export function comboParts(combo: string): string[] {
+  const mac = isMac()
+  return combo
+    .toLowerCase()
+    .split('+')
+    .map((part) => {
+      if (part === 'mod') return mac ? '⌘' : 'Ctrl'
+      if (part === 'shift') return mac ? '⇧' : 'Shift'
+      if (part === 'alt') return mac ? '⌥' : 'Alt'
+      const known = KEY_LABELS[part]
+      if (known) return known
+      if (part.length === 1) return part.toUpperCase()
+      return part.charAt(0).toUpperCase() + part.slice(1)
+    })
+}
+
+/** The same caps as one string: '⌘⇧O' on macOS, 'Ctrl+Shift+O' elsewhere. */
+export function formatCombo(combo: string): string {
+  return comboParts(combo).join(isMac() ? '' : '+')
+}
+
+/**
+ * Shift is a modifier for letters and digits ('shift+enter', 'mod+shift+o') but
+ * part of the character itself for the symbols it produces — '?' is Shift+/ on
+ * a US layout and nobody thinks of it as "shift question mark".
+ */
+function shiftBelongsToKey(key: string): boolean {
+  return key.length === 1 && !/[a-z0-9]/i.test(key)
+}
+
+function keyFromCode(code: string): string {
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3).toLowerCase()
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5)
+  return code.toLowerCase()
+}
+
+/**
+ * Every combo an event can be said to be.
+ *
+ * Two candidates, because the two readings disagree on non-US layouts and both
+ * matter: `e.key` is what the user typed (so '?' stays '?' wherever it lives),
+ * `e.code` is the physical key (so Cmd+Shift+O keeps working where KeyO does
+ * not produce "o" — the behaviour the pre-registry handler had via
+ * `e.code === 'KeyO'`). A spec matches if it equals either.
+ */
+export function eventCombos(
+  e: Pick<KeyboardEvent, 'key' | 'code' | 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey'>,
+): string[] {
+  const rawKey = (e.key || '').toLowerCase()
+  // Holding a modifier down is not a shortcut. Checked on e.key, before the
+  // code candidate is built — 'ShiftLeft' would otherwise read as a key named
+  // "shiftleft" and produce a combo nothing can ever match.
+  if (rawKey === 'control' || rawKey === 'meta' || rawKey === 'alt' || rawKey === 'shift') {
+    return []
+  }
+
+  const candidates: string[] = []
+  if (rawKey && rawKey !== 'unidentified') candidates.push(rawKey)
+  if (e.code) {
+    const fromCode = keyFromCode(e.code)
+    if (fromCode && !candidates.includes(fromCode)) candidates.push(fromCode)
+  }
+
+  const combos: string[] = []
+  for (const key of candidates) {
+    const parts: string[] = []
+    if (e.metaKey || e.ctrlKey) parts.push('mod')
+    if (e.altKey) parts.push('alt')
+    if (e.shiftKey && !shiftBelongsToKey(key)) parts.push('shift')
+    parts.push(key)
+    const combo = parts.join('+')
+    if (!combos.includes(combo)) combos.push(combo)
+  }
+  return combos
+}
+
+/** Group for display, preferring CATEGORY_ORDER. */
+export function groupByCategory(
+  shortcuts: RegisteredShortcut[],
+): Array<[string, RegisteredShortcut[]]> {
+  const groups = new Map<string, RegisteredShortcut[]>()
+  for (const item of [HELP_SHORTCUT, ...shortcuts]) {
+    const category = item.spec.category || 'Other'
+    const bucket = groups.get(category) ?? []
+    // The same key can legitimately appear in two categories (Esc means
+    // something different in the composer than it does globally); a repeat
+    // within one category is a duplicate registration.
+    if (bucket.some((existing) => existing.spec.combo === item.spec.combo)) continue
+    bucket.push(item)
+    groups.set(category, bucket)
+  }
+  return [...groups.entries()].sort(([a], [b]) => {
+    const ai = CATEGORY_ORDER.indexOf(a)
+    const bi = CATEGORY_ORDER.indexOf(b)
+    return (ai === -1 ? CATEGORY_ORDER.length : ai) - (bi === -1 ? CATEGORY_ORDER.length : bi)
+  })
+}

--- a/frontend/src/styles/control-surface.css
+++ b/frontend/src/styles/control-surface.css
@@ -378,7 +378,8 @@
 }
 
 .shell[data-design='unified'] .shell-nav-link:focus-visible,
-.shell[data-design='unified'] :is(.shell-sidebar__collapse, .shell-sidebar__theme):focus-visible {
+.shell[data-design='unified']
+  :is(.shell-sidebar__collapse, .shell-sidebar__theme, .shell-sidebar__shortcuts):focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
@@ -405,13 +406,13 @@
   font-size: 0.625rem;
 }
 
-.shell[data-design='unified'] .shell-sidebar__theme {
+.shell[data-design='unified'] :is(.shell-sidebar__theme, .shell-sidebar__shortcuts) {
   flex: none;
   border-radius: var(--radius-control);
   color: var(--dim);
 }
 
-.shell[data-design='unified'] .shell-sidebar__theme:hover {
+.shell[data-design='unified'] :is(.shell-sidebar__theme, .shell-sidebar__shortcuts):hover {
   background: var(--sidebar-accent);
   color: var(--foreground);
 }

--- a/frontend/src/views/chat/ChatPage.test.tsx
+++ b/frontend/src/views/chat/ChatPage.test.tsx
@@ -5,6 +5,7 @@ import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { toast } from 'sonner'
 import { ChatPage } from './ChatPage'
+import { KeyboardShortcutProvider } from '@/components/KeyboardShortcuts'
 import * as logicModule from './logic'
 
 vi.mock('sonner', () => ({
@@ -94,8 +95,12 @@ function renderPage(initialEntry = '/chat') {
       <QueryClientProvider
         client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
       >
-        <ChatPage />
-        <LocationProbe />
+        {/* The shortcut registry is wired in AppProviders in the real app;
+            ChatPage registers its document shortcuts into it (#137). */}
+        <KeyboardShortcutProvider>
+          <ChatPage />
+          <LocationProbe />
+        </KeyboardShortcutProvider>
       </QueryClientProvider>
     </MemoryRouter>,
   )
@@ -1219,16 +1224,18 @@ describe('ChatPage', () => {
     expect(mockRpc.call.mock.calls.length).toBe(before)
   })
 
-  it('does not start new chat when a modal is open', () => {
+  it('does not start new chat while an overlay owns the keyboard', async () => {
     mockRpc = makeRpc()
     renderPage()
 
+    // A real layer, not a fabricated `.modal-backdrop` node: the guard is
+    // registration-based now (#137), so what it must stand down for is an
+    // overlay that actually mounted — here the session actions menu.
+    const trigger = screen.getByRole('button', { name: 'Chat actions' })
+    fireEvent.click(trigger)
+    expect(await screen.findByRole('menu', { name: 'Chat actions' })).toBeInTheDocument()
+
     const before = mockRpc.call.mock.calls.length
-
-    const modal = document.createElement('div')
-    modal.className = 'modal-backdrop'
-
-    document.body.appendChild(modal)
 
     fireEvent.keyDown(document, {
       ctrlKey: true,
@@ -1237,8 +1244,30 @@ describe('ChatPage', () => {
     })
 
     expect(mockRpc.call.mock.calls.length).toBe(before)
+  })
 
-    modal.remove()
+  // #137 acceptance: the overlay must report what the console actually binds.
+  // The issue named four files as the places shortcuts hide in; this asserts
+  // each of them reaches the registry from a real ChatPage render.
+  it('lists chat, composer, slash-menu and session-switcher keys in the ? overlay', async () => {
+    mockRpc = makeRpc()
+    renderPage()
+
+    // The composer autofocuses; '?' is inert there on purpose, so move focus out
+    // the way an operator clicking the page background would.
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    fireEvent.keyDown(document, { key: '?', code: 'Slash', shiftKey: true })
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    const groups = Array.from(document.querySelectorAll('.shortcut-sheet__group-title')).map(
+      (el) => el.textContent,
+    )
+    expect(groups).toEqual(['Global', 'Chat', 'Composer', 'Slash commands', 'Session switcher'])
+
+    expect(screen.getByText('Start a new chat')).toBeInTheDocument()
+    expect(screen.getByText('Insert a newline')).toBeInTheDocument()
+    expect(screen.getByText('Run the highlighted command')).toBeInTheDocument()
+    expect(screen.getByText('Close the switcher and restore focus')).toBeInTheDocument()
   })
 
   it('shows the keyboard shortcut in the New chat tooltip', () => {

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence } from 'motion/react'
 import { useRpc } from '@/app/providers'
 import { ShellHeaderPortal, ShellPrimaryActionPortal } from '@/app/ShellHeaderSlot'
 import { ModalShell } from '@/components/ModalShell'
+import { formatCombo, useKeyboardShortcut } from '@/components/KeyboardShortcuts'
 import { Attachments, useAttachments } from './Attachments'
 import { Composer, type ComposerHandle } from './Composer'
 import {
@@ -32,6 +33,11 @@ import { useApprovalPending } from './useApprovalPending'
 import { usePendingQueue, type PendingComposerBridge } from './usePendingQueue'
 import { useSlashCommands } from './useSlashCommands'
 import { useTranscript } from './useTranscript'
+
+// chat.js:2519 — Cmd/Ctrl+Shift+O mirrors the New chat button from anywhere in
+// the app. The registry matches on the physical key too, so this keeps working
+// on layouts where KeyO does not produce "o".
+const NEW_CHAT_COMBO = 'mod+shift+o'
 
 // chat.js:1155-1157 `_genKey` — a fresh webchat key in the CURRENT agent, with a
 // random suffix, so `/new` (and the new-chat button) start an empty session.
@@ -548,37 +554,39 @@ export function ChatPage() {
     toast.info('Exported as Markdown')
   }, [containerRef, sessionKey])
 
-  const shortcutHint = /mac/i.test(navigator.userAgent) ? '⌘⇧O' : 'Ctrl+Shift+O'
+  const shortcutHint = formatCombo(NEW_CHAT_COMBO)
 
-  // chat.js:2518-2539 `_onDocKeydown` — document-level keyboard shortcuts.
-  // Cmd/Ctrl+Shift+O mirrors the New chat button from anywhere in the app,
-  // while Escape keeps the legacy priority chain:
+  // chat.js:2518-2539 `_onDocKeydown` — the two document-level chat shortcuts,
+  // now registered rather than bound here. The registry owns the overlay guard
+  // (no dialog or popover is on screen) and the editable-target guard; what
+  // stays local is the behaviour and which guards each key opts out of.
+  //
+  // New chat intentionally fires even when focus is inside the composer or
+  // another editable field; Escape does not, because editable targets handle
+  // their own Escape (the composer's rung chain lives in Composer.tsx).
+  useKeyboardShortcut(
+    {
+      combo: NEW_CHAT_COMBO,
+      description: 'Start a new chat',
+      category: 'Chat',
+      allowInInputs: true,
+    },
+    (e) => {
+      e.preventDefault()
+      startNewChat()
+    },
+  )
+
+  // Escape keeps the legacy priority chain:
   //   1. streaming         → abort the turn (which recovers pending).
   //   2. pending non-empty → recover the whole queue into the composer.
-  // Visible overlays own their shortcuts, and Escape inside other editable
-  // targets remains handled by those elements. Unlike Escape, the New chat
-  // shortcut intentionally works even when focus is inside the composer or
-  // another editable field.
-  useEffect(() => {
-    const onDocKeydown = (e: KeyboardEvent) => {
-      if (e.defaultPrevented) return
-      const isNewChatShortcut = (e.metaKey || e.ctrlKey) && e.shiftKey && e.code === 'KeyO'
-      const isEscape = e.key === 'Escape'
-      if (!isNewChatShortcut && !isEscape) return
-      const hasOverlay = !!document.querySelector(
-        '.modal-backdrop, .chat-session-popover, .chat-session-actions-menu',
-      )
-      if (hasOverlay) return
-      if (isNewChatShortcut) {
-        e.preventDefault()
-        startNewChat()
-        return
-      }
-      const target = e.target as HTMLElement | null
-      const isEditable =
-        !!target &&
-        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
-      if (isEditable) return
+  useKeyboardShortcut(
+    {
+      combo: 'escape',
+      description: 'Abort the streaming turn, else recover the queue into the composer',
+      category: 'Chat',
+    },
+    (e) => {
       if (busy) {
         e.preventDefault()
         abortAndRecover('webui_escape')
@@ -588,10 +596,8 @@ export function ChatPage() {
         e.preventDefault()
         pending.popAllIntoComposer()
       }
-    }
-    document.addEventListener('keydown', onDocKeydown)
-    return () => document.removeEventListener('keydown', onDocKeydown)
-  }, [busy, abortAndRecover, pending, startNewChat])
+    },
+  )
 
   return (
     <div className="chat-stage" onDrop={onDrop} onDragOver={onDragOver} onPaste={onPaste}>

--- a/frontend/src/views/chat/Composer.tsx
+++ b/frontend/src/views/chat/Composer.tsx
@@ -3,6 +3,23 @@ import { ArrowUpIcon, PaperclipIcon, SlidersHorizontalIcon, SquareIcon, XIcon } 
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { toast } from 'sonner'
 import { MAX_PENDING, sendButtonState, shouldAutofocusComposer } from './logic'
+import { useShortcutDocs } from '@/components/KeyboardShortcuts'
+
+// #137 — what the composer binds, in the order `onTextareaKeyDown` tests it, so
+// the `?` overlay reports the composer accurately without the handler leaving
+// the element it has to be bound to.
+const COMPOSER_SHORTCUTS = [
+  { combo: 'enter', description: 'Send the message' },
+  { combo: 'shift+enter', description: 'Insert a newline' },
+  {
+    combo: 'escape',
+    description: 'Abort the turn, else recover the queue, else clear the composer',
+  },
+  { combo: 'alt+arrowup', description: 'Pop the most recent queued message back for editing' },
+  { combo: 'alt+arrowdown', description: 'Queue the composer text behind the running turn' },
+  { combo: 'arrowup', description: 'Walk back through sent history' },
+  { combo: 'arrowdown', description: 'Walk forward through sent history' },
+] as const
 
 /**
  * The chat command line (React).
@@ -167,6 +184,12 @@ export function Composer({
   const toolbarTriggerRef = useRef<HTMLButtonElement>(null)
   const toolbarCloseRef = useRef<HTMLButtonElement>(null)
   const reduceMotion = useReducedMotion()
+
+  // The composer binds its own keys on the textarea (it needs them before the
+  // document sees them, and the slash menu has to be able to consume them), so
+  // these are documented rather than dispatched. Descriptions are written from
+  // `onTextareaKeyDown` below — keep them in step with it.
+  useShortcutDocs('Composer', COMPOSER_SHORTCUTS)
 
   // Close the composer-settings popover on an outside click / Escape (it
   // previously stayed open until the toolbar trigger was clicked again). Bound only

--- a/frontend/src/views/chat/SessionChip.tsx
+++ b/frontend/src/views/chat/SessionChip.tsx
@@ -12,6 +12,16 @@ import {
   type SessionGroup,
   type SessionListItem,
 } from './logic'
+import { useShortcutDocs } from '@/components/KeyboardShortcuts'
+import { useOverlayLayer } from '@/components/overlay-layer'
+
+// #137 — the switcher popover and the actions menu bind these to their own
+// elements (`onKey` / `onActionsKeyDown` below), so they are documented here.
+const SESSION_SHORTCUTS = [
+  { combo: 'arrowdown', description: 'Move to the next action' },
+  { combo: 'arrowup', description: 'Move to the previous action' },
+  { combo: 'escape', description: 'Close the switcher and restore focus' },
+] as const
 
 /**
  * Session chip + switcher (React) — ported from the legacy topbar-center chip
@@ -122,6 +132,12 @@ export function SessionChip({
   const rootRef = useRef<HTMLDivElement>(null)
   const actionsTriggerRef = useRef<HTMLButtonElement>(null)
   const actionsMenuRef = useRef<HTMLDivElement>(null)
+
+  useShortcutDocs('Session switcher', SESSION_SHORTCUTS)
+  // Neither of these is a ModalShell, but both are dismissible layers that own
+  // Escape while they are up — so document-level shortcuts must stand down for
+  // them, exactly as they did for the old `.chat-session-popover` selector.
+  useOverlayLayer(open || actionsOpen)
 
   const getSessionTrigger = useCallback(
     () => document.querySelector<HTMLButtonElement>('#chat-session-switcher-trigger'),

--- a/frontend/src/views/chat/SlashMenu.tsx
+++ b/frontend/src/views/chat/SlashMenu.tsx
@@ -8,6 +8,16 @@ import {
   useState,
 } from 'react'
 import { parseSlashInput, type SlashCommand } from './logic'
+import { useShortcutDocs } from '@/components/KeyboardShortcuts'
+
+// #137 — the menu consumes these from the composer's keydown (`handleKeyDown`
+// below) while it is open, so they are documented, not dispatched.
+const SLASH_SHORTCUTS = [
+  { combo: 'arrowdown', description: 'Move to the next command' },
+  { combo: 'arrowup', description: 'Move to the previous command' },
+  { combo: 'enter', description: 'Run the highlighted command' },
+  { combo: 'escape', description: 'Dismiss the menu for this input' },
+] as const
 
 /**
  * The slash-command menu (React).
@@ -79,6 +89,9 @@ export function SlashMenu({
 }: SlashMenuProps) {
   const generatedId = useId()
   const resolvedListboxId = listboxId ?? `chat-slash-${generatedId}`
+  // Registered from the always-mounted component (it renders null when closed),
+  // so the overlay lists these whether or not the menu happens to be open.
+  useShortcutDocs('Slash commands', SLASH_SHORTCUTS)
   // The active index into the filtered list (chat.js:2646 `_slashIdx`).
   const [activeIdx, setActiveIdx] = useState(0)
   // Escape dismisses the menu for the CURRENT input (chat.js:2675 sets


### PR DESCRIPTION
Closes #137. Supersedes #209 (closed — the registry shape there was right and is carried forward; the discoverability and layering findings are recorded on that PR).

The console already had real key handling — Enter / Shift+Enter in the composer, Escape's abort/recover chain, Cmd/Ctrl+Shift+O for New chat, arrow navigation in the slash menu and the session switcher — spread across five files as ad-hoc `keydown` listeners. Nothing could enumerate them, so nothing documented them, and each new binding re-litigated the same overlay and editable-target guards.

## What this does

**One registry.** Components declare a `ShortcutSpec` via `useKeyboardShortcut`; the provider owns the single document listener, the editable-target guard and the overlay guard. Keys that must stay bound to their own element — the composer, the slash menu and the session switcher need the event before the document and have to consume it — register `documentationOnly` via `useShortcutDocs`, so the list is complete without relocating any behaviour. All four files the issue named feed it, plus `AppShell`'s drawer Escape.

**The overlay guard stopped being a selector list.** It was hardcoded per handler and already stale: `.modal-backdrop` no longer exists outside a test fixture, and no list knew about the tokenised `*-modal__overlay` dialogs — the blocking approval prompt included. Layers register themselves now (`components/overlay-layer.ts`): `ModalShell` covers every tokenised dialog, and the session popover, which is not a `ModalShell`, opts in explicitly.

**`?` is actually reachable.** It opens the sheet and closes it again — the close direction has to be checked before the overlay guard, because the sheet is itself a layer. It stays inert in editable fields, and the composer autofocuses on every desktop load (`Composer.tsx:319` → `logic.ts:478-490`), so a key-only affordance would not be discoverable at all; the sidebar carries a visible entry point that also works on touch, where there is no keyboard.

**Labels live in one place.** `comboParts` is the only thing that turns a combo into a keycap, so the New chat tooltip and the sheet cannot drift. #131's hardcoded `⌘⇧O` was wrong on Windows and Linux.

**Layering.** The sheet sits at `z-index: 60` with the other route dialogs, not on `--z-critical-approval`, which the approval prompt owns alone and must keep — it portals into `<body>` later, so sharing that token would paint it over a pending approval. Pinned by `keyboard-shortcuts-css.test.ts` alongside the existing approval contract.

**Matching.** Combos are matched against both `e.key` and `e.code`, so `?` works wherever the layout puts it while Cmd+Shift+O keeps the layout independence the previous `e.code === 'KeyO'` check gave it.

## Bundle

The sheet loads lazily. The provider mounts at boot, and pulling `ModalShell` + `motion` into the eager tree cost **+44 KiB gzip** of initial JS for a panel most sessions never open — under the 180 KiB budget, so the check would not have caught it. Split into `shortcut-combo.ts` (pure) / `KeyboardShortcuts.tsx` (registry) / `ShortcutOverlay.tsx` (lazy UI), the change is **+2.0 KiB** (132.8 → 134.8 KiB).

## Notes for review

- `ChatPage.test.tsx`'s "does not start new chat when a modal is open" fabricated a `.modal-backdrop` node. The guard is registration-based now, so it opens the real session actions menu instead — a stronger assertion than the one it replaces.
- Two bugs the new tests caught while being written: a bare Shift press produced the combo `shift+shiftleft`, and `useShortcutDocs` re-registered forever when handed an inline array literal (registering re-renders the caller). Both fixed, both covered.

## Verification

`tsc --noEmit` clean, `eslint src` clean, `prettier --check src` clean, **1758 frontend tests across 84 files** (base `main`: 1738 / 82), Control UI build within budget.
