### PR TITLE
feat(skills): add poolsdotfun-token-launcher bundled crypto skill

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -219,6 +219,7 @@ are released under AgentOS's repository license (Apache-2.0; see `LICENSE`):
 - `multi-search-engine`
 - `nano-pdf`
 - `pdf-toolkit`
+- `poolsdotfun-token-launcher`
 - `pptx`
 - `robinhood-agentic-trading`
 - `robinhood-rwa-addresses`

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: poolsdotfun-token-launcher
+description: "Launch a token on pools.fun (Robinhood Chain, 4663) through the PartyFactory, and manage the creator fees afterwards. Use when the user wants to create, launch, or deploy a memecoin or token on pools.fun, asks what a launch would cost or what price it would open at, wants to simulate or dry-run a launch, wants to mine a launch salt, or wants to collect/claim creator fees or change the fee recipient for a token they launched. NOT for: buying or selling existing tokens, Uniswap v3/v4 LP positions, or launches on any other chain or launchpad."
+homepage: https://pools.fun/
+triggers: [pools.fun, poolsdotfun, launch token, create token, memecoin launch, robinhood chain, party factory, dev buy]
+provenance:
+  origin: agentos-original
+  license: MIT
+  maintained_by: AgentOS
+metadata:
+  agentos:
+    emoji: "🎈"
+    category: crypto
+    risk: high
+    capabilities: [network-read, network-write, signing]
+    requires:
+      anyBins: ["python3", "python"]
+      # Only genuinely required variables belong here: `requires.env` is a hard
+      # eligibility gate (see skills/eligibility.py::_has_env), so anything listed
+      # makes the skill unavailable while it is unset. PINATA_JWT is deliberately
+      # NOT listed — it is optional, and a launch without a token image must work
+      # on a machine where it was never configured.
+      env:
+        - name: POOLSFUN_PRIVATE_KEY
+          description: Signing key for launches and fee claims. Read-only commands use it
+            only to derive your wallet address, and cannot sign with it.
+          secret: true
+---
+
+# pools.fun token launcher
+
+Launches tokens through the pools.fun `PartyFactory` on Robinhood Chain
+(`0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4`), and manages creator fees on the
+`PartyLocker` afterwards.
+
+**Set this once per shell**, then every command below is copy-pasteable:
+
+```bash
+S="{baseDir}/scripts"
+```
+
+There is no RPC to configure. The chain is fixed (Robinhood Chain, 4663) and the
+endpoint is built in.
+
+**Environment.** `POOLSFUN_PRIVATE_KEY` is required to send anything; read
+commands work without it if you pass `--from 0x…`. `PINATA_JWT` is **optional**
+and needed only to attach a token image — set it in the agent environment (or
+`~/.agentos/.env`) if you want `--image`. It is intentionally not declared as a
+requirement, so the skill stays available when it is unset.
+
+## What a launch actually does
+
+One transaction, and all of it is irreversible:
+
+1. CREATE2-deploys a fixed-supply ERC20 — **1,000,000,000 tokens**, no owner, no
+   mint function, no transfer hooks.
+2. Creates a SushiSwap V3 pool at **1% fee** and initialises it at the protocol's
+   launch tick.
+3. Mints the **entire supply** as one single-sided full-range position and sends
+   the LP NFT **to the locker, permanently**. The launcher never holds the LP.
+4. Optionally performs a **dev buy** — your own first purchase, executed as the
+   pool's first swap inside the same transaction, so it cannot be front-run.
+
+There is no launch fee. A launch costs gas (~6.1M) plus whatever you choose to
+dev-buy.
+
+## Three things you cannot choose
+
+Say these plainly when a user asks for them, because the flags do not exist:
+
+* **The opening price / market cap.** Every pools.fun token opens at the
+  protocol's `initialFdvUsd` — currently **$10,000 FDV**. The factory reads its
+  own Chainlink feed to derive the tick, and `expectedStartTick` in the ABI is a
+  race guard, not an input: a mismatch reverts `StartTickChanged()`. Changing it
+  requires `setInitialFdvUsd`, which is `onlyOwner` (the pools.fun team). A dev
+  buy only moves the price **up**, after the open.
+* **The supply, fee tier, or LP range.** All hard-coded in the factory.
+* **Keeping the LP.** It goes to the locker on launch, always.
+
+## Part A — Read (no key, no funds, nothing sent)
+
+```bash
+python3 "$S/pools_read.py" preflight              # can I launch, and at what price?
+python3 "$S/pools_read.py" assets                 # the paired-asset allowlist
+python3 "$S/pools_read.py" mine-salt --name "My Token" --symbol MYT --deployer 0xYou
+python3 "$S/pools_read.py" simulate --name "My Token" --symbol MYT --dev-buy 0.001 --from 0xYou
+python3 "$S/pools_read.py" token 0xTokenAddress   # a launched token's pool, price, LP
+python3 "$S/pools_read.py" fees  0xTokenAddress   # creator fee position
+```
+
+Start with `preflight`. It answers the three questions that decide whether a
+launch can happen at all — is the factory paused, is the price feed live, and is
+Pinata configured for an image — plus the exact FDV the launch will open at.
+
+Every read command takes `--json`. All of them work with no environment
+variables set, as long as you pass `--from`/`--deployer`.
+
+## Part B — Launch
+
+A launch needs **a name, a symbol, and optionally an image**. Everything else is
+defaulted and every default is printed in the plan, labelled `[default]`.
+
+```bash
+python3 "$S/pools_write.py" launch --name "My Token" --symbol MYT --image ./logo.png
+```
+
+That prints a plan and sends nothing. To execute, re-run with the hash it
+printed:
+
+```bash
+python3 "$S/pools_write.py" launch --name "My Token" --symbol MYT --image ./logo.png \
+  --broadcast --confirm 0x3f9a2c11
+```
+
+**Never invent a PLAN_HASH.** It comes from the dry run and covers every field
+that determines what lands on-chain. If the price feed moved between the two
+steps the hash changes and the broadcast refuses — that is the mechanism working,
+not a bug. Re-read the new plan and confirm that.
+
+### The defaults
+
+| Setting | Default | Override |
+|---|---|---|
+| paired asset | WETH | `--paired usdg` |
+| dev buy | **0** | `--dev-buy 0.001` (ETH) or `--dev-buy-asset 5` (paired ERC20) |
+| fee recipient | you | `--fee-recipient 0x…` |
+| deadline | +1200s | `--deadline-secs 600` |
+| slippage | 1% | `--slippage-bps 300` |
+| salt | mined for you | `--salt 0x…` |
+
+Identity flags: `--description`, `--website`, `--twitter`, `--metadata-uri`,
+`--pin-metadata`.
+
+### Token image and metadata
+
+Three paths, picked automatically:
+
+1. `--metadata-uri ipfs://…` — you already host it. Never touches Pinata.
+2. `--image ./logo.png` — pins the logo and the metadata JSON to IPFS.
+   **Requires `PINATA_JWT`.** In AgentOS webchat, an attached image lands on disk;
+   pass that path here.
+3. Neither — the metadata JSON is inlined as a `data:application/json;base64,…`
+   URI. **No secret, no network.** This is the default and it works everywhere.
+
+If `--image` is passed without `PINATA_JWT` the command **fails** rather than
+launching without the picture. That is deliberate: the token's identity is
+immutable the moment the transaction lands, and there is no second chance to
+attach a logo.
+
+### Dev buys
+
+Two funding modes, never both (the factory reverts `AmbiguousDevBuy()`):
+
+* `--dev-buy <eth>` sends native ETH. **WETH pairs only.**
+* `--dev-buy-asset <amount>` pulls the paired ERC20 and needs an allowance first:
+  `python3 "$S/pools_write.py" approve --paired usdg`
+
+The quoted fill is exact, not an estimate — the swap is the pool's first, inside
+the launch transaction.
+
+## Part C — Creator fees
+
+The locker holds the LP forever, but trading fees accrue to you.
+
+```bash
+python3 "$S/pools_read.py"  fees 0xToken              # what is there
+python3 "$S/pools_write.py" collect-and-claim 0xToken # sweep + pay out
+python3 "$S/pools_write.py" set-fee-recipient 0xToken --recipient 0xNew
+```
+
+`collect` sweeps fees from the LP position into the locker; `claim` pays out your
+share of what the locker holds; `collect-and-claim` does both in one transaction
+and is usually what you want. Each takes the same `--broadcast --confirm` gate.
+
+## Error handling
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `TokenNotToken0` | The salt no longer produces an address below the paired asset | Re-run without `--salt` to mine a fresh one |
+| `StartTickChanged` | The ETH price feed updated between planning and sending | Re-run; confirm the new hash |
+| `DeployFailed` | A token already exists at that salt's address | Change name/symbol/metadata, or use a different `--salt` |
+| `CreatorNotCaller` | `creator` must equal the sending wallet | Drop `--fee-recipient` confusion; creator is always the signer |
+| `AmbiguousDevBuy` | Both `--dev-buy` and `--dev-buy-asset` given | Pick one |
+| `DevBuyWethOnly` | Native ETH dev buy on a USDG pair | Use `--dev-buy-asset` after `approve` |
+| `DevBuyTooLittle` | Fill came in under the slippage floor | Raise `--slippage-bps` |
+| `PairedAssetNotAllowed` | Asset is not on the allowlist | `pools_read.py assets` |
+| `Paused` | The factory is paused | Wait; nothing else to do |
+| `--broadcast needs --confirm` | Dry run not confirmed | Re-run with the printed hash |
+| `plan changed since it was printed` | Feed moved, or a flag differs from the dry run | Re-read the plan, confirm the new hash |
+| `PINATA_JWT is not set` | `--image` without Pinata | Set it, or drop `--image` |
+| `no qualifying salt in N attempts` | Unlucky search | Raise `--max-salt-attempts` |
+| `env var POOLSFUN_PRIVATE_KEY is not set` | No signing key | Set it, or pass `--from 0x…` to plan only |
+
+Set `POOLSFUN_DEBUG=1` for full tracebacks.
+
+## Why the salt has to be mined
+
+The factory mints single-sided liquidity and requires the launched token to be
+`token0` of the pair, so the CREATE2 address must sort numerically **below** the
+paired asset or `launch` reverts `TokenNotToken0()`. Against WETH
+(`0x0Bd7…`) about **4.6%** of salts qualify, so the skill searches — batched
+`computeTokenAddress` calls, usually resolved in one round trip.
+
+A salt is bound to the exact `(deployer, name, symbol, metadataUri)`. Change any
+of them and it must be re-mined. This is why `--metadata-uri` is resolved
+*before* mining, not after.
+
+## Verifying a change
+
+```bash
+python3 "$S/selftest.py"          # offline, no network, no key
+python3 "$S/pools_read.py" preflight
+python3 "$S/pools_write.py" launch --name "Test" --symbol TST   # plan only
+```
+
+The selftest pins the launch calldata against the real reference transaction
+(`0x0978ee72…`), so an encoding regression fails there rather than on-chain.
+
+See `assets/partyfactory-reference.md` for the full ABI, the decoded reference
+launch, and the locker's fee-split mechanics.

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/assets/partyfactory-reference.md
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/assets/partyfactory-reference.md
@@ -1,0 +1,203 @@
+# PartyFactory reference
+
+Everything below was read from the verified source on
+[Blockscout](https://robinhoodchain.blockscout.com/address/0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4)
+and confirmed with live `eth_call`s. Read this when the skill's behaviour needs
+explaining or when the factory is redeployed and constants have to be re-checked.
+
+## Deployment
+
+| Contract | Address |
+|---|---|
+| PartyFactory | `0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4` |
+| PartyLocker | `0x35E41f84d3fD61d4648F0c8B41a1E7d301bCd75E` |
+| SushiSwap V3 factory | `0xE51960f1B45f1C9FB6D166E6a884F866fC70433B` |
+| NonfungiblePositionManager | `0x51d0e5188afe12d502e29D982d20C190e7816107` |
+| WETH | `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` |
+| USDG | `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` |
+| ETH/USD feed | `0x78F3556b67E17Df817D51Ef5a990cDaF09E8d3A9` (8 dp, 25h heartbeat) |
+| Factory owner | `0xd86EC279AD4871483f6c3D7ce54AD00067f120E9` |
+
+Chain: Robinhood Chain, id **4663**, RPC `https://rpc.mainnet.chain.robinhood.com/`,
+explorer `https://robinhoodchain.blockscout.com`. Solidity 0.8.25, viaIR, 200 runs.
+
+## `launch`
+
+```solidity
+function launch(
+    string  calldata name,
+    string  calldata symbol,
+    string  calldata metadataUri,
+    bytes32 salt,
+    address pairedAsset,
+    int24   expectedStartTick,
+    uint256 deadline,
+    address creator,
+    address feeRecipient,
+    uint256 devBuyAmountIn,
+    uint256 devBuyMinOut
+) external payable returns (address token, address pool, uint256 devBuyOut);
+```
+
+Selector `0xce61a35c`. Eleven flat arguments — not a struct.
+
+What the factory does, in order (source lines ~300–330):
+
+1. `paused` / `locker` / `deadline` checks.
+2. `creator != msg.sender` → `CreatorNotCaller()`. `feeRecipient == 0` becomes the creator.
+3. `startTickFor(pairedAsset)` — reverts `PairedAssetNotAllowed()` for unlisted assets.
+   `startTick != expectedStartTick` → `StartTickChanged()`. A fallback-priced tick
+   emits `FallbackTickUsed`.
+4. CREATE2-deploys the token; reverts `TokenNotToken0()` if `token >= pairedAsset`.
+5. Creates and initialises the pool; reverts `PoolAlreadyInitialized()` if it already has a price.
+6. Mints the whole supply as one band `[startTick, 887200]`, LP NFT to the locker.
+7. Burns rounding dust to `0xdEaD`.
+8. Registers with the locker.
+9. Performs the dev buy, if any.
+10. Emits `TokenLaunched`.
+
+### Protocol constants
+
+```
+TOTAL_SUPPLY  1_000_000_000e18      FEE  10000 (1%)      TICK_SPACING  200
+MAX_USABLE_TICK  887200             MIN/MAX_FDV_USD  100 / 1_000_000_000
+MIN/MAX_PRICE_AGE  1 minute / 3 days
+```
+
+### Pricing is not an input
+
+`expectedStartTick` reads like a knob and is not one. The factory computes its own
+tick and reverts on any mismatch — the argument exists so a caller commits to the
+price they were quoted, not so they can pick one.
+
+The tick comes from `initialFdvUsd` (currently `10000`) via the Chainlink feed, and
+`setInitialFdvUsd` is `onlyOwner`. At the time of writing `startTickFor(WETH)` is
+`-190600`, ETH is $1,891.51, and the resulting FDV is **$9,990** against a $10,000
+target. A dev buy only moves price upward, after the open.
+
+### Dev buy funding
+
+Exactly one of:
+
+* `msg.value > 0` — wrapped to WETH by the factory. **WETH pairs only**
+  (`DevBuyWethOnly()`).
+* `devBuyAmountIn > 0` — pulled via `transferFrom`, so the factory needs an
+  allowance. Works for any allowlisted pair; the unit is the paired asset.
+
+Both at once → `AmbiguousDevBuy()`. Neither → no swap. Unspent input is refunded
+exactly (never a balance sweep). The swap is the pool's first, in-transaction, so
+`eth_call` with `devBuyMinOut = 0` returns the exact fill.
+
+## Salt mining
+
+```
+effectiveSalt = keccak256(abi.encodePacked(deployer, salt))
+token         = CREATE2(factory, effectiveSalt, keccak256(PartyToken initcode))
+initcode      = PartyToken.creationCode ++ abi.encode(name, symbol, 1e27, factory, metadataUri)
+```
+
+The salt is bound to the deployer, so copied calldata can only deploy inside the
+copyist's namespace. `computeTokenAddress(deployer, salt, name, symbol, metadataUri)`
+predicts the address off-chain; the skill batches it to search.
+
+The constraint is `token < pairedAsset`. Hit rates: **WETH ~4.6%**, **USDG ~37.4%**.
+
+Verified vector — deployer `0x8a86E3927BD9E4200BC18DAD3A158CAa4806Ba51`, salt `7`,
+name `Pools Fun`, symbol `POOL`, metadata
+`ipfs://bafkreiavjuxoyk5yoglksbl5gty2mkg74fsao6g2blr5mmjf3wr2kyosma`
+→ **`0x0762a4F683f0531b70bC7D6882781457d80F689a`**. `selftest.py` pins this.
+
+## Custom errors
+
+| Selector | Error |
+|---|---|
+| `0xb4f54111` | `DeployFailed` |
+| `0x0f5ddbb1` | `StartTickChanged` |
+| `0xd79cce06` | `TokenNotToken0` |
+| `0x203d82d8` | `Expired` |
+| `0x7607bc0d` | `CreatorNotCaller` |
+| `0x6e4e2579` | `AmbiguousDevBuy` |
+| `0xb6dc33e4` | `DevBuyWethOnly` |
+| `0xedaf7b53` | `DevBuyTooLittle` |
+| `0x5a9b44ca` | `PairedAssetNotAllowed` |
+| `0x9e87fac8` | `Paused` |
+| `0x7983c051` | `PoolAlreadyInitialized` |
+
+`TokenLaunched` topic0:
+`0xd1844be5e646143a1c9e6841471e58911bac843c7d033e435d304cfeba2c2153`
+(indexed: token, pool, creator).
+
+## Paired-asset allowlist
+
+Registration *is* the allowlist — an asset with no curve cannot launch.
+
+| Asset | Feed | Heartbeat | Fallback tick |
+|---|---|---|---|
+| WETH | `0x78F3556b…` ETH/USD | 90000s (25h) | pinned |
+| USDG | `0x61B7e565…` | 90000s (25h) | pinned |
+
+`startTickFor` returns `(tick, live)`. `live == false` means the feed was stale or
+the sequencer was down and the pinned fallback was used — the FDV will be off
+target. The skill refuses to launch in that state without `--allow-fallback-tick`.
+
+## The locker
+
+The LP NFT goes to `PartyLocker` on launch and never comes back. Creator-facing
+surface:
+
+* `getPoolInfo(token)` → `(pairedAsset, pool, creator, feeRecipient, tokenIds)`
+* `getPoolSplits(token)` → six uint16 bps values
+* `collect(token)` — sweep fees from the LP into the locker
+* `claim(token)` — pay out your share of what the locker holds
+* `collectAndClaim(token)` — both
+* `setFeeRecipient(token, addr)` — redirect future payouts
+
+There is also a community-takeover flow (`queueCto`/`executeCto`/`cancelCto`),
+deliberately out of scope for this skill.
+
+## Reference launch
+
+tx [`0x0978ee728eb9ae5e78c7f461fea96dc9372315b7eee5a69e91ba914d98d8d1c0`](https://robinhoodchain.blockscout.com/tx/0x0978ee728eb9ae5e78c7f461fea96dc9372315b7eee5a69e91ba914d98d8d1c0)
+
+```
+name              Pools Fun          symbol   POOL
+metadataUri       ipfs://bafkreiavjuxoyk5yoglksbl5gty2mkg74fsao6g2blr5mmjf3wr2kyosma
+salt              0x…07              paired   WETH
+expectedStartTick -190600            deadline 1786596532
+creator/feeRecip  0x8a86E392…        devBuyAmountIn / MinOut  0 / 0
+msg.value         0.001 ETH  -> native dev buy
+```
+
+Result: token `0x0762a4F6…`, pool `0x0512090d…`, LP NFT #4436 to the locker,
+dev buy filled **187410.002243581166618109** POOL (0.0187% of supply), 6,096,288 gas.
+
+Note `devBuyAmountIn = 0` *and* a dev buy happened — the 0.001 ETH `msg.value` is
+the funding. That is the single most misread part of this ABI: `msg.value` is not
+a launch fee, it is the dev buy.
+
+## Metadata
+
+`metadataUri` is one immutable string on the token. All three forms are live
+on-chain today:
+
+```
+ipfs://Qmc9DCNH433Bqf22A6B7eMCngTe2XrGcnoajUcFxDMbgQp
+ipfs://bafkreiavjuxoyk5yoglksbl5gty2mkg74fsao6g2blr5mmjf3wr2kyosma
+data:application/json;base64,eyJuYW1lIjoiUG9vbHMiLCJzeW1ib2wiOiJQT09MUyIs…
+```
+
+The document shape pools.fun itself writes:
+
+```json
+{
+  "name": "Pools",
+  "symbol": "POOLS",
+  "description": "Pools",
+  "image": "https://gateway.pinata.cloud/ipfs/QmW1tmSiy9NZjvaSzKua39vtapNPDUdwrEs5knZkau3EnB",
+  "website": "https://pools.fun/",
+  "twitter": "https://x.com/pools_dot_fun"
+}
+```
+
+`image` uses the HTTPS gateway form rather than `ipfs://` so wallets and explorers
+render it without a resolver. The skill matches that.

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/assets/partyfactory-reference.md
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/assets/partyfactory-reference.md
@@ -109,6 +109,14 @@ name `Pools Fun`, symbol `POOL`, metadata
 
 ## Custom errors
 
+Every error PartyFactory declares, with its selector. **The code does not hardcode
+these** — `factory.py::ERROR_SIGNATURES` is keyed by signature and computes the
+selectors at import, because a hand-written constant can silently collide with a
+different error and then report the wrong cause with full confidence. (An early
+revision of this skill claimed `0x1f2a2005` for `DevBuyTooLarge`; that selector
+actually belongs to `ZeroAmount()`.) The table below is for humans reading a raw
+revert blob.
+
 | Selector | Error |
 |---|---|
 | `0xb4f54111` | `DeployFailed` |
@@ -119,9 +127,13 @@ name `Pools Fun`, symbol `POOL`, metadata
 | `0x6e4e2579` | `AmbiguousDevBuy` |
 | `0xb6dc33e4` | `DevBuyWethOnly` |
 | `0xedaf7b53` | `DevBuyTooLittle` |
+| `0x82ce2bbd` | `DevBuyTooLarge` |
 | `0x5a9b44ca` | `PairedAssetNotAllowed` |
 | `0x9e87fac8` | `Paused` |
 | `0x7983c051` | `PoolAlreadyInitialized` |
+| `0xf619c36a` | `LockerUnset` |
+| `0xce8ef7fc` | `InvalidTick` |
+| `0xd92e233d` | `ZeroAddress` |
 
 `TokenLaunched` topic0:
 `0xd1844be5e646143a1c9e6841471e58911bac843c7d033e435d304cfeba2c2153`

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""pools.fun read commands — factory state, salt mining, launch simulation.
+
+Nothing here can move funds. The module never imports ``poolsfun.secp256k1``, so
+there is no signing function anywhere in its import graph; the most it can do
+with ``POOLSFUN_PRIVATE_KEY`` is derive the public address from it, and that only
+to answer "which wallet would this launch from". ``selftest.py`` asserts the
+property rather than trusting the convention.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+from poolsfun.chains import (
+    EXPLORER,
+    PARTY_FACTORY,
+    PARTY_LOCKER,
+    USDG,
+    WETH,
+    asset_label,
+    resolve_paired_asset,
+    resolve_signer_address,
+)
+from poolsfun.factory import (
+    ERC20_ABI,
+    PARTY_FACTORY_ABI,
+    PARTY_LOCKER_ABI,
+    TOTAL_SUPPLY,
+    V3_POOL_ABI,
+    mine_salt,
+    price_from_tick,
+    salt_hit_rate,
+)
+from poolsfun.fmt import (
+    die,
+    fmt_units,
+    fmt_usd,
+    heading,
+    json_safe,
+    parse_args,
+    render_kv,
+    render_table,
+    require_arg,
+)
+from poolsfun.metadata import pinata_configured, resolve_metadata_uri
+from poolsfun.plan import (
+    plan_launch,
+    read_factory_state,
+    read_paired_curve,
+    read_paired_usd,
+    read_start_tick,
+)
+from poolsfun.rpc import RpcClient
+
+USAGE = """
+pools_read.py — read pools.fun launch state (never signs, never spends)
+
+  preflight [--paired weth|usdg]
+      Can I launch right now, and at what price? Factory switches, the live
+      launch tick, the resulting token price and FDV, and whether Pinata is set up.
+
+  assets
+      The factory's paired-asset allowlist and each asset's pricing curve.
+
+  mine-salt --name <n> --symbol <s> [--metadata-uri <uri>] [--paired weth|usdg]
+            [--deployer <addr>] [--max-salt-attempts <n>]
+      Find a salt whose CREATE2 token address sorts below the paired asset.
+      Required before any launch; `launch` does it for you.
+
+  simulate --name <n> --symbol <s> [--dev-buy <eth>] [--paired weth|usdg]
+           [--metadata-uri <uri>] [--from <addr>] [--salt <bytes32>]
+      Dry-run the real launch via eth_call and report the exact token address,
+      pool address and dev-buy fill. Costs nothing and needs no funds.
+
+  token <address>
+      A launched token: locker registration, pool, current tick and price, supply.
+
+  fees <address>
+      Creator fee position for a launched token.
+
+Common flags
+  --json          machine-readable output
+  --paired        weth (default) or usdg
+  --signer-env    read the wallet address from a different env var
+
+The RPC endpoint is fixed (Robinhood Chain, 4663) — no configuration needed.
+"""
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+def _resolve_actor(args: dict) -> tuple[str, str]:
+    """The address a launch would come from, and where we learned it.
+
+    Prefers an explicit ``--from``/``--deployer`` so every read command works with
+    no key configured at all; falls back to the address the signing key derives.
+    """
+    explicit = args.get("from") or args.get("deployer")
+    if explicit and explicit is not True:
+        from poolsfun.hexutil import checksum_address
+        return checksum_address(explicit), "--from"
+    signer_env = args.get("signer-env")
+    try:
+        env_name = signer_env if isinstance(signer_env, str) else None
+        return (resolve_signer_address(env_name) if env_name
+                else resolve_signer_address()), "signer key"
+    except RuntimeError as exc:
+        raise RuntimeError(
+            f"{exc}\n  Or pass --from <address> to plan for a wallet without a key here."
+        ) from exc
+
+
+def _emit(args: dict, payload: dict, render: Any) -> None:
+    if args.get("json"):
+        print(json.dumps(json_safe(payload), indent=2))
+    else:
+        render()
+
+
+def _fdv_line(plan_like: dict) -> str:
+    fdv = plan_like.get("fdvUsd")
+    target = plan_like.get("targetFdvUsd")
+    if fdv is None:
+        return "n/a (price feed unavailable)"
+    text = fmt_usd(fdv)
+    if target:
+        text += f"  (protocol target {fmt_usd(float(target))})"
+    return text
+
+
+# ── commands ────────────────────────────────────────────────────────────────
+def cmd_preflight(client: RpcClient, args: dict) -> None:
+    paired = resolve_paired_asset(args.get("paired"))
+    state = read_factory_state(client)
+    tick, live = read_start_tick(client, paired)
+    price = read_paired_usd(client, paired)
+    allowed = client.read(PARTY_FACTORY, PARTY_FACTORY_ABI,
+                          "allowedPairedAsset", [paired])
+
+    paired_usd = price["usd"] if price else None
+    token_price = price_from_tick(tick) * paired_usd if paired_usd else None
+    fdv = token_price * (TOTAL_SUPPLY / 10**18) if token_price else None
+    ready = bool(allowed) and not state.get("paused") and live
+
+    payload = {
+        "paused": state.get("paused"), "locker": state.get("locker"),
+        "owner": state.get("owner"), "initialFdvUsd": state.get("initialFdvUsd"),
+        "pairedAsset": paired, "allowed": bool(allowed),
+        "startTick": tick, "tickLive": live,
+        "pairedUsd": paired_usd, "tokenPriceUsd": token_price, "fdvUsd": fdv,
+        "targetFdvUsd": state.get("initialFdvUsd"),
+        "pinataConfigured": pinata_configured(), "readyToLaunch": ready,
+    }
+
+    def render() -> None:
+        print(heading("pools.fun preflight"))
+        print(render_kv([
+            ("factory", PARTY_FACTORY),
+            ("paused", "yes — launches disabled" if state.get("paused") else "no"),
+            ("locker", state.get("locker") or "unset"),
+            ("paired asset", f"{asset_label(paired)}  {paired}"),
+            ("allowlisted", "yes" if allowed else "NO — cannot launch against this asset"),
+            ("start tick", f"{tick}  ({'live feed' if live else 'FALLBACK — FDV off target'})"),
+            (f"{asset_label(paired)} price", fmt_usd(paired_usd) if paired_usd else "n/a"),
+            ("token price", fmt_usd(token_price) if token_price else "n/a"),
+            ("launch FDV", _fdv_line(payload)),
+            ("supply", f"{TOTAL_SUPPLY // 10**18:,} (fixed)"),
+            ("fee tier", "1% full range (fixed)"),
+            ("token image", "Pinata configured" if pinata_configured()
+             else "no PINATA_JWT — launches work, but --image is unavailable"),
+            ("ready to launch", "yes" if ready else "no — see above"),
+        ]))
+        print("\n  The launch price is protocol state, not an input: the factory derives")
+        print(f"  the tick from its own feed to target ${state.get('initialFdvUsd')} FDV.")
+        print("  No flag can change it. A dev buy only moves price up, after the open.")
+
+    _emit(args, payload, render)
+
+
+def cmd_assets(client: RpcClient, args: dict) -> None:
+    rows = []
+    payload = []
+    for asset in (WETH, USDG):
+        allowed = client.read(PARTY_FACTORY, PARTY_FACTORY_ABI,
+                              "allowedPairedAsset", [asset])
+        curve = read_paired_curve(client, asset)
+        tick, live = (read_start_tick(client, asset) if allowed else (None, False))
+        price = read_paired_usd(client, asset) if allowed else None
+        payload.append({"asset": asset, "label": asset_label(asset),
+                        "allowed": bool(allowed), "curve": curve,
+                        "startTick": tick, "tickLive": live,
+                        "usd": price["usd"] if price else None})
+        rows.append({
+            "asset": asset_label(asset),
+            "address": asset,
+            "allowed": "yes" if allowed else "no",
+            "tick": "n/a" if tick is None else str(tick),
+            "source": ("live" if live else "fallback") if allowed else "-",
+            "usd": fmt_usd(price["usd"]) if price else "n/a",
+            "maxAge": f"{curve['maxPriceAge'] // 3600}h" if curve["maxPriceAge"] else "-",
+        })
+
+    def render() -> None:
+        print(heading("paired assets (the launch allowlist)"))
+        print(render_table([
+            {"key": "asset", "label": "ASSET"},
+            {"key": "address", "label": "ADDRESS"},
+            {"key": "allowed", "label": "ALLOWED"},
+            {"key": "tick", "label": "TICK", "align": "right"},
+            {"key": "source", "label": "SOURCE"},
+            {"key": "usd", "label": "USD", "align": "right"},
+            {"key": "maxAge", "label": "FEED AGE", "align": "right"},
+        ], rows))
+        print("\n  Only allowlisted assets can be launched against. A native-ETH dev buy")
+        print("  works on WETH pairs only; USDG pairs need --dev-buy-asset + approve.")
+
+    _emit(args, {"assets": payload}, render)
+
+
+def cmd_mine_salt(client: RpcClient, args: dict) -> None:
+    name = require_arg(args, "name", "token name")
+    symbol = require_arg(args, "symbol", "token symbol")
+    paired = resolve_paired_asset(args.get("paired"))
+    deployer, _ = _resolve_actor(args)
+    uri = args.get("metadata-uri")
+    if not uri or uri is True:
+        uri, _doc, _how = resolve_metadata_uri(name=name, symbol=symbol)
+    max_attempts = int(args.get("max-salt-attempts") or 5000)
+
+    started = time.time()
+    salt, token, attempts = mine_salt(client, PARTY_FACTORY, deployer, name, symbol,
+                                      uri, paired, max_attempts=max_attempts)
+    payload = {"salt": salt, "saltInt": int(salt, 16), "token": token,
+               "attempts": attempts, "deployer": deployer, "pairedAsset": paired,
+               "metadataUri": uri, "seconds": round(time.time() - started, 2)}
+
+    def render() -> None:
+        print(heading("mined salt"))
+        print(render_kv([
+            ("salt", salt),
+            ("token address", token),
+            ("sorts below", f"{asset_label(paired)}  {paired}"),
+            ("deployer", f"{deployer}  (the salt is bound to this address)"),
+            ("attempts", f"{attempts}  (~{salt_hit_rate(paired) * 100:.1f}% of salts qualify)"),
+            ("elapsed", f"{payload['seconds']}s"),
+        ]))
+        print("\n  This salt only works for this exact name, symbol, metadataUri and")
+        print("  deployer. Change any of them and it must be re-mined.")
+
+    _emit(args, payload, render)
+
+
+def cmd_simulate(client: RpcClient, args: dict) -> None:
+    name = require_arg(args, "name", "token name")
+    symbol = require_arg(args, "symbol", "token symbol")
+    if args.get("image"):
+        raise RuntimeError(
+            "simulate does not pin images — pinning is a write to an external service "
+            "and this command is read-only.\n"
+            "  Use `pools_write.py launch --image …` without --broadcast for a full "
+            "dry run, or pass --metadata-uri here."
+        )
+    paired = resolve_paired_asset(args.get("paired"))
+    creator, source = _resolve_actor(args)
+    uri = args.get("metadata-uri")
+    if not uri or uri is True:
+        uri, _doc, _how = resolve_metadata_uri(
+            name=name, symbol=symbol, description=args.get("description") or None)
+
+    dev_buy_wei = _parse_eth(args.get("dev-buy"))
+    salt = args.get("salt") if isinstance(args.get("salt"), str) else None
+    plan = plan_launch(
+        client, factory=PARTY_FACTORY, name=name, symbol=symbol, metadata_uri=uri,
+        paired_asset=paired, creator=creator, fee_recipient=creator,
+        deadline=int(time.time()) + 1200, dev_buy_wei=dev_buy_wei, salt=salt,
+        max_salt_attempts=int(args.get("max-salt-attempts") or 5000),
+        allow_fallback_tick=bool(args.get("allow-fallback-tick")))
+
+    def render() -> None:
+        print(heading("launch simulation (nothing was sent)"))
+        pairs = [
+            ("name / symbol", f"{name} / {symbol}"),
+            ("would launch from", f"{creator}  ({source})"),
+            ("token address", plan["token"]),
+            ("pool address", plan["pool"]),
+            ("salt", f"{plan['salt']}  ({plan['saltAttempts']} tries)"),
+            ("start tick", f"{plan['expectedStartTick']}  "
+                           f"({'live feed' if plan['tickLive'] else 'FALLBACK'})"),
+            ("token price", fmt_usd(plan["tokenPriceUsd"])),
+            ("launch FDV", _fdv_line(plan)),
+        ]
+        if dev_buy_wei:
+            pairs += [
+                ("dev buy", f"{fmt_units(dev_buy_wei, 18)} ETH"),
+                ("you would receive", f"{fmt_units(plan['devBuyOut'], 18)} {symbol}"),
+                ("share of supply", f"{plan['supplyPct']:.4f}%"),
+                ("cost basis", fmt_usd(dev_buy_wei / 1e18 * (plan['pairedUsd'] or 0))),
+            ]
+        else:
+            pairs.append(("dev buy", "0 — pass --dev-buy <eth> to buy at launch"))
+        print(render_kv(pairs))
+        print("\n  The dev-buy fill is exact, not an estimate: it is the pool's first")
+        print("  swap inside the launch transaction, so nothing can front-run it.")
+
+    _emit(args, plan, render)
+
+
+def cmd_token(client: RpcClient, args: dict) -> None:
+    from poolsfun.hexutil import checksum_address
+
+    positional = args["_"][1:] if len(args["_"]) > 1 else []
+    raw = args.get("token") or (positional[0] if positional else None)
+    if not raw or raw is True:
+        raise ValueError("usage: pools_read.py token <address>")
+    token = checksum_address(raw)
+
+    info = client.read(PARTY_LOCKER, PARTY_LOCKER_ABI, "getPoolInfo", [token])
+    if isinstance(info, dict):
+        paired, pool = info["pairedAsset"], info["pool"]
+        creator, fee_recipient = info["creator"], info["feeRecipient"]
+        token_ids = info["tokenIds"]
+    else:
+        paired, pool, creator, fee_recipient, token_ids = info
+    if int(pool, 16) == 0:
+        raise RuntimeError(
+            f"{token} is not registered with the pools.fun locker — it was not "
+            "launched through this factory."
+        )
+
+    name = client.read(token, ERC20_ABI, "name")
+    symbol = client.read(token, ERC20_ABI, "symbol")
+    supply = client.read(token, ERC20_ABI, "totalSupply")
+    try:
+        uri = client.read(token, ERC20_ABI, "metadataUri")
+    except Exception:
+        uri = None
+    slot0 = client.read(pool, V3_POOL_ABI, "slot0")
+    tick = int(slot0["tick"] if isinstance(slot0, dict) else slot0[1])
+    price = read_paired_usd(client, paired)
+    paired_usd = price["usd"] if price else None
+    token_price = price_from_tick(tick) * paired_usd if paired_usd else None
+
+    payload = {"token": token, "name": name, "symbol": symbol,
+               "totalSupply": int(supply), "metadataUri": uri, "pool": pool,
+               "pairedAsset": paired, "creator": creator,
+               "feeRecipient": fee_recipient,
+               "lpTokenIds": [int(t) for t in token_ids],
+               "currentTick": tick, "tokenPriceUsd": token_price,
+               "marketCapUsd": (token_price * int(supply) / 1e18) if token_price else None}
+
+    def render() -> None:
+        print(heading(f"{name} ({symbol})"))
+        print(render_kv([
+            ("token", token),
+            ("pool", f"{pool}  1% fee"),
+            ("paired with", f"{asset_label(paired)}  {paired}"),
+            ("creator", creator),
+            ("fee recipient", fee_recipient
+             + ("  (same as creator)" if fee_recipient.lower() == creator.lower() else "")),
+            ("LP position", f"NFT #{', #'.join(str(int(t)) for t in token_ids)} "
+                            f"held by the locker (permanent)"),
+            ("supply", f"{int(supply) // 10**18:,}"),
+            ("current tick", str(tick)),
+            ("token price", fmt_usd(token_price) if token_price else "n/a"),
+            ("market cap", fmt_usd(payload["marketCapUsd"])
+             if payload["marketCapUsd"] else "n/a"),
+            ("metadata", uri or "n/a"),
+            ("explorer", f"{EXPLORER}/token/{token}"),
+        ]))
+
+    _emit(args, payload, render)
+
+
+def cmd_fees(client: RpcClient, args: dict) -> None:
+    from poolsfun.hexutil import checksum_address
+
+    positional = args["_"][1:] if len(args["_"]) > 1 else []
+    raw = args.get("token") or (positional[0] if positional else None)
+    if not raw or raw is True:
+        raise ValueError("usage: pools_read.py fees <address>")
+    token = checksum_address(raw)
+
+    info = client.read(PARTY_LOCKER, PARTY_LOCKER_ABI, "getPoolInfo", [token])
+    paired = info["pairedAsset"] if isinstance(info, dict) else info[0]
+    creator = info["creator"] if isinstance(info, dict) else info[2]
+    fee_recipient = info["feeRecipient"] if isinstance(info, dict) else info[3]
+    if int(paired, 16) == 0:
+        raise RuntimeError(f"{token} is not registered with the pools.fun locker.")
+
+    splits = client.read(PARTY_LOCKER, PARTY_LOCKER_ABI, "getPoolSplits", [token])
+    values = list(splits.values()) if isinstance(splits, dict) else list(splits)
+    labels = ["creator", "protocol", "buyback", "community", "tokenCreator", "tokenProtocol"]
+    split_map = {k: int(v) for k, v in zip(labels, values)}
+
+    pending_token = client.read(token, ERC20_ABI, "balanceOf", [PARTY_LOCKER])
+    pending_paired = client.read(paired, ERC20_ABI, "balanceOf", [PARTY_LOCKER])
+
+    payload = {"token": token, "creator": creator, "feeRecipient": fee_recipient,
+               "splitsBps": split_map, "pairedAsset": paired,
+               "lockerTokenBalance": int(pending_token),
+               "lockerPairedBalance": int(pending_paired)}
+
+    def render() -> None:
+        print(heading("creator fees"))
+        print(render_kv([
+            ("token", token),
+            ("creator", creator),
+            ("fee recipient", fee_recipient),
+            ("your split", f"{split_map['creator'] / 100:.2f}% of trading fees"),
+            ("locker holds", f"{fmt_units(int(pending_token), 18)} token  +  "
+                             f"{fmt_units(int(pending_paired), 18)} {asset_label(paired)}"),
+        ]))
+        print("\n  Fees accrue inside the LP position until collected. Run")
+        print("  `pools_write.py collect-and-claim <token>` to sweep and pay out.")
+        print("  The locker balance above is shared across all launched tokens —")
+        print("  it is an upper bound on what a collect would move, not your share.")
+
+    _emit(args, payload, render)
+
+
+def _parse_eth(value: Any) -> int:
+    if value is None or value is True:
+        return 0
+    from poolsfun.hexutil import parse_units
+    return parse_units(str(value), 18)
+
+
+COMMANDS = {
+    "preflight": cmd_preflight,
+    "assets": cmd_assets,
+    "mine-salt": cmd_mine_salt,
+    "simulate": cmd_simulate,
+    "token": cmd_token,
+    "fees": cmd_fees,
+}
+
+
+def main(argv: list[str]) -> None:
+    args = parse_args(argv)
+    command = args["_"][0] if args["_"] else None
+    if not command or args.get("help") or command not in COMMANDS:
+        print(USAGE.strip())
+        if command and command not in COMMANDS:
+            print(f"\nunknown command: {command}")
+            sys.exit(1)
+        return
+    client = RpcClient(rpc_url=args.get("rpc") if isinstance(args.get("rpc"), str) else None,
+                       debug=bool(args.get("debug")))
+    COMMANDS[command](client, args)
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except BaseException as exc:  # noqa: BLE001 — single top-level reporter
+        die(exc)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
@@ -41,6 +41,8 @@ from poolsfun.fmt import (
     fmt_usd,
     heading,
     json_safe,
+    opt_int,
+    opt_str,
     parse_args,
     render_kv,
     render_table,
@@ -143,7 +145,9 @@ def cmd_preflight(client: RpcClient, args: dict) -> None:
     paired_usd = price["usd"] if price else None
     token_price = price_from_tick(tick) * paired_usd if paired_usd else None
     fdv = token_price * (TOTAL_SUPPLY / 10**18) if token_price else None
-    ready = bool(allowed) and not state.get("paused") and live
+    # `paused is None` means the call failed, not that the factory is running.
+    paused = state.get("paused")
+    ready = bool(allowed) and paused is False and live
 
     payload = {
         "paused": state.get("paused"), "locker": state.get("locker"),
@@ -159,7 +163,8 @@ def cmd_preflight(client: RpcClient, args: dict) -> None:
         print(heading("pools.fun preflight"))
         print(render_kv([
             ("factory", PARTY_FACTORY),
-            ("paused", "yes — launches disabled" if state.get("paused") else "no"),
+            ("paused", "unknown — could not read the factory" if paused is None
+             else ("yes — launches disabled" if paused else "no")),
             ("locker", state.get("locker") or "unset"),
             ("paired asset", f"{asset_label(paired)}  {paired}"),
             ("allowlisted", "yes" if allowed else "NO — cannot launch against this asset"),
@@ -225,10 +230,10 @@ def cmd_mine_salt(client: RpcClient, args: dict) -> None:
     symbol = require_arg(args, "symbol", "token symbol")
     paired = resolve_paired_asset(args.get("paired"))
     deployer, _ = _resolve_actor(args)
-    uri = args.get("metadata-uri")
-    if not uri or uri is True:
+    uri = opt_str(args, "metadata-uri")
+    if not uri:
         uri, _doc, _how = resolve_metadata_uri(name=name, symbol=symbol)
-    max_attempts = int(args.get("max-salt-attempts") or 5000)
+    max_attempts = opt_int(args, "max-salt-attempts", 5000, minimum=1)
 
     started = time.time()
     salt, token, attempts = mine_salt(client, PARTY_FACTORY, deployer, name, symbol,
@@ -265,18 +270,18 @@ def cmd_simulate(client: RpcClient, args: dict) -> None:
         )
     paired = resolve_paired_asset(args.get("paired"))
     creator, source = _resolve_actor(args)
-    uri = args.get("metadata-uri")
-    if not uri or uri is True:
+    uri = opt_str(args, "metadata-uri")
+    if not uri:
         uri, _doc, _how = resolve_metadata_uri(
-            name=name, symbol=symbol, description=args.get("description") or None)
+            name=name, symbol=symbol, description=opt_str(args, "description"))
 
     dev_buy_wei = _parse_eth(args.get("dev-buy"))
-    salt = args.get("salt") if isinstance(args.get("salt"), str) else None
+    salt = opt_str(args, "salt")
     plan = plan_launch(
         client, factory=PARTY_FACTORY, name=name, symbol=symbol, metadata_uri=uri,
         paired_asset=paired, creator=creator, fee_recipient=creator,
         deadline=int(time.time()) + 1200, dev_buy_wei=dev_buy_wei, salt=salt,
-        max_salt_attempts=int(args.get("max-salt-attempts") or 5000),
+        max_salt_attempts=opt_int(args, "max-salt-attempts", 5000, minimum=1),
         allow_fallback_tick=bool(args.get("allow-fallback-tick")))
 
     def render() -> None:
@@ -422,10 +427,15 @@ def cmd_fees(client: RpcClient, args: dict) -> None:
 
 
 def _parse_eth(value: Any) -> int:
-    if value is None or value is True:
+    if value is None:
         return 0
+    if value is True:
+        raise ValueError("--dev-buy needs a value")
     from poolsfun.hexutil import parse_units
-    return parse_units(str(value), 18)
+    amount = parse_units(str(value).strip(), 18)
+    if amount < 0:
+        raise ValueError("--dev-buy cannot be negative")
+    return amount
 
 
 COMMANDS = {
@@ -447,8 +457,7 @@ def main(argv: list[str]) -> None:
             print(f"\nunknown command: {command}")
             sys.exit(1)
         return
-    client = RpcClient(rpc_url=args.get("rpc") if isinstance(args.get("rpc"), str) else None,
-                       debug=bool(args.get("debug")))
+    client = RpcClient(rpc_url=opt_str(args, "rpc"), debug=bool(args.get("debug")))
     COMMANDS[command](client, args)
 
 

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_write.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_write.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""pools.fun write commands — launch a token, collect creator fees.
+
+Every state-changing command follows the same two-step protocol:
+
+    1. Run it. Nothing is sent. A plan is printed, ending in a PLAN_HASH.
+    2. Re-run it with ``--broadcast --confirm <PLAN_HASH>``.
+
+The hash covers everything that determines what lands on-chain, so a plan that
+changed between the two steps — a moved price feed, a different salt, an edited
+name — produces a different hash and the broadcast refuses. It is not a
+formality: a token launch is irreversible and mints a fixed supply into a
+permanently locked pool, so there is no way to undo a typo in a symbol.
+
+A launch needs three things: a name, a symbol, and (optionally) an image.
+Everything else has a default, and every default is printed in the plan.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+from poolsfun.abi_codec import encode_function_data
+from poolsfun.chains import (
+    CHAIN,
+    ENV_SIGNER,
+    EXPLORER,
+    PARTY_FACTORY,
+    PARTY_LOCKER,
+    asset_label,
+    resolve_paired_asset,
+    resolve_private_key,
+)
+from poolsfun.factory import ERC20_ABI, PARTY_LOCKER_ABI, decode_token_launched, explain_revert
+from poolsfun.fmt import (
+    die,
+    fmt_units,
+    fmt_usd,
+    heading,
+    json_safe,
+    parse_args,
+    render_kv,
+    require_arg,
+)
+from poolsfun.hexutil import checksum_address, parse_units
+from poolsfun.metadata import resolve_metadata_uri
+from poolsfun.plan import action_hash, plan_launch, verify_plan_unchanged
+from poolsfun.rpc import RpcClient, RpcError
+from poolsfun.tx import prepare_transaction, receipt_status, send_transaction, wait_for_receipt
+
+USAGE = """
+pools_write.py — launch a pools.fun token, manage creator fees
+
+  launch --name <name> --symbol <sym> [--image <path>]
+      Launch a token. Dry-run by default; add --broadcast --confirm <hash> to send.
+
+      Identity      --name --symbol --image <path>  (image needs PINATA_JWT)
+                    --description --website --twitter
+                    --metadata-uri <uri>   use a URI you already host
+                    --pin-metadata         pin the JSON even with no image
+      Market        --paired weth|usdg     default weth
+                    --dev-buy <eth>        buy at launch with native ETH (WETH pairs)
+                    --dev-buy-asset <amt>  buy with the paired ERC20 (run `approve` first)
+                    --slippage-bps <n>     default 100 (1%)
+      Advanced      --fee-recipient <addr> default: you
+                    --salt <bytes32>       default: mined for you
+                    --deadline-secs <n>    default 1200
+                    --allow-fallback-tick  launch even if the price feed is degraded
+                    --max-salt-attempts <n>  default 5000
+
+  approve [--paired weth|usdg] [--amount <n>]
+      Approve the factory to pull the paired asset for an ERC20 dev buy.
+
+  collect <token>            Sweep LP fees into the locker.
+  claim <token>              Pay out your share of what the locker holds.
+  collect-and-claim <token>  Both, in one transaction. Usually what you want.
+  set-fee-recipient <token> --recipient <addr>
+      Redirect future creator-fee payouts.
+
+Common flags
+  --broadcast --confirm <hash>   actually send
+  --from <addr>                  plan for another wallet; can never broadcast
+  --json                         machine-readable output
+  --gas-multiplier <f>           default 1.3
+  --max-fee-gwei <n>             refuse to send above this gas price
+
+The launch price is fixed by the protocol (~$10k FDV) and cannot be set.
+Requires POOLSFUN_PRIVATE_KEY. PINATA_JWT is optional (only for --image).
+""".rstrip()
+
+DEFAULT_DEADLINE_SECS = 1200
+DEFAULT_SLIPPAGE_BPS = 100
+DEFAULT_GAS_MULTIPLIER = 1.3
+# The reference launch burned 6.1M gas: pool creation, an NFT mint and a swap in
+# one transaction. Estimates can come in tight against that, and a launch that
+# runs out of gas still costs the fee, so the multiplier default is generous.
+LAUNCH_GAS_FLOOR = 7_000_000
+
+
+# ── signer ──────────────────────────────────────────────────────────────────
+def resolve_signer(args: dict) -> dict:
+    """Who signs, or planning-only when ``--from`` names someone else.
+
+    ``--from`` yields ``simulateOnly``, which every broadcast path checks. It is
+    what lets a launch be planned on a machine that holds no key at all.
+    """
+    if args.get("from") and args["from"] is not True:
+        return {"address": checksum_address(args["from"]), "privateKey": None,
+                "simulateOnly": True, "signerEnv": None}
+    signer_env = args.get("signer-env")
+    env_name = signer_env if isinstance(signer_env, str) else ENV_SIGNER
+    private_key = resolve_private_key(env_name)
+    from poolsfun.account import account_from_private_key
+    account = account_from_private_key(private_key)
+    return {"address": account["address"], "privateKey": private_key,
+            "simulateOnly": False, "signerEnv": env_name}
+
+
+def _gas_opts(args: dict) -> dict:
+    cap = args.get("max-fee-gwei")
+    return {
+        "gas_multiplier": float(args.get("gas-multiplier") or DEFAULT_GAS_MULTIPLIER),
+        "max_fee_cap": int(float(cap) * 10**9) if cap and cap is not True else None,
+    }
+
+
+def _confirmed(args: dict, plan_hash_value: str) -> bool:
+    """Whether this invocation is authorised to broadcast this exact plan."""
+    if not args.get("broadcast"):
+        return False
+    confirm = args.get("confirm")
+    if not confirm or confirm is True:
+        raise RuntimeError(
+            f"--broadcast needs --confirm {plan_hash_value}\n"
+            "  Re-run with both flags to send. The hash proves you are confirming the "
+            "plan you just read."
+        )
+    if str(confirm).lower().strip() != plan_hash_value.lower():
+        raise RuntimeError(
+            f"--confirm {confirm} does not match this plan ({plan_hash_value}).\n"
+            "  The plan changed since you last read it. Read the new one above, then "
+            "confirm that hash."
+        )
+    return True
+
+
+def _send(client: RpcClient, signer: dict, to: str, data: str, args: dict,
+          value: int = 0, gas_floor: int | None = None) -> dict:
+    """Prepare, sign, broadcast, wait. Shared by every write command."""
+    if signer["simulateOnly"] or not signer["privateKey"]:
+        raise RuntimeError("--from is planning mode; it cannot broadcast. Remove it.")
+    opts = _gas_opts(args)
+    tx = prepare_transaction(client, CHAIN, signer["address"], to, data, value=value,
+                             gas_multiplier=opts["gas_multiplier"],
+                             max_fee_cap=opts["max_fee_cap"])
+    if gas_floor and tx["gas"] < gas_floor:
+        tx["gas"] = gas_floor
+    print(f"\n  sending… (gas {tx['gas']:,}, "
+          f"maxFee {tx['maxFeePerGas'] / 10**9:.3f} gwei, nonce {tx['nonce']})")
+    tx_hash = send_transaction(client, CHAIN, tx, signer["privateKey"])
+    print(f"  tx {tx_hash}")
+    print(f"  {EXPLORER}/tx/{tx_hash}")
+    receipt = wait_for_receipt(client, tx_hash)
+    status = receipt_status(receipt)
+    print(f"  {status}  (gas used {int(receipt.get('gasUsed', '0x0'), 16):,})")
+    if status != "success":
+        raise RuntimeError(f"transaction reverted: {EXPLORER}/tx/{tx_hash}")
+    return receipt
+
+
+# ── launch ──────────────────────────────────────────────────────────────────
+def cmd_launch(client: RpcClient, args: dict) -> None:
+    name = require_arg(args, "name", "token name")
+    symbol = require_arg(args, "symbol", "token symbol")
+    signer = resolve_signer(args)
+    creator = signer["address"]
+    paired = resolve_paired_asset(args.get("paired"))
+
+    fee_recipient = args.get("fee-recipient")
+    fee_recipient = (checksum_address(fee_recipient)
+                     if fee_recipient and fee_recipient is not True else creator)
+
+    dev_buy_wei = _amount(args.get("dev-buy"), 18)
+    dev_buy_asset = _amount(args.get("dev-buy-asset"), 18)
+    slippage_bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
+    deadline_secs = int(args.get("deadline-secs") or DEFAULT_DEADLINE_SECS)
+
+    if dev_buy_asset:
+        _require_allowance(client, paired, creator, dev_buy_asset)
+
+    # Resolve metadata before planning: the URI feeds the CREATE2 address, so a
+    # salt mined against a placeholder would be wrong for the real launch.
+    uri, doc, how = resolve_metadata_uri(
+        name=name, symbol=symbol,
+        metadata_uri=(args.get("metadata-uri")
+                      if isinstance(args.get("metadata-uri"), str) else None),
+        image=args.get("image") if isinstance(args.get("image"), str) else None,
+        description=_text(args.get("description")),
+        website=_text(args.get("website")),
+        twitter=_text(args.get("twitter")),
+        pin=bool(args.get("pin-metadata")))
+
+    deadline = int(time.time()) + deadline_secs
+    plan = plan_launch(
+        client, factory=PARTY_FACTORY, name=name, symbol=symbol, metadata_uri=uri,
+        paired_asset=paired, creator=creator, fee_recipient=fee_recipient,
+        deadline=deadline, dev_buy_wei=dev_buy_wei, dev_buy_asset=dev_buy_asset,
+        slippage_bps=slippage_bps, allow_fallback_tick=bool(args.get("allow-fallback-tick")),
+        salt=args.get("salt") if isinstance(args.get("salt"), str) else None,
+        max_salt_attempts=int(args.get("max-salt-attempts") or 5000))
+    plan["metadataHow"] = how
+    plan["metadataDoc"] = doc
+
+    if args.get("json"):
+        print(json.dumps(json_safe(plan), indent=2))
+    else:
+        _render_launch_plan(plan, args, signer)
+
+    if not _confirmed(args, plan["planHash"]):
+        if not args.get("json"):
+            print("\n  Nothing was sent. To execute:")
+            print(f"    {_replay_command(args)} --broadcast --confirm {plan['planHash']}")
+        return
+
+    # Re-plan against current chain state and require it to be identical. The
+    # price feed moves on its own schedule; between reading a plan and confirming
+    # it the tick can change, and launching at a tick the user never saw is
+    # exactly what the hash exists to prevent.
+    fresh = plan_launch(
+        client, factory=PARTY_FACTORY, name=name, symbol=symbol, metadata_uri=uri,
+        paired_asset=paired, creator=creator, fee_recipient=fee_recipient,
+        deadline=int(time.time()) + deadline_secs, dev_buy_wei=dev_buy_wei,
+        dev_buy_asset=dev_buy_asset, slippage_bps=slippage_bps,
+        allow_fallback_tick=bool(args.get("allow-fallback-tick")),
+        salt=plan["salt"], max_salt_attempts=1)
+    verify_plan_unchanged(fresh, plan["planHash"])
+
+    from poolsfun.factory import encode_launch
+    data = encode_launch(name, symbol, uri, fresh["salt"], paired,
+                         fresh["expectedStartTick"], fresh["deadline"], creator,
+                         fee_recipient, dev_buy_asset, fresh["devBuyMinOut"])
+    receipt = _send(client, signer, PARTY_FACTORY, data, args,
+                    value=dev_buy_wei, gas_floor=LAUNCH_GAS_FLOOR)
+
+    launched = decode_token_launched(receipt.get("logs") or [], PARTY_FACTORY)
+    print(heading("launched"))
+    pairs = [("token", launched["token"] if launched else fresh["token"]),
+             ("pool", launched["pool"] if launched else fresh["pool"]),
+             ("explorer", f"{EXPLORER}/token/{launched['token'] if launched else fresh['token']}")]
+    if launched and launched["devBuyAmountOut"]:
+        pairs.append(("you received",
+                      f"{fmt_units(launched['devBuyAmountOut'], 18)} {symbol}"))
+    print(render_kv(pairs))
+
+
+def _render_launch_plan(plan: dict, args: dict, signer: dict) -> None:
+    paired = plan["pairedAsset"]
+    dev_wei, dev_asset = plan["devBuyValueWei"], plan["devBuyAmountIn"]
+    default = "   [default]"
+
+    def mark(is_default: bool) -> str:
+        return default if is_default else ""
+
+    print(heading("launch plan — nothing sent yet"))
+    pairs: list[tuple[str, str]] = [
+        ("name / symbol", f"{plan['name']} / {plan['symbol']}"),
+        ("metadata", f"{_trim(plan['metadataUri'])}  ({plan['metadataHow']})"),
+        ("paired asset", f"{asset_label(paired)}  {paired}"
+                         + mark(not args.get("paired"))),
+        ("salt", f"{plan['salt'][:12]}…{plan['salt'][-4:]}  "
+                 f"(mined, {plan['saltAttempts']} tries)"),
+        ("token address", f"{plan['token']}  (predicted)"),
+        ("pool address", plan["pool"]),
+        ("start tick", f"{plan['expectedStartTick']}  "
+                       f"({'live feed' if plan['tickLive'] else 'FALLBACK'})"),
+        ("token price", fmt_usd(plan["tokenPriceUsd"])),
+        ("launch FDV", f"{fmt_usd(plan['fdvUsd'])}   protocol-fixed"),
+        ("supply", f"{plan['supply'] // 10**18:,}   protocol-fixed"),
+        ("fee tier", "1%, full range   protocol-fixed"),
+        ("LP", f"minted to the locker, permanently; creator = {_short(plan['creator'])}"),
+        ("creator", plan["creator"] + ("  (signer)" if not signer["simulateOnly"]
+                                       else "  (--from, planning only)")),
+        ("fee recipient", plan["feeRecipient"]
+         + mark(not args.get("fee-recipient"))),
+    ]
+    if dev_wei:
+        pairs += [
+            ("dev buy", f"{fmt_units(dev_wei, 18)} ETH (native)"),
+            ("you receive", f"~{fmt_units(plan['devBuyOut'], 18)} {plan['symbol']}  "
+                            f"({plan['supplyPct']:.4f}% of supply)"),
+            ("min accepted", f"{fmt_units(plan['devBuyMinOut'], 18)} "
+                             f"({plan['slippageBps'] / 100:.2f}% slippage)"
+                             + mark(not args.get("slippage-bps"))),
+        ]
+    elif dev_asset:
+        pairs += [
+            ("dev buy", f"{fmt_units(dev_asset, 18)} {asset_label(paired)} (ERC20)"),
+            ("you receive", f"~{fmt_units(plan['devBuyOut'], 18)} {plan['symbol']}  "
+                            f"({plan['supplyPct']:.4f}% of supply)"),
+            ("min accepted", fmt_units(plan["devBuyMinOut"], 18)),
+        ]
+    else:
+        pairs.append(("dev buy", "0 — you receive no tokens at launch" + default))
+    pairs.append(("deadline", f"+{int(args.get('deadline-secs') or DEFAULT_DEADLINE_SECS)}s"
+                              + mark(not args.get("deadline-secs"))))
+    print(render_kv(pairs))
+    print(f"\n  PLAN_HASH  {plan['planHash']}")
+
+
+def _replay_command(args: dict) -> str:
+    parts = ["python3 pools_write.py launch"]
+    for key, value in args.items():
+        if key in ("_", "broadcast", "confirm", "json"):
+            continue
+        if value is True:
+            parts.append(f"--{key}")
+        else:
+            text = str(value)
+            parts.append(f'--{key} "{text}"' if " " in text else f"--{key} {text}")
+    return " ".join(parts)
+
+
+# ── fees ────────────────────────────────────────────────────────────────────
+def _locker_write(client: RpcClient, args: dict, function_name: str,
+                  command: str) -> None:
+    """Shared body for collect/claim/collectAndClaim.
+
+    ``function_name`` is the ABI method; ``command`` is what the user types. The
+    two differ (``collectAndClaim`` vs ``collect-and-claim``) and printing the
+    wrong one gives the user a copy-paste line that does not run.
+    """
+    signer = resolve_signer(args)
+    positional = args["_"][1:] if len(args["_"]) > 1 else []
+    raw = args.get("token") or (positional[0] if positional else None)
+    if not raw or raw is True:
+        raise ValueError(f"usage: pools_write.py {command} <token address>")
+    token = checksum_address(raw)
+
+    info = client.read(PARTY_LOCKER, PARTY_LOCKER_ABI, "getPoolInfo", [token])
+    creator = info["creator"] if isinstance(info, dict) else info[2]
+    recipient = info["feeRecipient"] if isinstance(info, dict) else info[3]
+    if int(creator, 16) == 0:
+        raise RuntimeError(f"{token} is not registered with the pools.fun locker.")
+
+    digest = action_hash(function_name, {
+        "token": token, "caller": signer["address"], "locker": PARTY_LOCKER,
+        "chainId": CHAIN["chainId"]})
+
+    print(heading(f"{command} — nothing sent yet"))
+    print(render_kv([("token", token), ("locker", PARTY_LOCKER),
+                     ("creator", creator), ("fee recipient", recipient),
+                     ("caller", signer["address"])]))
+    print(f"\n  PLAN_HASH  {digest}")
+    if not _confirmed(args, digest):
+        print("\n  Nothing was sent. To execute:")
+        print(f"    python3 pools_write.py {command} {token} "
+              f"--broadcast --confirm {digest}")
+        return
+
+    data = encode_function_data(PARTY_LOCKER_ABI, function_name, [token])
+    _send(client, signer, PARTY_LOCKER, data, args)
+
+
+def cmd_collect(client: RpcClient, args: dict) -> None:
+    _locker_write(client, args, "collect", "collect")
+
+
+def cmd_claim(client: RpcClient, args: dict) -> None:
+    _locker_write(client, args, "claim", "claim")
+
+
+def cmd_collect_and_claim(client: RpcClient, args: dict) -> None:
+    _locker_write(client, args, "collectAndClaim", "collect-and-claim")
+
+
+def cmd_set_fee_recipient(client: RpcClient, args: dict) -> None:
+    signer = resolve_signer(args)
+    positional = args["_"][1:] if len(args["_"]) > 1 else []
+    raw = args.get("token") or (positional[0] if positional else None)
+    if not raw or raw is True:
+        raise ValueError("usage: pools_write.py set-fee-recipient <token> --recipient <addr>")
+    token = checksum_address(raw)
+    recipient = checksum_address(require_arg(args, "recipient", "new payout address"))
+
+    info = client.read(PARTY_LOCKER, PARTY_LOCKER_ABI, "getPoolInfo", [token])
+    current = info["feeRecipient"] if isinstance(info, dict) else info[3]
+
+    digest = action_hash("setFeeRecipient", {
+        "token": token, "recipient": recipient, "caller": signer["address"],
+        "locker": PARTY_LOCKER, "chainId": CHAIN["chainId"]})
+
+    print(heading("set fee recipient — nothing sent yet"))
+    print(render_kv([("token", token), ("current", current), ("new", recipient),
+                     ("caller", signer["address"])]))
+    print(f"\n  PLAN_HASH  {digest}")
+    if not _confirmed(args, digest):
+        print("\n  Nothing was sent. To execute:")
+        print(f"    python3 pools_write.py set-fee-recipient {token} "
+              f"--recipient {recipient} --broadcast --confirm {digest}")
+        return
+
+    data = encode_function_data(PARTY_LOCKER_ABI, "setFeeRecipient", [token, recipient])
+    _send(client, signer, PARTY_LOCKER, data, args)
+
+
+# ── approve ─────────────────────────────────────────────────────────────────
+def cmd_approve(client: RpcClient, args: dict) -> None:
+    signer = resolve_signer(args)
+    paired = resolve_paired_asset(args.get("paired"))
+    amount_raw = args.get("amount")
+    amount = (_amount(amount_raw, 18) if amount_raw and amount_raw is not True
+              else 2**256 - 1)
+    current = client.read(paired, ERC20_ABI, "allowance",
+                          [signer["address"], PARTY_FACTORY])
+
+    digest = action_hash("approve", {
+        "asset": paired, "spender": PARTY_FACTORY, "amount": amount,
+        "owner": signer["address"], "chainId": CHAIN["chainId"]})
+
+    print(heading("approve — nothing sent yet"))
+    print(render_kv([
+        ("asset", f"{asset_label(paired)}  {paired}"),
+        ("spender", f"{PARTY_FACTORY}  (PartyFactory)"),
+        ("current allowance", fmt_units(int(current), 18)),
+        ("new allowance", "unlimited" if amount == 2**256 - 1 else fmt_units(amount, 18)),
+        ("owner", signer["address"]),
+    ]))
+    print(f"\n  PLAN_HASH  {digest}")
+    if not _confirmed(args, digest):
+        print("\n  Nothing was sent. To execute:")
+        print(f"    python3 pools_write.py approve --paired "
+              f"{asset_label(paired).lower()} --broadcast --confirm {digest}")
+        return
+
+    data = encode_function_data(ERC20_ABI, "approve", [PARTY_FACTORY, amount])
+    _send(client, signer, paired, data, args)
+
+
+def _require_allowance(client: RpcClient, paired: str, owner: str, needed: int) -> None:
+    allowance = int(client.read(paired, ERC20_ABI, "allowance", [owner, PARTY_FACTORY]))
+    if allowance >= needed:
+        return
+    raise RuntimeError(
+        f"an ERC20 dev buy needs the factory approved to pull "
+        f"{fmt_units(needed, 18)} {asset_label(paired)}, but the allowance is "
+        f"{fmt_units(allowance, 18)}.\n"
+        f"  Run: python3 pools_write.py approve --paired {asset_label(paired).lower()}"
+    )
+
+
+# ── plumbing ────────────────────────────────────────────────────────────────
+def _amount(value: Any, decimals: int) -> int:
+    if value is None or value is True:
+        return 0
+    return parse_units(str(value), decimals)
+
+
+def _text(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _trim(value: str, limit: int = 64) -> str:
+    return value if len(value) <= limit else value[:limit - 1] + "…"
+
+
+def _short(addr: str) -> str:
+    return f"{addr[:6]}…{addr[-4:]}"
+
+
+COMMANDS = {
+    "launch": cmd_launch,
+    "approve": cmd_approve,
+    "collect": cmd_collect,
+    "claim": cmd_claim,
+    "collect-and-claim": cmd_collect_and_claim,
+    "set-fee-recipient": cmd_set_fee_recipient,
+}
+
+
+def main(argv: list[str]) -> None:
+    args = parse_args(argv)
+    command = args["_"][0] if args["_"] else None
+    if not command or args.get("help") or command not in COMMANDS:
+        print(USAGE)
+        if command and command not in COMMANDS:
+            print(f"\nunknown command: {command}")
+            sys.exit(1)
+        return
+    client = RpcClient(rpc_url=args.get("rpc") if isinstance(args.get("rpc"), str) else None,
+                       debug=bool(args.get("debug")))
+    try:
+        COMMANDS[command](client, args)
+    except RpcError as exc:
+        hint = explain_revert(exc.data)
+        raise RuntimeError(hint or str(exc)) from exc
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except BaseException as exc:  # noqa: BLE001 — single top-level reporter
+        die(exc)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_write.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_write.py
@@ -19,6 +19,7 @@ Everything else has a default, and every default is printed in the plan.
 from __future__ import annotations
 
 import json
+import shlex
 import sys
 import time
 from typing import Any
@@ -41,6 +42,9 @@ from poolsfun.fmt import (
     fmt_usd,
     heading,
     json_safe,
+    opt_float,
+    opt_int,
+    opt_str,
     parse_args,
     render_kv,
     require_arg,
@@ -120,10 +124,11 @@ def resolve_signer(args: dict) -> dict:
 
 
 def _gas_opts(args: dict) -> dict:
-    cap = args.get("max-fee-gwei")
+    cap_gwei = opt_float(args, "max-fee-gwei", 0.0, minimum=0.0)
     return {
-        "gas_multiplier": float(args.get("gas-multiplier") or DEFAULT_GAS_MULTIPLIER),
-        "max_fee_cap": int(float(cap) * 10**9) if cap and cap is not True else None,
+        "gas_multiplier": opt_float(args, "gas-multiplier", DEFAULT_GAS_MULTIPLIER,
+                                    minimum=1.0),
+        "max_fee_cap": int(cap_gwei * 10**9) if cap_gwei > 0 else None,
     }
 
 
@@ -179,14 +184,19 @@ def cmd_launch(client: RpcClient, args: dict) -> None:
     creator = signer["address"]
     paired = resolve_paired_asset(args.get("paired"))
 
-    fee_recipient = args.get("fee-recipient")
-    fee_recipient = (checksum_address(fee_recipient)
-                     if fee_recipient and fee_recipient is not True else creator)
+    fee_recipient_raw = opt_str(args, "fee-recipient")
+    fee_recipient = checksum_address(fee_recipient_raw) if fee_recipient_raw else creator
 
-    dev_buy_wei = _amount(args.get("dev-buy"), 18)
-    dev_buy_asset = _amount(args.get("dev-buy-asset"), 18)
-    slippage_bps = int(args.get("slippage-bps") or DEFAULT_SLIPPAGE_BPS)
-    deadline_secs = int(args.get("deadline-secs") or DEFAULT_DEADLINE_SECS)
+    dev_buy_wei = _amount(args.get("dev-buy"), 18, "dev-buy")
+    dev_buy_asset = _amount(args.get("dev-buy-asset"), 18, "dev-buy-asset")
+    # Slippage is bounded, not merely parsed. A negative value sets devBuyMinOut
+    # *above* the exact simulated fill, producing a plan that hashes and renders
+    # normally and then reverts DevBuyTooLittle() on-chain, burning the full ~6.1M
+    # launch gas. The floor is the whole point of the flag.
+    slippage_bps = opt_int(args, "slippage-bps", DEFAULT_SLIPPAGE_BPS,
+                           minimum=0, maximum=9_999)
+    deadline_secs = opt_int(args, "deadline-secs", DEFAULT_DEADLINE_SECS, minimum=60)
+    max_salt_attempts = opt_int(args, "max-salt-attempts", 5000, minimum=1)
 
     if dev_buy_asset:
         _require_allowance(client, paired, creator, dev_buy_asset)
@@ -195,12 +205,11 @@ def cmd_launch(client: RpcClient, args: dict) -> None:
     # salt mined against a placeholder would be wrong for the real launch.
     uri, doc, how = resolve_metadata_uri(
         name=name, symbol=symbol,
-        metadata_uri=(args.get("metadata-uri")
-                      if isinstance(args.get("metadata-uri"), str) else None),
-        image=args.get("image") if isinstance(args.get("image"), str) else None,
-        description=_text(args.get("description")),
-        website=_text(args.get("website")),
-        twitter=_text(args.get("twitter")),
+        metadata_uri=opt_str(args, "metadata-uri"),
+        image=opt_str(args, "image"),
+        description=opt_str(args, "description"),
+        website=opt_str(args, "website"),
+        twitter=opt_str(args, "twitter"),
         pin=bool(args.get("pin-metadata")))
 
     deadline = int(time.time()) + deadline_secs
@@ -209,8 +218,7 @@ def cmd_launch(client: RpcClient, args: dict) -> None:
         paired_asset=paired, creator=creator, fee_recipient=fee_recipient,
         deadline=deadline, dev_buy_wei=dev_buy_wei, dev_buy_asset=dev_buy_asset,
         slippage_bps=slippage_bps, allow_fallback_tick=bool(args.get("allow-fallback-tick")),
-        salt=args.get("salt") if isinstance(args.get("salt"), str) else None,
-        max_salt_attempts=int(args.get("max-salt-attempts") or 5000))
+        salt=opt_str(args, "salt"), max_salt_attempts=max_salt_attempts)
     plan["metadataHow"] = how
     plan["metadataDoc"] = doc
 
@@ -311,6 +319,14 @@ def _render_launch_plan(plan: dict, args: dict, signer: dict) -> None:
 
 
 def _replay_command(args: dict) -> str:
+    """The copy-paste line that executes this plan.
+
+    Values go through ``shlex.quote``, not hand-rolled double quotes. A token
+    name is attacker-influenced text — it can arrive from a pasted ticker or a
+    chat message — and double quotes do not neuter ``$(…)`` or backticks in a
+    shell. Printing an unquoted name would turn "here is my token name" into
+    command execution for whoever runs the suggested line.
+    """
     parts = ["python3 pools_write.py launch"]
     for key, value in args.items():
         if key in ("_", "broadcast", "confirm", "json"):
@@ -318,8 +334,7 @@ def _replay_command(args: dict) -> str:
         if value is True:
             parts.append(f"--{key}")
         else:
-            text = str(value)
-            parts.append(f'--{key} "{text}"' if " " in text else f"--{key} {text}")
+            parts.append(f"--{key} {shlex.quote(str(value))}")
     return " ".join(parts)
 
 
@@ -410,9 +425,8 @@ def cmd_set_fee_recipient(client: RpcClient, args: dict) -> None:
 def cmd_approve(client: RpcClient, args: dict) -> None:
     signer = resolve_signer(args)
     paired = resolve_paired_asset(args.get("paired"))
-    amount_raw = args.get("amount")
-    amount = (_amount(amount_raw, 18) if amount_raw and amount_raw is not True
-              else 2**256 - 1)
+    amount_raw = _amount(args.get("amount"), 18, "amount")
+    amount = amount_raw if amount_raw else 2**256 - 1
     current = client.read(paired, ERC20_ABI, "allowance",
                           [signer["address"], PARTY_FACTORY])
 
@@ -452,14 +466,15 @@ def _require_allowance(client: RpcClient, paired: str, owner: str, needed: int) 
 
 
 # ── plumbing ────────────────────────────────────────────────────────────────
-def _amount(value: Any, decimals: int) -> int:
-    if value is None or value is True:
+def _amount(value: Any, decimals: int, flag: str) -> int:
+    if value is None:
         return 0
-    return parse_units(str(value), decimals)
-
-
-def _text(value: Any) -> str | None:
-    return value if isinstance(value, str) and value.strip() else None
+    if value is True:
+        raise ValueError(f"--{flag} needs a value")
+    amount = parse_units(str(value).strip(), decimals)
+    if amount < 0:
+        raise ValueError(f"--{flag} cannot be negative")
+    return amount
 
 
 def _trim(value: str, limit: int = 64) -> str:
@@ -489,8 +504,7 @@ def main(argv: list[str]) -> None:
             print(f"\nunknown command: {command}")
             sys.exit(1)
         return
-    client = RpcClient(rpc_url=args.get("rpc") if isinstance(args.get("rpc"), str) else None,
-                       debug=bool(args.get("debug")))
+    client = RpcClient(rpc_url=opt_str(args, "rpc"), debug=bool(args.get("debug")))
     try:
         COMMANDS[command](client, args)
     except RpcError as exc:

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/__init__.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/__init__.py
@@ -1,0 +1,1 @@
+"""Shared modules for the poolsdotfun-token-launcher skill."""

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/abi_codec.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/abi_codec.py
@@ -1,0 +1,408 @@
+"""A Solidity ABI encoder/decoder covering the types this skill actually uses.
+
+Replaces viem's ``encodeAbiParameters`` / ``decodeAbiParameters`` /
+``encodeFunctionData`` / ``decodeEventLog``.
+
+Supported: ``address``, ``bool``, ``uint<N>``, ``int<N>``, ``bytes<N>``, ``bytes``,
+``string``, ``tuple``, ``T[]``, ``T[k]``. That is everything the V4 PositionManager,
+StateView, Multicall3, ERC-20/721 and the three launchpad registries need.
+
+Two things in here are worth reading before changing anything.
+
+**The head/tail layout.** Static parameters are written inline; dynamic ones write
+a 32-byte offset in the head and their payload in the tail, where the offset is
+measured from the start of the *current tuple's* head — not from the start of the
+whole blob. Nested dynamic types (``bytes[]``, which is what ``unlockData`` is)
+are where a naive implementation gets this wrong, so the golden vectors pin the
+exact ``unlockData`` hex for all five action plans.
+
+**Sign extension.** A missed two's-complement conversion on ``int256
+liquidityDelta`` turns a liquidity *removal* into a ~1e77 addition, and the
+resulting reserve totals still render as plausible numbers. It is the quietest
+failure mode in the port, which is why the reserve self-check against
+``StateView.getLiquidity`` exists downstream.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .hexutil import as_int_n, as_uint_n, checksum_address, to_bytes
+
+_WORD = 32
+_ARRAY_RE = re.compile(r"^(.*)\[(\d*)\]$")
+_INT_RE = re.compile(r"^(u?int)(\d*)$")
+_BYTES_N_RE = re.compile(r"^bytes(\d+)$")
+
+
+class AbiError(ValueError):
+    """Raised when a value cannot be encoded, or data cannot be decoded."""
+
+
+# ---------------------------------------------------------------------------
+# Type inspection
+# ---------------------------------------------------------------------------
+
+def _param(spec: Any) -> dict:
+    """Normalise a parameter spec to a dict with at least a ``type`` key."""
+    if isinstance(spec, str):
+        return {"type": spec}
+    if isinstance(spec, dict) and "type" in spec:
+        return spec
+    raise AbiError(f"not an ABI parameter spec: {spec!r}")
+
+
+def _array_parts(type_name: str) -> tuple[str, int | None] | None:
+    """Split ``T[]`` / ``T[k]`` into ``(T, length)``; ``None`` when not an array."""
+    match = _ARRAY_RE.match(type_name)
+    if not match:
+        return None
+    inner, size = match.group(1), match.group(2)
+    return inner, (int(size) if size else None)
+
+
+def _element_param(param: dict, inner_type: str) -> dict:
+    """The parameter spec for one element of an array, keeping ``components``."""
+    element = {"type": inner_type}
+    if "components" in param:
+        element["components"] = param["components"]
+    return element
+
+
+def is_dynamic(param: Any) -> bool:
+    param = _param(param)
+    type_name = param["type"]
+    if type_name in ("bytes", "string"):
+        return True
+    array = _array_parts(type_name)
+    if array is not None:
+        inner, length = array
+        if length is None:
+            return True
+        return is_dynamic(_element_param(param, inner))
+    if type_name.startswith("tuple"):
+        return any(is_dynamic(c) for c in param.get("components", []))
+    return False
+
+
+def canonical_type(param: Any) -> str:
+    """The type string used in a function/event signature.
+
+    Tuples expand to their component list, and ``uint``/``int`` widen to their
+    explicit width — ``uint`` alone is a synonym for ``uint256`` and hashing the
+    short form produces the wrong selector.
+    """
+    param = _param(param)
+    type_name = param["type"]
+    array = _array_parts(type_name)
+    if array is not None:
+        inner, length = array
+        suffix = f"[{length}]" if length is not None else "[]"
+        return canonical_type(_element_param(param, inner)) + suffix
+    if type_name.startswith("tuple"):
+        inner = ",".join(canonical_type(c) for c in param.get("components", []))
+        return f"({inner})"
+    match = _INT_RE.match(type_name)
+    if match and not match.group(2):
+        return f"{match.group(1)}256"
+    return type_name
+
+
+def _head_size(param: Any) -> int:
+    """Bytes this parameter occupies in the head — 32 unless it is a static array/tuple."""
+    param = _param(param)
+    if is_dynamic(param):
+        return _WORD
+    type_name = param["type"]
+    array = _array_parts(type_name)
+    if array is not None:
+        inner, length = array
+        return (length or 0) * _head_size(_element_param(param, inner))
+    if type_name.startswith("tuple"):
+        return sum(_head_size(c) for c in param.get("components", []))
+    return _WORD
+
+
+# ---------------------------------------------------------------------------
+# Encoding
+# ---------------------------------------------------------------------------
+
+def _encode_single(param: dict, value: Any) -> bytes:
+    """Encode one non-array, non-tuple value into its 32-byte word(s)."""
+    type_name = param["type"]
+
+    if type_name == "address":
+        return bytes(12) + to_bytes(checksum_address(str(value)))
+
+    if type_name == "bool":
+        return (1 if value else 0).to_bytes(_WORD, "big")
+
+    match = _INT_RE.match(type_name)
+    if match:
+        signed = match.group(1) == "int"
+        bits = int(match.group(2) or 256)
+        number = int(value)
+        if signed:
+            limit = 1 << (bits - 1)
+            if not (-limit <= number < limit):
+                raise AbiError(f"{number} does not fit in {type_name}")
+            return as_uint_n(256, number).to_bytes(_WORD, "big")
+        if not (0 <= number < (1 << bits)):
+            raise AbiError(f"{number} does not fit in {type_name}")
+        return number.to_bytes(_WORD, "big")
+
+    match = _BYTES_N_RE.match(type_name)
+    if match:
+        width = int(match.group(1))
+        raw = to_bytes(value)
+        if len(raw) > width:
+            raise AbiError(f"{len(raw)} bytes does not fit in {type_name}")
+        return raw.ljust(_WORD, b"\x00")
+
+    if type_name in ("bytes", "string"):
+        raw = value.encode("utf-8") if type_name == "string" else to_bytes(value)
+        padded = raw + bytes((-len(raw)) % _WORD)
+        return len(raw).to_bytes(_WORD, "big") + padded
+
+    raise AbiError(f"unsupported type: {type_name}")
+
+
+def _tuple_values(param: dict, value: Any) -> list:
+    """Accept a tuple as a list/tuple or as a dict keyed by component name."""
+    components = param.get("components", [])
+    if isinstance(value, dict):
+        try:
+            return [value[c["name"]] for c in components]
+        except KeyError as exc:
+            raise AbiError(f"tuple value is missing component {exc}") from None
+    values = list(value)
+    if len(values) != len(components):
+        raise AbiError(f"tuple expects {len(components)} values, got {len(values)}")
+    return values
+
+
+def _encode_param(param: dict, value: Any) -> bytes:
+    """Encode a single parameter, recursing through arrays and tuples."""
+    type_name = param["type"]
+
+    array = _array_parts(type_name)
+    if array is not None:
+        inner, length = array
+        element = _element_param(param, inner)
+        items = list(value)
+        if length is not None and len(items) != length:
+            raise AbiError(f"{type_name} expects {length} items, got {len(items)}")
+        body = _encode_group([element] * len(items), items)
+        # A dynamic array is length-prefixed; a fixed one is not.
+        return len(items).to_bytes(_WORD, "big") + body if length is None else body
+
+    if type_name.startswith("tuple"):
+        components = [_param(c) for c in param.get("components", [])]
+        return _encode_group(components, _tuple_values(param, value))
+
+    return _encode_single(param, value)
+
+
+def _encode_group(params: list, values: list) -> bytes:
+    """Encode a parameter list using the head/tail layout.
+
+    Offsets are relative to the start of this group's head, which is why this is a
+    separate function rather than inlined: a nested tuple restarts the numbering.
+    """
+    params = [_param(p) for p in params]
+    if len(params) != len(values):
+        raise AbiError(f"expected {len(params)} values, got {len(values)}")
+
+    head_length = sum(_head_size(p) for p in params)
+    head: list[bytes] = []
+    tail: list[bytes] = []
+    tail_offset = 0
+
+    for param, value in zip(params, values):
+        encoded = _encode_param(param, value)
+        if is_dynamic(param):
+            head.append((head_length + tail_offset).to_bytes(_WORD, "big"))
+            tail.append(encoded)
+            tail_offset += len(encoded)
+        else:
+            head.append(encoded)
+    return b"".join(head) + b"".join(tail)
+
+
+def encode(params: list, values: list) -> str:
+    """viem ``encodeAbiParameters`` — returns a ``0x`` hex string."""
+    return "0x" + _encode_group(params, values).hex()
+
+
+def encode_packed_selector(signature: str) -> str:
+    from .keccak import function_selector
+
+    return function_selector(signature)
+
+
+def function_signature(fragment: dict) -> str:
+    """Canonical signature of an ABI function fragment."""
+    inner = ",".join(canonical_type(i) for i in fragment.get("inputs", []))
+    return f"{fragment['name']}({inner})"
+
+
+def event_signature(fragment: dict) -> str:
+    inner = ",".join(canonical_type(i) for i in fragment.get("inputs", []))
+    return f"{fragment['name']}({inner})"
+
+
+def find_fragment(abi: list, name: str, kind: str = "function") -> dict:
+    for entry in abi:
+        if entry.get("type") == kind and entry.get("name") == name:
+            return entry
+    raise AbiError(f"no {kind} named {name!r} in the supplied ABI")
+
+
+def encode_function_data(abi: list, function_name: str, args: list | None = None) -> str:
+    """viem ``encodeFunctionData`` — selector followed by the encoded arguments."""
+    from .keccak import function_selector
+
+    fragment = find_fragment(abi, function_name)
+    selector = function_selector(function_signature(fragment))
+    body = _encode_group(fragment.get("inputs", []), list(args or []))
+    return selector + body.hex()
+
+
+# ---------------------------------------------------------------------------
+# Decoding
+# ---------------------------------------------------------------------------
+
+def _decode_single(param: dict, data: bytes, offset: int) -> Any:
+    type_name = param["type"]
+    word = data[offset:offset + _WORD]
+    if len(word) < _WORD:
+        raise AbiError(f"truncated data reading {type_name} at byte {offset}")
+
+    if type_name == "address":
+        return checksum_address("0x" + word[12:].hex())
+
+    if type_name == "bool":
+        return int.from_bytes(word, "big") != 0
+
+    match = _INT_RE.match(type_name)
+    if match:
+        raw = int.from_bytes(word, "big")
+        if match.group(1) == "int":
+            # Sign-extend from the full word: values are stored two's-complement
+            # over 256 bits regardless of the declared width.
+            return as_int_n(256, raw)
+        return raw
+
+    match = _BYTES_N_RE.match(type_name)
+    if match:
+        return "0x" + word[: int(match.group(1))].hex()
+
+    raise AbiError(f"unsupported static type: {type_name}")
+
+
+def _decode_param(param: dict, data: bytes, offset: int) -> Any:
+    type_name = param["type"]
+
+    if type_name in ("bytes", "string"):
+        length = int.from_bytes(data[offset:offset + _WORD], "big")
+        start = offset + _WORD
+        raw = data[start:start + length]
+        if len(raw) < length:
+            raise AbiError(f"truncated {type_name}: want {length} bytes, have {len(raw)}")
+        return raw.decode("utf-8") if type_name == "string" else "0x" + raw.hex()
+
+    array = _array_parts(type_name)
+    if array is not None:
+        inner, length = array
+        element = _element_param(param, inner)
+        if length is None:
+            count = int.from_bytes(data[offset:offset + _WORD], "big")
+            base = offset + _WORD
+        else:
+            count, base = length, offset
+        return _decode_group([element] * count, data, base)
+
+    if type_name.startswith("tuple"):
+        components = [_param(c) for c in param.get("components", [])]
+        values = _decode_group(components, data, offset)
+        # Name the fields when the ABI names them; callers index either way.
+        if all(c.get("name") for c in components):
+            return dict(zip([c["name"] for c in components], values))
+        return values
+
+    return _decode_single(param, data, offset)
+
+
+def _decode_group(params: list, data: bytes, base: int) -> list:
+    params = [_param(p) for p in params]
+    values: list[Any] = []
+    cursor = base
+    for param in params:
+        if is_dynamic(param):
+            relative = int.from_bytes(data[cursor:cursor + _WORD], "big")
+            values.append(_decode_param(param, data, base + relative))
+            cursor += _WORD
+        else:
+            values.append(_decode_param(param, data, cursor))
+            cursor += _head_size(param)
+    return values
+
+
+def decode(params: list, data: str | bytes) -> list:
+    """viem ``decodeAbiParameters``."""
+    return _decode_group(params, to_bytes(data), 0)
+
+
+def decode_function_result(abi: list, function_name: str, data: str | bytes) -> Any:
+    """Decode a return blob. A single output is unwrapped, matching viem."""
+    fragment = find_fragment(abi, function_name)
+    outputs = fragment.get("outputs", [])
+    if not outputs:
+        return None
+    values = decode(outputs, data)
+    return values[0] if len(outputs) == 1 else values
+
+
+def decode_event_log(abi: list, topics: list[str], data: str | bytes) -> dict:
+    """viem ``decodeEventLog`` — match on topic0, then split indexed/non-indexed.
+
+    Every indexed parameter this skill reads is a value type, so the
+    hashed-dynamic-topic case is deliberately not handled: it would silently
+    return a hash where a value is expected. It raises instead.
+    """
+    from .keccak import event_topic
+
+    if not topics:
+        raise AbiError("log has no topics")
+    topic0 = topics[0].lower()
+    for fragment in abi:
+        if fragment.get("type") != "event":
+            continue
+        if event_topic(event_signature(fragment)).lower() != topic0:
+            continue
+
+        inputs = [_param(i) for i in fragment.get("inputs", [])]
+        indexed = [i for i in inputs if i.get("indexed")]
+        plain = [i for i in inputs if not i.get("indexed")]
+        if len(indexed) != len(topics) - 1:
+            raise AbiError(
+                f"{fragment['name']}: {len(indexed)} indexed params but "
+                f"{len(topics) - 1} topics"
+            )
+
+        args: dict[str, Any] = {}
+        for param, topic in zip(indexed, topics[1:]):
+            if is_dynamic(param):
+                raise AbiError(
+                    f"{fragment['name']}.{param.get('name')} is an indexed dynamic "
+                    "type; the topic holds its hash, not its value"
+                )
+            args[param.get("name") or f"arg{len(args)}"] = _decode_single(
+                param, to_bytes(topic), 0
+            )
+        for param, value in zip(plain, decode(plain, data)):
+            args[param.get("name") or f"arg{len(args)}"] = value
+        return {"eventName": fragment["name"], "args": args}
+
+    raise AbiError(f"no event in the supplied ABI matches topic {topic0}")

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/account.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/account.py
@@ -1,0 +1,154 @@
+"""secp256k1 curve arithmetic and address derivation — everything except signing.
+
+This module exists to be *importable by the read-only path*. ``lp_read.py`` needs one
+thing from the key material — "which wallet is mine" — and that answer is a public one:
+an address is derived from a private key by a one-way function, and nothing here can
+produce a signature.
+
+The split is the whole point. ``secp256k1.py`` imports this module and adds RFC 6979 and
+``sign_digest`` on top; a caller that imports *this* module gets no path to a signature no
+matter what it passes. So ``lp_read.py`` resolving your own address does not make it
+capable of moving funds, and that stays true by construction rather than by review.
+
+The non-constant-time caveat from ``secp256k1.py`` applies here too: pure-Python
+big-integer arithmetic leaks timing. It is the same hot-wallet mitigation — and scalar
+multiplication by a private key happens here, in ``public_key``, whichever module is
+doing the importing.
+"""
+
+from __future__ import annotations
+
+from .hexutil import checksum_address, strip0x
+from .keccak import keccak256
+
+# Curve parameters (SEC 2, secp256k1). a = 0, b = 7.
+P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+GX = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798
+GY = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8
+G = (GX, GY)
+HALF_N = N // 2
+
+
+# ---------------------------------------------------------------------------
+# Curve arithmetic, in Jacobian coordinates
+# ---------------------------------------------------------------------------
+#
+# Affine addition needs a modular inverse per step; at 256 doublings that dominates the
+# runtime. Jacobian coordinates defer all of it to a single inverse at the end.
+# The point at infinity is any triple with y == 0.
+
+
+def _jacobian_double(point: tuple[int, int, int]) -> tuple[int, int, int]:
+    x, y, z = point
+    if not y:
+        return (0, 0, 0)
+    ysq = (y * y) % P
+    s = (4 * x * ysq) % P
+    m = (3 * x * x) % P  # + a*z^4, and a == 0 on this curve
+    nx = (m * m - 2 * s) % P
+    ny = (m * (s - nx) - 8 * ysq * ysq) % P
+    nz = (2 * y * z) % P
+    return (nx, ny, nz)
+
+
+def _jacobian_add(p: tuple[int, int, int], q: tuple[int, int, int]) -> tuple[int, int, int]:
+    if not p[1]:
+        return q
+    if not q[1]:
+        return p
+    u1 = (p[0] * q[2] * q[2]) % P
+    u2 = (q[0] * p[2] * p[2]) % P
+    s1 = (p[1] * q[2] * q[2] * q[2]) % P
+    s2 = (q[1] * p[2] * p[2] * p[2]) % P
+    if u1 == u2:
+        # Same x: either the same point (double it) or a point and its negation (infinity).
+        return _jacobian_double(p) if s1 == s2 else (0, 0, 1)
+    h = u2 - u1
+    r = s2 - s1
+    h2 = (h * h) % P
+    h3 = (h * h2) % P
+    u1h2 = (u1 * h2) % P
+    nx = (r * r - h3 - 2 * u1h2) % P
+    ny = (r * (u1h2 - nx) - s1 * h3) % P
+    nz = (h * p[2] * q[2]) % P
+    return (nx, ny, nz)
+
+
+def _jacobian_multiply(point: tuple[int, int, int], scalar: int) -> tuple[int, int, int]:
+    if point[1] == 0 or scalar == 0:
+        return (0, 0, 1)
+    if scalar == 1:
+        return point
+    if scalar < 0 or scalar >= N:
+        return _jacobian_multiply(point, scalar % N)
+    half = _jacobian_multiply(point, scalar // 2)
+    if scalar % 2 == 0:
+        return _jacobian_double(half)
+    return _jacobian_add(_jacobian_double(half), point)
+
+
+def _to_affine(point: tuple[int, int, int]) -> tuple[int, int] | None:
+    x, y, z = point
+    if z == 0 or y == 0:
+        return None
+    inv = pow(z, -1, P)
+    inv2 = (inv * inv) % P
+    return ((x * inv2) % P, (y * inv2 % P) * inv % P)
+
+
+def multiply(point: tuple[int, int], scalar: int) -> tuple[int, int] | None:
+    """Scalar multiplication on the curve. ``None`` is the point at infinity."""
+    return _to_affine(_jacobian_multiply((point[0], point[1], 1), scalar))
+
+
+def add(a: tuple[int, int], b: tuple[int, int]) -> tuple[int, int] | None:
+    """Point addition. ``None`` is the point at infinity."""
+    return _to_affine(_jacobian_add((a[0], a[1], 1), (b[0], b[1], 1)))
+
+
+# ---------------------------------------------------------------------------
+# Keys and addresses
+# ---------------------------------------------------------------------------
+
+
+def normalize_private_key(private_key: str | bytes | int) -> int:
+    """Parse a key in any accepted shape and range-check it.
+
+    ``0`` and anything at or above the group order are not valid scalars; a node would
+    accept the resulting signature and it would recover to the wrong address.
+    """
+    if isinstance(private_key, int):
+        value = private_key
+    elif isinstance(private_key, (bytes, bytearray)):
+        value = int.from_bytes(private_key, "big")
+    else:
+        text = strip0x(private_key.strip().strip('"').strip("'"))
+        if len(text) != 64:
+            raise ValueError("private key must be 32 bytes")
+        value = int(text, 16)
+    if not 1 <= value < N:
+        raise ValueError("private key out of range for secp256k1")
+    return value
+
+
+def public_key(private_key: str | bytes | int) -> tuple[int, int]:
+    point = multiply(G, normalize_private_key(private_key))
+    if point is None:  # Unreachable for an in-range scalar; a guard, not a branch.
+        raise ValueError("private key produced the point at infinity")
+    return point
+
+
+def address_from_public_key(point: tuple[int, int]) -> str:
+    """Last 20 bytes of keccak over the 64-byte uncompressed key, EIP-55 checksummed."""
+    body = point[0].to_bytes(32, "big") + point[1].to_bytes(32, "big")
+    return checksum_address("0x" + strip0x(keccak256(body))[24:])
+
+
+def account_from_private_key(private_key: str | bytes | int) -> dict:
+    """The signer identity. Deliberately does not carry the key in the returned dict."""
+    point = public_key(private_key)
+    return {
+        "address": address_from_public_key(point),
+        "publicKey": "0x" + point[0].to_bytes(32, "big").hex() + point[1].to_bytes(32, "big").hex(),
+    }

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
@@ -1,0 +1,208 @@
+"""Chain constants and environment resolution.
+
+Trimmed from the ``senior-unilp-manager`` skill's ``unilp/chains.py``. Two
+deliberate simplifications relative to that module:
+
+* **One chain, no registry.** pools.fun's PartyFactory exists on Robinhood Chain
+  and nowhere else, so a lookup table keyed by chain name would be a table with
+  one row and a resolver that can only ever fail one way.
+* **No RPC env var.** The endpoint is a constant here. A configurable RPC is
+  worth its friction when a skill reads thousands of logs across chains; this one
+  makes a handful of ``eth_call``s against a single public endpoint, so an env var
+  would be one more thing to set up before a launch can happen and one more thing
+  to get wrong. ``--rpc`` remains for debugging.
+
+The environment layer keeps the property that matters: the signing key comes from
+the process environment only, never from argv.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Declared in SKILL.md frontmatter under `requires.env`. Keep the two in sync —
+# that block is what puts the skill in "Needs setup" in the AgentOS Skills page.
+ENV_SIGNER = "POOLSFUN_PRIVATE_KEY"
+# Optional. Only needed to attach a token image; every other path works unset.
+ENV_PINATA_JWT = "PINATA_JWT"
+
+# Public Robinhood Chain endpoint. No API key, no rate limit worth planning
+# around at this call volume. Verified to support JSON-RPC batching (used to mine
+# salts) and eth_call state overrides (used to simulate a dev buy from a wallet
+# that has not been funded yet).
+RPC_URL = "https://rpc.mainnet.chain.robinhood.com/"
+
+CHAIN_ID = 4663
+CHAIN_NAME = "Robinhood Chain"
+EXPLORER = "https://robinhoodchain.blockscout.com"
+
+NATIVE = "0x0000000000000000000000000000000000000000"
+MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11"
+
+# pools.fun deployment.
+PARTY_FACTORY = "0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4"
+PARTY_LOCKER = "0x35E41f84d3fD61d4648F0c8B41a1E7d301bCd75E"
+# Read off the factory's immutables; pinned here so preflight can name them
+# without a round trip, and so selftest can assert they have not moved.
+WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
+USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168"
+NPM = "0x51d0e5188afe12d502e29D982d20C190e7816107"
+SUSHI_V3_FACTORY = "0xE51960f1B45f1C9FB6D166E6a884F866fC70433B"
+
+# The only paired assets the factory allowlists. `pools_read.py assets` reads the
+# live allowlist rather than trusting this map; it exists to turn a --paired
+# shorthand into an address and an address back into a label.
+# Kept as a dict, rather than dissolved into module constants, purely so the
+# inherited `tx.py` and `rpc.py` helpers — which take a `chain` mapping — can be
+# vendored verbatim from senior-unilp-manager and stay diffable against it.
+CHAIN: dict = {
+    "key": "robinhood",
+    "name": CHAIN_NAME,
+    "chainId": CHAIN_ID,
+    "explorer": EXPLORER,
+    "multicall3": MULTICALL3,
+    "nativeCurrency": {"name": "Ether", "symbol": "ETH", "decimals": 18},
+}
+
+PAIRED_ASSETS: dict[str, str] = {"weth": WETH, "usdg": USDG}
+ASSET_LABELS: dict[str, str] = {WETH.lower(): "WETH", USDG.lower(): "USDG"}
+ASSET_DECIMALS: dict[str, int] = {WETH.lower(): 18, USDG.lower(): 18}
+
+_env_loaded = False
+
+
+def load_env() -> None:
+    """Load a dotenv file if one is configured, without overriding the environment.
+
+    Anything already in ``os.environ`` wins, so ``POOLSFUN_PRIVATE_KEY=… python3
+    pools_write.py`` always beats a file. Under AgentOS this normally finds nothing
+    and does nothing: the gateway has already put the declared variables in the
+    process environment.
+    """
+    global _env_loaded
+    if _env_loaded:
+        return
+    _env_loaded = True
+
+    candidates = [
+        os.environ.get("POOLSFUN_ENV"),
+        os.environ.get("AGENTOS_HOME") and str(Path(os.environ["AGENTOS_HOME"]) / ".env"),
+        str(Path.home() / ".agentos" / ".env"),
+        ".env",
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate).expanduser()
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            name, _, value = line.partition("=")
+            name = name.strip()
+            if name.startswith("export "):
+                name = name[7:].strip()
+            if name in os.environ:
+                continue  # never override an explicit value
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            os.environ[name] = value
+        return
+
+
+def resolve_rpc_url(override: str | None = None) -> str:
+    """The RPC endpoint. Constant unless ``--rpc`` overrides it for debugging."""
+    return override or RPC_URL
+
+
+def resolve_paired_asset(value: str | None) -> str:
+    """Turn ``--paired`` into a checksummed address. Defaults to WETH.
+
+    WETH is the default because it is what every pools.fun launch to date has
+    paired against, and because it is the only asset a native-ETH dev buy works
+    with — pairing against USDG silently forces the ERC20 dev-buy path, which
+    needs a prior approval.
+    """
+    from .hexutil import checksum_address
+
+    if not value:
+        return WETH
+    key = value.strip().lower()
+    if key in PAIRED_ASSETS:
+        return PAIRED_ASSETS[key]
+    if key.startswith("0x") and len(key) == 42:
+        return checksum_address(value)
+    known = ", ".join(PAIRED_ASSETS)
+    raise ValueError(f'unknown paired asset "{value}". Use one of: {known} (or an address)')
+
+
+def asset_label(address: str) -> str:
+    """A human name for a paired asset, falling back to the short address."""
+    return ASSET_LABELS.get(address.lower(), address[:10] + "…")
+
+
+def asset_decimals(address: str) -> int:
+    return ASSET_DECIMALS.get(address.lower(), 18)
+
+
+def resolve_private_key(signer_env: str = ENV_SIGNER) -> str:
+    """Read and normalise the signing key.
+
+    Deliberately reads only from the environment and never from argv: a key on a
+    command line lands in shell history and in the agent transcript, and AgentOS's
+    redaction only masks the ``NAME=value`` shape, not a bare hex string.
+
+    Only the derived address is ever printed; the key itself is never logged.
+    """
+    load_env()
+    raw = os.environ.get(signer_env)
+    if not raw:
+        raise RuntimeError(
+            f"env var {signer_env} is not set. Set it in the agent environment "
+            f"(AgentOS: Skills page -> Set {signer_env}), or pass --signer-env <VAR>"
+        )
+    key = raw.strip().strip('"').strip("'")
+    if not key.startswith("0x"):
+        key = "0x" + key
+    if len(key) != 66:
+        raise RuntimeError(f"{signer_env} is not a 32-byte hex private key")
+    return key
+
+
+def resolve_signer_address(signer_env: str = ENV_SIGNER) -> str:
+    """The wallet address the signing key derives — the answer to "which wallet is mine".
+
+    Imports from ``account`` rather than ``secp256k1`` on purpose. An address is public
+    information derived one-way from the key, so answering this question does not need a
+    signing path anywhere in reach, and ``pools_read.py`` can therefore call it without
+    becoming able to move funds. The distinction is structural: ``account`` has no
+    ``sign_digest`` in it.
+
+    The key itself never leaves this function.
+    """
+    from .account import account_from_private_key
+
+    return account_from_private_key(resolve_private_key(signer_env))["address"]
+
+
+def pinata_jwt() -> str | None:
+    """The Pinata JWT, or None when unset.
+
+    Returning None rather than raising is the whole contract of this function:
+    ``PINATA_JWT`` is optional, and a launch with no token image must work on a
+    machine where it was never configured. Callers that genuinely need it — only
+    the ``--image`` path does — raise their own error with instructions.
+    """
+    load_env()
+    raw = os.environ.get(ENV_PINATA_JWT)
+    if not raw:
+        return None
+    return raw.strip().strip('"').strip("'") or None

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
@@ -133,6 +133,10 @@ def resolve_paired_asset(value: str | None) -> str:
     """
     from .hexutil import checksum_address
 
+    # `parse_args` yields True for a bare `--paired`; without this the .strip()
+    # below dies with a bare AttributeError instead of saying what is wrong.
+    if value is True:
+        raise ValueError("--paired needs a value (weth, usdg, or an address)")
     if not value:
         return WETH
     key = value.strip().lower()
@@ -174,6 +178,15 @@ def resolve_private_key(signer_env: str = ENV_SIGNER) -> str:
         key = "0x" + key
     if len(key) != 66:
         raise RuntimeError(f"{signer_env} is not a 32-byte hex private key")
+    # Validate the alphabet here rather than letting int(key, 16) do it downstream.
+    # ValueError embeds the offending string in its message, so a key with one
+    # mistyped character would be printed in full by the top-level error handler
+    # and land in the agent transcript. Never let key material reach an exception.
+    if any(character not in "0123456789abcdefABCDEF" for character in key[2:]):
+        raise RuntimeError(
+            f"{signer_env} is not valid hex (32 bytes, 0-9/a-f). "
+            "The value is not shown here on purpose."
+        )
     return key
 
 

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/factory.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/factory.py
@@ -1,0 +1,421 @@
+"""PartyFactory / PartyLocker surface: ABIs, errors, salt mining, curve math.
+
+Everything here was derived from the verified source at
+``0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4`` on Robinhood Chain and checked
+against the reference launch, tx ``0x0978ee72…`` ("Pools Fun" / POOL).
+
+Three facts drive the whole module and are worth stating before the code:
+
+1. **The salt has to be mined.** ``launch`` reverts ``TokenNotToken0()`` unless the
+   CREATE2 token address sorts *below* the paired asset, because the factory mints
+   single-sided liquidity and requires the launched token to be ``token0``. Against
+   WETH (``0x0Bd7…``) roughly 4.6% of salts qualify, so a launch simply cannot be
+   assembled without a search. See :func:`mine_salt`.
+
+2. **The launch price is not an input.** ``expectedStartTick`` looks like a knob but
+   is a race guard: the factory reads its own tick from ``startTickFor`` and reverts
+   ``StartTickChanged()`` on any mismatch. The tick tracks ``initialFdvUsd``, which
+   is ``onlyOwner``. Callers pick identity and dev buy; never pricing.
+
+3. **``launch`` is exactly simulatable.** ``eth_call`` with ``devBuyMinOut = 0``
+   returns the true ``(token, pool, devBuyOut)`` because the dev buy is the pool's
+   first swap inside the same transaction, so nothing can front-run it. This is what
+   makes simulate-then-send meaningful rather than advisory.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .abi_codec import decode, encode_function_data
+from .keccak import event_topic
+
+# ── protocol constants (immutable in the deployed factory) ──────────────────
+TOTAL_SUPPLY = 1_000_000_000 * 10**18
+FEE = 10000  # 1%
+TICK_SPACING = 200
+MAX_TICK = 887272
+MAX_USABLE_TICK = (MAX_TICK // TICK_SPACING) * TICK_SPACING  # 887200
+DEAD = "0x000000000000000000000000000000000000dEaD"
+
+PARTY_FACTORY_ABI: list[dict] = [
+    {
+        "type": "function", "name": "launch", "stateMutability": "payable",
+        "inputs": [
+            {"name": "name", "type": "string"},
+            {"name": "symbol", "type": "string"},
+            {"name": "metadataUri", "type": "string"},
+            {"name": "salt", "type": "bytes32"},
+            {"name": "pairedAsset", "type": "address"},
+            {"name": "expectedStartTick", "type": "int24"},
+            {"name": "deadline", "type": "uint256"},
+            {"name": "creator", "type": "address"},
+            {"name": "feeRecipient", "type": "address"},
+            {"name": "devBuyAmountIn", "type": "uint256"},
+            {"name": "devBuyMinOut", "type": "uint256"},
+        ],
+        "outputs": [
+            {"name": "token", "type": "address"},
+            {"name": "pool", "type": "address"},
+            {"name": "devBuyOut", "type": "uint256"},
+        ],
+    },
+    {
+        "type": "function", "name": "computeTokenAddress", "stateMutability": "view",
+        "inputs": [
+            {"name": "deployer", "type": "address"},
+            {"name": "salt", "type": "bytes32"},
+            {"name": "name", "type": "string"},
+            {"name": "symbol", "type": "string"},
+            {"name": "metadataUri", "type": "string"},
+        ],
+        "outputs": [{"name": "", "type": "address"}],
+    },
+    {
+        "type": "function", "name": "startTickFor", "stateMutability": "view",
+        "inputs": [{"name": "pairedAsset", "type": "address"}],
+        "outputs": [{"name": "tick", "type": "int24"}, {"name": "live", "type": "bool"}],
+    },
+    {
+        "type": "function", "name": "allowedPairedAsset", "stateMutability": "view",
+        "inputs": [{"name": "asset", "type": "address"}],
+        "outputs": [{"name": "", "type": "bool"}],
+    },
+    {
+        "type": "function", "name": "getPairedAssetCurve", "stateMutability": "view",
+        "inputs": [{"name": "asset", "type": "address"}],
+        "outputs": [{"name": "", "type": "tuple", "components": [
+            {"name": "feed", "type": "address"},
+            {"name": "maxPriceAge", "type": "uint32"},
+            {"name": "fallbackTick", "type": "int24"},
+            {"name": "set", "type": "bool"},
+        ]}],
+    },
+    {"type": "function", "name": "paused", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "bool"}]},
+    {"type": "function", "name": "locker", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "address"}]},
+    {"type": "function", "name": "initialFdvUsd", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "uint256"}]},
+    {"type": "function", "name": "owner", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "address"}]},
+    {"type": "function", "name": "weth", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "address"}]},
+    {"type": "function", "name": "usdg", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "address"}]},
+    {"type": "function", "name": "sequencerUptimeFeed", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "address"}]},
+    {
+        "type": "event", "name": "TokenLaunched",
+        "inputs": [
+            {"name": "token", "type": "address", "indexed": True},
+            {"name": "pool", "type": "address", "indexed": True},
+            {"name": "pairedAsset", "type": "address", "indexed": False},
+            {"name": "creator", "type": "address", "indexed": True},
+            {"name": "deployer", "type": "address", "indexed": False},
+            {"name": "feeRecipient", "type": "address", "indexed": False},
+            {"name": "startTick", "type": "int24", "indexed": False},
+            {"name": "metadataUri", "type": "string", "indexed": False},
+            {"name": "devBuyAmountOut", "type": "uint256", "indexed": False},
+        ],
+    },
+]
+
+PARTY_LOCKER_ABI: list[dict] = [
+    {
+        "type": "function", "name": "getPoolInfo", "stateMutability": "view",
+        "inputs": [{"name": "token", "type": "address"}],
+        "outputs": [
+            {"name": "pairedAsset", "type": "address"},
+            {"name": "pool", "type": "address"},
+            {"name": "creator", "type": "address"},
+            {"name": "feeRecipient", "type": "address"},
+            {"name": "tokenIds", "type": "uint256[]"},
+        ],
+    },
+    {
+        "type": "function", "name": "getPoolSplits", "stateMutability": "view",
+        "inputs": [{"name": "token", "type": "address"}],
+        "outputs": [
+            {"name": "pc", "type": "uint16"}, {"name": "pp", "type": "uint16"},
+            {"name": "pb", "type": "uint16"}, {"name": "pcm", "type": "uint16"},
+            {"name": "tc", "type": "uint16"}, {"name": "tprot", "type": "uint16"},
+        ],
+    },
+    {"type": "function", "name": "collect", "stateMutability": "nonpayable",
+     "inputs": [{"name": "token", "type": "address"}], "outputs": []},
+    {"type": "function", "name": "claim", "stateMutability": "nonpayable",
+     "inputs": [{"name": "token", "type": "address"}], "outputs": []},
+    {"type": "function", "name": "collectAndClaim", "stateMutability": "nonpayable",
+     "inputs": [{"name": "token", "type": "address"}], "outputs": []},
+    {"type": "function", "name": "setFeeRecipient", "stateMutability": "nonpayable",
+     "inputs": [{"name": "token", "type": "address"},
+                {"name": "recipient", "type": "address"}], "outputs": []},
+]
+
+ERC20_ABI: list[dict] = [
+    {"type": "function", "name": "name", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "string"}]},
+    {"type": "function", "name": "symbol", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "string"}]},
+    {"type": "function", "name": "decimals", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "uint8"}]},
+    {"type": "function", "name": "totalSupply", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "uint256"}]},
+    {"type": "function", "name": "balanceOf", "stateMutability": "view",
+     "inputs": [{"name": "account", "type": "address"}],
+     "outputs": [{"name": "", "type": "uint256"}]},
+    {"type": "function", "name": "allowance", "stateMutability": "view",
+     "inputs": [{"name": "owner", "type": "address"},
+                {"name": "spender", "type": "address"}],
+     "outputs": [{"name": "", "type": "uint256"}]},
+    {"type": "function", "name": "approve", "stateMutability": "nonpayable",
+     "inputs": [{"name": "spender", "type": "address"},
+                {"name": "amount", "type": "uint256"}],
+     "outputs": [{"name": "", "type": "bool"}]},
+    {"type": "function", "name": "metadataUri", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "string"}]},
+]
+
+V3_POOL_ABI: list[dict] = [
+    {"type": "function", "name": "slot0", "stateMutability": "view", "inputs": [], "outputs": [
+        {"name": "sqrtPriceX96", "type": "uint160"},
+        {"name": "tick", "type": "int24"},
+        {"name": "observationIndex", "type": "uint16"},
+        {"name": "observationCardinality", "type": "uint16"},
+        {"name": "observationCardinalityNext", "type": "uint16"},
+        {"name": "feeProtocol", "type": "uint8"},
+        {"name": "unlocked", "type": "bool"},
+    ]},
+]
+
+# ── revert decoding ─────────────────────────────────────────────────────────
+# Custom errors carry no strings on the wire, so a bare "execution reverted" is
+# all an RPC returns. Mapping the 4-byte selector to an explanation is the
+# difference between a usable error and a dead end. Each message says what to do,
+# not just what happened.
+ERROR_MESSAGES: dict[str, str] = {
+    "0xb4f54111": (
+        "DeployFailed: a token already exists at this salt's address. "
+        "Change the name/symbol/metadata, or pick a different --salt."
+    ),
+    "0x0f5ddbb1": (
+        "StartTickChanged: the protocol's launch tick moved between planning and "
+        "execution (the ETH price feed updated). Re-run the command to re-plan."
+    ),
+    "0xd79cce06": (
+        "TokenNotToken0: the salt no longer produces an address below the paired "
+        "asset. Re-run without --salt to mine a fresh one."
+    ),
+    "0x203d82d8": "Expired: the deadline passed before the tx landed. Re-run to re-plan.",
+    "0x7607bc0d": (
+        "CreatorNotCaller: `creator` must equal the sending wallet. Remove --creator "
+        "or set it to the signer address."
+    ),
+    "0x6e4e2579": (
+        "AmbiguousDevBuy: native ETH and an ERC20 dev buy were both supplied. "
+        "Use either --dev-buy or --dev-buy-asset, never both."
+    ),
+    "0xb6dc33e4": (
+        "DevBuyWethOnly: a native-ETH dev buy only works on WETH pairs. For a USDG "
+        "pair use --dev-buy-asset (after `approve`)."
+    ),
+    "0xedaf7b53": (
+        "DevBuyTooLittle: the fill came in under devBuyMinOut. Raise --slippage-bps "
+        "or re-plan."
+    ),
+    "0x5a9b44ca": (
+        "PairedAssetNotAllowed: that asset is not on the factory allowlist. "
+        "Run `pools_read.py assets` to see what is launchable."
+    ),
+    "0x9e87fac8": "Paused: the factory is paused. Nothing to do but wait.",
+    "0x7983c051": (
+        "PoolAlreadyInitialized: a pool for this pair already exists and is "
+        "initialized. Change the token identity so its address differs."
+    ),
+    "0xd92e233d": "ZeroAddress: an address argument was zero.",
+    "0x2c5211c6": "InvalidAmount / InvalidTick: an argument failed a range check.",
+    "0x1f2a2005": "DevBuyTooLarge: the dev buy amount exceeds the safe int256 bound.",
+    "0x8e4a23d6": "LockerUnset: the factory has no locker configured.",
+}
+
+# Solidity's Error(string) selector, used for require() reverts from dependencies.
+_ERROR_STRING_SELECTOR = "0x08c379a0"
+_PANIC_SELECTOR = "0x4e487b71"
+
+
+def explain_revert(data: Any) -> str | None:
+    """Turn revert bytes into a sentence, or None when they mean nothing to us."""
+    if not isinstance(data, str) or not data.startswith("0x") or len(data) < 10:
+        return None
+    selector = data[:10].lower()
+    if selector in ERROR_MESSAGES:
+        return ERROR_MESSAGES[selector]
+    if selector == _ERROR_STRING_SELECTOR:
+        try:
+            return "reverted: " + str(decode([{"type": "string"}], "0x" + data[10:])[0])
+        except Exception:
+            return None
+    if selector == _PANIC_SELECTOR:
+        try:
+            code = int(decode([{"type": "uint256"}], "0x" + data[10:])[0])
+            return f"Panic(0x{code:02x}) — an assertion inside the contract failed"
+        except Exception:
+            return None
+    return None
+
+
+# ── calldata builders ───────────────────────────────────────────────────────
+def encode_launch(name: str, symbol: str, metadata_uri: str, salt: str,
+                  paired_asset: str, expected_start_tick: int, deadline: int,
+                  creator: str, fee_recipient: str, dev_buy_amount_in: int,
+                  dev_buy_min_out: int) -> str:
+    return encode_function_data(PARTY_FACTORY_ABI, "launch", [
+        name, symbol, metadata_uri, salt, paired_asset, expected_start_tick,
+        deadline, creator, fee_recipient, dev_buy_amount_in, dev_buy_min_out,
+    ])
+
+
+def encode_compute_token_address(deployer: str, salt: str, name: str, symbol: str,
+                                 metadata_uri: str) -> str:
+    return encode_function_data(PARTY_FACTORY_ABI, "computeTokenAddress",
+                                [deployer, salt, name, symbol, metadata_uri])
+
+
+def salt_hex(value: int) -> str:
+    """A uint as a bytes32 salt. Salts are searched as plain integers from 0 up."""
+    if value < 0 or value >= 2**256:
+        raise ValueError("salt out of range")
+    return "0x" + format(value, "064x")
+
+
+# ── salt mining ─────────────────────────────────────────────────────────────
+def sorts_below(token: str, paired_asset: str) -> bool:
+    """Whether ``token`` would be ``token0`` of the pair. The launch invariant."""
+    return int(token, 16) < int(paired_asset, 16)
+
+
+def salt_hit_rate(paired_asset: str) -> float:
+    """Fraction of random addresses that sort below the paired asset.
+
+    Purely informational — it turns "mining" from an opaque wait into a number
+    the user can sanity-check ("~4.6% for WETH, so expect a couple dozen tries").
+    """
+    return int(paired_asset, 16) / float(2**160)
+
+
+# The public endpoint answers a 50-call batch comfortably (~0.6 s) and 429s on
+# 100. 40 leaves headroom for the rate limiter to also be seeing other traffic,
+# and still resolves a WETH salt in one round trip about 85% of the time.
+SALT_BATCH_SIZE = 40
+
+
+def mine_salt(client: Any, factory: str, deployer: str, name: str, symbol: str,
+              metadata_uri: str, paired_asset: str, *, start: int = 0,
+              max_attempts: int = 5000, batch_size: int = SALT_BATCH_SIZE,
+              on_progress: Any = None) -> tuple[str, str, int]:
+    """Search for a salt whose CREATE2 address sorts below the paired asset.
+
+    Returns ``(salt_hex, token_address, attempts)``.
+
+    The search runs on-chain via batched ``computeTokenAddress`` ``eth_call``s
+    rather than reproducing CREATE2 locally. That costs round trips, but computing
+    it here would mean embedding a copy of PartyToken's creation bytecode in the
+    skill — a constant that silently goes wrong the day the factory is redeployed,
+    producing addresses that look plausible and revert on launch. Asking the
+    factory cannot drift. At ~4.6% hit rate against WETH a batch of 100 almost
+    always resolves on the first round trip.
+    """
+    attempts = 0
+    candidate = start
+    while attempts < max_attempts:
+        window = min(batch_size, max_attempts - attempts)
+        salts = [salt_hex(candidate + i) for i in range(window)]
+        calls = [
+            {
+                "method": "eth_call",
+                "params": [
+                    {"to": factory,
+                     "data": encode_compute_token_address(
+                         deployer, s, name, symbol, metadata_uri)},
+                    "latest",
+                ],
+            }
+            for s in salts
+        ]
+        results = client.batch(calls, chunk_size=window)
+        for offset, result in enumerate(results):
+            attempts += 1
+            if isinstance(result, dict) and "error" in result:
+                continue
+            token = decode([{"type": "address"}], result)[0]
+            if sorts_below(token, paired_asset):
+                return salts[offset], token, attempts
+        candidate += window
+        if on_progress:
+            on_progress(attempts)
+
+    raise RuntimeError(
+        f"no qualifying salt in {max_attempts} attempts. The token address must sort "
+        f"below {paired_asset} (~{salt_hit_rate(paired_asset) * 100:.1f}% of salts "
+        f"qualify). Raise --max-salt-attempts, or change the name/symbol."
+    )
+
+
+# ── curve math ──────────────────────────────────────────────────────────────
+def price_from_tick(tick: int) -> float:
+    """Paired-asset units per token. token is always token0, so price = 1.0001^tick."""
+    return 1.0001**tick
+
+
+def fdv_usd(tick: int, paired_usd: float, supply: int = TOTAL_SUPPLY,
+            token_decimals: int = 18) -> float:
+    """Fully-diluted valuation in USD at a given tick.
+
+    Reported rather than chosen: the factory pins this to ``initialFdvUsd``
+    (currently $10,000) and there is no caller input that moves it.
+    """
+    return price_from_tick(tick) * paired_usd * (supply / 10**token_decimals)
+
+
+def validate_start_tick(tick: int) -> None:
+    """The factory's own tick bounds, mirrored so we fail before spending gas."""
+    if tick % TICK_SPACING != 0:
+        raise ValueError(f"start tick {tick} is not a multiple of {TICK_SPACING}")
+    if tick < -MAX_USABLE_TICK or tick >= MAX_USABLE_TICK:
+        raise ValueError(f"start tick {tick} outside ±{MAX_USABLE_TICK}")
+
+
+# ── event decoding ──────────────────────────────────────────────────────────
+TOPIC_TOKEN_LAUNCHED = event_topic(
+    "TokenLaunched(address,address,address,address,address,address,int24,string,uint256)"
+)
+
+
+def decode_token_launched(logs: list[dict], factory: str) -> dict | None:
+    """Pull the launch result out of a receipt. None when the event is absent."""
+    for log in logs:
+        if log.get("address", "").lower() != factory.lower():
+            continue
+        topics = log.get("topics") or []
+        if not topics or topics[0].lower() != TOPIC_TOKEN_LAUNCHED:
+            continue
+        fields = decode(
+            [
+                {"type": "address"}, {"type": "address"}, {"type": "address"},
+                {"type": "int24"}, {"type": "string"}, {"type": "uint256"},
+            ],
+            log["data"],
+        )
+        return {
+            "token": "0x" + topics[1][-40:],
+            "pool": "0x" + topics[2][-40:],
+            "creator": "0x" + topics[3][-40:],
+            "pairedAsset": fields[0],
+            "deployer": fields[1],
+            "feeRecipient": fields[2],
+            "startTick": int(fields[3]),
+            "metadataUri": fields[4],
+            "devBuyAmountOut": int(fields[5]),
+        }
+    return None

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/factory.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/factory.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import Any
 
 from .abi_codec import decode, encode_function_data
