### PR TITLE
feat(tools): built-in x_search for X (Twitter) via xAI, with SuperGrok OAuth

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -289,8 +289,14 @@ SOFTWARE.
   - `src/agentos/tools/builtin/x_search.py` — adapted from
     `tools/x_search_tool.py`. The tool's request shape, client-side date
     validation, citation extraction, and degraded-result semantics follow the
-    upstream implementation; the credential path, HTTP client, retry budgeting,
-    and AgentOS wiring are original.
+    upstream implementation; the HTTP client, retry budgeting, and AgentOS
+    wiring are original.
+  - `src/agentos/xai_oauth.py` — adapted from the xAI OAuth section of
+    `hermes_cli/auth.py`. The device-code flow, OIDC discovery, endpoint and
+    inference-origin pinning, refresh-skew heuristics, tier-denial (HTTP 403)
+    handling, and dead-token quarantine follow the upstream implementation;
+    the token store, async refresh path, and network-free availability check
+    are original.
   - Cron prompt-injection scanner reference material (reviewed, not copied).
 - Upstream project: https://github.com/NousResearch/hermes-agent
 - License: MIT

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -283,16 +283,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## Hermes Agent reference material
+## Hermes Agent derived material
 
-- Component: cron prompt-injection scanner reference material.
+- Components:
+  - `src/agentos/tools/builtin/x_search.py` — adapted from
+    `tools/x_search_tool.py`. The tool's request shape, client-side date
+    validation, citation extraction, and degraded-result semantics follow the
+    upstream implementation; the credential path, HTTP client, retry budgeting,
+    and AgentOS wiring are original.
+  - Cron prompt-injection scanner reference material (reviewed, not copied).
 - Upstream project: https://github.com/NousResearch/hermes-agent
 - License: MIT
 - Copyright notice: Copyright (c) 2025 Nous Research
 
-AgentOS does not redistribute Hermes Agent. This notice records conservative
-attribution for reference material reviewed while hardening AgentOS's cron
-prompt scanner.
+AgentOS does not redistribute Hermes Agent as a whole.
 
 ```
 MIT License

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -69,6 +69,22 @@
 # search_proxy = ""               # e.g. "http://127.0.0.1:7890"
 # search_use_env_proxy = false    # true = allow HTTP_PROXY/HTTPS_PROXY if search_proxy is empty
 
+# X (Twitter) search via xAI's server-side x_search tool. A separate tool from
+# web_search, not one of its providers: xAI searches X's post index and returns
+# a synthesized answer with citations. The tool stays hidden from the model
+# until an xAI credential resolves, and it bills xAI directly — that spend does
+# not appear in `agentos cost`. See docs/x-search.md.
+# [x_search]
+# enabled = true
+# model = "grok-4.5"              # any Grok model with server-side x_search access
+# base_url = "https://api.x.ai/v1"
+# api_key = ""                    # env XAI_API_KEY also works
+# api_key_env = "XAI_API_KEY"
+# reasoning_effort = ""           # "", low, medium, high, xhigh
+# timeout_seconds = 180.0         # one attempt; 30-300
+# total_timeout_seconds = 300.0   # whole call including retries; 30-600
+# retries = 2                     # 5xx / timeout / connection errors only; 0-5
+
 [llm]
 provider = "openrouter"
 model = "openai/gpt-5.6-luna"

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ root release README with task-oriented guides.
 - [`providers-and-models.md`](providers-and-models.md) - LLM provider catalog,
   model selection, and runtime-backed model inspection.
 - [`search.md`](search.md) - web search providers and query workflow.
+- [`x-search.md`](x-search.md) - xAI-backed X (Twitter) search: setup,
+  credentials, and reading the `degraded` flag.
 - [`artifacts-and-media.md`](artifacts-and-media.md) - artifacts, generated
   files, images, PDF, and TTS.
 - [`tools-and-sandbox.md`](tools-and-sandbox.md) - built-in tools, approvals,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,6 +330,9 @@ With a SuperGrok / X Premium+ subscription, sign in instead of using a key:
 agentos auth login xai      # device-code flow; preferred over XAI_API_KEY
 agentos auth status         # never prints a token
 agentos auth logout xai
+
+agentos auth login xai --no-wait --json   # start, print link + code, exit
+agentos auth login xai --resume --json    # exit 0 done, 3 not yet, 1 failed
 ```
 
 ```sh

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ agentos <command> --help
 | `agentos upgrade` | Upgrade AgentOS and restart the managed gateway to match. |
 | `agentos doctor` | Diagnose readiness and print recovery steps. |
 | `agentos onboard` | Run or inspect first-run setup. |
-| `agentos configure` | Reconfigure provider, router, channels, search, image generation, or memory embedding. |
+| `agentos configure` | Reconfigure provider, router, channels, search, x-search, image generation, or memory embedding. |
 | `agentos gateway` | Run and manage the gateway server. |
 | `agentos chat` | Start interactive terminal chat. |
 | `agentos agent` | Run a single automation-friendly agent turn. |
@@ -321,6 +321,18 @@ agentos search configure duckduckgo
 agentos search query "latest AgentOS release"
 agentos configure search --search-provider duckduckgo
 ```
+
+X (Twitter) search — a separate xAI-backed tool, not a `web_search` backend:
+
+```sh
+agentos onboard catalog x-search
+agentos configure x-search --api-key-env XAI_API_KEY
+agentos configure x-search --x-search-model grok-4.5 --x-search-reasoning-effort low
+agentos configure x-search --no-x-search-enabled
+```
+
+The `x_search` tool stays hidden from the agent until an xAI credential is
+reachable. See [`x-search.md`](x-search.md).
 
 Channels:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,7 @@ agentos <command> --help
 | `agentos upgrade` | Upgrade AgentOS and restart the managed gateway to match. |
 | `agentos doctor` | Diagnose readiness and print recovery steps. |
 | `agentos onboard` | Run or inspect first-run setup. |
+| `agentos auth` | Provider logins that are not API keys (`login`/`status`/`logout`; xAI today). |
 | `agentos configure` | Reconfigure provider, router, channels, search, x-search, image generation, or memory embedding. |
 | `agentos gateway` | Run and manage the gateway server. |
 | `agentos chat` | Start interactive terminal chat. |
@@ -322,7 +323,14 @@ agentos search query "latest AgentOS release"
 agentos configure search --search-provider duckduckgo
 ```
 
-X (Twitter) search — a separate xAI-backed tool, not a `web_search` backend:
+X (Twitter) search — a separate xAI-backed tool, not a `web_search` backend.
+With a SuperGrok / X Premium+ subscription, sign in instead of using a key:
+
+```sh
+agentos auth login xai      # device-code flow; preferred over XAI_API_KEY
+agentos auth status         # never prints a token
+agentos auth logout xai
+```
 
 ```sh
 agentos onboard catalog x-search

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -331,8 +331,8 @@ agentos auth login xai      # device-code flow; preferred over XAI_API_KEY
 agentos auth status         # never prints a token
 agentos auth logout xai
 
-agentos auth login xai --no-wait --json   # start, print link + code, exit
-agentos auth login xai --resume --json    # exit 0 done, 3 not yet, 1 failed
+agentos auth login xai --no-wait --json 2>/dev/null   # start, print link + code, exit
+agentos auth login xai --resume --json 2>/dev/null    # exit 0 done, 3 not yet, 1 failed
 ```
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,6 +277,7 @@ agentos configure router --router recommended
 agentos configure router --router openrouter-mix
 agentos configure router --router disabled
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+agentos configure x-search --api-key-env XAI_API_KEY
 agentos configure channels
 agentos configure image-generation
 agentos configure memory-embedding
@@ -288,6 +289,7 @@ Supported sections:
 - `router`
 - `channels`
 - `search`
+- `x-search`
 - `image-generation`
 - `memory-embedding`
 
@@ -556,6 +558,34 @@ DuckDuckGo. Additional provider metadata may be present for future or
 not-yet-runtime-supported integrations.
 
 Read: [`search.md`](search.md)
+
+## X (Twitter) Search Configuration
+
+`x_search` is a separate tool, not a `web_search` backend: xAI runs the search
+against X's post index and returns a synthesized answer with citations.
+
+```sh
+agentos onboard catalog x-search
+agentos configure x-search --api-key-env XAI_API_KEY
+agentos configure x-search --x-search-model grok-4.5
+```
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `x_search.enabled` | `true` | Off hides the tool even when a key is present. |
+| `x_search.model` | `grok-4.5` | Any Grok model with server-side `x_search` access. |
+| `x_search.base_url` | `https://api.x.ai/v1` | Must be HTTPS; a rejected value falls back to the default. |
+| `x_search.api_key` | `""` | Pasted key. Persisted to config like other capability keys. |
+| `x_search.api_key_env` | `XAI_API_KEY` | Read at call time, so no restart after changing the variable. |
+| `x_search.reasoning_effort` | `""` | `low`, `medium`, `high`, `xhigh`, or empty for the model default. |
+| `x_search.timeout_seconds` | `180.0` | One attempt. Range 30-300. |
+| `x_search.total_timeout_seconds` | `300.0` | Whole call including retries. Range 30-600. |
+| `x_search.retries` | `2` | 5xx, timeout, and connection errors only. Range 0-5. |
+
+The tool is hidden from the model until a credential resolves, and its usage
+bills xAI directly rather than appearing in `agentos cost`.
+
+Read: [`x-search.md`](x-search.md)
 
 ## Channel Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -564,6 +564,14 @@ Read: [`search.md`](search.md)
 `x_search` is a separate tool, not a `web_search` backend: xAI runs the search
 against X's post index and returns a synthesized answer with citations.
 
+Credentials come from either a SuperGrok / X Premium+ login or an xAI API key,
+and the login wins when both exist:
+
+```sh
+agentos auth login xai
+agentos auth status
+```
+
 ```sh
 agentos onboard catalog x-search
 agentos configure x-search --api-key-env XAI_API_KEY

--- a/docs/tools-and-sandbox.md
+++ b/docs/tools-and-sandbox.md
@@ -17,7 +17,7 @@ For a focused permissions guide, see
 | Filesystem | `read_file`, `write_file`, `edit_file`, `list_dir`, `glob_search`, `grep_search`, spreadsheet reads. |
 | Shell and code | `exec_command`, `background_process`, `process`, `execute_code`. |
 | Git | `git_status`, `git_diff`, `git_log`, `git_commit`, `apply_patch`. |
-| Web | `web_search`, `web_fetch`, `http_request`. |
+| Web | `web_search`, `web_fetch`, `http_request`, `x_search` (X/Twitter via xAI — see [x-search.md](x-search.md); hidden without an xAI key). |
 | Memory | `memory_search`, `memory_save`, `memory_get`, `memory_delete`, `memory`. |
 | Sessions | `sessions_send`, `sessions_spawn`, `sessions_list`, `sessions_history`, `session_status`. |
 | Artifacts | `publish_artifact`. The mime decides the rendering: some draw inline in chat rather than as a download chip — see [artifacts-and-media.md](artifacts-and-media.md#inline-charts). |

--- a/docs/x-search.md
+++ b/docs/x-search.md
@@ -65,9 +65,10 @@ registration. It is a public client with no secret. Override it with
 
 ### Browser sign-in
 
-The Setup page shows which credential is in play but cannot run the login
-itself; the device-code flow is CLI-only for now. The card tells you the command
-to run.
+The Setup page can run the same flow: **Capabilities → X (Twitter) search →
+Sign in with xAI**. It shows the approval link and the code, then polls until
+you approve. The card also reports which credential is currently in play, so a
+key configured alongside a login does not look like the one being used.
 
 Without a reachable credential the tool is removed from the model's schema
 entirely. That is deliberate: every tool schema is fixed overhead on every

--- a/docs/x-search.md
+++ b/docs/x-search.md
@@ -79,8 +79,12 @@ registration. It is a public client with no secret. Override it with
 
 The Setup page can run the same flow: **Capabilities → X (Twitter) search →
 Sign in with xAI**. It shows the approval link and the code, then polls until
-you approve. The card also reports which credential is currently in play, so a
-key configured alongside a login does not look like the one being used.
+you approve. Once signed in the same control becomes **Sign out of xAI**. The
+card reports which credential is currently in play, so a key configured
+alongside a login does not look like the one being used.
+
+Signing out only forgets the local tokens; nothing is revoked at xAI, and
+`x_search` falls back to `XAI_API_KEY` if one is set.
 
 Without a reachable credential the tool is removed from the model's schema
 entirely. That is deliberate: every tool schema is fixed overhead on every

--- a/docs/x-search.md
+++ b/docs/x-search.md
@@ -45,8 +45,8 @@ For a caller that cannot hold a terminal open for minutes — a chat agent, a
 script — the same flow splits in two:
 
 ```sh
-agentos auth login xai --no-wait --json   # -> loginId, verificationUri, userCode
-agentos auth login xai --resume --json    # exit 0 done, 3 not yet, 1 failed
+agentos auth login xai --no-wait --json 2>/dev/null   # -> loginId, verificationUri, userCode
+agentos auth login xai --resume --json 2>/dev/null    # exit 0 done, 3 not yet, 1 failed
 ```
 
 `--resume` picks the newest pending login unless given `--login-id`. Pending

--- a/docs/x-search.md
+++ b/docs/x-search.md
@@ -1,0 +1,172 @@
+# X (Twitter) Search
+
+The `x_search` tool searches X posts, profiles, and threads. It is backed by
+xAI's server-side `x_search` tool on the Responses API at
+`https://api.x.ai/v1/responses`: Grok runs the search against X's index and
+returns a synthesized answer with citations to the posts it used.
+
+Reach for it instead of `web_search` when you want current discussion,
+reactions, or claims **on X**. General web pages still belong to `web_search`
+and `web_fetch`.
+
+## What it is not
+
+- **Not a search provider.** `agentos search list` covers the providers behind
+  `web_search`, which return ranked pages. `x_search` returns an answer plus
+  citations, so it is a separate tool and cannot be selected as a `web_search`
+  backend.
+- **Not a write path.** It cannot post, reply, like, DM, upload media, delete,
+  or read your authenticated X account. AgentOS ships no authenticated X
+  surface; an `x_search` answer is never evidence that anything was written.
+- **Not model-agnostic.** Only xAI has access to X's post index. Your agent can
+  run on any provider — the tool makes its own call to xAI regardless.
+
+## Credentials
+
+An xAI API key, and nothing else:
+
+| Path | How |
+| --- | --- |
+| `XAI_API_KEY` | Set it in `~/.agentos/.env` or the gateway environment. |
+| Pasted key | `agentos configure x-search --api-key <key>`, or the Setup page. |
+
+SuperGrok / X Premium+ OAuth is **not** supported. Hermes Agent accepts it;
+AgentOS has no OAuth subsystem, so `credential_source` in the result is always
+`"xai"`.
+
+Without a reachable credential the tool is removed from the model's schema
+entirely. That is deliberate: every tool schema is fixed overhead on every
+provider call, so an install with no xAI key should not pay for this one. It
+also means "the agent says it has no x_search tool" is the expected behaviour
+before setup, not a bug.
+
+`agentos context` still lists and prices `x_search`. That command reports what
+each *profile* would cost across the whole registry and does not model
+credential gating — `image_generate` appears there the same way without an
+image provider. The live per-turn surface is the one that drops it.
+
+## Cost
+
+`x_search` bills your xAI account directly. It does not pass through the
+AgentOS provider layer, so the spend does **not** appear in `agentos cost` or
+the Usage view. Watch it in the xAI console.
+
+## Configure
+
+```sh
+agentos onboard catalog x-search
+agentos configure x-search --api-key-env XAI_API_KEY
+agentos configure x-search --x-search-model grok-4.5 --x-search-reasoning-effort low
+agentos configure x-search --no-x-search-enabled
+```
+
+The Setup page carries the same fields under Capabilities → X (Twitter) search.
+Saving applies immediately; no gateway restart.
+
+```toml
+[x_search]
+enabled = true
+# Any Grok model with access to xAI's server-side x_search tool.
+model = "grok-4.5"
+base_url = "https://api.x.ai/v1"
+api_key = ""
+api_key_env = "XAI_API_KEY"
+# "", low, medium, high, or xhigh. Empty uses the model's own default;
+# xhigh is only accepted by models that document it.
+reasoning_effort = ""
+# One attempt. A complex X search runs 60-120s.
+timeout_seconds = 180.0
+# Hard wall for the whole call including retries.
+total_timeout_seconds = 300.0
+# Retried on 5xx, timeout, and connection errors only.
+retries = 2
+```
+
+`base_url` exists for an HTTPS proxy that speaks xAI's Responses API. A
+non-HTTPS URL, or one pointing at a cloud metadata endpoint, is rejected and
+the default is used — the request carries a bearer token.
+
+## Tool parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `query` | string (required) | What to look up on X. |
+| `allowed_x_handles` | string[] | Include these handles exclusively (max 10). A leading `@` is stripped. |
+| `excluded_x_handles` | string[] | Exclude these handles (max 10). Cannot be combined with `allowed_x_handles`. |
+| `from_date` | string | `YYYY-MM-DD` start date. |
+| `to_date` | string | `YYYY-MM-DD` end date. |
+| `enable_image_understanding` | boolean | Ask xAI to analyze images attached to matching posts. |
+| `enable_video_understanding` | boolean | Ask xAI to analyze videos attached to matching posts. |
+
+Dates are checked before the HTTP call. A malformed value, an inverted range,
+or a `from_date` in the future fails immediately rather than spending a
+billable call that could only return nothing. A future `to_date` is allowed —
+"from yesterday to tomorrow" is a legitimate way to catch posts as they arrive.
+
+## Result
+
+```json
+{
+  "success": true,
+  "provider": "xai",
+  "credential_source": "xai",
+  "tool": "x_search",
+  "model": "grok-4.5",
+  "query": "reactions to the new Grok image features",
+  "answer": "...",
+  "citations": ["https://x.com/..."],
+  "inline_citations": [{ "url": "...", "title": "...", "start_index": 0, "end_index": 42 }],
+  "degraded": false,
+  "degraded_reason": null
+}
+```
+
+### `degraded` is the field that matters
+
+xAI answers with HTTP 200 and a fluent, confident answer even when its X index
+matched nothing for your filters. That answer comes from the model's training
+data and is indistinguishable from a real one by shape alone.
+
+`degraded` is `true` when a narrowing filter (`allowed_x_handles`,
+`excluded_x_handles`, `from_date`, `to_date`) was active **and** both citation
+channels came back empty. Treat that answer as unsourced: it is not something
+found on X. A broad query with no citations is not degraded — it is just an
+answer.
+
+Common causes:
+
+- A typo in a handle, or an account that does not exist.
+- A date range too narrow, or sliding past the posts you wanted.
+- An index gap. Some active accounts intermittently fail to surface even when
+  they post regularly; retry after a few minutes.
+
+## Policy and limits
+
+- Member of `group:web`, so `deny = ["group:web"]` cuts the route to api.x.ai
+  along with the other network tools.
+- On the cron allowlist, next to `web_fetch` and `web_search` — a scheduled job
+  watching X is the obvious use, and the tool can only read.
+- Classified `external` for result budgeting, so a long answer is trimmed under
+  the same per-turn ceiling as other network results.
+- Runs under the `web.fetch` sandbox action kind.
+
+## Troubleshooting
+
+**The agent says it has no `x_search` tool.** No credential resolved. Check
+`agentos env list` for `XAI_API_KEY`, or that `[x_search] api_key` is set, and
+that `enabled` is not `false`.
+
+**`x_search is not enabled for this model`.** The configured `model` lacks
+access to xAI's server-side tool. Switch back to `grok-4.5` or another Grok
+model that documents it.
+
+**Timeouts.** `timeout_seconds` bounds one attempt; `total_timeout_seconds`
+bounds the whole call. Retries stop when the remaining budget cannot fit
+another attempt, so raising `retries` alone does nothing unless the total goes
+up too.
+
+## See also
+
+- [`search.md`](search.md) — general web search providers.
+- [`tools-and-sandbox.md`](tools-and-sandbox.md) — the built-in tool catalog.
+- [`configuration.md`](configuration.md) — every config key.

--- a/docs/x-search.md
+++ b/docs/x-search.md
@@ -20,19 +20,54 @@ and `web_fetch`.
   surface; an `x_search` answer is never evidence that anything was written.
 - **Not model-agnostic.** Only xAI has access to X's post index. Your agent can
   run on any provider — the tool makes its own call to xAI regardless.
+- **Not the X developer platform.** `developer.x.com` sells access to the X API
+  (raw posts, writes) and bills separately. This tool talks to `x.ai`.
 
 ## Credentials
 
-An xAI API key, and nothing else:
+Two paths. **OAuth wins when both are present**, because it spends a
+subscription you already pay for instead of API credit.
 
-| Path | How |
-| --- | --- |
-| `XAI_API_KEY` | Set it in `~/.agentos/.env` or the gateway environment. |
-| Pasted key | `agentos configure x-search --api-key <key>`, or the Setup page. |
+| Path | How | `credential_source` |
+| --- | --- | --- |
+| SuperGrok / X Premium+ | `agentos auth login xai` | `xai-oauth` |
+| xAI API key | `XAI_API_KEY` in `~/.agentos/.env`, or `agentos configure x-search --api-key <key>` | `xai` |
 
-SuperGrok / X Premium+ OAuth is **not** supported. Hermes Agent accepts it;
-AgentOS has no OAuth subsystem, so `credential_source` in the result is always
-`"xai"`.
+### Signing in with a subscription
+
+```sh
+agentos auth login xai      # device-code flow: open a URL, enter a code
+agentos auth status         # never prints a token
+agentos auth logout xai
+```
+
+The login is a device-code grant against `auth.x.ai`. Tokens land in
+`~/.agentos/auth.json` (owner-only, `0600`) and refresh themselves; you are not
+asked to paste anything into a prompt.
+
+Two things worth knowing:
+
+- **A subscription is not automatically entitled to API access.** xAI restricts
+  API/OAuth use to certain SuperGrok tiers, and an account outside them gets
+  HTTP 403 on refresh even though the in-app subscription is active. AgentOS
+  reports that as a tier problem rather than telling you to log in again,
+  because logging in again cannot fix it.
+- **A broken login is reported, not skipped.** If OAuth is configured but
+  unusable, `x_search` says so instead of quietly falling back to an API key
+  you may not have set.
+
+### Client identity
+
+The device-code flow uses xAI's public Grok CLI client id — the OAuth scope
+literally reads `grok-cli:access` — because xAI publishes no self-service client
+registration. It is a public client with no secret. Override it with
+`AGENTOS_XAI_OAUTH_CLIENT_ID` if you have your own registration.
+
+### Browser sign-in
+
+The Setup page shows which credential is in play but cannot run the login
+itself; the device-code flow is CLI-only for now. The card tells you the command
+to run.
 
 Without a reachable credential the tool is removed from the model's schema
 entirely. That is deliberate: every tool schema is fixed overhead on every
@@ -153,8 +188,17 @@ Common causes:
 ## Troubleshooting
 
 **The agent says it has no `x_search` tool.** No credential resolved. Check
-`agentos env list` for `XAI_API_KEY`, or that `[x_search] api_key` is set, and
-that `enabled` is not `false`.
+`agentos auth status`, `agentos env list` for `XAI_API_KEY`, or that
+`[x_search] api_key` is set, and that `enabled` is not `false`.
+
+**`xai_oauth_tier_denied`.** The OAuth grant is valid but xAI will not let the
+account use the API. Logging in again will not help — upgrade the subscription,
+or set `XAI_API_KEY` and use the key path.
+
+**The tool is offered but every call fails after a long break.** The stored
+refresh token was revoked or already used. AgentOS clears dead tokens when the
+refresh returns 400/401 so the next call fails locally instead of over the
+wire; run `agentos auth login xai` again.
 
 **`x_search is not enabled for this model`.** The configured `model` lacks
 access to xAI's server-side tool. Switch back to `grok-4.5` or another Grok

