### PR TITLE
webui: add an i18n seam and migrate the shell and five views

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,6 +2,20 @@ import tseslint from 'typescript-eslint'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
+// Files whose user-facing copy has been moved into src/i18n (issue #138).
+// This list IS the migration ledger: a view joins it in the same change that
+// extracts its strings, and can never silently regress afterwards. Views that
+// have not been migrated yet stay out, so the rule below is never noise.
+const I18N_MIGRATED = [
+  'src/app/**/*.tsx',
+  'src/components/**/*.tsx',
+  'src/views/approvals/**/*.tsx',
+  'src/views/env/**/*.tsx',
+  'src/views/health/**/*.tsx',
+  'src/views/logs/**/*.tsx',
+  'src/views/overview/**/*.tsx',
+]
+
 export default tseslint.config(
   ...tseslint.configs.recommended,
   {
@@ -10,6 +24,28 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+  {
+    // Built-in no-restricted-syntax rather than react/jsx-no-literals: this repo
+    // has no eslint-plugin-react, and the esquery selectors below enforce the
+    // same thing without adding a dependency. The {3,} letter threshold keeps
+    // punctuation, separators, and units out of the catalog.
+    files: I18N_MIGRATED,
+    ignores: ['**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXText[value=/[A-Za-z]{3,}/]',
+          message: 'User-facing text must come from t() — add it to src/i18n/en/<view>.ts.',
+        },
+        {
+          selector:
+            'JSXAttribute[name.name=/^(aria-label|aria-description|placeholder|title|alt)$/] > Literal[value=/[A-Za-z]{3,}/]',
+          message: 'Accessible and attribute copy must come from t().',
+        },
+      ],
     },
   },
 )

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -41,6 +41,7 @@ import {
   useKeyboardShortcut,
   useShortcutOverlay,
 } from '@/components/KeyboardShortcuts'
+import { t, tPlural } from '@/i18n'
 import { useTheme } from '@/stores/theme'
 import { useConnection } from '@/stores/connection'
 import { useApprovals } from '@/services/approval-monitor'
@@ -60,28 +61,31 @@ const NAV_GROUPS: ReadonlyArray<{
   label: string
   items: ReadonlyArray<{ path: string; title: string; icon: LucideIcon }>
 }> = [
-  { label: 'Chat', items: [{ path: 'chat', title: 'Chat', icon: MessageSquare }] },
   {
-    label: 'Control',
+    label: t('shell.navGroupChat'),
+    items: [{ path: 'chat', title: t('shell.viewChat'), icon: MessageSquare }],
+  },
+  {
+    label: t('shell.navGroupControl'),
     items: [
-      { path: 'overview', title: 'Overview', icon: LayoutDashboard },
-      { path: 'health', title: 'Health', icon: Activity },
-      { path: 'channels', title: 'Channels', icon: Radio },
-      { path: 'mcp', title: 'MCP Servers', icon: Network },
-      { path: 'skills', title: 'Skills', icon: Puzzle },
-      { path: 'sessions', title: 'Sessions', icon: History },
-      { path: 'agents', title: 'Agents', icon: Bot },
-      { path: 'usage', title: 'Usage', icon: BarChart3 },
-      { path: 'cron', title: 'Cron', icon: CalendarClock },
+      { path: 'overview', title: t('shell.viewOverview'), icon: LayoutDashboard },
+      { path: 'health', title: t('shell.viewHealth'), icon: Activity },
+      { path: 'channels', title: t('shell.viewChannels'), icon: Radio },
+      { path: 'mcp', title: t('shell.viewMcp'), icon: Network },
+      { path: 'skills', title: t('shell.viewSkills'), icon: Puzzle },
+      { path: 'sessions', title: t('shell.viewSessions'), icon: History },
+      { path: 'agents', title: t('shell.viewAgents'), icon: Bot },
+      { path: 'usage', title: t('shell.viewUsage'), icon: BarChart3 },
+      { path: 'cron', title: t('shell.viewCron'), icon: CalendarClock },
     ],
   },
   {
-    label: 'Settings',
+    label: t('shell.navGroupSettings'),
     items: [
-      { path: 'settings', title: 'Agent Setup', icon: Settings2 },
-      { path: 'env', title: 'Environment', icon: KeyRound },
-      { path: 'logs', title: 'Logs', icon: ScrollText },
-      { path: 'approvals', title: 'Approvals', icon: ShieldCheck },
+      { path: 'settings', title: t('shell.viewSettings'), icon: Settings2 },
+      { path: 'env', title: t('shell.viewEnv'), icon: KeyRound },
+      { path: 'logs', title: t('shell.viewLogs'), icon: ScrollText },
+      { path: 'approvals', title: t('shell.viewApprovals'), icon: ShieldCheck },
     ],
   },
 ]
@@ -108,6 +112,15 @@ const PILL_VARIANT: Record<string, string> = {
   connected: 'ok',
   connecting: 'warn',
   disconnected: 'err',
+}
+
+// Legacy derived the label by capitalising the state id. Translating it needs a
+// real map; an unmapped state still falls back to the capitalised id so a new
+// RpcState can never render an empty pill.
+const PILL_LABEL: Record<string, string> = {
+  connected: t('shell.connConnected'),
+  connecting: t('shell.connConnecting'),
+  disconnected: t('shell.connDisconnected'),
 }
 
 export const SIDEBAR_COLLAPSED_STORAGE_KEY = 'agentos-sidebar-collapsed'
