### PR TITLE
webui: migrate the usage view onto the i18n seam

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,6 +18,7 @@ const I18N_MIGRATED = [
   'src/views/overview/**/*.tsx',
   'src/views/sessions/**/*.tsx',
   'src/views/settings/**/*.tsx',
+  'src/views/usage/**/*.tsx',
 ]
 
 // #258: t() reads the locale at call time, so calling it at module scope

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -9,6 +9,7 @@ import { overview } from './overview'
 import { settings } from './settings'
 import { sessions } from './sessions'
 import { shell } from './shell'
+import { usage } from './usage'
 
 /**
  * Every English namespace in one object.
@@ -37,4 +38,5 @@ export const en = {
   sessions,
   settings,
   shell,
+  usage,
 } as const

--- a/frontend/src/i18n/en/usage.ts
+++ b/frontend/src/i18n/en/usage.ts
@@ -1,0 +1,132 @@
+import { defineNamespace } from '../registry'
+
+export const usage = defineNamespace('usage', {
+  documentTitle: 'Usage - AgentOS Control',
+  eyebrow: 'Control · Analytics',
+  title: 'Usage',
+  subtitle: 'Tokens, cost, and per-model spend across every session.',
+  exportTitle: 'Download CSV',
+  export: 'Export CSV',
+  refresh: 'Refresh',
+  refreshBusy: 'Refreshing',
+
+  // Error state.
+  errorTitle: 'Usage data is unavailable',
+  errorFallback: 'The gateway did not return usage data.',
+  toastLoadFailed: 'Failed to load usage: {message}',
+
+  // Range picker.
+  rangeAll: 'All',
+  range7: '7d',
+  range14: '14d',
+  range30: '30d',
+  rangeLabelAll: 'All recorded activity',
+  rangeLabelDays: 'Last {days} days',
+  hiddenSessions_one: '{count} undated legacy session hidden',
+  hiddenSessions_other: '{count} undated legacy sessions hidden',
+
+  // Overview.
+  metricSpend: 'Period spend',
+  metricTokens: 'Token volume',
+  summaryLandmark: 'Usage summary',
+  billingWindow: 'Billing window',
+  dateRange: 'Date range',
+  totalCost: 'Total cost',
+  noCostSource: 'No cost source yet',
+  totalTokens: 'Total tokens',
+  dtInput: 'Input',
+  dtOutput: 'Output',
+  dtCacheRead: 'Cache read',
+  dtCacheWrite: 'Cache write',
+  sessionsLandmark: 'Sessions',
+  dtSessions: 'Sessions',
+  hintInWindow: 'in this window',
+  averageLandmark: 'Avg cost / session',
+  dtAverage: 'Average / session',
+  hintRunningAverage: 'running average',
+
+  // Chart.
+  chartTitle: 'Session footprint',
+  chartSubtitle: 'Compare the highest-consumption sessions in the selected window.',
+  chartMetric: 'Chart metric',
+  segTokens: 'Tokens',
+  segCost: 'Cost',
+  chartCaptionCost: 'Top sessions by cost',
+  chartCaptionTokens: 'Top sessions by total tokens',
+  chartCaptionWithPool: '{caption} · showing {shown} of {pool}',
+  legendInput: 'Input',
+  legendOutput: 'Output',
+  chartEmptyTitle: 'No data in the selected window.',
+  chartEmptyMsg: 'Choose a wider billing window or run a new session.',
+  barTitle: 'Open {key}',
+
+  // Model allocation.
+  modelsTitle: 'Model allocation',
+  modelsSubtitle: 'Token volume, session reach, and cost contribution by model.',
+  modelCount_one: '{count} model',
+  modelCount_other: '{count} models',
+  modelsEmpty: 'No model usage yet.',
+  modelsLandmark: 'By model breakdown',
+  shareTitle: 'Share of total cost',
+  ofSpend: 'of spend',
+  dtTokens: 'Tokens',
+  dtInputOutput: 'Input / output',
+  dtCost: 'Cost',
+
+  // Sessions table.
+  tableTitle: 'Sessions',
+  tableSubtitle: 'Auditable usage records with provider billing provenance.',
+  sessionCount_one: '{count} session',
+  sessionCount_other: '{count} sessions',
+  colSession: 'Session',
+  colModified: 'Modified',
+  colInput: 'Input',
+  colOutput: 'Output',
+  colCacheRead: 'Cache R',
+  colCacheWrite: 'Cache W',
+  colCost: 'Cost',
+  colSource: 'Source',
+  colModel: 'Model',
+  tableEmptyTitle: 'No usage data yet',
+  tableEmptyMsg: 'Run a session and token spend will appear here automatically.',
+  openChatFor: 'Open chat for {key}',
+  loadingLabel: 'Loading usage data',
+
+  // Inline per-model expansion.
+  expandEyebrow: 'Model breakdown',
+  expandModels_one: '{count} model',
+  expandModels_other: '{count} models',
+  expandTotal: '{tokens} tokens · {cost}',
+  expandProrated: 'Per-model split is estimated; total is the actual billed amount.',
+
+  // Cost-source badges (logic.ts).
+  sourceEphemeral: 'Ephemeral',
+  sourceActual: 'Actual',
+  sourceEstimated: 'Estimated',
+  sourceMixed: 'Mixed',
+  sourceUnpriced: 'Unpriced',
+  sourceNone: 'None',
+  tipEphemeral: 'Ephemeral session — cost not yet persisted',
+  tipActual: 'Actual — cost billed by the provider',
+  tipProrated: 'Total is real billed; per-model split is estimated.',
+  tipEstimated: 'Estimated — derived locally from token counts',
+  tipMixed: 'Mixed — partial billing data, rest estimated',
+  tipUnpriced: 'Unpriced — no pricing table entry for this model',
+  tipNone: 'No cost recorded',
+
+  // Composition hint. Stored lowercase rather than lowercasing the badge label
+  // at runtime — `toLowerCase()` on a translated noun is wrong in languages
+  // that capitalise them.
+  compositionActual: 'actual',
+  compositionEstimated: 'estimated',
+  compositionMixed: 'mixed',
+  compositionUnpriced: 'unpriced',
+  compositionEphemeral: 'ephemeral',
+  compositionEntry: '{label} {count}',
+
+  // Relative timestamps (logic.ts).
+  relJustNow: 'just now',
+  relMinutes: '{count}m ago',
+  relHours: '{count}h ago',
+  relDays: '{count}d ago',
+} as const)

--- a/frontend/src/views/usage/UsagePage.tsx
+++ b/frontend/src/views/usage/UsagePage.tsx
@@ -15,6 +15,8 @@ import {
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
+import { t, tPlural } from '@/i18n'
+import '@/i18n/en/usage'
 import {
   buildCsv,
   chartRows,
@@ -42,23 +44,99 @@ import {
 } from './logic'
 
 const RANGE_KEY = 'agentos-usage-range'
+// `label` is a getter throughout: these are module constants, so a resolved
+// label would freeze at module-evaluation time and keep the boot locale (#258).
 const RANGE_OPTIONS: { value: UsageRange; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: '7', label: '7d' },
-  { value: '14', label: '14d' },
-  { value: '30', label: '30d' },
+  {
+    value: 'all',
+    get label() {
+      return t('usage.rangeAll')
+    },
+  },
+  {
+    value: '7',
+    get label() {
+      return t('usage.range7')
+    },
+  },
+  {
+    value: '14',
+    get label() {
+      return t('usage.range14')
+    },
+  },
+  {
+    value: '30',
+    get label() {
+      return t('usage.range30')
+    },
+  },
 ]
 // usage.js:16-26 — the sessions table columns; a subset is sortable.
 const TABLE_COLUMNS: { key: string; label: string; sortable: boolean }[] = [
-  { key: 'session', label: 'Session', sortable: true },
-  { key: 'updated_at', label: 'Modified', sortable: true },
-  { key: 'input_tokens', label: 'Input', sortable: true },
-  { key: 'output_tokens', label: 'Output', sortable: true },
-  { key: 'cache_read_tokens', label: 'Cache R', sortable: false },
-  { key: 'cache_write_tokens', label: 'Cache W', sortable: false },
-  { key: 'cost_usd', label: 'Cost', sortable: true },
-  { key: 'cost_source', label: 'Source', sortable: false },
-  { key: 'model', label: 'Model', sortable: true },
+  {
+    key: 'session',
+    get label() {
+      return t('usage.colSession')
+    },
+    sortable: true,
+  },
+  {
+    key: 'updated_at',
+    get label() {
+      return t('usage.colModified')
+    },
+    sortable: true,
+  },
+  {
+    key: 'input_tokens',
+    get label() {
+      return t('usage.colInput')
+    },
+    sortable: true,
+  },
+  {
+    key: 'output_tokens',
+    get label() {
+      return t('usage.colOutput')
+    },
+    sortable: true,
+  },
+  {
+    key: 'cache_read_tokens',
+    get label() {
+      return t('usage.colCacheRead')
+    },
+    sortable: false,
+  },
+  {
+    key: 'cache_write_tokens',
+    get label() {
+      return t('usage.colCacheWrite')
+    },
+    sortable: false,
+  },
+  {
+    key: 'cost_usd',
+    get label() {
+      return t('usage.colCost')
+    },
+    sortable: true,
+  },
+  {
+    key: 'cost_source',
+    get label() {
+      return t('usage.colSource')
+    },
+    sortable: false,
+  },
+  {
+    key: 'model',
+    get label() {
+      return t('usage.colModel')
+    },
+    sortable: true,
+  },
 ]
 
 interface UsageStatus {
@@ -99,7 +177,7 @@ export function UsagePage() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
   useEffect(() => {
-    document.title = 'Usage - AgentOS Control'
+    document.title = t('usage.documentTitle')
   }, [])
 
   // usage.js:350-366 — usage.status {} after waitForConnection; the view derives
@@ -122,7 +200,7 @@ export function UsagePage() {
     if (usageQuery.isError) {
       const err = usageQuery.error
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to load usage: ' + message, { id: 'usage-load-err' })
+      toast.error(t('usage.toastLoadFailed', { message }), { id: 'usage-load-err' })
     }
   }, [usageQuery.isError, usageQuery.error])
 
@@ -181,15 +259,23 @@ export function UsagePage() {
     URL.revokeObjectURL(url)
   }
 
-  const sessionMeta = [`${sorted.length} session${sorted.length === 1 ? '' : 's'}`, hiddenHint]
+  const sessionMeta = [tPlural('usage.sessionCount', sorted.length), hiddenHint]
     .filter(Boolean)
     .join(' · ')
 
+  const chartCaptionBase =
+    chartMode === 'cost' ? t('usage.chartCaptionCost') : t('usage.chartCaptionTokens')
   const chartCaption =
-    (chartMode === 'cost' ? 'Top sessions by cost' : 'Top sessions by total tokens') +
-    (chart.poolSize > chart.shown ? ` · showing ${chart.shown} of ${chart.poolSize}` : '')
+    chart.poolSize > chart.shown
+      ? t('usage.chartCaptionWithPool', {
+          caption: chartCaptionBase,
+          shown: chart.shown,
+          pool: chart.poolSize,
+        })
+      : chartCaptionBase
 
-  const rangeLabel = range === 'all' ? 'All recorded activity' : `Last ${range} days`
+  const rangeLabel =
+    range === 'all' ? t('usage.rangeLabelAll') : t('usage.rangeLabelDays', { days: range })
   const errorMessage =
     usageQuery.error instanceof Error ? usageQuery.error.message : String(usageQuery.error ?? '')
 
@@ -197,11 +283,9 @@ export function UsagePage() {
     <div className="usage-stage">
       <header className="usage-stage__header">
         <div className="usage-stage__title-block">
-          <span className="t-label">Control · Analytics</span>
-          <h1 className="t-display">Usage</h1>
-          <p className="usage-stage__subtitle">
-            Tokens, cost, and per-model spend across every session.
-          </p>
+          <span className="t-label">{t('usage.eyebrow')}</span>
+          <h1 className="t-display">{t('usage.title')}</h1>
+          <p className="usage-stage__subtitle">{t('usage.subtitle')}</p>
           {hiddenHint ? (
             <small className="usage-range-notice" aria-live="polite">
               {hiddenHint}
@@ -211,21 +295,21 @@ export function UsagePage() {
         <div className="usage-stage__actions">
           <Button
             variant="outline"
-            title="Download CSV"
+            title={t('usage.exportTitle')}
             disabled={visible.length === 0}
             onClick={exportCsv}
           >
             <DownloadIcon />
-            <span>Export CSV</span>
+            <span>{t('usage.export')}</span>
           </Button>
           <Button
             variant="outline"
-            title="Refresh"
+            title={t('usage.refresh')}
             disabled={usageQuery.isFetching}
             onClick={() => void queryClient.invalidateQueries({ queryKey: ['usage'] })}
           >
             <RefreshCwIcon className={usageQuery.isFetching ? 'usage-spin' : undefined} />
-            <span>{usageQuery.isFetching ? 'Refreshing' : 'Refresh'}</span>
+            <span>{usageQuery.isFetching ? t('usage.refreshBusy') : t('usage.refresh')}</span>
           </Button>
         </div>
       </header>
@@ -238,23 +322,23 @@ export function UsagePage() {
             <ActivityIcon />
           </div>
           <div>
-            <h2>Usage data is unavailable</h2>
-            <p>{errorMessage || 'The gateway did not return usage data.'}</p>
+            <h2>{t('usage.errorTitle')}</h2>
+            <p>{errorMessage || t('usage.errorFallback')}</p>
           </div>
           <Button variant="outline" onClick={() => void usageQuery.refetch()}>
             <RefreshCwIcon />
-            Retry
+            {t('common.retry')}
           </Button>
         </section>
       ) : (
         <>
-          <section className="usage-overview" aria-label="Usage summary">
+          <section className="usage-overview" aria-label={t('usage.summaryLandmark')}>
             <div className="usage-overview__toolbar">
               <div>
-                <span className="usage-overview__eyebrow">Billing window</span>
+                <span className="usage-overview__eyebrow">{t('usage.billingWindow')}</span>
                 <strong className="usage-overview__window">{rangeLabel}</strong>
               </div>
-              <div className="usage-range" role="group" aria-label="Date range">
+              <div className="usage-range" role="group" aria-label={t('usage.dateRange')}>
                 {RANGE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
@@ -270,59 +354,61 @@ export function UsagePage() {
             </div>
 
             <div className="usage-overview__body">
-              <div className="usage-overview__spend" aria-label="Total cost">
+              <div className="usage-overview__spend" aria-label={t('usage.totalCost')}>
                 <span className="usage-overview__metric-label">
                   <CoinsIcon aria-hidden="true" />
-                  Period spend
+                  {t('usage.metricSpend')}
                 </span>
                 <strong className="usage-overview__spend-value t-data">
                   {formatCost(metrics.cost, { decimals: 4 })}
                 </strong>
                 <span className="usage-overview__hint">
-                  {compositionHint || 'No cost source yet'}
+                  {compositionHint || t('usage.noCostSource')}
                 </span>
               </div>
 
-              <div className="usage-overview__tokens" aria-label="Total tokens">
+              <div className="usage-overview__tokens" aria-label={t('usage.totalTokens')}>
                 <span className="usage-overview__metric-label">
                   <ActivityIcon aria-hidden="true" />
-                  Token volume
+                  {t('usage.metricTokens')}
                 </span>
                 <strong className="usage-overview__token-value t-data">
                   {metrics.totalTokens.toLocaleString()}
                 </strong>
                 <dl className="usage-overview__token-grid">
                   <div>
-                    <dt>Input</dt>
+                    <dt>{t('usage.dtInput')}</dt>
                     <dd className="t-data">{metrics.input.toLocaleString()}</dd>
                   </div>
                   <div>
-                    <dt>Output</dt>
+                    <dt>{t('usage.dtOutput')}</dt>
                     <dd className="t-data">{metrics.output.toLocaleString()}</dd>
                   </div>
                   <div>
-                    <dt>Cache read</dt>
+                    <dt>{t('usage.dtCacheRead')}</dt>
                     <dd className="t-data">{metrics.cacheRead.toLocaleString()}</dd>
                   </div>
                   <div>
-                    <dt>Cache write</dt>
+                    <dt>{t('usage.dtCacheWrite')}</dt>
                     <dd className="t-data">{metrics.cacheWrite.toLocaleString()}</dd>
                   </div>
                 </dl>
               </div>
 
               <dl className="usage-overview__supporting">
-                <div aria-label="Sessions">
-                  <dt>Sessions</dt>
+                <div aria-label={t('usage.sessionsLandmark')}>
+                  <dt>{t('usage.dtSessions')}</dt>
                   <dd className="t-data">{metrics.sessions}</dd>
-                  <dd className="usage-overview__supporting-hint">in this window</dd>
+                  <dd className="usage-overview__supporting-hint">{t('usage.hintInWindow')}</dd>
                 </div>
-                <div aria-label="Avg cost / session">
-                  <dt>Average / session</dt>
+                <div aria-label={t('usage.averageLandmark')}>
+                  <dt>{t('usage.dtAverage')}</dt>
                   <dd className="t-data">
                     {metrics.avgCost != null ? formatCost(metrics.avgCost, { decimals: 4 }) : '—'}
                   </dd>
-                  <dd className="usage-overview__supporting-hint">running average</dd>
+                  <dd className="usage-overview__supporting-hint">
+                    {t('usage.hintRunningAverage')}
+                  </dd>
                 </div>
               </dl>
             </div>
@@ -335,18 +421,18 @@ export function UsagePage() {
                   <BarChart3Icon />
                 </span>
                 <div>
-                  <h2 id="usage-chart-title">Session footprint</h2>
-                  <p>Compare the highest-consumption sessions in the selected window.</p>
+                  <h2 id="usage-chart-title">{t('usage.chartTitle')}</h2>
+                  <p>{t('usage.chartSubtitle')}</p>
                 </div>
               </div>
-              <div className="usage-segs" role="group" aria-label="Chart metric">
+              <div className="usage-segs" role="group" aria-label={t('usage.chartMetric')}>
                 <button
                   type="button"
                   className={`usage-seg${chartMode === 'tokens' ? ' is-active' : ''}`}
                   aria-pressed={chartMode === 'tokens'}
                   onClick={() => setChartMode('tokens')}
                 >
-                  Tokens
+                  {t('usage.segTokens')}
                 </button>
                 <button
                   type="button"
@@ -354,7 +440,7 @@ export function UsagePage() {
                   aria-pressed={chartMode === 'cost'}
                   onClick={() => setChartMode('cost')}
                 >
-                  Cost
+                  {t('usage.segCost')}
                 </button>
               </div>
             </div>
@@ -365,20 +451,20 @@ export function UsagePage() {
               <span className="usage-chart__legend-spacer" />
               <span className="usage-chart__legend-item">
                 <span className="usage-chart__swatch usage-chart__swatch--input" />
-                Input
+                {t('usage.legendInput')}
               </span>
               {chartMode === 'tokens' ? (
                 <span className="usage-chart__legend-item">
                   <span className="usage-chart__swatch usage-chart__swatch--output" />
-                  Output
+                  {t('usage.legendOutput')}
                 </span>
               ) : null}
             </div>
             {chart.bars.length === 0 ? (
               <div className="usage-bars__empty">
                 <BarChart3Icon className="usage-bars__empty-icon" aria-hidden="true" />
-                <strong>No data in the selected window.</strong>
-                <span>Choose a wider billing window or run a new session.</span>
+                <strong>{t('usage.chartEmptyTitle')}</strong>
+                <span>{t('usage.chartEmptyMsg')}</span>
               </div>
             ) : (
               <div className="usage-bars" key={`${chartMode}-${range}`}>
@@ -387,7 +473,7 @@ export function UsagePage() {
                     key={bar.key + i}
                     type="button"
                     className="usage-bar-row"
-                    title={`Open ${bar.key}`}
+                    title={t('usage.barTitle', { key: bar.key })}
                     style={{ '--i': i } as React.CSSProperties}
                     onClick={() => openChat(bar.key)}
                   >
@@ -418,17 +504,17 @@ export function UsagePage() {
           <section className="usage-models">
             <div className="usage-section-head">
               <div>
-                <h2 className="usage-section-title">Model allocation</h2>
-                <p>Token volume, session reach, and cost contribution by model.</p>
+                <h2 className="usage-section-title">{t('usage.modelsTitle')}</h2>
+                <p>{t('usage.modelsSubtitle')}</p>
               </div>
               <span className="usage-section-meta t-data">
-                {grid.models.length} model{grid.models.length === 1 ? '' : 's'}
+                {tPlural('usage.modelCount', grid.models.length)}
               </span>
             </div>
             {grid.models.length === 0 ? (
-              <div className="usage-models__empty">No model usage yet.</div>
+              <div className="usage-models__empty">{t('usage.modelsEmpty')}</div>
             ) : (
-              <div className="usage-model-grid" key={range} aria-label="By model breakdown">
+              <div className="usage-model-grid" key={range} aria-label={t('usage.modelsLandmark')}>
                 {grid.models.map((m, i) => (
                   <article
                     className="usage-model-card"
@@ -451,7 +537,7 @@ export function UsagePage() {
                         </h3>
                       </div>
                     </div>
-                    <div className="usage-model-card__share" title="Share of total cost">
+                    <div className="usage-model-card__share" title={t('usage.shareTitle')}>
                       <span className="usage-model-card__share-bar" aria-hidden="true">
                         <span
                           className="usage-model-card__share-fill"
@@ -459,25 +545,25 @@ export function UsagePage() {
                         />
                       </span>
                       <strong className="t-data">{m.sharePct.toFixed(1)}%</strong>
-                      <span>of spend</span>
+                      <span>{t('usage.ofSpend')}</span>
                     </div>
                     <dl className="usage-model-card__rows">
                       <div>
-                        <dt>Tokens</dt>
+                        <dt>{t('usage.dtTokens')}</dt>
                         <dd className="t-data">{m.totalTokens.toLocaleString()}</dd>
                       </div>
                       <div>
-                        <dt>Input / output</dt>
+                        <dt>{t('usage.dtInputOutput')}</dt>
                         <dd className="t-data">
                           {m.inputTokens.toLocaleString()} / {m.outputTokens.toLocaleString()}
                         </dd>
                       </div>
                       <div>
-                        <dt>Sessions</dt>
+                        <dt>{t('usage.dtSessions')}</dt>
                         <dd className="t-data">{m.sessions}</dd>
                       </div>
                       <div>
-                        <dt>Cost</dt>
+                        <dt>{t('usage.dtCost')}</dt>
                         <dd className="t-data usage-cost">{formatCost(m.costUsd)}</dd>
                       </div>
                     </dl>
@@ -490,8 +576,8 @@ export function UsagePage() {
           <section className="usage-sessions">
             <div className="usage-section-head">
               <div>
-                <h2 className="usage-section-title">Sessions</h2>
-                <p>Auditable usage records with provider billing provenance.</p>
+                <h2 className="usage-section-title">{t('usage.tableTitle')}</h2>
+                <p>{t('usage.tableSubtitle')}</p>
               </div>
               <span className="usage-section-meta t-data">{sessionMeta}</span>
             </div>
@@ -523,10 +609,8 @@ export function UsagePage() {
                       <td colSpan={TABLE_COLUMNS.length} className="usage-empty-row">
                         <div className="usage-empty">
                           <BarChart3Icon className="usage-empty__icon" aria-hidden="true" />
-                          <div className="usage-empty__title">No usage data yet</div>
-                          <p className="usage-empty__msg">
-                            Run a session and token spend will appear here automatically.
-                          </p>
+                          <div className="usage-empty__title">{t('usage.tableEmptyTitle')}</div>
+                          <p className="usage-empty__msg">{t('usage.tableEmptyMsg')}</p>
                         </div>
                       </td>
                     </tr>
@@ -546,7 +630,7 @@ export function UsagePage() {
                           key={key || `row-${rowIndex}`}
                           row={row}
                           sessionKey={key}
-                          modified={ts != null ? formatRelTime(ts) : '—'}
+                          modified={ts != null ? formatRelTime(ts) : t('common.dash')}
                           badge={badge}
                           modelLabel={modelLabel}
                           canExpand={canExpand}
@@ -570,8 +654,8 @@ export function UsagePage() {
 
 function UsageLoading() {
   return (
-    <div className="usage-loading" role="status" aria-label="Loading usage data">
-      <span className="sr-only">Loading usage data</span>
+    <div className="usage-loading" role="status" aria-label={t('usage.loadingLabel')}>
+      <span className="sr-only">{t('usage.loadingLabel')}</span>
       <div className="usage-loading__overview" />
       <div className="usage-loading__chart" />
       <div className="usage-loading__rows">
@@ -615,13 +699,13 @@ function ExpandableRow({
             <button
               type="button"
               className="usage-sess-link t-data"
-              title={`Open chat for ${sessionKey}`}
+              title={t('usage.openChatFor', { key: sessionKey })}
               onClick={onOpenChat}
             >
               {sessionKey}
             </button>
           ) : (
-            '—'
+            t('common.dash')
           )}
         </td>
         <td data-label="Modified" className="t-data usage-dim">
@@ -679,21 +763,22 @@ function ModelExpansion({ row }: { row: UsageRow }) {
     <div className="usage-expand">
       <div className="usage-expand__head">
         <span className="usage-expand__connector" aria-hidden="true" />
-        <span className="usage-expand__eyebrow">Model breakdown</span>
-        <span className="usage-expand__count">
-          {ex.count} model{ex.count === 1 ? '' : 's'}
-        </span>
+        <span className="usage-expand__eyebrow">{t('usage.expandEyebrow')}</span>
+        <span className="usage-expand__count">{tPlural('usage.expandModels', ex.count)}</span>
         <span className="usage-expand__spacer" />
         <span className="usage-expand__total">
-          {ex.totalTokens.toLocaleString()} tokens · {formatCost(ex.totalCost)}
+          {t('usage.expandTotal', {
+            tokens: ex.totalTokens.toLocaleString(),
+            cost: formatCost(ex.totalCost),
+          })}
         </span>
       </div>
       {ex.anyProrated ? (
         <div className="usage-expand__notice" role="note">
-          Per-model split is estimated; total is the actual billed amount.
+          {t('usage.expandProrated')}
         </div>
       ) : null}
-      <div className="usage-expand__list" role="table" aria-label="Model breakdown">
+      <div className="usage-expand__list" role="table" aria-label={t('usage.expandEyebrow')}>
         {ex.rows.map((m, i) => (
           <div
             className="usage-expand__row"

--- a/frontend/src/views/usage/logic.ts
+++ b/frontend/src/views/usage/logic.ts
@@ -7,6 +7,9 @@
 
 /** A per-model breakdown entry (usage.status sessions[].modelBreakdown[]).
  *  Backend emits camelCase here; snake variants tolerated defensively. */
