### PR TITLE
docs: add agentic trading guide and lead with it in the product framing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AgentOS — Agent Instructions
 
-Token-efficient Python agent runtime with MCP-native tools, on-device
-Pilot Router, durable memory, a layered sandbox, and multi-channel
-messaging (Web UI, CLI, chat). One shared turn loop drives every client.
+Token-efficient Python agent runtime with native agentic trading,
+MCP-native tools, on-device Pilot Router, durable memory, a layered sandbox,
+and multi-channel messaging (Web UI, CLI, chat). One shared turn loop drives every client.
 
 - **Language / runtime:** Python **3.12+** only.
 - **Package manager:** **uv** (not pip/poetry). Never edit lockfiles by hand.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# AgentOS — Token-Efficient AI Agent with On-Device Pilot Router
+# AgentOS — Native Agentic Trading AI Agent, Token-Efficient by Design
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-hero-banner.png" alt="AgentOS — The Open Agent Operating System">
+  <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-hero-banner.png" alt="AgentOS — Native agentic trading, minimum tokens.">
 </p>
 
 <p align="center">
-  <b>Stop overpaying for AI. Let the router cook.</b><br>
-  A token-efficient AI agent with on-device Pilot Router for your CLI, Web UI, and chat channels.
+  <b>Native agentic trading, minimum tokens.</b><br>
+  An AI agent with native agentic trading, across CLI, Web UI, and chat channels.<br>
+  An on-device Pilot Router classifies each task locally and routes it to the cheapest capable model.
 </p>
 
 <p align="center">

--- a/README.product.md
+++ b/README.product.md
@@ -4,8 +4,9 @@
 
 # AgentOS Product Guide
 
-AgentOS is a token-efficient AI agent with on-device Pilot Router, for
-the terminal, a local Web UI, and messaging channels. It is designed for users who want one
+AgentOS is an AI agent with native agentic trading, for
+the terminal, a local Web UI, and messaging channels. An on-device Pilot Router
+classifies each task locally and routes it to the cheapest capable model. It is designed for users who want one
 agent surface that can chat, use tools, remember useful context, run scheduled
 work, publish artifacts, and route work across multiple LLM providers without
 rewriting their workflow for each provider.

--- a/README.release.md
+++ b/README.release.md
@@ -1,6 +1,6 @@
 # AgentOS
 
-AgentOS is a token-efficient AI agent with on-device Pilot Router,
+AgentOS is an AI agent with native agentic trading, an on-device Pilot Router,
 MCP-native tools, durable sessions, local memory, multi-channel messaging,
 and a local web control UI.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ root release README with task-oriented guides.
 ## Feature Guides
 
 - [`features.md`](features.md) - capability catalog.
+- [`features/agentic-trading.md`](features/agentic-trading.md) - trading
+  connections, bundled trading skills, and the safety model.
 - [`features/agentos-router.md`](features/agentos-router.md) - model routing.
 - [`features/tool-compression.md`](features/tool-compression.md) - compact tool
   results and handles.

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,6 +15,15 @@ channels, scheduling, and reusable skills.
 
 ## Distinctive Features
 
+### Agentic Trading
+
+Trading is a first-class capability. A featured Robinhood Trading MCP preset and
+bundled skills cover market research, portfolio analysis, order execution, and
+liquidity management, behind explicit confirmation and the standard approval
+layers.
+
+Read: [`features/agentic-trading.md`](features/agentic-trading.md)
+
 ### Pilot Router
 
 Local routing for model tier selection. It is designed to keep easy turns cheap