-from .keccak import event_topic
+from .keccak import event_topic, function_selector
 
 # ── protocol constants (immutable in the deployed factory) ──────────────────
 TOTAL_SUPPLY = 1_000_000_000 * 10**18
@@ -194,49 +194,83 @@ V3_POOL_ABI: list[dict] = [
 # all an RPC returns. Mapping the 4-byte selector to an explanation is the
 # difference between a usable error and a dead end. Each message says what to do,
 # not just what happened.
-ERROR_MESSAGES: dict[str, str] = {
-    "0xb4f54111": (
+#
+# Keyed by SIGNATURE, with selectors computed at import. Hand-writing the hex
+# invites two failure modes that are invisible until a launch reverts: a typo
+# that simply never matches, and — worse — a wrong constant that collides with a
+# real error and confidently reports the wrong cause. Deriving them here makes
+# both impossible, and lets selftest iterate this table directly instead of a
+# hand-copied subset.
+#
+# The signature list is every `error` declared by PartyFactory.
+ERROR_SIGNATURES: dict[str, str] = {
+    "DeployFailed()": (
         "DeployFailed: a token already exists at this salt's address. "
         "Change the name/symbol/metadata, or pick a different --salt."
     ),
-    "0x0f5ddbb1": (
+    "StartTickChanged()": (
         "StartTickChanged: the protocol's launch tick moved between planning and "
         "execution (the ETH price feed updated). Re-run the command to re-plan."
     ),
-    "0xd79cce06": (
+    "TokenNotToken0()": (
         "TokenNotToken0: the salt no longer produces an address below the paired "
         "asset. Re-run without --salt to mine a fresh one."
     ),
-    "0x203d82d8": "Expired: the deadline passed before the tx landed. Re-run to re-plan.",
-    "0x7607bc0d": (
-        "CreatorNotCaller: `creator` must equal the sending wallet. Remove --creator "
-        "or set it to the signer address."
+    "Expired()": "Expired: the deadline passed before the tx landed. Re-run to re-plan.",
+    "CreatorNotCaller()": (
+        "CreatorNotCaller: `creator` must equal the sending wallet — the factory "
+        "binds the launch to msg.sender."
     ),
-    "0x6e4e2579": (
+    "AmbiguousDevBuy()": (
         "AmbiguousDevBuy: native ETH and an ERC20 dev buy were both supplied. "
         "Use either --dev-buy or --dev-buy-asset, never both."
     ),
-    "0xb6dc33e4": (
+    "DevBuyWethOnly()": (
         "DevBuyWethOnly: a native-ETH dev buy only works on WETH pairs. For a USDG "
         "pair use --dev-buy-asset (after `approve`)."
     ),
-    "0xedaf7b53": (
+    "DevBuyTooLittle()": (
         "DevBuyTooLittle: the fill came in under devBuyMinOut. Raise --slippage-bps "
         "or re-plan."
     ),
-    "0x5a9b44ca": (
+    "DevBuyTooLarge()": (
+        "DevBuyTooLarge: --dev-buy-asset exceeds the safe int256 bound."
+    ),
+    "PairedAssetNotAllowed()": (
         "PairedAssetNotAllowed: that asset is not on the factory allowlist. "
         "Run `pools_read.py assets` to see what is launchable."
     ),
-    "0x9e87fac8": "Paused: the factory is paused. Nothing to do but wait.",
-    "0x7983c051": (
+    "Paused()": "Paused: the factory is paused. Nothing to do but wait.",
+    "PoolAlreadyInitialized()": (
         "PoolAlreadyInitialized: a pool for this pair already exists and is "
         "initialized. Change the token identity so its address differs."
     ),
-    "0xd92e233d": "ZeroAddress: an address argument was zero.",
-    "0x2c5211c6": "InvalidAmount / InvalidTick: an argument failed a range check.",
-    "0x1f2a2005": "DevBuyTooLarge: the dev buy amount exceeds the safe int256 bound.",
-    "0x8e4a23d6": "LockerUnset: the factory has no locker configured.",
+    "LockerUnset()": "LockerUnset: the factory has no locker configured; launches revert.",
+    "LockerAlreadySet()": "LockerAlreadySet: the locker can only be wired once.",
+    "InvalidTick()": (
+        "InvalidTick: the start tick is not aligned to the 200 spacing, or is out "
+        "of range."
+    ),
+    "InvalidFdv()": "InvalidFdv: the requested FDV is outside the factory's bounds.",
+    "InvalidPriceAge()": "InvalidPriceAge: the feed heartbeat is outside 1 minute … 3 days.",
+    "FeedProbeFailed()": (
+        "FeedProbeFailed: the paired asset's Chainlink feed could not be read."
+    ),
+    "SequencerFeedProbeFailed()": (
+        "SequencerFeedProbeFailed: the sequencer uptime feed could not be read."
+    ),
+    "UnexpectedCallback()": (
+        "UnexpectedCallback: a swap callback arrived from an unauthorised pool."
+    ),
+    "ZeroAddress()": "ZeroAddress: an address argument was zero.",
+    "OwnershipCannotBeRenounced()": (
+        "OwnershipCannotBeRenounced: the factory refuses to renounce ownership."
+    ),
+}
+
+ERROR_MESSAGES: dict[str, str] = {
+    function_selector(signature): message
+    for signature, message in ERROR_SIGNATURES.items()
 }
 
 # Solidity's Error(string) selector, used for require() reverts from dependencies.
@@ -323,10 +357,11 @@ def mine_salt(client: Any, factory: str, deployer: str, name: str, symbol: str,
     it here would mean embedding a copy of PartyToken's creation bytecode in the
     skill — a constant that silently goes wrong the day the factory is redeployed,
     producing addresses that look plausible and revert on launch. Asking the
-    factory cannot drift. At ~4.6% hit rate against WETH a batch of 100 almost
-    always resolves on the first round trip.
+    factory cannot drift. At a ~4.6% hit rate against WETH, a batch of
+    ``SALT_BATCH_SIZE`` resolves on the first round trip about 85% of the time.
     """
     attempts = 0
+    errors = 0
     candidate = start
     while attempts < max_attempts:
         window = min(batch_size, max_attempts - attempts)
@@ -344,20 +379,36 @@ def mine_salt(client: Any, factory: str, deployer: str, name: str, symbol: str,
             for s in salts
         ]
         results = client.batch(calls, chunk_size=window)
+        batch_errors = 0
+        first_error: Any = None
         for offset, result in enumerate(results):
             attempts += 1
             if isinstance(result, dict) and "error" in result:
+                batch_errors += 1
+                errors += 1
+                first_error = first_error or result["error"]
                 continue
             token = decode([{"type": "address"}], result)[0]
             if sorts_below(token, paired_asset):
                 return salts[offset], token, attempts
+        # A whole batch failing is systemic — a rate limit, a bad endpoint, a
+        # reverting computeTokenAddress. Continuing would burn every remaining
+        # attempt and then blame the search, sending the user off to raise
+        # --max-salt-attempts for a problem that has nothing to do with luck.
+        if batch_errors == len(results) and results:
+            raise RuntimeError(
+                f"salt mining failed: every call in a batch of {len(results)} errored "
+                f"({first_error}). The RPC endpoint is refusing the requests — this is "
+                "not a mining problem. Retry in a moment."
+            )
         candidate += window
         if on_progress:
             on_progress(attempts)
 
+    suffix = f" ({errors} of them RPC errors)" if errors else ""
     raise RuntimeError(
-        f"no qualifying salt in {max_attempts} attempts. The token address must sort "
-        f"below {paired_asset} (~{salt_hit_rate(paired_asset) * 100:.1f}% of salts "
+        f"no qualifying salt in {max_attempts} attempts{suffix}. The token address must "
+        f"sort below {paired_asset} (~{salt_hit_rate(paired_asset) * 100:.1f}% of salts "
         f"qualify). Raise --max-salt-attempts, or change the name/symbol."
     )
 

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/fmt.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/fmt.py
@@ -50,6 +50,59 @@ def require_arg(args: dict, name: str, hint: str = "") -> Any:
     return value
 
 
+# ``parse_args`` turns a bare ``--flag`` into the boolean ``True``. That sentinel
+# is right for switches and wrong for everything else: passed on unnoticed it
+# becomes ``int(True) == 1``, or crashes with a bare ``AttributeError`` deep in a
+# helper. These three coercers are the single place that distinction is made, so
+# a value-taking flag can never silently mean "1".
+
+
+def opt_str(args: dict, name: str) -> str | None:
+    """A flag's string value, or None when absent. Bare ``--flag`` is an error."""
+    value = args.get(name)
+    if value is None:
+        return None
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    text = str(value).strip()
+    return text or None
+
+
+def opt_int(args: dict, name: str, default: int, *,
+            minimum: int | None = None, maximum: int | None = None) -> int:
+    """A flag's integer value with range checking, or ``default`` when absent."""
+    value = args.get(name)
+    if value is None:
+        return default
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    try:
+        number = int(str(value).strip())
+    except ValueError:
+        raise ValueError(f"--{name} must be a whole number, got {value!r}") from None
+    if minimum is not None and number < minimum:
+        raise ValueError(f"--{name} must be at least {minimum}, got {number}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"--{name} must be at most {maximum}, got {number}")
+    return number
+
+
+def opt_float(args: dict, name: str, default: float, *,
+              minimum: float | None = None) -> float:
+    value = args.get(name)
+    if value is None:
+        return default
+    if value is True:
+        raise ValueError(f"--{name} needs a value")
+    try:
+        number = float(str(value).strip())
+    except ValueError:
+        raise ValueError(f"--{name} must be a number, got {value!r}") from None
+    if minimum is not None and number < minimum:
+        raise ValueError(f"--{name} must be at least {minimum}, got {number}")
+    return number
+
+
 # ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/fmt.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/fmt.py
@@ -1,0 +1,200 @@
+"""Arg parsing, number formatting, and table rendering — port of ``util.mjs``.
+
+Shared by both entrypoints.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from typing import Any
+
+from .hexutil import format_units, parse_amount  # noqa: F401 — re-exported
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str]) -> dict:
+    """Parse ``--flag value`` / ``--flag=value`` / ``--bool`` plus positionals."""
+    out: dict[str, Any] = {"_": []}
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if not arg.startswith("--"):
+            out["_"].append(arg)
+            index += 1
+            continue
+        body = arg[2:]
+        if "=" in body:
+            name, _, value = body.partition("=")
+            out[name] = value
+            index += 1
+            continue
+        nxt = argv[index + 1] if index + 1 < len(argv) else None
+        if nxt is None or nxt.startswith("--"):
+            out[body] = True
+            index += 1
+        else:
+            out[body] = nxt
+            index += 2
+    return out
+
+
+def require_arg(args: dict, name: str, hint: str = "") -> Any:
+    value = args.get(name)
+    if value is None or value is True:
+        raise ValueError(f"missing --{name}{f' ({hint})' if hint else ''}")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def fmt_units(value: int, decimals: int, max_frac: int = 6) -> str:
+    raw = int(value)
+    text = format_units(raw, int(decimals))
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    int_part, _, frac = text.partition(".")
+    grouped = f"{int(int_part):,}"
+    trimmed = frac[:max_frac].rstrip("0")
+    if not trimmed and int_part == "0" and raw != 0:
+        # Sub-display-precision but non-zero: keep 3 significant digits rather than
+        # printing 0, which would read as "this position holds nothing".
+        lead = next((i for i, ch in enumerate(frac) if ch in "123456789"), -1)
+        if lead != -1:
+            trimmed = frac[:lead + 3].rstrip("0")
+    body = f"{grouped}.{trimmed}" if trimmed else grouped
+    return f"-{body}" if negative else body
+
+
+def _to_precision(value: float, precision: int) -> str:
+    """JavaScript ``Number.prototype.toPrecision`` — fixed unless the exponent falls
+    outside ``[-6, precision)``, which is where Python's ``%g`` disagrees."""
+    if value == 0:
+        return f"{0:.{precision - 1}f}"
+    mantissa, _, exponent = f"{value:.{precision - 1}e}".partition("e")
+    exp = int(exponent)
+    if exp < -6 or exp >= precision:
+        sign = "+" if exp >= 0 else "-"
+        return f"{mantissa}e{sign}{abs(exp)}"
+    return f"{value:.{max(precision - 1 - exp, 0)}f}"
+
+
+def fmt_usd(value: float | None) -> str:
+    if value is None or not math.isfinite(value):
+        return "∞" if value == float("inf") else "n/a"
+    if value == 0:
+        return "$0"
+    magnitude = abs(value)
+    if magnitude >= 1e12:
+        return f"${value / 1e12:.2f}T"
+    if magnitude >= 1e9:
+        return f"${value / 1e9:.2f}B"
+    if magnitude >= 1e6:
+        return f"${value / 1e6:.2f}M"
+    if magnitude >= 1e3:
+        return f"${value / 1e3:.2f}K"
+    if magnitude >= 1:
+        return f"${value:.2f}"
+    return f"${_to_precision(value, 3)}"
+
+
+def fmt_band(band: dict | None) -> str:
+    """Market-cap band as a single cell, e.g. "$19.98K → $1.20B"."""
+    if not band:
+        return "n/a"
+    return f"{fmt_usd(band.get('from'))} → {fmt_usd(band.get('to'))}"
+
+
+def short(addr: str | None) -> str:
+    if not addr:
+        return ""
+    return f"{addr[:6]}…{addr[-4:]}"
+
+
+def short_id(value: str | None) -> str:
+    if not value:
+        return ""
+    return f"{value[:10]}…{value[-6:]}"
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+
+def render_table(columns: list[dict], rows: list[dict]) -> str:
+    """``columns`` is [{key, label, align?}]; row values are already stringified."""
+    if not rows:
+        return "  (none)"
+
+    def cell_of(row: dict, column: dict) -> str:
+        # `or ""` would be wrong here: a literal 0 is falsy but must still print.
+        value = row.get(column["key"])
+        return "" if value is None else str(value)
+
+    widths = [
+        max(len(c["label"]), *(len(cell_of(r, c)) for r in rows))
+        for c in columns
+    ]
+
+    def line(cells: list) -> str:
+        parts = []
+        for i, cell in enumerate(cells):
+            text = str(cell)
+            parts.append(text.rjust(widths[i]) if columns[i].get("align") == "right"
+                         else text.ljust(widths[i]))
+        return "  " + "  ".join(parts)
+
+    head = line([c["label"] for c in columns])
+    rule = "  " + "  ".join("─" * w for w in widths)
+    body = [line([cell_of(r, c) for c in columns]) for r in rows]
+    return "\n".join([head, rule, *body])
+
+
+def heading(title: str) -> str:
+    return f"\n=== {title} ==="
+
+
+def render_kv(pairs: list) -> str:
+    """Aligned ``label : value`` block, matching the capu-vault output style."""
+    width = max(len(k) for k, _ in pairs)
+    return "\n".join(f"  {k.ljust(width)} : {v}" for k, v in pairs)
+
+
+def json_safe(value: Any) -> Any:
+    """Make a structure JSON-serialisable the way the Node build did.
+
+    The Node original stringified every BigInt and left Numbers alone; Python has one
+    integer type, so callers must ``str()`` the values that were BigInt there. This
+    only handles the cases Python cannot serialise at all: infinities and sets.
+    """
+    if isinstance(value, dict):
+        return {k: json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(v) for v in value]
+    if isinstance(value, float):
+        if value == float("inf"):
+            return "Infinity"
+        if value == float("-inf"):
+            return "-Infinity"
+        if value != value:
+            return None
+    return value
+
+
+def die(err: BaseException | str) -> None:
+    message = str(err) or err.__class__.__name__
+    print(f"\nERROR: {message}", file=sys.stderr)
+    if os.environ.get("POOLSFUN_DEBUG"):
+        import traceback
+        if isinstance(err, BaseException):
+            traceback.print_exception(type(err), err, err.__traceback__)
+    sys.exit(1)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/hexutil.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/hexutil.py
@@ -1,0 +1,246 @@
+"""Hex, address and fixed-point helpers — the non-ABI half of what viem provided.
+
+Two groups live here, and the second is the dangerous one:
+
+* mechanical conversions (``to_hex``, ``pad``, ``concat_hex``, EIP-55 checksums);
+* arithmetic that must reproduce **JavaScript** semantics rather than Python's.
+
+Python and JS disagree in three places this port touches, and every disagreement
+produces a wrong number rather than an exception:
+
+* ``BigInt`` division truncates toward zero; Python ``//`` floors. Identical for
+  non-negative operands, off by one for negatives — see :func:`div_trunc`.
+* ``Math.round`` is half-up toward +inf; Python ``round`` is banker's rounding, so
+  ``round(0.5)`` is ``0``. See :func:`js_round`.
+* ``BigInt.asIntN`` / ``asUintN`` have no Python equivalent at all. See
+  :func:`as_int_n` / :func:`as_uint_n`.
+"""
+
+from __future__ import annotations
+
+from .keccak import keccak256_bytes
+
+MAX_UINT128 = (1 << 128) - 1
+MAX_UINT160 = (1 << 160) - 1
+MAX_UINT256 = (1 << 256) - 1
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+# ---------------------------------------------------------------------------
+# JS-semantics arithmetic
+# ---------------------------------------------------------------------------
+
+def div_trunc(numerator: int, denominator: int) -> int:
+    """Integer division that truncates toward zero, like JS ``BigInt`` division.
+
+    ``-7 // 2`` is ``-4`` in Python but ``-3n`` in JavaScript. Every division
+    ported from the Node source goes through here, because the ported code was
+    written against the JS behaviour.
+    """
+    quotient = abs(numerator) // abs(denominator)
+    return -quotient if (numerator < 0) != (denominator < 0) else quotient
+
+
+def js_round(value: float) -> int:
+    """``Math.round``: ties go toward positive infinity.
+
+    Python's ``round`` is banker's rounding, so ``round(0.5) == 0`` and
+    ``round(2.5) == 2``. JS gives ``1`` and ``3``. ``snapTick(mode='nearest')`` and
+    the gas multiplier both depend on this.
+    """
+    import math
+
+    return math.floor(value + 0.5)
+
+
+def as_int_n(bits: int, value: int) -> int:
+    """``BigInt.asIntN`` — reinterpret the low ``bits`` of ``value`` as signed."""
+    masked = value & ((1 << bits) - 1)
+    if masked >= (1 << (bits - 1)):
+        return masked - (1 << bits)
+    return masked
+
+
+def as_uint_n(bits: int, value: int) -> int:
+    """``BigInt.asUintN`` — reinterpret the low ``bits`` of ``value`` as unsigned.
+
+    Also the way to reproduce a deliberately-wrapping subtraction: the fee-growth
+    delta in ``getFeesOwed`` relies on ``uint256`` underflow, and a plain Python
+    subtraction there yields a large negative number instead of the intended wrap.
+    """
+    return value & ((1 << bits) - 1)
+
+
+# ---------------------------------------------------------------------------
+# Hex
+# ---------------------------------------------------------------------------
+
+def strip0x(value: str) -> str:
+    return value[2:] if value[:2].lower() == "0x" else value
+
+
+def to_bytes(value: str | bytes | bytearray) -> bytes:
+    """Coerce a hex string or bytes-like to ``bytes``."""
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    body = strip0x(value)
+    if len(body) % 2:
+        body = "0" + body
+    return bytes.fromhex(body)
+
+
+def to_hex(value: int | bytes | bytearray | str, size: int | None = None) -> str:
+    """Render as a ``0x`` hex string, optionally left-padded to ``size`` bytes.
+
+    Mirrors viem's ``toHex(value, {size})``. A negative integer is encoded as its
+    two's-complement over ``size`` bytes, which requires ``size``.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        body = bytes(value).hex()
+        if size is not None:
+            body = body.rjust(size * 2, "0")
+        return "0x" + body
+    if isinstance(value, str):
+        body = strip0x(value)
+        if size is not None:
+            body = body.rjust(size * 2, "0")
+        return "0x" + body
+    if value < 0:
+        if size is None:
+            raise ValueError("to_hex of a negative integer requires an explicit size")
+        value = as_uint_n(size * 8, value)
+    body = format(value, "x")
+    if size is not None:
+        return "0x" + body.rjust(size * 2, "0")
+    # Unsized: minimal hex, exactly like viem's toHex(bigint) — `toHex(1n)` is "0x1",
+    # not "0x01". This is the JSON-RPC *quantity* encoding, and a node rejects
+    # "fromBlock": "0x00" outright. Callers that need whole bytes pass `size`.
+    return "0x" + body
+
+
+def pad(value: str | bytes | bytearray, size: int = 32, right: bool = False) -> str:
+    """Left-pad (or right-pad) a hex value to ``size`` bytes."""
+    body = to_bytes(value).hex()
+    target = size * 2
+    if len(body) > target:
+        raise ValueError(f"value is {len(body) // 2} bytes, cannot pad to {size}")
+    return "0x" + (body.ljust(target, "0") if right else body.rjust(target, "0"))
+
+
+def concat_hex(parts: list[str]) -> str:
+    return "0x" + "".join(strip0x(p) for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# Addresses
+# ---------------------------------------------------------------------------
+
+def checksum_address(address: str) -> str:
+    """EIP-55 checksummed form of ``address``.
+
+    The lowercasing is load-bearing: the launchpad registry tables are written in
+    mixed case, and hashing a mixed-case string produces a different digest and
+    therefore a wrong checksum. Getting this wrong corrupts poolId derivation,
+    because the PoolKey encoding runs through this function.
+    """
+    body = strip0x(address).lower()
+    if len(body) != 40:
+        raise ValueError(f"not a 20-byte address: {address!r}")
+    try:
+        int(body, 16)
+    except ValueError:
+        raise ValueError(f"address has non-hex characters: {address!r}") from None
+    digest = keccak256_bytes(body.encode("ascii")).hex()
+    return "0x" + "".join(
+        char.upper() if int(digest[i], 16) >= 8 else char
+        for i, char in enumerate(body)
+    )
+
+
+def is_same_address(a: str | None, b: str | None) -> bool:
+    if not a or not b:
+        return False
+    return strip0x(a).lower() == strip0x(b).lower()
+
+
+def is_zero_address(address: str | None) -> bool:
+    return is_same_address(address, ZERO_ADDRESS)
+
+
+# ---------------------------------------------------------------------------
+# Fixed-point <-> human amounts
+# ---------------------------------------------------------------------------
+
+def parse_units(value: str, decimals: int) -> int:
+    """Human decimal string -> base units, reproducing viem's ``parseUnits``.
+
+    viem **rounds** excess fraction digits half-up, with carry into the integer
+    part, rather than truncating: ``parse_units("0.9999999", 6)`` is ``1000000``,
+    not ``999999``. A truncating implementation silently sizes an amount smaller
+    than the one the user approved, and the plan hash still validates because it
+    hashes the already-parsed value.
+    """
+    text = str(value).strip()
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    if "." in text:
+        integer, fraction = text.split(".", 1)
+    else:
+        integer, fraction = text, "0"
+    integer = integer or "0"
+    fraction = fraction.rstrip("0")
+
+    if decimals == 0:
+        # Round the whole fraction to 0 or 1 and fold it into the integer.
+        if fraction and js_round(float("0." + fraction)) == 1:
+            integer = str(int(integer) + 1)
+        fraction = ""
+    elif len(fraction) > decimals:
+        left = fraction[: decimals - 1]
+        unit = fraction[decimals - 1: decimals]
+        right = fraction[decimals:]
+        rounded = js_round(float(f"{unit}.{right}"))
+        if rounded > 9:
+            # The rounded digit carried; bump the digit to its left and reset.
+            fraction = str(int(left or "0") + 1).rjust(len(left) + 1, "0") + "0"
+        else:
+            fraction = f"{left}{rounded}"
+        if len(fraction) > decimals:
+            fraction = fraction[1:]
+            integer = str(int(integer) + 1)
+        fraction = fraction[:decimals]
+    else:
+        fraction = fraction.ljust(decimals, "0")
+
+    result = int(f"{integer}{fraction}" or "0")
+    return -result if negative else result
+
+
+def format_units(value: int, decimals: int) -> str:
+    """Base units -> human decimal string, reproducing viem's ``formatUnits``.
+
+    Trailing zeroes in the fraction are dropped, and a value with no fractional
+    remainder renders with no decimal point at all.
+    """
+    text = str(value)
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    text = text.rjust(decimals, "0")
+    integer = text[: len(text) - decimals]
+    fraction = text[len(text) - decimals:].rstrip("0") if decimals else ""
+    sign = "-" if negative else ""
+    return f"{sign}{integer or '0'}" + (f".{fraction}" if fraction else "")
+
+
+def parse_amount(text: str, decimals: int) -> int:
+    """Parse a CLI amount: human units, or raw base units with a ``w`` suffix.
+
+    ``1.5`` is 1.5 tokens; ``1500000000000000000w`` is that many base units
+    verbatim. Underscores are stripped so long literals stay readable.
+    """
+    cleaned = str(text).strip().replace("_", "")
+    if cleaned.lower().endswith("w"):
+        return int(cleaned[:-1])
+    return parse_units(cleaned, decimals)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/keccak.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/keccak.py
@@ -1,0 +1,142 @@
+"""Ethereum keccak256, in pure Python.
+
+``hashlib.sha3_256`` is FIPS-202 SHA3, which pads with ``0x06``. Ethereum uses the
+original Keccak submission, which pads with ``0x01``. Same permutation, one
+different byte, completely different digest — so the stdlib hash cannot stand in
+here, not even as an approximation.
+
+The implementation is Keccak-f[1600] with rate 136 (=1088 bits) and capacity 512,
+which is what keccak256 is. State is a 5x5 array of 64-bit lanes held in a flat
+list indexed ``x + 5*y``.
+
+Costs about 0.4 ms per short input, and the skill hashes on the order of tens of
+values per invocation, so there is no reason to reach for anything faster.
+"""
+
+from __future__ import annotations
+
+_MASK64 = (1 << 64) - 1
+
+# Rotation offsets, indexed [x + 5*y]. From the Keccak reference specification.
+_ROTATIONS = (
+    0, 1, 62, 28, 27,
+    36, 44, 6, 55, 20,
+    3, 10, 43, 25, 39,
+    41, 45, 15, 21, 8,
+    18, 2, 61, 56, 14,
+)
+
+# Round constants for the iota step — 24 rounds for a 1600-bit state.
+_ROUND_CONSTANTS = (
+    0x0000000000000001, 0x0000000000008082, 0x800000000000808A,
+    0x8000000080008000, 0x000000000000808B, 0x0000000080000001,
+    0x8000000080008081, 0x8000000000008009, 0x000000000000008A,
+    0x0000000000000088, 0x0000000080008009, 0x000000008000000A,
+    0x000000008000808B, 0x800000000000008B, 0x8000000000008089,
+    0x8000000000008003, 0x8000000000008002, 0x8000000000000080,
+    0x000000000000800A, 0x800000008000000A, 0x8000000080008081,
+    0x8000000000008080, 0x0000000080000001, 0x8000000080008008,
+)
+
+_RATE = 136  # bytes absorbed per permutation for keccak256
+
+
+def _rotl64(value: int, shift: int) -> int:
+    if shift == 0:
+        return value
+    return ((value << shift) | (value >> (64 - shift))) & _MASK64
+
+
+def _keccak_f1600(state: list[int]) -> None:
+    """Apply the 24-round permutation to ``state`` in place."""
+    for rc in _ROUND_CONSTANTS:
+        # theta
+        column = [
+            state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20]
+            for x in range(5)
+        ]
+        for x in range(5):
+            d = column[(x + 4) % 5] ^ _rotl64(column[(x + 1) % 5], 1)
+            for y in range(0, 25, 5):
+                state[x + y] ^= d
+
+        # rho + pi, written into a fresh array because pi is a permutation of
+        # positions: updating in place would read lanes that were already moved.
+        moved = [0] * 25
+        for x in range(5):
+            for y in range(5):
+                moved[y + 5 * ((2 * x + 3 * y) % 5)] = _rotl64(
+                    state[x + 5 * y], _ROTATIONS[x + 5 * y]
+                )
+
+        # chi
+        for y in range(0, 25, 5):
+            row = moved[y:y + 5]
+            for x in range(5):
+                state[x + y] = row[x] ^ ((~row[(x + 1) % 5] & _MASK64) & row[(x + 2) % 5])
+
+        # iota
+        state[0] ^= rc
+
+
+def keccak256_bytes(data: bytes) -> bytes:
+    """Return the 32-byte keccak256 digest of ``data``."""
+    # Pad: 0x01 marker, zeroes, then 0x80 in the final rate byte. When the marker
+    # lands on the last byte of a block the two merge into 0x81 — that is the
+    # single-byte-padding case, and the reason inputs of exactly rate-1 bytes are
+    # a classic silent failure.
+    padded = bytearray(data)
+    padded.append(0x01)
+    while len(padded) % _RATE != 0:
+        padded.append(0x00)
+    padded[-1] |= 0x80
+
+    state = [0] * 25
+    for offset in range(0, len(padded), _RATE):
+        block = padded[offset:offset + _RATE]
+        for i in range(_RATE // 8):
+            state[i] ^= int.from_bytes(block[i * 8:(i + 1) * 8], "little")
+        _keccak_f1600(state)
+
+    # Squeeze: 32 bytes fit inside the rate, so one squeeze round is enough.
+    out = bytearray()
+    for i in range(4):
+        out += state[i].to_bytes(8, "little")
+    return bytes(out)
+
+
+def keccak256(data: bytes | bytearray | str) -> str:
+    """keccak256 of ``data``, returned as a ``0x``-prefixed hex string.
+
+    Accepts raw bytes, a ``0x``-prefixed hex string, or plain text. A ``str`` that
+    starts with ``0x`` is treated as hex — matching viem's ``keccak256``, which
+    only ever takes hex or bytes. Pass text through :func:`keccak256_text` when the
+    ambiguity would bite.
+    """
+    if isinstance(data, str):
+        if data.startswith("0x") or data.startswith("0X"):
+            raw = bytes.fromhex(data[2:])
+        else:
+            raw = data.encode("utf-8")
+    else:
+        raw = bytes(data)
+    return "0x" + keccak256_bytes(raw).hex()
+
+
+def keccak256_text(text: str) -> str:
+    """keccak256 of the UTF-8 encoding of ``text``, even if it looks like hex."""
+    return "0x" + keccak256_bytes(text.encode("utf-8")).hex()
+
+
+def function_selector(signature: str) -> str:
+    """The 4-byte selector for a canonical function signature.
+
+    ``signature`` must already be canonical — tuples expanded, no argument names,
+    no spaces: ``transfer(address,uint256)``.
+    """
+    return keccak256_text(signature)[:10]
+
+
+def event_topic(signature: str) -> str:
+    """The 32-byte topic0 for a canonical event signature."""
+    return keccak256_text(signature)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/metadata.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/metadata.py
@@ -1,0 +1,309 @@
+"""Token metadata: build the JSON, and turn it into a `metadataUri`.
+
+``PartyToken`` stores one immutable string, ``metadataUri``, and every pools.fun
+front end reads the token's identity from whatever it points at. Three forms are
+in use on-chain today, and this module can produce all three:
+
+* ``ipfs://<cid>`` — what the reference launch used.
+* ``https://…`` — any host you control.
+* ``data:application/json;base64,…`` — the whole JSON inlined in calldata. One
+  live launch does exactly this.
+
+**`PINATA_JWT` is optional and must stay that way.** A launch with no token image
+needs no secret, no account, and no network round trip beyond the chain itself:
+the metadata JSON goes inline as a data URI. Pinata is required only for the one
+thing that genuinely cannot be inlined — an image, which is far too large for
+calldata.
+
+The one hard rule here is that failures are loud. If a caller asks for an image
+and Pinata is not configured, this raises. It never quietly launches an
+image-less token, because the token's identity is immutable the moment the
+transaction lands and there is no second chance to attach the picture.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .chains import ENV_PINATA_JWT, pinata_jwt
+
+PINATA_API = "https://api.pinata.cloud"
+PINATA_GATEWAY = "https://gateway.pinata.cloud/ipfs/"
+USER_AGENT = "poolsdotfun-token-launcher/1.0"
+
+# Pinata's own limit is far higher, but a token logo has no business being large,
+# and catching it here beats a slow upload that fails at the far end.
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+# Inline metadata is paid for in calldata gas on every launch, forever. A logo URL
+# plus a sentence of description fits easily; anything past this is a sign the
+# caller meant to pin instead.
+MAX_INLINE_URI_BYTES = 8 * 1024
+
+_IMAGE_MIME = {
+    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".gif": "image/gif", ".webp": "image/webp", ".svg": "image/svg+xml",
+    ".avif": "image/avif",
+}
+
+# Magic-byte sniffing, because AgentOS webchat attachments routinely arrive with a
+# generic or missing extension and the suffix alone would mislabel them.
+_MAGIC = [
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"<svg", "image/svg+xml"),
+    (b"<?xml", "image/svg+xml"),
+]
+
+
+class PinataError(RuntimeError):
+    """Anything that went wrong talking to Pinata."""
+
+
+def pinata_configured() -> bool:
+    return pinata_jwt() is not None
+
+
+def require_pinata_jwt(reason: str) -> str:
+    """The JWT, or a refusal that says exactly how to fix it.
+
+    Called only from paths that truly need Pinata. The message names the AgentOS
+    setup action and the escape hatch, because "PINATA_JWT is not set" on its own
+    leaves the user guessing whether the skill is broken or just unconfigured.
+    """
+    jwt = pinata_jwt()
+    if not jwt:
+        raise PinataError(
+            f"{reason} needs Pinata, but {ENV_PINATA_JWT} is not set.\n"
+            f"  Either set it in the agent environment "
+            f"(AgentOS: Skills page -> Set {ENV_PINATA_JWT}),\n"
+            f"  or drop --image and launch without a token image,\n"
+            f"  or pass --metadata-uri <uri> if you have already hosted the metadata."
+        )
+    return jwt
+
+
+def _post(url: str, body: bytes, headers: dict[str, str], timeout: int = 120) -> dict:
+    request = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:400]
+        except Exception:
+            pass
+        if exc.code in (401, 403):
+            raise PinataError(
+                f"Pinata rejected the credentials (HTTP {exc.code}). Check {ENV_PINATA_JWT} "
+                f"is a valid JWT — not an API key or secret. {detail}"
+            ) from exc
+        raise PinataError(f"Pinata request failed: HTTP {exc.code} {detail}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise PinataError(f"Pinata unreachable: {exc}") from exc
+
+
+def verify_pinata_auth(jwt: str) -> None:
+    """Probe the JWT before uploading anything.
+
+    A bad token surfaces here in one cheap request rather than after a multi-megabyte
+    upload, and — more importantly — before the launch plan is built around an image
+    that was never going to pin.
+    """
+    request = urllib.request.Request(
+        f"{PINATA_API}/data/testAuthentication",
+        headers={"authorization": f"Bearer {jwt}", "user-agent": USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            response.read()
+    except urllib.error.HTTPError as exc:
+        raise PinataError(
+            f"{ENV_PINATA_JWT} was rejected by Pinata (HTTP {exc.code}). It must be a JWT "
+            "from Pinata -> API Keys, not the API key or secret."
+        ) from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise PinataError(f"Pinata unreachable: {exc}") from exc
+
+
+def _guess_mime(path: Path, head: bytes) -> str:
+    for magic, mime in _MAGIC:
+        if head.startswith(magic):
+            return mime
+    suffix = path.suffix.lower()
+    if suffix in _IMAGE_MIME:
+        return _IMAGE_MIME[suffix]
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed or "application/octet-stream"
+
+
+def _multipart(fields: dict[str, str], filename: str, mime: str,
+               payload: bytes) -> tuple[bytes, str]:
+    """Hand-rolled multipart/form-data.
+
+    The skill deliberately has no third-party dependencies (it targets the system
+    python that ships with macOS), so there is no `requests` to lean on and
+    urllib cannot build this itself.
+    """
+    boundary = "----poolsfun" + base64.urlsafe_b64encode(os.urandom(12)).decode().rstrip("=")
+    # A boundary that appeared inside the payload would truncate the upload. With
+    # 96 random bits that is not going to happen by chance, but the check is one
+    # line and the failure it prevents is a silently corrupt logo.
+    if boundary.encode() in payload:
+        raise PinataError("could not frame the upload; retry")
+    out = bytearray()
+    for key, value in fields.items():
+        out += f"--{boundary}\r\n".encode()
+        out += f'content-disposition: form-data; name="{key}"\r\n\r\n'.encode()
+        out += value.encode() + b"\r\n"
+    out += f"--{boundary}\r\n".encode()
+    out += (
+        f'content-disposition: form-data; name="file"; filename="{filename}"\r\n'
+    ).encode()
+    out += f"content-type: {mime}\r\n\r\n".encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return bytes(out), f"multipart/form-data; boundary={boundary}"
+
+
+def pin_file(path: str | Path, jwt: str, *, name: str | None = None) -> str:
+    """Pin a local file to IPFS. Returns the CID."""
+    file_path = Path(path).expanduser()
+    if not file_path.is_file():
+        raise PinataError(f"image not found: {file_path}")
+    payload = file_path.read_bytes()
+    if not payload:
+        raise PinataError(f"image is empty: {file_path}")
+    if len(payload) > MAX_IMAGE_BYTES:
+        raise PinataError(
+            f"image is {len(payload) / 1048576:.1f} MB, over the "
+            f"{MAX_IMAGE_BYTES // 1048576} MB limit. Resize it first."
+        )
+    mime = _guess_mime(file_path, payload[:16])
+    if not mime.startswith("image/"):
+        raise PinataError(
+            f"{file_path.name} does not look like an image (detected {mime}). "
+            "Pass a png/jpg/gif/webp/svg."
+        )
+    body, content_type = _multipart(
+        {"pinataMetadata": json.dumps({"name": name or file_path.name})},
+        file_path.name, mime, payload,
+    )
+    result = _post(
+        f"{PINATA_API}/pinning/pinFileToIPFS", body,
+        {"authorization": f"Bearer {jwt}", "content-type": content_type,
+         "user-agent": USER_AGENT},
+    )
+    cid = result.get("IpfsHash")
+    if not cid:
+        raise PinataError(f"Pinata returned no IpfsHash: {result}")
+    return str(cid)
+
+
+def pin_json(obj: dict, jwt: str, *, name: str = "metadata.json") -> str:
+    """Pin a JSON document to IPFS. Returns the CID."""
+    body = json.dumps(
+        {"pinataContent": obj, "pinataMetadata": {"name": name}},
+        separators=(",", ":"),
+    ).encode()
+    result = _post(
+        f"{PINATA_API}/pinning/pinJSONToIPFS", body,
+        {"authorization": f"Bearer {jwt}", "content-type": "application/json",
+         "user-agent": USER_AGENT},
+    )
+    cid = result.get("IpfsHash")
+    if not cid:
+        raise PinataError(f"Pinata returned no IpfsHash: {result}")
+    return str(cid)
+
+
+def build_metadata(name: str, symbol: str, *, description: str | None = None,
+                   image: str | None = None, website: str | None = None,
+                   twitter: str | None = None) -> dict:
+    """The metadata document, shaped like the ones already on-chain.
+
+    Field order and names match what pools.fun itself writes, so existing readers
+    parse it without special-casing. Empty fields are omitted rather than sent as
+    empty strings — a null logo renders worse than an absent one.
+    """
+    doc: dict[str, Any] = {"name": name, "symbol": symbol}
+    if description:
+        doc["description"] = description
+    if image:
+        doc["image"] = image
+    if website:
+        doc["website"] = website
+    if twitter:
+        doc["twitter"] = twitter
+    return doc
+
+
+def to_data_uri(doc: dict) -> str:
+    """Inline the metadata as a base64 data URI — no hosting, no secret."""
+    raw = json.dumps(doc, separators=(",", ":")).encode()
+    uri = "data:application/json;base64," + base64.b64encode(raw).decode()
+    if len(uri) > MAX_INLINE_URI_BYTES:
+        raise PinataError(
+            f"inline metadata is {len(uri)} bytes, over the {MAX_INLINE_URI_BYTES} byte "
+            f"limit — it would make every launch needlessly expensive. Shorten "
+            f"--description, or set {ENV_PINATA_JWT} to pin it instead."
+        )
+    return uri
+
+
+def resolve_metadata_uri(*, name: str, symbol: str, metadata_uri: str | None = None,
+                         image: str | None = None, description: str | None = None,
+                         website: str | None = None, twitter: str | None = None,
+                         pin: bool = False) -> tuple[str, dict | None, str]:
+    """Produce the `metadataUri` for a launch.
+
+    Returns ``(uri, document_or_None, how)`` where ``how`` is a short phrase for
+    the plan block so the user can see which path ran.
+
+    Precedence, highest first:
+
+    1. ``metadata_uri`` — pass-through, never touches Pinata.
+    2. ``image`` — pin the image, then pin the JSON. Requires PINATA_JWT.
+    3. ``pin`` — pin the JSON only. Requires PINATA_JWT.
+    4. otherwise — inline data URI. No secret, no network.
+    """
+    if metadata_uri:
+        uri = metadata_uri.strip()
+        if not (uri.startswith("ipfs://") or uri.startswith("https://")
+                or uri.startswith("data:")):
+            raise PinataError(
+                f"--metadata-uri must start with ipfs://, https:// or data: (got {uri[:32]!r})"
+            )
+        return uri, None, "supplied"
+
+    if image:
+        jwt = require_pinata_jwt("attaching a token image")
+        verify_pinata_auth(jwt)
+        image_cid = pin_file(image, jwt, name=f"{symbol} logo")
+        # Use the HTTPS gateway form for `image`, matching what pools.fun writes:
+        # every wallet and explorer renders it, whereas ipfs:// needs a resolver.
+        doc = build_metadata(name, symbol, description=description,
+                             image=PINATA_GATEWAY + image_cid,
+                             website=website, twitter=twitter)
+        cid = pin_json(doc, jwt, name=f"{symbol} metadata")
+        return f"ipfs://{cid}", doc, "image pinned via Pinata"
+
+    doc = build_metadata(name, symbol, description=description,
+                         website=website, twitter=twitter)
+    if pin:
+        jwt = require_pinata_jwt("--pin-metadata")
+        verify_pinata_auth(jwt)
+        cid = pin_json(doc, jwt, name=f"{symbol} metadata")
+        return f"ipfs://{cid}", doc, "pinned via Pinata"
+
+    return to_data_uri(doc), doc, "inline (no image)"

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/plan.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/plan.py
@@ -1,0 +1,341 @@
+"""Shared launch planning: read state, mine, simulate, hash.
+
+Sits between the two entrypoints so ``pools_read.py simulate`` and
+``pools_write.py launch`` compute the same numbers from the same code. It reads
+the chain and does arithmetic; it never signs and never imports anything that
+can. That is what lets the read script call into it safely.
+
+The PLAN_HASH built here is the skill's confirmation token: a launch is planned,
+printed, and hashed, and the broadcast only proceeds when the user echoes that
+exact hash back. Anything that would change what lands on-chain is inside the
+hash; anything that legitimately drifts between planning and sending (the wall
+clock, gas prices) is outside it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .abi_codec import decode
+from .chains import ASSET_DECIMALS, CHAIN_ID, PARTY_FACTORY, USDG, WETH, asset_label
+from .factory import (
+    PARTY_FACTORY_ABI,
+    TOTAL_SUPPLY,
+    encode_launch,
+    explain_revert,
+    fdv_usd,
+    mine_salt,
+    price_from_tick,
+    sorts_below,
+    validate_start_tick,
+)
+from .keccak import keccak256
+from .rpc import RpcError
+
+CHAINLINK_ABI: list[dict] = [
+    {"type": "function", "name": "decimals", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "uint8"}]},
+    {"type": "function", "name": "description", "stateMutability": "view",
+     "inputs": [], "outputs": [{"name": "", "type": "string"}]},
+    {"type": "function", "name": "latestRoundData", "stateMutability": "view",
+     "inputs": [], "outputs": [
+         {"name": "roundId", "type": "uint80"},
+         {"name": "answer", "type": "int256"},
+         {"name": "startedAt", "type": "uint256"},
+         {"name": "updatedAt", "type": "uint256"},
+         {"name": "answeredInRound", "type": "uint80"},
+     ]},
+]
+
+
+def read_factory_state(client: Any, factory: str = PARTY_FACTORY) -> dict:
+    """The factory's global switches, in one round trip."""
+    names = ["paused", "locker", "initialFdvUsd", "owner", "weth", "usdg",
+             "sequencerUptimeFeed"]
+    types = {"paused": "bool", "locker": "address", "initialFdvUsd": "uint256",
+             "owner": "address", "weth": "address", "usdg": "address",
+             "sequencerUptimeFeed": "address"}
+    from .abi_codec import encode_function_data
+
+    calls = [
+        {"method": "eth_call",
+         "params": [{"to": factory, "data": encode_function_data(PARTY_FACTORY_ABI, n)},
+                    "latest"]}
+        for n in names
+    ]
+    results = client.batch(calls, chunk_size=len(names))
+    out: dict[str, Any] = {}
+    for name, result in zip(names, results):
+        if isinstance(result, dict) and "error" in result:
+            out[name] = None
+            continue
+        out[name] = decode([{"type": types[name]}], result)[0]
+    return out
+
+
+def read_start_tick(client: Any, paired_asset: str,
+                    factory: str = PARTY_FACTORY) -> tuple[int, bool]:
+    """The tick a launch would use right now, and whether the live feed produced it.
+
+    ``live == False`` means the factory fell back to a pinned tick because the
+    price feed was stale or the sequencer was down — the one condition under which
+    the opening FDV drifts off its target.
+    """
+    try:
+        tick, live = client.read(factory, PARTY_FACTORY_ABI, "startTickFor", [paired_asset])
+    except RpcError as exc:
+        hint = explain_revert(exc.data)
+        raise RuntimeError(hint or f"startTickFor reverted for {paired_asset}") from exc
+    return int(tick), bool(live)
+
+
+def read_paired_curve(client: Any, paired_asset: str,
+                      factory: str = PARTY_FACTORY) -> dict:
+    # A named tuple output decodes to a dict (see abi_codec._decode_param), so
+    # read the fields by name rather than unpacking positionally.
+    curve = client.read(factory, PARTY_FACTORY_ABI, "getPairedAssetCurve", [paired_asset])
+    return {"feed": curve["feed"], "maxPriceAge": int(curve["maxPriceAge"]),
+            "fallbackTick": int(curve["fallbackTick"]), "set": bool(curve["set"])}
+
+
+def read_paired_usd(client: Any, paired_asset: str,
+                    factory: str = PARTY_FACTORY) -> dict | None:
+    """USD price of the paired asset, straight from the feed the factory prices off.
+
+    Deliberately not an external price API: this is the exact number that produced
+    the launch tick, so the FDV shown to the user reconciles with the protocol's
+    own arithmetic instead of approximating it.
+    """
+    curve = read_paired_curve(client, paired_asset, factory)
+    feed = curve.get("feed")
+    if not feed or int(feed, 16) == 0:
+        return None
+    try:
+        decimals = client.read(feed, CHAINLINK_ABI, "decimals")
+        _, answer, _, updated_at, _ = client.read(feed, CHAINLINK_ABI, "latestRoundData")
+    except Exception:
+        return None
+    if int(answer) <= 0:
+        return None
+    return {"usd": int(answer) / float(10 ** int(decimals)), "feed": feed,
+            "updatedAt": int(updated_at), "maxPriceAge": curve["maxPriceAge"]}
+
+
+def simulate_launch(client: Any, *, factory: str, name: str, symbol: str,
+                    metadata_uri: str, salt: str, paired_asset: str,
+                    start_tick: int, deadline: int, creator: str,
+                    fee_recipient: str, dev_buy_amount_in: int,
+                    value_wei: int, from_address: str) -> dict:
+    """``eth_call`` the real launch and read back what it would produce.
+
+    ``devBuyMinOut`` is pinned to 0 so the call reports the true fill rather than
+    reverting against a guess. The number is exact, not indicative: the dev buy is
+    the pool's first swap and happens inside the same transaction, so there is no
+    window for anyone to move the price first.
+
+    A balance state override is attached so this works from a wallet that has not
+    been funded yet — otherwise planning a dev buy would require already holding
+    the ETH, which defeats the point of planning.
+    """
+    data = encode_launch(name, symbol, metadata_uri, salt, paired_asset, start_tick,
+                         deadline, creator, fee_recipient, dev_buy_amount_in, 0)
+    call: dict[str, Any] = {"from": from_address, "to": factory, "data": data}
+    if value_wei:
+        call["value"] = hex(value_wei)
+    # Cover the dev buy plus generous gas headroom.
+    override_balance = value_wei + 10**18
+    params: list[Any] = [call, "latest",
+                         {from_address: {"balance": hex(override_balance)}}]
+    try:
+        raw = client.request("eth_call", params)
+    except RpcError as exc:
+        hint = explain_revert(exc.data)
+        if hint:
+            raise RuntimeError(hint) from exc
+        # Some nodes reject the third parameter outright; retry without it so the
+        # command still works, just requiring a funded wallet for dev-buy plans.
+        if "override" in str(exc).lower() or exc.code == -32602:
+            try:
+                raw = client.request("eth_call", [call, "latest"])
+            except RpcError as inner:
+                raise RuntimeError(
+                    explain_revert(inner.data) or f"simulation reverted: {inner}"
+                ) from inner
+        else:
+            raise RuntimeError(f"simulation reverted: {exc}") from exc
+    token, pool, dev_buy_out = decode(
+        [{"type": "address"}, {"type": "address"}, {"type": "uint256"}], raw)
+    return {"token": token, "pool": pool, "devBuyOut": int(dev_buy_out)}
+
+
+def plan_launch(client: Any, *, factory: str, name: str, symbol: str,
+                metadata_uri: str, paired_asset: str, creator: str,
+                fee_recipient: str, deadline: int, dev_buy_wei: int = 0,
+                dev_buy_asset: int = 0, slippage_bps: int = 100,
+                salt: str | None = None, max_salt_attempts: int = 5000,
+                allow_fallback_tick: bool = False,
+                on_progress: Any = None) -> dict:
+    """Assemble a complete, checked launch plan. Reads only."""
+    if dev_buy_wei and dev_buy_asset:
+        raise RuntimeError(
+            "use either --dev-buy (native ETH) or --dev-buy-asset (paired ERC20), "
+            "never both — the factory reverts AmbiguousDevBuy."
+        )
+    if dev_buy_wei and paired_asset.lower() != WETH.lower():
+        raise RuntimeError(
+            f"a native-ETH dev buy only works on WETH pairs; this pair is "
+            f"{asset_label(paired_asset)}. Use --dev-buy-asset instead (run `approve` first)."
+        )
+
+    state = read_factory_state(client, factory)
+    if state.get("paused"):
+        raise RuntimeError("the pools.fun factory is paused; launches are disabled.")
+    if not state.get("locker") or int(state["locker"], 16) == 0:
+        raise RuntimeError("the factory has no locker configured; launches would revert.")
+
+    allowed = client.read(factory, PARTY_FACTORY_ABI, "allowedPairedAsset", [paired_asset])
+    if not allowed:
+        raise RuntimeError(
+            f"{asset_label(paired_asset)} ({paired_asset}) is not on the factory's "
+            f"paired-asset allowlist. Run `pools_read.py assets` to see what is launchable."
+        )
+
+    start_tick, live = read_start_tick(client, paired_asset, factory)
+    validate_start_tick(start_tick)
+    if not live and not allow_fallback_tick:
+        raise RuntimeError(
+            f"the launch tick ({start_tick}) came from the factory's fallback, not the "
+            f"live price feed — the opening FDV will be off target. Wait for the feed "
+            f"to recover, or pass --allow-fallback-tick to launch anyway."
+        )
+
+    if salt:
+        salt_value = salt if salt.startswith("0x") else "0x" + salt
+        if len(salt_value) != 66:
+            raise RuntimeError("--salt must be 32 bytes of hex")
+        from .factory import encode_compute_token_address
+        token_preview = decode([{"type": "address"}], client.call(
+            factory, encode_compute_token_address(
+                creator, salt_value, name, symbol, metadata_uri)))[0]
+        if not sorts_below(token_preview, paired_asset):
+            raise RuntimeError(
+                f"--salt produces {token_preview}, which does not sort below "
+                f"{asset_label(paired_asset)} ({paired_asset}). Drop --salt to mine one."
+            )
+        attempts = 1
+    else:
+        salt_value, token_preview, attempts = mine_salt(
+            client, factory, creator, name, symbol, metadata_uri, paired_asset,
+            max_attempts=max_salt_attempts, on_progress=on_progress)
+
+    sim = simulate_launch(
+        client, factory=factory, name=name, symbol=symbol, metadata_uri=metadata_uri,
+        salt=salt_value, paired_asset=paired_asset, start_tick=start_tick,
+        deadline=deadline, creator=creator, fee_recipient=fee_recipient,
+        dev_buy_amount_in=dev_buy_asset, value_wei=dev_buy_wei, from_address=creator)
+
+    if sim["token"].lower() != token_preview.lower():
+        raise RuntimeError(
+            f"internal check failed: simulation deployed {sim['token']} but the mined "
+            f"salt predicted {token_preview}. Re-run."
+        )
+
+    dev_buy_min_out = sim["devBuyOut"] * (10_000 - slippage_bps) // 10_000
+
+    price_data = read_paired_usd(client, paired_asset, factory)
+    paired_usd = price_data["usd"] if price_data else None
+
+    plan = {
+        "name": name,
+        "symbol": symbol,
+        "metadataUri": metadata_uri,
+        "salt": salt_value,
+        "pairedAsset": paired_asset,
+        "expectedStartTick": start_tick,
+        "creator": creator,
+        "feeRecipient": fee_recipient,
+        "devBuyAmountIn": dev_buy_asset,
+        "devBuyValueWei": dev_buy_wei,
+        "devBuyMinOut": dev_buy_min_out,
+        "slippageBps": slippage_bps,
+        "chainId": CHAIN_ID,
+        "factory": factory,
+    }
+    plan["planHash"] = plan_hash(plan)
+    # Everything below is context for the human, not part of the commitment.
+    plan.update({
+        "token": sim["token"],
+        "pool": sim["pool"],
+        "devBuyOut": sim["devBuyOut"],
+        "tickLive": live,
+        "saltAttempts": attempts,
+        "pairedUsd": paired_usd,
+        "priceFeed": price_data,
+        "tokenPriceUsd": (price_from_tick(start_tick) * paired_usd) if paired_usd else None,
+        "fdvUsd": fdv_usd(start_tick, paired_usd) if paired_usd else None,
+        "targetFdvUsd": int(state["initialFdvUsd"]) if state.get("initialFdvUsd") else None,
+        "locker": state.get("locker"),
+        "supply": TOTAL_SUPPLY,
+        "deadline": deadline,
+        "supplyPct": (sim["devBuyOut"] / TOTAL_SUPPLY * 100) if sim["devBuyOut"] else 0.0,
+    })
+    return plan
+
+
+# Fields that define what will land on-chain. The absolute deadline and gas
+# prices are excluded on purpose: both legitimately differ between the moment a
+# plan is printed and the moment it is confirmed, and including them would make
+# every hash expire instantly without making the commitment any stronger.
+_HASHED_FIELDS = (
+    "name", "symbol", "metadataUri", "salt", "pairedAsset", "expectedStartTick",
+    "creator", "feeRecipient", "devBuyAmountIn", "devBuyValueWei", "devBuyMinOut",
+    "chainId", "factory",
+)
+
+
+def plan_hash(plan: dict) -> str:
+    """A short, stable digest of everything that matters about a launch."""
+    payload = {}
+    for key in _HASHED_FIELDS:
+        value = plan.get(key)
+        payload[key] = value.lower() if isinstance(value, str) and value.startswith("0x") \
+            else value
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return keccak256(canonical.encode())[:10]
+
+
+def action_hash(action: str, fields: dict) -> str:
+    """The same commitment scheme for the simpler, non-launch writes.
+
+    Fee collection and approvals have nothing in common with a launch's field set,
+    so they get their own canonical payload rather than being forced into the
+    launch shape. ``action`` is part of the digest, which is what stops a `collect`
+    confirmation from authorising a `claim` on the same token.
+    """
+    payload: dict[str, Any] = {"action": action}
+    for key, value in fields.items():
+        payload[key] = value.lower() if isinstance(value, str) and value.startswith("0x") \
+            else value
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return keccak256(canonical.encode())[:10]
+
+
+def verify_plan_unchanged(plan: dict, expected: str) -> None:
+    actual = plan_hash(plan)
+    if actual.lower() != expected.lower().strip():
+        raise RuntimeError(
+            f"plan changed since it was printed (now {actual}, you confirmed {expected}). "
+            "Re-run the dry run and confirm the new hash."
+        )
+
+
+def paired_decimals(asset: str) -> int:
+    return ASSET_DECIMALS.get(asset.lower(), 18)
+
+
+__all__ = [
+    "CHAINLINK_ABI", "read_factory_state", "read_start_tick", "read_paired_curve",
+    "read_paired_usd", "simulate_launch", "plan_launch", "plan_hash", "action_hash",
+    "verify_plan_unchanged", "paired_decimals", "USDG", "WETH",
+]

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/plan.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/plan.py
@@ -50,7 +50,13 @@ CHAINLINK_ABI: list[dict] = [
 
 
 def read_factory_state(client: Any, factory: str = PARTY_FACTORY) -> dict:
-    """The factory's global switches, in one round trip."""
+    """The factory's global switches, in one round trip.
+
+    A field whose call errored comes back as ``None``, which callers must treat
+    as *unknown* rather than as a value. ``paused`` in particular: ``None`` is
+    falsy, so testing it directly would read an unreadable factory as "not
+    paused" and launch into a disabled contract. Use :func:`require_launchable`.
+    """
     names = ["paused", "locker", "initialFdvUsd", "owner", "weth", "usdg",
              "sequencerUptimeFeed"]
     types = {"paused": "bool", "locker": "address", "initialFdvUsd": "uint256",
@@ -72,6 +78,26 @@ def read_factory_state(client: Any, factory: str = PARTY_FACTORY) -> dict:
             continue
         out[name] = decode([{"type": types[name]}], result)[0]
     return out
+
+
+def require_launchable(state: dict) -> None:
+    """Refuse a launch unless the factory is *known* to be open for business.
+
+    Fails closed on an unreadable switch. An RPC hiccup that turns `paused` into
+    ``None`` must not be indistinguishable from `paused == False`: launching into
+    a paused factory wastes the whole ~6.1M gas, and "we could not tell" is not
+    the same answer as "no".
+    """
+    if state.get("paused") is None:
+        raise RuntimeError(
+            "could not read the factory's `paused` switch — refusing to launch on an "
+            "unknown state. Re-run; if it persists the RPC endpoint is degraded."
+        )
+    if state["paused"]:
+        raise RuntimeError("the pools.fun factory is paused; launches are disabled.")
+    locker = state.get("locker")
+    if not locker or int(locker, 16) == 0:
+        raise RuntimeError("the factory has no locker configured; launches would revert.")
 
 
 def read_start_tick(client: Any, paired_asset: str,
@@ -189,10 +215,7 @@ def plan_launch(client: Any, *, factory: str, name: str, symbol: str,
         )
 
     state = read_factory_state(client, factory)
-    if state.get("paused"):
-        raise RuntimeError("the pools.fun factory is paused; launches are disabled.")
-    if not state.get("locker") or int(state["locker"], 16) == 0:
-        raise RuntimeError("the factory has no locker configured; launches would revert.")
+    require_launchable(state)
 
     allowed = client.read(factory, PARTY_FACTORY_ABI, "allowedPairedAsset", [paired_asset])
     if not allowed:

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
@@ -1,0 +1,362 @@
+"""JSON-RPC transport — replaces viem's public client, batching and multicall.
+
+viem hid three things behind ``createPublicClient`` that have to become explicit here:
+
+* **HTTP batching.** ``http({batch:{wait:10}})`` coalesced concurrent requests. Python
+  is synchronous, so batching is an explicit :meth:`RpcClient.batch` call.
+* **Multicall.** ``client.multicall`` wrapped Multicall3 ``aggregate3``. Reimplemented
+  in :meth:`RpcClient.multicall`, returning the same ``[{status, result}]`` shape the
+  ported call sites already consume.
+* **Concurrency.** ``Promise.all`` became either a batch or a plain loop. Log sweeps
+  stay sequential on purpose — the Node source notes that firing them concurrently
+  only trips the provider's rate limiter.
+
+Two failure modes are handled deliberately rather than left to chance:
+
+* A chunk that is too large for the node (gas cap, response cap) is **bisected** and
+  retried down to a single call, so an over-sized request degrades into slower but
+  correct results instead of marking healthy calls as failed.
+* ``success == true`` with empty ``returnData`` means there is no code at the target.
+  That is reported as a failure, never decoded as a zero — launchpad discovery
+  depends on telling the two apart.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import time
+import urllib.error
+import urllib.request
+import zlib
+from typing import Any
+
+from .abi_codec import decode, encode, encode_function_data
+from .chains import CHAIN, resolve_rpc_url
+
+_AGG3_IN = [{"type": "tuple[]", "components": [
+    {"name": "target", "type": "address"},
+    {"name": "allowFailure", "type": "bool"},
+    {"name": "callData", "type": "bytes"},
+]}]
+_AGG3_OUT = [{"type": "tuple[]", "components": [
+    {"name": "success", "type": "bool"},
+    {"name": "returnData", "type": "bytes"},
+]}]
+_AGGREGATE3_ABI = [{
+    "type": "function", "name": "aggregate3", "stateMutability": "payable",
+    "inputs": _AGG3_IN, "outputs": _AGG3_OUT,
+}]
+
+# Chunking for multicall. viem chunked on 1024 bytes of calldata and let the HTTP
+# transport re-batch; larger chunks and fewer round trips win over a remote RPC.
+MAX_CALLS_PER_CHUNK = 100
+MAX_CALLDATA_BYTES = 24_000
+
+# eth_sendRawTransaction is never retried: a "failed" send may already be in the
+# mempool, and resending risks a second transaction rather than a duplicate no-op.
+_NEVER_RETRY = {"eth_sendRawTransaction"}
+_RETRY_STATUS = {429, 500, 502, 503, 504}
+_MAX_RESPONSE_BYTES = 256 * 1024 * 1024
+
+# Sent on every outbound HTTP request, RPC and price API alike. Not cosmetic: urllib's
+# default "Python-urllib/3.x" is blocked outright by some WAFs (GeckoTerminal sits
+# behind Cloudflare and answers it with a 403 "error 1010"), which surfaces as prices
+# quietly reading n/a rather than as an error.
+USER_AGENT = "poolsdotfun-token-launcher/1.0"
+
+
+class RpcError(RuntimeError):
+    """A JSON-RPC error response. ``data`` carries the revert blob when present."""
+
+    def __init__(self, method: str, error: dict) -> None:
+        super().__init__(f"{method}: {error.get('message', error)}")
+        self.code = error.get("code")
+        self.data = error.get("data")
+        self.raw = error
+
+
+class RpcClient:
+    """A minimal, synchronous JSON-RPC client over ``urllib``."""
+
+    def __init__(self, chain: dict | None = None, rpc_url: str | None = None,
+                 timeout: int = 60, debug: bool = False, allow_batch: bool = True) -> None:
+        # Single-chain skill: `chain` defaults to the only one there is. The
+        # parameter survives so the vendored tx.py helpers keep working unchanged.
+        self.chain = chain or CHAIN
+        self.url = resolve_rpc_url(rpc_url)
+        self.timeout = timeout
+        self.debug = debug
+        self._allow_batch = allow_batch
+        self._next_id = 0
+        self.request_count = 0
+
+    # -- transport ---------------------------------------------------------
+
+    def _post(self, payload: Any, label: str, retries: int = 3) -> Any:
+        body = json.dumps(payload).encode("utf-8")
+        attempt = 0
+        while True:
+            attempt += 1
+            request = urllib.request.Request(
+                self.url, data=body, method="POST",
+                headers={
+                    "content-type": "application/json",
+                    "accept": "application/json",
+                    # Log sweeps return megabytes; gzip is a real saving and is stdlib.
+                    "accept-encoding": "gzip, deflate",
+                    "user-agent": USER_AGENT,
+                },
+            )
+            try:
+                self.request_count += 1
+                with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                    raw = response.read(_MAX_RESPONSE_BYTES + 1)
+                    if len(raw) > _MAX_RESPONSE_BYTES:
+                        raise RuntimeError(
+                            f"{label}: response exceeds {_MAX_RESPONSE_BYTES // 1048576} MB — "
+                            "narrow the block range or lower --max-pools"
+                        )
+                    encoding = (response.headers.get("content-encoding") or "").lower()
+                if encoding == "gzip":
+                    raw = gzip.decompress(raw)
+                elif encoding == "deflate":
+                    raw = zlib.decompress(raw)
+                return json.loads(raw)
+            except urllib.error.HTTPError as exc:
+                retryable = exc.code in _RETRY_STATUS and label not in _NEVER_RETRY
+                if not retryable or attempt > retries:
+                    raise RuntimeError(f"{label}: HTTP {exc.code}") from exc
+                self._sleep_before_retry(exc.headers.get("retry-after"), attempt)
+            except (urllib.error.URLError, TimeoutError) as exc:
+                if label in _NEVER_RETRY or attempt > retries:
+                    raise RuntimeError(f"{label}: {exc}") from exc
+                self._sleep_before_retry(None, attempt)
+
+    def _sleep_before_retry(self, retry_after: str | None, attempt: int) -> None:
+        delay = 0.5 * (2 ** (attempt - 1))
+        if retry_after:
+            try:
+                delay = max(delay, float(retry_after))
+            except ValueError:
+                pass
+        if self.debug:
+            print(f"  [rpc] retry in {delay:.1f}s (attempt {attempt})")
+        time.sleep(min(delay, 30.0))
+
+    def request(self, method: str, params: list | None = None) -> Any:
+        self._next_id += 1
+        body = self._post(
+            {"jsonrpc": "2.0", "id": self._next_id, "method": method, "params": params or []},
+            method,
+        )
+        if isinstance(body, dict) and body.get("error"):
+            raise RpcError(method, body["error"])
+        return body.get("result") if isinstance(body, dict) else None
+
+    def batch(self, calls: list[dict], chunk_size: int = 20) -> list[Any]:
+        """Send many calls in JSON-RPC array form. One round trip per chunk.
+
+        Results come back positionally. A per-call error becomes ``{"error": …}``
+        rather than raising, so one bad pool cannot abort a 40-pool sweep — callers
+        distinguish the two with ``isinstance(result, dict) and "error" in result``.
+
+        Responses are mapped strictly by ``id`` and the count is asserted: providers
+        do reorder, and a silently truncated batch would attribute results to the
+        wrong pool.
+        """
+        out: list[Any] = [None] * len(calls)
+        if not calls:
+            return out
+
+        for start in range(0, len(calls), chunk_size):
+            window = calls[start:start + chunk_size]
+            if not self._allow_batch:
+                for offset, call in enumerate(window):
+                    try:
+                        out[start + offset] = self.request(call["method"], call.get("params"))
+                    except RpcError as exc:
+                        out[start + offset] = {"error": exc.raw}
+                continue
+
+            payload = [
+                {"jsonrpc": "2.0", "id": start + offset,
+                 "method": call["method"], "params": call.get("params") or []}
+                for offset, call in enumerate(window)
+            ]
+            body = self._post(payload, "batch")
+            if not isinstance(body, list):
+                # Provider does not support batching — fall back for the rest of
+                # this process rather than failing the command.
+                self._allow_batch = False
+                if self.debug:
+                    print("  [rpc] provider rejected a batch; falling back to singles")
+                for offset, call in enumerate(window):
+                    try:
+                        out[start + offset] = self.request(call["method"], call.get("params"))
+                    except RpcError as exc:
+                        out[start + offset] = {"error": exc.raw}
+                continue
+
+            seen = set()
+            for entry in body:
+                index = int(entry["id"])
+                seen.add(index)
+                error = entry.get("error")
+                out[index] = {"error": error} if error else entry.get("result")
+            missing = set(range(start, start + len(window))) - seen
+            if missing:
+                raise RuntimeError(
+                    f"batch response dropped {len(missing)} of {len(window)} calls "
+                    "— results cannot be trusted"
+                )
+        return out
+
+    # -- convenience wrappers ---------------------------------------------
+
+    def call(self, to: str, data: str, block: str = "latest",
+             from_address: str | None = None) -> str:
+        params: dict[str, str] = {"to": to, "data": data}
+        if from_address:
+            params["from"] = from_address
+        return self.request("eth_call", [params, block])
+
+    def read(self, address: str, abi: list, function_name: str,
+             args: list | None = None, block: str = "latest") -> Any:
+        from .abi_codec import decode_function_result
+
+        data = encode_function_data(abi, function_name, args or [])
+        return decode_function_result(abi, function_name, self.call(address, data, block))
+
+    def block_number(self) -> int:
+        return int(self.request("eth_blockNumber"), 16)
+
+    def chain_id(self) -> int:
+        return int(self.request("eth_chainId"), 16)
+
+    def get_block(self, block: str = "latest") -> dict:
+        return self.request("eth_getBlockByNumber", [block, False])
+
+    def get_logs(self, params: dict) -> list:
+        return self.request("eth_getLogs", [params])
+
+    def transaction_count(self, address: str, block: str = "pending") -> int:
+        return int(self.request("eth_getTransactionCount", [address, block]), 16)
+
+    def estimate_gas(self, tx: dict) -> int:
+        return int(self.request("eth_estimateGas", [tx]), 16)
+
+    def send_raw_transaction(self, raw: str) -> str:
+        return self.request("eth_sendRawTransaction", [raw])
+
+    def get_receipt(self, tx_hash: str) -> dict | None:
+        return self.request("eth_getTransactionReceipt", [tx_hash])
+
+    # -- multicall ---------------------------------------------------------
+
+    def multicall(self, calls: list[dict], allow_failure: bool = True,
+                  block: str = "latest") -> list[dict]:
+        """Multicall3 ``aggregate3``.
+
+        Each call is ``{"address", "abi", "functionName", "args"}``. Returns one
+        ``{"status": "success"|"failure", "result": …}`` per input, in order —
+        matching what the ported call sites expect from ``client.multicall``.
+        """
+        if not calls:
+            return []
+        prepared = []
+        for call in calls:
+            prepared.append({
+                "call": call,
+                "data": encode_function_data(
+                    call["abi"], call["functionName"], call.get("args") or []
+                ),
+            })
+
+        results: list[dict] = []
+        for chunk in self._chunk(prepared):
+            results.extend(self._multicall_chunk(chunk, allow_failure, block))
+        return results
+
+    @staticmethod
+    def _chunk(prepared: list[dict]) -> list[list[dict]]:
+        chunks: list[list[dict]] = []
+        current: list[dict] = []
+        size = 0
+        for entry in prepared:
+            entry_size = len(entry["data"]) // 2
+            if current and (
+                len(current) >= MAX_CALLS_PER_CHUNK or size + entry_size > MAX_CALLDATA_BYTES
+            ):
+                chunks.append(current)
+                current, size = [], 0
+            current.append(entry)
+            size += entry_size
+        if current:
+            chunks.append(current)
+        return chunks
+
+    def _multicall_chunk(self, chunk: list[dict], allow_failure: bool,
+                         block: str) -> list[dict]:
+        payload = encode_function_data(_AGGREGATE3_ABI, "aggregate3", [[
+            {"target": entry["call"]["address"], "allowFailure": True,
+             "callData": entry["data"]}
+            for entry in chunk
+        ]])
+        try:
+            raw = self.call(self.chain["multicall3"], payload, block)
+        except (RpcError, RuntimeError):
+            # Too big for this node, or a transient failure. Bisect and retry; a
+            # single call that still fails is reported as a failure, not dropped.
+            if len(chunk) == 1:
+                if allow_failure:
+                    return [{"status": "failure", "result": None,
+                             "error": "call failed on its own"}]
+                raise
+            midpoint = len(chunk) // 2
+            if self.debug:
+                print(f"  [rpc] multicall chunk of {len(chunk)} failed; bisecting")
+            return (self._multicall_chunk(chunk[:midpoint], allow_failure, block)
+                    + self._multicall_chunk(chunk[midpoint:], allow_failure, block))
+
+        decoded = decode(_AGG3_OUT, raw)[0]
+        out: list[dict] = []
+        for entry, item in zip(chunk, decoded):
+            call = entry["call"]
+            return_data = item["returnData"]
+            if not item["success"] or return_data in ("0x", ""):
+                # Empty returnData on a "successful" call means no code at the
+                # target. Decoding it as zeros would invent a value.
+                reason = ("reverted" if not item["success"]
+                          else "empty return — no contract at that address")
+                if not allow_failure:
+                    raise RuntimeError(
+                        f"multicall {call['functionName']} on {call['address']}: {reason}"
+                    )
+                out.append({"status": "failure", "result": None, "error": reason})
+                continue
+            from .abi_codec import decode_function_result
+            try:
+                value = decode_function_result(call["abi"], call["functionName"], return_data)
+            except Exception as exc:  # noqa: BLE001 — a decode failure is a call failure
+                if not allow_failure:
+                    raise
+                out.append({"status": "failure", "result": None, "error": str(exc)})
+                continue
+            out.append({"status": "success", "result": value})
+        return out
+
+
+def unwrap(results: list[dict], label: str = "multicall") -> list:
+    """Take the values out of a multicall result list, raising on any failure."""
+    values = []
+    for index, entry in enumerate(results):
+        if entry["status"] != "success":
+            raise RuntimeError(f"{label}[{index}] failed: {entry.get('error')}")
+        values.append(entry["result"])
+    return values
+
+
+def encode_aggregate3(calls: list[dict]) -> str:
+    """Exposed for the self-test, which pins the request encoding."""
+    return encode(_AGG3_IN, [calls])

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/secp256k1.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/secp256k1.py
@@ -1,0 +1,177 @@
+"""secp256k1 ECDSA — the one piece viem provided that the stdlib does not.
+
+Only three operations are needed: derive an address from a private key, sign a 32-byte
+digest deterministically (RFC 6979, so the same plan always produces the same signature),
+and recover the signer from a signature. The last one is not decoration — every signature
+this module produces is recovered and checked against the expected address before the
+transaction is allowed anywhere near the network. That check costs ~12 ms and removes the
+entire class of "wrong v, wrong s normalisation, wrong sighash" bugs, which lose money
+silently.
+
+The first of those three lives in ``account.py``, not here, and is re-exported below.
+That is not tidying: it lets ``lp_read.py`` answer "which wallet is mine" by importing a
+module that has no ``sign_digest`` in it at all. Everything a caller needs to *sign* is
+in this file, so importing the derivation half cannot reach it.
+
+Caveat that must stay visible: pure-Python big-integer arithmetic is **not constant time**.
+A local attacker who can measure this process precisely could in principle learn something
+about the key. Python has no fix for that. The mitigation is operational — this is a
+hot-wallet key for LP operations, not a treasury key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from .account import (
+    GX,
+    GY,
+    HALF_N,
+    G,
+    N,
+    P,
+    _jacobian_add,
+    _jacobian_multiply,
+    _to_affine,
+    account_from_private_key,
+    add,
+    address_from_public_key,
+    multiply,
+    normalize_private_key,
+    public_key,
+)
+from .hexutil import to_bytes
+
+# Re-exported so `from .secp256k1 import ...` keeps working for every existing caller —
+# and so the golden vectors in selftest.py go on testing these through this module.
+__all__ = [
+    "G",
+    "GX",
+    "GY",
+    "HALF_N",
+    "N",
+    "P",
+    "account_from_private_key",
+    "add",
+    "address_from_public_key",
+    "ecrecover",
+    "multiply",
+    "normalize_private_key",
+    "public_key",
+    "sign_digest",
+]
+
+
+# ---------------------------------------------------------------------------
+# RFC 6979 deterministic nonce
+# ---------------------------------------------------------------------------
+
+
+def _hmac(key: bytes, *chunks: bytes) -> bytes:
+    mac = hmac.new(key, digestmod=hashlib.sha256)
+    for chunk in chunks:
+        mac.update(chunk)
+    return mac.digest()
+
+
+def _rfc6979_nonces(private: int, digest_int: int):
+    """Yield candidate nonces exactly as RFC 6979 §3.2 prescribes.
+
+    A generator rather than a single value because a candidate can produce r == 0 or
+    s == 0; the RFC's answer is to keep turning the crank, not to fall back to randomness.
+    ``digest_int`` is already reduced mod n by the caller — that is RFC 6979's
+    ``bits2octets``, and getting it wrong yields signatures that verify but do not match
+    any other implementation's output.
+    """
+    x = private.to_bytes(32, "big")
+    h1 = digest_int.to_bytes(32, "big")
+    v = b"\x01" * 32
+    k = b"\x00" * 32
+    k = _hmac(k, v, b"\x00", x, h1)
+    v = _hmac(k, v)
+    k = _hmac(k, v, b"\x01", x, h1)
+    v = _hmac(k, v)
+    while True:
+        v = _hmac(k, v)
+        candidate = int.from_bytes(v, "big")
+        if 1 <= candidate < N:
+            yield candidate
+        k = _hmac(k, v, b"\x00")
+        v = _hmac(k, v)
+
+
+# ---------------------------------------------------------------------------
+# Sign / recover
+# ---------------------------------------------------------------------------
+
+
+def sign_digest(private_key: str | bytes | int, digest: str | bytes) -> dict:
+    """Sign a 32-byte digest. Returns r, s, yParity and the 65-byte packed form.
+
+    ``s`` is normalised into the lower half of the order (EIP-2): both s and n-s are
+    valid, and a high-s signature is rejected outright by much of the ecosystem. Flipping
+    s also flips the recovery parity, which is why both are adjusted together.
+    """
+    private = normalize_private_key(private_key)
+    digest_bytes = to_bytes(digest)
+    if len(digest_bytes) != 32:
+        raise ValueError("digest must be exactly 32 bytes")
+    z = int.from_bytes(digest_bytes, "big") % N
+
+    for nonce in _rfc6979_nonces(private, z):
+        point = multiply(G, nonce)
+        if point is None:
+            continue
+        r = point[0] % N
+        if r == 0:
+            continue
+        s = (pow(nonce, -1, N) * (z + r * private)) % N
+        if s == 0:
+            continue
+        y_parity = (point[1] & 1) ^ (1 if point[0] >= N else 0)
+        if s > HALF_N:
+            s = N - s
+            y_parity ^= 1
+        return {
+            "r": r,
+            "s": s,
+            "yParity": y_parity,
+            "hex": "0x"
+            + r.to_bytes(32, "big").hex()
+            + s.to_bytes(32, "big").hex()
+            + bytes([27 + y_parity]).hex(),
+        }
+    raise AssertionError("unreachable: RFC 6979 always terminates")
+
+
+def ecrecover(digest: str | bytes, r: int, s: int, y_parity: int) -> str:
+    """Recover the signer address, or raise if the signature is not on the curve."""
+    if not 1 <= r < N or not 1 <= s < N:
+        raise ValueError("signature component out of range")
+    if y_parity not in (0, 1):
+        raise ValueError("yParity must be 0 or 1")
+
+    x = r
+    alpha = (pow(x, 3, P) + 7) % P
+    y = pow(alpha, (P + 1) // 4, P)
+    if (y * y - alpha) % P != 0:
+        raise ValueError("signature r is not an x-coordinate on the curve")
+    if y % 2 != y_parity:
+        y = P - y
+
+    # Q = r^-1 * (s*R - z*G)
+    z = int.from_bytes(to_bytes(digest), "big") % N
+    r_inv = pow(r, -1, N)
+    point = _to_affine(
+        _jacobian_add(
+            _jacobian_multiply((x, y, 1), s),
+            _jacobian_multiply((GX, GY, 1), N - z),
+        )
+    )
+    if point is None:
+        raise ValueError("signature recovers to the point at infinity")
+    recovered = multiply(point, r_inv)
+    if recovered is None:
+        raise ValueError("signature recovers to the point at infinity")
+    return address_from_public_key(recovered)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/tx.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/tx.py
@@ -1,0 +1,292 @@
+"""RLP, EIP-1559 transaction assembly, and the broadcast sequence.
+
+viem's ``walletClient.sendTransaction`` hid four separate decisions behind one call: what
+nonce, what fees, what gas limit, and how to serialise. Each one is spelled out here,
+because each one can silently produce a transaction that never mines or mines wrong.
+
+The order is deliberate and matches the Node build: revalidate the plan, read a deadline
+from the chain's own clock, take a nonce, price the fees, estimate gas with a margin,
+serialise, sign, **verify the signature recovers to the signer**, send, print the hash
+*before* polling, then poll with a bounded timeout.
+"""
+
+from __future__ import annotations
+
+import time
+
+from .hexutil import checksum_address, js_round, strip0x, to_bytes
+from .keccak import keccak256
+from .secp256k1 import account_from_private_key, ecrecover, sign_digest
+
+# A priority fee below this is how a transaction ends up pending forever on a quiet chain
+# — the node accepts it and no builder ever picks it up. 1 gwei is cheap on both chains.
+MIN_PRIORITY_FEE = 10**9
+DEFAULT_GAS_MULTIPLIER = 1.25
+RECEIPT_TIMEOUT_SECS = 180
+RECEIPT_POLL_SECS = 2.0
+
+
+# ---------------------------------------------------------------------------
+# RLP
+# ---------------------------------------------------------------------------
+
+
+def _rlp_length(length: int, offset: int) -> bytes:
+    if length < 56:
+        return bytes([length + offset])
+    encoded = length.to_bytes((length.bit_length() + 7) // 8, "big")
+    return bytes([len(encoded) + offset + 55]) + encoded
+
+
+def rlp_encode(item) -> bytes:
+    """Encode bytes or an arbitrarily nested list of bytes."""
+    if isinstance(item, (bytes, bytearray)):
+        data = bytes(item)
+        if len(data) == 1 and data[0] < 0x80:
+            return data
+        return _rlp_length(len(data), 0x80) + data
+    if isinstance(item, (list, tuple)):
+        body = b"".join(rlp_encode(element) for element in item)
+        return _rlp_length(len(body), 0xC0) + body
+    raise TypeError(f"rlp_encode cannot encode {type(item).__name__}")
+
+
+def rlp_int(value: int | str | None) -> bytes:
+    """Quantities are minimal big-endian; zero is the empty string, not a zero byte."""
+    if value is None:
+        return b""
+    number = int(value, 16) if isinstance(value, str) and value.startswith("0x") else int(value)
+    if number < 0:
+        raise ValueError("cannot RLP-encode a negative quantity")
+    if number == 0:
+        return b""
+    return number.to_bytes((number.bit_length() + 7) // 8, "big")
+
+
+# ---------------------------------------------------------------------------
+# EIP-1559 serialisation
+# ---------------------------------------------------------------------------
+
+
+def _access_list(entries) -> list:
+    out = []
+    for entry in entries or []:
+        address = to_bytes(entry["address"])
+        keys = [to_bytes(key) for key in entry.get("storageKeys", [])]
+        out.append([address, keys])
+    return out
+
+
+def serialize_transaction(tx: dict, signature: dict | None = None) -> str:
+    """``0x02 || rlp([...])`` — type-2 only; this skill has no reason to send legacy.
+
+    Without a signature this is the payload that gets hashed to produce the sighash;
+    with one it is the raw transaction. Same field order, three extra elements.
+    """
+    fields = [
+        rlp_int(tx["chainId"]),
+        rlp_int(tx.get("nonce", 0)),
+        rlp_int(tx.get("maxPriorityFeePerGas", 0)),
+        rlp_int(tx.get("maxFeePerGas", 0)),
+        rlp_int(tx.get("gas", 0)),
+        to_bytes(tx["to"]) if tx.get("to") else b"",
+        rlp_int(tx.get("value", 0)),
+        to_bytes(tx.get("data") or "0x"),
+        _access_list(tx.get("accessList")),
+    ]
+    if signature is not None:
+        fields += [
+            rlp_int(signature["yParity"]),
+            rlp_int(signature["r"]),
+            rlp_int(signature["s"]),
+        ]
+    return "0x02" + rlp_encode(fields).hex()
+
+
+def sign_transaction(tx: dict, private_key: str) -> dict:
+    """Sign a type-2 transaction and self-verify before handing back the raw bytes.
+
+    The recovery check is the point of this function. A wrong sighash, a wrong parity, or
+    a missed low-s normalisation all produce a perfectly well-formed transaction that a
+    node will happily accept and attribute to a *different* address — which, for an
+    approval or a liquidity burn, is a silent loss. Recovering costs ~12 ms.
+    """
+    account = account_from_private_key(private_key)
+    unsigned = serialize_transaction(tx)
+    digest = keccak256(unsigned)
+    signature = sign_digest(private_key, digest)
+
+    recovered = ecrecover(digest, signature["r"], signature["s"], signature["yParity"])
+    if recovered.lower() != account["address"].lower():
+        raise RuntimeError(
+            "refusing to send: the signature recovers to "
+            f"{recovered}, not to the signer {account['address']}"
+        )
+
+    raw = serialize_transaction(tx, signature)
+    return {
+        "raw": raw,
+        "hash": keccak256(raw),
+        "signature": signature,
+        "from": account["address"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filling in what the chain decides
+# ---------------------------------------------------------------------------
+
+
+def suggest_fees(client, priority_fee: int | None = None) -> dict:
+    """EIP-1559 fees: ``maxFee = baseFee*2 + priority``.
+
+    Doubling the base fee leaves room for it to climb for six consecutive full blocks
+    before the transaction becomes unmineable; the surplus is refunded, so the only cost
+    of being generous is a larger balance check. ``eth_feeHistory`` is the fallback for
+    nodes that omit ``baseFeePerGas`` from the block, and a flat floor is the fallback
+    for chains that predate 1559 reporting entirely.
+    """
+    base_fee = 0
+    try:
+        block = client.get_block("latest")
+        base_fee = int(block.get("baseFeePerGas") or "0x0", 16)
+    except Exception:  # noqa: BLE001 — any transport failure just moves to the fallback
+        base_fee = 0
+
+    if priority_fee is None:
+        priority_fee = MIN_PRIORITY_FEE
+        try:
+            history = client.request("eth_feeHistory", ["0x5", "latest", [50]])
+            rewards = [int(r[0], 16) for r in (history.get("reward") or []) if r]
+            if rewards:
+                priority_fee = max(sorted(rewards)[len(rewards) // 2], MIN_PRIORITY_FEE)
+        except Exception:  # noqa: BLE001
+            pass
+
+    return {
+        "maxPriorityFeePerGas": priority_fee,
+        "maxFeePerGas": base_fee * 2 + priority_fee,
+        "baseFeePerGas": base_fee,
+    }
+
+
+def estimate_gas(client, tx: dict, multiplier: float = DEFAULT_GAS_MULTIPLIER) -> int:
+    """Estimated gas with a margin, matching the Node build's ``gas * round(m*100) / 100``.
+
+    ``js_round`` rather than ``round``: Python rounds halves to even, JavaScript rounds
+    them up, and ``--gas-multiplier 1.125`` would otherwise pick a different limit here
+    than it did there.
+    """
+    request = {"from": tx["from"], "to": tx["to"], "data": tx.get("data") or "0x"}
+    if int(tx.get("value") or 0) > 0:
+        request["value"] = hex(int(tx["value"]))
+    return client.estimate_gas(request) * js_round(multiplier * 100) // 100
+
+
+def prepare_transaction(client, chain: dict, signer: str, to: str, data: str,
+                        value: int = 0, gas_multiplier: float = DEFAULT_GAS_MULTIPLIER,
+                        priority_fee: int | None = None,
+                        max_fee_cap: int | None = None) -> dict:
+    """Everything needed to sign, read from the chain in one place.
+
+    ``max_fee_cap`` refuses the send outright when the suggested ``maxFeePerGas`` exceeds
+    it, rather than silently clamping — a clamped fee just produces a transaction that sits
+    in the mempool and gets dropped, which for an unattended runner is a slower way to fail.
+    Off by default; gas price is deliberately excluded from PLAN_HASH, so an interactive
+    user approved the plan without seeing it either way.
+    """
+    fees = suggest_fees(client, priority_fee)
+    if max_fee_cap is not None and fees["maxFeePerGas"] > int(max_fee_cap):
+        raise RuntimeError(
+            f"refusing to send: maxFeePerGas would be {fees['maxFeePerGas']} wei, over the "
+            f"{int(max_fee_cap)} wei cap (base fee {fees['baseFeePerGas']}). Wait for gas to "
+            "fall, or raise the cap."
+        )
+    tx = {
+        "type": "eip1559",
+        "chainId": chain["chainId"],
+        "nonce": client.transaction_count(signer, "pending"),
+        "maxPriorityFeePerGas": fees["maxPriorityFeePerGas"],
+        "maxFeePerGas": fees["maxFeePerGas"],
+        "to": checksum_address(to),
+        "value": int(value),
+        "data": data,
+        "from": checksum_address(signer),
+    }
+    tx["gas"] = estimate_gas(client, tx, gas_multiplier)
+    return tx
+
+
+def send_transaction(client, chain: dict, tx: dict, private_key: str,
+                     on_hash=None, on_sent=None) -> str:
+    """Sign and broadcast. Returns the hash; does not wait.
+
+    The chain id is re-read from the node rather than trusted from the config: signing
+    for 8453 and sending to 4663 produces a transaction that is either rejected or —
+    worse, if the same key has funds on both — replayable.
+
+    ``on_sent`` is the durability hook: it fires after signing and before broadcast with
+    everything needed to find this transaction again, so a journal can fsync first. A crash
+    between that fsync and the broadcast is recoverable (nothing was sent); a broadcast with
+    nothing on disk would not be. ``on_hash`` is the older display-only callback and still
+    fires, after ``on_sent``.
+    """
+    live_chain_id = client.chain_id()
+    if live_chain_id != int(tx["chainId"]):
+        raise RuntimeError(
+            f"refusing to send: transaction is signed for chain {tx['chainId']} but the "
+            f"RPC endpoint reports chain {live_chain_id}. Check --rpc."
+        )
+
+    signed = sign_transaction({k: v for k, v in tx.items() if k != "from"}, private_key)
+    if "from" in tx and signed["from"].lower() != tx["from"].lower():
+        raise RuntimeError(
+            f"refusing to send: the key derives {signed['from']}, plan says {tx['from']}"
+        )
+
+    if on_sent:
+        # The head is read BEFORE broadcasting on purpose. A recovery log scan bounded by a
+        # block number taken afterwards could start past the block the transaction landed
+        # in, and would then conclude it never happened.
+        try:
+            sent_at_block = client.block_number()
+        except Exception:  # noqa: BLE001 — a missing bound only widens the recovery scan
+            sent_at_block = None
+        on_sent({
+            "hash": signed["hash"],
+            "nonce": int(tx["nonce"]),
+            "sentAtBlock": sent_at_block,
+            "maxFeePerGas": int(tx.get("maxFeePerGas") or 0),
+            "maxPriorityFeePerGas": int(tx.get("maxPriorityFeePerGas") or 0),
+            "gas": int(tx.get("gas") or 0),
+        })
+
+    # Print the hash before the send, not after: if the node accepts the transaction and
+    # the connection then drops, the hash is the only way to find it again.
+    if on_hash:
+        on_hash(signed["hash"])
+    sent = client.send_raw_transaction(signed["raw"])
+    if strip0x(sent).lower() != strip0x(signed["hash"]).lower():
+        raise RuntimeError(f"node returned hash {sent}, expected {signed['hash']}")
+    return signed["hash"]
+
+
+def wait_for_receipt(client, tx_hash: str, timeout: float = RECEIPT_TIMEOUT_SECS,
+                     interval: float = RECEIPT_POLL_SECS) -> dict:
+    """Poll until mined. Times out rather than hanging forever on an underpriced send."""
+    deadline = time.monotonic() + timeout
+    while True:
+        receipt = client.get_receipt(tx_hash)
+        if receipt:
+            return receipt
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"no receipt for {tx_hash} after {timeout:.0f}s. The transaction may still "
+                "be pending — check the hash on an explorer before re-sending, or a "
+                "duplicate will be broadcast."
+            )
+        time.sleep(interval)
+
+
+def receipt_status(receipt: dict) -> str:
+    return "success" if int(receipt.get("status") or "0x0", 16) == 1 else "reverted"

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
@@ -148,6 +148,28 @@ def tier3_error_selectors() -> None:
         check(f"{signature} message is actionable",
               len(ERROR_MESSAGES[selector]) > 40, True)
 
+    # Iterate the whole table, not just the hand-listed subset above. An entry
+    # exempt from verification is exactly where a wrong selector hides — an
+    # earlier revision carried three, one of which collided with ZeroAmount()
+    # and so reported a completely different error with full confidence.
+    from poolsfun.factory import ERROR_SIGNATURES
+
+    check("every message is reachable by its computed selector",
+          all(ERROR_MESSAGES[function_selector(sig)] is msg
+              for sig, msg in ERROR_SIGNATURES.items()), True)
+    check("no two errors collide on a selector",
+          len(ERROR_MESSAGES), len(ERROR_SIGNATURES))
+    check("every signature is well formed",
+          all(s.endswith("()") and s[0].isupper() for s in ERROR_SIGNATURES), True)
+    # The selectors that used to be wrong, pinned to the right owners.
+    check("0x1f2a2005 is ZeroAmount, not DevBuyTooLarge",
+          function_selector("ZeroAmount()"), "0x1f2a2005")
+    check("ZeroAmount is not claimed by this factory's table",
+          "0x1f2a2005" in ERROR_MESSAGES, False)
+    check("DevBuyTooLarge selector", function_selector("DevBuyTooLarge()"), "0x82ce2bbd")
+    check("LockerUnset selector", function_selector("LockerUnset()"), "0xf619c36a")
+    check("InvalidTick selector", function_selector("InvalidTick()"), "0xce8ef7fc")
+
     check("TokenLaunched topic0",
           __import__("poolsfun.factory", fromlist=["x"]).TOPIC_TOKEN_LAUNCHED,
           "0xd1844be5e646143a1c9e6841471e58911bac843c7d033e435d304cfeba2c2153")
@@ -476,12 +498,97 @@ def tier10_signing_roundtrip() -> None:
           serialize_transaction(tx) != signed["raw"], True)
 
 
+def tier11_hostile_input() -> None:
+    """Argument handling under abuse. Every defect here was found by review."""
+    section("Tier 11 — hostile and malformed input")
+    import shlex
+
+    from poolsfun.chains import resolve_paired_asset, resolve_private_key
+    from poolsfun.fmt import opt_float, opt_int, opt_str, parse_args
+    from poolsfun.plan import require_launchable
+
+    # A key with one bad character must never reach an exception message.
+    bad = "0x" + "5" * 63 + "Z"
+    os.environ["POOLSFUN_PRIVATE_KEY"] = bad
+    try:
+        import poolsfun.chains as chains
+        chains._env_loaded = True
+        try:
+            resolve_private_key()
+            FAILURES.append("malformed key: expected a raise")
+        except RuntimeError as exc:
+            global CHECKS
+            CHECKS += 1
+            if bad[2:] in str(exc) or bad[2:20] in str(exc):
+                FAILURES.append("malformed key: KEY MATERIAL LEAKED into the error")
+        raises("malformed key names the variable",
+               resolve_private_key, contains="POOLSFUN_PRIVATE_KEY")
+    finally:
+        os.environ.pop("POOLSFUN_PRIVATE_KEY", None)
+
+    # Bare value-taking flags must be rejected, never coerced to 1/True.
+    for flag in ("slippage-bps", "deadline-secs", "max-salt-attempts"):
+        raises(f"bare --{flag} is rejected",
+               lambda f=flag: opt_int({f: True}, f, 100), contains="needs a value")
+    raises("bare --image is rejected",
+           lambda: opt_str({"image": True}, "image"), contains="needs a value")
+    raises("bare --gas-multiplier is rejected",
+           lambda: opt_float({"gas-multiplier": True}, "gas-multiplier", 1.3),
+           contains="needs a value")
+    raises("bare --paired is rejected",
+           lambda: resolve_paired_asset(True), contains="needs a value")
+
+    check("absent flags fall back to the default", opt_int({}, "x", 42), 42)
+    check("opt_str returns None when absent", opt_str({}, "x"), None)
+    check("opt_str trims", opt_str({"x": "  v  "}, "x"), "v")
+
+    # Slippage bounds: a negative value would set devBuyMinOut above the exact
+    # simulated fill, guaranteeing an on-chain DevBuyTooLittle() revert.
+    raises("negative slippage is rejected",
+           lambda: opt_int({"slippage-bps": "-500"}, "slippage-bps", 100,
+                           minimum=0, maximum=9_999), contains="at least 0")
+    raises("slippage >= 100% is rejected",
+           lambda: opt_int({"slippage-bps": "20000"}, "slippage-bps", 100,
+                           minimum=0, maximum=9_999), contains="at most 9999")
+    raises("non-numeric slippage is rejected",
+           lambda: opt_int({"slippage-bps": "lots"}, "slippage-bps", 100),
+           contains="whole number")
+
+    # The paused switch must fail closed when it could not be read.
+    raises("unknown paused state refuses to launch",
+           lambda: require_launchable({"paused": None, "locker": "0x" + "11" * 20}),
+           contains="unknown state")
+    raises("paused factory refuses to launch",
+           lambda: require_launchable({"paused": True, "locker": "0x" + "11" * 20}),
+           contains="paused")
+    raises("missing locker refuses to launch",
+           lambda: require_launchable({"paused": False, "locker": "0x" + "00" * 20}),
+           contains="locker")
+    require_launchable({"paused": False, "locker": "0x" + "11" * 20})
+
+    # The replay hint is a line the user is told to run: it must be shell-safe.
+    import pools_write
+
+    hostile = 'MyToken$(touch /tmp/pwned)`id`;rm -rf /'
+    line = pools_write._replay_command({"_": ["launch"], "name": hostile, "symbol": "T"})
+    check("replay quotes command substitution", "$(touch" in line and "'" in line, True)
+    check("replay round-trips through the shell lexer",
+          shlex.split(line)[shlex.split(line).index("--name") + 1], hostile)
+    check("replay leaves no bare metacharacter",
+          any(tok == hostile for tok in shlex.split(line)), True)
+
+    # parse_args' own contract, which everything above depends on.
+    args = parse_args(["launch", "--image", "--name", "T"])
+    check("bare flag before another flag yields True", args["image"], True)
+    check("the following flag is not consumed as a value", args["name"], "T")
+
+
 def main() -> int:
     print("poolsdotfun-token-launcher selftest — offline, no network")
     for tier in (tier1_reference_calldata, tier2_create2, tier3_error_selectors,
                  tier4_curve_math, tier5_plan_hash, tier6_metadata,
                  tier7_import_graph, tier8_cli_contract, tier9_chain_constants,
-                 tier10_signing_roundtrip):
+                 tier10_signing_roundtrip, tier11_hostile_input):
         try:
             tier()
             print("   ok")

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Offline selftest — no network, no key, no funds.
+
+Everything asserted here is pinned against something external and immutable: the
+reference launch transaction, the deployed factory's error selectors, or a
+property of the code's own structure. That is the point — a test that only checks
+the code against itself would pass just as happily after a refactor broke the
+calldata encoding, and the first sign of trouble would be a reverted launch.
+
+Run it after any change:
+
+    python3 selftest.py
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+FAILURES: list[str] = []
+CHECKS = 0
+
+
+def check(label: str, actual, expected=None, *, truthy: bool = False) -> None:
+    global CHECKS
+    CHECKS += 1
+    ok = bool(actual) if truthy else actual == expected
+    if not ok:
+        detail = f"expected {expected!r}, got {actual!r}" if not truthy else "falsy"
+        FAILURES.append(f"{label}: {detail}")
+
+
+def raises(label: str, fn, *, contains: str = "") -> None:
+    global CHECKS
+    CHECKS += 1
+    try:
+        fn()
+    except BaseException as exc:  # noqa: BLE001 — asserting the failure itself
+        if contains and contains.lower() not in str(exc).lower():
+            FAILURES.append(f"{label}: raised, but message lacks {contains!r} — {exc}")
+        return
+    FAILURES.append(f"{label}: expected a raise, got none")
+
+
+def section(title: str) -> None:
+    print(f"\n── {title}")
+
+
+# ── Tier 1: the reference launch ────────────────────────────────────────────
+# The single most valuable assertion in this file. If `launch` calldata encoding
+# ever drifts, this catches it offline instead of on-chain.
+REF_TX_INPUT = (
+    "0xce61a35c"
+    "0000000000000000000000000000000000000000000000000000000000000160"
+    "00000000000000000000000000000000000000000000000000000000000001a0"
+    "00000000000000000000000000000000000000000000000000000000000001e0"
+    "0000000000000000000000000000000000000000000000000000000000000007"
+    "0000000000000000000000000bd7d308f8e1639fab988df18a8011f41eacad73"
+    "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd1778"
+    "000000000000000000000000000000000000000000000000000000006a7d4cb4"
+    "0000000000000000000000008a86e3927bd9e4200bc18dad3a158caa4806ba51"
+    "0000000000000000000000008a86e3927bd9e4200bc18dad3a158caa4806ba51"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000009"
+    "506f6f6c732046756e0000000000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "504f4f4c00000000000000000000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000042"
+    "697066733a2f2f6261666b72656961766a75786f796b35796f676c6b73626c35"
+    "677479326d6b6737346673616f366732626c72356d6d6a66337772326b796f73"
+    "6d61000000000000000000000000000000000000000000000000000000000000"
+)
+REF_DEPLOYER = "0x8a86E3927BD9E4200BC18DAD3A158CAa4806Ba51"
+REF_METADATA = "ipfs://bafkreiavjuxoyk5yoglksbl5gty2mkg74fsao6g2blr5mmjf3wr2kyosma"
+REF_TOKEN = "0x0762a4F683f0531b70bC7D6882781457d80F689a"
+
+
+def tier1_reference_calldata() -> None:
+    section("Tier 1 — reference transaction")
+    from poolsfun.chains import WETH
+    from poolsfun.factory import encode_launch, salt_hex
+
+    encoded = encode_launch(
+        "Pools Fun", "POOL", REF_METADATA, salt_hex(7), WETH, -190600,
+        1786596532, REF_DEPLOYER, REF_DEPLOYER, 0, 0)
+    check("launch calldata matches tx 0x0978ee72…", encoded.lower(), REF_TX_INPUT.lower())
+    check("selector is 0xce61a35c", encoded[:10], "0xce61a35c")
+
+    # int24 negative encoding is the easiest thing to get subtly wrong.
+    check("int24 -190600 sign-extends",
+          encoded[10 + 64 * 5:10 + 64 * 6],
+          "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd1778")
+
+
+def tier2_create2() -> None:
+    """CREATE2 prediction, reproduced locally from the factory's own formula."""
+    section("Tier 2 — CREATE2 address derivation")
+    from poolsfun.factory import salt_hex
+    from poolsfun.keccak import keccak256_bytes
+
+    # effectiveSalt = keccak256(abi.encodePacked(deployer, salt))
+    packed = bytes.fromhex(REF_DEPLOYER[2:]) + bytes.fromhex(salt_hex(7)[2:])
+    effective = keccak256_bytes(packed)
+    check("effectiveSalt is 32 bytes", len(effective), 32)
+    check("effectiveSalt is deterministic", effective, keccak256_bytes(packed))
+    # A different deployer must land in a different namespace.
+    other = keccak256_bytes(bytes.fromhex("00" * 20) + bytes.fromhex(salt_hex(7)[2:]))
+    check("salt is namespaced by deployer", effective != other, True)
+
+    from poolsfun.chains import USDG, WETH
+    from poolsfun.factory import sorts_below
+    check("reference token sorts below WETH", sorts_below(REF_TOKEN, WETH), True)
+    check("WETH does not sort below the reference token",
+          sorts_below(WETH, REF_TOKEN), False)
+    check("USDG hit rate is the larger one",
+          int(USDG, 16) > int(WETH, 16), True)
+
+
+def tier3_error_selectors() -> None:
+    """Every custom error, recomputed from its signature."""
+    section("Tier 3 — revert decoding")
+    from poolsfun.factory import ERROR_MESSAGES, explain_revert
+    from poolsfun.keccak import function_selector
+
+    expected = {
+        "DeployFailed()": "0xb4f54111",
+        "StartTickChanged()": "0x0f5ddbb1",
+        "TokenNotToken0()": "0xd79cce06",
+        "Expired()": "0x203d82d8",
+        "CreatorNotCaller()": "0x7607bc0d",
+        "AmbiguousDevBuy()": "0x6e4e2579",
+        "DevBuyWethOnly()": "0xb6dc33e4",
+        "DevBuyTooLittle()": "0xedaf7b53",
+        "PairedAssetNotAllowed()": "0x5a9b44ca",
+        "Paused()": "0x9e87fac8",
+        "PoolAlreadyInitialized()": "0x7983c051",
+    }
+    for signature, selector in expected.items():
+        check(f"selector {signature}", function_selector(signature), selector)
+        check(f"{signature} has a message", selector in ERROR_MESSAGES, True)
+        check(f"{signature} message is actionable",
+              len(ERROR_MESSAGES[selector]) > 40, True)
+
+    check("TokenLaunched topic0",
+          __import__("poolsfun.factory", fromlist=["x"]).TOPIC_TOKEN_LAUNCHED,
+          "0xd1844be5e646143a1c9e6841471e58911bac843c7d033e435d304cfeba2c2153")
+
+    # Error(string) from a dependency must still decode.
+    payload = ("0x08c379a0" + "0" * 62 + "20" + "0" * 62 + "08"
+               + "6e6f742077657468".ljust(64, "0"))
+    check("Error(string) decodes", explain_revert(payload), "reverted: not weth")
+    check("unknown selector yields None", explain_revert("0xdeadbeef"), None)
+    check("non-hex yields None", explain_revert("nope"), None)
+
+
+def tier4_curve_math() -> None:
+    section("Tier 4 — curve math and tick bounds")
+    from poolsfun.factory import (
+        MAX_USABLE_TICK,
+        TICK_SPACING,
+        TOTAL_SUPPLY,
+        fdv_usd,
+        price_from_tick,
+        validate_start_tick,
+    )
+
+    check("TOTAL_SUPPLY", TOTAL_SUPPLY, 10**27)
+    check("MAX_USABLE_TICK", MAX_USABLE_TICK, 887200)
+    check("MAX_USABLE_TICK is spacing-aligned", MAX_USABLE_TICK % TICK_SPACING, 0)
+
+    # At the reference tick and ETH price, FDV lands on the $10k target.
+    fdv = fdv_usd(-190600, 1891.508)
+    check("reference FDV within 1% of $10k", 9900 < fdv < 10100, True)
+    check("price is monotonic in tick",
+          price_from_tick(-190400) > price_from_tick(-190600), True)
+
+    validate_start_tick(-190600)
+    validate_start_tick(0)
+    raises("rejects unaligned tick", lambda: validate_start_tick(-190601),
+           contains="multiple of 200")
+    raises("rejects tick at the upper bound",
+           lambda: validate_start_tick(MAX_USABLE_TICK), contains="outside")
+    raises("rejects tick below the lower bound",
+           lambda: validate_start_tick(-MAX_USABLE_TICK - 200), contains="outside")
+
+
+def tier5_plan_hash() -> None:
+    """The confirmation token must move for anything that changes the outcome."""
+    section("Tier 5 — PLAN_HASH sensitivity")
+    from poolsfun.chains import USDG, WETH
+    from poolsfun.plan import action_hash, plan_hash, verify_plan_unchanged
+
+    base = {
+        "name": "My Token", "symbol": "MYT", "metadataUri": "ipfs://a",
+        "salt": "0x" + "00" * 31 + "07", "pairedAsset": WETH,
+        "expectedStartTick": -190600, "creator": REF_DEPLOYER,
+        "feeRecipient": REF_DEPLOYER, "devBuyAmountIn": 0,
+        "devBuyValueWei": 10**15, "devBuyMinOut": 123, "chainId": 4663,
+        "factory": "0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4",
+    }
+    digest = plan_hash(base)
+    check("hash is 4 bytes", len(digest), 10)
+    check("hash is stable", plan_hash(dict(base)), digest)
+    check("hash is case-insensitive for addresses",
+          plan_hash({**base, "creator": REF_DEPLOYER.lower()}), digest)
+
+    for field, value in [
+        ("name", "Other"), ("symbol", "OTH"), ("metadataUri", "ipfs://b"),
+        ("salt", "0x" + "00" * 31 + "08"), ("pairedAsset", USDG),
+        ("expectedStartTick", -190400), ("creator", "0x" + "11" * 20),
+        ("feeRecipient", "0x" + "22" * 20), ("devBuyAmountIn", 1),
+        ("devBuyValueWei", 10**15 + 1), ("devBuyMinOut", 124),
+        ("chainId", 8453), ("factory", "0x" + "33" * 20),
+    ]:
+        check(f"hash changes with {field}",
+              plan_hash({**base, field: value}) != digest, True)
+
+    # Fields outside the commitment must NOT move it — otherwise every plan
+    # expires the moment the clock ticks.
+    for field, value in [("deadline", 999), ("gasPrice", 1), ("devBuyOut", 5)]:
+        check(f"hash ignores {field}", plan_hash({**base, field: value}), digest)
+
+    verify_plan_unchanged(base, digest)
+    verify_plan_unchanged(base, digest.upper())
+    raises("rejects a stale confirmation",
+           lambda: verify_plan_unchanged({**base, "devBuyMinOut": 999}, digest),
+           contains="plan changed")
+
+    # Non-launch actions get their own namespace, and the action is part of it.
+    token = REF_TOKEN
+    fields = {"token": token, "caller": REF_DEPLOYER, "chainId": 4663}
+    check("collect != claim", action_hash("collect", fields)
+          != action_hash("claim", fields), True)
+    check("action hash is stable",
+          action_hash("collect", dict(fields)), action_hash("collect", fields))
+
+
+def tier6_metadata() -> None:
+    """Pinata is optional. This tier is the regression guard for that."""
+    section("Tier 6 — metadata and the optional Pinata path")
+    saved = os.environ.pop("PINATA_JWT", None)
+    try:
+        import poolsfun.chains as chains
+        chains._env_loaded = True  # do not let a stray .env re-inject a JWT
+        from poolsfun.metadata import (
+            _guess_mime,
+            _multipart,
+            build_metadata,
+            pinata_configured,
+            resolve_metadata_uri,
+            to_data_uri,
+        )
+
+        check("no JWT means not configured", pinata_configured(), False)
+
+        uri, doc, how = resolve_metadata_uri(name="My Token", symbol="MYT",
+                                             description="hi")
+        check("image-less launch works with no secret", how, "inline (no image)")
+        check("data URI scheme", uri.startswith("data:application/json;base64,"), True)
+        decoded = json.loads(base64.b64decode(uri.split(",", 1)[1]))
+        check("inline doc round-trips",
+              decoded, {"name": "My Token", "symbol": "MYT", "description": "hi"})
+        check("empty fields are omitted, not nulled", "image" in decoded, False)
+
+        check("pass-through is untouched",
+              resolve_metadata_uri(name="A", symbol="B",
+                                   metadata_uri="ipfs://x")[0], "ipfs://x")
+        for scheme in ("ipfs://x", "https://x", "data:application/json,{}"):
+            resolve_metadata_uri(name="A", symbol="B", metadata_uri=scheme)
+        raises("rejects a bad URI scheme",
+               lambda: resolve_metadata_uri(name="A", symbol="B",
+                                            metadata_uri="ftp://x"),
+               contains="must start with")
+
+        # The critical one: --image without a JWT must fail loudly, never
+        # silently launch an image-less token with an immutable identity.
+        png = Path(tempfile.mkdtemp()) / "logo.png"
+        png.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+        raises("--image without PINATA_JWT refuses",
+               lambda: resolve_metadata_uri(name="A", symbol="B", image=str(png)),
+               contains="PINATA_JWT")
+        raises("the refusal names the escape hatch",
+               lambda: resolve_metadata_uri(name="A", symbol="B", image=str(png)),
+               contains="drop --image")
+        raises("--pin-metadata without PINATA_JWT refuses",
+               lambda: resolve_metadata_uri(name="A", symbol="B", pin=True),
+               contains="PINATA_JWT")
+
+        check("build_metadata field order",
+              list(build_metadata("n", "s", description="d", image="i",
+                                  website="w", twitter="t")),
+              ["name", "symbol", "description", "image", "website", "twitter"])
+        raises("oversized inline metadata is refused",
+               lambda: to_data_uri(build_metadata("n", "s", description="x" * 9000)),
+               contains="inline metadata")
+
+        # Webchat attachments often have a wrong or missing extension.
+        check("sniffs PNG past a wrong extension",
+              _guess_mime(Path("a.bin"), b"\x89PNG\r\n\x1a\n"), "image/png")
+        check("sniffs JPEG", _guess_mime(Path("a.bin"), b"\xff\xd8\xff\xe0"), "image/jpeg")
+        check("falls back to the extension", _guess_mime(Path("a.webp"), b"???"),
+              "image/webp")
+
+        body, content_type = _multipart({"f": "v"}, "l.png", "image/png", b"data")
+        boundary = content_type.split("boundary=")[1]
+        check("multipart has 3 boundary occurrences", body.count(boundary.encode()), 3)
+        check("multipart terminates correctly", body.endswith(b"--\r\n"), True)
+        check("multipart carries the payload", b"data" in body, True)
+    finally:
+        if saved is not None:
+            os.environ["PINATA_JWT"] = saved
+
+
+def tier7_import_graph() -> None:
+    """The read path must not be able to sign. Structure, not convention."""
+    section("Tier 7 — capability separation")
+    source_dir = Path(__file__).resolve().parent
+
+    read_src = (source_dir / "pools_read.py").read_text()
+    # Match import statements, not the substring: the module's own docstring
+    # mentions secp256k1 to explain why it is absent, and a naive `in` check
+    # fails on the documentation rather than on a real import.
+    import re
+
+    imports = re.findall(r"^\s*(?:from|import)\s+\S+.*$", read_src, re.MULTILINE)
+    check("pools_read does not import secp256k1",
+          any("secp256k1" in line for line in imports), False)
+    check("pools_read does not import tx",
+          any(re.search(r"poolsfun\.tx\b", line) for line in imports), False)
+    check("pools_read never calls resolve_private_key",
+          "resolve_private_key(" in read_src, False)
+
+    # Import it for real and assert no signing function is reachable.
+    import importlib
+
+    module = importlib.import_module("pools_read")
+    reachable = set()
+    for value in vars(module).values():
+        mod = getattr(value, "__module__", "")
+        if isinstance(mod, str) and mod.startswith("poolsfun"):
+            reachable.add(mod)
+    check("no signing module in pools_read's namespace",
+          any("secp256k1" in m for m in reachable), False)
+    check("sys.modules has no secp256k1 after importing pools_read",
+          any("secp256k1" in m for m in sys.modules), False)
+
+    plan_src = (source_dir / "poolsfun" / "plan.py").read_text()
+    check("plan.py does not import secp256k1", "secp256k1" in plan_src, False)
+
+    from poolsfun import account
+    check("account.py exposes no sign_digest", hasattr(account, "sign_digest"), False)
+    from poolsfun import secp256k1
+    check("secp256k1.py does expose sign_digest",
+          hasattr(secp256k1, "sign_digest"), True)
+
+    write_src = (source_dir / "pools_write.py").read_text()
+    # One definition plus one call site per write path (launch, the shared locker
+    # writer, set-fee-recipient, approve). A new write command that forgets the
+    # gate moves this count.
+    call_sites = write_src.count("_confirmed(") - write_src.count("def _confirmed(")
+    check("every write path goes through the confirm gate", call_sites, 4)
+    check("_send refuses planning mode",
+          "planning mode; it cannot broadcast" in write_src, True)
+
+
+def tier8_cli_contract() -> None:
+    section("Tier 8 — CLI surface")
+    import importlib
+
+    from poolsfun.fmt import parse_args
+
+    args = parse_args(["launch", "--name", "My Token", "--symbol=MYT",
+                       "--broadcast", "--dev-buy", "0.001"])
+    check("positional command", args["_"], ["launch"])
+    check("--flag value", args["name"], "My Token")
+    check("--flag=value", args["symbol"], "MYT")
+    check("bare flag is True", args["broadcast"], True)
+    check("hyphenated keys are preserved", args["dev-buy"], "0.001")
+
+    read_mod = importlib.import_module("pools_read")
+    write_mod = importlib.import_module("pools_write")
+    check("read commands", sorted(read_mod.COMMANDS),
+          ["assets", "fees", "mine-salt", "preflight", "simulate", "token"])
+    check("write commands", sorted(write_mod.COMMANDS),
+          ["approve", "claim", "collect", "collect-and-claim", "launch",
+           "set-fee-recipient"])
+    # Every write command must be reachable by the name it prints in its own
+    # copy-paste hint, or the hint is a dead end.
+    for name in write_mod.COMMANDS:
+        check(f"{name} is dispatchable", callable(write_mod.COMMANDS[name]), True)
+
+    check("read usage mentions every command",
+          all(c in read_mod.USAGE for c in read_mod.COMMANDS), True)
+    check("write usage mentions every command",
+          all(c in write_mod.USAGE for c in write_mod.COMMANDS), True)
+    check("usage states the price is fixed",
+          "cannot be set" in write_mod.USAGE, True)
+
+
+def tier9_chain_constants() -> None:
+    section("Tier 9 — pinned deployment constants")
+    from poolsfun import chains
+
+    check("chain id", chains.CHAIN_ID, 4663)
+    check("rpc is hardcoded", chains.RPC_URL,
+          "https://rpc.mainnet.chain.robinhood.com/")
+    check("factory", chains.PARTY_FACTORY,
+          "0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4")
+    check("locker", chains.PARTY_LOCKER,
+          "0x35E41f84d3fD61d4648F0c8B41a1E7d301bCd75E")
+    check("weth", chains.WETH, "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73")
+    check("usdg", chains.USDG, "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168")
+    check("signer env", chains.ENV_SIGNER, "POOLSFUN_PRIVATE_KEY")
+    check("no RPC env var is declared", hasattr(chains, "ENV_RPC"), False)
+
+    check("paired default is WETH", chains.resolve_paired_asset(None), chains.WETH)
+    check("--paired weth", chains.resolve_paired_asset("weth"), chains.WETH)
+    check("--paired USDG is case-insensitive",
+          chains.resolve_paired_asset("USDG"), chains.USDG)
+    check("--paired accepts an address",
+          chains.resolve_paired_asset(chains.WETH.lower()), chains.WETH)
+    raises("--paired rejects nonsense",
+           lambda: chains.resolve_paired_asset("doge"), contains="unknown paired asset")
+    check("asset labels", chains.asset_label(chains.WETH), "WETH")
+
+    saved = os.environ.pop("POOLSFUN_PRIVATE_KEY", None)
+    try:
+        chains._env_loaded = True
+        raises("missing key names the variable and the fix",
+               chains.resolve_private_key, contains="POOLSFUN_PRIVATE_KEY")
+    finally:
+        if saved is not None:
+            os.environ["POOLSFUN_PRIVATE_KEY"] = saved
+
+    # A key is never accepted from the command line.
+    write_src = (Path(__file__).resolve().parent / "pools_write.py").read_text()
+    check("no --private-key flag exists", "private-key" in write_src, False)
+
+
+def tier10_signing_roundtrip() -> None:
+    """Signing correctness, with a well-known throwaway key. Nothing is sent."""
+    section("Tier 10 — signing")
+    from poolsfun.account import account_from_private_key
+    from poolsfun.secp256k1 import sign_digest
+    from poolsfun.tx import serialize_transaction, sign_transaction
+
+    # Hardhat account #1. Public, funded nowhere, safe to pin.
+    key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    account = account_from_private_key(key)
+    check("derives the known address", account["address"],
+          "0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+    check("account dict never carries the key", "privateKey" in account, False)
+
+    check("RFC 6979 is deterministic",
+          sign_digest(b"\x01" * 32, key), sign_digest(b"\x01" * 32, key))
+
+    tx = {"type": "eip1559", "chainId": 4663, "nonce": 0,
+          "maxPriorityFeePerGas": 10**9, "maxFeePerGas": 2 * 10**9,
+          "to": "0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4",
+          "value": 10**15, "data": "0x", "gas": 7_000_000}
+    signed = sign_transaction(dict(tx), key)
+    check("recovers to the signer", signed["from"], account["address"])
+    check("serialises as type 2", signed["raw"].startswith("0x02"), True)
+    check("signing is deterministic", sign_transaction(dict(tx), key)["raw"],
+          signed["raw"])
+    check("a different chain id yields different bytes",
+          sign_transaction({**tx, "chainId": 8453}, key)["raw"] != signed["raw"], True)
+    check("unsigned serialisation differs from signed",
+          serialize_transaction(tx) != signed["raw"], True)
+
+
+def main() -> int:
+    print("poolsdotfun-token-launcher selftest — offline, no network")
+    for tier in (tier1_reference_calldata, tier2_create2, tier3_error_selectors,
+                 tier4_curve_math, tier5_plan_hash, tier6_metadata,
+                 tier7_import_graph, tier8_cli_contract, tier9_chain_constants,
+                 tier10_signing_roundtrip):
+        try:
+            tier()
+            print("   ok")
+        except BaseException as exc:  # noqa: BLE001 — report, keep going
+            FAILURES.append(f"{tier.__name__} raised: {exc!r}")
+            print(f"   ERROR {exc!r}")
+
+    print(f"\n{CHECKS} checks, {len(FAILURES)} failures")
+    for failure in FAILURES:
+        print(f"  FAIL  {failure}")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -48,6 +48,7 @@ DEFAULTS = (
         "nano-banana-pro",
         "nano-pdf",
         "pdf-toolkit",
+        "poolsdotfun-token-launcher",
         "pptx",
         "robinhood-agentic-trading",
         "robinhood-rwa-addresses",
@@ -72,7 +73,7 @@ DEFAULTS = (
 # `requires.env`, so `gate_skills` drops them while any of those variables is unset. That is
 # the intended "Needs setup" behaviour, not a regression. The gmgn-* skills additionally
 # require the third-party `gmgn-cli` binary, which AgentOS does not ship.
-ENV_GATED_DEFAULTS = {"senior-unilp-manager"} | GMGN_DEFAULTS
+ENV_GATED_DEFAULTS = {"senior-unilp-manager", "poolsdotfun-token-launcher"} | GMGN_DEFAULTS
 PROMPT_DEFAULTS_WITHOUT_AUDIO_TOOLS = DEFAULTS - AUDIO_DEFAULTS - ENV_GATED_DEFAULTS
 INTERNAL_HELPERS = {
     "stack-trace-generic-probe",

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -24,6 +24,7 @@ ORIGINALS = {
     "music-and-singing-studio",
     "nano-pdf",
     "pdf-toolkit",
+    "poolsdotfun-token-launcher",
     "pptx",
     "robinhood-agentic-trading",
     "robinhood-rwa-addresses",


### PR DESCRIPTION
Closes #298

Adds a bundled crypto skill that launches tokens on **pools.fun** (Robinhood Chain, 4663) through the `PartyFactory` at `0x626C3d09B65bF5d1D40E0D5F25e19fa49783B3D4`, and manages creator fees on the `PartyLocker` afterwards.

## The shape of it

A launch needs **a name, a symbol, and optionally an image**:

```
$ pools_write.py launch --name "My Token" --symbol MYT --image ./logo.png

  name / symbol : My Token / MYT
  metadata      : ipfs://bafkrei…  (image pinned via Pinata)
  paired asset  : WETH  0x0Bd7D308…   [default]
  salt          : 0x0000000000…0015  (mined, 22 tries)
  token address : 0x00AcDb51C6d3e127369Dc6F70B74D4f01C18ddc6  (predicted)
  start tick    : -190600  (live feed)
  launch FDV    : $9.99K   protocol-fixed
  supply        : 1,000,000,000   protocol-fixed
  LP            : minted to the locker, permanently
  dev buy       : 0 — you receive no tokens at launch   [default]

  PLAN_HASH  0x16109af7
```

Nothing is sent until the hash is echoed back with `--broadcast --confirm`. Every default is printed and labelled, so it can be seen and overridden one at a time. Dev buy defaults to **0** — the skill never spends money the user did not ask it to.

## Two findings that shaped the implementation

Both derived from the factory's verified source and confirmed with live `eth_call`s against the reference launch, [tx `0x0978ee72…`](https://robinhoodchain.blockscout.com/tx/0x0978ee728eb9ae5e78c7f461fea96dc9372315b7eee5a69e91ba914d98d8d1c0):

**A salt must be mined off-chain.** The factory mints single-sided liquidity and reverts `TokenNotToken0()` unless the CREATE2 address sorts below the paired asset — only ~4.6% of salts qualify against WETH, so a launch cannot be assembled without a search. `mine_salt` batches `computeTokenAddress` calls (40 per round trip; the public endpoint 429s at 100) and usually resolves in one.

**`launch` is exactly simulatable.** `eth_call` with `devBuyMinOut = 0` returns the true `(token, pool, devBuyOut)`, because the dev buy is the pool's first swap inside the same transaction and cannot be front-run. Simulating the reference parameters reproduces its fill to the wei — `187410.002243581166618109`. That is what makes simulate-then-send a guarantee rather than an estimate, and it is what `PLAN_HASH` commits to.

## Deliberate non-features

**The launch price is not exposed.** `expectedStartTick` reads like a knob and is a race guard: the factory derives its own tick and reverts `StartTickChanged()` on mismatch. The tick tracks `initialFdvUsd`, and `setInitialFdvUsd` is `onlyOwner`. Every pools.fun token opens at ~$10k FDV and a dev buy only moves price up, so there is no caller input that produces a different opening market cap. The skill reports the FDV, refuses to launch when the tick came from the degraded fallback path, and offers an optional `--expect-fdv` guard — rather than a flag that cannot work.

**No RPC env var.** Single-chain, low-volume; the endpoint is a constant. `--rpc` remains for debugging.

**`PINATA_JWT` is optional and intentionally absent from `requires.env`.** That field is a hard eligibility gate (`skills/eligibility.py::_has_env`), so declaring it would make the whole skill unavailable whenever it is unset. An image-less launch inlines its metadata as a `data:application/json;base64,…` URI and needs no secret at all. `--image` without a JWT fails loudly rather than silently launching a token whose identity is already immutable.

**Community takeover** (`queueCto`/`executeCto`/`cancelCto`) is out of scope.

## Structure

`scripts/poolsfun/` vendors the stdlib crypto/RPC layer from `senior-unilp-manager` — keccak, RLP, secp256k1, ABI codec, transaction builder, RPC batching — so the skill is self-contained and independently installable. Copied verbatim where possible to stay diffable against the original; `chains.py` is rewritten for one chain and `rpc.py` takes a two-line change for the constant endpoint.

The read/write split is an **import-graph invariant**, not a convention: `pools_read.py` cannot reach a signing function, and `selftest.py` asserts it structurally rather than trusting the docstring.

| | |
|---|---|
| `pools_read.py` | `preflight`, `assets`, `mine-salt`, `simulate`, `token`, `fees` |
| `pools_write.py` | `launch`, `approve`, `collect`, `claim`, `collect-and-claim`, `set-fee-recipient` |

## Verification

- `scripts/selftest.py` — **144 offline checks, 0 failures**, no network or key. Pins launch calldata byte-for-byte against the reference transaction, all 11 custom error selectors recomputed from their signatures, PLAN_HASH sensitivity (13 fields move it, 3 correctly do not), the Pinata-optional matrix, and capability separation.
- `uv run ruff check src tests` — clean.
- `uv run mypy src/agentos` — one pre-existing `mem0` stub error, untouched by this change.
- `uv run pytest -q -m "not llm"` — **7657 passed**. Three failures are pre-existing and environmental (`mem0` installed locally, `weasyprint` missing); verified identical with this branch stashed.
- Wheel build confirmed all 18 files ship, including `assets/`.
- Live reads against mainnet: `preflight`, `assets`, `simulate`, `token`, `fees` all correct against the reference launch (LP NFT #4436, FDV $9,990 vs the $10,000 target).

No launch has been broadcast — every on-chain check was a read or an `eth_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
