### PR TITLE
fix(channels): type until the first streamed chunk lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Streaming channels show the typing indicator again while the model is still
+  thinking. Since Telegram gained `send_streaming` its stream policy resolved to
+  `adapter_stream`, which suppressed the indicator for the whole turn — and
+  nothing can be streamed before the first token, so a user waiting out model
+  latency and tool calls saw nothing at all. Telegram and Discord now type until
+  the first chunk reaches the chat and drop the indicator the moment it lands,
+  rather than either suppressing it for the run or letting it flicker back under
+  a message that is already being edited. `typing_final` and `final_only`
+  adapters are unchanged. (Fixes #255)
+
 ## [2026.8.9] - 2026-08-09
 
 ### Added

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -196,11 +196,18 @@ edit loop stops and the remainder is delivered as one final message instead of
 fighting the limiter; no text is lost either way. Forum topic replies stream
 into the originating topic.
 
+Streaming adapters that also have a typing indicator — Telegram and Discord —
+show it while the model is still thinking, and drop it the moment the first
+chunk reaches the chat. Nothing can be streamed until the first token exists,
+and with tool calls in the loop that wait is often tens of seconds, so the
+indicator covers exactly that gap and then hands the chat over to the
+live-edited message.
+
 Adapters without a streaming surface fall back to their native typing
-indicator while AgentOS is working. Telegram still refreshes `sendChatAction`
-every four seconds in that mode, because Telegram clients expire the status
-after at most five seconds. Reply feedback is best-effort and never interrupts
-the underlying agent turn.
+indicator for the whole turn. Telegram refreshes `sendChatAction` every four
+seconds in either mode, because Telegram clients expire the status after at
+most five seconds. Reply feedback is best-effort and never interrupts the
+underlying agent turn.
 
 ## Webhook Channels
 

--- a/src/agentos/channels/stream_policy.py
+++ b/src/agentos/channels/stream_policy.py
@@ -18,6 +18,15 @@ class ChannelStreamPolicy:
     mode: ChannelStreamMode
     relay_stream: bool
     typing_keepalive: bool
+    typing_preamble: bool = False
+    """Show typing only until the first streamed chunk lands.
+
+    ``typing_keepalive`` covers a whole run for adapters that reply once at the
+    end.  A streaming adapter has nothing to show until the model emits its
+    first token — model latency plus tool calls make that window tens of
+    seconds — so it gets the indicator for that gap alone, then hands the chat
+    over to the live-edited message.
+    """
 
 
 def _strategy_override(channel: Any) -> str | None:
@@ -34,6 +43,7 @@ def _policy_for_mode(mode: ChannelStreamMode, *, has_typing: bool) -> ChannelStr
         mode=mode,
         relay_stream=mode == "adapter_stream",
         typing_keepalive=mode == "typing_final" and has_typing,
+        typing_preamble=mode == "adapter_stream" and has_typing,
     )
 
 

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -560,7 +560,11 @@ async def run_channel_dispatch(
             else:
                 await status_reactor.running(msg)
 
-                typing_task = _start_typing_keepalive(channel, msg)
+                typing_task = _start_typing_keepalive(
+                    channel,
+                    msg,
+                    stop_signal=stream_relay.first_chunk_sent if stream_relay is not None else None,
+                )
 
                 async def _reply_task_body(
                     _channel: Any = channel,
@@ -627,8 +631,10 @@ async def run_channel_dispatch(
                 reply_task.add_done_callback(_reply_done)
             continue
 
-        # Gap 3: Start typing indicator (background task)
-        typing_task = _start_typing_keepalive(channel, msg)
+        # Gap 3: Start typing indicator (background task). On a streaming
+        # adapter it only covers the wait before the first chunk.
+        first_chunk_sent = asyncio.Event()
+        typing_task = _start_typing_keepalive(channel, msg, stop_signal=first_chunk_sent)
         try:
             # Gap 4: Run agent turn with streaming (or batch fallback)
             await _run_turn_with_streaming(
@@ -641,6 +647,7 @@ async def run_channel_dispatch(
                 config=config,
                 route_envelope=route_envelope,
                 attachments=ingested.attachments,
+                first_chunk_sent=first_chunk_sent,
             )
         finally:
             if typing_task is not None:
@@ -895,7 +902,7 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
         _in_flight.release(_reservation_token)
 
     await status_reactor.running(msg)
-    typing_task = _start_typing_keepalive(channel, msg)
+    typing_task = _start_typing_keepalive(channel, msg, stop_signal=stream_relay.first_chunk_sent if stream_relay is not None else None)  # noqa: E501
     try:
         await _deliver_runtime_channel_reply(channel=channel, task_runtime=task_runtime, session_manager=session_manager, session_key=session_key, task_id=handle.task_id, route_envelope=route_envelope, inbound=msg, transcript_watermark=transcript_watermark, config=config, stream_relay=stream_relay)  # noqa: E501
     finally:
@@ -1150,16 +1157,25 @@ def _start_typing_keepalive(
     channel: Any,
     inbound: IncomingMessage | None = None,
     interval: float | None = None,
+    stop_signal: asyncio.Event | None = None,
 ) -> asyncio.Task | None:
     """Start a background task that periodically refreshes the typing status.
 
     Uses ``asyncio.create_task`` so typing continues even during long tool calls
     where no events are yielded (a timestamp-in-loop approach would fail here).
 
+    On a streaming adapter (``typing_preamble``) the indicator only covers the
+    wait before the first chunk: the task refreshes typing until *stop_signal*
+    is set, then returns.  That signal is required there — without it the
+    indicator would keep flickering back underneath a message that is already
+    being edited live, so a preamble with no signal is simply not started.
+
     Returns None if the adapter has no ``send_typing`` method (e.g. Terminal).
     The caller MUST cancel the returned task in a ``finally`` block.
     """
-    if not resolve_channel_stream_policy(channel).typing_keepalive:
+    policy = resolve_channel_stream_policy(channel)
+    preamble = policy.typing_preamble and stop_signal is not None
+    if not policy.typing_keepalive and not preamble:
         return None
     send_typing = getattr(channel, "send_typing", None)
     if not callable(send_typing):
@@ -1203,7 +1219,14 @@ def _start_typing_keepalive(
                 await send_typing(**typing_kwargs)
             except Exception:
                 pass  # typing is best-effort, never crash the loop
-            await asyncio.sleep(keepalive_interval)
+            if stop_signal is None:
+                await asyncio.sleep(keepalive_interval)
+                continue
+            try:
+                await asyncio.wait_for(stop_signal.wait(), timeout=keepalive_interval)
+            except TimeoutError:
+                continue
+            return
 
     return asyncio.create_task(_keepalive())
 
@@ -1269,6 +1292,7 @@ async def _run_turn_with_streaming(
     config: Any = None,
     route_envelope: Any = None,
     attachments: list[dict[str, Any]] | None = None,
+    first_chunk_sent: asyncio.Event | None = None,
 ) -> None:
     """Run the agent turn, sending reply via streaming or batch.
 
@@ -1314,6 +1338,7 @@ async def _run_turn_with_streaming(
             semantic_message,
             config,
             attachments,
+            first_chunk_sent=first_chunk_sent,
         )
     else:
         await _run_turn_batch_path(
@@ -1468,6 +1493,10 @@ class _RuntimeChannelStreamRelay:
         self._closed = False
         self.text_emitted = False
         self.stream_error: BaseException | None = None
+        # Set the moment the first chunk is handed to ``send_streaming``. The
+        # typing preamble waits on this: once the adapter has text to show, the
+        # indicator has nothing left to say.
+        self.first_chunk_sent = asyncio.Event()
         # Buffer of chunks already yielded to ``send_streaming``. If the
         # adapter raises mid-stream the relay falls back to ``channel.send``
         # with the chunks that never made it through.
@@ -1555,6 +1584,7 @@ class _RuntimeChannelStreamRelay:
                 tail = sanitizer.flush()
                 if tail:
                     self._yielded_chunks.append(tail)
+                    self.first_chunk_sent.set()
                     yield tail
                     # Only advance the delivered watermark when the consumer
                     # accepted the chunk (yield returned). If yield raises,
@@ -1568,12 +1598,14 @@ class _RuntimeChannelStreamRelay:
             chunk = sanitizer.clean(batched)
             if chunk:
                 self._yielded_chunks.append(chunk)
+                self.first_chunk_sent.set()
                 yield chunk
                 self._undelivered_index = len(self._yielded_chunks)
             if sentinel is _STREAM_DONE:
                 tail = sanitizer.flush()
                 if tail:
                     self._yielded_chunks.append(tail)
+                    self.first_chunk_sent.set()
                     yield tail
                     self._undelivered_index = len(self._yielded_chunks)
                 return
@@ -1607,6 +1639,9 @@ class _RuntimeChannelStreamRelay:
             await self._queue.put(f"{prefix}{artifact_text}")
             self.text_emitted = True
         await self._queue.put(_STREAM_DONE)
+        # A turn that ends without ever emitting text still has to release the
+        # typing preamble; nothing else will set the event in that case.
+        self.first_chunk_sent.set()
         if self._task is None:
             return
         try:
@@ -2186,6 +2221,7 @@ async def _run_turn_streaming_path(
     semantic_message: str | None,
     config: Any,
     attachments: list[dict[str, Any]] | None = None,
+    first_chunk_sent: asyncio.Event | None = None,
 ) -> None:
     """Streaming mode: feed text deltas through an async queue to send_streaming.
 
@@ -2201,6 +2237,11 @@ async def _run_turn_streaming_path(
     artifacts: list[dict[str, Any]] = []
     stream_sanitizer = _DirectiveTagStreamSanitizer()
 
+    def _release_typing_preamble() -> None:
+        """Stop the typing indicator: the adapter now has text to show."""
+        if first_chunk_sent is not None:
+            first_chunk_sent.set()
+
     async def _chunk_iter() -> AsyncIterator[str]:
         """Async iterator that yields text chunks from the queue."""
         nonlocal stream_delivered_index
@@ -2210,12 +2251,15 @@ async def _run_turn_streaming_path(
                 tail = stream_sanitizer.flush()
                 if tail:
                     yielded_stream_chunks.append(tail)
+                    _release_typing_preamble()
                     yield tail
                     stream_delivered_index = len(yielded_stream_chunks)
+                _release_typing_preamble()
                 return
             cleaned = stream_sanitizer.clean(chunk)
             if cleaned:
                 yielded_stream_chunks.append(cleaned)
+                _release_typing_preamble()
                 yield cleaned
                 stream_delivered_index = len(yielded_stream_chunks)
 

--- a/tests/test_channels/test_telegram_typing.py
+++ b/tests/test_channels/test_telegram_typing.py
@@ -116,6 +116,7 @@ def test_telegram_streaming_capability_selects_adapter_stream_policy() -> None:
     assert policy.mode == "adapter_stream"
     assert policy.relay_stream is True
     assert policy.typing_keepalive is False
+    assert policy.typing_preamble is True
     assert 0 < channel.typing_keepalive_interval_s < 5
 
 
@@ -127,6 +128,7 @@ def test_telegram_typing_final_override_selects_keepalive_policy() -> None:
     assert policy.mode == "typing_final"
     assert policy.relay_stream is False
     assert policy.typing_keepalive is True
+    assert policy.typing_preamble is False
 
 
 @pytest.mark.asyncio
@@ -201,3 +203,57 @@ async def test_telegram_keepalive_treats_api_failure_as_best_effort(
 
     assert attempts == 1
     assert sleep_intervals == [4.0]
+
+
+@pytest.mark.asyncio
+async def test_telegram_streaming_shows_typing_until_the_first_chunk() -> None:
+    """A streaming Telegram turn still gets the indicator during model latency.
+
+    Nothing can be edited into the chat before the first token exists, and with
+    tool calls in the loop that wait is routinely tens of seconds — the
+    preamble covers exactly that gap, then releases on the stop signal.
+    """
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    api_calls: list[tuple[str, dict[str, Any] | None]] = []
+    first_call = asyncio.Event()
+
+    async def fake_api(method: str, payload: dict[str, Any] | None = None) -> bool:
+        api_calls.append((method, payload))
+        first_call.set()
+        return True
+
+    channel._api = fake_api  # type: ignore[method-assign]  # noqa: SLF001
+    inbound = IncomingMessage(sender_id="user-1", channel_id="-100123", content="hello")
+    first_chunk_sent = asyncio.Event()
+
+    task = channel_dispatch._start_typing_keepalive(  # noqa: SLF001
+        channel,
+        inbound,
+        stop_signal=first_chunk_sent,
+    )
+
+    assert task is not None
+    await asyncio.wait_for(first_call.wait(), timeout=1)
+    assert api_calls == [("sendChatAction", {"chat_id": "-100123", "action": "typing"})]
+
+    # The adapter now has text on screen: the indicator must stop on its own,
+    # without waiting to be cancelled.
+    first_chunk_sent.set()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert task.cancelled() is False
+    assert api_calls == [("sendChatAction", {"chat_id": "-100123", "action": "typing"})]
+
+
+@pytest.mark.asyncio
+async def test_telegram_streaming_typing_needs_a_stop_signal() -> None:
+    """No signal, no preamble — never leave typing ticking under a live stream."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+
+    async def unexpected_api(_method: str, _payload: dict[str, Any] | None = None) -> bool:
+        raise AssertionError("typing must not start without a stop signal")
+
+    channel._api = unexpected_api  # type: ignore[method-assign]  # noqa: SLF001
+    inbound = IncomingMessage(sender_id="user-1", channel_id="-100123", content="hello")
+
+    assert channel_dispatch._start_typing_keepalive(channel, inbound) is None  # noqa: SLF001

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -2260,3 +2260,151 @@ async def test_runtime_channel_stream_relay_handles_late_failure_gracefully() ->
     # Successfully-yielded chunks must NOT be duplicated.
     assert "alpha" not in fallback
     assert "beta" not in fallback
+
+
+# ── Typing preamble on streaming adapters ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runtime_relay_releases_typing_preamble_on_first_chunk() -> None:
+    """The relay owns the hand-off: typing stops when the adapter gets text."""
+
+    class StreamingChannel:
+        def __init__(self) -> None:
+            self.chunks: list[str] = []
+
+        async def send_streaming(self, chunks, **kwargs):
+            async for chunk in chunks:
+                self.chunks.append(chunk)
+
+    class FakeTaskRuntime:
+        async def enqueue(self, envelope, message: str, *, stream_event_sink=None):
+            return None
+
+    relay = _RuntimeChannelStreamRelay.maybe_start(
+        StreamingChannel(),
+        _message(),
+        FakeTaskRuntime(),
+    )
+
+    assert relay is not None
+    assert relay.first_chunk_sent.is_set() is False
+
+    await relay.emit(TextDeltaEvent(text="hello"))
+    await asyncio.wait_for(relay.first_chunk_sent.wait(), timeout=1)
+    await relay.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_relay_releases_typing_preamble_when_turn_emits_no_text() -> None:
+    """A silent turn must still drop the indicator rather than hang on it."""
+
+    class StreamingChannel:
+        async def send_streaming(self, chunks, **kwargs):
+            async for _ in chunks:
+                pass
+
+    class FakeTaskRuntime:
+        async def enqueue(self, envelope, message: str, *, stream_event_sink=None):
+            return None
+
+    relay = _RuntimeChannelStreamRelay.maybe_start(
+        StreamingChannel(),
+        _message(),
+        FakeTaskRuntime(),
+    )
+
+    assert relay is not None
+
+    await relay.close()
+
+    assert relay.first_chunk_sent.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_direct_streaming_path_releases_typing_preamble_on_first_chunk(
+    tmp_path,
+) -> None:
+    """Same hand-off on the turn_runner path, which has no relay to lean on."""
+    seen_while_streaming: list[bool] = []
+
+    class StreamingChannel:
+        def __init__(self) -> None:
+            self.chunks: list[str] = []
+
+        async def send_streaming(self, chunks, **kwargs):
+            async for chunk in chunks:
+                self.chunks.append(chunk)
+                seen_while_streaming.append(first_chunk_sent.is_set())
+
+    class FakeTurnRunner:
+        async def run(self, message: str, session_key: str, **kwargs):
+            yield TextDeltaEvent(text="hello")
+            yield DoneEvent()
+
+    first_chunk_sent = asyncio.Event()
+    msg = _message()
+    config = SimpleNamespace(
+        workspace_dir=str(tmp_path),
+        workspace_strict=True,
+        agent_stream_heartbeat_interval_seconds=0.0,
+        agent_stream_idle_timeout_seconds=1.0,
+    )
+    channel = StreamingChannel()
+
+    await _run_turn_with_streaming(
+        channel,
+        FakeTurnRunner(),
+        msg,
+        "agent:main:telegram:u1",
+        config=config,
+        first_chunk_sent=first_chunk_sent,
+    )
+
+    assert channel.chunks == ["hello"]
+    assert seen_while_streaming == [True]
+    assert first_chunk_sent.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_batch_path_leaves_typing_running_for_the_whole_turn(tmp_path) -> None:
+    """``typing_final`` adapters are untouched: no early release, no preamble."""
+
+    class TypingOnlyChannel:
+        def __init__(self) -> None:
+            self.sent: list[OutgoingMessage] = []
+
+        async def send_typing(self) -> None:
+            return None
+
+        async def send(self, message: OutgoingMessage) -> None:
+            self.sent.append(message)
+
+    class FakeTurnRunner:
+        async def run(self, message: str, session_key: str, **kwargs):
+            yield TextDeltaEvent(text="hello")
+            yield DoneEvent()
+
+    channel = TypingOnlyChannel()
+    policy = resolve_channel_stream_policy(channel)
+    first_chunk_sent = asyncio.Event()
+    config = SimpleNamespace(
+        workspace_dir=str(tmp_path),
+        workspace_strict=True,
+        agent_stream_heartbeat_interval_seconds=0.0,
+        agent_stream_idle_timeout_seconds=1.0,
+    )
+
+    await _run_turn_with_streaming(
+        channel,
+        FakeTurnRunner(),
+        _message(),
+        "agent:main:feishu:u1",
+        config=config,
+        first_chunk_sent=first_chunk_sent,
+    )
+
+    assert policy.typing_preamble is False
+    assert policy.typing_keepalive is True
+    assert first_chunk_sent.is_set() is False
+    assert channel.sent[-1].content == "hello"


### PR DESCRIPTION
## Summary

After #250 a Telegram user gets nothing back between sending a message and the
first streamed token — no typing indicator, no placeholder, nothing. The policy
resolves Telegram to `adapter_stream` (`stream_policy.py:57`), and
`typing_keepalive` is true only for `typing_final` (`stream_policy.py:32-36`), so
`_start_typing_keepalive` returns `None` (`channel_dispatch.py:1162`). The adapter
cannot cover the gap either: `send_streaming` posts its first message only when
the throttle flushes real text, and with model latency plus tool calls that wait
is routinely tens of seconds. Discord has the same dead window.

Typing and streaming are sequential, not mutually exclusive. This types until the
first chunk lands, then hands the chat over to the live-edited message.

Fixes #255.

## What's in it

- **`ChannelStreamPolicy.typing_preamble`** — true when the mode is
  `adapter_stream` *and* the adapter exposes `send_typing`. `typing_keepalive`
  keeps its meaning (indicator for the whole run) and stays false for streaming
  adapters, so nothing about `typing_final` / `final_only` moves.
- **`_start_typing_keepalive(..., stop_signal=)`** — in preamble mode the loop
  refreshes typing on the adapter's own cadence (Telegram: every 4s, because
  clients expire the status after five) and returns as soon as the signal is set.
- **The signal is mandatory for a preamble.** A preamble with no signal is not
  started at all. Both Telegram and Discord clear typing when the bot posts a
  message, so a keepalive still ticking would make "bot is typing…" flicker back
  underneath a message that is already being edited — worse than the status quo.
  Making the wiring a precondition means a future call site cannot regress into
  that quietly.
- **Two signal sources, one per streaming path.** The runtime path uses
  `_RuntimeChannelStreamRelay.first_chunk_sent`, set where a chunk is handed to
  `send_streaming` — including the sanitizer's flush tail, and on `close()` so a
  turn that emits no text still releases the indicator. The direct `turn_runner`
  path sets an event threaded through `_run_turn_with_streaming` into
  `_run_turn_streaming_path`.

Signalling at the hand-off to the adapter (rather than at `emit`) means the
indicator survives exactly as long as the chat is empty.

| phase | before #250 | on `main` | this PR |
|---|---|---|---|
| user sends → first token | typing | *(nothing)* | typing |
| first token → end | typing, no text | live-edited message | live-edited message |

## Tests

- `typing_preamble` asserted on both the streaming policy and the
  `typing_final`-pinned subclass.
- Real `TelegramChannel`: the preamble posts `sendChatAction`, then ends *itself*
  when the stop signal fires (`task.cancelled() is False`) with no further calls;
  and starting one without a stop signal returns `None` and never touches the API.
- Relay: `first_chunk_sent` unset at start, set once a chunk reaches the adapter,
  and set by `close()` when the turn produced no text.
- Direct path: the event is already set inside `send_streaming` while the first
  chunk is being consumed.
- `typing_final` adapter: unchanged — batch path, event never set, keepalive still
  covers the whole turn.

```sh
uv run pytest tests/test_gateway tests/test_channels -q   # 1386 passed
uv run pytest -q                                          # 7423 passed, 26 skipped
uv run ruff check src tests                               # clean
uv run mypy src                                           # no new errors
```

The three failures in the full run (`test_mem0_provider`, `test_provider_config`,
`test_skill_html_to_pdf`) reproduce on an unmodified `main` in this environment —
optional deps, unrelated to this change. `ruff format` reports pre-existing drift
in `channel_dispatch.py` on `main` too; the touched regions are formatted and the
drift is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