@@ -152,8 +165,8 @@ export function AppShell() {
   useKeyboardShortcut(
     {
       combo: 'escape',
-      description: 'Close the navigation drawer (mobile)',
-      category: 'Global',
+      description: t('shell.shortcutDrawerEscape'),
+      category: t('shell.shortcutCategoryGlobal'),
       documentationOnly: true,
     },
     () => {},
@@ -323,10 +336,11 @@ export function AppShell() {
   // reactive state here avoids duplicating the same readout in the header.
   const pillState = connState
   const pillVariant = PILL_VARIANT[pillState] ?? 'err'
-  const pillLabel = pillState.charAt(0).toUpperCase() + pillState.slice(1)
+  const pillLabel = PILL_LABEL[pillState] ?? pillState.charAt(0).toUpperCase() + pillState.slice(1)
   const pillOk = pillVariant === 'ok'
 
   const version = sidebarVersion(bootstrap.version)
+  const themeName = mode === 'dark' ? t('shell.themeDark') : t('shell.themeLight')
 
   const focusMainContent = (event: ReactMouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
@@ -354,13 +368,13 @@ export function AppShell() {
       style={{ ['--shell-header-h' as string]: '0px' }}
     >
       <a className="shell-skip-link" href="#main-content" onClick={focusMainContent}>
-        Skip to main content
+        {t('shell.navSkipToContent')}
       </a>
       <aside
         ref={sidebarRef}
         id="sidebar-nav"
         role={isMobile && sidebarOpen ? 'dialog' : undefined}
-        aria-label={isMobile && sidebarOpen ? 'Workspace navigation' : undefined}
+        aria-label={isMobile && sidebarOpen ? t('shell.navDrawerLandmark') : undefined}
         aria-modal={isMobile && sidebarOpen ? true : undefined}
         aria-hidden={drawerHidden || undefined}
         inert={drawerHidden || undefined}
@@ -373,16 +387,16 @@ export function AppShell() {
           <div className="shell-sidebar__brand min-w-0">
             <img className="shell-sidebar__brand-mark" src={agentosMark} alt="" />
             <span className="shell-sidebar__brand-copy">
-              <span>AgentOS</span>
-              <span className="text-primary">Control</span>
+              <span>{t('shell.brandName')}</span>
+              <span className="text-primary">{t('shell.brandSuffix')}</span>
             </span>
           </div>
           <Button
             variant="ghost"
             size="icon-sm"
             className="shell-sidebar__collapse ml-auto shrink-0 max-md:hidden"
-            title={compactSidebar ? 'Expand navigation' : 'Collapse navigation'}
-            aria-label={compactSidebar ? 'Expand navigation' : 'Collapse navigation'}
+            title={compactSidebar ? t('shell.navExpand') : t('shell.navCollapse')}
+            aria-label={compactSidebar ? t('shell.navExpand') : t('shell.navCollapse')}
             aria-controls="sidebar-nav"
             aria-expanded={!compactSidebar}
             aria-hidden={isMobile || undefined}
@@ -396,7 +410,10 @@ export function AppShell() {
             )}
           </Button>
         </div>
-        <nav aria-label="Main" className="shell-sidebar__nav flex-1 overflow-y-auto px-2.5 py-5">
+        <nav
+          aria-label={t('shell.navLandmark')}
+          className="shell-sidebar__nav flex-1 overflow-y-auto px-2.5 py-5"
+        >
           {NAV_GROUPS.map((group) => (
             <div key={group.label} className="shell-nav-group mb-6">
               <div className="shell-nav-group__label nav-group px-2.5 pb-2">{group.label}</div>
@@ -435,9 +452,7 @@ export function AppShell() {
                         id="approval-count"
                         data-testid="approval-badge"
                         className="shell-nav-link__badge t-data ml-auto inline-flex min-w-5 items-center justify-center rounded-full border border-warn/40 px-1.5 text-[10px] font-semibold text-warn"
-                        aria-label={`${approvalCount} pending ${
-                          approvalCount === 1 ? 'approval' : 'approvals'
-                        }`}
+                        aria-label={tPlural('shell.navApprovalBadge', approvalCount)}
                       >
                         {approvalCount}
                       </span>
@@ -458,7 +473,7 @@ export function AppShell() {
             className="shell-sidebar__connection t-data"
             data-testid="nav-foot"
             data-variant={pillVariant}
-            title={version ? `${pillLabel}, version ${version}` : pillLabel}
+            title={version ? t('shell.connWithVersion', { state: pillLabel, version }) : pillLabel}
           >
             <span
               aria-hidden="true"
@@ -486,8 +501,8 @@ export function AppShell() {
               size="icon-sm"
               className="shell-sidebar__shortcuts"
               onClick={shortcutOverlay.open}
-              title={`Keyboard shortcuts (${formatCombo(HELP_COMBO)})`}
-              aria-label="Keyboard shortcuts"
+              title={t('shell.shortcutsTitle', { combo: formatCombo(HELP_COMBO) })}
+              aria-label={t('shell.shortcutsLabel')}
             >
               <Keyboard className="size-4" />
             </Button>
@@ -497,8 +512,8 @@ export function AppShell() {
             size="icon-sm"
             className="shell-sidebar__theme"
             onClick={toggle}
-            title={`Theme: ${mode}`}
-            aria-label={`Theme: ${mode}. Toggle theme`}
+            title={t('shell.themeTitle', { mode: themeName })}
+            aria-label={t('shell.themeToggleLabel', { mode: themeName })}
             aria-pressed={mode === 'dark'}
           >
             {mode === 'dark' ? <Moon className="size-4" /> : <Sun className="size-4" />}
@@ -509,7 +524,7 @@ export function AppShell() {
         <button
           type="button"
           className="shell-sidebar__backdrop"
-          aria-label="Close navigation"
+          aria-label={t('shell.navClose')}
           onClick={() => closeMobileDrawer(true)}
         />
       ) : null}
@@ -523,8 +538,8 @@ export function AppShell() {
           variant="ghost"
           size="icon"
           className="shell-mobile-menu"
-          title="Toggle menu"
-          aria-label="Toggle menu"
+          title={t('shell.navToggleMenu')}
+          aria-label={t('shell.navToggleMenu')}
           aria-controls="sidebar-nav"
           aria-expanded={sidebarOpen}
           onClick={() => {
@@ -541,7 +556,7 @@ export function AppShell() {
         {isChat ? (
           <section
             className="shell-chat-header"
-            aria-label="Chat toolbar"
+            aria-label={t('shell.chatToolbar')}
             data-testid="shell-chat-header"
           >
             <div className="shell-chat-header__identity">
@@ -549,7 +564,7 @@ export function AppShell() {
                 <MessageSquare />
               </span>
               <span className="shell-chat-header__copy">
-                <strong>Chat</strong>
+                <strong>{t('shell.viewChat')}</strong>
               </span>
             </div>
             <div

--- a/frontend/src/app/RouteErrorBoundary.tsx
+++ b/frontend/src/app/RouteErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { isRouteErrorResponse, Link, useNavigate, useRouteError } from 'react-router'
 import { LayoutDashboardIcon, RefreshCwIcon, TriangleAlertIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { t } from '@/i18n'
 import './route-error.css'
 
 const MAX_DEVELOPER_MESSAGE_LENGTH = 240
@@ -27,10 +28,9 @@ export function routeErrorCopy(
   if (isRouteErrorResponse(error)) {
     const unavailable = error.status === 401 || error.status === 403 || error.status === 404
     return {
-      code: `HTTP ${error.status}`,
-      title: unavailable ? 'This view is unavailable' : 'This view hit a snag',
-      message:
-        'AgentOS kept the rest of your workspace intact. Reload this view or return to Overview.',
+      code: t('shell.errorHttpCode', { status: error.status }),
+      title: unavailable ? t('shell.errorUnavailableTitle') : t('shell.errorSnagTitle'),
+      message: t('shell.errorMessage'),
     }
   }
 
@@ -40,10 +40,9 @@ export function routeErrorCopy(
       : undefined
 
   return {
-    code: 'VIEW ERROR',
-    title: 'This view hit a snag',
-    message:
-      'AgentOS kept the rest of your workspace intact. Reload this view or return to Overview.',
+    code: t('shell.errorViewCode'),
+    title: t('shell.errorSnagTitle'),
+    message: t('shell.errorMessage'),
     developerMessage,
   }
 }
@@ -55,7 +54,7 @@ export function RouteErrorBoundary() {
   const copy = routeErrorCopy(error)
 
   useEffect(() => {
-    document.title = 'Recovery - AgentOS Control'
+    document.title = t('shell.errorDocumentTitle')
     headingRef.current?.focus()
   }, [])
 
@@ -67,10 +66,10 @@ export function RouteErrorBoundary() {
             <TriangleAlertIcon />
           </span>
           <div className="route-error__identity">
-            <span className="route-error__eyebrow">Workspace recovery</span>
+            <span className="route-error__eyebrow">{t('shell.errorEyebrow')}</span>
             <span className="route-error__status">
               <span aria-hidden="true" />
-              View paused safely
+              {t('shell.errorStatus')}
             </span>
           </div>
           <code className="route-error__code">{copy.code}</code>
@@ -84,20 +83,20 @@ export function RouteErrorBoundary() {
 
           {copy.developerMessage ? (
             <div className="route-error__developer">
-              <span>Developer detail</span>
+              <span>{t('shell.errorDeveloperDetail')}</span>
               <code>{copy.developerMessage}</code>
             </div>
           ) : null}
 
-          <div className="route-error__actions" aria-label="Recovery actions">
+          <div className="route-error__actions" aria-label={t('shell.errorActions')}>
             <Button type="button" onClick={() => navigate(0)}>
               <RefreshCwIcon />
-              Reload view
+              {t('shell.errorReload')}
             </Button>
             <Button asChild variant="outline">
               <Link to="/overview">
                 <LayoutDashboardIcon />
-                Go to Overview
+                {t('shell.errorGoOverview')}
               </Link>
             </Button>
           </div>

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { fallbackBootstrap, fetchBootstrap, resolveWsUrl, type Bootstrap } from 
 import { WsRpcClient } from '@/lib/ws-rpc'
 import { useConnection } from '@/stores/connection'
 import { initTheme } from '@/stores/theme'
+import { initLocale, t } from '@/i18n'
 import { approvalMonitor } from '@/services/approval-monitor'
 import type { RpcState } from '@/lib/ws-rpc'
 import { KeyboardShortcutProvider } from '@/components/KeyboardShortcuts'
@@ -36,6 +37,9 @@ export function AppProviders({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     initTheme()
+    // Constant today. When the gateway starts advertising a locale this becomes
+    // setLocale(b.locale) inside the bootstrap .then() below, before setBootstrap.
+    initLocale()
     let cancelled = false
     const unsubscribe = rpc.on('_state', (s) => useConnection.getState().setState(s as RpcState))
     fetchBootstrap()
@@ -85,7 +89,7 @@ export function AppProviders({ children }: { children: ReactNode }) {
     return () => approvalMonitor.stop()
   }, [])
 
-  if (!bootstrap) return <div className="p-8 text-sm">Connecting…</div>
+  if (!bootstrap) return <div className="p-8 text-sm">{t('shell.connecting')}</div>
 
   return (
     <BootstrapContext.Provider value={bootstrap}>

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,5 +1,6 @@
 import { lazy as reactLazy, Suspense, useEffect } from 'react'
 import { type RouteObject, useLocation } from 'react-router'
+import { t } from '@/i18n'
 import { RouteErrorBoundary } from './RouteErrorBoundary'
 
 type LazyRoute = NonNullable<RouteObject['lazy']>
@@ -53,23 +54,26 @@ const loadEnv: LazyRoute = async () => ({
   Component: (await import('@/views/env/EnvPage')).EnvPage,
 })
 
+// Titles resolve at module load. That is correct while the locale is chosen
+// once at boot (see i18n/locale.ts); a future runtime locale switch would have
+// to turn `title` into a getter.
 const VIEW_ROUTES: ReadonlyArray<ViewRoute> = [
-  { path: 'overview', title: 'Overview', lazy: loadOverview },
-  { path: 'health', title: 'Health', lazy: loadHealth },
-  { path: 'chat', title: 'Chat', lazy: loadChat },
-  { path: 'sessions', title: 'Sessions', lazy: loadSessions },
-  { path: 'agents', title: 'Agents', lazy: loadAgents },
-  { path: 'cron', title: 'Cron', lazy: loadCron },
-  { path: 'usage', title: 'Usage', lazy: loadUsage },
-  { path: 'settings', title: 'Agent Setup', lazy: loadSettings },
-  { path: 'config', title: 'Config', lazy: loadSettings },
-  { path: 'setup', title: 'Setup', lazy: loadSettings },
-  { path: 'channels', title: 'Channels', lazy: loadChannels },
-  { path: 'mcp', title: 'MCP Servers', lazy: loadMcp },
-  { path: 'approvals', title: 'Approvals', lazy: loadApprovals },
-  { path: 'skills', title: 'Skills', lazy: loadSkills },
-  { path: 'env', title: 'Environment', lazy: loadEnv },
-  { path: 'logs', title: 'Logs', lazy: loadLogs },
+  { path: 'overview', title: t('shell.viewOverview'), lazy: loadOverview },
+  { path: 'health', title: t('shell.viewHealth'), lazy: loadHealth },
+  { path: 'chat', title: t('shell.viewChat'), lazy: loadChat },
+  { path: 'sessions', title: t('shell.viewSessions'), lazy: loadSessions },
+  { path: 'agents', title: t('shell.viewAgents'), lazy: loadAgents },
+  { path: 'cron', title: t('shell.viewCron'), lazy: loadCron },
+  { path: 'usage', title: t('shell.viewUsage'), lazy: loadUsage },
+  { path: 'settings', title: t('shell.viewSettings'), lazy: loadSettings },
+  { path: 'config', title: t('shell.viewConfig'), lazy: loadSettings },
+  { path: 'setup', title: t('shell.viewSetup'), lazy: loadSettings },
+  { path: 'channels', title: t('shell.viewChannels'), lazy: loadChannels },
+  { path: 'mcp', title: t('shell.viewMcp'), lazy: loadMcp },
+  { path: 'approvals', title: t('shell.viewApprovals'), lazy: loadApprovals },
+  { path: 'skills', title: t('shell.viewSkills'), lazy: loadSkills },
+  { path: 'env', title: t('shell.viewEnv'), lazy: loadEnv },
+  { path: 'logs', title: t('shell.viewLogs'), lazy: loadLogs },
 ]
 
 export const VIEWS: ReadonlyArray<{ path: string; title: string }> = VIEW_ROUTES.map(
@@ -115,15 +119,19 @@ function NotFound() {
   // useLocation().pathname is basename-relative under react-router.
   const { pathname } = useLocation()
   useEffect(() => {
-    document.title = 'Not Found - AgentOS Control'
+    document.title = t('shell.routeNotFoundTitle')
   }, [])
-  return <div className="p-8 text-muted-foreground">{'Page not found: ' + pathname}</div>
+  return (
+    <div className="p-8 text-muted-foreground">
+      {t('shell.routeNotFoundBody', { path: pathname })}
+    </div>
+  )
 }
 
 function RoutePending() {
   return (
     <div className="p-8 text-muted-foreground" aria-hidden="true">
-      Opening view…
+      {t('shell.routePending')}
     </div>
   )
 }

--- a/frontend/src/components/ApprovalPrompt.tsx
+++ b/frontend/src/components/ApprovalPrompt.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { CommandLine } from '@/components/CommandLine'
 import { ModalShell } from '@/components/ModalShell'
+import { t } from '@/i18n'
 import {
   approvalCommand,
   approvalDetail,
@@ -75,7 +76,7 @@ export function ApprovalPrompt() {
   const detail = approvalDetail(item)
   const meta = approvalMeta(item, item.mode || mode)
   const showAlways = canAlwaysAllow(item)
-  const toolLabel = item.toolName || item.actionKind || 'Tool execution'
+  const toolLabel = item.toolName || item.actionKind || t('shell.approvalFallbackTool')
 
   async function resolve(action: 'once' | 'always' | 'bypass' | 'deny'): Promise<void> {
     if (busy || !item) return
@@ -108,7 +109,7 @@ export function ApprovalPrompt() {
       className="approval-modal panel tone-warn"
     >
       <div className="panel__head">
-        <span id="approval-modal-title">Approval Required</span>
+        <span id="approval-modal-title">{t('shell.approvalTitle')}</span>
       </div>
       <div className="panel__body approval-modal__body">
         <div className="approval-modal__tool">{toolLabel}</div>
@@ -120,30 +121,30 @@ export function ApprovalPrompt() {
         <Button
           type="button"
           disabled={busy}
-          title="Approve only this pending tool call"
+          title={t('shell.approvalOnceTitle')}
           onClick={() => void resolve('once')}
         >
-          Approve This Time
+          {t('shell.approvalOnce')}
         </Button>
         {showAlways ? (
           <Button
             type="button"
             variant="outline"
             disabled={busy}
-            title="Remember this operation type for future matching intents"
+            title={t('shell.approvalAlwaysTitle')}
             onClick={() => void resolve('always')}
           >
-            Always Allow This Type
+            {t('shell.approvalAlways')}
           </Button>
         ) : null}
         <Button
           type="button"
           variant="outline"
           disabled={busy}
-          title="Enable approval bypass in this browser session and approve this pending tool call"
+          title={t('shell.approvalBypassTitle')}
           onClick={() => void resolve('bypass')}
         >
-          Bypass Approvals
+          {t('shell.approvalBypass')}
         </Button>
         <Button
           type="button"
@@ -151,7 +152,7 @@ export function ApprovalPrompt() {
           disabled={busy}
           onClick={() => void resolve('deny')}
         >
-          Deny
+          {t('shell.approvalDeny')}
         </Button>
       </div>
     </ModalShell>

--- a/frontend/src/components/CommandLine.tsx
+++ b/frontend/src/components/CommandLine.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { t } from '@/i18n'
 
 // Common terminal command line: `$ <command>` with an integrated copy action.
 // Copy semantics carry the legacy UI.toast contract (health.js:35-62 +
@@ -22,7 +23,7 @@ function copyText(text: string): Promise<void> {
   ta.select()
   const ok = document.execCommand('copy')
   document.body.removeChild(ta)
-  return ok ? Promise.resolve() : Promise.reject(new Error('Copy command failed'))
+  return ok ? Promise.resolve() : Promise.reject(new Error(t('shell.commandCopyError')))
 }
 
 export function CommandLine({
@@ -39,13 +40,16 @@ export function CommandLine({
     if (!command) return
     try {
       await copyText(command)
-      toast.success('Copied command', { id: `${toastIdPrefix}-ok`, duration: 1600 })
+      toast.success(t('shell.commandCopied'), { id: `${toastIdPrefix}-ok`, duration: 1600 })
       setCopied(true)
       if (resetTimer.current) clearTimeout(resetTimer.current)
       resetTimer.current = setTimeout(() => setCopied(false), 1400)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Copy failed: ' + message, { id: `${toastIdPrefix}-err`, duration: 2500 })
+      toast.error(t('shell.commandCopyFailed', { message }), {
+        id: `${toastIdPrefix}-err`,
+        duration: 2500,
+      })
     }
   }
 
@@ -60,8 +64,8 @@ export function CommandLine({
         variant="ghost"
         size="icon-xs"
         className="cmdline__copy"
-        title="Copy command"
-        aria-label="Copy command"
+        title={t('shell.commandCopyLabel')}
+        aria-label={t('shell.commandCopyLabel')}
         onClick={() => void onCopy()}
       >
         {copied ? <CheckIcon className="text-ok" /> : <CopyIcon />}

--- a/frontend/src/components/ShortcutOverlay.tsx
+++ b/frontend/src/components/ShortcutOverlay.tsx
@@ -8,6 +8,7 @@ import { Fragment } from 'react'
 import { AnimatePresence } from 'motion/react'
 import { X } from 'lucide-react'
 import { ModalShell } from '@/components/ModalShell'
+import { t } from '@/i18n'
 import { comboParts, groupByCategory, isMac, type RegisteredShortcut } from './shortcut-combo'
 import './KeyboardShortcuts.css'
 
@@ -45,13 +46,13 @@ function Sheet({ shortcuts, onClose }: { shortcuts: RegisteredShortcut[]; onClos
     >
       <div className="panel__head shortcut-sheet__head">
         <h2 id="shortcut-overlay-title" className="shortcut-sheet__title">
-          Keyboard shortcuts
+          {t('shell.shortcutsLabel')}
         </h2>
         <button
           type="button"
           className="shortcut-sheet__close"
           onClick={onClose}
-          aria-label="Close dialog"
+          aria-label={t('shell.shortcutClose')}
         >
           <X size={18} />
         </button>

--- a/frontend/src/i18n/catalog.test.ts
+++ b/frontend/src/i18n/catalog.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { en } from './en'
+
+/**
+ * Generic invariants over the catalogs. These are what keep the per-view
+ * migration honest — every new namespace is covered the moment it is added to
+ * `en`, with no per-view test file to remember to write.
+ */
+
+type Leaf = [namespace: string, key: string, value: string]
+
+const LEAVES: Leaf[] = Object.entries(en).flatMap(([namespace, messages]) =>
+  Object.entries(messages as Record<string, string>).map(
+    ([key, value]) => [namespace, key, value] as Leaf,
+  ),
+)
+
+function placeholders(value: string): string[] {
+  return [...value.matchAll(/\{(\w+)\}/g)].map((m) => m[1] as string).sort()
+}
+
+describe('the English catalog', () => {
+  it('is not empty', () => {
+    expect(LEAVES.length).toBeGreaterThan(0)
+  })
+
+  it('has a string value for every key', () => {
+    for (const [namespace, key, value] of LEAVES) {
+      expect(typeof value, `${namespace}.${key}`).toBe('string')
+    }
+  })
+
+  it('has no empty or whitespace-padded values', () => {
+    // A padded value is the signature of a JSX text node copied across with its
+    // surrounding indentation, which silently changes the rendered output.
+    for (const [namespace, key, value] of LEAVES) {
+      const label = `${namespace}.${key}`
+      // `unset` is a legitimate empty label (env's SOURCE_LABELS sentinel).
+      if (value === '') continue
+      expect(value.trim(), label).toBe(value)
+    }
+  })
+
+  it('uses exactly two levels — no dots inside a key', () => {
+    // `MessageKey` splits on the first dot; a dotted key would produce an
+    // unreachable entry.
+    for (const [namespace, key] of LEAVES) {
+      expect(key, `${namespace}.${key}`).not.toContain('.')
+      expect(namespace).not.toContain('.')
+    }
+  })
+
+  it('pairs every _other plural key with an _one and carries {count} in both', () => {
+    const byNamespace = new Map<string, Set<string>>()
+    for (const [namespace, key] of LEAVES) {
+      const keys = byNamespace.get(namespace) ?? new Set<string>()
+      keys.add(key)
+      byNamespace.set(namespace, keys)
+    }
+    let checked = 0
+    for (const [namespace, key, value] of LEAVES) {
+      if (!key.endsWith('_other')) continue
+      checked += 1
+      const base = key.slice(0, -'_other'.length)
+      const siblings = byNamespace.get(namespace)!
+      expect(siblings.has(`${base}_one`), `${namespace}.${base}_one is missing`).toBe(true)
+      expect(placeholders(value), `${namespace}.${key}`).toContain('count')
+      const one = (en as Record<string, Record<string, string>>)[namespace]![`${base}_one`]!
+      expect(placeholders(one), `${namespace}.${base}_one`).toContain('count')
+    }
+    // Guard the guard: if the plural convention is ever dropped this test would
+    // otherwise pass vacuously.
+    expect(checked).toBeGreaterThan(0)
+  })
+})
+
+// Deliberately NOT asserted: that no two keys share a value. Identical copy in
+// different contexts (approvals' `scopeSession` and `cardSession` are both
+// "Session") is normal — a translator may well render them differently, so
+// collapsing them into one key would be the bug.

--- a/frontend/src/i18n/en/approvals.ts
+++ b/frontend/src/i18n/en/approvals.ts
@@ -1,0 +1,74 @@
+export const approvals = {
+  documentTitle: 'Approvals - AgentOS Control',
+  eyebrow: 'Control · Approvals',
+  title: 'Approvals',
+  subtitle: 'Tool execution gate — keep risky actions paused until you say go.',
+  refreshTitle: 'Refresh approvals',
+  refresh: 'Refresh',
+  refreshing: 'Refreshing…',
+
+  // Approval-strategy options (approvals.js:82-86).
+  modePromptLabel: 'Ask every time',
+  modePromptDesc: 'Every risky tool execution opens an approval prompt.',
+  modeAutoApproveLabel: 'Auto approve',
+  modeAutoApproveDesc: 'All tool executions are automatically approved.',
+  modeAutoDenyLabel: 'Auto deny',
+  modeAutoDenyDesc: 'All tool executions are automatically denied.',
+
+  // Effective execution mode (approvals.js:194-216).
+  scopeSession: 'Session',
+  scopeGlobal: 'Global',
+  execLabel: '{scope} {mode}',
+  execBypassSession: 'Approval prompts are currently bypassed for this browser chat session.',
+  execBypassGlobal: 'Approval prompts are currently bypassed by the global permission mode.',
+  execFullSession:
+    'Approval and sensitive-path prompts are bypassed for this browser chat session.',
+  execFullGlobal: 'Approval and sensitive-path prompts are bypassed by the global permission mode.',
+  execOn: 'Host execution is enabled; risky tool calls still use approval prompts.',
+  execNoneLabel: 'Approval prompts',
+  execNoneDesc: 'Risky tool calls will open approval prompts.',
+
+  // Pending approval card.
+  cardUnknownTool: 'Unknown',
+  cardLandmark: 'Approval request {tool}',
+  cardAwaiting: 'awaiting decision',
+  cardAgent: 'Agent',
+  cardSession: 'Session',
+  cardCommand: 'Command',
+  cardDetails: 'Details',
+  cardApproveOnce: 'Approve once',
+  cardAlways: 'Always allow this type',
+  cardBypassTitle: 'Bypass approval prompts while keeping sensitive-path checks',
+  cardBypass: 'Bypass approvals',
+  cardDeny: 'Deny',
+
+  // Operations panel.
+  opsLandmark: 'Approval operations',
+  opsEyebrow: 'Execution gate',
+  opsTitle: 'Decision posture',
+  opsWaiting: '{count} waiting',
+  opsQueueClear: 'Queue clear',
+  statsLandmark: 'Approvals summary',
+  statPending: 'Pending',
+  statPendingHint: 'awaiting decision',
+  statAllClear: 'all clear',
+  statStrategy: 'Strategy',
+  statExecution: 'Effective execution mode',
+
+  // Queue.
+  emptyTitle: 'No pending approvals.',
+  emptyText: 'When an agent reaches a risky tool call, it will appear here for your sign-off.',
+  pendingLandmark: 'Pending approvals',
+  pendingTitle: 'Decision inbox',
+  pendingSubtitle: 'Review the requested operation and choose the narrowest safe permission.',
+  pendingCount: '{count} pending',
+
+  // Policy panel.
+  policyTitle: 'Approval policy',
+  policySubtitle: 'Default response for future requests',
+  policyLandmark: 'Approval strategy',
+
+  // Toasts.
+  toastStrategySaved: 'Approval strategy: {mode}',
+  toastStrategyFailed: 'Failed to save strategy: {message}',
+} as const

--- a/frontend/src/i18n/en/common.ts
+++ b/frontend/src/i18n/en/common.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared copy that recurs across views. Anything view-specific belongs in that
+ * view's own namespace module, not here.
+ */
+export const common = {
+  cancel: 'Cancel',
+  close: 'Close',
+  copy: 'Copy',
+  dash: '—',
+  loading: 'Loading…',
+  retry: 'Retry',
+  save: 'Save',
+} as const

--- a/frontend/src/i18n/en/env.ts
+++ b/frontend/src/i18n/en/env.ts
@@ -1,0 +1,110 @@
+export const env = {
+  documentTitle: 'Environment - AgentOS Control',
+  eyebrow: 'Configuration',
+  title: 'Environment',
+  subtitle:
+    'Credentials and settings the gateway, its providers, and your skills read from the environment.',
+  refresh: 'Refresh',
+  addVariable: 'Add variable',
+
+  // Category labels.
+  categoryProvider: 'LLM providers',
+  categorySearch: 'Search',
+  categoryImage: 'Image generation',
+  categoryAudio: 'Audio',
+  categoryMemory: 'Memory embedding',
+  categorySkill: 'Skills',
+  categoryCustom: 'Your own variables',
+
+  // Where a value is coming from.
+  sourceProcess: 'process env',
+  sourceCwdFile: 'project .env',
+  sourceHomeFile: 'AgentOS .env',
+
+  // Summary strip.
+  statSet: 'Set',
+  statSetTotal: '/{total}',
+  statMissing: 'Missing',
+  statShadowed: 'Shadowed',
+  metaFile: 'File',
+  shortPath: '…/{tail}',
+
+  // Shadowing warning.
+  shadowWarningTitle: '{count} variable(s) are shadowed by the process environment.',
+  shadowWarningBody:
+    'The shell that started the gateway exported them, and that value wins over the file. Editing them here will not take effect until the export is removed and the gateway restarts.',
+  rowShadowed:
+    'Shadowed by the process environment — changes here take effect only after the export is removed and the gateway restarts.',
+
+  // Toolbar.
+  search: 'Search variables',
+  filterLandmark: 'Filter variables',
+  filterAll: 'All',
+  filterMissing: 'Missing',
+  filterSet: 'Set',
+  filterCustom: 'Custom',
+
+  // List.
+  loading: 'Loading variables…',
+  emptyFiltered: 'No variables match this filter.',
+  groupCount: '{set}/{total} set',
+  tailShow: 'Show {count} unset',
+  tailHide: 'Hide {count} unset',
+
+  // Row.
+  rowLockTitle:
+    'Blocked by AgentOS security policy — edit ~/.agentos/.env directly if you genuinely need it.',
+  rowLockLabel: 'Not writable through AgentOS',
+  badgeSet: 'set',
+  badgeMissing: 'missing',
+  badgeUnset: 'unset',
+  rowOwner: 'Needed by {owner}',
+  rowLink: 'Where to get this',
+  rowEdit: 'Edit',
+  rowSet: 'Set',
+  rowEditLabel: 'Edit {name}',
+  rowSetLabel: 'Set {name}',
+  rowImport: 'Use {source}',
+  rowReveal: 'Reveal {name}',
+  rowRemove: 'Remove {name}',
+  rowValueLabel: 'Value for {name}',
+  rowSave: 'Save',
+  rowCancel: 'Cancel',
+
+  // Add-a-variable dialog.
+  addTitle: 'Add a variable',
+  // Rendered around a <code>.env</code> element; see EnvPage.
+  addBodyLead: 'Stored in the AgentOS',
+  addBodyTail: 'and applied to the running gateway.',
+  addNameLabel: 'Name',
+  addNamePlaceholder: 'MY_SERVICE_TOKEN',
+  addNameField: 'New variable name',
+  addValueLabel: 'Value',
+  addValueField: 'New variable value',
+  addSave: 'Save',
+  addCancel: 'Cancel',
+
+  // Name validation.
+  validateEmpty: 'Enter a variable name.',
+  validateCharset: 'Use letters, digits, and underscores, starting with a letter or underscore.',
+  validateReadOnly: 'This name cannot be written through AgentOS.',
+
+  // Confirmations.
+  confirmRevealTitle: 'Show {name}?',
+  confirmRevealBody: 'The real value appears on screen and hides again after 30 seconds.',
+  confirmRevealAction: 'Show value',
+  confirmRemoveTitle: 'Remove {name}?',
+  confirmRemoveBody: 'It is deleted from the AgentOS .env and from the running gateway.',
+  confirmRemoveAction: 'Remove',
+  confirmCancel: 'Cancel',
+
+  // Load failure.
+  loadErrorTitle: 'Environment unavailable',
+  loadErrorRetry: 'Retry',
+
+  // Toasts.
+  toastSavedRestart: '{name} saved — restart the gateway for it to take full effect.',
+  toastSaved: '{name} saved.',
+  toastImported: "{name} imported. It will not follow that source's own rotation.",
+  toastRemoved: '{name} removed.',
+} as const

--- a/frontend/src/i18n/en/health.ts
+++ b/frontend/src/i18n/en/health.ts
@@ -1,0 +1,94 @@
+export const health = {
+  documentTitle: 'Health - AgentOS Control',
+  eyebrow: 'Control · Health',
+  title: 'Health',
+  refreshTitle: 'Refresh health report',
+  refresh: 'Refresh',
+  checking: 'Checking',
+
+  // Readiness labels (health.js:462-472).
+  statusReadyWithWarnings: 'Ready with warnings',
+  statusReady: 'Ready',
+  statusActionRequired: 'Action required',
+  statusDegraded: 'Degraded',
+  statusUnavailable: 'Unavailable',
+
+  // Header summary line.
+  summaryChecking: 'Checking readiness',
+  summaryUnavailable: 'Health report unavailable',
+  summaryLoaded: 'Health report loaded',
+
+  // Readiness rail.
+  railLandmark: 'Health summary',
+  railReadiness: 'System readiness',
+  railWaiting: 'Waiting for doctor.status',
+  railImpactHead: 'Impact distribution',
+  railImpactChecks: '{count} checks',
+  railImpactRunning: 'Running checks',
+  railImpactMeter: 'Impact distribution: {breakdown}',
+  railCountValue: '{label}: {value}',
+  railCountChecking: 'checking',
+  railCountShare: '{percent}%',
+
+  // Count tiles / finding groups.
+  countBlocksReady: 'Needs action',
+  countDegrades: 'Degraded',
+  countOptional: 'Optional',
+  countNone: 'Ready',
+
+  // Impact labels on a finding meta line (health.js:422-430).
+  impactBlocksReady: 'Blocks readiness',
+  impactDegrades: 'Degrades',
+  impactOptional: 'Optional',
+  impactNone: 'Reference',
+
+  // Report context row.
+  contextLandmark: 'Health report context',
+  contextGateway: 'Gateway',
+  contextConfig: 'Config',
+  contextRequestedConfig: 'Requested config',
+  contextAgent: 'Agent',
+
+  // Finding groups (health.js:281-301).
+  groupActionTitle: 'Needs action',
+  groupActionNote: 'Fix these first to make AgentOS ready.',
+  groupDegradedTitle: 'Degraded capabilities',
+  groupDegradedNote: 'AgentOS can run, but these capabilities need attention.',
+  groupOptionalTitle: 'Optional setup',
+  groupOptionalNote: 'These improve capability or posture but do not block readiness.',
+  groupReadyTitle: 'Ready checks',
+  groupReadyNote: 'These surfaces are already working.',
+
+  // Findings section.
+  findingsEyebrow: 'Diagnostics',
+  findingsTitle: 'What needs attention',
+  findingsIntro: 'Ordered by readiness impact so the next useful action stays obvious.',
+  findingsEmpty: 'No findings returned.',
+  findingsLoading: 'Loading health report',
+
+  // Finding card.
+  findingFallbackTitle: 'Finding {index}',
+  findingRestart: 'Recovery requires restart',
+  findingEvidence: 'Finding evidence',
+  badgeDiagnosticsIncomplete: 'Diagnostics incomplete',
+  badgeRepairPending: 'Repair pending',
+  badgeConfigMismatch: 'Config mismatch',
+
+  // Fix steps.
+  stepsOptional: 'Optional setup steps',
+  stepsReference: 'Reference steps',
+  stepsRecovery: 'Recovery steps',
+  stepFallbackLabel: 'Step',
+  stepInspectRemote: 'Inspect remote gateway',
+  stepRepairRemote: 'Repair remote deployment',
+  stepRepairRemoteDetail:
+    'Start or repair the remote AgentOS gateway deployment, then refresh health.',
+  stepRunDoctor: 'Run local doctor',
+  stepRunDoctorDetail: 'Checks local config and onboarding before restarting the gateway.',
+  stepStartGateway: 'Start local gateway',
+  stepInspectGateway: 'Inspect local gateway',
+
+  // Synthetic gateway.unavailable finding (health.js:86-115).
+  gatewayUnavailableTitle: 'Gateway health report unavailable',
+  gatewayUnavailableDetail: 'Cannot load doctor.status from {url}. {reason}',
+} as const

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,0 +1,22 @@
+import { approvals } from './approvals'
+import { common } from './common'
+import { env } from './env'
+import { health } from './health'
+import { logs } from './logs'
+import { overview } from './overview'
+import { shell } from './shell'
+
+/**
+ * The English catalog — the default locale and the fallback for every other
+ * locale. Its shape is the source of truth for `MessageKey`, so adding a
+ * namespace here is what makes its keys callable from `t()`.
+ */
+export const en = {
+  approvals,
+  common,
+  env,
+  health,
+  logs,
+  overview,
+  shell,
+} as const

--- a/frontend/src/i18n/en/logs.ts
+++ b/frontend/src/i18n/en/logs.ts
@@ -1,0 +1,55 @@
+export const logs = {
+  documentTitle: 'Logs - AgentOS Control',
+  eyebrow: 'Control · Logs',
+  title: 'Logs',
+  subtitle: 'Live gateway log stream — filter, follow, and export.',
+  exportTitle: 'Download filtered log lines',
+  export: 'Export',
+
+  // Console header.
+  consoleLandmark: 'Live log console',
+  consoleEyebrow: 'Observability stream',
+  consoleTitle: 'Gateway output',
+  consoleCadence: 'Polling every 3s',
+
+  // Status pills (logs.js:262-290).
+  statusLandmark: 'Log status',
+  statusUnavailable: 'Log status unavailable',
+  statusOn: 'on',
+  statusOff: 'off',
+  statusFileLog: 'File log {state}',
+  statusRawTurnCall: 'Raw turn-call {state}',
+  statusDiagnosticsRaw: 'Diagnostics raw',
+  statusDiagnosticsStandard: 'Diagnostics standard',
+  statusDiagnosticsOff: 'Diagnostics off',
+
+  // Summary tiles.
+  statsLandmark: 'Log summary',
+  statInView: 'In view',
+  statInViewHint: 'of {total} loaded',
+  statErrors: 'Errors',
+  statErrorsReview: 'review needed',
+  statErrorsClear: 'all clear',
+  statWarnings: 'Warnings',
+  statWarningsRecent: 'recent advisories',
+  statWarningsNone: 'none',
+  statInfoDebugLandmark: 'Info and Debug',
+  statInfoDebug: 'Info / Debug',
+  statInfoDebugHint: 'routine output',
+
+  // Toolbar.
+  toolbarLevels: 'Levels',
+  toolbarToggleLevel: 'Toggle {level} level',
+  toolbarSearchLabel: 'Filter log messages',
+  toolbarSearchPlaceholder: 'Filter messages…',
+  toolbarAutoFollow: 'Auto-follow',
+
+  // Stream placeholders.
+  streamLoading: 'Loading logs…',
+  streamNoMatch: 'No lines match the current filter.',
+  streamEmpty: 'No logs yet.',
+
+  // Toasts.
+  toastRefreshFailed: 'Log refresh failed: {message}',
+  toastUnknownError: 'unknown error',
+} as const

--- a/frontend/src/i18n/en/overview.ts
+++ b/frontend/src/i18n/en/overview.ts
@@ -1,0 +1,75 @@
+export const overview = {
+  documentTitle: 'Overview - AgentOS Control',
+  eyebrow: 'Control · Overview',
+  title: 'Overview',
+  subtitle: 'Live status, recent sessions, and the gateway event stream.',
+  refresh: 'Refresh',
+  openChat: 'Open chat',
+  toastStatusFailed: 'Failed to load status: {message}',
+
+  // Gateway summary tiles.
+  summaryLandmark: 'Gateway summary',
+  summaryEyebrow: 'System pulse',
+  summaryCadence: 'Refreshes every 30s',
+  tileHealth: 'Health',
+  tileHealthOpen: 'open health',
+  tileHealthDetails: 'view details',
+  tileTokens: 'Total tokens',
+  tileTokensHint: 'view usage',
+  tileSpent: '{amount} spent',
+  tileSessions: 'Total sessions',
+  tileSessionsHint: 'view all',
+  tileProvider: 'Provider',
+  tileProviderHint: 'manage agents',
+  tileUptime: 'Uptime',
+  tileVersion: 'v{version}',
+
+  // Readiness status labels (overview.js:352-365).
+  readyReady: 'Ready',
+  readyDegraded: 'Degraded',
+  readyActionRequired: 'Action required',
+  readyUnavailable: 'Unavailable',
+  readyUnknown: 'Unknown',
+
+  // Session status labels (components.js:249-269).
+  sessionRunning: 'Running',
+  sessionDone: 'Completed',
+  sessionFailed: 'Failed',
+  sessionKilled: 'Aborted by operator',
+  sessionTimeout: 'Timed out',
+  sessionUnknown: 'Unknown',
+
+  // Formatting.
+  uptime: '{hours}h {minutes}m {seconds}s',
+  relJustNow: 'just now',
+  relMinutes: '{count}m ago',
+  relHours: '{count}h ago',
+  relDays: '{count}d ago',
+
+  // Recent sessions panel.
+  recentTitle: 'Recent sessions',
+  recentSubtitle: 'Resume the latest agent work',
+  recentViewAllLabel: 'View all sessions',
+  recentViewAll: 'View all →',
+  recentUnavailable: 'Recent sessions unavailable.',
+  recentEmpty: 'No sessions yet — open chat to start your first one.',
+  recentMessages: '{count} msg',
+  recentOpenSession: 'Open session {key}',
+
+  // Event stream panel.
+  eventsTitle: 'Event stream',
+  eventsSubtitle: 'Live gateway activity',
+  eventsCount_one: '{count} event',
+  eventsCount_other: '{count} events',
+  eventsEmpty: 'Listening for events…',
+
+  // Gateway connection panel.
+  connTitle: 'Gateway connection',
+  connSubtitle: 'Override the active endpoint for this browser',
+  connUrlLabel: 'WebSocket URL',
+  connUrlPlaceholder: 'ws://…',
+  connTokenLabel: 'Token',
+  connTokenOptional: 'optional',
+  connConnect: 'Connect',
+  connDisconnect: 'Disconnect',
+} as const

--- a/frontend/src/i18n/en/shell.ts
+++ b/frontend/src/i18n/en/shell.ts
@@ -1,0 +1,102 @@
+/**
+ * The app shell: navigation, connection footer, route errors, the global
+ * approval prompt, and the shared chrome components. View bodies live in their
+ * own namespaces.
+ */
+export const shell = {
+  // Brand. Not translated in practice, but routed through the catalog so the
+  // shell has no literal copy left for a translator to miss.
+  brandName: 'AgentOS',
+  brandSuffix: 'Control',
+
+  // View titles. One definition, read by both the router and the sidebar.
+  viewAgents: 'Agents',
+  viewApprovals: 'Approvals',
+  viewChannels: 'Channels',
+  viewChat: 'Chat',
+  viewConfig: 'Config',
+  viewCron: 'Cron',
+  viewEnv: 'Environment',
+  viewHealth: 'Health',
+  viewLogs: 'Logs',
+  viewMcp: 'MCP Servers',
+  viewOverview: 'Overview',
+  viewSessions: 'Sessions',
+  viewSettings: 'Agent Setup',
+  viewSetup: 'Setup',
+  viewSkills: 'Skills',
+  viewUsage: 'Usage',
+
+  // Sidebar groups.
+  navGroupChat: 'Chat',
+  navGroupControl: 'Control',
+  navGroupSettings: 'Settings',
+  navLandmark: 'Main',
+  navDrawerLandmark: 'Workspace navigation',
+  navCollapse: 'Collapse navigation',
+  navExpand: 'Expand navigation',
+  navClose: 'Close navigation',
+  navToggleMenu: 'Toggle menu',
+  navSkipToContent: 'Skip to main content',
+  navApprovalBadge_one: '{count} pending approval',
+  navApprovalBadge_other: '{count} pending approvals',
+
+  // Connection footer.
+  connConnected: 'Connected',
+  connConnecting: 'Connecting',
+  connDisconnected: 'Disconnected',
+  connWithVersion: '{state}, version {version}',
+  connecting: 'Connecting…',
+
+  // Sidebar utilities.
+  shortcutsTitle: 'Keyboard shortcuts ({combo})',
+  shortcutsLabel: 'Keyboard shortcuts',
+  shortcutClose: 'Close dialog',
+  shortcutDrawerEscape: 'Close the navigation drawer (mobile)',
+  shortcutCategoryGlobal: 'Global',
+  themeDark: 'dark',
+  themeLight: 'light',
+  themeTitle: 'Theme: {mode}',
+  themeToggleLabel: 'Theme: {mode}. Toggle theme',
+
+  // Chat surface header.
+  chatToolbar: 'Chat toolbar',
+
+  // Routing.
+  routeNotFoundTitle: 'Not Found - AgentOS Control',
+  routeNotFoundBody: 'Page not found: {path}',
+  routePending: 'Opening view…',
+
+  // Route error boundary.
+  errorDocumentTitle: 'Recovery - AgentOS Control',
+  errorHttpCode: 'HTTP {status}',
+  errorViewCode: 'VIEW ERROR',
+  errorUnavailableTitle: 'This view is unavailable',
+  errorSnagTitle: 'This view hit a snag',
+  errorMessage:
+    'AgentOS kept the rest of your workspace intact. Reload this view or return to Overview.',
+  errorEyebrow: 'Workspace recovery',
+  errorStatus: 'View paused safely',
+  errorDeveloperDetail: 'Developer detail',
+  errorActions: 'Recovery actions',
+  errorReload: 'Reload view',
+  errorGoOverview: 'Go to Overview',
+
+  // Global approval prompt.
+  approvalTitle: 'Approval Required',
+  approvalFallbackTool: 'Tool execution',
+  approvalOnceTitle: 'Approve only this pending tool call',
+  approvalOnce: 'Approve This Time',
+  approvalAlwaysTitle: 'Remember this operation type for future matching intents',
+  approvalAlways: 'Always Allow This Type',
+  approvalBypassTitle:
+    'Enable approval bypass in this browser session and approve this pending tool call',
+  approvalBypass: 'Bypass Approvals',
+  approvalDeny: 'Deny',
+
+  // Command line with copy action.
+  commandCopyLabel: 'Copy command',
+  commandCopied: 'Copied command',
+  commandCopyFailed: 'Copy failed: {message}',
+  commandCopyError: 'Copy command failed',
+} as const

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_LOCALE,
+  getLocale,
+  registerCatalog,
+  resolveLocale,
+  setLocale,
+  t,
+  tPlural,
+} from './index'
+import type { MessageKey } from './types'
+
+// A stub locale registered once, deliberately incomplete: it overrides a single
+// key and omits a whole namespace, so both rungs of the fallback ladder are
+// exercised against real catalog data rather than a mock.
+registerCatalog('xx', { common: { save: 'XX save' } })
+
+afterEach(() => {
+  setLocale(DEFAULT_LOCALE)
+})
+
+describe('t', () => {
+  it('returns the English string for a known key', () => {
+    expect(t('common.save')).toBe('Save')
+    expect(getLocale()).toBe('en')
+  })
+
+  it('interpolates a placeholder', () => {
+    expect(t('overview.toastStatusFailed', { message: 'boom' })).toBe('Failed to load status: boom')
+  })
+
+  it('interpolates numbers and multiple placeholders', () => {
+    expect(t('overview.uptime', { hours: 1, minutes: 2, seconds: 3 })).toBe('1h 2m 3s')
+    expect(t('env.groupCount', { set: 2, total: 7 })).toBe('2/7 set')
+  })
+
+  it('leaves an unknown token literal rather than rendering undefined', () => {
+    // The vars object is deliberately missing `version`, which the type system
+    // would normally reject — the runtime must still not print "undefined".
+    const vars = {} as { version: string }
+    expect(t('overview.tileVersion', vars)).toBe('v{version}')
+  })
+
+  it('returns the key itself and warns when the key is unknown', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(t('common.nope' as MessageKey)).toBe('common.nope')
+    expect(warn).toHaveBeenCalledWith('[i18n] missing key: common.nope')
+    warn.mockRestore()
+  })
+
+  it('falls back to English for a key the active locale omits', () => {
+    setLocale('xx')
+    expect(t('common.save')).toBe('XX save')
+    // Present in the namespace it overrides, but not translated.
+    expect(t('common.cancel')).toBe('Cancel')
+  })
+
+  it('falls back to English for a namespace the active locale omits entirely', () => {
+    setLocale('xx')
+    expect(t('shell.viewOverview')).toBe('Overview')
+  })
+})
+
+describe('resolveLocale', () => {
+  it('defaults to English for empty, nullish, and unknown input', () => {
+    expect(resolveLocale('')).toBe('en')
+    expect(resolveLocale(null)).toBe('en')
+    expect(resolveLocale(undefined)).toBe('en')
+    expect(resolveLocale('  ')).toBe('en')
+    expect(resolveLocale('zz')).toBe('en')
+  })
+
+  it('is case-insensitive and falls back to the primary subtag', () => {
+    expect(resolveLocale('EN')).toBe('en')
+    expect(resolveLocale('en-US')).toBe('en')
+    expect(resolveLocale('xx_YZ')).toBe('xx')
+  })
+
+  it('resolves an unregistered region to English, not to the region tag', () => {
+    expect(resolveLocale('pt-BR')).toBe('en')
+  })
+})
+
+describe('setLocale', () => {
+  it('applies the resolved locale and mirrors it onto <html lang>', () => {
+    expect(setLocale('xx')).toBe('xx')
+    expect(getLocale()).toBe('xx')
+    expect(document.documentElement.lang).toBe('xx')
+  })
+
+  it('resolves unknown input to English rather than throwing', () => {
+    expect(setLocale('nope')).toBe('en')
+    expect(getLocale()).toBe('en')
+    expect(document.documentElement.lang).toBe('en')
+  })
+})
+
+describe('tPlural', () => {
+  it('selects the singular for exactly one', () => {
+    expect(tPlural('shell.navApprovalBadge', 1)).toBe('1 pending approval')
+  })
+
+  it('selects the plural for zero and for many', () => {
+    expect(tPlural('shell.navApprovalBadge', 0)).toBe('0 pending approvals')
+    expect(tPlural('shell.navApprovalBadge', 3)).toBe('3 pending approvals')
+    expect(tPlural('overview.eventsCount', 12)).toBe('12 events')
+  })
+
+  it('degrades to _other for a category no catalog defines', () => {
+    // Polish selects 'few' for 3. No catalog has an `_few` key, so the lookup
+    // must fall through to `_other` rather than rendering the raw key.
+    registerCatalog('pl', {})
+    setLocale('pl')
+    expect(new Intl.PluralRules('pl').select(3)).toBe('few')
+    expect(tPlural('overview.eventsCount', 3)).toBe('3 events')
+  })
+})

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,76 @@
+import { en } from './en'
+import { catalogFor, getLocale } from './locale'
+import type { Args, MessageKey, PluralBase, Vars } from './types'
+
+export {
+  DEFAULT_LOCALE,
+  getLocale,
+  initLocale,
+  registerCatalog,
+  resolveLocale,
+  setLocale,
+  type Locale,
+} from './locale'
+export type { MessageKey, PartialMessages } from './types'
+
+const PLACEHOLDER = /\{(\w+)\}/g
+
+type Catalog = Record<string, Record<string, string | undefined> | undefined>
+
+function interpolate(template: string, vars?: Vars): string {
+  if (!vars) return template
+  return template.replace(PLACEHOLDER, (match, name: string) => {
+    const value = vars[name]
+    // An unmatched token stays literal — a template rendering "undefined" to a
+    // user is strictly worse than one rendering "{count}".
+    return value === undefined ? match : String(value)
+  })
+}
+
+/** Raw lookup, active locale first, then English, with no interpolation. */
+function lookupOptional(key: string): string | undefined {
+  const dot = key.indexOf('.')
+  if (dot < 0) return undefined
+  const ns = key.slice(0, dot)
+  const leaf = key.slice(dot + 1)
+  const fromLocale = (catalogFor(getLocale()) as Catalog)[ns]?.[leaf]
+  if (typeof fromLocale === 'string') return fromLocale
+  const fromEn = (en as Catalog)[ns]?.[leaf]
+  return typeof fromEn === 'string' ? fromEn : undefined
+}
+
+function lookup(key: string): string {
+  const found = lookupOptional(key)
+  if (found !== undefined) return found
+  if (import.meta.env.DEV) console.warn(`[i18n] missing key: ${key}`)
+  // Render the key rather than an empty node: a missing string should be
+  // obvious in the UI, not invisible.
+  return key
+}
+
+/**
+ * Translate a catalog key. A plain function, deliberately not a hook — most of
+ * the console's copy lives outside components (view `logic.ts` label maps,
+ * module-scope route titles, imperative DOM builders in the chat transcript),
+ * and a hook could not serve any of them.
+ *
+ * English is both the default locale and the per-key fallback, so a single
+ * locale build behaves exactly as the hardcoded strings did.
+ */
+export function t<K extends MessageKey>(key: K, ...args: Args<K>): string {
+  return interpolate(lookup(key), args[0] as Vars | undefined)
+}
+
+/**
+ * Translate a count-dependent key pair, `<base>_one` / `<base>_other`, using
+ * `Intl.PluralRules` — a platform API, so pluralisation costs no dependency.
+ * `count` is injected into the template automatically.
+ *
+ * Locales with categories beyond one/other degrade to `_other` rather than
+ * failing, so a translator can add `_few` later without a code change.
+ */
+export function tPlural<B extends PluralBase>(base: B, count: number, vars?: Vars): string {
+  const category = new Intl.PluralRules(getLocale()).select(count)
+  const template = lookupOptional(`${base}_${category}`) ?? lookup(`${base}_other`)
+  return interpolate(template, { count, ...vars })
+}

--- a/frontend/src/i18n/locale.ts
+++ b/frontend/src/i18n/locale.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand'
+import { en } from './en'
+import type { PartialMessages } from './types'
+
+/** A BCP 47 primary subtag that has a catalog registered. */
+export type Locale = string
+
+export const DEFAULT_LOCALE = 'en'
+
+/**
+ * Registered catalogs, keyed by lowercased tag. A future locale ships as its
+ * own directory plus one `registerCatalog('pt', pt)` call — this module never
+ * needs editing again.
+ */
+const CATALOGS = new Map<string, PartialMessages>([[DEFAULT_LOCALE, en]])
+
+export function registerCatalog(tag: string, messages: PartialMessages): void {
+  CATALOGS.set(tag.trim().toLowerCase(), messages)
+}
+
+export function catalogFor(locale: Locale): PartialMessages {
+  return CATALOGS.get(locale) ?? en
+}
+
+/**
+ * Held in a store rather than a bare module variable so a later
+ * `useLocale()` subscription can re-render on change without touching a single
+ * `t()` call site. Nothing subscribes today — locale is set once at boot.
+ */
+const useLocaleStore = create<{ locale: Locale }>(() => ({ locale: DEFAULT_LOCALE }))
+
+export function getLocale(): Locale {
+  return useLocaleStore.getState().locale
+}
+
+/**
+ * Narrow a requested tag to one we actually have: exact match first, then the
+ * primary subtag (`pt-BR` -> `pt`), then English. Unknown input is never an
+ * error — it resolves to the default.
+ */
+export function resolveLocale(candidate?: string | null): Locale {
+  const raw = String(candidate ?? '')
+    .trim()
+    .toLowerCase()
+  if (!raw) return DEFAULT_LOCALE
+  if (CATALOGS.has(raw)) return raw
+  const primary = raw.split(/[-_]/)[0] ?? ''
+  return CATALOGS.has(primary) ? primary : DEFAULT_LOCALE
+}
+
+export function setLocale(candidate?: string | null): Locale {
+  const locale = resolveLocale(candidate)
+  useLocaleStore.setState({ locale })
+  try {
+    document.documentElement.lang = locale
+  } catch {
+    /* non-DOM environment */
+  }
+  return locale
+}
+
+/**
+ * Called once at boot, alongside `initTheme()`. The locale is a constant today;
+ * when the gateway starts advertising one, this becomes
+ * `setLocale(bootstrap.locale)` in `AppProviders` and nothing else moves.
+ */
+export function initLocale(): void {
+  setLocale(DEFAULT_LOCALE)
+}

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -1,0 +1,56 @@
+import type { en } from './en'
+
+export type Messages = typeof en
+export type Namespace = keyof Messages & string
+
+/**
+ * Every valid key, as `namespace.leaf`. Exactly one dot: catalogs are two
+ * levels deep on purpose, so this resolves as a cheap distributive mapped type
+ * rather than a recursive walk over every leaf in the tree. `npm run check`
+ * gates on `tsc --noEmit`, and recursion at catalog scale is what makes that
+ * slow.
+ */
+export type MessageKey = {
+  [N in Namespace]: `${N}.${keyof Messages[N] & string}`
+}[Namespace]
+
+type Ns<K extends MessageKey> = K extends `${infer N}.${string}` ? N & Namespace : never
+type Leaf<K extends MessageKey> = K extends `${string}.${infer L}` ? L : never
+
+/** The literal English string behind a key. Drives placeholder typing below. */
+export type Value<K extends MessageKey> = Messages[Ns<K>][Leaf<K> & keyof Messages[Ns<K>]] & string
+
+/** `'{a} and {b}'` -> `'a' | 'b'` */
+type Placeholders<S extends string> = S extends `${string}{${infer P}}${infer Rest}`
+  ? P | Placeholders<Rest>
+  : never
+
+export type Vars = Record<string, string | number>
+
+/**
+ * Interpolation vars are required iff the English value has placeholders, and
+ * the accepted names are read straight off that value — so a renamed or
+ * forgotten placeholder is a compile error, not a `{message}` rendered raw.
+ */
+export type Args<K extends MessageKey> = [Placeholders<Value<K>>] extends [never]
+  ? []
+  : [vars: Record<Placeholders<Value<K>>, string | number>]
+
+/** Bases of plural key pairs — `'ns.thing'` for a `ns.thing_other` key. */
+export type PluralBase = MessageKey extends infer K
+  ? K extends `${infer B}_other`
+    ? B
+    : never
+  : never
+
+/**
+ * A translated catalog. Every namespace and every key is optional: a partial
+ * translation compiles, and each missing key falls back to English on its own.
+ *
+ * Values widen to `string` — `en` is declared `as const` so its values carry
+ * literal types (which is what makes placeholder checking work), and a
+ * translation obviously must not be required to repeat the English literal.
+ */
+export type PartialMessages = {
+  [N in Namespace]?: { [K in keyof Messages[N]]?: string }
+}

--- a/frontend/src/views/approvals/ApprovalsPage.tsx
+++ b/frontend/src/views/approvals/ApprovalsPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import { CommandLine } from '@/components/CommandLine'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
+import { t } from '@/i18n'
 import {
   approvalCommand,
   approvalMonitor,
@@ -37,51 +38,54 @@ function ApprovalCard({
   busy: boolean
   onResolve: (item: Approval, action: 'once' | 'always' | 'bypass' | 'deny') => void
 }) {
-  const toolName = item.toolName || item.actionKind || 'Unknown'
+  const toolName = item.toolName || item.actionKind || t('approvals.cardUnknownTool')
   const command = approvalCommand(item)
   // Card renders the FULL args JSON (approvals.js:314-322), not the modal's
   // 900-char-truncated approvalDetail(); see approvalCardDetail in ./logic.
   const detail = approvalCardDetail(item)
   const showAlways = canAlwaysAllow(item)
   return (
-    <article className="ap-card tone-warn" aria-label={`Approval request ${toolName}`}>
+    <article
+      className="ap-card tone-warn"
+      aria-label={t('approvals.cardLandmark', { tool: toolName })}
+    >
       <header className="ap-card__head">
         <div className="ap-card__title-row">
           <span className="ap-card__name">{toolName}</span>
           {item.namespace ? <span className="ap-card__ns t-label">{item.namespace}</span> : null}
         </div>
-        <span className="ap-card__time t-label">awaiting decision</span>
+        <span className="ap-card__time t-label">{t('approvals.cardAwaiting')}</span>
       </header>
       {item.agent || item.sessionKey ? (
         <div className="ap-card__meta t-data">
           {item.agent ? (
             <span>
-              <b>Agent</b> {item.agent}
+              <b>{t('approvals.cardAgent')}</b> {item.agent}
             </span>
           ) : null}
           {item.sessionKey ? (
             <span>
-              <b>Session</b> <code>{item.sessionKey}</code>
+              <b>{t('approvals.cardSession')}</b> <code>{item.sessionKey}</code>
             </span>
           ) : null}
         </div>
       ) : null}
       {command ? (
         <div className="ap-card__block">
-          <div className="ap-card__block-label t-label">Command</div>
+          <div className="ap-card__block-label t-label">{t('approvals.cardCommand')}</div>
           <CommandLine command={command} toastIdPrefix="approvals-copy" />
         </div>
       ) : null}
       {detail ? (
         <div className="ap-card__block">
-          <div className="ap-card__block-label t-label">Details</div>
+          <div className="ap-card__block-label t-label">{t('approvals.cardDetails')}</div>
           <pre className="ap-card__pre">{detail}</pre>
         </div>
       ) : null}
       <div className="ap-card__actions">
         <Button type="button" disabled={busy} onClick={() => onResolve(item, 'once')}>
           <CheckIcon />
-          <span>Approve once</span>
+          <span>{t('approvals.cardApproveOnce')}</span>
         </Button>
         {showAlways ? (
           <Button
@@ -90,17 +94,17 @@ function ApprovalCard({
             disabled={busy}
             onClick={() => onResolve(item, 'always')}
           >
-            Always allow this type
+            {t('approvals.cardAlways')}
           </Button>
         ) : null}
         <Button
           type="button"
           variant="outline"
           disabled={busy}
-          title="Bypass approval prompts while keeping sensitive-path checks"
+          title={t('approvals.cardBypassTitle')}
           onClick={() => onResolve(item, 'bypass')}
         >
-          Bypass approvals
+          {t('approvals.cardBypass')}
         </Button>
         <Button
           type="button"
@@ -109,7 +113,7 @@ function ApprovalCard({
           onClick={() => onResolve(item, 'deny')}
         >
           <XIcon />
-          <span>Deny</span>
+          <span>{t('approvals.cardDeny')}</span>
         </Button>
       </div>
     </article>
@@ -127,7 +131,7 @@ export function ApprovalsPage() {
   const elevatedMode = useApprovals((s) => s.elevatedMode)
 
   useEffect(() => {
-    document.title = 'Approvals - AgentOS Control'
+    document.title = t('approvals.documentTitle')
   }, [])
 
   // The durable pending list + count are published by the always-running
@@ -169,7 +173,7 @@ export function ApprovalsPage() {
       // approvals.js:297-299 — outcome toast (warn for auto-approve, else info)
       // + re-poll the monitor.
       const opts = { id: 'approvals-strategy', duration: 2500 }
-      const message = 'Approval strategy: ' + next
+      const message = t('approvals.toastStrategySaved', { mode: next })
       if (next === 'auto-approve') toast.warning(message, opts)
       else toast.success(message, opts)
       await approvalMonitor.pollNow()
@@ -177,7 +181,7 @@ export function ApprovalsPage() {
       // approvals.js:301 — revert the optimistic selection on failure.
       setPendingMode(null)
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to save strategy: ' + message, {
+      toast.error(t('approvals.toastStrategyFailed', { message }), {
         id: 'approvals-strategy-err',
         duration: 4000,
       })
@@ -213,55 +217,55 @@ export function ApprovalsPage() {
     <div className="ap-stage">
       <header className="ap-stage__header">
         <div className="ap-stage__title-block">
-          <span className="t-label">Control · Approvals</span>
-          <h1 className="t-display">Approvals</h1>
-          <p className="ap-stage__subtitle">
-            Tool execution gate — keep risky actions paused until you say go.
-          </p>
+          <span className="t-label">{t('approvals.eyebrow')}</span>
+          <h1 className="t-display">{t('approvals.title')}</h1>
+          <p className="ap-stage__subtitle">{t('approvals.subtitle')}</p>
         </div>
         <Button
           variant="outline"
-          title="Refresh approvals"
+          title={t('approvals.refreshTitle')}
           className="ap-stage__refresh text-xs uppercase tracking-[0.14em]"
           disabled={refreshing}
           onClick={() => void onRefresh()}
         >
           <RefreshCwIcon className={refreshing ? 'ap-refresh-spin' : undefined} />
-          <span>{refreshing ? 'Refreshing…' : 'Refresh'}</span>
+          <span>{refreshing ? t('approvals.refreshing') : t('approvals.refresh')}</span>
         </Button>
       </header>
 
-      <section className="ap-command" aria-label="Approval operations">
+      <section className="ap-command" aria-label={t('approvals.opsLandmark')}>
         <div className="ap-command__toolbar">
           <div className="ap-command__heading">
             <span className="ap-command__icon" aria-hidden="true">
               <ShieldAlertIcon />
             </span>
             <div>
-              <span className="t-label">Execution gate</span>
-              <strong>Decision posture</strong>
+              <span className="t-label">{t('approvals.opsEyebrow')}</span>
+              <strong>{t('approvals.opsTitle')}</strong>
             </div>
           </div>
           <span className="ap-command__meta">
             <span className={pending.length ? 'tone-warn' : 'tone-ok'} aria-hidden="true" />
-            {pending.length ? `${pending.length} waiting` : 'Queue clear'}
+            {pending.length
+              ? t('approvals.opsWaiting', { count: pending.length })
+              : t('approvals.opsQueueClear')}
           </span>
         </div>
-        <div className="ap-stats" aria-label="Approvals summary">
+        <div className="ap-stats" aria-label={t('approvals.statsLandmark')}>
           <div className={`ap-stat ap-stat--hero tone-${modeStateTone(mode)}`}>
-            <span className="ap-stat__label t-label">Pending</span>
+            <span className="ap-stat__label t-label">{t('approvals.statPending')}</span>
             <strong className="ap-stat__value t-data">{pending.length}</strong>
             <span className="ap-stat__hint">
-              {pending.length ? 'awaiting decision' : 'all clear'}
+              {pending.length ? t('approvals.statPendingHint') : t('approvals.statAllClear')}
             </span>
           </div>
           <div className="ap-stat">
-            <span className="ap-stat__label t-label">Strategy</span>
+            <span className="ap-stat__label t-label">{t('approvals.statStrategy')}</span>
             <strong className="ap-stat__value">{activeOpt.label}</strong>
             <span className="ap-stat__hint">{activeOpt.desc}</span>
           </div>
           <div className="ap-stat">
-            <span className="ap-stat__label t-label">Effective execution mode</span>
+            <span className="ap-stat__label t-label">{t('approvals.statExecution')}</span>
             <strong className="ap-stat__value t-data">{execution.label}</strong>
             <span className="ap-stat__hint">{execution.desc}</span>
           </div>
@@ -274,19 +278,19 @@ export function ApprovalsPage() {
             <div className="ap-empty__signal" aria-hidden="true">
               <CheckIcon />
             </div>
-            <div className="ap-empty__title">No pending approvals.</div>
-            <p className="ap-empty__text">
-              When an agent reaches a risky tool call, it will appear here for your sign-off.
-            </p>
+            <div className="ap-empty__title">{t('approvals.emptyTitle')}</div>
+            <p className="ap-empty__text">{t('approvals.emptyText')}</p>
           </section>
         ) : (
-          <section className="ap-pending" aria-label="Pending approvals">
+          <section className="ap-pending" aria-label={t('approvals.pendingLandmark')}>
             <header className="ap-pending__head">
               <div>
-                <h2>Decision inbox</h2>
-                <p>Review the requested operation and choose the narrowest safe permission.</p>
+                <h2>{t('approvals.pendingTitle')}</h2>
+                <p>{t('approvals.pendingSubtitle')}</p>
               </div>
-              <span className="ap-pending__count t-data">{pending.length} pending</span>
+              <span className="ap-pending__count t-data">
+                {t('approvals.pendingCount', { count: pending.length })}
+              </span>
             </header>
             <div className="ap-pending__list">
               {pending.map((item) => (
@@ -299,12 +303,16 @@ export function ApprovalsPage() {
         <section className="ap-strategy panel">
           <div className="panel__head">
             <div>
-              <span>Approval policy</span>
-              <small>Default response for future requests</small>
+              <span>{t('approvals.policyTitle')}</span>
+              <small>{t('approvals.policySubtitle')}</small>
             </div>
           </div>
           <div className="panel__body">
-            <div className="ap-strategy__options" role="radiogroup" aria-label="Approval strategy">
+            <div
+              className="ap-strategy__options"
+              role="radiogroup"
+              aria-label={t('approvals.policyLandmark')}
+            >
               {MODE_OPTIONS.map((opt) => (
                 <label
                   key={opt.value}

--- a/frontend/src/views/approvals/logic.ts
+++ b/frontend/src/views/approvals/logic.ts
@@ -11,6 +11,7 @@ import {
   type Approval,
   type ElevatedMode,
 } from '@/services/approval-monitor'
+import { t } from '@/i18n'
 
 // Re-exported from the single elevated-mode source of truth
 // (services/approval-monitor.ts) so existing approvals-view imports of
@@ -44,18 +45,18 @@ export interface ModeOption {
 export const MODE_OPTIONS: ReadonlyArray<ModeOption> = [
   {
     value: 'prompt',
-    label: 'Ask every time',
-    desc: 'Every risky tool execution opens an approval prompt.',
+    label: t('approvals.modePromptLabel'),
+    desc: t('approvals.modePromptDesc'),
   },
   {
     value: 'auto-approve',
-    label: 'Auto approve',
-    desc: 'All tool executions are automatically approved.',
+    label: t('approvals.modeAutoApproveLabel'),
+    desc: t('approvals.modeAutoApproveDesc'),
   },
   {
     value: 'auto-deny',
-    label: 'Auto deny',
-    desc: 'All tool executions are automatically denied.',
+    label: t('approvals.modeAutoDenyLabel'),
+    desc: t('approvals.modeAutoDenyDesc'),
   },
 ]
 
@@ -88,30 +89,25 @@ export interface ExecutionModeSummary {
 }
 
 // approvals.js:194-216 — "<Scope> <MODE>" label + a scope/mode-specific blurb.
+// `scope` is the DISPLAY word, so the session/global branch compares against the
+// translated scope label rather than a hardcoded 'Session'. resolveExecutionMode
+// below passes exactly these values, so the two stay in step in every locale.
 export function executionModeSummary(scope: string, mode: string): ExecutionModeSummary {
-  const label = `${scope} ${String(mode).toUpperCase()}`
+  const label = t('approvals.execLabel', { scope, mode: String(mode).toUpperCase() })
+  const isSession = scope === t('approvals.scopeSession')
   if (mode === 'bypass') {
     return {
       label,
-      desc:
-        scope === 'Session'
-          ? 'Approval prompts are currently bypassed for this browser chat session.'
-          : 'Approval prompts are currently bypassed by the global permission mode.',
+      desc: isSession ? t('approvals.execBypassSession') : t('approvals.execBypassGlobal'),
     }
   }
   if (mode === 'full') {
     return {
       label,
-      desc:
-        scope === 'Session'
-          ? 'Approval and sensitive-path prompts are bypassed for this browser chat session.'
-          : 'Approval and sensitive-path prompts are bypassed by the global permission mode.',
+      desc: isSession ? t('approvals.execFullSession') : t('approvals.execFullGlobal'),
     }
   }
-  return {
-    label,
-    desc: 'Host execution is enabled; risky tool calls still use approval prompts.',
-  }
+  return { label, desc: t('approvals.execOn') }
 }
 
 /**
@@ -126,11 +122,11 @@ export function resolveExecutionMode(
   globalDefaultMode: string,
 ): ExecutionModeSummary {
   const session = normalizeElevatedMode(sessionMode)
-  if (session) return executionModeSummary('Session', session)
+  if (session) return executionModeSummary(t('approvals.scopeSession'), session)
   const global = normalizeElevatedMode(globalDefaultMode)
-  if (global) return executionModeSummary('Global', global)
+  if (global) return executionModeSummary(t('approvals.scopeGlobal'), global)
   return {
-    label: 'Approval prompts',
-    desc: 'Risky tool calls will open approval prompts.',
+    label: t('approvals.execNoneLabel'),
+    desc: t('approvals.execNoneDesc'),
   }
 }

--- a/frontend/src/views/env/EnvPage.tsx
+++ b/frontend/src/views/env/EnvPage.tsx
@@ -16,6 +16,7 @@ import { toast } from 'sonner'
 import { useRpc } from '@/app/providers'
 import { ModalShell } from '@/components/ModalShell'
 import { Button } from '@/components/ui/button'
+import { t } from '@/i18n'
 import {
   ENV_QUERY_KEY,
   filterVars,
@@ -32,10 +33,10 @@ import {
 } from './logic'
 
 const FILTERS: ReadonlyArray<{ id: EnvFilter; label: string }> = [
-  { id: 'all', label: 'All' },
-  { id: 'missing', label: 'Missing' },
-  { id: 'set', label: 'Set' },
-  { id: 'custom', label: 'Custom' },
+  { id: 'all', label: t('env.filterAll') },
+  { id: 'missing', label: t('env.filterMissing') },
+  { id: 'set', label: t('env.filterSet') },
+  { id: 'custom', label: t('env.filterCustom') },
 ]
 
 function errorMessage(error: unknown): string {
@@ -66,7 +67,7 @@ export function EnvPage() {
   const [expandedTails, setExpandedTails] = useState<Set<string>>(new Set())
 
   useEffect(() => {
-    document.title = 'Environment - AgentOS Control'
+    document.title = t('env.documentTitle')
   }, [])
 
   const listQuery = useQuery<EnvListResponse>({
@@ -102,9 +103,9 @@ export function EnvPage() {
       setDraft('')
       await refresh()
       if (result?.restartRequired) {
-        toast.warning(`${name} saved — restart the gateway for it to take full effect.`)
+        toast.warning(t('env.toastSavedRestart', { name }))
       } else {
-        toast.success(`${name} saved.`)
+        toast.success(t('env.toastSaved', { name }))
       }
       return true
     } catch (error) {
@@ -123,7 +124,7 @@ export function EnvPage() {
     try {
       await rpc.call('env.import', { name, sourceId })
       await refresh()
-      toast.success(`${name} imported. It will not follow that source's own rotation.`)
+      toast.success(t('env.toastImported', { name }))
     } catch (error) {
       toast.error(errorMessage(error))
     } finally {
@@ -136,7 +137,7 @@ export function EnvPage() {
     try {
       await rpc.call('env.unset', { name })
       await refresh()
-      toast.success(`${name} removed.`)
+      toast.success(t('env.toastRemoved', { name }))
     } catch (error) {
       toast.error(errorMessage(error))
     } finally {
@@ -192,14 +193,14 @@ export function EnvPage() {
   const confirmCopy = confirming
     ? confirming.kind === 'reveal'
       ? {
-          title: `Show ${confirming.name}?`,
-          body: 'The real value appears on screen and hides again after 30 seconds.',
-          action: 'Show value',
+          title: t('env.confirmRevealTitle', { name: confirming.name }),
+          body: t('env.confirmRevealBody'),
+          action: t('env.confirmRevealAction'),
         }
       : {
-          title: `Remove ${confirming.name}?`,
-          body: 'It is deleted from the AgentOS .env and from the running gateway.',
-          action: 'Remove',
+          title: t('env.confirmRemoveTitle', { name: confirming.name }),
+          body: t('env.confirmRemoveBody'),
+          action: t('env.confirmRemoveAction'),
         }
     : null
 
@@ -210,11 +211,11 @@ export function EnvPage() {
           <span aria-hidden="true">
             <AlertTriangleIcon />
           </span>
-          <h1>Environment unavailable</h1>
+          <h1>{t('env.loadErrorTitle')}</h1>
           <p>{errorMessage(listQuery.error)}</p>
           <Button type="button" variant="outline" onClick={() => void listQuery.refetch()}>
             <RefreshCwIcon />
-            Retry
+            {t('env.loadErrorRetry')}
           </Button>
         </div>
       </section>
@@ -225,12 +226,9 @@ export function EnvPage() {
     <section className="env-stage" aria-busy={listQuery.isLoading || undefined}>
       <header className="env-stage__header">
         <div className="env-stage__title-block">
-          <div className="t-label">Configuration</div>
-          <h1 className="t-display">Environment</h1>
-          <p className="env-stage__subtitle">
-            Credentials and settings the gateway, its providers, and your skills read from the
-            environment.
-          </p>
+          <div className="t-label">{t('env.eyebrow')}</div>
+          <h1 className="t-display">{t('env.title')}</h1>
+          <p className="env-stage__subtitle">{t('env.subtitle')}</p>
         </div>
         <div className="env-stage__actions">
           <Button
@@ -240,11 +238,11 @@ export function EnvPage() {
             onClick={() => void refresh()}
           >
             <RefreshCwIcon className={listQuery.isFetching ? 'env-spin' : undefined} />
-            Refresh
+            {t('env.refresh')}
           </Button>
           <Button type="button" onClick={openAdd}>
             <PlusIcon />
-            Add variable
+            {t('env.addVariable')}
           </Button>
         </div>
       </header>
@@ -252,23 +250,23 @@ export function EnvPage() {
       <div className="env-meta">
         <dl className="env-stats">
           <div className="env-stat">
-            <dt>Set</dt>
+            <dt>{t('env.statSet')}</dt>
             <dd>
               {summary.setCount}
-              <span>/{summary.totalCount}</span>
+              <span>{t('env.statSetTotal', { total: summary.totalCount })}</span>
             </dd>
           </div>
           <div className={summary.missingCount ? 'env-stat is-warn' : 'env-stat'}>
-            <dt>Missing</dt>
+            <dt>{t('env.statMissing')}</dt>
             <dd>{summary.missingCount}</dd>
           </div>
           <div className={summary.shadowedCount ? 'env-stat is-warn' : 'env-stat'}>
-            <dt>Shadowed</dt>
+            <dt>{t('env.statShadowed')}</dt>
             <dd>{summary.shadowedCount}</dd>
           </div>
         </dl>
         <p className="env-meta__path">
-          <span className="t-label">File</span>
+          <span className="t-label">{t('env.metaFile')}</span>
           <code title={listQuery.data?.envFilePath}>{shortPath(listQuery.data?.envFilePath)}</code>
         </p>
       </div>
@@ -279,14 +277,8 @@ export function EnvPage() {
             <AlertTriangleIcon />
           </span>
           <div>
-            <strong>
-              {summary.shadowedCount} variable(s) are shadowed by the process environment.
-            </strong>
-            <p>
-              The shell that started the gateway exported them, and that value wins over the file.
-              Editing them here will not take effect until the export is removed and the gateway
-              restarts.
-            </p>
+            <strong>{t('env.shadowWarningTitle', { count: summary.shadowedCount })}</strong>
+            <p>{t('env.shadowWarningBody')}</p>
           </div>
         </div>
       ) : null}
@@ -296,10 +288,10 @@ export function EnvPage() {
           className="env-search"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search variables"
-          aria-label="Search variables"
+          placeholder={t('env.search')}
+          aria-label={t('env.search')}
         />
-        <div className="env-filters" role="group" aria-label="Filter variables">
+        <div className="env-filters" role="group" aria-label={t('env.filterLandmark')}>
           {FILTERS.map((entry) => (
             <button
               key={entry.id}
@@ -316,7 +308,7 @@ export function EnvPage() {
 
       {groups.length === 0 ? (
         <p className="env-empty">
-          {listQuery.isLoading ? 'Loading variables…' : 'No variables match this filter.'}
+          {listQuery.isLoading ? t('env.loading') : t('env.emptyFiltered')}
         </p>
       ) : (
         groups.map((group) => {
@@ -328,7 +320,7 @@ export function EnvPage() {
               <h2 className="env-group__header">
                 <span className="env-group__label">{group.label}</span>
                 <span className="env-group__count">
-                  {group.setCount}/{group.rows.length} set
+                  {t('env.groupCount', { set: group.setCount, total: group.rows.length })}
                 </span>
               </h2>
               <ul className="env-list">
@@ -338,27 +330,27 @@ export function EnvPage() {
                       <div className="env-row__name">
                         <code>{row.name}</code>
                         {row.writable ? null : (
-                          <span
-                            className="env-row__lock"
-                            title="Blocked by AgentOS security policy — edit ~/.agentos/.env directly if you genuinely need it."
-                          >
-                            <LockIcon aria-label="Not writable through AgentOS" />
+                          <span className="env-row__lock" title={t('env.rowLockTitle')}>
+                            <LockIcon aria-label={t('env.rowLockLabel')} />
                           </span>
                         )}
                         <span className={row.isSet ? 'env-badge is-set' : 'env-badge'}>
-                          {row.isSet ? 'set' : row.missing ? 'missing' : 'unset'}
+                          {row.isSet
+                            ? t('env.badgeSet')
+                            : row.missing
+                              ? t('env.badgeMissing')
+                              : t('env.badgeUnset')}
                         </span>
                         {row.isSet ? (
                           <span className="env-row__source">{sourceLabel(row.source)}</span>
                         ) : null}
                       </div>
                       {row.description ? <p className="env-row__desc">{row.description}</p> : null}
-                      {row.owner ? <p className="env-row__owner">Needed by {row.owner}</p> : null}
+                      {row.owner ? (
+                        <p className="env-row__owner">{t('env.rowOwner', { owner: row.owner })}</p>
+                      ) : null}
                       {isShadowed(row) ? (
-                        <p className="env-row__shadow">
-                          Shadowed by the process environment — changes here take effect only after
-                          the export is removed and the gateway restarts.
-                        </p>
+                        <p className="env-row__shadow">{t('env.rowShadowed')}</p>
                       ) : null}
                       {row.url ? (
                         <a
@@ -367,7 +359,7 @@ export function EnvPage() {
                           target="_blank"
                           rel="noreferrer noopener"
                         >
-                          Where to get this
+                          {t('env.rowLink')}
                         </a>
                       ) : null}
                     </div>
@@ -376,7 +368,7 @@ export function EnvPage() {
                       {revealed[row.name] ? (
                         <code className="env-row__revealed">{revealed[row.name]}</code>
                       ) : (
-                        <code>{row.masked ?? '—'}</code>
+                        <code>{row.masked ?? t('common.dash')}</code>
                       )}
                     </div>
 
@@ -392,9 +384,13 @@ export function EnvPage() {
                               setEditing(editing === row.name ? null : row.name)
                               setDraft('')
                             }}
-                            aria-label={row.isSet ? `Edit ${row.name}` : `Set ${row.name}`}
+                            aria-label={
+                              row.isSet
+                                ? t('env.rowEditLabel', { name: row.name })
+                                : t('env.rowSetLabel', { name: row.name })
+                            }
                           >
-                            {row.isSet ? 'Edit' : 'Set'}
+                            {row.isSet ? t('env.rowEdit') : t('env.rowSet')}
                           </Button>
                           {!row.isSet && row.availableFrom ? (
                             <Button
@@ -404,7 +400,7 @@ export function EnvPage() {
                               disabled={busy === row.name}
                               onClick={() => void importFrom(row.name, row.availableFrom!.id)}
                             >
-                              Use {row.availableFrom.label}
+                              {t('env.rowImport', { source: row.availableFrom.label })}
                             </Button>
                           ) : null}
                           {row.isSet && row.secret ? (
@@ -416,7 +412,9 @@ export function EnvPage() {
                               onClick={() => setConfirming({ kind: 'reveal', name: row.name })}
                             >
                               <EyeIcon />
-                              <span className="sr-only">Reveal {row.name}</span>
+                              <span className="sr-only">
+                                {t('env.rowReveal', { name: row.name })}
+                              </span>
                             </Button>
                           ) : null}
                           {row.isSet ? (
@@ -428,7 +426,9 @@ export function EnvPage() {
                               onClick={() => setConfirming({ kind: 'unset', name: row.name })}
                             >
                               <Trash2Icon />
-                              <span className="sr-only">Remove {row.name}</span>
+                              <span className="sr-only">
+                                {t('env.rowRemove', { name: row.name })}
+                              </span>
                             </Button>
                           ) : null}
                         </>
@@ -447,12 +447,12 @@ export function EnvPage() {
                           type={row.secret ? 'password' : 'text'}
                           value={draft}
                           onChange={(event) => setDraft(event.target.value)}
-                          aria-label={`Value for ${row.name}`}
+                          aria-label={t('env.rowValueLabel', { name: row.name })}
                           autoFocus
                         />
                         <Button type="submit" size="sm" disabled={busy === row.name}>
                           <CheckIcon />
-                          Save
+                          {t('env.rowSave')}
                         </Button>
                         <Button
                           type="button"
@@ -460,7 +460,7 @@ export function EnvPage() {
                           size="sm"
                           onClick={() => setEditing(null)}
                         >
-                          Cancel
+                          {t('env.rowCancel')}
                         </Button>
                       </form>
                     ) : null}
@@ -478,7 +478,9 @@ export function EnvPage() {
                     className={tailOpen ? 'env-group__chevron is-open' : 'env-group__chevron'}
                     aria-hidden="true"
                   />
-                  {tailOpen ? `Hide ${rest.length} unset` : `Show ${rest.length} unset`}
+                  {tailOpen
+                    ? t('env.tailHide', { count: rest.length })
+                    : t('env.tailShow', { count: rest.length })}
                 </button>
               ) : null}
             </section>
@@ -494,9 +496,14 @@ export function EnvPage() {
             overlayClassName="env-modal__overlay"
             className="env-modal panel"
           >
-            <h2 id="env-add-title">Add a variable</h2>
+            <h2 id="env-add-title">{t('env.addTitle')}</h2>
+            {/* Split around the <code> element rather than translated whole: a
+                translator cannot reorder across the element, which is the one
+                place in this view where markup sits inside a sentence. */}
             <p>
-              Stored in the AgentOS <code>.env</code> and applied to the running gateway.
+              {t('env.addBodyLead')}{' '}
+              {/* eslint-disable-next-line no-restricted-syntax -- a filename, not copy */}
+              <code>.env</code> {t('env.addBodyTail')}
             </p>
             <form
               className="env-add"
@@ -506,23 +513,23 @@ export function EnvPage() {
               }}
             >
               <label>
-                Name
+                {t('env.addNameLabel')}
                 <input
                   value={newName}
                   onChange={(event) => setNewName(event.target.value)}
-                  placeholder="MY_SERVICE_TOKEN"
-                  aria-label="New variable name"
+                  placeholder={t('env.addNamePlaceholder')}
+                  aria-label={t('env.addNameField')}
                   aria-invalid={newError ? true : undefined}
                   aria-describedby={newError ? 'env-add-error' : undefined}
                 />
               </label>
               <label>
-                Value
+                {t('env.addValueLabel')}
                 <input
                   type="password"
                   value={newValue}
                   onChange={(event) => setNewValue(event.target.value)}
-                  aria-label="New variable value"
+                  aria-label={t('env.addValueField')}
                 />
               </label>
               {newError ? (
@@ -532,10 +539,10 @@ export function EnvPage() {
               ) : null}
               <div className="env-modal__actions">
                 <Button type="submit" disabled={busy === newName.trim()}>
-                  Save
+                  {t('env.addSave')}
                 </Button>
                 <Button type="button" variant="outline" onClick={closeAdd}>
-                  Cancel
+                  {t('env.addCancel')}
                 </Button>
               </div>
             </form>
@@ -572,7 +579,7 @@ export function EnvPage() {
                 {confirmCopy.action}
               </Button>
               <Button type="button" variant="outline" onClick={() => setConfirming(null)}>
-                Cancel
+                {t('env.confirmCancel')}
               </Button>
             </div>
           </ModalShell>

--- a/frontend/src/views/env/logic.ts
+++ b/frontend/src/views/env/logic.ts
@@ -5,6 +5,8 @@
  * can be tested without a DOM — the same split the Skills and MCP views use.
  */
 
+import { t } from '@/i18n'
+
 /** Shared so the Settings glance and the Environment screen hit one cache. */
 export const ENV_QUERY_KEY = ['env', 'list'] as const
 
@@ -49,19 +51,19 @@ export type EnvFilter = 'all' | 'missing' | 'set' | 'custom'
 const CATEGORY_ORDER = ['provider', 'search', 'image', 'audio', 'memory', 'skill', 'custom']
 
 const CATEGORY_LABELS: Record<string, string> = {
-  provider: 'LLM providers',
-  search: 'Search',
-  image: 'Image generation',
-  audio: 'Audio',
-  memory: 'Memory embedding',
-  skill: 'Skills',
-  custom: 'Your own variables',
+  provider: t('env.categoryProvider'),
+  search: t('env.categorySearch'),
+  image: t('env.categoryImage'),
+  audio: t('env.categoryAudio'),
+  memory: t('env.categoryMemory'),
+  skill: t('env.categorySkill'),
+  custom: t('env.categoryCustom'),
 }
 
 const SOURCE_LABELS: Record<EnvSource, string> = {
-  process: 'process env',
-  cwd_file: 'project .env',
-  home_file: 'AgentOS .env',
+  process: t('env.sourceProcess'),
+  cwd_file: t('env.sourceCwdFile'),
+  home_file: t('env.sourceHomeFile'),
   unset: '',
 }
 
@@ -178,13 +180,13 @@ export function summarize(payload: EnvListResponse | undefined): EnvSummary {
  */
 export function validateNewName(name: string, known: EnvVarRow[]): string | null {
   const trimmed = name.trim()
-  if (!trimmed) return 'Enter a variable name.'
+  if (!trimmed) return t('env.validateEmpty')
   if (!isValidEnvName(trimmed)) {
-    return 'Use letters, digits, and underscores, starting with a letter or underscore.'
+    return t('env.validateCharset')
   }
   const existing = known.find((row) => row.name === trimmed)
   if (existing && !existing.writable) {
-    return 'This name cannot be written through AgentOS.'
+    return t('env.validateReadOnly')
   }
   return null
 }
@@ -203,5 +205,5 @@ export function shortPath(path: string | undefined): string {
   if (!path) return ''
   const segments = path.split('/').filter(Boolean)
   if (segments.length <= 2) return path
-  return `…/${segments.slice(-2).join('/')}`
+  return t('env.shortPath', { tail: segments.slice(-2).join('/') })
 }

--- a/frontend/src/views/health/HealthPage.tsx
+++ b/frontend/src/views/health/HealthPage.tsx
@@ -5,6 +5,7 @@ import { CommandLine } from '@/components/CommandLine'
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
+import { t } from '@/i18n'
 import {
   evidenceLabel,
   evidenceValue,
@@ -26,10 +27,10 @@ const WS_URL_KEY = 'agentos.wsUrl'
 
 // health.js:422-430 — impact -> human label for the finding meta line.
 const IMPACT_LABELS: Record<Impact, string> = {
-  blocks_ready: 'Blocks readiness',
-  degrades: 'Degrades',
-  optional: 'Optional',
-  none: 'Reference',
+  blocks_ready: t('health.impactBlocksReady'),
+  degrades: t('health.impactDegrades'),
+  optional: t('health.impactOptional'),
+  none: t('health.impactNone'),
 }
 
 // health.js:432-437 — finding kind -> tone token used for the card accent.
@@ -42,9 +43,9 @@ const FINDING_TONE: Record<GroupKind, string> = {
 
 // health.js:397-401 — steps heading by group kind.
 function stepsHeading(kind: GroupKind): string {
-  if (kind === 'optional') return 'Optional setup steps'
-  if (kind === 'ready') return 'Reference steps'
-  return 'Recovery steps'
+  if (kind === 'optional') return t('health.stepsOptional')
+  if (kind === 'ready') return t('health.stepsReference')
+  return t('health.stepsRecovery')
 }
 
 // health.js:485-487 — normalize a value into a CSS-safe class token.
@@ -57,9 +58,9 @@ function classToken(value: string): string {
 // health.js:356-368 — id-derived badge for known finding families.
 function findingBadge(finding: Finding): string | null {
   const id = String(finding?.id || '')
-  if (id.endsWith('.diagnostic.incomplete')) return 'Diagnostics incomplete'
-  if (id.endsWith('.repair.pending')) return 'Repair pending'
-  if (id === 'gateway.config.mismatch') return 'Config mismatch'
+  if (id.endsWith('.diagnostic.incomplete')) return t('health.badgeDiagnosticsIncomplete')
+  if (id.endsWith('.repair.pending')) return t('health.badgeRepairPending')
+  if (id === 'gateway.config.mismatch') return t('health.badgeConfigMismatch')
   return null
 }
 
@@ -67,7 +68,7 @@ function findingBadge(finding: Finding): string | null {
 function gatewayUnavailableDetail(gatewayUrl: string, err: unknown): string {
   const reason = err instanceof Error ? err.message : String(err)
   if (!gatewayUrl) return reason
-  return `Cannot load doctor.status from ${gatewayUrl}. ${reason}`
+  return t('health.gatewayUnavailableDetail', { url: gatewayUrl, reason })
 }
 
 // health.js:35-62 + components.js UI.toast — copy handling now lives in the
@@ -91,7 +92,7 @@ function StepsList({ steps, kind }: { steps: NonNullable<Finding['fixSteps']>; k
           <li className="health-step" key={index}>
             <span className="health-step__number">{index + 1}</span>
             <span className="health-step__body">
-              <b>{step.label || 'Step'}</b>
+              <b>{step.label || t('health.stepFallbackLabel')}</b>
               {step.command ? <CommandRow command={step.command} /> : null}
               {step.detail ? <span className="health-step__detail">{step.detail}</span> : null}
             </span>
@@ -107,7 +108,7 @@ function EvidenceTags({ evidence }: { evidence?: Record<string, unknown> }) {
   const entries = visibleEvidenceEntries(evidence).slice(0, 6)
   if (!entries.length) return null
   return (
-    <div className="health-evidence" aria-label="Finding evidence">
+    <div className="health-evidence" aria-label={t('health.findingEvidence')}>
       {entries.map(([key, value]) => (
         <span key={key}>
           <b>{evidenceLabel(key)}</b>
@@ -138,11 +139,11 @@ function FindingCard({ finding, index }: { finding: Finding; index: number }) {
           <span className="health-surface">{surface}</span>
           {badge ? <span className="health-chip health-chip--badge">{badge}</span> : null}
           {finding.restartRequired ? (
-            <span className="health-chip">Recovery requires restart</span>
+            <span className="health-chip">{t('health.findingRestart')}</span>
           ) : null}
         </div>
         <div className="health-finding__title">
-          {finding.title || finding.id || `Finding ${index + 1}`}
+          {finding.title || finding.id || t('health.findingFallbackTitle', { index: index + 1 })}
         </div>
         <div className="health-finding__detail">{finding.detail || ''}</div>
         <EvidenceTags evidence={finding.evidence} />
@@ -156,30 +157,30 @@ const GROUPS: Array<{ kind: GroupKind; title: string; note: string }> = [
   // health.js:281-301
   {
     kind: 'action',
-    title: 'Needs action',
-    note: 'Fix these first to make AgentOS ready.',
+    title: t('health.groupActionTitle'),
+    note: t('health.groupActionNote'),
   },
   {
     kind: 'degraded',
-    title: 'Degraded capabilities',
-    note: 'AgentOS can run, but these capabilities need attention.',
+    title: t('health.groupDegradedTitle'),
+    note: t('health.groupDegradedNote'),
   },
   {
     kind: 'optional',
-    title: 'Optional setup',
-    note: 'These improve capability or posture but do not block readiness.',
+    title: t('health.groupOptionalTitle'),
+    note: t('health.groupOptionalNote'),
   },
   {
     kind: 'ready',
-    title: 'Ready checks',
-    note: 'These surfaces are already working.',
+    title: t('health.groupReadyTitle'),
+    note: t('health.groupReadyNote'),
   },
 ]
 
 function FindingsSection({ findings }: { findings: Finding[] }) {
   // health.js:277-313 — empty state else grouped sections.
   if (!findings.length) {
-    return <article className="health-empty">No findings returned.</article>
+    return <article className="health-empty">{t('health.findingsEmpty')}</article>
   }
   const groups = GROUPS.map((group) => ({
     ...group,
@@ -224,12 +225,16 @@ function CountTile({
   return (
     <div
       className={`health-count is-${classToken(kind)}${loading ? ' is-loading' : ''}`}
-      aria-label={`${label}: ${Number(value || 0)}`}
+      aria-label={t('health.railCountValue', { label, value: Number(value || 0) })}
     >
       <span className="health-count__dot" aria-hidden="true" />
       <span className="health-count__label">{label}</span>
-      <strong>{loading ? '—' : Number(value || 0)}</strong>
-      <span className="health-count__share">{loading ? 'checking' : `${percentage}%`}</span>
+      <strong>{loading ? t('common.dash') : Number(value || 0)}</strong>
+      <span className="health-count__share">
+        {loading
+          ? t('health.railCountChecking')
+          : t('health.railCountShare', { percent: percentage })}
+      </span>
     </div>
   )
 }
@@ -250,15 +255,15 @@ function ReportContext({
   // health.js:152-170 — gateway/config/agent context row.
   const items: Array<[string, string]> = []
   const gatewayUrl = report.gatewayUrl || fallbackGatewayUrl
-  if (gatewayUrl) items.push(['Gateway', gatewayUrl])
-  if (report.configPath) items.push(['Config', report.configPath])
+  if (gatewayUrl) items.push([t('health.contextGateway'), gatewayUrl])
+  if (report.configPath) items.push([t('health.contextConfig'), report.configPath])
   if (report.requestedConfigPath && report.requestedConfigPath !== report.configPath) {
-    items.push(['Requested config', report.requestedConfigPath])
+    items.push([t('health.contextRequestedConfig'), report.requestedConfigPath])
   }
-  if (report.agentId) items.push(['Agent', report.agentId])
+  if (report.agentId) items.push([t('health.contextAgent'), report.agentId])
   if (!items.length) return null
   return (
-    <div className="health-report-context" aria-label="Health report context">
+    <div className="health-report-context" aria-label={t('health.contextLandmark')}>
       {items.map(([label, value]) => (
         <span className="health-report-context__item" key={label}>
           <b>{label}</b>
@@ -280,33 +285,42 @@ function StatusRail({
   const impactCounts = report.impactCounts || impactCountsFromSeverity(report.counts || {})
   const status = report.status || 'unknown'
   const counts = [
-    { label: 'Needs action', value: impactCounts.blocks_ready || 0, kind: 'blocks_ready' },
-    { label: 'Degraded', value: impactCounts.degrades || 0, kind: 'degrades' },
-    { label: 'Optional', value: impactCounts.optional || 0, kind: 'optional' },
-    { label: 'Ready', value: impactCounts.none || 0, kind: 'none' },
+    {
+      label: t('health.countBlocksReady'),
+      value: impactCounts.blocks_ready || 0,
+      kind: 'blocks_ready',
+    },
+    { label: t('health.countDegrades'), value: impactCounts.degrades || 0, kind: 'degrades' },
+    { label: t('health.countOptional'), value: impactCounts.optional || 0, kind: 'optional' },
+    { label: t('health.countNone'), value: impactCounts.none || 0, kind: 'none' },
   ]
   const total = counts.reduce((sum, item) => sum + item.value, 0)
   return (
-    <section className={`health-status__rail is-${classToken(status)}`} aria-label="Health summary">
+    <section
+      className={`health-status__rail is-${classToken(status)}`}
+      aria-label={t('health.railLandmark')}
+    >
       <div className="health-score">
         <span className="health-score__icon" aria-hidden="true">
           <StatusIcon status={status} />
         </span>
         <div className="health-score__copy">
-          <span className="health-score__label">System readiness</span>
+          <span className="health-score__label">{t('health.railReadiness')}</span>
           <strong>{statusLabel(status, report.ready)}</strong>
           <span className="health-score__summary">{report.summary || status}</span>
         </div>
       </div>
       <div className="health-impact-profile">
         <div className="health-impact-profile__head">
-          <span>Impact distribution</span>
-          <strong>{total} checks</strong>
+          <span>{t('health.railImpactHead')}</span>
+          <strong>{t('health.railImpactChecks', { count: total })}</strong>
         </div>
         <div
           className={`health-impact-meter${total === 0 ? ' is-empty' : ''}`}
           role="img"
-          aria-label={`Impact distribution: ${counts.map((item) => `${item.label} ${item.value}`).join(', ')}`}
+          aria-label={t('health.railImpactMeter', {
+            breakdown: counts.map((item) => `${item.label} ${item.value}`).join(', '),
+          })}
         >
           {counts
             .filter((item) => item.value > 0)
@@ -332,30 +346,48 @@ function StatusRail({
 function LoadingRail() {
   // health.js:118-130 — loading strip.
   return (
-    <section className="health-status__rail is-loading" aria-label="Health summary">
+    <section className="health-status__rail is-loading" aria-label={t('health.railLandmark')}>
       <div className="health-score">
         <span className="health-score__icon" aria-hidden="true">
           <ActivityIcon />
         </span>
         <div className="health-score__copy">
-          <span className="health-score__label">System readiness</span>
-          <strong>Checking</strong>
-          <span className="health-score__summary">Waiting for doctor.status</span>
+          <span className="health-score__label">{t('health.railReadiness')}</span>
+          <strong>{t('health.checking')}</strong>
+          <span className="health-score__summary">{t('health.railWaiting')}</span>
         </div>
       </div>
       <div className="health-impact-profile">
         <div className="health-impact-profile__head">
-          <span>Impact distribution</span>
-          <strong>Running checks</strong>
+          <span>{t('health.railImpactHead')}</span>
+          <strong>{t('health.railImpactRunning')}</strong>
         </div>
         <div className="health-impact-meter is-loading" aria-hidden="true">
           <span />
         </div>
         <div className="health-count-grid">
-          <CountTile label="Needs action" value={0} kind="blocks_ready" total={0} loading />
-          <CountTile label="Degraded" value={0} kind="degrades" total={0} loading />
-          <CountTile label="Optional" value={0} kind="optional" total={0} loading />
-          <CountTile label="Ready" value={0} kind="none" total={0} loading />
+          <CountTile
+            label={t('health.countBlocksReady')}
+            value={0}
+            kind="blocks_ready"
+            total={0}
+            loading
+          />
+          <CountTile
+            label={t('health.countDegrades')}
+            value={0}
+            kind="degrades"
+            total={0}
+            loading
+          />
+          <CountTile
+            label={t('health.countOptional')}
+            value={0}
+            kind="optional"
+            total={0}
+            loading
+          />
+          <CountTile label={t('health.countNone')} value={0} kind="none" total={0} loading />
         </div>
       </div>
     </section>
@@ -367,7 +399,7 @@ export function HealthPage() {
   const bootstrap = useBootstrap()
 
   useEffect(() => {
-    document.title = 'Health - AgentOS Control'
+    document.title = t('health.documentTitle')
   }, [])
 
   // Simplification (parity matrix): legacy _gatewayContextUrl() read
@@ -413,18 +445,18 @@ export function HealthPage() {
   const showLoading = query.isFetching
 
   const summaryText = showLoading
-    ? 'Checking readiness'
+    ? t('health.summaryChecking')
     : query.isError
-      ? 'Health report unavailable'
+      ? t('health.summaryUnavailable')
       : query.data
-        ? query.data.summary || query.data.status || 'Health report loaded'
-        : 'Checking readiness'
+        ? query.data.summary || query.data.status || t('health.summaryLoaded')
+        : t('health.summaryChecking')
 
   let railNode
   let findingsNode
   if (showLoading) {
     railNode = <LoadingRail />
-    findingsNode = <article className="health-empty">Loading health report</article>
+    findingsNode = <article className="health-empty">{t('health.findingsLoading')}</article>
   } else if (query.isError) {
     // health.js:86-115 — synthetic gateway.unavailable report + finding.
     // health.js:227-238 — usesDefault is URL-equality against the default RPC
@@ -441,7 +473,7 @@ export function HealthPage() {
       // report, so the readiness rail reads a human sentence rather than the raw
       // "unavailable" status token. (The header #health-summary line stays the
       // distinct "Health report unavailable" per health.js:89.)
-      summary: 'Gateway health report unavailable',
+      summary: t('health.gatewayUnavailableTitle'),
       gatewayUrl,
       configPath: errorConfigPath,
       counts: { error: 1, warn: 0, info: 0, ok: 0 },
@@ -452,7 +484,7 @@ export function HealthPage() {
       severity: 'error',
       readinessImpact: 'blocks_ready',
       surface: 'gateway',
-      title: 'Gateway health report unavailable',
+      title: t('health.gatewayUnavailableTitle'),
       detail: gatewayUnavailableDetail(gatewayUrl, query.error),
       evidence: errorConfigPath ? { gatewayUrl, configPath: errorConfigPath } : { gatewayUrl },
       fixSteps: gatewayUnavailableFixSteps(gatewayUrl, errorConfigPath, usesDefault),
@@ -465,37 +497,37 @@ export function HealthPage() {
     findingsNode = <FindingsSection findings={query.data.findings || []} />
   } else {
     railNode = <LoadingRail />
-    findingsNode = <article className="health-empty">Loading health report</article>
+    findingsNode = <article className="health-empty">{t('health.findingsLoading')}</article>
   }
 
   return (
     <div className="health-layout health-stage">
       <header className="health-stage__header">
         <div className="health-stage__title-block">
-          <span className="health-eyebrow">Control · Health</span>
-          <h1>Health</h1>
+          <span className="health-eyebrow">{t('health.eyebrow')}</span>
+          <h1>{t('health.title')}</h1>
           <p id="health-summary">{summaryText}</p>
         </div>
         <Button
           variant="outline"
           id="health-refresh"
-          title="Refresh health report"
+          title={t('health.refreshTitle')}
           className="btn-refresh btn-term"
           disabled={showLoading}
           onClick={() => void query.refetch()}
         >
           <RefreshCwIcon className={showLoading ? 'health-spin' : undefined} />
-          <span>{showLoading ? 'Checking' : 'Refresh'}</span>
+          <span>{showLoading ? t('health.checking') : t('health.refresh')}</span>
         </Button>
       </header>
       {railNode}
       <section className="health-findings" aria-labelledby="health-findings-title">
         <div className="health-findings__intro">
           <div>
-            <span className="health-findings__eyebrow">Diagnostics</span>
-            <h2 id="health-findings-title">What needs attention</h2>
+            <span className="health-findings__eyebrow">{t('health.findingsEyebrow')}</span>
+            <h2 id="health-findings-title">{t('health.findingsTitle')}</h2>
           </div>
-          <p>Ordered by readiness impact so the next useful action stays obvious.</p>
+          <p>{t('health.findingsIntro')}</p>
         </div>
         <div className="health-findings__stack">{findingsNode}</div>
       </section>

--- a/frontend/src/views/health/logic.ts
+++ b/frontend/src/views/health/logic.ts
@@ -2,6 +2,8 @@
 // (src/agentos/gateway/static/js/views/health.js). Each function below carries
 // the legacy line range it mirrors so the parity matrix stays auditable.
 
+import { t } from '@/i18n'
+
 export type Impact = 'blocks_ready' | 'degrades' | 'optional' | 'none'
 export type GroupKind = 'action' | 'degraded' | 'optional' | 'ready'
 
@@ -55,13 +57,13 @@ export function impactCountsFromSeverity(counts: Record<string, number>): Record
 
 /** health.js:462-472 — readiness label incl. "Ready with warnings". */
 export function statusLabel(status: string, ready?: boolean): string {
-  if (ready && status === 'degraded') return 'Ready with warnings'
-  if (ready) return 'Ready'
+  if (ready && status === 'degraded') return t('health.statusReadyWithWarnings')
+  if (ready) return t('health.statusReady')
   const labels: Record<string, string> = {
-    action_required: 'Action required',
-    degraded: 'Degraded',
-    unavailable: 'Unavailable',
-    ready: 'Ready',
+    action_required: t('health.statusActionRequired'),
+    degraded: t('health.statusDegraded'),
+    unavailable: t('health.statusUnavailable'),
+    ready: t('health.statusReady'),
   }
   return labels[status] || status
 }
@@ -147,12 +149,12 @@ export function gatewayUnavailableFixSteps(
   if (!isLocalGatewayUrl(url)) {
     return [
       {
-        label: 'Inspect remote gateway',
+        label: t('health.stepInspectRemote'),
         command: `agentos gateway status --gateway ${shellArg(url)} --json`,
       },
       {
-        label: 'Repair remote deployment',
-        detail: 'Start or repair the remote AgentOS gateway deployment, then refresh health.',
+        label: t('health.stepRepairRemote'),
+        detail: t('health.stepRepairRemoteDetail'),
       },
     ]
   }
@@ -164,13 +166,16 @@ export function gatewayUnavailableFixSteps(
   const targetArgs = useConfigTarget ? '' : bindArgs
   return [
     {
-      label: 'Run local doctor',
+      label: t('health.stepRunDoctor'),
       command: `agentos doctor${doctorTarget}${configTarget} --json`,
-      detail: 'Checks local config and onboarding before restarting the gateway.',
+      detail: t('health.stepRunDoctorDetail'),
     },
-    { label: 'Start local gateway', command: `agentos gateway start${targetArgs}${configTarget}` },
     {
-      label: 'Inspect local gateway',
+      label: t('health.stepStartGateway'),
+      command: `agentos gateway start${targetArgs}${configTarget}`,
+    },
+    {
+      label: t('health.stepInspectGateway'),
       command: `agentos gateway status${targetArgs} --json${configTarget}`,
     },
   ]

--- a/frontend/src/views/logs/LogsPage.tsx
+++ b/frontend/src/views/logs/LogsPage.tsx
@@ -5,6 +5,7 @@ import { ActivityIcon, DownloadIcon, ScrollTextIcon, SearchIcon } from 'lucide-r
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
+import { t } from '@/i18n'
 import {
   DEFAULT_LEVELS,
   LEVELS,
@@ -51,8 +52,8 @@ function StatusPill({ label, tone }: { label: string; tone?: 'warn' }) {
 function StatusPills({ status }: { status: LogsStatus | null }) {
   if (!status) {
     return (
-      <div className="lg-status-pills" aria-label="Log status">
-        <StatusPill label="Log status unavailable" tone="warn" />
+      <div className="lg-status-pills" aria-label={t('logs.statusLandmark')}>
+        <StatusPill label={t('logs.statusUnavailable')} tone="warn" />
       </div>
     )
   }
@@ -61,18 +62,19 @@ function StatusPills({ status }: { status: LogsStatus | null }) {
   const diagnostics = status.diagnostics_enabled || {}
   const diagnosticsLabel =
     diagnostics.detail === 'raw'
-      ? 'Diagnostics raw'
+      ? t('logs.statusDiagnosticsRaw')
       : diagnostics.effective
-        ? 'Diagnostics standard'
-        : 'Diagnostics off'
+        ? t('logs.statusDiagnosticsStandard')
+        : t('logs.statusDiagnosticsOff')
+  const onOff = (enabled?: boolean) => (enabled ? t('logs.statusOn') : t('logs.statusOff'))
   return (
-    <div className="lg-status-pills" aria-label="Log status">
+    <div className="lg-status-pills" aria-label={t('logs.statusLandmark')}>
       <StatusPill
-        label={`File log ${fileLog.enabled ? 'on' : 'off'}`}
+        label={t('logs.statusFileLog', { state: onOff(fileLog.enabled) })}
         tone={fileLog.enabled ? undefined : 'warn'}
       />
       <StatusPill
-        label={`Raw turn-call ${rawLog.enabled ? 'on' : 'off'}`}
+        label={t('logs.statusRawTurnCall', { state: onOff(rawLog.enabled) })}
         tone={rawLog.enabled ? undefined : 'warn'}
       />
       <StatusPill label={diagnosticsLabel} tone="warn" />
@@ -114,7 +116,7 @@ export function LogsPage() {
   const rpc = useRpc()
 
   useEffect(() => {
-    document.title = 'Logs - AgentOS Control'
+    document.title = t('logs.documentTitle')
   }, [])
 
   // Accumulated tail buffer is React state (rendered data): the poll appends to
@@ -183,8 +185,8 @@ export function LogsPage() {
       // logs.js:209-213 — one warn toast per error run, suppressed until a
       // successful poll clears the flag.
       if (!pollErrorShownRef.current) {
-        const message = err instanceof Error ? err.message : 'unknown error'
-        toast.warning('Log refresh failed: ' + message, {
+        const message = err instanceof Error ? err.message : t('logs.toastUnknownError')
+        toast.warning(t('logs.toastRefreshFailed', { message }), {
           id: 'logs-refresh-err',
           duration: 2500,
         })
@@ -259,7 +261,7 @@ export function LogsPage() {
     streamBody = (
       <div className="lg-display__placeholder">
         <span className="lg-spinner" aria-hidden="true" />
-        Loading logs…
+        {t('logs.streamLoading')}
       </div>
     )
   } else if (filtered.length === 0) {
@@ -269,7 +271,7 @@ export function LogsPage() {
         <span className="lg-display__placeholder-icon" aria-hidden="true">
           <ScrollTextIcon />
         </span>
-        {hasAnyLines ? 'No lines match the current filter.' : 'No logs yet.'}
+        {hasAnyLines ? t('logs.streamNoMatch') : t('logs.streamEmpty')}
       </div>
     )
   } else {
@@ -282,74 +284,84 @@ export function LogsPage() {
     <div className="lg-stage">
       <header className="lg-stage__header">
         <div className="lg-stage__title-block">
-          <span className="t-label">Control · Logs</span>
-          <h1 className="t-display">Logs</h1>
-          <p className="lg-stage__subtitle">
-            Live gateway log stream — filter, follow, and export.
-          </p>
+          <span className="t-label">{t('logs.eyebrow')}</span>
+          <h1 className="t-display">{t('logs.title')}</h1>
+          <p className="lg-stage__subtitle">{t('logs.subtitle')}</p>
         </div>
         <div className="lg-stage__actions">
           <Button
             variant="outline"
-            title="Download filtered log lines"
+            title={t('logs.exportTitle')}
             className="text-xs uppercase tracking-[0.14em]"
             onClick={onExport}
           >
             <DownloadIcon />
-            <span>Export</span>
+            <span>{t('logs.export')}</span>
           </Button>
         </div>
       </header>
 
-      <section className="lg-console" aria-label="Live log console">
+      <section className="lg-console" aria-label={t('logs.consoleLandmark')}>
         <div className="lg-console__head">
           <div className="lg-console__heading">
             <span className="lg-console__icon" aria-hidden="true">
               <ActivityIcon />
             </span>
             <div>
-              <span className="t-label">Observability stream</span>
-              <strong>Gateway output</strong>
+              <span className="t-label">{t('logs.consoleEyebrow')}</span>
+              <strong>{t('logs.consoleTitle')}</strong>
             </div>
           </div>
           <div className="lg-console__status">
             <StatusPills status={statusQuery.data ?? null} />
             <span className="lg-console__cadence t-data">
-              <span aria-hidden="true" /> Polling every 3s
+              <span aria-hidden="true" /> {t('logs.consoleCadence')}
             </span>
           </div>
         </div>
 
-        <div className="lg-stats" aria-label="Log summary">
-          <div className="lg-stat lg-stat--hero" aria-label="In view">
-            <span className="lg-stat__label t-label">In view</span>
+        <div className="lg-stats" aria-label={t('logs.statsLandmark')}>
+          <div className="lg-stat lg-stat--hero" aria-label={t('logs.statInView')}>
+            <span className="lg-stat__label t-label">{t('logs.statInView')}</span>
             <strong className="lg-stat__value t-data">{filtered.length.toLocaleString()}</strong>
-            <span className="lg-stat__hint">of {counts.total.toLocaleString()} loaded</span>
+            <span className="lg-stat__hint">
+              {t('logs.statInViewHint', { total: counts.total.toLocaleString() })}
+            </span>
           </div>
-          <div className={`lg-stat${counts.errors ? ' tone-danger' : ''}`} aria-label="Errors">
-            <span className="lg-stat__label t-label">Errors</span>
+          <div
+            className={`lg-stat${counts.errors ? ' tone-danger' : ''}`}
+            aria-label={t('logs.statErrors')}
+          >
+            <span className="lg-stat__label t-label">{t('logs.statErrors')}</span>
             <strong className="lg-stat__value t-data">{counts.errors}</strong>
-            <span className="lg-stat__hint">{counts.errors ? 'review needed' : 'all clear'}</span>
+            <span className="lg-stat__hint">
+              {counts.errors ? t('logs.statErrorsReview') : t('logs.statErrorsClear')}
+            </span>
           </div>
-          <div className={`lg-stat${counts.warns ? ' tone-warn' : ''}`} aria-label="Warnings">
-            <span className="lg-stat__label t-label">Warnings</span>
+          <div
+            className={`lg-stat${counts.warns ? ' tone-warn' : ''}`}
+            aria-label={t('logs.statWarnings')}
+          >
+            <span className="lg-stat__label t-label">{t('logs.statWarnings')}</span>
             <strong className="lg-stat__value t-data">{counts.warns}</strong>
-            <span className="lg-stat__hint">{counts.warns ? 'recent advisories' : 'none'}</span>
+            <span className="lg-stat__hint">
+              {counts.warns ? t('logs.statWarningsRecent') : t('logs.statWarningsNone')}
+            </span>
           </div>
-          <div className="lg-stat" aria-label="Info and Debug">
-            <span className="lg-stat__label t-label">Info / Debug</span>
+          <div className="lg-stat" aria-label={t('logs.statInfoDebugLandmark')}>
+            <span className="lg-stat__label t-label">{t('logs.statInfoDebug')}</span>
             <strong className="lg-stat__value t-data">
               {counts.infos}
               <span className="lg-stat__sep">/</span>
               {counts.debug}
             </strong>
-            <span className="lg-stat__hint">routine output</span>
+            <span className="lg-stat__hint">{t('logs.statInfoDebugHint')}</span>
           </div>
         </div>
 
         <div className="lg-toolbar">
           <div className="lg-levels">
-            <span className="lg-toolbar__label t-label">Levels</span>
+            <span className="lg-toolbar__label t-label">{t('logs.toolbarLevels')}</span>
             <div className="lg-levels__row">
               {LEVELS.map((level) => {
                 const isActive = activeLevels.has(level)
@@ -358,7 +370,7 @@ export function LogsPage() {
                     type="button"
                     key={level}
                     className={`lg-level-btn lg-level-btn--${level.toLowerCase()}${isActive ? ' is-active' : ''}`}
-                    aria-label={`Toggle ${level} level`}
+                    aria-label={t('logs.toolbarToggleLevel', { level })}
                     aria-pressed={isActive}
                     onClick={() => toggleLevel(level)}
                   >
@@ -376,8 +388,8 @@ export function LogsPage() {
             <input
               className="lg-search-input"
               type="search"
-              aria-label="Filter log messages"
-              placeholder="Filter messages…"
+              aria-label={t('logs.toolbarSearchLabel')}
+              placeholder={t('logs.toolbarSearchPlaceholder')}
               autoComplete="off"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -392,7 +404,7 @@ export function LogsPage() {
             <span className="lg-toggle__track" aria-hidden="true">
               <span className="lg-toggle__thumb" />
             </span>
-            <span className="lg-toggle__label">Auto-follow</span>
+            <span className="lg-toggle__label">{t('logs.toolbarAutoFollow')}</span>
           </label>
         </div>
 

--- a/frontend/src/views/overview/OverviewPage.tsx
+++ b/frontend/src/views/overview/OverviewPage.tsx
@@ -15,6 +15,7 @@ import {
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
+import { t, tPlural } from '@/i18n'
 import {
   formatCost,
   formatEventPayload,
@@ -128,7 +129,7 @@ export function OverviewPage() {
   const queryClient = useQueryClient()
 
   useEffect(() => {
-    document.title = 'Overview - AgentOS Control'
+    document.title = t('overview.documentTitle')
   }, [])
 
   // overview.js:212-311 — four independent reads run in parallel; each tile
@@ -153,7 +154,7 @@ export function OverviewPage() {
     if (statusQuery.isError) {
       const err = statusQuery.error
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to load status: ' + message, { id: 'overview-status-err' })
+      toast.error(t('overview.toastStatusFailed', { message }), { id: 'overview-status-err' })
     }
   }, [statusQuery.isError, statusQuery.error])
 
@@ -263,49 +264,47 @@ export function OverviewPage() {
     <div className="ov-stage">
       <header className="ov-stage__header">
         <div className="ov-stage__title-block">
-          <span className="t-label">Control · Overview</span>
-          <h1 className="t-display">Overview</h1>
-          <p className="ov-stage__subtitle">
-            Live status, recent sessions, and the gateway event stream.
-          </p>
+          <span className="t-label">{t('overview.eyebrow')}</span>
+          <h1 className="t-display">{t('overview.title')}</h1>
+          <p className="ov-stage__subtitle">{t('overview.subtitle')}</p>
         </div>
         <div className="ov-stage__actions">
           <Button
             variant="outline"
-            title="Refresh"
+            title={t('overview.refresh')}
             className="text-xs uppercase tracking-[0.14em]"
             aria-busy={overviewRefreshing}
             disabled={overviewRefreshing}
             onClick={refreshAll}
           >
             <RefreshCwIcon className={overviewRefreshing ? 'ov-refresh-spin' : undefined} />
-            <span>Refresh</span>
+            <span>{t('overview.refresh')}</span>
           </Button>
           <Button
-            title="Open chat"
+            title={t('overview.openChat')}
             className="text-xs uppercase tracking-[0.14em]"
             onClick={() => navigate('/chat')}
           >
             <MessageSquareIcon />
-            <span>Open chat</span>
+            <span>{t('overview.openChat')}</span>
           </Button>
         </div>
       </header>
 
-      <section className="ov-command" aria-label="Gateway summary">
+      <section className="ov-command" aria-label={t('overview.summaryLandmark')}>
         <div className="ov-command__toolbar">
           <div>
-            <span className="ov-command__eyebrow">System pulse</span>
-            <strong>Gateway summary</strong>
+            <span className="ov-command__eyebrow">{t('overview.summaryEyebrow')}</span>
+            <strong>{t('overview.summaryLandmark')}</strong>
           </div>
           <span className="ov-command__cadence">
             <span aria-hidden="true" />
-            Refreshes every 30s
+            {t('overview.summaryCadence')}
           </span>
         </div>
         <div className="ov-command__body">
           <StatTile
-            label="Health"
+            label={t('overview.tileHealth')}
             icon={<StethoscopeIcon />}
             to="/health"
             tone={doctorFailed ? 'err' : readinessTone(doctor?.status)}
@@ -313,51 +312,65 @@ export function OverviewPage() {
             loading={doctorQuery.isFetching}
           >
             <strong className="ov-stat__value ov-stat__value--status t-data">
-              {doctorFailed ? 'Unavailable' : readinessStatusLabel(doctor?.status)}
+              {doctorFailed ? t('overview.readyUnavailable') : readinessStatusLabel(doctor?.status)}
             </strong>
             <span className="ov-stat__hint">
-              {doctorFailed ? 'open health' : (doctor?.summary ?? 'view details')}
+              {doctorFailed
+                ? t('overview.tileHealthOpen')
+                : (doctor?.summary ?? t('overview.tileHealthDetails'))}
             </span>
           </StatTile>
           <div className="ov-command__metrics">
             <StatTile
-              label="Total tokens"
+              label={t('overview.tileTokens')}
               icon={<CoinsIcon />}
               to="/usage"
               loading={usageQuery.isFetching}
             >
               <strong className="ov-stat__value t-data">{formatTokens(usage?.totalTokens)}</strong>
               <span className="ov-stat__hint">
-                {usage ? formatCost(usage.totalCostUsd) + ' spent' : 'view usage'}
+                {usage
+                  ? t('overview.tileSpent', { amount: formatCost(usage.totalCostUsd) })
+                  : t('overview.tileTokensHint')}
               </span>
             </StatTile>
             <StatTile
-              label="Total sessions"
+              label={t('overview.tileSessions')}
               icon={<ActivityIcon />}
               to="/sessions"
               loading={usageQuery.isFetching}
             >
               {/* overview.js:262 — legacy printed the raw integer (data.totalSessions
                   ?? '—'); no toLocaleString grouping, unlike the token tile. */}
-              <strong className="ov-stat__value t-data">{usage?.totalSessions ?? '—'}</strong>
-              <span className="ov-stat__hint">view all</span>
+              <strong className="ov-stat__value t-data">
+                {usage?.totalSessions ?? t('common.dash')}
+              </strong>
+              <span className="ov-stat__hint">{t('overview.tileSessionsHint')}</span>
             </StatTile>
             <StatTile
-              label="Provider"
+              label={t('overview.tileProvider')}
               icon={<BotIcon />}
               to="/agents"
               loading={statusQuery.isFetching}
             >
               <strong className="ov-stat__value ov-stat__value--mono t-data">
-                {status?.provider ?? '—'}
+                {status?.provider ?? t('common.dash')}
               </strong>
-              <span className="ov-stat__hint">manage agents</span>
+              <span className="ov-stat__hint">{t('overview.tileProviderHint')}</span>
             </StatTile>
-            <StatTile label="Uptime" icon={<ClockIcon />} loading={statusQuery.isFetching}>
+            <StatTile
+              label={t('overview.tileUptime')}
+              icon={<ClockIcon />}
+              loading={statusQuery.isFetching}
+            >
               <strong className="ov-stat__value ov-stat__value--mono t-data">
                 {formatUptime(status?.uptime_ms)}
               </strong>
-              <span className="ov-stat__hint">{status?.version ? `v${status.version}` : '—'}</span>
+              <span className="ov-stat__hint">
+                {status?.version
+                  ? t('overview.tileVersion', { version: status.version })
+                  : t('common.dash')}
+              </span>
             </StatTile>
           </div>
         </div>
@@ -369,17 +382,17 @@ export function OverviewPage() {
             <div className="ov-panel__heading">
               <MessageSquareIcon aria-hidden="true" />
               <div>
-                <span>Recent sessions</span>
-                <small>Resume the latest agent work</small>
+                <span>{t('overview.recentTitle')}</span>
+                <small>{t('overview.recentSubtitle')}</small>
               </div>
             </div>
             <button
               type="button"
               className="ov-link"
               onClick={() => navigate('/sessions')}
-              aria-label="View all sessions"
+              aria-label={t('overview.recentViewAllLabel')}
             >
-              View all →
+              {t('overview.recentViewAll')}
             </button>
           </div>
           <div className="panel__body ov-recent">
@@ -388,27 +401,31 @@ export function OverviewPage() {
               // account: keep a neutral placeholder (legacy left the skeleton),
               // never the "No sessions yet" empty CTA.
               <div className="ov-recent__empty" role="status">
-                <span>Recent sessions unavailable.</span>
+                <span>{t('overview.recentUnavailable')}</span>
               </div>
             ) : recent.length === 0 ? (
               <div className="ov-recent__empty">
                 <MessageSquareIcon className="ov-recent__empty-icon" aria-hidden="true" />
-                <span>No sessions yet — open chat to start your first one.</span>
+                <span>{t('overview.recentEmpty')}</span>
               </div>
             ) : (
               recent.map((s) => {
                 const status = (s.status || 'unknown').toLowerCase()
                 const dot = sessionStatusClass(status)
                 const label = sessionStatusLabel(status)
-                const rel = s.updated_at ? relTime(s.updated_at) : '—'
+                const rel = s.updated_at ? relTime(s.updated_at) : t('common.dash')
                 const msgs =
-                  s.message_count != null ? `${Number(s.message_count).toLocaleString()} msg` : ''
+                  s.message_count != null
+                    ? t('overview.recentMessages', {
+                        count: Number(s.message_count).toLocaleString(),
+                      })
+                    : ''
                 return (
                   <button
                     key={s.key}
                     type="button"
                     className="ov-recent__row"
-                    aria-label={`Open session ${s.key}`}
+                    aria-label={t('overview.recentOpenSession', { key: s.key ?? '' })}
                     onClick={() => navigate(`/chat?session=${encodeURIComponent(s.key ?? '')}`)}
                   >
                     <span
@@ -435,20 +452,20 @@ export function OverviewPage() {
             <div className="ov-panel__heading">
               <ActivityIcon aria-hidden="true" />
               <div>
-                <span>Event stream</span>
-                <small>Live gateway activity</small>
+                <span>{t('overview.eventsTitle')}</span>
+                <small>{t('overview.eventsSubtitle')}</small>
               </div>
             </div>
             <span className="ov-panel__meta" data-slot="panel-meta">
               <span className="ov-panel__live" aria-hidden="true" />
-              {events.length} event{events.length === 1 ? '' : 's'}
+              {tPlural('overview.eventsCount', events.length)}
             </span>
           </div>
           <div className="panel__body ov-event-log" role="log" aria-live="polite">
             {events.length === 0 ? (
               <div className="ov-event-log__empty">
                 <span className="ov-event-log__pulse" aria-hidden="true" />
-                Listening for events…
+                {t('overview.eventsEmpty')}
               </div>
             ) : (
               events.map((e, i) => (
@@ -467,18 +484,18 @@ export function OverviewPage() {
             <div className="ov-panel__heading">
               <BotIcon aria-hidden="true" />
               <div>
-                <span>Gateway connection</span>
-                <small>Override the active endpoint for this browser</small>
+                <span>{t('overview.connTitle')}</span>
+                <small>{t('overview.connSubtitle')}</small>
               </div>
             </div>
           </div>
           <div className="panel__body ov-form">
             <label className="ov-field">
-              <span className="ov-field__label t-label">WebSocket URL</span>
+              <span className="ov-field__label t-label">{t('overview.connUrlLabel')}</span>
               <input
                 className="ov-field__input t-data"
                 type="text"
-                placeholder="ws://…"
+                placeholder={t('overview.connUrlPlaceholder')}
                 autoComplete="off"
                 value={wsUrl}
                 onChange={(e) => setWsUrl(e.target.value)}
@@ -486,12 +503,13 @@ export function OverviewPage() {
             </label>
             <label className="ov-field">
               <span className="ov-field__label t-label">
-                Token <span className="ov-field__optional">optional</span>
+                {t('overview.connTokenLabel')}{' '}
+                <span className="ov-field__optional">{t('overview.connTokenOptional')}</span>
               </span>
               <input
                 className="ov-field__input"
                 type="password"
-                placeholder="—"
+                placeholder={t('common.dash')}
                 autoComplete="off"
                 value={wsToken}
                 onChange={(e) => setWsToken(e.target.value)}
@@ -499,10 +517,10 @@ export function OverviewPage() {
             </label>
             <div className="ov-form__actions">
               <Button size="sm" onClick={onConnect}>
-                Connect
+                {t('overview.connConnect')}
               </Button>
               <Button size="sm" variant="outline" onClick={() => rpc.disconnect()}>
-                Disconnect
+                {t('overview.connDisconnect')}
               </Button>
             </div>
           </div>

--- a/frontend/src/views/overview/logic.ts
+++ b/frontend/src/views/overview/logic.ts
@@ -5,6 +5,8 @@
 // RPC calls, event subscriptions, and rendering live in OverviewPage.tsx; this
 // module owns the pure derivations (label mapping, formatting, session sort).
 
+import { t } from '@/i18n'
+
 /** A recent session row as returned by sessions.list (all fields optional). */
 export interface OverviewSession {
   key?: string
@@ -19,11 +21,11 @@ export interface OverviewSession {
  *  nullish falls back to "Unknown". */
 export function readinessStatusLabel(status?: string | null): string {
   const labels: Record<string, string> = {
-    ready: 'Ready',
-    degraded: 'Degraded',
-    action_required: 'Action required',
-    unavailable: 'Unavailable',
-    unknown: 'Unknown',
+    ready: t('overview.readyReady'),
+    degraded: t('overview.readyDegraded'),
+    action_required: t('overview.readyActionRequired'),
+    unavailable: t('overview.readyUnavailable'),
+    unknown: t('overview.readyUnknown'),
   }
   const key = String(status || 'unknown').toLowerCase()
   if (labels[key]) return labels[key]
@@ -32,11 +34,11 @@ export function readinessStatusLabel(status?: string | null): string {
 
 /** overview.js:234-242 — uptime_ms -> "Hh Mm Ss"; null/undefined -> "—". */
 export function formatUptime(ms?: number | null): string {
-  if (ms == null) return '—'
+  if (ms == null) return t('common.dash')
   const s = Math.floor(ms / 1000)
   const h = Math.floor(s / 3600)
   const m = Math.floor((s % 3600) / 60)
-  return `${h}h ${m}m ${s % 60}s`
+  return t('overview.uptime', { hours: h, minutes: m, seconds: s % 60 })
 }
 
 // components.js:249-269 — session status -> dot color variant / tooltip label.
@@ -48,11 +50,11 @@ const SESSION_STATUS_DOT: Record<string, string> = {
   timeout: 'warn',
 }
 const SESSION_STATUS_LABEL: Record<string, string> = {
-  running: 'Running',
-  done: 'Completed',
-  failed: 'Failed',
-  killed: 'Aborted by operator',
-  timeout: 'Timed out',
+  running: t('overview.sessionRunning'),
+  done: t('overview.sessionDone'),
+  failed: t('overview.sessionFailed'),
+  killed: t('overview.sessionKilled'),
+  timeout: t('overview.sessionTimeout'),
 }
 
 /** components.js:272-275 — dot color variant ("ok"/"warn"/"err"/"off"). */
@@ -64,7 +66,7 @@ export function sessionStatusClass(status?: string | null): string {
 /** components.js:284-287 — tooltip label; raw string else "Unknown" when empty. */
 export function sessionStatusLabel(status?: string | null): string {
   const k = String(status || '').toLowerCase()
-  return SESSION_STATUS_LABEL[k] || (status ? String(status) : 'Unknown')
+  return SESSION_STATUS_LABEL[k] || (status ? String(status) : t('overview.sessionUnknown'))
 }
 
 /** components.js:228-241 — relative time. Numeric input is treated as an epoch
@@ -79,12 +81,12 @@ export function relTime(isoOrTs: string | number): string {
   const d = Number.isFinite(numeric)
     ? new Date(Math.abs(numeric) < 10_000_000_000 ? numeric * 1000 : numeric)
     : new Date(isoOrTs)
-  if (Number.isNaN(d.getTime())) return '—'
+  if (Number.isNaN(d.getTime())) return t('common.dash')
   const diff = (Date.now() - d.getTime()) / 1000
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86_400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86_400)}d ago`
+  if (diff < 60) return t('overview.relJustNow')
+  if (diff < 3600) return t('overview.relMinutes', { count: Math.floor(diff / 60) })
+  if (diff < 86_400) return t('overview.relHours', { count: Math.floor(diff / 3600) })
+  return t('overview.relDays', { count: Math.floor(diff / 86_400) })
 }
 
 /** overview.js:320-326 — JSON-stringify a payload, truncating at 80 chars with
@@ -120,10 +122,10 @@ export function sortRecentSessions(sessions: OverviewSession[]): OverviewSession
 
 /** overview.js:263 — localized token count; null/undefined -> "—". */
 export function formatTokens(total?: number | null): string {
-  return total != null ? total.toLocaleString() : '—'
+  return total != null ? total.toLocaleString() : t('common.dash')
 }
 
 /** overview.js:266-268 — total cost as "$X.XXXX"; null/undefined -> "—". */
 export function formatCost(usd?: number | null): string {
-  return usd != null ? '$' + Number(usd).toFixed(4) : '—'
+  return usd != null ? '$' + Number(usd).toFixed(4) : t('common.dash')
 }


### PR DESCRIPTION
Refs #138. Lands **the seam, not the translations** — no locales, no picker, no docs/CLI/agent-output change.

## Deciding first

The issue asks a question before it asks for code: *"If AgentOS is meant to stay English-only, close this."* That call is yours — this PR is cheap to reject on that basis alone, and nothing else depends on it.

## What's here

`frontend/src/i18n/` — `t()`, `tPlural()`, a locale registry with a `locale → en → key` fallback chain, and two test files. English is both the default locale and the per-key fallback, so a single-locale build renders byte-identical copy.

**`t()` is a plain module function, not a hook.** That's forced by the codebase, not a preference: most of the console's copy lives outside components — the `views/*/logic.ts` label maps, the module-scope route titles in `app/routes.tsx`, the imperative DOM builders in `views/chat/transcript/*.ts`. A hook cannot serve any of them, and a hook-only design would leave half the strings unmigrated. It also means no provider, so no existing test gained a wrapper.

**No runtime dependency.** Pluralisation rides on `Intl.PluralRules`, a browser platform API. It's included rather than deferred because ~10 real sites currently bake English grammar into TSX (`{n} {n === 1 ? 'field' : 'fields'}`); two are in this PR's scope, and without the helper the later phases would invent the pattern ad hoc.

**Type safety with zero runtime cost.** `MessageKey` is derived from the catalog, and required interpolation vars are parsed out of the *English value itself*:

```ts
t('overview.nope')                                  // ✗ unknown key
t('overview.toastStatusFailed')                     // ✗ missing {message}
t('overview.toastStatusFailed', { msg })            // ✗ wrong placeholder name
t('shell.viewOverview', { x: 1 })                   // ✗ key takes no vars
```

All four fail `tsc --noEmit` (verified with a `@ts-expect-error` scratch file). Catalogs are deliberately two levels deep — a recursive key type over 1000+ leaves measurably slows the `tsc` gate this repo runs in CI.

**Locale wiring.** `initLocale()` sits next to `initTheme()` in `AppProviders` and also syncs `document.documentElement.lang`. When the gateway starts advertising a locale, this becomes `setLocale(bootstrap.locale)` and nothing else moves. Adding a translation is a new directory plus one `registerCatalog()` call — `locale.ts` never needs editing again.

## Migrated

App shell, routes, route error boundary, the shared chrome components (`ApprovalPrompt`, `CommandLine`, `ShortcutOverlay`), and the **overview / health / approvals / env / logs** views. `sonner.tsx`, `ModalShell.tsx`, `KeyboardShortcuts.tsx` and `logs/logic.ts` are untouched — they carry no user-facing copy.

Eleven views remain (chat and skills are the heavy ones). They're mechanical follow-ups, one PR each, with no design left to re-litigate — hence `Refs` and not `Closes`.

## The ledger keeps it from regressing

`eslint.config.js` gains a `no-restricted-syntax` rule scoped to an `I18N_MIGRATED` path list. That list **is** the migration ledger: a view joins it in the same change that extracts its strings and can never silently regress, while un-migrated views stay quiet so the rule is never noise. Built-in rule with esquery selectors rather than `react/jsx-no-literals` — this repo has deliberately avoided `eslint-plugin-react`, and this needs no new devDependency. It already earned its keep by catching a stray `<code>.env</code>`.

## Verification

- **`npm run check` green** — `tsc --noEmit && eslint src && prettier --check src && vitest run`. **86 test files, 1797 tests.**
- **Zero existing test files changed.** The only test files in this diff are the two new `src/i18n/*.test.ts`. Because `t()` returns the identical English string, the DOM is byte-identical and every assertion on literal copy passes untouched — including the character-exact ones like `'Failed to load status:'`. A test-file change in a later phase is the signal that copy actually drifted; fix the catalog, not the assertion.
- **Nothing outside `frontend/`.** No Python, no docs. The bootstrap payload deliberately gets no `locale` field yet.
- Copy was moved **verbatim**, `…` and `—` included.

## One tradeoff worth your attention

Initial JS grows **134.8 → 140.1 KiB gzip (+5.3)**. Catalogs are eagerly imported (they're the synchronous fallback source) while views are lazy, so the five views' copy shifts from the lazy chunks into the entry chunk. Comfortably inside the 180 KiB budget, but it will keep growing as the remaining eleven views land. If it approaches the limit, `en/index.ts` can be split into per-namespace dynamic imports — measured now so the next phase doesn't have to guess.

## Note

@Preciousuche commented on #138 wanting to work on it and nobody appears assigned. Happy to hand this over or split the remaining views — flagging it so we don't duplicate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
