### PR TITLE
webui: resolve user-facing strings at render time, not module load

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -16,6 +16,40 @@ const I18N_MIGRATED = [
   'src/views/overview/**/*.tsx',
 ]
 
+// #258: t() reads the locale at call time, so calling it at module scope
+// resolves the string once — at module evaluation — and freezes it for the life
+// of the page. Every user-facing string must be produced inside a function (a
+// component, a helper, a getter) that re-runs after a locale change. The :not()
+// clauses spell out "this call has no function ancestor".
+const NO_MODULE_SCOPE_T = {
+  selector: [
+    'CallExpression[callee.name=/^t(Plural)?$/]',
+    ':not(FunctionDeclaration CallExpression)',
+    ':not(FunctionExpression CallExpression)',
+    ':not(ArrowFunctionExpression CallExpression)',
+    ':not(MethodDefinition CallExpression)',
+    ':not(PropertyDefinition CallExpression)',
+  ].join(''),
+  message:
+    'Module-scope t() freezes the string at module-evaluation time (#258). Move it inside a function so it re-resolves after a locale change.',
+}
+
+// Built-in no-restricted-syntax rather than react/jsx-no-literals: this repo
+// has no eslint-plugin-react, and the esquery selectors below enforce the same
+// thing without adding a dependency. The {3,} letter threshold keeps
+// punctuation, separators, and units out of the catalog.
+const NO_HARDCODED_COPY = [
+  {
+    selector: 'JSXText[value=/[A-Za-z]{3,}/]',
+    message: 'User-facing text must come from t() — add it to src/i18n/en/<view>.ts.',
+  },
+  {
+    selector:
+      'JSXAttribute[name.name=/^(aria-label|aria-description|placeholder|title|alt)$/] > Literal[value=/[A-Za-z]{3,}/]',
+    message: 'Accessible and attribute copy must come from t().',
+  },
+]
+
 export default tseslint.config(
   ...tseslint.configs.recommended,
   {
@@ -27,25 +61,15 @@ export default tseslint.config(
     },
   },
   {
-    // Built-in no-restricted-syntax rather than react/jsx-no-literals: this repo
-    // has no eslint-plugin-react, and the esquery selectors below enforce the
-    // same thing without adding a dependency. The {3,} letter threshold keeps
-    // punctuation, separators, and units out of the catalog.
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}'],
+    // no-restricted-syntax is replaced, not merged, by a later config that also
+    // sets it — so the migrated-view block below repeats this entry.
+    rules: { 'no-restricted-syntax': ['error', NO_MODULE_SCOPE_T] },
+  },
+  {
     files: I18N_MIGRATED,
     ignores: ['**/*.test.{ts,tsx}'],
-    rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'JSXText[value=/[A-Za-z]{3,}/]',
-          message: 'User-facing text must come from t() — add it to src/i18n/en/<view>.ts.',
-        },
-        {
-          selector:
-            'JSXAttribute[name.name=/^(aria-label|aria-description|placeholder|title|alt)$/] > Literal[value=/[A-Za-z]{3,}/]',
-          message: 'Accessible and attribute copy must come from t().',
-        },
-      ],
-    },
+    rules: { 'no-restricted-syntax': ['error', NO_MODULE_SCOPE_T, ...NO_HARDCODED_COPY] },
   },
 )

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { RouterProvider, createMemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { routeChildren, VIEWS } from './routes'
+import { getViews, routeChildren } from './routes'
 import { AppProviders } from './providers'
 import { AppShell, SIDEBAR_COLLAPSED_STORAGE_KEY } from './AppShell'
 import { KeyboardShortcutProvider } from '@/components/KeyboardShortcuts'
@@ -57,11 +57,12 @@ describe('routes', () => {
   })
 
   it('registers every major view as a route-object lazy module', () => {
+    const views = getViews()
     const registered = routeChildren.filter(
-      (route) => typeof route.path === 'string' && VIEWS.some((view) => view.path === route.path),
+      (route) => typeof route.path === 'string' && views.some((view) => view.path === route.path),
     )
 
-    expect(registered).toHaveLength(VIEWS.length)
+    expect(registered).toHaveLength(views.length)
     expect(registered.every((route) => route.lazy != null)).toBe(true)
     expect(registered.every((route) => route.element == null && route.Component == null)).toBe(true)
   })

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -41,7 +41,7 @@ import {
   useKeyboardShortcut,
   useShortcutOverlay,
 } from '@/components/KeyboardShortcuts'
-import { t, tPlural } from '@/i18n'
+import { t, tPlural, useLocale } from '@/i18n'
 import { useTheme } from '@/stores/theme'
 import { useConnection } from '@/stores/connection'
 import { useApprovals } from '@/services/approval-monitor'
@@ -56,39 +56,43 @@ const ApprovalPrompt = lazy(async () => ({
 
 // app.js:72-88 — legacy sidebar information architecture: nav items grouped
 // under labels, Chat first, Approvals last under Settings. Order within each
-// group matches the legacy markup exactly.
-const NAV_GROUPS: ReadonlyArray<{
+// group matches the legacy markup exactly. Built per render rather than held in
+// a module constant: labels resolved at module-evaluation time would freeze and
+// keep the boot locale forever (#258).
+function navGroups(): ReadonlyArray<{
   label: string
   items: ReadonlyArray<{ path: string; title: string; icon: LucideIcon }>
-}> = [
-  {
-    label: t('shell.navGroupChat'),
-    items: [{ path: 'chat', title: t('shell.viewChat'), icon: MessageSquare }],
-  },
-  {
-    label: t('shell.navGroupControl'),
-    items: [
-      { path: 'overview', title: t('shell.viewOverview'), icon: LayoutDashboard },
-      { path: 'health', title: t('shell.viewHealth'), icon: Activity },
-      { path: 'channels', title: t('shell.viewChannels'), icon: Radio },
-      { path: 'mcp', title: t('shell.viewMcp'), icon: Network },
-      { path: 'skills', title: t('shell.viewSkills'), icon: Puzzle },
-      { path: 'sessions', title: t('shell.viewSessions'), icon: History },
-      { path: 'agents', title: t('shell.viewAgents'), icon: Bot },
-      { path: 'usage', title: t('shell.viewUsage'), icon: BarChart3 },
-      { path: 'cron', title: t('shell.viewCron'), icon: CalendarClock },
-    ],
-  },
-  {
-    label: t('shell.navGroupSettings'),
-    items: [
-      { path: 'settings', title: t('shell.viewSettings'), icon: Settings2 },
-      { path: 'env', title: t('shell.viewEnv'), icon: KeyRound },
-      { path: 'logs', title: t('shell.viewLogs'), icon: ScrollText },
-      { path: 'approvals', title: t('shell.viewApprovals'), icon: ShieldCheck },
-    ],
-  },
-]
+}> {
+  return [
+    {
+      label: t('shell.navGroupChat'),
+      items: [{ path: 'chat', title: t('shell.viewChat'), icon: MessageSquare }],
+    },
+    {
+      label: t('shell.navGroupControl'),
+      items: [
+        { path: 'overview', title: t('shell.viewOverview'), icon: LayoutDashboard },
+        { path: 'health', title: t('shell.viewHealth'), icon: Activity },
+        { path: 'channels', title: t('shell.viewChannels'), icon: Radio },
+        { path: 'mcp', title: t('shell.viewMcp'), icon: Network },
+        { path: 'skills', title: t('shell.viewSkills'), icon: Puzzle },
+        { path: 'sessions', title: t('shell.viewSessions'), icon: History },
+        { path: 'agents', title: t('shell.viewAgents'), icon: Bot },
+        { path: 'usage', title: t('shell.viewUsage'), icon: BarChart3 },
+        { path: 'cron', title: t('shell.viewCron'), icon: CalendarClock },
+      ],
+    },
+    {
+      label: t('shell.navGroupSettings'),
+      items: [
+        { path: 'settings', title: t('shell.viewSettings'), icon: Settings2 },
+        { path: 'env', title: t('shell.viewEnv'), icon: KeyRound },
+        { path: 'logs', title: t('shell.viewLogs'), icon: ScrollText },
+        { path: 'approvals', title: t('shell.viewApprovals'), icon: ShieldCheck },
+      ],
+    },
+  ]
+}
 
 // app.js:123 — the drawer breakpoint shared with the legacy CSS.
 function mobileQuery(): MediaQueryList | null {
@@ -117,10 +121,13 @@ const PILL_VARIANT: Record<string, string> = {
 // Legacy derived the label by capitalising the state id. Translating it needs a
 // real map; an unmapped state still falls back to the capitalised id so a new
 // RpcState can never render an empty pill.
-const PILL_LABEL: Record<string, string> = {
-  connected: t('shell.connConnected'),
-  connecting: t('shell.connConnecting'),
-  disconnected: t('shell.connDisconnected'),
+function pillLabel(state: string): string {
+  const labels: Record<string, string> = {
+    connected: t('shell.connConnected'),
+    connecting: t('shell.connConnecting'),
+    disconnected: t('shell.connDisconnected'),
+  }
+  return labels[state] ?? state.charAt(0).toUpperCase() + state.slice(1)
 }
 
 export const SIDEBAR_COLLAPSED_STORAGE_KEY = 'agentos-sidebar-collapsed'
@@ -148,6 +155,11 @@ function normalizedRoutePath(pathname: string): string {
 }
 
 export function AppShell() {
+  // #258 — the shell is the one subscriber the whole console needs. Its own
+  // chrome re-renders here; the routed view is remounted through the container
+  // key below, because `<Outlet/>` hands back the same element object on a
+  // parent re-render and React would otherwise bail out of the subtree.
+  const locale = useLocale()
   const mode = useTheme((s) => s.mode)
   const toggle = useTheme((s) => s.toggle)
   const connState = useConnection((s) => s.state)
@@ -336,7 +348,7 @@ export function AppShell() {
   // reactive state here avoids duplicating the same readout in the header.
   const pillState = connState
   const pillVariant = PILL_VARIANT[pillState] ?? 'err'
-  const pillLabel = PILL_LABEL[pillState] ?? pillState.charAt(0).toUpperCase() + pillState.slice(1)
+  const connectionLabel = pillLabel(pillState)
   const pillOk = pillVariant === 'ok'
 
   const version = sidebarVersion(bootstrap.version)
@@ -414,7 +426,7 @@ export function AppShell() {
           aria-label={t('shell.navLandmark')}
           className="shell-sidebar__nav flex-1 overflow-y-auto px-2.5 py-5"
         >
-          {NAV_GROUPS.map((group) => (
+          {navGroups().map((group) => (
             <div key={group.label} className="shell-nav-group mb-6">
               <div className="shell-nav-group__label nav-group px-2.5 pb-2">{group.label}</div>
               {group.items.map((v) => {
@@ -473,7 +485,11 @@ export function AppShell() {
             className="shell-sidebar__connection t-data"
             data-testid="nav-foot"
             data-variant={pillVariant}
-            title={version ? t('shell.connWithVersion', { state: pillLabel, version }) : pillLabel}
+            title={
+              version
+                ? t('shell.connWithVersion', { state: connectionLabel, version })
+                : connectionLabel
+            }
           >
             <span
               aria-hidden="true"
@@ -486,7 +502,7 @@ export function AppShell() {
                 pillOk ? 'text-ok' : pillVariant === 'warn' ? 'text-warn' : 'text-danger'
               }`}
             >
-              {pillLabel.toUpperCase()}
+              {connectionLabel.toUpperCase()}
             </span>
             {version ? <span className="shell-sidebar__version ml-auto">v{version}</span> : null}
           </div>
@@ -596,7 +612,7 @@ export function AppShell() {
             onPrimaryAction={() => setSidebarOpen(false)}
           >
             <div
-              key={location.pathname}
+              key={`${locale}:${location.pathname}`}
               className={`view-container ${
                 isChat ? 'chat-surface chat-view-enter' : 'control-surface view-enter'
               }`}

--- a/frontend/src/app/locale-switch.test.tsx
+++ b/frontend/src/app/locale-switch.test.tsx
@@ -1,0 +1,141 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { RouterProvider, createMemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_LOCALE, registerCatalog, setLocale } from '@/i18n'
+import { useConnection } from '@/stores/connection'
+import { AppShell } from './AppShell'
+import { getViews, routeChildren } from './routes'
+import type { Bootstrap } from '@/lib/bootstrap'
+
+// #258 — the regression guard for module-scope t(). Every string asserted below
+// used to be resolved once at module-evaluation time, so it kept the boot
+// locale forever while the rest of the UI switched. The catalog overrides only
+// the keys under test; everything else still falls back to English, which is
+// also how a real partial translation would behave.
+registerCatalog('zz', {
+  shell: {
+    navGroupControl: 'ZZ Control',
+    viewOverview: 'ZZ Overview',
+    viewHealth: 'ZZ Health',
+    connDisconnected: 'ZZ Offline',
+  },
+  overview: {
+    documentTitle: 'ZZ Overview - AgentOS Control',
+    sessionRunning: 'ZZ Running',
+  },
+})
+
+const mockBootstrap: Bootstrap = {
+  version: '',
+  ws_url: 'ws://localhost/ws',
+  auth_mode: '',
+  base_path: '/control',
+  config_path: '',
+  features: { diagnostics: false },
+}
+
+const noopRpc = {
+  waitForConnection: () => new Promise<void>(() => {}),
+  call: () => new Promise(() => {}),
+  on: () => () => {},
+  connect: () => {},
+  disconnect: () => {},
+}
+
+vi.mock('./providers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./providers')>()
+  return { ...actual, useBootstrap: () => mockBootstrap, useRpc: () => noopRpc }
+})
+
+function renderShellAt(path: string) {
+  const router = createMemoryRouter([{ element: <AppShell />, children: routeChildren }], {
+    initialEntries: [path],
+  })
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('locale changes after module load', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    )
+    useConnection.getState().setState('disconnected')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    setLocale(DEFAULT_LOCALE)
+  })
+
+  it('re-resolves the route title table', () => {
+    const titleFor = (path: string) => getViews().find((view) => view.path === path)?.title
+    expect(titleFor('overview')).toBe('Overview')
+
+    setLocale('zz')
+
+    expect(titleFor('overview')).toBe('ZZ Overview')
+  })
+
+  it('follows the change in the nav group labels and nav item titles', async () => {
+    renderShellAt('/overview')
+    const groupLabels = () =>
+      Array.from(document.querySelectorAll('.shell-nav-group__label')).map((el) => el.textContent)
+
+    expect(await screen.findByRole('link', { name: 'Overview' })).toBeInTheDocument()
+    expect(groupLabels()).toEqual(['Chat', 'Control', 'Settings'])
+
+    act(() => {
+      setLocale('zz')
+    })
+
+    expect(screen.getByRole('link', { name: 'ZZ Overview' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'ZZ Health' })).toBeInTheDocument()
+    // An untranslated key still falls back to English rather than the raw key.
+    expect(groupLabels()).toEqual(['Chat', 'ZZ Control', 'Settings'])
+  })
+
+  it('follows the change in the connection pill', async () => {
+    renderShellAt('/overview')
+    const pill = await screen.findByTestId('nav-foot')
+    expect(pill).toHaveTextContent('DISCONNECTED')
+
+    act(() => {
+      setLocale('zz')
+    })
+
+    expect(pill).toHaveTextContent('ZZ OFFLINE')
+  })
+
+  it('follows the change inside the routed view, not just the shell chrome', async () => {
+    renderShellAt('/overview')
+    await waitFor(() => expect(document.title).toBe('Overview - AgentOS Control'))
+
+    act(() => {
+      setLocale('zz')
+    })
+
+    // The view is remounted by the container key, so its own copy and the
+    // document title it owns both re-resolve.
+    await waitFor(() => expect(document.title).toBe('ZZ Overview - AgentOS Control'))
+  })
+
+  it('mirrors the active locale onto <html lang>', () => {
+    renderShellAt('/overview')
+
+    act(() => {
+      setLocale('zz')
+    })
+
+    expect(document.documentElement.lang).toBe('zz')
+  })
+})

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,13 +1,13 @@
 import { lazy as reactLazy, Suspense, useEffect } from 'react'
 import { type RouteObject, useLocation } from 'react-router'
-import { t } from '@/i18n'
+import { t, type MessageKey } from '@/i18n'
 import { RouteErrorBoundary } from './RouteErrorBoundary'
 
 type LazyRoute = NonNullable<RouteObject['lazy']>
 
 interface ViewRoute {
   path: string
-  title: string
+  titleKey: MessageKey
   lazy: LazyRoute
 }
 
@@ -54,31 +54,32 @@ const loadEnv: LazyRoute = async () => ({
   Component: (await import('@/views/env/EnvPage')).EnvPage,
 })
 
-// Titles resolve at module load. That is correct while the locale is chosen
-// once at boot (see i18n/locale.ts); a future runtime locale switch would have
-// to turn `title` into a getter.
+// The table holds catalog *keys*, never resolved strings: a route table is a
+// module constant, so a title resolved here would freeze at module-evaluation
+// time and survive a later locale change (#258).
 const VIEW_ROUTES: ReadonlyArray<ViewRoute> = [
-  { path: 'overview', title: t('shell.viewOverview'), lazy: loadOverview },
-  { path: 'health', title: t('shell.viewHealth'), lazy: loadHealth },
-  { path: 'chat', title: t('shell.viewChat'), lazy: loadChat },
-  { path: 'sessions', title: t('shell.viewSessions'), lazy: loadSessions },
-  { path: 'agents', title: t('shell.viewAgents'), lazy: loadAgents },
-  { path: 'cron', title: t('shell.viewCron'), lazy: loadCron },
-  { path: 'usage', title: t('shell.viewUsage'), lazy: loadUsage },
-  { path: 'settings', title: t('shell.viewSettings'), lazy: loadSettings },
-  { path: 'config', title: t('shell.viewConfig'), lazy: loadSettings },
-  { path: 'setup', title: t('shell.viewSetup'), lazy: loadSettings },
-  { path: 'channels', title: t('shell.viewChannels'), lazy: loadChannels },
-  { path: 'mcp', title: t('shell.viewMcp'), lazy: loadMcp },
-  { path: 'approvals', title: t('shell.viewApprovals'), lazy: loadApprovals },
-  { path: 'skills', title: t('shell.viewSkills'), lazy: loadSkills },
-  { path: 'env', title: t('shell.viewEnv'), lazy: loadEnv },
-  { path: 'logs', title: t('shell.viewLogs'), lazy: loadLogs },
+  { path: 'overview', titleKey: 'shell.viewOverview', lazy: loadOverview },
+  { path: 'health', titleKey: 'shell.viewHealth', lazy: loadHealth },
+  { path: 'chat', titleKey: 'shell.viewChat', lazy: loadChat },
+  { path: 'sessions', titleKey: 'shell.viewSessions', lazy: loadSessions },
+  { path: 'agents', titleKey: 'shell.viewAgents', lazy: loadAgents },
+  { path: 'cron', titleKey: 'shell.viewCron', lazy: loadCron },
+  { path: 'usage', titleKey: 'shell.viewUsage', lazy: loadUsage },
+  { path: 'settings', titleKey: 'shell.viewSettings', lazy: loadSettings },
+  { path: 'config', titleKey: 'shell.viewConfig', lazy: loadSettings },
+  { path: 'setup', titleKey: 'shell.viewSetup', lazy: loadSettings },
+  { path: 'channels', titleKey: 'shell.viewChannels', lazy: loadChannels },
+  { path: 'mcp', titleKey: 'shell.viewMcp', lazy: loadMcp },
+  { path: 'approvals', titleKey: 'shell.viewApprovals', lazy: loadApprovals },
+  { path: 'skills', titleKey: 'shell.viewSkills', lazy: loadSkills },
+  { path: 'env', titleKey: 'shell.viewEnv', lazy: loadEnv },
+  { path: 'logs', titleKey: 'shell.viewLogs', lazy: loadLogs },
 ]
 
-export const VIEWS: ReadonlyArray<{ path: string; title: string }> = VIEW_ROUTES.map(
-  ({ path, title }) => ({ path, title }),
-)
+/** Resolved per call, so the titles follow the active locale. */
+export function getViews(): ReadonlyArray<{ path: string; title: string }> {
+  return VIEW_ROUTES.map(({ path, titleKey }) => ({ path, title: t(titleKey) }))
+}
 
 /**
  * Parity: js/router.js:32 — evaluated per resolve, not once at module load.

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -9,6 +9,7 @@ export {
   registerCatalog,
   resolveLocale,
   setLocale,
+  useLocale,
   type Locale,
 } from './locale'
 export type { MessageKey, PartialMessages } from './types'
@@ -49,10 +50,16 @@ function lookup(key: string): string {
 }
 
 /**
- * Translate a catalog key. A plain function, deliberately not a hook — most of
+ * Translate a catalog key. A plain function, deliberately not a hook — much of
  * the console's copy lives outside components (view `logic.ts` label maps,
- * module-scope route titles, imperative DOM builders in the chat transcript),
- * and a hook could not serve any of them.
+ * imperative DOM builders in the chat transcript), and a hook could not serve
+ * any of them.
+ *
+ * It resolves against the locale that is active *at call time*, so it must be
+ * called from inside a function that re-runs after a locale change, never at
+ * module scope where the result would freeze for the life of the page (#258 —
+ * `no-restricted-syntax` in eslint.config.js enforces this). `useLocale()` is
+ * what makes a component re-run.
  *
  * English is both the default locale and the per-key fallback, so a single
  * locale build behaves exactly as the hardcoded strings did.

--- a/frontend/src/i18n/locale.ts
+++ b/frontend/src/i18n/locale.ts
@@ -23,14 +23,24 @@ export function catalogFor(locale: Locale): PartialMessages {
 }
 
 /**
- * Held in a store rather than a bare module variable so a later
- * `useLocale()` subscription can re-render on change without touching a single
- * `t()` call site. Nothing subscribes today — locale is set once at boot.
+ * Held in a store rather than a bare module variable so `useLocale()` can
+ * re-render subscribers on change without touching a single `t()` call site.
  */
 const useLocaleStore = create<{ locale: Locale }>(() => ({ locale: DEFAULT_LOCALE }))
 
 export function getLocale(): Locale {
   return useLocaleStore.getState().locale
+}
+
+/**
+ * Subscribe to the active locale. `t()` resolves at call time, so a component
+ * shows a new locale only once something re-renders it — this hook is that
+ * something. `AppShell` subscribes on behalf of the console: its own chrome
+ * re-renders, and the routed view is remounted through the view-container key.
+ * A component outside that tree needs its own call.
+ */
+export function useLocale(): Locale {
+  return useLocaleStore((s) => s.locale)
 }
 
 /**
@@ -62,7 +72,8 @@ export function setLocale(candidate?: string | null): Locale {
 /**
  * Called once at boot, alongside `initTheme()`. The locale is a constant today;
  * when the gateway starts advertising one, this becomes
- * `setLocale(bootstrap.locale)` in `AppProviders` and nothing else moves.
+ * `setLocale(bootstrap.locale)` in `AppProviders` and nothing else moves —
+ * `setLocale` is already safe to call after boot (#258).
  */
 export function initLocale(): void {
   setLocale(DEFAULT_LOCALE)

--- a/frontend/src/views/approvals/ApprovalsPage.tsx
+++ b/frontend/src/views/approvals/ApprovalsPage.tsx
@@ -16,7 +16,7 @@ import {
   type Approval,
 } from '@/services/approval-monitor'
 import {
-  MODE_OPTIONS,
+  modeOptions,
   activeModeOption,
   approvalCardDetail,
   modeStateTone,
@@ -313,7 +313,7 @@ export function ApprovalsPage() {
               role="radiogroup"
               aria-label={t('approvals.policyLandmark')}
             >
-              {MODE_OPTIONS.map((opt) => (
+              {modeOptions().map((opt) => (
                 <label
                   key={opt.value}
                   className={`ap-radio${opt.value === mode ? ' is-active' : ''} tone-${modeStateTone(opt.value)}`}

--- a/frontend/src/views/approvals/logic.test.ts
+++ b/frontend/src/views/approvals/logic.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  MODE_OPTIONS,
+  modeOptions,
   activeModeOption,
   approvalCardDetail,
   executionModeSummary,
@@ -19,16 +19,16 @@ afterEach(() => {
   localStorage.clear()
 })
 
-describe('MODE_OPTIONS / activeModeOption', () => {
+describe('modeOptions / activeModeOption', () => {
   it('lists prompt, auto-approve, auto-deny in legacy order (approvals.js:82-86)', () => {
-    expect(MODE_OPTIONS.map((o) => o.value)).toEqual(['prompt', 'auto-approve', 'auto-deny'])
+    expect(modeOptions().map((o) => o.value)).toEqual(['prompt', 'auto-approve', 'auto-deny'])
   })
   it('selects the option matching the active mode', () => {
     expect(activeModeOption('auto-deny').label).toBe('Auto deny')
   })
   it('falls back to the first option (prompt) for an unknown mode (approvals.js:87)', () => {
-    expect(activeModeOption('nonsense')).toBe(MODE_OPTIONS[0])
-    expect(activeModeOption('')).toBe(MODE_OPTIONS[0])
+    expect(activeModeOption('nonsense')).toEqual(modeOptions()[0])
+    expect(activeModeOption('')).toEqual(modeOptions()[0])
   })
 })
 

--- a/frontend/src/views/approvals/logic.ts
+++ b/frontend/src/views/approvals/logic.ts
@@ -42,27 +42,30 @@ export interface ModeOption {
 }
 
 // approvals.js:82-86 — the three approval-strategy choices, in legacy order.
-export const MODE_OPTIONS: ReadonlyArray<ModeOption> = [
-  {
-    value: 'prompt',
-    label: t('approvals.modePromptLabel'),
-    desc: t('approvals.modePromptDesc'),
-  },
-  {
-    value: 'auto-approve',
-    label: t('approvals.modeAutoApproveLabel'),
-    desc: t('approvals.modeAutoApproveDesc'),
-  },
-  {
-    value: 'auto-deny',
-    label: t('approvals.modeAutoDenyLabel'),
-    desc: t('approvals.modeAutoDenyDesc'),
-  },
-]
+export function modeOptions(): ReadonlyArray<ModeOption> {
+  return [
+    {
+      value: 'prompt',
+      label: t('approvals.modePromptLabel'),
+      desc: t('approvals.modePromptDesc'),
+    },
+    {
+      value: 'auto-approve',
+      label: t('approvals.modeAutoApproveLabel'),
+      desc: t('approvals.modeAutoApproveDesc'),
+    },
+    {
+      value: 'auto-deny',
+      label: t('approvals.modeAutoDenyLabel'),
+      desc: t('approvals.modeAutoDenyDesc'),
+    },
+  ]
+}
 
 // approvals.js:87 — active option else the first (prompt) as the fallback.
 export function activeModeOption(mode: string): ModeOption {
-  return MODE_OPTIONS.find((m) => m.value === mode) || MODE_OPTIONS[0]!
+  const options = modeOptions()
+  return options.find((m) => m.value === mode) || options[0]!
 }
 
 // approvals.js:310-314 — strategy mode -> status tone. Legacy returned the

--- a/frontend/src/views/env/EnvPage.tsx
+++ b/frontend/src/views/env/EnvPage.tsx
@@ -32,12 +32,14 @@ import {
   type EnvVarRow,
 } from './logic'
 
-const FILTERS: ReadonlyArray<{ id: EnvFilter; label: string }> = [
-  { id: 'all', label: t('env.filterAll') },
-  { id: 'missing', label: t('env.filterMissing') },
-  { id: 'set', label: t('env.filterSet') },
-  { id: 'custom', label: t('env.filterCustom') },
-]
+function filterOptions(): ReadonlyArray<{ id: EnvFilter; label: string }> {
+  return [
+    { id: 'all', label: t('env.filterAll') },
+    { id: 'missing', label: t('env.filterMissing') },
+    { id: 'set', label: t('env.filterSet') },
+    { id: 'custom', label: t('env.filterCustom') },
+  ]
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -292,7 +294,7 @@ export function EnvPage() {
           aria-label={t('env.search')}
         />
         <div className="env-filters" role="group" aria-label={t('env.filterLandmark')}>
-          {FILTERS.map((entry) => (
+          {filterOptions().map((entry) => (
             <button
               key={entry.id}
               type="button"

--- a/frontend/src/views/env/logic.ts
+++ b/frontend/src/views/env/logic.ts
@@ -50,32 +50,30 @@ export type EnvFilter = 'all' | 'missing' | 'set' | 'custom'
 /** Category order in the UI: what a new install configures first comes first. */
 const CATEGORY_ORDER = ['provider', 'search', 'image', 'audio', 'memory', 'skill', 'custom']
 
-const CATEGORY_LABELS: Record<string, string> = {
-  provider: t('env.categoryProvider'),
-  search: t('env.categorySearch'),
-  image: t('env.categoryImage'),
-  audio: t('env.categoryAudio'),
-  memory: t('env.categoryMemory'),
-  skill: t('env.categorySkill'),
-  custom: t('env.categoryCustom'),
-}
-
-const SOURCE_LABELS: Record<EnvSource, string> = {
-  process: t('env.sourceProcess'),
-  cwd_file: t('env.sourceCwdFile'),
-  home_file: t('env.sourceHomeFile'),
-  unset: '',
-}
-
 /** POSIX-portable variable name — mirrors the server-side gate. */
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
 
 export function categoryLabel(category: string): string {
-  return CATEGORY_LABELS[category] ?? category
+  const labels: Record<string, string> = {
+    provider: t('env.categoryProvider'),
+    search: t('env.categorySearch'),
+    image: t('env.categoryImage'),
+    audio: t('env.categoryAudio'),
+    memory: t('env.categoryMemory'),
+    skill: t('env.categorySkill'),
+    custom: t('env.categoryCustom'),
+  }
+  return labels[category] ?? category
 }
 
 export function sourceLabel(source: EnvSource): string {
-  return SOURCE_LABELS[source] ?? source
+  const labels: Record<EnvSource, string> = {
+    process: t('env.sourceProcess'),
+    cwd_file: t('env.sourceCwdFile'),
+    home_file: t('env.sourceHomeFile'),
+    unset: '',
+  }
+  return labels[source] ?? source
 }
 
 export function isValidEnvName(name: string): boolean {

--- a/frontend/src/views/health/HealthPage.tsx
+++ b/frontend/src/views/health/HealthPage.tsx
@@ -26,11 +26,14 @@ import {
 const WS_URL_KEY = 'agentos.wsUrl'
 
 // health.js:422-430 — impact -> human label for the finding meta line.
-const IMPACT_LABELS: Record<Impact, string> = {
-  blocks_ready: t('health.impactBlocksReady'),
-  degrades: t('health.impactDegrades'),
-  optional: t('health.impactOptional'),
-  none: t('health.impactNone'),
+function impactLabel(impact: Impact): string {
+  const labels: Record<Impact, string> = {
+    blocks_ready: t('health.impactBlocksReady'),
+    degrades: t('health.impactDegrades'),
+    optional: t('health.impactOptional'),
+    none: t('health.impactNone'),
+  }
+  return labels[impact]
 }
 
 // health.js:432-437 — finding kind -> tone token used for the card accent.
@@ -135,7 +138,7 @@ function FindingCard({ finding, index }: { finding: Finding; index: number }) {
       <div className="health-finding__body">
         <div className="health-finding__meta">
           <span>{severity}</span>
-          <span className="health-impact">{IMPACT_LABELS[impact]}</span>
+          <span className="health-impact">{impactLabel(impact)}</span>
           <span className="health-surface">{surface}</span>
           {badge ? <span className="health-chip health-chip--badge">{badge}</span> : null}
           {finding.restartRequired ? (
@@ -153,39 +156,43 @@ function FindingCard({ finding, index }: { finding: Finding; index: number }) {
   )
 }
 
-const GROUPS: Array<{ kind: GroupKind; title: string; note: string }> = [
+function findingGroups(): Array<{ kind: GroupKind; title: string; note: string }> {
   // health.js:281-301
-  {
-    kind: 'action',
-    title: t('health.groupActionTitle'),
-    note: t('health.groupActionNote'),
-  },
-  {
-    kind: 'degraded',
-    title: t('health.groupDegradedTitle'),
-    note: t('health.groupDegradedNote'),
-  },
-  {
-    kind: 'optional',
-    title: t('health.groupOptionalTitle'),
-    note: t('health.groupOptionalNote'),
-  },
-  {
-    kind: 'ready',
-    title: t('health.groupReadyTitle'),
-    note: t('health.groupReadyNote'),
-  },
-]
+  return [
+    {
+      kind: 'action',
+      title: t('health.groupActionTitle'),
+      note: t('health.groupActionNote'),
+    },
+    {
+      kind: 'degraded',
+      title: t('health.groupDegradedTitle'),
+      note: t('health.groupDegradedNote'),
+    },
+    {
+      kind: 'optional',
+      title: t('health.groupOptionalTitle'),
+      note: t('health.groupOptionalNote'),
+    },
+    {
+      kind: 'ready',
+      title: t('health.groupReadyTitle'),
+      note: t('health.groupReadyNote'),
+    },
+  ]
+}
 
 function FindingsSection({ findings }: { findings: Finding[] }) {
   // health.js:277-313 — empty state else grouped sections.
   if (!findings.length) {
     return <article className="health-empty">{t('health.findingsEmpty')}</article>
   }
-  const groups = GROUPS.map((group) => ({
-    ...group,
-    findings: findings.filter((finding) => findingGroupKind(finding) === group.kind),
-  })).filter((group) => group.findings.length)
+  const groups = findingGroups()
+    .map((group) => ({
+      ...group,
+      findings: findings.filter((finding) => findingGroupKind(finding) === group.kind),
+    }))
+    .filter((group) => group.findings.length)
 
   return (
     <>

--- a/frontend/src/views/overview/logic.ts
+++ b/frontend/src/views/overview/logic.ts
@@ -49,13 +49,6 @@ const SESSION_STATUS_DOT: Record<string, string> = {
   killed: 'off',
   timeout: 'warn',
 }
-const SESSION_STATUS_LABEL: Record<string, string> = {
-  running: t('overview.sessionRunning'),
-  done: t('overview.sessionDone'),
-  failed: t('overview.sessionFailed'),
-  killed: t('overview.sessionKilled'),
-  timeout: t('overview.sessionTimeout'),
-}
 
 /** components.js:272-275 — dot color variant ("ok"/"warn"/"err"/"off"). */
 export function sessionStatusClass(status?: string | null): string {
@@ -65,8 +58,15 @@ export function sessionStatusClass(status?: string | null): string {
 
 /** components.js:284-287 — tooltip label; raw string else "Unknown" when empty. */
 export function sessionStatusLabel(status?: string | null): string {
+  const labels: Record<string, string> = {
+    running: t('overview.sessionRunning'),
+    done: t('overview.sessionDone'),
+    failed: t('overview.sessionFailed'),
+    killed: t('overview.sessionKilled'),
+    timeout: t('overview.sessionTimeout'),
+  }
   const k = String(status || '').toLowerCase()
-  return SESSION_STATUS_LABEL[k] || (status ? String(status) : t('overview.sessionUnknown'))
+  return labels[k] || (status ? String(status) : t('overview.sessionUnknown'))
 }
 
 /** components.js:228-241 — relative time. Numeric input is treated as an epoch


### PR DESCRIPTION
Closes #258.

## Problem

`t()` reads the active locale at call time, so calling it at module scope resolves the string **once, at module evaluation**, and freezes it for the life of the page. The issue names three call sites; a sweep of the AST found **73 across 8 files** — beyond the shell nav, route titles and health labels, the connection pill, the env filter/category/source labels, the approval mode options and the overview session labels were frozen too.

This is latent today (the locale is set once at boot) and becomes a partially-translated shell the moment `setLocale()` is reachable at runtime.

## Fix

Option 1 from the issue — nothing resolves at module-evaluation time any more.

- Every frozen constant is now a function that re-resolves per call. `VIEW_ROUTES` holds catalog **keys** rather than resolved titles.
- New `useLocale()` hook (the zustand store was already there for it). `AppShell` subscribes on behalf of the console: its chrome re-renders, and the routed view is remounted through the view-container key — `<Outlet/>` hands back the same element object on a parent re-render, so React would otherwise bail out of the subtree and leave view copy stale.
- A `no-restricted-syntax` rule pins the invariant. It flagged exactly the 73 sites this PR removes, so the bug class cannot return silently when a locale picker or a gateway-advertised locale ships.

Renames: `VIEWS` → `getViews()`, `MODE_OPTIONS` → `modeOptions()`.

## Tests

`src/app/locale-switch.test.tsx` changes the locale after module load against a partially-populated catalog and asserts the shell chrome follows: nav group labels, nav item titles, connection pill, the route title table, the document title owned by the routed view, and `<html lang>`. Untranslated keys must still fall back to English rather than the raw key.

Verified the test is a real guard: re-freezing `navGroups()` at module scope fails it.

## Verification

- `npm run check` green — tsc, eslint, prettier, 1804 tests.
- `scripts/build_control_ui.py build` green; initial JS 140.2 KiB gzip against the 180 KiB budget.
- Live E2E against a gateway on this branch: walked overview / health / env / approvals in the production bundle and confirmed every de-frozen label renders correctly, with a clean console. Ran a real agent turn from the web UI and from the CLI.
- Ran the locale switch for real in the browser (dev server, real components): nav group `Control → ZZ Control`, nav items `Overview/Health → ZZ Overview/ZZ Health`, pill `CONNECTED → ZZ ONLINE`, title `Overview - AgentOS Control → ZZ Overview - AgentOS Control`, `lang=en → zz`, with untranslated `Chat`/`Settings` still falling back to English.