### PR TITLE
webui: migrate the skills view onto the i18n seam

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,6 +18,7 @@ const I18N_MIGRATED = [
   'src/views/overview/**/*.tsx',
   'src/views/sessions/**/*.tsx',
   'src/views/settings/**/*.tsx',
+  'src/views/skills/**/*.tsx',
   'src/views/usage/**/*.tsx',
 ]
 
@@ -52,6 +53,22 @@ const NO_HARDCODED_COPY = [
     selector:
       'JSXAttribute[name.name=/^(aria-label|aria-description|placeholder|title|alt)$/] > Literal[value=/[A-Za-z]{3,}/]',
     message: 'Accessible and attribute copy must come from t().',
+  },
+  {
+    // JSXText only covers bare text nodes. Copy also reaches the DOM through
+    // expression containers — `{busy ? 'Saving…' : 'Save'}`, `{x || 'None'}` —
+    // which the rule above cannot see, and which is exactly how the skills
+    // dialog's Update/Remove buttons survived the first migration pass.
+    // The :not() excludes attribute values, so the `className={x ? 'a' : 'b'}`
+    // ternaries all over this codebase stay legal. Only direct ternary branches
+    // and `||` fallbacks, so a `{'main'}` identifier escape hatch still passes.
+    selector: [
+      'JSXExpressionContainer:not(JSXAttribute JSXExpressionContainer)',
+      '> :matches(ConditionalExpression, LogicalExpression)',
+      '> Literal[value=/[A-Za-z]{3,}/]',
+    ].join(' '),
+    message:
+      'Copy inside a JSX expression must come from t() too — a ternary or || fallback still renders to the user.',
   },
 ]
 

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -9,6 +9,7 @@ import { overview } from './overview'
 import { settings } from './settings'
 import { sessions } from './sessions'
 import { shell } from './shell'
+import { skills } from './skills'
 import { usage } from './usage'
 
 /**
@@ -38,5 +39,6 @@ export const en = {
   sessions,
   settings,
   shell,
+  skills,
   usage,
 } as const

--- a/frontend/src/i18n/en/skills.ts
+++ b/frontend/src/i18n/en/skills.ts
@@ -1,0 +1,241 @@
+import { defineNamespace } from '../registry'
+
+export const skills = defineNamespace('skills', {
+  documentTitle: 'Skills - AgentOS Control',
+  title: 'Skills',
+  subtitle: 'Manage installed capabilities and discover trusted skills for your agents.',
+  refresh: 'Refresh',
+
+  // Brand artwork. Brand *names* (Bankr / Capminal / Robinhood) are proper
+  // nouns and stay literal in the component.
+  altGmgnLogo: 'GMGN logo',
+  altAgentosLogo: 'AgentOS logo',
+
+  // Source tabs.
+  tabsLandmark: 'Skill source',
+  tabInstalled: 'Installed',
+  tabInstalledDesc: '{count} local skills',
+  tabPartnerDesc: 'Partner catalog',
+  tabRobinhoodDesc: 'Bundled partner',
+  tabCommunity: 'Community',
+  tabCommunityDesc: 'Open catalog',
+
+  // Installed toolbar.
+  searchPlaceholder: 'Search installed skills',
+  searchLabel: 'Filter installed skills',
+  metricsLandmark: 'Skills summary',
+  metricAll: 'All',
+  metricReady: 'Ready',
+  metricNeedsSetup: 'Needs setup',
+  metricDisabled: 'Disabled',
+
+  // Install from GitHub.
+  githubTitle: 'Install from GitHub',
+  githubDesc: 'Add a skill directly from a public repository or folder.',
+  githubPlaceholder: 'https://github.com/owner/repo/tree/main/skill',
+  githubUrlLabel: 'Install from GitHub URL',
+  githubInstall: 'Install',
+
+  // Cards.
+  cardSkillLabel: 'Skill {name}',
+  cardViewDetails: 'View details',
+  cardUse: 'Use',
+  cardDetailsFor: 'View details for {name}',
+  cardOpenDetails: 'Open details',
+  catalogSkillLabel: 'Catalog skill {name}',
+  partnerSkillLabel: '{brand} skill {name}',
+
+  // Install button.
+  installed: 'Installed',
+  forceInstalling: 'Force installing…',
+  forceInstall: 'Force install',
+  installing: 'Installing…',
+  installSkill: 'Install skill',
+  install: 'Install',
+
+  // Catalog panels.
+  communityTitle: 'Community catalog',
+  communityDesc: 'Discover skills published by the wider AgentOS community.',
+  registryLabelCommunity: 'community',
+  registrySearchPlaceholder: 'Search {label} skills…',
+  registrySearchLabel: 'Search {label} skills',
+  loadingCatalog: 'Loading {label} catalog',
+  loadFailed: 'Failed to load: {error}',
+  retryHintCommunity: 'Re-open the tab or press Refresh to retry.',
+  retryHintRobinhood: 'Press Refresh to retry.',
+  importantPrefix: 'IMPORTANT:',
+  // The partner count renders in its own <strong>, so the noun is a plain key
+  // rather than a tPlural() pair (which must carry {count} in the value).
+  skillWord: 'skill',
+  skillsWord: 'skills',
+
+  // Partner catalog intros.
+  bankrTitle: 'Bankr skill catalog',
+  bankrDesc: 'Curated financial and on-chain capabilities maintained by the Bankr ecosystem.',
+  bankrNotice: "the 'bankr' skill is required for all skills in this catalog.",
+  capminalTitle: 'Capminal skill catalog',
+  capminalDesc:
+    'Wallet, token-launch, and on-chain execution skills maintained by the Capminal team.',
+  capminalNotice: "the 'capminal' skill is required for all skills in this catalog.",
+  robinhoodTitle: 'Robinhood skills',
+  robinhoodDesc:
+    'Official bundled capabilities for Robinhood products and on-chain assets, maintained by AgentOS against the Robinhood Trading MCP.',
+  robinhoodNotice:
+    "the 'robinhood-agentic-trading' skill trades from a dedicated Robinhood Agentic account — create that account in Robinhood and complete its authorization flow before using the skill.",
+
+  // Robinhood panel.
+  robinhoodStatusLandmark: 'Robinhood skill status',
+  robinhoodFilterLabel: 'Filter Robinhood skills: {label}',
+  loadingRobinhood: 'Loading Robinhood skills',
+
+  // Installed panel.
+  installedLoadFailed: 'Failed to load skills: {error}',
+  loadingInstalled: 'Loading installed skills',
+
+  // Requirements section.
+  reqTitle: 'Requirements',
+  reqReady: 'ready',
+  reqNeedsSetup: 'needs setup',
+  reqMissingSkill: 'missing skill',
+  reqNotDeclared: 'no deps declared',
+  reqMissingLead: 'Missing',
+  reqOneOf: 'one of {list}',
+  reqEnv: '{name} env',
+  reqNoDeps: 'No declared dependencies',
+  reqUnknown: 'unknown',
+
+  // Skill detail dialog.
+  chipReady: '✓ ready',
+  chipDisabled: 'disabled',
+  chipNeedsDeps: 'needs deps',
+  sectionAvailability: 'Agent availability',
+  sectionMissing: 'Missing',
+  missingBinary: 'binary',
+  missingEnvVar: 'env var',
+  whereToGet: 'where to get it ↗',
+  setEnvAria: 'Set {name}',
+  setEnvAction: 'Set',
+  sectionInstall: 'Install',
+  homepage: 'Homepage ↗',
+  useInChat: 'Use in chat',
+  installVia: 'Install via {kind}',
+  updating: 'Updating…',
+  update: 'Update',
+  removing: 'Removing…',
+  remove: 'Remove',
+  removeBlockedNote:
+    'AgentOS cannot remove this skill: the configured managed skills directory does not hold it. Check skills.managed_dir, or delete the files by hand.',
+
+  // Registry detail dialog.
+  descPending: "Description loads after install (from the skill's SKILL.md).",
+  sectionSetup: 'Setup',
+  sectionDemo: 'Demo',
+  sourceLink: 'Source ↗',
+  trustCommunity: 'community',
+
+  // Set-env dialog.
+  setEnvTitle: 'Set {name}',
+  setEnvDescLead: 'Stored in the AgentOS',
+  setEnvDescTail: 'and applied to the running gateway.',
+  saving: 'Saving…',
+
+  // Toasts.
+  toastLoadFailed: 'Failed to load skills: {message}',
+  toastInstalled: 'Installed {name}',
+  toastScanBlocked: 'Security scan flagged {target}. Click again to install anyway.',
+  toastScanTarget_one: '{name} ({count} finding)',
+  toastScanTarget_other: '{name} ({count} findings)',
+  toastScanUnnamed: 'this skill',
+  toastInstallFailed: 'Install failed',
+  toastRemoved: 'Removed {name}',
+  toastUninstallFailed: 'Uninstall failed',
+  toastUpdated: 'Updated {name}',
+  toastUpdateFailed: 'Update failed',
+  toastDepsInstalled: 'Installed',
+  toastEnvSaved: '{name} saved.',
+
+  // Loading layers (logic.ts).
+  layerWorkspace: 'Workspace',
+  layerBundled: 'Bundled',
+  layerManaged: 'Managed',
+  layerPersonal: 'Personal',
+  layerProject: 'Project',
+  layerExtra: 'Extra',
+  layerUnknown: 'Unknown',
+  layerHelpWorkspace: 'Workspace skills are local to the active workspace.',
+  layerHelpBundled: 'Bundled skills ship with AgentOS.',
+  layerHelpManaged: 'Managed skills are locally installed into AgentOS state.',
+  layerHelpPersonal: 'Personal skills are local user installs, not bundled.',
+  layerHelpProject: 'Project skills are local to the current project.',
+  layerHelpExtra: 'Extra skills come from configured local directories.',
+  layerHelpFallback: 'Configured local skill directory.',
+
+  // Acquisition provenance (logic.ts).
+  srcHub: 'hub',
+  srcShipped: 'shipped',
+  srcLocal: 'local',
+
+  // Catalog categories (logic.ts).
+  catAll: 'All',
+  catTrading: 'Trading',
+  catDefi: 'DeFi',
+  catWallet: 'Wallets',
+  catMarkets: 'Markets',
+  catSocial: 'Social',
+  catData: 'Data',
+  catNft: 'NFT',
+  catDev: 'Dev tools',
+  catInfra: 'Infra',
+  catCrypto: 'Crypto',
+  catOther: 'Other',
+
+  // Installed empty states (logic.ts).
+  emptyMatch: 'No skills match {query}.',
+  emptyReady: 'No skills are ready. Install dependencies to enable them.',
+  emptyNeedsSetup: 'No skills currently need setup.',
+  emptyDisabled: 'No skills are switched off.',
+  emptyNone: 'No skills installed.',
+
+  // Provenance groups (logic.ts).
+  groupPartners: 'Partner Skills',
+  groupCrypto: 'AgentOS Crypto Skills',
+  groupShipped: 'AgentOS Normal Skills',
+  groupHub: 'Installed from a hub',
+  groupLocal: 'Your local skills',
+  groupHelpPartners: 'Skills published by an AgentOS partner.',
+  groupHelpCrypto: 'On-chain and wallet skills that ship with AgentOS.',
+  groupHelpShipped: 'Skills that ship with AgentOS.',
+  groupHelpHub: 'Skills you installed from a skill hub.',
+  groupHelpLocal: 'Skills you added yourself, from a local skill directory.',
+
+  // Status buckets + dot tooltip (logic.ts).
+  bucketReady: 'Ready',
+  bucketNeedsSetup: 'Setup required',
+  bucketDisabled: 'Disabled',
+  dotDisabled: 'Disabled in config',
+  dotReady: 'Ready',
+  dotNeedsSetup: 'Needs setup',
+
+  // Availability (logic.ts).
+  availOffered: 'Offered to the agent',
+  availNotOffered: 'Not offered to the agent',
+  availModelInvocationDisabled: 'Not offered — agent cannot invoke',
+  availIneligible: 'Not offered — needs setup',
+  availToolGate: 'Not offered — missing tools',
+  availFallbackSuperseded: 'Not offered — superseded',
+  availNotRetrieved: 'Not offered — not retrieved',
+  availPromptBudget: 'Not offered — prompt too long',
+
+  // Partner empty states (logic.ts).
+  partnerEmptyMatch: 'No {brand} skills match {query}.',
+  partnerEmptyReady: 'No {brand} skills are ready.',
+  partnerEmptyNeedsSetup: 'No {brand} skills currently need setup.',
+  partnerEmptyDisabled: 'No {brand} skills are switched off.',
+  partnerEmptyNone: '{brand} skills are on the way. No {brand} skills are installed yet.',
+
+  // Catalog empty states (logic.ts).
+  registryEmptyMatch: 'No skills match {query}.',
+  registryEmptyBankr: 'No Bankr skills available right now.',
+  registryEmptyCapminal: 'No Capminal skills available right now.',
+  registryEmptyCommunity: 'No community skills available right now.',
+} as const)

--- a/frontend/src/views/skills/SkillsPage.tsx
+++ b/frontend/src/views/skills/SkillsPage.tsx
@@ -19,6 +19,8 @@ import { toast } from 'sonner'
 import { MotionListItem } from '@/lib/motion'
 import { ModalShell } from '@/components/ModalShell'
 import { Button } from '@/components/ui/button'
+import { t, tPlural } from '@/i18n'
+import '@/i18n/en/skills'
 import { useRpc } from '@/app/providers'
 import agentosMarkUrl from '@/assets/agentos-mark.png'
 import bankrSymbolUrl from '@/assets/bankr-symbol.svg'
@@ -26,7 +28,7 @@ import capminalSymbolUrl from '@/assets/capminal-symbol.svg'
 import gmgnSymbolUrl from '@/assets/gmgn-symbol.png'
 import robinhoodSymbolUrl from '@/assets/robinhood-symbol.png'
 import {
-  CAT_LABEL,
+  catLabel,
   REGISTRY_SEARCH_DEBOUNCE_MS,
   categoryChips,
   communityFilter,
@@ -40,7 +42,7 @@ import {
   installedEmptyMessage,
   isGmgnSkill,
   isPartnerSkill,
-  SKILL_BUCKET_LABEL,
+  skillBucketLabel,
   skillBucket,
   layerHelp,
   layerLabel,
@@ -112,21 +114,22 @@ const PARTNER_BRANDS: Record<PartnerBrand, { label: string; asset: string }> = {
  * renders its own intro (`ROBINHOOD_INTRO`) rather than going through
  * `RegistryPanel`.
  */