--- a/docs/features/agentic-trading.md
+++ b/docs/features/agentic-trading.md
@@ -1,0 +1,133 @@
+# Agentic Trading
+
+AgentOS treats trading as a first-class capability. Market research, portfolio
+analysis, and order execution reach the agent through partner-authorized
+connections and skills that ship with the product, so you do not have to wire up
+an unofficial API or paste credentials into a chat window.
+
+Two mechanisms provide it:
+
+- **MCP connections** — a featured Robinhood Trading preset in the Web UI, and
+  any other MCP server you choose to add.
+- **Bundled skills** — trading, research, and liquidity skills installed with
+  AgentOS and loaded only when a task needs them.
+
+Both run behind the same approval and sandbox layers as every other tool.
+
+> Agentic trading involves significant risk. Review a connection's access and
+> action permissions before authorizing it, and read
+> [`../approvals-and-permissions.md`](../approvals-and-permissions.md) before
+> letting any automation place orders.
+
+## Robinhood Trading MCP
+
+The Web UI ships a featured preset for Robinhood Agentic Trading.
+
+| Setting | Value |
+| --- | --- |
+| Endpoint | `https://agent.robinhood.com/mcp/trading` |
+| Transport | Streamable HTTP |
+| Authorization | Provider-hosted OAuth flow |
+
+Open **Settings > MCP Servers**, select the Robinhood Trading preset, and save
+it. Saving opens the provider authorization flow and loads the server's tools
+without a gateway restart.
+
+For scripted deployments, declare the same server in TOML:
+
+```toml
+[mcp]
+enabled = true
+connect_timeout_seconds = 10
+
+[[mcp.servers]]
+name = "robinhood-trading"
+transport = "streamable_http"
+url = "https://agent.robinhood.com/mcp/trading"
+oauth = true
+tool_timeout_seconds = 30
+```
+
+See [`../configuration.md`](../configuration.md) for the full MCP configuration
+reference and [`../web-ui.md`](../web-ui.md) for the connection UI.
+
+### Account scope
+
+Robinhood's own documentation defines the product scope; the live authenticated
+MCP schemas are authoritative for tool names, parameters, supported order types,
+and available asset classes.
+
+- The connected agent can **read** all Robinhood accounts, including account
+  numbers, positions, balances, transaction and order history, watchlists, and
+  scans.
+- Trade **placement** is restricted to the dedicated Robinhood Agentic account,
+  even though read access is broader.
+
+### How the agent is expected to behave
+
+The bundled `robinhood-agentic-trading` skill encodes the operating rules:
+
+1. Confirm the connected server is the intended Robinhood Trading endpoint.
+2. Complete the provider-hosted authentication flow. Never ask for OAuth codes,
+   access tokens, account numbers, or credentials in chat.
+3. Discover the current tools and read their complete input schemas before
+   planning calls. Never invent a tool name, parameter, enum value, order type,
+   or asset class.
+4. Re-discover tools after reconnecting, or when a schema error indicates that
+   capabilities changed.
+5. If the connection, authentication, or a required tool is unavailable, stop
+   and explain the gap rather than substituting an unofficial API.
+
+## Bundled trading and research skills
+
+These install with AgentOS and load on demand. Skills marked
+`risk: high` declare `signing` capability and require explicit confirmation
+before they execute anything.
+
+| Skill | What it does |
+| --- | --- |
+| `robinhood-agentic-trading` | Account and portfolio analysis, market research, order preview, placement, cancellation, rebalancing, and bounded automation over the Trading MCP. |
+| `robinhood-rwa-addresses` | Resolves a company name or ticker to its Robinhood tokenized-asset token on Robinhood Chain (`4663`) — symbol, contract address, chain id, decimals. Public data source, no key. |
+| `gmgn-swap` | Buy and sell tokens on Solana, BSC, Base, and Ethereum: single swap, multi-wallet batch, limit orders, stop loss, take profit, and trailing variants. |
+| `gmgn-market` | Price charts (K-line, OHLCV), trending rankings by volume, new launchpad listings, and hot-search rankings. |
+| `gmgn-token` | Per-token research: price, market cap, liquidity, holders, top Smart Money and KOL positions, security audit, and social links. |
+| `gmgn-portfolio` | Wallet analysis: holdings, realized and unrealized P&L, win rate, history, and developer-wallet token history. |
+| `gmgn-track` | Real-time buy and sell activity from Smart Money wallets, KOL wallets, and wallets you follow. |
+| `gmgn-holder-analysis` | Holder-structure analysis: chip distribution, entry cost, whale and dev behavior, and risk wallets. |
+| `gmgn-cooking` | Token creation and launchpad launches, and launchpad creation statistics. |
+| `senior-unilp-manager` | Uniswap V4 liquidity on Base (`8453`) and Robinhood Chain (`4663`): inspect pools and positions, then mint, increase, decrease, collect fees, or burn. |
+
+The GMGN skills require a `gmgn-cli` install plus `GMGN_API_KEY` and
+`GMGN_PRIVATE_KEY`. The signing key authorizes orders — treat it as a
+credential. See [`skills.md`](skills.md) for how skill requirements and secrets
+are declared and surfaced.
+
+## Safety model
+
+Trading skills are held to a stricter standard than ordinary tools.
+
+- **Explicit confirmation.** Skills tagged `[FINANCIAL EXECUTION]` do not act on
+  an inferred intent; they require the user to confirm the specific action.
+- **Dry run by default.** `senior-unilp-manager` splits reads from writes. Its
+  read script cannot sign at all, and a write is a dry run unless it is given
+  both `--broadcast` and the plan hash printed by that same dry run.
+- **Schema truth.** The agent plans against the live authenticated schemas of
+  the connected server, not remembered API shapes.
+- **Publisher verification.** A skill cannot mint its own brand. Only bundled
+  skills that ship inside the wheel may name a publisher, and the displayed
+  name, URL, and logo always come from an internal allowlist — currently
+  Robinhood, Bankr, and Capminal. Every other skill takes its brand from the
+  catalog row that installed it, so a look-alike dropped on disk renders as an
+  ordinary unbranded skill.
+- **Standard approvals.** Everything above sits on top of the normal permission
+  and sandbox layers described in
+  [`../approvals-and-permissions.md`](../approvals-and-permissions.md) and
+  [`../tools-and-sandbox.md`](../tools-and-sandbox.md).
+
+## Related
+
+- [`../web-ui.md`](../web-ui.md) - connecting and authorizing MCP servers.
+- [`../configuration.md`](../configuration.md) - MCP and skill configuration.
+- [`skills.md`](skills.md) - skill discovery, install, and authoring.
+- [`../approvals-and-permissions.md`](../approvals-and-permissions.md) -
+  permission tiers and approval prompts.

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>AgentOS Setup Guide - Install & Run the Token-Efficient AI Agent</title>
-<meta name="description" content="Set up AgentOS in four steps: install it, connect a model provider, start the gateway, and open the console. A token-efficient microkernel AI agent for your CLI, Web UI, and chat channels." />
+<title>AgentOS Setup Guide - Install & Run the Agentic Trading AI Agent</title>
+<meta name="description" content="Set up AgentOS in four steps: install it, connect a model provider, start the gateway, and open the console. An AI agent with native agentic trading, across CLI, Web UI, and chat channels." />
 <meta name="robots" content="index, follow, max-image-preview:large" />
 <meta name="theme-color" content="#CCFF00" />
 <link rel="canonical" href="https://useagentos.dev/setup-guide.html" />