--- a/docs/x-search.md
+++ b/docs/x-search.md
@@ -41,6 +41,18 @@ agentos auth status         # never prints a token
 agentos auth logout xai
 ```
 
+For a caller that cannot hold a terminal open for minutes — a chat agent, a
+script — the same flow splits in two:
+
+```sh
+agentos auth login xai --no-wait --json   # -> loginId, verificationUri, userCode
+agentos auth login xai --resume --json    # exit 0 done, 3 not yet, 1 failed
+```
+
+`--resume` picks the newest pending login unless given `--login-id`. Pending
+logins live in the token store, so the half that starts one and the half that
+finishes it can be different processes.
+
 The login is a device-code grant against `auth.x.ai`. Tokens land in
 `~/.agentos/auth.json` (owner-only, `0600`) and refresh themselves; you are not
 asked to paste anything into a prompt.

--- a/frontend/src/i18n/en/setup.ts
+++ b/frontend/src/i18n/en/setup.ts
@@ -230,6 +230,12 @@ export const setup = defineNamespace('setup', {
   xSearchTotalTimeoutAria: 'X Search total timeout in seconds',
   xSearchRetries: 'Retries',
   xSearchRetriesAria: 'X Search retries',
+  xSearchOauthActive: 'Signed in to xAI — x_search will use that subscription.',
+  xSearchOauthIncomplete: 'Signed in to xAI, but the login has no refresh token. Sign in again.',
+  // One literal, not a concatenation: the catalog's types read placeholders off
+  // the string literal, and `a + b` widens it to `string` so {envKey} is lost.
+  xSearchOauthAbsent:
+    'Not signed in to xAI. Using {envKey} if set. For SuperGrok / X Premium+, run: agentos auth login xai',
   xSearchSave: 'Save X Search',
 
   // Memory embedding card.

--- a/frontend/src/i18n/en/setup.ts
+++ b/frontend/src/i18n/en/setup.ts
@@ -237,6 +237,8 @@ export const setup = defineNamespace('setup', {
   xSearchOauthAbsent:
     'Not signed in to xAI. Using {envKey} if set. Sign in below to use a SuperGrok / X Premium+ subscription instead.',
   xSearchSignIn: 'Sign in with xAI',
+  xSearchSignOut: 'Sign out of xAI',
+  xSearchSignOutDone: 'Signed out of xAI. x_search will fall back to XAI_API_KEY if set.',
   xSearchLoginStarting: 'Starting sign-in…',
   xSearchLoginPending: 'xAI sign-in in progress',
   xSearchLoginWaiting: 'Waiting for you to approve this device on xAI.',

--- a/frontend/src/i18n/en/setup.ts
+++ b/frontend/src/i18n/en/setup.ts
@@ -248,6 +248,7 @@ export const setup = defineNamespace('setup', {
   xSearchLoginDone: 'Signed in to xAI.',
   xSearchLoginExpired: 'The sign-in code expired. Start again.',
   xSearchLoginFailed: 'Sign-in failed:',
+  xSearchSignOutFailed: 'Sign-out failed:',
   xSearchSave: 'Save X Search',
 
   // Memory embedding card.

--- a/frontend/src/i18n/en/setup.ts
+++ b/frontend/src/i18n/en/setup.ts
@@ -207,6 +207,31 @@ export const setup = defineNamespace('setup', {
   searchDiagnostics: 'Diagnostics',
   searchSave: 'Save web search',
 
+  // X (Twitter) search card.
+  xSearchTitle: 'X (Twitter) search',
+  xSearchHint:
+    'Searches X posts through xAI and returns a synthesized answer with citations. ' +
+    'Read-only, and billed to your xAI account rather than tracked in AgentOS usage.',
+  xSearchNeeds: 'X Search needs',
+  xSearchEnabled: 'Enable X Search',
+  xSearchEnabledAria: 'Enable X Search',
+  xSearchApiKeyAria: 'xAI API key',
+  xSearchApiKeyEnvAria: 'xAI API key env',
+  xSearchModel: 'Grok model',
+  xSearchModelAria: 'X Search Grok model',
+  xSearchAdvanced: 'Advanced X Search options',
+  xSearchBehavior: 'X Search behavior',
+  xSearchEffort: 'Reasoning effort',
+  xSearchEffortAria: 'X Search reasoning effort',
+  xSearchEffortDefault: 'Model default',
+  xSearchTimeout: 'Per-attempt timeout (s)',
+  xSearchTimeoutAria: 'X Search per-attempt timeout in seconds',
+  xSearchTotalTimeout: 'Total timeout (s)',
+  xSearchTotalTimeoutAria: 'X Search total timeout in seconds',
+  xSearchRetries: 'Retries',
+  xSearchRetriesAria: 'X Search retries',
+  xSearchSave: 'Save X Search',
+
   // Memory embedding card.
   memoryEmbeddingTitle: 'Memory embedding',
   memoryNeeds: 'Memory needs',

--- a/frontend/src/i18n/en/setup.ts
+++ b/frontend/src/i18n/en/setup.ts
@@ -235,7 +235,17 @@ export const setup = defineNamespace('setup', {
   // One literal, not a concatenation: the catalog's types read placeholders off
   // the string literal, and `a + b` widens it to `string` so {envKey} is lost.
   xSearchOauthAbsent:
-    'Not signed in to xAI. Using {envKey} if set. For SuperGrok / X Premium+, run: agentos auth login xai',
+    'Not signed in to xAI. Using {envKey} if set. Sign in below to use a SuperGrok / X Premium+ subscription instead.',
+  xSearchSignIn: 'Sign in with xAI',
+  xSearchLoginStarting: 'Starting sign-in…',
+  xSearchLoginPending: 'xAI sign-in in progress',
+  xSearchLoginWaiting: 'Waiting for you to approve this device on xAI.',
+  xSearchLoginOpen: 'Open the xAI approval page',
+  xSearchLoginCode: 'Enter this code if asked:',
+  xSearchLoginCancel: 'Cancel sign-in',
+  xSearchLoginDone: 'Signed in to xAI.',
+  xSearchLoginExpired: 'The sign-in code expired. Start again.',
+  xSearchLoginFailed: 'Sign-in failed:',
   xSearchSave: 'Save X Search',
 
   // Memory embedding card.

--- a/frontend/src/views/chat/markdown.test.ts
+++ b/frontend/src/views/chat/markdown.test.ts
@@ -23,6 +23,30 @@ describe('chat markdown renderer', () => {
     expect(root.querySelector('a')?.getAttribute('href')).toBe('https://example.com')
   })
 
+  it('opens external links in a new tab', () => {
+    // Following a link in place unmounts the transcript, losing scroll
+    // position and any in-flight turn — painful for a link the assistant just
+    // asked the user to open, like an OAuth approval page.
+    const root = fragment('[approve](https://accounts.x.ai/oauth2/device?user_code=ABCD)')
+    const link = root.querySelector('a')
+
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.getAttribute('rel')).toContain('noopener')
+    expect(link?.getAttribute('rel')).toContain('noreferrer')
+  })
+
+  it('leaves in-page and app-relative links alone', () => {
+    const root = fragment('[top](#section) and [settings](/control/setup)')
+    const targets = Array.from(root.querySelectorAll('a')).map((a) => a.getAttribute('target'))
+
+    expect(targets).toEqual([null, null])
+  })
+
+  it('does not let the model choose its own browsing context', () => {
+    const root = fragment('<a href="/control/setup" target="_top">go</a>')
+    expect(root.querySelector('a')?.getAttribute('target')).toBeNull()
+  })
+
   it('sanitizes scripts, event handlers, and unsafe link protocols', () => {
     const root = fragment(
       '<script>alert(1)</script><img src="x" onerror="alert(2)"><a href="javascript:alert(3)">bad</a>',

--- a/frontend/src/views/chat/markdown.ts
+++ b/frontend/src/views/chat/markdown.ts
@@ -123,6 +123,32 @@ function fallbackRender(text: string): string {
   return html.replace(/\n\n/g, '<br><br>')
 }
 
+/**
+ * Send external links to a new tab.
+ *
+ * The transcript is a long-lived surface: following a link in place unmounts
+ * the chat and loses the scroll position and any in-flight turn. Assistant
+ * markdown is untrusted, so this runs before the final sanitize pass and
+ * touches only http(s) hrefs — in-page anchors and app-relative paths keep
+ * their default behaviour.
+ */
+function openExternalLinksInNewTab(html: string): string {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  for (const anchor of template.content.querySelectorAll('a[href]')) {
+    if (!/^https?:/i.test(anchor.getAttribute('href') || '')) {
+      // Anything the model wrote itself is not trusted to pick a browsing
+      // context — only the branch below gets to set one.
+      anchor.removeAttribute('target')
+      continue
+    }
+    anchor.setAttribute('target', '_blank')
+    // noopener also blunts reverse-tabnabbing from a link the model wrote.
+    anchor.setAttribute('rel', 'noreferrer noopener')
+  }
+  return template.innerHTML
+}
+
 /** Render untrusted assistant Markdown to sanitized terminal-chat HTML. */
 export function render(text: string): string {
   if (!text) return ''
@@ -134,9 +160,12 @@ export function render(text: string): string {
     html = wrapCodeBlocks(html)
     html = markInlineCode(html)
     html = restoreMath(html, stash)
+    html = openExternalLinksInNewTab(html)
     // The transforms above add only controlled markup, but sanitize the final
     // result as the last operation so every innerHTML call receives clean HTML.
-    return String(DOMPurify.sanitize(html))
+    // `target` is allowed through because the pass above is what sets it, and
+    // strips any the model tried to choose for itself.
+    return String(DOMPurify.sanitize(html, { ADD_ATTR: ['target'] }))
   } catch {
     return fallbackRender(text)
   }

--- a/frontend/src/views/setup/ExtrasSection.tsx
+++ b/frontend/src/views/setup/ExtrasSection.tsx
@@ -22,6 +22,7 @@ import {
   buildMemoryConfigureParams,
   buildMemorySettingsPatches,
   buildSearchConfigureParams,
+  buildXSearchConfigureParams,
   capabilityIsPrimary,
   credentialNeedList,
   envRecoveryCommand,
@@ -38,7 +39,8 @@ import {
   type SetupConfig,
 } from './logic'
 
-type ExtrasResetTarget = 'search' | 'memoryEmbedding' | 'memorySettings' | 'image' | 'audio'
+type ExtrasResetTarget =
+  'search' | 'xSearch' | 'memoryEmbedding' | 'memorySettings' | 'image' | 'audio'
 
 function saveVariant(status: OnboardingStatus, name: string): 'default' | 'outline' {
   return capabilityIsPrimary(status, name) ? 'default' : 'outline'
@@ -259,6 +261,170 @@ function SearchCard({
         onClick={collect}
       >
         {t('setup.searchSave')}
+      </Button>
+    </div>
+  )
+}
+
+// xAI API values, not display copy: these are sent verbatim and must never be
+// translated. Kept as identifiers so the i18n lint does not read them as text.
+const X_SEARCH_DEFAULT_MODEL = 'grok-4.5'
+const X_SEARCH_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const
+
+// ── X (Twitter) search ──────────────────────────────────────────────────────
+// Not a web-search provider: it answers from X's post index through xAI, so it
+// gets its own card rather than a row in the search provider select.
+function XSearchCard({
+  catalog,
+  config,
+  onSave,
+  saving,
+}: {
+  catalog: Catalog
+  config: SetupConfig
+  onSave: (params: Record<string, unknown>) => void
+  saving: boolean
+}) {
+  const spec: ProviderSpec = catalog.xSearch?.[0] || { providerId: 'x_search' }
+  const current = config.x_search || {}
+  const envKey = spec.envKey || 'XAI_API_KEY'
+
+  const [enabled, setEnabled] = useState(current.enabled !== false)
+  const [apiKey, setApiKey] = useState('')
+  const [apiKeyEnv, setApiKeyEnv] = useState(current.api_key_env || envKey)
+  const [model, setModel] = useState(current.model || X_SEARCH_DEFAULT_MODEL)
+  const [effort, setEffort] = useState(current.reasoning_effort || '')
+  const [timeout, setTimeout] = useState(String(current.timeout_seconds ?? 180))
+  const [totalTimeout, setTotalTimeout] = useState(String(current.total_timeout_seconds ?? 300))
+  const [retries, setRetries] = useState(String(current.retries ?? 2))
+
+  const collect = () => {
+    const field = (name: string, value: string, type: string, secret = false): CapabilityField => ({
+      name,
+      value,
+      checked: false,
+      type,
+      secret,
+      disabled: false,
+    })
+    const fields: CapabilityField[] = [
+      field('api_key', apiKey, 'password', true),
+      field('api_key_env', apiKeyEnv, 'text'),
+      field('model', model, 'text'),
+      field('reasoning_effort', effort, 'text'),
+      field('timeout_seconds', timeout, 'number'),
+      field('total_timeout_seconds', totalTimeout, 'number'),
+      field('retries', retries, 'number'),
+    ]
+    onSave(buildXSearchConfigureParams(enabled, fields))
+  }
+
+  return (
+    <div className="setup-mini panel">
+      <div className="setup-mini__head">
+        <h3 className="t-label">{t('setup.xSearchTitle')}</h3>
+      </div>
+      <p className="setup-muted">{t('setup.xSearchHint')}</p>
+      <NeedList
+        items={credentialNeedList(spec.whatYouNeed, apiKeyEnv || envKey)}
+        label={t('setup.xSearchNeeds')}
+      />
+      <SetupCheckbox
+        ariaLabel={t('setup.xSearchEnabledAria')}
+        checked={enabled}
+        onChange={setEnabled}
+      >
+        {t('setup.xSearchEnabled')}
+      </SetupCheckbox>
+      <label>
+        <span>{t('setup.fieldApiKey')}</span>
+        <input
+          type="password"
+          aria-label={t('setup.xSearchApiKeyAria')}
+          placeholder={t('setup.keepCurrentPlaceholder')}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+      </label>
+      <label>
+        <span>{t('setup.fieldApiKeyEnv')}</span>
+        <input
+          aria-label={t('setup.xSearchApiKeyEnvAria')}
+          value={apiKeyEnv}
+          placeholder={envKey}
+          onChange={(e) => setApiKeyEnv(e.target.value)}
+        />
+      </label>
+      <label>
+        <span>{t('setup.xSearchModel')}</span>
+        <input
+          aria-label={t('setup.xSearchModelAria')}
+          value={model}
+          placeholder={X_SEARCH_DEFAULT_MODEL}
+          onChange={(e) => setModel(e.target.value)}
+        />
+      </label>
+      <details
+        className="setup-advanced"
+        open={Boolean(effort || timeout !== '180' || totalTimeout !== '300' || retries !== '2')}
+      >
+        <summary>{t('setup.xSearchAdvanced')}</summary>
+        <div className="setup-advanced__body" aria-label={t('setup.xSearchBehavior')}>
+          <label>
+            <span>{t('setup.xSearchEffort')}</span>
+            <SetupSelect
+              aria-label={t('setup.xSearchEffortAria')}
+              value={effort}
+              onChange={(e) => setEffort(e.target.value)}
+            >
+              <option value="">{t('setup.xSearchEffortDefault')}</option>
+              {X_SEARCH_EFFORTS.map((level) => (
+                <option key={level} value={level}>
+                  {level}
+                </option>
+              ))}
+            </SetupSelect>
+          </label>
+          <label>
+            <span>{t('setup.xSearchTimeout')}</span>
+            <input
+              type="number"
+              min={30}
+              max={300}
+              step={1}
+              aria-label={t('setup.xSearchTimeoutAria')}
+              value={timeout}
+              onChange={(e) => setTimeout(e.target.value)}
+            />
+          </label>
+          <label>
+            <span>{t('setup.xSearchTotalTimeout')}</span>
+            <input
+              type="number"
+              min={30}
+              max={600}
+              step={1}
+              aria-label={t('setup.xSearchTotalTimeoutAria')}
+              value={totalTimeout}
+              onChange={(e) => setTotalTimeout(e.target.value)}
+            />
+          </label>
+          <label>
+            <span>{t('setup.xSearchRetries')}</span>
+            <input
+              type="number"
+              min={0}
+              max={5}
+              step={1}
+              aria-label={t('setup.xSearchRetriesAria')}
+              value={retries}
+              onChange={(e) => setRetries(e.target.value)}
+            />
+          </label>
+        </div>
+      </details>
+      <Button type="button" variant="outline" disabled={saving} onClick={collect}>
+        {t('setup.xSearchSave')}
       </Button>
     </div>
   )
@@ -925,6 +1091,7 @@ export function ExtrasSection({
   status,
   config,
   onSaveSearch,
+  onSaveXSearch,
   onSaveMemory,
   onSaveMemorySettings,
   onSaveImage,
@@ -940,6 +1107,7 @@ export function ExtrasSection({
   status: OnboardingStatus
   config: SetupConfig
   onSaveSearch: (params: Record<string, unknown>) => void
+  onSaveXSearch: (params: Record<string, unknown>) => void
   onSaveMemory: (params: Record<string, unknown>) => void
   onSaveMemorySettings: (patches: Record<string, unknown>) => void
   onSaveImage: (params: Record<string, unknown>) => void
@@ -949,6 +1117,7 @@ export function ExtrasSection({
   saving: boolean
   resetVersions: {
     search: number
+    xSearch: number
     memoryEmbedding: number
     memorySettings: number
     image: number
@@ -969,6 +1138,15 @@ export function ExtrasSection({
             config={config}
             onSave={onSaveSearch}
             saving={saving || conflicts.search}
+          />
+        </div>
+        <div className="setup-capability-slot" onChangeCapture={() => onDirtyChange('xSearch')}>
+          <XSearchCard
+            key={`x-search:${resetVersions.xSearch}`}
+            catalog={catalog}
+            config={config}
+            onSave={onSaveXSearch}
+            saving={saving || conflicts.xSearch}
           />
         </div>
         <div

--- a/frontend/src/views/setup/ExtrasSection.tsx
+++ b/frontend/src/views/setup/ExtrasSection.tsx
@@ -32,6 +32,8 @@ import {
   memoryNeedList,
   memorySettingsOverBudget,
   searchStatusText,
+  xSearchCredentialText,
+  type AuthStatus,
   type CapabilityField,
   type Catalog,
   type OnboardingStatus,
@@ -277,11 +279,13 @@ const X_SEARCH_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const
 function XSearchCard({
   catalog,
   config,
+  authStatus,
   onSave,
   saving,
 }: {
   catalog: Catalog
   config: SetupConfig
+  authStatus: AuthStatus
   onSave: (params: Record<string, unknown>) => void
   saving: boolean
 }) {
@@ -325,6 +329,7 @@ function XSearchCard({
         <h3 className="t-label">{t('setup.xSearchTitle')}</h3>
       </div>
       <p className="setup-muted">{t('setup.xSearchHint')}</p>
+      <p className="setup-muted">{xSearchCredentialText(authStatus, config)}</p>
       <NeedList
         items={credentialNeedList(spec.whatYouNeed, apiKeyEnv || envKey)}
         label={t('setup.xSearchNeeds')}
@@ -1090,6 +1095,7 @@ export function ExtrasSection({
   catalog,
   status,
   config,
+  authStatus,
   onSaveSearch,
   onSaveXSearch,
   onSaveMemory,
@@ -1106,6 +1112,7 @@ export function ExtrasSection({
   catalog: Catalog
   status: OnboardingStatus
   config: SetupConfig
+  authStatus: AuthStatus
   onSaveSearch: (params: Record<string, unknown>) => void
   onSaveXSearch: (params: Record<string, unknown>) => void
   onSaveMemory: (params: Record<string, unknown>) => void
@@ -1145,6 +1152,7 @@ export function ExtrasSection({
             key={`x-search:${resetVersions.xSearch}`}
             catalog={catalog}
             config={config}
+            authStatus={authStatus}
             onSave={onSaveXSearch}
             saving={saving || conflicts.xSearch}
           />

--- a/frontend/src/views/setup/ExtrasSection.tsx
+++ b/frontend/src/views/setup/ExtrasSection.tsx
@@ -3,7 +3,10 @@
 // its own draft state, conditional field enablement (from logic.ts), masked
 // secrets, and a Save wired to the matching onboarding.*.configure RPC (memory
 // settings uses config.patch). All decision-shaped derivation lives in logic.ts.
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useRpc } from '@/app/providers'
 import { Button } from '@/components/ui/button'
 import { t } from '@/i18n'
 import '@/i18n/en/setup'
@@ -39,6 +42,8 @@ import {
   type OnboardingStatus,
   type ProviderSpec,
   type SetupConfig,
+  type XaiLoginPoll,
+  type XaiPendingLogin,
 } from './logic'
 
 type ExtrasResetTarget =
@@ -273,6 +278,137 @@ function SearchCard({
 const X_SEARCH_DEFAULT_MODEL = 'grok-4.5'
 const X_SEARCH_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const
 
+const DEFAULT_POLL_SECONDS = 5
+
+/** Seconds to wait before the next poll. `0` is a real answer, not a missing one. */
+function pollDelay(interval: number | undefined, fallback: number): number {
+  return typeof interval === 'number' && interval >= 0 ? interval : fallback
+}
+
+/**
+ * The xAI device-code login, as a button.
+ *
+ * Unlike the cards around it this talks to the RPC layer directly rather than
+ * through props: it owns a multi-step flow (start → poll → refresh status)
+ * whose intermediate states nothing above it needs to see, and threading four
+ * callbacks and a state machine through two levels of props to avoid one hook
+ * would not make it clearer.
+ *
+ * It also lives outside XSearchCard on purpose — that component binds a state
+ * setter named `setTimeout`, which shadows the global this polling needs.
+ */
+function XaiLoginButton({ disabled }: { disabled: boolean }) {
+  const rpc = useRpc()
+  const queryClient = useQueryClient()
+  const [phase, setPhase] = useState<'idle' | 'starting' | 'awaiting' | 'error'>('idle')
+  const [login, setLogin] = useState<XaiPendingLogin | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  // Survives unmount mid-flight: a resolved poll must not setState on a card
+  // the operator has already navigated away from.
+  const cancelled = useRef(false)
+  useEffect(() => {
+    cancelled.current = false
+    return () => {
+      cancelled.current = true
+    }
+  }, [])
+
+  const fail = (message: string) => {
+    if (cancelled.current) return
+    setPhase('error')
+    setErrorMessage(message)
+    setLogin(null)
+  }
+
+  const poll = async (pending: XaiPendingLogin, wait: number) => {
+    await new Promise((resolve) => window.setTimeout(resolve, wait * 1000))
+    if (cancelled.current) return
+    try {
+      const result = await rpc.call<XaiLoginPoll>('auth.xai.login.poll', {
+        loginId: pending.loginId,
+      })
+      if (cancelled.current) return
+      if (result?.status === 'complete') {
+        setPhase('idle')
+        setLogin(null)
+        await queryClient.invalidateQueries({ queryKey: ['setup', 'auth'] })
+        toast.info(t('setup.xSearchLoginDone'), { id: 'setup-xai-login' })
+        return
+      }
+      if (result?.status === 'expired') {
+        fail(t('setup.xSearchLoginExpired'))
+        return
+      }
+      void poll(pending, pollDelay(result?.interval, pending.interval))
+    } catch (err) {
+      fail(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const start = async () => {
+    setPhase('starting')
+    setErrorMessage('')
+    try {
+      const pending = await rpc.call<XaiPendingLogin>('auth.xai.login.start')
+      if (cancelled.current) return
+      if (!pending?.loginId) {
+        fail(t('setup.xSearchLoginExpired'))
+        return
+      }
+      setLogin(pending)
+      setPhase('awaiting')
+      void poll(pending, pollDelay(pending.interval, DEFAULT_POLL_SECONDS))
+    } catch (err) {
+      fail(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  if (phase === 'awaiting' && login) {
+    return (
+      <div className="setup-advanced__body" aria-label={t('setup.xSearchLoginPending')}>
+        <p className="setup-muted">{t('setup.xSearchLoginWaiting')}</p>
+        <p>
+          <a href={login.verificationUri} target="_blank" rel="noreferrer noopener">
+            {t('setup.xSearchLoginOpen')}
+          </a>
+        </p>
+        <p>
+          {t('setup.xSearchLoginCode')} <code>{login.userCode}</code>
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            setPhase('idle')
+            setLogin(null)
+          }}
+        >
+          {t('setup.xSearchLoginCancel')}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <Button
+        type="button"
+        variant="outline"
+        disabled={disabled || phase === 'starting'}
+        onClick={() => void start()}
+      >
+        {phase === 'starting' ? t('setup.xSearchLoginStarting') : t('setup.xSearchSignIn')}
+      </Button>
+      {phase === 'error' ? (
+        <p className="setup-muted">
+          {t('setup.xSearchLoginFailed')} {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
 // ── X (Twitter) search ──────────────────────────────────────────────────────
 // Not a web-search provider: it answers from X's post index through xAI, so it
 // gets its own card rather than a row in the search provider select.
@@ -330,6 +466,7 @@ function XSearchCard({
       </div>
       <p className="setup-muted">{t('setup.xSearchHint')}</p>
       <p className="setup-muted">{xSearchCredentialText(authStatus, config)}</p>
+      <XaiLoginButton disabled={saving} />
       <NeedList
         items={credentialNeedList(spec.whatYouNeed, apiKeyEnv || envKey)}
         label={t('setup.xSearchNeeds')}

--- a/frontend/src/views/setup/ExtrasSection.tsx
+++ b/frontend/src/views/setup/ExtrasSection.tsx
@@ -304,6 +304,7 @@ function XaiLoginButton({ disabled, signedIn }: { disabled: boolean; signedIn: b
   const [phase, setPhase] = useState<'idle' | 'starting' | 'awaiting' | 'error'>('idle')
   const [login, setLogin] = useState<XaiPendingLogin | null>(null)
   const [errorMessage, setErrorMessage] = useState('')
+  const [errorAction, setErrorAction] = useState<'signIn' | 'signOut'>('signIn')
 
   // Survives unmount mid-flight: a resolved poll must not setState on a card
   // the operator has already navigated away from.
@@ -315,12 +316,16 @@ function XaiLoginButton({ disabled, signedIn }: { disabled: boolean; signedIn: b
     }
   }, [])
 
-  const fail = (message: string) => {
+  const fail = (message: string, action: 'signIn' | 'signOut' = 'signIn') => {
     if (cancelled.current) return
     setPhase('error')
     setErrorMessage(message)
+    setErrorAction(action)
     setLogin(null)
   }
+
+  const errorLabel = () =>
+    errorAction === 'signOut' ? t('setup.xSearchSignOutFailed') : t('setup.xSearchLoginFailed')
 
   const poll = async (pending: XaiPendingLogin, wait: number) => {
     await new Promise((resolve) => window.setTimeout(resolve, wait * 1000))
@@ -354,7 +359,7 @@ function XaiLoginButton({ disabled, signedIn }: { disabled: boolean; signedIn: b
       await queryClient.invalidateQueries({ queryKey: ['setup', 'auth'] })
       toast.info(t('setup.xSearchSignOutDone'), { id: 'setup-xai-login' })
     } catch (err) {
-      fail(err instanceof Error ? err.message : String(err))
+      fail(err instanceof Error ? err.message : String(err), 'signOut')
     }
   }
 
@@ -423,7 +428,7 @@ function XaiLoginButton({ disabled, signedIn }: { disabled: boolean; signedIn: b
         </Button>
         {phase === 'error' ? (
           <p className="setup-muted">
-            {t('setup.xSearchLoginFailed')} {errorMessage}
+            {errorLabel()} {errorMessage}
           </p>
         ) : null}
       </div>
@@ -442,7 +447,7 @@ function XaiLoginButton({ disabled, signedIn }: { disabled: boolean; signedIn: b
       </Button>
       {phase === 'error' ? (
         <p className="setup-muted">
-          {t('setup.xSearchLoginFailed')} {errorMessage}
+          {errorLabel()} {errorMessage}
         </p>
       ) : null}
     </div>

--- a/frontend/src/views/setup/ExtrasSection.tsx
+++ b/frontend/src/views/setup/ExtrasSection.tsx
@@ -36,6 +36,7 @@ import {
   memorySettingsOverBudget,
   searchStatusText,
   xSearchCredentialText,
+  xSearchSignedIn,
   type AuthStatus,
   type CapabilityField,
   type Catalog,
@@ -297,7 +298,7 @@ function pollDelay(interval: number | undefined, fallback: number): number {
  * It also lives outside XSearchCard on purpose — that component binds a state
  * setter named `setTimeout`, which shadows the global this polling needs.
  */
-function XaiLoginButton({ disabled }: { disabled: boolean }) {
+function XaiLoginButton({ disabled, signedIn }: { disabled: boolean; signedIn: boolean }) {
   const rpc = useRpc()
   const queryClient = useQueryClient()
   const [phase, setPhase] = useState<'idle' | 'starting' | 'awaiting' | 'error'>('idle')
@@ -341,6 +342,17 @@ function XaiLoginButton({ disabled }: { disabled: boolean }) {
         return
       }
       void poll(pending, pollDelay(result?.interval, pending.interval))
+    } catch (err) {
+      fail(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const signOut = async () => {
+    try {
+      await rpc.call('auth.xai.logout')
+      if (cancelled.current) return
+      await queryClient.invalidateQueries({ queryKey: ['setup', 'auth'] })
+      toast.info(t('setup.xSearchSignOutDone'), { id: 'setup-xai-login' })
     } catch (err) {
       fail(err instanceof Error ? err.message : String(err))
     }
@@ -392,6 +404,28 @@ function XaiLoginButton({ disabled }: { disabled: boolean }) {
         >
           {t('setup.xSearchLoginCancel')}
         </Button>
+      </div>
+    )
+  }
+
+  // Offering "Sign in" to someone already signed in is the wrong control and
+  // reads as though the login did not take.
+  if (signedIn) {
+    return (
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled || phase === 'starting'}
+          onClick={() => void signOut()}
+        >
+          {t('setup.xSearchSignOut')}
+        </Button>
+        {phase === 'error' ? (
+          <p className="setup-muted">
+            {t('setup.xSearchLoginFailed')} {errorMessage}
+          </p>
+        ) : null}
       </div>
     )
   }
@@ -476,7 +510,7 @@ function XSearchCard({
         label={t('setup.xSearchNeeds')}
       />
       <p className="setup-muted">{xSearchCredentialText(authStatus, config)}</p>
-      <XaiLoginButton disabled={saving} />
+      <XaiLoginButton disabled={saving} signedIn={xSearchSignedIn(authStatus)} />
       <SetupCheckbox
         ariaLabel={t('setup.xSearchEnabledAria')}
         checked={enabled}

--- a/frontend/src/views/setup/ExtrasSection.tsx
+++ b/frontend/src/views/setup/ExtrasSection.tsx
@@ -369,12 +369,18 @@ function XaiLoginButton({ disabled }: { disabled: boolean }) {
       <div className="setup-advanced__body" aria-label={t('setup.xSearchLoginPending')}>
         <p className="setup-muted">{t('setup.xSearchLoginWaiting')}</p>
         <p>
-          <a href={login.verificationUri} target="_blank" rel="noreferrer noopener">
+          <a
+            className="setup-xai-login__link"
+            href={login.verificationUri}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
             {t('setup.xSearchLoginOpen')}
           </a>
         </p>
         <p>
-          {t('setup.xSearchLoginCode')} <code>{login.userCode}</code>
+          {t('setup.xSearchLoginCode')}{' '}
+          <code className="setup-xai-login__code">{login.userCode}</code>
         </p>
         <Button
           type="button"
@@ -465,12 +471,12 @@ function XSearchCard({
         <h3 className="t-label">{t('setup.xSearchTitle')}</h3>
       </div>
       <p className="setup-muted">{t('setup.xSearchHint')}</p>
-      <p className="setup-muted">{xSearchCredentialText(authStatus, config)}</p>
-      <XaiLoginButton disabled={saving} />
       <NeedList
         items={credentialNeedList(spec.whatYouNeed, apiKeyEnv || envKey)}
         label={t('setup.xSearchNeeds')}
       />
+      <p className="setup-muted">{xSearchCredentialText(authStatus, config)}</p>
+      <XaiLoginButton disabled={saving} />
       <SetupCheckbox
         ariaLabel={t('setup.xSearchEnabledAria')}
         checked={enabled}

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -435,6 +435,34 @@ describe('SetupPage', () => {
     expect(params).not.toHaveProperty('apiKey')
   })
 
+  it('x search card reports which xAI credential is in play', async () => {
+    mockRpc.call.mockImplementation((method: string) => {
+      if (method === 'onboarding.catalog') return Promise.resolve(CATALOG)
+      if (method === 'onboarding.status') return Promise.resolve(statusFor())
+      if (method === 'config.get') return Promise.resolve(CONFIG)
+      if (method === 'auth.status')
+        return Promise.resolve({ xai: { logged_in: true, has_refresh_token: true } })
+      if (method === 'doctor.memory.status') return Promise.resolve(null)
+      return Promise.resolve({})
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
+    await waitFor(() =>
+      expect(
+        screen.getByText('Signed in to xAI — x_search will use that subscription.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('x search card falls back to the api key hint when not signed in', async () => {
+    wireCalls()
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
+    await waitFor(() => expect(screen.getByText(/agentos auth login xai/)).toBeInTheDocument())
+  })
+
   it('switching search provider re-seeds api_key_env to the new provider envKey', async () => {
     wireCalls()
     renderPage()

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -104,6 +104,15 @@ const CATALOG = {
       whatYouNeed: ['API key via BRAVE_API_KEY or a one-time paste.'],
     },
   ],
+  xSearch: [
+    {
+      providerId: 'x_search',
+      label: 'X (Twitter) Search',
+      requiresApiKey: true,
+      envKey: 'XAI_API_KEY',
+      whatYouNeed: ['An xAI API key via XAI_API_KEY or a one-time paste.'],
+    },
+  ],
   memoryEmbeddingProviders: [
     { providerId: 'auto', label: 'Auto' },
     { providerId: 'openai', label: 'OpenAI', requiresApiKey: true, envKey: 'OPENAI_API_KEY' },
@@ -393,6 +402,37 @@ describe('SetupPage', () => {
         expect.objectContaining({ providerId: 'brave' }),
       ),
     )
+  })
+
+  it('x search save posts the card fields; a blank key is omitted so the stored one survives', async () => {
+    wireCalls()
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save X Search' })).toBeInTheDocument(),
+    )
+    const key = screen.getByLabelText('xAI API key') as HTMLInputElement
+    expect(key.type).toBe('password')
+    expect((screen.getByLabelText('xAI API key env') as HTMLInputElement).value).toBe('XAI_API_KEY')
+    fireEvent.change(screen.getByLabelText('X Search Grok model'), {
+      target: { value: 'grok-4.20-multi-agent' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save X Search' }))
+    await waitFor(() =>
+      expect(mockRpc.call).toHaveBeenCalledWith(
+        'onboarding.x_search.configure',
+        expect.objectContaining({
+          enabled: true,
+          model: 'grok-4.20-multi-agent',
+          apiKeyEnv: 'XAI_API_KEY',
+        }),
+      ),
+    )
+    const params = mockRpc.call.mock.calls.find(
+      (c: unknown[]) => c[0] === 'onboarding.x_search.configure',
+    )?.[1] as Record<string, unknown>
+    expect(params).not.toHaveProperty('apiKey')
   })
 
   it('switching search provider re-seeds api_key_env to the new provider envKey', async () => {

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -455,12 +455,13 @@ describe('SetupPage', () => {
     )
   })
 
-  it('x search card falls back to the api key hint when not signed in', async () => {
+  it('x search card names the api key and offers sign-in when not signed in', async () => {
     wireCalls()
     renderPage()
     await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
-    await waitFor(() => expect(screen.getByText(/agentos auth login xai/)).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText(/Not signed in to xAI/)).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Sign in with xAI' })).toBeInTheDocument()
   })
 
   it('reads the xAI login even when mounted from a Settings snapshot', async () => {
@@ -483,6 +484,71 @@ describe('SetupPage', () => {
       ).toBeInTheDocument(),
     )
     expect(mockRpc.call.mock.calls.map((c: unknown[]) => c[0])).toContain('auth.status')
+  })
+
+  it('xai sign-in shows the code, polls, and refreshes the credential line', async () => {
+    let signedIn = false
+    let polls = 0
+    mockRpc.call.mockImplementation((method: string) => {
+      if (method === 'onboarding.catalog') return Promise.resolve(CATALOG)
+      if (method === 'onboarding.status') return Promise.resolve(statusFor())
+      if (method === 'config.get') return Promise.resolve(CONFIG)
+      if (method === 'auth.status')
+        return Promise.resolve({ xai: { logged_in: signedIn, has_refresh_token: signedIn } })
+      if (method === 'auth.xai.login.start')
+        return Promise.resolve({
+          loginId: 'login-1',
+          verificationUri: 'https://accounts.x.ai/oauth2/device?code=ABCD',
+          userCode: 'ABCD-EFGH',
+          interval: 0,
+        })
+      if (method === 'auth.xai.login.poll') {
+        polls += 1
+        // Approval never lands on the first poll in practice.
+        if (polls < 2) return Promise.resolve({ status: 'pending', interval: 0 })
+        signedIn = true
+        return Promise.resolve({ status: 'complete' })
+      }
+      return Promise.resolve({})
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with xAI' }))
+
+    // The operator needs both halves before they can approve anything.
+    expect(await screen.findByText('ABCD-EFGH')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open the xAI approval page' })).toHaveAttribute(
+      'href',
+      'https://accounts.x.ai/oauth2/device?code=ABCD',
+    )
+
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText('Signed in to xAI — x_search will use that subscription.'),
+        ).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    expect(polls).toBeGreaterThanOrEqual(2)
+  })
+
+  it('xai sign-in surfaces a start failure instead of hanging on a spinner', async () => {
+    mockRpc.call.mockImplementation((method: string) => {
+      if (method === 'onboarding.catalog') return Promise.resolve(CATALOG)
+      if (method === 'onboarding.status') return Promise.resolve(statusFor())
+      if (method === 'config.get') return Promise.resolve(CONFIG)
+      if (method === 'auth.xai.login.start')
+        return Promise.reject(new Error('xAI OIDC discovery failed'))
+      return Promise.resolve({})
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with xAI' }))
+
+    await waitFor(() => expect(screen.getByText(/xAI OIDC discovery failed/)).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Sign in with xAI' })).toBeEnabled()
   })
 
   it('switching search provider re-seeds api_key_env to the new provider envKey', async () => {

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -463,6 +463,28 @@ describe('SetupPage', () => {
     await waitFor(() => expect(screen.getByText(/agentos auth login xai/)).toBeInTheDocument())
   })
 
+  it('reads the xAI login even when mounted from a Settings snapshot', async () => {
+    // How the real app mounts this page. Provider logins are not part of the
+    // config snapshot, so gating that read alongside the config reads made
+    // every signed-in user render as signed out.
+    mockRpc.call.mockImplementation((method: string) => {
+      if (method === 'auth.status')
+        return Promise.resolve({ xai: { logged_in: true, has_refresh_token: true } })
+      if (method === 'doctor.memory.status') return Promise.resolve(null)
+      return Promise.resolve({})
+    })
+    renderPage({
+      embedded: true,
+      externalSnapshot: { catalog: CATALOG, status: statusFor(), config: CONFIG },
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText('Signed in to xAI — x_search will use that subscription.'),
+      ).toBeInTheDocument(),
+    )
+    expect(mockRpc.call.mock.calls.map((c: unknown[]) => c[0])).toContain('auth.status')
+  })
+
   it('switching search provider re-seeds api_key_env to the new provider envKey', async () => {
     wireCalls()
     renderPage()

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -551,6 +551,28 @@ describe('SetupPage', () => {
     expect(screen.getByRole('button', { name: 'Sign in with xAI' })).toBeEnabled()
   })
 
+  it('a failed sign-out is not reported as a failed sign-in', async () => {
+    // Both paths shared one label, so a stale gateway rejecting the logout RPC
+    // told the operator their sign-in had failed.
+    mockRpc.call.mockImplementation((method: string) => {
+      if (method === 'onboarding.catalog') return Promise.resolve(CATALOG)
+      if (method === 'onboarding.status') return Promise.resolve(statusFor())
+      if (method === 'config.get') return Promise.resolve(CONFIG)
+      if (method === 'auth.status')
+        return Promise.resolve({ xai: { logged_in: true, has_refresh_token: true } })
+      if (method === 'auth.xai.logout')
+        return Promise.reject(new Error('Method not found: auth.xai.logout'))
+      return Promise.resolve({})
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Setup')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^Capabilities:/ }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out of xAI' }))
+
+    await waitFor(() => expect(screen.getByText(/Sign-out failed:/)).toBeInTheDocument())
+    expect(screen.queryByText(/Sign-in failed:/)).not.toBeInTheDocument()
+  })
+
   it('switching search provider re-seeds api_key_env to the new provider envKey', async () => {
     wireCalls()
     renderPage()

--- a/frontend/src/views/setup/SetupPage.tsx
+++ b/frontend/src/views/setup/SetupPage.tsx
@@ -73,6 +73,7 @@ type GuidedResetTarget =
   | 'provider'
   | 'router'
   | 'search'
+  | 'xSearch'
   | 'memoryEmbedding'
   | 'memorySettings'
   | 'image'
@@ -83,6 +84,7 @@ const INITIAL_RESET_VERSIONS: Record<GuidedResetTarget, number> = {
   provider: 0,
   router: 0,
   search: 0,
+  xSearch: 0,
   memoryEmbedding: 0,
   memorySettings: 0,
   image: 0,
@@ -383,6 +385,23 @@ export function SetupPage({
     onError: (err) => saveError('setup-search', err),
   })
 
+  const xSearchMutation = useMutation({
+    mutationFn: (params: Record<string, unknown>) =>
+      rpc.call<{ warnings?: string[] }>(
+        'onboarding.x_search.configure',
+        withExpectedRevision('xSearch', params),
+      ),
+    onSuccess: async (result) => {
+      const warning = result?.warnings?.[0]
+      if (warning) toast.info(warning, { id: 'setup-x-search' })
+      else toast.info('X Search saved.', { id: 'setup-x-search' })
+      resetSavedTarget('xSearch')
+      const fresh = await reloadAfterSave('setup-x-search')
+      adoptTargetRevision('xSearch', fresh?.revision ?? undefined)
+    },
+    onError: (err) => saveError('setup-x-search', err),
+  })
+
   interface ConfigureResult {
     entry?: { api_key_env?: string; api_key?: string; api_key_source?: string }
     restartRequired?: boolean
@@ -670,6 +689,7 @@ export function SetupPage({
               saving={
                 writeBlocked ||
                 searchMutation.isPending ||
+                xSearchMutation.isPending ||
                 memoryMutation.isPending ||
                 memorySettingsMutation.isPending ||
                 imageMutation.isPending ||
@@ -677,6 +697,7 @@ export function SetupPage({
               }
               resetVersions={{
                 search: resetVersions.search,
+                xSearch: resetVersions.xSearch,
                 memoryEmbedding: resetVersions.memoryEmbedding,
                 memorySettings: resetVersions.memorySettings,
                 image: resetVersions.image,
@@ -684,6 +705,7 @@ export function SetupPage({
               }}
               conflicts={{
                 search: targetConflicted('search'),
+                xSearch: targetConflicted('xSearch'),
                 memoryEmbedding: targetConflicted('memoryEmbedding'),
                 memorySettings: targetConflicted('memorySettings'),
                 image: targetConflicted('image'),
@@ -691,6 +713,7 @@ export function SetupPage({
               }}
               onDirtyChange={markTargetDirty}
               onSaveSearch={(params) => searchMutation.mutate(params)}
+              onSaveXSearch={(params) => xSearchMutation.mutate(params)}
               onSaveMemory={(params) => memoryMutation.mutate(params)}
               onSaveMemorySettings={(patches) => memorySettingsMutation.mutate(patches)}
               onSaveImage={(params) => imageMutation.mutate(params)}

--- a/frontend/src/views/setup/SetupPage.tsx
+++ b/frontend/src/views/setup/SetupPage.tsx
@@ -32,6 +32,7 @@ import {
   setupHeadline,
   stepStatus,
   STEPS,
+  type AuthStatus,
   type Catalog,
   type OnboardingStatus,
   type RouterConfigureParams,
@@ -138,6 +139,15 @@ export function SetupPage({
     queryFn: async () => {
       await rpc.waitForConnection()
       return (await rpc.call<OnboardingStatus>('onboarding.status')) ?? {}
+    },
+    enabled: !usesExternalSnapshot,
+    refetchOnWindowFocus: false,
+  })
+  const authQuery = useQuery<AuthStatus>({
+    queryKey: ['setup', 'auth'],
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      return (await rpc.call<AuthStatus>('auth.status')) ?? {}
     },
     enabled: !usesExternalSnapshot,
     refetchOnWindowFocus: false,
@@ -686,6 +696,7 @@ export function SetupPage({
               catalog={catalog}
               status={status}
               config={config}
+              authStatus={authQuery.data ?? {}}
               saving={
                 writeBlocked ||
                 searchMutation.isPending ||

--- a/frontend/src/views/setup/SetupPage.tsx
+++ b/frontend/src/views/setup/SetupPage.tsx
@@ -143,13 +143,18 @@ export function SetupPage({
     enabled: !usesExternalSnapshot,
     refetchOnWindowFocus: false,
   })
+  // Deliberately not gated on `usesExternalSnapshot`. Provider logins are not
+  // part of the config snapshot: they carry no revision, are never edited
+  // through a config commit, and so have no coherency requirement with it.
+  // Gating this the way the config reads are gated left the embedded Settings
+  // workspace — which is how the real app mounts this page — reporting every
+  // signed-in user as signed out.
   const authQuery = useQuery<AuthStatus>({
     queryKey: ['setup', 'auth'],
     queryFn: async () => {
       await rpc.waitForConnection()
       return (await rpc.call<AuthStatus>('auth.status')) ?? {}
     },
-    enabled: !usesExternalSnapshot,
     refetchOnWindowFocus: false,
   })
   const configQuery = useQuery<SetupConfig>({

--- a/frontend/src/views/setup/logic.test.ts
+++ b/frontend/src/views/setup/logic.test.ts
@@ -351,7 +351,7 @@ describe('capability status text (setup.js:977-1058)', () => {
     )
     expect(xSearchCredentialText({}, {})).toContain('XAI_API_KEY')
     expect(xSearchCredentialText({}, { x_search: { api_key_env: 'MY_KEY' } })).toContain('MY_KEY')
-    expect(xSearchCredentialText({}, {})).toContain('agentos auth login xai')
+    expect(xSearchCredentialText({}, {})).toContain('Sign in below')
   })
 
   it('searchStatusText branches', () => {

--- a/frontend/src/views/setup/logic.test.ts
+++ b/frontend/src/views/setup/logic.test.ts
@@ -50,6 +50,7 @@ import {
   routerMode,
   searchStatusText,
   xSearchCredentialText,
+  xSearchSignedIn,
   setupHeadline,
   setupStepForSection,
   shellArg,
@@ -340,6 +341,13 @@ describe('credentialNeedList / memoryNeedList (setup.js:333-353)', () => {
 })
 
 describe('capability status text (setup.js:977-1058)', () => {
+  it('xSearchSignedIn accepts either casing the gateway might send', () => {
+    expect(xSearchSignedIn({ xai: { logged_in: true } })).toBe(true)
+    expect(xSearchSignedIn({ xai: { loggedIn: true } })).toBe(true)
+    expect(xSearchSignedIn({ xai: { logged_in: false } })).toBe(false)
+    expect(xSearchSignedIn({})).toBe(false)
+  })
+
   it('xSearchCredentialText names the credential that actually wins', () => {
     // OAuth beats an API key at call time, so a configured key must not be
     // reported as the thing in use while a subscription login exists.

--- a/frontend/src/views/setup/logic.test.ts
+++ b/frontend/src/views/setup/logic.test.ts
@@ -49,6 +49,7 @@ import {
   resolveJudgeModelParam,
   routerMode,
   searchStatusText,
+  xSearchCredentialText,
   setupHeadline,
   setupStepForSection,
   shellArg,
@@ -339,6 +340,20 @@ describe('credentialNeedList / memoryNeedList (setup.js:333-353)', () => {
 })
 
 describe('capability status text (setup.js:977-1058)', () => {
+  it('xSearchCredentialText names the credential that actually wins', () => {
+    // OAuth beats an API key at call time, so a configured key must not be
+    // reported as the thing in use while a subscription login exists.
+    expect(xSearchCredentialText({ xai: { logged_in: true, has_refresh_token: true } }, {})).toBe(
+      'Signed in to xAI — x_search will use that subscription.',
+    )
+    expect(xSearchCredentialText({ xai: { logged_in: true, has_refresh_token: false } }, {})).toBe(
+      'Signed in to xAI, but the login has no refresh token. Sign in again.',
+    )
+    expect(xSearchCredentialText({}, {})).toContain('XAI_API_KEY')
+    expect(xSearchCredentialText({}, { x_search: { api_key_env: 'MY_KEY' } })).toContain('MY_KEY')
+    expect(xSearchCredentialText({}, {})).toContain('agentos auth login xai')
+  })
+
   it('searchStatusText branches', () => {
     expect(searchStatusText({}, {})).toBe('Web search is off until a provider is selected.')
     expect(searchStatusText({ searchConfigured: true }, { search_provider: 'brave' })).toBe(

--- a/frontend/src/views/setup/logic.ts
+++ b/frontend/src/views/setup/logic.ts
@@ -71,6 +71,8 @@ export interface ChannelSpec {
 export interface Catalog {
   providers?: ProviderSpec[]
   searchProviders?: ProviderSpec[]
+  /** One-row list: the catalog is uniform, and the CLI renderer walks rows. */
+  xSearch?: ProviderSpec[]
   imageGenerationProviders?: ProviderSpec[]
   audioProviders?: ProviderSpec[]
   memoryEmbeddingProviders?: ProviderSpec[]
@@ -188,6 +190,17 @@ export interface SetupConfig {
   search_use_env_proxy?: boolean
   search_fallback_policy?: string
   search_diagnostics?: boolean
+  x_search?: {
+    enabled?: boolean
+    model?: string
+    base_url?: string
+    api_key_env?: string
+    reasoning_effort?: string
+    timeout_seconds?: number
+    total_timeout_seconds?: number
+    retries?: number
+    [key: string]: unknown
+  }
   image_generation?: { providers?: Record<string, Record<string, unknown>>; [key: string]: unknown }
   audio?: {
     enabled?: boolean
@@ -932,6 +945,25 @@ export function buildSearchConfigureParams(
   fields: CapabilityField[],
 ): Record<string, unknown> {
   const params: Record<string, unknown> = { providerId: providerId || 'duckduckgo' }
+  fields.forEach((f) => {
+    if (f.value === '' && f.secret) return
+    const key = camel(f.name)
+    if (f.type === 'checkbox') params[key] = f.checked
+    else params[key] = f.type === 'number' ? Number.parseInt(f.value || '0', 10) : f.value
+  })
+  return params
+}
+
+/**
+ * onboarding.x_search.configure params. Same blank-secret rule as search — an
+ * empty api_key means "keep the stored one" — plus an explicit `enabled` flag
+ * so the card can turn the tool off without clearing the credential.
+ */
+export function buildXSearchConfigureParams(
+  enabled: boolean,
+  fields: CapabilityField[],
+): Record<string, unknown> {
+  const params: Record<string, unknown> = { enabled }
   fields.forEach((f) => {
     if (f.value === '' && f.secret) return
     const key = camel(f.name)

--- a/frontend/src/views/setup/logic.ts
+++ b/frontend/src/views/setup/logic.ts
@@ -67,6 +67,20 @@ export interface ChannelSpec {
   [key: string]: unknown
 }
 
+/** auth.xai.login.start response. Neither field is a secret on its own. */
+export interface XaiPendingLogin {
+  loginId: string
+  verificationUri: string
+  userCode: string
+  interval: number
+}
+
+/** auth.xai.login.poll response. */
+export interface XaiLoginPoll {
+  status: 'pending' | 'complete' | 'expired'
+  interval?: number
+}
+
 /** auth.status response. Token values are never included. */
 export interface AuthStatus {
   xai?: {

--- a/frontend/src/views/setup/logic.ts
+++ b/frontend/src/views/setup/logic.ts
@@ -677,9 +677,15 @@ export function searchStatusText(status: OnboardingStatus, config: SetupConfig):
  * in play — "you have a key configured" is misleading when a SuperGrok login is
  * quietly taking precedence.
  */
+/** Whether a SuperGrok / X Premium+ login is stored. */
+export function xSearchSignedIn(auth: AuthStatus): boolean {
+  const xai = auth.xai || {}
+  return xai.loggedIn === true || xai.logged_in === true
+}
+
 export function xSearchCredentialText(auth: AuthStatus, config: SetupConfig): string {
   const xai = auth.xai || {}
-  const loggedIn = xai.loggedIn === true || xai.logged_in === true
+  const loggedIn = xSearchSignedIn(auth)
   if (loggedIn) {
     return xai.has_refresh_token === false
       ? t('setup.xSearchOauthIncomplete')

--- a/frontend/src/views/setup/logic.ts
+++ b/frontend/src/views/setup/logic.ts
@@ -67,6 +67,19 @@ export interface ChannelSpec {
   [key: string]: unknown
 }
 
+/** auth.status response. Token values are never included. */
+export interface AuthStatus {
+  xai?: {
+    loggedIn?: boolean
+    logged_in?: boolean
+    expires_at?: string | null
+    expiring_soon?: boolean
+    has_refresh_token?: boolean
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
 /** onboarding.catalog response. */
 export interface Catalog {
   providers?: ProviderSpec[]
@@ -641,6 +654,25 @@ export function searchStatusText(status: OnboardingStatus, config: SetupConfig):
     )
   }
   return t('setup.searchNeedsKey')
+}
+
+/**
+ * Which xAI credential x_search will actually use.
+ *
+ * OAuth wins over an API key at call time, so the card has to say which one is
+ * in play — "you have a key configured" is misleading when a SuperGrok login is
+ * quietly taking precedence.
+ */
+export function xSearchCredentialText(auth: AuthStatus, config: SetupConfig): string {
+  const xai = auth.xai || {}
+  const loggedIn = xai.loggedIn === true || xai.logged_in === true
+  if (loggedIn) {
+    return xai.has_refresh_token === false
+      ? t('setup.xSearchOauthIncomplete')
+      : t('setup.xSearchOauthActive')
+  }
+  const envKey = config.x_search?.api_key_env || 'XAI_API_KEY'
+  return t('setup.xSearchOauthAbsent', { envKey })
 }
 
 /** setup.js:994-1012 — image generation status text. */

--- a/frontend/src/views/setup/setup-css.test.ts
+++ b/frontend/src/views/setup/setup-css.test.ts
@@ -27,6 +27,12 @@ describe('Setup embedded surface CSS contract', () => {
     expect(css).toContain(".setup-tier-table input:not([type='checkbox'])")
   })
 
+  it('makes the xAI approval link look clickable', () => {
+    // It is the only actionable thing in the pending state; unstyled it
+    // inherits body text and reads as another line of copy.
+    expect(css).toMatch(/\.setup-xai-login__link \{[\s\S]*?color: var\(--primary\);/)
+  })
+
   it('uses a soft disclosure surface instead of another hard nested border', () => {
     expect(css).toMatch(/\.setup-advanced \{[\s\S]*?border: 0;[\s\S]*?background: color-mix\(/)
   })

--- a/frontend/src/views/setup/setup.css
+++ b/frontend/src/views/setup/setup.css
@@ -849,3 +849,16 @@
     transition: none;
   }
 }
+
+/* The device-code approval link is the whole point of the pending state, so it
+   has to read as clickable. Without a colour it inherits body text and looks
+   like another line of copy. */
+.setup-xai-login__link {
+  color: var(--primary);
+  text-decoration: underline;
+}
+
+.setup-xai-login__code {
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.04em;
+}

--- a/src/agentos/cli/auth_cmd.py
+++ b/src/agentos/cli/auth_cmd.py
@@ -28,17 +28,108 @@ def _require_xai(provider: str) -> None:
         raise typer.Exit(code=2)
 
 
+#: ``--resume`` when the operator has not approved yet. Distinct from a real
+#: failure so a caller can retry without parsing prose.
+EXIT_STILL_PENDING = 3
+
+
 @auth_app.command("login")
 def auth_login(
     provider: str = typer.Argument("xai", help="Provider to log in to. Currently: xai."),
+    no_wait: bool = typer.Option(
+        False,
+        "--no-wait",
+        help="Print the approval link and code, then exit instead of waiting.",
+    ),
+    resume: bool = typer.Option(
+        False,
+        "--resume",
+        help="Check a login started with --no-wait. Exit 0 done, 3 not yet, 1 failed.",
+    ),
+    login_id: str = typer.Option(
+        "", "--login-id", help="Which pending login to resume. Defaults to the newest."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
     timeout_seconds: float = typer.Option(
         20.0, "--timeout", help="Per-request timeout for the OAuth endpoints."
     ),
 ) -> None:
-    """Log in to xAI with a SuperGrok / X Premium+ account (device-code flow)."""
-    from agentos.xai_oauth import XaiOAuthError, device_code_login
+    """Log in to xAI with a SuperGrok / X Premium+ account (device-code flow).
+
+    Blocks until you approve, unless split with ``--no-wait`` / ``--resume``.
+    The split exists for callers that cannot hold a terminal open for minutes —
+    a chat agent driving this through exec_command, most obviously.
+    """
+    from agentos.cli.output import print_json
+    from agentos.xai_oauth import (
+        XaiOAuthError,
+        device_code_login,
+        get_pending_login,
+        latest_pending_login,
+        poll_device_login,
+        start_device_login,
+    )
 
     _require_xai(provider)
+
+    if no_wait and resume:
+        error_console.print("[red]Error:[/red] --no-wait and --resume are mutually exclusive")
+        raise typer.Exit(code=2)
+
+    if resume:
+        pending = get_pending_login(login_id) if login_id else latest_pending_login()
+        if pending is None:
+            message = "No pending xAI login. Start one with `agentos auth login xai --no-wait`."
+            if json_output:
+                print_json({"status": "expired", "message": message})
+            else:
+                error_console.print(f"[yellow]{message}[/yellow]")
+            raise typer.Exit(code=1)
+        try:
+            complete, interval = poll_device_login(pending, timeout_seconds=timeout_seconds)
+        except XaiOAuthError as exc:
+            if json_output:
+                print_json({"status": "failed", "message": str(exc), "code": exc.code})
+            else:
+                error_console.print(f"[red]Login failed:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
+        if complete:
+            if json_output:
+                print_json({"status": "complete"})
+            else:
+                console.print("[green]Logged in to xAI.[/green]")
+            return
+        if json_output:
+            print_json({"status": "pending", "interval": interval, "loginId": pending.login_id})
+        else:
+            console.print(f"Not approved yet. Check again in {interval}s.")
+        raise typer.Exit(code=EXIT_STILL_PENDING)
+
+    if no_wait:
+        try:
+            pending = start_device_login(timeout_seconds=timeout_seconds)
+        except XaiOAuthError as exc:
+            if json_output:
+                print_json({"status": "failed", "message": str(exc), "code": exc.code})
+            else:
+                error_console.print(f"[red]Login failed:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
+        if json_output:
+            print_json(
+                {
+                    "status": "pending",
+                    "loginId": pending.login_id,
+                    "verificationUri": pending.verification_uri,
+                    "userCode": pending.user_code,
+                    "interval": pending.interval,
+                }
+            )
+        else:
+            console.print("To authorize AgentOS with your xAI account:")
+            console.print(f"  1. Open: [bold]{pending.verification_uri}[/bold]")
+            console.print(f"  2. If prompted, enter the code: [bold]{pending.user_code}[/bold]")
+            console.print("Then run: agentos auth login xai --resume")
+        return
 
     def prompt(url: str, user_code: str, interval: int) -> None:
         console.print()

--- a/src/agentos/cli/auth_cmd.py
+++ b/src/agentos/cli/auth_cmd.py
@@ -1,0 +1,111 @@
+"""`agentos auth` — provider logins that are not plain API keys.
+
+Only xAI is here today. The command exists because a SuperGrok / X Premium+
+subscription cannot be expressed as an API key: the only way to spend it is an
+OAuth grant, and the only way to get that grant is an interactive login the
+operator performs themselves.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+error_console = Console(stderr=True)
+
+auth_app = typer.Typer(help="Manage provider logins (xAI OAuth).", no_args_is_help=True)
+
+_XAI_ALIASES = {"xai", "xai-oauth", "grok", "supergrok"}
+
+
+def _require_xai(provider: str) -> None:
+    if provider.strip().lower() not in _XAI_ALIASES:
+        error_console.print(
+            f"[red]Error:[/red] unknown auth provider {provider!r} (expected: xai)"
+        )
+        raise typer.Exit(code=2)
+
+
+@auth_app.command("login")
+def auth_login(
+    provider: str = typer.Argument("xai", help="Provider to log in to. Currently: xai."),
+    timeout_seconds: float = typer.Option(
+        20.0, "--timeout", help="Per-request timeout for the OAuth endpoints."
+    ),
+) -> None:
+    """Log in to xAI with a SuperGrok / X Premium+ account (device-code flow)."""
+    from agentos.xai_oauth import XaiOAuthError, device_code_login
+
+    _require_xai(provider)
+
+    def prompt(url: str, user_code: str, interval: int) -> None:
+        console.print()
+        console.print("To authorize AgentOS with your xAI account:")
+        console.print(f"  1. Open: [bold]{url}[/bold]")
+        console.print(f"  2. If prompted, enter the code: [bold]{user_code}[/bold]")
+        console.print(f"Waiting for approval (checking every {max(1, interval)}s)...")
+
+    try:
+        device_code_login(on_prompt=prompt, timeout_seconds=timeout_seconds)
+    except XaiOAuthError as exc:
+        error_console.print(f"[red]Login failed:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except KeyboardInterrupt:
+        error_console.print("\n[yellow]Login cancelled.[/yellow]")
+        raise typer.Exit(code=130) from None
+
+    console.print("[green]Logged in to xAI.[/green]")
+    console.print("x_search will use this subscription in preference to XAI_API_KEY.")
+
+
+@auth_app.command("status")
+def auth_status(
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Show which provider logins are stored. Never prints a token."""
+    from agentos.cli.output import print_json
+    from agentos.xai_oauth import oauth_status
+
+    status = oauth_status()
+    if json_output:
+        print_json({"xai": status})
+        return
+
+    table = Table(title="AgentOS provider logins")
+    table.add_column("Provider")
+    table.add_column("State")
+    table.add_column("Detail", overflow="fold")
+
+    if not status["logged_in"]:
+        detail = "Run `agentos auth login xai` to use a SuperGrok / X Premium+ subscription."
+        table.add_row("xai", "not logged in", detail)
+    else:
+        expires = status["expires_at"] or "unknown"
+        detail = f"expires {expires}"
+        if status["expiring_soon"]:
+            detail += " (refreshes on next use)"
+        if not status["has_refresh_token"]:
+            detail += " — no refresh token; log in again"
+        table.add_row("xai", "logged in", detail)
+
+    console.print(table)
+    last_error = status.get("last_auth_error")
+    if isinstance(last_error, dict) and last_error.get("message"):
+        console.print(f"[yellow]Last error:[/yellow] {last_error['message']}")
+    console.print(f"Store: {status['store_path']}")
+
+
+@auth_app.command("logout")
+def auth_logout(
+    provider: str = typer.Argument("xai", help="Provider to log out of. Currently: xai."),
+) -> None:
+    """Forget a stored login."""
+    from agentos.xai_oauth import clear_oauth_state
+
+    _require_xai(provider)
+    if clear_oauth_state():
+        console.print("[green]Logged out of xAI.[/green]")
+    else:
+        console.print("No stored xAI login.")

--- a/src/agentos/cli/main.py
+++ b/src/agentos/cli/main.py
@@ -60,6 +60,7 @@ warn_if_proxy_ignored()
 
 from agentos.cli.agent_cmd import run_agent_command  # noqa: E402
 from agentos.cli.agents_cmd import agents_app  # noqa: E402
+from agentos.cli.auth_cmd import auth_app  # noqa: E402
 from agentos.cli.channels_cmd import channels_app  # noqa: E402
 from agentos.cli.config_cmd import app as config_app  # noqa: E402
 from agentos.cli.context_cmd import app as context_app  # noqa: E402
@@ -91,6 +92,7 @@ app = typer.Typer(
 
 # ── Sub-apps ─────────────────────────────────────────────────────────────────
 
+app.add_typer(auth_app, name="auth")
 app.add_typer(channels_app, name="channels")
 app.add_typer(agents_app, name="agents")
 app.add_typer(config_app, name="config")

--- a/src/agentos/cli/onboard_cmd.py
+++ b/src/agentos/cli/onboard_cmd.py
@@ -39,6 +39,7 @@ from agentos.onboarding.section_status import SectionStatus
 from agentos.onboarding.setup_engine import (
     IMAGE_GENERATION_SECTION_ALIASES,
     MEMORY_EMBEDDING_SECTION_ALIASES,
+    X_SEARCH_SECTION_ALIASES,
     setup_catalog_payload,
 )
 from agentos.onboarding.setup_paths import web_setup_url
@@ -589,6 +590,7 @@ _CATALOG_COMMANDS = {
         "agentos onboard configure search --search-provider <provider> "
         "--api-key-env <ENV_NAME>"
     ),
+    "xSearch": "agentos onboard configure x-search --api-key-env XAI_API_KEY",
     "channels": (
         "agentos onboard configure channels --channel-type <type> --name <name> "
         "--field key=value"
@@ -607,6 +609,7 @@ _CATALOG_SECTION_COMMANDS = {
     "providers": "agentos onboard catalog providers",
     "routerProfiles": "agentos onboard catalog router",
     "searchProviders": "agentos onboard catalog search",
+    "xSearch": "agentos onboard catalog x-search",
     "channels": "agentos onboard catalog channels",
     "imageGenerationProviders": "agentos onboard catalog image",
     "memoryEmbeddingProviders": "agentos onboard catalog memory",
@@ -616,6 +619,7 @@ _CATALOG_TITLES = {
     "providers": "Text providers",
     "routerProfiles": "Pilot Router profiles",
     "searchProviders": "Web search providers",
+    "xSearch": "X (Twitter) search",
     "channels": "Channel types",
     "imageGenerationProviders": "Image generation providers",
     "memoryEmbeddingProviders": "Memory embedding providers",
@@ -695,6 +699,10 @@ def _catalog_try_command(
         if row.get("requiresApiKey"):
             command += f" --api-key-env {_catalog_value(row, 'envKey', '<ENV_NAME>')}"
         return f"{command}{config_arg}"
+
+    if name == "xSearch":
+        env_key = _catalog_value(row, "envKey", "XAI_API_KEY")
+        return f"agentos onboard configure x-search --api-key-env {env_key}{config_arg}"
 
     if name == "channels":
         channel_type = _catalog_value(row, "type", "<type>")
@@ -780,6 +788,18 @@ def _print_list_catalog(
                 f" | route {_catalog_provider_route(row)}"
                 f" | key {_catalog_key_requirement(row)}"
                 f" | default {_catalog_value(row, 'defaultDirectModel', 'custom')}"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
+    if name == "xSearch":
+        console.print("[bold]AgentOS X (Twitter) search[/bold]")
+        _print_catalog_recipe_hint()
+        for row in rows:
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'providerId')}: {_catalog_value(row, 'label')}"
+                f" | key {_catalog_key_requirement(row)}"
+                f" | {_catalog_value(row, 'deployment')}"
             )
             _print_catalog_try_command(name, row, config_arg)
         return
@@ -1026,7 +1046,7 @@ def configure_command(
         metavar="SECTION",
         help=(
             "Section to configure: provider, router, channels, search, "
-            "image (alias for image-generation), or memory "
+            "x-search, image (alias for image-generation), or memory "
             "(alias for memory-embedding)."
         ),
     ),
@@ -1035,7 +1055,7 @@ def configure_command(
         "--section",
         help=(
             "Section to configure: provider, router, channels, search, "
-            "image (alias for image-generation), or memory "
+            "x-search, image (alias for image-generation), or memory "
             "(alias for memory-embedding)."
         ),
         rich_help_panel="Target section",
@@ -1117,6 +1137,24 @@ def configure_command(
         "--diagnostics/--no-diagnostics",
         help="Include search provider attempt/error details for troubleshooting.",
         rich_help_panel="Search",
+    ),
+    x_search_model: str = typer.Option(
+        "",
+        "--x-search-model",
+        help="Grok model used for X Search, e.g. grok-4.5.",
+        rich_help_panel="X Search",
+    ),
+    x_search_enabled: bool = typer.Option(
+        True,
+        "--x-search-enabled/--no-x-search-enabled",
+        help="Offer the x_search tool when an xAI credential is present.",
+        rich_help_panel="X Search",
+    ),
+    x_search_reasoning_effort: str = typer.Option(
+        "",
+        "--x-search-reasoning-effort",
+        help="X Search reasoning effort: low, medium, high, or xhigh.",
+        rich_help_panel="X Search",
     ),
     channel_type: str = typer.Option(
         "",
@@ -1228,6 +1266,24 @@ def configure_command(
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_env_reference_warnings(_load_config_for_cli(result.path))
+                return
+            if normalized in X_SEARCH_SECTION_ALIASES:
+                engine = SetupEngine(path=config_path)
+                res = engine.apply(
+                    "x-search",
+                    {
+                        "enabled": x_search_enabled,
+                        "apiKey": api_key,
+                        "apiKeyEnv": api_key_env,
+                        "model": x_search_model,
+                        "reasoningEffort": x_search_reasoning_effort,
+                    },
+                )
+                result = engine.persist()
+                _print_saved_path(result.path)
+                for warning in res.warnings:
+                    console.print(f"[yellow]Note:[/yellow] {markup_escape(warning)}")
                 _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized in {"channel", "channels"} and channel_type and name:

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -3681,6 +3681,7 @@ class TurnRunner:
             gateway_config=getattr(self, "_config", None) is not None,
             channel_backing=detected.channel_backing,
             image_generation=detected.image_generation,
+            x_search=detected.x_search,
         )
         return resolve_runtime_tool_surface(ctx, capabilities=capabilities)
 

--- a/src/agentos/env_catalog.py
+++ b/src/agentos/env_catalog.py
@@ -102,10 +102,12 @@ def _provider_specs() -> list[EnvVarSpec]:
     )
     from agentos.onboarding.provider_specs import list_provider_setup_specs
     from agentos.onboarding.search_specs import list_search_provider_setup_specs
+    from agentos.onboarding.x_search_specs import get_x_search_setup_spec
 
     families: list[tuple[Category, str, list[Any]]] = [
         (CATEGORY_PROVIDER, "LLM provider", list(list_provider_setup_specs())),
         (CATEGORY_SEARCH, "Search provider", list(list_search_provider_setup_specs())),
+        (CATEGORY_SEARCH, "X Search provider", [get_x_search_setup_spec()]),
         (
             CATEGORY_IMAGE,
             "Image generation provider",

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -236,6 +236,7 @@ class ServiceContainer:
     - tools.builtin.skill_tools (create_skill_tools)
     - tools.builtin.control (set_gateway_config, set_scheduler)
     - search.providers (configure_search)
+    - tools.builtin.x_search (configure_x_search)
     Do not call build_services() twice in the same process without
     understanding these side effects.
     """
@@ -1813,6 +1814,15 @@ async def build_services(
         log.info("build_services.search_provider_initialized", provider=provider)
     except Exception as e:
         log.warning("build_services.search_provider_failed", error=str(e))
+
+    # ── X (Twitter) search via xAI ──────────────────────────────────
+    try:
+        from agentos.tools.builtin.x_search import configure_x_search, x_search_available
+
+        configure_x_search(config.x_search)
+        log.info("build_services.x_search_initialized", available=x_search_available())
+    except Exception as e:
+        log.warning("build_services.x_search_failed", error=str(e))
 
     # ── MCP discovery (boot order 22) ───────────────────────────────
     await _discover_configured_mcp_servers(config, tool_registry)

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1476,6 +1476,32 @@ class AudioConfig(BaseSettings):
     providers: AudioProvidersConfig = Field(default_factory=AudioProvidersConfig)
 
 
+class XSearchConfig(BaseSettings):
+    """xAI-backed X (Twitter) search.
+
+    ``enabled`` only says the operator wants the tool; it still needs an xAI
+    credential before the model is shown its schema. ``timeout_seconds`` bounds
+    one attempt and ``total_timeout_seconds`` bounds the whole call including
+    retries — the tool declares a static execution ceiling above the latter so
+    the engine's own tool timeout never cuts a live attempt.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AGENTOS_X_SEARCH_",
+        env_nested_delimiter="__",
+    )
+
+    enabled: bool = True
+    model: str = "grok-4.5"
+    base_url: str = "https://api.x.ai/v1"
+    api_key: str = ""
+    api_key_env: str = "XAI_API_KEY"
+    reasoning_effort: Literal["", "low", "medium", "high", "xhigh"] = ""
+    timeout_seconds: float = Field(default=180.0, ge=30.0, le=300.0)
+    total_timeout_seconds: float = Field(default=300.0, ge=30.0, le=600.0)
+    retries: int = Field(default=2, ge=0, le=5)
+
+
 # ---------------------------------------------------------------------------
 # Channel config (BaseModel — no env-var binding, validated at TOML load)
 # Names use *Entry suffix to avoid shadowing adapter-level *ChannelConfig.
@@ -1771,6 +1797,7 @@ class GatewayConfig(BaseSettings):
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
     image_generation: ImageGenerationConfig = Field(default_factory=ImageGenerationConfig)
     audio: AudioConfig = Field(default_factory=AudioConfig)
+    x_search: XSearchConfig = Field(default_factory=XSearchConfig)
     sandbox: SandboxSettings = Field(default_factory=SandboxSettings)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     agents: list[AgentEntryConfig] = Field(default_factory=list)

--- a/src/agentos/gateway/config_commit.py
+++ b/src/agentos/gateway/config_commit.py
@@ -359,6 +359,12 @@ def sync_search(config: Any) -> None:
     )
 
 
+def sync_x_search(config: Any) -> None:
+    from agentos.tools.builtin.x_search import configure_x_search
+
+    configure_x_search(getattr(config, "x_search", None))
+
+
 def _runtime_steps(ctx: RpcContext, changed_paths: set[str]) -> list[tuple[str, HotApply]]:
     if getattr(ctx, "config", None) is None:
         return []
@@ -382,6 +388,8 @@ def _runtime_steps(ctx: RpcContext, changed_paths: set[str]) -> list[tuple[str, 
         steps.append(("media", sync_media))
     if _touches(changed_paths, search_roots):
         steps.append(("search", sync_search))
+    if _touches(changed_paths, {"x_search"}):
+        steps.append(("x_search", sync_x_search))
     return steps
 
 

--- a/src/agentos/gateway/rpc_onboarding.py
+++ b/src/agentos/gateway/rpc_onboarding.py
@@ -313,6 +313,14 @@ async def _channel_probe(params: Any, ctx: RpcContext) -> dict[str, Any]:
     }
 
 
+@_d.method("auth.status")
+async def _auth_status(params: Any, ctx: RpcContext) -> dict[str, Any]:
+    """Report stored provider logins. Never returns a token value."""
+    from agentos.xai_oauth import oauth_status
+
+    return {"xai": oauth_status()}
+
+
 @_d.method("onboarding.x_search.configure")
 async def _x_search_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
     from agentos.onboarding.mutations import upsert_x_search

--- a/src/agentos/gateway/rpc_onboarding.py
+++ b/src/agentos/gateway/rpc_onboarding.py
@@ -313,6 +313,42 @@ async def _channel_probe(params: Any, ctx: RpcContext) -> dict[str, Any]:
     }
 
 
+@_d.method("onboarding.x_search.configure")
+async def _x_search_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
+    from agentos.onboarding.mutations import upsert_x_search
+
+    fields = params if isinstance(params, dict) else {}
+    cfg = _active_config(ctx)
+    res = upsert_x_search(
+        cfg,
+        enabled=bool(fields.get("enabled", True)),
+        api_key=fields.get("apiKey", ""),
+        api_key_env=fields.get("apiKeyEnv", ""),
+        model=fields.get("model", ""),
+        base_url=fields.get("baseUrl", ""),
+        reasoning_effort=fields.get("reasoningEffort", ""),
+        timeout_seconds=fields.get("timeoutSeconds"),
+        total_timeout_seconds=fields.get("totalTimeoutSeconds"),
+        retries=fields.get("retries"),
+    )
+    commit = _commit_mutation(
+        ctx,
+        cfg,
+        res.config,
+        params,
+        changed_paths={"x_search"},
+        restart_required=res.restart_required,
+        restart_reason="x_search",
+    )
+    return {
+        "changed": res.changed,
+        "restartRequired": commit.restart_required,
+        "configPath": str(commit.path),
+        "entry": res.public_payload,
+        "warnings": res.warnings,
+    }
+
+
 @_d.method("onboarding.search.configure")
 async def _search_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
     from agentos.onboarding.mutations import upsert_search_provider

--- a/src/agentos/gateway/rpc_onboarding.py
+++ b/src/agentos/gateway/rpc_onboarding.py
@@ -321,6 +321,14 @@ async def _auth_status(params: Any, ctx: RpcContext) -> dict[str, Any]:
     return {"xai": oauth_status()}
 
 
+@_d.method("auth.xai.logout")
+async def _auth_xai_logout(params: Any, ctx: RpcContext) -> dict[str, Any]:
+    """Forget the stored xAI login. Local only — nothing is revoked at xAI."""
+    from agentos.xai_oauth import clear_oauth_state
+
+    return {"cleared": clear_oauth_state()}
+
+
 @_d.method("auth.xai.login.start")
 async def _auth_xai_login_start(params: Any, ctx: RpcContext) -> dict[str, Any]:
     """Begin a device-code login and return what the operator has to approve.

--- a/src/agentos/gateway/rpc_onboarding.py
+++ b/src/agentos/gateway/rpc_onboarding.py
@@ -321,6 +321,48 @@ async def _auth_status(params: Any, ctx: RpcContext) -> dict[str, Any]:
     return {"xai": oauth_status()}
 
 
+@_d.method("auth.xai.login.start")
+async def _auth_xai_login_start(params: Any, ctx: RpcContext) -> dict[str, Any]:
+    """Begin a device-code login and return what the operator has to approve.
+
+    The two halves are separate calls because approval takes as long as it
+    takes: a single blocking method would hold the request open for minutes and
+    never get the code in front of the person who needs it.
+    """
+    from agentos.xai_oauth import XaiOAuthError, start_device_login
+
+    try:
+        pending = await asyncio.to_thread(start_device_login)
+    except XaiOAuthError as exc:
+        raise ValueError(str(exc)) from exc
+
+    return {
+        "loginId": pending.login_id,
+        "verificationUri": pending.verification_uri,
+        "userCode": pending.user_code,
+        "interval": pending.interval,
+    }
+
+
+@_d.method("auth.xai.login.poll")
+async def _auth_xai_login_poll(params: Any, ctx: RpcContext) -> dict[str, Any]:
+    """Poll a pending login once. Returns ``pending`` or ``complete``."""
+    from agentos.xai_oauth import XaiOAuthError, get_pending_login, poll_device_login
+
+    login_id = _require(params, "loginId")
+    pending = get_pending_login(str(login_id))
+    if pending is None:
+        # Expired, already completed, or from a previous gateway process.
+        return {"status": "expired"}
+
+    try:
+        complete, interval = await asyncio.to_thread(poll_device_login, pending)
+    except XaiOAuthError as exc:
+        raise ValueError(str(exc)) from exc
+
+    return {"status": "complete" if complete else "pending", "interval": interval}
+
+
 @_d.method("onboarding.x_search.configure")
 async def _x_search_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
     from agentos.onboarding.mutations import upsert_x_search

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -36,6 +36,7 @@ from agentos.onboarding.redaction import (
     redact_memory_embedding_payload,
     redact_provider_payload,
     redact_search_payload,
+    redact_x_search_payload,
 )
 from agentos.onboarding.search_specs import get_search_provider_setup_spec
 from agentos.provider.registry import is_local_provider
@@ -156,6 +157,31 @@ def _positive_int(value: int | str, *, label: str) -> int:
     if parsed < 1:
         raise ValueError(f"{label} must be >= 1")
     return parsed
+
+
+def _non_negative_int(value: int | str, *, label: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be an integer >= 0") from None
+    if parsed < 0:
+        raise ValueError(f"{label} must be >= 0")
+    return parsed
+
+
+def _validation_detail(exc: ValidationError, *, fallback: str) -> str:
+    """Summarize a pydantic failure without echoing the rejected input.
+
+    ``str(ValidationError)`` embeds ``input_value``, which for these sections is
+    routinely a credential. Keep the field locations and messages, drop the
+    values.
+    """
+    issues: list[str] = []
+    for issue in exc.errors(include_url=False, include_input=False):
+        location = ".".join(str(part) for part in issue.get("loc", ()))
+        message = str(issue.get("msg") or "invalid value")
+        issues.append(f"{location}: {message}" if location else message)
+    return "; ".join(issues) or fallback
 
 
 # Only the routing-relevant flags survive a local-tier rewrite. thinking_level
@@ -918,6 +944,92 @@ def upsert_router(
         restart_required=False,
         warnings=warnings,
         public_payload=public_payload,
+    )
+
+
+def upsert_x_search(
+    config: GatewayConfig,
+    *,
+    enabled: bool = True,
+    api_key: str = "",
+    api_key_env: str = "",
+    model: str = "",
+    base_url: str = "",
+    reasoning_effort: str = "",
+    timeout_seconds: int | str | None = None,
+    total_timeout_seconds: int | str | None = None,
+    retries: int | str | None = None,
+) -> MutationResult:
+    """Persist the ``[x_search]`` section from a setup form.
+
+    A blank ``api_key`` means "keep whatever is already configured" so the form
+    can render a masked field without the operator having to retype the key.
+    """
+    from agentos.gateway.config import XSearchConfig
+
+    current = config.x_search
+    effective_api_key = clean_header_secret(api_key, label="xAI API key")
+    effective_api_key_env = api_key_env.strip() or current.api_key_env
+    if not effective_api_key:
+        effective_api_key = current.api_key
+
+    # The allowed set lives on XSearchConfig.reasoning_effort as a Literal, so
+    # normalizing case here is enough — pydantic rejects anything else below.
+    effort = (reasoning_effort or "").strip().lower()
+
+    payload: dict[str, Any] = {
+        "enabled": bool(enabled),
+        "model": (model or "").strip() or current.model,
+        "base_url": (base_url or "").strip() or current.base_url,
+        "api_key": effective_api_key,
+        "api_key_env": effective_api_key_env,
+        "reasoning_effort": effort,
+        "timeout_seconds": (
+            current.timeout_seconds
+            if timeout_seconds is None
+            else _positive_int(timeout_seconds, label="timeout_seconds")
+        ),
+        "total_timeout_seconds": (
+            current.total_timeout_seconds
+            if total_timeout_seconds is None
+            else _positive_int(total_timeout_seconds, label="total_timeout_seconds")
+        ),
+        "retries": (
+            current.retries if retries is None else _non_negative_int(retries, label="retries")
+        ),
+    }
+
+    try:
+        section = XSearchConfig(**payload)
+    except ValidationError as exc:
+        raise ValueError(_validation_detail(exc, fallback="invalid x_search settings")) from exc
+
+    new_cfg = _clone(config)
+    new_cfg.x_search = section
+    if api_key:
+        new_cfg.clear_runtime_secret("x_search.api_key")
+
+    warnings: list[str] = []
+    if not section.api_key and not os.environ.get(section.api_key_env, "").strip():
+        warnings.append(
+            f"No xAI credential found: set {section.api_key_env} or paste a key. "
+            "x_search stays hidden from the agent until one is present."
+        )
+
+    public_payload = dict(payload)
+    if section.api_key:
+        api_key_source = "explicit"
+    elif os.environ.get(section.api_key_env):
+        api_key_source = "env"
+    else:
+        api_key_source = "none"
+    public_payload["api_key_source"] = api_key_source
+    return MutationResult(
+        config=new_cfg,
+        changed=True,
+        restart_required=False,
+        warnings=warnings,
+        public_payload=redact_x_search_payload(public_payload),
     )
 
 

--- a/src/agentos/onboarding/redaction.py
+++ b/src/agentos/onboarding/redaction.py
@@ -26,6 +26,13 @@ def redact_search_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def redact_x_search_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    out = dict(payload)
+    if out.get("api_key"):
+        out["api_key"] = REDACTED_PLACEHOLDER
+    return out
+
+
 def redact_image_generation_payload(payload: dict[str, Any]) -> dict[str, Any]:
     out = dict(payload)
     if out.get("api_key"):

--- a/src/agentos/onboarding/setup_engine.py
+++ b/src/agentos/onboarding/setup_engine.py
@@ -25,12 +25,14 @@ from agentos.onboarding.mutations import (
     upsert_memory_embedding,
     upsert_router,
     upsert_search_provider,
+    upsert_x_search,
 )
 from agentos.onboarding.next_steps import format_next_steps
 from agentos.onboarding.provider_specs import provider_catalog_payload
 from agentos.onboarding.router_specs import router_catalog_payload
 from agentos.onboarding.search_specs import search_provider_catalog_payload
 from agentos.onboarding.status import OnboardingStatus, get_onboarding_status
+from agentos.onboarding.x_search_specs import x_search_catalog_payload
 
 IMAGE_GENERATION_SECTION_ALIASES = frozenset(
     {"image", "image-generation", "image_generation"}
@@ -39,12 +41,14 @@ MEMORY_EMBEDDING_SECTION_ALIASES = frozenset(
     {"memory", "memory-embedding", "memory_embedding"}
 )
 AUDIO_SECTION_ALIASES = frozenset({"audio", "voice-audio", "voice_audio"})
+X_SEARCH_SECTION_ALIASES = frozenset({"x-search", "x_search", "xsearch"})
 
 _CATALOG_SECTION_ALIASES = {
     "provider": "providers",
     "providers": "providers",
     "router": "routerProfiles",
     "search": "searchProviders",
+    **{alias: "xSearch" for alias in X_SEARCH_SECTION_ALIASES},
     "channels": "channels",
     "channel": "channels",
     **{alias: "imageGenerationProviders" for alias in IMAGE_GENERATION_SECTION_ALIASES},
@@ -58,6 +62,7 @@ def setup_catalog_payload(section: str | None = None) -> dict[str, Any]:
         "providers": provider_catalog_payload(),
         "routerProfiles": router_catalog_payload(),
         "searchProviders": search_provider_catalog_payload(),
+        "xSearch": x_search_catalog_payload(),
         "channels": channel_catalog_payload(),
         "imageGenerationProviders": image_generation_provider_catalog_payload(),
         "audioProviders": audio_provider_catalog_payload(),
@@ -131,6 +136,19 @@ class SetupEngine:
                 use_env_proxy=bool(payload.get("useEnvProxy", False)),
                 fallback_policy=str(payload.get("fallbackPolicy", "off")),
                 diagnostics=bool(payload.get("diagnostics", False)),
+            )
+        elif normalized in X_SEARCH_SECTION_ALIASES:
+            res = upsert_x_search(
+                self.config,
+                enabled=bool(payload.get("enabled", True)),
+                api_key=str(payload.get("apiKey", "")),
+                api_key_env=str(payload.get("apiKeyEnv", "")),
+                model=str(payload.get("model", "")),
+                base_url=str(payload.get("baseUrl", "")),
+                reasoning_effort=str(payload.get("reasoningEffort", "")),
+                timeout_seconds=payload.get("timeoutSeconds"),
+                total_timeout_seconds=payload.get("totalTimeoutSeconds"),
+                retries=payload.get("retries"),
             )
         elif normalized in {"channel", "channels"}:
             entry = payload.get("entry", payload)

--- a/src/agentos/onboarding/x_search_specs.py
+++ b/src/agentos/onboarding/x_search_specs.py
@@ -126,8 +126,9 @@ def get_x_search_setup_spec() -> XSearchSetupSpec:
         env_key=X_SEARCH_ENV_KEY,
         deployment="cloud",
         what_you_need=(
-            f"An xAI API key via {X_SEARCH_ENV_KEY} or a one-time paste.",
-            "SuperGrok / X Premium+ OAuth is not supported; AgentOS uses API keys only.",
+            f"An xAI API key via {X_SEARCH_ENV_KEY} or a one-time paste,",
+            "or a SuperGrok / X Premium+ login: run `agentos auth login xai`.",
+            "A login is preferred over a key when both are present.",
         ),
         capabilities=("x_posts", "citations", "image_understanding", "video_understanding"),
         fields=_fields(),

--- a/src/agentos/onboarding/x_search_specs.py
+++ b/src/agentos/onboarding/x_search_specs.py
@@ -127,7 +127,8 @@ def get_x_search_setup_spec() -> XSearchSetupSpec:
         deployment="cloud",
         what_you_need=(
             f"An xAI API key via {X_SEARCH_ENV_KEY} or a one-time paste,",
-            "or a SuperGrok / X Premium+ login: run `agentos auth login xai`.",
+            "or a SuperGrok / X Premium+ login (sign in below, or "
+            "`agentos auth login xai`).",
             "A login is preferred over a key when both are present.",
         ),
         capabilities=("x_posts", "citations", "image_understanding", "video_understanding"),

--- a/src/agentos/onboarding/x_search_specs.py
+++ b/src/agentos/onboarding/x_search_specs.py
@@ -1,0 +1,170 @@
+"""Onboarding descriptor for the xAI-backed X (Twitter) search tool.
+
+X Search is not a web-search provider — it answers from X's post index rather
+than returning ranked pages — so it does not appear in
+``agentos.search.registry``. Setup surfaces still need a field list, a label,
+and the env key to explain, which is what this module provides.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, get_args
+
+from agentos.gateway.config import XSearchConfig
+
+FieldType = Literal["text", "password", "select", "bool", "int"]
+
+X_SEARCH_PROVIDER_ID = "x_search"
+X_SEARCH_LABEL = "X (Twitter) Search"
+X_SEARCH_ENV_KEY = "XAI_API_KEY"
+
+
+@dataclass(frozen=True)
+class XSearchSetupField:
+    name: str
+    label: str
+    field_type: FieldType
+    required: bool
+    default: str | int | bool | None = None
+    choices: tuple[str, ...] = ()
+    description: str = ""
+    secret: bool = False
+
+
+@dataclass(frozen=True)
+class XSearchSetupSpec:
+    provider_id: str
+    label: str
+    requires_api_key: bool
+    env_key: str
+    deployment: Literal["cloud", "local"]
+    what_you_need: tuple[str, ...]
+    capabilities: tuple[str, ...]
+    fields: tuple[XSearchSetupField, ...]
+
+
+def _reasoning_effort_choices() -> tuple[str, ...]:
+    """The accepted values, read off the config field that enforces them."""
+    annotation = XSearchConfig.model_fields["reasoning_effort"].annotation
+    return tuple(str(value) for value in get_args(annotation))
+
+
+def _fields() -> tuple[XSearchSetupField, ...]:
+    # Defaults come from the config model, not from the tool module: onboarding
+    # describes configuration, and importing the tool here would both invert the
+    # layering and register ``x_search`` on the default registry as a side
+    # effect of a descriptor lookup.
+    defaults = XSearchConfig()
+
+    return (
+        XSearchSetupField(
+            name="api_key",
+            label="xAI API key",
+            field_type="password",
+            required=True,
+            description=f"Stored under env key {defaults.api_key_env}.",
+            secret=True,
+        ),
+        XSearchSetupField(
+            name="model",
+            label="Grok model",
+            field_type="text",
+            required=False,
+            default=defaults.model,
+            description="Any Grok model with access to xAI's server-side x_search tool.",
+        ),
+        XSearchSetupField(
+            name="reasoning_effort",
+            label="Reasoning effort",
+            field_type="select",
+            required=False,
+            default="",
+            choices=_reasoning_effort_choices(),
+            description="Leave empty to use the model's own default.",
+        ),
+        XSearchSetupField(
+            name="timeout_seconds",
+            label="Per-attempt timeout (s)",
+            field_type="int",
+            required=False,
+            default=int(defaults.timeout_seconds),
+            description="A complex X Search can take 60-120s.",
+        ),
+        XSearchSetupField(
+            name="total_timeout_seconds",
+            label="Total timeout (s)",
+            field_type="int",
+            required=False,
+            default=int(defaults.total_timeout_seconds),
+            description="Hard wall for the whole call, retries included.",
+        ),
+        XSearchSetupField(
+            name="retries",
+            label="Retries",
+            field_type="int",
+            required=False,
+            default=defaults.retries,
+            description="Retried only on 5xx, timeout, and connection errors.",
+        ),
+        XSearchSetupField(
+            name="base_url",
+            label="Base URL",
+            field_type="text",
+            required=False,
+            default=defaults.base_url,
+            description="Only change this for an HTTPS proxy that speaks xAI's Responses API.",
+        ),
+    )
+
+
+def get_x_search_setup_spec() -> XSearchSetupSpec:
+    return XSearchSetupSpec(
+        provider_id=X_SEARCH_PROVIDER_ID,
+        label=X_SEARCH_LABEL,
+        requires_api_key=True,
+        env_key=X_SEARCH_ENV_KEY,
+        deployment="cloud",
+        what_you_need=(
+            f"An xAI API key via {X_SEARCH_ENV_KEY} or a one-time paste.",
+            "SuperGrok / X Premium+ OAuth is not supported; AgentOS uses API keys only.",
+        ),
+        capabilities=("x_posts", "citations", "image_understanding", "video_understanding"),
+        fields=_fields(),
+    )
+
+
+def x_search_catalog_payload() -> list[dict[str, Any]]:
+    """Return the section as a one-row list.
+
+    There is only ever one X Search provider, but every other catalog section is
+    a list and the CLI renderer walks rows generically. A lone dict would need a
+    special case in three places to display at all.
+    """
+    spec = get_x_search_setup_spec()
+    return [_spec_payload(spec)]
+
+
+def _spec_payload(spec: XSearchSetupSpec) -> dict[str, Any]:
+    return {
+        "providerId": spec.provider_id,
+        "label": spec.label,
+        "requiresApiKey": spec.requires_api_key,
+        "envKey": spec.env_key,
+        "deployment": spec.deployment,
+        "whatYouNeed": list(spec.what_you_need),
+        "capabilities": list(spec.capabilities),
+        "fields": [
+            {
+                "name": f.name,
+                "label": f.label,
+                "type": f.field_type,
+                "required": f.required,
+                "default": f.default,
+                "choices": list(f.choices),
+                "description": f.description,
+                "secret": f.secret,
+            }
+            for f in spec.fields
+        ],
+    }

--- a/src/agentos/result_budget.py
+++ b/src/agentos/result_budget.py
@@ -35,6 +35,7 @@ EXTERNAL_TOOL_NAMES: frozenset[str] = frozenset(
         "http_request",
         "web_fetch",
         "web_search",
+        "x_search",
     }
 )
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentos
-description: "Operate and configure AgentOS itself: the `agentos` CLI, agentos.toml, gateway/Web UI, providers and models, skills, channels, sessions, cron, sandbox, and memory. Use when: (1) the user asks to change an AgentOS setting (model, provider, router tier, auth, channels, search), (2) starting, stopping, or debugging the gateway or Web UI, (3) installing, updating, or removing skills and taps, (4) inspecting sessions, usage/cost, cron jobs, or diagnostics, (5) migrating from another agent runtime. NOT for: authoring new skills (see docs/features/skills.md), operating other agent CLIs, or modifying AgentOS source code."
+description: "Operate and configure AgentOS itself: the `agentos` CLI, agentos.toml, gateway/Web UI, providers and models, web search, X (Twitter) search via xAI (`x_search`; SuperGrok login or XAI_API_KEY), skills, channels, sessions, cron, sandbox, and memory. Use when: (1) the user asks to change an AgentOS setting or turn a capability on (model, provider, router tier, auth/login, channels, search), (2) starting, stopping, or debugging the gateway or Web UI, (3) installing, updating, or removing skills and taps, (4) inspecting sessions, usage/cost, cron jobs, or diagnostics, (5) migrating from another agent runtime. NOT for: authoring new skills (see docs/features/skills.md), operating other agent CLIs, or modifying AgentOS source code."
 always: false
 triggers:
   - agentos
@@ -12,6 +12,11 @@ triggers:
   - "install skill"
   - onboard
   - doctor
+  - x search
+  - x_search
+  - twitter
+  - xai
+  - supergrok
 provenance:
   origin: agentos-original
   license: MIT
@@ -206,6 +211,21 @@ agentos configure                                                     # interact
 agentos gateway restart                                               # apply to a running gateway
 ```
 
