### PR TITLE
perf(webui): register catalogs per namespace so view copy leaves the entry chunk

### DIFF
--- a/frontend/src/i18n/chunking.test.ts
+++ b/frontend/src/i18n/chunking.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { en } from './en'
+
+/**
+ * The rules that keep view copy out of the entry bundle (#261).
+ *
+ * `t()` is synchronous, so a namespace has to be registered before anything
+ * reads it — which the bundler guarantees only if the module that reads it also
+ * imports it. These are static checks: they catch a missing import at
+ * `npm run check`, where the alternative is a key rendered raw in a view
+ * nobody opened during review.
+ */
+
+const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function sourceFiles(directory: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) found.push(...sourceFiles(path))
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) found.push(path)
+  }
+  return found
+}
+
+const FILES = sourceFiles(srcDir).map((path) => ({
+  path: relative(srcDir, path),
+  text: readFileSync(path, 'utf8'),
+}))
+
+const NAMESPACES = Object.keys(en)
+
+/** Namespaces the entry bundle carries, read off the imports that make it so. */
+const EAGER = new Set(
+  [...readFileSync(resolve(srcDir, 'i18n/index.ts'), 'utf8').matchAll(/^import '\.\/en\/(\w+)'$/gm)]
+    .map((match) => match[1] as string)
+    .filter((name) => NAMESPACES.includes(name)),
+)
+
+/** `t('logs.title')` / `tPlural('overview.eventsCount', n)` -> `logs`, `overview`. */
+function namespacesUsedIn(text: string): string[] {
+  const used = [...text.matchAll(/\bt(?:Plural)?\(\s*'(\w+)\./g)].map((match) => match[1] as string)
+  return [...new Set(used)].filter((name) => NAMESPACES.includes(name))
+}
+
+describe('catalog chunking', () => {
+  it('keeps only shared namespaces eager', () => {
+    // A view namespace here would put its copy back in the entry bundle, which
+    // is the regression the budget gate would report several PRs later.
+    expect([...EAGER].sort()).toEqual(['common', 'shell'])
+  })
+
+  it('imports its namespace in every module that translates from it', () => {
+    const missing: string[] = []
+    for (const { path, text } of FILES) {
+      if (path.startsWith('i18n/en/')) continue
+      for (const namespace of namespacesUsedIn(text)) {
+        if (EAGER.has(namespace)) continue
+        if (text.includes(`'@/i18n/en/${namespace}'`)) continue
+        missing.push(`${path} translates ${namespace}.* without importing @/i18n/en/${namespace}`)
+      }
+    }
+    expect(missing).toEqual([])
+  })
+
+  it('never pulls the full catalog into runtime code', () => {
+    // `import type { en }` is fine — types are erased. A value import is not:
+    // it drags all seven namespaces into the importing chunk.
+    const offenders = FILES.filter(({ path }) => path !== 'i18n/en/index.ts')
+      .filter(({ text }) =>
+        /^import\s+(?!type\b)[^;\n]*from '(?:@\/i18n\/en|\.{1,2}\/en)'$/m.test(text),
+      )
+      .map(({ path }) => path)
+    expect(offenders).toEqual([])
+  })
+
+  it('registers a namespace as a side effect of importing its module', () => {
+    // Without this, the side-effect imports above would be dead code a future
+    // "unused import" cleanup could delete.
+    for (const namespace of NAMESPACES) {
+      const text = readFileSync(resolve(srcDir, `i18n/en/${namespace}.ts`), 'utf8')
+      expect(text, `${namespace}.ts`).toContain(`defineNamespace('${namespace}'`)
+    }
+  })
+})

--- a/frontend/src/i18n/en/approvals.ts
+++ b/frontend/src/i18n/en/approvals.ts
@@ -1,4 +1,6 @@
-export const approvals = {
+import { defineNamespace } from '../registry'
+
+export const approvals = defineNamespace('approvals', {
   documentTitle: 'Approvals - AgentOS Control',
   eyebrow: 'Control · Approvals',
   title: 'Approvals',
@@ -71,4 +73,4 @@ export const approvals = {
   // Toasts.
   toastStrategySaved: 'Approval strategy: {mode}',
   toastStrategyFailed: 'Failed to save strategy: {message}',
-} as const
+} as const)

--- a/frontend/src/i18n/en/common.ts
+++ b/frontend/src/i18n/en/common.ts
@@ -1,8 +1,10 @@
+import { defineNamespace } from '../registry'
+
 /**
  * Shared copy that recurs across views. Anything view-specific belongs in that
  * view's own namespace module, not here.
  */
-export const common = {
+export const common = defineNamespace('common', {
   cancel: 'Cancel',
   close: 'Close',
   copy: 'Copy',
@@ -10,4 +12,4 @@ export const common = {
   loading: 'Loading…',
   retry: 'Retry',
   save: 'Save',
-} as const
+} as const)

--- a/frontend/src/i18n/en/env.ts
+++ b/frontend/src/i18n/en/env.ts
@@ -1,4 +1,6 @@
-export const env = {
+import { defineNamespace } from '../registry'
+
+export const env = defineNamespace('env', {
   documentTitle: 'Environment - AgentOS Control',
   eyebrow: 'Configuration',
   title: 'Environment',
@@ -107,4 +109,4 @@ export const env = {
   toastSaved: '{name} saved.',
   toastImported: "{name} imported. It will not follow that source's own rotation.",
   toastRemoved: '{name} removed.',
-} as const
+} as const)

--- a/frontend/src/i18n/en/health.ts
+++ b/frontend/src/i18n/en/health.ts
@@ -1,4 +1,6 @@
-export const health = {
+import { defineNamespace } from '../registry'
+
+export const health = defineNamespace('health', {
   documentTitle: 'Health - AgentOS Control',
   eyebrow: 'Control · Health',
   title: 'Health',
@@ -91,4 +93,4 @@ export const health = {
   // Synthetic gateway.unavailable finding (health.js:86-115).
   gatewayUnavailableTitle: 'Gateway health report unavailable',
   gatewayUnavailableDetail: 'Cannot load doctor.status from {url}. {reason}',
-} as const
+} as const)

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -7,9 +7,19 @@ import { overview } from './overview'
 import { shell } from './shell'
 
 /**
- * The English catalog — the default locale and the fallback for every other
- * locale. Its shape is the source of truth for `MessageKey`, so adding a
- * namespace here is what makes its keys callable from `t()`.
+ * Every English namespace in one object.
+ *
+ * This is the *type* source of truth — `MessageKey` is derived from it, so
+ * adding a namespace here is what makes its keys callable from `t()` — and the
+ * shape tests read it at runtime.
+ *
+ * It is NOT how the app loads copy. Importing this module pulls all seven
+ * namespaces into whichever chunk does so, which for anything reachable from
+ * the entry graph is exactly the growth #261 fixed. Runtime code must import
+ * the one namespace it needs (`@/i18n/en/logs`) and let `t()` read the
+ * registry; `i18n/chunking.test.ts` enforces that. `src/test/setup.ts` imports
+ * this module once so unit tests see the complete catalog, standing in for the
+ * views that register their own namespace in the browser.
  */
 export const en = {
   approvals,

--- a/frontend/src/i18n/en/logs.ts
+++ b/frontend/src/i18n/en/logs.ts
@@ -1,4 +1,6 @@
-export const logs = {
+import { defineNamespace } from '../registry'
+
+export const logs = defineNamespace('logs', {
   documentTitle: 'Logs - AgentOS Control',
   eyebrow: 'Control · Logs',
   title: 'Logs',
@@ -52,4 +54,4 @@ export const logs = {
   // Toasts.
   toastRefreshFailed: 'Log refresh failed: {message}',
   toastUnknownError: 'unknown error',
-} as const
+} as const)

--- a/frontend/src/i18n/en/overview.ts
+++ b/frontend/src/i18n/en/overview.ts
@@ -1,4 +1,6 @@
-export const overview = {
+import { defineNamespace } from '../registry'
+
+export const overview = defineNamespace('overview', {
   documentTitle: 'Overview - AgentOS Control',
   eyebrow: 'Control · Overview',
   title: 'Overview',
@@ -72,4 +74,4 @@ export const overview = {
   connTokenOptional: 'optional',
   connConnect: 'Connect',
   connDisconnect: 'Disconnect',
-} as const
+} as const)

--- a/frontend/src/i18n/en/shell.ts
+++ b/frontend/src/i18n/en/shell.ts
@@ -1,9 +1,11 @@
+import { defineNamespace } from '../registry'
+
 /**
  * The app shell: navigation, connection footer, route errors, the global
  * approval prompt, and the shared chrome components. View bodies live in their
  * own namespaces.
  */
-export const shell = {
+export const shell = defineNamespace('shell', {
   // Brand. Not translated in practice, but routed through the catalog so the
   // shell has no literal copy left for a translator to miss.
   brandName: 'AgentOS',
@@ -99,4 +101,4 @@ export const shell = {
   commandCopied: 'Copied command',
   commandCopyFailed: 'Copy failed: {message}',
   commandCopyError: 'Copy command failed',
-} as const
+} as const)

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,5 +1,10 @@
-import { en } from './en'
-import { catalogFor, getLocale } from './locale'
+// The shell's copy is the only catalog the entry bundle carries. Every other
+// namespace is imported by the view that uses it and so rides in that view's
+// lazy chunk — see registry.ts for why the fallback is assembled by import.
+import './en/common'
+import './en/shell'
+import { getLocale } from './locale'
+import { catalogFor, enFallback, type LooseCatalog } from './registry'
 import type { Args, MessageKey, PluralBase, Vars } from './types'
 
 export {
@@ -14,8 +19,6 @@ export {
 export type { MessageKey, PartialMessages } from './types'
 
 const PLACEHOLDER = /\{(\w+)\}/g
-
-type Catalog = Record<string, Record<string, string | undefined> | undefined>
 
 function interpolate(template: string, vars?: Vars): string {
   if (!vars) return template
@@ -33,9 +36,9 @@ function lookupOptional(key: string): string | undefined {
   if (dot < 0) return undefined
   const ns = key.slice(0, dot)
   const leaf = key.slice(dot + 1)
-  const fromLocale = (catalogFor(getLocale()) as Catalog)[ns]?.[leaf]
+  const fromLocale = (catalogFor(getLocale()) as LooseCatalog)[ns]?.[leaf]
   if (typeof fromLocale === 'string') return fromLocale
-  const fromEn = (en as Catalog)[ns]?.[leaf]
+  const fromEn = enFallback[ns]?.[leaf]
   return typeof fromEn === 'string' ? fromEn : undefined
 }
 

--- a/frontend/src/i18n/locale.ts
+++ b/frontend/src/i18n/locale.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { en } from './en'
+import { hasCatalog, putCatalog } from './registry'
 import type { PartialMessages } from './types'
 
 /** A BCP 47 primary subtag that has a catalog registered. */
@@ -8,18 +8,13 @@ export type Locale = string
 export const DEFAULT_LOCALE = 'en'
 
 /**
- * Registered catalogs, keyed by lowercased tag. A future locale ships as its
- * own directory plus one `registerCatalog('pt', pt)` call — this module never
- * needs editing again.
+ * Register a locale's messages, keyed by lowercased tag. A future locale ships
+ * as its own directory plus one `registerCatalog('pt', pt)` call — this module
+ * never needs editing again. English is seeded by the registry itself and
+ * filled in namespace by namespace as catalog modules load.
  */
-const CATALOGS = new Map<string, PartialMessages>([[DEFAULT_LOCALE, en]])
-
 export function registerCatalog(tag: string, messages: PartialMessages): void {
-  CATALOGS.set(tag.trim().toLowerCase(), messages)
-}
-
-export function catalogFor(locale: Locale): PartialMessages {
-  return CATALOGS.get(locale) ?? en
+  putCatalog(tag.trim().toLowerCase(), messages)
 }
 
 /**
@@ -43,9 +38,9 @@ export function resolveLocale(candidate?: string | null): Locale {
     .trim()
     .toLowerCase()
   if (!raw) return DEFAULT_LOCALE
-  if (CATALOGS.has(raw)) return raw
+  if (hasCatalog(raw)) return raw
   const primary = raw.split(/[-_]/)[0] ?? ''
-  return CATALOGS.has(primary) ? primary : DEFAULT_LOCALE
+  return hasCatalog(primary) ? primary : DEFAULT_LOCALE
 }
 
 export function setLocale(candidate?: string | null): Locale {

--- a/frontend/src/i18n/registry.ts
+++ b/frontend/src/i18n/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * The catalog registry: where every namespace lands and where `t()` reads.
+ *
+ * `t()` is synchronous, so the English fallback it consults must already be in
+ * memory — but assembling that fallback in one eager module drags every view's
+ * copy into the entry bundle, which is what made initial JS grow with each
+ * migrated view (#261). So the fallback is assembled *by import*: a namespace
+ * module registers itself when it is evaluated, and the bundler places it in
+ * whichever chunk imports it. The shell's namespaces are imported by
+ * `i18n/index.ts` and stay eager; a view's namespace is imported by that view
+ * and travels inside its lazy chunk.
+ *
+ * Registration is a module-scope side effect, so a namespace is present before
+ * the importing module's body runs — which is what keeps module-scope `t()`
+ * calls (view `logic.ts` label maps, imperative DOM builders) working.
+ *
+ * Deliberately import-free. Catalog modules import this one, so anything it
+ * imported back would form a cycle whose `const` initialisers are still in the
+ * temporal dead zone when the first `defineNamespace()` call fires.
+ */
+
+type Leaves = Record<string, string | undefined>
+
+/** A locale's messages, loosely typed — `PartialMessages` is the public shape. */
+export type LooseCatalog = Record<string, Leaves | undefined>
+
+/**
+ * Live: namespaces appear as their modules evaluate, and every holder of this
+ * object (the `en` entry below, `t()`'s fallback) observes them immediately.
+ */
+const EN: LooseCatalog = {}
+
+const CATALOGS = new Map<string, LooseCatalog>([['en', EN]])
+
+/** The English fallback, for `t()`'s second lookup rung. */
+export const enFallback: LooseCatalog = EN
+
+/**
+ * Declare an English namespace and register it. Returns the messages unchanged
+ * so the module can still `export const <ns> = defineNamespace(...)`, which is
+ * what `MessageKey` is derived from.
+ */
+export function defineNamespace<M extends Readonly<Record<string, string>>>(
+  namespace: string,
+  messages: M,
+): M {
+  EN[namespace] = messages
+  return messages
+}
+
+/** Registered namespace names, in registration order. For tests. */
+export function registeredNamespaces(): string[] {
+  return Object.keys(EN)
+}
+
+export function putCatalog(tag: string, messages: LooseCatalog): void {
+  CATALOGS.set(tag, messages)
+}
+
+export function hasCatalog(tag: string): boolean {
+  return CATALOGS.has(tag)
+}
+
+export function catalogFor(locale: string): LooseCatalog {
+  return CATALOGS.get(locale) ?? EN
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,4 +1,9 @@
 import '@testing-library/jest-dom/vitest'
+// Register every English namespace. In the browser each view registers its own
+// as part of its lazy chunk (see i18n/registry.ts); a unit test renders a
+// component without that chunk boundary, so the suite stands in for it here
+// rather than making every test remember an import.
+import '@/i18n/en'
 import { cleanup } from '@testing-library/react'
 import { transferableAbortController } from 'node:util'
 import { afterEach, vi } from 'vitest'

--- a/frontend/src/views/approvals/ApprovalsPage.tsx
+++ b/frontend/src/views/approvals/ApprovalsPage.tsx
@@ -6,6 +6,8 @@ import { toast } from 'sonner'
 import { CommandLine } from '@/components/CommandLine'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/approvals'
 import { t } from '@/i18n'
 import {
   approvalCommand,

--- a/frontend/src/views/approvals/logic.ts
+++ b/frontend/src/views/approvals/logic.ts
@@ -11,6 +11,8 @@ import {
   type Approval,
   type ElevatedMode,
 } from '@/services/approval-monitor'
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/approvals'
 import { t } from '@/i18n'
 
 // Re-exported from the single elevated-mode source of truth

--- a/frontend/src/views/env/EnvPage.tsx
+++ b/frontend/src/views/env/EnvPage.tsx
@@ -16,6 +16,8 @@ import { toast } from 'sonner'
 import { useRpc } from '@/app/providers'
 import { ModalShell } from '@/components/ModalShell'
 import { Button } from '@/components/ui/button'
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/env'
 import { t } from '@/i18n'
 import {
   ENV_QUERY_KEY,

--- a/frontend/src/views/env/logic.ts
+++ b/frontend/src/views/env/logic.ts
@@ -5,6 +5,8 @@
  * can be tested without a DOM — the same split the Skills and MCP views use.
  */
 
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/env'
 import { t } from '@/i18n'
 
 /** Shared so the Settings glance and the Environment screen hit one cache. */

--- a/frontend/src/views/health/HealthPage.tsx
+++ b/frontend/src/views/health/HealthPage.tsx
@@ -5,6 +5,8 @@ import { CommandLine } from '@/components/CommandLine'
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/health'
 import { t } from '@/i18n'
 import {
   evidenceLabel,

--- a/frontend/src/views/health/logic.ts
+++ b/frontend/src/views/health/logic.ts
@@ -2,6 +2,8 @@
 // (src/agentos/gateway/static/js/views/health.js). Each function below carries
 // the legacy line range it mirrors so the parity matrix stays auditable.
 
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/health'
 import { t } from '@/i18n'
 
 export type Impact = 'blocks_ready' | 'degrades' | 'optional' | 'none'

--- a/frontend/src/views/logs/LogsPage.tsx
+++ b/frontend/src/views/logs/LogsPage.tsx
@@ -5,6 +5,8 @@ import { ActivityIcon, DownloadIcon, ScrollTextIcon, SearchIcon } from 'lucide-r
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/logs'
 import { t } from '@/i18n'
 import {
   DEFAULT_LEVELS,

--- a/frontend/src/views/overview/OverviewPage.tsx
+++ b/frontend/src/views/overview/OverviewPage.tsx
@@ -15,6 +15,8 @@ import {
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/overview'
 import { t, tPlural } from '@/i18n'
 import {
   formatCost,

--- a/frontend/src/views/overview/logic.ts
+++ b/frontend/src/views/overview/logic.ts
@@ -5,6 +5,8 @@
 // RPC calls, event subscriptions, and rendering live in OverviewPage.tsx; this
 // module owns the pure derivations (label mapping, formatting, session sort).
 
+// Registers this view's copy; it ships in this chunk, not the entry bundle.
+import '@/i18n/en/overview'
 import { t } from '@/i18n'
 
 /** A recent session row as returned by sessions.list (all fields optional). */


### PR DESCRIPTION
Closes #261.

## Problem

`en/index.ts` imported every namespace eagerly, because `t()` is synchronous and needs its fallback in memory. Views are lazy, so each migrated view moved its copy *out of* its lazy chunk and *into* the entry chunk. Five views cost 5.3 KiB gzip (#253); eleven remain.

## Fix

Assemble the English fallback **by import** instead of declaring it in one module.

- `i18n/registry.ts` (new) owns a live `en` object. Each namespace registers itself via `defineNamespace()`, so the bundler places it in whichever chunk imports it.
- `i18n/index.ts` imports `common` and `shell` — those stay eager.
- A view imports its own namespace (`import '@/i18n/en/logs'`), so the copy travels inside that view's lazy chunk.
- Registration is a module-scope side effect, so the namespace is registered when the chunk loads — before anything in it resolves a key.

`en/index.ts` remains the full eager aggregate, but only as the type source for `MessageKey` and as the catalog the shape tests read. Runtime code importing it would put all seven namespaces back in the entry chunk, so a test forbids it.

`t()` is untouched: same synchronous signature, same `locale → en → key` ladder, no call site changed.

## Result

| | Initial JS (gzip) |
|---|---|
| before #253 | 134.8 KiB |
| `main` (5218dec) | 140.2 KiB |
| this PR | **136.4 KiB** |

Against the 180 KiB budget. More importantly it stops tracking the migrated-view count — each of the remaining eleven views adds to its own chunk. The residual over pre-#253 is `shell` + `common`, which are genuinely entry copy (nav labels, route titles, connection footer).

Verified in the built bundle: every migrated view's copy is absent from `assets/index-*.js` and present in its view chunk.

## New guard

`i18n/chunking.test.ts` fails if a view namespace is made eager, if a module translates from a namespace it does not import, if runtime code imports the full catalog, or if a namespace stops self-registering. Each was confirmed to fail by breaking it.

## Testing

Rebased onto `main` through #262 (locale validation) and #264 (render-time resolution) and re-verified after each — #262 conflicted in `locale.ts` and was resolved keeping both sides.

- `python scripts/build_control_ui.py build` — passes, 136.4 KiB
- `npm run check` — 1812 tests, 88 files; tsc, eslint, prettier green. No existing test file changed; `src/test/setup.ts` registers every namespace so unit tests keep seeing the complete catalog, standing in for the chunk boundary the browser provides.
- `ruff` / `mypy` (593 files) / `pytest` (7424 passed, 23 skipped) / `uv build --wheel` — green
- Live gateway E2E: overview, health, logs, env, and approvals all render real copy on cold load *and* on client-side navigation, with no raw keys in the DOM and no console errors. A real chat turn (routed `c1 → gpt-5.6-luna`) and a CLI `agentos agent` turn both completed normally.