@@ -12,21 +12,21 @@
 <!-- Open Graph (Facebook, LinkedIn, Discord, Slack, etc.) -->
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="AgentOS" />
-<meta property="og:title" content="AgentOS Setup Guide - Install & Run the Token-Efficient AI Agent" />
-<meta property="og:description" content="Stop overpaying for AI. Let the router cook. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
+<meta property="og:title" content="AgentOS Setup Guide - Install & Run the Agentic Trading AI Agent" />
+<meta property="og:description" content="Native agentic trading, minimum tokens. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
 <meta property="og:url" content="https://useagentos.dev/setup-guide.html" />
 <meta property="og:image" content="https://useagentos.dev/agentos-hero-banner.png" />
-<meta property="og:image:alt" content="AgentOS - The Open Agent Operating System" />
+<meta property="og:image:alt" content="AgentOS - Native agentic trading, minimum tokens." />
 <meta property="og:locale" content="en_US" />
 
 <!-- Twitter / X Card -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@useAgentOS" />
 <meta name="twitter:creator" content="@useAgentOS" />
-<meta name="twitter:title" content="AgentOS Setup Guide - Install & Run the Token-Efficient AI Agent" />
-<meta name="twitter:description" content="Stop overpaying for AI. Let the router cook. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
+<meta name="twitter:title" content="AgentOS Setup Guide - Install & Run the Agentic Trading AI Agent" />
+<meta name="twitter:description" content="Native agentic trading, minimum tokens. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
 <meta name="twitter:image" content="https://useagentos.dev/agentos-hero-banner.png" />
