### PR TITLE
webui: migrate the settings view onto the i18n seam

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,6 +14,7 @@ const I18N_MIGRATED = [
   'src/views/health/**/*.tsx',
   'src/views/logs/**/*.tsx',
   'src/views/overview/**/*.tsx',
+  'src/views/settings/**/*.tsx',
 ]
 
 // #258: t() reads the locale at call time, so calling it at module scope

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -4,6 +4,7 @@ import { env } from './env'
 import { health } from './health'
 import { logs } from './logs'
 import { overview } from './overview'
+import { settings } from './settings'
 import { shell } from './shell'
 
 /**
@@ -13,8 +14,8 @@ import { shell } from './shell'
  * adding a namespace here is what makes its keys callable from `t()` — and the
  * shape tests read it at runtime.
  *
- * It is NOT how the app loads copy. Importing this module pulls all seven
- * namespaces into whichever chunk does so, which for anything reachable from
+ * It is NOT how the app loads copy. Importing this module pulls every
+ * namespace into whichever chunk does so, which for anything reachable from
  * the entry graph is exactly the growth #261 fixed. Runtime code must import
  * the one namespace it needs (`@/i18n/en/logs`) and let `t()` read the
  * registry; `i18n/chunking.test.ts` enforces that. `src/test/setup.ts` imports
@@ -28,5 +29,6 @@ export const en = {
   health,
   logs,
   overview,
+  settings,
   shell,
 } as const

--- a/frontend/src/i18n/en/settings.ts
+++ b/frontend/src/i18n/en/settings.ts
@@ -1,0 +1,45 @@
+import { defineNamespace } from '../registry'
+
+export const settings = defineNamespace('settings', {
+  documentTitle: 'Agent Setup - AgentOS Control',
+  eyebrow: 'Control · Settings',
+  title: 'Agent Setup',
+  subtitle: 'Choose the model, routing, and tools this agent can use.',
+
+  // Header status pill + refresh control.
+  statusChangesPaused: 'Changes paused',
+  statusRestartNeeded: 'Restart needed',
+  statusUnavailable: 'Status unavailable',
+  statusChecking: 'Checking setup',
+  statusReady: 'Ready to use',
+  setupItemsLeft_one: '{count} setup item left',
+  setupItemsLeft_other: '{count} setup items left',
+  refreshTitle: 'Refresh agent state',
+  refreshBusy: 'Refreshing…',
+  refresh: 'Refresh',
+
+  // Guided / Advanced tablist.
+  toolbarLandmark: 'Settings workspace',
+  tabsLandmark: 'Settings mode',
+  tabGuided: 'Guided setup',
+  tabGuidedNote: 'Recommended',
+  tabAdvanced: 'Advanced',
+  tabAdvancedNote: 'Edit config',
+
+  // "At a glance" strip.
+  glanceLandmark: 'Current agent setup',
+  glanceProgress: 'Setup progress',
+  readinessCount: '{ready} of {total} ready',
+  providerUnset: 'Provider not connected',
+  modelUnset: 'Choose a model',
+  glanceEnvironment: 'Environment',
+  envCount: '{set} of {total} set',
+  envManage: 'Manage variables',
+
+  // Blocking banners.
+  divergedBody:
+    'The config file changed outside AgentOS. Writes are blocked until the gateway reloads or restarts with that file.',
+  divergedAction: 'Refresh state',
+  loadErrorBody:
+    'Agent state could not be loaded. Retry before changing guided or advanced settings.',
+} as const)

--- a/frontend/src/views/settings/SettingsPage.tsx
+++ b/frontend/src/views/settings/SettingsPage.tsx
@@ -15,6 +15,8 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
+import { t, tPlural } from '@/i18n'
+import '@/i18n/en/settings'
 import { SetupPage } from '@/views/setup/SetupPage'
 import { ENV_QUERY_KEY, type EnvListResponse } from '@/views/env/logic'
 import { ConfigPage } from '@/views/config/ConfigPage'
@@ -44,7 +46,7 @@ export function SettingsPage() {
   }
 
   useEffect(() => {
-    document.title = 'Agent Setup - AgentOS Control'
+    document.title = t('settings.documentTitle')
   }, [])
 
   useEffect(() => {
@@ -68,36 +70,36 @@ export function SettingsPage() {
     refetchOnWindowFocus: false,
   })
   const envLabel = envQuery.data
-    ? `${envQuery.data.setCount} of ${envQuery.data.totalCount} set`
-    : 'Manage variables'
+    ? t('settings.envCount', { set: envQuery.data.setCount, total: envQuery.data.totalCount })
+    : t('settings.envManage')
 
   const snapshot = snapshotQuery.data
   const snapshotUnavailable = snapshotQuery.isError && !snapshot
   const readiness = useMemo(() => readinessFromSnapshot(snapshot), [snapshot])
   const readinessLabel =
     readiness.total > 0
-      ? `${readiness.ready} of ${readiness.total} ready`
+      ? t('settings.readinessCount', { ready: readiness.ready, total: readiness.total })
       : snapshotQuery.isError
-        ? 'Status unavailable'
-        : 'Checking setup'
-  const activeModel = snapshot?.config?.llm?.model || 'Choose a model'
+        ? t('settings.statusUnavailable')
+        : t('settings.statusChecking')
+  const activeModel = snapshot?.config?.llm?.model || t('settings.modelUnset')
   const activeProviderId = snapshot?.config?.llm?.provider
   const activeProvider =
     snapshot?.catalog?.providers?.find((provider) => provider.providerId === activeProviderId)
       ?.label ||
     activeProviderId ||
-    'Provider not connected'
+    t('settings.providerUnset')
   const statusLabel = snapshot?.writeBlocked
-    ? 'Changes paused'
+    ? t('settings.statusChangesPaused')
     : snapshot?.pendingRestart
-      ? 'Restart needed'
+      ? t('settings.statusRestartNeeded')
       : snapshotQuery.isError
-        ? 'Status unavailable'
+        ? t('settings.statusUnavailable')
         : readiness.actionRequired > 0
-          ? `${readiness.actionRequired} setup item${readiness.actionRequired === 1 ? '' : 's'} left`
+          ? tPlural('settings.setupItemsLeft', readiness.actionRequired)
           : snapshotQuery.isSuccess
-            ? 'Ready to use'
-            : 'Checking setup'
+            ? t('settings.statusReady')
+            : t('settings.statusChecking')
   const statusTone = snapshot?.writeBlocked
     ? 'tone-danger'
     : snapshot?.pendingRestart
@@ -135,11 +137,9 @@ export function SettingsPage() {
     <div className="settings-workspace">
       <header className="settings-stage__header">
         <div className="settings-stage__title-block">
-          <span className="t-label">Control · Settings</span>
-          <h1 className="t-display">Agent Setup</h1>
-          <p className="settings-stage__subtitle">
-            Choose the model, routing, and tools this agent can use.
-          </p>
+          <span className="t-label">{t('settings.eyebrow')}</span>
+          <h1 className="t-display">{t('settings.title')}</h1>
+          <p className="settings-stage__subtitle">{t('settings.subtitle')}</p>
         </div>
 
         <div className="settings-stage__actions">
@@ -154,20 +154,26 @@ export function SettingsPage() {
             type="button"
             variant="outline"
             className="text-xs uppercase tracking-[0.14em]"
-            title="Refresh agent state"
-            aria-label="Refresh agent state"
+            title={t('settings.refreshTitle')}
+            aria-label={t('settings.refreshTitle')}
             aria-busy={snapshotQuery.isFetching}
             disabled={snapshotQuery.isFetching}
             onClick={() => void reloadSnapshot()}
           >
             <RefreshCwIcon className={snapshotQuery.isFetching ? 'settings-spin' : ''} />
-            <span>{snapshotQuery.isFetching ? 'Refreshing…' : 'Refresh'}</span>
+            <span>
+              {snapshotQuery.isFetching ? t('settings.refreshBusy') : t('settings.refresh')}
+            </span>
           </Button>
         </div>
       </header>
 
-      <section className="settings-toolbar" aria-label="Settings workspace">
-        <nav className="settings-surface-tabs" aria-label="Settings mode" role="tablist">
+      <section className="settings-toolbar" aria-label={t('settings.toolbarLandmark')}>
+        <nav
+          className="settings-surface-tabs"
+          aria-label={t('settings.tabsLandmark')}
+          role="tablist"
+        >
           <button
             id="settings-tab-guided"
             type="button"
@@ -181,8 +187,8 @@ export function SettingsPage() {
           >
             <SlidersHorizontalIcon aria-hidden="true" />
             <span>
-              <strong>Guided setup</strong>
-              <small>Recommended</small>
+              <strong>{t('settings.tabGuided')}</strong>
+              <small>{t('settings.tabGuidedNote')}</small>
             </span>
           </button>
           <button
@@ -198,17 +204,17 @@ export function SettingsPage() {
           >
             <FileCode2Icon aria-hidden="true" />
             <span>
-              <strong>Advanced</strong>
-              <small>Edit config</small>
+              <strong>{t('settings.tabAdvanced')}</strong>
+              <small>{t('settings.tabAdvancedNote')}</small>
             </span>
           </button>
         </nav>
 
-        <div className="settings-glance" aria-label="Current agent setup">
+        <div className="settings-glance" aria-label={t('settings.glanceLandmark')}>
           <div className="settings-glance__item">
             <CheckCircle2Icon aria-hidden="true" />
             <span>
-              <small>Setup progress</small>
+              <small>{t('settings.glanceProgress')}</small>
               <strong>{readinessLabel}</strong>
             </span>
           </div>
@@ -228,7 +234,7 @@ export function SettingsPage() {
           >
             <KeyRoundIcon aria-hidden="true" />
             <span>
-              <small>Environment</small>
+              <small>{t('settings.glanceEnvironment')}</small>
               <strong>{envLabel}</strong>
             </span>
           </button>
@@ -237,23 +243,18 @@ export function SettingsPage() {
 
       {snapshot?.diskDiverged ? (
         <div className="settings-load-error tone-danger" role="alert">
-          <span>
-            The config file changed outside AgentOS. Writes are blocked until the gateway reloads or
-            restarts with that file.
-          </span>
+          <span>{t('settings.divergedBody')}</span>
           <Button type="button" size="sm" variant="outline" onClick={() => void reloadSnapshot()}>
-            Refresh state
+            {t('settings.divergedAction')}
           </Button>
         </div>
       ) : null}
 
       {snapshotQuery.isError ? (
         <div className="settings-load-error tone-danger" role="alert">
-          <span>
-            Agent state could not be loaded. Retry before changing guided or advanced settings.
-          </span>
+          <span>{t('settings.loadErrorBody')}</span>
           <Button type="button" size="sm" variant="outline" onClick={() => void reloadSnapshot()}>
-            Retry
+            {t('common.retry')}
           </Button>
         </div>
       ) : null}


### PR DESCRIPTION
Refs #257 — 1 of 11.

Extracts the 18 hardcoded strings in `SettingsPage` into a new `settings` namespace and adds `src/views/settings/**/*.tsx` to `I18N_MIGRATED` in the same commit.

Notes:
- Copy is verbatim. **No existing test file changed** — the settings suite passes untouched, which is the check that the DOM stayed byte-identical.
- The two ad-hoc interpolations (`X of Y ready`, `X of Y set`) become placeholder keys.
- The ternary plural `setup item${n === 1 ? '' : 's'} left` becomes a `tPlural()` pair.
- `Retry` reuses the existing `common.retry`.
- The namespace module is imported by the view (`import '@/i18n/en/settings'`), per the #261 chunking rules.

## Bundle

Initial JS unchanged at **136.6 KiB gzip** / 180 KiB budget — the copy travels in the lazy chunk, `SettingsPage` 23.5 → 23.9 KiB gzip (+509 B).

## Verification

`npm run check` green (tsc, eslint, prettier, 1822 tests). Rendered the view against a live gateway: eyebrow/title/subtitle, status pill, refresh control, both tabs, and the glance strip all correct, with `5 of 7 ready` and `3 of 31 set` interpolating.