### PR TITLE
feat(router): cap translation turns at the cheapest tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Translation requests now route to the cheapest tier. The router scores
+  reasoning difficulty rather than task type, so an ordinary "translate this"
+  landed on `c1` even in English — and because the Pilot corpus is English-only,
+  the same request drifted a tier in either direction depending only on the
+  language it was written in: measured against the English baseline, `trivial`
+  moved from `c0` to `c1`/`c2` in 13 of 14 languages, while a genuinely hard
+  request in Chinese, Japanese, or Thai *dropped* to `c1`. A deterministic
+  detector now recognises a translate verb in the first or last paragraph of a
+  turn across English, Vietnamese, Chinese, Japanese, Korean, Thai, Indonesian,
+  French, Spanish, German, Portuguese, Russian, Arabic, and Hindi, and caps the
+  turn at `agentos_router.translate_ceiling_tier` (default `c0`; set
+  `translate_ceiling_enabled = false` to turn it off, or pick the tier in the
+  setup wizard's **Translation cap** field). Every detected translation is
+  capped, extras and all — a complaint upgrade, the large-context floor, and a
+  programming language named as the target ("translate this Python module to
+  Rust", a request to write code) are the only things that override it. Verb
+  matching is word-bounded and guarded against overloaded stems, so Vietnamese
+  `giao dịch`/`dịch vụ`, English "address translation bug", and Thai `แปลก` are
+  not mistaken for translation work.
+
 ## [2026.8.9] - 2026-08-09
 
 ### Added

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -304,6 +304,16 @@ kv_cache_anti_downgrade_window_seconds = 600
 complaint_upgrade_enabled = true
 complaint_upgrade_steps = 1
 complaint_upgrade_max_chars = 160
+# Translation ceiling. The router scores reasoning difficulty, so an ordinary
+# "translate this" lands on c1 even in English, and drifts further in other
+# languages because they are outside the training corpus. A deterministic
+# detector (14 languages) caps a translation turn at translate_ceiling_tier.
+# Every detected translation is capped, extras and all. A complaint upgrade
+# wins over the cap and the large-context floor still applies after it; the
+# only request that keeps the verb without taking the cap is porting code
+# ("translate this Python module to Rust"), which is a request to write code.
+translate_ceiling_enabled = true
+translate_ceiling_tier = "c0"
 estimated_output_savings_pct = 0.03
 upgrade_to_c3_compaction_enabled = true
 

--- a/docs/features/agentos-router.md
+++ b/docs/features/agentos-router.md
@@ -78,12 +78,51 @@ order, and a later one can override an earlier one:
 6. **cache continuity holds a higher tier** — when a recent turn (within
    `kv_cache_anti_downgrade_window_seconds`, default 600) ran higher, the turn
    is not downgraded below it;
-7. **a large context raises a floor** — roughly 25,000 material tokens floors
+7. **a translation request drops to a ceiling** — see
+   [Translation requests](#translation-requests) below;
+8. **a large context raises a floor** — roughly 25,000 material tokens floors
    the turn at `c2`, and roughly 80,000 tokens, or 40% of the model's context
    window, floors it at `c3`.
 
 To see which of these applied to a given turn, turn on diagnostics as described
 in [What the Router Can Affect](#what-the-router-can-affect).
+
+### Translation Requests
+
+The strategies score *reasoning difficulty*, not task type, so an ordinary
+"translate this paragraph" is scored as ordinary work and lands on `c1` — and
+because the Pilot corpus is English-only, the same request written in another
+language drifts a tier in either direction for no reason but its script.
+
+Whether translation deserves more than the cheapest model is a policy question
+rather than something a classifier can be trained into, so it is answered
+deterministically. A translate verb in the first or last paragraph of a turn
+— recognised in English, Vietnamese, Chinese, Japanese, Korean, Thai,
+Indonesian, French, Spanish, German, Portuguese, Russian, Arabic, and Hindi —
+caps the turn at `translate_ceiling_tier` (default `c0`).
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `translate_ceiling_enabled` | `true` | Turn the cap off entirely. |
+| `translate_ceiling_tier` | `c0` | Tier a translation turn is capped at. |
+
+Every detected translation is capped, extras and all: asking for commentary
+alongside the translation, or for a poem's rhyme to survive it, does not lift
+the turn. Three things still do:
+
+- **a complaint upgrade**, so a follow-up saying the last answer was wrong is
+  never capped in the same turn;
+- **the large-context floor**, which runs after the cap and lifts a document
+  too big for the cheap tier back to one that can hold it;
+- **a programming language as the target** — "translate this Python module to
+  Rust" is a request to write code, not to translate prose, and is the one
+  phrasing that shares the verb without sharing the task.
+
+Detection reads only the leading and trailing paragraph of a turn, so a pasted
+document that merely mentions translation is not treated as a translation
+request. When a turn is capped, `routing_extra` carries `task_type`,
+`task_type_ceiling_from_tier`, and the matched language; when the verb matched
+but the cap did not apply, `task_type_blocked_by` records why.
 
 ## Strategies
 

--- a/frontend/src/views/setup/RouterSection.tsx
+++ b/frontend/src/views/setup/RouterSection.tsx
@@ -84,6 +84,15 @@ export function RouterSection({
     router.pilot?.safety_net_threshold != null ? String(router.pilot.safety_net_threshold) : '0.5'
   const [pilotThreshold, setPilotThreshold] = useState(pilotThresholdInitial)
 
+  // The translation cap is an engine guard rather than a strategy setting, so
+  // it stays visible for every mode. An absent key means the default (on).
+  const [translateCeilingEnabled, setTranslateCeilingEnabled] = useState(
+    router.translate_ceiling_enabled !== false,
+  )
+  const [translateCeilingTier, setTranslateCeilingTier] = useState(
+    router.translate_ceiling_tier || 'c0',
+  )
+
   // Judge model catalog: AUTO is judge_model === null → the empty option.
   const judgeCatalog = routerCatalog.judge || {}
   const judgeProfiles =
@@ -215,6 +224,8 @@ export function RouterSection({
       defaultTier,
       judgeModel,
       pilotThresholdRaw: pilotThreshold,
+      translateCeilingEnabled,
+      translateCeilingTier,
       // Tiers select the MODEL; requests always go through llm.provider, and a
       // tier naming a different provider is degraded back to llm.model at boot
       // (boot.py:1106-1120). The cell is a read-only chip for that reason, so
@@ -301,6 +312,34 @@ export function RouterSection({
             </small>
           </label>
         ) : null}
+        <label>
+          <span>Translation cap</span>
+          <SetupSelect
+            aria-label="Translation cap tier"
+            value={translateCeilingEnabled ? translateCeilingTier : 'off'}
+            disabled={!provider}
+            onChange={(e) => {
+              const next = e.target.value
+              if (next === 'off') {
+                setTranslateCeilingEnabled(false)
+                return
+              }
+              setTranslateCeilingEnabled(true)
+              setTranslateCeilingTier(next)
+            }}
+          >
+            <option value="off">Off - route translations normally</option>
+            {TEXT_TIERS.map((t) => (
+              <option key={t} value={t}>
+                {tierLabel(t)}
+              </option>
+            ))}
+          </SetupSelect>
+          <small className="setup-hint">
+            Translation requests are capped at this tier in 14 languages. A complaint upgrade and
+            the large-context floor still override it.
+          </small>
+        </label>
       </div>
 
       {provider ? (

--- a/frontend/src/views/setup/logic.test.ts
+++ b/frontend/src/views/setup/logic.test.ts
@@ -443,6 +443,8 @@ describe('router derivation (setup.js:550-635,1767-1846)', () => {
       defaultTier: 'c2',
       judgeModel: null,
       pilotThresholdRaw: '0.7',
+      translateCeilingEnabled: true,
+      translateCeilingTier: 'c0',
       tiers: [
         { tier: 'c0', provider: 'openai', model: 'a', thinkingLevel: 'low', supportsImage: false },
         {
@@ -466,11 +468,44 @@ describe('router derivation (setup.js:550-635,1767-1846)', () => {
       defaultTier: 'c1',
       judgeModel: null,
       pilotThresholdRaw: '0.5',
+      translateCeilingEnabled: true,
+      translateCeilingTier: 'c0',
       tiers: [],
     })
     expect(params.mode).toBe('disabled')
     expect(params.strategy).toBeUndefined()
     expect(params.safetyNetThreshold).toBeUndefined()
+  })
+  it('buildRouterConfigureParams: translation cap is forwarded for every mode', () => {
+    // The cap is an engine guard, so unlike the pilot threshold it must survive
+    // a judge or disabled selection rather than being dropped with the strategy.
+    const forMode = (sel: 'pilot-v1' | 'llm_judge' | 'disabled') =>
+      buildRouterConfigureParams({
+        sel,
+        defaultTier: 'c1',
+        judgeModel: null,
+        pilotThresholdRaw: '0.5',
+        translateCeilingEnabled: true,
+        translateCeilingTier: 'c0',
+        tiers: [],
+      })
+    for (const sel of ['pilot-v1', 'llm_judge', 'disabled'] as const) {
+      expect(forMode(sel).translateCeilingEnabled).toBe(true)
+      expect(forMode(sel).translateCeilingTier).toBe('c0')
+    }
+  })
+  it('buildRouterConfigureParams: translation cap can be turned off', () => {
+    const params = buildRouterConfigureParams({
+      sel: 'pilot-v1',
+      defaultTier: 'c1',
+      judgeModel: null,
+      pilotThresholdRaw: '0.5',
+      translateCeilingEnabled: false,
+      translateCeilingTier: 'c1',
+      tiers: [],
+    })
+    expect(params.translateCeilingEnabled).toBe(false)
+    expect(params.translateCeilingTier).toBe('c1')
   })
   it('buildRouterConfigureParams: judge mode never forwards threshold', () => {
     const params = buildRouterConfigureParams({
@@ -478,6 +513,8 @@ describe('router derivation (setup.js:550-635,1767-1846)', () => {
       defaultTier: 'c1',
       judgeModel: 'j',
       pilotThresholdRaw: '0.9',
+      translateCeilingEnabled: true,
+      translateCeilingTier: 'c0',
       tiers: [],
     })
     expect(params.strategy).toBe('llm_judge')

--- a/frontend/src/views/setup/logic.ts
+++ b/frontend/src/views/setup/logic.ts
@@ -159,6 +159,8 @@ export interface SetupConfig {
     judge_base_url?: string
     tiers?: Record<string, TierSpec>
     pilot?: { safety_net_threshold?: number | null }
+    translate_ceiling_enabled?: boolean | null
+    translate_ceiling_tier?: string | null
     [key: string]: unknown
   }
   memory?: {
@@ -755,6 +757,8 @@ export interface RouterConfigureParams {
   defaultTier: string
   judgeModel: string | null
   safetyNetThreshold?: number
+  translateCeilingEnabled: boolean
+  translateCeilingTier: string
   tiers: Record<string, Record<string, unknown>>
 }
 
@@ -769,6 +773,8 @@ export function buildRouterConfigureParams(input: {
   defaultTier: string
   judgeModel: string | null
   pilotThresholdRaw: string | undefined
+  translateCeilingEnabled: boolean
+  translateCeilingTier: string
   tiers: RouterTierInput[]
 }): RouterConfigureParams {
   const tiers: Record<string, Record<string, unknown>> = {}
@@ -796,6 +802,10 @@ export function buildRouterConfigureParams(input: {
     defaultTier: input.defaultTier,
     judgeModel: input.judgeModel,
     safetyNetThreshold,
+    // Sent for every mode: the translation cap is an engine guard, not a
+    // property of the selected strategy.
+    translateCeilingEnabled: input.translateCeilingEnabled,
+    translateCeilingTier: input.translateCeilingTier,
     tiers,
   }
 }

--- a/src/agentos/agentos_router/task_type.py
+++ b/src/agentos/agentos_router/task_type.py
@@ -1,0 +1,208 @@
+"""Deterministic task-type detection for router tier policy.
+
+The Pilot classifier scores *reasoning difficulty*, not task type, and it was
+trained on an English-only corpus (see ``scripts/pilot_router/DATA.md``). Two
+consequences motivate this module:
+
+* Translation is scored as ordinary work — an English "translate this
+  paragraph" lands on ``R1``/``c1`` even though an operator's policy may be
+  that translation never needs more than the cheapest tier.
+* Non-English input is out of distribution, so the same request drifts by a
+  tier or more depending only on the language it happens to be written in.
+
+Both are policy questions rather than model-accuracy questions, so they are
+answered deterministically here instead of by retraining. This module is a
+pure function: no I/O, no config loading, no model. The engine step owns when
+to consult it and which ceiling to apply.
+
+**Detection contract.** A message is ``"translate"`` when a translate verb
+matches in the instruction window. Every detected translation is treated the
+same — asking for an explanation alongside the translation, or for a poem's
+metre to survive it, does not change the verdict, because the operator policy
+this serves is that translation as such never needs more than the ceiling
+tier.
+
+Detection is nevertheless deliberately asymmetric — a miss only forfeits a
+saving, a false positive sends real work to the cheapest tier — so anything
+that is not translation returns ``None``. Three rules keep that honest:
+
+* Only **verb** forms are matched, never the noun. ``translate this to
+  French`` is an instruction; ``the address translation bug`` is not, and a
+  developer's message should never be mistaken for the former.
+* Overloaded verbs carry explicit negative guards. Vietnamese ``dịch`` also
+  appears in ``giao dịch`` (transaction), ``dịch vụ`` (service), ``dịch
+  bệnh`` (epidemic); Thai ``แปล`` is a prefix of ``แปลก`` (strange).
+* A **programming language** as the target is a port, not a translation.
+  "Translate this Python module to Rust" is a request to write code, and it
+  is the one case that shares the verb without sharing the task.
+
+**Instruction window.** Only the first and last paragraph of a message are
+examined, each length-capped. Instructions bracket a pasted body rather than
+hide inside it, and paragraph boundaries — not a raw character count — are
+what separate the two: an article being translated routinely contains the word
+"explain" or "analysis" in its body, and reading those as escalation signals
+would suppress most genuine requests. The same window bounds verb matching, so
+a document that merely *mentions* translation does not trip the detector
+either.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: Task type ids this module can return.
+TASK_TYPE_TRANSLATE = "translate"
+
+#: Caps on the leading and trailing paragraph that form the instruction window.
+#: Generous enough for a multi-sentence instruction, short enough that a body
+#: run together with its instruction contributes only its opening.
+INSTRUCTION_HEAD_CHARS = 600
+INSTRUCTION_TAIL_CHARS = 300
+
+#: A blank line (optionally carrying whitespace) separates paragraphs.
+_PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n")
+
+# --------------------------------------------------------------------------- #
+# Translate verbs, per language
+# --------------------------------------------------------------------------- #
+# Each entry is (language_tag, pattern), matched case-insensitively against the
+# scan window. Noun forms (translation / traduction / Übersetzung / перевод)
+# are deliberately absent: they are what appears in technical prose, and
+# matching them is how "fix the address translation bug" becomes a c0 task.
+
+_TRANSLATE_PATTERNS: tuple[tuple[str, str], ...] = (
+    # English — imperative/infinitive only.
+    ("en", r"\btranslate\b"),
+    # Vietnamese — "dịch" is heavily overloaded, so require the verb sense:
+    # either an explicit direction ("sang/ra/qua/thành ...") close by, or an
+    # object/politeness particle that only the verb takes.
+    (
+        "vi",
+        r"(?<!\bgiao )(?<!\bphiên )\bdịch\b"
+        r"(?!\s*(?:vụ|bệnh|chuyển|tễ|hạch|giả|thuật))"
+        r"(?=[^\n]{0,80}?\b(?:sang|ra|qua|thành)\b"
+        r"|\s*(?:giúp|hộ|dùm|giùm|đoạn|câu|bài|văn bản|tài liệu|toàn bộ|nội dung|cái|này))",
+    ),
+    # Chinese — simplified and traditional.
+    ("zh", r"翻译|翻譯|译成|譯成|翻成|译为|譯為"),
+    # Japanese — 翻訳 or the て/plain form of 訳す (bare 訳 is "reason").
+    ("ja", r"翻訳|訳して|訳す"),
+    # Korean — 번역.
+    ("ko", r"번역"),
+    # Thai — แปล, but not แปลก ("strange") or แปลง ("convert").
+    ("th", r"แปล(?![กง])"),
+    # Indonesian/Malay.
+    ("id", r"\bterjemah\w*\b|\balih\s?bahasa\w*\b"),
+    # French — verb forms only.
+    ("fr", r"\btradui(?:s|re|sez|t|sons)\b"),
+    # Spanish — verb forms only.
+    ("es", r"\btraduce\b|\btraducir\b|\btraduzca\b|\btraducid\b|\btraduzcan\b"),
+    # German — verb forms only, incl. the ue- transliteration.
+    ("de", r"\b(?:ü|ue)bersetz(?:e|en|t|st)\b"),
+    # Portuguese — verb forms only.
+    ("pt", r"\btraduza\b|\btraduzir\b|\btraduz\b|\btraduzam\b"),
+    # Russian — imperative and infinitive only (noun "перевод" excluded).
+    ("ru", r"\bперевед(?:и|ите)\b|\bперевести\b"),
+    # Arabic — ترجم and its inflections.
+    ("ar", r"ترجم\w*"),
+    # Hindi — अनुवाद (used with a light verb).
+    ("hi", r"अनुवाद"),
+)
+
+_TRANSLATE_RES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (lang, re.compile(pattern, re.IGNORECASE)) for lang, pattern in _TRANSLATE_PATTERNS
+)
+
+# --------------------------------------------------------------------------- #
+# Not-a-translation guard
+# --------------------------------------------------------------------------- #
+
+#: A programming language named alongside the verb: this is a port/rewrite that
+#: happens to be phrased as "translate", and it is a request to write code. This
+#: is the only guard — it exists because the task is different, not because the
+#: translation is judged hard. Suppression is the safe direction: it forfeits a
+#: saving and hands the turn back to ordinary model routing.
+_CODE_TARGET_RE = re.compile(
+    r"\b(?:python|javascript|typescript|golang|rust|java|kotlin|swift|scala"
+    r"|haskell|ruby|php|perl|sql|bash|powershell|matlab|fortran|cobol"
+    r"|c\+\+|c#|\.net|react|vue|svelte|jquery|regex|assembly|solidity"
+    r"|dart|elixir|erlang|clojure|lua|zig)\b",
+    re.IGNORECASE,
+)
+
+BLOCK_CODE_TARGET = "programming_language_target"
+
+
+@dataclass(frozen=True, slots=True)
+class TaskTypeVerdict:
+    """Outcome of task-type detection for one message.
+
+    ``task_type`` is ``None`` when nothing matched or when an escalation signal
+    suppressed a match. ``matched_language`` and ``evidence`` name the pattern
+    that fired, so a routing decision stays explainable after the fact;
+    ``blocked_by`` names the escalation signal when one suppressed an
+    otherwise-matching verb.
+    """
+
+    task_type: str | None = None
+    matched_language: str | None = None
+    evidence: str | None = None
+    blocked_by: str | None = None
+
+
+def instruction_window(message: str) -> str:
+    """Return the leading and trailing paragraph of *message*, length-capped.
+
+    A single-paragraph message contributes only its opening; otherwise the
+    first paragraph's head and the last paragraph's tail are joined, and
+    everything between them — the pasted body — is excluded.
+    """
+    blocks = [block.strip() for block in _PARAGRAPH_SPLIT_RE.split(message)]
+    blocks = [block for block in blocks if block]
+    if not blocks:
+        return ""
+    head = blocks[0][:INSTRUCTION_HEAD_CHARS]
+    if len(blocks) == 1:
+        return head
+    return f"{head}\n{blocks[-1][-INSTRUCTION_TAIL_CHARS:]}"
+
+
+def detect_task_type(message: str) -> TaskTypeVerdict:
+    """Classify *message* into a coarse task type, or ``None`` when unsure.
+
+    Only ``"translate"`` is recognised today. See the module docstring for the
+    detection contract and why it errs toward returning ``None``.
+    """
+    if not message or not message.strip():
+        return TaskTypeVerdict()
+
+    window = instruction_window(message)
+
+    match: re.Match[str] | None = None
+    language: str | None = None
+    for lang, pattern in _TRANSLATE_RES:
+        found = pattern.search(window)
+        if found is not None:
+            match, language = found, lang
+            break
+
+    if match is None:
+        return TaskTypeVerdict()
+
+    evidence = match.group(0).strip()[:40]
+
+    # Checked inside the instruction window, not the whole message: a document
+    # being translated may well mention Python without being a porting request.
+    if _CODE_TARGET_RE.search(window) is not None:
+        return TaskTypeVerdict(
+            matched_language=language,
+            evidence=evidence,
+            blocked_by=BLOCK_CODE_TARGET,
+        )
+
+    return TaskTypeVerdict(
+        task_type=TASK_TYPE_TRANSLATE,
+        matched_language=language,
+        evidence=evidence,
+    )

--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -25,6 +25,7 @@ from agentos.agentos_router.controller import (
     synthetic_one_hot,
     thinking_mode_to_level,
 )
+from agentos.agentos_router.task_type import TASK_TYPE_TRANSLATE, detect_task_type
 from agentos.engine.pipeline import TurnContext
 from agentos.engine.pricing import lookup_price
 from agentos.provider.context_capabilities import provider_state_continuity_diagnostic
@@ -864,6 +865,85 @@ def _route_class_for_tier(tier: str) -> str | None:
     return _TIER_TO_ROUTE_CLASS.get(normalized)
 
 
+def _apply_task_type_ceiling(
+    decision: RoutingDecision,
+    *,
+    ctx: TurnContext,
+    router_cfg: object,
+    tiers: dict,
+    valid_tiers: list[str],
+    semantic_message: str,
+    extra: dict | None,
+) -> RoutingDecision:
+    """Cap a detected translation turn at the configured ceiling tier.
+
+    The classifier scores reasoning difficulty and puts ordinary translation on
+    ``R1``/``c1`` even for English (its only in-distribution language), while
+    the same request in another language drifts a tier or more in either
+    direction. Whether translation is worth more than the cheapest tier is an
+    operator policy rather than something the model can be trained into, so it
+    is decided here, and it applies to every detected translation — a request
+    that also asks for commentary is still a translation.
+
+    Two guards bound the override. A complaint upgrade wins: when the user has
+    just said the last answer was wrong, they are asking for a *better* model
+    and must not be capped in the same turn. And the large-context floor runs
+    after this, so a document too big for the cheap tier still lands on one
+    that can hold it.
+
+    The KV-cache anti-downgrade guard is deliberately *not* honoured here: it
+    holds a tier up to keep a warm cache, but a translation is self-contained
+    work whose saving outweighs one cache miss. When the cap overrides it,
+    ``task_type_overrode_anti_downgrade`` records that in ``routing_extra``.
+    """
+    if not getattr(router_cfg, "translate_ceiling_enabled", True):
+        return decision
+    if decision.tier not in valid_tiers:
+        return decision
+
+    ceiling = normalize_text_tier(getattr(router_cfg, "translate_ceiling_tier", "c0"))
+    if ceiling is None or ceiling not in valid_tiers or ceiling not in tiers:
+        return decision
+    if _tier_index(decision.tier, valid_tiers) <= _tier_index(ceiling, valid_tiers):
+        return decision
+    if isinstance(extra, dict) and extra.get("complaint_upgrade_applied"):
+        return decision
+
+    verdict = detect_task_type(semantic_message)
+    if verdict.task_type != TASK_TYPE_TRANSLATE:
+        if isinstance(extra, dict) and verdict.blocked_by is not None:
+            # The verb matched but the task turned out to be something else.
+            # Record it so an unexpectedly expensive turn stays explainable.
+            extra["task_type_blocked_by"] = verdict.blocked_by
+            extra["task_type_language"] = verdict.matched_language
+        return decision
+
+    capped = RoutingDecision(
+        tier=ceiling,
+        model=tiers[ceiling].get("model", decision.model),
+        confidence=decision.confidence,
+        source="task_type_ceiling",
+    )
+    ctx.metadata["task_type_ceiling_from_tier"] = decision.tier
+    ctx.metadata["task_type"] = verdict.task_type
+
+    if extra is not None:
+        extra.setdefault("base_tier", decision.tier)
+        extra["task_type"] = verdict.task_type
+        extra["task_type_language"] = verdict.matched_language
+        extra["task_type_evidence"] = verdict.evidence
+        extra["task_type_ceiling_applied"] = True
+        extra["task_type_ceiling_from_tier"] = decision.tier
+        extra["task_type_ceiling_tier"] = ceiling
+        extra["task_type_pre_ceiling_source"] = decision.source
+        if extra.get("anti_downgrade_applied"):
+            extra["task_type_overrode_anti_downgrade"] = True
+        extra["final_tier"] = ceiling
+        extra["final_route_class"] = _route_class_for_tier(ceiling)
+
+    return capped
+
+
 def _apply_large_context_floor(
     decision: RoutingDecision,
     *,
@@ -1422,6 +1502,24 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
         )
 
     routing_extra = ctx.metadata.get("routing_extra")
+    # Task-type ceiling runs BEFORE the large-context floor so that a document
+    # too large for the cheap tier is still floored back up afterwards.
+    decision = _apply_task_type_ceiling(
+        decision,
+        ctx=ctx,
+        router_cfg=router_cfg,
+        tiers=tiers,
+        valid_tiers=valid_tiers,
+        semantic_message=semantic_message,
+        extra=routing_extra if isinstance(routing_extra, dict) else None,
+    )
+    if decision.source == "task_type_ceiling" and isinstance(routing_extra, dict):
+        thinking_mode, prompt_policy = _reconcile_controller_with_final_tier(
+            thinking_mode,
+            prompt_policy,
+            routing_extra,
+        )
+
     decision = _apply_large_context_floor(
         decision,
         ctx=ctx,
@@ -1546,6 +1644,9 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
         confidence_threshold=routing_extra.get("confidence_threshold"),
         confidence_gate_applied=routing_extra.get("confidence_gate_applied"),
         anti_downgrade_applied=routing_extra.get("anti_downgrade_applied"),
+        task_type=routing_extra.get("task_type"),
+        task_type_ceiling_applied=routing_extra.get("task_type_ceiling_applied"),
+        task_type_blocked_by=routing_extra.get("task_type_blocked_by"),
         probabilities=routing_extra.get("probabilities"),
         margin=routing_extra.get("margin"),
         provider_state_continuity=ctx.metadata.get("provider_state_continuity"),

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -32,6 +32,7 @@ from agentos.paths import default_agentos_home
 from agentos.router_tiers import (
     DEFAULT_ROUTER_STRATEGY,
     DEFAULT_TEXT_TIER,
+    TEXT_TIERS,
     normalize_text_tier,
     normalize_tier_mapping,
 )
@@ -1151,8 +1152,28 @@ class AgentOSRouterConfig(BaseSettings):
     complaint_upgrade_enabled: bool = True
     complaint_upgrade_steps: int = 1
     complaint_upgrade_max_chars: int = 160
+    # Translation is scored by the router as ordinary work (English, the only
+    # language it was trained on, lands on c1), and non-English input drifts a
+    # tier or more in either direction because it is out of distribution.
+    # Whether translation deserves more than the cheapest tier is an operator
+    # policy, so a deterministic detector (14 languages) caps every detected
+    # translation here instead. A complaint upgrade wins over the cap, and the
+    # large-context floor runs after it.
+    translate_ceiling_enabled: bool = True
+    translate_ceiling_tier: str = "c0"
     estimated_output_savings_pct: float = 0.03
     upgrade_to_c3_compaction_enabled: bool = True
+
+    @field_validator("translate_ceiling_tier")
+    @classmethod
+    def _validate_translate_ceiling_tier(cls, value: str) -> str:
+        tier = normalize_text_tier(value)
+        if tier is None:
+            allowed = ", ".join(repr(t) for t in TEXT_TIERS)
+            raise ValueError(
+                f"agentos_router.translate_ceiling_tier must be one of {allowed}; got {value!r}"
+            )
+        return tier
 
     @field_validator("strategy")
     @classmethod

--- a/src/agentos/gateway/rpc_onboarding.py
+++ b/src/agentos/gateway/rpc_onboarding.py
@@ -228,6 +228,12 @@ async def _router_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
     safety_net_threshold = (
         params.get("safetyNetThreshold") if isinstance(params, dict) else None
     )
+    translate_ceiling_enabled = (
+        params.get("translateCeilingEnabled") if isinstance(params, dict) else None
+    )
+    translate_ceiling_tier = (
+        params.get("translateCeilingTier") if isinstance(params, dict) else None
+    )
     verify_local_endpoint = bool(judge_base_url)
     # ``upsert_router`` is synchronous, and with ``verify_local_endpoint=True`` it
     # runs a full test classification against the local judge endpoint (up to the
@@ -249,6 +255,8 @@ async def _router_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
             judge_base_url=judge_base_url,
             judge_api_key=judge_api_key,
             safety_net_threshold=safety_net_threshold,
+            translate_ceiling_enabled=translate_ceiling_enabled,
+            translate_ceiling_tier=translate_ceiling_tier,
             verify_local_endpoint=True,
         )
     else:
@@ -263,6 +271,8 @@ async def _router_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
             judge_base_url=judge_base_url,
             judge_api_key=judge_api_key,
             safety_net_threshold=safety_net_threshold,
+            translate_ceiling_enabled=translate_ceiling_enabled,
+            translate_ceiling_tier=translate_ceiling_tier,
             verify_local_endpoint=False,
         )
     commit = _commit_mutation(

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -739,6 +739,8 @@ def upsert_router(
     judge_base_url: str | None = None,
     judge_api_key: str | None = None,
     safety_net_threshold: float | None = None,
+    translate_ceiling_enabled: bool | None = None,
+    translate_ceiling_tier: str | None = None,
     verify_local_endpoint: bool = False,
 ) -> MutationResult:
     """Upsert router config.
@@ -761,6 +763,11 @@ def upsert_router(
     (only meaningful under ``strategy="pilot-v1"``): ``None`` preserves the
     persisted value; any provided value is range-validated (0.0–1.0) by
     ``PilotConfig`` and persisted.
+
+    ``translate_ceiling_enabled`` / ``translate_ceiling_tier`` set the
+    translation cap (``[agentos_router]``), which applies to every strategy:
+    ``None`` preserves the persisted value, and the tier is validated by
+    ``AgentOSRouterConfig`` when the payload is reconstructed below.
 
     ``verify_local_endpoint`` runs a one-shot connectivity probe (spec D2) when a
     new local ``judge_base_url`` is being set, raising if it is unreachable or
@@ -796,6 +803,13 @@ def upsert_router(
         pilot_payload = dict(router_payload.get("pilot") or {})
         pilot_payload["safety_net_threshold"] = safety_net_threshold
         router_payload["pilot"] = pilot_payload
+
+    # Translation ceiling. Strategy-independent: the cap is an engine guard, so
+    # it is written at the top level rather than into the pilot sub-table.
+    if translate_ceiling_enabled is not None:
+        router_payload["translate_ceiling_enabled"] = bool(translate_ceiling_enabled)
+    if translate_ceiling_tier is not None:
+        router_payload["translate_ceiling_tier"] = translate_ceiling_tier
 
     default_tier_override = _normalize_explicit_text_tier(default_tier)
     default_tier_clean = default_tier_override or str(

--- a/tests/test_agentos_router/test_pilot_golden.py
+++ b/tests/test_agentos_router/test_pilot_golden.py
@@ -126,6 +126,15 @@ async def test_pilot_meets_golden_accuracy_floor() -> None:
             config = GatewayConfig()
             config.agentos_router.enabled = True
             config.agentos_router.rollout_phase = "full"
+            # ``gold_class`` is a rubric-anchored *reasoning difficulty* label,
+            # and this floor guards the classifier's grasp of that difficulty.
+            # The translation ceiling is a spend policy that deliberately
+            # ignores difficulty — capping a metered-verse translation at c0 is
+            # the feature working, not the classifier regressing. Leaving it on
+            # would score two properties with one number, so every future policy
+            # knob would read here as a classification regression. Production
+            # fidelity for those rows is asserted separately below.
+            config.agentos_router.translate_ceiling_enabled = False
             ctx = TurnContext(
                 message=row["text"],
                 session_key=f"golden-{i}",
@@ -155,3 +164,59 @@ async def test_pilot_meets_golden_accuracy_floor() -> None:
         f"(aspirational target {GOLDEN_ACCURACY_TARGET}) "
         f"({correct}/{len(rows)} correct)"
     )
+
+
+@pytest.mark.asyncio
+async def test_golden_translation_rows_are_capped_under_production_defaults() -> None:
+    """The rows the accuracy run excludes must still be capped in production.
+
+    The accuracy test above disables the translation ceiling so it keeps
+    scoring reasoning difficulty alone. This is the other half: with the
+    shipped defaults, every golden row whose text is a translation request
+    routes to ``c0`` regardless of its difficulty label — including
+    ``r2_translate_poem``, whose gold class is ``R2``.
+    """
+    artifact = _resolve_pilot_artifact()
+    if artifact is None:
+        pytest.skip("no loadable Pilot artifact (shipped bundle absent, staging gitignored)")
+
+    from agentos.agentos_router.pilot import PilotStrategy
+    from agentos.agentos_router.task_type import detect_task_type
+    from agentos.engine.pipeline import TurnContext
+    from agentos.engine.steps import agentos_router as step
+    from agentos.gateway.config import GatewayConfig
+
+    rows = [r for r in _load_golden() if detect_task_type(r["text"]).task_type == "translate"]
+    assert rows, "golden set must retain at least one translation exemplar"
+
+    strategy = PilotStrategy(
+        artifact_dir=str(artifact),
+        safety_net_threshold=0.5,
+        confidence_threshold=0.5,
+    )
+    step._history_store.clear()
+    original = step._get_strategy
+    step._get_strategy = lambda _config, _llm_cfg=None: strategy  # type: ignore[assignment]
+    try:
+        for i, row in enumerate(rows):
+            config = GatewayConfig()
+            config.agentos_router.enabled = True
+            config.agentos_router.rollout_phase = "full"
+            ctx = TurnContext(
+                message=row["text"],
+                session_key=f"golden-translate-{i}",
+                config=config,
+                provider=None,
+                model=config.llm.model,
+                tool_defs=[],
+                system_prompt="system",
+            )
+            routed = await step.apply_agentos_router(ctx)
+            extra = routed.metadata.get("routing_extra") or {}
+            assert routed.metadata["routed_tier"] == "c0", row["id"]
+            assert extra["task_type_ceiling_applied"] is True, row["id"]
+    finally:
+        step._get_strategy = original
+        step._history_store.clear()
+        step._strategy = None
+        step._strategy_key = None

--- a/tests/test_agentos_router/test_task_type.py
+++ b/tests/test_agentos_router/test_task_type.py
@@ -1,0 +1,146 @@
+"""Contract tests for the deterministic task-type detector.
+
+The detector is asymmetric by design: a miss forfeits an optimization, a false
+positive sends real work to the cheapest tier. The negative suite is therefore
+the load-bearing half of this file — it pins the overloaded verbs that would
+otherwise misfire (Vietnamese ``dịch`` inside ``giao dịch``/``dịch vụ``,
+English ``translation`` in technical prose, Thai ``แปล`` inside ``แปลก``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.agentos_router.task_type import (
+    BLOCK_CODE_TARGET,
+    INSTRUCTION_HEAD_CHARS,
+    TASK_TYPE_TRANSLATE,
+    detect_task_type,
+)
+
+# One natural-language translate request per supported language.
+TRANSLATE_REQUESTS: tuple[tuple[str, str], ...] = (
+    ("en", "Translate this sentence into English: The weather is nice today."),
+    ("vi", "Dịch câu này sang tiếng Anh: Hôm nay trời đẹp quá."),
+    ("zh", "把这句话翻译成英语：今天天气很好。"),
+    ("ja", "この文を英語に翻訳してください：今日はいい天気ですね。"),
+    ("ko", "이 문장을 영어로 번역해 주세요: 오늘 날씨가 참 좋네요."),
+    ("th", "ช่วยแปลประโยคนี้เป็นภาษาอังกฤษ: วันนี้อากาศดีมาก"),
+    ("id", "Terjemahkan kalimat ini ke bahasa Inggris: Cuaca hari ini sangat bagus."),
+    ("fr", "Traduisez cette phrase en anglais : Il fait beau aujourd'hui."),
+    ("es", "Traduce esta frase al inglés: Hoy hace muy buen tiempo."),
+    ("de", "Übersetze diesen Satz ins Englische: Das Wetter ist heute schön."),
+    ("pt", "Traduza esta frase para o inglês: O tempo está muito bom hoje."),
+    ("ru", "Переведите это предложение на английский: Сегодня прекрасная погода."),
+    ("ar", "ترجم هذه الجملة إلى الإنجليزية: الطقس جميل اليوم."),
+    ("hi", "इस वाक्य का अंग्रेज़ी में अनुवाद करें: आज मौसम बहुत अच्छा है।"),
+)
+
+
+@pytest.mark.parametrize(
+    ("lang", "message"), TRANSLATE_REQUESTS, ids=[t[0] for t in TRANSLATE_REQUESTS]
+)
+def test_translate_request_detected_in_every_supported_language(lang: str, message: str) -> None:
+    verdict = detect_task_type(message)
+    assert verdict.task_type == TASK_TYPE_TRANSLATE
+    assert verdict.matched_language == lang
+    assert verdict.evidence
+    assert verdict.blocked_by is None
+
+
+# Messages that contain a translate-adjacent word but are NOT translation work.
+# Each would cost a wrong answer if it were capped to the cheapest tier.
+NON_TRANSLATE: tuple[tuple[str, str], ...] = (
+    ("vi_transaction", "Giao dịch này bị lỗi, kiểm tra lại log của node giúp tôi."),
+    ("vi_service", "Dịch vụ thanh toán trả về 502 khi tải cao, tìm nguyên nhân."),
+    ("vi_epidemic", "Dịch bệnh ảnh hưởng thế nào tới chuỗi cung ứng năm nay?"),
+    ("vi_shift", "Cần dịch chuyển toàn bộ dữ liệu sang cluster mới."),
+    ("vi_interpreter", "Thuê một phiên dịch viên cho buổi họp ngày mai."),
+    ("en_nat_bug", "Fix the address translation bug in the NAT layer."),
+    ("en_i18n_keys", "Our translation keys are out of sync with the locale files."),
+    ("en_past_tense", "The translated output was cached before the deploy."),
+    ("th_strange", "เรื่องนี้แปลกมาก ช่วยดูให้หน่อย"),
+    ("th_convert", "ช่วยแปลงไฟล์นี้เป็น PDF"),
+    ("ja_reason", "その訳ではうまくいかない理由を教えてください。"),
+)
+
+
+@pytest.mark.parametrize(("name", "message"), NON_TRANSLATE, ids=[t[0] for t in NON_TRANSLATE])
+def test_non_translate_message_is_not_detected(name: str, message: str) -> None:
+    verdict = detect_task_type(message)
+    assert verdict.task_type is None
+    assert verdict.blocked_by is None, "no verb should have matched at all"
+
+
+def test_empty_and_blank_messages_are_not_detected() -> None:
+    assert detect_task_type("").task_type is None
+    assert detect_task_type("   \n\t ").task_type is None
+
+
+class TestEveryTranslationIsATranslation:
+    """Operator policy: translation as such never escapes the ceiling.
+
+    A translation that also asks for commentary, or for a poem's form to
+    survive, is still a translation. These cases used to be carved out; the
+    carve-outs were removed deliberately, so they are pinned here to keep a
+    future "helpful" exception from creeping back in unnoticed.
+    """
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Translate this idiom into Vietnamese and explain the wordplay.",
+            "Dịch đoạn này sang tiếng Anh và phân tích giọng văn.",
+            "Translate this poem into English, preserving the rhyme scheme.",
+            "Translate the comments to Japanese:\n\n```\n// hello\n```",
+            "Translate this contract clause into German for our legal team.",
+        ],
+    )
+    def test_translation_with_extras_is_still_translate(self, message: str) -> None:
+        verdict = detect_task_type(message)
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
+
+class TestProgrammingLanguageTarget:
+    """The one guard: porting code is a different task, not a hard translation."""
+
+    def test_programming_language_target_blocks(self) -> None:
+        verdict = detect_task_type("Translate this Python module to Rust, same public API.")
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+    def test_programming_language_target_blocks_in_vietnamese(self) -> None:
+        verdict = detect_task_type("Dịch đoạn code này sang Rust giúp tôi.")
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+    def test_language_named_only_in_the_body_does_not_block(self) -> None:
+        """A document mentioning Python is not a porting request."""
+        body = ("The team migrated the Python service last quarter. " * 40) + ("z" * 1500)
+        verdict = detect_task_type(f"Dịch tài liệu sau sang tiếng Việt:\n\n{body}")
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+
+
+class TestScanWindow:
+    """Instructions bracket a pasted body; the middle is not scanned."""
+
+    def test_instruction_at_the_tail_is_detected(self) -> None:
+        body = "x" * 4000
+        message = f"Quarterly report follows.\n\n{body}\n\nDịch toàn bộ sang tiếng Việt."
+        verdict = detect_task_type(message)
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.matched_language == "vi"
+
+    def test_verb_buried_mid_document_is_ignored(self) -> None:
+        """A document that merely mentions translation is not a translate turn."""
+        filler = "x" * (INSTRUCTION_HEAD_CHARS + 500)
+        message = f"Review this report.\n\n{filler}\nplease translate it\n{filler}\nThanks."
+        assert detect_task_type(message).task_type is None
+
+    def test_body_content_does_not_veto_the_instruction(self) -> None:
+        """A long pasted body must not suppress its own instruction."""
+        body = ("The committee met to explain the budget. " * 60) + ("y" * 2000)
+        message = f"Translate the following into Korean:\n\n{body}"
+        verdict = detect_task_type(message)
+        assert verdict.task_type == TASK_TYPE_TRANSLATE

--- a/tests/test_engine/test_router_task_type_ceiling.py
+++ b/tests/test_engine/test_router_task_type_ceiling.py
@@ -1,0 +1,265 @@
+"""Engine tests for the translate task-type ceiling.
+
+Every assertion runs through the FULL ``apply_agentos_router`` step, never
+``_apply_task_type_ceiling`` directly, so the guard is proven in the position
+it actually occupies: after the history guards, before the large-context
+floor. The Pilot strategy is injected through the step's ``_get_strategy``
+seam with a fixed encoder, so the routed tier depends on the injected argmax
+rather than on the message text — which lets each test vary only the thing it
+is about.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from agentos.agentos_router.pilot import PilotStrategy
+from agentos.agentos_router.pilot.features import EMBED_DIM
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps import agentos_router as agentos_router_step
+from agentos.engine.steps.agentos_router import apply_agentos_router
+from agentos.gateway.config import GatewayConfig
+
+FIXTURE_DIR = Path(__file__).parent.parent / "test_agentos_router" / "data" / "pilot_fixture"
+
+TRANSLATE_MESSAGE = "Dịch đoạn văn dưới đây sang tiếng Anh giúp tôi."
+PLAIN_MESSAGE = "Rà soát lại kiến trúc dịch vụ thanh toán và chỉ ra điểm nghẽn."
+
+
+class _ProbEncoder:
+    """Deterministic ``PilotEncoder`` returning a fixed raw embedding."""
+
+    def __init__(self, vector: np.ndarray) -> None:
+        self._vector = vector
+
+    def encode_sync(self, texts: list[str]) -> np.ndarray:
+        return np.asarray([self._vector for _ in texts], dtype=np.float32)
+
+    def count_tokens_pretrunc(self, text: str) -> int:
+        return len(text.split())
+
+
+def _seed_vector_for_argmax(target_argmax: int) -> np.ndarray:
+    from agentos.agentos_router.pilot.features import build_features
+    from agentos.agentos_router.pilot.model import PilotModel
+
+    model = PilotModel(FIXTURE_DIR)
+    assert model.available
+    for seed in range(400):
+        rng = np.random.default_rng(seed)
+        vector = rng.standard_normal(EMBED_DIM).astype(np.float32)
+        feats = build_features(
+            "probe message",
+            encoder=_ProbEncoder(vector),
+            token_count_pretrunc_8k=3,
+        )
+        if int(np.argmax(model.predict_proba(feats.reshape(1, -1))[0])) == target_argmax:
+            return vector
+    raise AssertionError(f"no seed produced argmax {target_argmax}")
+
+
+@pytest.fixture(autouse=True)
+def reset_agentos_router_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    agentos_router_step._history_store.clear()
+    agentos_router_step._strategy = None
+    agentos_router_step._strategy_key = None
+    yield
+    agentos_router_step._history_store.clear()
+    agentos_router_step._strategy = None
+    agentos_router_step._strategy_key = None
+    monkeypatch.undo()
+
+
+def _make_context(message: str, *, session_key: str = "task-type-session") -> TurnContext:
+    config = GatewayConfig()
+    config.agentos_router.rollout_phase = "full"
+    # Keep the confidence gate inert so the injected c2 route reaches the
+    # ceiling unmodified; the gate has its own coverage elsewhere.
+    config.agentos_router.confidence_threshold = 0.0
+    return TurnContext(
+        message=message,
+        session_key=session_key,
+        config=config,
+        provider=None,
+        model=config.llm.model,
+        tool_defs=[],
+        system_prompt="system",
+    )
+
+
+def _inject_pilot(monkeypatch: pytest.MonkeyPatch, *, argmax: int = 2) -> PilotStrategy:
+    strategy = PilotStrategy(
+        artifact_dir=FIXTURE_DIR,
+        encoder=_ProbEncoder(_seed_vector_for_argmax(argmax)),
+        safety_net_threshold=1.0,
+        confidence_threshold=0.0,
+    )
+    monkeypatch.setattr(
+        agentos_router_step, "_get_strategy", lambda _config, _llm_cfg=None: strategy
+    )
+    return strategy
+
+
+@pytest.mark.asyncio
+async def test_translate_turn_is_capped_to_the_ceiling_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A c2 route for a translation request is capped to c0."""
+    _inject_pilot(monkeypatch)
+    ctx = _make_context(TRANSLATE_MESSAGE)
+
+    routed = await apply_agentos_router(ctx)
+    extra = routed.metadata["routing_extra"]
+
+    assert routed.metadata["routed_tier"] == "c0"
+    assert routed.metadata["routing_source"] == "task_type_ceiling"
+    assert extra["task_type"] == "translate"
+    assert extra["task_type_language"] == "vi"
+    assert extra["task_type_ceiling_applied"] is True
+    assert extra["task_type_ceiling_from_tier"] == "c2"
+    assert extra["final_tier"] == "c0"
+    assert extra["final_route_class"] == "R0"
+    # The classifier's own opinion stays visible next to the override.
+    assert extra["base_tier"] == "c2"
+    assert extra["route_class"] == "R2"
+
+
+@pytest.mark.asyncio
+async def test_non_translate_turn_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An overloaded Vietnamese verb ('dịch vụ') must not trigger the cap."""
+    _inject_pilot(monkeypatch)
+    ctx = _make_context(PLAIN_MESSAGE)
+
+    routed = await apply_agentos_router(ctx)
+    extra = routed.metadata["routing_extra"]
+
+    assert routed.metadata["routed_tier"] == "c2"
+    assert routed.metadata["routing_source"] == "pilot_v1"
+    assert "task_type_ceiling_applied" not in extra
+
+
+@pytest.mark.asyncio
+async def test_code_port_is_recorded_without_capping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A port phrased as a translation keeps its tier and says why."""
+    _inject_pilot(monkeypatch)
+    ctx = _make_context("Dịch đoạn code này sang Rust giúp tôi.")
+
+    routed = await apply_agentos_router(ctx)
+    extra = routed.metadata["routing_extra"]
+
+    assert routed.metadata["routed_tier"] == "c2"
+    assert extra["task_type_blocked_by"] == "programming_language_target"
+    assert "task_type_ceiling_applied" not in extra
+
+
+@pytest.mark.asyncio
+async def test_translation_asking_for_commentary_is_still_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Policy: translation as such is capped, extras and all."""
+    _inject_pilot(monkeypatch)
+    ctx = _make_context("Dịch đoạn này sang tiếng Anh và phân tích giọng văn.")
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.metadata["routed_tier"] == "c0"
+    assert routed.metadata["routing_extra"]["task_type_ceiling_applied"] is True
+
+
+@pytest.mark.asyncio
+async def test_complaint_upgrade_wins_over_the_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Asking for a better answer must not be capped in the same turn."""
+    _inject_pilot(monkeypatch)
+    ctx = _make_context("Sai rồi, dịch lại câu này sang tiếng Anh giúp tôi.")
+
+    routed = await apply_agentos_router(ctx)
+    extra = routed.metadata["routing_extra"]
+
+    assert extra["complaint_upgrade_applied"] is True
+    assert routed.metadata["routed_tier"] == "c3"
+    assert "task_type_ceiling_applied" not in extra
+
+
+@pytest.mark.asyncio
+async def test_large_context_floor_wins_over_the_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A document too large for the cheap tier is floored back up after the cap."""
+    _inject_pilot(monkeypatch)
+    body = "word " * 30_000  # ~150k chars -> ~37k estimated tokens, over the c2 floor
+    ctx = _make_context(f"Dịch tài liệu sau sang tiếng Việt:\n\n{body}")
+
+    routed = await apply_agentos_router(ctx)
+    extra = routed.metadata["routing_extra"]
+
+    assert routed.metadata["routed_tier"] == "c2"
+    assert routed.metadata["routing_source"] == "large_context_floor"
+    # The cap did fire first; the floor then lifted it back.
+    assert extra["task_type_ceiling_applied"] is True
+    assert extra["large_context_floor_applied"] is True
+    assert extra["large_context_floor_from_tier"] == "c0"
+    assert extra["final_tier"] == "c2"
+
+
+@pytest.mark.asyncio
+async def test_ceiling_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject_pilot(monkeypatch)
+    ctx = _make_context(TRANSLATE_MESSAGE)
+    ctx.config.agentos_router.translate_ceiling_enabled = False
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.metadata["routed_tier"] == "c2"
+    assert "task_type_ceiling_applied" not in routed.metadata["routing_extra"]
+
+
+@pytest.mark.asyncio
+async def test_ceiling_tier_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject_pilot(monkeypatch)
+    ctx = _make_context(TRANSLATE_MESSAGE)
+    ctx.config.agentos_router.translate_ceiling_tier = "c1"
+
+    routed = await apply_agentos_router(ctx)
+    extra = routed.metadata["routing_extra"]
+
+    assert routed.metadata["routed_tier"] == "c1"
+    assert extra["task_type_ceiling_tier"] == "c1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ceiling", ["c2", "c3"])
+async def test_route_at_or_below_the_ceiling_is_untouched(
+    monkeypatch: pytest.MonkeyPatch, ceiling: str
+) -> None:
+    """The guard is a ceiling, never a floor: it must not lift a cheaper route.
+
+    ``c2`` exercises the equality case and ``c3`` the strictly-below case, both
+    against the same injected c2 route.
+    """
+    _inject_pilot(monkeypatch)
+    ctx = _make_context(TRANSLATE_MESSAGE)
+    ctx.config.agentos_router.translate_ceiling_tier = ceiling
+
+    routed = await apply_agentos_router(ctx)
+
+    assert routed.metadata["routed_tier"] == "c2"
+    assert routed.metadata["routing_source"] == "pilot_v1"
+    assert "task_type_ceiling_applied" not in routed.metadata["routing_extra"]
+
+
+def test_ceiling_tier_rejects_an_unknown_value() -> None:
+    config = GatewayConfig()
+    with pytest.raises(ValueError, match="translate_ceiling_tier"):
+        config.agentos_router.__class__(translate_ceiling_tier="c9")
+
+
+def test_ceiling_tier_accepts_the_legacy_alias() -> None:
+    cfg = GatewayConfig().agentos_router.__class__(translate_ceiling_tier="t0")
+    assert cfg.translate_ceiling_tier == "c0"

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from agentos.gateway.config import GatewayConfig, _router_tier_profile_defaults
 from agentos.gateway.llm_runtime import resolve_llm_runtime_config
@@ -1134,6 +1135,50 @@ def test_upsert_router_auto_judge_clears_previous_local_endpoint():
     assert res.config.agentos_router.judge_model is None
     assert res.config.agentos_router.judge_base_url is None
     assert res.config.agentos_router.judge_api_key is None
+
+
+def test_upsert_router_translate_ceiling_defaults_are_on_at_c0():
+    cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
+    res = upsert_router(cfg, mode="recommended")
+
+    assert res.config.agentos_router.translate_ceiling_enabled is True
+    assert res.config.agentos_router.translate_ceiling_tier == "c0"
+
+
+def test_upsert_router_persists_translate_ceiling_overrides():
+    cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
+    res = upsert_router(
+        cfg,
+        mode="recommended",
+        translate_ceiling_enabled=False,
+        translate_ceiling_tier="c1",
+    )
+
+    assert res.config.agentos_router.translate_ceiling_enabled is False
+    assert res.config.agentos_router.translate_ceiling_tier == "c1"
+
+
+def test_upsert_router_omitted_translate_ceiling_preserves_persisted_values():
+    """The CLI never sends these; an omitted param must not reset the operator's
+    choice back to the default."""
+    cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
+    cfg = upsert_router(
+        cfg,
+        mode="recommended",
+        translate_ceiling_enabled=False,
+        translate_ceiling_tier="c2",
+    ).config
+
+    res = upsert_router(cfg, mode="recommended", default_tier="c1")
+
+    assert res.config.agentos_router.translate_ceiling_enabled is False
+    assert res.config.agentos_router.translate_ceiling_tier == "c2"
+
+
+def test_upsert_router_rejects_an_unknown_translate_ceiling_tier():
+    cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
+    with pytest.raises(ValidationError, match="translate_ceiling_tier"):
+        upsert_router(cfg, mode="recommended", translate_ceiling_tier="c9")
 
 
 def test_upsert_router_cloud_judge_clears_stale_local_endpoint_when_base_url_omitted():


### PR DESCRIPTION
## Problem

The router scores *reasoning difficulty*, not task type, so an ordinary "translate this paragraph" is scored as ordinary work and lands on `c1` — even in English, the only language the Pilot corpus contains.

Because that corpus is English-only (`scripts/pilot_router/DATA.md`), non-English input is out of distribution and the tier drifts for no reason but the script it is written in. Measured over a 14-language × 5-task matrix against the English baseline, using the shipped `pilot_v1` artifact:

| lang | trivial | translate | summarize | write | hard |
| --- | --- | --- | --- | --- | --- |
| en | c0 | c1 | c1 | c1 | c2 |
| vi | c2 | c2 | c2 | c1 | c2 |
| zh | c1 | c1 | c1 | c1 | **c1** |
| ja | c1 | c1 | c2 | c1 | **c1** |
| th | c1 | c1 | c0 | c1 | **c1** |
| pt | c1 | c1 | c2 | c3 | c3 |

`trivial` moves off `c0` in 13 of 14 languages, and the drift runs both ways: a genuinely hard request in Chinese, Japanese, or Thai *drops* to `c1`.

Ablation isolates the cause. Swapping only the embedding half of the feature vector flips the decision, while the eight scalars are near-identical:

```
VI emb + VI scalars  -> c2   VI scalars: [3.761 2.944 0.693 0 0 0 0 0]
VI emb + EN scalars  -> c2   EN scalars: [3.892 2.398 0.693 0 0 0 0 0]
EN emb + VI scalars  -> c1
EN emb + EN scalars  -> c1
```

Neither existing lever helps: the safety net never fires on these turns, and the large-context floor only engages from ~25,000 tokens.

## Approach

Whether translation deserves more than the cheapest model is an operator policy, not something a difficulty classifier can be trained into — English translation is *correctly* scored `R1` under the rubric. So it is answered deterministically.

`_apply_task_type_ceiling` is a new engine guard, symmetric with `_apply_large_context_floor` and placed immediately before it. A translate verb in the first or last paragraph of a turn caps it at `agentos_router.translate_ceiling_tier` (default `c0`). Policy lives in the engine; the strategies keep owning probabilities, so the cap applies to `llm_judge` as well as `pilot-v1`.

Three things override the cap:

- **a complaint upgrade** — a user saying the last answer was wrong is asking for a better model, and must not be capped in the same turn;
- **the large-context floor** — it runs after the cap, so a document too big for the cheap tier is lifted back to one that can hold it;
- **a programming language as the target** — "translate this Python module to Rust" is a request to write code, and is the one phrasing that shares the verb without sharing the task.

The KV-cache anti-downgrade guard is deliberately not honoured; a translation is self-contained work whose saving outweighs one cache miss, and `task_type_overrode_anti_downgrade` records it when that happens.

## Detection

`agentos_router/task_type.py` is a pure function covering English, Vietnamese, Chinese, Japanese, Korean, Thai, Indonesian, French, Spanish, German, Portuguese, Russian, Arabic, and Hindi. It is asymmetric on purpose — a miss forfeits a saving, a false positive sends real work to the cheapest tier — so three rules keep it conservative:

- **verbs only, never nouns.** `translate this to French` is an instruction; "the address translation bug" is not.
- **overloaded stems carry negative guards.** Vietnamese `dịch` also appears in `giao dịch` (transaction), `dịch vụ` (service), `dịch bệnh` (epidemic); Thai `แปล` is a prefix of `แปลก` (strange).
- **only the leading and trailing paragraph are read.** A pasted document that merely mentions translation does not trip the detector, and a body containing "explain" cannot veto its own instruction.

## Verification

Replayed through the full `apply_agentos_router` step with the shipped artifact: all 14 translate cells reach `c0`, and the other 56 matrix cells are unchanged.

Live against a real provider, on the same session:

```
Dịch đoạn này sang tiếng Anh: ...
  task_type=translate  base_tier=c2  final_tier=c0
  source=task_type_ceiling  applied_model=deepseek-v4-flash

Phân tích vì sao một giao dịch swap trên DEX có thể bị revert ...
  task_type=None  source=pilot_v1  applied_model=gpt-5.6-luna
```

The second message contains the overloaded `giao dịch` and is correctly left alone.

Config surfaces are in `agentos.toml.example`, `docs/features/agentos-router.md`, and a **Translation cap** field in the setup wizard's Router step.

## Scope

This does not address the under-routing the matrix also exposes — hard requests in Chinese, Japanese, and Thai landing on `c1`. That needs a multilingual backbone and a retrain, and is worth its own issue.