-<meta name="twitter:image:alt" content="AgentOS - The Open Agent Operating System" />
+<meta name="twitter:image:alt" content="AgentOS - Native agentic trading, minimum tokens." />
 
 <!-- Structured data for rich results -->
 <script type="application/ld+json">
@@ -34,9 +34,9 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "AgentOS",
-  "applicationCategory": "DeveloperApplication",
+  "applicationCategory": ["DeveloperApplication", "FinanceApplication"],
   "operatingSystem": "macOS, Linux, Windows",
-  "description": "A token-efficient microkernel AI agent for your CLI, Web UI, and chat channels. A local model router picks the cheapest model that can do each job.",
+  "description": "An AI agent with native agentic trading, across CLI, Web UI, and chat channels. An on-device Pilot Router picks the cheapest model that can reliably do each job.",
   "url": "https://useagentos.dev/",
   "image": "https://useagentos.dev/agentos-hero-banner.png",
   "softwareVersion": "0.0.1",
@@ -177,7 +177,7 @@
       </h1>
       <p class="mt-6 max-w-[60ch] text-[17px] leading-relaxed text-[var(--text-dim)]">
         <span class="font-semibold text-[var(--text)]">Stop overpaying for AI. Let the router cook.</span>
-        A token-efficient, microkernel AI agent for your CLI, Web UI, and chat channels.
+        An AI agent with native agentic trading, across CLI, Web UI, and chat channels.
         Install it, connect a model provider, start the gateway, open the console. This guide covers all of it.
       </p>
       <div class="mt-8 flex flex-wrap gap-3">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "use-agent-os"
 version = "2026.8.11"
-description = "Token-Efficient AI agent with on-device Pilot Router"
+description = "Native agentic trading AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]
 readme = "README.md"


### PR DESCRIPTION
## Why

Agentic trading is already a real capability — a featured Robinhood Trading MCP preset plus bundled skills for GMGN, Robinhood tokenized stocks, and Uniswap V4 liquidity — but it was only documented incidentally inside `web-ui.md` and `configuration.md`, and the product framing never mentioned it at all.

## What

**New guide** — `docs/features/agentic-trading.md`:
- Robinhood Trading MCP preset: endpoint, transport, OAuth, and the TOML form for scripted deployments
- Account scope (read spans all accounts; placement is restricted to the Agentic account)
- The operating rules the bundled `robinhood-agentic-trading` skill encodes
- Catalog of the 10 bundled trading and research skills
- Safety model: explicit confirmation, dry-run liquidity writes gated on a plan hash, schema truth, and the publisher allowlist

Registered in `docs/README.md` (nav order) and `docs/features.md` (catalog).

**Slogan sync** — `README.md`, `README.product.md`, `README.release.md`, `AGENTS.md`, `pyproject.toml`, `docs/setup-guide.html` now lead with agentic trading and keep token efficiency as the second beat, matching the landing site.

`RELEASES.md` is deliberately untouched — it records what past releases said.

## Notes

- `pyproject.toml` `description` changes the published package metadata.
- `docs/setup-guide.html` JSON-LD was validated with a JSON parse; `applicationCategory` is now `["DeveloperApplication", "FinanceApplication"]`.
- The new doc passes the landing site's branding guard (no `agent-os` / `agent os` in prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)