### PR TITLE
webui: migrate the channels view onto the i18n seam

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -11,6 +11,7 @@ const I18N_MIGRATED = [
   'src/components/**/*.tsx',
   'src/views/agents/**/*.tsx',
   'src/views/approvals/**/*.tsx',
+  'src/views/channels/**/*.tsx',
   'src/views/config/**/*.tsx',
   'src/views/env/**/*.tsx',
   'src/views/health/**/*.tsx',

--- a/frontend/src/i18n/en/channels.ts
+++ b/frontend/src/i18n/en/channels.ts
@@ -1,0 +1,149 @@
+import { defineNamespace } from '../registry'
+
+export const channels = defineNamespace('channels', {
+  documentTitle: 'Channels - AgentOS Control',
+  eyebrow: 'Control · Channels',
+  title: 'Channels',
+  subtitle: 'Add messaging adapters, monitor runtime health, and pair Telegram connections.',
+  refresh: 'Refresh',
+  refreshBusy: 'Refreshing…',
+  addChannel: 'Add channel',
+
+  // Command strip + stat tiles.
+  operationsLandmark: 'Channel operations',
+  meshEyebrow: 'Integration mesh',
+  meshTitle: 'Channel posture',
+  cadence: 'Live · refreshes every 5s',
+  statsLandmark: 'Channels summary',
+  statTotal: 'Total channels',
+  statTotalHint_one: '{count} type configured',
+  statTotalHint_other: '{count} types configured',
+  statConnected: 'Connected',
+  statConnectedLive: 'live now',
+  statConnectedUnhealthy: '{count} unhealthy',
+  statConnectedIdle: 'all idle',
+  statInactive: 'Inactive',
+  statInactiveAttention: '{count} need attention',
+  statRestarts: 'Restart attempts',
+  statRestartsHint: 'since gateway start',
+  statPairing: 'Pairing requests',
+  statPairingWaiting: 'Telegram connections waiting',
+  statPairingIdle: 'nothing waiting',
+
+  // Channel list.
+  listTitle: 'Configured channels',
+  listDescription: 'Runtime adapters, connection health, and Telegram pairing in one place.',
+  listCount_one: '{count} channel',
+  listCount_other: '{count} channels',
+  emptyTitle: 'No configured channels.',
+  emptyMsg:
+    'Connect Telegram, Slack, Discord, or another adapter here. AgentOS validates the configuration before saving and keeps credentials write-only.',
+  emptyAction: 'Add your first channel',
+
+  // Channel card.
+  cardTypeUnknown: 'unknown',
+  cardConfigure: 'Configure',
+  cardAdvanced: 'Advanced config',
+  cardLoading: 'Loading…',
+  cardConnected: 'Connected',
+  cardRestartAttempts: 'Restart attempts',
+  cardAdapterConfig: 'Adapter config',
+
+  // Telegram pairing panel.
+  accessEyebrow: 'Telegram connections',
+  accessTitle: 'Pairing',
+  accessLocked: 'Pairing is locked for one hour after repeated invalid codes.',
+  accessNoteLead: 'Direct messages always require pairing.',
+  // Two whole sentences rather than a sentence plus a padded ' and a bot
+  // mention' fragment: catalog.test.ts rejects padded values, and a translator
+  // cannot place a dangling clause correctly anyway.
+  accessGroupsEnabled: '{count} configured group(s) also require a paired sender.',
+  accessGroupsEnabledMention:
+    '{count} configured group(s) also require a paired sender and a bot mention.',
+  accessGroupsDisabled: 'Group messaging is disabled.',
+  accessPendingTitle: 'Pending pairing',
+  accessPairedTitle: 'Paired',
+  accessNoPending: 'No Telegram connections are waiting to pair.',
+  accessNoPaired: 'No paired Telegram connections yet.',
+  accessPair: 'Pair',
+  accessDeny: 'Deny',
+  accessDisconnect: 'Disconnect',
+
+  // Setup dialog chrome.
+  panelTitleEdit: 'Configure {name}',
+  panelTitleAdd: 'Add a channel',
+  setupTryAgain: 'Try again',
+  setupOpenAdvanced: 'Open Advanced config',
+  setupGuide: 'Setup guide',
+  feedbackWriteBlocked: 'Configuration changed on disk. Reload the gateway state before saving.',
+  feedbackConflict: 'Settings changed elsewhere. Your channel draft is still preserved.',
+  feedbackUseLatest: 'Use latest version',
+  feedbackWriteOnly: 'Credentials are write-only and never shown again.',
+  discardKeepEditing: 'Keep editing',
+  discardConfirm: 'Discard draft',
+  setupEditTitle: 'Channel configuration',
+  setupNewTitle: 'New integration',
+  setupEditSubtitle: 'Update this adapter without exposing its saved credentials.',
+  setupNewSubtitle: 'Choose an adapter, add its credentials, then validate and save it.',
+  setupClose: 'Close channel setup',
+  setupProgress: 'Channel setup progress',
+  setupLoading: 'Loading channel options…',
+  setupLoadingHint: 'Reading the current configuration and adapter catalog.',
+  setupLoadFailed: 'Channel setup could not be loaded.',
+  setupNoAdapters: 'No channel adapters are available.',
+  setupNoAdaptersHint: 'Check the gateway catalog, then refresh this page.',
+  setupNeedsAdvancedTitle: 'This adapter needs Advanced config.',
+  setupNeedsAdvancedBody:
+    '{type} is running, but it is not available in the guided channel catalog.',
+
+  // Setup dialog steps.
+  stepOne: 'Step 1',
+  stepOneTitle: 'Choose an adapter',
+  stepTypeLocked: 'Type locked while editing',
+  stepAdapterLandmark: 'Channel adapter',
+  adapterTransportFallback: 'messaging adapter',
+  stepTwo: 'Step 2',
+  stepTwoTitle: '{adapter} details',
+  beforeYouStart: 'Before you start',
+  advancedOptions: 'Advanced options',
+  toggleOn: 'On',
+  toggleOff: 'Off',
+  saveValidating: 'Validating…',
+  saveUpdate: 'Validate & update',
+  saveAdd: 'Validate & add',
+
+  // Discard confirmation.
+  discardTitle: 'Discard this channel draft?',
+  discardBodyNavigating: 'Leaving this page will clear unsaved credentials and field changes.',
+  discardBody: 'Your unsaved credentials and field changes will be cleared.',
+  unsavedBlocker: 'Channel setup has unsaved changes.',
+
+  // Toasts.
+  toastLoadFailed: 'Failed to load channels: {message}',
+  toastSavedRestart: 'Channel saved. Restart AgentOS to activate it.',
+  toastSaved: 'Channel saved.',
+  toastConflict: 'Channel draft needs a fresh configuration.',
+  toastPaired: 'Telegram connection paired.',
+  toastPairingDenied: 'Telegram pairing denied.',
+  toastResolveFailed: 'Failed to resolve pairing request: {message}',
+  toastDisconnected: 'Telegram connection disconnected.',
+  toastRevokeFailed: 'Failed to disconnect Telegram: {message}',
+
+  // Derived copy (logic.ts).
+  nameUnknown: 'Unknown',
+  inactiveNone: 'no inactive channels',
+  inactiveDisabled: '{count} disabled',
+  inactiveIdle: 'configured but idle',
+  hintDisabled:
+    'Disabled in config — gateway restart required after re-enabling. Run `agentos onboard configure channels` to change.',
+  hintDead: 'Adapter is dead. Inspect gateway logs, then `agentos channels restart {name}`.',
+  hintRunning: 'Adapter is live in the current gateway process.',
+  hintRestarting: 'Adapter is restarting after dispatch errors.',
+  hintExhausted: 'Adapter exhausted its retry budget. Try `agentos channels restart {name}`.',
+  hintConfigured:
+    'Configured on disk but not active in this gateway process — restart the gateway to load it.',
+  senderFallback: 'Telegram user {id}',
+  senderUnknownId: 'unknown',
+  senderMetaId: 'ID {id}',
+  senderMetaExpires: 'expires {time}',
+} as const)

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,5 +1,6 @@
 import { agents } from './agents'
 import { approvals } from './approvals'
+import { channels } from './channels'
 import { common } from './common'
 import { config } from './config'
 import { env } from './env'
@@ -30,6 +31,7 @@ import { usage } from './usage'
 export const en = {
   agents,
   approvals,
+  channels,
   common,
   config,
   env,

--- a/frontend/src/views/channels/ChannelSetupDialog.tsx
+++ b/frontend/src/views/channels/ChannelSetupDialog.tsx
@@ -11,6 +11,8 @@ import {
   XIcon,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { t } from '@/i18n'
+import '@/i18n/en/channels'
 import { ModalShell } from '@/components/ModalShell'
 import {
   readScopedFields,
@@ -94,7 +96,7 @@ function ChannelField({
             <CheckIcon />
           </span>
           <span>
-            <strong>{draft.checked ? 'On' : 'Off'}</strong>
+            <strong>{draft.checked ? t('channels.toggleOn') : t('channels.toggleOff')}</strong>
           </span>
         </span>
       </label>
@@ -374,7 +376,9 @@ export function ChannelSetupDialog({
 
   const confirmationOpen = confirmDiscard || navigationBlocked
   const phase = saving ? 3 : spec ? 2 : 1
-  const panelTitle = isEditing ? `Configure ${editingName}` : 'Add a channel'
+  const panelTitle = isEditing
+    ? t('channels.panelTitleEdit', { name: String(editingName) })
+    : t('channels.panelTitleAdd')
 
   return (
     <AnimatePresence>
@@ -398,19 +402,17 @@ export function ChannelSetupDialog({
               </span>
               <div>
                 <span className="t-label">
-                  {isEditing ? 'Channel configuration' : 'New integration'}
+                  {isEditing ? t('channels.setupEditTitle') : t('channels.setupNewTitle')}
                 </span>
                 <h2 id="channel-setup-title">{panelTitle}</h2>
                 <p id="channel-setup-description">
-                  {isEditing
-                    ? 'Update this adapter without exposing its saved credentials.'
-                    : 'Choose an adapter, add its credentials, then validate and save it.'}
+                  {isEditing ? t('channels.setupEditSubtitle') : t('channels.setupNewSubtitle')}
                 </p>
               </div>
               <button
                 type="button"
                 className="ch-setup__close"
-                aria-label="Close channel setup"
+                aria-label={t('channels.setupClose')}
                 disabled={saving}
                 onClick={requestClose}
               >
@@ -418,7 +420,7 @@ export function ChannelSetupDialog({
               </button>
             </header>
 
-            <ol className="ch-setup__flow" aria-label="Channel setup progress">
+            <ol className="ch-setup__flow" aria-label={t('channels.setupProgress')}>
               {['Choose adapter', 'Enter details', 'Validate & save'].map((label, index) => {
                 const step = index + 1
                 return (
@@ -438,30 +440,28 @@ export function ChannelSetupDialog({
               {loading ? (
                 <div className="ch-setup__state" role="status">
                   <LoaderCircleIcon className="ch-refresh-spin" />
-                  <strong>Loading channel options…</strong>
-                  <span>Reading the current configuration and adapter catalog.</span>
+                  <strong>{t('channels.setupLoading')}</strong>
+                  <span>{t('channels.setupLoadingHint')}</span>
                 </div>
               ) : loadError ? (
                 <div className="ch-setup__state is-error" role="alert">
-                  <strong>Channel setup could not be loaded.</strong>
+                  <strong>{t('channels.setupLoadFailed')}</strong>
                   <span>{loadError}</span>
                   <Button type="button" variant="outline" onClick={onRetry}>
-                    Try again
+                    {t('channels.setupTryAgain')}
                   </Button>
                 </div>
               ) : specs.length === 0 ? (
                 <div className="ch-setup__state" role="status">
-                  <strong>No channel adapters are available.</strong>
-                  <span>Check the gateway catalog, then refresh this page.</span>
+                  <strong>{t('channels.setupNoAdapters')}</strong>
+                  <span>{t('channels.setupNoAdaptersHint')}</span>
                 </div>
               ) : unsupportedEdit ? (
                 <div className="ch-setup__state" role="status">
-                  <strong>This adapter needs Advanced config.</strong>
-                  <span>
-                    {initialType} is running, but it is not available in the guided channel catalog.
-                  </span>
+                  <strong>{t('channels.setupNeedsAdvancedTitle')}</strong>
+                  <span>{t('channels.setupNeedsAdvancedBody', { type: String(initialType) })}</span>
                   <Button type="button" variant="outline" onClick={onOpenAdvanced}>
-                    Open Advanced config
+                    {t('channels.setupOpenAdvanced')}
                   </Button>
                 </div>
               ) : (
@@ -469,14 +469,18 @@ export function ChannelSetupDialog({
                   <section className="ch-setup__section" aria-labelledby="channel-adapter-heading">
                     <div className="ch-setup__section-head">
                       <div>
-                        <span className="t-label">Step 1</span>
-                        <h3 id="channel-adapter-heading">Choose an adapter</h3>
+                        <span className="t-label">{t('channels.stepOne')}</span>
+                        <h3 id="channel-adapter-heading">{t('channels.stepOneTitle')}</h3>
                       </div>
                       {isEditing ? (
-                        <span className="ch-setup__locked">Type locked while editing</span>
+                        <span className="ch-setup__locked">{t('channels.stepTypeLocked')}</span>
                       ) : null}
                     </div>
-                    <div className="ch-setup__types" role="radiogroup" aria-label="Channel adapter">
+                    <div
+                      className="ch-setup__types"
+                      role="radiogroup"
+                      aria-label={t('channels.stepAdapterLandmark')}
+                    >
                       {specs.map((candidate) => (
                         <button
                           key={candidate.type}
@@ -492,7 +496,9 @@ export function ChannelSetupDialog({
                           </span>
                           <span>
                             <strong>{candidate.label || candidate.type}</strong>
-                            <small>{candidate.transport || 'messaging adapter'}</small>
+                            <small>
+                              {candidate.transport || t('channels.adapterTransportFallback')}
+                            </small>
                           </span>
                           <span className="ch-setup__radio-dot" aria-hidden="true" />
                         </button>
@@ -507,12 +513,14 @@ export function ChannelSetupDialog({
                     >
                       <div className="ch-setup__section-head">
                         <div>
-                          <span className="t-label">Step 2</span>
-                          <h3 id="channel-details-heading">{spec.label || spec.type} details</h3>
+                          <span className="t-label">{t('channels.stepTwo')}</span>
+                          <h3 id="channel-details-heading">
+                            {t('channels.stepTwoTitle', { adapter: spec.label || spec.type })}
+                          </h3>
                         </div>
                         {spec.docsHint ? (
                           <a href={spec.docsHint} target="_blank" rel="noreferrer">
-                            Setup guide
+                            {t('channels.setupGuide')}
                             <ExternalLinkIcon aria-hidden="true" />
                           </a>
                         ) : null}
@@ -524,7 +532,7 @@ export function ChannelSetupDialog({
                         <div className="ch-setup__needs">
                           <ShieldCheckIcon aria-hidden="true" />
                           <div>
-                            <strong>Before you start</strong>
+                            <strong>{t('channels.beforeYouStart')}</strong>
                             <ul>
                               {spec.whatYouNeed.map((item) => (
                                 <li key={item}>{item}</li>
@@ -549,7 +557,7 @@ export function ChannelSetupDialog({
 
                       {advancedFields.length ? (
                         <details className="ch-setup__advanced">
-                          <summary>Advanced options</summary>
+                          <summary>{t('channels.advancedOptions')}</summary>
                           <div className="ch-setup__fields">
                             {advancedFields.map((field) => (
                               <ChannelField
@@ -573,16 +581,12 @@ export function ChannelSetupDialog({
             <footer className="ch-setup__footer">
               <div className="ch-setup__feedback" aria-live="polite">
                 {writeBlocked ? (
-                  <span className="is-error">
-                    Configuration changed on disk. Reload the gateway state before saving.
-                  </span>
+                  <span className="is-error">{t('channels.feedbackWriteBlocked')}</span>
                 ) : conflicted ? (
                   <div className="ch-setup__conflict">
-                    <span className="is-error">
-                      Settings changed elsewhere. Your channel draft is still preserved.
-                    </span>
+                    <span className="is-error">{t('channels.feedbackConflict')}</span>
                     <Button type="button" size="sm" variant="outline" onClick={resolveConflict}>
-                      Use latest version
+                      {t('channels.feedbackUseLatest')}
                     </Button>
                   </div>
                 ) : validationMessage || saveError ? (
@@ -590,13 +594,13 @@ export function ChannelSetupDialog({
                 ) : (
                   <span>
                     <LockKeyholeIcon aria-hidden="true" />
-                    Credentials are write-only and never shown again.
+                    {t('channels.feedbackWriteOnly')}
                   </span>
                 )}
               </div>
               <div className="ch-setup__footer-actions">
                 <Button type="button" variant="outline" disabled={saving} onClick={requestClose}>
-                  Cancel
+                  {t('common.cancel')}
                 </Button>
                 <Button
                   type="button"
@@ -607,7 +611,11 @@ export function ChannelSetupDialog({
                 >
                   {saving ? <LoaderCircleIcon className="ch-refresh-spin" /> : <ShieldCheckIcon />}
                   <span>
-                    {saving ? 'Validating…' : isEditing ? 'Validate & update' : 'Validate & add'}
+                    {saving
+                      ? t('channels.saveValidating')
+                      : isEditing
+                        ? t('channels.saveUpdate')
+                        : t('channels.saveAdd')}
                   </span>
                 </Button>
               </div>
@@ -629,11 +637,11 @@ export function ChannelSetupDialog({
               }}
             >
               <div>
-                <strong id="discard-channel-title">Discard this channel draft?</strong>
+                <strong id="discard-channel-title">{t('channels.discardTitle')}</strong>
                 <span>
                   {navigationBlocked
-                    ? 'Leaving this page will clear unsaved credentials and field changes.'
-                    : 'Your unsaved credentials and field changes will be cleared.'}
+                    ? t('channels.discardBodyNavigating')
+                    : t('channels.discardBody')}
                 </span>
               </div>
               <div>
@@ -647,7 +655,7 @@ export function ChannelSetupDialog({
                     else setConfirmDiscard(false)
                   }}
                 >
-                  Keep editing
+                  {t('channels.discardKeepEditing')}
                 </Button>
                 <Button
                   type="button"
@@ -655,7 +663,7 @@ export function ChannelSetupDialog({
                   disabled={saving}
                   onClick={navigationBlocked ? onDiscardNavigation : onDiscard}
                 >
-                  Discard draft
+                  {t('channels.discardConfirm')}
                 </Button>
               </div>
             </div>

--- a/frontend/src/views/channels/ChannelsPage.tsx
+++ b/frontend/src/views/channels/ChannelsPage.tsx
@@ -6,6 +6,8 @@ import { AnimatePresence } from 'motion/react'
 import { CableIcon, PlusIcon, RefreshCwIcon, Settings2Icon } from 'lucide-react'
 import { toast } from 'sonner'
 import { CommandLine } from '@/components/CommandLine'
+import { t, tPlural } from '@/i18n'
+import '@/i18n/en/channels'
 import { MotionListItem } from '@/lib/motion'
 import { Button } from '@/components/ui/button'
 import { useRpc } from '@/app/providers'
@@ -77,7 +79,7 @@ function PersonRow({
       {variant === 'pending' ? (
         <div className="ch-access__person-actions">
           <Button type="button" size="sm" disabled={disabled} onClick={onApprove}>
-            Pair
+            {t('channels.accessPair')}
           </Button>
           <Button
             type="button"
@@ -86,12 +88,12 @@ function PersonRow({
             disabled={disabled}
             onClick={onDeny}
           >
-            Deny
+            {t('channels.accessDeny')}
           </Button>
         </div>
       ) : (
         <Button type="button" size="sm" variant="outline" disabled={disabled} onClick={onRevoke}>
-          Disconnect
+          {t('channels.accessDisconnect')}
         </Button>
       )}
     </div>
@@ -121,26 +123,27 @@ function AccessPanel({
     <section className={`ch-access${pending.length ? ' ch-access--pending' : ''}`}>
       <div className="ch-access__head">
         <div>
-          <span className="ch-access__eyebrow t-label">Telegram connections</span>
-          <h3 className="ch-access__title">Pairing</h3>
+          <span className="ch-access__eyebrow t-label">{t('channels.accessEyebrow')}</span>
+          <h3 className="ch-access__title">{t('channels.accessTitle')}</h3>
         </div>
       </div>
 
-      {locked ? (
-        <p className="ch-access__warning">
-          Pairing is locked for one hour after repeated invalid codes.
-        </p>
-      ) : null}
+      {locked ? <p className="ch-access__warning">{t('channels.accessLocked')}</p> : null}
 
       <p className="ch-access__note">
-        Direct messages always require pairing.{' '}
+        {t('channels.accessNoteLead')}{' '}
         {access.groups_enabled
-          ? `${access.group_chat_ids?.length || 0} configured group(s) also require a paired sender${access.group_mention_required ? ' and a bot mention' : ''}.`
-          : 'Group messaging is disabled.'}
+          ? t(
+              access.group_mention_required
+                ? 'channels.accessGroupsEnabledMention'
+                : 'channels.accessGroupsEnabled',
+              { count: access.group_chat_ids?.length || 0 },
+            )
+          : t('channels.accessGroupsDisabled')}
       </p>
       <div className="ch-access__group">
         <div className="ch-access__group-title t-label">
-          Pending pairing <span>{pending.length}</span>
+          {t('channels.accessPendingTitle')} <span>{pending.length}</span>
         </div>
         {pending.length ? (
           <div className="ch-access__people">
@@ -156,12 +159,12 @@ function AccessPanel({
             ))}
           </div>
         ) : (
-          <p className="ch-access__empty">No Telegram connections are waiting to pair.</p>
+          <p className="ch-access__empty">{t('channels.accessNoPending')}</p>
         )}
       </div>
       <div className="ch-access__group">
         <div className="ch-access__group-title t-label">
-          Paired <span>{paired.length}</span>
+          {t('channels.accessPairedTitle')} <span>{paired.length}</span>
         </div>
         {paired.length ? (
           <div className="ch-access__people">
@@ -176,7 +179,7 @@ function AccessPanel({
             ))}
           </div>
         ) : (
-          <p className="ch-access__empty">No paired Telegram connections yet.</p>
+          <p className="ch-access__empty">{t('channels.accessNoPaired')}</p>
         )}
       </div>
     </section>
@@ -224,7 +227,9 @@ function ChannelCard({
             <span className="ch-card__name" title={d.name}>
               {d.name}
             </span>
-            <span className="ch-card__type t-data">{channel.type || 'unknown'}</span>
+            <span className="ch-card__type t-data">
+              {channel.type || t('channels.cardTypeUnknown')}
+            </span>
           </div>
         </div>
         <div className="ch-card__head-actions">
@@ -237,7 +242,7 @@ function ChannelCard({
               onClick={onConfigure}
             >
               <Settings2Icon />
-              <span>Configure</span>
+              <span>{t('channels.cardConfigure')}</span>
             </Button>
           ) : (
             <Button
@@ -249,7 +254,11 @@ function ChannelCard({
               onClick={onOpenAdvanced}
             >
               <Settings2Icon />
-              <span>{configurationMode === 'loading' ? 'Loading…' : 'Advanced config'}</span>
+              <span>
+                {configurationMode === 'loading'
+                  ? t('channels.cardLoading')
+                  : t('channels.cardAdvanced')}
+              </span>
             </Button>
           )}
           <span className={`ch-card__chip t-data ${toneClass(d.tone)}`}>{d.status}</span>
@@ -258,18 +267,18 @@ function ChannelCard({
       <div className="ch-card__body">
         <dl className="ch-card__meta">
           <div>
-            <dt className="t-label">Connected</dt>
+            <dt className="t-label">{t('channels.cardConnected')}</dt>
             <dd className="t-data">{since}</dd>
           </div>
           <div>
-            <dt className="t-label">Restart attempts</dt>
+            <dt className="t-label">{t('channels.cardRestartAttempts')}</dt>
             <dd className="t-data">{d.attempts}</dd>
           </div>
         </dl>
         <p className="ch-card__hint">{hint}</p>
         <AccessPanel channel={channel} busy={busy} onResolve={onResolve} onRevoke={onRevoke} />
         <details className="ch-card__config">
-          <summary>Adapter config</summary>
+          <summary>{t('channels.cardAdapterConfig')}</summary>
           <pre className="ch-card__config-pre t-data">{d.configJson}</pre>
         </details>
       </div>
@@ -318,7 +327,7 @@ export function ChannelsPage() {
   const editingName = searchParams.get('channel') || undefined
 
   useEffect(() => {
-    document.title = 'Channels - AgentOS Control'
+    document.title = t('channels.documentTitle')
   }, [])
 
   // Load runtime status and Telegram pairing state in parallel.
@@ -349,7 +358,7 @@ export function ChannelsPage() {
     if (channelsQuery.isError) {
       const err = channelsQuery.error
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to load channels: ' + message, { id: 'channels-load-err' })
+      toast.error(t('channels.toastLoadFailed', { message }), { id: 'channels-load-err' })
     }
   }, [channelsQuery.isError, channelsQuery.error])
 
@@ -427,9 +436,7 @@ export function ChannelsPage() {
         queryClient.invalidateQueries({ queryKey: SETTINGS_SNAPSHOT_QUERY_KEY }),
       ])
       toast.success(
-        result.restartRequired
-          ? 'Channel saved. Restart AgentOS to activate it.'
-          : 'Channel saved.',
+        result.restartRequired ? t('channels.toastSavedRestart') : t('channels.toastSaved'),
         { id: 'channels-setup-save' },
       )
       if (setupNavigationBlockerRef.current.state === 'blocked') {
@@ -449,7 +456,7 @@ export function ChannelsPage() {
           : `Channel could not be saved: ${message}`,
       )
       if (conflict) void setupSnapshotQuery.refetch()
-      toast.error(conflict ? 'Channel draft needs a fresh configuration.' : message, {
+      toast.error(conflict ? t('channels.toastConflict') : message, {
         id: 'channels-setup-save-error',
       })
     },
@@ -475,13 +482,13 @@ export function ChannelsPage() {
         senderId: vars.senderId,
       }),
     onSuccess: (_data, vars) => {
-      if (vars.approved) toast.info('Telegram connection paired.', { id: 'channels-resolve' })
-      else toast.warning('Telegram pairing denied.', { id: 'channels-resolve' })
+      if (vars.approved) toast.info(t('channels.toastPaired'), { id: 'channels-resolve' })
+      else toast.warning(t('channels.toastPairingDenied'), { id: 'channels-resolve' })
       void invalidate()
     },
     onError: (err) => {
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to resolve pairing request: ' + message, { id: 'channels-resolve-err' })
+      toast.error(t('channels.toastResolveFailed', { message }), { id: 'channels-resolve-err' })
     },
   })
 
@@ -490,12 +497,12 @@ export function ChannelsPage() {
     mutationFn: (vars: { channel: string; senderId: string }) =>
       rpc.call('channels.pairing.revoke', vars),
     onSuccess: () => {
-      toast.info('Telegram connection disconnected.', { id: 'channels-revoke' })
+      toast.info(t('channels.toastDisconnected'), { id: 'channels-revoke' })
       void invalidate()
     },
     onError: (err) => {
       const message = err instanceof Error ? err.message : String(err)
-      toast.error('Failed to disconnect Telegram: ' + message, { id: 'channels-revoke-err' })
+      toast.error(t('channels.toastRevokeFailed', { message }), { id: 'channels-revoke-err' })
     },
   })
 
@@ -516,33 +523,33 @@ export function ChannelsPage() {
     <div className="ch-stage">
       <header className="ch-stage__header">
         <div className="ch-stage__title-block">
-          <span className="t-label">Control · Channels</span>
-          <h1 className="t-display">Channels</h1>
-          <p className="ch-stage__subtitle">
-            Add messaging adapters, monitor runtime health, and pair Telegram connections.
-          </p>
+          <span className="t-label">{t('channels.eyebrow')}</span>
+          <h1 className="t-display">{t('channels.title')}</h1>
+          <p className="ch-stage__subtitle">{t('channels.subtitle')}</p>
         </div>
         <div className="ch-stage__actions">
           <Button
             variant="outline"
-            title="Refresh"
+            title={t('channels.refresh')}
             className="ch-stage__refresh text-xs uppercase tracking-[0.14em]"
             disabled={channelsQuery.isFetching}
             onClick={() => void invalidate()}
           >
             <RefreshCwIcon className={channelsQuery.isFetching ? 'ch-refresh-spin' : undefined} />
-            <span>{channelsQuery.isFetching ? 'Refreshing…' : 'Refresh'}</span>
+            <span>
+              {channelsQuery.isFetching ? t('channels.refreshBusy') : t('channels.refresh')}
+            </span>
           </Button>
           <Button type="button" className="ch-stage__add" onClick={() => openSetup()}>
             <PlusIcon />
-            <span>Add channel</span>
+            <span>{t('channels.addChannel')}</span>
           </Button>
         </div>
       </header>
 
       <section
         className={`ch-command${channelsQuery.isFetching ? ' is-loading' : ''}`}
-        aria-label="Channel operations"
+        aria-label={t('channels.operationsLandmark')}
         aria-busy={channelsQuery.isFetching}
       >
         <div className="ch-command__toolbar">
@@ -551,50 +558,58 @@ export function ChannelsPage() {
               <CableIcon />
             </span>
             <div>
-              <span className="t-label">Integration mesh</span>
-              <strong>Channel posture</strong>
+              <span className="t-label">{t('channels.meshEyebrow')}</span>
+              <strong>{t('channels.meshTitle')}</strong>
             </div>
           </div>
           <span className="ch-command__cadence t-data">
-            <span aria-hidden="true" /> Live · refreshes every 5s
+            <span aria-hidden="true" /> {t('channels.cadence')}
           </span>
         </div>
-        <div className="ch-stats" aria-label="Channels summary">
+        <div className="ch-stats" aria-label={t('channels.statsLandmark')}>
           <StatTile
-            label="Total channels"
+            label={t('channels.statTotal')}
             hero
             value={stats.total}
-            hint={`${stats.typeCount} type${stats.typeCount === 1 ? '' : 's'} configured`}
+            hint={tPlural('channels.statTotalHint', stats.typeCount)}
           />
           <StatTile
-            label="Connected"
+            label={t('channels.statConnected')}
             value={stats.connected}
             hint={
               stats.connected
-                ? 'live now'
+                ? t('channels.statConnectedLive')
                 : stats.attention
-                  ? `${stats.attention} unhealthy`
-                  : 'all idle'
+                  ? t('channels.statConnectedUnhealthy', { count: stats.attention })
+                  : t('channels.statConnectedIdle')
             }
           />
           <StatTile
-            label="Inactive"
+            label={t('channels.statInactive')}
             value={stats.inactive}
             hint={
               stats.attention ? (
                 // channels.js:139 — legacy wraps this hint in .ch-neg (--danger).
-                <span className="ch-neg">{stats.attention} need attention</span>
+                <span className="ch-neg">
+                  {t('channels.statInactiveAttention', { count: stats.attention })}
+                </span>
               ) : (
                 inactiveHint(stats.inactive, stats.disabled)
               )
             }
           />
-          <StatTile label="Restart attempts" value={stats.restarts} hint="since gateway start" />
           <StatTile
-            label="Pairing requests"
+            label={t('channels.statRestarts')}
+            value={stats.restarts}
+            hint={t('channels.statRestartsHint')}
+          />
+          <StatTile
+            label={t('channels.statPairing')}
             value={stats.pendingAccess}
             attention={stats.pendingAccess > 0}
-            hint={stats.pendingAccess ? 'Telegram connections waiting' : 'nothing waiting'}
+            hint={
+              stats.pendingAccess ? t('channels.statPairingWaiting') : t('channels.statPairingIdle')
+            }
           />
         </div>
       </section>
@@ -602,15 +617,13 @@ export function ChannelsPage() {
       <section className="ch-list">
         <div className="ch-list__head">
           <div>
-            <h2 className="ch-list__title">Configured channels</h2>
-            <p className="ch-list__description">
-              Runtime adapters, connection health, and Telegram pairing in one place.
-            </p>
+            <h2 className="ch-list__title">{t('channels.listTitle')}</h2>
+            <p className="ch-list__description">{t('channels.listDescription')}</p>
           </div>
           <div className="ch-list__actions">
             {channels.length ? (
               <span className="ch-list__count t-data">
-                {channels.length} channel{channels.length === 1 ? '' : 's'}
+                {tPlural('channels.listCount', channels.length)}
               </span>
             ) : null}
           </div>
@@ -618,15 +631,12 @@ export function ChannelsPage() {
 
         {channels.length === 0 ? (
           <div className="ch-empty">
-            <div className="ch-empty__title">No configured channels.</div>
-            <p className="ch-empty__msg">
-              Connect Telegram, Slack, Discord, or another adapter here. AgentOS validates the
-              configuration before saving and keeps credentials write-only.
-            </p>
+            <div className="ch-empty__title">{t('channels.emptyTitle')}</div>
+            <p className="ch-empty__msg">{t('channels.emptyMsg')}</p>
             <div className="ch-empty__actions">
               <Button type="button" onClick={() => openSetup()}>
                 <PlusIcon />
-                <span>Add your first channel</span>
+                <span>{t('channels.emptyAction')}</span>
               </Button>
             </div>
             <div className="ch-empty__commands">
@@ -696,7 +706,7 @@ export function ChannelsPage() {
         onDirtyChange={updateSetupDirty}
       />
       <span className="sr-only" aria-live="polite">
-        {setupDirty ? 'Channel setup has unsaved changes.' : ''}
+        {setupDirty ? t('channels.unsavedBlocker') : ''}
       </span>
     </div>
   )

--- a/frontend/src/views/channels/logic.ts
+++ b/frontend/src/views/channels/logic.ts
@@ -6,6 +6,9 @@
 // formatting).
 
 /** A raw channel row from channels.status (all fields optional). */
+import { t } from '@/i18n'
+import '@/i18n/en/channels'
+
 export interface RawChannel {
   name?: string
   id?: string
@@ -139,9 +142,9 @@ export function channelStats(channels: MergedChannel[]): ChannelStats {
 
 /** channels.js:402-406 — Inactive-tile hint text. */
 export function inactiveHint(inactive: number, disabled: number): string {
-  if (!inactive) return 'no inactive channels'
-  if (disabled) return `${disabled} disabled`
-  return 'configured but idle'
+  if (!inactive) return t('channels.inactiveNone')
+  if (disabled) return t('channels.inactiveDisabled', { count: disabled })
+  return t('channels.inactiveIdle')
 }
 
 export interface ChannelDisplay {
@@ -160,7 +163,7 @@ export interface ChannelDisplay {
  * --tone), restart-attempt string, and the pretty-printed adapter config.
  */
 export function channelDisplay(ch: MergedChannel): ChannelDisplay {
-  const name = String(ch.name || ch.id || 'Unknown')
+  const name = String(ch.name || ch.id || t('channels.nameUnknown'))
   const status = String(ch.status || (ch.connected ? 'connected' : 'stopped'))
   const isRunning = status === 'running' || status === 'connected'
   const isDead = status === 'dead'
@@ -184,15 +187,12 @@ export function statusHint(args: {
   name: string
 }): string {
   const safeName = args.name || '<name>'
-  if (!args.enabled)
-    return 'Disabled in config — gateway restart required after re-enabling. Run `agentos onboard configure channels` to change.'
-  if (args.isDead)
-    return `Adapter is dead. Inspect gateway logs, then \`agentos channels restart ${safeName}\`.`
-  if (args.isRunning) return 'Adapter is live in the current gateway process.'
-  if (args.status === 'restarting') return 'Adapter is restarting after dispatch errors.'
-  if (args.status === 'exhausted')
-    return `Adapter exhausted its retry budget. Try \`agentos channels restart ${safeName}\`.`
-  return 'Configured on disk but not active in this gateway process — restart the gateway to load it.'
+  if (!args.enabled) return t('channels.hintDisabled')
+  if (args.isDead) return t('channels.hintDead', { name: safeName })
+  if (args.isRunning) return t('channels.hintRunning')
+  if (args.status === 'restarting') return t('channels.hintRestarting')
+  if (args.status === 'exhausted') return t('channels.hintExhausted', { name: safeName })
+  return t('channels.hintConfigured')
 }
 
 /** channels.js:253 — pairing approval is locked while locked_until*1000 > now. */
@@ -204,16 +204,22 @@ export function isAccessLocked(lockedUntil: number | undefined, now: number = Da
 export function senderLabel(item: AccessAccount): string {
   if (item.username) return '@' + item.username
   if (item.display_name) return item.display_name
-  return 'Telegram user ' + (item.sender_id || 'unknown')
+  return t('channels.senderFallback', {
+    id: item.sender_id || t('channels.senderUnknownId'),
+  })
 }
 
 /** channels.js:379-386 — the secondary meta line (bits joined with " · "). */
 export function senderMeta(item: AccessAccount): string {
   const bits: string[] = []
   if (item.display_name && item.display_name !== senderLabel(item)) bits.push(item.display_name)
-  if (item.sender_id) bits.push('ID ' + item.sender_id)
+  if (item.sender_id) bits.push(t('channels.senderMetaId', { id: item.sender_id }))
   if (item.expires_at)
-    bits.push('expires ' + new Date(Number(item.expires_at) * 1000).toLocaleTimeString())
+    bits.push(
+      t('channels.senderMetaExpires', {
+        time: new Date(Number(item.expires_at) * 1000).toLocaleTimeString(),
+      }),
+    )
   if (item.source) bits.push(item.source)
   return bits.join(' · ')
 }


### PR DESCRIPTION
Refs #257 — 7 of 11.

Extracts the channels view's copy into a new `channels` namespace and adds `src/views/channels/**/*.tsx` to `I18N_MIGRATED` in the same commit. Covers the page, the guided setup dialog, and the `logic.ts` derivations (inactive hint, per-card status hints, Telegram sender label and meta line).

**No existing test file changed.**

### Notes

- The group-pairing note was one sentence with a conditional `' and a bot mention'` fragment spliced into it. That is a padded value `catalog.test.ts` rejects, and a dangling clause a translator cannot place, so it became two whole sentences selected by the flag.
- The strengthened expression-container lint rule from #272 caught `{draft.checked ? 'On' : 'Off'}`, `{saving ? 'Validating…' : …}` and the two dialog subtitle ternaries up front — none of them are `JSXText`, so before that rule they would have shipped untranslated.
- `String(editingName)` at the interpolation site keeps the rendered title byte-identical for the optional field.

## Bundle

Initial JS unchanged at **136.6 KiB gzip** / 180 KiB budget.

## Verification

`npm run check` green (tsc, eslint, prettier, 1824 tests).

Walked the built UI against a gateway with a **live Telegram adapter and a real paired account**:
- stat tiles (`1 type configured`, `live now`, `no inactive channels`, `since gateway start`, `nothing waiting`) and `1 channel` — both singular `tPlural` branches;
- the card's status hint `Adapter is live in the current gateway process.` from `statusHint()`;
- the pairing panel: note + `Group messaging is disabled.`, `Pending pairing 0` with its empty state, `Paired 1` with the sender meta line and `Disconnect`;
- the setup dialog end to end — `New integration` / `Add a channel`, Step 1 / Step 2, `Discord details` interpolation, adapter transports, `Cancel` / `Validate & add`, and the write-only credentials note;
- no raw `channels.*` keys leaked into the DOM.