### PR TITLE
feat(setup): pick router tier models from the catalog instead of typing them

### DIFF
--- a/frontend/src/views/setup/RouterSection.test.tsx
+++ b/frontend/src/views/setup/RouterSection.test.tsx
@@ -1,7 +1,36 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
 import { RouterSection } from './RouterSection'
 import type { Catalog } from './logic'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+// `models.list` is the live half of the tier picker (#142). Tests that care
+// about it set `modelsResponse`; the rest run on the offline catalog alone,
+// which is what a gateway with no provider key configured actually serves.
+let modelsResponse: unknown = []
+const mockRpc = {
+  waitForConnection: vi.fn().mockResolvedValue(undefined),
+  // Mirrors rpc_models.py:58-66: the SERVER applies both filters, so a test
+  // that returned the same rows for `capabilities: ['vision']` would prove
+  // nothing about the image row.
+  call: vi.fn((method: string, params?: { capabilities?: string[] }) => {
+    if (method !== 'models.list') return Promise.resolve({})
+    if (!Array.isArray(modelsResponse)) return Promise.resolve(modelsResponse)
+    const required = params?.capabilities
+    if (!required?.length) return Promise.resolve(modelsResponse)
+    return Promise.resolve(
+      (modelsResponse as Array<{ capabilities?: string[] }>).filter((model) =>
+        required.every((capability) => (model.capabilities || []).includes(capability)),
+      ),
+    )
+  }),
+}
+vi.mock('@/app/providers', () => ({ useRpc: () => mockRpc }))
 
 const STATUS = {
   hasConfig: true,
@@ -46,11 +75,15 @@ function renderSection(catalog: Catalog, onSave = vi.fn()) {
     onNext: vi.fn(),
     saving: false,
   }
-  const result = render(<RouterSection {...props} />)
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrap = (node: React.ReactNode) => (
+    <QueryClientProvider client={client}>{node}</QueryClientProvider>
+  )
+  const result = render(wrap(<RouterSection {...props} />))
   return {
     ...result,
     rerenderCatalog: (nextCatalog: Catalog) =>
-      result.rerender(<RouterSection {...props} catalog={nextCatalog} />),
+      result.rerender(wrap(<RouterSection {...props} catalog={nextCatalog} />)),
   }
 }
 
@@ -72,7 +105,8 @@ describe('RouterSection', () => {
       }),
     )
 
-    expect(screen.getByLabelText('c1 provider')).toHaveValue('openai')
+    // The provider cell is a read-only chip now (#142), not an input.
+    expect(screen.getByLabelText('c1 provider')).toHaveTextContent('openai')
     expect(screen.getByLabelText('c1 model')).toHaveValue('gpt-4o')
     expect(screen.getByLabelText('image_model model')).toHaveValue('gpt-image-1')
   })
