### PR TITLE
feat(webui): pick the model route from the chat composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The chat composer now carries a route picker, so choosing which model answers
+  no longer means remembering a slash command. It lists the text tiers your
+  `[agentos_router]` config actually defines — labelled with the model each
+  resolves to, e.g. `c1 · gpt-5.6-luna` — plus `Auto`, which hands routing back
+  to the Pilot Router and reports the tier it last chose (`Auto · c2`) so
+  automatic routing stays legible. The pin is read back from the gateway over a
+  new `router.hold.get` RPC rather than mirrored in the browser, so a reload
+  shows the pin that is really in force and a pin set from `/c3` and one set
+  from the picker agree. With no Pilot Router configured the control is disabled
+  rather than hidden, keeping the composer from reflowing when the router is
+  toggled.
+- The picker is a searchable list, so the choice is not limited to the four
+  configured tiers: it also offers every model of the active provider, and
+  `/use <model-id>` does the same from a slash command on web, TUI and channels.
+  A directly-named model rides on the default tier, inheriting the thinking
+  level and pricing baseline that live on a tier and not on a model id — which
+  also keeps the router step's `tiers[hold.tier]` lookup valid. Only the active
+  provider's models are offered: every turn runs through the single configured
+  `llm.provider` (a tier's `provider` field is metadata, not a client selector),
+  so anything else is refused when chosen rather than failing on the next turn.
+  `/use` is a new verb rather than an argument to `/model`, whose argument
+  already filters the listing. Only models the provider publishes in its
+  catalog can be pinned — on OpenCAP that is the bare canonical ids, not the
+  namespaced `<upstream>/<model>` aliases its inference endpoint also answers to.
+- The router-fx strip is suppressed while a tier or model is pinned. It exists
+  to show the router weighing candidates and settling on one; a pin decides the
+  route up front, so the animation was dramatizing a deliberation that never
+  happened and restating the composer's own picker every turn. It returns the
+  moment routing goes back to Auto.
+- A pin now withdraws the model's own `router_control` tool for the duration,
+  along with its target menu in the system prompt. The user's choice already
+  outranked the model inside the router step; leaving the lever on the surface
+  only invited calls that could not take effect and paid tokens to describe
+  them. Holds the model installs for itself are unaffected — hiding the tool on
+  its own hold would strand a session on a transient escalation.
+
+### Changed
+
+- **Breaking:** a tier pin set by a user is now sticky. `/c0`…`/c3` — in the Web
+  UI, the TUI, and every channel — hold until `/auto` clears them instead of
+  lapsing after ten idle minutes. A pin is a standing instruction, and a
+  selection that silently reverted would have made the new composer control lie
+  about what is running. The practical consequence is a bill: pin `/c3` and
+  forget, and every later turn keeps paying for `c3` until someone runs `/auto`.
+  Routing the model chooses for itself mid-turn is unchanged and still lapses on
+  its own. Two things still outrank a pin, both pre-existing: image turns are
+  routed to a vision tier before pins are consulted (the Web UI flags such a
+  turn), and a pinned turn skips the large-context tier floor, so it fails at
+  the provider rather than being upgraded if the conversation outgrows the
+  pinned model's context window.
+
 ## [2026.8.11] - 2026-08-11
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,8 @@ The most useful ones:
 | `/compact` | Compact older context into a summary. |
 | `/cost` | Show per-session token and cost totals. |
 | `/save [path]` | Save the transcript to a Markdown file. |
-| `/c0` … `/c3` | Pin the Pilot Router to a configured tier for this session. The pin appears in the bottom toolbar (e.g. `tier:c3`) and stays active until you exit, run `/auto`, or the hold expires. |
+| `/c0` … `/c3` | Pin the Pilot Router to a configured tier for this session. The pin appears in the bottom toolbar (e.g. `tier:c3`) and stays active until you exit or run `/auto`. |
+| `/use <model-id>` | Pin the route to a specific model, outside the configured tiers. The model must belong to the active provider. |
 | `/auto` | Restore automatic Pilot Router routing (clears the tier pin). |
 | `/help` | List the commands available on the current surface. |
 | `/exit` / `/quit` | Leave the REPL. |
@@ -94,6 +95,32 @@ and `--standalone` modes. Tiers not present in your `[agentos_router]`
 config are rejected with a readable error. In `--standalone` mode the
 router must be enabled in config; otherwise the command reports
 "Pilot Router is disabled or unavailable."
+
+A tier pin you set is **sticky**: it holds every turn until you clear it with
+`/auto` (or the process ends). It does not time out. Pin `/c3` and forget, and
+every later turn keeps paying for `c3` — check `/status` if you are unsure what
+is in force. This differs from the routing the model may pick for itself
+mid-turn, which still lapses on its own after ten idle minutes.
+
+`/use` pins a model that is not one of your four configured tiers. It is a
+separate verb from `/model`, whose argument filters the model listing — `/model
+gpt` shows you the gpt models, `/use gpt-5.6-terra` switches to one. Because
+every turn runs through the single configured `llm.provider` (a tier's
+`provider` field is metadata, not a client selector), only that provider's
+models can be pinned; anything else is refused at the point of choosing rather
+than failing on the next turn. A directly-named model rides on the default tier,
+inheriting its thinking level and pricing baseline — settings a bare model id
+does not carry.
+
+While a pin is in force the model's own `router_control` tool is withdrawn, so
+it cannot route around your choice. Two exceptions are worth knowing:
+
+- **Image turns.** A turn with an image attachment is routed to a vision-capable
+  tier before pins are consulted, so it runs on that tier, not your pinned one.
+  The Web UI flags such a turn.
+- **Large context.** A pinned turn skips the large-context tier floor. If the
+  conversation outgrows the pinned model's context window, the turn fails at the
+  provider rather than being quietly upgraded. Pin a larger tier, or run `/auto`.
 
 ### Assistant label and session chrome
 

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -149,7 +149,24 @@ export const chat = defineNamespace('chat', {
   slashRoutingRestored: 'Automatic routing restored',
   slashRoutingAlready: 'Automatic routing already active',
   slashRouterUnpinFailed: 'Router unpin failed: {message}',
+  slashUseNeedsModel: 'Usage: /use <model-id>',
   slashUnsupported: 'Unsupported command: {command}',
+
+  // Composer route picker.
+  routeLabel: 'Model route',
+  routeAuto: 'Auto',
+  routeAutoHint: 'Let the Pilot Router choose',
+  routeAutoWithTier: 'Auto · {tier}',
+  routeAutoTitle: 'The Pilot Router picks a tier for each turn',
+  routePinned: 'Pinned to {target}',
+  routePinnedTitle: 'Pinned to {tier} until you change it',
+  routeModelPinnedTitle: 'Pinned to {model} until you change it',
+  routeSearchPlaceholder: 'Search tiers and models',
+  routeNoMatch: 'No route matches',
+  routeDisabledTitle: 'Turn on the Pilot Router to pick a tier',
+  routeImageOverride: 'image route',
+  routeImageOverrideTitle:
+    'This turn used the image tier: image turns are routed before the pin is applied',
 
   // Transcript wiring.
   attachmentsPrompt: 'Describe these attachments',

--- a/frontend/src/views/chat/ChatPage.tsx
+++ b/frontend/src/views/chat/ChatPage.tsx
@@ -26,11 +26,13 @@ import {
 } from './logic'
 import { PendingQueue } from './PendingQueue'
 import { resetSession as requestSessionReset } from './resetSession'
+import { RoutePicker } from './RoutePicker'
 import { SessionChip } from './SessionChip'
 import { SlashMenu, type SlashMenuHandle } from './SlashMenu'
 import { Toolbar } from './Toolbar'
 import { useApprovalPending } from './useApprovalPending'
 import { usePendingQueue, type PendingComposerBridge } from './usePendingQueue'
+import { useRoutePin } from './useRoutePin'
 import { useSlashCommands } from './useSlashCommands'
 import { useTranscript } from './useTranscript'
 import { t } from '@/i18n'
@@ -232,6 +234,10 @@ export function ChatPage() {
     setComposerValue(text)
   }, [])
 
+  // Declared before useTranscript: the router-fx animation is suppressed while a
+  // tier is pinned, so the transcript needs the pin state as an input.
+  const route = useRoutePin(rpc, sessionKey)
+
   const {
     containerRef,
     routerFxDockRef,
@@ -251,6 +257,9 @@ export function ChatPage() {
     onEditMessage: editMessage,
     onRegenerateMessage: regenerateMessage,
     onSessionKeyResolved: switchToSession,
+    // Either kind of pin removes the router's choice, so both suppress the
+    // router-fx strip — a model pin is no less decided than a tier pin.
+    routePinned: route.isPinned,
   })
   const attachments = useAttachments()
 
@@ -671,6 +680,7 @@ export function ChatPage() {
         routerFxDock={
           <div id="chat-routerfx-dock" className="chat-routerfx-dock" ref={routerFxDockRef} />
         }
+        routePicker={<RoutePicker route={route} />}
         toolbar={
           <Toolbar
             sessionKey={sessionKey}

--- a/frontend/src/views/chat/Composer.tsx
+++ b/frontend/src/views/chat/Composer.tsx
@@ -133,6 +133,12 @@ export interface ComposerProps {
   /** Imperative router-fx mount point, rendered as a compact status above the input row. */
   routerFxDock?: React.ReactNode
   /**
+   * Optional route picker, mounted at the right of the input bar next to the
+   * send button so the active model route is readable without opening the
+   * settings popover, and sits with the other per-send controls.
+   */
+  routePicker?: React.ReactNode
+  /**
    * Optional composer-settings toolbar (execution mode + Pilot Router + usage),
    * mounted behind a gear trigger in the input bar (chat.js:1248-1281
    * `chat-toolbar-wrap`). Absent when the view has no toolbar.
@@ -173,6 +179,7 @@ export function Composer({
   onAttachFiles,
   tray,
   routerFxDock,
+  routePicker,
   toolbar,
   pendingCount = 0,
   onRecoverPending,
@@ -576,6 +583,7 @@ export function Composer({
           aria-controls={slashActiveDescendant ? slashListboxId : undefined}
           aria-activedescendant={slashActiveDescendant}
         />
+        {routePicker}
         {busy ? (
           <button
             type="button"

--- a/frontend/src/views/chat/RoutePicker.test.tsx
+++ b/frontend/src/views/chat/RoutePicker.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { RoutePicker } from './RoutePicker'
+import type { RoutePinApi } from './useRoutePin'
+
+function route(overrides: Partial<RoutePinApi> = {}): RoutePinApi {
+  const base: RoutePinApi = {
+    enabled: true,
+    tiers: [
+      { tier: 'c0', model: 'deepseek-v4-flash' },
+      { tier: 'c1', model: 'gpt-5.6-luna' },
+      { tier: 'c2', model: 'glm-5.2' },
+      { tier: 'c3', model: 'claude-opus-5' },
+    ],
+    models: [
+      // gpt-5.6-luna is also tier c1's model — the overlap the dedup handles.
+      { id: 'gpt-5.6-luna', name: 'gpt-5.6-luna' },
+      { id: 'gpt-5.6-terra', name: 'gpt-5.6-terra' },
+      { id: 'grok-5', name: 'grok-5' },
+    ],
+    pinned: null,
+    pinnedModel: null,
+    isPinned: false,
+    lastRoutedTier: null,
+    imageOverride: false,
+    busy: false,
+    pin: vi.fn(),
+    pinModel: vi.fn(),
+    clear: vi.fn(),
+    ...overrides,
+  }
+  // Derived in the hook, so derive it here too rather than making every case
+  // restate it — a fixture that let the two drift would hide the very bug this
+  // field exists to prevent.
+  return { ...base, isPinned: base.pinned !== null || base.pinnedModel !== null }
+}
+
+const trigger = () => screen.getByRole('button', { name: 'Model route' })
+
+describe('RoutePicker', () => {
+  it('labels the pinned tier with the model it resolves to', () => {
+    render(<RoutePicker route={route({ pinned: 'c1' })} />)
+    expect(trigger()).toHaveTextContent('c1 · gpt-5.6-luna')
+  })
+
+  it('names the tier the router actually chose while on Auto', () => {
+    render(<RoutePicker route={route({ lastRoutedTier: 'c2' })} />)
+    expect(trigger()).toHaveTextContent('Auto · c2')
+  })
+
+  it('falls back to a bare Auto before any turn has been routed', () => {
+    render(<RoutePicker route={route()} />)
+    expect(trigger()).toHaveTextContent('Auto')
+    expect(trigger()).not.toHaveTextContent('·')
+  })
+
+  it('marks a pin as active so a standing override does not read as neutral', () => {
+    render(<RoutePicker route={route({ pinned: 'c3' })} />)
+    expect(trigger()).toHaveClass('chat-route-trigger--pinned')
+  })
+
+  it('disables rather than hides the control when no router is configured', () => {
+    render(<RoutePicker route={route({ enabled: false })} />)
+    expect(trigger()).toBeDisabled()
+    expect(trigger()).toHaveAttribute('title', 'Turn on the Pilot Router to pick a tier')
+  })
+
+  it('disables the trigger while a pin round-trip is in flight', () => {
+    render(<RoutePicker route={route({ busy: true })} />)
+    expect(trigger()).toBeDisabled()
+  })
+
+  it('lists Auto, every pinnable tier, then the remaining models', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    const options = screen.getAllByRole('option')
+    // Auto + 4 tiers + terra + grok. gpt-5.6-luna is dropped: tier c1 already
+    // offers that model AND carries its configured thinking level.
+    expect(options).toHaveLength(7)
+    expect(options[0]).toHaveTextContent('Auto')
+    expect(options[2]).toHaveTextContent('c1')
+    expect(options[2]).toHaveTextContent('gpt-5.6-luna')
+    expect(options[6]).toHaveTextContent('grok-5')
+  })
+
+  it('does not offer a model a tier already covers', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    const luna = screen.getAllByRole('option').filter((o) => o.textContent?.includes('luna'))
+    expect(luna).toHaveLength(1)
+    expect(luna[0]).toHaveTextContent('c1')
+  })
+
+  it('checks the option matching the active pin', () => {
+    render(<RoutePicker route={route({ pinned: 'c2' })} />)
+    fireEvent.click(trigger())
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+    expect(options[3]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('checks Auto when nothing is pinned', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    expect(screen.getAllByRole('option')[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('pins the chosen tier and closes the menu', () => {
+    const pin = vi.fn()
+    render(<RoutePicker route={route({ pin })} />)
+    fireEvent.click(trigger())
+    fireEvent.click(screen.getAllByRole('option')[4]!)
+    expect(pin).toHaveBeenCalledWith('c3')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('pins a directly-named model through pinModel, not pin', () => {
+    const pin = vi.fn()
+    const pinModel = vi.fn()
+    render(<RoutePicker route={route({ pin, pinModel })} />)
+    fireEvent.click(trigger())
+    fireEvent.click(screen.getByRole('option', { name: /grok-5/ }))
+    expect(pinModel).toHaveBeenCalledWith('grok-5')
+    expect(pin).not.toHaveBeenCalled()
+  })
+
+  it('labels a model pin with the model alone — no tier was chosen', () => {
+    render(<RoutePicker route={route({ pinnedModel: 'grok-5' })} />)
+    expect(trigger()).toHaveTextContent('grok-5')
+    expect(trigger()).toHaveClass('chat-route-trigger--pinned')
+  })
+
+  it('checks the pinned model rather than Auto', () => {
+    render(<RoutePicker route={route({ pinnedModel: 'grok-5' })} />)
+    fireEvent.click(trigger())
+    expect(screen.getAllByRole('option')[0]).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('option', { name: /grok-5/ })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('filters the list by tier or model text', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'grok' } })
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent('grok-5')
+  })
+
+  it('reports an empty filter result rather than an empty box', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'zzz' } })
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+    expect(screen.getByText('No route matches')).toBeInTheDocument()
+  })
+
+  it('clears the filter after a pick so the next open starts fresh', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'grok' } })
+    fireEvent.click(screen.getByRole('option', { name: /grok-5/ }))
+    fireEvent.click(trigger())
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('restores automatic routing through Auto rather than pinning it', () => {
+    const pin = vi.fn()
+    const clear = vi.fn()
+    render(<RoutePicker route={route({ pinned: 'c3', pin, clear })} />)
+    fireEvent.click(trigger())
+    fireEvent.click(screen.getAllByRole('option')[0]!)
+    expect(clear).toHaveBeenCalledTimes(1)
+    expect(pin).not.toHaveBeenCalled()
+  })
+
+  it('flags the turns an image route took instead of the pin', () => {
+    render(<RoutePicker route={route({ pinned: 'c0', imageOverride: true })} />)
+    expect(screen.getByText('image route')).toBeInTheDocument()
+  })
+
+  it('shows no override badge on ordinary text turns', () => {
+    render(<RoutePicker route={route({ pinned: 'c0' })} />)
+    expect(screen.queryByText('image route')).not.toBeInTheDocument()
+  })
+
+  it('closes on Escape without reaching the composer abort chain', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('closes on an outside mousedown', () => {
+    render(<RoutePicker route={route()} />)
+    fireEvent.click(trigger())
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/views/chat/RoutePicker.tsx
+++ b/frontend/src/views/chat/RoutePicker.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { CheckIcon, RouteIcon } from 'lucide-react'
+import type { RoutePinApi } from './useRoutePin'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
+/**
+ * The composer's route picker: hand routing to the Pilot Router, pin one of the
+ * configured tiers, or name a model directly.
+ *
+ * The three live in ONE searchable list because they answer one question —
+ * "what answers the next turn?" — even though they are different mechanisms
+ * underneath. Tiers carry settings (thinking level, pricing baseline) that a
+ * bare model id does not; a directly-named model borrows them from the default
+ * tier. That distinction matters to the router, not to the person choosing, so
+ * it stays out of the list and lives in the tier rows' own labels.
+ *
+ * The button reports what is actually in force:
+ *
+ *   - tier pinned  → `c1 · gpt-5.6-luna`
+ *   - model pinned → the model id alone; no tier was chosen
+ *   - auto         → `Auto · c2`, the tier the router last picked, so "let it
+ *                    decide" is still legible
+ *   - image turn   → an override note, because an image turn is routed to a
+ *                    vision tier before pins are consulted; the pin did not run
+ *                    that turn and saying otherwise would misreport the bill
+ *
+ * Disabled (not hidden) when no Pilot Router is configured, so the composer
+ * does not reflow when the router is toggled.
+ */
+
+export interface RoutePickerProps {
+  route: RoutePinApi
+}
+
+/**
+ * One menu row, flattened for display. `kind` + `value` are all the click
+ * handler needs; `primary`/`secondary` are what the row shows. Keeping the
+ * presentation resolved here rather than branching inside the JSX keeps the
+ * three row types rendering through one path.
+ */
+interface Row {
+  kind: 'auto' | 'tier' | 'model'
+  value: string
+  key: string
+  primary: string
+  secondary: string
+}
+
+export function RoutePicker({ route }: RoutePickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  // Close on outside click / Escape, mirroring the composer toolbar popover.
+  // `mousedown` (not `click`) so it lands before the trigger's own toggle.
+  useEffect(() => {
+    if (!open) return
+    searchRef.current?.focus()
+    const onDocMouseDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      // The open menu owns Escape before the composer's abort/clear chain.
+      e.preventDefault()
+      e.stopPropagation()
+      setOpen(false)
+      triggerRef.current?.focus()
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown)
+      document.removeEventListener('keydown', onKeyDown, true)
+    }
+  }, [open])
+
+  // Bumped when a row is picked, to hand focus back to the trigger. The focus
+  // itself happens in the effect below rather than in the handler: a callback
+  // that reads a ref and is invoked from JSX trips the refs lint, and routing
+  // it through state also keeps the restore scoped to a deliberate SELECTION —
+  // closing by clicking elsewhere must not yank focus back out of wherever the
+  // user just clicked.
+  const [refocus, setRefocus] = useState(0)
+  useEffect(() => {
+    if (refocus === 0) return
+    triggerRef.current?.focus()
+  }, [refocus])
+
+  const choose = useCallback(
+    (kind: Row['kind'], value: string) => {
+      setOpen(false)
+      setQuery('')
+      setRefocus((n) => n + 1)
+      if (kind === 'auto') route.clear()
+      else if (kind === 'tier') route.pin(value)
+      else route.pinModel(value)
+    },
+    [route],
+  )
+
+  const rows = useMemo<Row[]>(() => {
+    const tierRows: Row[] = route.tiers.map((row) => ({
+      kind: 'tier',
+      value: row.tier,
+      key: `t:${row.tier}`,
+      primary: row.tier,
+      secondary: row.model,
+    }))
+    // Models already offered as a tier are dropped: the tier row pins the same
+    // model AND carries its configured thinking level, so it is strictly the
+    // better of two rows that would otherwise look identical.
+    const tierModels = new Set(route.tiers.map((row) => row.model).filter(Boolean))
+    const modelRows: Row[] = route.models
+      .filter((model) => !tierModels.has(model.id))
+      .map((model) => ({
+        kind: 'model',
+        value: model.id,
+        key: `m:${model.id}`,
+        primary: model.name,
+        secondary: '',
+      }))
+    const all: Row[] = [
+      {
+        kind: 'auto',
+        value: '',
+        key: 'auto',
+        primary: t('chat.routeAuto'),
+        secondary: t('chat.routeAutoHint'),
+      },
+      ...tierRows,
+      ...modelRows,
+    ]
+    const needle = query.trim().toLowerCase()
+    if (!needle) return all
+    return all.filter(
+      (row) =>
+        row.primary.toLowerCase().includes(needle) ||
+        row.secondary.toLowerCase().includes(needle),
+    )
+  }, [route.tiers, route.models, query])
+
+  const selectedKey =
+    route.pinnedModel !== null
+      ? `m:${route.pinnedModel}`
+      : route.pinned !== null
+        ? `t:${route.pinned}`
+        : 'auto'
+
+  const pinnedModelLabel = route.pinned
+    ? route.tiers.find((row) => row.tier === route.pinned)?.model || ''
+    : ''
+  const label = route.pinnedModel
+    ? route.pinnedModel
+    : route.pinned
+      ? pinnedModelLabel
+        ? `${route.pinned} · ${pinnedModelLabel}`
+        : route.pinned
+      : route.lastRoutedTier
+        ? t('chat.routeAutoWithTier', { tier: route.lastRoutedTier })
+        : t('chat.routeAuto')
+
+  const title = !route.enabled
+    ? t('chat.routeDisabledTitle')
+    : route.pinnedModel
+      ? t('chat.routeModelPinnedTitle', { model: route.pinnedModel })
+      : route.pinned
+        ? t('chat.routePinnedTitle', { tier: route.pinned })
+        : t('chat.routeAutoTitle')
+
+  return (
+    <div className="chat-route-wrap" ref={wrapRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={
+          route.isPinned ? 'chat-route-trigger chat-route-trigger--pinned' : 'chat-route-trigger'
+        }
+        disabled={!route.enabled || route.busy}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls="chat-route-menu"
+        aria-label={t('chat.routeLabel')}
+        title={title}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <RouteIcon aria-hidden="true" />
+        <span className="chat-route-trigger__label">{label}</span>
+      </button>
+      {route.imageOverride ? (
+        <span className="chat-route-badge" title={t('chat.routeImageOverrideTitle')}>
+          {t('chat.routeImageOverride')}
+        </span>
+      ) : null}
+      {open ? (
+        <div className="chat-route-menu">
+          <input
+            ref={searchRef}
+            type="text"
+            className="chat-route-search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('chat.routeSearchPlaceholder')}
+            aria-label={t('chat.routeSearchPlaceholder')}
+          />
+          <ul id="chat-route-menu" className="chat-route-list" role="listbox">
+            {rows.length === 0 ? (
+              <li className="chat-route-empty">{t('chat.routeNoMatch')}</li>
+            ) : (
+              rows.map((row) => (
+                <li role="none" key={row.key}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={row.key === selectedKey}
+                    className="chat-route-option"
+                    onClick={() => choose(row.kind, row.value)}
+                  >
+                    <span className="chat-route-option__check" aria-hidden="true">
+                      {row.key === selectedKey ? <CheckIcon /> : null}
+                    </span>
+                    <span className="chat-route-option__tier">{row.primary}</span>
+                    <span className="chat-route-option__model">{row.secondary}</span>
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/views/chat/RoutePicker.tsx
+++ b/frontend/src/views/chat/RoutePicker.tsx
@@ -138,8 +138,7 @@ export function RoutePicker({ route }: RoutePickerProps) {
     if (!needle) return all
     return all.filter(
       (row) =>
-        row.primary.toLowerCase().includes(needle) ||
-        row.secondary.toLowerCase().includes(needle),
+        row.primary.toLowerCase().includes(needle) || row.secondary.toLowerCase().includes(needle),
     )
   }, [route.tiers, route.models, query])
 

--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -2743,6 +2743,179 @@
   }
 }
 
+/* Route picker: pin the Pilot Router to one tier from the composer input bar.
+   Sized to its label rather than the square icon buttons beside it — the label
+   carries the model name, which is the reason the control exists. */
+.chat-route-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  flex: none;
+  gap: 6px;
+  z-index: 10;
+}
+.chat-route-trigger {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 14rem;
+  height: 2.5rem;
+  gap: 6px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: none;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.chat-route-trigger svg {
+  display: block;
+  width: 15px;
+  height: 15px;
+  flex: none;
+  stroke-width: 1.8;
+}
+.chat-route-trigger__label {
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-route-trigger:hover:not(:disabled) {
+  border-color: var(--border);
+  background: var(--elevated);
+  color: var(--foreground);
+}
+.chat-route-trigger:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+.chat-route-trigger:disabled {
+  color: var(--dim);
+  cursor: default;
+}
+/* A pin is a standing override, so it reads as active rather than neutral. */
+.chat-route-trigger--pinned {
+  border-color: color-mix(in srgb, var(--primary) 32%, var(--border));
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  color: var(--foreground);
+}
+.chat-route-badge {
+  flex: none;
+  padding: 2px 6px;
+  border-radius: var(--radius-control);
+  background: color-mix(in srgb, var(--warning, var(--primary)) 14%, transparent);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.chat-route-menu {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  /* Right-anchored: the trigger sits at the right edge of the input bar, so a
+     left-anchored menu would open off the composer. */
+  right: -9px;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  width: max-content;
+  min-width: 16rem;
+  max-width: min(24rem, calc(100vw - 2rem));
+  /* The search box stays put while only the rows scroll — with a full model
+     catalog the list is long, and a filter you have to scroll back up to reach
+     is not a filter. */
+  max-height: min(22rem, calc(100dvh - 8rem));
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--primary) 22%, var(--border));
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow:
+    0 18px 48px color-mix(in srgb, var(--background) 72%, transparent),
+    0 2px 10px color-mix(in srgb, var(--background) 45%, transparent);
+}
+.chat-route-search {
+  flex: none;
+  width: 100%;
+  margin-bottom: 4px;
+  padding: 7px 9px;
+  border: 1px solid var(--hairline);
+  border-radius: calc(var(--radius) - 3px);
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+.chat-route-search::placeholder {
+  color: var(--dim);
+}
+.chat-route-search:focus-visible {
+  border-color: var(--ring);
+  outline: none;
+}
+.chat-route-list {
+  overflow-y: auto;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.chat-route-empty {
+  padding: 9px;
+  color: var(--dim);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+.chat-route-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: calc(var(--radius) - 3px);
+  background: none;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.3;
+  text-align: left;
+  cursor: pointer;
+}
+.chat-route-option:hover,
+.chat-route-option:focus-visible {
+  background: var(--elevated);
+  outline: none;
+}
+.chat-route-option__check {
+  display: grid;
+  width: 14px;
+  height: 14px;
+  flex: none;
+  place-items: center;
+}
+.chat-route-option__check svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2.2;
+}
+.chat-route-option__tier {
+  flex: none;
+}
+.chat-route-option__model {
+  overflow: hidden;
+  min-width: 0;
+  color: var(--dim);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Gear trigger + popover holding the toolbar in the composer input bar
    (chat.js:1248-1281 chat-toolbar-wrap). */
 .chat-toolbar-wrap {

--- a/frontend/src/views/chat/transcript/routerFx.test.ts
+++ b/frontend/src/views/chat/transcript/routerFx.test.ts
@@ -395,6 +395,136 @@ describe('createRouterFxRenderer (factory smoke)', () => {
   })
 })
 
+describe('createRouterFxRenderer route-pin suppression', () => {
+  // A pinned tier decides the route before the router runs, so the strip would
+  // animate a deliberation that never happened — and restate what the composer's
+  // route picker already shows, every turn.
+  function pinnedHarness(pinned: boolean) {
+    const reg = seededRegistry()
+    const host = document.createElement('div')
+    const thread = document.createElement('div')
+    const dock = document.createElement('div')
+    const anchor = document.createElement('div')
+    anchor.className = 'msg user'
+    thread.appendChild(anchor)
+    host.append(thread, dock)
+    document.body.appendChild(host)
+    const renderer = createRouterFxRenderer({
+      thread: () => thread,
+      dock: () => dock,
+      getSessionKey: () => 's',
+      registry: reg,
+      pref: { enabled: true, variant: 'default' },
+      routerFeatureEnabled: () => true,
+      isRoutePinned: () => pinned,
+      esc: (s) => s,
+      scrollToBottom: () => {},
+    })
+    return { anchor, dock, reg, renderer, cleanup: () => host.remove() }
+  }
+
+  it('refuses to begin a scan while a tier is pinned', () => {
+    const h = pinnedHarness(true)
+    try {
+      expect(h.renderer.beginScan(h.anchor, 'seed')).toBe(false)
+      expect(h.dock.querySelector('.router-fx')).toBeNull()
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('still scans normally when nothing is pinned', () => {
+    const h = pinnedHarness(false)
+    try {
+      expect(h.renderer.beginScan(h.anchor, 'seed')).toBe(true)
+    } finally {
+      h.renderer.clearRouterFxVisuals()
+      h.cleanup()
+    }
+  })
+
+  it('refuses to schedule a delayed scan while a tier is pinned', () => {
+    const h = pinnedHarness(true)
+    try {
+      expect(h.renderer.scheduleBeginScan(h.anchor, 'seed')).toBe(false)
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('mounts no strip for a decision while a tier is pinned', async () => {
+    const h = pinnedHarness(true)
+    try {
+      await h.renderer.handleRouterDecision({ tier: 'c1', model: 'anthropic/claude-a' })
+      expect(h.dock.querySelector('.router-fx')).toBeNull()
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('does not learn a tier→model pair from a pinned turn', async () => {
+    // A directly-named model rides on a HOST tier: the decision reports c1
+    // (where the settings came from) with the user's model. Learning that pair
+    // would rewrite c1's model in the registry and mislabel later strips for a
+    // tier that never ran it.
+    const h = pinnedHarness(true)
+    try {
+      await h.renderer.handleRouterDecision({ tier: 'c1', model: 'z-ai/glm-5.2' })
+      expect(h.reg.models['c1']).not.toBe('z-ai/glm-5.2')
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('suppresses a hold-routed decision even when this view knows of no pin', async () => {
+    // A `/c3` slash command or another client pins without passing through the
+    // picker's state, so the decision's own source has to be enough.
+    const h = pinnedHarness(false)
+    try {
+      await h.renderer.handleRouterDecision({
+        tier: 'c1',
+        model: 'z-ai/glm-5.2',
+        source: 'router_control_hold',
+      })
+      expect(h.dock.querySelector('.router-fx')).toBeNull()
+      expect(h.reg.models['c1']).not.toBe('z-ai/glm-5.2')
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('rebuilds no history strip for a turn that was pinned', () => {
+    // History outlives the pin: the turn was not a routing decision then and is
+    // not one now, so no strip is reconstructed on reload.
+    const h = pinnedHarness(false)
+    try {
+      const strip = h.renderer.buildRouterFxFromUsage(
+        {
+          routed_tier: 'c1',
+          routed_model: 'z-ai/glm-5.2',
+          routing_source: 'router_control_hold',
+        },
+        'seed-1',
+      )
+      expect(strip).toBeNull()
+      expect(h.reg.models['c1']).not.toBe('z-ai/glm-5.2')
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('still learns the pair on an ordinary unpinned turn', async () => {
+    const h = pinnedHarness(false)
+    try {
+      await h.renderer.handleRouterDecision({ tier: 'c1', model: 'anthropic/claude-a' })
+      expect(h.reg.models['c1']).toBe('anthropic/claude-a')
+    } finally {
+      h.renderer.clearRouterFxVisuals()
+      h.cleanup()
+    }
+  })
+})
+
 describe('createRouterFxRenderer history reconciliation', () => {
   it('reconstructs a settled strip from persisted usage with the stable session seed', () => {
     localStorage.clear()

--- a/frontend/src/views/chat/transcript/routerFx.ts
+++ b/frontend/src/views/chat/transcript/routerFx.ts
@@ -502,6 +502,15 @@ export interface RouterFxRendererDeps {
   pref: RouterFxPref
   /** chat.js `_routerFeatureEnabled` — operator routing on/off, read live. */
   routerFeatureEnabled: () => boolean
+  /**
+   * True while the user has pinned a router tier, read live. The strip exists to
+   * show the router weighing candidates and settling on one; a pin decides the
+   * route up front, so there is no deliberation to animate and the strip would
+   * just restate the composer's own route picker every turn. Suppressed exactly
+   * like the single-candidate case below — because that is what a pin is.
+   * Default: never pinned.
+   */
+  isRoutePinned?: () => boolean
   /** chat.js:661 — HTML-escape. */
   esc: (s: string) => string
   /** chat.js `_scrollToBottom`. */
@@ -533,6 +542,18 @@ export interface RouterFxRendererDeps {
  * `staticizeCompletedStrips` / … so `useTranscript` can route the
  * `session.event.router_decision` event and the stream lifecycle can drive it.
  */
+/**
+ * True when a turn was routed by a user pin rather than by the router choosing.
+ *
+ * The router step stamps this on the decision and persists it in usage, so it
+ * travels with the turn — which makes it the reliable signal: a pin set from a
+ * slash command or another client never passes through this view's state, and a
+ * turn stays "pinned" in history long after the pin itself is gone.
+ */
+function isHoldRouted(source: string | undefined | null): boolean {
+  return String(source || '').toLowerCase() === 'router_control_hold'
+}
+
 export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
   const {
     thread,
@@ -544,6 +565,7 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
     esc,
     scrollToBottom,
   } = deps
+  const isRoutePinned = deps.isRoutePinned ?? (() => false)
   const isSuppressedForCompactionTurn = deps.isSuppressedForCompactionTurn ?? (() => false)
   const isCompactInFlightForCurrentSession =
     deps.isCompactInFlightForCurrentSession ?? (() => false)
@@ -1062,6 +1084,10 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       })
       return false
     }
+    if (isRoutePinned()) {
+      diag('router_scan.schedule.skip.route_pinned', {})
+      return false
+    }
     if (reg.configTiers !== null && !routerFxHasMultipleCandidates(reg, requestKind, null)) {
       diag('router_scan.schedule.skip.single_candidate', {
         requestKind,
@@ -1108,6 +1134,10 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
         routerFxEnabled: !!pref.enabled,
         routerFeatureEnabled: !!routerFeatureEnabled(),
       })
+      return false
+    }
+    if (isRoutePinned()) {
+      diag('router_scan.skip.route_pinned', {})
       return false
     }
     if (!routerFxHasMultipleCandidates(reg, requestKind, null)) {
@@ -1445,8 +1475,33 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       diag('router_decision.skip.no_tier', summarizePayload(payload))
       return
     }
-    reg.rememberTierDecision(tier, payload.model || '')
     const turnIndex = countUserMessages()
+    // `isRoutePinned` covers a pin this view knows about; the decision's own
+    // source covers one it does not — a `/c3` slash command or another client
+    // pins without ever passing through the picker's state.
+    if (isRoutePinned() || isHoldRouted(payload.source || payload.routing_source)) {
+      // Deliberately WITHOUT rememberTierDecision. A pinned turn is not a
+      // routing observation, it is the user's instruction, and for a
+      // directly-named model the pair is actively wrong: the hold reports the
+      // tier that lends it settings (say c1) alongside the chosen model (say
+      // glm-5.2), so learning it would rewrite c1's model in the registry and
+      // mislabel later strips for a tier that never ran that model.
+      // Also sweep a live strip already on screen: the pin may have been set
+      // mid-turn, after the scan began.
+      if (thread()) {
+        strips('.router-fx[data-live="true"]').forEach((el) => {
+          if (!el.dataset.turnIndex || el.dataset.turnIndex === String(turnIndex)) {
+            removeStrip(el)
+          }
+        })
+      }
+      diag('router_decision.skip.route_pinned', summarizePayload(payload))
+      return
+    }
+    // An unpinned turn IS a routing observation, so the tier→model pair is
+    // learned here — before the remaining suppressions, which are about whether
+    // to ANIMATE, not about whether the routing happened.
+    reg.rememberTierDecision(tier, payload.model || '')
     if (routerFxIsSuppressedForCompactionTurn(String(turnIndex))) {
       if (thread()) {
         strips('.router-fx[data-live="true"]').forEach((el) => {
@@ -1570,6 +1625,13 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
   ): RouterFxDecision | null {
     if (!usage || !pref.enabled) return null
     if (reg.configTiers !== null && !routerFeatureEnabled()) return null
+    // A turn the user pinned gets no strip, now or on any later reload. Gated on
+    // the SOURCE recorded for that turn rather than on the current pin: history
+    // outlives the pin, so "was this turn a routing decision?" is the question,
+    // not "is a pin in force right now?". This is also what keeps the pair out
+    // of the registry below — a model pin records its HOST tier alongside the
+    // user's model, and learning that would rewrite the tier's own model.
+    if (isHoldRouted(usage.routing_source)) return null
     const tier = routerFxNormalizeTier(usage.routed_tier || '')
     if (!tier) return null
     if (reg.configTiers !== null && !reg.configTiers.has(tier)) return null

--- a/frontend/src/views/chat/transcript/stream.ts
+++ b/frontend/src/views/chat/transcript/stream.ts
@@ -262,6 +262,12 @@ export interface StreamControllerDeps {
   routerFxRegistry?: RouterFxRegistry
   routerFxPref?: RouterFxPref
   routerFeatureEnabled?: () => boolean
+  /**
+   * True while the user has pinned a router tier. Default: false (unpinned).
+   * A pin decides the route before the router runs, so the strip would animate
+   * a deliberation that never happened.
+   */
+  routePinned?: () => boolean
   routerFxDock?: () => HTMLElement | null
   /** chat.js:3569 — await the router-fx config-ready gate. Default: resolve now. */
   routerFxAwaitConfig?: () => Promise<void>
@@ -433,6 +439,7 @@ export function createStreamController(
     registry: routerFxRegistry,
     pref: routerFxPref,
     routerFeatureEnabled: deps.routerFeatureEnabled ?? (() => false),
+    isRoutePinned: deps.routePinned ?? (() => false),
     esc,
     scrollToBottom: () => scrollToBottom(),
     isCompactInFlightForCurrentSession,

--- a/frontend/src/views/chat/useRoutePin.test.ts
+++ b/frontend/src/views/chat/useRoutePin.test.ts
@@ -105,9 +105,7 @@ describe('useRoutePin', () => {
     await waitFor(() => expect(result.current.models).toHaveLength(2))
 
     rerender({ key: 'agent:main:two' })
-    await waitFor(() =>
-      expect(calls.filter((c) => c.method === 'router.hold.get')).toHaveLength(2),
-    )
+    await waitFor(() => expect(calls.filter((c) => c.method === 'router.hold.get')).toHaveLength(2))
 
     expect(calls.filter((c) => c.method === 'models.list')).toHaveLength(1)
   })
@@ -144,9 +142,7 @@ describe('useRoutePin', () => {
     const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
     await waitFor(() => expect(result.current.enabled).toBe(true))
 
-    act(() =>
-      emit('session.event.router_decision', { tier: 'image_model', source: 'image_route' }),
-    )
+    act(() => emit('session.event.router_decision', { tier: 'image_model', source: 'image_route' }))
 
     expect(result.current.imageOverride).toBe(true)
   })

--- a/frontend/src/views/chat/useRoutePin.test.ts
+++ b/frontend/src/views/chat/useRoutePin.test.ts
@@ -1,0 +1,314 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useRoutePin } from './useRoutePin'
+import type { WsRpcClient } from '@/lib/ws-rpc'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}))
+
+type Handler = (...args: unknown[]) => void
+
+const HOLD_GET_OK = {
+  enabled: true,
+  provider: 'opencap',
+  hold: null,
+  tiers: [
+    { tier: 'c0', model: 'deepseek-v4-flash' },
+    { tier: 'c3', model: 'claude-opus-5' },
+  ],
+}
+
+const MODELS_OK = [
+  { id: 'grok-5', name: 'grok-5', provider: 'opencap' },
+  { id: 'claude-opus-5', name: 'claude-opus-5', provider: 'opencap' },
+]
+
+function fakeRpc(overrides: Record<string, unknown> = {}) {
+  const listeners = new Map<string, Set<Handler>>()
+  const calls: { method: string; params: unknown }[] = []
+  const responses: Record<string, unknown> = {
+    'router.hold.get': HOLD_GET_OK,
+    'models.list': MODELS_OK,
+    ...overrides,
+  }
+  const rpc = {
+    call: vi.fn((method: string, params: unknown) => {
+      calls.push({ method, params })
+      const value = responses[method]
+      if (value instanceof Error) return Promise.reject(value)
+      return Promise.resolve(value ?? {})
+    }),
+    on: vi.fn((event: string, handler: Handler) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(handler)
+      return () => listeners.get(event)?.delete(handler)
+    }),
+  }
+  const emit = (event: string, payload: unknown) =>
+    listeners.get(event)?.forEach((handler) => handler(payload))
+  return { rpc: rpc as unknown as WsRpcClient, calls, emit }
+}
+
+describe('useRoutePin', () => {
+  it('reads the pin back from the gateway rather than guessing it', async () => {
+    const { rpc } = fakeRpc({
+      'router.hold.get': { ...HOLD_GET_OK, hold: { tier: 'c3' } },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.pinned).toBe('c3'))
+    expect(result.current.enabled).toBe(true)
+    expect(result.current.tiers.map((row) => row.tier)).toEqual(['c0', 'c3'])
+  })
+
+  it('reports no pin and no tiers when the router is off', async () => {
+    const { rpc } = fakeRpc({
+      'router.hold.get': { enabled: false, hold: null, tiers: [] },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(rpc.call).toHaveBeenCalled())
+    expect(result.current.enabled).toBe(false)
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('stays disabled when the read fails instead of surfacing an error', async () => {
+    const { rpc } = fakeRpc({ 'router.hold.get': new Error('no such method') })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(rpc.call).toHaveBeenCalled())
+    expect(result.current.enabled).toBe(false)
+    expect(result.current.tiers).toEqual([])
+  })
+
+  it('re-reads the pin when the session changes', async () => {
+    const { rpc, calls } = fakeRpc()
+    const holdReads = () => calls.filter((c) => c.method === 'router.hold.get')
+    const { rerender } = renderHook(({ key }) => useRoutePin(rpc, key), {
+      initialProps: { key: 'agent:main:one' },
+    })
+    await waitFor(() => expect(holdReads()).toHaveLength(1))
+
+    rerender({ key: 'agent:main:two' })
+
+    await waitFor(() => expect(holdReads()).toHaveLength(2))
+    expect(holdReads()[1]!.params).toEqual({ key: 'agent:main:two' })
+  })
+
+  it('does not refetch the model catalog on a session switch', async () => {
+    // The catalog is a gateway-wide fact; only the pin is per-session.
+    const { rpc, calls } = fakeRpc()
+    const { rerender, result } = renderHook(({ key }) => useRoutePin(rpc, key), {
+      initialProps: { key: 'agent:main:one' },
+    })
+    await waitFor(() => expect(result.current.models).toHaveLength(2))
+
+    rerender({ key: 'agent:main:two' })
+    await waitFor(() =>
+      expect(calls.filter((c) => c.method === 'router.hold.get')).toHaveLength(2),
+    )
+
+    expect(calls.filter((c) => c.method === 'models.list')).toHaveLength(1)
+  })
+
+  it('does not carry one session’s pin over to the next', async () => {
+    // Holds are per-session; a stale label would claim a route the new session
+    // is not on. The second read resolves only after the assertion below.
+    const { rpc } = fakeRpc({
+      'router.hold.get': { ...HOLD_GET_OK, hold: { tier: 'c3' } },
+    })
+    const { result, rerender } = renderHook(({ key }) => useRoutePin(rpc, key), {
+      initialProps: { key: 'agent:main:one' },
+    })
+    await waitFor(() => expect(result.current.pinned).toBe('c3'))
+
+    rerender({ key: 'agent:main:two' })
+
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('tracks the tier the router actually used', async () => {
+    const { rpc, emit } = fakeRpc()
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    act(() => emit('session.event.router_decision', { tier: 'c2', source: 'pilot' }))
+
+    expect(result.current.lastRoutedTier).toBe('c2')
+    expect(result.current.imageOverride).toBe(false)
+  })
+
+  it('flags an image route as an override of the pin', async () => {
+    const { rpc, emit } = fakeRpc()
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    act(() =>
+      emit('session.event.router_decision', { tier: 'image_model', source: 'image_route' }),
+    )
+
+    expect(result.current.imageOverride).toBe(true)
+  })
+
+  it('clears the override flag once a text turn routes normally again', async () => {
+    const { rpc, emit } = fakeRpc()
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    act(() => emit('session.event.router_decision', { tier: 'image_model', source: 'image_route' }))
+    act(() => emit('session.event.router_decision', { tier: 'c1', source: 'pilot' }))
+
+    expect(result.current.imageOverride).toBe(false)
+  })
+
+  it('pins through router.hold.set and reflects it immediately', async () => {
+    const { calls, result } = await (async () => {
+      const fake = fakeRpc({ 'router.hold.set': { tier: 'c3', model: 'claude-opus-5' } })
+      const hook = renderHook(() => useRoutePin(fake.rpc, 'agent:main:main'))
+      await waitFor(() => expect(hook.result.current.enabled).toBe(true))
+      return { ...fake, result: hook.result }
+    })()
+
+    await act(async () => result.current.pin('c3'))
+
+    expect(calls.some((c) => c.method === 'router.hold.set')).toBe(true)
+    expect(result.current.pinned).toBe('c3')
+  })
+
+  it('clears through router.hold.clear and returns to Auto', async () => {
+    const { rpc, calls } = fakeRpc({
+      'router.hold.get': { ...HOLD_GET_OK, hold: { tier: 'c3' } },
+      'router.hold.clear': { cleared: true },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.pinned).toBe('c3'))
+
+    await act(async () => result.current.clear())
+
+    expect(calls.some((c) => c.method === 'router.hold.clear')).toBe(true)
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('lists models scoped to the active provider', async () => {
+    const { rpc, calls } = fakeRpc()
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.models).toHaveLength(2))
+    // The provider comes from router.hold.get; routing runs through exactly one
+    // provider, so an unfiltered catalog would offer unreachable models.
+    const listCall = calls.find((c) => c.method === 'models.list')
+    expect(listCall?.params).toEqual({ provider: 'opencap' })
+  })
+
+  it('does not fetch models until the active provider is known', async () => {
+    const { rpc, calls } = fakeRpc({
+      'router.hold.get': { enabled: false, hold: null, tiers: [], provider: '' },
+    })
+    renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'router.hold.get')).toBe(true))
+    expect(calls.some((c) => c.method === 'models.list')).toBe(false)
+  })
+
+  it('reports isPinned for a model pin, not only for a tier pin', async () => {
+    // The router-fx strip is suppressed off this flag; a consumer that checked
+    // only `pinned` kept animating over a pinned model.
+    const { rpc } = fakeRpc({
+      'router.hold.get': {
+        ...HOLD_GET_OK,
+        hold: { tier: 'c1', model: 'grok-5', targetType: 'model' },
+      },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.isPinned).toBe(true))
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('reports isPinned for a tier pin', async () => {
+    const { rpc } = fakeRpc({
+      'router.hold.get': { ...HOLD_GET_OK, hold: { tier: 'c3', targetType: 'tier' } },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.isPinned).toBe(true))
+  })
+
+  it('reports isPinned false when routing is automatic', async () => {
+    const { rpc } = fakeRpc()
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+    expect(result.current.isPinned).toBe(false)
+  })
+
+  it('reads a model pin back as a model, not as its host tier', async () => {
+    // A model pin still reports the tier hosting it; only targetType says which
+    // the user actually chose.
+    const { rpc } = fakeRpc({
+      'router.hold.get': {
+        ...HOLD_GET_OK,
+        hold: { tier: 'c1', model: 'grok-5', targetType: 'model' },
+      },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.pinnedModel).toBe('grok-5'))
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('pins a model through router.hold.set and drops any tier pin', async () => {
+    const { rpc, calls } = fakeRpc({
+      'router.hold.get': { ...HOLD_GET_OK, hold: { tier: 'c3', targetType: 'tier' } },
+      'router.hold.set': { tier: 'c1', model: 'grok-5', targetType: 'model' },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.pinned).toBe('c3'))
+
+    await act(async () => result.current.pinModel('grok-5'))
+
+    expect(calls.some((c) => c.method === 'router.hold.set')).toBe(true)
+    expect(result.current.pinnedModel).toBe('grok-5')
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('clears both a tier pin and a model pin', async () => {
+    const { rpc } = fakeRpc({
+      'router.hold.get': {
+        ...HOLD_GET_OK,
+        hold: { tier: 'c1', model: 'grok-5', targetType: 'model' },
+      },
+      'router.hold.clear': { cleared: true },
+    })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+    await waitFor(() => expect(result.current.pinnedModel).toBe('grok-5'))
+
+    await act(async () => result.current.clear())
+
+    expect(result.current.pinnedModel).toBeNull()
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('keeps the tier rows usable when the catalog fetch fails', async () => {
+    const { rpc } = fakeRpc({ 'models.list': new Error('catalog down') })
+    const { result } = renderHook(() => useRoutePin(rpc, 'agent:main:main'))
+
+    await waitFor(() => expect(result.current.tiers).toHaveLength(2))
+    expect(result.current.models).toEqual([])
+    expect(result.current.enabled).toBe(true)
+  })
+
+  it('falls back to the config tier list before the first read lands', () => {
+    const { rpc } = fakeRpc()
+    const { result } = renderHook(() =>
+      useRoutePin(rpc, 'agent:main:main', {
+        c1: { model: 'gpt-5.6-luna', supportsImage: false, imageOnly: false },
+        image_model: { model: 'minimax-m3', supportsImage: true, imageOnly: true },
+      }),
+    )
+
+    // image_only tiers are not pinnable text routes and must not be offered.
+    expect(result.current.tiers).toEqual([{ tier: 'c1', model: 'gpt-5.6-luna' }])
+  })
+})

--- a/frontend/src/views/chat/useRoutePin.ts
+++ b/frontend/src/views/chat/useRoutePin.ts
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  routerFxNormalizeTier,
+  type RouterFxDecision,
+  type RouterFxTierConfig,
+} from './transcript/routerFx'
+import type { WsRpcClient } from '@/lib/ws-rpc'
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
+/**
+ * State for the composer's route picker: which tier the user has pinned, which
+ * tiers can be pinned, and what the router actually did last turn.
+ *
+ * The pin itself lives in the gateway's `RouterControlHoldStore` — process
+ * memory the browser cannot see — so this hook reads it back over
+ * `router.hold.get` rather than mirroring it locally. That read is what makes a
+ * reload show the real pin instead of a hopeful guess, and it is why a pin set
+ * from a slash command (`/c3`) and one set from the picker converge on the same
+ * label. `router.hold.get` deliberately does not error when the router is off,
+ * so mounting the picker on a gateway with no Pilot Router is silent.
+ */
+
+/** One pinnable route, as reported by `router.hold.get`. */
+export interface RoutePinTier {
+  tier: string
+  model: string
+}
+
+/** One directly-pinnable model from the active provider's catalog. */
+export interface RoutePinModel {
+  id: string
+  name: string
+}
+
+export interface RoutePinState {
+  /** Whether the Pilot Router is configured and on. Drives the disabled state. */
+  enabled: boolean
+  /** Pinnable text tiers, config order. Empty while loading or when disabled. */
+  tiers: RoutePinTier[]
+  /**
+   * Every model of the ACTIVE provider. Routing runs through one provider, so a
+   * model from any other provider in the catalog would be sent to this one
+   * under a name it does not know — those are filtered out server-side rather
+   * than offered and rejected.
+   */
+  models: RoutePinModel[]
+  /** The pinned tier, or null when routing is automatic or a model is pinned. */
+  pinned: string | null
+  /** The directly-pinned model id, or null when a tier (or nothing) is pinned. */
+  pinnedModel: string | null
+  /**
+   * Whether the route is pinned at all, either way. Derived here rather than
+   * recomputed per consumer: a caller that checks only `pinned` silently treats
+   * a model pin as automatic routing, which is how the router-fx strip once
+   * kept animating over a pinned model.
+   */
+  isPinned: boolean
+  /** The tier the router last actually used, pin or not. Labels the Auto state. */
+  lastRoutedTier: string | null
+  /**
+   * Set when the last turn was routed to a vision tier while a pin was active.
+   * Image turns are chosen before holds are consulted in the router step, so a
+   * pinned text tier genuinely does not run them — the picker says so rather
+   * than claiming a route the turn did not take.
+   */
+  imageOverride: boolean
+  /** True while a pin/clear round-trip is in flight. */
+  busy: boolean
+}
+
+export interface RoutePinApi extends RoutePinState {
+  pin: (tier: string) => void
+  pinModel: (model: string) => void
+  clear: () => void
+}
+
+interface HoldGetResult {
+  enabled?: boolean
+  provider?: string
+  hold?: { tier?: string; model?: string; targetType?: string } | null
+  tiers?: { tier?: string; model?: string }[]
+}
+
+const EMPTY_TIERS: RoutePinTier[] = []
+const EMPTY_MODELS: RoutePinModel[] = []
+
+interface HoldSlice {
+  session: string
+  enabled: boolean
+  provider: string
+  tiers: RoutePinTier[]
+  pinned: string | null
+  pinnedModel: string | null
+}
+
+interface RoutedSlice {
+  session: string
+  lastRoutedTier: string | null
+  imageOverride: boolean
+}
+
+const EMPTY_HOLD = {
+  enabled: false,
+  provider: '',
+  tiers: EMPTY_TIERS,
+  pinned: null,
+  pinnedModel: null,
+} as const
+const EMPTY_ROUTED = { lastRoutedTier: null, imageOverride: false } as const
+
+export function useRoutePin(
+  rpc: WsRpcClient,
+  sessionKey: string,
+  /**
+   * Tier config from `config.get`, used only as a fallback model label while the
+   * first `router.hold.get` is in flight so the button does not flash empty.
+   */
+  tierConfigs?: Record<string, RouterFxTierConfig>,
+): RoutePinApi {
+  // Both slices are STAMPED with the session they describe rather than reset on
+  // switch. Holds are per-session, so the previous session's pin must not label
+  // the new one — but clearing state from an effect costs an extra render pass
+  // and a cascading-render lint waiver. Stamping lets the reads below simply
+  // ignore anything that does not belong to the current session, which also
+  // discards a slow response that lands after the user has moved on.
+  const [hold, setHold] = useState<HoldSlice>(() => ({ session: '', ...EMPTY_HOLD }))
+  const [routed, setRouted] = useState<RoutedSlice>(() => ({ session: '', ...EMPTY_ROUTED }))
+  const [busy, setBusy] = useState(false)
+
+  const live = hold.session === sessionKey ? hold : EMPTY_HOLD
+  const liveRouted = routed.session === sessionKey ? routed : EMPTY_ROUTED
+
+  const refresh = useCallback(() => {
+    const forSession = sessionKey
+    rpc
+      .call('router.hold.get', { key: forSession })
+      .then((res: unknown) => {
+        const result = (res ?? {}) as HoldGetResult
+        // A model pin still names the tier hosting it; only `targetType` says
+        // which of the two the user actually chose, so the picker must not read
+        // the tier as a tier selection.
+        const byModel = result.hold?.targetType === 'model'
+        setHold({
+          session: forSession,
+          enabled: result.enabled === true,
+          provider: typeof result.provider === 'string' ? result.provider : '',
+          pinned: byModel ? null : routerFxNormalizeTier(result.hold?.tier || '') || null,
+          pinnedModel: byModel ? String(result.hold?.model || '') || null : null,
+          tiers: (Array.isArray(result.tiers) ? result.tiers : [])
+            .map((row) => ({
+              tier: routerFxNormalizeTier(row?.tier || ''),
+              model: typeof row?.model === 'string' ? row.model : '',
+            }))
+            .filter((row) => row.tier),
+        })
+      })
+      .catch(() => {
+        // A gateway without the RPC (older build) or a dropped socket: leave the
+        // picker disabled rather than surfacing an error the user cannot act on.
+        setHold({ session: forSession, ...EMPTY_HOLD })
+      })
+  }, [rpc, sessionKey])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // The catalog is global, not per-session, and only worth fetching once the
+  // active provider is known — it is the filter that makes the list pinnable.
+  // Read from the raw slice, NOT the session-scoped `live`: a session switch
+  // blanks `live` until the new read lands, which would drop the provider and
+  // refetch the whole catalog for a fact that did not change.
+  const [models, setModels] = useState<RoutePinModel[]>(EMPTY_MODELS)
+  const provider = hold.provider
+  useEffect(() => {
+    if (!provider) return
+    let ignore = false
+    rpc
+      .call('models.list', { provider })
+      .then((res: unknown) => {
+        if (ignore) return
+        const rows = Array.isArray(res) ? (res as Record<string, unknown>[]) : []
+        setModels(
+          rows
+            .map((row) => ({
+              id: String(row?.id ?? ''),
+              name: String(row?.name || row?.id || ''),
+            }))
+            .filter((row) => row.id),
+        )
+      })
+      .catch(() => {
+        // No catalog is a usable state: the tier rows still pin.
+        if (!ignore) setModels(EMPTY_MODELS)
+      })
+    return () => {
+      ignore = true
+    }
+  }, [rpc, provider])
+
+  // Track what the router actually did, which is the only honest source for the
+  // Auto label and for noticing that an image turn bypassed the pin. Re-subscribed
+  // per session so the stamp is captured without a render-time ref write.
+  useEffect(() => {
+    const forSession = sessionKey
+    return rpc.on('session.event.router_decision', (payload: unknown) => {
+      const decision = (payload ?? {}) as RouterFxDecision
+      const tier = routerFxNormalizeTier(String(decision.tier || decision.routed_tier || ''))
+      if (!tier) return
+      const source = String(decision.source || decision.routing_source || '').toLowerCase()
+      setRouted({
+        session: forSession,
+        lastRoutedTier: tier,
+        imageOverride: source === 'image_route' || tier === 'image_model',
+      })
+    })
+  }, [rpc, sessionKey])
+
+  const pin = useCallback(
+    (tier: string) => {
+      const target = routerFxNormalizeTier(tier)
+      if (!target) return
+      const forSession = sessionKey
+      setBusy(true)
+      rpc
+        .call('router.hold.set', { key: sessionKey, tier: target })
+        .then((res: unknown) => {
+          const model = (res as { model?: string })?.model
+          setHold((prev) =>
+            prev.session === forSession
+              ? { ...prev, pinned: target, pinnedModel: null }
+              : prev,
+          )
+          toast.info(t('chat.routePinned', { target: target + (model ? ' → ' + model : '') }))
+        })
+        .catch((err: unknown) =>
+          toast.error(
+            t('chat.slashRouterPinFailed', {
+              message: err instanceof Error ? err.message : String(err),
+            }),
+          ),
+        )
+        .finally(() => setBusy(false))
+    },
+    [rpc, sessionKey],
+  )
+
+  const pinModel = useCallback(
+    (model: string) => {
+      const target = model.trim()
+      if (!target) return
+      const forSession = sessionKey
+      setBusy(true)
+      rpc
+        .call('router.hold.set', { key: forSession, model: target })
+        .then(() => {
+          setHold((prev) =>
+            prev.session === forSession
+              ? { ...prev, pinned: null, pinnedModel: target }
+              : prev,
+          )
+          toast.info(t('chat.routePinned', { target }))
+        })
+        .catch((err: unknown) =>
+          // `router.unknown_model` names the active provider — pass the message
+          // through rather than restating it less precisely.
+          toast.error(
+            t('chat.slashRouterPinFailed', {
+              message: err instanceof Error ? err.message : String(err),
+            }),
+          ),
+        )
+        .finally(() => setBusy(false))
+    },
+    [rpc, sessionKey],
+  )
+
+  const clear = useCallback(() => {
+    const forSession = sessionKey
+    setBusy(true)
+    rpc
+      .call('router.hold.clear', { key: forSession })
+      .then(() => {
+        setHold((prev) =>
+          prev.session === forSession ? { ...prev, pinned: null, pinnedModel: null } : prev,
+        )
+        toast.info(t('chat.slashRoutingRestored'))
+      })
+      .catch((err: unknown) =>
+        toast.error(
+          t('chat.slashRouterUnpinFailed', {
+            message: err instanceof Error ? err.message : String(err),
+          }),
+        ),
+      )
+      .finally(() => setBusy(false))
+  }, [rpc, sessionKey])
+
+  // Fall back to the config-derived tier list until the first read lands, so the
+  // menu is populated on the very first open rather than after a round-trip.
+  const effectiveTiers = useMemo(() => {
+    if (live.tiers.length > 0) return live.tiers
+    if (!tierConfigs) return EMPTY_TIERS
+    return Object.entries(tierConfigs)
+      .filter(([, cfg]) => !cfg.imageOnly)
+      .map(([tier, cfg]) => ({ tier, model: cfg.model || '' }))
+  }, [live.tiers, tierConfigs])
+
+  return {
+    enabled: live.enabled,
+    tiers: effectiveTiers,
+    models,
+    pinned: live.pinned,
+    pinnedModel: live.pinnedModel,
+    isPinned: live.pinned !== null || live.pinnedModel !== null,
+    lastRoutedTier: liveRouted.lastRoutedTier,
+    imageOverride: liveRouted.imageOverride,
+    busy,
+    pin,
+    pinModel,
+    clear,
+  }
+}

--- a/frontend/src/views/chat/useRoutePin.ts
+++ b/frontend/src/views/chat/useRoutePin.ts
@@ -229,9 +229,7 @@ export function useRoutePin(
         .then((res: unknown) => {
           const model = (res as { model?: string })?.model
           setHold((prev) =>
-            prev.session === forSession
-              ? { ...prev, pinned: target, pinnedModel: null }
-              : prev,
+            prev.session === forSession ? { ...prev, pinned: target, pinnedModel: null } : prev,
           )
           toast.info(t('chat.routePinned', { target: target + (model ? ' → ' + model : '') }))
         })
@@ -257,9 +255,7 @@ export function useRoutePin(
         .call('router.hold.set', { key: forSession, model: target })
         .then(() => {
           setHold((prev) =>
-            prev.session === forSession
-              ? { ...prev, pinned: null, pinnedModel: target }
-              : prev,
+            prev.session === forSession ? { ...prev, pinned: null, pinnedModel: target } : prev,
           )
           toast.info(t('chat.routePinned', { target }))
         })

--- a/frontend/src/views/chat/useSlashCommands.ts
+++ b/frontend/src/views/chat/useSlashCommands.ts
@@ -272,8 +272,28 @@ export function useSlashCommands(opts?: {
             )
           return
         }
-        // chat.js:2819-2829 — pin the router to a tier (/c0-/c3).
+        // chat.js:2819-2829 — pin the router to a tier (/c0-/c3), or to a
+        // directly-named model (/use <model-id>). Both ride the same RPC; the
+        // command word says which parameter to send.
         case 'router.hold.set': {
+          if ((commandName || '').toLowerCase() === '/use') {
+            const model = args.trim()
+            if (!model) {
+              toast.warning(t('chat.slashUseNeedsModel'))
+              return
+            }
+            rpc
+              .call('router.hold.set', { key, model })
+              .then(() => toast.info(t('chat.routePinned', { target: model })))
+              .catch((err: unknown) =>
+                toast.error(
+                  t('chat.slashRouterPinFailed', {
+                    message: err instanceof Error ? err.message : String(err),
+                  }),
+                ),
+              )
+            return
+          }
           const tier = (commandName || '').replace(/^\//, '').toLowerCase()
           rpc
             .call('router.hold.set', { key, tier })

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -229,6 +229,12 @@ export function useTranscript(opts: {
   onEditMessage?: (text: string) => void
   onRegenerateMessage?: (text: string) => void
   onSessionKeyResolved?: (key: string) => void
+  /**
+   * True while the user has pinned a router tier. A pin removes the choice the
+   * router-fx strip exists to dramatize, so the animation is suppressed for the
+   * duration — see `isRoutePinned` in `createRouterFxRenderer`.
+   */
+  routePinned?: boolean
 }): {
   containerRef: React.RefObject<HTMLDivElement | null>
   routerFxDockRef: React.RefObject<HTMLDivElement | null>
@@ -273,6 +279,9 @@ export function useTranscript(opts: {
   const containerRef = useRef<HTMLDivElement>(null)
   const routerFxDockRef = useRef<HTMLDivElement>(null)
   const routerFeatureEnabledRef = useRef(false)
+  // Read live by the router-fx renderer, which is built once; a plain prop would
+  // be captured stale in that closure.
+  const routePinnedRef = useRef(false)
   const [routerConfigGate] = useState(createRouterConfigGate)
 
   // chat.js:1470-1535 `_loadFeatureToggles` — the animation engine needs the
@@ -484,6 +493,7 @@ export function useTranscript(opts: {
             : '',
       routerFxDock: () => routerFxDockRef.current,
       routerFeatureEnabled: () => routerFeatureEnabledRef.current,
+      routePinned: () => routePinnedRef.current,
       routerFxAwaitConfig: () => awaitRouterConfigReady(routerConfigGate.promise),
       historyHasRendered: () => historyHasRenderedRef.current,
       historyHydrating: () => historyHydratingRef.current,
@@ -659,6 +669,11 @@ export function useTranscript(opts: {
     thread.addEventListener('click', onArtifactClick)
     return () => thread.removeEventListener('click', onArtifactClick)
   }, [controller])
+
+  // Mirror the pin into the ref the router-fx renderer reads live.
+  useEffect(() => {
+    routePinnedRef.current = opts.routePinned === true
+  }, [opts.routePinned])
 
   useEffect(() => {
     if (routerConfigQuery.isPending) return

--- a/scripts/live_route_pin_gateway_e2e.py
+++ b/scripts/live_route_pin_gateway_e2e.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Live end-to-end check of the composer route pin against a running gateway.
+
+Drives the SAME WebSocket RPC surface the web UI uses — `router.hold.set/get/
+clear` plus `chat.send` — and reads the `session.event.router_decision` the
+gateway emits for each turn. That event is what the UI paints, so asserting on
+it proves the pin reached the router step rather than merely being stored.
+
+Real provider calls that cost real money, so prompts are one word and only five
+turns run. Uses a throwaway session key, deleted at the end, so nothing lands in
+the operator's chat history.
+
+Point it at an already-running gateway::
+
+    uv run python scripts/live_route_pin_gateway_e2e.py
+
+Exits non-zero if any check fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import uuid
+
+import websockets
+
+URL = os.environ.get("AGENTOS_GATEWAY_WS", "ws://127.0.0.1:18791/ws")
+SESSION = f"agent:main:webchat:e2e-{uuid.uuid4().hex[:8]}"
+PROMPT = "Reply with the single word: ok"
+
+
+class Rpc:
+    def __init__(self, ws) -> None:
+        self.ws = ws
+        self.n = 0
+        self.pending: dict[str, asyncio.Future] = {}
+        self.decisions: list[dict] = []
+        self.turn_done = asyncio.Event()
+        self.errors: list[str] = []
+        self.hello_id = "0"
+
+    async def handshake(self) -> dict:
+        """The gateway rejects any frame before a `connect` request."""
+
+        self.n += 1
+        self.hello_id = str(self.n)
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self.pending[self.hello_id] = fut
+        await self.ws.send(
+            json.dumps(
+                {
+                    "type": "req",
+                    "id": self.hello_id,
+                    "method": "connect",
+                    "params": {
+                        "minProtocol": 3,
+                        "maxProtocol": 3,
+                        "clientKind": "control",
+                        "client": {"name": "agentos-e2e"},
+                    },
+                }
+            )
+        )
+        return await asyncio.wait_for(fut, timeout=15)
+
+    async def pump(self) -> None:
+        async for raw in self.ws:
+            data = json.loads(raw)
+            if data.get("type") == "res":
+                fut = self.pending.pop(str(data.get("id")), None)
+                if fut and not fut.done():
+                    if data.get("ok"):
+                        fut.set_result(data.get("payload"))
+                    else:
+                        fut.set_exception(RuntimeError(json.dumps(data.get("error"))))
+            elif data.get("protocol") is not None:
+                # HelloOk answers the connect handshake; it carries no "type".
+                fut = self.pending.pop(str(self.hello_id), None)
+                if fut and not fut.done():
+                    fut.set_result(data)
+            elif data.get("type") == "event":
+                event = str(data.get("event"))
+                payload = data.get("payload") or {}
+                if event == "session.event.router_decision":
+                    self.decisions.append(payload)
+                elif event in ("session.event.done", "session.event.complete"):
+                    self.turn_done.set()
+                elif event == "session.event.error":
+                    self.errors.append(json.dumps(payload)[:200])
+                    self.turn_done.set()
+
+    async def call(self, method: str, params: dict | None = None):
+        self.n += 1
+        rid = str(self.n)
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self.pending[rid] = fut
+        await self.ws.send(
+            json.dumps({"type": "req", "id": rid, "method": method, "params": params or {}})
+        )
+        return await asyncio.wait_for(fut, timeout=30)
+
+    async def turn(self, label: str) -> dict | None:
+        """Send one real turn and return its routing decision."""
+
+        self.decisions.clear()
+        self.errors.clear()
+        self.turn_done.clear()
+        await self.call("chat.send", {"sessionKey": SESSION, "message": PROMPT})
+        try:
+            await asyncio.wait_for(self.turn_done.wait(), timeout=180)
+        except TimeoutError:
+            print(f"  [{label}] TIMEOUT waiting for the turn to finish")
+        if self.errors:
+            print(f"  [{label}] stream error: {self.errors[0]}")
+        return self.decisions[-1] if self.decisions else None
+
+
+results: list[tuple[bool, str]] = []
+
+
+def check(ok: bool, detail: str) -> None:
+    results.append((ok, detail))
+    print(("  PASS  " if ok else "  FAIL  ") + detail)
+
+
+async def main() -> int:
+    async with websockets.connect(URL, max_size=None) as ws:
+        rpc = Rpc(ws)
+        pump = asyncio.create_task(rpc.pump())
+        hello = await rpc.handshake()
+        print(f"connected: protocol={hello.get('protocol')}")
+        await rpc.call("sessions.subscribe")
+        await rpc.call("sessions.messages.subscribe", {"key": SESSION})
+
+        print(f"session: {SESSION}\n")
+
+        state = await rpc.call("router.hold.get", {"key": SESSION})
+        provider = state.get("provider")
+        tiers = {t["tier"]: t["model"] for t in state.get("tiers", [])}
+        print(f"provider={provider} tiers={tiers}\n")
+        check(state.get("enabled") is True, "router reports enabled")
+        check(state.get("hold") is None, "fresh session starts unpinned")
+
+        # ── 1. pin a model that is NOT one of the tiers ─────────────────────
+        # Chosen from the live catalog rather than hardcoded, both so the script
+        # runs against any profile and so "routed to the pinned model" cannot be
+        # satisfied by the router happening to pick that tier anyway.
+        catalog = await rpc.call("models.list", {"provider": provider})
+        off_tier = next(
+            (m["id"] for m in catalog if m["id"] not in set(tiers.values())), None
+        )
+        if not off_tier:
+            print("no off-tier model in the catalog; cannot test a model pin")
+            return 1
+
+        print(f"\n1. pin model {off_tier}")
+        payload = await rpc.call("router.hold.set", {"key": SESSION, "model": off_tier})
+        check(
+            payload.get("model") == off_tier,
+            f"hold.set echoes the model ({payload.get('model')})",
+        )
+        check(payload.get("targetType") == "model", "hold.set reports targetType=model")
+        check(payload.get("sticky") is True, "the pin is sticky")
+
+        read = await rpc.call("router.hold.get", {"key": SESSION})
+        check((read.get("hold") or {}).get("model") == off_tier, "hold.get reads the model back")
+
+        decision = await rpc.turn("model-pin")
+        got = (decision or {}).get("model")
+        check(got == off_tier, f"LIVE TURN routed to {off_tier} (got {got!r})")
+        check(
+            (decision or {}).get("source") == "router_control_hold",
+            f"routing source is the hold (got {(decision or {}).get('source')!r})",
+        )
+
+        # ── 2. the pin holds across a second turn (sticky, no TTL) ──────────
+        print("\n2. second turn keeps the pin")
+        decision = await rpc.turn("model-pin-2")
+        got = (decision or {}).get("model")
+        check(got == off_tier, f"second turn still on {off_tier} (got {got!r})")
+
+        # ── 3. switch to a tier pin ─────────────────────────────────────────
+        print("\n3. pin tier c3")
+        payload = await rpc.call("router.hold.set", {"key": SESSION, "tier": "c3"})
+        check(payload.get("targetType") == "tier", "hold.set reports targetType=tier")
+        expected = tiers.get("c3")
+        decision = await rpc.turn("tier-pin")
+        got = (decision or {}).get("model")
+        check(got == expected, f"LIVE TURN routed to c3's model {expected!r} (got {got!r})")
+        check((decision or {}).get("tier") == "c3", "decision reports tier c3")
+
+        # ── 4. the catalog is the boundary of what can be pinned ────────────
+        # OpenCAP's inference endpoint also answers to namespaced aliases
+        # (`openrouter/gpt-5.4`), but its PUBLIC catalog publishes only bare
+        # canonical ids. So aliases are neither offered nor pinnable — asserted
+        # rather than assumed, because assuming the opposite is what this run
+        # caught the first time.
+        print("\n4. catalog scope")
+        listed = await rpc.call("models.list", {"provider": provider})
+        ids = {m["id"] for m in listed}
+        check(
+            not any("/" in i for i in ids),
+            f"catalog carries no namespaced ids ({len(ids)} models)",
+        )
+        alias = "openrouter/gpt-5.4"
+        try:
+            await rpc.call("router.hold.set", {"key": SESSION, "model": alias})
+            check(False, f"{alias} was pinned despite being outside the catalog")
+        except RuntimeError as exc:
+            check("unknown_model" in str(exc), f"{alias} refused — outside the catalog")
+
+        # ── 5. a bogus model is refused ─────────────────────────────────────
+        print("\n5. refuse an unknown model")
+        try:
+            await rpc.call("router.hold.set", {"key": SESSION, "model": "no-such-model-xyz"})
+            check(False, "bogus model was accepted (should have been refused)")
+        except RuntimeError as exc:
+            check("unknown_model" in str(exc), f"bogus model refused ({str(exc)[:60]})")
+
+        # ── 6. clear returns to automatic routing ───────────────────────────
+        print("\n6. clear the pin")
+        cleared = await rpc.call("router.hold.clear", {"key": SESSION})
+        check(cleared.get("cleared") is True, "hold.clear reports cleared")
+        read = await rpc.call("router.hold.get", {"key": SESSION})
+        check(read.get("hold") is None, "hold.get reports no pin")
+
+        decision = await rpc.turn("auto")
+        source = (decision or {}).get("source")
+        check(
+            source not in (None, "router_control_hold"),
+            f"LIVE TURN routed automatically (source={source!r}, "
+            f"model={(decision or {}).get('model')!r})",
+        )
+
+        # ── cleanup ─────────────────────────────────────────────────────────
+        try:
+            await rpc.call("sessions.delete", {"key": SESSION})
+            print("\n(throwaway session deleted)")
+        except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+            print(f"\n(could not delete throwaway session: {str(exc)[:80]})")
+
+        pump.cancel()
+
+    failed = [d for ok, d in results if not ok]
+    print(f"\n{'=' * 60}\n{len(results) - len(failed)}/{len(results)} checks passed")
+    for d in failed:
+        print(f"  FAILED: {d}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/agentos/channels/command_registry.py
+++ b/src/agentos/channels/command_registry.py
@@ -73,7 +73,11 @@ class CommandRegistry:
         if match is None:
             return None
         name, method, params_factory = match
-        params = params_factory(envelope)
+        # Everything after the command word. Most factories ignore it; the ones
+        # that take an argument (`/use <model-id>`) would otherwise have no way
+        # to see what the user typed.
+        _head, _sep, args = message_content.strip().partition(" ")
+        params = params_factory(envelope, args.strip())
         if method == "chat.history":
             params = {**params, "limit": 10}
         res = await rpc_dispatcher.dispatch(

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -59,6 +59,7 @@ GATEWAY_SLASH_HANDLER_WORDS = frozenset(
         "/save",
         "/status",
         "/usage",
+        "/use",
     }
 )
 
@@ -341,6 +342,29 @@ async def handle_gateway_slash_command(
             f"{payload.get('totalTokens', 0):,} tok · "
             f"${float(payload.get('totalCostUsd', 0.0) or 0.0):.6f}[/dim]"
         )
+        return True
+
+    if cmd == "/use" or cmd.startswith("/use "):
+        model = cmd[len("/use ") :].strip() if cmd.startswith("/use ") else ""
+        if not model:
+            console.print("[yellow]Usage: /use <model-id>[/yellow]")
+            return True
+        try:
+            await client.call(
+                "router.hold.set",
+                {"key": state.session_key, "model": model},
+            )
+        except Exception as exc:  # noqa: BLE001 - keep chat alive on RPC error
+            # ``router.unknown_model`` arrives when the id is not in the active
+            # provider's catalog; its message names the provider, so print it
+            # verbatim rather than guessing at the cause.
+            console.print(f"[yellow]{exc}[/yellow]")
+            return True
+        # A model pin rides on the default tier, so the tier chip would be
+        # misleading here; show the model itself as the active route.
+        state.router_hold_tier = model
+        sync_session_chrome_from_state(state)
+        console.print(f"[{ACCENT}]router pinned to model[/] {model}")
         return True
 
     if cmd in {"/c0", "/c1", "/c2", "/c3"}:

--- a/src/agentos/cli/tui/adapters/slash_standalone.py
+++ b/src/agentos/cli/tui/adapters/slash_standalone.py
@@ -48,6 +48,7 @@ STANDALONE_SLASH_HANDLER_WORDS = frozenset(
         "/save",
         "/session",
         "/status",
+        "/use",
     }
 )
 
@@ -403,11 +404,16 @@ async def _apply_router_hold_standalone(
     context: StandaloneSlashContext,
     *,
     tier: str | None,
+    model: str | None = None,
 ) -> None:
     """Mutate the in-process Pilot Router hold store for the active session.
 
     ``tier=None`` means "clear" (restore automatic routing); a non-empty
-    string pins the router to that tier. Mirrors what the gateway's
+    string pins the router to that tier. ``model`` pins a directly-named model
+    instead — unlike the gateway path this cannot check the id against a
+    catalog, because standalone mode has no model listing at all (``/models``
+    says as much), so a bad id surfaces as a provider error on the next turn.
+    Mirrors what the gateway's
     ``router.hold.set`` / ``router.hold.clear`` RPCs do, but touches the
     ``TurnRunner`` instance living in this process directly. The store
     and config come from ``turn_runner.router_control_hold_store`` /
@@ -425,12 +431,33 @@ async def _apply_router_hold_standalone(
     # Lazily import so the slash adapter never pays the router_control
     # import cost when no tier command is issued.
     from agentos.router_control import (
+        HOLD_SOURCE_USER,
         RouterControlValidationError,
+        resolve_router_control_model_target,
         resolve_router_control_target,
     )
     from agentos.session.keys import canonicalize_session_key
 
     session_key = canonicalize_session_key(context.session_key)
+
+    if model:
+        try:
+            model_target = resolve_router_control_model_target(cfg, model)
+        except RouterControlValidationError as exc:
+            console.print(f"[yellow]{exc}[/yellow]")
+            return
+        store.set_hold(
+            session_key,
+            model_target,
+            evidence=f"slash command /use {model}",
+            source=HOLD_SOURCE_USER,
+        )
+        # The chip shows the model, not the tier hosting it — the tier is an
+        # implementation detail of where the settings come from.
+        context.state.router_hold_tier = model
+        sync_session_chrome_from_state(context.state)
+        console.print(f"[{ACCENT}]router pinned to model[/] {model}")
+        return
 
     if tier is None:
         cleared = store.clear(session_key)
@@ -449,7 +476,14 @@ async def _apply_router_hold_standalone(
             f"[yellow]Tier '{tier}' is not configured on the Pilot Router.[/yellow]"
         )
         return
-    store.set_hold(session_key, target, evidence=f"slash command /{tier}")
+    # A slash pin is the user speaking, so it is sticky: it holds until /auto
+    # clears it, unlike the self-expiring hold the model installs for itself.
+    store.set_hold(
+        session_key,
+        target,
+        evidence=f"slash command /{tier}",
+        source=HOLD_SOURCE_USER,
+    )
     context.state.router_hold_tier = tier
     sync_session_chrome_from_state(context.state)
     model_suffix = f" · {target.model}" if target.model else ""
@@ -519,6 +553,13 @@ async def handle_standalone_slash_command(
 
     if cmd == "/cost":
         console.print(state.usage.render())
+        return True
+
+    if parts := _slash_parts(cmd, "/use"):
+        if len(parts) == 1:
+            console.print("[yellow]Usage: /use <model-id>[/yellow]")
+        else:
+            await _apply_router_hold_standalone(context, tier=None, model=parts[1].strip())
         return True
 
     if cmd in {"/c0", "/c1", "/c2", "/c3"}:

--- a/src/agentos/engine/commands.py
+++ b/src/agentos/engine/commands.py
@@ -55,7 +55,11 @@ def parse_surface(value: str) -> Surface:
 # Callable to avoid a cycle with agentos.gateway.routing.RouteEnvelope at
 # import time — the channel dispatcher passes its own envelope and we only
 # require attribute access (`session_key`).
-ParamsFactory = Callable[[Any], dict[str, Any]]
+#
+# The second argument is the command's argument text — everything after the
+# command word, already stripped, "" when the user typed the bare command. A
+# factory that ignores it (most do) simply takes it and drops it.
+ParamsFactory = Callable[[Any, str], dict[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -178,27 +182,38 @@ class SlashCommandRegistry:
 # ---------------------------------------------------------------------------
 
 
-def _key(envelope: Any) -> dict[str, str]:
+def _key(envelope: Any, _args: str = "") -> dict[str, str]:
     return {"key": envelope.session_key}
 
 
-def _session_key(envelope: Any) -> dict[str, str]:
+def _session_key(envelope: Any, _args: str = "") -> dict[str, str]:
     return {"sessionKey": envelope.session_key}
 
 
-def _channel_commands(_envelope: Any) -> dict[str, str]:
+def _channel_commands(_envelope: Any, _args: str = "") -> dict[str, str]:
     return {"surface": Surface.CHANNEL.value}
 
 
-def _empty(_envelope: Any) -> dict[str, Any]:
+def _empty(_envelope: Any, _args: str = "") -> dict[str, Any]:
     return {}
 
 
 def _tier_hold(tier: str) -> ParamsFactory:
-    def factory(envelope: Any) -> dict[str, str]:
+    def factory(envelope: Any, _args: str = "") -> dict[str, str]:
         return {"key": envelope.session_key, "tier": tier}
 
     return factory
+
+
+def _model_hold(envelope: Any, args: str = "") -> dict[str, str]:
+    """`/use <model-id>` — pin the route to a directly-named model.
+
+    The id is passed through verbatim; ``router.hold.set`` is what checks it
+    against the active provider's catalog, so a typo comes back as one readable
+    error instead of a hold that fails every later turn.
+    """
+
+    return {"key": envelope.session_key, "model": args.strip()}
 
 
 _W = Surface.WEB_CHAT
@@ -277,6 +292,23 @@ _COMMANDS: tuple[CommandDef, ...] = (
             },
         )
         for tier in ("c0", "c1", "c2", "c3")
+    ),
+    # `/use <model-id>` pins the route to a model that is not one of the four
+    # configured tiers. It is a separate verb rather than an argument to
+    # `/model`, whose argument already filters the listing — overloading it
+    # would make `/model gpt` ambiguous between "show me the gpt models" and
+    # "switch to gpt". The model rides on the default tier for its thinking
+    # level and pricing baseline, and must belong to the active provider.
+    CommandDef(
+        name="/use",
+        usage="/use <model-id>",
+        description="Pin the route to a specific model for this session.",
+        execution={
+            _W: _rpc("router.hold.set", _model_hold),
+            _T: _rpc("router.hold.set", _model_hold),
+            _S: _local("router.hold.set_model"),
+            _C: _rpc("router.hold.set", _model_hold),
+        },
     ),
     CommandDef(
         name="/auto",

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -3623,6 +3623,7 @@ class TurnRunner:
                     hard_denied=hard_denied,
                 )
             ctx = self._apply_runtime_capability_denies(ctx)
+            ctx = self._apply_user_route_pin_denies(ctx)
             log.debug(
                 "tool_policy.policy_pre",
                 allowed_tool_count=len(self._tool_registry.to_tool_definitions(ctx)),
@@ -3661,6 +3662,35 @@ class TurnRunner:
     def _filter_tool_defs_by_capability(self, tool_defs: list) -> list:
         """Compatibility shim; runtime capability filtering is resolved in ToolContext."""
         return tool_defs
+
+    def _apply_user_route_pin_denies(self, ctx: ToolContext) -> ToolContext:
+        """Withdraw ``router_control`` while the user has pinned a route.
+
+        A user pin outranks the model's own routing, so leaving the tool on the
+        surface would only invite calls that cannot take effect. Denying it
+        instead removes the tool AND — because the Router Control prompt block
+        is rendered only when the tool is in ``tool_defs`` — its target menu,
+        so the model spends no tokens describing a lever it does not have.
+
+        Only USER holds gate this. A hold the model set for itself through the
+        tool must not then hide the tool, which would strand the session on a
+        transient escalation with no way back.
+        """
+
+        session_key = ctx.session_key
+        if not session_key:
+            return ctx
+        try:
+            from agentos.session.keys import canonicalize_session_key
+
+            hold = self._router_control_hold_store.get_user_hold(
+                canonicalize_session_key(session_key)
+            )
+        except Exception:  # noqa: BLE001 - tool surfacing must survive a hold-store fault
+            return ctx
+        if hold is None:
+            return ctx
+        return replace(ctx, denied_tools=set(ctx.denied_tools) | {"router_control"})
 
     def _apply_runtime_capability_denies(self, ctx: ToolContext) -> ToolContext:
         from agentos.tools.policy import (

--- a/src/agentos/gateway/rpc_models.py
+++ b/src/agentos/gateway/rpc_models.py
@@ -30,10 +30,33 @@ def _model_info_to_wire(m: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-@_d.method("models.list", CONTROL_AND_CHANNEL)
-async def _handle_models_list(params: dict | None, ctx: RpcContext) -> list[dict[str, Any]]:
-    provider_filter = (params or {}).get("provider")
-    capabilities_filter: list[str] | None = (params or {}).get("capabilities")
+def active_provider_id(ctx: RpcContext) -> str:
+    """The single provider every turn runs through (``llm.provider``).
+
+    The runtime never builds a per-tier or per-model provider client, so this is
+    the only provider whose models can actually be reached — see
+    ``_degrade_model_for_local_provider`` in the router step.
+    """
+
+    return str(getattr(getattr(ctx.config, "llm", None), "provider", "") or "").strip()
+
+
+async def collect_models(
+    ctx: RpcContext,
+    *,
+    provider_filter: str | None = None,
+    capabilities_filter: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Gather the model catalog in wire format.
+
+    Shared with ``router.hold.set``, which validates a user-named model against
+    it before pinning: a typo'd id would otherwise install a hold that fails
+    every subsequent turn at the provider.
+
+    Note on OpenCAP: its inference endpoint also serves namespaced ``<upstream>/
+    <model>`` aliases, but the PUBLIC catalog this reads publishes only the bare
+    canonical ids, so those aliases never appear here and are not pinnable.
+    """
 
     models: list[dict[str, Any]] = []
     catalog = ctx.model_catalog or getattr(ctx.turn_runner, "_model_catalog", None)
@@ -43,8 +66,7 @@ async def _handle_models_list(params: dict | None, ctx: RpcContext) -> list[dict
         except Exception:
             pass
 
-    active_provider = str(getattr(getattr(ctx.config, "llm", None), "provider", "") or "")
-    catalog_is_canonical = bool(models) and active_provider.strip().lower() == "opencap"
+    catalog_is_canonical = bool(models) and active_provider_id(ctx).lower() == "opencap"
     if ctx.provider_selector is not None and not catalog_is_canonical:
         try:
             raw = await ctx.provider_selector.list_models()
@@ -64,3 +86,12 @@ async def _handle_models_list(params: dict | None, ctx: RpcContext) -> list[dict
         models = [m for m in models if required.issubset(set(m["capabilities"]))]
 
     return models
+
+
+@_d.method("models.list", CONTROL_AND_CHANNEL)
+async def _handle_models_list(params: dict | None, ctx: RpcContext) -> list[dict[str, Any]]:
+    return await collect_models(
+        ctx,
+        provider_filter=(params or {}).get("provider"),
+        capabilities_filter=(params or {}).get("capabilities"),
+    )

--- a/src/agentos/gateway/rpc_router.py
+++ b/src/agentos/gateway/rpc_router.py
@@ -1,20 +1,32 @@
 """RPC handlers for user-directed Pilot Router tier holds.
 
-Backs the /c0-/c3 and /auto slash commands: a session-scoped, short-lived
-tier hold set through the same ``RouterControlHoldStore`` the LLM-facing
-``router_control`` tool uses, so both paths share expiry and precedence
-semantics inside the router step.
+Backs the /c0-/c3 and /auto slash commands and the chat composer's route
+picker: a session-scoped tier hold set through the same
+``RouterControlHoldStore`` the LLM-facing ``router_control`` tool uses, so
+both paths share precedence semantics inside the router step.
+
+Expiry is where the two paths deliberately part. A hold set here is marked
+``HOLD_SOURCE_USER`` and is sticky — it survives until ``router.hold.clear``,
+because a user who picks a route is stating an intent, not asking for a
+ten-minute nudge. The model's own escalations keep the idle TTL so they decay
+on their own. ``router.hold.get`` lets a reconnecting client read the pin back
+rather than guessing, since the store is process memory the UI cannot see.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from agentos.gateway.access import CONTROL_AND_CHANNEL
+from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
 from agentos.gateway.rpc import RpcContext, RpcHandlerError, get_dispatcher
 from agentos.router_control import (
+    HOLD_SOURCE_USER,
+    RouterControlHold,
     RouterControlHoldStore,
+    RouterControlTarget,
     RouterControlValidationError,
+    build_router_control_targets,
+    resolve_router_control_model_target,
     resolve_router_control_target,
 )
 from agentos.session.keys import canonicalize_session_key
@@ -29,6 +41,32 @@ def _require_key(params: dict | None) -> str:
     if not isinstance(key, str):
         raise ValueError("params.key must be a string")
     return canonicalize_session_key(key)
+
+
+def _hold_payload(hold: RouterControlHold) -> dict[str, Any]:
+    """Serialize a hold for the wire.
+
+    ``ttlSeconds`` is None for a sticky hold rather than its real
+    ``math.inf``: ``json.dumps`` would emit a bare ``Infinity`` token, which is
+    not valid JSON and throws in ``JSON.parse`` on the browser side. Clients
+    read ``sticky`` for the "never expires" case and treat ``ttlSeconds`` as the
+    countdown only when it is a number.
+    """
+
+    sticky = hold.sticky
+    # A model pin still reports the tier hosting it — clients need that to render
+    # "borrowed from c1" — so `targetType` is what distinguishes "the user picked
+    # tier c1" from "the user picked a model that happens to sit on c1".
+    return {
+        "tier": hold.tier,
+        "model": hold.model,
+        "provider": hold.provider,
+        "targetId": hold.target_id,
+        "targetType": "model" if hold.target_id.startswith("model:") else "tier",
+        "source": hold.source,
+        "sticky": sticky,
+        "ttlSeconds": None if sticky else hold.ttl_seconds,
+    }
 
 
 def _router_state(ctx: RpcContext) -> tuple[Any, RouterControlHoldStore]:
@@ -48,30 +86,123 @@ def _router_state(ctx: RpcContext) -> tuple[Any, RouterControlHoldStore]:
     return cfg, store
 
 
-@_d.method("router.hold.set", CONTROL_AND_CHANNEL)
-async def _handle_router_hold_set(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
-    key = _require_key(params)
-    tier = str((params or {}).get("tier") or "").strip().lower()
-    if not tier:
-        raise ValueError("params.tier is required")
+async def _resolve_named_model(ctx: RpcContext, cfg: Any, model: str) -> RouterControlTarget:
+    """Resolve a directly-named model, refusing anything the provider cannot run.
 
-    cfg, store = _router_state(ctx)
+    Only the ACTIVE provider's catalog counts. Every turn goes through the one
+    configured ``llm.provider`` — a tier's ``provider`` field is metadata, not a
+    client selector — so a model belonging to some other provider in the catalog
+    would be sent to the active one under a name it does not know. Rejecting it
+    here turns a per-turn provider error into one legible message at the moment
+    of choosing.
+    """
+
+    from agentos.gateway.rpc_models import active_provider_id, collect_models
+
+    provider = active_provider_id(ctx)
+    known = await collect_models(ctx, provider_filter=provider or None)
+    match = next((m for m in known if str(m.get("id", "")) == model), None)
+    if match is None:
+        raise RpcHandlerError(
+            "router.unknown_model",
+            f"Model '{model}' is not available from the active provider"
+            + (f" ({provider})" if provider else ""),
+            details={"model": model, "provider": provider},
+        )
     try:
-        target = resolve_router_control_target(cfg, f"tier:{tier}")
+        return resolve_router_control_model_target(cfg, model)
     except RouterControlValidationError as exc:
         raise RpcHandlerError(
-            "router.unknown_tier",
-            f"Tier '{tier}' is not configured on the Pilot Router",
-            details={"tier": tier},
+            "router.unknown_model",
+            str(exc),
+            details={"model": model},
         ) from exc
 
-    hold = store.set_hold(key, target, evidence=f"slash command /{tier}")
+
+@_d.method("router.hold.set", CONTROL_AND_CHANNEL)
+async def _handle_router_hold_set(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    """Pin the route, by tier or by a directly-named model.
+
+    ``tier`` picks one of the configured routes wholesale. ``model`` names a
+    model outside that list; it rides on the default tier so the settings a tier
+    carries and a model does not — thinking level, provider, the savings
+    baseline — stay defined. Exactly one of the two is required.
+    """
+
+    key = _require_key(params)
+    tier = str((params or {}).get("tier") or "").strip().lower()
+    model = str((params or {}).get("model") or "").strip()
+    if not tier and not model:
+        raise ValueError("params.tier or params.model is required")
+    if tier and model:
+        raise ValueError("params.tier and params.model are mutually exclusive")
+
+    cfg, store = _router_state(ctx)
+    if model:
+        target = await _resolve_named_model(ctx, cfg, model)
+        evidence = f"user pinned model {model}"
+    else:
+        try:
+            target = resolve_router_control_target(cfg, f"tier:{tier}")
+        except RouterControlValidationError as exc:
+            raise RpcHandlerError(
+                "router.unknown_tier",
+                f"Tier '{tier}' is not configured on the Pilot Router",
+                details={"tier": tier},
+            ) from exc
+        evidence = f"user pinned tier {tier}"
+
+    hold = store.set_hold(key, target, evidence=evidence, source=HOLD_SOURCE_USER)
+    return _hold_payload(hold)
+
+
+@_d.method("router.hold.get", CONTROL_ONLY)
+async def _handle_router_hold_get(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    """Report the session's user pin plus the tiers that can be pinned.
+
+    CONTROL_ONLY, unlike its set/clear siblings: those are projected from
+    channel slash commands, while this exists to paint a control-surface
+    picker. Channels have no such surface, and ``CHANNEL_RPC_METHODS`` is
+    deliberately limited to methods a slash command actually reaches.
+
+    Unlike set/clear this never raises when the router is off. The chat
+    composer calls it on every mount and session switch purely to render its
+    route picker, and a gateway with no router configured is an ordinary state
+    to display (a disabled control), not an error worth a toast. Callers read
+    ``enabled`` to tell "no router" from "router on, nothing pinned".
+
+    ``hold`` reports only a USER pin. A hold the model installed for itself via
+    ``router_control`` is transient in-turn state, not a setting the user chose,
+    so surfacing it here would make the picker claim a selection nobody made.
+
+    ``provider`` is the active provider id, so a client can list the models it
+    is actually allowed to pin without having to know that routing runs through
+    a single provider.
+    """
+
+    from agentos.gateway.rpc_models import active_provider_id
+
+    key = _require_key(params)
+    try:
+        cfg, store = _router_state(ctx)
+    except RpcHandlerError:
+        return {"enabled": False, "hold": None, "tiers": [], "provider": ""}
+
+    hold = store.get_user_hold(key)
     return {
-        "tier": hold.tier,
-        "model": hold.model,
-        "provider": hold.provider,
-        "targetId": hold.target_id,
-        "ttlSeconds": hold.ttl_seconds,
+        "enabled": True,
+        "provider": active_provider_id(ctx),
+        "hold": _hold_payload(hold) if hold is not None else None,
+        "tiers": [
+            {
+                "tier": target.tier,
+                "model": target.model,
+                "provider": target.provider,
+                "description": target.description,
+            }
+            for target in build_router_control_targets(cfg)
+            if target.target_type == "tier"
+        ],
     }
 
 

--- a/src/agentos/router_control.py
+++ b/src/agentos/router_control.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import threading
 import time
 from dataclasses import dataclass, fields, is_dataclass
@@ -16,6 +17,19 @@ from agentos.router_tiers import (
 # Zero means no turn-count cap; the hold expires after an idle TTL.
 DEFAULT_HOLD_TURNS = 0
 DEFAULT_HOLD_TTL_SECONDS = 600.0
+
+# Hold provenance. A hold the MODEL installed for itself through the
+# ``router_control`` tool is an in-turn escalation and must decay on its own —
+# it keeps the idle TTL above. A hold the USER pinned (the composer route picker
+# or a /c0-/c3 slash command) is a standing instruction: it holds until the user
+# clears it, so it carries no TTL at all. `RouterControlHoldStore.set_hold`
+# derives the TTL from the source unless a caller overrides it explicitly.
+HOLD_SOURCE_TOOL = "router_control_tool"
+HOLD_SOURCE_USER = "user"
+# math.inf rather than a large finite number: `is_expired` compares
+# ``now - last_activity >= ttl_seconds``, which is False for every finite
+# elapsed time against inf, so a user hold never expires on its own.
+USER_HOLD_TTL_SECONDS = math.inf
 
 
 class RouterControlValidationError(ValueError):
@@ -44,7 +58,13 @@ class RouterControlHold:
     last_activity_at_monotonic: float | None = None
     turns_remaining: int = DEFAULT_HOLD_TURNS
     ttl_seconds: float = DEFAULT_HOLD_TTL_SECONDS
-    source: str = "router_control_tool"
+    source: str = HOLD_SOURCE_TOOL
+
+    @property
+    def sticky(self) -> bool:
+        """True when nothing but an explicit clear can end this hold."""
+
+        return self.turns_remaining <= 0 and not math.isfinite(self.ttl_seconds)
 
     def is_expired(self, now_monotonic: float) -> tuple[bool, str | None]:
         if self.turns_remaining < 0:
@@ -118,6 +138,47 @@ def resolve_router_control_target(
         ) from exc
 
 
+def resolve_router_control_model_target(
+    router_cfg: object | None,
+    model: str,
+) -> RouterControlTarget:
+    """Build a target for a model the user named directly, off the tier list.
+
+    Tiers carry more than a model id — ``thinking_level``, ``provider``, and the
+    baseline the savings figure is computed against all live on the tier, not on
+    the model. A bare model id therefore cannot stand alone: it is HOSTED on the
+    default text tier and inherits that tier's settings. That also keeps the
+    router step's ``tiers[decision.tier]`` lookup valid, which would raise a
+    ``KeyError`` and kill the turn if a hold ever named a tier that is not
+    configured.
+
+    The model itself is not validated here. Whether an id exists is a question
+    about the live provider catalog, which this module has no access to; the RPC
+    layer checks it against the active provider before installing a hold.
+    """
+
+    chosen = str(model or "").strip()
+    if not chosen:
+        raise RouterControlValidationError("router_control model is required")
+
+    text_tiers = _text_tiers(router_cfg)
+    if not text_tiers:
+        raise RouterControlValidationError("no text tier is configured to host a model choice")
+    default_tier = str(getattr(router_cfg, "default_tier", "") or "").strip().lower()
+    host_tier = default_tier if default_tier in text_tiers else next(iter(text_tiers))
+    host_cfg = text_tiers[host_tier]
+    thinking = host_cfg.get("thinking_level", host_cfg.get("thinking"))
+    return RouterControlTarget(
+        target_id=f"model:{chosen}",
+        target_type="model",
+        tier=host_tier,
+        model=chosen,
+        provider=str(host_cfg.get("provider") or "").strip() or None,
+        description=None,
+        thinking_level=str(thinking).strip() if thinking is not None else None,
+    )
+
+
 def render_router_control_prompt_block(router_cfg: object | None) -> str:
     targets = [
         target
@@ -181,9 +242,22 @@ class RouterControlHoldStore:
         evidence: str,
         now_monotonic: float | None = None,
         turns_remaining: int = DEFAULT_HOLD_TURNS,
-        ttl_seconds: float = DEFAULT_HOLD_TTL_SECONDS,
+        ttl_seconds: float | None = None,
+        source: str = HOLD_SOURCE_TOOL,
     ) -> RouterControlHold:
+        """Install a hold for ``session_key``, replacing any existing one.
+
+        ``ttl_seconds`` defaults to the source's own lifetime — infinite for a
+        user pin, the idle TTL for a tool escalation — so callers that do not
+        care about expiry cannot accidentally give a user pin the tool's TTL
+        (or vice versa) by omitting the argument.
+        """
+
         now = time.monotonic() if now_monotonic is None else now_monotonic
+        if ttl_seconds is None:
+            ttl_seconds = (
+                USER_HOLD_TTL_SECONDS if source == HOLD_SOURCE_USER else DEFAULT_HOLD_TTL_SECONDS
+            )
         hold = RouterControlHold(
             tier=target.tier,
             model=target.model,
@@ -194,9 +268,28 @@ class RouterControlHoldStore:
             last_activity_at_monotonic=now,
             turns_remaining=turns_remaining,
             ttl_seconds=ttl_seconds,
+            source=source,
         )
         with self._lock:
             self._holds[session_key] = hold
+        return hold
+
+    def get_user_hold(
+        self,
+        session_key: str,
+        *,
+        now_monotonic: float | None = None,
+    ) -> RouterControlHold | None:
+        """Return the live USER hold for ``session_key``, else None.
+
+        A pure peek: it never decrements a turn budget nor refreshes the idle
+        TTL, so callers outside the router step (tool-surface gating, the
+        ``router.hold.get`` RPC) cannot keep a hold alive just by observing it.
+        """
+
+        hold = self.get_valid(session_key, now_monotonic=now_monotonic)
+        if hold is None or hold.source != HOLD_SOURCE_USER:
+            return None
         return hold
 
     def clear(self, session_key: str) -> RouterControlHold | None:

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -69,8 +69,21 @@ in both gateway and `--standalone` modes:
 
 - `/c0` … `/c3` — pin the Pilot Router to a configured tier for this session.
   The active tier shows in the bottom toolbar (e.g. `tier:c3`) and in
-  `/status` until you run `/auto`, exit, or the hold expires.
+  `/status` until you run `/auto` or exit. The pin is sticky: it does not time
+  out, so a forgotten `/c3` keeps billing at `c3`.
+- `/use <model-id>` — pin the route to a specific model instead of a tier. Only
+  the active provider's models can be pinned, since every turn runs through the
+  single configured `llm.provider`; the model inherits the default tier's
+  thinking level and pricing baseline. Distinct from `/model`, whose argument
+  filters the listing rather than switching.
 - `/auto` — restore automatic Pilot Router routing (clear the pin).
+
+A pin withdraws the model's own `router_control` tool, so it cannot route
+around the choice. Image turns still go to a vision tier (they are routed
+before pins apply), and a pinned turn skips the large-context tier floor — it
+fails at the provider rather than being upgraded if the context outgrows the
+pinned model. In the Web UI the same pin is set from the route picker in the
+chat composer, which also shows which tier automatic routing last chose.
 
 The assistant speaker label on the `◢` marker defaults to `agentos`; override
 with the `AGENTOS_ASSISTANT_LABEL` env var. The active input row is framed by a

--- a/tests/test_engine/test_router_control.py
+++ b/tests/test_engine/test_router_control.py
@@ -18,6 +18,7 @@ from agentos.router_control import (
     RouterControlValidationError,
     build_router_control_targets,
     render_router_control_prompt_block,
+    resolve_router_control_model_target,
     resolve_router_control_target,
 )
 
@@ -264,6 +265,46 @@ async def test_agentos_router_applies_hold_before_normal_classification(monkeypa
     assert out.metadata["routing_source"] == "router_control_hold"
     assert out.metadata["router_control_hold_applied"] is True
     assert out.metadata["router_control_target_tier"] == "c3"
+
+
+@pytest.mark.asyncio
+async def test_a_model_hold_routes_to_that_model_not_its_host_tier(monkeypatch) -> None:
+    """A directly-named model must actually run — the host tier only lends settings.
+
+    The hold carries both a tier (where thinking level and the pricing baseline
+    come from) and a model. Nothing downstream may substitute the tier's own
+    configured model for the one the user named.
+    """
+
+    cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
+    cfg.default_tier = "c1"
+    target = resolve_router_control_model_target(cfg, "z-ai/glm-5.2")
+    store = RouterControlHoldStore()
+    store.set_hold("agent:main:test-model", target, evidence="use glm")
+
+    def fail_strategy(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("router classification should not run while hold is valid")
+
+    monkeypatch.setattr("agentos.engine.steps.agentos_router._get_strategy", fail_strategy)
+    ctx = TurnContext(
+        message="review this",
+        session_key="agent:main:test-model",
+        config=SimpleNamespace(agentos_router=cfg),
+        provider=None,
+        model="default-model",
+        tool_defs=[],
+        system_prompt="system",
+        metadata={"router_control_hold_store": store},
+    )
+
+    out = await apply_agentos_router(ctx)
+
+    assert out.model == "z-ai/glm-5.2"
+    assert out.metadata["routed_model"] == "z-ai/glm-5.2"
+    # The tier rides along for settings, and must remain a REAL configured tier
+    # so `tiers[decision.tier]` downstream cannot raise.
+    assert out.metadata["routed_tier"] == "c1"
+    assert out.metadata["routed_tier"] in cfg.tiers
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_runtime_user_route_pin_tool_gate.py
+++ b/tests/test_engine/test_runtime_user_route_pin_tool_gate.py
@@ -1,0 +1,94 @@
+"""A user route pin withdraws the ``router_control`` tool from the surface.
+
+The pin already outranks the model inside the router step, so leaving the tool
+exposed would only invite calls that cannot take effect. Denying it also drops
+the Router Control prompt block, which ``TurnRunner._render_system_prompt``
+renders only when the tool is present in ``tool_defs``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agentos.engine.runtime import TurnRunner
+from agentos.router_control import (
+    HOLD_SOURCE_USER,
+    RouterControlHoldStore,
+    resolve_router_control_target,
+)
+from agentos.tools.types import ToolContext
+
+_SESSION = "agent:main:main"
+
+
+def _router_cfg() -> SimpleNamespace:
+    return SimpleNamespace(
+        enabled=True,
+        tiers={
+            "c0": {"model": "gemini-flash-lite", "provider": "openrouter"},
+            "c3": {"model": "claude-opus-4-8", "provider": "openrouter"},
+        },
+    )
+
+
+def _apply(store: RouterControlHoldStore, ctx: ToolContext) -> ToolContext:
+    # The gate reads nothing but the hold store, so bind it to a stand-in rather
+    # than paying for a fully wired TurnRunner.
+    runner = SimpleNamespace(_router_control_hold_store=store)
+    return TurnRunner._apply_user_route_pin_denies(runner, ctx)
+
+
+def _pin(store: RouterControlHoldStore, tier: str = "c3") -> None:
+    target = resolve_router_control_target(_router_cfg(), f"tier:{tier}")
+    store.set_hold(_SESSION, target, evidence="user pin", source=HOLD_SOURCE_USER)
+
+
+def test_user_pin_denies_router_control() -> None:
+    store = RouterControlHoldStore()
+    _pin(store)
+
+    out = _apply(store, ToolContext(session_key=_SESSION))
+
+    assert "router_control" in out.denied_tools
+
+
+def test_no_pin_leaves_the_tool_exposed() -> None:
+    out = _apply(RouterControlHoldStore(), ToolContext(session_key=_SESSION))
+
+    assert "router_control" not in out.denied_tools
+
+
+def test_model_installed_hold_does_not_hide_the_tool() -> None:
+    """Hiding the tool on its own hold would strand the model with no way back."""
+
+    store = RouterControlHoldStore()
+    target = resolve_router_control_target(_router_cfg(), "tier:c3")
+    store.set_hold(_SESSION, target, evidence="escalating")
+
+    out = _apply(store, ToolContext(session_key=_SESSION))
+
+    assert "router_control" not in out.denied_tools
+
+
+def test_pin_on_another_session_does_not_leak() -> None:
+    store = RouterControlHoldStore()
+    _pin(store)
+
+    out = _apply(store, ToolContext(session_key="agent:main:other"))
+
+    assert "router_control" not in out.denied_tools
+
+
+def test_existing_denies_are_preserved() -> None:
+    store = RouterControlHoldStore()
+    _pin(store)
+
+    out = _apply(store, ToolContext(session_key=_SESSION, denied_tools={"exec_command"}))
+
+    assert {"exec_command", "router_control"} <= out.denied_tools
+
+
+def test_missing_session_key_is_a_no_op() -> None:
+    out = _apply(RouterControlHoldStore(), ToolContext(session_key=None))
+
+    assert "router_control" not in out.denied_tools

--- a/tests/test_gateway/test_rpc_models_catalog_scope.py
+++ b/tests/test_gateway/test_rpc_models_catalog_scope.py
@@ -1,0 +1,120 @@
+"""What the model catalog offers, and therefore what can be pinned.
+
+OpenCAP's INFERENCE endpoint serves each model twice — under a bare canonical id
+and under namespaced ``<upstream>/<model>`` aliases — but the PUBLIC catalog the
+gateway reads (``/api/public/models``) publishes only the bare ids. So aliases
+never reach ``models.list`` and are not pinnable, and no alias-stripping filter
+is needed or wanted: on OpenRouter every id is ``vendor/model``, and one applied
+there would empty the list.
+
+These tests pin that contract down, because it is the reason `router.hold.set`
+can validate against the catalog at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.router_control import RouterControlHoldStore
+
+_OPENCAP_ROWS = [
+    {"id": "claude-opus-5", "provider": "opencap"},
+    {"id": "gpt-5.6-terra", "provider": "opencap"},
+]
+
+
+def _ctx(provider: str = "opencap", rows: list[dict] | None = None) -> RpcContext:
+    ctx = RpcContext(conn_id="test")
+    ctx.config = SimpleNamespace(llm=SimpleNamespace(provider=provider))
+    catalog_rows = _OPENCAP_ROWS if rows is None else rows
+    ctx.model_catalog = SimpleNamespace(
+        list_models=lambda: [
+            SimpleNamespace(
+                model_dump=lambda row=row: {
+                    "model_id": row["id"],
+                    "display_name": row["id"],
+                    "provider": row["provider"],
+                }
+            )
+            for row in catalog_rows
+        ]
+    )
+    return ctx
+
+
+def _list(params: dict, ctx: RpcContext) -> list[dict]:
+    result = asyncio.run(get_dispatcher().dispatch("r1", "models.list", params, ctx))
+    assert result.error is None, result.error
+    return result.payload or []
+
+
+def _with_router(ctx: RpcContext) -> RpcContext:
+    ctx.turn_runner = SimpleNamespace(
+        router_control_hold_store=RouterControlHoldStore(),
+        router_control_config=SimpleNamespace(
+            enabled=True,
+            default_tier="c1",
+            tiers={"c1": {"model": "gpt-5.6-terra", "provider": "opencap"}},
+        ),
+    )
+    return ctx
+
+
+def test_models_list_returns_the_catalog_verbatim() -> None:
+    """No id-shape filtering: whatever the provider publishes is what is offered."""
+
+    ids = {m["id"] for m in _list({}, _ctx())}
+
+    assert ids == {"claude-opus-5", "gpt-5.6-terra"}
+
+
+def test_namespaced_ids_survive_for_providers_that_use_them() -> None:
+    """On OpenRouter every id is `vendor/model`; stripping them would empty the list."""
+
+    rows = [
+        {"id": "anthropic/claude-opus-5", "provider": "openrouter"},
+        {"id": "openai/gpt-5.6-luna", "provider": "openrouter"},
+    ]
+    ids = {m["id"] for m in _list({}, _ctx("openrouter", rows))}
+
+    assert ids == {"anthropic/claude-opus-5", "openai/gpt-5.6-luna"}
+
+
+def test_a_catalog_model_can_be_pinned() -> None:
+    ctx = _with_router(_ctx())
+
+    result = asyncio.run(
+        get_dispatcher().dispatch(
+            "r2",
+            "router.hold.set",
+            {"key": "agent:main:main", "model": "claude-opus-5"},
+            ctx,
+        )
+    )
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["model"] == "claude-opus-5"
+
+
+def test_a_model_outside_the_catalog_cannot_be_pinned() -> None:
+    """Covers OpenCAP's inference-only aliases as well as plain typos.
+
+    Verified against the live gateway: `/use openrouter/gpt-5.4` is refused with
+    `router.unknown_model` because the public catalog does not list it.
+    """
+
+    ctx = _with_router(_ctx())
+
+    result = asyncio.run(
+        get_dispatcher().dispatch(
+            "r3",
+            "router.hold.set",
+            {"key": "agent:main:main", "model": "openrouter/gpt-5.4"},
+            ctx,
+        )
+    )
+
+    assert result.error is not None

--- a/tests/test_gateway/test_rpc_router_hold.py
+++ b/tests/test_gateway/test_rpc_router_hold.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 from agentos.engine.commands import DEFAULT_REGISTRY, Surface
+from agentos.gateway.access import CHANNEL_RPC_METHODS
 from agentos.gateway.rpc import RpcContext, get_dispatcher
-from agentos.router_control import RouterControlHoldStore
+from agentos.router_control import (
+    HOLD_SOURCE_TOOL,
+    HOLD_SOURCE_USER,
+    RouterControlHoldStore,
+    resolve_router_control_target,
+)
 
 _TIERS = ("c0", "c1", "c2", "c3")
 
@@ -22,12 +29,35 @@ def _router_cfg(enabled: bool = True) -> SimpleNamespace:
     )
 
 
-def _ctx(cfg: SimpleNamespace | None = None, store: RouterControlHoldStore | None = None):
+def _ctx(
+    cfg: SimpleNamespace | None = None,
+    store: RouterControlHoldStore | None = None,
+    *,
+    models: list[dict] | None = None,
+    provider: str = "opencap",
+):
     runner = SimpleNamespace(
         router_control_hold_store=store if store is not None else RouterControlHoldStore(),
         router_control_config=cfg if cfg is not None else _router_cfg(),
     )
-    return RpcContext(conn_id="test", turn_runner=runner)
+    ctx = RpcContext(conn_id="test", turn_runner=runner)
+    ctx.config = SimpleNamespace(llm=SimpleNamespace(provider=provider))
+    # `models.list` reads the catalog off the context; a stand-in keeps the
+    # model-pin validation path exercised without a live provider.
+    catalog_rows = models if models is not None else [{"id": "grok-5", "provider": provider}]
+    ctx.model_catalog = SimpleNamespace(
+        list_models=lambda: [
+            SimpleNamespace(
+                model_dump=lambda row=row: {
+                    "model_id": row["id"],
+                    "display_name": row["id"],
+                    "provider": row["provider"],
+                }
+            )
+            for row in catalog_rows
+        ]
+    )
+    return ctx
 
 
 async def _dispatch(method: str, params: dict, ctx: RpcContext):
@@ -151,3 +181,263 @@ def test_router_hold_clear_without_hold_reports_not_cleared() -> None:
     assert result.error is None, result.error
     assert result.payload is not None
     assert result.payload["cleared"] is False
+
+
+# ---------------------------------------------------------------------------
+# Sticky user pins
+# ---------------------------------------------------------------------------
+
+
+def test_router_hold_set_marks_the_pin_as_a_sticky_user_hold() -> None:
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+
+    result = asyncio.run(
+        _dispatch("router.hold.set", {"key": "agent:main:main", "tier": "c3"}, ctx)
+    )
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["source"] == HOLD_SOURCE_USER
+    assert result.payload["sticky"] is True
+    hold = store.get_valid("agent:main:main")
+    assert hold is not None
+    assert hold.sticky is True
+
+
+def test_user_pin_outlives_the_tool_hold_idle_ttl() -> None:
+    """A user pin must not decay; only an explicit clear ends it."""
+
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+    asyncio.run(_dispatch("router.hold.set", {"key": "agent:main:main", "tier": "c3"}, ctx))
+
+    # Far past the 600s idle TTL a tool hold would have expired at.
+    later = 10_000_000.0
+    assert store.get_valid("agent:main:main", now_monotonic=later) is not None
+
+
+def test_model_installed_hold_still_expires_on_the_idle_ttl() -> None:
+    """The tool path keeps its self-expiring lifetime — only users pin."""
+
+    store = RouterControlHoldStore()
+    target = resolve_router_control_target(_router_cfg(), "tier:c3")
+    store.set_hold("agent:main:main", target, evidence="escalating", now_monotonic=0.0)
+
+    hold = store.get_valid("agent:main:main", now_monotonic=0.0)
+    assert hold is not None
+    assert hold.source == HOLD_SOURCE_TOOL
+    assert hold.sticky is False
+    assert store.get_valid("agent:main:main", now_monotonic=601.0) is None
+
+
+def test_sticky_hold_payload_is_valid_json() -> None:
+    """`math.inf` would serialize as a bare `Infinity`, which JSON.parse rejects."""
+
+    ctx = _ctx()
+
+    result = asyncio.run(
+        _dispatch("router.hold.set", {"key": "agent:main:main", "tier": "c3"}, ctx)
+    )
+
+    assert result.payload is not None
+    assert result.payload["ttlSeconds"] is None
+    encoded = json.dumps(result.payload)
+    assert "Infinity" not in encoded
+
+
+# ---------------------------------------------------------------------------
+# Pinning a directly-named model
+# ---------------------------------------------------------------------------
+
+
+def test_router_hold_set_pins_a_named_model() -> None:
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+
+    result = asyncio.run(
+        _dispatch("router.hold.set", {"key": "agent:main:main", "model": "grok-5"}, ctx)
+    )
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["model"] == "grok-5"
+    assert result.payload["targetType"] == "model"
+    assert result.payload["sticky"] is True
+
+
+def test_a_model_pin_rides_on_the_default_tier() -> None:
+    """The router step indexes `tiers[hold.tier]`; an unhosted model would crash it."""
+
+    store = RouterControlHoldStore()
+    cfg = _router_cfg()
+    cfg.default_tier = "c3"
+    ctx = _ctx(cfg=cfg, store=store)
+
+    asyncio.run(_dispatch("router.hold.set", {"key": "agent:main:main", "model": "grok-5"}, ctx))
+
+    hold = store.get_valid("agent:main:main")
+    assert hold is not None
+    assert hold.tier == "c3"
+    assert hold.tier in cfg.tiers
+    assert hold.model == "grok-5"
+
+
+def test_router_hold_set_rejects_a_model_the_active_provider_lacks() -> None:
+    """Routing runs through one provider; an unreachable id must fail at choice time."""
+
+    ctx = _ctx()
+
+    result = asyncio.run(
+        _dispatch("router.hold.set", {"key": "agent:main:main", "model": "no-such-model"}, ctx)
+    )
+
+    assert result.error is not None
+
+
+def test_router_hold_set_rejects_a_model_from_another_provider() -> None:
+    ctx = _ctx(
+        models=[{"id": "grok-5", "provider": "opencap"}, {"id": "far-away", "provider": "ollama"}],
+    )
+
+    result = asyncio.run(
+        _dispatch("router.hold.set", {"key": "agent:main:main", "model": "far-away"}, ctx)
+    )
+
+    assert result.error is not None
+
+
+def test_router_hold_set_refuses_both_tier_and_model() -> None:
+    ctx = _ctx()
+
+    result = asyncio.run(
+        _dispatch(
+            "router.hold.set",
+            {"key": "agent:main:main", "tier": "c3", "model": "grok-5"},
+            ctx,
+        )
+    )
+
+    assert result.error is not None
+
+
+def test_router_hold_set_requires_one_of_tier_or_model() -> None:
+    ctx = _ctx()
+
+    result = asyncio.run(_dispatch("router.hold.set", {"key": "agent:main:main"}, ctx))
+
+    assert result.error is not None
+
+
+def test_use_command_sends_its_argument_as_the_model() -> None:
+    cmd = DEFAULT_REGISTRY.find("/use")
+    assert cmd is not None
+    channel_exec = cmd.execution_for(Surface.CHANNEL)
+    assert channel_exec is not None
+    assert channel_exec.rpc_method == "router.hold.set"
+    assert channel_exec.rpc_params is not None
+    params = channel_exec.rpc_params(SimpleNamespace(session_key="agent:main:main"), "grok-5")
+    assert params == {"key": "agent:main:main", "model": "grok-5"}
+
+
+# ---------------------------------------------------------------------------
+# RPC: router.hold.get
+# ---------------------------------------------------------------------------
+
+
+def test_router_hold_get_is_control_only() -> None:
+    """The picker read is a control-surface concern, not a channel command."""
+
+    assert "router.hold.get" not in CHANNEL_RPC_METHODS
+
+
+def test_router_hold_get_distinguishes_a_model_pin_from_its_host_tier() -> None:
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+    asyncio.run(_dispatch("router.hold.set", {"key": "agent:main:main", "model": "grok-5"}, ctx))
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, ctx))
+
+    assert result.payload is not None
+    hold = result.payload["hold"]
+    # The tier is reported (it is where the settings came from) but targetType
+    # is what says the user chose a model, not that tier.
+    assert hold["targetType"] == "model"
+    assert hold["model"] == "grok-5"
+    assert hold["tier"] in ("c0", "c3")
+
+
+def test_router_hold_get_reports_the_active_provider() -> None:
+    """Clients need it to list only the models that can actually be pinned."""
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, _ctx()))
+
+    assert result.payload is not None
+    assert result.payload["provider"] == "opencap"
+
+
+def test_router_hold_get_reports_the_active_pin_and_pinnable_tiers() -> None:
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+    asyncio.run(_dispatch("router.hold.set", {"key": "agent:main:main", "tier": "c3"}, ctx))
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, ctx))
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["enabled"] is True
+    assert result.payload["hold"]["tier"] == "c3"
+    assert {tier["tier"] for tier in result.payload["tiers"]} == {"c0", "c3"}
+
+
+def test_router_hold_get_reports_no_pin_when_unpinned() -> None:
+    ctx = _ctx()
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, ctx))
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["enabled"] is True
+    assert result.payload["hold"] is None
+
+
+def test_router_hold_get_hides_a_model_installed_hold() -> None:
+    """A tool escalation is in-turn state, not a selection the user made."""
+
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+    target = resolve_router_control_target(_router_cfg(), "tier:c3")
+    store.set_hold("agent:main:main", target, evidence="escalating")
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, ctx))
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["hold"] is None
+
+
+def test_router_hold_get_reports_disabled_router_without_erroring() -> None:
+    """The composer probes this on every mount; "no router" is a state, not a fault."""
+
+    ctx = _ctx(cfg=_router_cfg(enabled=False))
+
+    result = asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, ctx))
+
+    assert result.error is None, result.error
+    assert result.payload is not None
+    assert result.payload["enabled"] is False
+    assert result.payload["hold"] is None
+    assert result.payload["tiers"] == []
+
+
+def test_router_hold_get_does_not_refresh_the_hold_it_reads() -> None:
+    """Polling the picker must not keep a tool hold alive forever."""
+
+    store = RouterControlHoldStore()
+    ctx = _ctx(store=store)
+    target = resolve_router_control_target(_router_cfg(), "tier:c3")
+    store.set_hold("agent:main:main", target, evidence="escalating", now_monotonic=0.0)
+
+    asyncio.run(_dispatch("router.hold.get", {"key": "agent:main:main"}, ctx))
+
+    assert store.get_valid("agent:main:main", now_monotonic=601.0) is None


### PR DESCRIPTION
Choosing which model answers a turn meant remembering a slash command. The composer now carries a route picker: one searchable list holding `Auto`, the configured tiers, and every model of the active provider.

The button reports what is actually in force — `c1 · gpt-5.6-luna` when a tier is pinned, the model id alone when a model is, and `Auto · c2` naming the tier the router last chose, so "let it decide" stays legible.

## How it holds together

**The pin lives in the gateway, not the browser.** A new `router.hold.get` RPC reads it back, so a reload shows the pin that is really in force and a pin set from `/c3` agrees with one set from the picker. With no Pilot Router configured the control is disabled rather than hidden, keeping the composer from reflowing when the router is toggled.

**A directly-named model rides on the default tier.** Thinking level, provider and the savings baseline live on a tier, not on a model id; hosting the model on one keeps them defined and keeps the router step's `tiers[hold.tier]` lookup valid — an unhosted model would raise `KeyError` and kill the turn.

**Only the active provider's models are offered and accepted.** Every turn runs through the single configured `llm.provider` — a tier's `provider` field is metadata, not a client selector — so anything else is refused when chosen rather than failing on the next turn.

**A pin withdraws `router_control`** for its duration, along with the target menu in the system prompt. The user's choice already outranked the model inside the router step; leaving the lever on the surface only invited calls that could not take effect and paid tokens to describe them. Holds the model installs for itself are unaffected — hiding the tool on its own hold would strand a session on a transient escalation.

**`/use <model-id>`** does the same from a slash command on web, TUI and channels. A new verb rather than an argument to `/model`, whose argument already filters the listing: overloading it would make `/model gpt` ambiguous between "show me the gpt models" and "switch to gpt". Reaching channels meant widening `ParamsFactory` to `(envelope, args)`; every existing factory keeps its behaviour through a default.

**The router-fx strip is suppressed for a pinned turn.** It exists to show the router weighing candidates and settling on one; a pin decides the route up front, so the animation dramatized a deliberation that never happened and restated the picker every turn. The gate keys off the source recorded on the turn rather than the current pin, because history outlives the pin and a pin set from a slash command never passes through the view's state. That also keeps the pair out of the tier registry — a model pin records its HOST tier alongside the user's model, and learning it would rewrite that tier's own model.

## Breaking change

**A tier pin set by a user is now sticky.** `/c0`–`/c3`, everywhere, hold until `/auto` clears them instead of lapsing after ten idle minutes. A pin is a standing instruction, and a selection that silently reverted would make the new control lie about what is running.

The practical consequence is a bill: pin `/c3` and forget, and every later turn keeps paying for it until someone runs `/auto`. Routing the model chooses for itself mid-turn is unchanged and still lapses on its own.

Two things still outrank a pin, both pre-existing:

- **Image turns** are routed to a vision tier before pins are consulted, so a pinned text tier does not run them. The UI flags such a turn.
- **Large context**: a pinned turn skips the large-context tier floor, so it fails at the provider rather than being upgraded if the conversation outgrows the pinned model.

## Verification

`scripts/live_route_pin_gateway_e2e.py` drives the whole surface against a running gateway with real turns — 18/18. It caught two defects unit tests missed: an alias-stripping filter built on the wrong catalog endpoint (removed; the public catalog never carried those ids), and the claim that hidden aliases stayed pinnable (they do not).

Driving the real browser caught a third: the strip was suppressed on the live path but still rebuilt from history, which also re-poisoned the tier registry on every reload. Confirmed after the fix with real turns — pinned `glm-5.2`, `c3` and `c0` each ran exactly the pinned model, with zero strips across 14 samples spanning a turn.

Backend 7660 passed, frontend 1891 passed, ruff + mypy + eslint + tsc clean, bundle 136.6 KiB / 180 KiB.