-const REGISTRY_INTRO: Record<
+function registryIntro(): Record<
   Exclude<RegistryGroup, 'community'>,
   { title: string; description: string; notice?: string }
-> = {
-  bankr: {
-    title: 'Bankr skill catalog',
-    description: 'Curated financial and on-chain capabilities maintained by the Bankr ecosystem.',
-    notice: "the 'bankr' skill is required for all skills in this catalog.",
-  },
-  capminal: {
-    title: 'Capminal skill catalog',
-    description:
-      'Wallet, token-launch, and on-chain execution skills maintained by the Capminal team.',
-    notice: "the 'capminal' skill is required for all skills in this catalog.",
-  },
+> {
+  return {
+    bankr: {
+      title: t('skills.bankrTitle'),
+      description: t('skills.bankrDesc'),
+      notice: t('skills.bankrNotice'),
+    },
+    capminal: {
+      title: t('skills.capminalTitle'),
+      description: t('skills.capminalDesc'),
+      notice: t('skills.capminalNotice'),
+    },
+  }
 }
 
 /**
@@ -140,17 +143,17 @@ const REGISTRY_INTRO: Record<
  * create it, so a user who installs and runs it first only finds out when the
  * first tool call fails.
  */
-const ROBINHOOD_INTRO = {
-  title: 'Robinhood skills',
-  description:
-    'Official bundled capabilities for Robinhood products and on-chain assets, maintained by AgentOS against the Robinhood Trading MCP.',
-  notice:
-    "the 'robinhood-agentic-trading' skill trades from a dedicated Robinhood Agentic account — create that account in Robinhood and complete its authorization flow before using the skill.",
+function robinhoodIntro() {
+  return {
+    title: t('skills.robinhoodTitle'),
+    description: t('skills.robinhoodDesc'),
+    notice: t('skills.robinhoodNotice'),
+  }
 }
 
 /** The brand name for a catalog tab's search/loading copy ('community' has none). */
 function registryLabel(group: RegistryGroup): string {
-  return group === 'community' ? 'community' : PARTNER_BRANDS[group].label
+  return group === 'community' ? t('skills.registryLabelCommunity') : PARTNER_BRANDS[group].label
 }
 
 /**
@@ -160,9 +163,9 @@ function registryLabel(group: RegistryGroup): string {
  */
 function acquisitionSourceLabel(skill: RawSkill): string {
   const acq = skill.acquisition
-  if (acq?.kind === 'hub') return acq.source_id || 'hub'
-  if (acq?.kind === 'shipped') return 'shipped'
-  if (acq?.kind === 'local') return 'local'
+  if (acq?.kind === 'hub') return acq.source_id || t('skills.srcHub')
+  if (acq?.kind === 'shipped') return t('skills.srcShipped')
+  if (acq?.kind === 'local') return t('skills.srcLocal')
   // Pre-#130 gateway: fall back to the location layer rather than claim one.
   return layerLabel(skill.layer).toLowerCase()
 }
@@ -174,8 +177,9 @@ function acquisitionSourceLabel(skill: RawSkill): string {
  * string names filesystem paths and is deliberately kept off the wire, so say
  * what the operator has to do instead of rendering a button that half-succeeds.
  */
-const REMOVE_BLOCKED_NOTE =
-  'AgentOS cannot remove this skill: the configured managed skills directory does not hold it. Check skills.managed_dir, or delete the files by hand.'
+function removeBlockedNote(): string {
+  return t('skills.removeBlockedNote')
+}
 
 /**
  * The "installed, but the agent is not being offered it" chip.
@@ -332,7 +336,13 @@ function SkillIcon({
   const emoji = (skill.emoji ?? '').trim()
   if (isGmgnSkill(skill)) {
     const mark = (
-      <img className={brandClass} src={gmgnSymbolUrl} alt="GMGN logo" width="40" height="40" />
+      <img
+        className={brandClass}
+        src={gmgnSymbolUrl}
+        alt={t('skills.altGmgnLogo')}
+        width="40"
+        height="40"
+      />
     )
     if (!emoji) return mark
     // The wrapper takes its footprint from the mark it holds, so one pair of
@@ -354,7 +364,13 @@ function SkillIcon({
   // move the skill into Partner Skills.
   if (skillGroupKey(skill) === 'crypto') {
     return (
-      <img className={brandClass} src={agentosMarkUrl} alt="AgentOS logo" width="40" height="40" />
+      <img
+        className={brandClass}
+        src={agentosMarkUrl}
+        alt={t('skills.altAgentosLogo')}
+        width="40"
+        height="40"
+      />
     )
   }
   return (
@@ -398,7 +414,7 @@ function SkillCard({
   onUse: () => void
 }) {
   const desc = skill.description || ''
-  const statusLabel = SKILL_BUCKET_LABEL[skillBucket(skill)]
+  const statusLabel = skillBucketLabel(skillBucket(skill))
   // The card used to be one big <button>. "Use" is a second action, and a
   // button cannot nest inside a button, so the shell splits the same way
   // RegistryCard/PartnerSkillCard already do: an <article> wrapper, a details
@@ -410,7 +426,7 @@ function SkillCard({
         type="button"
         className="sk-card__details"
         onClick={onOpen}
-        aria-label={`Skill ${skill.name}`}
+        aria-label={t('skills.cardSkillLabel', { name: String(skill.name) })}
         title={skill.name + (desc ? ': ' + desc : '')}
       >
         <div className="sk-card__head">
@@ -443,11 +459,11 @@ function SkillCard({
           tabIndex={-1}
           aria-hidden="true"
         >
-          View details
+          {t('skills.cardViewDetails')}
           <ChevronRightIcon />
         </button>
         <Button type="button" variant="outline" size="sm" onClick={onUse}>
-          Use
+          {t('skills.cardUse')}
         </Button>
       </div>
     </article>
@@ -473,11 +489,14 @@ function RegistryCard({
   // category (label from CAT_LABEL, falling back to the raw category key).
   const cat = item.category && item.category !== 'other' ? item.category : ''
   return (
-    <article className="sk-rcard" aria-label={`Catalog skill ${item.name}`}>
+    <article
+      className="sk-rcard"
+      aria-label={t('skills.catalogSkillLabel', { name: String(item.name) })}
+    >
       <button
         type="button"
         className="sk-rcard__details"
-        aria-label={`View details for ${item.name}`}
+        aria-label={t('skills.cardDetailsFor', { name: String(item.name) })}
         onClick={onOpen}
       >
         <div className="sk-rcard__head">
@@ -486,9 +505,9 @@ function RegistryCard({
             <span className="sk-rcard__name">{item.name}</span>
             <span className="sk-rcard__provider">{item.provider || item.source || ''}</span>
           </div>
-          {cat ? <span className="sk-rcard__cat">{CAT_LABEL[cat] || cat}</span> : null}
+          {cat ? <span className="sk-rcard__cat">{catLabel(cat)}</span> : null}
         </div>
-        <span className="sk-rcard__desc">{item.description || 'Open details'}</span>
+        <span className="sk-rcard__desc">{item.description || t('skills.cardOpenDetails')}</span>
       </button>
       <div className="sk-rcard__foot">
         <span className="sk-rcard__src sk-mono">{item.source || ''}</span>
@@ -516,7 +535,7 @@ function PartnerSkillCard({
 }) {
   const label = PARTNER_BRANDS[brand].label
   const bucket = skillBucket(skill)
-  const statusLabel = SKILL_BUCKET_LABEL[bucket]
+  const statusLabel = skillBucketLabel(bucket)
   const statusClass =
     bucket === 'ready'
       ? 'sk-chip--ok'
@@ -525,11 +544,14 @@ function PartnerSkillCard({
         : 'sk-chip--unverified'
 
   return (
-    <article className="sk-rcard sk-rcard--partner" aria-label={`${label} skill ${skill.name}`}>
+    <article
+      className="sk-rcard sk-rcard--partner"
+      aria-label={t('skills.partnerSkillLabel', { brand: label, name: String(skill.name) })}
+    >
       <button
         type="button"
         className="sk-rcard__details"
-        aria-label={`View details for ${skill.name}`}
+        aria-label={t('skills.cardDetailsFor', { name: String(skill.name) })}
         onClick={onOpen}
       >
         <div className="sk-rcard__head">
@@ -539,7 +561,7 @@ function PartnerSkillCard({
             <span className="sk-rcard__provider">{label}</span>
           </div>
         </div>
-        <span className="sk-rcard__desc">{skill.description || 'Open details'}</span>
+        <span className="sk-rcard__desc">{skill.description || t('skills.cardOpenDetails')}</span>
       </button>
       <div className="sk-rcard__foot">
         {/* Not every partner skill ships with AgentOS — a partner hub install
@@ -572,7 +594,7 @@ function InstallButton({
     return (
       <span className={`sk-chip sk-chip--ok${large ? ' sk-chip--lg' : ' sk-chip--card-action'}`}>
         <CheckIcon aria-hidden="true" />
-        Installed
+        {t('skills.installed')}
       </span>
     )
   if (action === 'force') {
@@ -585,7 +607,7 @@ function InstallButton({
         onClick={(e) => onInstall(true, e)}
       >
         {!busy ? <TriangleAlertIcon aria-hidden="true" /> : null}
-        {busy ? 'Force installing…' : 'Force install'}
+        {busy ? t('skills.forceInstalling') : t('skills.forceInstall')}
       </Button>
     )
   }
@@ -596,7 +618,7 @@ function InstallButton({
       disabled={busy}
       onClick={(e) => onInstall(false, e)}
     >
-      {busy ? 'Installing…' : large ? 'Install skill' : 'Install'}
+      {busy ? t('skills.installing') : large ? t('skills.installSkill') : t('skills.install')}
     </Button>
   )
 }
@@ -662,7 +684,7 @@ export function SkillsPage() {
   const [sessionInstalls, setSessionInstalls] = useState<RegistryItem[]>([])
 
   useEffect(() => {
-    document.title = 'Skills - AgentOS Control'
+    document.title = t('skills.documentTitle')
   }, [])
 
   // skills.js:210-220 — debounce the community search input (250ms). A cleared
@@ -689,9 +711,12 @@ export function SkillsPage() {
   useEffect(() => {
     if (skillsQuery.isError) {
       const err = skillsQuery.error
-      toast.error('Failed to load skills: ' + (err instanceof Error ? err.message : String(err)), {
-        id: 'skills-load-err',
-      })
+      toast.error(
+        t('skills.toastLoadFailed', {
+          message: err instanceof Error ? err.message : String(err),
+        }),
+        { id: 'skills-load-err' },
+      )
     }
   }, [skillsQuery.isError, skillsQuery.error])
 
@@ -805,7 +830,9 @@ export function SkillsPage() {
     onSuccess: (res, vars) => {
       if (res?.success) {
         armForce(vars.identifier, false)
-        toast.success('Installed ' + (res.name || vars.identifier), { id: 'skills-install' })
+        toast.success(t('skills.toastInstalled', { name: res.name || vars.identifier }), {
+          id: 'skills-install',
+        })
         if (vars.item) {
           const row = { ...vars.item, installed: true }
           setSessionInstalls((prev) => mergeRegistryRows([row], prev))
@@ -819,14 +846,15 @@ export function SkillsPage() {
       const n = (res?.scan_findings || []).length
       if (blocked && !vars.force) {
         armForce(vars.identifier, true)
+        const name = res?.name || t('skills.toastScanUnnamed')
         toast.error(
-          `Security scan flagged ${res?.name || 'this skill'}${
-            n ? ` (${n} finding${n === 1 ? '' : 's'})` : ''
-          }. Click again to install anyway.`,
+          t('skills.toastScanBlocked', {
+            target: n ? tPlural('skills.toastScanTarget', n, { name }) : name,
+          }),
           { id: 'skills-install-err' },
         )
       } else {
-        toast.error(res?.message || 'Install failed', { id: 'skills-install-err' })
+        toast.error(res?.message || t('skills.toastInstallFailed'), { id: 'skills-install-err' })
       }
     },
     onError: (err) => {
@@ -845,7 +873,7 @@ export function SkillsPage() {
     onSuccess: (res, vars) => {
       const name = vars.name
       if (res?.success) {
-        toast.success('Removed ' + name, { id: 'skills-uninstall' })
+        toast.success(t('skills.toastRemoved', { name }), { id: 'skills-uninstall' })
         setDialog({ kind: 'none' })
         setSessionInstalls((prev) =>
           prev.filter((r) => r.name !== name && registryKey(r) !== vars.identifier),
@@ -857,7 +885,9 @@ export function SkillsPage() {
         // always invalidated it; removal never did.
         void invalidateRegistry()
       } else {
-        toast.error(res?.message || 'Uninstall failed', { id: 'skills-uninstall-err' })
+        toast.error(res?.message || t('skills.toastUninstallFailed'), {
+          id: 'skills-uninstall-err',
+        })
       }
     },
     onError: (err) => {
@@ -874,10 +904,14 @@ export function SkillsPage() {
     onSuccess: (res, name) => {
       const result = firstUpdateResult(res)
       if (result.success) {
-        toast.success(result.message || `Updated ${name}`, { id: 'skills-update' })
+        toast.success(result.message || t('skills.toastUpdated', { name }), {
+          id: 'skills-update',
+        })
         void invalidateSkills()
       } else {
-        toast.error(result.message || res?.message || 'Update failed', { id: 'skills-update-err' })
+        toast.error(result.message || res?.message || t('skills.toastUpdateFailed'), {
+          id: 'skills-update-err',
+        })
       }
     },
     onError: (err) => {
@@ -897,10 +931,10 @@ export function SkillsPage() {
     onSettled: (_d, _e, vars) => setBusy('deps:' + vars.name + ':' + vars.installId, false),
     onSuccess: (res) => {
       if (res?.success) {
-        toast.success(res.message || 'Installed', { id: 'skills-deps' })
+        toast.success(res.message || t('skills.toastDepsInstalled'), { id: 'skills-deps' })
         if (stillMissingCount(res) === 0) setDialog({ kind: 'none' })
       } else {
-        toast.error(res?.message || 'Install failed', { id: 'skills-deps-err' })
+        toast.error(res?.message || t('skills.toastInstallFailed'), { id: 'skills-deps-err' })
       }
       void invalidateSkills()
     },
@@ -1005,27 +1039,30 @@ export function SkillsPage() {
     <div className="sk-stage">
       <header className="sk-stage__header">
         <div className="sk-stage__title-block">
-          <h1 className="t-display">Skills</h1>
-          <p className="sk-stage__subtitle">
-            Manage installed capabilities and discover trusted skills for your agents.
-          </p>
+          <h1 className="t-display">{t('skills.title')}</h1>
+          <p className="sk-stage__subtitle">{t('skills.subtitle')}</p>
         </div>
         <div className="sk-stage__actions">
-          <Button variant="outline" title="Refresh" className="sk-refresh" onClick={refresh}>
+          <Button
+            variant="outline"
+            title={t('skills.refresh')}
+            className="sk-refresh"
+            onClick={refresh}
+          >
             <RefreshCwIcon />
-            <span>Refresh</span>
+            <span>{t('skills.refresh')}</span>
           </Button>
         </div>
       </header>
 
       {/* Tabs (skills.js:107-112) */}
-      <nav className="sk-source-nav" aria-label="Skill source">
-        <div className="sk-tabs" role="tablist" aria-label="Skill source">
+      <nav className="sk-source-nav" aria-label={t('skills.tabsLandmark')}>
+        <div className="sk-tabs" role="tablist" aria-label={t('skills.tabsLandmark')}>
           <TabButton
             current={tab}
             tab="installed"
-            label="Installed"
-            description={`${stats.total} local skills`}
+            label={t('skills.tabInstalled')}
+            description={t('skills.tabInstalledDesc', { count: stats.total })}
             icon={<PackageIcon aria-hidden="true" />}
             onSelect={setTab}
           />
@@ -1033,8 +1070,8 @@ export function SkillsPage() {
             <TabButton
               current={tab}
               tab="bankr"
-              label="Bankr"
-              description="Partner catalog"
+              label={PARTNER_BRANDS.bankr.label}
+              description={t('skills.tabPartnerDesc')}
               icon={<PartnerLogo brand="bankr" className="sk-tab__brand" decorative />}
               onSelect={setTab}
             />
@@ -1043,8 +1080,8 @@ export function SkillsPage() {
             <TabButton
               current={tab}
               tab="capminal"
-              label="Capminal"
-              description="Partner catalog"
+              label={PARTNER_BRANDS.capminal.label}
+              description={t('skills.tabPartnerDesc')}
               icon={<PartnerLogo brand="capminal" className="sk-tab__brand" decorative />}
               onSelect={setTab}
             />
@@ -1052,16 +1089,16 @@ export function SkillsPage() {
           <TabButton
             current={tab}
             tab="robinhood"
-            label="Robinhood"
-            description="Bundled partner"
+            label={PARTNER_BRANDS.robinhood.label}
+            description={t('skills.tabRobinhoodDesc')}
             icon={<PartnerLogo brand="robinhood" className="sk-tab__brand" decorative />}
             onSelect={setTab}
           />
           <TabButton
             current={tab}
             tab="community"
-            label="Community"
-            description="Open catalog"
+            label={t('skills.tabCommunity')}
+            description={t('skills.tabCommunityDesc')}
             icon={<GlobeIcon aria-hidden="true" />}
             onSelect={setTab}
           />
@@ -1075,31 +1112,31 @@ export function SkillsPage() {
             <input
               type="search"
               className="sk-search-input sk-search-input--library"
-              placeholder="Search installed skills"
-              aria-label="Filter installed skills"
+              placeholder={t('skills.searchPlaceholder')}
+              aria-label={t('skills.searchLabel')}
               autoComplete="off"
               value={filterText}
               onChange={(e) => setFilterText(e.target.value)}
             />
           </div>
           {/* Metric pills → status filter (skills.js:342-367) */}
-          <section className="sk-metrics" aria-label="Skills summary">
+          <section className="sk-metrics" aria-label={t('skills.metricsLandmark')}>
             <MetricPill
-              label="All"
+              label={t('skills.metricAll')}
               value={stats.total}
               tone="accent"
               active={statusFilter === 'all'}
               onClick={() => setStatusFilter('all')}
             />
             <MetricPill
-              label="Ready"
+              label={t('skills.metricReady')}
               value={stats.ready}
               tone="ok"
               active={statusFilter === 'ready'}
               onClick={() => setStatusFilter('ready')}
             />
             <MetricPill
-              label="Needs setup"
+              label={t('skills.metricNeedsSetup')}
               value={stats.needs}
               tone="warn"
               active={statusFilter === 'needs-setup'}
@@ -1110,7 +1147,7 @@ export function SkillsPage() {
                 filter next to the ones that matter. */}
             {stats.disabled > 0 || statusFilter === 'disabled' ? (
               <MetricPill
-                label="Disabled"
+                label={t('skills.metricDisabled')}
                 value={stats.disabled}
                 active={statusFilter === 'disabled'}
                 onClick={() => setStatusFilter('disabled')}
@@ -1191,8 +1228,8 @@ export function SkillsPage() {
                 <DownloadIcon />
               </span>
               <div>
-                <h2 id="sk-github-title">Install from GitHub</h2>
-                <p>Add a skill directly from a public repository or folder.</p>
+                <h2 id="sk-github-title">{t('skills.githubTitle')}</h2>
+                <p>{t('skills.githubDesc')}</p>
               </div>
             </div>
             <div className="sk-github-install__controls">
@@ -1200,8 +1237,8 @@ export function SkillsPage() {
                 <input
                   type="url"
                   className="sk-search-input sk-search-input--lg"
-                  placeholder="https://github.com/owner/repo/tree/main/skill"
-                  aria-label="Install from GitHub URL"
+                  placeholder={t('skills.githubPlaceholder')}
+                  aria-label={t('skills.githubUrlLabel')}
                   autoComplete="off"
                   value={githubUrl}
                   onChange={(e) => setGithubUrl(e.target.value)}
@@ -1227,7 +1264,7 @@ export function SkillsPage() {
                     })
                 }}
               >
-                Install
+                {t('skills.githubInstall')}
               </Button>
             </div>
           </section>
@@ -1294,7 +1331,7 @@ export function SkillsPage() {
               try {
                 await rpc.call('env.set', { name: envPrompt.name, value: envValue })
                 await queryClient.invalidateQueries({ queryKey: ['skills'] })
-                toast.success(`${envPrompt.name} saved.`)
+                toast.success(t('skills.toastEnvSaved', { name: envPrompt.name }))
                 setEnvPrompt(null)
                 setEnvValue('')
               } catch (error) {
@@ -1430,10 +1467,10 @@ function InstalledPanel({
   if (error)
     return (
       <div id="sk-panel-installed" role="tabpanel" className="sk-error">
-        Failed to load skills: {error}
+        {t('skills.installedLoadFailed', { error })}
       </div>
     )
-  if (loading) return <SkillsSkeleton label="Loading installed skills" />
+  if (loading) return <SkillsSkeleton label={t('skills.loadingInstalled')} />
   if (empty)
     return (
       <div id="sk-panel-installed" role="tabpanel" className="sk-empty__state">
@@ -1513,15 +1550,14 @@ function PartnerIntro({
           <p className="sk-partner__notice" role="note">
             <TriangleAlertIcon size={13} aria-hidden="true" />
             <span>
-              <strong>IMPORTANT:</strong> {notice}
+              <strong>{t('skills.importantPrefix')}</strong> {notice}
             </span>
           </p>
         ) : null}
       </div>
       {typeof count === 'number' ? (
         <span className="sk-partner__count">
-          <strong>{count}</strong>
-          {count === 1 ? ' skill' : ' skills'}
+          <strong>{count}</strong> {count === 1 ? t('skills.skillWord') : t('skills.skillsWord')}
         </span>
       ) : null}
     </div>
@@ -1550,10 +1586,10 @@ function RobinhoodPanel({
   const stats = skillStats(skills)
   const filtered = filterSkills(skills, query.trim(), statusFilter)
   const filters = [
-    { key: 'all' as const, label: 'All', count: stats.total },
-    { key: 'ready' as const, label: 'Ready', count: stats.ready },
-    { key: 'needs-setup' as const, label: 'Needs setup', count: stats.needs },
-    { key: 'disabled' as const, label: 'Disabled', count: stats.disabled },
+    { key: 'all' as const, label: t('skills.metricAll'), count: stats.total },
+    { key: 'ready' as const, label: t('skills.metricReady'), count: stats.ready },
+    { key: 'needs-setup' as const, label: t('skills.metricNeedsSetup'), count: stats.needs },
+    { key: 'disabled' as const, label: t('skills.metricDisabled'), count: stats.disabled },
   ].filter((item) => item.key === 'all' || item.count > 0 || item.key === statusFilter)
 
   return (
@@ -1565,9 +1601,9 @@ function RobinhoodPanel({
     >
       <PartnerIntro
         brand="robinhood"
-        title={ROBINHOOD_INTRO.title}
-        description={ROBINHOOD_INTRO.description}
-        notice={ROBINHOOD_INTRO.notice}
+        title={robinhoodIntro().title}
+        description={robinhoodIntro().description}
+        notice={robinhoodIntro().notice}
         count={skills.length}
       />
       <div className="sk-browse__bar">
@@ -1576,8 +1612,12 @@ function RobinhoodPanel({
           <input
             type="search"
             className="sk-search-input sk-search-input--lg"
-            placeholder="Search Robinhood skills…"
-            aria-label="Search Robinhood skills"
+            placeholder={t('skills.registrySearchPlaceholder', {
+              label: PARTNER_BRANDS.robinhood.label,
+            })}
+            aria-label={t('skills.registrySearchLabel', {
+              label: PARTNER_BRANDS.robinhood.label,
+            })}
             autoComplete="off"
             value={query}
             onChange={(event) => onQuery(event.target.value)}
@@ -1585,13 +1625,13 @@ function RobinhoodPanel({
         </div>
       </div>
       {filters.length > 1 ? (
-        <div className="sk-chips" aria-label="Robinhood skill status">
+        <div className="sk-chips" aria-label={t('skills.robinhoodStatusLandmark')}>
           {filters.map((filter) => (
             <button
               key={filter.key}
               type="button"
               className={`sk-chip-btn${statusFilter === filter.key ? ' is-active' : ''}`}
-              aria-label={`Filter Robinhood skills: ${filter.label}`}
+              aria-label={t('skills.robinhoodFilterLabel', { label: filter.label })}
               aria-pressed={statusFilter === filter.key}
               onClick={() => onStatusFilter(filter.key)}
             >
@@ -1603,15 +1643,15 @@ function RobinhoodPanel({
       <div className="sk-browse__results">
         {error ? (
           <div className="sk-error">
-            Failed to load: {error}
+            {t('skills.loadFailed', { error })}
             <br />
-            <span className="sk-dim">Press Refresh to retry.</span>
+            <span className="sk-dim">{t('skills.retryHintRobinhood')}</span>
           </div>
         ) : loading ? (
-          <SkillsSkeleton label="Loading Robinhood skills" />
+          <SkillsSkeleton label={t('skills.loadingRobinhood')} />
         ) : filtered.length === 0 ? (
           <div className="sk-registry__hint">
-            {partnerEmptyMessage('Robinhood', query, statusFilter)}
+            {partnerEmptyMessage(PARTNER_BRANDS.robinhood.label, query, statusFilter)}
           </div>
         ) : (
           <div className="sk-grid sk-grid--registry">
@@ -1686,15 +1726,15 @@ function RegistryPanel({
       className={`sk-panel sk-panel--source sk-panel--${group}`}
     >
       {group !== 'community' ? (
-        <PartnerIntro brand={group} {...REGISTRY_INTRO[group]} count={snapshot.length} />
+        <PartnerIntro brand={group} {...registryIntro()[group]} count={snapshot.length} />
       ) : (
         <div className="sk-community-intro">
           <span className="sk-community-intro__icon" aria-hidden="true">
             <GlobeIcon />
           </span>
           <div>
-            <h2>Community catalog</h2>
-            <p>Discover skills published by the wider AgentOS community.</p>
+            <h2>{t('skills.communityTitle')}</h2>
+            <p>{t('skills.communityDesc')}</p>
           </div>
         </div>
       )}
@@ -1704,8 +1744,8 @@ function RegistryPanel({
           <input
             type="search"
             className="sk-search-input sk-search-input--lg"
-            placeholder={`Search ${registryLabel(group)} skills…`}
-            aria-label={`Search ${registryLabel(group)} skills`}
+            placeholder={t('skills.registrySearchPlaceholder', { label: registryLabel(group) })}
+            aria-label={t('skills.registrySearchLabel', { label: registryLabel(group) })}
             autoComplete="off"
             value={query}
             onChange={(e) => onQuery(e.target.value)}
@@ -1729,12 +1769,12 @@ function RegistryPanel({
       <div className="sk-browse__results">
         {error ? (
           <div className="sk-error">
-            Failed to load: {error}
+            {t('skills.loadFailed', { error })}
             <br />
-            <span className="sk-dim">Re-open the tab or press Refresh to retry.</span>
+            <span className="sk-dim">{t('skills.retryHintCommunity')}</span>
           </div>
         ) : loading ? (
-          <SkillsSkeleton label={`Loading ${registryLabel(group)} catalog`} />
+          <SkillsSkeleton label={t('skills.loadingCatalog', { label: registryLabel(group) })} />
         ) : items.length === 0 ? (
           <div className="sk-registry__hint">{registryEmptyMessage(group, query)}</div>
         ) : (
@@ -1763,10 +1803,10 @@ function RegistryPanel({
 // Per-requirement name + status chip + missing/requires detail. Renders nothing
 // when there are no requirement items.
 function reqStatusLabel(status: string): string {
-  if (status === 'ready') return 'ready'
-  if (status === 'needs_setup') return 'needs setup'
-  if (status === 'missing_skill') return 'missing skill'
-  return 'no deps declared'
+  if (status === 'ready') return t('skills.reqReady')
+  if (status === 'needs_setup') return t('skills.reqNeedsSetup')
+  if (status === 'missing_skill') return t('skills.reqMissingSkill')
+  return t('skills.reqNotDeclared')
 }
 
 function reqStatusClass(status: string): string {
@@ -1781,9 +1821,9 @@ function RequirementRow({ item }: { item: SkillRequirementItem }) {
   // skills.js:750-755 — declared requirements as plain text fragments.
   const requires: string[] = [...(item.requires_bins || [])]
   if ((item.requires_any_bins || []).length) {
-    requires.push(`one of ${(item.requires_any_bins || []).join(' / ')}`)
+    requires.push(t('skills.reqOneOf', { list: (item.requires_any_bins || []).join(' / ') }))
   }
-  ;(item.requires_env || []).forEach((e) => requires.push(`${e} env`))
+  ;(item.requires_env || []).forEach((e) => requires.push(t('skills.reqEnv', { name: e })))
   const status = item.status || 'not_declared'
 
   // skills.js:764-766 — detail prefers the missing codes, else the requires
@@ -1792,7 +1832,7 @@ function RequirementRow({ item }: { item: SkillRequirementItem }) {
   if (missing.length) {
     detail = (
       <>
-        Missing{' '}
+        {t('skills.reqMissingLead')}{' '}
         {missing.map((m, i) => (
           <span key={m}>
             {i > 0 ? ', ' : ''}
@@ -1804,12 +1844,12 @@ function RequirementRow({ item }: { item: SkillRequirementItem }) {
   } else if (requires.length) {
     detail = requires.join(', ')
   } else {
-    detail = 'No declared dependencies'
+    detail = t('skills.reqNoDeps')
   }
 
   return (
     <div className="sk-dialog__req-row">
-      <span className="sk-dialog__req-name">{item.name || 'unknown'}</span>
+      <span className="sk-dialog__req-name">{item.name || t('skills.reqUnknown')}</span>
       <span className={`sk-chip ${reqStatusClass(status)}`}>{reqStatusLabel(status)}</span>
       <span className="sk-dialog__req-detail">{detail}</span>
     </div>
@@ -1821,7 +1861,7 @@ function RequirementsSection({ requirements }: { requirements?: SkillRequirement
   if (!items.length) return null
   return (
     <div className="sk-dialog__section">
-      <div className="sk-dialog__section-title">Requirements</div>
+      <div className="sk-dialog__section-title">{t('skills.reqTitle')}</div>
       <div className="sk-dialog__requirements">
         {items.map((item, i) => (
           <RequirementRow key={item.name || i} item={item} />
@@ -1894,16 +1934,22 @@ function SkillDialog({
             </span>
             <OriginChip skill={skill} />
             {bucket === 'ready' ? (
-              <span className="sk-chip sk-chip--ok">✓ ready</span>
+              <span className="sk-chip sk-chip--ok">{t('skills.chipReady')}</span>
             ) : bucket === 'disabled' ? (
-              <span className="sk-chip sk-chip--unverified">disabled</span>
+              <span className="sk-chip sk-chip--unverified">{t('skills.chipDisabled')}</span>
             ) : (
-              <span className="sk-chip sk-chip--warn">needs deps</span>
+              <span className="sk-chip sk-chip--warn">{t('skills.chipNeedsDeps')}</span>
             )}
             <AvailabilityChip skill={skill} />
           </div>
         </div>
-        <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label={t('common.close')}
+        >
           <XIcon />
         </Button>
       </header>
@@ -1914,20 +1960,20 @@ function SkillDialog({
             still not find it?" — the gateway writes the prose. */}
         {availabilityDetail ? (
           <div className="sk-dialog__section sk-dialog__withheld">
-            <div className="sk-dialog__section-title">Agent availability</div>
+            <div className="sk-dialog__section-title">{t('skills.sectionAvailability')}</div>
             <p className="sk-dialog__desc">{availabilityDetail}</p>
           </div>
         ) : null}
         <RequirementsSection requirements={skill.requirements} />
         {hasMissing ? (
           <div className="sk-dialog__section">
-            <div className="sk-dialog__section-title">Missing</div>
+            <div className="sk-dialog__section-title">{t('skills.sectionMissing')}</div>
             <ul className="sk-dialog__missing">
               {missingBins.map((b) => (
                 <li key={`bin:${b}`} className="sk-dialog__missing-row">
                   <div className="sk-dialog__missing-info">
                     <div className="sk-dialog__missing-head">
-                      <code>{b}</code> <span className="sk-dim">binary</span>
+                      <code>{b}</code> <span className="sk-dim">{t('skills.missingBinary')}</span>
                     </div>
                   </div>
                 </li>
@@ -1941,7 +1987,7 @@ function SkillDialog({
                   <li key={`env:${e}`} className="sk-dialog__missing-row sk-dialog__missing-env">
                     <div className="sk-dialog__missing-info">
                       <div className="sk-dialog__missing-head">
-                        <code>{e}</code> <span className="sk-dim">env var</span>
+                        <code>{e}</code> <span className="sk-dim">{t('skills.missingEnvVar')}</span>
                       </div>
                       {detail?.description || detail?.url ? (
                         <p className="sk-dialog__missing-desc">
@@ -1955,7 +2001,7 @@ function SkillDialog({
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >
-                                where to get it ↗
+                                {t('skills.whereToGet')}
                               </a>
                             </>
                           ) : null}
@@ -1969,10 +2015,10 @@ function SkillDialog({
                       type="button"
                       variant="outline"
                       size="sm"
-                      aria-label={`Set ${e}`}
+                      aria-label={t('skills.setEnvAria', { name: e })}
                       onClick={() => onSetEnv(e)}
                     >
-                      Set
+                      {t('skills.setEnvAction')}
                     </Button>
                   </li>
                 )
@@ -1982,7 +2028,7 @@ function SkillDialog({
         ) : null}
         {installs.length ? (
           <div className="sk-dialog__section">
-            <div className="sk-dialog__section-title">Install</div>
+            <div className="sk-dialog__section-title">{t('skills.sectionInstall')}</div>
             {installs.map((i) => {
               const busy = busyKeys.has('deps:' + skill.name + ':' + i.id)
               return (
@@ -1999,7 +2045,9 @@ function SkillDialog({
                     disabled={busy}
                     onClick={() => onInstallDeps(i.id!)}
                   >
-                    {busy ? 'Installing…' : `Install via ${i.kind}`}
+                    {busy
+                      ? t('skills.installing')
+                      : t('skills.installVia', { kind: String(i.kind) })}
                   </Button>
                 </div>
               )
@@ -2009,19 +2057,19 @@ function SkillDialog({
         {homepage ? (
           <div className="sk-dialog__section">
             <a href={homepage} target="_blank" rel="noopener" className="sk-dialog__link">
-              Homepage ↗
+              {t('skills.homepage')}
             </a>
           </div>
         ) : null}
       </section>
       <footer className="sk-dialog__foot">
         {removeBlocked ? (
-          <small className="sk-dim sk-dialog__note">{REMOVE_BLOCKED_NOTE}</small>
+          <small className="sk-dim sk-dialog__note">{removeBlockedNote()}</small>
         ) : skill.file_path ? (
           <small className="sk-dim sk-dialog__path">{skill.file_path}</small>
         ) : null}
         <Button type="button" size="sm" onClick={onUse}>
-          Use in chat
+          {t('skills.useInChat')}
         </Button>
         {canUpdate ? (
           <Button
@@ -2031,7 +2079,7 @@ function SkillDialog({
             disabled={updateBusy}
             onClick={onUpdate}
           >
-            {updateBusy ? 'Updating…' : 'Update'}
+            {updateBusy ? t('skills.updating') : t('skills.update')}
           </Button>
         ) : null}
         {canRemove ? (
@@ -2042,7 +2090,7 @@ function SkillDialog({
             disabled={removeBusy}
             onClick={onRemove}
           >
-            {removeBusy ? 'Removing…' : 'Remove'}
+            {removeBusy ? t('skills.removing') : t('skills.remove')}
           </Button>
         ) : null}
       </footer>
@@ -2090,7 +2138,13 @@ function RegistryDialog({
             <div className="sk-dialog__provider">{item.provider || ''}</div>
           </div>
         </div>
-        <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label={t('common.close')}
+        >
           <XIcon />
         </Button>
       </header>
@@ -2099,21 +2153,19 @@ function RegistryDialog({
           <span
             className={`sk-chip ${item.trust_level === 'trusted' ? 'sk-chip--ok' : 'sk-chip--warn'}`}
           >
-            {item.trust_level || 'community'}
+            {item.trust_level || t('skills.trustCommunity')}
           </span>
-          {cat ? <span className="sk-chip">{CAT_LABEL[cat] || cat}</span> : null}
+          {cat ? <span className="sk-chip">{catLabel(cat)}</span> : null}
           <span className="sk-chip sk-mono">{item.source || ''}</span>
         </div>
         {item.description ? (
           <p className="sk-dialog__desc">{item.description}</p>
         ) : (
-          <p className="sk-dialog__desc sk-dim">
-            Description loads after install (from the skill&apos;s SKILL.md).
-          </p>
+          <p className="sk-dialog__desc sk-dim">{t('skills.descPending')}</p>
         )}
         {Array.isArray(item.setup) && item.setup.length ? (
           <div className="sk-dialog__section">
-            <div className="sk-dialog__section-title">Setup</div>
+            <div className="sk-dialog__section-title">{t('skills.sectionSetup')}</div>
             <ol className="sk-dialog__setup">
               {item.setup.map((s, i) => (
                 <li key={i}>{s}</li>
@@ -2124,7 +2176,7 @@ function RegistryDialog({
         {item.demo && item.demo.code ? (
           <div className="sk-dialog__section">
             <div className="sk-dialog__section-title">
-              Demo{' '}
+              {t('skills.sectionDemo')}{' '}
               {demoTitle ? (
                 <span className="sk-dialog__demo-title sk-mono">{demoTitle}</span>
               ) : null}{' '}
@@ -2138,7 +2190,7 @@ function RegistryDialog({
         {homepage ? (
           <div className="sk-dialog__section">
             <a href={homepage} target="_blank" rel="noopener" className="sk-dialog__link">
-              Source ↗
+              {t('skills.sourceLink')}
             </a>
           </div>
         ) : null}
@@ -2178,9 +2230,15 @@ function SetEnvDialog({
     >
       <header className="sk-dialog__head">
         <h2 id={titleId} className="sk-dialog__title">
-          Set {name}
+          {t('skills.setEnvTitle', { name })}
         </h2>
-        <Button type="button" variant="ghost" size="icon-sm" aria-label="Close" onClick={onClose}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={t('common.close')}
+          onClick={onClose}
+        >
           <XIcon />
         </Button>
       </header>
@@ -2192,7 +2250,7 @@ function SetEnvDialog({
         }}
       >
         <p className="sk-dialog__desc">
-          Stored in the AgentOS <code>.env</code> and applied to the running gateway.
+          {t('skills.setEnvDescLead')} <code>{'.env'}</code> {t('skills.setEnvDescTail')}
         </p>
         <input
           type="password"
@@ -2204,10 +2262,10 @@ function SetEnvDialog({
         />
         <div className="sk-dialog__install-row">
           <Button type="submit" size="sm" disabled={saving || !value}>
-            {saving ? 'Saving…' : 'Save'}
+            {saving ? t('skills.saving') : t('common.save')}
           </Button>
           <Button type="button" variant="outline" size="sm" onClick={onClose}>
-            Cancel
+            {t('common.cancel')}
           </Button>
         </div>
       </form>

--- a/frontend/src/views/skills/logic.ts
+++ b/frontend/src/views/skills/logic.ts
@@ -8,6 +8,9 @@
 // ── Types ────────────────────────────────────────────────────────────────────
 
 /** An installed skill row from skills.list (all fields optional). */
+import { t } from '@/i18n'
+import '@/i18n/en/skills'
+
 export interface RawSkill {
   name?: string
   description?: string
@@ -204,37 +207,45 @@ export function skillBucket(skill: RawSkill): SkillBucket {
 // longer groups the Installed tab (see SKILL_GROUP_ORDER below) — grouping on
 // it split the same partner's skills across two headings.
 
-export const LAYER_LABEL: Record<string, string> = {
-  workspace: 'Workspace',
-  bundled: 'Bundled',
-  managed: 'Managed',
-  personal: 'Personal',
-  project: 'Project',
-  extra: 'Extra',
+function layerLabels(): Record<string, string> {
+  return {
+    workspace: t('skills.layerWorkspace'),
+    bundled: t('skills.layerBundled'),
+    managed: t('skills.layerManaged'),
+    personal: t('skills.layerPersonal'),
+    project: t('skills.layerProject'),
+    extra: t('skills.layerExtra'),
+  }
 }
 
-export const LAYER_HELP: Record<string, string> = {
-  workspace: 'Workspace skills are local to the active workspace.',
-  bundled: 'Bundled skills ship with AgentOS.',
-  managed: 'Managed skills are locally installed into AgentOS state.',
-  personal: 'Personal skills are local user installs, not bundled.',
-  project: 'Project skills are local to the current project.',
-  extra: 'Extra skills come from configured local directories.',
+function layerHelps(): Record<string, string> {
+  return {
+    workspace: t('skills.layerHelpWorkspace'),
+    bundled: t('skills.layerHelpBundled'),
+    managed: t('skills.layerHelpManaged'),
+    personal: t('skills.layerHelpPersonal'),
+    project: t('skills.layerHelpProject'),
+    extra: t('skills.layerHelpExtra'),
+  }
 }
 
-export const CAT_LABEL: Record<string, string> = {
-  all: 'All',
-  trading: 'Trading',
-  defi: 'DeFi',
-  wallet: 'Wallets',
-  markets: 'Markets',
-  social: 'Social',
-  data: 'Data',
-  nft: 'NFT',
-  dev: 'Dev tools',
-  infra: 'Infra',
-  crypto: 'Crypto',
-  other: 'Other',
+/** Catalog category labels, resolved per call so they follow the locale. */
+export function catLabel(category: string): string {
+  const labels: Record<string, string> = {
+    all: t('skills.catAll'),
+    trading: t('skills.catTrading'),
+    defi: t('skills.catDefi'),
+    wallet: t('skills.catWallet'),
+    markets: t('skills.catMarkets'),
+    social: t('skills.catSocial'),
+    data: t('skills.catData'),
+    nft: t('skills.catNft'),
+    dev: t('skills.catDev'),
+    infra: t('skills.catInfra'),
+    crypto: t('skills.catCrypto'),
+    other: t('skills.catOther'),
+  }
+  return labels[category] || category
 }
 
 /** skills.js:210,220 — the registry-search debounce interval (ms). */
@@ -243,11 +254,11 @@ export const REGISTRY_SEARCH_DEBOUNCE_MS = 250
 // ── Layer label/help (skills.js:1070-1076) ───────────────────────────────────
 
 export function layerLabel(layer?: string): string {
-  return (layer && LAYER_LABEL[layer]) || layer || 'Unknown'
+  return (layer && layerLabels()[layer]) || layer || t('skills.layerUnknown')
 }
 
 export function layerHelp(layer?: string): string {
-  return (layer && LAYER_HELP[layer]) || 'Configured local skill directory.'
+  return (layer && layerHelps()[layer]) || t('skills.layerHelpFallback')
 }
 
 // ── Installed stats (skills.js:342-367) ──────────────────────────────────────
@@ -298,11 +309,11 @@ export function filterSkills(
 
 /** skills.js:391-399 — the empty-state message for the installed list. */
 export function installedEmptyMessage(filterText: string, statusFilter: StatusFilter): string {
-  if (filterText) return `No skills match ${filterText}.`
-  if (statusFilter === 'ready') return 'No skills are ready. Install dependencies to enable them.'
-  if (statusFilter === 'needs-setup') return 'No skills currently need setup.'
-  if (statusFilter === 'disabled') return 'No skills are switched off.'
-  return 'No skills installed.'
+  if (filterText) return t('skills.emptyMatch', { query: filterText })
+  if (statusFilter === 'ready') return t('skills.emptyReady')
+  if (statusFilter === 'needs-setup') return t('skills.emptyNeedsSetup')
+  if (statusFilter === 'disabled') return t('skills.emptyDisabled')
+  return t('skills.emptyNone')
 }
 
 // ── Provenance grouping + ready-first sort (skills.js:407-442) ────────────────
@@ -343,20 +354,24 @@ export function skillChatPromptPath(name: string): string {
   return '/chat?prompt=' + encodeURIComponent('use skill ' + name + '\n')
 }
 
-export const SKILL_GROUP_LABEL: Record<SkillGroupKey, string> = {
-  partners: 'Partner Skills',
-  crypto: 'AgentOS Crypto Skills',
-  shipped: 'AgentOS Normal Skills',
-  hub: 'Installed from a hub',
-  local: 'Your local skills',
+function skillGroupLabels(): Record<SkillGroupKey, string> {
+  return {
+    partners: t('skills.groupPartners'),
+    crypto: t('skills.groupCrypto'),
+    shipped: t('skills.groupShipped'),
+    hub: t('skills.groupHub'),
+    local: t('skills.groupLocal'),
+  }
 }
 
-export const SKILL_GROUP_HELP: Record<SkillGroupKey, string> = {
-  partners: 'Skills published by an AgentOS partner.',
-  crypto: 'On-chain and wallet skills that ship with AgentOS.',
-  shipped: 'Skills that ship with AgentOS.',
-  hub: 'Skills you installed from a skill hub.',
-  local: 'Skills you added yourself, from a local skill directory.',
+function skillGroupHelps(): Record<SkillGroupKey, string> {
+  return {
+    partners: t('skills.groupHelpPartners'),
+    crypto: t('skills.groupHelpCrypto'),
+    shipped: t('skills.groupHelpShipped'),
+    hub: t('skills.groupHelpHub'),
+    local: t('skills.groupHelpLocal'),
+  }
 }
 
 /**
@@ -470,8 +485,8 @@ export function groupSkills(skills: RawSkill[]): SkillGroup[] {
     if (!list || list.length === 0) return
     out.push({
       key,
-      label: SKILL_GROUP_LABEL[key],
-      help: SKILL_GROUP_HELP[key],
+      label: skillGroupLabels()[key],
+      help: skillGroupHelps()[key],
       skills: sortByReady(list),
     })
   })
@@ -499,16 +514,19 @@ export function skillDotClass(skill: RawSkill): SkillDot {
 }
 
 /** The label under the dot, per bucket. */
-export const SKILL_BUCKET_LABEL: Record<SkillBucket, string> = {
-  ready: 'Ready',
-  'needs-setup': 'Setup required',
-  disabled: 'Disabled',
+export function skillBucketLabel(bucket: SkillBucket): string {
+  const labels: Record<SkillBucket, string> = {
+    ready: t('skills.bucketReady'),
+    'needs-setup': t('skills.bucketNeedsSetup'),
+    disabled: t('skills.bucketDisabled'),
+  }
+  return labels[bucket]
 }
 
 /** skills.js:454 — the dot tooltip. */
 export function skillDotTitle(skill: RawSkill): string {
-  if (skill.disabled) return skill.status_detail || 'Disabled in config'
-  return skill.status_detail || (skill.eligible ? 'Ready' : 'Needs setup')
+  if (skill.disabled) return skill.status_detail || t('skills.dotDisabled')
+  return skill.status_detail || (skill.eligible ? t('skills.dotReady') : t('skills.dotNeedsSetup'))
 }
 
 // ── Availability: installed and eligible, but is it offered? ──────────────────
@@ -530,22 +548,24 @@ export function skillAvailabilityTone(skill: RawSkill): SkillAvailabilityTone {
 }
 
 /** Short labels per withheld reason, for the card chip. */
-export const AVAILABILITY_REASON_LABEL: Record<string, string> = {
-  model_invocation_disabled: 'Not offered — agent cannot invoke',
-  ineligible: 'Not offered — needs setup',
-  tool_gate: 'Not offered — missing tools',
-  fallback_superseded: 'Not offered — superseded',
-  not_retrieved: 'Not offered — not retrieved',
-  prompt_budget: 'Not offered — prompt too long',
+function availabilityReasonLabels(): Record<string, string> {
+  return {
+    model_invocation_disabled: t('skills.availModelInvocationDisabled'),
+    ineligible: t('skills.availIneligible'),
+    tool_gate: t('skills.availToolGate'),
+    fallback_superseded: t('skills.availFallbackSuperseded'),
+    not_retrieved: t('skills.availNotRetrieved'),
+    prompt_budget: t('skills.availPromptBudget'),
+  }
 }
 
 /** The chip label; '' when availability was not computed (nothing to show). */
 export function skillAvailabilityLabel(skill: RawSkill): string {
   const tone = skillAvailabilityTone(skill)
   if (tone === 'unknown') return ''
-  if (tone === 'offered') return 'Offered to the agent'
+  if (tone === 'offered') return t('skills.availOffered')
   const reason = String(skill.availability?.reason || '')
-  return AVAILABILITY_REASON_LABEL[reason] || 'Not offered to the agent'
+  return availabilityReasonLabels()[reason] || t('skills.availNotOffered')
 }
 
 /** The chip tooltip: the server's prose when it wrote any, else the label. */
@@ -592,11 +612,11 @@ export function partnerEmptyMessage(
   statusFilter: StatusFilter,
 ): string {
   const query = (filterText || '').trim()
-  if (query) return `No ${brand} skills match ${query}.`
-  if (statusFilter === 'ready') return `No ${brand} skills are ready.`
-  if (statusFilter === 'needs-setup') return `No ${brand} skills currently need setup.`
-  if (statusFilter === 'disabled') return `No ${brand} skills are switched off.`
-  return `${brand} skills are on the way. No ${brand} skills are installed yet.`
+  if (query) return t('skills.partnerEmptyMatch', { brand, query })
+  if (statusFilter === 'ready') return t('skills.partnerEmptyReady', { brand })
+  if (statusFilter === 'needs-setup') return t('skills.partnerEmptyNeedsSetup', { brand })
+  if (statusFilter === 'disabled') return t('skills.partnerEmptyDisabled', { brand })
+  return t('skills.partnerEmptyNone', { brand })
 }
 
 // ── Registry (community / bankr) derivations ──────────────────────────────────
@@ -650,7 +670,7 @@ export function categoryChips(snapshot: RegistryItem[], activeCat: string): Cate
   const cats = ['all', ...keys.sort((a, b) => (counts[b] ?? 0) - (counts[a] ?? 0))]
   return cats.map((c) => ({
     cat: c,
-    label: CAT_LABEL[c] || c,
+    label: catLabel(c),
     count: c === 'all' ? snapshot.length : (counts[c] ?? 0),
     active: activeCat === c,
   }))
@@ -710,10 +730,10 @@ export function registryEmptyMessage(
   query: string,
 ): string {
   const q = (query || '').trim()
-  if (q) return `No skills match ${q}.`
-  if (group === 'bankr') return 'No Bankr skills available right now.'
-  if (group === 'capminal') return 'No Capminal skills available right now.'
-  return 'No community skills available right now.'
+  if (q) return t('skills.registryEmptyMatch', { query: q })
+  if (group === 'bankr') return t('skills.registryEmptyBankr')
+  if (group === 'capminal') return t('skills.registryEmptyCapminal')
+  return t('skills.registryEmptyCommunity')
 }
 
 /** skills.js:662,715,283 — the stable identifier key for a registry row. */


### PR DESCRIPTION
Refs #257 — 6 of 11.

Extracts the skills view's copy into a new `skills` namespace and adds `src/views/skills/**/*.tsx` to `I18N_MIGRATED` in the same commit. `logic.ts` carries a large share of it: loading-layer labels and help, catalog categories, provenance group labels and help, status buckets, availability reasons, and the installed / partner / catalog empty-state builders.

**No existing test file changed.**

### The lint rule had a hole

`JSXText` cannot see copy that reaches the DOM through an expression container, so these passed the gate completely untouched:

```jsx
{busy ? 'Updating…' : 'Update'}
{busy ? 'Removing…' : 'Remove'}
{item.trust_level || 'community'}
```

I found them by walking the real UI, not from the linter. A third selector now covers ternary branches and `||` fallbacks in element children, scoped with `:not(JSXAttribute …)` so the `className={x ? 'a' : 'b'}` ternaries throughout the codebase stay legal — it reports **zero** false positives across `src/`. Re-running it over the five already-migrated views reports nothing, so skills was the only view affected.

### Other notes

- Brand names (Bankr / Capminal / Robinhood) stay literal — proper nouns, read off `PARTNER_BRANDS` rather than the catalog.
- `<code>.env</code>` becomes an identifier expression, not a key.
- `String(skill.name)` at the interpolation sites keeps the rendered text byte-identical for the optional-`name` rows, rather than quietly turning `undefined` into an empty string.

## Bundle

Initial JS unchanged at **136.6 KiB gzip** / 180 KiB budget; the lazy `SkillsPage` chunk grows 16.0 → 16.4 KiB gzip.

## Verification

`npm run check` green (tsc, eslint, prettier, 1824 tests).

Walked the built UI against a gateway with **70 real installed skills**:
- all five provenance groups render with their labels and help text;
- tabs (`70 local skills`, `Partner catalog`, `Bundled partner`, `Open catalog`), metric pills (All 70 / Ready 64 / Needs setup 6);
- Bankr and Robinhood partner intros, `IMPORTANT:` notices, `3 skills` / `2 skills` counts, per-brand search placeholders, `shipped` provenance chips;
- the skill detail dialog (Requirements, `✓ ready`, layer chip, `Homepage ↗`, `Use in chat`);
- all three empty-state builders: `No skills match zzzznomatch.`, `No Robinhood skills match zzzznomatch.`;
- no raw `skills.*` keys leaked into the DOM on any tab.