### PR TITLE
fix(webui): format numeric placeholders with Intl.NumberFormat

### DIFF
--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_LOCALE,
+  formatNumber,
   getLocale,
   registerCatalog,
   resolveLocale,
@@ -14,6 +15,17 @@ import type { MessageKey } from './types'
 // key and omits a whole namespace, so both rungs of the fallback ladder are
 // exercised against real catalog data rather than a mock.
 registerCatalog('xx', { common: { save: 'XX save' } })
+
+// A second stub, under a real tag whose grouping and decimal marks differ from
+// English, so the number assertions below are about `Intl` rather than about an
+// invented tag quietly resolving to the runtime default. Its one template
+// carries the placeholder names the exemption rule has to tell apart.
+registerCatalog('de', {
+  common: { save: 'Port {socketPort} · Sitzung {sessionId} · {count} offen · {ratio}' },
+})
+
+/** `common.save` takes no vars in `en`, so the stub template's vars need a cast. */
+const tStub = t as (key: MessageKey, vars: Record<string, string | number>) => string
 
 afterEach(() => {
   setLocale(DEFAULT_LOCALE)
@@ -93,6 +105,69 @@ describe('registerCatalog', () => {
   })
 })
 
+describe('numeric interpolation', () => {
+  it('groups a quantity for the active locale', () => {
+    expect(t('env.statSetTotal', { total: 1234567 })).toBe('/1,234,567')
+    setLocale('de')
+    expect(t('env.statSetTotal', { total: 1234567 })).toBe('/1.234.567')
+  })
+
+  it('renders decimals with the active locale separator', () => {
+    expect(t('health.railCountShare', { percent: 12.5 })).toBe('12.5%')
+    setLocale('de')
+    expect(t('health.railCountShare', { percent: 12.5 })).toBe('12,5%')
+  })
+
+  it('leaves identifiers and machine codes ungrouped in every locale', () => {
+    // `HTTP 1,001` and `Finding 1,024` are wrong everywhere, not just in English.
+    expect(t('shell.errorHttpCode', { status: 1001 })).toBe('HTTP 1001')
+    expect(t('health.findingFallbackTitle', { index: 1024 })).toBe('Finding 1024')
+    setLocale('de')
+    expect(t('shell.errorHttpCode', { status: 1001 })).toBe('HTTP 1001')
+    expect(t('health.findingFallbackTitle', { index: 1024 })).toBe('Finding 1024')
+  })
+
+  it('reads the exemption off the last word of the placeholder name', () => {
+    // `socketPort` and `sessionId` are exempt without being named anywhere;
+    // `count` and `ratio` next to them still take the locale's marks.
+    setLocale('de')
+    expect(
+      tStub('common.save', { socketPort: 8080, sessionId: 1024, count: 1024, ratio: 1.5 }),
+    ).toBe('Port 8080 · Sitzung 1024 · 1.024 offen · 1,5')
+  })
+
+  it('leaves strings alone, so a pre-formatted value is not formatted twice', () => {
+    setLocale('de')
+    expect(t('overview.tileSpent', { amount: '$1,234.50' })).toBe('$1,234.50 spent')
+  })
+
+  it('falls back to String for non-finite numbers', () => {
+    // An upstream NaN should read as "NaN", not as a localised "∞".
+    expect(t('health.railCountShare', { percent: Number.NaN })).toBe('NaN%')
+    expect(t('health.railCountShare', { percent: Number.POSITIVE_INFINITY })).toBe('Infinity%')
+  })
+})
+
+describe('formatNumber', () => {
+  it('formats for the active locale, not the browser default', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567')
+    setLocale('de')
+    expect(formatNumber(1234567)).toBe('1.234.567')
+  })
+
+  it('matches what the same number renders as inside a template', () => {
+    // The counters rendered outside `t()` sit next to ones rendered through it;
+    // a tile whose value and caption disagree on the separator is the bug.
+    setLocale('de')
+    expect(t('env.statSetTotal', { total: 2000 })).toBe(`/${formatNumber(2000)}`)
+  })
+
+  it('passes non-finite values through unformatted', () => {
+    expect(formatNumber(Number.NaN)).toBe('NaN')
+    expect(formatNumber(Number.POSITIVE_INFINITY)).toBe('Infinity')
+  })
+})
+
 describe('resolveLocale', () => {
   it('defaults to English for empty, nullish, and unknown input', () => {
     expect(resolveLocale('')).toBe('en')
@@ -136,6 +211,12 @@ describe('tPlural', () => {
     expect(tPlural('shell.navApprovalBadge', 0)).toBe('0 pending approvals')
     expect(tPlural('shell.navApprovalBadge', 3)).toBe('3 pending approvals')
     expect(tPlural('overview.eventsCount', 12)).toBe('12 events')
+  })
+
+  it('groups the injected count', () => {
+    expect(tPlural('overview.eventsCount', 1234)).toBe('1,234 events')
+    setLocale('de')
+    expect(tPlural('overview.eventsCount', 1234)).toBe('1.234 events')
   })
 
   it('degrades to _other for a category no catalog defines', () => {

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -17,13 +17,81 @@ const PLACEHOLDER = /\{(\w+)\}/g
 
 type Catalog = Record<string, Record<string, string | undefined> | undefined>
 
+/**
+ * Trailing words that mark a numeric placeholder as an identifier or a machine
+ * code rather than a quantity. Those render raw in every locale: `port 8,080`,
+ * `session 1,024` and `HTTP 1,001` are bugs, not localisation.
+ *
+ * The rule is deliberately on the *name*, not the value, because the type
+ * alone cannot tell a count from a port. Matching is on the last word of the
+ * placeholder — split on camelCase and `_` — so `socketPort`, `exit_code` and
+ * `sessionId` are already covered and this set only grows for a genuinely new
+ * kind of identifier. Everything else numeric is a quantity and gets grouped.
+ */
+const RAW_TAIL_WORDS = new Set([
+  'bytes',
+  'code',
+  'id',
+  'index',
+  'line',
+  'offset',
+  'pid',
+  'port',
+  'status',
+  'version',
+  'year',
+])
+
+/** `'httpStatus'` -> `'status'`, `'exit_code'` -> `'code'`, `'HTTPStatus'` -> `'status'`. */
+function tailWord(name: string): string {
+  const words = name
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .split(/[\s_]+/)
+  return (words[words.length - 1] ?? '').toLowerCase()
+}
+
+/**
+ * One formatter per locale. `Intl.NumberFormat` construction is the expensive
+ * half of the API and `t()` runs on every render of every label.
+ */
+const NUMBER_FORMATS = new Map<string, Intl.NumberFormat>()
+
+function formatFor(locale: string): Intl.NumberFormat {
+  let format = NUMBER_FORMATS.get(locale)
+  if (!format) {
+    format = new Intl.NumberFormat(locale)
+    NUMBER_FORMATS.set(locale, format)
+  }
+  return format
+}
+
+/**
+ * Render a quantity for the active locale.
+ *
+ * Exported for the counters the console renders outside a template: a bare
+ * `n.toLocaleString()` there follows the *browser's* locale, which need not be
+ * the console's — and a tile whose value and caption disagree on the thousands
+ * separator is the visible symptom.
+ */
+export function formatNumber(value: number): string {
+  return Number.isFinite(value) ? formatFor(getLocale()).format(value) : String(value)
+}
+
 function interpolate(template: string, vars?: Vars): string {
   if (!vars) return template
   return template.replace(PLACEHOLDER, (match, name: string) => {
     const value = vars[name]
     // An unmatched token stays literal — a template rendering "undefined" to a
     // user is strictly worse than one rendering "{count}".
-    return value === undefined ? match : String(value)
+    if (value === undefined) return match
+    // Quantities pick up the active locale's grouping and decimal marks;
+    // identifiers stay raw. Non-finite values fall through to `String` so a
+    // NaN leaking in from upstream still reads as "NaN", not a localised "∞".
+    if (typeof value === 'number' && !RAW_TAIL_WORDS.has(tailWord(name))) {
+      return formatNumber(value)
+    }
+    return String(value)
   })
 }
 
@@ -56,6 +124,9 @@ function lookup(key: string): string {
  *
  * English is both the default locale and the per-key fallback, so a single
  * locale build behaves exactly as the hardcoded strings did.
+ *
+ * Numeric vars are rendered through `Intl.NumberFormat` for the active locale;
+ * see `RAW_TAIL_WORDS` for the placeholder names that opt out of that.
  */
 export function t<K extends MessageKey>(key: K, ...args: Args<K>): string {
   return interpolate(lookup(key), args[0] as Vars | undefined)

--- a/frontend/src/views/health/HealthPage.tsx
+++ b/frontend/src/views/health/HealthPage.tsx
@@ -5,7 +5,7 @@ import { CommandLine } from '@/components/CommandLine'
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { useBootstrap, useRpc } from '@/app/providers'
-import { t } from '@/i18n'
+import { formatNumber, t } from '@/i18n'
 import {
   evidenceLabel,
   evidenceValue,
@@ -229,7 +229,7 @@ function CountTile({
     >
       <span className="health-count__dot" aria-hidden="true" />
       <span className="health-count__label">{label}</span>
-      <strong>{loading ? t('common.dash') : Number(value || 0)}</strong>
+      <strong>{loading ? t('common.dash') : formatNumber(Number(value || 0))}</strong>
       <span className="health-count__share">
         {loading
           ? t('health.railCountChecking')

--- a/frontend/src/views/logs/LogsPage.tsx
+++ b/frontend/src/views/logs/LogsPage.tsx
@@ -5,7 +5,7 @@ import { ActivityIcon, DownloadIcon, ScrollTextIcon, SearchIcon } from 'lucide-r
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
-import { t } from '@/i18n'
+import { formatNumber, t } from '@/i18n'
 import {
   DEFAULT_LEVELS,
   LEVELS,
@@ -323,9 +323,9 @@ export function LogsPage() {
         <div className="lg-stats" aria-label={t('logs.statsLandmark')}>
           <div className="lg-stat lg-stat--hero" aria-label={t('logs.statInView')}>
             <span className="lg-stat__label t-label">{t('logs.statInView')}</span>
-            <strong className="lg-stat__value t-data">{filtered.length.toLocaleString()}</strong>
+            <strong className="lg-stat__value t-data">{formatNumber(filtered.length)}</strong>
             <span className="lg-stat__hint">
-              {t('logs.statInViewHint', { total: counts.total.toLocaleString() })}
+              {t('logs.statInViewHint', { total: counts.total })}
             </span>
           </div>
           <div

--- a/frontend/src/views/overview/OverviewPage.tsx
+++ b/frontend/src/views/overview/OverviewPage.tsx
@@ -416,9 +416,7 @@ export function OverviewPage() {
                 const rel = s.updated_at ? relTime(s.updated_at) : t('common.dash')
                 const msgs =
                   s.message_count != null
-                    ? t('overview.recentMessages', {
-                        count: Number(s.message_count).toLocaleString(),
-                      })
+                    ? t('overview.recentMessages', { count: Number(s.message_count) })
                     : ''
                 return (
                   <button


### PR DESCRIPTION
Closes #259.

## Problem

`interpolate()` stringified every substitution with `String(value)`, so `{count}`, `{total}`, `{percent}` and friends never reached `Intl`. Correct and invisible under `en`; wrong on sight under any locale with different grouping or decimal marks.

## Fix

Numbers render through `Intl.NumberFormat(getLocale())`, one cached formatter per locale.

**Identifiers opt out by name, not by type.** A placeholder is exempt when its last camelCase/snake_case word is in `RAW_TAIL_WORDS` — `id`, `index`, `port`, `pid`, `code`, `status`, `version`, `bytes`, `line`, `offset`, `year`. Splitting on the word boundary means `socketPort`, `exit_code` and `sessionId` are covered without extending the set, so `port 8,080` and `session 1,024` cannot happen. The rule is documented on the constant.

Unchanged: strings pass through untouched, non-finite numbers still fall back to `String` (an upstream `NaN` reads as `NaN`, not a localised `∞`), and an unmatched token still stays literal.

## Call sites

Two sites pre-formatted with `.toLocaleString()` before handing the value to `t()` — that used the *browser's* locale, not the console's. They now pass the raw number (`logs.statInViewHint`, `overview.recentMessages`).

`formatNumber()` is exported for the counters rendered outside a template. The Logs hero tile renders the same kind of number twice — value in JSX, total inside `t()` — and without this it read `1,475` over `of 1.475 loaded` as soon as the two locales diverged. Health's count tile had the same split between its visible value and its `aria-label`. The remaining bare `.toLocaleString()` counters in Usage, Sessions and Chat are untouched; they are a separate sweep.

## Verification

- `npm run check` green — 1809 tests, no existing test file changed.
- 10 new tests: grouped quantity, decimal separator, exempt identifiers (`status`, `index`), the camelCase word-boundary rule (`socketPort` / `sessionId` raw beside a grouped `count`), strings not double-formatted, non-finite fallback, and `tPlural`'s injected count. Non-`en` assertions run against a stub `de` catalog, so separators are compared against real `Intl` output rather than an invented tag.
- Real browser smoke (`tests/functional/test_webui_browser*_e2e.py`) green against a freshly built bundle.
- Live gateway walkthrough with a real model turn (opencap `gpt-5.6-luna`): Overview, Logs, Health, Usage and Chat render correctly, no console errors. With a `de` locale registered locally, the Logs tile reads `2.000` / `of 2.000 loaded` where `en` reads `2,000` / `of 2,000 loaded`.

`en` output is unchanged at every existing call site.