+### Enable X (Twitter) search
+
+`x_search` searches X posts through xAI and returns a synthesized answer with
+citations. It is **hidden from your own tool list until a credential resolves**,
+so if you cannot see it, that is why — say so and offer one of these:
+
+```sh
+agentos auth status                       # is a SuperGrok / X Premium+ login stored?
+agentos configure x-search --api-key-env XAI_API_KEY   # or use an xAI API key
+```
+
+A subscription login is preferred over a key when both exist. The Web UI has
+the same controls under Capabilities. Billing goes to the user's xAI account
+and does not appear in `agentos cost`.
+
 ### Sign the user in to xAI (SuperGrok / X Premium+) from a conversation
 
 Enables `x_search` without an API key. Never run the plain `agentos auth login
@@ -213,16 +233,20 @@ xai`: it blocks polling for up to 30 minutes and will hit the tool timeout
 before the user can approve. Use the split form.
 
 ```sh
-agentos auth login xai --no-wait --json   # -> loginId, verificationUri, userCode
+agentos auth login xai --no-wait --json 2>/dev/null   # -> loginId, verificationUri, userCode
 ```
+
+**Keep the `2>/dev/null`.** Every `agentos` invocation writes startup logs to
+stderr, and merged into the result they bury the one line that matters — the
+JSON. With stderr dropped the output is a single object you can read reliably.
 
 Give the user the `verificationUri` and the `userCode`, then **wait for them to
 say they have approved it**. Do not poll in a loop — approval is human-paced,
 and each check costs a turn.
 
 ```sh
-agentos auth login xai --resume --json    # exit 0 done, 3 not yet, 1 failed/expired
-agentos auth status --json                # confirm; never prints a token
+agentos auth login xai --resume --json 2>/dev/null    # exit 0 done, 3 not yet, 1 failed/expired
+agentos auth status --json 2>/dev/null                # confirm; never prints a token
 ```
 
 Exit 3 means keep waiting, not an error. On exit 1 the code expired — start

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -114,7 +114,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `memory` | `status`, `index`, `list`, `search`, `show`, `embedding-download`, `raw-fallbacks …` |
 | `sandbox` | `status`, `on`, `bypass`, `full`, `reset` |
 | `search` | `list`, `status`, `query`, `configure` |