@@ -124,5 +158,164 @@ describe('RouterSection', () => {
 
     expect(screen.getByLabelText('image_model supports image')).toBeChecked()
     expect(screen.getByLabelText('image_model supports image')).toBeDisabled()
+  })
+})
+
+// ── tier model pickers (#142) ───────────────────────────────────────────────
+
+describe('RouterSection tier model pickers', () => {
+  const PROFILE = {
+    c0: { provider: 'openai', model: 'gpt-4o-mini' },
+    c1: { provider: 'openai', model: 'gpt-4o' },
+    image_model: { provider: 'openai', model: 'gpt-image-1', supports_image: true },
+  }
+
+  const LIVE = [
+    {
+      id: 'gpt-4o',
+      name: 'GPT-4o',
+      provider: 'openai',
+      contextWindow: 128000,
+      capabilities: ['chat', 'tools'],
+      pricing: { inputPer1k: 0.0025, outputPer1k: 0.01 },
+    },
+    {
+      id: 'gpt-image-1',
+      name: 'GPT Image 1',
+      provider: 'openai',
+      contextWindow: 128000,
+      capabilities: ['chat', 'vision'],
+      pricing: { inputPer1k: 0.005, outputPer1k: 0.04 },
+    },
+  ]
+
+  function optionsFor(tier: string): string[] {
+    const list = document.getElementById(`setup-tier-models-${tier}`) as HTMLDataListElement | null
+    return list ? Array.from(list.options).map((option) => option.value) : []
+  }
+
+  beforeEach(() => {
+    modelsResponse = []
+    vi.mocked(toast.warning).mockClear()
+    mockRpc.call.mockClear()
+  })
+
+  it('asks the RPC to do the filtering, per provider and per capability', async () => {
+    renderSection(catalogWithTiers(PROFILE))
+    await waitFor(() => {
+      const calls = mockRpc.call.mock.calls.filter(([method]) => method === 'models.list')
+      expect(calls).toHaveLength(2)
+      expect(calls.map(([, params]) => params)).toEqual(
+        expect.arrayContaining([
+          { provider: 'openai' },
+          { provider: 'openai', capabilities: ['vision'] },
+        ]),
+      )
+    })
+  })
+
+  it('offers the image tier only vision models, even with no live catalog', async () => {
+    // A provider whose catalog the gateway never fetched — the common case
+    // while the operator is still filling this form in.
+    modelsResponse = []
+    renderSection(catalogWithTiers(PROFILE))
+
+    await waitFor(() => expect(optionsFor('c0')).toContain('gpt-4o'))
+    expect(optionsFor('c0')).toEqual(['gpt-4o-mini', 'gpt-4o', 'gpt-image-1'])
+    expect(optionsFor('image_model')).toEqual(['gpt-image-1'])
+  })
+
+  it('shows context window and price for the entered model', async () => {
+    modelsResponse = LIVE
+    renderSection(catalogWithTiers(PROFILE))
+    expect(await screen.findByText('128k ctx · $2.50/$10.00 per 1M')).toBeInTheDocument()
+  })
+
+  it('saves an untouched form without warning about its own defaults', async () => {
+    const onSave = vi.fn()
+    renderSection(catalogWithTiers(PROFILE), onSave)
+    await waitFor(() => expect(optionsFor('c0')).not.toHaveLength(0))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+    expect(toast.warning).not.toHaveBeenCalled()
+    expect(onSave).toHaveBeenCalled()
+  })
+
+  it('warns on an unknown id but still saves it', async () => {
+    const onSave = vi.fn()
+    renderSection(catalogWithTiers(PROFILE), onSave)
+    await waitFor(() => expect(optionsFor('c0')).not.toHaveLength(0))
+
+    fireEvent.change(screen.getByLabelText('c0 model'), {
+      target: { value: 'z-ai/glm-5.2-turbo-max' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining('z-ai/glm-5.2-turbo-max'),
+      expect.any(Object),
+    )
+    expect(onSave).toHaveBeenCalled()
+  })
+
+  it('warns separately when the image tier is pointed at a text model', async () => {
+    const onSave = vi.fn()
+    modelsResponse = LIVE
+    renderSection(catalogWithTiers(PROFILE), onSave)
+    await waitFor(() => expect(optionsFor('c0')).toContain('gpt-4o'))
+
+    fireEvent.change(screen.getByLabelText('image_model model'), { target: { value: 'gpt-4o' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining('no vision capability'),
+      expect.any(Object),
+    )
+    expect(toast.warning).not.toHaveBeenCalledWith(
+      expect.stringContaining("openai's catalog"),
+      expect.any(Object),
+    )
+    expect(onSave).toHaveBeenCalled()
+  })
+
+  it('says it could not check when no catalog exists at all', async () => {
+    const onSave = vi.fn()
+    const catalog = catalogWithTiers({ c0: { provider: 'openai' } })
+    renderSection(catalog, onSave)
+
+    fireEvent.change(screen.getByLabelText('c0 model'), { target: { value: 'some-model' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+
+    await waitFor(() =>
+      expect(toast.warning).toHaveBeenCalledWith(
+        expect.stringContaining('No model catalog available'),
+        expect.any(Object),
+      ),
+    )
+    expect(onSave).toHaveBeenCalled()
+  })
+
+  it('writes the configured provider on every tier, whatever the config held', async () => {
+    const onSave = vi.fn()
+    const catalog = catalogWithTiers({
+      // A stale per-tier provider, reachable by the free-text cell this
+      // replaces. The runtime ignores it (boot.py:1106-1120), so save
+      // normalises rather than preserving it.
+      c0: { provider: 'anthropic', model: 'gpt-4o-mini' },
+      c1: { provider: 'openai', model: 'gpt-4o' },
+    })
+    renderSection(catalog, onSave)
+    await waitFor(() => expect(optionsFor('c0')).not.toHaveLength(0))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Router' }))
+    const params = onSave.mock.calls[0]![0] as { tiers: Record<string, { provider?: string }> }
+    expect(Object.values(params.tiers).map((tier) => tier.provider)).toEqual(['openai', 'openai'])
+  })
+
+  it('tells the operator when there is nothing to pick from', async () => {
+    renderSection(catalogWithTiers({ c0: { provider: 'openai' } }))
+    expect(
+      await screen.findByText('No catalog models known for openai — type an id.'),
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/views/setup/RouterSection.tsx
+++ b/frontend/src/views/setup/RouterSection.tsx
@@ -2,20 +2,29 @@
 // default text model tier, judge model, pilot safety-net threshold, and the
 // editable tier table. Save via onboarding.router.configure, gated on the
 // provider being saved (effective === configured).
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useRpc } from '@/app/providers'
 import { Button } from '@/components/ui/button'
 import { PanelHead, SetupCheckbox, SetupSelect } from './parts'
 import {
   buildRouterConfigureParams,
+  classifyRouterModels,
   configuredProvider as configuredProviderFn,
   effectiveProvider as effectiveProviderFn,
   isVisibleTier,
+  mergeModelOptions,
   mergeTiers,
+  modelOptionLabel,
+  modelOptionMeta,
+  offlineTierModels,
   resolveJudgeModelParam,
   routerMode as routerModeFn,
   tierLabel,
   TEXT_TIERS,
   type Catalog,
+  type ModelListEntry,
   type OnboardingStatus,
   type RouterConfigureParams,
   type RouterMode,
@@ -54,6 +63,7 @@ export function RouterSection({
   saving: boolean
 }) {
   const router = config.agentos_router || {}
+  const rpc = useRpc()
   const provider = effectiveProviderFn(status, config, draftProvider)
   const configured = configuredProviderFn(status, config)
   const canSave = Boolean(provider && provider === configured)
@@ -96,6 +106,57 @@ export function RouterSection({
 
   // Editable tier rows (only text tiers + image_model).
   const visibleTiers = Object.entries(tiers).filter(([name]) => isVisibleTier(name))
+  const hasImageTier = visibleTiers.some(([name]) => name === 'image_model')
+
+  // The RPC owns both filters (rpc_models.py:58-66). Asking for everything and
+  // narrowing here would be indistinguishable from "this provider has no
+  // models" whenever the gateway has not loaded that provider's catalog, and
+  // it would leave the vision filter guessing at capability data the server
+  // already has.
+  const modelsQuery = useQuery<ModelListEntry[]>({
+    queryKey: ['setup', 'models', provider],
+    enabled: Boolean(provider),
+    retry: false,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      return (await rpc.call<ModelListEntry[]>('models.list', { provider })) ?? []
+    },
+  })
+  const visionQuery = useQuery<ModelListEntry[]>({
+    queryKey: ['setup', 'models', provider, 'vision'],
+    enabled: Boolean(provider) && hasImageTier,
+    retry: false,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      return (
+        (await rpc.call<ModelListEntry[]>('models.list', {
+          provider,
+          capabilities: ['vision'],
+        })) ?? []
+      )
+    },
+  })
+
+  // Offline options come from the catalog profile, NOT from the merged tiers:
+  // a model the operator saved earlier should still be checked against what
+  // the catalog actually knows, or a typo goes unflagged forever once saved.
+  const textOptions = useMemo(
+    () => mergeModelOptions(modelsQuery.data, offlineTierModels(profile?.tiers)),
+    [modelsQuery.data, profile?.tiers],
+  )
+  const visionOptions = useMemo(
+    () =>
+      mergeModelOptions(visionQuery.data, offlineTierModels(profile?.tiers, { visionOnly: true })),
+    [visionQuery.data, profile?.tiers],
+  )
+  const optionsFor = useCallback(
+    (name: string) => (name === 'image_model' ? visionOptions : textOptions),
+    [textOptions, visionOptions],
+  )
   const [rowKey, setRowKey] = useState(provider)
   const [rows, setRows] = useState<Record<string, TierRowState>>(() => seedRows(visibleTiers))
   if (rowKey !== provider) {
@@ -118,13 +179,52 @@ export function RouterSection({
 
   const collectAndSave = () => {
     if (!canSave) return
+
+    // Warn, never block: unknown ids are legitimate (self-hosted, brand new,
+    // offline), silently accepting a typo is not. A tier a request never
+    // escalates to can carry a bad model for a long time before the first
+    // failed turn.
+    const warnings = classifyRouterModels(
+      visibleTiers.map(([name, tier]) => ({ tier: name, model: rowFor(name, tier).model })),
+      textOptions,
+      visionOptions,
+    )
+    if (warnings.noCatalog) {
+      toast.warning(
+        `No model catalog available for ${provider} — tier model ids were not checked.`,
+        { id: 'setup-router-no-catalog' },
+      )
+    }
+    if (warnings.unknown.length > 0) {
+      const scope = modelsQuery.isPending ? 'the catalog loaded so far' : `${provider}'s catalog`
+      toast.warning(
+        `Saved, but not in ${scope}: ${warnings.unknown.join(', ')}. Check for a typo.`,
+        { id: 'setup-router-unknown-model' },
+      )
+    }
+    if (warnings.nonVision.length > 0) {
+      toast.warning(
+        `Saved, but the image tier points at a model with no vision capability: ${warnings.nonVision.join(', ')}.`,
+        { id: 'setup-router-non-vision-model' },
+      )
+    }
+
     const judgeModel = resolveJudgeModelParam(judge, judgeLoaded, judgeIsLocal)
     const params = buildRouterConfigureParams({
       sel: mode,
       defaultTier,
       judgeModel,
       pilotThresholdRaw: pilotThreshold,
-      tiers: visibleTiers.map(([name, tier]) => ({ tier: name, ...rowFor(name, tier) })),
+      // Tiers select the MODEL; requests always go through llm.provider, and a
+      // tier naming a different provider is degraded back to llm.model at boot
+      // (boot.py:1106-1120). The cell is a read-only chip for that reason, so
+      // the saved value follows the configured provider rather than whatever a
+      // previous free-text edit left behind.
+      tiers: visibleTiers.map(([name, tier]) => ({
+        tier: name,
+        ...rowFor(name, tier),
+        provider,
+      })),
     })
     onSave(params)
   }
@@ -219,6 +319,15 @@ export function RouterSection({
             const row = rowFor(name, tier)
             const isImageModel = name === 'image_model'
             const supportsImage = isImageModel || row.supportsImage
+            const options = optionsFor(name)
+            const listId = `setup-tier-models-${name}`
+            // Browsers disagree about whether a <datalist> option's label is
+            // shown at all (Safari renders values only), so the numbers that
+            // decide a tier choice are also rendered under the input for
+            // whatever is currently entered.
+            const selectedMeta = modelOptionMeta(
+              options.find((option) => option.id === row.model) ?? { id: '', name: '' },
+            )
             return (
               <div className="setup-tier-table__row" role="row" key={name}>
                 <div className="setup-tier-table__cell setup-tier-table__cell--tier" role="cell">
@@ -231,11 +340,12 @@ export function RouterSection({
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">
                     Provider
                   </span>
-                  <input
-                    aria-label={`${name} provider`}
-                    value={row.provider}
-                    onChange={(e) => setRow(name, tier, { provider: e.target.value })}
-                  />
+                  {/* Read-only: five editable copies of one value are five
+                      chances to get it wrong, and the runtime ignores the
+                      difference anyway. */}
+                  <code className="setup-provider-chip" aria-label={`${name} provider`}>
+                    {provider}
+                  </code>
                 </div>
                 <div className="setup-tier-table__cell setup-tier-table__cell--model" role="cell">
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">
@@ -244,8 +354,31 @@ export function RouterSection({
                   <input
                     aria-label={`${name} model`}
                     value={row.model}
+                    list={options.length > 0 ? listId : undefined}
+                    autoComplete="off"
+                    // The column is narrower than a real model id.
+                    title={row.model}
                     onChange={(e) => setRow(name, tier, { model: e.target.value })}
                   />
+                  {options.length > 0 ? (
+                    <datalist id={listId}>
+                      {options.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {modelOptionLabel(option)}
+                        </option>
+                      ))}
+                    </datalist>
+                  ) : null}
+                  {options.length === 0 && !modelsQuery.isPending ? (
+                    <small className="setup-hint setup-hint--field">
+                      {isImageModel
+                        ? `No vision-capable models known for ${provider} — type an id.`
+                        : `No catalog models known for ${provider} — type an id.`}
+                    </small>
+                  ) : null}
+                  {selectedMeta ? (
+                    <small className="setup-hint setup-hint--field">{selectedMeta}</small>
+                  ) : null}
                 </div>
                 <div className="setup-tier-table__cell" role="cell">
                   <span className="setup-tier-table__mobile-label" aria-hidden="true">

--- a/frontend/src/views/setup/logic.test.ts
+++ b/frontend/src/views/setup/logic.test.ts
@@ -12,12 +12,17 @@ import {
   capabilityBadge,
   capabilityIsPrimary,
   configCliArg,
+  classifyRouterModels,
   configuredProvider,
   credentialNeedList,
   detailStepStatus,
   effectiveProvider,
   envFixCommands,
   envRecoveryCommand,
+  mergeModelOptions,
+  modelOptionLabel,
+  modelOptionMeta,
+  offlineTierModels,
   envReferenceSaveAdvisory,
   finishSummary,
   handoffCommands,
@@ -708,5 +713,108 @@ describe('capability badge / primary (setup.js:959-969)', () => {
   it('capabilityBadge tone + label', () => {
     const status: OnboardingStatus = { sectionDetails: { audio: detail({ status: 'ok' }) } }
     expect(capabilityBadge(status, 'audio')).toEqual({ tone: 'is-ok', label: 'Ready' })
+  })
+})
+
+// ── router tier model catalog (#142) ────────────────────────────────────────
+
+describe('router tier model options', () => {
+  // The real onboarding.catalog profile shape: every tier carries its
+  // recommended model, and image_model is one of them.
+  const PROFILE_TIERS = {
+    c0: { provider: 'openai', model: 'gpt-4o-mini' },
+    c1: { provider: 'openai', model: 'gpt-4o' },
+    c2: { provider: 'openai', model: 'gpt-4o' },
+    image_model: { provider: 'openai', model: 'gpt-image-1', supports_image: true },
+  }
+
+  it('offers every tier model offline, deduped', () => {
+    expect(offlineTierModels(PROFILE_TIERS).map((o) => o.id)).toEqual([
+      'gpt-4o-mini',
+      'gpt-4o',
+      'gpt-image-1',
+    ])
+  })
+
+  it('offers only image tiers to the image row — not the text tiers', () => {
+    // The offline list must never present a text model as vision-capable: the
+    // image tier is the one place that distinction decides whether a turn works.
+    expect(offlineTierModels(PROFILE_TIERS, { visionOnly: true }).map((o) => o.id)).toEqual([
+      'gpt-image-1',
+    ])
+  })
+
+  it('unions the live list with the offline one, live winning on metadata', () => {
+    const live = [
+      {
+        id: 'gpt-4o',
+        name: 'GPT-4o',
+        provider: 'openai',
+        contextWindow: 128000,
+        capabilities: ['chat', 'tools'],
+        pricing: { inputPer1k: 0.0025, outputPer1k: 0.01 },
+      },
+    ]
+    const merged = mergeModelOptions(live, offlineTierModels(PROFILE_TIERS))
+    expect(merged.map((o) => o.id)).toEqual(['gpt-4o', 'gpt-4o-mini', 'gpt-image-1'])
+    expect(modelOptionMeta(merged[0]!)).toBe('128k ctx · $2.50/$10.00 per 1M')
+    // Offline entries carry no numbers, and must not invent any.
+    expect(modelOptionMeta(merged[1]!)).toBe('')
+    expect(modelOptionLabel(merged[1]!)).toBe('gpt-4o-mini')
+  })
+
+  it('degrades to the offline list when models.list answers with a non-array', () => {
+    // An older gateway, or a handler that errored into an object.
+    expect(mergeModelOptions({} as unknown, offlineTierModels(PROFILE_TIERS))).toHaveLength(3)
+    expect(mergeModelOptions(undefined, [])).toEqual([])
+  })
+})
+
+describe('classifyRouterModels', () => {
+  const text = [
+    { id: 'gpt-4o', name: 'GPT-4o' },
+    { id: 'gpt-4o-mini', name: 'GPT-4o Mini' },
+  ]
+  const vision = [{ id: 'gpt-image-1', name: 'gpt-image-1', supportsVision: true }]
+
+  it('says nothing about a form seeded from the catalog', () => {
+    const rows = [
+      { tier: 'c0', model: 'gpt-4o-mini' },
+      { tier: 'c1', model: 'gpt-4o' },
+      { tier: 'image_model', model: 'gpt-image-1' },
+    ]
+    expect(classifyRouterModels(rows, text, vision)).toEqual({
+      noCatalog: false,
+      unknown: [],
+      nonVision: [],
+    })
+  })
+
+  it('flags an id neither source knows, once', () => {
+    const rows = [
+      { tier: 'c0', model: 'z-ai/glm-5.2-turbo-max' },
+      { tier: 'c1', model: 'z-ai/glm-5.2-turbo-max' },
+    ]
+    expect(classifyRouterModels(rows, text, vision).unknown).toEqual(['z-ai/glm-5.2-turbo-max'])
+  })
+
+  it('separates "no such model" from "that model cannot do images"', () => {
+    const rows = [{ tier: 'image_model', model: 'gpt-4o' }]
+    expect(classifyRouterModels(rows, text, vision)).toEqual({
+      noCatalog: false,
+      unknown: [],
+      nonVision: ['gpt-4o'],
+    })
+  })
+
+  it('reports that it could not check rather than accepting silently', () => {
+    const rows = [{ tier: 'c0', model: 'anything' }]
+    expect(classifyRouterModels(rows, [], [])).toEqual({
+      noCatalog: true,
+      unknown: [],
+      nonVision: [],
+    })
+    // Nothing entered, nothing to say.
+    expect(classifyRouterModels([{ tier: 'c0', model: '' }], [], []).noCatalog).toBe(false)
   })
 })

--- a/frontend/src/views/setup/logic.ts
+++ b/frontend/src/views/setup/logic.ts
@@ -1138,3 +1138,168 @@ export function capabilityBadge(
   const detail = (status.sectionDetails || {})[name] || {}
   return { tone: readinessTone(detail, name), label: readinessStatusLabel(detail, name) }
 }
+
+// ── router tier model catalog (#142) ────────────────────────────────────────
+//
+// Two sources, and they have to be unioned rather than chosen between:
+//
+//   `models.list` (rpc_models.py:33) is live but partial — it aggregates the
+//   currently configured provider chain, and a full `ModelCatalog` is only
+//   fetched for some providers. It answers nothing at all before an API key is
+//   saved, which is exactly when this form is being filled in.
+//
+//   `onboarding.catalog.routerProfiles` ships with the package, is per
+//   provider, and carries the recommended model for every tier including
+//   `image_model`. It is small, and it is the source the tier rows are seeded
+//   from — so treating it as authoritative on its own would flag ids the
+//   gateway does know, and treating it as absent would flag the form's own
+//   defaults.
+
+/** A model the tier picker can offer, from either source. */
+export interface ModelOption {
+  id: string
+  name: string
+  contextWindow?: number
+  inputPer1k?: number
+  outputPer1k?: number
+  supportsVision?: boolean
+}
+
+/** A `models.list` row (rpc_models.py:13-30). */
+export interface ModelListEntry {
+  id?: string
+  name?: string
+  provider?: string
+  contextWindow?: number
+  capabilities?: string[]
+  pricing?: { inputPer1k?: number; outputPer1k?: number }
+}
+
+/**
+ * The models the offline catalog knows for a provider, from its router profile
+ * tiers. `visionOnly` keeps just the tiers that generate images — the image row
+ * must not be offered text models, which is what the tier table is for.
+ */
+export function offlineTierModels(
+  profileTiers: Record<string, TierSpec> | undefined,
+  opts: { visionOnly?: boolean } = {},
+): ModelOption[] {
+  const seen = new Set<string>()
+  const options: ModelOption[] = []
+  for (const [name, tier] of Object.entries(profileTiers || {})) {
+    const id = String(tier?.model || '').trim()
+    if (!id || seen.has(id)) continue
+    const isImageTier = name === 'image_model'
+    const supportsVision = isImageTier || Boolean(tier?.supportsImage ?? tier?.supports_image)
+    if (opts.visionOnly && !supportsVision) continue
+    seen.add(id)
+    options.push({ id, name: id, supportsVision })
+  }
+  return options
+}
+
+/**
+ * Live rows first (they carry context window and pricing), then offline.
+ *
+ * `live` is whatever the RPC returned — an older gateway, or a handler that
+ * errored into an object, must degrade to the offline list rather than throw
+ * inside a render.
+ */
+export function mergeModelOptions(
+  live: ModelListEntry[] | undefined | unknown,
+  offline: ModelOption[],
+): ModelOption[] {
+  const byId = new Map<string, ModelOption>()
+  for (const entry of Array.isArray(live) ? (live as ModelListEntry[]) : []) {
+    const id = String(entry?.id || '').trim()
+    if (!id || byId.has(id)) continue
+    byId.set(id, {
+      id,
+      name: entry.name || id,
+      contextWindow: entry.contextWindow,
+      inputPer1k: entry.pricing?.inputPer1k,
+      outputPer1k: entry.pricing?.outputPer1k,
+      supportsVision: (entry.capabilities || []).includes('vision'),
+    })
+  }
+  for (const option of offline) {
+    if (!byId.has(option.id)) byId.set(option.id, option)
+  }
+  return [...byId.values()]
+}
+
+/**
+ * "128k ctx · $2.50/$10.00 per 1M" — the numbers that decide a tier choice.
+ * Empty when the offline catalog is the only source, which carries neither.
+ */
+export function modelOptionMeta(option: ModelOption): string {
+  const parts: string[] = []
+  const ctx = Number(option.contextWindow || 0)
+  if (ctx > 0) parts.push(`${Math.round(ctx / 1000)}k ctx`)
+  const input = Number(option.inputPer1k || 0) * 1000
+  const output = Number(option.outputPer1k || 0) * 1000
+  if (input > 0 || output > 0) {
+    parts.push(`$${input.toFixed(2)}/$${output.toFixed(2)} per 1M`)
+  }
+  return parts.join(' · ')
+}
+
+/** A datalist option's visible label. */
+export function modelOptionLabel(option: ModelOption): string {
+  const meta = modelOptionMeta(option)
+  const base = option.name || option.id
+  return meta ? `${base} (${meta})` : base
+}
+
+export interface RouterModelWarnings {
+  /** Nothing to check against — say so instead of silently accepting. */
+  noCatalog: boolean
+  /** Entered ids no source knows. */
+  unknown: string[]
+  /** The image tier pointed at a model the catalog says is not vision-capable. */
+  nonVision: string[]
+}
+
+/**
+ * Warn-only validation for Save (#142: "Warn, don't block — unknown ids are
+ * legitimate; silently accepting a typo is not").
+ *
+ * Membership is checked against every known id, not per-row: typing a text
+ * model into the image row is a different mistake from typing a model that
+ * does not exist, and conflating them reports the wrong one.
+ */
+export function classifyRouterModels(
+  rows: Array<{ tier: string; model: string }>,
+  textOptions: ModelOption[],
+  visionOptions: ModelOption[],
+): RouterModelWarnings {
+  const known = new Set<string>()
+  const vision = new Set<string>()
+  for (const option of textOptions) {
+    known.add(option.id)
+    if (option.supportsVision) vision.add(option.id)
+  }
+  for (const option of visionOptions) {
+    known.add(option.id)
+    vision.add(option.id)
+  }
+
+  const entered = rows.filter((row) => row.model.trim())
+  if (known.size === 0) {
+    return { noCatalog: entered.length > 0, unknown: [], nonVision: [] }
+  }
+
+  const unknown: string[] = []
+  const nonVision: string[] = []
+  for (const row of entered) {
+    const model = row.model.trim()
+    if (!known.has(model)) {
+      if (!unknown.includes(model)) unknown.push(model)
+      continue
+    }
+    if (row.tier === 'image_model' && !vision.has(model) && !nonVision.includes(model)) {
+      nonVision.push(model)
+    }
+  }
+  return { noCatalog: false, unknown, nonVision }
+}

--- a/frontend/src/views/setup/setup-css.test.ts
+++ b/frontend/src/views/setup/setup-css.test.ts
@@ -31,6 +31,23 @@ describe('Setup embedded surface CSS contract', () => {
     expect(css).toMatch(/\.setup-advanced \{[\s\S]*?border: 0;[\s\S]*?background: color-mix\(/)
   })
 
+  it('styles the read-only tier provider chip like the tier chip beside it', () => {
+    // #142 replaced a free-text provider input with a <code> chip; without a
+    // rule it renders at the browser default next to a tokenised sibling.
+    expect(css).toMatch(
+      /\.setup-provider-chip \{[\s\S]*?font-family: var\(--font-mono\);[\s\S]*?text-overflow: ellipsis;/,
+    )
+    expect(css).toMatch(/\.setup-hint--field \{[\s\S]*?display: block;/)
+  })
+
+  it('gives the model column room for a real model id', () => {
+    // 'anthropic/claude-opus-4.8' rendered as 'anthropic/claude-opus' at the
+    // previous width, and the model cell is the one that must stay readable.
+    expect(css).toMatch(
+      /grid-template-columns:\s*\n?\s*4\.5rem minmax\(5\.5rem, 0\.6fr\) minmax\(14rem, 2fr\)/,
+    )
+  })
+
   it('reflows router tier rows into labelled mobile fields', () => {
     expect(css).toMatch(
       /@media \(max-width: 720px\) \{[\s\S]*?\.setup-tier-table__row \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\) 6\.5rem;/,

--- a/frontend/src/views/setup/setup.css
+++ b/frontend/src/views/setup/setup.css
@@ -563,8 +563,11 @@
 }
 .setup-tier-table__row {
   display: grid;
+  /* The model column carries the longest value in the row by far
+     ('anthropic/claude-opus-4.8'); the provider column is now a read-only
+     chip and needs only enough width for a provider id. */
   grid-template-columns:
-    4.5rem minmax(7rem, 0.85fr) minmax(10rem, 1.45fr) minmax(7rem, 0.75fr)
+    4.5rem minmax(5.5rem, 0.6fr) minmax(14rem, 2fr) minmax(7rem, 0.75fr)
     5rem;
   gap: 0.5rem;
   align-items: center;
@@ -592,6 +595,19 @@
 .setup-tier-table__cell > input,
 .setup-tier-table__cell > .setup-select {
   width: 100%;
+}
+.setup-provider-chip {
+  min-width: 0;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.setup-hint--field {
+  display: block;
+  margin-top: 0.3rem;
 }
 .setup-tier-table__cell--tier code {
   color: var(--foreground);


### PR DESCRIPTION
Closes #142. Supersedes #191 (closed — the read-only provider chip and the widened model column from that PR are carried forward; the findings that made it unmergeable are recorded there).

Agent settings → Router Tiers made you type the provider and the model for all five tiers as free text, from memory, with nothing validating either. A tier a request only escalates to can carry a typo for a long time before the first failed turn.

## Provider cell → read-only chip

Tiers select the **model**; requests always go through `llm.provider`, and a tier naming a different provider is degraded back to `llm.model` at boot (`boot.py:1106-1120`). Five editable copies of one value were five chances to get it wrong, so the cell shows the configured provider and save writes it on every tier.

## Model cell → combobox over a real catalog

Options come from two sources, and they have to be **unioned**, not chosen between:

- **`models.list`** (`rpc_models.py:33`) is live but partial — it aggregates the currently configured provider chain and answers nothing before an API key is saved, which is exactly when this form is being filled in. It is called with its own `provider` and `capabilities` filters rather than being filtered client-side, so "the gateway has no catalog for this provider" stays distinguishable from "this provider has no models", and the vision filter uses the server's capability data instead of guessing at it.
- **`onboarding.catalog.routerProfiles`** ships with the package, is per provider, and carries the recommended model for every tier — `image_model` included.

Taking either alone gets it wrong in both directions: the offline list on its own flags ids the gateway does know, and dropping it flags the form's own seeded defaults.

The image row is offered only vision-capable models — from the server's `capabilities` filter, and offline from the tiers that actually generate images. It is never handed text models relabelled as vision.

## Save warns, never blocks

Per the issue: "unknown ids are legitimate; silently accepting a typo is not." Three distinct things get three distinct warnings:

| Case | Message |
|---|---|
| Id no source knows | `Saved, but not in openai's catalog: … Check for a typo.` |
| Image tier on a non-vision model | `Saved, but the image tier points at a model with no vision capability: …` |
| No catalog at all to check against | `No model catalog available for openai — tier model ids were not checked.` |

An untouched form seeded from the catalog warns about nothing. Everything saves either way.

## Readability

The model column goes `minmax(10rem, 1.45fr)` → `minmax(14rem, 2fr)` (provider gives up the width it no longer needs), the input carries a `title`, and the context window and price per 1M render under the entered model — browsers disagree about whether a `<datalist>` option's label is shown at all (Safari renders values only), and those numbers are the whole reason to pick one tier model over another.

## Acceptance

| # | Criterion | |
|---|---|---|
| 1 | picking a provider populates the model options for every tier row | ✅ keyed on the provider, filtered server-side |
| 2 | selecting a model writes the same value the text input writes today | ✅ no config-shape change |
| 3 | an id not in the catalog can still be entered, and saving it shows a warning | ✅ warn-only, three distinguished cases |
| 4 | the image tier only offers vision-capable models | ✅ live and offline |

## Verification

`tsc --noEmit` clean, `eslint src` clean, `prettier --check src` clean, **1757 frontend tests across 82 files** (base `main`: 1738), Control UI build unchanged at 132.8 KiB gzip initial JS. New coverage sits in `logic.test.ts` (pure catalog/validation), `RouterSection.test.tsx` (picker behaviour, including the no-live-catalog path) and `setup-css.test.ts` (the chip and column contracts).
