### PR TITLE
fix(skills): bind lockfile entries by install path, not manifest name

### DIFF
--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -94,28 +94,18 @@ def _emit_skill_mutation_result(
     raise typer.Exit(1)
 
 
-def _load_skill_rows() -> list[dict[str, Any]]:
-    """Build the offline ``skills list`` rows from the shared inventory.
+def _offline_loader() -> tuple[Any, Any]:
+    """Build the layer loader (and its config) this process reads skills through.
 
-    This runs without a gateway, so it re-derives the layer directories, but the
-    facts it reports — eligibility, acquisition, publisher — come from
-    :func:`~agentos.skills.inventory.build_skill_inventory`, the same builder the
-    RPC surfaces use. That is the point: the CLI and the Web UI used to answer
-    "where did this skill come from" differently for the same skill.
-
-    ``availability`` is the one block this surface omits. It is a question about
-    a chat session's tool surface, and a CLI process has none; a fabricated
-    verdict here would be worse than an absent key.
+    Only the no-gateway paths need it: every command prefers the running
+    gateway, which already owns a loader. Extracted so ``skills list`` and
+    ``skills uninstall`` resolve a skill the same way offline — they disagreed
+    once and the CLI reported a skill it could not then remove.
     """
     import os
     from pathlib import Path
 
     from agentos.gateway.config import GatewayConfig
-    from agentos.skills.inventory import (
-        acquisition_payload,
-        build_skill_inventory,
-        publisher_payload,
-    )
     from agentos.skills.loader import SkillLoader
     from agentos.skills.paths import resolve_skill_layer_dirs
 
@@ -137,6 +127,52 @@ def _load_skill_rows() -> list[dict[str, Any]]:
         project_agents_dir=layer_dirs.project_agents_dir,
         extra_dirs=layer_dirs.extra_dirs,
     )
+    return loader, config
+
+
+def _offline_lock_key(name: str) -> str:
+    """Return the lockfile key for ``name``, or ``name`` when nothing loads.
+
+    The installer is keyed by the install directory while a user types the name
+    a manifest declares; see
+    :func:`~agentos.skills.inventory.lock_key_for_skill`. Best-effort: a broken
+    config must not turn ``skills uninstall`` into a traceback, so a failure to
+    build the loader falls back to the typed name — exactly what this command
+    passed before.
+    """
+    from agentos.skills.hub.lockfile import Lockfile, default_lockfile_path
+    from agentos.skills.inventory import lock_key_for_skill
+
+    try:
+        loader, _ = _offline_loader()
+        spec = loader.get_by_name(name)
+    except Exception:  # pragma: no cover - config/IO shapes vary by install
+        return name
+    if spec is None:
+        return name
+    return lock_key_for_skill(spec, Lockfile.load(default_lockfile_path()))
+
+
+def _load_skill_rows() -> list[dict[str, Any]]:
+    """Build the offline ``skills list`` rows from the shared inventory.
+
+    This runs without a gateway, so it re-derives the layer directories, but the
+    facts it reports — eligibility, acquisition, publisher — come from
+    :func:`~agentos.skills.inventory.build_skill_inventory`, the same builder the
+    RPC surfaces use. That is the point: the CLI and the Web UI used to answer
+    "where did this skill come from" differently for the same skill.
+
+    ``availability`` is the one block this surface omits. It is a question about
+    a chat session's tool surface, and a CLI process has none; a fabricated
+    verdict here would be worse than an absent key.
+    """
+    from agentos.skills.inventory import (
+        acquisition_payload,
+        build_skill_inventory,
+        publisher_payload,
+    )
+
+    loader, config = _offline_loader()
     inventory = build_skill_inventory(loader, config=config)
     rows: list[dict[str, Any]] = []
     for row in sorted(inventory, key=lambda r: r.spec.name):
@@ -415,7 +451,7 @@ def skills_uninstall(
         from agentos.skills.hub.defaults import build_default_skill_installer
 
         installer = build_default_skill_installer()
-        result = await installer.uninstall(name)
+        result = await installer.uninstall(_offline_lock_key(name))
 
         if json_output:
             print_json(_install_result_payload(result))

--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -29,6 +29,7 @@ from agentos.skills.inventory import (
     acquisition_payload,
     availability_payload,
     build_skill_inventory,
+    lock_key_for_skill,
     publisher_payload,
 )
 from agentos.skills.loader import SkillLoader
@@ -393,6 +394,26 @@ def _installed_names() -> set[str]:
     return installed_skill_names()
 
 
+def _lock_key(ctx: RpcContext, name: str) -> str:
+    """Translate a skill's displayed name into the key its lockfile entry uses.
+
+    Both actions below address the installer, which is keyed by the install
+    directory, while every surface addresses a skill by the name its ``SKILL.md``
+    declares. Those differ whenever a published skill's manifest names itself
+    something other than its directory — ``ytdlp-transcript`` ships a manifest
+    named ``youtube-transcript`` — and without this translation Remove and
+    Update reported "not found" for an install sitting right there on disk.
+
+    The name is returned unchanged when no skill loads under it, so cleaning up
+    a stale lockfile entry by its own key still works.
+    """
+    loader = _get_loader(ctx)
+    spec = loader.get_by_name(name) if loader is not None else None
+    if spec is None:
+        return name
+    return lock_key_for_skill(spec, Lockfile.load(default_lockfile_path()))
+
+
 def _installed_lock_entries() -> dict[str, LockEntry]:
     """Return the lockfile's installed entries, keyed by installed skill name."""
     return Lockfile.load(default_lockfile_path()).installed
@@ -594,7 +615,7 @@ async def _handle_skills_update(params: dict | None, ctx: RpcContext) -> dict[st
 
     name = (params or {}).get("name")
     try:
-        results = await installer.update(name)
+        results = await installer.update(_lock_key(ctx, name) if name else None)
     except OSError as exc:
         return {
             "results": [],
@@ -618,7 +639,7 @@ async def _handle_skills_uninstall(params: dict | None, ctx: RpcContext) -> dict
     if installer is None:
         return {"success": False, "message": "No skill installer configured"}
 
-    result = await installer.uninstall(params["name"])
+    result = await installer.uninstall(_lock_key(ctx, params["name"]))
     if result.success:
         _invalidate_loader(ctx)
     return {"success": result.success, "name": result.name, "message": result.message}

--- a/src/agentos/skills/inventory.py
+++ b/src/agentos/skills/inventory.py
@@ -46,6 +46,7 @@ __all__ = [
     "acquisition_payload",
     "availability_payload",
     "build_skill_inventory",
+    "lock_key_for_skill",
     "publisher_payload",
 ]
 
@@ -120,19 +121,92 @@ def build_skill_inventory(
         )
         availability = {**availability, **plan.availability}
 
+    by_path = _entries_by_path(lockfile)
     rows: list[SkillRow] = []
     for spec in skills:
-        entry = lockfile.get(spec.name)
+        key, entry = _bind_lock_entry(spec, lockfile, by_path)
         rows.append(
             SkillRow(
                 spec=spec,
                 eligibility=diagnose_eligibility(spec, elig_ctx),
-                acquisition=_derive_acquisition(spec, entry, managed_dir),
+                acquisition=_derive_acquisition(spec, key, entry, managed_dir),
                 publisher=_derive_publisher(spec, entry),
                 availability=availability.get(spec.name),
             )
         )
     return rows
+
+
+def _entries_by_path(lockfile: Lockfile) -> dict[Path, tuple[str, LockEntry]]:
+    """Index the lockfile by the resolved directory each entry records.
+
+    Built once per sweep rather than per skill: ``Path.resolve`` hits the
+    filesystem, and an install with a hundred skills would otherwise stat every
+    recorded path a hundred times.
+    """
+    index: dict[Path, tuple[str, LockEntry]] = {}
+    for key, entry in lockfile.installed.items():
+        if not entry.path:
+            continue
+        try:
+            resolved = Path(entry.path).expanduser().resolve()
+        except OSError:  # pragma: no cover - resolve() only raises on exotic filesystems
+            continue
+        # First writer wins: two entries recording the same directory is a
+        # corrupt lockfile, and picking the earlier one at least stays stable
+        # across reloads.
+        index.setdefault(resolved, (key, entry))
+    return index
+
+
+def lock_key_for_skill(spec: SkillSpec, lockfile: Lockfile) -> str:
+    """Return the lockfile key for a loaded skill, or its name when unmatched.
+
+    ``skills.uninstall`` and ``skills.update`` are addressed by the name a user
+    sees, which is the manifest's; the installer addresses the key the lockfile
+    is written under, which is the install *directory*. Resolving between them
+    lives here so both actions and the Installed rows agree on which entry a
+    skill is.
+    """
+    key, _ = _bind_lock_entry(spec, lockfile, _entries_by_path(lockfile))
+    return key or spec.name
+
+
+def _bind_lock_entry(
+    spec: SkillSpec,
+    lockfile: Lockfile,
+    by_path: dict[Path, tuple[str, LockEntry]],
+) -> tuple[str, LockEntry | None]:
+    """Match a loaded skill to its lockfile entry, by path and then by name.
+
+    The lockfile is keyed by the install *directory* — ``bundle.name``, the
+    source's slug, which is also the directory the installer writes into (see
+    ``SkillInstaller.install``). A ``SKILL.md`` is free to declare a different
+    ``name:``, and several published skills do: ``ytdlp-transcript`` installs a
+    manifest named ``youtube-transcript``. Looking the entry up by the manifest
+    name alone therefore missed, and the install was reported as a hand-copied
+    local directory with no source, no version, and no working Remove button.
+
+    The recorded ``path`` is the unambiguous join key, so it is tried first. The
+    name is the fallback for entries written before ``path`` was recorded, which
+    is also the only case where the two can disagree without the filesystem
+    saying so.
+    """
+    if spec.layer == SkillLayer.BUNDLED:
+        # Nothing can be installed into the packaged bundled directory, so any
+        # entry naming a shipped skill belongs to a different, since-removed
+        # install. See :func:`_derive_acquisition`.
+        return "", None
+    directory = Path(spec.base_dir) if spec.base_dir else spec.path
+    if directory is not None:
+        try:
+            hit = by_path.get(directory.expanduser().resolve())
+        except OSError:  # pragma: no cover - resolve() only raises on exotic filesystems
+            hit = None
+        if hit is not None:
+            return hit
+    entry = lockfile.get(spec.name)
+    return (spec.name, entry) if entry is not None else ("", None)
 
 
 def publisher_payload(publisher: SkillPublisher | None) -> dict[str, Any]:
@@ -218,6 +292,7 @@ def _derive_publisher(spec: SkillSpec, entry: LockEntry | None) -> SkillPublishe
 
 def _derive_acquisition(
     spec: SkillSpec,
+    key: str,
     entry: LockEntry | None,
     managed_dir: Path | None,
 ) -> SkillAcquisition:
@@ -238,7 +313,11 @@ def _derive_acquisition(
         shipped = spec.layer == SkillLayer.BUNDLED
         return SkillAcquisition(kind=AcquisitionKind.SHIPPED if shipped else AcquisitionKind.LOCAL)
 
-    removable, detail = _removability(spec.name, entry, managed_dir)
+    # ``key``, not ``spec.name``: uninstall deletes ``<managed_dir>/<key>``,
+    # which is the directory the entry was written for. Checking the manifest
+    # name instead reported a perfectly removable install as an orphan whenever
+    # a SKILL.md declared a name other than its directory's.
+    removable, detail = _removability(key, entry, managed_dir)
     return SkillAcquisition(
         kind=AcquisitionKind.HUB,
         source_id=entry.source,

--- a/tests/test_gateway/test_rpc_skills_uninstall_key.py
+++ b/tests/test_gateway/test_rpc_skills_uninstall_key.py
@@ -1,0 +1,122 @@
+"""`skills.uninstall` addresses the lockfile key, not the name it is called with.
+
+Every surface names a skill the way its ``SKILL.md`` does; the installer names
+it the way the lockfile does, which is the directory the bundle was written
+into. Those differ for published skills whose manifest renames them — hub
+``ytdlp-transcript`` ships a manifest named ``youtube-transcript`` — and the
+Remove button reported "not found" for an install sitting on disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agentos.gateway import rpc_skills
+from agentos.gateway.rpc import RpcContext
+from agentos.skills.hub.installer import InstallResult
+from agentos.skills.hub.lockfile import LockEntry, Lockfile
+from agentos.skills.loader import SkillLoader
+
+
+class _RecordingInstaller:
+    """Stands in for :class:`~agentos.skills.hub.installer.SkillInstaller`.
+
+    Mirrors only the two coroutines the handlers call, with the same signatures
+    and return type, so a drift in either is a test failure rather than a fake
+    that quietly keeps passing.
+    """
+
+    def __init__(self) -> None:
+        self.uninstalled: list[str] = []
+        self.updated: list[str | None] = []
+
+    async def uninstall(self, name: str) -> InstallResult:
+        self.uninstalled.append(name)
+        return InstallResult(success=True, name=name, message=f"Uninstalled '{name}'")
+
+    async def update(self, name: str | None = None) -> list[InstallResult]:
+        self.updated.append(name)
+        return [InstallResult(success=True, name=name or "", message="updated")]
+
+
+def _install(managed_dir: Path, directory: str, manifest_name: str) -> Path:
+    skill_dir = managed_dir / directory
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {manifest_name}\ndescription: Renamed by its manifest.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _lockfile(tmp_path: Path, key: str, install_dir: Path) -> Path:
+    lock_path = tmp_path / "skills-lock.json"
+    lockfile = Lockfile()
+    lockfile.add(key, LockEntry(source="clawhub", identifier="id", path=str(install_dir)))
+    lockfile.save(lock_path)
+    return lock_path
+
+
+@pytest.fixture
+def wired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[RpcContext, _RecordingInstaller]:
+    managed_dir = tmp_path / "managed"
+    install_dir = _install(managed_dir, "ytdlp-transcript", "youtube-transcript")
+    lock_path = _lockfile(tmp_path, "ytdlp-transcript", install_dir)
+    monkeypatch.setattr(rpc_skills, "default_lockfile_path", lambda: lock_path)
+
+    installer = _RecordingInstaller()
+    monkeypatch.setattr(
+        rpc_skills,
+        "build_default_skill_installer",
+        lambda *, managed_dir=None: installer,
+    )
+    loader = SkillLoader(managed_dir=managed_dir, snapshot_path=tmp_path / "snapshot.json")
+    return RpcContext(conn_id="test", skill_loader=loader), installer
+
+
+def test_uninstall_translates_a_manifest_name_into_its_lockfile_key(
+    wired: tuple[RpcContext, _RecordingInstaller],
+) -> None:
+    ctx, installer = wired
+
+    result = asyncio.run(rpc_skills._handle_skills_uninstall({"name": "youtube-transcript"}, ctx))
+
+    assert installer.uninstalled == ["ytdlp-transcript"]
+    assert result["success"] is True
+
+
+def test_update_translates_the_same_way(
+    wired: tuple[RpcContext, _RecordingInstaller],
+) -> None:
+    ctx, installer = wired
+
+    asyncio.run(rpc_skills._handle_skills_update({"name": "youtube-transcript"}, ctx))
+
+    assert installer.updated == ["ytdlp-transcript"]
+
+
+def test_update_with_no_name_still_means_every_skill(
+    wired: tuple[RpcContext, _RecordingInstaller],
+) -> None:
+    """A bare `skills.update` updates everything; translation must not invent a target."""
+    ctx, installer = wired
+
+    asyncio.run(rpc_skills._handle_skills_update({}, ctx))
+
+    assert installer.updated == [None]
+
+
+def test_a_name_no_skill_loads_under_is_passed_through(
+    wired: tuple[RpcContext, _RecordingInstaller],
+) -> None:
+    """Clearing a stale lockfile entry by its own key has to keep working."""
+    ctx, installer = wired
+
+    asyncio.run(rpc_skills._handle_skills_uninstall({"name": "long-gone"}, ctx))
+
+    assert installer.uninstalled == ["long-gone"]

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -11,7 +11,7 @@ from agentos.skills.availability import REASON_PROMPT_BUDGET, REASON_TOOL_GATE
 from agentos.skills.hub.installer import SkillInstaller
 from agentos.skills.hub.lockfile import LockEntry, Lockfile
 from agentos.skills.hub.source import SkillBundle, SkillMeta
-from agentos.skills.inventory import SkillRow, build_skill_inventory
+from agentos.skills.inventory import SkillRow, build_skill_inventory, lock_key_for_skill
 from agentos.skills.loader import SkillLoader
 from agentos.skills.publishers import RECOGNIZED_PUBLISHERS
 from agentos.skills.types import AcquisitionKind, SkillPublisher
@@ -699,3 +699,149 @@ def test_a_row_reports_the_budget_that_will_drop_it(tmp_path: Path) -> None:
         loader, config=_RoomyConfig(), lockfile_path=lock, available_tools=set()
     )
     assert all(r.availability is not None and r.availability.offered for r in rows)
+
+
+# ── The lockfile key is a directory name, not a manifest name ────────────────
+
+
+def _write_renamed_skill(root: Path, directory: str, manifest_name: str) -> Path:
+    """Install-shaped directory whose SKILL.md declares a different name.
+
+    Published skills do this: ``ytdlp-transcript`` on the hub ships a manifest
+    named ``youtube-transcript``. The installer keys the lockfile by the
+    directory it wrote (``bundle.name``), so the two names diverge on disk.
+    """
+    skill_dir = root / directory
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {manifest_name}\ndescription: Synthetic skill.\n---\n\n# body\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_a_hub_install_is_still_a_hub_install_when_its_manifest_renames_it(
+    tmp_path: Path,
+) -> None:
+    """Regression: the manifest name missed the entry and the row read as local.
+
+    Every hub fact — source, version, trust, the Remove button — hung off a
+    lookup keyed by the wrong name, so a perfectly ordinary install rendered as
+    a directory the user had hand-copied.
+    """
+    managed = tmp_path / "managed"
+    install_dir = _write_renamed_skill(managed, "ytdlp-transcript", "youtube-transcript")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "ytdlp-transcript",
+        source="clawhub",
+        identifier="https://example.com/skills/ytdlp-transcript",
+        version="1.2.0",
+        path=str(install_dir),
+        source_trust="community",
+        scan_verdict="safe",
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    acquisition = _row(rows, "youtube-transcript").acquisition
+    assert acquisition.kind is AcquisitionKind.HUB
+    assert acquisition.source_id == "clawhub"
+    assert acquisition.version == "1.2.0"
+    assert acquisition.scan_verdict == "safe"
+    # The uninstall target is the directory the entry records, which exists.
+    assert acquisition.removable is True
+    assert acquisition.detail == ""
+    assert acquisition.updatable is True
+
+
+def test_a_renamed_install_resolves_to_the_key_uninstall_acts_on(tmp_path: Path) -> None:
+    """`skills.uninstall` deletes `<managed_dir>/<key>`; the key is the directory."""
+    managed = tmp_path / "managed"
+    install_dir = _write_renamed_skill(managed, "ytdlp-transcript", "youtube-transcript")
+    lock_path = _lockfile(
+        tmp_path / "lock.json",
+        "ytdlp-transcript",
+        identifier="id",
+        path=str(install_dir),
+    )
+    loader = _loader(tmp_path, managed_dir=managed)
+    spec = next(s for s in loader.load_all() if s.name == "youtube-transcript")
+
+    assert lock_key_for_skill(spec, Lockfile.load(lock_path)) == "ytdlp-transcript"
+
+
+def test_an_unmatched_skill_resolves_to_its_own_name(tmp_path: Path) -> None:
+    """No entry, no translation — the caller's name is passed through unchanged."""
+    workspace = tmp_path / "workspace"
+    _write_skill(workspace, "hand-written")
+    loader = _loader(tmp_path, workspace_dir=workspace)
+    spec = next(s for s in loader.load_all() if s.name == "hand-written")
+
+    assert lock_key_for_skill(spec, Lockfile()) == "hand-written"
+
+
+def test_an_entry_with_no_recorded_path_still_matches_by_name(tmp_path: Path) -> None:
+    """`path` postdates the lockfile; entries written before it must still bind."""
+    managed = tmp_path / "managed"
+    _write_skill(managed, "legacy")
+    lock = _lockfile(tmp_path / "lock.json", "legacy", identifier="id")
+
+    rows = build_skill_inventory(_loader(tmp_path, managed_dir=managed), lockfile_path=lock)
+
+    assert rows[0].acquisition.kind is AcquisitionKind.HUB
+    assert rows[0].acquisition.removable is True
+
+
+def test_a_renamed_directory_does_not_borrow_an_unrelated_entry(tmp_path: Path) -> None:
+    """Matching is by path, so a same-named manifest elsewhere claims nothing.
+
+    Two skills, one installed and one hand-written under a different root, whose
+    manifests both say ``shared``. Only the directory the lockfile recorded is
+    the install; the other must stay local or the Remove button would delete
+    somebody else's files.
+    """
+    managed = tmp_path / "managed"
+    workspace = tmp_path / "workspace"
+    install_dir = _write_renamed_skill(managed, "shared-from-hub", "shared")
+    _write_renamed_skill(workspace, "shared-by-hand", "also-shared")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "shared-from-hub",
+        identifier="id",
+        path=str(install_dir),
+    )
+
+    rows = build_skill_inventory(
+        _loader(tmp_path, managed_dir=managed, workspace_dir=workspace),
+        lockfile_path=lock,
+    )
+
+    assert _row(rows, "shared").acquisition.kind is AcquisitionKind.HUB
+    assert _row(rows, "also-shared").acquisition.kind is AcquisitionKind.LOCAL
+
+
+def test_a_stale_entry_pointing_at_a_bundled_directory_is_still_ignored(
+    tmp_path: Path,
+) -> None:
+    """The BUNDLED exception survives the path join.
+
+    Matching by path would otherwise re-open the hole the name-keyed check was
+    already closing: an entry that records the packaged bundled directory must
+    not turn a shipped skill into a removable hub install.
+    """
+    bundled = tmp_path / "bundled"
+    install_dir = _write_skill(bundled, "shipped-collides")
+    lock = _lockfile(
+        tmp_path / "lock.json",
+        "shipped-collides",
+        identifier="id",
+        path=str(install_dir),
+        publisher_id="bankr",
+    )
+
+    rows = build_skill_inventory(_loader(tmp_path, bundled_dir=bundled), lockfile_path=lock)
+
+    assert rows[0].acquisition.kind is AcquisitionKind.SHIPPED
+    assert rows[0].acquisition.removable is False
+    assert rows[0].publisher == SkillPublisher()


### PR DESCRIPTION
Fixes #285.

## The bug

The skills lockfile is keyed by the **install directory** — `bundle.name`, the source's slug, which is also the directory the installer writes into (`installer.py:135,204,221`) — but it was read back by the **manifest name** (`inventory.py:126`, `lockfile.get(spec.name)`, where `spec.name` comes from the frontmatter).

Published skills do rename themselves. Hub `ytdlp-transcript` installs a `SKILL.md` that declares `name: youtube-transcript`. The lookup missed, `_derive_acquisition` saw `entry is None`, and the row came back `AcquisitionKind.LOCAL`:

- Web UI filed it under **Your local skills** instead of **From the hub**
- no source label, author credit, version, trust level, or scan verdict
- **no Remove button** — the skill could not be uninstalled from the UI at all
- **no Update button** — it could never be re-pulled
- `agentos skills list` and the agent's `skill_list` carry the same wrong row, since all three share `build_skill_inventory`
- silent: nothing logged, so it read as "the user hand-copied this directory"

`_removability` had the same defect independently: it built the uninstall target as `managed_dir / spec.name`, so even a correctly classified renamed install would have been reported as an orphan.

## The fix

Join lockfile entries to loaded skills by **resolved install path**, falling back to the name for legacy entries with no recorded `path`. The path is the join key the lockfile already writes at install time, it is unambiguous where a name is not, and it is the directory `_removability` has to check anyway.

- `inventory.py` — `_bind_lock_entry` resolves `(key, entry)` by path then by name; the resolved key, not `spec.name`, is what `_removability` checks. The path index is built once per sweep, so a hundred-skill install does not stat every recorded path a hundred times. The `BUNDLED` exception is applied **before** either lookup, so a stale entry recording the packaged bundled directory still cannot turn a shipped skill into a removable hub install.
- `rpc_skills.py` — `skills.uninstall` and `skills.update` translate the caller's name into the lockfile key via the new `lock_key_for_skill`. The wire contract is unchanged ("send the skill's name"), and a name no skill loads under is passed through so clearing a stale entry by its own key still works.
- `skills_cmd.py` — the no-gateway uninstall path resolves the same way, against a loader now extracted and shared with `skills list` instead of built twice.

No lockfile migration, no re-install, no frontend change — installs already on disk are fixed on the next read.

## Verified against a real install

Before, `youtube-transcript` sat under "Your local skills". After, on the same machine and the same untouched lockfile:

```
$ agentos skills list --json | ...
bankr                     | hub | bankr    | removable True | updatable True
capminal                  | hub | capminal | removable True | updatable True
contract-interaction      | hub | capminal | removable True | updatable True
stock-premium-lp-manager  | hub | bankr    | removable True | updatable True
token-scam-analysis       | hub | bankr    | removable True | updatable True
youtube-transcript        | hub | clawhub  | removable True | updatable True
```

## Tests

`tests/test_skills_inventory.py` — six new cases: a renamed hub install keeps every hub fact and stays removable; the resolved key is the directory uninstall acts on; an unmatched skill resolves to its own name; a legacy entry with no `path` still binds by name; a same-named manifest under another root does not borrow an entry it does not own; a stale entry pointing at the bundled directory is still ignored.

`tests/test_gateway/test_rpc_skills_uninstall_key.py` (new) — uninstall and update translate the manifest name to the lockfile key, a bare `skills.update` still means every skill, and an unknown name is passed through. The stand-in installer mirrors the real coroutine signatures and return type so a drift in either fails the test.

Gate: `ruff check` clean, `ruff format` clean, `mypy` clean on the three changed modules, `pytest` 7605 passed. Two pre-existing failures in this environment are unrelated (`test_mem0_provider` / `test_provider_config` assert mem0 is *not* installed; it is here) and one is a missing WeasyPrint system library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
