### PR TITLE
webui: migrate the config view onto the i18n seam

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -10,6 +10,7 @@ const I18N_MIGRATED = [
   'src/app/**/*.tsx',
   'src/components/**/*.tsx',
   'src/views/approvals/**/*.tsx',
+  'src/views/config/**/*.tsx',
   'src/views/env/**/*.tsx',
   'src/views/health/**/*.tsx',
   'src/views/logs/**/*.tsx',

--- a/frontend/src/i18n/en/config.ts
+++ b/frontend/src/i18n/en/config.ts
@@ -1,0 +1,182 @@
+import { defineNamespace } from '../registry'
+
+export const config = defineNamespace('config', {
+  documentTitle: 'Config - AgentOS Control',
+  eyebrow: 'Control · Config',
+  title: 'Config',
+  subtitle:
+    'Advanced gateway configuration. Use guided setup for provider, router, channels, and extras.',
+  embeddedEyebrow: 'Advanced workspace',
+  embeddedTitle: 'Configuration editor',
+  embeddedSubtitle: 'Edit the complete runtime surface with a reviewed diff before it is applied.',
+
+  // Header controls.
+  modeLandmark: 'Editor mode',
+  modeForm: 'Form',
+  modeYaml: 'YAML',
+  guidedTitle: 'Open guided setup',
+  guided: 'Guided setup',
+  reloadTitle: 'Reload config',
+  reload: 'Reload',
+  saveTitle: 'Save config',
+  save: 'Save',
+
+  // Load / conflict states.
+  stateLoading: 'Loading configuration…',
+  stateError: 'Configuration could not be loaded.',
+  conflictBody:
+    'Configuration changed while this draft was open. Discard the stale draft before saving against the latest revision.',
+  conflictAction: 'Discard draft & reload',
+  divergedBody:
+    'The config file changed outside AgentOS. Writes are blocked until the gateway reloads or restarts with that file.',
+  divergedAction: 'Refresh state',
+
+  // Form surface.
+  tabsLandmark: 'Config sections',
+  tabCore: 'Core',
+  tabAi: 'AI & Agents',
+  tabMemory: 'Memory',
+  tabCapabilities: 'Capabilities',
+  tabConnections: 'Connections',
+  tabSafety: 'Safety',
+  tabRuntime: 'Runtime',
+  tabOther: 'Other',
+  tabSearchResults: 'Search results',
+  searchLabel: 'Search config',
+  searchPlaceholder: 'Search keys & values…',
+  emptyNoMatches: 'No matching fields',
+  groupGeneral: 'General',
+  groupFields_one: '{count} field',
+  groupFields_other: '{count} fields',
+  fieldEnabled: 'Enabled',
+  fieldDisabled: 'Disabled',
+  fieldEdit: 'Edit',
+  fieldInvalidJson: 'Invalid JSON',
+  fieldHelpLabel: 'Help for {key}',
+  fieldSecretShow: 'Show {key}',
+  fieldSecretHide: 'Hide {key}',
+  yamlEditorLabel: 'YAML editor',
+
+  // Sticky save bar.
+  pendingLandmark: 'Pending changes',
+  // Not a tPlural pair: the sticky bar renders the number in its own <strong>
+  // node (pinned by ConfigPage.test.tsx), and the catalog convention requires
+  // {count} inside every _one/_other value. So the noun is selected directly.
+  pendingChangeWord: 'change pending',
+  pendingChangesWord: 'changes pending',
+  diffHide: 'Hide diff',
+  diffShow: 'View diff',
+  discard: 'Discard',
+  diffYamlKey: 'YAML',
+  diffYamlOld: 'loaded config',
+  diffYamlNew: 'unsaved draft',
+  diffInvalidOld: 'loaded JSON',
+  diffInvalidNew: 'Fix invalid JSON',
+
+  // Toasts.
+  toastLoadFailed: 'Failed to load config: {message}',
+  toastSavedRestart: 'Config saved. Gateway restart required for the change to take effect.',
+  toastSaved: 'Config saved',
+  toastSaveFailed: 'Save failed: {message}',
+  toastAppliedRestart: 'Config applied. Gateway restart required for the change to take effect.',
+  toastApplied: 'Config applied',
+  toastApplyFailed: 'Apply failed: {message}',
+  toastWriteBlocked:
+    'The config file changed outside AgentOS. Restart or reload the gateway first.',
+  toastConflict: 'Configuration changed in another workspace. Discard and reload before saving.',
+  toastPendingForm: 'Save or discard the pending Form changes before applying YAML.',
+  toastPendingYaml: 'Save or discard the pending YAML change before saving Form fields.',
+  toastFixJson: 'Fix invalid JSON before saving',
+  toastNoChanges: 'No changes to save',
+  toastReloadBlocked: 'Discard pending changes before reloading the configuration.',
+
+  // Per-field help (config.js:32-125), keyed by config path.
+  helpHost:
+    'Network interface the gateway binds to. Read-only here — set via agentos gateway run --bind (CLI only). Defaults to 127.0.0.1 (loopback); 0.0.0.0 exposes on all interfaces and requires auth.',
+  helpPort:
+    'TCP port for the ASGI gateway. Read-only here — set via agentos gateway run --port (CLI only). Default 18791; the WebSocket and REST endpoints share it.',
+  helpDebug:
+    'Security-sensitive developer mode. Starlette debug, uvicorn log level, and some startup wiring need a gateway restart. Keep it off in shared deployments.',
+  helpDiagnosticsEnabled:
+    'Default standard diagnostics mode at gateway startup. Raw turn-call capture stays off unless AGENTOS_TURN_CALL_LOG=1 or the running gateway is switched with agentos diagnostics on --raw.',
+  helpLogFileEnabled:
+    'Writes gateway debug.log records for operator troubleshooting. This is separate from raw turn-call capture, which requires AGENTOS_TURN_CALL_LOG=1 or agentos diagnostics on --raw.',
+  helpLogLevel: 'Minimum gateway file log level. AGENTOS_LOG_LEVEL can override this at runtime.',
+  helpLogFileMaxBytes:
+    'Maximum debug.log size before rotation. Set to 0 to disable rotation in the stdlib handler.',
+  helpLogFileBackupCount: 'Number of rotated debug.log backups to retain.',
+  helpAgentTokenSavingToolResultProjectionMaxInlineChars:
+    'Maximum inline size for canonical tokenjuice tool-result projections. Raw tool output is transient and is not stored.',
+  helpAgentosRouterEnabled:
+    'Turn the auto tier router on or off. When off, every request uses the default model regardless of complexity.',
+  helpAgentosRouterRolloutPhase:
+    'Rollout stage for new router model versions. Higher phases enable more aggressive routing decisions.',
+  helpAgentosRouterStrategy:
+    '"pilot-v1" (default) classifies each turn with the local Pilot ML router (MiniLM+ONNX bundle, no LLM call); "llm_judge" classifies via a small LLM call instead. The pilot bundle ships in the wheel and degrades to the default tier if absent.',
+  helpAgentosRouterJudgeModel:
+    'Explicit LLM-judge model. Leave unset for Auto: the judge follows the tier profile’s cheapest text tier (c0 first), so profile switches auto-update it.',
+  helpAgentosRouterJudgeProvider:
+    'Optional provider for judge_model. Must match llm.provider — tier entries carry no credentials, so a cross-provider judge has no credential source.',
+  helpAgentosRouterJudgeBaseUrl:
+    'Local OpenAI-compatible judge endpoint (Ollama / LM Studio / llama.cpp / vLLM). Only takes effect when judge_model is set; the judge client is then built against this base URL with judge_api_key, bypassing the provider-match constraint (a local endpoint needs no cloud credentials).',
+  helpAgentosRouterJudgeApiKey:
+    'API key for the local judge endpoint (judge_base_url). Optional — local endpoints usually accept any token; a placeholder is used when unset. Redacted in logs.',
+  helpAgentosRouterJudgeInputMaxChars:
+    'Character budget for the message body sent to the judge (head/tail truncation with an elision marker). Signals are computed before truncation.',
+  helpAgentosRouterJudgeShortCircuitEnabled:
+    'Skip the judge call for trivial short greetings/acknowledgements (exact allowlist match) and route them to the cheapest tier directly.',
+  helpAgentosRouterJudgeShortCircuitAllowlist:
+    'Extra exact greeting/ack phrases (case-insensitive) that skip the judge. These are ADDED to the built-in default allowlist (en/vi/zh), not a replacement — leave empty to use just the defaults.',
+  helpMemoryEmbedding:
+    'Long-term memory embedding provider. Auto mode prefers a downloaded EmbeddingGemma model, then the bundled BGE ONNX, then a configured remote key, then FTS-only. Run `agentos memory embedding-download` to fetch the EmbeddingGemma upgrade; switching the local model triggers a full reindex. Remote embeddings require explicit memory embedding configuration.',
+  helpMemoryEmbeddingProvider:
+    'Canonical memory embedding provider: auto, none, local, openai/openai-compatible, or ollama. This is independent from the chat LLM provider.',
+  helpMemoryEmbeddingRemoteApiKey:
+    'API key for the memory embedding endpoint. This does not inherit the chat/OpenRouter key in auto mode.',
+  helpMemoryEmbeddingRemoteBaseUrl:
+    'OpenAI-compatible API root for memory indexing, for example https://api.openai.com/v1. The provider appends /embeddings.',
+  helpMemoryEmbeddingLocalModel:
+    'Optional local embedding model id to pin. Leave empty for auto (a downloaded EmbeddingGemma export when present, otherwise the bundled BGE-small). Set "google/embeddinggemma-300m" or "BAAI/bge-small-zh-v1.5" to force one. Changing this triggers a full reindex.',
+  helpMemoryEmbeddingLocalOnnxDir:
+    'Optional ONNX directory for a custom local embedding model. Leave empty to use the resolved model’s export (downloaded EmbeddingGemma or bundled BGE-small).',
+  helpMemoryRetrievalMode:
+    'Memory retrieval mode. "hybrid" uses vectors when an embedding provider is available; "fts_only" disables vectors.',
+  helpMemoryCuratedMemoryCharLimit:
+    'Character budget for MEMORY.md, the agent’s curated notes file. When full, the agent consolidates existing entries via the memory tool instead of growing the file further.',
+  helpMemoryCuratedUserCharLimit: 'Character budget for USER.md, the curated user profile file.',
+  helpMemoryInjectLimit:
+    'Cap on the combined curated MEMORY.md + USER.md blocks injected into every system prompt. Keep it above the sum of the two char-limit budgets plus roughly 310 chars of header/separator overhead, or the user-profile block is dropped whole to stay under budget.',
+  helpMemoryProviderName:
+    'Optional external memory provider layered on top of built-in memory. Empty (the default) keeps built-in memory only; "mem0" enables the mem0 provider (prompt recall block, fenced recall, per-turn sync, write mirror). The provider is built once at boot, so changing this requires a gateway restart. mem0 needs the extra: pip install "use-agent-os[mem0]".',
+  helpMemoryProviderMem0LlmProvider:
+    'Backend the mem0 provider uses for its extraction/summarization LLM. Defaults to "ollama" for a fully local stack. Requires a gateway restart.',
+  helpMemoryProviderMem0LlmModel:
+    'mem0 extraction/summarization model. Default "qwen3:4b" (a small local Ollama model). Requires a gateway restart.',
+  helpMemoryProviderMem0LlmBaseUrl:
+    'Base URL for the mem0 LLM backend. Defaults to the local Ollama endpoint http://localhost:11434. Requires a gateway restart.',
+  helpMemoryProviderMem0EmbedderProvider:
+    'Backend for mem0 embeddings. Defaults to "ollama" so embeddings stay local. Requires a gateway restart.',
+  helpMemoryProviderMem0EmbedderModel:
+    'mem0 embedding model. Default "embeddinggemma" (local via Ollama). Requires a gateway restart.',
+  helpMemoryProviderMem0EmbedderBaseUrl:
+    'Base URL for the mem0 embedder backend. Defaults to the local Ollama endpoint http://localhost:11434. Requires a gateway restart.',
+  helpMemoryProviderMem0VectorStorePath:
+    'On-disk directory for the mem0 vector store. Empty resolves to <agent state dir>/mem0 at boot, keeping all data local. Requires a gateway restart.',
+  helpSandboxSandbox:
+    'Runtime sandbox switch. The out-of-box posture keeps this false; use agentos sandbox on|bypass|full to change sandbox and permission defaults together.',
+  helpSandboxSecurityGrading:
+    'Risk grading and approval gate for tool actions. Keep this paired with sandbox.sandbox unless using the sandbox CLI posture commands.',
+  helpPermissionsDefaultMode:
+    'Default interactive Control permission mode: bypass is the out-of-box local posture, off keeps sandboxed execution, on uses host execution with approvals, and full bypasses sensitive-path gates too.',
+  helpPromptCacheMode:
+    'Anthropic prompt cache control. "auto" (default) lets the provider decide; "on" forces caching; "off" disables it entirely.',
+  helpContextBudgetTokens:
+    'Soft cap on the assembled prompt size. When exceeded, the configured overflow policy kicks in (summarize, truncate, or refuse).',
+  helpContextOverflowPolicy:
+    '"auto_summarize" compacts older history via a small LLM; "hard_truncate" drops oldest turns; "refuse" rejects the turn with a stable error.',
+  helpAuthMode:
+    'Gateway auth scheme. "token" requires a static bearer token; "none" is open (loopback only); other modes per deployment.',
+  helpControlUiAllowedOrigins:
+    'Extra browser origins allowed to open the Control UI WebSocket, call the HTTP API, and send Host headers, beyond loopback (which is always allowed). Add your reverse-proxy origin here (e.g. https://agent.example.com) when serving the UI off another host; default ports 80/443 are normalized. Cross-origin requests are otherwise rejected to block cross-site WebSocket hijacking and DNS rebinding.',
+  helpNone: 'No description yet — see the docs.',
+} as const)

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,5 +1,6 @@
 import { approvals } from './approvals'
 import { common } from './common'
+import { config } from './config'
 import { env } from './env'
 import { health } from './health'
 import { logs } from './logs'
@@ -25,6 +26,7 @@ import { shell } from './shell'
 export const en = {
   approvals,
   common,
+  config,
   env,
   health,
   logs,

--- a/frontend/src/views/config/ConfigPage.tsx
+++ b/frontend/src/views/config/ConfigPage.tsx
@@ -14,6 +14,8 @@ import {
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
+import { t, tPlural } from '@/i18n'
+import '@/i18n/en/config'
 import {
   isMethodNotFoundRpcError,
   SETTINGS_SNAPSHOT_QUERY_KEY,
@@ -68,13 +70,19 @@ interface ConfigPageProps {
 
 type EditorMode = 'form' | 'yaml'
 
-const SEARCH_TAB: TabDef = { id: 'search', label: 'Search results', prefixes: [] }
+function searchTab(): TabDef {
+  return { id: 'search', label: t('config.tabSearchResults'), prefixes: [] }
+}
 
 // ── Per-field help tooltip trigger ───────────────────────────────────────────
 function HelpTrigger({ configKey }: { configKey: string }) {
   return (
     <span className="cfg-help">
-      <button type="button" className="cfg-help__btn" aria-label={`Help for ${configKey}`}>
+      <button
+        type="button"
+        className="cfg-help__btn"
+        aria-label={t('config.fieldHelpLabel', { key: configKey })}
+      >
         <HelpCircleIcon aria-hidden="true" />
       </button>
       {/* config.js:747-810 — help copy, surfaced on hover/focus (CSS-driven, no
@@ -145,7 +153,9 @@ function ConfigField({
         <span className="cfg-switch__track" aria-hidden="true">
           <span className="cfg-switch__thumb" />
         </span>
-        <span className="cfg-switch__text">{checked ? 'Enabled' : 'Disabled'}</span>
+        <span className="cfg-switch__text">
+          {checked ? t('config.fieldEnabled') : t('config.fieldDisabled')}
+        </span>
       </label>
     )
   } else if (kind === 'number') {
@@ -168,7 +178,7 @@ function ConfigField({
       <details className="cfg-object" open={dirty || invalid}>
         <summary>
           <span className="cfg-object__summary">{objectSummary(value)}</span>
-          <span className="cfg-object__action">Edit</span>
+          <span className="cfg-object__action">{t('config.fieldEdit')}</span>
         </summary>
         <textarea
           id={inputId}
@@ -180,7 +190,7 @@ function ConfigField({
           onChange={(e) => onChange(configKey, 'json', e.target.value)}
         />
         <div id={errorId} className={`cfg-json-error${invalid ? '' : ' cfg-hidden'}`}>
-          Invalid JSON
+          {t('config.fieldInvalidJson')}
         </div>
       </details>
     )
@@ -199,7 +209,11 @@ function ConfigField({
           <button
             type="button"
             className="cfg-secret-toggle"
-            aria-label={`${secretVisible ? 'Hide' : 'Show'} ${configKey}`}
+            aria-label={
+              secretVisible
+                ? t('config.fieldSecretHide', { key: configKey })
+                : t('config.fieldSecretShow', { key: configKey })
+            }
             aria-pressed={secretVisible}
             onClick={() => setSecretVisible((visible) => !visible)}
           >
@@ -254,7 +268,7 @@ function FormTab({
 }) {
   const entries = entriesForTab(config, tab, search)
   if (entries.length === 0) {
-    return <div className="cfg-empty">No matching fields</div>
+    return <div className="cfg-empty">{t('config.emptyNoMatches')}</div>
   }
   const groups = groupEntries(entries)
   return (
@@ -264,7 +278,7 @@ function FormTab({
           <header className="cfg-group__head">
             <h2 className="cfg-group__title t-label">{group.title}</h2>
             <span className="cfg-group__meta t-data">
-              {group.entries.length} {group.entries.length === 1 ? 'field' : 'fields'}
+              {tPlural('config.groupFields', group.entries.length)}
             </span>
           </header>
           <div className="cfg-group__fields">
@@ -320,13 +334,16 @@ function StickyBar({
     <div
       className="cfg-stickybar panel tone-info tone-rail"
       role="region"
-      aria-label="Pending changes"
+      aria-label={t('config.pendingLandmark')}
       aria-live="polite"
     >
       <div className="cfg-stickybar__row">
         <span className="cfg-stickybar__pulse" aria-hidden="true" />
         <span className="cfg-stickybar__count">
-          <strong>{count}</strong> <span>{count === 1 ? 'change pending' : 'changes pending'}</span>
+          <strong>{count}</strong>{' '}
+          <span>
+            {count === 1 ? t('config.pendingChangeWord') : t('config.pendingChangesWord')}
+          </span>
         </span>
         <span className="cfg-stickybar__sep" aria-hidden="true">
           ·
@@ -338,27 +355,27 @@ function StickyBar({
           aria-controls={diffId}
           onClick={onToggleDiff}
         >
-          {diffOpen ? 'Hide diff' : 'View diff'}
+          {diffOpen ? t('config.diffHide') : t('config.diffShow')}
         </button>
         <span className="cfg-stickybar__spacer" />
         <Button type="button" variant="ghost" size="sm" disabled={saving} onClick={onDiscard}>
-          Discard
+          {t('config.discard')}
         </Button>
         <Button type="button" size="sm" disabled={saveDisabled} onClick={onSave}>
           <CheckIcon />
-          <span>Save</span>
+          <span>{t('config.save')}</span>
         </Button>
       </div>
       {diffOpen ? (
         <div className="cfg-stickybar__diff" id={diffId}>
           {yamlMode ? (
             <div className="cfg-diff-row">
-              <span className="cfg-diff-row__key t-data">YAML</span>
-              <span className="cfg-diff-row__old">loaded config</span>
+              <span className="cfg-diff-row__key t-data">{t('config.diffYamlKey')}</span>
+              <span className="cfg-diff-row__old">{t('config.diffYamlOld')}</span>
               <span className="cfg-diff-row__arrow" aria-hidden="true">
                 {'->'}
               </span>
-              <span className="cfg-diff-row__new">unsaved draft</span>
+              <span className="cfg-diff-row__new">{t('config.diffYamlNew')}</span>
             </div>
           ) : (
             <>
@@ -377,11 +394,11 @@ function StickyBar({
               {Object.keys(invalid).map((key) => (
                 <div className="cfg-diff-row" key={key}>
                   <span className="cfg-diff-row__key t-data">{key}</span>
-                  <span className="cfg-diff-row__old">loaded JSON</span>
+                  <span className="cfg-diff-row__old">{t('config.diffInvalidOld')}</span>
                   <span className="cfg-diff-row__arrow" aria-hidden="true">
                     {'->'}
                   </span>
-                  <span className="cfg-diff-row__new">Fix invalid JSON</span>
+                  <span className="cfg-diff-row__new">{t('config.diffInvalidNew')}</span>
                 </div>
               ))}
             </>
@@ -426,7 +443,7 @@ export function ConfigPage({
   const [yamlDraft, setYamlDraft] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!embedded) document.title = 'Config - AgentOS Control'
+    if (!embedded) document.title = t('config.documentTitle')
   }, [embedded])
 
   const configQuery = useQuery<ConfigEditorSnapshot>({
@@ -460,7 +477,7 @@ export function ConfigPage({
     if (!usesExternalSnapshot && configQuery.isError) {
       const err = configQuery.error
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to load config: ' + message, { id: 'config-load-err' })
+      toast.error(t('config.toastLoadFailed', { message }), { id: 'config-load-err' })
     }
   }, [usesExternalSnapshot, configQuery.isError, configQuery.error])
 
@@ -595,11 +612,9 @@ export function ConfigPage({
       rpc.call<SaveResult>('config.patch', payload),
     onSuccess: (res) => {
       if (res?.restartRequired) {
-        toast.info('Config saved. Gateway restart required for the change to take effect.', {
-          id: 'config-save',
-        })
+        toast.info(t('config.toastSavedRestart'), { id: 'config-save' })
       } else {
-        toast.success('Config saved', { id: 'config-save' })
+        toast.success(t('config.toastSaved'), { id: 'config-save' })
       }
       clearEditorDraft()
       void queryClient.invalidateQueries({ queryKey: ['config'] })
@@ -607,7 +622,7 @@ export function ConfigPage({
     },
     onError: (err) => {
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Save failed: ' + message, { id: 'config-save-err' })
+      toast.error(t('config.toastSaveFailed', { message }), { id: 'config-save-err' })
     },
   })
 
@@ -619,11 +634,9 @@ export function ConfigPage({
     }) => rpc.call<SaveResult>('config.apply', payload),
     onSuccess: (res) => {
       if (res?.restartRequired) {
-        toast.info('Config applied. Gateway restart required for the change to take effect.', {
-          id: 'config-apply',
-        })
+        toast.info(t('config.toastAppliedRestart'), { id: 'config-apply' })
       } else {
-        toast.success('Config applied', { id: 'config-apply' })
+        toast.success(t('config.toastApplied'), { id: 'config-apply' })
       }
       clearEditorDraft()
       void queryClient.invalidateQueries({ queryKey: ['config'] })
@@ -631,7 +644,7 @@ export function ConfigPage({
     },
     onError: (err) => {
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Apply failed: ' + message, { id: 'config-apply-err' })
+      toast.error(t('config.toastApplyFailed', { message }), { id: 'config-apply-err' })
     },
   })
 
@@ -655,27 +668,21 @@ export function ConfigPage({
   // with the invalid-JSON gate + the no-op short-circuit.
   const onSave = useCallback(() => {
     if (writeBlocked) {
-      toast.error('The config file changed outside AgentOS. Restart or reload the gateway first.', {
-        id: 'config-save',
-      })
+      toast.error(t('config.toastWriteBlocked'), { id: 'config-save' })
       return
     }
     if (snapshotConflict) {
-      toast.error('Configuration changed in another workspace. Discard and reload before saving.', {
-        id: 'config-save',
-      })
+      toast.error(t('config.toastConflict'), { id: 'config-save' })
       return
     }
     if (mode === 'yaml') {
       if (formPendingKeys > 0) {
-        toast.warning('Save or discard the pending Form changes before applying YAML.', {
-          id: 'config-save',
-        })
+        toast.warning(t('config.toastPendingForm'), { id: 'config-save' })
         return
       }
       const text = yamlDraft ?? baselineYaml
       if (!yamlDirty) {
-        toast.info('No changes to save', { id: 'config-save' })
+        toast.info(t('config.toastNoChanges'), { id: 'config-save' })
         return
       }
       applyMutation.mutate({
@@ -685,18 +692,16 @@ export function ConfigPage({
       return
     }
     if (yamlDirty) {
-      toast.warning('Save or discard the pending YAML change before saving Form fields.', {
-        id: 'config-save',
-      })
+      toast.warning(t('config.toastPendingYaml'), { id: 'config-save' })
       return
     }
     if (invalidJson) {
-      toast.error('Fix invalid JSON before saving', { id: 'config-save' })
+      toast.error(t('config.toastFixJson'), { id: 'config-save' })
       return
     }
     const payload = buildPatchPayload(dirty)
     if (Object.keys(payload.patches).length === 0) {
-      toast.info('No changes to save', { id: 'config-save' })
+      toast.info(t('config.toastNoChanges'), { id: 'config-save' })
       return
     }
     patchMutation.mutate({
@@ -734,9 +739,7 @@ export function ConfigPage({
 
   const onReload = () => {
     if (barVisible) {
-      toast.warning('Discard pending changes before reloading the configuration.', {
-        id: 'config-reload',
-      })
+      toast.warning(t('config.toastReloadBlocked'), { id: 'config-reload' })
       return
     }
     onDiscardOrReload()
@@ -758,50 +761,51 @@ export function ConfigPage({
 
   const onTabKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const tabs = TABS
       let nextIndex: number | null = null
-      if (event.key === 'ArrowRight') nextIndex = (index + 1) % TABS.length
-      if (event.key === 'ArrowLeft') nextIndex = (index - 1 + TABS.length) % TABS.length
+      if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length
+      if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length
       if (event.key === 'Home') nextIndex = 0
-      if (event.key === 'End') nextIndex = TABS.length - 1
+      if (event.key === 'End') nextIndex = tabs.length - 1
       if (nextIndex === null) return
       event.preventDefault()
-      const next = TABS[nextIndex]
+      const next = tabs[nextIndex]
       if (!next) return
       setActiveTab(next.id)
-      const tabs =
+      const buttons =
         event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
-      tabs?.[nextIndex]?.focus()
+      buttons?.[nextIndex]?.focus()
     },
     [],
   )
 
-  const visibleTab = search.trim() ? SEARCH_TAB : TABS.find((tab) => tab.id === activeTab)
+  const visibleTab = search.trim() ? searchTab() : TABS.find((tab) => tab.id === activeTab)
 
   return (
     <div className={`cfg-stage${embedded ? ' cfg-stage--embedded' : ''}`}>
       <header className={`cfg-stage__header${embedded ? ' cfg-stage__header--embedded' : ''}`}>
         <div className="cfg-stage__title-block">
-          <span className="t-label">{embedded ? 'Advanced workspace' : 'Control · Config'}</span>
+          <span className="t-label">
+            {embedded ? t('config.embeddedEyebrow') : t('config.eyebrow')}
+          </span>
           {embedded ? (
-            <h2 className="cfg-stage__embedded-title">Configuration editor</h2>
+            <h2 className="cfg-stage__embedded-title">{t('config.embeddedTitle')}</h2>
           ) : (
-            <h1 className="t-display">Config</h1>
+            <h1 className="t-display">{t('config.title')}</h1>
           )}
           <p className="cfg-stage__subtitle">
-            {embedded
-              ? 'Edit the complete runtime surface with a reviewed diff before it is applied.'
-              : 'Advanced gateway configuration. Use guided setup for provider, router, channels, and extras.'}
+            {embedded ? t('config.embeddedSubtitle') : t('config.subtitle')}
           </p>
         </div>
         <div className="cfg-stage__actions">
-          <div className="cfg-mode-toggle" role="group" aria-label="Editor mode">
+          <div className="cfg-mode-toggle" role="group" aria-label={t('config.modeLandmark')}>
             <button
               type="button"
               className={`cfg-mode-btn${mode === 'form' ? ' is-active' : ''}`}
               aria-pressed={mode === 'form'}
               onClick={() => setMode('form')}
             >
-              Form
+              {t('config.modeForm')}
             </button>
             <button
               type="button"
@@ -809,77 +813,71 @@ export function ConfigPage({
               aria-pressed={mode === 'yaml'}
               onClick={() => setMode('yaml')}
             >
-              YAML
+              {t('config.modeYaml')}
             </button>
           </div>
           {!embedded ? (
             <Button
               variant="outline"
               className="text-xs uppercase tracking-[0.14em]"
-              title="Open guided setup"
+              title={t('config.guidedTitle')}
               onClick={() => navigate('/setup')}
             >
               <SlidersHorizontalIcon />
-              <span>Guided setup</span>
+              <span>{t('config.guided')}</span>
             </Button>
           ) : null}
           <Button
             variant="outline"
             className="text-xs uppercase tracking-[0.14em]"
-            title="Reload config"
+            title={t('config.reloadTitle')}
             onClick={onReload}
           >
             <RefreshCwIcon />
-            <span>Reload</span>
+            <span>{t('config.reload')}</span>
           </Button>
           <Button
             className="text-xs uppercase tracking-[0.14em]"
-            title="Save config"
-            aria-label="Save config"
+            title={t('config.saveTitle')}
+            aria-label={t('config.saveTitle')}
             disabled={saving || snapshotConflict || writeBlocked || !activeEditorCanSave}
             onClick={onSave}
           >
             <CheckIcon />
-            <span>Save</span>
+            <span>{t('config.save')}</span>
           </Button>
         </div>
       </header>
 
       {configLoading ? (
         <div className="cfg-state" role="status">
-          Loading configuration…
+          {t('config.stateLoading')}
         </div>
       ) : null}
 
       {configError ? (
         <div className="cfg-state cfg-state--error" role="alert">
-          <span>Configuration could not be loaded.</span>
+          <span>{t('config.stateError')}</span>
           <Button type="button" size="sm" variant="outline" onClick={retryConfig}>
-            Retry
+            {t('common.retry')}
           </Button>
         </div>
       ) : null}
 
       {snapshotConflict ? (
         <div className="cfg-state cfg-state--error" role="alert">
-          <span>
-            Configuration changed while this draft was open. Discard the stale draft before saving
-            against the latest revision.
-          </span>
+          <span>{t('config.conflictBody')}</span>
           <Button type="button" size="sm" variant="outline" onClick={onDiscardOrReload}>
-            Discard draft &amp; reload
+            {t('config.conflictAction')}
           </Button>
         </div>
       ) : null}
 
       {diskDiverged && !embedded ? (
         <div className="cfg-state cfg-state--error" role="alert">
-          <span>
-            The config file changed outside AgentOS. Writes are blocked until the gateway reloads or
-            restarts with that file.
-          </span>
+          <span>{t('config.divergedBody')}</span>
           <Button type="button" size="sm" variant="outline" onClick={onDiscardOrReload}>
-            Refresh state
+            {t('config.divergedAction')}
           </Button>
         </div>
       ) : null}
@@ -887,7 +885,7 @@ export function ConfigPage({
       {configReady && mode === 'form' ? (
         <div className="cfg-form">
           <div className="cfg-toolbar">
-            <div className="cfg-tabs" role="tablist" aria-label="Config sections">
+            <div className="cfg-tabs" role="tablist" aria-label={t('config.tabsLandmark')}>
               {TABS.map((tab, index) => (
                 <button
                   key={tab.id}
@@ -908,8 +906,8 @@ export function ConfigPage({
               <input
                 className="cfg-search__input"
                 type="search"
-                aria-label="Search config"
-                placeholder="Search keys & values…"
+                aria-label={t('config.searchLabel')}
+                placeholder={t('config.searchPlaceholder')}
                 autoComplete="off"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
@@ -937,7 +935,7 @@ export function ConfigPage({
         <div className="cfg-yaml">
           <textarea
             className="cfg-input cfg-yaml__area"
-            aria-label="YAML editor"
+            aria-label={t('config.yamlEditorLabel')}
             spellCheck={false}
             value={yamlDraft ?? baselineYaml}
             onChange={(e) => onYamlChange(e.target.value)}

--- a/frontend/src/views/config/logic.ts
+++ b/frontend/src/views/config/logic.ts
@@ -7,6 +7,9 @@
 // dirty/no-op diff (the core of the sticky bar + save gating), value parsing +
 // JSON validation, YAML serialisation and the diff/summary formatting.
 
+import { t } from '@/i18n'
+import '@/i18n/en/config'
+
 /** The raw config object returned by config.get (a nested JSON tree). */
 export type ConfigData = Record<string, unknown>
 
@@ -24,10 +27,14 @@ export interface TabDef {
 // that matching contract, but classifies the complete GatewayConfig surface so
 // newly added runtime/safety/capability fields cannot silently disappear from
 // Form mode. `other` is a forward-compatible catch-all for future top-level keys.
+// `label` is a getter: a tab table is a module constant, so a label resolved
+// here would freeze at module-evaluation time and keep the boot locale (#258).
 export const TABS: readonly TabDef[] = [
   {
     id: 'core',
-    label: 'Core',
+    get label() {
+      return t('config.tabCore')
+    },
     prefixes: [
       'general',
       'host',
@@ -45,7 +52,9 @@ export const TABS: readonly TabDef[] = [
   },
   {
     id: 'ai',
-    label: 'AI & Agents',
+    get label() {
+      return t('config.tabAi')
+    },
     prefixes: [
       'provider',
       'model',
@@ -75,15 +84,25 @@ export const TABS: readonly TabDef[] = [
       'subagents',
     ],
   },
-  { id: 'memory', label: 'Memory', prefixes: ['memory'] },
+  {
+    id: 'memory',
+    get label() {
+      return t('config.tabMemory')
+    },
+    prefixes: ['memory'],
+  },
   {
     id: 'capabilities',
-    label: 'Capabilities',
+    get label() {
+      return t('config.tabCapabilities')
+    },
     prefixes: ['tools', 'skills', 'attachments', 'search', 'image_generation', 'audio', 'mcp'],
   },
   {
     id: 'connections',
-    label: 'Connections',
+    get label() {
+      return t('config.tabConnections')
+    },
     prefixes: [
       'channel',
       'channels',
@@ -97,12 +116,16 @@ export const TABS: readonly TabDef[] = [
   },
   {
     id: 'safety',
-    label: 'Safety',
+    get label() {
+      return t('config.tabSafety')
+    },
     prefixes: ['auth', 'cors', 'tls', 'permissions', 'safety', 'sandbox', 'rate_limit'],
   },
   {
     id: 'runtime',
-    label: 'Runtime',
+    get label() {
+      return t('config.tabRuntime')
+    },
     prefixes: [
       'task_runtime',
       'log',
@@ -115,103 +138,78 @@ export const TABS: readonly TabDef[] = [
       'scheduler',
     ],
   },
-  { id: 'other', label: 'Other', prefixes: [] },
+  {
+    id: 'other',
+    get label() {
+      return t('config.tabOther')
+    },
+    prefixes: [],
+  },
 ]
 
 // config.js:32-125 — per-field help, keyed by config path. Falls back to a
 // generic message (config.js:127-130).
-const HELP: Record<string, string> = {
-  host: 'Network interface the gateway binds to. Read-only here — set via agentos gateway run --bind (CLI only). Defaults to 127.0.0.1 (loopback); 0.0.0.0 exposes on all interfaces and requires auth.',
-  port: 'TCP port for the ASGI gateway. Read-only here — set via agentos gateway run --port (CLI only). Default 18791; the WebSocket and REST endpoints share it.',
-  debug:
-    'Security-sensitive developer mode. Starlette debug, uvicorn log level, and some startup wiring need a gateway restart. Keep it off in shared deployments.',
-  diagnostics_enabled:
-    'Default standard diagnostics mode at gateway startup. Raw turn-call capture stays off unless AGENTOS_TURN_CALL_LOG=1 or the running gateway is switched with agentos diagnostics on --raw.',
-  log_file_enabled:
-    'Writes gateway debug.log records for operator troubleshooting. This is separate from raw turn-call capture, which requires AGENTOS_TURN_CALL_LOG=1 or agentos diagnostics on --raw.',
-  log_level: 'Minimum gateway file log level. AGENTOS_LOG_LEVEL can override this at runtime.',
-  log_file_max_bytes:
-    'Maximum debug.log size before rotation. Set to 0 to disable rotation in the stdlib handler.',
-  log_file_backup_count: 'Number of rotated debug.log backups to retain.',
-  'agent_token_saving.tool_result_projection_max_inline_chars':
-    'Maximum inline size for canonical tokenjuice tool-result projections. Raw tool output is transient and is not stored.',
-  'agentos_router.enabled':
-    'Turn the auto tier router on or off. When off, every request uses the default model regardless of complexity.',
-  'agentos_router.rollout_phase':
-    'Rollout stage for new router model versions. Higher phases enable more aggressive routing decisions.',
-  'agentos_router.strategy':
-    '"pilot-v1" (default) classifies each turn with the local Pilot ML router (MiniLM+ONNX bundle, no LLM call); "llm_judge" classifies via a small LLM call instead. The pilot bundle ships in the wheel and degrades to the default tier if absent.',
-  'agentos_router.judge_model':
-    'Explicit LLM-judge model. Leave unset for Auto: the judge follows the tier profile’s cheapest text tier (c0 first), so profile switches auto-update it.',
-  'agentos_router.judge_provider':
-    'Optional provider for judge_model. Must match llm.provider — tier entries carry no credentials, so a cross-provider judge has no credential source.',
-  'agentos_router.judge_base_url':
-    'Local OpenAI-compatible judge endpoint (Ollama / LM Studio / llama.cpp / vLLM). Only takes effect when judge_model is set; the judge client is then built against this base URL with judge_api_key, bypassing the provider-match constraint (a local endpoint needs no cloud credentials).',
-  'agentos_router.judge_api_key':
-    'API key for the local judge endpoint (judge_base_url). Optional — local endpoints usually accept any token; a placeholder is used when unset. Redacted in logs.',
-  'agentos_router.judge_input_max_chars':
-    'Character budget for the message body sent to the judge (head/tail truncation with an elision marker). Signals are computed before truncation.',
-  'agentos_router.judge_short_circuit_enabled':
-    'Skip the judge call for trivial short greetings/acknowledgements (exact allowlist match) and route them to the cheapest tier directly.',
-  'agentos_router.judge_short_circuit_allowlist':
-    'Extra exact greeting/ack phrases (case-insensitive) that skip the judge. These are ADDED to the built-in default allowlist (en/vi/zh), not a replacement — leave empty to use just the defaults.',
-  'memory.embedding':
-    'Long-term memory embedding provider. Auto mode prefers a downloaded EmbeddingGemma model, then the bundled BGE ONNX, then a configured remote key, then FTS-only. Run `agentos memory embedding-download` to fetch the EmbeddingGemma upgrade; switching the local model triggers a full reindex. Remote embeddings require explicit memory embedding configuration.',
-  'memory.embedding.provider':
-    'Canonical memory embedding provider: auto, none, local, openai/openai-compatible, or ollama. This is independent from the chat LLM provider.',
-  'memory.embedding.remote.api_key':
-    'API key for the memory embedding endpoint. This does not inherit the chat/OpenRouter key in auto mode.',
-  'memory.embedding.remote.base_url':
-    'OpenAI-compatible API root for memory indexing, for example https://api.openai.com/v1. The provider appends /embeddings.',
-  'memory.embedding.local.model':
-    'Optional local embedding model id to pin. Leave empty for auto (a downloaded EmbeddingGemma export when present, otherwise the bundled BGE-small). Set "google/embeddinggemma-300m" or "BAAI/bge-small-zh-v1.5" to force one. Changing this triggers a full reindex.',
-  'memory.embedding.local.onnx_dir':
-    'Optional ONNX directory for a custom local embedding model. Leave empty to use the resolved model’s export (downloaded EmbeddingGemma or bundled BGE-small).',
-  'memory.retrieval_mode':
-    'Memory retrieval mode. "hybrid" uses vectors when an embedding provider is available; "fts_only" disables vectors.',
-  'memory.curated_memory_char_limit':
-    'Character budget for MEMORY.md, the agent’s curated notes file. When full, the agent consolidates existing entries via the memory tool instead of growing the file further.',
-  'memory.curated_user_char_limit': 'Character budget for USER.md, the curated user profile file.',
-  'memory.inject_limit':
-    'Cap on the combined curated MEMORY.md + USER.md blocks injected into every system prompt. Keep it above the sum of the two char-limit budgets plus roughly 310 chars of header/separator overhead, or the user-profile block is dropped whole to stay under budget.',
-  'memory.provider.name':
-    'Optional external memory provider layered on top of built-in memory. Empty (the default) keeps built-in memory only; "mem0" enables the mem0 provider (prompt recall block, fenced recall, per-turn sync, write mirror). The provider is built once at boot, so changing this requires a gateway restart. mem0 needs the extra: pip install "use-agent-os[mem0]".',
-  'memory.provider.mem0.llm_provider':
-    'Backend the mem0 provider uses for its extraction/summarization LLM. Defaults to "ollama" for a fully local stack. Requires a gateway restart.',
-  'memory.provider.mem0.llm_model':
-    'mem0 extraction/summarization model. Default "qwen3:4b" (a small local Ollama model). Requires a gateway restart.',
-  'memory.provider.mem0.llm_base_url':
-    'Base URL for the mem0 LLM backend. Defaults to the local Ollama endpoint http://localhost:11434. Requires a gateway restart.',
-  'memory.provider.mem0.embedder_provider':
-    'Backend for mem0 embeddings. Defaults to "ollama" so embeddings stay local. Requires a gateway restart.',
-  'memory.provider.mem0.embedder_model':
-    'mem0 embedding model. Default "embeddinggemma" (local via Ollama). Requires a gateway restart.',
-  'memory.provider.mem0.embedder_base_url':
-    'Base URL for the mem0 embedder backend. Defaults to the local Ollama endpoint http://localhost:11434. Requires a gateway restart.',
-  'memory.provider.mem0.vector_store_path':
-    'On-disk directory for the mem0 vector store. Empty resolves to <agent state dir>/mem0 at boot, keeping all data local. Requires a gateway restart.',
-  'sandbox.sandbox':
-    'Runtime sandbox switch. The out-of-box posture keeps this false; use agentos sandbox on|bypass|full to change sandbox and permission defaults together.',
-  'sandbox.security_grading':
-    'Risk grading and approval gate for tool actions. Keep this paired with sandbox.sandbox unless using the sandbox CLI posture commands.',
-  'permissions.default_mode':
-    'Default interactive Control permission mode: bypass is the out-of-box local posture, off keeps sandboxed execution, on uses host execution with approvals, and full bypasses sensitive-path gates too.',
-  'prompt_cache.mode':
-    'Anthropic prompt cache control. "auto" (default) lets the provider decide; "on" forces caching; "off" disables it entirely.',
-  context_budget_tokens:
-    'Soft cap on the assembled prompt size. When exceeded, the configured overflow policy kicks in (summarize, truncate, or refuse).',
-  context_overflow_policy:
-    '"auto_summarize" compacts older history via a small LLM; "hard_truncate" drops oldest turns; "refuse" rejects the turn with a stable error.',
-  auth_mode:
-    'Gateway auth scheme. "token" requires a static bearer token; "none" is open (loopback only); other modes per deployment.',
-  'control_ui.allowed_origins':
-    'Extra browser origins allowed to open the Control UI WebSocket, call the HTTP API, and send Host headers, beyond loopback (which is always allowed). Add your reverse-proxy origin here (e.g. https://agent.example.com) when serving the UI off another host; default ports 80/443 are normalized. Cross-origin requests are otherwise rejected to block cross-site WebSocket hijacking and DNS rebinding.',
+function helpMap(): Record<string, string> {
+  return {
+    host: t('config.helpHost'),
+    port: t('config.helpPort'),
+    debug: t('config.helpDebug'),
+    diagnostics_enabled: t('config.helpDiagnosticsEnabled'),
+    log_file_enabled: t('config.helpLogFileEnabled'),
+    log_level: t('config.helpLogLevel'),
+    log_file_max_bytes: t('config.helpLogFileMaxBytes'),
+    log_file_backup_count: t('config.helpLogFileBackupCount'),
+    'agent_token_saving.tool_result_projection_max_inline_chars': t(
+      'config.helpAgentTokenSavingToolResultProjectionMaxInlineChars',
+    ),
+    'agentos_router.enabled': t('config.helpAgentosRouterEnabled'),
+    'agentos_router.rollout_phase': t('config.helpAgentosRouterRolloutPhase'),
+    'agentos_router.strategy': t('config.helpAgentosRouterStrategy'),
+    'agentos_router.judge_model': t('config.helpAgentosRouterJudgeModel'),
+    'agentos_router.judge_provider': t('config.helpAgentosRouterJudgeProvider'),
+    'agentos_router.judge_base_url': t('config.helpAgentosRouterJudgeBaseUrl'),
+    'agentos_router.judge_api_key': t('config.helpAgentosRouterJudgeApiKey'),
+    'agentos_router.judge_input_max_chars': t('config.helpAgentosRouterJudgeInputMaxChars'),
+    'agentos_router.judge_short_circuit_enabled': t(
+      'config.helpAgentosRouterJudgeShortCircuitEnabled',
+    ),
+    'agentos_router.judge_short_circuit_allowlist': t(
+      'config.helpAgentosRouterJudgeShortCircuitAllowlist',
+    ),
+    'memory.embedding': t('config.helpMemoryEmbedding'),
+    'memory.embedding.provider': t('config.helpMemoryEmbeddingProvider'),
+    'memory.embedding.remote.api_key': t('config.helpMemoryEmbeddingRemoteApiKey'),
+    'memory.embedding.remote.base_url': t('config.helpMemoryEmbeddingRemoteBaseUrl'),
+    'memory.embedding.local.model': t('config.helpMemoryEmbeddingLocalModel'),
+    'memory.embedding.local.onnx_dir': t('config.helpMemoryEmbeddingLocalOnnxDir'),
+    'memory.retrieval_mode': t('config.helpMemoryRetrievalMode'),
+    'memory.curated_memory_char_limit': t('config.helpMemoryCuratedMemoryCharLimit'),
+    'memory.curated_user_char_limit': t('config.helpMemoryCuratedUserCharLimit'),
+    'memory.inject_limit': t('config.helpMemoryInjectLimit'),
+    'memory.provider.name': t('config.helpMemoryProviderName'),
+    'memory.provider.mem0.llm_provider': t('config.helpMemoryProviderMem0LlmProvider'),
+    'memory.provider.mem0.llm_model': t('config.helpMemoryProviderMem0LlmModel'),
+    'memory.provider.mem0.llm_base_url': t('config.helpMemoryProviderMem0LlmBaseUrl'),
+    'memory.provider.mem0.embedder_provider': t('config.helpMemoryProviderMem0EmbedderProvider'),
+    'memory.provider.mem0.embedder_model': t('config.helpMemoryProviderMem0EmbedderModel'),
+    'memory.provider.mem0.embedder_base_url': t('config.helpMemoryProviderMem0EmbedderBaseUrl'),
+    'memory.provider.mem0.vector_store_path': t('config.helpMemoryProviderMem0VectorStorePath'),
+    'sandbox.sandbox': t('config.helpSandboxSandbox'),
+    'sandbox.security_grading': t('config.helpSandboxSecurityGrading'),
+    'permissions.default_mode': t('config.helpPermissionsDefaultMode'),
+    'prompt_cache.mode': t('config.helpPromptCacheMode'),
+    context_budget_tokens: t('config.helpContextBudgetTokens'),
+    context_overflow_policy: t('config.helpContextOverflowPolicy'),
+    auth_mode: t('config.helpAuthMode'),
+    'control_ui.allowed_origins': t('config.helpControlUiAllowedOrigins'),
+  }
 }
 
 /** config.js:127-130 — per-field help text; generic fallback when unknown. */
 export function helpFor(key: string): string {
-  if (key in HELP) return HELP[key]!
-  return 'No description yet — see the docs.'
+  const help = helpMap()
+  if (key in help) return help[key]!
+  return t('config.helpNone')
 }
 
 // config.js:422 — max object levels to descend before falling back to a
@@ -304,7 +302,7 @@ export function groupIdForKey(k: string, v: unknown): string {
 
 /** config.js:497-500 — a group title: de-cased separators, title-cased words. */
 export function groupTitle(id: string): string {
-  if (id === 'general') return 'General'
+  if (id === 'general') return t('config.groupGeneral')
   const acronyms: Record<string, string> = {
     agentos: 'AgentOS',
     api: 'API',


### PR DESCRIPTION
Refs #257 — 2 of 11.

Extracts the config editor's copy into a new `config` namespace and adds `src/views/config/**/*.tsx` to `I18N_MIGRATED` in the same commit.

Larger than the JSX count suggests: `logic.ts` also owns the **45-entry per-field help map**, the form tab labels and the `General` group title. The help entries were lifted through the TypeScript AST rather than retyped, so they are verbatim.

**No existing test file changed.** Two structures the suite pins directly shaped the design:

- `TABS` stays an exported array — the tests read `.id` / `.prefixes` off it — so `label` becomes a **getter** instead of a resolved string. That keeps it out of module-evaluation time (#258) without changing the export or the DOM.
- The sticky bar renders its count in its own `<strong>` node, which `getByText('1')` pins. A `tPlural()` pair must carry `{count}` inside the value (`catalog.test.ts`), so using one here would either duplicate the number or collapse the node. The noun is therefore selected from two plain keys, with a comment recording why.

`HELP` becomes `helpMap()` so tooltips re-resolve per call.

## Bundle

Initial JS unchanged at **136.6 KiB gzip** / 180 KiB budget — the namespace travels in the lazy config chunk.

## Verification

`npm run check` green (tsc, eslint, prettier, 1822 tests). Rendered against a live gateway: all eight tab labels, the search placeholder, group titles, `11 fields`, the `Help for host` aria-label, a full help tooltip and the `No description yet — see the docs.` fallback all resolve.