### PR TITLE
webui: finish the mcp validation-message migration

### DIFF
--- a/frontend/src/i18n/en/mcp.ts
+++ b/frontend/src/i18n/en/mcp.ts
@@ -141,8 +141,10 @@ export const mcp = defineNamespace('mcp', {
 
   // Validation (logic.ts).
   errorName: 'Enter a server name.',
+  errorNameCharset: 'Use letters, numbers, dots, underscores, or hyphens.',
   errorNameTaken: 'This server name already exists.',
   errorCommand: 'Enter a command.',
+  errorUrlScheme: 'Use an HTTP or HTTPS URL.',
   errorUrl: 'Enter a valid absolute URL.',
   errorHeadersObject: 'Headers must be a JSON object.',
   errorHeaderValues: 'Header values must be strings.',

--- a/frontend/src/views/mcp/logic.ts
+++ b/frontend/src/views/mcp/logic.ts
@@ -125,7 +125,7 @@ export function validateServerDraft(
   const name = draft.name.trim()
   if (!name) errors.name = t('mcp.errorName')
   else if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
-    errors.name = 'Use letters, numbers, dots, underscores, or hyphens.'
+    errors.name = t('mcp.errorNameCharset')
   } else if (servers.some((server) => server.name === name && server.name !== draft.originalName)) {
     errors.name = t('mcp.errorNameTaken')
   }
@@ -136,7 +136,7 @@ export function validateServerDraft(
     try {
       const url = new URL(draft.url.trim())
       if (!['http:', 'https:'].includes(url.protocol)) {
-        errors.url = 'Use an HTTP or HTTPS URL.'
+        errors.url = t('mcp.errorUrlScheme')
       }
     } catch {
       errors.url = t('mcp.errorUrl')


### PR DESCRIPTION
Follow-up to #274. Refs #257.

Two of `validateServerDraft`'s messages stayed hardcoded when the MCP view was migrated:

```ts
errors.name = 'Use letters, numbers, dots, underscores, or hyphens.'
errors.url  = 'Use an HTTP or HTTPS URL.'
```

Both live in `logic.ts`. The `I18N_MIGRATED` lint globs match `**/*.tsx` only, so the hardcoded-copy rule never sees `.ts` logic modules — nothing flagged these, and the view's own gate was green with them still in English. I found them by scanning the `.ts` files directly rather than trusting the linter.

Copy is verbatim, so `logic.test.ts` passes untouched.

Worth noting for the remaining views: this blind spot is why each migration needs a manual `.ts` pass — the label maps, help text and validation messages in `logic.ts` are invisible to the lint ledger.

## Verification

`npm run check` green (tsc, eslint, prettier, 1824 tests). Re-scanned every migrated view's `.ts` files; `mcp` was the only one with a remaining gap.