### PR TITLE
fix(shell): detect redirection write targets without surrounding whitespace

### DIFF
--- a/docs/tools-and-sandbox.md
+++ b/docs/tools-and-sandbox.md
@@ -83,6 +83,14 @@ agentos agent \
 `--workspace-lockdown` is intended for automation where writes must stay inside
 the workspace or scratch directory.
 
+For shell commands, lockdown inspects the command text for write targets —
+redirections (`>`, `>>`, `2>`, `&>`, `>&`, `>|`, with or without surrounding
+whitespace) and `tee`. That is defense in depth, not a security boundary: a
+command can still reach outside the workspace through an interpreter
+(`python -c`), a copy (`cp`, `dd of=`), an in-place edit (`sed -i`), or a path
+built from a shell variable. Use the OS sandbox (`agentos sandbox on`) when you
+need containment that does not depend on reading the command line.
+
 ## Sandbox Commands
 
 ```sh

--- a/docs/tools-and-sandbox.md
+++ b/docs/tools-and-sandbox.md
@@ -85,7 +85,11 @@ the workspace or scratch directory.
 
 For shell commands, lockdown inspects the command text for write targets —
 redirections (`>`, `>>`, `2>`, `&>`, `>&`, `>|`, with or without surrounding
-whitespace) and `tee`. That is defense in depth, not a security boundary: a
+whitespace) and `tee` (including pipe-adjacent `|tee` and long options such as
+`tee --append`). The scan reads text, not shell syntax, so it deliberately fails
+closed: a command that merely *mentions* a path after `>` inside quotes — say
+`grep '>/dev/null' script.sh` — is refused under lockdown even though it writes
+nothing. That is defense in depth, not a security boundary: a
 command can still reach outside the workspace through an interpreter
 (`python -c`), a copy (`cp`, `dd of=`), an in-place edit (`sed -i`), or a path
 built from a shell variable. Use the OS sandbox (`agentos sandbox on`) when you

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -326,12 +326,24 @@ def _resolve_shell_write_target(raw_target: str, workdir: str | None) -> Path:
     return path.resolve(strict=False)
 
 
+# ``2>&1``, ``>&2`` and ``>&-`` duplicate or close a descriptor: what follows the
+# operator is a descriptor number, not a path. Blank those out before scanning so
+# they are never mistaken for a write target.
+_FD_DUP_PATTERN = re.compile(r"\d*>&\s*(?:\d+-?|-)(?=$|[\s|&;<>)])")
+
+# Redirection operators that create or truncate a file: ``>``, ``>>``, ``n>``,
+# ``n>>``, ``&>``, ``&>>``, ``>&file`` and the noclobber override ``>|``. The
+# operator is deliberately *not* anchored to a word boundary — ``echo x>file`` is
+# valid shell and must be caught just like ``echo x > file``.
+_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
+
+_TEE_PATTERN = re.compile(r"(?:^|\s)tee(?:\s+-[A-Za-z]+)*\s+(['\"]?)([^'\"\s|&;]+)\1")
+
+
 def _shell_write_targets(command: str) -> list[str]:
-    targets: list[str] = []
-    redirection_pattern = r"(?:^|\s)(?:\d?>{1,2}|&>{1,2})\s*(['\"]?)([^'\"\s|&;]+)\1"
-    targets.extend(match.group(2) for match in re.finditer(redirection_pattern, command))
-    tee_pattern = r"(?:^|\s)tee(?:\s+-[A-Za-z]+)*\s+(['\"]?)([^'\"\s|&;]+)\1"
-    targets.extend(match.group(2) for match in re.finditer(tee_pattern, command))
+    scanned = _FD_DUP_PATTERN.sub(" ", command)
+    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
+    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
     return targets
 
 

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -337,7 +337,16 @@ _FD_DUP_PATTERN = re.compile(r"\d*>&\s*(?:\d+-?|-)(?=$|[\s|&;<>)])")
 # valid shell and must be caught just like ``echo x > file``.
 _REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
 
-_TEE_PATTERN = re.compile(r"(?:^|\s)tee(?:\s+-[A-Za-z]+)*\s+(['\"]?)([^'\"\s|&;]+)\1")
+# ``tee`` is the other write primitive this parser covers, and it needs the same
+# treatment as the redirection operators: ``echo x|tee /etc/passwd`` is valid
+# shell, so a preceding ``|``, ``;``, ``&`` or ``(`` has to count just like a
+# space. The lookbehind keeps ``mytee``/``notee`` out while still matching a
+# fully qualified ``/usr/bin/tee``. Options may be short (``-a``), long
+# (``--append``) or long with a value (``--output-error=warn``); all of them are
+# skipped so the first non-option word is the real target.
+_TEE_PATTERN = re.compile(
+    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"\s|&;]+)\1"
+)
 
 
 def _shell_write_targets(command: str) -> list[str]:

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -492,6 +492,38 @@ def test_shell_write_targets_ignores_descriptor_duplication(command: str) -> Non
     assert shell._shell_write_targets(command) == []
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo x|tee /etc/passwd",
+        "echo x|tee -a /etc/passwd",
+        "echo x;tee /etc/passwd",
+        "echo x | tee /etc/passwd",
+        "tee --append /etc/passwd",
+        "tee --output-error=warn /etc/passwd",
+        "tee -a -i /etc/passwd",
+        "echo x | /usr/bin/tee /etc/passwd",
+    ],
+)
+def test_shell_write_targets_detects_tee_without_whitespace_or_short_options(
+    command: str,
+) -> None:
+    assert "/etc/passwd" in shell._shell_write_targets(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "mytee /etc/passwd",
+        "notee /etc/passwd",
+        "committee /etc/passwd",
+        "echo tee",
+    ],
+)
+def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
+    assert shell._shell_write_targets(command) == []
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "template",
@@ -531,6 +563,94 @@ async def test_workspace_lockdown_blocks_redirection_without_whitespace(
     assert result["status"] == "blocked"
     assert result["reason"] == "workspace_lockdown"
     assert result["resolved_path"] == str(outside)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template",
+    [
+        "echo ok|tee {target}",
+        "echo ok|tee -a {target}",
+        "echo ok | tee --append {target}",
+        "echo ok | tee --output-error=warn {target}",
+    ],
+)
+async def test_workspace_lockdown_blocks_tee_without_whitespace_or_long_options(
+    tmp_path: Path,
+    template: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        template.format(target=outside),
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["resolved_path"] == str(outside)
+
+
+@pytest.mark.asyncio
+async def test_workspace_write_deny_globs_block_tee_without_whitespace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_write_deny_globs = ["reports/*.txt"]  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "echo ok|tee --append reports/out.txt",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_write_deny"
+    assert result["matched_pattern"] == "reports/*.txt"
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_allows_tee_inside_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "echo ok|tee -a out.txt",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -311,6 +311,7 @@ async def test_approved_background_process_uses_host_grant_when_sandbox_enabled(
     )
 
     import os
+
     cmd = "del target.txt" if os.name == "nt" else "rm target.txt"
     pending = json.loads(await shell.background_process(cmd, workdir=str(tmp_path)))
     assert pending["status"] == "approval_required"
@@ -456,6 +457,107 @@ async def test_workspace_lockdown_blocks_obvious_outside_shell_redirection(
     assert result["reason"] == "workspace_lockdown"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo malicious>/etc/passwd",
+        "echo malicious>>/etc/passwd",
+        "cmd 2>/etc/leak.txt",
+        "cmd 1>>/etc/leak.txt",
+        "cmd 10>/etc/leak.txt",
+        ">&/etc/both.txt",
+        "cmd &>/etc/both.txt",
+        "cmd &>>/etc/both.txt",
+        "cmd >|/etc/clobber.txt",
+        "cat<input>/etc/out.txt",
+        "cmd 2>&1 >/etc/out.txt",
+    ],
+)
+def test_shell_write_targets_detects_redirection_without_whitespace(command: str) -> None:
+    assert [target for target in shell._shell_write_targets(command) if target.startswith("/etc/")]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd 2>&1",
+        "cmd >&2",
+        "cmd 2>&-",
+        "cmd 2>&1 | grep x",
+        "ls -la",
+        "grep -R needle src",
+    ],
+)
+def test_shell_write_targets_ignores_descriptor_duplication(command: str) -> None:
+    assert shell._shell_write_targets(command) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template",
+    [
+        "echo ok>{target}",
+        "echo ok>>{target}",
+        "echo ok 2>{target}",
+        ">&{target}",
+        "echo ok &>{target}",
+        "cat<in>{target}",
+    ],
+)
+async def test_workspace_lockdown_blocks_redirection_without_whitespace(
+    tmp_path: Path,
+    template: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        template.format(target=outside),
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["resolved_path"] == str(outside)
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_allows_descriptor_duplication_inside_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "echo ok>out.txt 2>&1",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is None
+
+
 @pytest.mark.asyncio
 async def test_workspace_write_deny_globs_block_shell_redirection(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
@@ -470,6 +572,33 @@ async def test_workspace_write_deny_globs_block_shell_redirection(tmp_path: Path
     result = await shell._check_exec_approval(
         "exec_command",
         "echo ok > reports/out.txt",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_write_deny"
+
+
+@pytest.mark.asyncio
+async def test_workspace_write_deny_globs_block_redirection_without_whitespace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_write_deny_globs = ["reports/*.txt"]  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        "echo ok>reports/out.txt",
         str(workspace),
         "command requires approval",
         None,


### PR DESCRIPTION
Fixes #197

## The bug

`--workspace-lockdown` and `workspace_write_deny_globs` both decide what a shell command writes by calling `_shell_write_targets()` in `src/agentos/tools/builtin/shell.py`. Its redirection regex was anchored with `(?:^|\s)`:

```python
r"(?:^|\s)(?:\d?>{1,2}|&>{1,2})\s*(['\"]?)([^'\"\s|&;]+)\1"
```

The operator had to be preceded by whitespace or start-of-string, so `echo x>/etc/passwd` — valid shell — parsed as containing no write target and passed both checks. `>&file` was missing from the operator set entirely (so `cmd >&/etc/x` slipped through even *with* a space), and the noclobber override `>|` was never handled.

I reproduced this against the regex on `main` with the cases from the issue. Worth noting for triage: only 2 of the 6 reported repro lines were actually broken — `cmd 2>/tmp/leak.txt`, `true | cat >/tmp/out.txt`, `true; echo x >/tmp/out.txt` and `(echo x) >/tmp/out.txt` all have whitespace before the operator and were already blocked. The real gaps were the no-whitespace form and `>&`. I also found a third the issue did not list: `cat<in>/etc/x`.

## The fix

- Drop the leading-whitespace anchor so the operator is matched wherever it appears.
- Add `>&` to the operator set and support the `>|` noclobber override.
- Blank out descriptor duplication/closing (`2>&1`, `>&2`, `2>&-`) *before* scanning, so the descriptor number after `>&` is never mistaken for a path. Without this, dropping the anchor would turn every `2>&1` into a bogus write to a file named `1`.
- Exclude `<`, `>`, `(` and `)` from the target character class so `cat<in>/etc/x` resolves to `/etc/x` and process substitution `>(cmd)` does not produce a garbage target.

## Scope — please read before merging

This is a regex over command text, and it will never be airtight. This PR closes the reported whitespace and `>&` gaps, but a command can still write outside the workspace through `python -c "open('/etc/x','w')"`, `cp`, `dd of=`, `sed -i`, `eval`, or a path built from a shell variable (`F=/etc/x; echo hi > $F`). None of those are new, and none are fixed here.

Because `docs/tools-and-sandbox.md` described lockdown as "writes must stay inside the workspace" with no caveat, I added a paragraph stating plainly that shell lockdown is defense in depth rather than a security boundary, and pointing at the OS sandbox for real containment. Without that, the same class of issue will keep getting filed as p0 for each newly discovered bypass. Happy to drop the docs hunk if you would rather keep it code-only.

## Tests

New coverage in `tests/test_tools/test_shell_approval_policy.py`:

- parametrized `_shell_write_targets` cases for `>`, `>>`, `n>`, `n>>`, `10>`, `&>`, `&>>`, `>&`, `>|` and `<in>` without whitespace
- parametrized negative cases asserting `2>&1`, `>&2`, `2>&-` yield no targets
- end-to-end `_check_exec_approval` tests that lockdown blocks each no-whitespace form with `reason == "workspace_lockdown"` and the expected `resolved_path`
- a test that `echo ok>out.txt 2>&1` inside the workspace is still allowed (no false positive)
- the same no-whitespace coverage for the `workspace_write_deny` path, which shares the parser

Gate: `ruff check src tests`, `ruff format`, `mypy src/agentos` and the full suite all pass locally (7373 passed, 23 skipped).

No CLI surface change, so `docs/cli.md` and the bundled `SKILL.md` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)