### PR TITLE
feat(webui): stream model thinking to the web UI as collapsible reasoning blocks

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -518,6 +518,10 @@ default_mode = "bypass"                 # off | on | bypass | full
 # default ports 80/443 are normalized, so "https://agent.example.com" and
 # "https://agent.example.com:443" are equivalent):
 # allowed_origins = ["https://agent.example.com"]
+# Stream model reasoning ("thinking") into the WebUI live and expose it in chat
+# history as collapsible blocks. WebUI-only: channel adapters (Slack, Telegram,
+# ...) never receive thinking regardless of this flag. Default: true.
+# show_thinking = true
 
 # [channels]
 # [[channels.channels]]

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -172,6 +172,7 @@ than as a save failure.
 The chat UI supports:
 
 - streaming assistant output;
+- live model reasoning ("thinking") as a collapsible block;
 - tool-call cards;
 - artifact cards;
 - pending message queue behavior while compaction or runtime work is in flight;
@@ -182,6 +183,20 @@ The chat UI supports:
 Use the session selector to switch between existing sessions. Copy the session
 key when reporting a bug or asking another AgentOS surface to inspect the
 same session.
+
+### Model reasoning (thinking)
+
+When the routed model streams reasoning (Anthropic thinking blocks, DeepSeek
+`reasoning_content`, or local `<think>` models), the WebUI shows it live in a
+collapsible block that folds away as soon as the reply text starts. Replies
+whose reasoning was persisted show a collapsed **Thinking** block in history;
+the reasoning body loads on first expand (it is not shipped with history
+pages).
+
+Turn it off with `control_ui.show_thinking = false` (or
+`AGENTOS_CONTROL_UI_SHOW_THINKING=false`) — the gateway then neither streams
+thinking events nor serves reasoning bodies. This is WebUI-only either way:
+channel adapters (Slack, Telegram, …) never receive thinking.
 
 ## Manual Compaction
 

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -208,6 +208,12 @@ export const chat = defineNamespace('chat', {
   verbPolishing: 'Polishing',
   stillWaiting: 'Still waiting for agent response…',
 
+  // Transcript: collapsible model-reasoning block.
+  thinkingBlockLabel: 'Thinking',
+  thinkingBlockLoading: 'Loading reasoning…',
+  thinkingBlockEmpty: 'No reasoning recorded for this reply.',
+  thinkingBlockError: 'Failed to load reasoning. Expand again to retry.',
+
   // Transcript: tool cards.
   toolRunning: 'Running',
   toolCompleted: 'Completed',

--- a/frontend/src/i18n/en/config.ts
+++ b/frontend/src/i18n/en/config.ts
@@ -178,5 +178,7 @@ export const config = defineNamespace('config', {
     'Gateway auth scheme. "token" requires a static bearer token; "none" is open (loopback only); other modes per deployment.',
   helpControlUiAllowedOrigins:
     'Extra browser origins allowed to open the Control UI WebSocket, call the HTTP API, and send Host headers, beyond loopback (which is always allowed). Add your reverse-proxy origin here (e.g. https://agent.example.com) when serving the UI off another host; default ports 80/443 are normalized. Cross-origin requests are otherwise rejected to block cross-site WebSocket hijacking and DNS rebinding.',
+  helpControlUiShowThinking:
+    'Stream model reasoning ("thinking") into the WebUI live and expose it in chat history as collapsible blocks. WebUI-only: channel adapters (Slack, Telegram, …) never receive thinking regardless of this flag.',
   helpNone: 'No description yet — see the docs.',
 } as const)

--- a/frontend/src/views/chat/Composer.tsx
+++ b/frontend/src/views/chat/Composer.tsx
@@ -485,7 +485,7 @@ export function Composer({
       {routerFxDock}
       {tray}
       {slashMenu}
-      <div className="chat-composer">
+      <div className={busy ? 'chat-composer chat-composer--busy' : 'chat-composer'}>
         {toolbar ? (
           <div className="chat-toolbar-wrap" ref={toolbarWrapRef}>
             <button

--- a/frontend/src/views/chat/chat-unified.css
+++ b/frontend/src/views/chat/chat-unified.css
@@ -530,6 +530,63 @@
     0 18px 46px color-mix(in srgb, var(--background) 42%, transparent);
 }
 
+/* ── Busy composer: brighter border + a light sweeping around it ────────── */
+@property --chat-composer-sweep {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.chat-surface .chat-composer--busy {
+  position: relative;
+  border-color: color-mix(in srgb, var(--primary) 55%, var(--border));
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--primary) 8%, transparent),
+    0 0 22px color-mix(in srgb, var(--primary) 14%, transparent),
+    0 18px 46px color-mix(in srgb, var(--background) 42%, transparent);
+}
+
+/* The ring: a conic highlight orbiting the border, masked to a 2px outline.
+   Later than (and same specificity as) the ::before/::after neutralizer above,
+   so this rule wins while busy. */
+.chat-surface .chat-composer--busy::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: calc(var(--chat-composer-radius) + 2px);
+  padding: 2px;
+  background: conic-gradient(
+    from var(--chat-composer-sweep),
+    transparent 0deg 268deg,
+    color-mix(in srgb, var(--primary) 45%, transparent) 300deg,
+    color-mix(in srgb, var(--primary) 95%, #fff) 332deg,
+    transparent 360deg
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  animation: chat-composer-sweep 2.4s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes chat-composer-sweep {
+  to {
+    --chat-composer-sweep: 360deg;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-surface .chat-composer--busy::after {
+    animation: none;
+    opacity: 0.55;
+  }
+}
+
 .chat-surface .chat-composer__input {
   min-height: 2.75rem;
   padding: 0.7rem 0.5rem;

--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -524,6 +524,52 @@
   cursor: help;
 }
 
+/* ── Thinking block — streamed/persisted model reasoning ────────────────── */
+.thinking-block {
+  margin: 2px 0 6px;
+  border-left: 2px solid color-mix(in srgb, var(--primary) 40%, var(--border));
+  padding-left: 10px;
+}
+.thinking-block-summary {
+  cursor: pointer;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  user-select: none;
+}
+.thinking-block-summary::-webkit-details-marker {
+  display: none;
+}
+.thinking-block-summary::before {
+  content: '▸';
+  color: var(--primary);
+  transition: transform 120ms ease;
+}
+.thinking-block[open] > .thinking-block-summary::before {
+  transform: rotate(90deg);
+}
+.thinking-block-content {
+  margin-top: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+@media (prefers-reduced-motion: reduce) {
+  .thinking-block-summary::before {
+    transition: none;
+  }
+}
+
 /* ── Thinking indicator (chat.js:6379-6501) ─────────────────────────────── */
 .msg.thinking .thinking-body {
   padding: 4px 0 4px 10px;

--- a/frontend/src/views/chat/transcript/history.test.ts
+++ b/frontend/src/views/chat/transcript/history.test.ts
@@ -683,3 +683,65 @@ describe('createHistoryRenderer chart artifacts', () => {
     expect(() => renderer.renderHistoryMessages(messages, pagingState(messages))).not.toThrow()
   })
 })
+
+describe('history thinking block (has_thinking → chat.thinking fetch-on-expand)', () => {
+  it('renders a collapsed thinking block at the top of a flagged assistant body', () => {
+    const thread = document.createElement('div')
+    document.body.appendChild(thread)
+    const messages = [
+      { role: 'assistant', text: 'the reply', message_id: 'msg-9', has_thinking: true },
+    ] as unknown as ChatMessage[]
+    const fetchThinking = vi.fn().mockResolvedValue('why I said that')
+    const renderer = createHistoryRenderer(historyDeps(thread, { fetchThinking }))
+
+    renderer.renderHistoryMessages(messages, pagingState(messages))
+
+    const details = thread.querySelector<HTMLDetailsElement>('.msg-body > .thinking-block')
+    expect(details).not.toBeNull()
+    expect(details!.open).toBe(false)
+    expect(details!.previousElementSibling).toBeNull()
+    expect(fetchThinking).not.toHaveBeenCalled()
+  })
+
+  it('fetches the reasoning body once on first expand', async () => {
+    const thread = document.createElement('div')
+    document.body.appendChild(thread)
+    const messages = [
+      { role: 'assistant', text: 'the reply', message_id: 'msg-9', has_thinking: true },
+    ] as unknown as ChatMessage[]
+    const fetchThinking = vi.fn().mockResolvedValue('why I said that')
+    const renderer = createHistoryRenderer(historyDeps(thread, { fetchThinking }))
+    renderer.renderHistoryMessages(messages, pagingState(messages))
+
+    const details = thread.querySelector<HTMLDetailsElement>('.thinking-block')!
+    details.open = true
+    details.dispatchEvent(new Event('toggle'))
+    details.dispatchEvent(new Event('toggle'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fetchThinking).toHaveBeenCalledTimes(1)
+    expect(fetchThinking).toHaveBeenCalledWith('msg-9')
+    expect(details.querySelector('.thinking-block-content')!.textContent).toBe('why I said that')
+  })
+
+  it('skips the block for unflagged rows and when no fetcher is wired', () => {
+    const thread = document.createElement('div')
+    document.body.appendChild(thread)
+    const unflagged = [
+      { role: 'assistant', text: 'plain reply', message_id: 'msg-1' },
+    ] as unknown as ChatMessage[]
+    const renderer = createHistoryRenderer(
+      historyDeps(thread, { fetchThinking: vi.fn().mockResolvedValue(null) }),
+    )
+    renderer.renderHistoryMessages(unflagged, pagingState(unflagged))
+    expect(thread.querySelector('.thinking-block')).toBeNull()
+
+    const flagged = [
+      { role: 'assistant', text: 'reply', message_id: 'msg-2', has_thinking: true },
+    ] as unknown as ChatMessage[]
+    const noFetcher = createHistoryRenderer(historyDeps(thread))
+    noFetcher.renderHistoryMessages(flagged, pagingState(flagged))
+    expect(thread.querySelector('.thinking-block')).toBeNull()
+  })
+})

--- a/frontend/src/views/chat/transcript/history.ts
+++ b/frontend/src/views/chat/transcript/history.ts
@@ -18,6 +18,7 @@ import type { TurnMeta, TurnUsage } from './message'
 import type { TranscriptHeaderStateRef } from './stream'
 import { historyFallbackMessageIdentity, historyStableMessageIdentity } from '../logic'
 import { routerFxRequestKindFromAttachments, type RouterFxHistoryOptions } from './routerFx'
+import { createThinkingBlock, wireLazyThinkingBlock } from './thinking'
 
 /** chat.js:350 — history page size for `chat.history` reads. */
 export const CHAT_HISTORY_PAGE_SIZE = 50
@@ -218,6 +219,10 @@ export interface HistoryRenderDeps {
   /** Live nodes preserved/reordered during a history refresh (chat.js:5554-5587/5753-5777). */
   getStreamBubble: () => HTMLElement | null
   getThinkingIndicator: () => HTMLElement | null
+  /** Live reasoning block row (AgentOS-native; kept alongside the stream bubble). */
+  getLiveThinkingBlock?: () => HTMLElement | null
+  /** `chat.thinking` fetch-on-expand for history rows flagged `has_thinking`. */
+  fetchThinking?: (messageId: string) => Promise<string | null>
   getCurrentSessionLiveUserAnchor: () => HTMLElement | null
   getPendingFinalizedAssistantBubble: () => HTMLElement | null
   isPendingFinalizedAssistantBubble: (el: HTMLElement | null) => boolean
@@ -450,12 +455,20 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
       const streamBubble = deps.getStreamBubble()
       const liveUserAnchor = deps.getCurrentSessionLiveUserAnchor()
       const thinking = deps.getThinkingIndicator()
+      const liveThinkingBlock = deps.getLiveThinkingBlock?.() || null
       if (deps.isStreaming() && (streamBubble || liveUserAnchor || thinking)) {
         th.querySelectorAll<HTMLElement>('.msg').forEach((el) => {
-          if (el !== streamBubble && el !== liveUserAnchor && el !== thinking) el.remove()
+          if (
+            el !== streamBubble &&
+            el !== liveUserAnchor &&
+            el !== thinking &&
+            el !== liveThinkingBlock
+          )
+            el.remove()
         })
         th.querySelectorAll('.chat-day-sep, .chat-empty').forEach((el) => el.remove())
         if (liveUserAnchor && !liveUserAnchor.isConnected) th.appendChild(liveUserAnchor)
+        if (liveThinkingBlock && !liveThinkingBlock.isConnected) th.appendChild(liveThinkingBlock)
         if (streamBubble && !streamBubble.isConnected) th.appendChild(streamBubble)
         if (thinking && !thinking.isConnected) th.appendChild(thinking)
         if (deps.shouldAutoScroll()) th.scrollTop = th.scrollHeight
@@ -572,6 +585,23 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
         deps.reconstructToolCalls(div, toolCalls)
       }
 
+      // Collapsed reasoning block at the top of the body; the reasoning text
+      // itself is fetched from `chat.thinking` on first expand.
+      const hasThinking = Boolean((msg as { has_thinking?: boolean }).has_thinking)
+      if (msg.role === 'assistant' && hasThinking && deps.fetchThinking) {
+        const messageId = String(
+          (msg as { message_id?: string | number | null }).message_id ??
+            (msg as { id?: string | number | null }).id ??
+            '',
+        )
+        const body = div.querySelector<HTMLElement>('.msg-body')
+        if (body && messageId && !body.querySelector('.thinking-block')) {
+          const parts = createThinkingBlock({ open: false })
+          wireLazyThinkingBlock(parts, () => deps.fetchThinking!(messageId))
+          body.insertAdjacentElement('afterbegin', parts.details)
+        }
+      }
+
       const attachments = historyMessageRecords(msg, 'attachments')
       if (attachments.length > 0) {
         const body = div.querySelector<HTMLElement>('.msg-body')
@@ -645,9 +675,11 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
     const streamBubble = deps.getStreamBubble()
     const thinking = deps.getThinkingIndicator()
     const liveUserAnchor = deps.getCurrentSessionLiveUserAnchor()
+    const liveThinkingBlock = deps.getLiveThinkingBlock?.() || null
     th.querySelectorAll<HTMLElement>('.msg').forEach((el) => {
       if (deps.isStreaming() && el === streamBubble) return
       if (deps.isStreaming() && el === thinking) return
+      if (deps.isStreaming() && el === liveThinkingBlock) return
       if (deps.isStreaming() && el === liveUserAnchor) return
       if (deps.isPendingFinalizedAssistantBubble(el) && historyStillWaitingForAssistant(messages))
         return

--- a/frontend/src/views/chat/transcript/stream.ts
+++ b/frontend/src/views/chat/transcript/stream.ts
@@ -36,6 +36,7 @@ import {
   type CompactionRenderer,
   type CompactionSummary,
 } from './compaction'
+import { createThinkingBlock } from './thinking'
 
 /* ── Constants (ported verbatim from chat.js) ───────────────────────────── */
 
@@ -512,6 +513,12 @@ export function createStreamController(
   let _thinkingTimerInterval: ReturnType<typeof setInterval> | null = null
   let _thinkingStartTime = 0
 
+  // live thinking block — streamed model reasoning (session.event.thinking)
+  let _thinkingBlockRow: HTMLElement | null = null
+  let _thinkingBlockDetails: HTMLDetailsElement | null = null
+  let _thinkingBlockContent: HTMLElement | null = null
+  let _thinkingBlockRaw = ''
+
   // finalize/reconcile bookkeeping (chat.js:59-60)
   let _pendingFinalizedAssistantBubble: HTMLElement | null = null
   let _pendingFinalizedAssistantFallbackId = ''
@@ -776,6 +783,62 @@ export function createStreamController(
     if (hadThinking) diag('thinking.hide', {})
   }
 
+  /* ── live thinking block — streamed model reasoning ────────────────────── */
+
+  function appendThinkingDelta(text: string): void {
+    if (!text || isAborted()) return
+    if (!_isStreaming) startStreaming()
+    // Real reasoning replaces the synthetic indicator.
+    hideThinkingIndicator()
+    if (!_thinkingBlockRow || !_thinkingBlockRow.isConnected) {
+      const th = thread()
+      if (!th) return
+      const row = document.createElement('div')
+      row.className = 'msg assistant thinking-live'
+      row.dataset.sessionKey = _streamSessionKey || getSessionKey() || ''
+      const body = document.createElement('div')
+      body.className = 'msg-body'
+      const parts = createThinkingBlock({ open: true })
+      body.appendChild(parts.details)
+      row.appendChild(body)
+      // Reasoning precedes reply text: keep the block above the live bubble.
+      if (_streamBubble && _streamBubble.isConnected) th.insertBefore(row, _streamBubble)
+      else th.appendChild(row)
+      _thinkingBlockRow = row
+      _thinkingBlockDetails = parts.details
+      _thinkingBlockContent = parts.content
+      _thinkingBlockRaw = ''
+      diag('thinking.block.show', {})
+    }
+    _thinkingBlockRaw += text
+    if (_thinkingBlockContent) _thinkingBlockContent.textContent = _thinkingBlockRaw
+    if (_autoScroll) scrollToBottom()
+  }
+
+  function collapseLiveThinkingBlock(): void {
+    // Reply text started (or the turn ended): fold the reasoning away. Later
+    // reasoning in the same turn keeps accumulating into the collapsed block.
+    if (_thinkingBlockDetails?.open) {
+      _thinkingBlockDetails.open = false
+      diag('thinking.block.collapse', {})
+    }
+  }
+
+  function releaseLiveThinkingBlock(): void {
+    // Turn is over: the row stays in the DOM until the history resync
+    // reconciles it away (the persisted turn re-renders it via has_thinking).
+    collapseLiveThinkingBlock()
+    _thinkingBlockRow = null
+    _thinkingBlockDetails = null
+    _thinkingBlockContent = null
+    _thinkingBlockRaw = ''
+  }
+
+  function removeLiveThinkingBlock(): void {
+    if (_thinkingBlockRow?.parentNode) _thinkingBlockRow.remove()
+    releaseLiveThinkingBlock()
+  }
+
   /* ── awaiting-model hint + stream-active reveal (chat.js:6503-6551) ────── */
 
   function clearAwaitingModelHint(): void {
@@ -874,6 +937,7 @@ export function createStreamController(
       activeTextRawLen: _activeTextRaw.length,
     })
     hideThinkingIndicator()
+    collapseLiveThinkingBlock()
     routerFxSettleForOutput()
     if (!_streamBubble) {
       const th = thread()
@@ -1015,6 +1079,7 @@ export function createStreamController(
       streamRawLen: _streamRaw.length,
     })
     hideThinkingIndicator()
+    releaseLiveThinkingBlock()
     cancelPendingRouterFxScan('stream_end')
     clearAwaitingModelHint()
     _lastVisibleStreamEvent = ''
@@ -1178,7 +1243,8 @@ export function createStreamController(
       _streamArtifacts.length ||
       currentSessionLiveRouterStrips(_streamSessionKey || getSessionKey() || '').length ||
       _thinkingEl ||
-      _thinkingDelayTimer
+      _thinkingDelayTimer ||
+      _thinkingBlockRow
     )
   }
 
@@ -1211,6 +1277,7 @@ export function createStreamController(
     }
     liveStreamStateBySession.set(key, state)
     hideThinkingIndicator()
+    removeLiveThinkingBlock()
     clearHistorySyncTimer()
     if (_renderRafId) {
       cancelAnimationFrame(_renderRafId)
@@ -1311,6 +1378,7 @@ export function createStreamController(
     const hadPendingFinalized = !!_pendingFinalizedAssistantBubble
     const routerStrips = currentSessionLiveRouterStrips(_streamSessionKey || getSessionKey() || '')
     hideThinkingIndicator()
+    removeLiveThinkingBlock()
     cancelPendingRouterFxScan(reason || 'clear_view_state')
     clearHistorySyncTimer()
     if (_renderRafId) {
@@ -1484,6 +1552,8 @@ export function createStreamController(
     // thinking
     showThinkingIndicator,
     hideThinkingIndicator,
+    appendThinkingDelta,
+    getLiveThinkingBlock: () => _thinkingBlockRow,
     // hints
     markVisibleStreamEvent,
     showAwaitingModelHintAfterToolResult,

--- a/frontend/src/views/chat/transcript/stream.ts
+++ b/frontend/src/views/chat/transcript/stream.ts
@@ -790,21 +790,34 @@ export function createStreamController(
     if (!_isStreaming) startStreaming()
     // Real reasoning replaces the synthetic indicator.
     hideThinkingIndicator()
-    if (!_thinkingBlockRow || !_thinkingBlockRow.isConnected) {
-      const th = thread()
-      if (!th) return
-      const row = document.createElement('div')
-      row.className = 'msg assistant thinking-live'
-      row.dataset.sessionKey = _streamSessionKey || getSessionKey() || ''
-      const body = document.createElement('div')
-      body.className = 'msg-body'
+    // A collapsed block means its reasoning round is over (reply text already
+    // started). New reasoning — e.g. between tool rounds — opens a FRESH block
+    // so the user always sees live streaming while the model thinks.
+    const needNewBlock =
+      !_thinkingBlockDetails || !_thinkingBlockDetails.isConnected || !_thinkingBlockDetails.open
+    if (needNewBlock) {
       const parts = createThinkingBlock({ open: true })
-      body.appendChild(parts.details)
-      row.appendChild(body)
-      // Reasoning precedes reply text: keep the block above the live bubble.
-      if (_streamBubble && _streamBubble.isConnected) th.insertBefore(row, _streamBubble)
-      else th.appendChild(row)
-      _thinkingBlockRow = row
+      const bubbleBody = _streamBubble?.isConnected
+        ? _streamBubble.querySelector<HTMLElement>('.msg-body')
+        : null
+      if (bubbleBody) {
+        // Mid-turn reasoning: ride inside the stream bubble so the block sits
+        // chronologically after the text/tool segments already rendered.
+        bubbleBody.appendChild(parts.details)
+        _thinkingBlockRow = null
+      } else {
+        const th = thread()
+        if (!th) return
+        const row = document.createElement('div')
+        row.className = 'msg assistant thinking-live'
+        row.dataset.sessionKey = _streamSessionKey || getSessionKey() || ''
+        const body = document.createElement('div')
+        body.className = 'msg-body'
+        body.appendChild(parts.details)
+        row.appendChild(body)
+        th.appendChild(row)
+        _thinkingBlockRow = row
+      }
       _thinkingBlockDetails = parts.details
       _thinkingBlockContent = parts.content
       _thinkingBlockRaw = ''
@@ -816,8 +829,8 @@ export function createStreamController(
   }
 
   function collapseLiveThinkingBlock(): void {
-    // Reply text started (or the turn ended): fold the reasoning away. Later
-    // reasoning in the same turn keeps accumulating into the collapsed block.
+    // Reply text started (or the turn ended): fold this reasoning round away.
+    // Later reasoning in the same turn opens a fresh block (appendThinkingDelta).
     if (_thinkingBlockDetails?.open) {
       _thinkingBlockDetails.open = false
       diag('thinking.block.collapse', {})

--- a/frontend/src/views/chat/transcript/thinking.ts
+++ b/frontend/src/views/chat/transcript/thinking.ts
@@ -1,0 +1,50 @@
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
+/**
+ * Collapsible model-reasoning block shared by the live stream (open while the
+ * model thinks, collapsed once reply text starts) and history rows (collapsed,
+ * body fetched on first expand via `chat.thinking`).
+ *
+ * Reasoning renders as plain text (`textContent`) on purpose: it is untrusted
+ * model output and never goes through the markdown/innerHTML pipeline.
+ */
+export interface ThinkingBlockParts {
+  details: HTMLDetailsElement
+  content: HTMLElement
+}
+
+export function createThinkingBlock(opts: { open: boolean }): ThinkingBlockParts {
+  const details = document.createElement('details')
+  details.className = 'thinking-block'
+  details.open = opts.open
+  const summary = document.createElement('summary')
+  summary.className = 'thinking-block-summary'
+  summary.textContent = t('chat.thinkingBlockLabel')
+  const content = document.createElement('div')
+  content.className = 'thinking-block-content'
+  details.appendChild(summary)
+  details.appendChild(content)
+  return { details, content }
+}
+
+/** History rows: resolve the reasoning body from the gateway on first expand. */
+export function wireLazyThinkingBlock(
+  parts: ThinkingBlockParts,
+  fetchThinking: () => Promise<string | null>,
+): void {
+  let requested = false
+  parts.details.addEventListener('toggle', () => {
+    if (!parts.details.open || requested) return
+    requested = true
+    parts.content.textContent = t('chat.thinkingBlockLoading')
+    void fetchThinking()
+      .then((reasoning) => {
+        parts.content.textContent = reasoning || t('chat.thinkingBlockEmpty')
+      })
+      .catch(() => {
+        requested = false
+        parts.content.textContent = t('chat.thinkingBlockError')
+      })
+  })
+}

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -811,6 +811,14 @@ export function useTranscript(opts: {
       shouldAutoScroll: () => controller.isAutoScrollEnabled(),
       getStreamBubble: () => controller.getStreamBubble(),
       getThinkingIndicator: () => controller.getThinkingIndicator(),
+      getLiveThinkingBlock: () => controller.getLiveThinkingBlock(),
+      fetchThinking: async (messageId: string) => {
+        const res = (await rpc.call('chat.thinking', {
+          sessionKey: sessionKeyRef.current,
+          messageId,
+        })) as { reasoning?: string | null } | null
+        return res?.reasoning ?? null
+      },
       getCurrentSessionLiveUserAnchor: () => controller.getCurrentSessionLiveUserAnchor(),
       getPendingFinalizedAssistantBubble: () => controller.getPendingFinalizedAssistantBubble(),
       isPendingFinalizedAssistantBubble: (row) => controller.isPendingFinalizedAssistantBubble(row),
@@ -1377,6 +1385,15 @@ export function useTranscript(opts: {
         if (!gateStreamFrame('event.text_delta', payload)) return
         controller.resetStreamIdleTimer()
         controller.appendDelta((payload as { text?: string }).text || '')
+      }),
+    )
+
+    // session.event.thinking — streamed model reasoning → live collapsible block.
+    unsubs.push(
+      onEvent('session.event.thinking', (payload: StreamEventPayload) => {
+        if (!gateStreamFrame('event.thinking', payload)) return
+        controller.resetStreamIdleTimer()
+        controller.appendThinkingDelta((payload as { text?: string }).text || '')
       }),
     )
 

--- a/frontend/src/views/config/logic.ts
+++ b/frontend/src/views/config/logic.ts
@@ -202,6 +202,7 @@ function helpMap(): Record<string, string> {
     context_overflow_policy: t('config.helpContextOverflowPolicy'),
     auth_mode: t('config.helpAuthMode'),
     'control_ui.allowed_origins': t('config.helpControlUiAllowedOrigins'),
+    'control_ui.show_thinking': t('config.helpControlUiShowThinking'),
   }
 }
 

--- a/src/agentos/chat/history.py
+++ b/src/agentos/chat/history.py
@@ -59,6 +59,10 @@ def transcript_entries_to_chat_messages(
         transcript_id = getattr(entry, "id", None)
         if transcript_id is not None:
             msg["transcript_id"] = transcript_id
+        # Cheap flag only — the reasoning body itself is served on demand by
+        # ``chat.thinking`` so history pages don't balloon with thinking text.
+        if getattr(entry, "reasoning_content", None):
+            msg["has_thinking"] = True
         if attachments:
             msg["attachments"] = attachments
         if artifacts:

--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -81,6 +81,9 @@ from agentos.provider import (
     TextDeltaEvent as ProviderTextDelta,
 )
 from agentos.provider import (
+    ThinkingDeltaEvent as ProviderThinkingDelta,
+)
+from agentos.provider import (
     ToolUseStartEvent as ProviderToolUseStart,
 )
 from agentos.provider.failures import ProviderFailureKind, classify_provider_error
@@ -125,6 +128,7 @@ from .types import (
     RunHeartbeatEvent,
     StateChangeEvent,
     TextDeltaEvent,
+    ThinkingEvent,
     ThinkingLevel,
     ToolCall,
     ToolResult,
@@ -2239,6 +2243,12 @@ class Agent:
                                 if raw_ev.text:
                                     attempt_user_visible_emitted = True
                                 yield TextDeltaEvent(text=raw_ev.text)
+
+                            elif isinstance(raw_ev, ProviderThinkingDelta):
+                                # Reasoning is display-only: never mixed into the
+                                # reply text, never counted as user-visible output.
+                                if raw_ev.text:
+                                    yield ThinkingEvent(text=raw_ev.text)
 
                             elif isinstance(raw_ev, ProviderToolUseStart):
                                 if not tools_supported_for_call:

--- a/src/agentos/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/agentos/engine/turn_runner/turn_finalizer_stage.py
@@ -425,7 +425,6 @@ class TurnFinalizerStage:
         import json as _json
 
         from agentos.engine.runtime import (
-            _is_deepseek_model_id,
             _normalize_heartbeat_text,
         )
         from agentos.engine.turn_runner.outcome import StageOutcome
@@ -473,12 +472,12 @@ class TurnFinalizerStage:
                 if inp.turn_artifacts
                 else final_text
             )
+            # Persist reasoning for every provider: the WebUI renders it from
+            # history (fetch-on-expand). Whether it is REPLAYED to a provider on
+            # later turns stays a per-provider decision
+            # (``_should_replay_reasoning_content``), not a persistence one.
             reasoning_content: str | None = None
-            if (
-                inp.done_event is not None
-                and inp.done_event.reasoning_content
-                and _is_deepseek_model_id(inp.done_event.model or inp.resolved_model or "")
-            ):
+            if inp.done_event is not None and inp.done_event.reasoning_content:
                 reasoning_content = inp.done_event.reasoning_content
             token_count = inp.done_event.output_tokens if inp.done_event is not None else None
             transcript_appended = await self._transcript_append.append_message(

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -103,6 +103,9 @@ class ControlUiConfig(BaseSettings):
     enabled: bool = True
     base_path: str = "/control"
     allowed_origins: list[str] = Field(default_factory=list)
+    # Stream model reasoning to the WebUI and expose it in chat history.
+    # WebUI-only: channel adapters never receive thinking, regardless of this flag.
+    show_thinking: bool = True
 
     @field_validator("base_path")
     @classmethod

--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -10,7 +10,7 @@ import structlog
 from agentos.chat.conversation import ChatSendRequest, sessions_send_params
 from agentos.chat.history import transcript_entries_to_chat_messages
 from agentos.chat.source import chat_source_metadata
-from agentos.gateway.access import CONTROL_AND_CHANNEL
+from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
 from agentos.gateway.config import GatewayConfig
 from agentos.gateway.context_overflow import apply_context_overflow_policy
 from agentos.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
@@ -458,6 +458,46 @@ async def _handle_chat_abort(params: dict | None, ctx: RpcContext) -> dict:
     return {"sessionKey": session_key, **result}
 
 
+def _control_ui_show_thinking(ctx: RpcContext) -> bool:
+    control_ui_cfg = getattr(getattr(ctx, "config", None), "control_ui", None)
+    return bool(getattr(control_ui_cfg, "show_thinking", True))
+
+
+@_d.method("chat.thinking", CONTROL_ONLY)
+async def _handle_chat_thinking(params: dict | None, ctx: RpcContext) -> dict:
+    """Serve one message's reasoning on demand (WebUI fetch-on-expand).
+
+    Deliberately CONTROL_ONLY: reasoning never flows to channel surfaces.
+    """
+    raw_params = params or {}
+    session_key = _canonical_webchat_session_key(raw_params.get("sessionKey"))
+    message_id = raw_params.get("messageId") or raw_params.get("message_id")
+    if not message_id:
+        raise ValueError("params.messageId is required")
+    payload: dict[str, Any] = {
+        "sessionKey": session_key,
+        "messageId": message_id,
+        "reasoning": None,
+    }
+    if not _control_ui_show_thinking(ctx) or ctx.session_manager is None:
+        return payload
+    mgr = _require_chat_session_manager(ctx)
+    try:
+        transcript, _ = await _chat_history_transcript(
+            mgr,
+            session_key,
+            include_canonical=True,
+        )
+    except KeyError:
+        return payload
+    for entry in reversed(transcript):
+        if str(getattr(entry, "message_id", "")) == str(message_id):
+            reasoning = getattr(entry, "reasoning_content", None)
+            payload["reasoning"] = reasoning or None
+            break
+    return payload
+
+
 @_d.method("chat.history", CONTROL_AND_CHANNEL)
 async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
     raw_params = params or {}
@@ -507,6 +547,9 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
         history_scope = "complete"
 
     messages = transcript_entries_to_chat_messages(page_entries, limit=None)
+    if not _control_ui_show_thinking(ctx):
+        for message in messages:
+            message.pop("has_thinking", None)
     return {
         "messages": _annotate_transcript_attachment_downloads(
             messages,

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1251,6 +1251,8 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
             heartbeat_interval = _optional_positive_timeout(
                 ctx.config, "agent_stream_heartbeat_interval_seconds", 15.0
             )
+            control_ui_cfg = getattr(ctx.config, "control_ui", None)
+            show_thinking = bool(getattr(control_ui_cfg, "show_thinking", True))
             async for event in wrap_stream(
                 raw_stream,
                 idle_timeout=stream_idle_timeout,
@@ -1259,6 +1261,10 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
             ):
                 event_dict = asdict(event)
                 event_kind = event_dict.pop("kind", event.__class__.__name__)
+                if event_kind == "thinking" and not show_thinking:
+                    continue
+                if event_kind == "done" and not show_thinking:
+                    event_dict.pop("reasoning_content", None)
                 if event_kind in ("done", "error"):
                     await _emit_terminal_once(f"session.event.{event_kind}", event_dict)
                 else:

--- a/src/agentos/gateway/session_streams.py
+++ b/src/agentos/gateway/session_streams.py
@@ -38,6 +38,7 @@ class SessionStreamRegistry:
     def _is_replay_lossy(event_name: str) -> bool:
         return event_name in {
             "session.event.text_delta",
+            "session.event.thinking",
             "session.event.run_heartbeat",
         }
 

--- a/src/agentos/provider/__init__.py
+++ b/src/agentos/provider/__init__.py
@@ -54,6 +54,7 @@ from .types import (
     QuotaStatus,
     StreamEvent,
     TextDeltaEvent,
+    ThinkingDeltaEvent,
     ToolDefinition,
     ToolInputSchema,
     ToolUseDeltaEvent,
@@ -103,6 +104,7 @@ __all__ = [
     # Types
     "StreamEvent",
     "TextDeltaEvent",
+    "ThinkingDeltaEvent",
     "ToolUseStartEvent",
     "ToolUseDeltaEvent",
     "ToolUseEndEvent",

--- a/src/agentos/provider/anthropic.py
+++ b/src/agentos/provider/anthropic.py
@@ -25,6 +25,7 @@ from .types import (
     ModelInfo,
     StreamEvent,
     TextDeltaEvent,
+    ThinkingDeltaEvent,
     ToolDefinition,
     ToolUseDeltaEvent,
     ToolUseEndEvent,
@@ -518,7 +519,10 @@ class AnthropicProvider:
                                 else:
                                     log.debug("anthropic.unknown_delta_index", index=index)
                             elif dtype == "thinking_delta":
-                                thinking_parts.append(delta.get("thinking", ""))
+                                thinking_text = delta.get("thinking", "")
+                                thinking_parts.append(thinking_text)
+                                if thinking_text:
+                                    yield ThinkingDeltaEvent(text=thinking_text)
                             elif dtype == "signature_delta":
                                 thinking_signature = delta.get("signature") or thinking_signature
 

--- a/src/agentos/provider/auxiliary.py
+++ b/src/agentos/provider/auxiliary.py
@@ -402,6 +402,9 @@ class AuxiliaryClient:
                 output_tokens = int(getattr(event, "output_tokens", 0) or 0)
                 self._record(task, session_key, event, cfg.model)
                 continue
+            if kind == "thinking_delta":
+                # Reasoning is never part of an auxiliary task's answer.
+                continue
             text = getattr(event, "text", None)
             if isinstance(text, str):
                 parts.append(text)

--- a/src/agentos/provider/model_catalog.py
+++ b/src/agentos/provider/model_catalog.py
@@ -227,9 +227,16 @@ class ModelCatalog:
                     ("minimax-m3", "gemini-", "kimi-", "claude-", "grok-", "gpt-5.5")
                 )
             )
+            # DeepSeek V4 through these gateways honors the DeepSeek-native
+            # thinking payload and streams reasoning_content deltas (verified
+            # live against OpenCAP). Without this, tier thinking_level settings
+            # silently no-op for gateway DeepSeek routes.
+            supports_reasoning = basename.startswith("deepseek-v4")
             return ModelCapabilities(
+                supports_reasoning=supports_reasoning,
                 supports_tools=True,
                 supports_vision=supports_vision,
+                reasoning_format="deepseek" if supports_reasoning else "none",
             )
         if provider_id == "dashscope":
             supports_reasoning = model_l.startswith(

--- a/src/agentos/provider/ollama.py
+++ b/src/agentos/provider/ollama.py
@@ -10,6 +10,7 @@ import httpx
 
 from agentos.env import trust_env as _trust_env
 
+from .reasoning import ThinkTagStreamSplitter
 from .types import (
     ChatConfig,
     DoneEvent,
@@ -18,6 +19,7 @@ from .types import (
     ModelInfo,
     StreamEvent,
     TextDeltaEvent,
+    ThinkingDeltaEvent,
     ToolDefinition,
     ToolUseDeltaEvent,
     ToolUseEndEvent,
@@ -210,6 +212,15 @@ class OllamaProvider:
         response_model = self._model
         # Ollama tool calls accumulate in the full response (not streamed per-chunk)
         pending_tool_calls: list[dict[str, Any]] = []
+        reasoning_parts: list[str] = []
+        # think_tags models interleave reasoning into content; the splitter keeps
+        # it out of user-visible text even when a tag spans chunks.
+        caps = cfg.model_capabilities
+        think_splitter = (
+            ThinkTagStreamSplitter()
+            if caps is not None and caps.reasoning_format == "think_tags"
+            else None
+        )
 
         try:
             async with httpx.AsyncClient(
@@ -247,10 +258,24 @@ class OllamaProvider:
                         if isinstance(chunk_model, str) and chunk_model:
                             response_model = chunk_model
 
+                        # Native thinking channel (Ollama `think` support)
+                        thinking = msg_chunk.get("thinking", "")
+                        if isinstance(thinking, str) and thinking:
+                            reasoning_parts.append(thinking)
+                            yield ThinkingDeltaEvent(text=thinking)
+
                         # Text content
                         text = msg_chunk.get("content", "")
                         if isinstance(text, str) and text:
-                            yield TextDeltaEvent(text=text)
+                            if think_splitter is not None:
+                                visible, think_text = think_splitter.feed(text)
+                                if visible:
+                                    yield TextDeltaEvent(text=visible)
+                                if think_text:
+                                    reasoning_parts.append(think_text)
+                                    yield ThinkingDeltaEvent(text=think_text)
+                            else:
+                                yield TextDeltaEvent(text=text)
 
                         # Ollama delivers tool_calls in a single chunk (non-streaming)
                         raw_tool_calls = msg_chunk.get("tool_calls", [])
@@ -271,6 +296,15 @@ class OllamaProvider:
                             if isinstance(raw_done_reason, str) and raw_done_reason:
                                 done_reason = raw_done_reason
 
+                    # Resolve any partial <think> tag held back at end of stream.
+                    if think_splitter is not None:
+                        visible, think_text = think_splitter.flush()
+                        if visible:
+                            yield TextDeltaEvent(text=visible)
+                        if think_text:
+                            reasoning_parts.append(think_text)
+                            yield ThinkingDeltaEvent(text=think_text)
+
                     # Emit tool events after streaming completes
                     for call in pending_tool_calls:
                         yield ToolUseStartEvent(tool_use_id=call["id"], tool_name=call["name"])
@@ -286,6 +320,7 @@ class OllamaProvider:
                         stop_reason="tool_use" if pending_tool_calls else done_reason,
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
+                        reasoning_content="".join(reasoning_parts) or None,
                         model=response_model,
                     )
 

--- a/src/agentos/provider/openai.py
+++ b/src/agentos/provider/openai.py
@@ -26,6 +26,7 @@ from .error_body import read_bounded_body, summarize_error_body
 from .minimax_compat import contains_minimax_protocol, parse_minimax_tool_calls
 from .openrouter_attribution import openrouter_app_headers
 from .protocol import ProviderConnectionConfig, ProviderMetadata
+from .reasoning import ThinkTagStreamSplitter
 from .request_proof import (
     ProviderRequestBudgetExceededError,
     prove_provider_payload_from_env,
@@ -40,6 +41,7 @@ from .types import (
     ProviderHeartbeatEvent,
     StreamEvent,
     TextDeltaEvent,
+    ThinkingDeltaEvent,
     ToolDefinition,
     ToolUseDeltaEvent,
     ToolUseEndEvent,
@@ -905,6 +907,13 @@ class OpenAIProvider:
         pending_calls: dict[int, dict[str, Any]] = {}
         reasoning_parts: list[str] = []
         assistant_text_parts: list[str] = []
+        # think_tags models interleave reasoning into the content stream; the
+        # splitter routes it to reasoning_parts so it never reaches user text.
+        think_splitter = (
+            ThinkTagStreamSplitter()
+            if caps is not None and caps.reasoning_format == "think_tags"
+            else None
+        )
         input_tokens = 0
         output_tokens = 0
         reasoning_tokens = 0
@@ -1042,8 +1051,17 @@ class OpenAIProvider:
                             text = delta.get("content")
                             if text:
                                 emitted_stream_event = True
-                                yield TextDeltaEvent(text=text)
-                                assistant_text_parts.append(text)
+                                if think_splitter is not None:
+                                    visible, thinking = think_splitter.feed(text)
+                                    if visible:
+                                        yield TextDeltaEvent(text=visible)
+                                        assistant_text_parts.append(visible)
+                                    if thinking:
+                                        reasoning_parts.append(thinking)
+                                        yield ThinkingDeltaEvent(text=thinking)
+                                else:
+                                    yield TextDeltaEvent(text=text)
+                                    assistant_text_parts.append(text)
 
                             # Reasoning content (always parsed, not gated on thinking)
                             reasoning_details = delta.get("reasoning_details")
@@ -1053,9 +1071,11 @@ class OpenAIProvider:
                                         text_val = detail.get("text", "")
                                         if text_val:
                                             reasoning_parts.append(text_val)
+                                            yield ThinkingDeltaEvent(text=text_val)
                             reasoning_str = delta.get("reasoning_content")
                             if reasoning_str:
                                 reasoning_parts.append(reasoning_str)
+                                yield ThinkingDeltaEvent(text=reasoning_str)
 
                             # Tool calls (may stream over multiple chunks)
                             for tc in delta.get("tool_calls") or []:
@@ -1092,6 +1112,17 @@ class OpenAIProvider:
                                         tool_use_id=pending_calls[idx]["id"],
                                         json_fragment=fragment,
                                     )
+
+                    # Resolve any partial <think> tag held back at end of stream.
+                    if think_splitter is not None:
+                        visible, thinking = think_splitter.flush()
+                        if visible:
+                            emitted_stream_event = True
+                            yield TextDeltaEvent(text=visible)
+                            assistant_text_parts.append(visible)
+                        if thinking:
+                            reasoning_parts.append(thinking)
+                            yield ThinkingDeltaEvent(text=thinking)
 
                     # Emit ToolUseEnd for each completed call
                     for call in pending_calls.values():

--- a/src/agentos/provider/reasoning.py
+++ b/src/agentos/provider/reasoning.py
@@ -1,0 +1,52 @@
+"""Streaming helpers for models that interleave reasoning into content text."""
+
+from __future__ import annotations
+
+
+class ThinkTagStreamSplitter:
+    """Split a streaming text delta sequence into visible text and <think> reasoning.
+
+    Models with ``reasoning_format == "think_tags"`` interleave reasoning into
+    the ordinary content stream as ``<think>…</think>`` blocks. Feeding every
+    content delta through this splitter keeps reasoning out of the user-visible
+    text even when a tag is cut across chunk boundaries: any trailing prefix of
+    a tag is held back until the next chunk (or ``flush``) resolves it.
+    """
+
+    _OPEN = "<think>"
+    _CLOSE = "</think>"
+
+    def __init__(self) -> None:
+        self._in_think = False
+        self._pending = ""
+
+    def feed(self, chunk: str) -> tuple[str, str]:
+        """Return ``(visible_text, thinking_text)`` extracted from ``chunk``."""
+        text = self._pending + chunk
+        self._pending = ""
+        text_out: list[str] = []
+        think_out: list[str] = []
+        while text:
+            tag = self._CLOSE if self._in_think else self._OPEN
+            idx = text.find(tag)
+            if idx != -1:
+                (think_out if self._in_think else text_out).append(text[:idx])
+                text = text[idx + len(tag) :]
+                self._in_think = not self._in_think
+                continue
+            keep = len(text)
+            for probe in range(min(len(tag) - 1, len(text)), 0, -1):
+                if tag.startswith(text[-probe:]):
+                    keep = len(text) - probe
+                    break
+            (think_out if self._in_think else text_out).append(text[:keep])
+            self._pending = text[keep:]
+            break
+        return "".join(text_out), "".join(think_out)
+
+    def flush(self) -> tuple[str, str]:
+        """Resolve any held-back partial tag at end of stream."""
+        pending, self._pending = self._pending, ""
+        if not pending:
+            return "", ""
+        return ("", pending) if self._in_think else (pending, "")

--- a/src/agentos/provider/types.py
+++ b/src/agentos/provider/types.py
@@ -21,6 +21,14 @@ class TextDeltaEvent:
 
 
 @dataclass
+class ThinkingDeltaEvent:
+    """A chunk of model reasoning/thinking text (never user-facing reply text)."""
+
+    kind: Literal["thinking_delta"] = field(default="thinking_delta", init=False)
+    text: str = ""
+
+
+@dataclass
 class ToolUseStartEvent:
     """LLM begins a tool call."""
 
@@ -121,6 +129,7 @@ class ModelCapabilities:
 
 StreamEvent = (
     TextDeltaEvent
+    | ThinkingDeltaEvent
     | ToolUseStartEvent
     | ToolUseDeltaEvent
     | ToolUseEndEvent

--- a/src/agentos/scheduler/handlers.py
+++ b/src/agentos/scheduler/handlers.py
@@ -419,7 +419,8 @@ def make_agent_run_handler(
                                 }
                             )
                     elif (
-                        event_kind not in {"done", "state_change", "tool_use_start", "tool_result"}
+                        event_kind
+                        not in {"done", "state_change", "thinking", "tool_use_start", "tool_result"}
                         and hasattr(event, "text")
                         and event.text
                     ):

--- a/src/agentos/scheduler/heartbeat_service.py
+++ b/src/agentos/scheduler/heartbeat_service.py
@@ -211,7 +211,7 @@ class HeartbeatService:
             if kind == "done":
                 done_text = getattr(event, "text", "")
                 continue
-            if kind not in {"state_change", "tool_use_start", "tool_result"}:
+            if kind not in {"state_change", "thinking", "tool_use_start", "tool_result"}:
                 text = getattr(event, "text", "")
                 if text:
                     parts.append(text)

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -189,7 +189,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |
 | `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`) |
 | `[auth]` | gateway admission: `mode` (`none` on loopback or `token`), `token` |
-| `[control_ui]` | `allowed_origins` for reverse-proxy setups |
+| `[control_ui]` | `allowed_origins` for reverse-proxy setups; `show_thinking` (default true) streams model reasoning to the WebUI as collapsible blocks — WebUI-only, channels never receive it |
 | `[updates]` | `notify` (default true) — the once-per-24h "new release available" notice |
 | `[channels]` | messaging channels (`[[channels.channels]]` entries) |
 | `[auxiliary]` | model for work AgentOS runs itself, not the agent's turn (document analysis, image description): `provider`, `model`, `timeout_seconds`, `[auxiliary.tasks.<task>]`. Empty = reuse `[llm]` |

--- a/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
@@ -472,7 +472,9 @@ async def test_reasoning_content_included_for_deepseek_model() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reasoning_content_excluded_for_non_deepseek_model() -> None:
+async def test_reasoning_content_persisted_for_any_model() -> None:
+    # Persistence is provider-agnostic (the WebUI renders reasoning from
+    # history); only provider-side REPLAY stays model-gated.
     stage, recs = _make_stage()
     done = DoneEvent(
         text="hi",
@@ -487,7 +489,7 @@ async def test_reasoning_content_excluded_for_non_deepseek_model() -> None:
         resolved_model="synthetic-long-model-4",
     )
     await stage.run(inp)
-    assert recs["transcript_append"].calls[0]["reasoning_content"] is None
+    assert recs["transcript_append"].calls[0]["reasoning_content"] == "thinking..."
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_chat_thinking.py
+++ b/tests/test_gateway/test_rpc_chat_thinking.py
@@ -1,0 +1,134 @@
+"""chat.thinking RPC + has_thinking history flag + control_ui.show_thinking gate."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentos.gateway.rpc import RpcContext
+from agentos.gateway.rpc_chat import _handle_chat_history, _handle_chat_thinking
+from agentos.gateway.session_streams import SessionStreamRegistry
+from agentos.session.models import TranscriptEntry
+
+_SESSION_KEY = "agent:main:webchat:test"
+
+
+class _FakeSessionManager:
+    def __init__(self, entries):
+        self._entries = entries
+
+    async def get_transcript(self, session_key):
+        return self._entries
+
+    async def get_canonical_transcript(self, session_key):
+        return self._entries
+
+    async def get_summaries(self, session_key):
+        return []
+
+
+def _entry(idx: int, role: str = "assistant", reasoning: str | None = None) -> TranscriptEntry:
+    return TranscriptEntry(
+        id=idx,
+        session_id="parent",
+        session_key=_SESSION_KEY,
+        role=role,
+        content=f"message {idx}",
+        created_at=idx,
+        message_id=f"msg-{idx}",
+        reasoning_content=reasoning,
+    )
+
+
+def _ctx(entries, *, show_thinking: bool | None = None) -> RpcContext:
+    config = None
+    if show_thinking is not None:
+        config = SimpleNamespace(control_ui=SimpleNamespace(show_thinking=show_thinking))
+    return RpcContext(
+        conn_id="test",
+        session_manager=_FakeSessionManager(entries),
+        config=config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_history_flags_messages_with_reasoning() -> None:
+    entries = [
+        _entry(1, role="user"),
+        _entry(2, reasoning="chain of thought"),
+        _entry(3),
+    ]
+
+    result = await _handle_chat_history({"sessionKey": _SESSION_KEY}, _ctx(entries))
+
+    flags = [msg.get("has_thinking") for msg in result["messages"]]
+    assert flags == [None, True, None]
+    # The reasoning body itself must NOT ride along with history pages.
+    assert all("reasoning" not in msg for msg in result["messages"])
+
+
+@pytest.mark.asyncio
+async def test_chat_history_strips_flag_when_show_thinking_disabled() -> None:
+    entries = [_entry(1, reasoning="chain of thought")]
+
+    result = await _handle_chat_history(
+        {"sessionKey": _SESSION_KEY},
+        _ctx(entries, show_thinking=False),
+    )
+
+    assert all("has_thinking" not in msg for msg in result["messages"])
+
+
+@pytest.mark.asyncio
+async def test_chat_thinking_returns_reasoning_for_message() -> None:
+    entries = [_entry(1), _entry(2, reasoning="the hidden reasoning")]
+
+    result = await _handle_chat_thinking(
+        {"sessionKey": _SESSION_KEY, "messageId": "msg-2"},
+        _ctx(entries),
+    )
+
+    assert result["reasoning"] == "the hidden reasoning"
+    assert result["messageId"] == "msg-2"
+
+
+@pytest.mark.asyncio
+async def test_chat_thinking_returns_none_for_message_without_reasoning() -> None:
+    entries = [_entry(1)]
+
+    result = await _handle_chat_thinking(
+        {"sessionKey": _SESSION_KEY, "messageId": "msg-1"},
+        _ctx(entries),
+    )
+
+    assert result["reasoning"] is None
+
+
+@pytest.mark.asyncio
+async def test_chat_thinking_disabled_by_config() -> None:
+    entries = [_entry(1, reasoning="should stay hidden")]
+
+    result = await _handle_chat_thinking(
+        {"sessionKey": _SESSION_KEY, "messageId": "msg-1"},
+        _ctx(entries, show_thinking=False),
+    )
+
+    assert result["reasoning"] is None
+
+
+@pytest.mark.asyncio
+async def test_chat_thinking_requires_message_id() -> None:
+    with pytest.raises(ValueError):
+        await _handle_chat_thinking({"sessionKey": _SESSION_KEY}, _ctx([]))
+
+
+def test_session_stream_thinking_events_are_replay_lossy() -> None:
+    registry = SessionStreamRegistry(max_events_per_session=2)
+    registry.record("s", "session.event.thinking", {"text": "a"})
+    registry.record("s", "session.event.tool_use_start", {"tool_name": "t"})
+    registry.record("s", "session.event.done", {})
+
+    events = registry.replay("s", 0).events
+    names = [event.event_name for event in events]
+    # The thinking delta is trimmed first; durable events survive.
+    assert "session.event.thinking" not in names
+    assert "session.event.done" in names

--- a/tests/test_provider_opencap.py
+++ b/tests/test_provider_opencap.py
@@ -271,3 +271,25 @@ def test_opencap_gateway_uses_conservative_shared_id_limits() -> None:
 
     assert catalog.resolve_max_tokens("deepseek-v4-flash", provider_name="opencap") == 128_000
     assert catalog.resolve_context_window("deepseek-v4-flash", provider_name="opencap") == 1_000_000
+
+
+def test_opencap_deepseek_v4_models_resolve_deepseek_reasoning() -> None:
+    # DeepSeek V4 via the OpenCAP/Bankr gateways honors the DeepSeek-native
+    # thinking payload and streams reasoning_content (verified live); the
+    # capability gate must say so or tier thinking_level silently no-ops.
+    catalog = ModelCatalog()
+
+    for provider in ("opencap", "bankr"):
+        caps = catalog.get_capabilities("deepseek-v4-flash", provider_name=provider)
+        assert caps.supports_reasoning is True
+        assert caps.reasoning_format == "deepseek"
+
+    pro = catalog.get_capabilities("deepseek-v4-pro", provider_name="opencap")
+    assert pro.supports_reasoning is True
+
+    # Non-DeepSeek gateway ids stay reasoning-off: OpenAI/Anthropic never
+    # expose chain-of-thought through these OpenAI-compat gateways.
+    for model in ("gpt-5.6-terra", "gpt-5.6-luna", "claude-opus-5"):
+        caps = catalog.get_capabilities(model, provider_name="opencap")
+        assert caps.supports_reasoning is False
+        assert caps.reasoning_format == "none"

--- a/tests/test_provider_thinking_stream.py
+++ b/tests/test_provider_thinking_stream.py
@@ -1,0 +1,328 @@
+"""Streaming thinking/reasoning delta extraction across providers.
+
+Covers the ``ThinkingDeltaEvent`` contract: Anthropic ``thinking_delta`` SSE
+blocks, OpenAI-compatible ``reasoning_content`` deltas, the streaming
+``<think>`` tag splitter for models whose reasoning rides inside content, and
+the Ollama native ``thinking`` channel. Reasoning must reach subscribers as
+typed events and must never leak into user-visible text deltas.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from typing import Any
+
+import httpx
+import pytest
+
+from agentos.provider import (
+    ChatConfig,
+    DoneEvent,
+    Message,
+    TextDeltaEvent,
+    ThinkingDeltaEvent,
+)
+from agentos.provider.anthropic import AnthropicProvider
+from agentos.provider.ollama import OllamaProvider
+from agentos.provider.openai import OpenAIProvider
+from agentos.provider.reasoning import ThinkTagStreamSplitter
+from agentos.provider.types import ModelCapabilities
+
+# ---------------------------------------------------------------------------
+# ThinkTagStreamSplitter
+# ---------------------------------------------------------------------------
+
+
+def _run_splitter(chunks: list[str]) -> tuple[str, str]:
+    splitter = ThinkTagStreamSplitter()
+    text_parts: list[str] = []
+    think_parts: list[str] = []
+    for chunk in chunks:
+        text, think = splitter.feed(chunk)
+        text_parts.append(text)
+        think_parts.append(think)
+    text, think = splitter.flush()
+    text_parts.append(text)
+    think_parts.append(think)
+    return "".join(text_parts), "".join(think_parts)
+
+
+def test_splitter_passes_plain_text_through() -> None:
+    text, think = _run_splitter(["plain ", "text < not a tag"])
+    assert text == "plain text < not a tag"
+    assert think == ""
+
+
+def test_splitter_separates_single_block() -> None:
+    text, think = _run_splitter(["hello <think>secret</think> world"])
+    assert text == "hello  world"
+    assert think == "secret"
+
+
+def test_splitter_handles_tags_cut_across_chunks() -> None:
+    text, think = _run_splitter(["<thi", "nk>only think", "</th", "ink>"])
+    assert text == ""
+    assert think == "only think"
+
+
+def test_splitter_routes_unclosed_trailing_think_to_reasoning() -> None:
+    text, think = _run_splitter(["before <think>never closed"])
+    assert text == "before "
+    assert think == "never closed"
+
+
+def test_splitter_flushes_pending_partial_tag_as_text() -> None:
+    # A lone "<th" that never becomes a tag must not be swallowed.
+    text, think = _run_splitter(["tail <th"])
+    assert text == "tail <th"
+    assert think == ""
+
+
+def test_splitter_is_chunking_invariant() -> None:
+    full = "ab<think>c d</think>ef<think>gh</think> tail"
+    rng = random.Random(7)
+    for _ in range(200):
+        cut_count = rng.randint(0, min(9, len(full) - 1))
+        cuts = sorted(rng.sample(range(1, len(full)), cut_count))
+        chunks, prev = [], 0
+        for cut in [*cuts, len(full)]:
+            chunks.append(full[prev:cut])
+            prev = cut
+        text, think = _run_splitter(chunks)
+        assert text == "abef tail", chunks
+        assert think == "c dgh", chunks
+
+
+# ---------------------------------------------------------------------------
+# Provider streams
+# ---------------------------------------------------------------------------
+
+
+def _patch_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    module_path: str,
+    response_body: bytes,
+    *,
+    content_type: str = "text/event-stream",
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": content_type},
+            content=response_body,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(f"{module_path}.httpx.AsyncClient", patched_async_client)
+
+
+def _collect(provider: Any, config: ChatConfig) -> list[Any]:
+    async def _run() -> list[Any]:
+        return [
+            event
+            async for event in provider.chat(
+                [Message(role="user", content="hi")],
+                config=config,
+            )
+        ]
+
+    return asyncio.run(_run())
+
+
+def _anthropic_sse(events: list[dict]) -> bytes:
+    parts = []
+    for ev in events:
+        parts.append(f"event: {ev['type']}\n".encode())
+        parts.append(f"data: {json.dumps(ev)}\n\n".encode())
+    return b"".join(parts)
+
+
+def test_anthropic_stream_yields_thinking_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _anthropic_sse(
+        [
+            {
+                "type": "message_start",
+                "message": {"id": "msg_1", "model": "claude-fable-5", "usage": {}},
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "pondering "},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "deeply"},
+            },
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "answer"},
+            },
+            {"type": "message_stop"},
+        ]
+    )
+    _patch_transport(monkeypatch, "agentos.provider.anthropic", body)
+    provider = AnthropicProvider(api_key="test-key", model="claude-fable-5")
+
+    events = _collect(provider, ChatConfig())
+
+    thinking = [e.text for e in events if isinstance(e, ThinkingDeltaEvent)]
+    text = [e.text for e in events if isinstance(e, TextDeltaEvent)]
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert thinking == ["pondering ", "deeply"]
+    assert text == ["answer"]
+    assert done.reasoning_content == "pondering deeply"
+
+
+def _openai_sse(deltas: list[dict], *, finish: str = "stop") -> bytes:
+    lines = []
+    for delta in deltas:
+        chunk = {"choices": [{"delta": delta, "finish_reason": None}]}
+        lines.append(f"data: {json.dumps(chunk)}\n\n")
+    lines.append(f'data: {json.dumps({"choices": [{"delta": {}, "finish_reason": finish}]})}\n\n')
+    lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+def test_openai_compat_reasoning_content_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _openai_sse(
+        [
+            {"reasoning_content": "step one; "},
+            {"reasoning_content": "step two"},
+            {"content": "final answer"},
+        ]
+    )
+    _patch_transport(monkeypatch, "agentos.provider.openai", body)
+    provider = OpenAIProvider(api_key="test-key", model="deepseek-reasoner")
+
+    events = _collect(provider, ChatConfig())
+
+    thinking = [e.text for e in events if isinstance(e, ThinkingDeltaEvent)]
+    text = [e.text for e in events if isinstance(e, TextDeltaEvent)]
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert thinking == ["step one; ", "step two"]
+    assert text == ["final answer"]
+    assert done.reasoning_content == "step one; step two"
+
+
+def test_openai_compat_think_tags_split_across_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _openai_sse(
+        [
+            {"content": "<thi"},
+            {"content": "nk>hidden reasoning</th"},
+            {"content": "ink>visible reply"},
+        ]
+    )
+    _patch_transport(monkeypatch, "agentos.provider.openai", body)
+    provider = OpenAIProvider(api_key="test-key", model="qwen3-local")
+    config = ChatConfig(
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="think_tags",
+        )
+    )
+
+    events = _collect(provider, config)
+
+    thinking = "".join(e.text for e in events if isinstance(e, ThinkingDeltaEvent))
+    text = "".join(e.text for e in events if isinstance(e, TextDeltaEvent))
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert thinking == "hidden reasoning"
+    assert text == "visible reply"
+    assert "<think>" not in text
+    assert done.reasoning_content == "hidden reasoning"
+
+
+def test_openai_compat_without_capability_leaves_content_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = _openai_sse([{"content": "just <thinking about life> text"}])
+    _patch_transport(monkeypatch, "agentos.provider.openai", body)
+    provider = OpenAIProvider(api_key="test-key", model="gpt-4o")
+
+    events = _collect(provider, ChatConfig())
+
+    text = "".join(e.text for e in events if isinstance(e, TextDeltaEvent))
+    assert text == "just <thinking about life> text"
+    assert not any(isinstance(e, ThinkingDeltaEvent) for e in events)
+
+
+def _ollama_ndjson(chunks: list[dict]) -> bytes:
+    return "".join(json.dumps(chunk) + "\n" for chunk in chunks).encode()
+
+
+def test_ollama_native_thinking_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _ollama_ndjson(
+        [
+            {"message": {"thinking": "mulling it over"}},
+            {"message": {"content": "the reply"}},
+            {"done": True, "prompt_eval_count": 3, "eval_count": 5, "done_reason": "stop"},
+        ]
+    )
+    _patch_transport(
+        monkeypatch,
+        "agentos.provider.ollama",
+        body,
+        content_type="application/x-ndjson",
+    )
+    provider = OllamaProvider(model="qwen3")
+
+    events = _collect(provider, ChatConfig())
+
+    thinking = [e.text for e in events if isinstance(e, ThinkingDeltaEvent)]
+    text = [e.text for e in events if isinstance(e, TextDeltaEvent)]
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert thinking == ["mulling it over"]
+    assert text == ["the reply"]
+    assert done.reasoning_content == "mulling it over"
+
+
+def test_ollama_think_tags_content_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _ollama_ndjson(
+        [
+            {"message": {"content": "<think>local reason"}},
+            {"message": {"content": "ing</think>clean answer"}},
+            {"done": True, "prompt_eval_count": 1, "eval_count": 2, "done_reason": "stop"},
+        ]
+    )
+    _patch_transport(
+        monkeypatch,
+        "agentos.provider.ollama",
+        body,
+        content_type="application/x-ndjson",
+    )
+    provider = OllamaProvider(model="qwen3")
+    config = ChatConfig(
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="think_tags",
+        )
+    )
+
+    events = _collect(provider, config)
+
+    thinking = "".join(e.text for e in events if isinstance(e, ThinkingDeltaEvent))
+    text = "".join(e.text for e in events if isinstance(e, TextDeltaEvent))
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert thinking == "local reasoning"
+    assert text == "clean answer"
+    assert done.reasoning_content == "local reasoning"


### PR DESCRIPTION
## Summary

The web UI previously showed only a synthetic "is thinking" indicator ("Watching (Ns)"); real model reasoning was accumulated at the provider layer for history replay and never reached any UI. This PR wires the full pipeline, Hermes-style: typed thinking events end to end, a live collapsible block, history fetch-on-expand, and a hard WebUI-only boundary.

## Provider layer

- New `ThinkingDeltaEvent` in `provider/types.py`, joined to the `StreamEvent` union.
- **Anthropic**: `thinking_delta` SSE blocks now yield events (accumulation for signed replay unchanged).
- **OpenAI-compatible** (OpenRouter/DeepSeek/GLM/DashScope/…): `reasoning_content` and `reasoning_details` deltas yield events.
- **Ollama**: the native `thinking` channel yields events and lands in `DoneEvent.reasoning_content`.
- New `ThinkTagStreamSplitter` (`provider/reasoning.py`) for `reasoning_format == "think_tags"` models: routes `<think>…</think>` content to reasoning even when a tag is cut across chunk boundaries, with a 200-trial chunking-invariance test.

### Bug fixed on the way

For think-tag models, raw `<think>` text was streaming into user-visible replies and being persisted into transcripts — `_strip_think_tags` existed but was never called on the stream path. The splitter fixes both the live leak and the persisted text.

## Engine

- Provider thinking deltas map to the previously dead `ThinkingEvent`, which flows through the turn pipeline (stream-consumer pass-through) untouched.
- `reasoning_content` is now persisted for **every** provider (it was DeepSeek-only). Provider **replay** stays model-gated exactly as before (`_should_replay_reasoning_content`), so no provider request payloads change.
- Scheduler handlers/heartbeat and auxiliary-task collectors explicitly skip thinking so reasoning never bleeds into cron output or auxiliary results.

## Gateway

- The web send path's generic emitter now carries `session.event.thinking` to WS subscribers. The channel dispatch path uses an isinstance allowlist, so **channel adapters never receive thinking by construction**.
- `chat.history` marks reasoning-bearing rows with a cheap `has_thinking` flag — the reasoning body is *not* shipped with history pages.
- New `chat.thinking` RPC (deliberately `CONTROL_ONLY`) serves one message's reasoning on demand.
- `session.event.thinking` is replay-lossy in the reconnect buffer, like `text_delta`.
- New config: `control_ui.show_thinking` (default **true**). Off = no thinking events, `reasoning_content` scrubbed from `session.event.done`, no history flags, `chat.thinking` returns null.

## Web UI

- Live streamed reasoning renders in a collapsible **Thinking** block that auto-collapses the moment reply text starts; later reasoning in the same turn keeps accumulating into the collapsed block. The synthetic indicator remains as fallback when no reasoning streams.
- History rows flagged `has_thinking` show a collapsed block; the body is fetched via `chat.thinking` on first expand (plain `textContent`, never markdown/innerHTML).
- Live block is protected through mid-stream history reconciliation and cleaned up on park/session-swap.
- Config view gets help text for the new key; `agentos.toml.example`, `docs/web-ui.md`, and the bundled skill's config table are updated.

## Tests

- `tests/test_provider_thinking_stream.py` — 12 tests: splitter unit + chunking-invariance fuzz, Anthropic SSE, OpenAI-compat reasoning deltas + think-tag splitting + no-capability passthrough, Ollama native thinking + think-tag content.
- `tests/test_gateway/test_rpc_chat_thinking.py` — 7 tests: history flag, toggle-off stripping, `chat.thinking` happy/empty/disabled/validation, replay-lossy trim.
- Frontend: 3 new history-renderer tests (collapsed block placement, single fetch-on-expand, unflagged/no-fetcher skips).
- Updated the finalizer unit test that asserted the old DeepSeek-only persistence gate.

## Quality gate

`build_control_ui.py build` ✓ · `npm run check` (tsc/eslint/prettier/vitest, 1840 tests) ✓ · `ruff` ✓ · `mypy` (599 files) ✓ · `pytest -q` 7619 passed / 27 skipped ✓ · `uv build --wheel` ✓

---

## Follow-ups in this PR (found while testing against a live gateway)

### `fix(provider)`: DeepSeek V4 reasoning capability on OpenCAP/Bankr routes

Pre-existing bug the new UI surfaced. The `bankr`/`opencap` branch of
`ModelCatalog.get_capabilities` returned `supports_reasoning=False` for **every**
model, so a tier's `thinking_level` silently no-oped: the request never carried the
DeepSeek thinking payload, the model never reasoned, and there was nothing to stream.
`deepseek-v4*` ids now resolve `supports_reasoning=True` /
`reasoning_format="deepseek"` (verified live against the OpenCAP gateway: it honors
`thinking: {"type": "enabled"}` and streams `reasoning_content` deltas). GPT/Claude
gateway ids stay reasoning-off — those vendors do not expose chain-of-thought through
OpenAI-compat APIs. Regression test added in `tests/test_provider_opencap.py`.

### `fix(webui)`: a fresh live thinking block per reasoning round

Once the first reply text collapsed the block, reasoning from later iterations (between
tool rounds) kept accumulating into the *collapsed* block — mid-turn the UI showed no
motion at all and a working agent looked hung. A collapsed block now means its round is
over: new reasoning opens a fresh open-streaming block, placed inside the stream bubble
so it sits chronologically after the text and tool segments already rendered, and folds
again when the next reply text starts.

### `feat(webui)`: light sweep on the composer border while a turn runs

Turn-liveness feedback that does not depend on the model emitting reasoning: while
`busy`, the composer border brightens and a conic highlight orbits it (masked 2px ring,
`@property`-driven angle, 2.4s). Static brighter border under
`prefers-reduced-motion`. Bound to the existing `busy` prop, so it is exactly in sync
with the Abort affordance and the turn lifecycle.
