### PR TITLE
fix(webui): reject malformed locale tags at catalog registration

### DIFF
--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -61,6 +61,38 @@ describe('t', () => {
   })
 })
 
+describe('registerCatalog', () => {
+  it('rejects a tag Intl.PluralRules would reject, and registers nothing', () => {
+    // The issue's exact case: an underscore instead of a hyphen used to register
+    // cleanly and then kill the first pluralised string in an unrelated view.
+    expect(() => registerCatalog('pt_BR', {})).toThrow(RangeError)
+    expect(() => registerCatalog('', {})).toThrow(RangeError)
+    expect(() => registerCatalog('nope', {})).toThrow(RangeError)
+    expect(resolveLocale('pt_BR')).toBe('en')
+  })
+
+  it('folds non-canonical casing onto a single entry', () => {
+    registerCatalog('YY-zz', { common: { save: 'first' } })
+    registerCatalog('yy-ZZ', { common: { save: 'second' } })
+    // A second entry would have left the first one reachable.
+    setLocale('yy-ZZ')
+    expect(t('common.save')).toBe('second')
+    expect(resolveLocale('YY-ZZ')).toBe('yy-zz')
+    expect(resolveLocale('yy_zz')).toBe('yy-zz')
+  })
+
+  it('canonicalises a deprecated tag to its modern form', () => {
+    registerCatalog('iw', {})
+    expect(resolveLocale('he')).toBe('he')
+  })
+
+  it('leaves every registered tag safe for Intl.PluralRules', () => {
+    registerCatalog('zh-hant-cn', {})
+    setLocale('zh-Hant-CN')
+    expect(() => tPlural('overview.eventsCount', 3)).not.toThrow()
+  })
+})
+
 describe('resolveLocale', () => {
   it('defaults to English for empty, nullish, and unknown input', () => {
     expect(resolveLocale('')).toBe('en')

--- a/frontend/src/i18n/locale.ts
+++ b/frontend/src/i18n/locale.ts
@@ -14,8 +14,33 @@ export const DEFAULT_LOCALE = 'en'
  */
 const CATALOGS = new Map<string, PartialMessages>([[DEFAULT_LOCALE, en]])
 
+/**
+ * Fold a tag onto the key catalogs are stored under, or `null` if it is not a
+ * well-formed BCP 47 tag. `Intl.getCanonicalLocales` accepts exactly what
+ * `Intl.PluralRules` accepts, so a key that survives this is safe to hand to
+ * `tPlural()` later; canonicalising rather than merely lowercasing also folds
+ * `pt-br`/`PT-BR` and deprecated aliases (`iw` -> `he`) onto one entry.
+ */
+function localeKey(tag: string): string | null {
+  try {
+    return Intl.getCanonicalLocales(tag.trim())[0]?.toLowerCase() ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Catalogs are registered at module load by our own code, so a malformed tag is
+ * a programming error and throws here — loudly, at the source. Accepting it
+ * would surface instead as a `RangeError` from `new Intl.PluralRules()` at the
+ * first pluralised string of some unrelated view.
+ */
 export function registerCatalog(tag: string, messages: PartialMessages): void {
-  CATALOGS.set(tag.trim().toLowerCase(), messages)
+  const key = localeKey(tag)
+  if (key === null) {
+    throw new RangeError(`registerCatalog: ${JSON.stringify(tag)} is not a valid BCP 47 locale tag`)
+  }
+  CATALOGS.set(key, messages)
 }
 
 export function catalogFor(locale: Locale): PartialMessages {
@@ -39,12 +64,13 @@ export function getLocale(): Locale {
  * error — it resolves to the default.
  */
 export function resolveLocale(candidate?: string | null): Locale {
-  const raw = String(candidate ?? '')
-    .trim()
-    .toLowerCase()
-  if (!raw) return DEFAULT_LOCALE
-  if (CATALOGS.has(raw)) return raw
-  const primary = raw.split(/[-_]/)[0] ?? ''
+  // `_` is tolerated here but not in `registerCatalog`: a candidate arrives from
+  // outside (a POSIX-style `pt_BR`, a browser, the gateway) and must resolve
+  // rather than throw, while a registered tag is ours to get right.
+  const key = localeKey(String(candidate ?? '').replace(/_/g, '-'))
+  if (key === null) return DEFAULT_LOCALE
+  if (CATALOGS.has(key)) return key
+  const primary = key.split('-')[0] ?? ''
   return CATALOGS.has(primary) ? primary : DEFAULT_LOCALE
 }
 


### PR DESCRIPTION
Closes #260.

## Problem

`registerCatalog()` accepted any string as a locale tag. A typo registered cleanly and the failure surfaced somewhere else entirely — `tPlural()` builds `new Intl.PluralRules(getLocale())`, which throws a `RangeError` on a malformed tag. `registerCatalog('pt_BR', pt)` succeeded, `resolveLocale('pt_BR')` then returned `'pt_br'` because the map contained it, and the app died at the first pluralised string in an unrelated view.

## Fix

Validate through `Intl.getCanonicalLocales()` — it accepts exactly what `Intl.PluralRules` accepts, so any key that survives registration is safe to hand to `tPlural()` later.

Catalogs are now keyed by the canonical form rather than a bare lowercase, so `pt-br`/`PT-BR` and deprecated aliases (`iw` → `he`) cannot become separate entries.

Registration throws rather than warning: catalogs are registered at module load by our own code, so a bad tag is a build-time programming error and should fail loudly at the source.

`resolveLocale()` keeps its documented contract — unknown input is never an error. It shares the canonicalisation but maps a rejected tag to `DEFAULT_LOCALE` instead of throwing, and still tolerates a POSIX-style `pt_BR` arriving from a browser or the gateway.

## Tests

Four cases in `frontend/src/i18n/index.test.ts`: a malformed tag throws and registers nothing, non-canonical casing folds onto a single entry, a deprecated tag canonicalises, and every registered tag stays safe for `Intl.PluralRules`.

## Verification

- `npm run check` green — tsc, eslint, prettier, 1803 tests.
- `npm run build` green, within bundle budget.
- Gateway serving the built bundle, driven in a real browser: app boots, `<html lang="en">`, translated nav and titles, `tPlural`-backed copy renders, no console errors. A live chat turn against a paid model round-tripped end to end.