### PR TITLE
docs: frame AgentOS trading as local-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# AgentOS — Native Agentic Trading AI Agent, Token-Efficient by Design
+# AgentOS — Local-First Agentic Trading AI Agent, Token-Efficient by Design
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-hero-banner.png" alt="AgentOS — Native agentic trading, minimum tokens.">
+  <img src="https://raw.githubusercontent.com/use-agent-os/agent-os/main/assets/agentos-hero-banner.png" alt="AgentOS — Local-first agentic trading, minimum tokens.">
 </p>
 
 <p align="center">
-  <b>Native agentic trading, minimum tokens.</b><br>
-  An AI agent with native agentic trading, across CLI, Web UI, and chat channels.<br>
+  <b>Local-first agentic trading, minimum tokens.</b><br>
+  An AI agent with native agentic trading that runs on your own machine, across CLI, Web UI, and chat channels.<br>
   An on-device Pilot Router classifies each task locally and routes it to the cheapest capable model.
 </p>
 

--- a/README.product.md
+++ b/README.product.md
@@ -4,7 +4,7 @@
 
 # AgentOS Product Guide
 
-AgentOS is an AI agent with native agentic trading, for
+AgentOS is a local-first AI agent with native agentic trading, for
 the terminal, a local Web UI, and messaging channels. An on-device Pilot Router
 classifies each task locally and routes it to the cheapest capable model. It is designed for users who want one
 agent surface that can chat, use tools, remember useful context, run scheduled

--- a/README.release.md
+++ b/README.release.md
@@ -1,6 +1,6 @@
 # AgentOS
 
-AgentOS is an AI agent with native agentic trading, an on-device Pilot Router,
+AgentOS is a local-first AI agent with native agentic trading, an on-device Pilot Router,
 MCP-native tools, durable sessions, local memory, multi-channel messaging,
 and a local web control UI.
 

--- a/docs/features/agentic-trading.md
+++ b/docs/features/agentic-trading.md
@@ -102,6 +102,32 @@ The GMGN skills require a `gmgn-cli` install plus `GMGN_API_KEY` and
 credential. See [`skills.md`](skills.md) for how skill requirements and secrets
 are declared and surfaced.
 
+## Local by default
+
+AgentOS runs on your own machine. For trading, that changes three things.
+
+**Credentials stay on the device.** MCP authorization tokens are written to a
+`0700` directory on POSIX systems; Windows uses the current user's
+state-directory ACL. The GMGN request-signing key (`GMGN_PRIVATE_KEY`) and the
+Uniswap LP signing key (`UNIV4_LP_PRIVATE_KEY`) are local environment values.
+Nothing is escrowed with a hosted service, and the agent never asks you to paste
+a credential into chat.
+
+**The routing decision never leaves the machine.** The Pilot Router classifies
+each turn on-device, so a strategy prompt is not shipped to a third party merely
+to decide which model should handle it. Only the turn that actually runs reaches
+your chosen model provider. See
+[`agentos-router.md`](agentos-router.md) for the classifier and its
+alternatives.
+
+**Always-on work runs on hardware you already have.** Scheduled and recurring
+trading tasks execute through the local gateway rather than a rented agent
+cloud — see [`../scheduling.md`](../scheduling.md). Combined with router-driven
+model selection, running an agent continuously stays inexpensive.
+
+What still leaves the machine is exactly what has to: the broker or exchange API
+calls themselves, and the model turns you route to a remote provider.
+
 ## Safety model
 
 Trading skills are held to a stricter standard than ordinary tools.

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>AgentOS Setup Guide - Install & Run the Agentic Trading AI Agent</title>
+<title>AgentOS Setup Guide - Install the Local-First Trading AI Agent</title>
 <meta name="description" content="Set up AgentOS in four steps: install it, connect a model provider, start the gateway, and open the console. An AI agent with native agentic trading, across CLI, Web UI, and chat channels." />
 <meta name="robots" content="index, follow, max-image-preview:large" />
 <meta name="theme-color" content="#CCFF00" />
@@ -12,8 +12,8 @@
 <!-- Open Graph (Facebook, LinkedIn, Discord, Slack, etc.) -->
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="AgentOS" />
-<meta property="og:title" content="AgentOS Setup Guide - Install & Run the Agentic Trading AI Agent" />
-<meta property="og:description" content="Native agentic trading, minimum tokens. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
+<meta property="og:title" content="AgentOS Setup Guide - Install the Local-First Trading AI Agent" />
+<meta property="og:description" content="Local-first agentic trading, minimum tokens. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
 <meta property="og:url" content="https://useagentos.dev/setup-guide.html" />
 <meta property="og:image" content="https://useagentos.dev/agentos-hero-banner.png" />
 <meta property="og:image:alt" content="AgentOS - Native agentic trading, minimum tokens." />
@@ -23,7 +23,7 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@useAgentOS" />
 <meta name="twitter:creator" content="@useAgentOS" />
-<meta name="twitter:title" content="AgentOS Setup Guide - Install & Run the Agentic Trading AI Agent" />
+<meta name="twitter:title" content="AgentOS Setup Guide - Install the Local-First Trading AI Agent" />
 <meta name="twitter:description" content="Native agentic trading, minimum tokens. Set up AgentOS in four steps - install, connect a provider, start the gateway, open the console." />
 <meta name="twitter:image" content="https://useagentos.dev/agentos-hero-banner.png" />
 <meta name="twitter:image:alt" content="AgentOS - Native agentic trading, minimum tokens." />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "use-agent-os"
 version = "2026.8.11"
-description = "Native agentic trading AI agent with on-device Pilot Router"
+description = "Local-first agentic trading AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]
 readme = "README.md"


### PR DESCRIPTION
Follow-up to #289.

Trading is where "runs on your own machine" stops being an architecture note and becomes the product argument. This adds a **Local by default** section to `docs/features/agentic-trading.md`:

- **Credentials stay on the device** — MCP tokens in a `0700` dir (Windows ACL), `GMGN_PRIVATE_KEY` and `UNIV4_LP_PRIVATE_KEY` as local env values, nothing escrowed with a hosted service.
- **The routing decision never leaves the machine** — the Pilot Router classifies on-device, so a strategy prompt is not shipped out merely to pick a model.
- **Always-on work runs on your own hardware** — scheduled tasks go through the local gateway, not a rented agent cloud.

It also states plainly what *does* still leave the machine (broker/exchange API calls, and model turns routed to a remote provider) so the claim is not read as "fully offline".

Slogan updated to **Local-first agentic trading, minimum tokens.** across `README.md`, `README.product.md`, `README.release.md`, `pyproject.toml`, and `docs/setup-guide.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)