### PR TITLE
docs: keep the uv tool install code span on one line

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -235,9 +235,9 @@ agentos upgrade --timeout 900   # bound the upgrade subprocess (default 600s)
 
 Per install method:
 
-- **uv tool** — delegated automatically as `uv tool install --force --python
-  <running major.minor> "use-agent-os[recommended]"`, resolving `uv` to an
-  absolute path over a hardened PATH. `install` rather than `upgrade` is
+- **uv tool** — delegated automatically as
+  `uv tool install --force --python <running major.minor> "use-agent-os[recommended]"`,
+  resolving `uv` to an absolute path over a hardened PATH. `install` rather than `upgrade` is
   load-bearing: `uv tool upgrade` takes only a bare tool name and re-resolves
   whatever uv's receipt recorded, so an install laid down from a checkout
   (`install_source.sh` passes `.`) keeps rebuilding the wheel from the working


### PR DESCRIPTION
The inline code span in `docs/cli.md` was wrapped across two source lines, leaving `<running major.minor>` at the start of a line.

Any MDX consumer of these docs parses `<running` as a JSX tag and then fails on the `.` in `major.minor`:

```
cli.mdx:242:17: Unexpected character `.` (U+002E) in attribute name
```

This currently breaks the landing site's docs build. Reflowing the span onto one line fixes it; GitHub's rendered output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)