+import { t, tPlural } from '@/i18n'
+import '@/i18n/en/usage'
+
 export interface ModelBreakdownEntry {
   model?: string
   inputTokens?: number
@@ -144,21 +147,21 @@ export function undatedHiddenCount(rows: UsageRow[], range: UsageRange): number 
 export function rangeHiddenHint(rows: UsageRow[], range: UsageRange): string {
   const hidden = undatedHiddenCount(rows, range)
   if (hidden <= 0) return ''
-  return `${hidden} undated legacy session${hidden === 1 ? '' : 's'} hidden`
+  return tPlural('usage.hiddenSessions', hidden)
 }
 
 // ── Formatting (usage.js:187-192,515-521,228-241 relTime) ────────────────────
 
 /** usage.js:187-192 — "$"+toFixed(decimals) (default 4); null → em dash. */
 export function formatCost(usd: number | null | undefined, opts?: { decimals?: number }): string {
-  if (usd == null) return '—'
+  if (usd == null) return t('common.dash')
   const decimals = opts?.decimals != null ? opts.decimals : 4
   return '$' + Number(usd).toFixed(decimals)
 }
 
 /** usage.js:515-521 — abbreviate a token count (M/K one-decimal); null → dash. */
 export function formatNum(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return t('common.dash')
   const v = Number(n)
   if (v >= 1_000_000) return (v / 1_000_000).toFixed(1) + 'M'
   if (v >= 1_000) return (v / 1_000).toFixed(1) + 'K'
@@ -178,12 +181,12 @@ export function formatRelTime(isoOrTs: string | number): string {
   const d = Number.isFinite(numeric)
     ? new Date(Math.abs(numeric) < 10_000_000_000 ? numeric * 1000 : numeric)
     : new Date(isoOrTs)
-  if (Number.isNaN(d.getTime())) return '—'
+  if (Number.isNaN(d.getTime())) return t('common.dash')
   const diff = (Date.now() - d.getTime()) / 1000
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86_400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86_400)}d ago`
+  if (diff < 60) return t('usage.relJustNow')
+  if (diff < 3600) return t('usage.relMinutes', { count: Math.floor(diff / 60) })
+  if (diff < 86_400) return t('usage.relHours', { count: Math.floor(diff / 3600) })
+  return t('usage.relDays', { count: Math.floor(diff / 86_400) })
 }
 
 // ── Metrics (usage.js:243-252,385-423) ───────────────────────────────────────
@@ -246,41 +249,56 @@ function costSourceClass(source: string): string {
   return KNOWN_COST_SOURCES.includes(source) ? source : 'none'
 }
 
-/** usage.js:276-290 — the human label for a source; ephemeral wins. */
-function costSourceLabel(source: string, ephemeral: boolean): string {
-  if (ephemeral) return 'Ephemeral'
+/** The locale-independent identity of a cost source; ephemeral wins. */
+type CostSourceToken = 'ephemeral' | 'actual' | 'estimated' | 'mixed' | 'unpriced' | 'none'
+
+function costSourceToken(source: string, ephemeral: boolean): CostSourceToken {
+  if (ephemeral) return 'ephemeral'
   switch (source) {
     case 'provider_billed':
-      return 'Actual'
+      return 'actual'
     case 'provider_billed_prorated':
-      return 'Actual'
+      return 'actual'
     case 'agentos_estimate':
-      return 'Estimated'
+      return 'estimated'
     case 'mixed':
-      return 'Mixed'
+      return 'mixed'
     case 'unavailable':
-      return 'Unpriced'
+      return 'unpriced'
     default:
-      return 'None'
+      return 'none'
   }
+}
+
+/** usage.js:276-290 — the human label for a source; ephemeral wins. */
+function costSourceLabel(source: string, ephemeral: boolean): string {
+  const labels: Record<CostSourceToken, string> = {
+    ephemeral: t('usage.sourceEphemeral'),
+    actual: t('usage.sourceActual'),
+    estimated: t('usage.sourceEstimated'),
+    mixed: t('usage.sourceMixed'),
+    unpriced: t('usage.sourceUnpriced'),
+    none: t('usage.sourceNone'),
+  }
+  return labels[costSourceToken(source, ephemeral)]
 }
 
 /** usage.js:292-302 — the tooltip for a source; ephemeral wins. */
 function costSourceTooltip(source: string, ephemeral: boolean): string {
-  if (ephemeral) return 'Ephemeral session — cost not yet persisted'
+  if (ephemeral) return t('usage.tipEphemeral')
   switch (source) {
     case 'provider_billed':
-      return 'Actual — cost billed by the provider'
+      return t('usage.tipActual')
     case 'provider_billed_prorated':
-      return 'Total is real billed; per-model split is estimated.'
+      return t('usage.tipProrated')
     case 'agentos_estimate':
-      return 'Estimated — derived locally from token counts'
+      return t('usage.tipEstimated')
     case 'mixed':
-      return 'Mixed — partial billing data, rest estimated'
+      return t('usage.tipMixed')
     case 'unavailable':
-      return 'Unpriced — no pricing table entry for this model'
+      return t('usage.tipUnpriced')
     default:
-      return 'No cost recorded'
+      return t('usage.tipNone')
   }
 }
 
@@ -307,24 +325,33 @@ export function costSourceBadge(row: Record<string, unknown>): CostSourceBadge {
 /** usage.js:312-322 — the cost-composition hint ("actual 2 · estimated 1 · …")
  *  over the given rows; only the five counted labels contribute. */
 export function sourceCompositionHint(rows: UsageRow[]): string {
+  // Counted by token, not by the rendered label: keying on English wording
+  // would stop matching the moment the badge label is translated.
   const counts: Record<string, number> = {
-    Actual: 0,
-    Estimated: 0,
-    Mixed: 0,
-    Unpriced: 0,
-    Ephemeral: 0,
+    actual: 0,
+    estimated: 0,
+    mixed: 0,
+    unpriced: 0,
+    ephemeral: 0,
   }
   rows.forEach((row) => {
     const r = row as Record<string, unknown>
-    const label = costSourceLabel(
+    const token = costSourceToken(
       costSource(r),
       Boolean(rowVal(r, 'cost_ephemeral', 'costEphemeral')),
     )
-    if (counts[label] != null) counts[label] += 1
+    if (counts[token] != null) counts[token] += 1
   })
+  const words: Record<string, string> = {
+    actual: t('usage.compositionActual'),
+    estimated: t('usage.compositionEstimated'),
+    mixed: t('usage.compositionMixed'),
+    unpriced: t('usage.compositionUnpriced'),
+    ephemeral: t('usage.compositionEphemeral'),
+  }
   return Object.entries(counts)
     .filter(([, n]) => n > 0)
-    .map(([label, n]) => `${label.toLowerCase()} ${n}`)
+    .map(([token, n]) => t('usage.compositionEntry', { label: words[token]!, count: n }))
     .join(' · ')
 }
 


### PR DESCRIPTION
Refs #257 — 5 of 11.

Extracts the usage view's copy into a new `usage` namespace and adds `src/views/usage/**/*.tsx` to `I18N_MIGRATED` in the same commit. `logic.ts` moves too — it owns the cost-source badges and tooltips, the composition hint, and the number/cost/relative-time formatters.

**No existing test file changed.**

### One latent bug fixed on the way

`sourceCompositionHint` counted rows into a map keyed by the **English badge label** and then `toLowerCase()`d it for display. Both halves break the moment that label is translated: the lookup silently stops matching (every count reads 0), and lowercasing a noun is wrong in languages that capitalise them. Counts now key on a stable `CostSourceToken`, and the lowercase words are their own catalog entries.

### Other notes

- `RANGE_OPTIONS` and `TABLE_COLUMNS` keep their array shape, with `label` as a getter so nothing resolves at module-evaluation time (#258).
- `data-label` attributes on the table cells are left alone — no CSS reads them, so they are not user-visible.
- The chart caption's optional " · showing X of Y" suffix became one key with a `{caption}` placeholder rather than a padded fragment, which `catalog.test.ts` rejects.

## Bundle

Initial JS unchanged at **136.6 KiB gzip** / 180 KiB budget.

## Verification

`npm run check` green (tsc, eslint, prettier, 1824 tests).