-| `auth` | `login xai`, `status`, `logout xai` — xAI OAuth (SuperGrok / X Premium+) for `x_search`; tokens in `~/.agentos/auth.json`, never printed |
+| `auth` | `login xai` (`--no-wait`/`--resume`/`--json` for non-blocking use), `status`, `logout xai` — xAI OAuth (SuperGrok / X Premium+) for `x_search`; tokens in `~/.agentos/auth.json`, never printed |
 | `configure x-search` | xAI X (Twitter) search: `--api-key-env`, `--x-search-model`, `--x-search-reasoning-effort`, `--no-x-search-enabled`; catalog via `onboard catalog x-search` |
 | `cost` | usage and estimated cost report |
 | `diagnostics` | `status`, `on`, `off` |
@@ -205,6 +205,29 @@ agentos config set llm.model "anthropic/claude-sonnet-4"              # just the
 agentos configure                                                     # interactive wizard
 agentos gateway restart                                               # apply to a running gateway
 ```
+
+### Sign the user in to xAI (SuperGrok / X Premium+) from a conversation
+
+Enables `x_search` without an API key. Never run the plain `agentos auth login
+xai`: it blocks polling for up to 30 minutes and will hit the tool timeout
+before the user can approve. Use the split form.
+
+```sh
+agentos auth login xai --no-wait --json   # -> loginId, verificationUri, userCode
+```
+
+Give the user the `verificationUri` and the `userCode`, then **wait for them to
+say they have approved it**. Do not poll in a loop — approval is human-paced,
+and each check costs a turn.
+
+```sh
+agentos auth login xai --resume --json    # exit 0 done, 3 not yet, 1 failed/expired
+agentos auth status --json                # confirm; never prints a token
+```
+
+Exit 3 means keep waiting, not an error. On exit 1 the code expired — start
+over. The user code and link are safe to show in chat; neither works without
+the user's own xAI session, and no token ever reaches the conversation.
 
 ### Gateway lifecycle
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -114,6 +114,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `memory` | `status`, `index`, `list`, `search`, `show`, `embedding-download`, `raw-fallbacks …` |
 | `sandbox` | `status`, `on`, `bypass`, `full`, `reset` |
 | `search` | `list`, `status`, `query`, `configure` |
+| `configure x-search` | xAI X (Twitter) search: `--api-key-env`, `--x-search-model`, `--x-search-reasoning-effort`, `--no-x-search-enabled`; catalog via `onboard catalog x-search` |
 | `cost` | usage and estimated cost report |
 | `diagnostics` | `status`, `on`, `off` |
 | `migrate` | `openclaw`, `hermes` (`--source`, `--profile`, `--apply`, `--migrate-secrets`; dry-run without `--apply`) |
@@ -173,6 +174,7 @@ Main `agentos.toml` sections (full commented reference:
 | Section | Controls |
 | --- | --- |
 | top-level | `workspace_dir`, `state_dir`, logging, `search_provider`/`search_api_key`, timeouts |
+| `[x_search]` | xAI-backed X (Twitter) search: `enabled`, `model` (default `grok-4.5`), `api_key`/`api_key_env` (`XAI_API_KEY`), `reasoning_effort`, `timeout_seconds`, `total_timeout_seconds`, `retries`. The `x_search` tool is hidden until a credential resolves |
 | `[llm]` | `provider`, `model`, `api_key`, `base_url`, `proxy`, `[llm.provider_routing]` |
 | `[agentos_router]` | router on/off, `strategy` (`pilot-v1`), tier settings under `[agentos_router.tiers.c0..c3]` |
 | `[skills]` | skill filtering/injection: `filter_strategy`, `filter_top_k`, `injection_mode`, `max_skills_prompt_chars` (default 24000), `max_skill_view_chars` (default 10000, 0 disables) |

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -114,6 +114,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `memory` | `status`, `index`, `list`, `search`, `show`, `embedding-download`, `raw-fallbacks …` |
 | `sandbox` | `status`, `on`, `bypass`, `full`, `reset` |
 | `search` | `list`, `status`, `query`, `configure` |
+| `auth` | `login xai`, `status`, `logout xai` — xAI OAuth (SuperGrok / X Premium+) for `x_search`; tokens in `~/.agentos/auth.json`, never printed |
 | `configure x-search` | xAI X (Twitter) search: `--api-key-env`, `--x-search-model`, `--x-search-reasoning-effort`, `--no-x-search-enabled`; catalog via `onboard catalog x-search` |
 | `cost` | usage and estimated cost report |
 | `diagnostics` | `status`, `on`, `off` |

--- a/src/agentos/tools/builtin/__init__.py
+++ b/src/agentos/tools/builtin/__init__.py
@@ -26,6 +26,7 @@ _NAMES = [
     "shell",
     "web",
     "web_fetch",
+    "x_search",
 ]
 
 log = structlog.get_logger(__name__)

--- a/src/agentos/tools/builtin/x_search.py
+++ b/src/agentos/tools/builtin/x_search.py
@@ -1,0 +1,569 @@
+"""X (Twitter) search built-in tool backed by xAI's server-side ``x_search``.
+
+Adapted from NousResearch/hermes-agent ``tools/x_search_tool.py``
+(MIT, Copyright (c) 2025 Nous Research) — see ``THIRD_PARTY_NOTICES.md``.
+
+What this is
+------------
+Not a search provider. ``agentos.search`` providers return a list of
+``(title, url, snippet)`` rows; xAI's ``x_search`` runs the search server-side
+on X's post index and returns a *synthesized answer* plus citations. The two
+shapes do not compose, so this stays a distinct tool rather than a
+``web_search`` backend.
+
+Credentials
+-----------
+An xAI API key only (``XAI_API_KEY`` by default). Hermes also accepts a
+SuperGrok / X Premium+ OAuth token; AgentOS has no OAuth subsystem, so that
+path is deliberately absent and ``credential_source`` is always ``"xai"``.
+Without a key the tool is hidden from the model's schema entirely — see
+:func:`x_search_available` and ``tools.policy_runtime``.
+
+Defensive output
+----------------
+Two signals beyond xAI's raw response let a caller tell a citation-backed
+answer from an unsourced one:
+
+* ``from_date`` / ``to_date`` are validated before the HTTP call. Malformed,
+  inverted, and pure-future ranges fail fast instead of burning a billable
+  call that is guaranteed to return nothing.
+* ``degraded`` is ``True`` when a narrowing filter was active AND xAI returned
+  no citations in either channel. The answer then came from the model's own
+  training data and must not be treated as an X result.
+
+Timeouts
+--------
+Hermes runs this synchronously with no outer deadline. AgentOS caps every tool
+call (``EngineConfig.tool_timeout``, 60s by default), so the retry loop here is
+deadline-aware: ``timeout_seconds`` bounds one attempt, ``total_timeout_seconds``
+bounds the whole call, and the tool declares a static ceiling above both so the
+engine never cuts an attempt the tool still considers live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import UTC, date, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from agentos.env import trust_env as _trust_env
+from agentos.sandbox.integration import sandboxed
+from agentos.tools.registry import tool
+from agentos.tools.ssrf import assert_not_metadata_endpoint
+
+log = structlog.get_logger(__name__)
+
+DEFAULT_X_SEARCH_MODEL = "grok-4.5"
+DEFAULT_X_SEARCH_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_X_SEARCH_API_KEY_ENV = "XAI_API_KEY"
+DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180.0
+DEFAULT_X_SEARCH_TOTAL_TIMEOUT_SECONDS = 300.0
+DEFAULT_X_SEARCH_RETRIES = 2
+
+X_SEARCH_REASONING_EFFORTS = ("low", "medium", "high", "xhigh")
+MAX_HANDLES = 10
+
+# Ceiling handed to the engine as this tool's static execution timeout. It sits
+# above the largest configurable ``total_timeout_seconds`` so the engine acts as
+# a backstop for a wedged client, never as the thing that cuts a live attempt.
+_ENGINE_TIMEOUT_CEILING_SECONDS = 620.0
+_MAX_TOTAL_TIMEOUT_SECONDS = 600.0
+_MIN_ATTEMPT_TIMEOUT_SECONDS = 30.0
+_MAX_BACKOFF_SECONDS = 5.0
+
+_USER_AGENT = "AgentOS/x_search"
+
+
+# ---------------------------------------------------------------------------
+# Runtime configuration
+# ---------------------------------------------------------------------------
+
+_active_enabled: bool = True
+_active_model: str = DEFAULT_X_SEARCH_MODEL
+_active_base_url: str = DEFAULT_X_SEARCH_BASE_URL
+_active_api_key: str = ""
+_active_api_key_env: str = DEFAULT_X_SEARCH_API_KEY_ENV
+_active_reasoning_effort: str = ""
+_active_timeout_seconds: float = DEFAULT_X_SEARCH_TIMEOUT_SECONDS
+_active_total_timeout_seconds: float = DEFAULT_X_SEARCH_TOTAL_TIMEOUT_SECONDS
+_active_retries: int = DEFAULT_X_SEARCH_RETRIES
+
+
+def _normalize_base_url(raw: str) -> str:
+    """Return a usable xAI base URL, or fall back to the default.
+
+    The value is operator-controlled rather than model-controlled, so this is
+    not an SSRF boundary in the ``web_fetch`` sense. It is still worth refusing
+    the instance-credential endpoint and plain HTTP: a bearer token is attached
+    to every request this URL receives.
+    """
+    candidate = (raw or "").strip().rstrip("/")
+    if not candidate:
+        return DEFAULT_X_SEARCH_BASE_URL
+    if not candidate.startswith("https://"):
+        log.warning("x_search.base_url_rejected", reason="not_https", base_url=candidate)
+        return DEFAULT_X_SEARCH_BASE_URL
+    try:
+        assert_not_metadata_endpoint(candidate)
+    except Exception:  # noqa: BLE001 - configuration must not take the gateway down
+        log.warning("x_search.base_url_rejected", reason="metadata_endpoint")
+        return DEFAULT_X_SEARCH_BASE_URL
+    return candidate
+
+
+def configure_x_search(config: Any | None = None) -> None:
+    """Apply an ``XSearchConfig``-shaped object to process-wide runtime state."""
+    global _active_enabled, _active_model, _active_base_url, _active_api_key
+    global _active_api_key_env, _active_reasoning_effort, _active_timeout_seconds
+    global _active_total_timeout_seconds, _active_retries
+
+    def _get(name: str, default: Any) -> Any:
+        if config is None:
+            return default
+        value = getattr(config, name, None)
+        return default if value is None else value
+
+    _active_enabled = bool(_get("enabled", True))
+    _active_model = str(_get("model", DEFAULT_X_SEARCH_MODEL)).strip() or DEFAULT_X_SEARCH_MODEL
+    _active_base_url = _normalize_base_url(str(_get("base_url", DEFAULT_X_SEARCH_BASE_URL)))
+    _active_api_key = str(_get("api_key", "")).strip()
+    _active_api_key_env = (
+        str(_get("api_key_env", DEFAULT_X_SEARCH_API_KEY_ENV)).strip()
+        or DEFAULT_X_SEARCH_API_KEY_ENV
+    )
+    _active_reasoning_effort = str(_get("reasoning_effort", "")).strip().lower()
+
+    timeout = float(_get("timeout_seconds", DEFAULT_X_SEARCH_TIMEOUT_SECONDS))
+    _active_timeout_seconds = max(_MIN_ATTEMPT_TIMEOUT_SECONDS, timeout)
+    total = float(_get("total_timeout_seconds", DEFAULT_X_SEARCH_TOTAL_TIMEOUT_SECONDS))
+    _active_total_timeout_seconds = min(
+        _MAX_TOTAL_TIMEOUT_SECONDS, max(_active_timeout_seconds, total)
+    )
+    # Retries are not clamped against the total budget here: attempts usually
+    # finish well inside ``timeout_seconds``, and pre-clamping on the worst case
+    # would disable retries for every sane config. The deadline in
+    # :func:`_post_with_retries` is what actually bounds the call.
+    _active_retries = max(0, int(_get("retries", DEFAULT_X_SEARCH_RETRIES)))
+
+
+def reset_x_search_runtime() -> None:
+    """Restore boot defaults. Used by tests and by a config reload to a bare state."""
+    configure_x_search(None)
+
+
+def _resolve_api_key() -> str:
+    """Return the xAI bearer, preferring the pasted key over the environment."""
+    import os
+
+    if _active_api_key:
+        return _active_api_key
+    env_name = _active_api_key_env or DEFAULT_X_SEARCH_API_KEY_ENV
+    return os.environ.get(env_name, "").strip()
+
+
+def x_search_available() -> bool:
+    """Whether ``x_search`` has everything it needs to run.
+
+    Called every time the tool surface is rebuilt. A tool schema is fixed
+    overhead on every provider call, so a user with no xAI credential should
+    never pay for this one — returning ``False`` here removes it from the
+    model's schema rather than letting it fail at call time.
+    """
+    if not _active_enabled:
+        return False
+    try:
+        return bool(_resolve_api_key())
+    except Exception:  # noqa: BLE001 - capability checks must never raise
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Request helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_handles(handles: list[str] | None, field_name: str) -> list[str]:
+    cleaned: list[str] = []
+    for handle in handles or []:
+        normalized = str(handle or "").strip().lstrip("@")
+        if normalized:
+            cleaned.append(normalized)
+    if len(cleaned) > MAX_HANDLES:
+        raise ValueError(f"{field_name} supports at most {MAX_HANDLES} handles")
+    return cleaned
+
+
+def _parse_iso_date(value: str, field_name: str) -> date:
+    """Parse a strict ``YYYY-MM-DD`` string.
+
+    xAI accepts any string in the date slots and silently answers with no
+    citations when the value is malformed. That burns a billable call and
+    produces a confident-sounding result the caller cannot distinguish from a
+    real one, so the check happens here.
+    """
+    raw = value.strip()
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=UTC).date()
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD (got {raw!r})") from exc
+
+
+def _validate_date_range(from_date: str, to_date: str) -> None:
+    """Reject ranges that cannot match a post before spending an API call."""
+    parsed_from = _parse_iso_date(from_date, "from_date") if from_date.strip() else None
+    parsed_to = _parse_iso_date(to_date, "to_date") if to_date.strip() else None
+    if parsed_from and parsed_to and parsed_from > parsed_to:
+        raise ValueError(
+            f"from_date ({parsed_from.isoformat()}) must be on or before "
+            f"to_date ({parsed_to.isoformat()})"
+        )
+    if parsed_from is not None:
+        today_utc = datetime.now(UTC).date()
+        if parsed_from > today_utc:
+            raise ValueError(
+                f"from_date ({parsed_from.isoformat()}) is in the future; X Search only "
+                f"indexes past posts (today UTC is {today_utc.isoformat()})"
+            )
+    # ``to_date`` in the future is legitimate: "from yesterday to tomorrow"
+    # is how a caller asks for posts as they arrive.
+
+
+def _resolve_reasoning_effort() -> str:
+    if not _active_reasoning_effort:
+        return ""
+    if _active_reasoning_effort not in X_SEARCH_REASONING_EFFORTS:
+        allowed = ", ".join(X_SEARCH_REASONING_EFFORTS)
+        raise ValueError(
+            f"x_search.reasoning_effort must be one of: {allowed} "
+            f"(got {_active_reasoning_effort!r})"
+        )
+    return _active_reasoning_effort
+
+
+def _extract_response_text(payload: dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: list[str] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if content.get("type") in {"output_text", "text"}:
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_inline_citations(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    citations: list[dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            for annotation in content.get("annotations", []) or []:
+                if annotation.get("type") != "url_citation":
+                    continue
+                citations.append(
+                    {
+                        "url": annotation.get("url", ""),
+                        "title": annotation.get("title", ""),
+                        "start_index": annotation.get("start_index"),
+                        "end_index": annotation.get("end_index"),
+                    }
+                )
+    return citations
+
+
+def _http_error_message(exc: httpx.HTTPStatusError) -> str:
+    """Summarize an xAI error body without echoing anything unbounded."""
+    response = exc.response
+    try:
+        payload = response.json()
+    except Exception:  # noqa: BLE001 - error bodies are not always JSON
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error = str(payload.get("error") or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message[:500] or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    return text[:500] if text else str(exc)
+
+
+def _build_tool_definition(
+    allowed: list[str],
+    excluded: list[str],
+    from_date: str,
+    to_date: str,
+    enable_image_understanding: bool,
+    enable_video_understanding: bool,
+) -> dict[str, Any]:
+    tool_def: dict[str, Any] = {"type": "x_search"}
+    if allowed:
+        tool_def["allowed_x_handles"] = allowed
+    if excluded:
+        tool_def["excluded_x_handles"] = excluded
+    if from_date.strip():
+        tool_def["from_date"] = from_date.strip()
+    if to_date.strip():
+        tool_def["to_date"] = to_date.strip()
+    if enable_image_understanding:
+        tool_def["enable_image_understanding"] = True
+    if enable_video_understanding:
+        tool_def["enable_video_understanding"] = True
+    return tool_def
+
+
+def _failure(message: str, *, error_type: str = "ToolError") -> str:
+    return json.dumps(
+        {
+            "success": False,
+            "provider": "xai",
+            "tool": "x_search",
+            "error": message,
+            "error_type": error_type,
+        },
+        ensure_ascii=False,
+    )
+
+
+async def _post_with_retries(
+    api_key: str,
+    payload: dict[str, Any],
+    deadline: float,
+) -> httpx.Response:
+    """POST to xAI, retrying transient failures inside the total budget."""
+    attempt = 0
+    last_exc: Exception | None = None
+    async with httpx.AsyncClient(trust_env=_trust_env()) as client:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            attempt_timeout = min(_active_timeout_seconds, remaining)
+            try:
+                response = await client.post(
+                    f"{_active_base_url}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": _USER_AGENT,
+                    },
+                    json=payload,
+                    timeout=attempt_timeout,
+                )
+                response.raise_for_status()
+                return response
+            except httpx.HTTPStatusError as exc:
+                # 4xx is the caller's problem — a bad key or a model without
+                # x_search access will fail identically on every retry.
+                if exc.response.status_code < 500 or attempt >= _active_retries:
+                    raise
+                last_exc = exc
+                log.warning(
+                    "x_search.upstream_failure",
+                    attempt=attempt + 1,
+                    attempts=_active_retries + 1,
+                    status=exc.response.status_code,
+                )
+            except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.ConnectError) as exc:
+                if attempt >= _active_retries:
+                    raise
+                last_exc = exc
+                log.warning(
+                    "x_search.transient_failure",
+                    attempt=attempt + 1,
+                    attempts=_active_retries + 1,
+                    error_type=type(exc).__name__,
+                )
+
+            backoff = min(_MAX_BACKOFF_SECONDS, 1.5 * (attempt + 1))
+            if time.monotonic() + backoff >= deadline:
+                break
+            await asyncio.sleep(backoff)
+            attempt += 1
+
+    if last_exc is not None:
+        raise last_exc
+    raise httpx.ReadTimeout("x_search exhausted its total timeout budget")
+
+
+def _degraded_state(
+    allowed: list[str],
+    excluded: list[str],
+    from_date: str,
+    to_date: str,
+    citations: list[Any],
+    inline_citations: list[Any],
+) -> tuple[bool, str | None]:
+    """Flag an answer that xAI synthesized without matching any indexed post.
+
+    xAI returns 200 with a fluent answer even when its X index has nothing for
+    the caller's filters; the answer then comes from training data and looks
+    identical to a real one. A broad query with no citations is just an answer,
+    so only a *narrowed* query with zero citations counts as degraded.
+    """
+    active_filters: list[str] = []
+    if allowed:
+        active_filters.append("allowed_x_handles")
+    if excluded:
+        active_filters.append("excluded_x_handles")
+    if from_date.strip():
+        active_filters.append("from_date")
+    if to_date.strip():
+        active_filters.append("to_date")
+    degraded = bool(active_filters) and not citations and not inline_citations
+    if not degraded:
+        return False, None
+    return True, f"no citations returned despite filters: {', '.join(active_filters)}"
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="x_search",
+    description=(
+        "Search X (Twitter) posts, profiles, and threads using xAI's built-in X Search. "
+        "Read-only discovery: use it for current discussion, reactions, or claims on "
+        "public X rather than general web pages, which belong to web_search. It cannot "
+        "post, reply, like, DM, upload media, delete, or read an authenticated X "
+        "account. A result with \"degraded\": true was synthesized without matching any "
+        "indexed post and must not be reported as something found on X."
+    ),
+    params={
+        "query": {"type": "string", "description": "What to look up on X."},
+        "allowed_x_handles": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Optional X handles to include exclusively (max 10).",
+        },
+        "excluded_x_handles": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Optional X handles to exclude (max 10). "
+                "Cannot be combined with allowed_x_handles."
+            ),
+        },
+        "from_date": {"type": "string", "description": "Optional start date, YYYY-MM-DD."},
+        "to_date": {"type": "string", "description": "Optional end date, YYYY-MM-DD."},
+        "enable_image_understanding": {
+            "type": "boolean",
+            "description": "Ask xAI to analyze images attached to matching posts.",
+        },
+        "enable_video_understanding": {
+            "type": "boolean",
+            "description": "Ask xAI to analyze videos attached to matching posts.",
+        },
+    },
+    required=["query"],
+    execution_timeout_seconds=_ENGINE_TIMEOUT_CEILING_SECONDS,
+    result_budget_class="external",
+)
+@sandboxed(
+    kind="web.fetch",
+    argv_factory=lambda a: ("x_search", str(a.get("query", ""))),
+    record_payload=False,
+)
+async def x_search(
+    query: str,
+    allowed_x_handles: list[str] | None = None,
+    excluded_x_handles: list[str] | None = None,
+    from_date: str = "",
+    to_date: str = "",
+    enable_image_understanding: bool = False,
+    enable_video_understanding: bool = False,
+) -> str:
+    if not query or not query.strip():
+        return _failure("query is required for x_search")
+
+    api_key = _resolve_api_key()
+    if not api_key:
+        return _failure(
+            "No xAI credentials available. Set XAI_API_KEY in ~/.agentos/.env or "
+            "configure x_search.api_key."
+        )
+
+    try:
+        allowed = _normalize_handles(allowed_x_handles, "allowed_x_handles")
+        excluded = _normalize_handles(excluded_x_handles, "excluded_x_handles")
+        if allowed and excluded:
+            raise ValueError("allowed_x_handles and excluded_x_handles cannot be used together")
+        _validate_date_range(from_date, to_date)
+        reasoning_effort = _resolve_reasoning_effort()
+    except ValueError as exc:
+        return _failure(str(exc), error_type="ValueError")
+
+    payload: dict[str, Any] = {
+        "model": _active_model,
+        "input": [{"role": "user", "content": query.strip()}],
+        "tools": [
+            _build_tool_definition(
+                allowed,
+                excluded,
+                from_date,
+                to_date,
+                enable_image_understanding,
+                enable_video_understanding,
+            )
+        ],
+        "store": False,
+    }
+    if reasoning_effort:
+        payload["reasoning"] = {"effort": reasoning_effort}
+
+    deadline = time.monotonic() + _active_total_timeout_seconds
+    try:
+        response = await _post_with_retries(api_key, payload, deadline)
+        data = response.json()
+    except httpx.HTTPStatusError as exc:
+        log.warning("x_search.failed", status=exc.response.status_code)
+        return _failure(_http_error_message(exc), error_type=type(exc).__name__)
+    except (httpx.ReadTimeout, httpx.ConnectTimeout) as exc:
+        log.warning("x_search.timed_out", total_timeout_seconds=_active_total_timeout_seconds)
+        return _failure(
+            f"xAI x_search timed out after {_active_total_timeout_seconds:g} seconds",
+            error_type=type(exc).__name__,
+        )
+    except Exception as exc:  # noqa: BLE001 - a tool returns errors, it does not raise them
+        log.warning("x_search.failed", error_type=type(exc).__name__)
+        return _failure(str(exc), error_type=type(exc).__name__)
+
+    answer = _extract_response_text(data)
+    citations = list(data.get("citations") or [])
+    inline_citations = _extract_inline_citations(data)
+    degraded, degraded_reason = _degraded_state(
+        allowed, excluded, from_date, to_date, citations, inline_citations
+    )
+
+    return json.dumps(
+        {
+            "success": True,
+            "provider": "xai",
+            "credential_source": "xai",
+            "tool": "x_search",
+            "model": _active_model,
+            "query": query.strip(),
+            "answer": answer,
+            "citations": citations,
+            "inline_citations": inline_citations,
+            "degraded": degraded,
+            "degraded_reason": degraded_reason,
+        },
+        ensure_ascii=False,
+    )

--- a/src/agentos/tools/builtin/x_search.py
+++ b/src/agentos/tools/builtin/x_search.py
@@ -13,10 +13,13 @@ shapes do not compose, so this stays a distinct tool rather than a
 
 Credentials
 -----------
-An xAI API key only (``XAI_API_KEY`` by default). Hermes also accepts a
-SuperGrok / X Premium+ OAuth token; AgentOS has no OAuth subsystem, so that
-path is deliberately absent and ``credential_source`` is always ``"xai"``.
-Without a key the tool is hidden from the model's schema entirely — see
+Two paths, and SuperGrok / X Premium+ OAuth wins when both are present — it
+spends a subscription the user already pays for instead of API credit:
+
+1. OAuth via ``agentos auth login xai`` (``credential_source: "xai-oauth"``)
+2. ``XAI_API_KEY``, or a pasted key in config (``credential_source: "xai"``)
+
+With neither, the tool is hidden from the model's schema entirely — see
 :func:`x_search_available` and ``tools.policy_runtime``.
 
 Defensive output
@@ -157,7 +160,7 @@ def reset_x_search_runtime() -> None:
 
 
 def _resolve_api_key() -> str:
-    """Return the xAI bearer, preferring the pasted key over the environment."""
+    """Return the pasted key, else the one named by ``api_key_env``."""
     import os
 
     if _active_api_key:
@@ -166,18 +169,59 @@ def _resolve_api_key() -> str:
     return os.environ.get(env_name, "").strip()
 
 
+def _oauth_login_present() -> bool:
+    try:
+        from agentos.xai_oauth import has_oauth_credentials
+
+        return has_oauth_credentials()
+    except Exception:  # noqa: BLE001 - capability checks must never raise
+        return False
+
+
+async def _resolve_credential() -> tuple[str, str, str]:
+    """Return ``(bearer, base_url, source)``.
+
+    OAuth is tried first so a SuperGrok subscriber spends their subscription
+    rather than API credit. A *broken* OAuth login is reported rather than
+    skipped: falling through to an API key the user may not have would turn
+    "your xAI login expired" into "no credentials configured".
+    """
+    from agentos.xai_oauth import XaiOAuthError, resolve_oauth_bearer
+
+    try:
+        resolved = await resolve_oauth_bearer()
+    except XaiOAuthError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - a store problem must not mask the key path
+        log.warning("x_search.oauth_resolve_failed", error_type=type(exc).__name__)
+        resolved = None
+
+    if resolved is not None:
+        access_token, oauth_base_url = resolved
+        return access_token, oauth_base_url, "xai-oauth"
+
+    api_key = _resolve_api_key()
+    if api_key:
+        return api_key, _active_base_url, "xai"
+    raise XaiOAuthError(
+        "No xAI credentials available. Run `agentos auth login xai` to use a "
+        "SuperGrok / X Premium+ subscription, or set XAI_API_KEY.",
+        code="xai_no_credentials",
+    )
+
+
 def x_search_available() -> bool:
     """Whether ``x_search`` has everything it needs to run.
 
-    Called every time the tool surface is rebuilt. A tool schema is fixed
-    overhead on every provider call, so a user with no xAI credential should
-    never pay for this one — returning ``False`` here removes it from the
-    model's schema rather than letting it fail at call time.
+    Called every time the tool surface is rebuilt, so it stays local: an
+    OAuth login counts as present without validating it over the network. A
+    revoked token surfaces as a call error, which is better than a tool that
+    disappears from the schema partway through a session.
     """
     if not _active_enabled:
         return False
     try:
-        return bool(_resolve_api_key())
+        return bool(_resolve_api_key()) or _oauth_login_present()
     except Exception:  # noqa: BLE001 - capability checks must never raise
         return False
 
@@ -341,6 +385,7 @@ def _failure(message: str, *, error_type: str = "ToolError") -> str:
 
 async def _post_with_retries(
     api_key: str,
+    base_url: str,
     payload: dict[str, Any],
     deadline: float,
 ) -> httpx.Response:
@@ -355,7 +400,7 @@ async def _post_with_retries(
             attempt_timeout = min(_active_timeout_seconds, remaining)
             try:
                 response = await client.post(
-                    f"{_active_base_url}/responses",
+                    f"{base_url}/responses",
                     headers={
                         "Authorization": f"Bearer {api_key}",
                         "Content-Type": "application/json",
@@ -492,12 +537,12 @@ async def x_search(
     if not query or not query.strip():
         return _failure("query is required for x_search")
 
-    api_key = _resolve_api_key()
-    if not api_key:
-        return _failure(
-            "No xAI credentials available. Set XAI_API_KEY in ~/.agentos/.env or "
-            "configure x_search.api_key."
-        )
+    from agentos.xai_oauth import XaiOAuthError
+
+    try:
+        api_key, base_url, credential_source = await _resolve_credential()
+    except XaiOAuthError as exc:
+        return _failure(str(exc), error_type=exc.code)
 
     try:
         allowed = _normalize_handles(allowed_x_handles, "allowed_x_handles")
@@ -529,7 +574,7 @@ async def x_search(
 
     deadline = time.monotonic() + _active_total_timeout_seconds
     try:
-        response = await _post_with_retries(api_key, payload, deadline)
+        response = await _post_with_retries(api_key, base_url, payload, deadline)
         data = response.json()
     except httpx.HTTPStatusError as exc:
         log.warning("x_search.failed", status=exc.response.status_code)
@@ -555,7 +600,7 @@ async def x_search(
         {
             "success": True,
             "provider": "xai",
-            "credential_source": "xai",
+            "credential_source": credential_source,
             "tool": "x_search",
             "model": _active_model,
             "query": query.strip(),

--- a/src/agentos/tools/policy_config.py
+++ b/src/agentos/tools/policy_config.py
@@ -25,7 +25,7 @@ _TOOL_GROUPS: Mapping[str, frozenset[str]] = {
         {"sessions_list", "sessions_history", "sessions_send", "sessions_spawn", "session_status"}
     ),
     "group:memory": frozenset({"memory_search", "memory_get"}),
-    "group:web": frozenset({"web_search", "web_fetch", "http_request"}),
+    "group:web": frozenset({"web_search", "web_fetch", "http_request", "x_search"}),
     "group:messaging": frozenset({"message"}),
     "channel:chat": frozenset(
         {

--- a/src/agentos/tools/policy_runtime.py
+++ b/src/agentos/tools/policy_runtime.py
@@ -10,6 +10,7 @@ _PRIVATE_MEMORY_READ_TOOL_NAMES: frozenset[str] = frozenset(
     {"memory_get", "memory_search", "session_search"}
 )
 _IMAGE_GENERATION_TOOL_NAMES: frozenset[str] = frozenset({"image_generate"})
+_X_SEARCH_TOOL_NAMES: frozenset[str] = frozenset({"x_search"})
 _SESSION_READ_TOOL_NAMES: frozenset[str] = frozenset(
     {"session_status", "sessions_history", "sessions_list"}
 )
@@ -32,6 +33,7 @@ class ToolSurfaceCapabilities:
     gateway_config: bool = False
     channel_backing: bool = False
     image_generation: bool = True
+    x_search: bool = True
 
 
 def private_memory_read_tools_blocked(ctx: ToolContext | None) -> bool:
@@ -71,6 +73,15 @@ def _detect_image_generation_capability() -> bool:
         return False
 
 
+def _detect_x_search_capability() -> bool:
+    try:
+        from agentos.tools.builtin.x_search import x_search_available
+
+        return x_search_available()
+    except Exception:
+        return False
+
+
 def tool_surface_capabilities_from_runtime(
     *,
     session_manager: object | None = None,
@@ -80,6 +91,7 @@ def tool_surface_capabilities_from_runtime(
     channel_manager: object | None = None,
     originating_envelope: object | None = None,
     image_generation: bool | None = None,
+    x_search: bool | None = None,
 ) -> ToolSurfaceCapabilities:
     """Build tool-surface capabilities from injected runtime dependencies."""
 
@@ -94,6 +106,7 @@ def tool_surface_capabilities_from_runtime(
             if image_generation is None
             else image_generation
         ),
+        x_search=(_detect_x_search_capability() if x_search is None else x_search),
     )
 
 
@@ -119,6 +132,8 @@ def resolve_runtime_tool_surface(
 
     if not caps.image_generation:
         denied_tools |= set(_IMAGE_GENERATION_TOOL_NAMES)
+    if not caps.x_search:
+        denied_tools |= set(_X_SEARCH_TOOL_NAMES)
     if not caps.session_manager:
         denied_tools |= set(_SESSION_READ_TOOL_NAMES | _SESSION_RUNTIME_TOOL_NAMES)
     if not caps.task_runtime:
@@ -170,4 +185,5 @@ def detect_runtime_tool_surface_capabilities(
         gateway_config=gateway_config,
         channel_backing=channel_backing,
         image_generation=_detect_image_generation_capability(),
+        x_search=_detect_x_search_capability(),
     )

--- a/src/agentos/tools/types.py
+++ b/src/agentos/tools/types.py
@@ -128,6 +128,9 @@ CRON_AGENT_ALLOW: frozenset[str] = frozenset(
         "skill_view",
         "web_fetch",
         "web_search",
+        # Read-only external discovery, same shape as the two above. A cron job
+        # watching X is the obvious use for it, and it can only read.
+        "x_search",
     }
 )
 

--- a/src/agentos/xai_oauth.py
+++ b/src/agentos/xai_oauth.py
@@ -403,17 +403,73 @@ class PendingDeviceLogin:
 
     @property
     def expired(self) -> bool:
-        return time.monotonic() >= self.expires_at
+        return time.time() >= self.expires_at
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "login_id": self.login_id,
+            "device_code": self.device_code,
+            "user_code": self.user_code,
+            "verification_uri": self.verification_uri,
+            "interval": self.interval,
+            "expires_at": self.expires_at,
+            "token_endpoint": self.token_endpoint,
+            "discovery": dict(self.discovery),
+        }
+
+    @classmethod
+    def from_json(cls, raw: dict[str, Any]) -> PendingDeviceLogin | None:
+        try:
+            return cls(
+                login_id=str(raw["login_id"]),
+                device_code=str(raw["device_code"]),
+                user_code=str(raw["user_code"]),
+                verification_uri=str(raw["verification_uri"]),
+                interval=max(1, int(raw["interval"])),
+                expires_at=float(raw["expires_at"]),
+                token_endpoint=str(raw["token_endpoint"]),
+                discovery=_dict_field(raw, "discovery"),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
 
 
-# Logins in flight, keyed by an opaque id. A caller that starts a login and
-# never finishes it leaves one entry that the next start sweeps out.
-_pending_logins: dict[str, PendingDeviceLogin] = {}
+# Pending logins live in the token store rather than in memory, because the
+# half that starts a login and the half that finishes it are often different
+# processes: `agentos auth login --no-wait` in one shell, `--resume` in
+# another, or an agent driving both through exec_command. Keeping them in RAM
+# also meant a gateway restart silently voided a login the operator was in the
+# middle of approving. Expiry is wall-clock for the same reason — a monotonic
+# deadline means nothing to the next process.
+_PENDING_KEY = "pending_logins"
 
 
-def _sweep_pending() -> None:
-    for login_id in [lid for lid, p in _pending_logins.items() if p.expired]:
-        _pending_logins.pop(login_id, None)
+def _read_pending() -> dict[str, Any]:
+    return _dict_field(_read_store(), _PENDING_KEY)
+
+
+def _write_pending(entries: dict[str, Any]) -> None:
+    store = _read_store()
+    store[_PENDING_KEY] = entries
+    _write_store(store)
+
+
+def _sweep_pending() -> dict[str, Any]:
+    entries = _read_pending()
+    live = {
+        login_id: raw
+        for login_id, raw in entries.items()
+        if isinstance(raw, dict) and float(raw.get("expires_at") or 0) > time.time()
+    }
+    if len(live) != len(entries):
+        _write_pending(live)
+    return live
+
+
+def _forget_pending(login_id: str) -> None:
+    entries = _read_pending()
+    if entries.pop(login_id, None) is not None:
+        _write_pending(entries)
 
 
 def _persist_login(payload: dict[str, Any], discovery: dict[str, str]) -> dict[str, Any]:
@@ -466,17 +522,35 @@ def start_device_login(
             device.get("verification_uri_complete") or device["verification_uri"]
         ),
         interval=max(1, int(device["interval"])),
-        expires_at=time.monotonic() + max(1, int(device["expires_in"])),
+        expires_at=time.time() + max(1, int(device["expires_in"])),
         token_endpoint=discovery["token_endpoint"],
         discovery=discovery,
     )
-    _pending_logins[pending.login_id] = pending
+    entries = _sweep_pending()
+    entries[pending.login_id] = pending.as_json()
+    _write_pending(entries)
     return pending
 
 
 def get_pending_login(login_id: str) -> PendingDeviceLogin | None:
-    _sweep_pending()
-    return _pending_logins.get(login_id)
+    raw = _sweep_pending().get(login_id)
+    return PendingDeviceLogin.from_json(raw) if isinstance(raw, dict) else None
+
+
+def latest_pending_login() -> PendingDeviceLogin | None:
+    """The most recently started login still awaiting approval, if any.
+
+    Lets a caller resume without having to carry the id around — the common
+    case, since only one login is ever in flight for one operator.
+    """
+    candidates = [
+        parsed
+        for raw in _sweep_pending().values()
+        if isinstance(raw, dict) and (parsed := PendingDeviceLogin.from_json(raw)) is not None
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.expires_at)
 
 
 def poll_device_login(
@@ -489,7 +563,7 @@ def poll_device_login(
     ``False`` so the caller can wait and ask again.
     """
     if pending.expired:
-        _pending_logins.pop(pending.login_id, None)
+        _forget_pending(pending.login_id)
         raise XaiOAuthError(
             "The xAI device authorization expired before it was approved.",
             code="xai_device_code_timeout",
@@ -512,19 +586,19 @@ def poll_device_login(
     if response.status_code == 200:
         payload = response.json()
         if not payload.get("access_token") or not payload.get("refresh_token"):
-            _pending_logins.pop(pending.login_id, None)
+            _forget_pending(pending.login_id)
             raise XaiOAuthError(
                 "xAI device-code token response was missing required tokens.",
                 code="xai_device_token_invalid",
             )
+        _forget_pending(pending.login_id)
         _persist_login(dict(payload), pending.discovery)
-        _pending_logins.pop(pending.login_id, None)
         return True, pending.interval
 
     try:
         error_payload = response.json()
     except Exception:  # noqa: BLE001 - a non-JSON error is still terminal
-        _pending_logins.pop(pending.login_id, None)
+        _forget_pending(pending.login_id)
         raise XaiOAuthError(
             f"xAI device-code polling returned HTTP {response.status_code}.",
             code="xai_device_token_failed",
@@ -535,10 +609,12 @@ def poll_device_login(
         return False, pending.interval
     if error_code == "slow_down":
         widened = min(pending.interval + 1, _MAX_POLL_INTERVAL_SECONDS)
-        _pending_logins[pending.login_id] = replace(pending, interval=widened)
+        entries = _read_pending()
+        entries[pending.login_id] = replace(pending, interval=widened).as_json()
+        _write_pending(entries)
         return False, widened
 
-    _pending_logins.pop(pending.login_id, None)
+    _forget_pending(pending.login_id)
     detail = error_payload.get("error_description") or error_code or (
         f"HTTP {response.status_code}"
     )

--- a/src/agentos/xai_oauth.py
+++ b/src/agentos/xai_oauth.py
@@ -166,13 +166,26 @@ def _read_store() -> dict[str, Any]:
 
 
 def _write_store(store: dict[str, Any]) -> None:
+    """Write the store atomically, owner-only where the platform supports it.
+
+    Windows has no POSIX mode bits, so the file there is protected by the
+    profile directory's ACL rather than by ``chmod``. Mirrors the tolerant
+    handling in :mod:`agentos.env_store`.
+    """
     path = auth_store_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(store, indent=2, sort_keys=True), encoding="utf-8")
-    os.chmod(tmp, 0o600)
+    _restrict(tmp)
     tmp.replace(path)
-    os.chmod(path, 0o600)
+    _restrict(path)
+
+
+def _restrict(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:  # pragma: no cover - no-op on Windows
+        pass
 
 
 def _dict_field(source: dict[str, Any], key: str) -> dict[str, Any]:

--- a/src/agentos/xai_oauth.py
+++ b/src/agentos/xai_oauth.py
@@ -1,0 +1,601 @@
+"""xAI OAuth (SuperGrok / X Premium+) device-code login and token storage.
+
+Ported from NousResearch/hermes-agent ``hermes_cli/auth.py`` (MIT, Copyright
+(c) 2025 Nous Research) — see ``THIRD_PARTY_NOTICES.md``.
+
+Why this exists
+---------------
+xAI sells API credit and subscriptions separately. Someone paying for SuperGrok
+or X Premium+ has no API key and no way to spend their subscription through an
+API key. OAuth is the only path that bills ``x_search`` against a subscription
+they already hold.
+
+Client identity
+---------------
+The default client id is xAI's public Grok CLI client — the scope literally
+reads ``grok-cli:access`` — which is what every third-party client uses because
+xAI publishes no self-service registration. It is a *public* OAuth client
+(device-code, no secret), so nothing here is confidential. Override it with
+``AGENTOS_XAI_OAUTH_CLIENT_ID`` if you have your own registration.
+
+Design notes that differ from upstream
+--------------------------------------
+* **Availability never touches the network.** Upstream's ``check_fn`` refreshes
+  the token every time the model's tool list is rebuilt, i.e. once per turn.
+  Here :func:`has_oauth_credentials` reads local state only, and the refresh
+  happens on the async call path where a round trip is already expected.
+* **Refresh is async** so it cannot block the gateway event loop, and is
+  serialized by an in-process lock: xAI's refresh tokens are single-use, and
+  two concurrent refreshes race one another into ``invalid_grant``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+
+from agentos.env import trust_env as _trust_env
+from agentos.paths import default_agentos_home
+
+log = structlog.get_logger(__name__)
+
+XAI_OAUTH_ISSUER = "https://auth.x.ai"
+XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
+XAI_OAUTH_DEVICE_CODE_URL = f"{XAI_OAUTH_ISSUER}/oauth2/device/code"
+XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+DEFAULT_XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
+
+PROVIDER_ID = "xai-oauth"
+
+# A SuperGrok access token can run hours; a device-code token is often ~15
+# minutes. Refreshing an hour early suits the former and would refresh the
+# latter on literally every resolution, burning single-use refresh tokens — so
+# the skew shrinks for short-lived tokens.
+MAX_REFRESH_SKEW_SECONDS = 3600
+SHORT_TOKEN_SKEW_SECONDS = 120
+SHORT_TOKEN_THRESHOLD_SECONDS = 45 * 60
+
+_DEFAULT_TIMEOUT_SECONDS = 20.0
+_MAX_POLL_INTERVAL_SECONDS = 30
+
+_refresh_lock = asyncio.Lock()
+
+
+class XaiOAuthError(Exception):
+    """An xAI OAuth failure, with enough shape for callers to react."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "xai_oauth_error",
+        relogin_required: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.relogin_required = relogin_required
+
+
+def client_id() -> str:
+    return os.environ.get("AGENTOS_XAI_OAUTH_CLIENT_ID", "").strip() or (
+        DEFAULT_XAI_OAUTH_CLIENT_ID
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint pinning
+# ---------------------------------------------------------------------------
+
+
+def _validate_oauth_endpoint(url: str, *, field: str) -> str:
+    """Refuse a discovery endpoint that is not HTTPS on the xAI origin.
+
+    Discovery output is cached on disk, so one MITM at login time would
+    otherwise substitute a ``token_endpoint`` that receives the refresh token
+    on every future refresh — a permanent leak from a single interception.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise XaiOAuthError(
+            f"xAI OIDC discovery returned a non-HTTPS {field}: {url!r}.",
+            code="xai_discovery_invalid",
+        )
+    host = (parsed.hostname or "").lower()
+    if not host or (host != "x.ai" and not host.endswith(".x.ai")):
+        raise XaiOAuthError(
+            f"xAI OIDC discovery {field} host {host!r} is not on the xAI origin. "
+            "Refusing a cached endpoint that may have been substituted; log in again.",
+            code="xai_discovery_invalid",
+        )
+    return url
+
+
+def validate_inference_base_url(value: str, *, fallback: str = DEFAULT_XAI_OAUTH_BASE_URL) -> str:
+    """Pin the OAuth-authenticated inference origin to xAI.
+
+    An API key is something the operator pasted knowingly. An OAuth bearer is
+    tied to a live subscription and refreshes itself, so a stray
+    ``base_url`` override pointing elsewhere would quietly ship it to a third
+    party on every call. Reject rather than trust, but fall back instead of
+    raising: a bad override should not lock someone out of their own account.
+    """
+    candidate = (value or "").strip().rstrip("/")
+    if not candidate:
+        return fallback
+    parsed = urlparse(candidate)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme == "https" and host and (host == "x.ai" or host.endswith(".x.ai")):
+        return candidate
+    log.warning("xai_oauth.base_url_rejected", host=host or "<none>", fallback=fallback)
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Token store
+# ---------------------------------------------------------------------------
+
+
+def auth_store_path() -> Path:
+    override = os.environ.get("AGENTOS_AUTH_STORE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return default_agentos_home() / "auth.json"
+
+
+def _read_store() -> dict[str, Any]:
+    path = auth_store_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:  # noqa: BLE001 - a corrupt store must not be fatal
+        log.warning("xai_oauth.store_unreadable", error=str(exc))
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _write_store(store: dict[str, Any]) -> None:
+    path = auth_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(store, indent=2, sort_keys=True), encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+    os.chmod(path, 0o600)
+
+
+def _dict_field(source: dict[str, Any], key: str) -> dict[str, Any]:
+    """Return ``source[key]`` when it is a dict, else an empty one."""
+    value = source.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def read_oauth_state() -> dict[str, Any]:
+    providers = _read_store().get("providers")
+    if not isinstance(providers, dict):
+        return {}
+    state = providers.get(PROVIDER_ID)
+    return state if isinstance(state, dict) else {}
+
+
+def write_oauth_state(state: dict[str, Any]) -> None:
+    store = _read_store()
+    providers = store.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+    providers[PROVIDER_ID] = state
+    store["providers"] = providers
+    _write_store(store)
+
+
+def clear_oauth_state() -> bool:
+    """Forget the stored login. Returns whether anything was removed."""
+    store = _read_store()
+    providers = store.get("providers")
+    if not isinstance(providers, dict) or PROVIDER_ID not in providers:
+        return False
+    providers.pop(PROVIDER_ID, None)
+    store["providers"] = providers
+    _write_store(store)
+    return True
+
+
+def _quarantine(reason: str, message: str) -> None:
+    """Drop dead tokens so the next call fails locally instead of over the wire."""
+    state = read_oauth_state()
+    tokens = dict(state.get("tokens") or {})
+    tokens.pop("access_token", None)
+    tokens.pop("refresh_token", None)
+    state["tokens"] = tokens
+    state["last_auth_error"] = {
+        "code": reason,
+        "message": message,
+        "relogin_required": True,
+        "at": datetime.now(UTC).isoformat(),
+    }
+    write_oauth_state(state)
+
+
+# ---------------------------------------------------------------------------
+# Token inspection
+# ---------------------------------------------------------------------------
+
+
+def _jwt_expiry(token: str) -> float | None:
+    if not isinstance(token, str) or "." not in token:
+        return None
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8"))
+    except Exception:  # noqa: BLE001 - an opaque token is not an error
+        return None
+    exp = payload.get("exp")
+    return float(exp) if isinstance(exp, int | float) else None
+
+
+def proactive_skew_seconds(access_token: str) -> int:
+    expiry = _jwt_expiry(access_token)
+    if expiry is None:
+        return MAX_REFRESH_SKEW_SECONDS
+    remaining = expiry - time.time()
+    if 0 < remaining <= SHORT_TOKEN_THRESHOLD_SECONDS:
+        return min(SHORT_TOKEN_SKEW_SECONDS, MAX_REFRESH_SKEW_SECONDS)
+    return MAX_REFRESH_SKEW_SECONDS
+
+
+def access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
+    expiry = _jwt_expiry(access_token)
+    if expiry is None:
+        return False
+    return expiry <= time.time() + max(0, int(skew_seconds))
+
+
+def has_oauth_credentials() -> bool:
+    """Whether a login is on disk. Local only — never makes a request.
+
+    Capability detection runs whenever the tool surface is rebuilt, so this
+    must stay cheap. A token that turns out to be revoked surfaces as a call
+    error, not as a tool that silently vanishes mid-session.
+    """
+    tokens = _dict_field(read_oauth_state(), "tokens")
+    return bool(str(tokens.get("refresh_token") or "").strip()) or bool(
+        str(tokens.get("access_token") or "").strip()
+    )
+
+
+def oauth_status() -> dict[str, Any]:
+    """A description of the stored login. Never includes a token value."""
+    state = read_oauth_state()
+    tokens = _dict_field(state, "tokens")
+    access = str(tokens.get("access_token") or "").strip()
+    expiry = _jwt_expiry(access)
+    return {
+        "provider": PROVIDER_ID,
+        "logged_in": has_oauth_credentials(),
+        "has_refresh_token": bool(str(tokens.get("refresh_token") or "").strip()),
+        "expires_at": (
+            datetime.fromtimestamp(expiry, tz=UTC).isoformat() if expiry is not None else None
+        ),
+        "expiring_soon": access_token_is_expiring(access, proactive_skew_seconds(access)),
+        "base_url": str(state.get("base_url") or DEFAULT_XAI_OAUTH_BASE_URL),
+        "source": str(state.get("source") or ""),
+        "last_refresh": state.get("last_refresh"),
+        "last_auth_error": state.get("last_auth_error"),
+        "store_path": str(auth_store_path()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+def _discover_sync(timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS) -> dict[str, str]:
+    try:
+        response = httpx.get(
+            XAI_OAUTH_DISCOVERY_URL,
+            headers={"Accept": "application/json"},
+            timeout=timeout_seconds,
+            trust_env=_trust_env(),
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001 - one error shape for every failure mode
+        raise XaiOAuthError(
+            f"xAI OIDC discovery failed: {exc}", code="xai_discovery_failed"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise XaiOAuthError(
+            "xAI OIDC discovery response was not a JSON object.", code="xai_discovery_invalid"
+        )
+    authorization_endpoint = str(payload.get("authorization_endpoint") or "").strip()
+    token_endpoint = str(payload.get("token_endpoint") or "").strip()
+    if not authorization_endpoint or not token_endpoint:
+        raise XaiOAuthError(
+            "xAI OIDC discovery response was missing required endpoints.",
+            code="xai_discovery_incomplete",
+        )
+    _validate_oauth_endpoint(authorization_endpoint, field="authorization_endpoint")
+    _validate_oauth_endpoint(token_endpoint, field="token_endpoint")
+    return {
+        "authorization_endpoint": authorization_endpoint,
+        "token_endpoint": token_endpoint,
+    }
+
+
+def _request_device_code(client: httpx.Client) -> dict[str, Any]:
+    response = client.post(
+        XAI_OAUTH_DEVICE_CODE_URL,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        data={"client_id": client_id(), "scope": XAI_OAUTH_SCOPE},
+    )
+    if response.status_code != 200:
+        raise XaiOAuthError(
+            f"xAI device-code request failed (HTTP {response.status_code}).",
+            code="xai_device_code_failed",
+        )
+    payload = response.json()
+    required = (
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "expires_in",
+        "interval",
+    )
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise XaiOAuthError(
+            f"xAI device-code response missing fields: {', '.join(missing)}",
+            code="xai_device_code_invalid",
+        )
+    return dict(payload)
+
+
+def _poll_device_token(
+    client: httpx.Client,
+    *,
+    token_endpoint: str,
+    device_code: str,
+    expires_in: int,
+    poll_interval: int,
+    sleep: Any = time.sleep,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max(1, int(expires_in))
+    interval = max(1, int(poll_interval))
+    while time.monotonic() < deadline:
+        response = client.post(
+            token_endpoint,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "client_id": client_id(),
+                "device_code": device_code,
+            },
+        )
+        if response.status_code == 200:
+            payload = response.json()
+            if not payload.get("access_token") or not payload.get("refresh_token"):
+                raise XaiOAuthError(
+                    "xAI device-code token response was missing required tokens.",
+                    code="xai_device_token_invalid",
+                )
+            return dict(payload)
+
+        try:
+            error_payload = response.json()
+        except Exception:  # noqa: BLE001 - a non-JSON error is still terminal
+            raise XaiOAuthError(
+                f"xAI device-code polling returned HTTP {response.status_code}.",
+                code="xai_device_token_failed",
+            ) from None
+        error_code = str(error_payload.get("error") or "")
+        if error_code == "authorization_pending":
+            sleep(interval)
+            continue
+        if error_code == "slow_down":
+            interval = min(interval + 1, _MAX_POLL_INTERVAL_SECONDS)
+            sleep(interval)
+            continue
+        detail = (
+            error_payload.get("error_description") or error_code or f"HTTP {response.status_code}"
+        )
+        raise XaiOAuthError(
+            f"xAI device-code polling failed: {detail}", code="xai_device_token_failed"
+        )
+    raise XaiOAuthError(
+        "Timed out waiting for xAI device authorization.", code="xai_device_code_timeout"
+    )
+
+
+def device_code_login(
+    *,
+    on_prompt: Any,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    sleep: Any = time.sleep,
+) -> dict[str, Any]:
+    """Run the device-code flow and persist the result.
+
+    ``on_prompt(verification_url, user_code, interval)`` is called once the
+    codes are known, so the caller decides how to present them — the CLI prints
+    them, and nothing here opens a browser or writes to stdout on its own.
+    """
+    discovery = _discover_sync(timeout_seconds)
+    timeout = httpx.Timeout(max(20.0, float(timeout_seconds)))
+    with httpx.Client(
+        timeout=timeout, headers={"Accept": "application/json"}, trust_env=_trust_env()
+    ) as client:
+        device = _request_device_code(client)
+        on_prompt(
+            str(device.get("verification_uri_complete") or device["verification_uri"]),
+            str(device["user_code"]),
+            int(device["interval"]),
+        )
+        payload = _poll_device_token(
+            client,
+            token_endpoint=discovery["token_endpoint"],
+            device_code=str(device["device_code"]),
+            expires_in=int(device["expires_in"]),
+            poll_interval=int(device["interval"]),
+            sleep=sleep,
+        )
+
+    state = {
+        "tokens": {
+            "access_token": str(payload.get("access_token") or "").strip(),
+            "refresh_token": str(payload.get("refresh_token") or "").strip(),
+            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        },
+        "discovery": discovery,
+        "base_url": validate_inference_base_url(
+            os.environ.get("XAI_BASE_URL", ""), fallback=DEFAULT_XAI_OAUTH_BASE_URL
+        ),
+        "source": "oauth-device-code",
+        "last_refresh": datetime.now(UTC).isoformat(),
+        "last_auth_error": None,
+    }
+    write_oauth_state(state)
+    return state
+
+
+async def _refresh(
+    refresh_token: str, token_endpoint: str, timeout_seconds: float
+) -> dict[str, Any]:
+    _validate_oauth_endpoint(token_endpoint, field="token_endpoint")
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(max(5.0, timeout_seconds)),
+        headers={"Accept": "application/json"},
+        trust_env=_trust_env(),
+    ) as client:
+        response = await client.post(
+            token_endpoint,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "client_id": client_id(),
+                "refresh_token": refresh_token,
+            },
+        )
+
+    if response.status_code == 403:
+        # The grant exists but the account is not entitled to API access.
+        # Logging in again cannot fix that, so do not suggest it.
+        raise XaiOAuthError(
+            "xAI refused this OAuth account for API access (HTTP 403). xAI restricts "
+            "API/OAuth use to certain SuperGrok tiers even when the in-app subscription "
+            "is active. Logging in again will not change it — set XAI_API_KEY instead, "
+            "or upgrade at https://x.ai/grok.",
+            code="xai_oauth_tier_denied",
+            relogin_required=False,
+        )
+    if response.status_code != 200:
+        raise XaiOAuthError(
+            f"xAI token refresh failed (HTTP {response.status_code}).",
+            code="xai_refresh_failed",
+            relogin_required=response.status_code in {400, 401},
+        )
+
+    try:
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        raise XaiOAuthError(
+            "xAI token refresh returned invalid JSON.",
+            code="xai_refresh_invalid_json",
+            relogin_required=True,
+        ) from exc
+    access_token = str(payload.get("access_token") or "").strip()
+    if not access_token:
+        raise XaiOAuthError(
+            "xAI token refresh response was missing access_token.",
+            code="xai_refresh_invalid_response",
+            relogin_required=True,
+        )
+    return {
+        "access_token": access_token,
+        "refresh_token": str(payload.get("refresh_token") or refresh_token).strip(),
+        "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+    }
+
+
+async def resolve_oauth_bearer(
+    *, timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+) -> tuple[str, str] | None:
+    """Return ``(access_token, base_url)``, refreshing first if it is due.
+
+    ``None`` means no login is stored. A stored-but-broken login raises, so the
+    caller can report why instead of silently falling back to an API key that
+    the user may not have.
+    """
+    state = read_oauth_state()
+    tokens = _dict_field(state, "tokens")
+    access_token = str(tokens.get("access_token") or "").strip()
+    refresh_token = str(tokens.get("refresh_token") or "").strip()
+    if not access_token and not refresh_token:
+        return None
+
+    base_url = validate_inference_base_url(
+        str(state.get("base_url") or ""), fallback=DEFAULT_XAI_OAUTH_BASE_URL
+    )
+    skew = proactive_skew_seconds(access_token)
+    if access_token and not access_token_is_expiring(access_token, skew):
+        return access_token, base_url
+
+    if not refresh_token:
+        raise XaiOAuthError(
+            "The stored xAI login has no refresh token. Run `agentos auth login xai`.",
+            code="xai_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+
+    async with _refresh_lock:
+        # Re-read under the lock: a concurrent caller may already have
+        # refreshed, and xAI's refresh tokens are single-use.
+        state = read_oauth_state()
+        tokens = _dict_field(state, "tokens")
+        access_token = str(tokens.get("access_token") or "").strip()
+        refresh_token = str(tokens.get("refresh_token") or "").strip()
+        if access_token and not access_token_is_expiring(access_token, skew):
+            return access_token, base_url
+        if not refresh_token:
+            raise XaiOAuthError(
+                "The stored xAI login has no refresh token. Run `agentos auth login xai`.",
+                code="xai_auth_missing_refresh_token",
+                relogin_required=True,
+            )
+
+        discovery = _dict_field(state, "discovery")
+        token_endpoint = str(discovery.get("token_endpoint") or "").strip()
+        if not token_endpoint:
+            token_endpoint = _discover_sync(timeout_seconds)["token_endpoint"]
+
+        try:
+            refreshed = await _refresh(refresh_token, token_endpoint, timeout_seconds)
+        except XaiOAuthError as exc:
+            if exc.relogin_required:
+                _quarantine(exc.code, str(exc))
+            raise
+
+        state["tokens"] = refreshed
+        state["last_refresh"] = datetime.now(UTC).isoformat()
+        state["last_auth_error"] = None
+        write_oauth_state(state)
+        return refreshed["access_token"], base_url

--- a/src/agentos/xai_oauth.py
+++ b/src/agentos/xai_oauth.py
@@ -36,6 +36,8 @@ import base64
 import json
 import os
 import time
+import uuid
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -381,97 +383,40 @@ def _request_device_code(client: httpx.Client) -> dict[str, Any]:
     return dict(payload)
 
 
-def _poll_device_token(
-    client: httpx.Client,
-    *,
-    token_endpoint: str,
-    device_code: str,
-    expires_in: int,
-    poll_interval: int,
-    sleep: Any = time.sleep,
-) -> dict[str, Any]:
-    deadline = time.monotonic() + max(1, int(expires_in))
-    interval = max(1, int(poll_interval))
-    while time.monotonic() < deadline:
-        response = client.post(
-            token_endpoint,
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Accept": "application/json",
-            },
-            data={
-                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-                "client_id": client_id(),
-                "device_code": device_code,
-            },
-        )
-        if response.status_code == 200:
-            payload = response.json()
-            if not payload.get("access_token") or not payload.get("refresh_token"):
-                raise XaiOAuthError(
-                    "xAI device-code token response was missing required tokens.",
-                    code="xai_device_token_invalid",
-                )
-            return dict(payload)
+@dataclass(frozen=True)
+class PendingDeviceLogin:
+    """A device authorization awaiting the user's approval.
 
-        try:
-            error_payload = response.json()
-        except Exception:  # noqa: BLE001 - a non-JSON error is still terminal
-            raise XaiOAuthError(
-                f"xAI device-code polling returned HTTP {response.status_code}.",
-                code="xai_device_token_failed",
-            ) from None
-        error_code = str(error_payload.get("error") or "")
-        if error_code == "authorization_pending":
-            sleep(interval)
-            continue
-        if error_code == "slow_down":
-            interval = min(interval + 1, _MAX_POLL_INTERVAL_SECONDS)
-            sleep(interval)
-            continue
-        detail = (
-            error_payload.get("error_description") or error_code or f"HTTP {response.status_code}"
-        )
-        raise XaiOAuthError(
-            f"xAI device-code polling failed: {detail}", code="xai_device_token_failed"
-        )
-    raise XaiOAuthError(
-        "Timed out waiting for xAI device authorization.", code="xai_device_code_timeout"
-    )
-
-
-def device_code_login(
-    *,
-    on_prompt: Any,
-    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
-    sleep: Any = time.sleep,
-) -> dict[str, Any]:
-    """Run the device-code flow and persist the result.
-
-    ``on_prompt(verification_url, user_code, interval)`` is called once the
-    codes are known, so the caller decides how to present them — the CLI prints
-    them, and nothing here opens a browser or writes to stdout on its own.
+    Carries no secret the user must handle: ``user_code`` is meaningless
+    without their own xAI session, and ``device_code`` is the client's half of
+    a grant that only becomes a token once they approve it.
     """
-    discovery = _discover_sync(timeout_seconds)
-    timeout = httpx.Timeout(max(20.0, float(timeout_seconds)))
-    with httpx.Client(
-        timeout=timeout, headers={"Accept": "application/json"}, trust_env=_trust_env()
-    ) as client:
-        device = _request_device_code(client)
-        on_prompt(
-            str(device.get("verification_uri_complete") or device["verification_uri"]),
-            str(device["user_code"]),
-            int(device["interval"]),
-        )
-        payload = _poll_device_token(
-            client,
-            token_endpoint=discovery["token_endpoint"],
-            device_code=str(device["device_code"]),
-            expires_in=int(device["expires_in"]),
-            poll_interval=int(device["interval"]),
-            sleep=sleep,
-        )
 
+    login_id: str
+    device_code: str
+    user_code: str
+    verification_uri: str
+    interval: int
+    expires_at: float
+    token_endpoint: str
+    discovery: dict[str, str]
+
+    @property
+    def expired(self) -> bool:
+        return time.monotonic() >= self.expires_at
+
+
+# Logins in flight, keyed by an opaque id. A caller that starts a login and
+# never finishes it leaves one entry that the next start sweeps out.
+_pending_logins: dict[str, PendingDeviceLogin] = {}
+
+
+def _sweep_pending() -> None:
+    for login_id in [lid for lid, p in _pending_logins.items() if p.expired]:
+        _pending_logins.pop(login_id, None)
+
+
+def _persist_login(payload: dict[str, Any], discovery: dict[str, str]) -> dict[str, Any]:
     state = {
         "tokens": {
             "access_token": str(payload.get("access_token") or "").strip(),
@@ -488,6 +433,148 @@ def device_code_login(
     }
     write_oauth_state(state)
     return state
+
+
+def _new_client(timeout_seconds: float) -> httpx.Client:
+    return httpx.Client(
+        timeout=httpx.Timeout(max(20.0, float(timeout_seconds))),
+        headers={"Accept": "application/json"},
+        trust_env=_trust_env(),
+    )
+
+
+def start_device_login(
+    *, timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+) -> PendingDeviceLogin:
+    """Ask xAI for a device code and return what the user needs to see.
+
+    Split from the polling half so a caller that cannot block — a Web UI
+    request, or an agent turn — can show the code immediately and poll on its
+    own schedule. :func:`device_code_login` is the blocking composition of the
+    two, for the CLI.
+    """
+    _sweep_pending()
+    discovery = _discover_sync(timeout_seconds)
+    with _new_client(timeout_seconds) as client:
+        device = _request_device_code(client)
+
+    pending = PendingDeviceLogin(
+        login_id=uuid.uuid4().hex,
+        device_code=str(device["device_code"]),
+        user_code=str(device["user_code"]),
+        verification_uri=str(
+            device.get("verification_uri_complete") or device["verification_uri"]
+        ),
+        interval=max(1, int(device["interval"])),
+        expires_at=time.monotonic() + max(1, int(device["expires_in"])),
+        token_endpoint=discovery["token_endpoint"],
+        discovery=discovery,
+    )
+    _pending_logins[pending.login_id] = pending
+    return pending
+
+
+def get_pending_login(login_id: str) -> PendingDeviceLogin | None:
+    _sweep_pending()
+    return _pending_logins.get(login_id)
+
+
+def poll_device_login(
+    pending: PendingDeviceLogin, *, timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+) -> tuple[bool, int]:
+    """Poll once. Returns ``(complete, next_interval)``.
+
+    On completion the tokens are persisted and the pending entry is dropped.
+    A denial or an expiry raises; ``authorization_pending`` simply returns
+    ``False`` so the caller can wait and ask again.
+    """
+    if pending.expired:
+        _pending_logins.pop(pending.login_id, None)
+        raise XaiOAuthError(
+            "The xAI device authorization expired before it was approved.",
+            code="xai_device_code_timeout",
+        )
+
+    with _new_client(timeout_seconds) as client:
+        response = client.post(
+            pending.token_endpoint,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "client_id": client_id(),
+                "device_code": pending.device_code,
+            },
+        )
+
+    if response.status_code == 200:
+        payload = response.json()
+        if not payload.get("access_token") or not payload.get("refresh_token"):
+            _pending_logins.pop(pending.login_id, None)
+            raise XaiOAuthError(
+                "xAI device-code token response was missing required tokens.",
+                code="xai_device_token_invalid",
+            )
+        _persist_login(dict(payload), pending.discovery)
+        _pending_logins.pop(pending.login_id, None)
+        return True, pending.interval
+
+    try:
+        error_payload = response.json()
+    except Exception:  # noqa: BLE001 - a non-JSON error is still terminal
+        _pending_logins.pop(pending.login_id, None)
+        raise XaiOAuthError(
+            f"xAI device-code polling returned HTTP {response.status_code}.",
+            code="xai_device_token_failed",
+        ) from None
+
+    error_code = str(error_payload.get("error") or "")
+    if error_code == "authorization_pending":
+        return False, pending.interval
+    if error_code == "slow_down":
+        widened = min(pending.interval + 1, _MAX_POLL_INTERVAL_SECONDS)
+        _pending_logins[pending.login_id] = replace(pending, interval=widened)
+        return False, widened
+
+    _pending_logins.pop(pending.login_id, None)
+    detail = error_payload.get("error_description") or error_code or (
+        f"HTTP {response.status_code}"
+    )
+    raise XaiOAuthError(
+        f"xAI device-code polling failed: {detail}", code="xai_device_token_failed"
+    )
+
+
+def device_code_login(
+    *,
+    on_prompt: Any,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    sleep: Any = time.sleep,
+) -> dict[str, Any]:
+    """Run the whole device-code flow, blocking until approval. Used by the CLI.
+
+    ``on_prompt(verification_url, user_code, interval)`` fires once the codes
+    are known, so the caller decides how to present them — nothing here opens a
+    browser or writes to stdout on its own.
+    """
+    pending = start_device_login(timeout_seconds=timeout_seconds)
+    on_prompt(pending.verification_uri, pending.user_code, pending.interval)
+
+    interval = pending.interval
+    while True:
+        complete, interval = poll_device_login(pending, timeout_seconds=timeout_seconds)
+        if complete:
+            return read_oauth_state()
+        sleep(interval)
+        refreshed = get_pending_login(pending.login_id)
+        if refreshed is None:
+            raise XaiOAuthError(
+                "The xAI device authorization expired before it was approved.",
+                code="xai_device_code_timeout",
+            )
+        pending = refreshed
 
 
 async def _refresh(

--- a/tests/test_cli/test_auth_cmd.py
+++ b/tests/test_cli/test_auth_cmd.py
@@ -1,0 +1,171 @@
+"""`agentos auth` — the split login an agent or a script can drive.
+
+Exit codes are the contract here: a caller that cannot read prose branches on
+them, so they are asserted rather than the wording around them.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos import xai_oauth as oauth
+from agentos.cli.auth_cmd import EXIT_STILL_PENDING, auth_app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "auth.json"
+    monkeypatch.setenv("AGENTOS_AUTH_STORE", str(path))
+    return path
+
+
+def _pending(**overrides: Any) -> oauth.PendingDeviceLogin:
+    base: dict[str, Any] = {
+        "login_id": "login-1",
+        "device_code": "dev-secret",
+        "user_code": "ABCD-EFGH",
+        "verification_uri": "https://accounts.x.ai/oauth2/device?user_code=ABCD-EFGH",
+        "interval": 5,
+        "expires_at": time.time() + 600,
+        "token_endpoint": "https://auth.x.ai/oauth2/token",
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    }
+    base.update(overrides)
+    return oauth.PendingDeviceLogin(**base)
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    return json.loads(result.stdout)
+
+
+class TestNoWait:
+    def test_it_prints_what_the_user_must_approve_and_exits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(oauth, "start_device_login", lambda **_kw: _pending())
+
+        result = runner.invoke(auth_app, ["login", "xai", "--no-wait", "--json"])
+
+        assert result.exit_code == 0
+        payload = _payload(result)
+        assert payload["status"] == "pending"
+        assert payload["userCode"] == "ABCD-EFGH"
+        assert payload["loginId"] == "login-1"
+        # The device code is the client's half of the grant; it has no business
+        # in a transcript an agent might echo.
+        assert "dev-secret" not in result.stdout
+
+    def test_a_start_failure_exits_nonzero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(**_kw: Any) -> None:
+            raise oauth.XaiOAuthError("discovery failed", code="xai_discovery_failed")
+
+        monkeypatch.setattr(oauth, "start_device_login", _boom)
+
+        result = runner.invoke(auth_app, ["login", "xai", "--no-wait", "--json"])
+
+        assert result.exit_code == 1
+        assert _payload(result)["code"] == "xai_discovery_failed"
+
+
+class TestResume:
+    def test_not_approved_yet_is_its_own_exit_code(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Distinct from failure so a caller retries instead of giving up."""
+        monkeypatch.setattr(oauth, "latest_pending_login", lambda: _pending())
+        monkeypatch.setattr(oauth, "poll_device_login", lambda _p, **_kw: (False, 7))
+
+        result = runner.invoke(auth_app, ["login", "xai", "--resume", "--json"])
+
+        assert result.exit_code == EXIT_STILL_PENDING
+        assert _payload(result) == {"status": "pending", "interval": 7, "loginId": "login-1"}
+
+    def test_approval_completes_with_exit_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(oauth, "latest_pending_login", lambda: _pending())
+        monkeypatch.setattr(oauth, "poll_device_login", lambda _p, **_kw: (True, 5))
+
+        result = runner.invoke(auth_app, ["login", "xai", "--resume", "--json"])
+
+        assert result.exit_code == 0
+        assert _payload(result)["status"] == "complete"
+
+    def test_nothing_pending_says_so_rather_than_hanging(self) -> None:
+        result = runner.invoke(auth_app, ["login", "xai", "--resume", "--json"])
+
+        assert result.exit_code == 1
+        assert _payload(result)["status"] == "expired"
+
+    def test_an_explicit_login_id_is_honoured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[str] = []
+
+        def _get(login_id: str) -> oauth.PendingDeviceLogin:
+            seen.append(login_id)
+            return _pending(login_id=login_id)
+
+        monkeypatch.setattr(oauth, "get_pending_login", _get)
+        monkeypatch.setattr(oauth, "poll_device_login", lambda _p, **_kw: (True, 5))
+
+        result = runner.invoke(
+            auth_app, ["login", "xai", "--resume", "--login-id", "other", "--json"]
+        )
+
+        assert result.exit_code == 0
+        assert seen == ["other"]
+
+    def test_a_terminal_failure_exits_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(_p: Any, **_kw: Any) -> None:
+            raise oauth.XaiOAuthError("access_denied", code="xai_device_token_failed")
+
+        monkeypatch.setattr(oauth, "latest_pending_login", lambda: _pending())
+        monkeypatch.setattr(oauth, "poll_device_login", _boom)
+
+        result = runner.invoke(auth_app, ["login", "xai", "--resume", "--json"])
+
+        assert result.exit_code == 1
+        assert _payload(result)["status"] == "failed"
+
+
+class TestArgumentHandling:
+    def test_the_two_split_flags_are_mutually_exclusive(self) -> None:
+        result = runner.invoke(auth_app, ["login", "xai", "--no-wait", "--resume"])
+        assert result.exit_code == 2
+
+    @pytest.mark.parametrize("command", [["login", "github"], ["logout", "github"]])
+    def test_an_unknown_provider_is_refused(self, command: list[str]) -> None:
+        assert runner.invoke(auth_app, command).exit_code == 2
+
+    @pytest.mark.parametrize("alias", ["xai", "grok", "supergrok", "xai-oauth"])
+    def test_the_provider_aliases_all_resolve(
+        self, monkeypatch: pytest.MonkeyPatch, alias: str
+    ) -> None:
+        monkeypatch.setattr(oauth, "start_device_login", lambda **_kw: _pending())
+        result = runner.invoke(auth_app, ["login", alias, "--no-wait", "--json"])
+        assert result.exit_code == 0
+
+
+class TestStatus:
+    def test_status_never_prints_a_token(self) -> None:
+        oauth.write_oauth_state(
+            {"tokens": {"access_token": "a-token", "refresh_token": "r-token"}}
+        )
+
+        result = runner.invoke(auth_app, ["status", "--json"])
+
+        assert result.exit_code == 0
+        assert "r-token" not in result.stdout
+        assert "a-token" not in result.stdout
+        assert _payload(result)["xai"]["logged_in"] is True
+
+    def test_logout_is_idempotent(self) -> None:
+        oauth.write_oauth_state({"tokens": {"refresh_token": "r"}})
+        assert runner.invoke(auth_app, ["logout", "xai"]).exit_code == 0
+        assert runner.invoke(auth_app, ["logout", "xai"]).exit_code == 0
+        assert oauth.has_oauth_credentials() is False

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -766,6 +766,81 @@ async def test_search_configure_accepts_webui_string_max_results(tmp_path, monke
 
 
 @pytest.mark.asyncio
+async def test_x_search_configure_redacts_api_key_and_persists(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.x_search.configure",
+        {"apiKey": "xai-secret", "model": "grok-4.5", "retries": "3"},
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["changed"] is True
+    assert res.payload["entry"]["api_key"] == "***"
+    assert res.payload["entry"]["retries"] == 3
+    # x_search config is hot-applied, so saving it must not demand a restart.
+    assert res.payload["restartRequired"] is False
+    # A pasted key is persisted like every other one; only the RPC echo is masked.
+    assert 'api_key = "xai-secret"' in target.read_text()
+
+
+@pytest.mark.asyncio
+async def test_x_search_configure_keeps_an_env_only_credential_out_of_the_file(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("XAI_API_KEY", "from-the-environment")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.x_search.configure",
+        {"enabled": True, "model": "grok-4.5"},
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["api_key_source"] == "env"
+    assert "from-the-environment" not in target.read_text()
+
+
+@pytest.mark.asyncio
+async def test_x_search_configure_warns_when_no_credential_is_reachable(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.x_search.configure",
+        {"enabled": True},
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert any("XAI_API_KEY" in w for w in res.payload["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_x_search_configure_rejects_an_unknown_reasoning_effort(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.x_search.configure",
+        {"apiKey": "xai-secret", "reasoningEffort": "turbo"},
+        _admin_ctx(),
+    )
+
+    assert res.error is not None
+    assert "reasoning_effort" in res.error.message
+    assert "xai-secret" not in res.error.message
+
+
+@pytest.mark.asyncio
 async def test_image_generation_configure_redacts_api_key(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(target))

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import platform
+import time
 import tomllib
 
 import pytest
@@ -763,6 +765,80 @@ async def test_search_configure_accepts_webui_string_max_results(tmp_path, monke
 
     assert res.error is None, res.error
     assert res.payload["entry"]["max_results"] == 5
+
+
+@pytest.mark.asyncio
+async def test_xai_login_start_returns_only_what_the_operator_must_approve(monkeypatch):
+    from agentos import xai_oauth
+
+    pending = xai_oauth.PendingDeviceLogin(
+        login_id="login-1",
+        device_code="dev-secret",
+        user_code="ABCD-EFGH",
+        verification_uri="https://accounts.x.ai/oauth2/device?code=ABCD",
+        interval=5,
+        expires_at=time.monotonic() + 600,
+        token_endpoint="https://auth.x.ai/oauth2/token",
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    )
+    monkeypatch.setattr(xai_oauth, "start_device_login", lambda: pending)
+
+    res = await get_dispatcher().dispatch("r1", "auth.xai.login.start", {}, _admin_ctx())
+
+    assert res.error is None, res.error
+    assert res.payload == {
+        "loginId": "login-1",
+        "verificationUri": "https://accounts.x.ai/oauth2/device?code=ABCD",
+        "userCode": "ABCD-EFGH",
+        "interval": 5,
+    }
+    # The device code is the client's half of the grant and has no business
+    # crossing the wire to the browser.
+    assert "dev-secret" not in json.dumps(res.payload)
+
+
+@pytest.mark.asyncio
+async def test_xai_login_poll_reports_pending_then_complete(monkeypatch):
+    from agentos import xai_oauth
+
+    pending = xai_oauth.PendingDeviceLogin(
+        login_id="login-1",
+        device_code="dev",
+        user_code="ABCD",
+        verification_uri="https://accounts.x.ai/oauth2/device",
+        interval=5,
+        expires_at=time.monotonic() + 600,
+        token_endpoint="https://auth.x.ai/oauth2/token",
+        discovery={},
+    )
+    monkeypatch.setattr(xai_oauth, "get_pending_login", lambda _id: pending)
+    answers = iter([(False, 5), (True, 5)])
+    monkeypatch.setattr(xai_oauth, "poll_device_login", lambda _p: next(answers))
+
+    first = await get_dispatcher().dispatch(
+        "r1", "auth.xai.login.poll", {"loginId": "login-1"}, _admin_ctx()
+    )
+    second = await get_dispatcher().dispatch(
+        "r2", "auth.xai.login.poll", {"loginId": "login-1"}, _admin_ctx()
+    )
+
+    assert first.payload == {"status": "pending", "interval": 5}
+    assert second.payload == {"status": "complete", "interval": 5}
+
+
+@pytest.mark.asyncio
+async def test_xai_login_poll_reports_an_unknown_id_as_expired(monkeypatch):
+    """A gateway restart drops pending logins; the UI must be told to start over."""
+    from agentos import xai_oauth
+
+    monkeypatch.setattr(xai_oauth, "get_pending_login", lambda _id: None)
+
+    res = await get_dispatcher().dispatch(
+        "r1", "auth.xai.login.poll", {"loginId": "gone"}, _admin_ctx()
+    )
+
+    assert res.error is None, res.error
+    assert res.payload == {"status": "expired"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -768,6 +768,22 @@ async def test_search_configure_accepts_webui_string_max_results(tmp_path, monke
 
 
 @pytest.mark.asyncio
+async def test_xai_logout_clears_the_stored_login(tmp_path, monkeypatch):
+    from agentos import xai_oauth
+
+    monkeypatch.setenv("AGENTOS_AUTH_STORE", str(tmp_path / "auth.json"))
+    xai_oauth.write_oauth_state({"tokens": {"refresh_token": "r-1"}})
+
+    first = await get_dispatcher().dispatch("r1", "auth.xai.logout", {}, _admin_ctx())
+    second = await get_dispatcher().dispatch("r2", "auth.xai.logout", {}, _admin_ctx())
+
+    assert first.payload == {"cleared": True}
+    # Idempotent: a double click must not read as a failure.
+    assert second.payload == {"cleared": False}
+    assert xai_oauth.has_oauth_credentials() is False
+
+
+@pytest.mark.asyncio
 async def test_xai_login_start_returns_only_what_the_operator_must_approve(monkeypatch):
     from agentos import xai_oauth
 

--- a/tests/test_onboarding/test_x_search_specs.py
+++ b/tests/test_onboarding/test_x_search_specs.py
@@ -1,0 +1,69 @@
+"""The X Search onboarding descriptor and the catalog shape the WebUI consumes."""
+
+from __future__ import annotations
+
+from typing import Any, get_args
+
+from agentos.gateway.config import XSearchConfig
+from agentos.onboarding.setup_engine import setup_catalog_payload
+from agentos.onboarding.x_search_specs import (
+    X_SEARCH_ENV_KEY,
+    get_x_search_setup_spec,
+    x_search_catalog_payload,
+)
+
+
+def _fields_by_name() -> dict[str, Any]:
+    return {field.name: field for field in get_x_search_setup_spec().fields}
+
+
+def test_the_spec_advertises_the_api_key_env_the_runtime_reads() -> None:
+    spec = get_x_search_setup_spec()
+    assert spec.env_key == X_SEARCH_ENV_KEY == XSearchConfig().api_key_env
+    assert spec.requires_api_key is True
+
+
+def test_every_field_default_matches_the_config_model() -> None:
+    """The form must not advertise a default the gateway would not apply."""
+    defaults = XSearchConfig()
+    fields = _fields_by_name()
+    assert fields["model"].default == defaults.model
+    assert fields["base_url"].default == defaults.base_url
+    assert fields["retries"].default == defaults.retries
+    assert fields["timeout_seconds"].default == int(defaults.timeout_seconds)
+    assert fields["total_timeout_seconds"].default == int(defaults.total_timeout_seconds)
+
+
+def test_the_effort_choices_come_from_the_validating_literal() -> None:
+    allowed = set(get_args(XSearchConfig.model_fields["reasoning_effort"].annotation))
+    assert set(_fields_by_name()["reasoning_effort"].choices) == allowed
+
+
+def test_the_api_key_field_is_marked_secret() -> None:
+    api_key = _fields_by_name()["api_key"]
+    assert api_key.secret is True
+    assert api_key.field_type == "password"
+
+
+def test_the_catalog_section_is_a_list_like_every_other_section() -> None:
+    """The WebUI and the CLI renderer both walk catalog sections as rows."""
+    payload = setup_catalog_payload()
+    rows = payload["xSearch"]
+    assert isinstance(rows, list)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["providerId"] == "x_search"
+    assert row["envKey"] == X_SEARCH_ENV_KEY
+    assert row["requiresApiKey"] is True
+    assert isinstance(row["fields"], list)
+    assert {"name", "type", "default", "choices", "secret"} <= set(row["fields"][0])
+
+
+def test_the_section_is_reachable_by_each_alias() -> None:
+    for alias in ("x-search", "x_search", "xsearch"):
+        assert setup_catalog_payload(alias) == {"xSearch": x_search_catalog_payload()}
+
+
+def test_oauth_is_called_out_as_unsupported() -> None:
+    """Hermes Agent accepts SuperGrok OAuth; arriving from its docs should not confuse."""
+    assert any("OAuth" in line for line in get_x_search_setup_spec().what_you_need)

--- a/tests/test_onboarding/test_x_search_specs.py
+++ b/tests/test_onboarding/test_x_search_specs.py
@@ -64,6 +64,9 @@ def test_the_section_is_reachable_by_each_alias() -> None:
         assert setup_catalog_payload(alias) == {"xSearch": x_search_catalog_payload()}
 
 
-def test_oauth_is_called_out_as_unsupported() -> None:
-    """Hermes Agent accepts SuperGrok OAuth; arriving from its docs should not confuse."""
-    assert any("OAuth" in line for line in get_x_search_setup_spec().what_you_need)
+def test_both_credential_paths_are_offered() -> None:
+    """The card is the only place a key-only user learns the login exists."""
+    needs = " ".join(get_x_search_setup_spec().what_you_need)
+    assert X_SEARCH_ENV_KEY in needs
+    assert "agentos auth login xai" in needs
+    assert "preferred" in needs

--- a/tests/test_tools/test_policy_runtime_boundary.py
+++ b/tests/test_tools/test_policy_runtime_boundary.py
@@ -156,6 +156,10 @@ def test_policy_runtime_builds_capabilities_from_injected_dependencies() -> None
         channel_manager=None,
         originating_envelope=object(),
         image_generation=False,
+        # Both credential-backed capabilities are passed explicitly: left to
+        # auto-detection they would read the ambient environment and flip on a
+        # machine that happens to export the provider key.
+        x_search=False,
     )
 
     assert caps == ToolSurfaceCapabilities(
@@ -165,6 +169,7 @@ def test_policy_runtime_builds_capabilities_from_injected_dependencies() -> None
         gateway_config=True,
         channel_backing=True,
         image_generation=False,
+        x_search=False,
     )
 
 

--- a/tests/test_tools/test_x_search.py
+++ b/tests/test_tools/test_x_search.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any, cast
 
 import httpx
@@ -84,7 +85,11 @@ class _Recorder:
 
 
 @pytest.fixture(autouse=True)
-def _clean_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+def _clean_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Point the OAuth store at an empty temp file. Without this the tests read
+    # the developer's real ~/.agentos/auth.json, and a machine that happens to
+    # be logged in to xAI would take the OAuth branch instead of the key path.
+    monkeypatch.setenv("AGENTOS_AUTH_STORE", str(tmp_path / "auth.json"))
     monkeypatch.setenv(ENV_KEY, FAKE_KEY)
     x_search_mod.reset_x_search_runtime()
     yield
@@ -555,6 +560,98 @@ class TestConfiguration:
         monkeypatch.setenv(ENV_KEY, FAKE_KEY)
         x_search_mod.configure_x_search(_Cfg(enabled=False))
         assert x_search_mod.x_search_available() is False
+
+
+class TestCredentialSelection:
+    """OAuth wins over an API key: it spends a subscription the user already has."""
+
+    @staticmethod
+    def _login(monkeypatch: pytest.MonkeyPatch, token: str = "oauth-access-token") -> None:
+        from agentos import xai_oauth
+
+        async def _resolve(**_kwargs: Any) -> tuple[str, str]:
+            return token, "https://api.x.ai/v1"
+
+        monkeypatch.setattr(xai_oauth, "resolve_oauth_bearer", _resolve)
+
+    @pytest.mark.asyncio
+    async def test_oauth_is_preferred_over_the_api_key(
+        self, answered: _Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._login(monkeypatch)
+        result = await _call(query="grok")
+        assert result["credential_source"] == "xai-oauth"
+        assert answered.requests[-1]["headers"]["Authorization"] == "Bearer oauth-access-token"
+
+    @pytest.mark.asyncio
+    async def test_the_api_key_is_used_when_no_login_exists(
+        self, answered: _Recorder
+    ) -> None:
+        result = await _call(query="grok")
+        assert result["credential_source"] == "xai"
+        assert answered.requests[-1]["headers"]["Authorization"] == f"Bearer {FAKE_KEY}"
+
+    @pytest.mark.asyncio
+    async def test_a_broken_login_is_reported_rather_than_skipped(
+        self, answered: _Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falling back would turn "your login expired" into "no credentials"."""
+        from agentos import xai_oauth
+
+        async def _resolve(**_kwargs: Any) -> tuple[str, str]:
+            raise xai_oauth.XaiOAuthError(
+                "xAI refused this OAuth account for API access (HTTP 403).",
+                code="xai_oauth_tier_denied",
+            )
+
+        monkeypatch.setattr(xai_oauth, "resolve_oauth_bearer", _resolve)
+        result = await _call(query="grok")
+        assert result["success"] is False
+        assert result["error_type"] == "xai_oauth_tier_denied"
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_the_oauth_base_url_overrides_the_configured_one(
+        self, answered: _Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bearer belongs to the OAuth origin, not to x_search.base_url."""
+        from agentos import xai_oauth
+
+        async def _resolve(**_kwargs: Any) -> tuple[str, str]:
+            return "oauth-token", "https://staging.x.ai/v1"
+
+        monkeypatch.setattr(xai_oauth, "resolve_oauth_bearer", _resolve)
+        monkeypatch.setattr(x_search_mod, "_active_base_url", "https://proxy.example.test/v1")
+        await _call(query="grok")
+        assert answered.requests[-1]["url"] == "https://staging.x.ai/v1/responses"
+
+    def test_a_stored_login_alone_makes_the_tool_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentos import xai_oauth
+
+        monkeypatch.delenv(ENV_KEY, raising=False)
+        x_search_mod.reset_x_search_runtime()
+        assert x_search_mod.x_search_available() is False
+
+        xai_oauth.write_oauth_state({"tokens": {"refresh_token": "r-1"}})
+        assert x_search_mod.x_search_available() is True
+
+    def test_availability_never_makes_a_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """It runs on every tool-surface rebuild; a network call there is a per-turn cost."""
+        from agentos import xai_oauth
+
+        monkeypatch.delenv(ENV_KEY, raising=False)
+        xai_oauth.write_oauth_state({"tokens": {"refresh_token": "r-1"}})
+
+        def _explode(**_kwargs: Any) -> None:
+            raise AssertionError("availability must not open a client")
+
+        monkeypatch.setattr(xai_oauth.httpx, "AsyncClient", _explode)
+        monkeypatch.setattr(xai_oauth.httpx, "Client", _explode)
+        assert x_search_mod.x_search_available() is True
 
 
 class TestToolVisibility:

--- a/tests/test_tools/test_x_search.py
+++ b/tests/test_tools/test_x_search.py
@@ -1,0 +1,595 @@
+"""The x_search tool: input validation, degraded detection, retries, gating.
+
+Offline by construction — every test swaps ``httpx.AsyncClient`` for a fake, so
+nothing here reaches api.x.ai or needs a credential.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from agentos.tools.builtin import x_search as x_search_mod
+from agentos.tools.registry import get_default_registry
+from agentos.tools.visibility import effective_tool_context
+
+XSearch = Callable[..., Awaitable[str]]
+
+ENV_KEY = "XAI_API_KEY"
+FAKE_KEY = "placeholder-not-a-real-key"
+
+
+def _x_search() -> XSearch:
+    return cast(XSearch, x_search_mod.x_search.__wrapped__.__wrapped__)
+
+
+def _response(payload: dict[str, Any], status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status,
+        json=payload,
+        request=httpx.Request("POST", "https://api.x.ai/v1/responses"),
+    )
+
+
+class _Recorder:
+    """Captures every request body and replays a scripted list of responses."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+        self.timeouts: list[float] = []
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorder = self
+
+        class FakeAsyncClient:
+            def __init__(self, **kwargs: object) -> None:
+                pass
+
+            async def __aenter__(self) -> FakeAsyncClient:
+                return self
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+            async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+                recorder.requests.append(
+                    {"url": url, "json": kwargs.get("json"), "headers": kwargs.get("headers")}
+                )
+                recorder.timeouts.append(float(kwargs.get("timeout", 0.0)))
+                if not recorder.responses:
+                    raise AssertionError("no scripted response left for x_search")
+                response = recorder.responses.pop(0)
+                response.raise_for_status()
+                return response
+
+        monkeypatch.setattr(x_search_mod.httpx, "AsyncClient", FakeAsyncClient)
+
+    @property
+    def call_count(self) -> int:
+        return len(self.requests)
+
+    @property
+    def last_payload(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self.requests[-1]["json"])
+
+    @property
+    def tool_definition(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self.last_payload["tools"][0])
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_KEY, FAKE_KEY)
+    x_search_mod.reset_x_search_runtime()
+    yield
+    x_search_mod.reset_x_search_runtime()
+
+
+@pytest.fixture
+def answered(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    recorder = _Recorder([_response({"output_text": "people are talking about it"})])
+    recorder.install(monkeypatch)
+    return recorder
+
+
+async def _call(**kwargs: Any) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(await _x_search()(**kwargs)))
+
+
+# ── Input validation happens before any HTTP call ───────────────────────────
+
+
+class TestInputValidation:
+    @pytest.mark.asyncio
+    async def test_blank_query_is_refused(self, answered: _Recorder) -> None:
+        result = await _call(query="   ")
+        assert result["success"] is False
+        assert "query is required" in result["error"]
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_are_stripped_and_deduplicated_of_blanks(
+        self, answered: _Recorder
+    ) -> None:
+        await _call(query="grok", allowed_x_handles=["@xai", "  ", "grok"])
+        assert answered.tool_definition["allowed_x_handles"] == ["xai", "grok"]
+
+    @pytest.mark.asyncio
+    async def test_more_than_ten_handles_is_refused(self, answered: _Recorder) -> None:
+        result = await _call(query="grok", allowed_x_handles=[f"h{i}" for i in range(11)])
+        assert result["success"] is False
+        assert "at most 10 handles" in result["error"]
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_allowed_and_excluded_together_is_refused(self, answered: _Recorder) -> None:
+        result = await _call(query="grok", allowed_x_handles=["a"], excluded_x_handles=["b"])
+        assert result["success"] is False
+        assert "cannot be used together" in result["error"]
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", ["2026-13-01", "08/10/2026", "yesterday", "2026-8"])
+    async def test_a_malformed_date_never_reaches_xai(
+        self, answered: _Recorder, bad: str
+    ) -> None:
+        result = await _call(query="grok", from_date=bad)
+        assert result["success"] is False
+        assert "must be YYYY-MM-DD" in result["error"]
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_an_inverted_range_is_refused(self, answered: _Recorder) -> None:
+        result = await _call(query="grok", from_date="2026-08-10", to_date="2026-08-01")
+        assert result["success"] is False
+        assert "must be on or before" in result["error"]
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_future_from_date_is_refused(self, answered: _Recorder) -> None:
+        tomorrow = (datetime.now(UTC).date() + timedelta(days=1)).isoformat()
+        result = await _call(query="grok", from_date=tomorrow)
+        assert result["success"] is False
+        assert "in the future" in result["error"]
+        assert answered.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_future_to_date_is_allowed(self, answered: _Recorder) -> None:
+        """"From yesterday to tomorrow" is how a caller asks for posts as they arrive."""
+        tomorrow = (datetime.now(UTC).date() + timedelta(days=1)).isoformat()
+        result = await _call(query="grok", to_date=tomorrow)
+        assert result["success"] is True
+        assert answered.tool_definition["to_date"] == tomorrow
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_reasoning_effort_is_refused(
+        self, answered: _Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(x_search_mod, "_active_reasoning_effort", "turbo")
+        result = await _call(query="grok")
+        assert result["success"] is False
+        assert "reasoning_effort must be one of" in result["error"]
+        assert answered.call_count == 0
+
+
+# ── Request shape ───────────────────────────────────────────────────────────
+
+
+class TestRequestShape:
+    @pytest.mark.asyncio
+    async def test_an_unfiltered_query_sends_only_the_tool_type(
+        self, answered: _Recorder
+    ) -> None:
+        await _call(query="what is happening")
+        assert answered.tool_definition == {"type": "x_search"}
+        assert answered.last_payload["store"] is False
+        assert "reasoning" not in answered.last_payload
+
+    @pytest.mark.asyncio
+    async def test_every_filter_is_forwarded(self, answered: _Recorder) -> None:
+        await _call(
+            query="grok",
+            excluded_x_handles=["@spam"],
+            from_date="2026-08-01",
+            to_date="2026-08-09",
+            enable_image_understanding=True,
+            enable_video_understanding=True,
+        )
+        assert answered.tool_definition == {
+            "type": "x_search",
+            "excluded_x_handles": ["spam"],
+            "from_date": "2026-08-01",
+            "to_date": "2026-08-09",
+            "enable_image_understanding": True,
+            "enable_video_understanding": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_reasoning_effort_is_sent_when_configured(
+        self, answered: _Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(x_search_mod, "_active_reasoning_effort", "low")
+        await _call(query="grok")
+        assert answered.last_payload["reasoning"] == {"effort": "low"}
+
+    @pytest.mark.asyncio
+    async def test_the_bearer_is_the_resolved_key(self, answered: _Recorder) -> None:
+        await _call(query="grok")
+        assert answered.requests[-1]["headers"]["Authorization"] == f"Bearer {FAKE_KEY}"
+
+
+# ── Response parsing ────────────────────────────────────────────────────────
+
+
+class TestResponseParsing:
+    @pytest.mark.asyncio
+    async def test_answer_falls_back_to_message_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorder = _Recorder(
+            [
+                _response(
+                    {
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [
+                                    {"type": "output_text", "text": "first"},
+                                    {"type": "text", "text": "second"},
+                                ],
+                            },
+                            {"type": "reasoning", "content": [{"type": "text", "text": "skip"}]},
+                        ]
+                    }
+                )
+            ]
+        )
+        recorder.install(monkeypatch)
+        result = await _call(query="grok")
+        assert result["answer"] == "first\n\nsecond"
+
+    @pytest.mark.asyncio
+    async def test_inline_citations_are_extracted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorder = _Recorder(
+            [
+                _response(
+                    {
+                        "output_text": "answer",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": "answer",
+                                        "annotations": [
+                                            {
+                                                "type": "url_citation",
+                                                "url": "https://x.com/example/status/1",
+                                                "title": "a post",
+                                                "start_index": 0,
+                                                "end_index": 6,
+                                            },
+                                            {"type": "file_citation", "url": "ignored"},
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
+            ]
+        )
+        recorder.install(monkeypatch)
+        result = await _call(query="grok")
+        assert result["inline_citations"] == [
+            {
+                "url": "https://x.com/example/status/1",
+                "title": "a post",
+                "start_index": 0,
+                "end_index": 6,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_credential_source_is_always_the_api_key_path(
+        self, answered: _Recorder
+    ) -> None:
+        """AgentOS has no xAI OAuth, unlike hermes-agent. The field stays for shape."""
+        result = await _call(query="grok")
+        assert result["credential_source"] == "xai"
+
+
+# ── Degraded detection ──────────────────────────────────────────────────────
+
+
+class TestDegradedDetection:
+    @pytest.mark.asyncio
+    async def test_a_filtered_query_with_no_citations_is_degraded(
+        self, answered: _Recorder
+    ) -> None:
+        result = await _call(query="grok", allowed_x_handles=["xai"], from_date="2026-08-01")
+        assert result["degraded"] is True
+        assert "allowed_x_handles" in result["degraded_reason"]
+        assert "from_date" in result["degraded_reason"]
+
+    @pytest.mark.asyncio
+    async def test_an_unfiltered_query_with_no_citations_is_not_degraded(
+        self, answered: _Recorder
+    ) -> None:
+        """A broad answer with no citations is just an answer, not a filter miss."""
+        result = await _call(query="grok")
+        assert result["degraded"] is False
+        assert result["degraded_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_top_level_citations_clear_the_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorder = _Recorder(
+            [_response({"output_text": "answer", "citations": ["https://x.com/a/status/1"]})]
+        )
+        recorder.install(monkeypatch)
+        result = await _call(query="grok", allowed_x_handles=["xai"])
+        assert result["degraded"] is False
+
+    @pytest.mark.asyncio
+    async def test_inline_citations_alone_clear_the_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorder = _Recorder(
+            [
+                _response(
+                    {
+                        "output_text": "answer",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": "answer",
+                                        "annotations": [
+                                            {"type": "url_citation", "url": "https://x.com/a/1"}
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
+            ]
+        )
+        recorder.install(monkeypatch)
+        result = await _call(query="grok", excluded_x_handles=["spam"])
+        assert result["degraded"] is False
+
+
+# ── Failure handling ────────────────────────────────────────────────────────
+
+
+class TestFailureHandling:
+    @pytest.mark.asyncio
+    async def test_a_5xx_is_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(x_search_mod, "_active_retries", 2)
+        recorder = _Recorder(
+            [
+                _response({"error": "upstream"}, status=503),
+                _response({"output_text": "recovered"}),
+            ]
+        )
+        recorder.install(monkeypatch)
+        monkeypatch.setattr(x_search_mod.asyncio, "sleep", _no_sleep)
+        result = await _call(query="grok")
+        assert result["success"] is True
+        assert result["answer"] == "recovered"
+        assert recorder.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_a_4xx_is_not_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bad key or a model without x_search access fails the same way every time."""
+        recorder = _Recorder([_response({"code": "invalid_request", "error": "no access"}, 400)])
+        recorder.install(monkeypatch)
+        result = await _call(query="grok")
+        assert result["success"] is False
+        assert result["error"] == "invalid_request: no access"
+        assert recorder.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_stop_at_the_configured_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(x_search_mod, "_active_retries", 1)
+        recorder = _Recorder([_response({"error": "upstream"}, 500) for _ in range(3)])
+        recorder.install(monkeypatch)
+        monkeypatch.setattr(x_search_mod.asyncio, "sleep", _no_sleep)
+        result = await _call(query="grok")
+        assert result["success"] is False
+        assert recorder.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_an_exhausted_total_budget_reports_a_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(x_search_mod, "_active_total_timeout_seconds", 0.0)
+        recorder = _Recorder([_response({"output_text": "never reached"})])
+        recorder.install(monkeypatch)
+        result = await _call(query="grok")
+        assert result["success"] is False
+        assert "timed out" in result["error"]
+        assert recorder.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_an_attempt_never_outlives_the_total_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(x_search_mod, "_active_timeout_seconds", 180.0)
+        monkeypatch.setattr(x_search_mod, "_active_total_timeout_seconds", 20.0)
+        recorder = _Recorder([_response({"output_text": "ok"})])
+        recorder.install(monkeypatch)
+        await _call(query="grok")
+        assert recorder.timeouts[0] <= 20.0
+
+    @pytest.mark.asyncio
+    async def test_an_error_body_is_bounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorder = _Recorder([_response({"error": "x" * 5000}, 500)])
+        recorder.install(monkeypatch)
+        monkeypatch.setattr(x_search_mod, "_active_retries", 0)
+        result = await _call(query="grok")
+        assert len(result["error"]) <= 500
+
+    @pytest.mark.asyncio
+    async def test_the_api_key_never_appears_in_an_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorder = _Recorder([_response({"error": "unauthorized"}, 401)])
+        recorder.install(monkeypatch)
+        raw = await _x_search()(query="grok")
+        assert FAKE_KEY not in raw
+
+    @pytest.mark.asyncio
+    async def test_a_missing_credential_is_reported_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ENV_KEY, raising=False)
+        x_search_mod.reset_x_search_runtime()
+        result = await _call(query="grok")
+        assert result["success"] is False
+        assert "No xAI credentials available" in result["error"]
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+# ── Configuration and visibility ────────────────────────────────────────────
+
+
+class _Cfg:
+    def __init__(self, **kwargs: Any) -> None:
+        defaults = {
+            "enabled": True,
+            "model": "grok-4.5",
+            "base_url": "https://api.x.ai/v1",
+            "api_key": "",
+            "api_key_env": ENV_KEY,
+            "reasoning_effort": "",
+            "timeout_seconds": 180.0,
+            "total_timeout_seconds": 300.0,
+            "retries": 2,
+        }
+        defaults.update(kwargs)
+        for key, value in defaults.items():
+            setattr(self, key, value)
+
+
+class TestConfiguration:
+    def test_the_config_model_and_the_tool_agree_on_every_default(self) -> None:
+        """Two sources of "the default" exist and must not drift.
+
+        ``XSearchConfig`` supplies the setup form and the TOML defaults;
+        the module constants supply the no-config path in
+        ``configure_x_search(None)``. Onboarding reads only the former, so a
+        silent divergence would make the form advertise settings the runtime
+        does not use.
+        """
+        from agentos.gateway.config import XSearchConfig
+
+        defaults = XSearchConfig()
+        assert defaults.model == x_search_mod.DEFAULT_X_SEARCH_MODEL
+        assert defaults.base_url == x_search_mod.DEFAULT_X_SEARCH_BASE_URL
+        assert defaults.api_key_env == x_search_mod.DEFAULT_X_SEARCH_API_KEY_ENV
+        assert defaults.timeout_seconds == x_search_mod.DEFAULT_X_SEARCH_TIMEOUT_SECONDS
+        assert (
+            defaults.total_timeout_seconds
+            == x_search_mod.DEFAULT_X_SEARCH_TOTAL_TIMEOUT_SECONDS
+        )
+        assert defaults.retries == x_search_mod.DEFAULT_X_SEARCH_RETRIES
+
+    def test_the_config_literal_covers_every_accepted_effort(self) -> None:
+        from typing import get_args
+
+        from agentos.gateway.config import XSearchConfig
+
+        allowed = set(get_args(XSearchConfig.model_fields["reasoning_effort"].annotation))
+        assert allowed == {"", *x_search_mod.X_SEARCH_REASONING_EFFORTS}
+
+    def test_retries_survive_the_default_timeouts(self) -> None:
+        """A budget-aware retry loop must not silently disable retries at boot."""
+        x_search_mod.configure_x_search(_Cfg())
+        assert x_search_mod._active_retries == 2
+
+    def test_an_explicit_key_beats_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ENV_KEY, "from-env")
+        x_search_mod.configure_x_search(_Cfg(api_key="from-config"))
+        assert x_search_mod._resolve_api_key() == "from-config"
+
+    def test_a_custom_env_var_is_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_XAI_KEY", "from-custom-env")
+        x_search_mod.configure_x_search(_Cfg(api_key_env="MY_XAI_KEY"))
+        assert x_search_mod._resolve_api_key() == "from-custom-env"
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["http://api.x.ai/v1", "https://169.254.169.254/latest", ""],
+    )
+    def test_an_unusable_base_url_falls_back_to_the_default(self, base_url: str) -> None:
+        x_search_mod.configure_x_search(_Cfg(base_url=base_url))
+        assert x_search_mod._active_base_url == "https://api.x.ai/v1"
+
+    def test_a_trailing_slash_is_trimmed(self) -> None:
+        x_search_mod.configure_x_search(_Cfg(base_url="https://proxy.example.test/v1/"))
+        assert x_search_mod._active_base_url == "https://proxy.example.test/v1"
+
+    def test_disabling_hides_the_tool_even_with_a_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ENV_KEY, FAKE_KEY)
+        x_search_mod.configure_x_search(_Cfg(enabled=False))
+        assert x_search_mod.x_search_available() is False
+
+
+class TestToolVisibility:
+    @staticmethod
+    def _visible() -> bool:
+        from agentos.tools.policy_runtime import (
+            detect_runtime_tool_surface_capabilities,
+            resolve_runtime_tool_surface,
+        )
+
+        ctx = resolve_runtime_tool_surface(
+            effective_tool_context(session_key="chat:test", agent_id="main"),
+            capabilities=detect_runtime_tool_surface_capabilities(),
+        )
+        return "x_search" in {d.name for d in get_default_registry().to_tool_definitions(ctx)}
+
+    def test_the_tool_is_registered(self) -> None:
+        assert "x_search" in get_default_registry().list_names()
+
+    def test_no_credential_keeps_the_schema_out_of_the_prompt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tool schemas cost tokens on every call, so an unusable tool must not ship one."""
+        monkeypatch.delenv(ENV_KEY, raising=False)
+        x_search_mod.reset_x_search_runtime()
+        assert self._visible() is False
+
+    def test_a_credential_surfaces_the_tool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_KEY, FAKE_KEY)
+        x_search_mod.reset_x_search_runtime()
+        assert self._visible() is True
+
+    def test_the_web_group_covers_x_search(self) -> None:
+        """``deny = ["group:web"]`` should cut the route to api.x.ai too."""
+        from agentos.tools.policy_config import expand_selectors
+
+        available = frozenset(get_default_registry().list_names())
+        assert "x_search" in expand_selectors(frozenset({"group:web"}), available)

--- a/tests/test_xai_oauth.py
+++ b/tests/test_xai_oauth.py
@@ -1,0 +1,415 @@
+"""xAI OAuth: endpoint pinning, device-code flow, refresh, and the token store.
+
+Offline: every test swaps httpx for a fake. Nothing here reaches auth.x.ai.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from agentos import xai_oauth as oauth
+
+TOKEN_ENDPOINT = "https://auth.x.ai/oauth2/token"
+AUTHZ_ENDPOINT = "https://auth.x.ai/oauth2/authorize"
+
+
+def _jwt(exp_offset_seconds: float) -> str:
+    """A token whose only meaningful claim is ``exp``."""
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": int(time.time() + exp_offset_seconds)}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def _response(payload: dict[str, Any], status: int = 200, url: str = TOKEN_ENDPOINT):
+    return httpx.Response(status, json=payload, request=httpx.Request("POST", url))
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "auth.json"
+    monkeypatch.setenv("AGENTOS_AUTH_STORE", str(path))
+    monkeypatch.delenv("AGENTOS_XAI_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+    return path
+
+
+# ── Endpoint pinning ────────────────────────────────────────────────────────
+
+
+class TestEndpointPinning:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://auth.x.ai/oauth2/token",
+            "https://auth.evil.test/oauth2/token",
+            "https://x.ai.evil.test/oauth2/token",
+            "https://",
+        ],
+    )
+    def test_a_non_xai_discovery_endpoint_is_refused(self, url: str) -> None:
+        """A cached endpoint would receive every future refresh token."""
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            oauth._validate_oauth_endpoint(url, field="token_endpoint")
+        assert excinfo.value.code == "xai_discovery_invalid"
+
+    @pytest.mark.parametrize(
+        "url", ["https://auth.x.ai/oauth2/token", "https://x.ai/oauth2/token"]
+    )
+    def test_the_xai_origin_is_accepted(self, url: str) -> None:
+        assert oauth._validate_oauth_endpoint(url, field="token_endpoint") == url
+
+    @pytest.mark.parametrize(
+        "value",
+        ["http://api.x.ai/v1", "https://attacker.example/v1", "not a url"],
+    )
+    def test_an_off_origin_inference_base_url_falls_back(self, value: str) -> None:
+        """Reject, but do not raise: a bad override must not lock the account out."""
+        assert oauth.validate_inference_base_url(value) == oauth.DEFAULT_XAI_OAUTH_BASE_URL
+
+    def test_an_xai_subdomain_base_url_is_kept(self) -> None:
+        assert (
+            oauth.validate_inference_base_url("https://staging.x.ai/v1/")
+            == "https://staging.x.ai/v1"
+        )
+
+
+# ── Token store ─────────────────────────────────────────────────────────────
+
+
+class TestTokenStore:
+    def test_an_absent_store_reads_as_empty(self) -> None:
+        assert oauth.read_oauth_state() == {}
+        assert oauth.has_oauth_credentials() is False
+
+    def test_a_corrupt_store_does_not_raise(self, _isolated_store: Path) -> None:
+        _isolated_store.write_text("{not json", encoding="utf-8")
+        assert oauth.read_oauth_state() == {}
+
+    def test_the_store_is_written_owner_only(self, _isolated_store: Path) -> None:
+        oauth.write_oauth_state({"tokens": {"refresh_token": "r"}})
+        assert _isolated_store.stat().st_mode & 0o077 == 0
+
+    def test_logout_removes_only_the_xai_entry(self, _isolated_store: Path) -> None:
+        _isolated_store.write_text(
+            json.dumps({"providers": {"xai-oauth": {"tokens": {}}, "other": {"keep": True}}}),
+            encoding="utf-8",
+        )
+        assert oauth.clear_oauth_state() is True
+        remaining = json.loads(_isolated_store.read_text(encoding="utf-8"))
+        assert remaining["providers"] == {"other": {"keep": True}}
+
+    def test_logout_reports_when_there_was_nothing_to_remove(self) -> None:
+        assert oauth.clear_oauth_state() is False
+
+    def test_status_never_exposes_a_token(self) -> None:
+        oauth.write_oauth_state(
+            {"tokens": {"access_token": _jwt(3600), "refresh_token": "super-secret-refresh"}}
+        )
+        rendered = json.dumps(oauth.oauth_status())
+        assert "super-secret-refresh" not in rendered
+        assert oauth.oauth_status()["logged_in"] is True
+
+
+# ── Expiry ──────────────────────────────────────────────────────────────────
+
+
+class TestExpiry:
+    def test_an_opaque_token_is_never_treated_as_expiring(self) -> None:
+        assert oauth.access_token_is_expiring("opaque-token", 3600) is False
+
+    def test_an_expired_jwt_is_expiring(self) -> None:
+        assert oauth.access_token_is_expiring(_jwt(-10), 0) is True
+
+    def test_a_long_lived_token_uses_the_full_skew(self) -> None:
+        assert oauth.proactive_skew_seconds(_jwt(6 * 3600)) == oauth.MAX_REFRESH_SKEW_SECONDS
+
+    def test_a_short_lived_token_uses_a_narrow_skew(self) -> None:
+        """Device-code tokens run ~15 min; an hour of skew would refresh every call."""
+        assert oauth.proactive_skew_seconds(_jwt(15 * 60)) == oauth.SHORT_TOKEN_SKEW_SECONDS
+
+
+# ── Device-code login ───────────────────────────────────────────────────────
+
+
+class _FakeClient:
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.requests.append({"url": url, "data": kwargs.get("data")})
+        return self.responses.pop(0)
+
+
+def _install_login(
+    monkeypatch: pytest.MonkeyPatch, responses: list[httpx.Response]
+) -> _FakeClient:
+    client = _FakeClient(responses)
+    monkeypatch.setattr(
+        oauth,
+        "_discover_sync",
+        lambda *a, **k: {
+            "authorization_endpoint": AUTHZ_ENDPOINT,
+            "token_endpoint": TOKEN_ENDPOINT,
+        },
+    )
+    monkeypatch.setattr(oauth.httpx, "Client", lambda **kwargs: client)
+    return client
+
+
+DEVICE_PAYLOAD = {
+    "device_code": "dev-123",
+    "user_code": "ABCD-EFGH",
+    "verification_uri": "https://x.ai/device",
+    "verification_uri_complete": "https://x.ai/device?code=ABCD-EFGH",
+    "expires_in": 600,
+    "interval": 5,
+}
+
+
+class TestDeviceCodeLogin:
+    def test_a_successful_login_is_persisted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _install_login(
+            monkeypatch,
+            [
+                _response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL),
+                _response({"access_token": _jwt(3600), "refresh_token": "r-1"}),
+            ],
+        )
+        prompts: list[tuple[str, str, int]] = []
+        oauth.device_code_login(
+            on_prompt=lambda url, code, interval: prompts.append((url, code, interval)),
+            sleep=lambda _s: None,
+        )
+
+        assert prompts == [("https://x.ai/device?code=ABCD-EFGH", "ABCD-EFGH", 5)]
+        assert oauth.has_oauth_credentials() is True
+        assert oauth.read_oauth_state()["source"] == "oauth-device-code"
+        assert client.requests[0]["data"]["client_id"] == oauth.DEFAULT_XAI_OAUTH_CLIENT_ID
+        assert client.requests[0]["data"]["scope"] == oauth.XAI_OAUTH_SCOPE
+
+    def test_authorization_pending_is_polled_until_approval(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _install_login(
+            monkeypatch,
+            [
+                _response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL),
+                _response({"error": "authorization_pending"}, status=400),
+                _response({"error": "authorization_pending"}, status=400),
+                _response({"access_token": _jwt(3600), "refresh_token": "r-1"}),
+            ],
+        )
+        slept: list[float] = []
+        oauth.device_code_login(on_prompt=lambda *a: None, sleep=slept.append)
+        assert slept == [5, 5]
+        assert len(client.requests) == 4
+
+    def test_slow_down_widens_the_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_login(
+            monkeypatch,
+            [
+                _response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL),
+                _response({"error": "slow_down"}, status=400),
+                _response({"access_token": _jwt(3600), "refresh_token": "r-1"}),
+            ],
+        )
+        slept: list[float] = []
+        oauth.device_code_login(on_prompt=lambda *a: None, sleep=slept.append)
+        assert slept == [6]
+
+    def test_a_token_response_without_a_refresh_token_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without one, the login is unusable the moment the access token expires."""
+        _install_login(
+            monkeypatch,
+            [
+                _response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL),
+                _response({"access_token": _jwt(3600)}),
+            ],
+        )
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            oauth.device_code_login(on_prompt=lambda *a: None, sleep=lambda _s: None)
+        assert excinfo.value.code == "xai_device_token_invalid"
+        assert oauth.has_oauth_credentials() is False
+
+    def test_a_denied_authorization_fails_immediately(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_login(
+            monkeypatch,
+            [
+                _response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL),
+                _response({"error": "access_denied"}, status=400),
+            ],
+        )
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            oauth.device_code_login(on_prompt=lambda *a: None, sleep=lambda _s: None)
+        assert excinfo.value.code == "xai_device_token_failed"
+
+    def test_the_client_id_is_overridable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENTOS_XAI_OAUTH_CLIENT_ID", "my-own-registration")
+        client = _install_login(
+            monkeypatch,
+            [
+                _response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL),
+                _response({"access_token": _jwt(3600), "refresh_token": "r-1"}),
+            ],
+        )
+        oauth.device_code_login(on_prompt=lambda *a: None, sleep=lambda _s: None)
+        assert client.requests[0]["data"]["client_id"] == "my-own-registration"
+
+
+# ── Refresh ─────────────────────────────────────────────────────────────────
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.requests.append({"url": url, "data": kwargs.get("data")})
+        return self.responses.pop(0)
+
+
+def _install_refresh(
+    monkeypatch: pytest.MonkeyPatch, responses: list[httpx.Response]
+) -> _FakeAsyncClient:
+    client = _FakeAsyncClient(responses)
+    monkeypatch.setattr(oauth.httpx, "AsyncClient", lambda **kwargs: client)
+    return client
+
+
+def _stored(access_token: str, refresh_token: str = "r-1") -> None:
+    oauth.write_oauth_state(
+        {
+            "tokens": {"access_token": access_token, "refresh_token": refresh_token},
+            "discovery": {"token_endpoint": TOKEN_ENDPOINT},
+            "base_url": oauth.DEFAULT_XAI_OAUTH_BASE_URL,
+        }
+    )
+
+
+class TestResolveBearer:
+    @pytest.mark.asyncio
+    async def test_no_login_resolves_to_none(self) -> None:
+        assert await oauth.resolve_oauth_bearer() is None
+
+    @pytest.mark.asyncio
+    async def test_a_live_token_is_returned_without_a_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        token = _jwt(6 * 3600)
+        _stored(token)
+        client = _install_refresh(monkeypatch, [])
+        resolved = await oauth.resolve_oauth_bearer()
+        assert resolved == (token, oauth.DEFAULT_XAI_OAUTH_BASE_URL)
+        assert client.requests == []
+
+    @pytest.mark.asyncio
+    async def test_an_expiring_token_is_refreshed_and_stored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stored(_jwt(30))
+        fresh = _jwt(6 * 3600)
+        client = _install_refresh(
+            monkeypatch, [_response({"access_token": fresh, "refresh_token": "r-2"})]
+        )
+        resolved = await oauth.resolve_oauth_bearer()
+        assert resolved is not None and resolved[0] == fresh
+        assert client.requests[0]["data"]["grant_type"] == "refresh_token"
+        assert oauth.read_oauth_state()["tokens"]["refresh_token"] == "r-2"
+
+    @pytest.mark.asyncio
+    async def test_a_rotated_refresh_token_replaces_the_old_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """xAI refresh tokens are single-use; keeping the old one bricks the login."""
+        _stored(_jwt(30), refresh_token="r-old")
+        _install_refresh(
+            monkeypatch, [_response({"access_token": _jwt(3600), "refresh_token": "r-new"})]
+        )
+        await oauth.resolve_oauth_bearer()
+        assert oauth.read_oauth_state()["tokens"]["refresh_token"] == "r-new"
+
+    @pytest.mark.asyncio
+    async def test_a_403_is_reported_as_a_tier_gate_not_a_relogin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-logging in cannot fix an entitlement problem, so do not suggest it."""
+        _stored(_jwt(30))
+        _install_refresh(monkeypatch, [_response({"error": "forbidden"}, status=403)])
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            await oauth.resolve_oauth_bearer()
+        assert excinfo.value.code == "xai_oauth_tier_denied"
+        assert excinfo.value.relogin_required is False
+        # Tokens survive: the grant is still valid, the account just is not entitled.
+        assert oauth.read_oauth_state()["tokens"]["refresh_token"] == "r-1"
+
+    @pytest.mark.asyncio
+    async def test_an_invalid_grant_quarantines_the_dead_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Next call should fail locally instead of making another doomed request."""
+        _stored(_jwt(30))
+        _install_refresh(monkeypatch, [_response({"error": "invalid_grant"}, status=400)])
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            await oauth.resolve_oauth_bearer()
+        assert excinfo.value.relogin_required is True
+        assert oauth.has_oauth_credentials() is False
+        assert oauth.read_oauth_state()["last_auth_error"]["code"] == "xai_refresh_failed"
+
+    @pytest.mark.asyncio
+    async def test_a_5xx_does_not_quarantine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A transient upstream failure must not throw away a working login."""
+        _stored(_jwt(30))
+        _install_refresh(monkeypatch, [_response({"error": "oops"}, status=503)])
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            await oauth.resolve_oauth_bearer()
+        assert excinfo.value.relogin_required is False
+        assert oauth.has_oauth_credentials() is True
+
+    @pytest.mark.asyncio
+    async def test_a_login_without_a_refresh_token_asks_for_relogin(self) -> None:
+        oauth.write_oauth_state({"tokens": {"access_token": _jwt(-10)}})
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            await oauth.resolve_oauth_bearer()
+        assert excinfo.value.code == "xai_auth_missing_refresh_token"
+
+    @pytest.mark.asyncio
+    async def test_a_poisoned_token_endpoint_is_refused_on_the_refresh_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-validate the cached endpoint: the store may predate the pinning rule."""
+        oauth.write_oauth_state(
+            {
+                "tokens": {"access_token": _jwt(30), "refresh_token": "r-1"},
+                "discovery": {"token_endpoint": "https://attacker.example/token"},
+            }
+        )
+        _install_refresh(monkeypatch, [_response({"access_token": _jwt(3600)})])
+        with pytest.raises(oauth.XaiOAuthError) as excinfo:
+            await oauth.resolve_oauth_bearer()
+        assert excinfo.value.code == "xai_discovery_invalid"

--- a/tests/test_xai_oauth.py
+++ b/tests/test_xai_oauth.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import base64
 import json
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -93,9 +94,19 @@ class TestTokenStore:
         _isolated_store.write_text("{not json", encoding="utf-8")
         assert oauth.read_oauth_state() == {}
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows has no POSIX mode bits; the store is protected by the profile ACL.",
+    )
     def test_the_store_is_written_owner_only(self, _isolated_store: Path) -> None:
         oauth.write_oauth_state({"tokens": {"refresh_token": "r"}})
         assert _isolated_store.stat().st_mode & 0o077 == 0
+
+    def test_the_store_is_written_atomically(self, _isolated_store: Path) -> None:
+        """A crash mid-write must not leave a half-parsed token file behind."""
+        oauth.write_oauth_state({"tokens": {"refresh_token": "r"}})
+        assert json.loads(_isolated_store.read_text(encoding="utf-8"))["providers"]
+        assert not list(_isolated_store.parent.glob("*.tmp"))
 
     def test_logout_removes_only_the_xai_entry(self, _isolated_store: Path) -> None:
         _isolated_store.write_text(

--- a/tests/test_xai_oauth.py
+++ b/tests/test_xai_oauth.py
@@ -273,6 +273,61 @@ class TestDeviceCodeLogin:
             oauth.device_code_login(on_prompt=lambda *a: None, sleep=lambda _s: None)
         assert excinfo.value.code == "xai_device_token_failed"
 
+    def test_a_pending_login_survives_the_process_that_started_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--no-wait` and `--resume` are different processes, as is a restarted gateway."""
+        _install_login(
+            monkeypatch,
+            [_response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL)],
+        )
+        pending = oauth.start_device_login()
+
+        # Nothing in memory: a fresh reader sees it only because it is on disk.
+        recovered = oauth.get_pending_login(pending.login_id)
+        assert recovered is not None
+        assert recovered.device_code == pending.device_code
+        assert oauth.latest_pending_login() is not None
+
+    def test_an_expired_pending_login_is_swept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_login(
+            monkeypatch,
+            [
+                _response(
+                    {**DEVICE_PAYLOAD, "expires_in": 1},
+                    url=oauth.XAI_OAUTH_DEVICE_CODE_URL,
+                )
+            ],
+        )
+        pending = oauth.start_device_login()
+        monkeypatch.setattr(oauth.time, "time", lambda: pending.expires_at + 1)
+        assert oauth.get_pending_login(pending.login_id) is None
+        assert oauth.latest_pending_login() is None
+
+    def test_completing_a_login_clears_its_pending_entry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed grant left on disk would be replayed by the next resume."""
+        _install_login(
+            monkeypatch,
+            [_response(DEVICE_PAYLOAD, url=oauth.XAI_OAUTH_DEVICE_CODE_URL)],
+        )
+        pending = oauth.start_device_login()
+        _install_refresh(monkeypatch, [])
+        monkeypatch.setattr(
+            oauth.httpx,
+            "Client",
+            lambda **kwargs: _FakeClient(
+                [_response({"access_token": _jwt(3600), "refresh_token": "r-1"})]
+            ),
+        )
+
+        complete, _interval = oauth.poll_device_login(pending)
+
+        assert complete is True
+        assert oauth.get_pending_login(pending.login_id) is None
+        assert oauth.has_oauth_credentials() is True
+
     def test_the_client_id_is_overridable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AGENTOS_XAI_OAUTH_CLIENT_ID", "my-own-registration")
         client = _install_login(


### PR DESCRIPTION
Adds `x_search`, a built-in tool for searching X (Twitter), plus the xAI OAuth
login that lets a SuperGrok / X Premium+ subscriber use it without buying
separate API credit.

## What it does

xAI runs the search server-side against X's post index and returns a
synthesized answer with citations, not a list of ranked pages. That is a
different shape from what a search provider returns, so this is a distinct
tool rather than a `web_search` backend, and it does not enter the search
provider registry.

```
> What are people on X saying about the new Grok image features?
  → x_search(query=..., allowed_x_handles=["xai"])
  → answer + citations to the posts it used
```

Read-only. It cannot post, reply, like, DM, or read an authenticated account.

## Credentials

Two paths, and OAuth wins when both are present so a subscription is spent
before API credit:

| Path | How | `credential_source` |
| --- | --- | --- |
| SuperGrok / X Premium+ | `agentos auth login xai` | `xai-oauth` |
| xAI API key | `XAI_API_KEY`, or a pasted key | `xai` |

`agentos auth` is a new command group (`login` / `status` / `logout`). The
login is an OIDC device-code flow against `auth.x.ai`; tokens live in
`~/.agentos/auth.json` at `0600` and refresh themselves. `auth status` never
prints a token.

Three ways to sign in, all the same flow:

- **Setup page** — *Capabilities → X (Twitter) search → Sign in with xAI*.
  Shows the approval link and code, polls until you approve, then turns into
  *Sign out of xAI*.
- **CLI** — `agentos auth login xai`, blocking until approval.
- **A chat agent** — `--no-wait` starts a login and prints the link and code;
  `--resume` checks it once. Exit codes carry the outcome (0 approved, 3 not
  yet, 1 failed) so a caller need not read prose. The blocking form would hit a
  tool timeout long before a human could approve, which is why the halves are
  separate at all.

Pending logins live in the token store, not in gateway memory: the half that
starts a login and the half that finishes it are routinely different
processes, and a gateway restart used to void a login mid-approval.

The default OAuth client id is xAI's public Grok CLI client — the scope reads
`grok-cli:access` — because xAI publishes no self-service registration. It is
a public client with no secret, and `AGENTOS_XAI_OAUTH_CLIENT_ID` overrides it.

## The `degraded` flag

xAI answers with HTTP 200 and a fluent, confident answer even when its index
matched nothing for your filters. That answer comes from training data and is
indistinguishable from a real one by shape alone.

`degraded` is `true` when a narrowing filter was active **and** both citation
channels came back empty. The tool description tells the model to treat that
as unsourced rather than reporting it as something found on X. A broad query
with no citations is not degraded — it is just an answer.

## Design decisions worth reviewing

**Capability gating, not just config.** Tool schemas are fixed overhead on
every provider call. `x_search` is hidden from the model's schema unless a
credential resolves, so an install without xAI never pays for it. This follows
the existing `image_generation` pattern; those two are now the only
capability-gated tools. Availability is a local check — no network — because
it runs on every tool-surface rebuild.

**Deadline-aware retries.** Every tool call is capped by
`EngineConfig.tool_timeout` (60s). `timeout_seconds` bounds one attempt,
`total_timeout_seconds` bounds the whole call, and the tool declares a static
ceiling above both so the engine never cuts an attempt the tool still
considers live.

**Origin pinning.** OIDC discovery endpoints and the OAuth inference base URL
are pinned to `https` on `x.ai`/`*.x.ai`. The token endpoint is cached on
disk, so one MITM at login would otherwise receive the refresh token on every
future refresh — a permanent leak from a single interception. The check runs
again on the refresh path.

**HTTP 403 is a tier gate, not a re-login prompt.** xAI restricts API access
to certain SuperGrok tiers; an account outside them gets 403 even with an
active subscription. Logging in again cannot fix it, so the error does not
suggest it. A terminal 400/401 quarantines the dead tokens instead.

**A broken login is reported, not skipped.** Falling through to an API key
would turn "your xAI login expired" into "no credentials configured".

**Policy placement.** `x_search` joins `group:web`, so `deny = ["group:web"]`
also cuts the route to api.x.ai, and `CRON_AGENT_ALLOW` next to `web_fetch` /
`web_search` since it is read-only. Classified `external` for result
budgeting; runs under the `web.fetch` sandbox action kind.

## Surfaces

`[x_search]` config with hot-apply (no restart), a Setup page card,
`onboarding.x_search.configure` and `auth.status` RPCs,
`agentos configure x-search`, `agentos onboard catalog x-search`, and
`XAI_API_KEY` in the env catalog.

## Cost

`x_search` bills xAI directly and does **not** appear in `agentos cost` or the
Usage view, because it does not pass through the provider layer. `docs/x-search.md`
says so rather than leaving it to be discovered.

## Verification

Gates: `ruff`, `mypy` (598 files), `pytest` (7576 passed), `npm run check`
(1829 passed), `uv build --wheel`.

Beyond the suite, this was exercised against a live gateway on an isolated
port and state dir:

- Boot wiring, and `tools.effective` gaining/losing `x_search` with the
  credential (54 → 55 tools).
- Hot-apply proved observably: `enabled=false` over RPC removes the tool from
  the live surface with no restart; `true` brings it back.
- The Setup card in a real browser, including a save that wrote through to the
  config file, and the sign-in / sign-out controls.
- CLI: `auth --help/status/logout`, the `--no-wait` / `--resume` split and its
  exit codes, and `0600` store permissions.
- A chat agent driving the login end to end on a real profile: it read the
  skill, ran the non-blocking form, and returned a live approval link and code.
- Real network: OIDC discovery and device-code issuance against `auth.x.ai`
  succeed (the client id and scope are accepted), and a request to
  `api.x.ai/v1/responses` returns a parsed `invalid-argument` error for a bad
  credential with no token in the payload.

Not verified: approving a device code and running a successful search, both of
which need a real xAI account.

## Known gaps

- `agentos context` still prices `x_search` without a credential. That command
  reports what each profile would cost across the whole registry and does not
  model capability gating — `image_generate` behaves the same.
- Signing out only forgets the local tokens; nothing is revoked upstream.

## Also in here

Two fixes the feature surfaced rather than caused:

- Transcript links opened in place, unmounting the chat and losing any
  in-flight turn — painful for a link the assistant just asked you to open.
  External links now open in a new tab, and a `target` the model writes for
  itself is stripped before ours is applied.
- The bundled operator skill's description never mentioned X search, so an
  agent asked "how do I search X" answered from general knowledge instead of
  naming the built-in. A capability-gated tool is invisible to the model by
  design, which makes the skill description the only thing left to say it
  exists.
