### PR TITLE
webui: migrate the chat view onto the i18n seam

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,6 +12,7 @@ const I18N_MIGRATED = [
   'src/views/agents/**/*.tsx',
   'src/views/approvals/**/*.tsx',
   'src/views/channels/**/*.tsx',
+  'src/views/chat/**/*.tsx',
   'src/views/config/**/*.tsx',
   'src/views/cron/**/*.tsx',
   'src/views/env/**/*.tsx',

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -1,0 +1,251 @@
+import { defineNamespace } from '../registry'
+
+export const chat = defineNamespace('chat', {
+  // Page chrome.
+  srTitle: 'Chat',
+  newChat: 'New chat',
+  newChatTitle: 'New chat ({shortcut})',
+  sessionControls: 'Chat session controls',
+  opening: 'Opening conversation…',
+  toolOutputEyebrow: 'Tool output',
+  toolOutputClose: 'Close tool output',
+  toolOutputFull: 'Full result',
+  toolOutputChars: '{count} characters',
+
+  // Composer.
+  runModes: 'Run modes',
+  runModesTitle: 'Run modes: execution and routing',
+  runModesClose: 'Close run modes',
+  attachFiles: 'Attach files',
+  attachFileTitle: 'Attach a file',
+  messagePlaceholder: 'Send a message...',
+  messageLabel: 'Message',
+  stopTitle: 'Stop (Esc)',
+  stop: 'Stop',
+  send: 'Send',
+
+  // Attachments.
+  attachmentIconFallback: 'file',
+  attachmentRemove: 'Remove',
+  attachmentRemoveAria: 'Remove attachment {name}',
+
+  // Pending queue.
+  pendingLandmark: 'Pending messages',
+  pendingLabelTitle:
+    'Alt+↑ pulls the most recent back into the input · ESC recovers all to input · sends FIFO when the current response finishes',
+  pendingCount: 'Pending {count}/{max}',
+  pendingClearAllAria: 'Clear all pending messages',
+  pendingClearAll: 'Clear all',
+  pendingAttachmentOnly: '(attachment only)',
+  pendingRemove: 'Remove',
+
+  // Toolbar.
+  toolbarExecutionMode: 'Execution mode',
+  toolbarPilotRouter: 'Pilot Router',
+  toolbarVisualEffects: 'Visual effects',
+  toolbarUsageTitle: 'Session usage',
+  toolbarModel: 'Model',
+  toolbarModelUnreported: 'Not reported',
+  toolbarOut: 'out',
+  toolbarCost: 'cost',
+  toolbarNoUsage: 'No usage yet',
+  bypassConfirmTitle: 'Enable approval bypass?',
+  bypassConfirmBody:
+    'This allows host execution without approval prompts in this browser session. This maps to /elevated bypass.',
+  bypassConfirmNote: 'Sensitive-path checks remain active.',
+  bypassConfirmAction: 'Enable bypass',
+
+  // Elevated-mode pill (chat.js:2314-2343).
+  pillUnavailable: 'Bypass N/A',
+  pillTitleUnavailable:
+    'Bypass requires an admitted Control connection. Reconnect with the configured Control token.',
+  pillSession: 'Session {mode}',
+  pillTitleSession:
+    'Session permission override is active. Approval prompts are bypassed for this browser chat session. Click to clear the override.',
+  pillGlobal: 'Global {mode}',
+  pillTitleGlobal:
+    'Global permission default controls execution mode and is configured by agentos sandbox on|bypass|full|reset.',
+  pillNeutral: 'Approval prompts',
+  pillTitleNeutral:
+    'Approval prompts are active. Click to enable approval bypass for this browser session.',
+
+  // Slash menu.
+  slashLandmark: 'Slash commands',
+
+  // Session chip.
+  sessionLabel: 'session',
+  sessionSwitchAria: 'Switch chat session',
+  sessionActions: 'Chat actions',
+  sessionCopyKeyAria: 'Copy session key',
+  sessionCopyKey: 'Copy session key',
+  sessionResetAria: 'Reset session',
+  sessionReset: 'Reset session',
+  sessionExportAria: 'Export chat as Markdown',
+  sessionExport: 'Export Markdown',
+  sessionSwitchDialog: 'Switch session',
+  sessionKeyPlaceholder: 'Enter session key...',
+  sessionKeyLabel: 'Session key',
+  sessionListUnavailable: 'Session list unavailable. Enter a key above.',
+  sessionSwitchTyped: 'Switch to typed session',
+  sessionSearchPlaceholder: 'Search sessions…',
+  sessionSearchLabel: 'Search sessions',
+  sessionLoading: 'Loading…',
+  sessionNoMatches: 'No matches.',
+  sessionNoSessions: 'No sessions found.',
+  sessionCurrent: 'current',
+
+  // Session groups — the SessionGroup union stays a stable token set (it is a
+  // type and a bucket key); only the rendered label is translated.
+  groupWebChat: 'Web chat',
+  groupCli: 'CLI',
+  groupSubagents: 'Sub-agents',
+  groupAgents: 'Agents',
+  groupSessions: 'Sessions',
+  groupOther: 'Other',
+
+  // Run status labels (logic.ts).
+  runQueued: 'Queued',
+  runRunning: 'Running',
+  runApprovalPending: 'Waiting for approval',
+  runInterrupted: 'Interrupted',
+  runFailed: 'Failed',
+  runTimeout: 'Timed out',
+  runCancelled: 'Cancelled',
+  runIdle: 'Idle',
+
+  // Day separators + send button (logic.ts).
+  dayToday: 'Today',
+  dayYesterday: 'Yesterday',
+  sendQueuedCompaction: 'Send (queues until compaction finishes)',
+  sendQueuedBusy: 'Send (queues for after current response)',
+  sendLabel: 'Send',
+
+  // Markdown code blocks.
+  copyCode: 'Copy code',
+  mathTitle: 'LaTeX formula (not rendered)',
+  copyFailed: 'Copy failed. Select the code manually.',
+
+  // Session reset.
+  resetNoBackup: 'Session reset without transcript backup',
+  resetNoBackupDenied: 'Reset without backup requires an admitted Control connection.',
+  resetFailed: 'Reset failed: {message}',
+  resetDone: 'Session reset',
+  resetBackupUnavailable: 'Transcript backup is unavailable.',
+  resetBackupPrompt: 'Discard the current transcript and reset this session?',
+  resetDiscardAction: 'Discard & reset',
+
+  // Slash commands.
+  slashNewChatHint: 'New chat is available from the session menu',
+  slashCompactionRequested: 'Context compaction requested',
+  slashCompactionFailed: 'Compaction failed: {message}',
+  slashUsageHint: 'Usage page is available from the sidebar',
+  slashUsageUnavailable: 'Usage cost unavailable',
+  slashUsageFailed: 'Usage failed: {message}',
+  slashNoModelsMatch: 'No models match "{filter}"',
+  slashNoModels: 'No models available',
+  slashModelListFailed: 'Model list failed: {message}',
+  slashRouterPinned: 'Router pinned to {target}',
+  slashRouterPinFailed: 'Router pin failed: {message}',
+  slashRoutingRestored: 'Automatic routing restored',
+  slashRoutingAlready: 'Automatic routing already active',
+  slashRouterUnpinFailed: 'Router unpin failed: {message}',
+  slashUnsupported: 'Unsupported command: {command}',
+
+  // Transcript wiring.
+  attachmentsPrompt: 'Describe these attachments',
+  sendFailed: 'Send failed: {message}',
+  historyLoadFailed: 'Could not load chat history.',
+  historyEarlierFailed: 'Could not load earlier history.',
+  noSubscriptionManager: 'No subscription manager available',
+  streamMissedEvents: 'Missed live stream events; transcript refreshed.',
+  streamSubscribeFailed: 'Session stream subscription failed: {message}',
+  capWarning: 'Cap warning',
+  taskTimedOut: 'The task timed out before it could finish.',
+  taskStopped: 'The task stopped before it could finish.',
+  taskCancelled: 'The task was cancelled before it finished.',
+  agentError: 'Agent error',
+  streamGap: 'Stream connection gap detected; reconnecting.',
+
+  // Transcript: artifacts + charts.
+  artifactDownload: 'Download',
+  artifactDownloadTitle: 'Download {name}',
+  chartLoading: 'Loading chart…',
+  chartUnavailable: 'Chart data is unavailable.',
+  chartUnreadable: 'Chart data could not be read.',
+  chartFailed: 'Chart failed to load.',
+
+  // Transcript: history paging.
+  historyLoadingEarlier: 'Loading earlier messages...',
+  historyOlderAvailable: 'Older history is available.',
+  historyCompacted: 'Older context was compacted for the model.',
+  historyExportHint: 'Export the session for exact text.',
+  historyLoadEarlier: 'Load earlier',
+  historyRetry: 'Retry',
+  historyRetryHistory: 'Retry history',
+  historyEmpty: 'No messages yet.',
+
+  // Transcript: message actions.
+  msgCronTag: 'Cron',
+  msgSubagentCompletion: 'Subagent completion',
+  msgUserActions: 'User message actions',
+  msgAgentActions: 'Agent message actions',
+  msgCopy: 'Copy message',
+  msgRegenerate: 'Regenerate response',
+  msgEdit: 'Edit message',
+  msgCopied: 'Copied',
+  msgCopyFailedError: 'Copy failed',
+  msgCopyFailed: 'Copy failed: {message}',
+  msgWaitForResponse: 'Wait for the current response to finish',
+  msgNoPrevious: 'No previous message to regenerate',
+
+  // Transcript: thinking indicator verbs (chat.js:381-382).
+  verbWatching: 'Watching',
+  verbTracking: 'Tracking',
+  verbSensing: 'Sensing',
+  verbPulsing: 'Pulsing',
+  verbThinking: 'Thinking',
+  verbDrafting: 'Drafting',
+  verbPolishing: 'Polishing',
+  stillWaiting: 'Still waiting for agent response…',
+
+  // Transcript: tool cards.
+  toolRunning: 'Running',
+  toolCompleted: 'Completed',
+  toolFailed: 'Failed',
+  toolUnknownStatus: 'Unknown status',
+  toolSearchProvider: 'Search provider: {provider}',
+  toolViewFull: 'View full',
+  toolResultTitle: 'Tool Result',
+
+  // Transcript: router visualization.
+  routerChoosing: 'Choosing a model',
+  routerSuggested: 'Suggested model',
+  routerSelected: 'Model selected',
+  routerFinalizing: 'Finalizing model',
+
+  // Transcript: compaction.
+  compactSkipCoverage:
+    'Context was left unchanged because required details could not be preserved.',
+  compactSkipEmptyEphemeral: 'No compactable chat history yet.',
+  compactSkipEmptySummary: 'Context was left unchanged because no usable summary was produced.',
+  compactSkipNoEntries: 'No compactable chat history yet.',
+  compactSkipNoBoundary: 'Context cannot be compacted safely during the current tool turn.',
+  compactDetailCoverage: 'Required details could not be preserved',
+  compactDetailEmptyEphemeral: 'No compactable history',
+  compactDetailEmptySummary: 'No usable summary was produced',
+  compactDetailNoEntries: 'No compactable history',
+  compactDetailNoBoundary: 'Current tool turn boundary is not safe to compact',
+  compactDetailUnsafeFlush: 'Memory safety check did not complete',
+  compactWithinBudget: 'Already within context budget; no compact was applied.',
+  compactCouldNotApply: 'Context compaction could not be applied',
+  compactSkipped: 'Context compaction skipped',
+  compactEphemeralDetail: 'Request-scoped; session history was not rewritten',
+  compactMemoryOrganizing: 'Memory saved; organizing',
+  compactTemporaryToast: 'Continuing with temporary context compaction for this turn',
+  compactSeparatorDone: 'context compacted',
+  compactSeparatorFailed: 'compaction failed',
+  compactFailedToast: 'Compact failed{detail}{pending}',
+  compactPendingPreserved: '; pending message preserved',
+  compactPendingRecovered: '; pending message recovered to input',
+  compactCancelledToast: 'Compact cancelled{pending}',
+} as const)

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,6 +1,7 @@
 import { agents } from './agents'
 import { approvals } from './approvals'
 import { channels } from './channels'
+import { chat } from './chat'
 import { common } from './common'
 import { config } from './config'
 import { cron } from './cron'
@@ -35,6 +36,7 @@ export const en = {
   agents,
   approvals,
   channels,
+  chat,
   common,
   config,
   cron,

--- a/frontend/src/views/chat/Attachments.tsx
+++ b/frontend/src/views/chat/Attachments.tsx
@@ -13,6 +13,8 @@ import {
   type NormalizedComposerPayload,
   type PendingAttachment,
 } from './logic'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 /**
  * Chat attachments — the pending-attachment buffer + tray (React).
@@ -301,7 +303,11 @@ export function Attachments({ api }: AttachmentsProps) {
                 key={att.local_id}
               >
                 <span className="attachment-chip__icon" aria-hidden="true">
-                  {isBusy ? <span className="spinner attachment-chip__spinner" /> : 'file'}
+                  {isBusy ? (
+                    <span className="spinner attachment-chip__spinner" />
+                  ) : (
+                    t('chat.attachmentIconFallback')
+                  )}
                 </span>
                 <span className="attachment-chip__name">{att.name}</span>
                 <span className="attachment-chip__meta">{meta}</span>
@@ -309,8 +315,8 @@ export function Attachments({ api }: AttachmentsProps) {
                   type="button"
                   className="attachment-remove"
                   onClick={() => remove(att.local_id)}
-                  title="Remove"
-                  aria-label={`Remove attachment ${att.name}`}
+                  title={t('chat.attachmentRemove')}
+                  aria-label={t('chat.attachmentRemoveAria', { name: att.name })}
                 >
                   &times;
                 </button>

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -33,6 +33,8 @@ import { useApprovalPending } from './useApprovalPending'
 import { usePendingQueue, type PendingComposerBridge } from './usePendingQueue'
 import { useSlashCommands } from './useSlashCommands'
 import { useTranscript } from './useTranscript'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 // chat.js:2519 — Cmd/Ctrl+Shift+O mirrors the New chat button from anywhere in
 // the app. The registry matches on the physical key too, so this keeps working
@@ -601,27 +603,27 @@ export function ChatPage() {
 
   return (
     <div className="chat-stage" onDrop={onDrop} onDragOver={onDragOver} onPaste={onPaste}>
-      <h1 className="sr-only">Chat</h1>
+      <h1 className="sr-only">{t('chat.srTitle')}</h1>
       {/* New chat is a conversation-level action, so it lives in the floating
           Chat workspace header instead of competing with Send. */}
       <ShellPrimaryActionPortal>
         <button
           type="button"
           className="chat-new-button"
-          title={`New chat (${shortcutHint})`}
-          aria-label="New chat"
+          title={t('chat.newChatTitle', { shortcut: shortcutHint })}
+          aria-label={t('chat.newChat')}
           onClick={startNewChat}
         >
           <span className="chat-new-button__icon" aria-hidden="true">
             <SquarePen />
           </span>
-          <span className="chat-new-button__label">New chat</span>
+          <span className="chat-new-button__label">{t('chat.newChat')}</span>
         </button>
       </ShellPrimaryActionPortal>
       {/* Session context is portalled into the detached Chat header so the
           switch/reset/export workflow stays close to conversation identity. */}
       <ShellHeaderPortal>
-        <div className="chat-session-bar" role="group" aria-label="Chat session controls">
+        <div className="chat-session-bar" role="group" aria-label={t('chat.sessionControls')}>
           <SessionChip
             sessionKey={sessionKey}
             runState={runState}
@@ -634,7 +636,7 @@ export function ChatPage() {
       <div className="chat-thread" ref={containerRef} data-history-ready="false" />
       <div className="chat-history-loading" role="status" aria-live="polite">
         <span className="chat-history-loading__dot" aria-hidden="true" />
-        <span>Opening conversation…</span>
+        <span>{t('chat.opening')}</span>
       </div>
       <PendingQueue queue={pending.queue} onRemove={pending.remove} onClearAll={pending.clearAll} />
       <Composer
@@ -693,23 +695,27 @@ export function ChatPage() {
                   <Terminal />
                 </span>
                 <div>
-                  <div className="chat-output-modal__eyebrow">Tool output</div>
+                  <div className="chat-output-modal__eyebrow">{t('chat.toolOutputEyebrow')}</div>
                   <h2 id="chat-tool-result-modal-title">{toolResultModal.title}</h2>
                 </div>
               </div>
               <button
                 type="button"
                 className="chat-output-modal__close"
-                aria-label="Close"
-                title="Close tool output"
+                aria-label={t('common.close')}
+                title={t('chat.toolOutputClose')}
                 onClick={() => setToolResultModal(null)}
               >
                 <X aria-hidden="true" />
               </button>
             </header>
             <div className="chat-output-modal__meta">
-              <span>Full result</span>
-              <span>{toolResultModal.content.length.toLocaleString()} characters</span>
+              <span>{t('chat.toolOutputFull')}</span>
+              <span>
+                {t('chat.toolOutputChars', {
+                  count: toolResultModal.content.length.toLocaleString(),
+                })}
+              </span>
             </div>
             <pre id="chat-tool-result-modal-content" className="chat-tool-result-full">
               {toolResultModal.content}

--- a/frontend/src/views/chat/Composer.tsx
+++ b/frontend/src/views/chat/Composer.tsx
@@ -4,6 +4,8 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { toast } from 'sonner'
 import { MAX_PENDING, sendButtonState, shouldAutofocusComposer } from './logic'
 import { useShortcutDocs } from '@/components/KeyboardShortcuts'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 // #137 — what the composer binds, in the order `onTextareaKeyDown` tests it, so
 // the `?` overlay reports the composer accurately without the handler leaving
@@ -493,8 +495,8 @@ export function Composer({
               aria-haspopup="dialog"
               aria-expanded={toolbarOpen}
               aria-controls="chat-toolbar-popover"
-              aria-label="Run modes"
-              title="Run modes: execution and routing"
+              aria-label={t('chat.runModes')}
+              title={t('chat.runModesTitle')}
               onClick={() => setToolbarOpen((v) => !v)}
             >
               <SlidersHorizontalIcon aria-hidden="true" />
@@ -515,14 +517,14 @@ export function Composer({
                 >
                   <div className="chat-toolbar-popover__header">
                     <h2 id="chat-toolbar-popover-title" className="chat-toolbar-popover__title">
-                      Run modes
+                      {t('chat.runModes')}
                     </h2>
                     <button
                       ref={toolbarCloseRef}
                       type="button"
                       className="chat-toolbar-popover__close"
-                      aria-label="Close run modes"
-                      title="Close run modes"
+                      aria-label={t('chat.runModesClose')}
+                      title={t('chat.runModesClose')}
                       onClick={() => {
                         setToolbarOpen(false)
                         toolbarTriggerRef.current?.focus()
@@ -546,15 +548,15 @@ export function Composer({
               accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/plain,text/markdown,text/html,text/csv,application/json,.png,.jpg,.jpeg,.gif,.webp,.pdf,.txt,.md,.markdown,.html,.htm,.csv,.json"
               className="chat-composer__file-input"
               onChange={onFilePicked}
-              aria-label="Attach files"
+              aria-label={t('chat.attachFiles')}
               hidden
             />
             <button
               type="button"
               className="btn-term chat-composer__attach"
               onClick={() => fileInputRef.current?.click()}
-              title="Attach a file"
-              aria-label="Attach files"
+              title={t('chat.attachFileTitle')}
+              aria-label={t('chat.attachFiles')}
             >
               <PaperclipIcon aria-hidden="true" />
             </button>
@@ -566,9 +568,9 @@ export function Composer({
           value={value}
           onChange={onChange}
           onKeyDown={onKeyDown}
-          placeholder="Send a message..."
+          placeholder={t('chat.messagePlaceholder')}
           rows={1}
-          aria-label="Message"
+          aria-label={t('chat.messageLabel')}
           aria-autocomplete={slashListboxId ? 'list' : undefined}
           aria-expanded={slashListboxId ? Boolean(slashActiveDescendant) : undefined}
           aria-controls={slashActiveDescendant ? slashListboxId : undefined}
@@ -579,8 +581,8 @@ export function Composer({
             type="button"
             className="btn-term chat-composer__abort"
             onClick={() => onAbort?.()}
-            title="Stop (Esc)"
-            aria-label="Stop"
+            title={t('chat.stopTitle')}
+            aria-label={t('chat.stop')}
           >
             <SquareIcon aria-hidden="true" />
           </button>
@@ -591,7 +593,7 @@ export function Composer({
             onClick={doSend}
             disabled={sendDisabled}
             title={sendLabel}
-            aria-label="Send"
+            aria-label={t('chat.send')}
           >
             <ArrowUpIcon aria-hidden="true" />
           </button>

--- a/frontend/src/views/chat/ElevatedPill.tsx
+++ b/frontend/src/views/chat/ElevatedPill.tsx
@@ -1,16 +1,11 @@
 import { effectiveElevatedMode } from './logic'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 // The elevated-mode pill titles, ported verbatim from _updateElevatedPill
-// (chat.js:2314-2343). Kept as constants so the presentational component and any
-// future readout share one copy of the operator-facing wording.
-const TITLE_UNAVAILABLE =
-  'Bypass requires an admitted Control connection. Reconnect with the configured Control token.'
-const TITLE_SESSION =
-  'Session permission override is active. Approval prompts are bypassed for this browser chat session. Click to clear the override.'
-const TITLE_GLOBAL =
-  'Global permission default controls execution mode and is configured by agentos sandbox on|bypass|full|reset.'
-const TITLE_NEUTRAL =
-  'Approval prompts are active. Click to enable approval bypass for this browser session.'
+// (chat.js:2314-2343). Resolved per render rather than held as module
+// constants: a title frozen at module-evaluation time keeps the boot locale
+// forever (#258).
 
 export interface ElevatedPillProps {
   // The browser SESSION override (from the shared elevated-mode store).
@@ -45,10 +40,10 @@ export function ElevatedPill({
         type="button"
         className="chat-pill chat-pill--disabled"
         aria-disabled="true"
-        title={TITLE_UNAVAILABLE}
+        title={t('chat.pillTitleUnavailable')}
         onClick={onToggle}
       >
-        Bypass N/A
+        {t('chat.pillUnavailable')}
       </button>
     )
   }
@@ -60,16 +55,16 @@ export function ElevatedPill({
   let title: string
   if (sessionMode) {
     // chat.js:2330-2333
-    text = `Session ${sessionMode.toUpperCase()}`
-    title = TITLE_SESSION
+    text = t('chat.pillSession', { mode: sessionMode.toUpperCase() })
+    title = t('chat.pillTitleSession')
   } else if (globalMode) {
     // chat.js:2334-2337
-    text = `Global ${globalMode.toUpperCase()}`
-    title = TITLE_GLOBAL
+    text = t('chat.pillGlobal', { mode: globalMode.toUpperCase() })
+    title = t('chat.pillTitleGlobal')
   } else {
     // chat.js:2338-2341
-    text = 'Approval prompts'
-    title = TITLE_NEUTRAL
+    text = t('chat.pillNeutral')
+    title = t('chat.pillTitleNeutral')
   }
 
   return (

--- a/frontend/src/views/chat/PendingQueue.tsx
+++ b/frontend/src/views/chat/PendingQueue.tsx
@@ -1,4 +1,6 @@
 import { MAX_PENDING, type PendingItem } from './logic'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 /**
  * The pending-queue rail (chat.js:8474-8503 `_renderPendingQueue`).
@@ -24,10 +26,6 @@ export interface PendingQueueProps {
   onClearAll: () => void
 }
 
-// chat.js:8484 — the label title string, verbatim.
-const LABEL_TITLE =
-  'Alt+↑ pulls the most recent back into the input · ESC recovers all to input · sends FIFO when the current response finishes'
-
 export function PendingQueue({ queue, onRemove, onClearAll }: PendingQueueProps) {
   // chat.js:8476-8480 — hidden (nothing rendered) when the queue is empty.
   if (queue.length === 0) return null
@@ -36,19 +34,19 @@ export function PendingQueue({ queue, onRemove, onClearAll }: PendingQueueProps)
   const showClearAll = queue.length >= 2
 
   return (
-    <div className="chat-pending" role="region" aria-label="Pending messages">
+    <div className="chat-pending" role="region" aria-label={t('chat.pendingLandmark')}>
       <div className="chat-pending-header">
-        <span className="chat-pending-label" title={LABEL_TITLE}>
-          Pending {queue.length}/{MAX_PENDING}
+        <span className="chat-pending-label" title={t('chat.pendingLabelTitle')}>
+          {t('chat.pendingCount', { count: queue.length, max: MAX_PENDING })}
         </span>
         {showClearAll && (
           <button
             type="button"
             className="chat-pending-clear"
-            aria-label="Clear all pending messages"
+            aria-label={t('chat.pendingClearAllAria')}
             onClick={onClearAll}
           >
-            Clear all
+            {t('chat.pendingClearAll')}
           </button>
         )}
       </div>
@@ -56,7 +54,7 @@ export function PendingQueue({ queue, onRemove, onClearAll }: PendingQueueProps)
         {queue.map((p, i) => {
           // chat.js:8490-8494 — 30-char preview (ellipsis past 30), attachment
           // count chip, and the full text as the chip title / aria label.
-          const raw = p.text || (p.attachments.length ? '(attachment only)' : '')
+          const raw = p.text || (p.attachments.length ? t('chat.pendingAttachmentOnly') : '')
           const preview = raw.slice(0, 30) + (raw.length > 30 ? '…' : '')
           const chipLabel = `Pending message ${i + 1}: ${raw.slice(0, 80)}`
           return (
@@ -69,7 +67,7 @@ export function PendingQueue({ queue, onRemove, onClearAll }: PendingQueueProps)
                 type="button"
                 className="chat-pending-chip-remove"
                 aria-label={`Remove ${chipLabel}`}
-                title="Remove"
+                title={t('chat.pendingRemove')}
                 onClick={() => onRemove(i)}
               >
                 ×

--- a/frontend/src/views/chat/SessionChip.tsx
+++ b/frontend/src/views/chat/SessionChip.tsx
@@ -14,6 +14,8 @@ import {
 } from './logic'
 import { useShortcutDocs } from '@/components/KeyboardShortcuts'
 import { useOverlayLayer } from '@/components/overlay-layer'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 // #137 — the switcher popover and the actions menu bind these to their own
 // elements (`onKey` / `onActionsKeyDown` below), so they are documented here.
@@ -39,6 +41,22 @@ const SESSION_SHORTCUTS = [
 
 // chat.js:1903 — the switcher group order (empty groups are skipped).
 const GROUP_ORDER: SessionGroup[] = ['Web chat', 'CLI', 'Sub-agents', 'Agents', 'Sessions', 'Other']
+
+/**
+ * `SessionGroup` is a stable token set — it is both a type and the bucket key
+ * `classifySessionKey` returns — so only the rendered label is translated.
+ */
+function groupLabel(group: SessionGroup): string {
+  const labels: Record<SessionGroup, string> = {
+    'Web chat': t('chat.groupWebChat'),
+    CLI: t('chat.groupCli'),
+    'Sub-agents': t('chat.groupSubagents'),
+    Agents: t('chat.groupAgents'),
+    Sessions: t('chat.groupSessions'),
+    Other: t('chat.groupOther'),
+  }
+  return labels[group]
+}
 
 const COMPACT_RUN_LABEL: Record<RunStatusResult['status'], string> = {
   idle: 'Idle',
@@ -327,12 +345,12 @@ export function SessionChip({
 
   return (
     <div className="chat-session" ref={rootRef}>
-      <span className="chat-session-label">session</span>
+      <span className="chat-session-label">{t('chat.sessionLabel')}</span>
       <button
         id="chat-session-switcher-trigger"
         type="button"
         className={`chat-session-chip${open ? ' is-active' : ''}`}
-        aria-label="Switch chat session"
+        aria-label={t('chat.sessionSwitchAria')}
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={toggle}
@@ -366,8 +384,8 @@ export function SessionChip({
           ref={actionsTriggerRef}
           type="button"
           className="chat-session-actions-trigger"
-          title="Chat actions"
-          aria-label="Chat actions"
+          title={t('chat.sessionActions')}
+          aria-label={t('chat.sessionActions')}
           aria-haspopup="menu"
           aria-expanded={actionsOpen}
           onClick={toggleActions}
@@ -380,7 +398,7 @@ export function SessionChip({
             ref={actionsMenuRef}
             className="chat-session-actions-menu"
             role="menu"
-            aria-label="Chat actions"
+            aria-label={t('chat.sessionActions')}
             onKeyDown={onActionsKeyDown}
           >
             <button
@@ -388,24 +406,24 @@ export function SessionChip({
               className="chat-session-actions-menu__item"
               role="menuitem"
               tabIndex={-1}
-              aria-label="Copy session key"
+              aria-label={t('chat.sessionCopyKeyAria')}
               onMouseDown={(event) => event.preventDefault()}
               onClick={() => runHeaderAction(copy)}
             >
               <Copy aria-hidden="true" />
-              <span>Copy session key</span>
+              <span>{t('chat.sessionCopyKey')}</span>
             </button>
             <button
               type="button"
               className="chat-session-actions-menu__item"
               role="menuitem"
               tabIndex={-1}
-              aria-label="Reset session"
+              aria-label={t('chat.sessionResetAria')}
               onMouseDown={(event) => event.preventDefault()}
               onClick={() => runHeaderAction(onReset)}
             >
               <RotateCcw aria-hidden="true" />
-              <span>Reset session</span>
+              <span>{t('chat.sessionReset')}</span>
             </button>
             {onExport ? (
               <button
@@ -413,12 +431,12 @@ export function SessionChip({
                 className="chat-session-actions-menu__item"
                 role="menuitem"
                 tabIndex={-1}
-                aria-label="Export chat as Markdown"
+                aria-label={t('chat.sessionExportAria')}
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => runHeaderAction(onExport)}
               >
                 <FileDown aria-hidden="true" />
-                <span>Export Markdown</span>
+                <span>{t('chat.sessionExport')}</span>
               </button>
             ) : null}
           </div>
@@ -426,14 +444,18 @@ export function SessionChip({
       </div>
 
       {open && (
-        <div className="chat-session-popover" role="dialog" aria-label="Switch session">
+        <div
+          className="chat-session-popover"
+          role="dialog"
+          aria-label={t('chat.sessionSwitchDialog')}
+        >
           {failed ? (
             <>
               <input
                 type="search"
                 className="chat-session-popover-search"
-                placeholder="Enter session key..."
-                aria-label="Session key"
+                placeholder={t('chat.sessionKeyPlaceholder')}
+                aria-label={t('chat.sessionKeyLabel')}
                 autoComplete="off"
                 spellCheck={false}
                 value={manualKey}
@@ -447,16 +469,16 @@ export function SessionChip({
                 autoFocus
               />
               <div className="chat-session-popover-list">
-                <div className="chat-session-popover-empty">
-                  Session list unavailable. Enter a key above.
-                </div>
+                <div className="chat-session-popover-empty">{t('chat.sessionListUnavailable')}</div>
                 <button
                   type="button"
                   className="chat-session-popover-item"
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => switchTo(manualKey.trim())}
                 >
-                  <span className="chat-session-popover-item-key">Switch to typed session</span>
+                  <span className="chat-session-popover-item-key">
+                    {t('chat.sessionSwitchTyped')}
+                  </span>
                 </button>
               </div>
             </>
@@ -465,8 +487,8 @@ export function SessionChip({
               <input
                 type="search"
                 className="chat-session-popover-search"
-                placeholder="Search sessions…"
-                aria-label="Search sessions"
+                placeholder={t('chat.sessionSearchPlaceholder')}
+                aria-label={t('chat.sessionSearchLabel')}
                 autoComplete="off"
                 spellCheck={false}
                 value={filter}
@@ -475,15 +497,17 @@ export function SessionChip({
               />
               <div className="chat-session-popover-list">
                 {sessions === null ? (
-                  <div className="chat-session-popover-empty">Loading…</div>
+                  <div className="chat-session-popover-empty">{t('chat.sessionLoading')}</div>
                 ) : total === 0 ? (
                   <div className="chat-session-popover-empty">
-                    {filter.trim() ? 'No matches.' : 'No sessions found.'}
+                    {filter.trim() ? t('chat.sessionNoMatches') : t('chat.sessionNoSessions')}
                   </div>
                 ) : (
                   groups.map((group) => (
                     <div className="chat-session-popover-group" key={group.label}>
-                      <div className="chat-session-popover-group-label">{group.label}</div>
+                      <div className="chat-session-popover-group-label">
+                        {groupLabel(group.label)}
+                      </div>
                       {group.items.map((item) => {
                         const k = sessionItemKey(item)
                         const run = sessionRunStatus(typeof item === 'object' ? item : {})
@@ -507,7 +531,9 @@ export function SessionChip({
                               </span>
                             )}
                             {isCurrent && (
-                              <span className="chat-session-popover-item-tag">current</span>
+                              <span className="chat-session-popover-item-tag">
+                                {t('chat.sessionCurrent')}
+                              </span>
                             )}
                           </button>
                         )

--- a/frontend/src/views/chat/SlashMenu.tsx
+++ b/frontend/src/views/chat/SlashMenu.tsx
@@ -9,6 +9,8 @@ import {
 } from 'react'
 import { parseSlashInput, type SlashCommand } from './logic'
 import { useShortcutDocs } from '@/components/KeyboardShortcuts'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 // #137 — the menu consumes these from the composer's keydown (`handleKeyDown`
 // below) while it is open, so they are documented, not dispatched.
@@ -205,7 +207,12 @@ export function SlashMenu({
   if (!open) return null
 
   return (
-    <div id={resolvedListboxId} className="chat-slash" role="listbox" aria-label="Slash commands">
+    <div
+      id={resolvedListboxId}
+      className="chat-slash"
+      role="listbox"
+      aria-label={t('chat.slashLandmark')}
+    >
       {filtered.map((cmd, i) => (
         <div
           key={cmd.cmd || cmd.name || i}

--- a/frontend/src/views/chat/Toolbar.tsx
+++ b/frontend/src/views/chat/Toolbar.tsx
@@ -20,6 +20,8 @@ import {
   normalizeSessionUsage,
   type SessionUsage,
 } from './logic'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
 
 // config.get carries the router feature state + the global permission default.
 interface ConfigGetResponse {
@@ -249,7 +251,7 @@ export function Toolbar({
     <div className="chat-toolbar" data-bypass={bypass ? 'on' : undefined}>
       <div className="chat-toolbar-controls">
         <div className="chat-toolbar-row chat-toolbar-row--mode">
-          <span className="chat-toolbar-row-label t-label">Execution mode</span>
+          <span className="chat-toolbar-row-label t-label">{t('chat.toolbarExecutionMode')}</span>
           <ElevatedPill
             sessionMode={sessionMode}
             globalMode={globalMode}
@@ -259,8 +261,8 @@ export function Toolbar({
         </div>
 
         <div className="chat-toolbar-row">
-          <span className="chat-toolbar-row-label t-label">Pilot Router</span>
-          <label className="chat-toggle" aria-label="Pilot Router">
+          <span className="chat-toolbar-row-label t-label">{t('chat.toolbarPilotRouter')}</span>
+          <label className="chat-toggle" aria-label={t('chat.toolbarPilotRouter')}>
             <input
               type="checkbox"
               checked={routerChecked}
@@ -273,8 +275,8 @@ export function Toolbar({
         </div>
 
         <div className="chat-toolbar-row">
-          <span className="chat-toolbar-row-label t-label">Visual effects</span>
-          <label className="chat-toggle" aria-label="Visual effects">
+          <span className="chat-toolbar-row-label t-label">{t('chat.toolbarVisualEffects')}</span>
+          <label className="chat-toggle" aria-label={t('chat.toolbarVisualEffects')}>
             <input
               type="checkbox"
               checked={routerFxChecked}
@@ -289,17 +291,17 @@ export function Toolbar({
 
       <div className="chat-toolbar-usage" role="group" aria-labelledby="chat-toolbar-usage-title">
         <div id="chat-toolbar-usage-title" className="chat-toolbar-usage-title t-label">
-          Session usage
+          {t('chat.toolbarUsageTitle')}
         </div>
         {usage ? (
           <>
             <div className="chat-toolbar-usage-model">
-              <span className="t-label">Model</span>
+              <span className="t-label">{t('chat.toolbarModel')}</span>
               <span
                 className="chat-toolbar-usage-model-value t-data"
-                title={usage.model || 'Not reported'}
+                title={usage.model || t('chat.toolbarModelUnreported')}
               >
-                {usage.model || 'Not reported'}
+                {usage.model || t('chat.toolbarModelUnreported')}
               </span>
             </div>
             <div className="chat-toolbar-usage-metrics" data-has-cost={usage.cost != null}>
@@ -308,19 +310,19 @@ export function Toolbar({
                 <span className="t-data">{tokens(usage.input)}</span>
               </span>
               <span className="chat-toolbar-usage-metric">
-                <span className="t-label">out</span>
+                <span className="t-label">{t('chat.toolbarOut')}</span>
                 <span className="t-data">{tokens(usage.output)}</span>
               </span>
               {usage.cost != null ? (
                 <span className="chat-toolbar-usage-metric">
-                  <span className="t-label">cost</span>
+                  <span className="t-label">{t('chat.toolbarCost')}</span>
                   <span className="t-data">${usage.cost.toFixed(4)}</span>
                 </span>
               ) : null}
             </div>
           </>
         ) : (
-          <span className="chat-toolbar-usage-empty t-label">No usage yet</span>
+          <span className="chat-toolbar-usage-empty t-label">{t('chat.toolbarNoUsage')}</span>
         )}
       </div>
 
@@ -335,18 +337,15 @@ export function Toolbar({
             onClose={() => setConfirmOpen(false)}
           >
             <h2 id="chat-bypass-confirm-title" className="t-display">
-              Enable approval bypass?
+              {t('chat.bypassConfirmTitle')}
             </h2>
             <div id="chat-bypass-confirm-body" className="chat-modal-body">
-              <p>
-                This allows host execution without approval prompts in this browser session. This
-                maps to /elevated bypass.
-              </p>
-              <p>Sensitive-path checks remain active.</p>
+              <p>{t('chat.bypassConfirmBody')}</p>
+              <p>{t('chat.bypassConfirmNote')}</p>
             </div>
             <div className="chat-modal-actions">
               <Button type="button" variant="outline" onClick={() => setConfirmOpen(false)}>
-                Cancel
+                {t('common.cancel')}
               </Button>
               <Button
                 type="button"
@@ -356,7 +355,7 @@ export function Toolbar({
                   applyElevatedMode('bypass')
                 }}
               >
-                Enable bypass
+                {t('chat.bypassConfirmAction')}
               </Button>
             </div>
           </ModalShell>

--- a/frontend/src/views/chat/logic.ts
+++ b/frontend/src/views/chat/logic.ts
@@ -4,6 +4,9 @@
 // so each helper is unit-testable in isolation. Cited legacy line ranges are
 // against static/js/views/chat.js.
 
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import {
   isApprovalBypassMode,
   normalizeElevatedMode,
@@ -177,16 +180,16 @@ export interface RunStatusResult {
 /** chat.js:1571-1583 — the human label for a normalized run status. */
 export function runStatusLabel(status: string): string {
   const labels: Record<string, string> = {
-    queued: 'Queued',
-    running: 'Running',
-    approval_pending: 'Waiting for approval',
-    interrupted: 'Interrupted',
-    failed: 'Failed',
-    timeout: 'Timed out',
-    cancelled: 'Cancelled',
-    idle: 'Idle',
+    queued: t('chat.runQueued'),
+    running: t('chat.runRunning'),
+    approval_pending: t('chat.runApprovalPending'),
+    interrupted: t('chat.runInterrupted'),
+    failed: t('chat.runFailed'),
+    timeout: t('chat.runTimeout'),
+    cancelled: t('chat.runCancelled'),
+    idle: t('chat.runIdle'),
   }
-  return labels[status] || 'Idle'
+  return labels[status] || t('chat.runIdle')
 }
 
 /** chat.js:1585-1595 — collapse legacy synonyms onto the normalized vocabulary. */
@@ -461,8 +464,8 @@ export function dayLabel(isoDay: string): string {
   const today = new Date()
   const todayKey = today.toISOString().slice(0, 10)
   const yesterKey = new Date(today.getTime() - 86400000).toISOString().slice(0, 10)
-  if (isoDay === todayKey) return 'Today'
-  if (isoDay === yesterKey) return 'Yesterday'
+  if (isoDay === todayKey) return t('chat.dayToday')
+  if (isoDay === yesterKey) return t('chat.dayYesterday')
   const d = new Date(isoDay + 'T12:00:00')
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
@@ -515,10 +518,10 @@ export function sendButtonState(
   const hasText = (input ?? '').trim().length > 0
   const disabled = !hasText && !hasPendingAttachments
   const label = pendingCompaction
-    ? 'Send (queues until compaction finishes)'
+    ? t('chat.sendQueuedCompaction')
     : busy
-      ? 'Send (queues for after current response)'
-      : 'Send'
+      ? t('chat.sendQueuedBusy')
+      : t('chat.sendLabel')
   return { disabled, label }
 }
 

--- a/frontend/src/views/chat/markdown.ts
+++ b/frontend/src/views/chat/markdown.ts
@@ -1,3 +1,6 @@
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import DOMPurify from 'dompurify'
 import hljs from 'highlight.js/lib/core'
 import bash from 'highlight.js/lib/languages/bash'
@@ -60,7 +63,7 @@ function restoreMath(html: string, stash: string[]): string {
   return html.replace(MATH_SENTINEL, (_match, rawIndex: string) => {
     const raw = stash[Number(rawIndex)]
     if (raw === undefined) return ''
-    return `<code class="math-raw" title="LaTeX formula (not rendered)">${escapeHtml(raw)}</code>`
+    return `<code class="math-raw" title="${escapeHtml(t('chat.mathTitle'))}">${escapeHtml(raw)}</code>`
   })
 }
 
@@ -75,7 +78,7 @@ function wrapCodeBlocks(html: string): string {
         '<div class="code-block">' +
         '<div class="code-block-header">' +
         `<span class="code-lang">${language}</span>` +
-        `<button type="button" class="copy-btn" data-target="${id}" aria-label="Copy code">` +
+        `<button type="button" class="copy-btn" data-target="${id}" aria-label="${escapeHtml(t('chat.copyCode'))}">` +
         '<span aria-hidden="true">⧉</span> Copy</button>' +
         '</div>' +
         `<pre id="${id}"><code class="code-content${languageClass}">${code}</code></pre>` +
@@ -102,7 +105,7 @@ function fallbackRender(text: string): string {
       '<div class="code-block">' +
       '<div class="code-block-header">' +
       `<span class="code-lang">${language}</span>` +
-      `<button type="button" class="copy-btn" data-target="${id}" aria-label="Copy code">` +
+      `<button type="button" class="copy-btn" data-target="${id}" aria-label="${escapeHtml(t('chat.copyCode'))}">` +
       '<span aria-hidden="true">⧉</span> Copy</button>' +
       '</div>' +
       `<pre id="${id}"><code class="code-content${languageClass}">${code}</code></pre>` +
@@ -227,7 +230,7 @@ export function bindCopy(container: HTMLElement): void {
         .then(() => showCopyStatus(button, '✓ Copied'))
         .catch(() => {
           showCopyStatus(button, '! Failed', 1800)
-          toast.error('Copy failed. Select the code manually.')
+          toast.error(t('chat.copyFailed'))
         })
         .finally(() => {
           button.disabled = false

--- a/frontend/src/views/chat/resetSession.ts
+++ b/frontend/src/views/chat/resetSession.ts
@@ -1,3 +1,6 @@
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import { toast } from 'sonner'
 
 interface SessionResetRpc {
@@ -27,13 +30,13 @@ function errorMessage(error: unknown): string {
 async function discardAndReset(rpc: SessionResetRpc, sessionKey: string): Promise<void> {
   try {
     await rpc.call('sessions.reset', { key: sessionKey, force: true })
-    toast.info('Session reset without transcript backup')
+    toast.info(t('chat.resetNoBackup'))
   } catch (error) {
     if (errorCode(error) === 'permission_denied') {
-      toast.error('Reset without backup requires an admitted Control connection.')
+      toast.error(t('chat.resetNoBackupDenied'))
       return
     }
-    toast.error('Reset failed: ' + errorMessage(error))
+    toast.error(t('chat.resetFailed', { message: errorMessage(error) }))
   }
 }
 
@@ -45,15 +48,15 @@ async function discardAndReset(rpc: SessionResetRpc, sessionKey: string): Promis
 export async function resetSession(rpc: SessionResetRpc, sessionKey: string): Promise<void> {
   try {
     await rpc.call('sessions.reset', { key: sessionKey })
-    toast.info('Session reset')
+    toast.info(t('chat.resetDone'))
   } catch (error) {
     if (errorCode(error) === 'flush_unavailable') {
-      toast.warning('Transcript backup is unavailable.', {
+      toast.warning(t('chat.resetBackupUnavailable'), {
         id: 'session-reset-flush-unavailable',
-        description: 'Discard the current transcript and reset this session?',
+        description: t('chat.resetBackupPrompt'),
         duration: Infinity,
         action: {
-          label: 'Discard & reset',
+          label: t('chat.resetDiscardAction'),
           onClick: () => {
             void discardAndReset(rpc, sessionKey)
           },
@@ -61,6 +64,6 @@ export async function resetSession(rpc: SessionResetRpc, sessionKey: string): Pr
       })
       return
     }
-    toast.error('Reset failed: ' + errorMessage(error))
+    toast.error(t('chat.resetFailed', { message: errorMessage(error) }))
   }
 }

--- a/frontend/src/views/chat/transcript/artifacts.ts
+++ b/frontend/src/views/chat/transcript/artifacts.ts
@@ -25,6 +25,9 @@
 // chat.js:7043) is NOT re-ported here — Task 4 already ported it into tools.ts;
 // this module re-exports it from there so there is one definition (DRY).
 
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 export { publishArtifactTargetName } from './tools'
 
 import { isChartArtifact } from './chart'
@@ -313,21 +316,21 @@ export function createArtifactRenderer(deps: ArtifactRendererDeps) {
         html += `<div class="msg-artifact-chart" data-chart-src="${escAttr(payloadUrl)}" data-artifact-category="${escAttr(category)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}">
           <div class="msg-artifact-chart__header">
             <span class="msg-artifact-chart__name">${esc(name)}</span>
-            <a class="msg-artifact-chart__download" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-download="${escAttr(downloadUrl)}">Download</a>
+            <a class="msg-artifact-chart__download" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-download="${escAttr(downloadUrl)}">${escAttr(t('chat.artifactDownload'))}</a>
           </div>
           <div class="msg-artifact-chart__readout"></div>
           <div class="msg-artifact-chart__canvas"></div>
-          <p class="msg-artifact-chart__status">Loading chart…</p>
+          <p class="msg-artifact-chart__status">${escAttr(t('chat.chartLoading'))}</p>
         </div>`
       } else if (isImageArtifact(artifact)) {
         const previewUrl = artifactPreviewUrl(artifact || {}, { sessionKey, token })
-        html += `<a class="msg-artifact-card msg-artifact-card--image" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-category="${escAttr(category)}" data-artifact-download="${escAttr(downloadUrl)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}" title="Download ${escAttr(name)}">
+        html += `<a class="msg-artifact-card msg-artifact-card--image" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-category="${escAttr(category)}" data-artifact-download="${escAttr(downloadUrl)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}" title="${escAttr(t('chat.artifactDownloadTitle', { name }))}">
           ${previewUrl ? `<img class="msg-artifact-preview" src="${esc(previewUrl)}" alt="${esc(name)}" loading="lazy">` : '<span class="msg-artifact-preview msg-artifact-preview--empty" aria-hidden="true"></span>'}
           <span class="msg-artifact-card__body">
             <span class="msg-artifact-card__name">${esc(name)}</span>
             <span class="msg-artifact-card__meta">${esc(meta)}</span>
           </span>
-          <span class="msg-artifact-card__action" aria-hidden="true">Download</span>
+          <span class="msg-artifact-card__action" aria-hidden="true">${escAttr(t('chat.artifactDownload'))}</span>
         </a>`
       } else if (isAudioArtifact(artifact)) {
         html += `<div class="msg-artifact-card msg-artifact-card--audio" data-artifact-category="${escAttr(category)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}">
@@ -336,7 +339,7 @@ export function createArtifactRenderer(deps: ArtifactRendererDeps) {
             <span class="msg-artifact-card__name">${esc(name)}</span>
             <span class="msg-artifact-card__meta">${esc(meta)}</span>
           </span>
-          <a class="msg-artifact-card__action" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-download="${escAttr(downloadUrl)}">Download</a>
+          <a class="msg-artifact-card__action" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-download="${escAttr(downloadUrl)}">${escAttr(t('chat.artifactDownload'))}</a>
         </div>`
       } else {
         html += `<a class="msg-artifact-chip" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-category="${escAttr(category)}" data-artifact-download="${escAttr(downloadUrl)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}" title="${escAttr(name)}">

--- a/frontend/src/views/chat/transcript/chart.ts
+++ b/frontend/src/views/chat/transcript/chart.ts
@@ -20,6 +20,9 @@
 
 // Type-only — erased at compile time, so it does not pull the library into the
 // Chat chunk. The runtime import stays dynamic, inside `draw`.
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import type { MouseEventParams, Time, UTCTimestamp } from 'lightweight-charts'
 
 import type { Artifact } from './artifacts'
@@ -555,7 +558,7 @@ export function createChartMounter(deps: ChartMounterDeps) {
   async function mountOne(host: HTMLElement): Promise<void> {
     const url = host.dataset.chartSrc || ''
     if (!url) {
-      setStatus(host, 'Chart data is unavailable.')
+      setStatus(host, t('chat.chartUnavailable'))
       return
     }
     try {
@@ -563,14 +566,14 @@ export function createChartMounter(deps: ChartMounterDeps) {
       const raw = await deps.fetchPayload(url)
       const payload = normalizeChartPayload(raw)
       if (!payload) {
-        setStatus(host, 'Chart data could not be read.')
+        setStatus(host, t('chat.chartUnreadable'))
         diag('chart.mount.empty', { url })
         return
       }
       await draw(host, payload)
       diag('chart.mount.done', { url, candles: payload.candles.length })
     } catch (error) {
-      setStatus(host, 'Chart failed to load.')
+      setStatus(host, t('chat.chartFailed'))
       diag('chart.mount.error', { url, error: String(error) })
     }
   }

--- a/frontend/src/views/chat/transcript/compaction.ts
+++ b/frontend/src/views/chat/transcript/compaction.ts
@@ -30,6 +30,9 @@
 /* ── Constants (ported verbatim from chat.js) ───────────────────────────── */
 
 // chat.js:2991-2998 — the six terminal compaction statuses.
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 const COMPACTION_TERMINAL_STATUSES = new Set([
   'completed',
   'skipped',
@@ -53,22 +56,26 @@ export const INTERNAL_COMPACTION_SKIP_REASONS = new Set([
 ])
 
 // chat.js:3210-3216 — manual-compact user-facing skip messages by reason.
-const COMPACTION_SKIP_MESSAGES: Record<string, string> = {
-  coverage_blocked: 'Context was left unchanged because required details could not be preserved.',
-  empty_ephemeral_webchat_session: 'No compactable chat history yet.',
-  empty_summary: 'Context was left unchanged because no usable summary was produced.',
-  no_entries: 'No compactable chat history yet.',
-  no_safe_turn_boundary: 'Context cannot be compacted safely during the current tool turn.',
+function compactionSkipMessages(): Record<string, string> {
+  return {
+    coverage_blocked: t('chat.compactSkipCoverage'),
+    empty_ephemeral_webchat_session: t('chat.compactSkipEmptyEphemeral'),
+    empty_summary: t('chat.compactSkipEmptySummary'),
+    no_entries: t('chat.compactSkipNoEntries'),
+    no_safe_turn_boundary: t('chat.compactSkipNoBoundary'),
+  }
 }
 
 // chat.js:3218-3225 — short separator-detail strings by reason.
-const COMPACTION_SKIP_DETAILS: Record<string, string> = {
-  coverage_blocked: 'Required details could not be preserved',
-  empty_ephemeral_webchat_session: 'No compactable history',
-  empty_summary: 'No usable summary was produced',
-  no_entries: 'No compactable history',
-  no_safe_turn_boundary: 'Current tool turn boundary is not safe to compact',
-  unsafe_flush_receipt: 'Memory safety check did not complete',
+function compactionSkipDetails(): Record<string, string> {
+  return {
+    coverage_blocked: t('chat.compactDetailCoverage'),
+    empty_ephemeral_webchat_session: t('chat.compactDetailEmptyEphemeral'),
+    empty_summary: t('chat.compactDetailEmptySummary'),
+    no_entries: t('chat.compactDetailNoEntries'),
+    no_safe_turn_boundary: t('chat.compactDetailNoBoundary'),
+    unsafe_flush_receipt: t('chat.compactDetailUnsafeFlush'),
+  }
 }
 
 // chat.js:2973 — default separator auto-removal delay.
@@ -206,13 +213,11 @@ export function compactionSkipMessage(
 ): string {
   const reason = compactionReason(payload)
   if (source === 'manual') {
-    return (
-      COMPACTION_SKIP_MESSAGES[reason] || 'Already within context budget; no compact was applied.'
-    )
+    return compactionSkipMessages()[reason] || t('chat.compactWithinBudget')
   }
-  if (COMPACTION_SKIP_MESSAGES[reason]) return 'Context compaction could not be applied'
-  if (reason) return 'Context compaction skipped'
-  return 'Already within context budget; no compact was applied.'
+  if (compactionSkipMessages()[reason]) return t('chat.compactCouldNotApply')
+  if (reason) return t('chat.compactSkipped')
+  return t('chat.compactWithinBudget')
 }
 
 // chat.js:3253-3261
@@ -222,10 +227,11 @@ export function compactionStatusDetail(
   status = '',
 ): string {
   if (!compactionUserVisible(payload, source, status)) return ''
-  if (status === 'emergency_ephemeral') return 'Request-scoped; session history was not rewritten'
+  if (status === 'emergency_ephemeral') return t('chat.compactEphemeralDetail')
   const reason = compactionReason(payload)
   if (INTERNAL_COMPACTION_SKIP_REASONS.has(reason)) return ''
-  if (COMPACTION_SKIP_DETAILS[reason]) return COMPACTION_SKIP_DETAILS[reason]
+  const detail = compactionSkipDetails()[reason]
+  if (detail) return detail
   if (reason) return reason.replace(/_/g, ' ')
   return ''
 }
@@ -262,7 +268,7 @@ export function compactSemanticMemoryNotice(payload: CompactionPayload | null | 
   const semanticStatus = String((semantic && semantic.status) || '').toLowerCase()
   const safetyStatus = String((safety && safety.status) || '').toLowerCase()
   if (semanticStatus === 'degraded' && safetyStatus !== 'error') {
-    return 'Memory saved; organizing'
+    return t('chat.compactMemoryOrganizing')
   }
   return ''
 }
@@ -690,7 +696,7 @@ export function createCompactionRenderer(deps: CompactionRendererDeps) {
     if (status === 'emergency_ephemeral') {
       settleCompactInFlight(payload || {})
       if (!isReplay) {
-        toast('Continuing with temporary context compaction for this turn', 'info', 4500)
+        toast(t('chat.compactTemporaryToast'), 'info', 4500)
       }
       return
     }
@@ -704,7 +710,7 @@ export function createCompactionRenderer(deps: CompactionRendererDeps) {
       settleCompactInFlight(payload || {})
       syncCompactionSeparator(payload || {}, 'completed', source, {
         tone: 'ok',
-        label: 'context compacted',
+        label: t('chat.compactSeparatorDone'),
       })
       scheduleHistorySync()
       return
@@ -719,19 +725,24 @@ export function createCompactionRenderer(deps: CompactionRendererDeps) {
       const safe = compactSafeMessageDetail(payload || {})
       const msg = safe ? ': ' + safe : ''
       const pendingSuffix = keepPendingQueued
-        ? '; pending message preserved'
+        ? t('chat.compactPendingPreserved')
         : recovered
-          ? '; pending message recovered to input'
+          ? t('chat.compactPendingRecovered')
           : ''
-      syncCompactionSeparator(payload || {}, status, source, { label: 'compaction failed' })
-      if (!isReplay) toast('Compact failed' + msg + pendingSuffix, 'err', 5000)
+      syncCompactionSeparator(payload || {}, status, source, {
+        label: t('chat.compactSeparatorFailed'),
+      })
+      if (!isReplay)
+        toast(t('chat.compactFailedToast', { detail: msg, pending: pendingSuffix }), 'err', 5000)
       return
     }
     if (status === 'cancelled') {
       const recovered = settleCompactInFlight(payload || {}, { recoverPending: true })
       if (!isReplay) {
         toast(
-          'Compact cancelled' + (recovered ? '; pending message recovered to input' : ''),
+          t('chat.compactCancelledToast', {
+            pending: recovered ? t('chat.compactPendingRecovered') : '',
+          }),
           'info',
           4500,
         )

--- a/frontend/src/views/chat/transcript/history.ts
+++ b/frontend/src/views/chat/transcript/history.ts
@@ -9,6 +9,9 @@
 // The react-query wiring that DRIVES these (fetch + backward pagination) lives
 // in useTranscript.ts (idiomatic React). Legacy source: static/js/views/chat.js.
 
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import type { ChatMessage } from '../types'
 import type { Artifact } from './artifacts'
 import type { TurnMeta, TurnUsage } from './message'
@@ -369,7 +372,7 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
 
     if (state.loadingEarlier) {
       tone = 'loading'
-      message = 'Loading earlier messages...'
+      message = t('chat.historyLoadingEarlier')
     } else if (state.error) {
       tone = 'error'
       message = state.error
@@ -377,12 +380,12 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
     } else if (state.hasMore || state.scope === 'latest_window') {
       tone = 'partial'
       message = `Showing latest ${state.loadedMessages.length} messages.`
-      detail = 'Older history is available.'
+      detail = t('chat.historyOlderAvailable')
       showLoadEarlier = !!state.oldestCursor
     } else if (state.scope === 'compacted' || state.compactionSummaries.length > 0) {
       tone = 'compacted'
-      message = 'Older context was compacted for the model.'
-      detail = 'Export the session for exact text.'
+      message = t('chat.historyCompacted')
+      detail = t('chat.historyExportHint')
     } else {
       return
     }
@@ -400,7 +403,7 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
       const btn = document.createElement('button')
       btn.type = 'button'
       btn.className = 'btn btn--sm btn--ghost'
-      btn.textContent = 'Load earlier'
+      btn.textContent = t('chat.historyLoadEarlier')
       btn.disabled = state.loadingEarlier
       btn.addEventListener('click', () => deps.loadEarlierHistory())
       actions.appendChild(btn)
@@ -409,7 +412,8 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
       const btn = document.createElement('button')
       btn.type = 'button'
       btn.className = 'btn btn--sm btn--ghost'
-      btn.textContent = state.hasMore && state.oldestCursor ? 'Retry' : 'Retry history'
+      btn.textContent =
+        state.hasMore && state.oldestCursor ? t('chat.historyRetry') : t('chat.historyRetryHistory')
       btn.addEventListener('click', () => {
         if (state.hasMore && state.oldestCursor) {
           deps.loadEarlierHistory()
@@ -473,7 +477,7 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
       headerState.current.role = ''
       const empty = document.createElement('div')
       empty.className = 'chat-empty'
-      empty.textContent = 'No messages yet.'
+      empty.textContent = t('chat.historyEmpty')
       th.appendChild(empty)
       deps.markHistoryRendered()
       diag('history.empty.rendered_empty_state', {})

--- a/frontend/src/views/chat/transcript/message.ts
+++ b/frontend/src/views/chat/transcript/message.ts
@@ -1,3 +1,6 @@
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import type { MarkdownDep, TranscriptHeaderStateRef } from './stream'
 import { modelDisplayName } from './routerFx'
 import {
@@ -143,7 +146,7 @@ function appendSubagentDisclosure(body: HTMLElement, text: string): void {
     summary.textContent = `Subagent: ${payload.child_session_key || payload.session_key || 'completion'}`
     pre.textContent = JSON.stringify(payload, null, 2)
   } catch {
-    summary.textContent = 'Subagent completion'
+    summary.textContent = t('chat.msgSubagentCompletion')
     pre.classList.add('chat-subagent-disclosure-body--raw')
     pre.textContent = text
   }
@@ -209,7 +212,7 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
     } finally {
       textarea.remove()
     }
-    return copied ? Promise.resolve() : Promise.reject(new Error('Copy failed'))
+    return copied ? Promise.resolve() : Promise.reject(new Error(t('chat.msgCopyFailedError')))
   }
 
   function attachHoverActions(row: HTMLElement, role: string): void {
@@ -222,17 +225,17 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
     actions.setAttribute('role', 'toolbar')
     actions.setAttribute(
       'aria-label',
-      role === 'user' ? 'User message actions' : 'Agent message actions',
+      role === 'user' ? t('chat.msgUserActions') : t('chat.msgAgentActions'),
     )
     actions.appendChild(
-      actionButton('copy', 'Copy message', [
+      actionButton('copy', t('chat.msgCopy'), [
         'M9 9h11a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H11a2 2 0 0 1-2-2V9Z',
         'M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1',
       ]),
     )
     if (role === 'assistant' && deps.onRegenerate) {
       actions.appendChild(
-        actionButton('regenerate', 'Regenerate response', [
+        actionButton('regenerate', t('chat.msgRegenerate'), [
           'M20 11a8.1 8.1 0 1 1-2.3-5.7L20 8',
           'M20 4v4h-4',
         ]),
@@ -240,7 +243,7 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
     }
     if (role === 'user' && deps.onEdit) {
       actions.appendChild(
-        actionButton('edit', 'Edit message', [
+        actionButton('edit', t('chat.msgEdit'), [
           'M12 20h9',
           'M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4Z',
         ]),
@@ -254,10 +257,12 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
       const action = button.dataset.action
       if (action === 'copy') {
         void copyText(extractBubbleText(row))
-          .then(() => deps.toast('Copied', 'info', 1200))
+          .then(() => deps.toast(t('chat.msgCopied'), 'info', 1200))
           .catch((error: unknown) =>
             deps.toast(
-              'Copy failed: ' + (error instanceof Error ? error.message : String(error)),
+              t('chat.msgCopyFailed', {
+                message: error instanceof Error ? error.message : String(error),
+              }),
               'error',
               2500,
             ),
@@ -265,7 +270,7 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
         return
       }
       if (deps.isStreaming()) {
-        deps.toast('Wait for the current response to finish', 'warn', 2000)
+        deps.toast(t('chat.msgWaitForResponse'), 'warn', 2000)
         return
       }
       if (action === 'edit' && deps.onEdit) {
@@ -282,7 +287,7 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
         while (user && !user.matches('.msg.user'))
           user = user.previousElementSibling as HTMLElement | null
         if (!user) {
-          deps.toast('No previous message to regenerate', 'info', 2000)
+          deps.toast(t('chat.msgNoPrevious'), 'info', 2000)
           return
         }
         const text = extractBubbleText(user)
@@ -366,7 +371,7 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
       tags.className = 'msg-tags'
       const tag = document.createElement('span')
       tag.className = 'cron-tag'
-      tag.textContent = 'Cron'
+      tag.textContent = t('chat.msgCronTag')
       tags.appendChild(tag)
       header.appendChild(tags)
     }

--- a/frontend/src/views/chat/transcript/routerFx.ts
+++ b/frontend/src/views/chat/transcript/routerFx.ts
@@ -29,6 +29,9 @@
 /* ── Constants (ported verbatim from chat.js) ───────────────────────────── */
 
 // chat.js:3375 — default tier ids until config replaces them.
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 export const ROUTER_FX_DEFAULT_TIERS = ['c0', 'c1', 'c2', 'c3'] as const
 // chat.js:3392 — per-browser visualisation preference key.
 export const ROUTER_FX_PREF_KEY = 'agentos-router-fx'
@@ -631,7 +634,7 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
     header.className = 'router-fx-header'
     header.innerHTML =
       '<span class="glyph">←</span>' +
-      '<span class="title">Choosing a model</span>' +
+      `<span class="title">${t('chat.routerChoosing')}</span>` +
       '<span class="glyph">→</span>'
     wrap.appendChild(header)
 
@@ -752,9 +755,9 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
     const statusLabel =
       hasWinner && name
         ? wrap.dataset.observe === 'true'
-          ? 'Suggested model'
-          : 'Model selected'
-        : 'Finalizing model'
+          ? t('chat.routerSuggested')
+          : t('chat.routerSelected')
+        : t('chat.routerFinalizing')
     const title = wrap.querySelector<HTMLElement>('.router-fx-header .title')
     if (title) title.textContent = statusLabel
     wrap.dataset.hasWinner = hasWinner ? 'true' : 'false'

--- a/frontend/src/views/chat/transcript/stream.ts
+++ b/frontend/src/views/chat/transcript/stream.ts
@@ -16,6 +16,9 @@
 // is extracted as `createSeqGate()` and unit-tested (stream.test.ts). The DOM
 // mutation is verified by a live-browser sweep (parity matrix), not RTL.
 
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import type { StreamEventPayload } from '../types'
 import { createToolRenderer, type ToolRenderer } from './tools'
 import { createArtifactRenderer, type Artifact, type ArtifactRenderer } from './artifacts'
@@ -44,15 +47,17 @@ export const STREAM_SEQ_SEEN_WINDOW = 800
 export const THINKING_DELAY_MS = 400
 export const THINKING_TTL_MS = 60000
 // chat.js:381-382 — "Watching · N.Ns" verb cycle for the thinking indicator.
-export const CAP_VERBS = [
-  'Watching',
-  'Tracking',
-  'Sensing',
-  'Pulsing',
-  'Thinking',
-  'Drafting',
-  'Polishing',
-] as const
+export function capVerbs(): readonly string[] {
+  return [
+    t('chat.verbWatching'),
+    t('chat.verbTracking'),
+    t('chat.verbSensing'),
+    t('chat.verbPulsing'),
+    t('chat.verbThinking'),
+    t('chat.verbDrafting'),
+    t('chat.verbPolishing'),
+  ]
+}
 export const CAP_DWELL_MS = 2500
 // chat.js:45-47 — hint/reveal classes toggled on the streaming bubble.
 export const AWAITING_MODEL_CLASS = 'awaiting-model'
@@ -716,7 +721,8 @@ export function createStreamController(
     elapsed.setAttribute('aria-live', 'off')
     const elapsedMs = Date.now() - _thinkingStartTime
     const seconds = Math.floor(elapsedMs / 1000)
-    const verb = CAP_VERBS[Math.floor(elapsedMs / CAP_DWELL_MS) % CAP_VERBS.length]
+    const verbs = capVerbs()
+    const verb = verbs[Math.floor(elapsedMs / CAP_DWELL_MS) % verbs.length]
     elapsed.textContent = `${verb} (${seconds}s)`
 
     const agent = document.createElement('span')
@@ -740,13 +746,14 @@ export function createStreamController(
       }
       const eMs = Date.now() - _thinkingStartTime
       const s = Math.floor(eMs / 1000)
-      const v = CAP_VERBS[Math.floor(eMs / CAP_DWELL_MS) % CAP_VERBS.length]
+      const verbs = capVerbs()
+      const v = verbs[Math.floor(eMs / CAP_DWELL_MS) % verbs.length]
       const label = _thinkingEl.querySelector('.thinking-elapsed')
       if (label) label.textContent = `${v} (${s}s)`
 
       if (s >= THINKING_TTL_MS / 1000) {
         hideThinkingIndicator()
-        addMessage('system', 'Still waiting for agent response…')
+        addMessage('system', t('chat.stillWaiting'))
       }
     }, 1000)
   }

--- a/frontend/src/views/chat/transcript/tools.ts
+++ b/frontend/src/views/chat/transcript/tools.ts
@@ -17,6 +17,9 @@
 //      the streaming path mutates. DOM behavior is verified by a live-browser
 //      sweep (parity matrix), not RTL.
 
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import type { StreamEventPayload } from '../types'
 
 /* ── Constants (ported from chat.js, modernized to vector icon keys) ────── */
@@ -293,17 +296,17 @@ function applyToolSummaryStatus(statusSpan: HTMLElement, status: string, duratio
   statusSpan.setAttribute('aria-live', 'polite')
   const accessibleStatus =
     status === 'running'
-      ? 'Running'
+      ? t('chat.toolRunning')
       : status === 'success'
         ? visibleStatus
           ? `Completed in ${visibleStatus}`
-          : 'Completed'
+          : t('chat.toolCompleted')
         : status === 'error'
           ? visibleStatus
             ? `Failed in ${visibleStatus}`
-            : 'Failed'
+            : t('chat.toolFailed')
           : status === 'unknown'
-            ? 'Unknown status'
+            ? t('chat.toolUnknownStatus')
             : ''
   if (accessibleStatus) statusSpan.setAttribute('aria-label', accessibleStatus)
   else statusSpan.removeAttribute('aria-label')
@@ -342,7 +345,7 @@ function injectProviderBadge(summary: Element | null, providerRaw: string): void
     summary.insertBefore(badge, status)
   }
   badge.textContent = provider
-  badge.title = 'Search provider: ' + provider
+  badge.title = t('chat.toolSearchProvider', { provider })
 }
 
 /* ── DOM lookup helpers (chat.js:7167-7179) ─────────────────────────────── */
@@ -528,13 +531,15 @@ export function createToolRenderer(deps: ToolRendererDeps) {
       const viewBtn = document.createElement('button')
       viewBtn.className = 'btn btn--sm btn--ghost chat-tool-view-btn'
       viewBtn.type = 'button'
-      viewBtn.textContent = 'View full'
+      viewBtn.textContent = t('chat.toolViewFull')
       viewBtn.addEventListener('click', (event) => {
         event.preventDefault()
         event.stopPropagation()
-        openModal('Tool Result', '<pre class="chat-tool-result-full">' + esc(content) + '</pre>', [
-          { label: 'Close', cls: 'btn-secondary' },
-        ])
+        openModal(
+          t('chat.toolResultTitle'),
+          '<pre class="chat-tool-result-full">' + esc(content) + '</pre>',
+          [{ label: t('common.close'), cls: 'btn-secondary' }],
+        )
       })
       div.appendChild(viewBtn)
     }

--- a/frontend/src/views/chat/useSlashCommands.ts
+++ b/frontend/src/views/chat/useSlashCommands.ts
@@ -1,3 +1,6 @@
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useRpc } from '@/app/providers'
@@ -144,7 +147,7 @@ export function useSlashCommands(opts?: {
         case 'new_chat':
         case '/new': {
           if (onSessionActionRef.current) onSessionActionRef.current('new_chat', cmd, args)
-          else toast.info('New chat is available from the session menu')
+          else toast.info(t('chat.slashNewChatHint'))
           return
         }
         // chat.js:2716-2737 — reset the current session. (The `/new`-named-but-
@@ -166,10 +169,12 @@ export function useSlashCommands(opts?: {
           }
           rpc
             .call('sessions.contextCompact', { key })
-            .then(() => toast.info('Context compaction requested'))
+            .then(() => toast.info(t('chat.slashCompactionRequested')))
             .catch((err: unknown) =>
               toast.error(
-                'Compaction failed: ' + (err instanceof Error ? err.message : String(err)),
+                t('chat.slashCompactionFailed', {
+                  message: err instanceof Error ? err.message : String(err),
+                }),
               ),
             )
           return
@@ -180,7 +185,7 @@ export function useSlashCommands(opts?: {
         case '/usage': {
           const arg = args.trim().toLowerCase()
           if (arg === 'page') {
-            toast.info('Usage page is available from the sidebar')
+            toast.info(t('chat.slashUsageHint'))
             return
           }
           const method = arg === 'cost' ? 'usage.cost' : 'usage.status'
@@ -194,7 +199,7 @@ export function useSlashCommands(opts?: {
                 toast.info(
                   total != null
                     ? `Usage cost: $${Number(total).toFixed(6)}`
-                    : 'Usage cost unavailable',
+                    : t('chat.slashUsageUnavailable'),
                 )
                 return
               }
@@ -213,7 +218,11 @@ export function useSlashCommands(opts?: {
               )
             })
             .catch((err: unknown) =>
-              toast.error('Usage failed: ' + (err instanceof Error ? err.message : String(err))),
+              toast.error(
+                t('chat.slashUsageFailed', {
+                  message: err instanceof Error ? err.message : String(err),
+                }),
+              ),
             )
           return
         }
@@ -235,7 +244,9 @@ export function useSlashCommands(opts?: {
                   )
                 : list
               if (matches.length === 0) {
-                toast.info(filter ? `No models match "${filter}"` : 'No models available')
+                toast.info(
+                  filter ? t('chat.slashNoModelsMatch', { filter }) : t('chat.slashNoModels'),
+                )
                 return
               }
               const lines = matches.map((m) => {
@@ -254,7 +265,9 @@ export function useSlashCommands(opts?: {
             })
             .catch((err: unknown) =>
               toast.error(
-                'Model list failed: ' + (err instanceof Error ? err.message : String(err)),
+                t('chat.slashModelListFailed', {
+                  message: err instanceof Error ? err.message : String(err),
+                }),
               ),
             )
           return
@@ -266,11 +279,15 @@ export function useSlashCommands(opts?: {
             .call('router.hold.set', { key, tier })
             .then((res: unknown) => {
               const model = (res as { model?: string })?.model
-              toast.info('Router pinned to ' + tier + (model ? ' → ' + model : ''))
+              toast.info(
+                t('chat.slashRouterPinned', { target: tier + (model ? ' → ' + model : '') }),
+              )
             })
             .catch((err: unknown) =>
               toast.error(
-                'Router pin failed: ' + (err instanceof Error ? err.message : String(err)),
+                t('chat.slashRouterPinFailed', {
+                  message: err instanceof Error ? err.message : String(err),
+                }),
               ),
             )
           return
@@ -282,13 +299,15 @@ export function useSlashCommands(opts?: {
             .then((res: unknown) =>
               toast.info(
                 (res as { cleared?: boolean })?.cleared
-                  ? 'Automatic routing restored'
-                  : 'Automatic routing already active',
+                  ? t('chat.slashRoutingRestored')
+                  : t('chat.slashRoutingAlready'),
               ),
             )
             .catch((err: unknown) =>
               toast.error(
-                'Router unpin failed: ' + (err instanceof Error ? err.message : String(err)),
+                t('chat.slashRouterUnpinFailed', {
+                  message: err instanceof Error ? err.message : String(err),
+                }),
               ),
             )
           return
@@ -320,7 +339,7 @@ export function useSlashCommands(opts?: {
       const rest = parts.slice(1)
       const cmd = commandMapRef.current.get(slashCommandKey(cmdText))
       if (!cmd) {
-        toast.warning('Unsupported command: ' + cmdText)
+        toast.warning(t('chat.slashUnsupported', { command: cmdText }))
         return true
       }
       dispatch(cmd, rest.join(' '))

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -1,3 +1,6 @@
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -881,7 +884,7 @@ export function useTranscript(opts: {
       // chat.js:6129 — the model receives a fallback prompt when text is empty but
       // attachments are present ("Describe these attachments").
       const userText = trimmed
-      const providerText = trimmed || 'Describe these attachments'
+      const providerText = trimmed || t('chat.attachmentsPrompt')
 
       // Show the user turn through the shared imperative `_addMessage` port.
       const userTs = new Date().toISOString()
@@ -952,7 +955,7 @@ export function useTranscript(opts: {
           seamsRef.current.diag?.('send.rpc.error', { message })
           // chat.js:6202-6203 — end streaming + surface the failure inline.
           if (controller.isStreaming()) controller.endStreaming()
-          messageRendererRef.current?.addMessage('error', 'Send failed: ' + message)
+          messageRendererRef.current?.addMessage('error', t('chat.sendFailed', { message }))
         })
     },
     [rpc, controller, routerConfigGate],
@@ -1113,7 +1116,7 @@ export function useTranscript(opts: {
   useLayoutEffect(() => {
     if (!historyQuery.isError) return
     historyHydratingRef.current = false
-    pagingRef.current.error = 'Could not load chat history.'
+    pagingRef.current.error = t('chat.historyLoadFailed')
     historyRenderer.renderHistoryScopeRow(pagingRef.current)
     historySettledSessionRef.current = opts.sessionKey
     revealTranscriptIfSettled(opts.sessionKey, historyQuery.fetchStatus)
@@ -1172,7 +1175,7 @@ export function useTranscript(opts: {
         controller.renderCompactionSummarySeparators(mergedMessages)
       } catch {
         state.loadingEarlier = false
-        state.error = 'Could not load earlier history.'
+        state.error = t('chat.historyEarlierFailed')
         historyRenderer.renderHistoryScopeRow(state)
       } finally {
         loadingEarlierGuard.current = false
@@ -1266,7 +1269,7 @@ export function useTranscript(opts: {
           current_stream_seq?: unknown
         } | null
         if (cancelled || sessionKey !== sessionKeyRef.current) return
-        if (res && res.subscribed === false) throw new Error('No subscription manager available')
+        if (res && res.subscribed === false) throw new Error(t('chat.noSubscriptionManager'))
         const subscribedState = (res as Record<string, unknown>) ?? {}
         applySessionRunState(subscribedState)
         seams().applySessionRunState?.(subscribedState)
@@ -1286,7 +1289,7 @@ export function useTranscript(opts: {
         if (res && res.replay_complete === false) {
           const gapReason = res.replay_gap_reason || res.replayGapReason || ''
           if (replayGapShouldWarn(gapReason)) {
-            toast.warning('Missed live stream events; transcript refreshed.', { duration: 5000 })
+            toast.warning(t('chat.streamMissedEvents'), { duration: 5000 })
           }
           resyncHistory()
         }
@@ -1294,8 +1297,9 @@ export function useTranscript(opts: {
         if (controller.isStreaming()) controller.resetStreamIdleTimer()
       } catch (error: unknown) {
         toast.error(
-          'Session stream subscription failed: ' +
-            (error instanceof Error ? error.message : String(error)),
+          t('chat.streamSubscribeFailed', {
+            message: error instanceof Error ? error.message : String(error),
+          }),
           { duration: 6000 },
         )
         diag('session.subscribe.error', { sessionKey })
@@ -1501,7 +1505,7 @@ export function useTranscript(opts: {
       onEvent('session.event.warning', (payload: StreamEventPayload) => {
         if (isForeign(payload)) return
         if (isStaleEpoch(payload)) return
-        const message = (payload as { message?: string })?.message || 'Cap warning'
+        const message = (payload as { message?: string })?.message || t('chat.capWarning')
         toast.warning(message, { duration: 5000 })
         seams().showWarningToast?.(message)
       }),
@@ -1792,14 +1796,14 @@ export function useTranscript(opts: {
             typeof payload.terminal_message === 'string' && payload.terminal_message.trim()
               ? payload.terminal_message.trim()
               : code.includes('timeout')
-                ? 'The task timed out before it could finish.'
+                ? t('chat.taskTimedOut')
                 : code.includes('abandoned')
-                  ? 'The task stopped before it could finish.'
+                  ? t('chat.taskStopped')
                   : code.includes('cancelled')
-                    ? 'The task was cancelled before it finished.'
+                    ? t('chat.taskCancelled')
                     : typeof payload.message === 'string' && payload.message
                       ? payload.message
-                      : 'Agent error'
+                      : t('chat.agentError')
           messageRendererRef.current?.addMessage('error', message)
           // chat.js:5146 — recover pending after a failed turn.
           pendingDelegatesRef.current.popAllPendingIntoComposer()
@@ -1847,8 +1851,8 @@ export function useTranscript(opts: {
       rpc.on('_gap', () => {
         if (!controller.isStreaming()) return
         controller.clearStreamIdleTimer()
-        toast.warning('Stream connection gap detected; reconnecting.')
-        seams().showWarningToast?.('Stream connection gap detected; reconnecting.')
+        toast.warning(t('chat.streamGap'))
+        seams().showWarningToast?.(t('chat.streamGap'))
         // Terminal-history resync: the socket will reconnect and re-subscribe
         // (chat.js:1713 / 5177) — refresh history so the transcript is whole.
         resyncHistory()


### PR DESCRIPTION
Refs #257 — 11 of 11. **This completes the `I18N_MIGRATED` ledger.**

Extracts the chat view's copy into a new `chat` namespace and adds `src/views/chat/**/*.tsx` to `I18N_MIGRATED` in the same commit.

Most of this view's copy is invisible to the lint rule: only **70 of the ~215 strings are JSX**. The rest live in `logic.ts`, the hooks, and the imperative `transcript/*.ts` DOM builders the issue singles out — message actions, tool cards, history paging, compaction notices, the router visualization, the thinking-indicator verbs.

**No existing test file changed.**

### Three deliberate non-migrations, each commented in place

- **`PAGE_DUMP_MARKERS` stay English.** They are a heuristic that detects a paste of the English UI back into the composer, not copy shown to anyone. Translating them would break the detector.
- **The `SessionGroup` union stays a stable token set** — it is both a type and the bucket key `classifySessionKey` returns, and `logic.test.ts` asserts those values. Only the rendered label is translated, via a `groupLabel()` map in `SessionChip`.
- `CAP_VERBS` became `capVerbs()` so the thinking-verb cycle re-resolves per call.

## Bundle

Initial JS unchanged at **136.6 KiB gzip** / 180 KiB budget.

## Verification

`npm run check` green (tsc, eslint, prettier, 1824 tests).

Drove a **real agent turn** in the built UI against a live gateway (`Say PONG and nothing else` → `PONG`, gpt-5.6-luna) and checked the imperative builders that only exist at runtime:
- message action buttons from `message.ts` — `Copy message`, `Regenerate response`, `Edit message`, and the `User message actions` / `Agent message actions` groups;
- the `Copy code` control injected by `markdown.ts` into fenced blocks;
- the session menu (`Copy session key`, `Reset session`, `Export Markdown`);
- the run-modes popover (`Run modes`, `Execution mode`, `Pilot Router`, `Visual effects`, `Session usage`);
- existing history with markdown, code blocks and usage footers still renders unchanged.

No raw `chat.*` keys leaked into the DOM.