### PR TITLE
feat(skills): flamingo mark + make chat-attached logos findable

### DIFF
--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
@@ -152,53 +152,55 @@ attach a logo.
 
 **Read this before hunting for a path.** When a user attaches an image and says
 "use this as the logo", you receive the *pixels* — an image content block. You
-are never told a filename or a path, and for anything under about 2 MB **no file
-is written at all**: AgentOS keeps small attachments inline in the transcript.
-Guessing at paths like `./logo.png` or `/tmp/image.png` will fail, and repeated
-guessing is the failure mode this section exists to prevent.
+are never told a filename or a path, and anything under about 2 MB (most logos)
+is never written to the filesystem at all.
 
-Larger attachments (and everything arriving through a channel adapter) *are*
-staged to disk, content-addressed and with no file extension:
-
-```
-~/.agentos/media/transcripts/<session-id>/<sha256-of-the-bytes>
-```
-
-Nothing hands you that sha, so run:
+The bytes are not lost, though: every attachment is recorded in the transcript
+database. Run:
 
 ```bash
 python3 "$S/pools_read.py" find-image
 ```
 
-It lists staged images newest-first with type, size and full path, and prints
-the exact `launch --image …` line to use. If it finds nothing, that is a real
-answer — the image is not on disk — and it prints the alternatives.
+It reads the transcript, lists image attachments **newest message first** with
+age and session, extracts the newest to a real file, and prints the
+`launch --image …` line to use:
 
-**In order of preference:**
+```
+  WHEN         AGE  NAME        TYPE     SIZE  SOURCE  SESSION
+  08-13 14:27   8m  image.png   png    210 KB  inline  twan0934
+  08-10 07:42   3d  shot.png    png   3088 KB  staged  9ep5wkxp
 
-1. `find-image` returns a candidate whose type and size match what was sent →
-   pass that path to `--image`.
-2. Otherwise **ask the user for the file path** on their machine. In the CLI they
-   can run `! ls ~/Downloads/*.png`, or drag the file into the terminal to paste
-   its path. This is the reliable route and it is not a failure to ask.
-3. If the logo is already hosted anywhere, skip Pinata: `--metadata-uri
-   ipfs://…` or an `https://…` URL pointing at the metadata JSON.
-4. Launch with no logo. The metadata still inlines and the token still launches —
-   but say so explicitly first, because **a logo cannot be added afterwards**.
+  newest written to: /tmp/poolsfun-logos/1fac1c53dc6af1cd.png
+```
 
-Never fabricate a path, and never silently launch without the image when the
-user asked for one.
+**Always open the extracted file and confirm it is the right picture before
+pinning it.** A token's logo is immutable once the transaction lands.
 
-### Dev buys
+Two things that make this trustworthy, and which a directory listing cannot do:
 
-Two funding modes, never both (the factory reverts `AmbiguousDevBuy()`):
+* Ordering is by the **message's own timestamp**, so "newest" means "most
+  recently sent", not "most recently written to disk".
+* Each row carries its **session**. A candidate from another session, or one
+  hours old, is flagged — it is almost certainly not what was just sent.
 
-* `--dev-buy <eth>` sends native ETH. **WETH pairs only.**
-* `--dev-buy-asset <amount>` pulls the paired ERC20 and needs an allowance first:
-  `python3 "$S/pools_write.py" approve --paired usdg`
+Do not fall back to scanning `~/.agentos/media` by hand. Blobs there are
+content-addressed with no extension and no link back to a message; picking the
+newest one has already produced a completely unrelated image.
 
-The quoted fill is exact, not an estimate — the swap is the pool's first, inside
-the launch transaction.
+**If `find-image` reports nothing**, in order of preference:
+
+1. **Ask the user for the file path** on their machine. In the CLI they can run
+   `! ls ~/Downloads/*.png`, or drag the file into the terminal. This is not a
+   failure — it is the reliable route.
+2. If the logo is already hosted, skip Pinata: `--metadata-uri ipfs://…` or an
+   `https://…` URL pointing at the metadata JSON.
+3. Launch with no logo. The metadata still inlines and the token still
+   launches — but say so explicitly first, because **a logo cannot be added
+   afterwards**.
+
+Never fabricate a path, never pin an image you have not looked at, and never
+silently launch without the image when the user asked for one.
 
 ## Part C — Creator fees
 

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
@@ -9,7 +9,7 @@ provenance:
   maintained_by: AgentOS
 metadata:
   agentos:
-    emoji: "🎈"
+    emoji: "🦩"
     category: crypto
     risk: high
     capabilities: [network-read, network-write, signing]

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: poolsdotfun-token-launcher
-description: "Launch a token on pools.fun (Robinhood Chain, 4663) through the PartyFactory, and manage the creator fees afterwards. Use when the user wants to create, launch, or deploy a memecoin or token on pools.fun, asks what a launch would cost or what price it would open at, wants to simulate or dry-run a launch, wants to mine a launch salt, or wants to collect/claim creator fees or change the fee recipient for a token they launched. NOT for: buying or selling existing tokens, Uniswap v3/v4 LP positions, or launches on any other chain or launchpad."
+description: "Launch a token on pools.fun (Robinhood Chain, 4663) through the PartyFactory, and manage the creator fees afterwards. Use when the user wants to create, launch, or deploy a memecoin or token on pools.fun, asks what a launch would cost or what price it would open at, wants to simulate or dry-run a launch, wants to mine a launch salt, wants to attach an image or logo to a token they are launching, or wants to collect/claim creator fees or change the fee recipient for a token they launched. NOT for: buying or selling existing tokens, Uniswap v3/v4 LP positions, or launches on any other chain or launchpad."
 homepage: https://pools.fun/
-triggers: [pools.fun, poolsdotfun, launch token, create token, memecoin launch, robinhood chain, party factory, dev buy]
+triggers: [pools.fun, poolsdotfun, launch token, create token, memecoin launch, robinhood chain, party factory, dev buy, token logo]
 provenance:
   origin: agentos-original
   license: MIT
@@ -86,6 +86,7 @@ python3 "$S/pools_read.py" mine-salt --name "My Token" --symbol MYT --deployer 0
 python3 "$S/pools_read.py" simulate --name "My Token" --symbol MYT --dev-buy 0.001 --from 0xYou
 python3 "$S/pools_read.py" token 0xTokenAddress   # a launched token's pool, price, LP
 python3 "$S/pools_read.py" fees  0xTokenAddress   # creator fee position
+python3 "$S/pools_read.py" find-image             # locate a chat-attached logo
 ```
 
 Start with `preflight`. It answers the three questions that decide whether a
@@ -136,9 +137,9 @@ Identity flags: `--description`, `--website`, `--twitter`, `--metadata-uri`,
 Three paths, picked automatically:
 
 1. `--metadata-uri ipfs://…` — you already host it. Never touches Pinata.
-2. `--image ./logo.png` — pins the logo and the metadata JSON to IPFS.
-   **Requires `PINATA_JWT`.** In AgentOS webchat, an attached image lands on disk;
-   pass that path here.
+2. `--image <path>` — pins the logo and the metadata JSON to IPFS.
+   **Requires `PINATA_JWT`.** `<path>` is a real file on this machine — see
+   "Getting the image" below, because a chat attachment usually is not one.
 3. Neither — the metadata JSON is inlined as a `data:application/json;base64,…`
    URI. **No secret, no network.** This is the default and it works everywhere.
 
@@ -146,6 +147,47 @@ If `--image` is passed without `PINATA_JWT` the command **fails** rather than
 launching without the picture. That is deliberate: the token's identity is
 immutable the moment the transaction lands, and there is no second chance to
 attach a logo.
+
+### Getting the image when the user attached it in chat
+
+**Read this before hunting for a path.** When a user attaches an image and says
+"use this as the logo", you receive the *pixels* — an image content block. You
+are never told a filename or a path, and for anything under about 2 MB **no file
+is written at all**: AgentOS keeps small attachments inline in the transcript.
+Guessing at paths like `./logo.png` or `/tmp/image.png` will fail, and repeated
+guessing is the failure mode this section exists to prevent.
+
+Larger attachments (and everything arriving through a channel adapter) *are*
+staged to disk, content-addressed and with no file extension:
+
+```
+~/.agentos/media/transcripts/<session-id>/<sha256-of-the-bytes>
+```
+
+Nothing hands you that sha, so run:
+
+```bash
+python3 "$S/pools_read.py" find-image
+```
+
+It lists staged images newest-first with type, size and full path, and prints
+the exact `launch --image …` line to use. If it finds nothing, that is a real
+answer — the image is not on disk — and it prints the alternatives.
+
+**In order of preference:**
+
+1. `find-image` returns a candidate whose type and size match what was sent →
+   pass that path to `--image`.
+2. Otherwise **ask the user for the file path** on their machine. In the CLI they
+   can run `! ls ~/Downloads/*.png`, or drag the file into the terminal to paste
+   its path. This is the reliable route and it is not a failure to ask.
+3. If the logo is already hosted anywhere, skip Pinata: `--metadata-uri
+   ipfs://…` or an `https://…` URL pointing at the metadata JSON.
+4. Launch with no logo. The metadata still inlines and the token still launches —
+   but say so explicitly first, because **a logo cannot be added afterwards**.
+
+Never fabricate a path, and never silently launch without the image when the
+user asked for one.
 
 ### Dev buys
 
@@ -188,6 +230,7 @@ and is usually what you want. Each takes the same `--broadcast --confirm` gate.
 | `--broadcast needs --confirm` | Dry run not confirmed | Re-run with the printed hash |
 | `plan changed since it was printed` | Feed moved, or a flag differs from the dry run | Re-read the plan, confirm the new hash |
 | `PINATA_JWT is not set` | `--image` without Pinata | Set it, or drop `--image` |
+| `image not found: …` | Guessed a path for a chat attachment | Run `find-image`; if empty, ask the user for the real path |
 | `no qualifying salt in N attempts` | Unlucky search | Raise `--max-salt-attempts` |
 | `env var POOLSFUN_PRIVATE_KEY is not set` | No signing key | Set it, or pass `--from 0x…` to plan only |
 

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
@@ -84,6 +84,11 @@ pools_read.py — read pools.fun launch state (never signs, never spends)
   fees <address>
       Creator fee position for a launched token.
 
+  find-image [--session <id>] [--limit <n>]
+      Locate an image the user attached in chat, so it can be passed to
+      `launch --image`. AgentOS never tells you the path, and small images
+      are never written to disk at all — this reports what is actually there.
+
 Common flags
   --json          machine-readable output
   --paired        weth (default) or usdg
@@ -426,6 +431,63 @@ def cmd_fees(client: RpcClient, args: dict) -> None:
     _emit(args, payload, render)
 
 
+def cmd_find_image(client: RpcClient, args: dict) -> None:
+    """Locate a user-attached image on disk, or explain why there is none.
+
+    Exists because AgentOS never tells the model where an attachment lives, so
+    an agent asked to "use the image I just sent as the logo" has nothing to
+    pass to --image and will otherwise guess at paths that do not exist.
+    """
+    import time as _time
+
+    from poolsfun.metadata import agentos_media_root, find_attachment_images
+
+    session = opt_str(args, "session")
+    limit = opt_int(args, "limit", 10, minimum=1, maximum=200)
+    root = agentos_media_root()
+    images = find_attachment_images(session=session, limit=limit)
+
+    payload = {"mediaRoot": str(root), "session": session,
+               "images": images, "found": len(images)}
+
+    def render() -> None:
+        print(heading("attached images found on disk"))
+        if not images:
+            print(f"  none under {root}/transcripts\n")
+            print("  This usually means the image was never written to disk. AgentOS")
+            print("  keeps attachments under ~2 MB inline in the transcript, so the")
+            print("  model receives the pixels but no file exists to pin.")
+            print("\n  To attach a logo anyway, pick one:")
+            print("    - Ask the user for the image's path on their machine, then")
+            print("      pass it to `pools_write.py launch --image <path>`.")
+            print("    - If the logo is already hosted, skip Pinata entirely:")
+            print("      `--metadata-uri ipfs://…` or an https URL.")
+            print("    - Launch without a logo now; the metadata is inlined and the")
+            print("      token still launches. Note it cannot be added later.")
+            return
+        print(render_table([
+            {"key": "when", "label": "WHEN"},
+            {"key": "mime", "label": "TYPE"},
+            {"key": "size", "label": "SIZE", "align": "right"},
+            {"key": "session", "label": "SESSION"},
+            {"key": "path", "label": "PATH"},
+        ], [
+            {
+                "when": _time.strftime("%Y-%m-%d %H:%M", _time.localtime(i["mtime"])),
+                "mime": i["mime"].split("/")[-1],
+                "size": f"{i['bytes'] / 1024:.0f} KB",
+                "session": i["session"][:12],
+                "path": i["path"],
+            }
+            for i in images
+        ]))
+        print("\n  Newest first. Staged attachments are named after their sha256 and")
+        print("  carry no extension — confirm it is the right picture before pinning.")
+        print(f"\n  Then: pools_write.py launch --name … --symbol … --image {images[0]['path']}")
+
+    _emit(args, payload, render)
+
+
 def _parse_eth(value: Any) -> int:
     if value is None:
         return 0
@@ -445,6 +507,7 @@ COMMANDS = {
     "simulate": cmd_simulate,
     "token": cmd_token,
     "fees": cmd_fees,
+    "find-image": cmd_find_image,
 }
 
 

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/pools_read.py
@@ -440,52 +440,104 @@ def cmd_find_image(client: RpcClient, args: dict) -> None:
     """
     import time as _time
 
-    from poolsfun.metadata import agentos_media_root, find_attachment_images
+    from poolsfun.metadata import (
+        STALE_ATTACHMENT_SECONDS,
+        agentos_media_root,
+        find_attachment_images,
+        find_chat_images,
+        materialize_chat_image,
+        sessions_db_path,
+    )
 
     session = opt_str(args, "session")
     limit = opt_int(args, "limit", 10, minimum=1, maximum=200)
-    root = agentos_media_root()
-    images = find_attachment_images(session=session, limit=limit)
+    extract = not args.get("no-extract")
 
-    payload = {"mediaRoot": str(root), "session": session,
-               "images": images, "found": len(images)}
+    images = find_chat_images(session=session, limit=limit)
+    now = _time.time()
+    written: str | None = None
+    error: str | None = None
+
+    if images and extract:
+        try:
+            written = str(materialize_chat_image(images[0]))
+        except Exception as exc:  # noqa: BLE001 — reported, not fatal
+            error = str(exc)
+
+    # Only if the transcript told us nothing: the media directory cannot say
+    # which message a blob belongs to, so it is a hint, never an answer.
+    staged = [] if images else find_attachment_images(limit=limit)
+
+    payload = {"images": images, "found": len(images), "extractedTo": written,
+               "extractError": error, "staged": staged,
+               "sessionsDb": str(sessions_db_path())}
 
     def render() -> None:
-        print(heading("attached images found on disk"))
+        print(heading("images the user attached in chat"))
         if not images:
-            print(f"  none under {root}/transcripts\n")
-            print("  This usually means the image was never written to disk. AgentOS")
-            print("  keeps attachments under ~2 MB inline in the transcript, so the")
-            print("  model receives the pixels but no file exists to pin.")
-            print("\n  To attach a logo anyway, pick one:")
-            print("    - Ask the user for the image's path on their machine, then")
-            print("      pass it to `pools_write.py launch --image <path>`.")
-            print("    - If the logo is already hosted, skip Pinata entirely:")
-            print("      `--metadata-uri ipfs://…` or an https URL.")
-            print("    - Launch without a logo now; the metadata is inlined and the")
-            print("      token still launches. Note it cannot be added later.")
+            print(f"  no image attachment found in {sessions_db_path()}")
+            if staged:
+                print(f"\n  {len(staged)} image(s) exist under "
+                      f"{agentos_media_root()}/transcripts, but nothing in the")
+                print("  transcript points at them — they belong to older sessions and are")
+                print("  almost certainly NOT what the user just sent. Do not pin one.")
+            print("\n  Pick one, in this order:")
+            print("    - Ask the user for the image's path on their machine.")
+            print("      (In the CLI they can run `! ls ~/Downloads/*.png`.)")
+            print("    - If the logo is already hosted: `--metadata-uri ipfs://…`")
+            print("    - Launch with no logo — but say so first; it cannot be added later.")
             return
+
+        rows = []
+        for image in images:
+            age = now - image["sent_at"] if image["sent_at"] else None
+            rows.append({
+                "when": (_time.strftime("%m-%d %H:%M", _time.localtime(image["sent_at"]))
+                         if image["sent_at"] else "?"),
+                "age": _age(age),
+                "name": str(image["name"])[:28],
+                "type": image["mime"].split("/")[-1],
+                "size": f"{image['bytes'] / 1024:.0f} KB",
+                "src": image["source"],
+                "session": image["session_key"].rsplit(":", 1)[-1][:12],
+            })
         print(render_table([
             {"key": "when", "label": "WHEN"},
-            {"key": "mime", "label": "TYPE"},
+            {"key": "age", "label": "AGE", "align": "right"},
+            {"key": "name", "label": "NAME"},
+            {"key": "type", "label": "TYPE"},
             {"key": "size", "label": "SIZE", "align": "right"},
+            {"key": "src", "label": "SOURCE"},
             {"key": "session", "label": "SESSION"},
-            {"key": "path", "label": "PATH"},
-        ], [
-            {
-                "when": _time.strftime("%Y-%m-%d %H:%M", _time.localtime(i["mtime"])),
-                "mime": i["mime"].split("/")[-1],
-                "size": f"{i['bytes'] / 1024:.0f} KB",
-                "session": i["session"][:12],
-                "path": i["path"],
-            }
-            for i in images
-        ]))
-        print("\n  Newest first. Staged attachments are named after their sha256 and")
-        print("  carry no extension — confirm it is the right picture before pinning.")
-        print(f"\n  Then: pools_write.py launch --name … --symbol … --image {images[0]['path']}")
+        ], rows))
+
+        newest = images[0]
+        age = now - newest["sent_at"] if newest["sent_at"] else None
+        if age is not None and age > STALE_ATTACHMENT_SECONDS:
+            print(f"\n  WARNING: the newest attachment is {_age(age)} old, in session "
+                  f"{newest['session_key'].rsplit(':', 1)[-1]}.")
+            print("  That is probably NOT the image just sent. Confirm with the user")
+            print("  before pinning it — a token's logo cannot be changed afterwards.")
+        if error:
+            print(f"\n  could not extract it: {error}")
+        elif written:
+            print(f"\n  newest written to: {written}")
+            print("  Open it and confirm it is the right picture, then:")
+            print(f"    pools_write.py launch --name … --symbol … --image {written}")
 
     _emit(args, payload, render)
+
+
+def _age(seconds: float | None) -> str:
+    if seconds is None:
+        return "?"
+    if seconds < 90:
+        return f"{int(seconds)}s"
+    if seconds < 5400:
+        return f"{int(seconds // 60)}m"
+    if seconds < 172800:
+        return f"{int(seconds // 3600)}h"
+    return f"{int(seconds // 86400)}d"
 
 
 def _parse_eth(value: Any) -> int:

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/metadata.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/metadata.py
@@ -69,6 +69,97 @@ class PinataError(RuntimeError):
     """Anything that went wrong talking to Pinata."""
 
 
+# ── finding a user-attached image ───────────────────────────────────────────
+# AgentOS never tells the model where an attachment lives. An image the user
+# drags into webchat reaches the model as pixels — a base64 image block — and
+# for anything under ~2 MB it is stored as base64 in the transcript row and
+# never touches the filesystem at all. Larger attachments (and everything
+# arriving through a channel adapter) are staged to disk, content-addressed:
+#
+#     <media_root>/transcripts/<session_id>/<sha256 of the bytes>
+#
+# with no file extension and no trace of the original filename. Nothing hands
+# the agent that sha, so the only way to locate a staged attachment is to look.
+# That is what `find_attachment_images` does — and when it finds nothing, that
+# is a real answer ("this image is not on disk"), not a failed search.
+
+_MEDIA_ROOT_ENV = "AGENTOS_ATTACHMENTS_MEDIA_ROOT"
+_STATE_DIR_ENV = "AGENTOS_STATE_DIR"
+
+
+def agentos_media_root() -> Path:
+    """Where AgentOS stages attachments, mirroring ``agentos.paths``.
+
+    Kept as a small reimplementation rather than an import: this skill's scripts
+    run as standalone python against the system interpreter and cannot assume
+    the ``agentos`` package is importable.
+    """
+    override = os.environ.get(_MEDIA_ROOT_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    state_dir = os.environ.get(_STATE_DIR_ENV, "").strip()
+    home = Path(state_dir).expanduser() if state_dir else Path.home() / ".agentos"
+    return home / "media"
+
+
+def sniff_image_mime(path: Path) -> str | None:
+    """The image type from magic bytes, or None when it is not an image.
+
+    Magic bytes, not the extension: staged attachments have no extension at all.
+    """
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(32)
+    except OSError:
+        return None
+    if not head:
+        return None
+    for magic, mime in _MAGIC:
+        if head.startswith(magic):
+            return mime
+    # RIFF....WEBP
+    if head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "image/webp"
+    if head[4:12] in (b"ftypavif", b"ftypavis"):
+        return "image/avif"
+    return None
+
+
+def find_attachment_images(*, session: str | None = None, limit: int = 10,
+                           media_root: Path | None = None) -> list[dict]:
+    """Staged attachment images, newest first.
+
+    Returns ``[{path, session, bytes, mime, mtime}]``. An empty list means no
+    attachment was staged to disk — most often because the image was small
+    enough to travel inline.
+    """
+    root = (media_root or agentos_media_root()) / "transcripts"
+    if not root.is_dir():
+        return []
+    found: list[dict] = []
+    session_dirs = [root / session] if session else sorted(
+        (d for d in root.iterdir() if d.is_dir()), reverse=True)
+    for directory in session_dirs:
+        if not directory.is_dir():
+            continue
+        for candidate in directory.iterdir():
+            if not candidate.is_file():
+                continue
+            mime = sniff_image_mime(candidate)
+            if not mime:
+                continue
+            try:
+                stat = candidate.stat()
+            except OSError:
+                continue
+            found.append({
+                "path": str(candidate), "session": directory.name,
+                "bytes": stat.st_size, "mime": mime, "mtime": stat.st_mtime,
+            })
+    found.sort(key=lambda entry: entry["mtime"], reverse=True)
+    return found[:limit]
+
+
 def pinata_configured() -> bool:
     return pinata_jwt() is not None
 
@@ -195,9 +286,15 @@ def pin_file(path: str | Path, jwt: str, *, name: str | None = None) -> str:
             f"{file_path.name} does not look like an image (detected {mime}). "
             "Pass a png/jpg/gif/webp/svg."
         )
+    # A staged AgentOS attachment is named after its sha256 with no extension.
+    # Give Pinata a sensible filename derived from the sniffed type instead, so
+    # the pinned object is not called "68c79977460f28…".
+    upload_name = file_path.name
+    if not file_path.suffix:
+        upload_name = f"{(name or 'logo').replace(' ', '-')}.{mime.split('/')[-1]}"
     body, content_type = _multipart(
-        {"pinataMetadata": json.dumps({"name": name or file_path.name})},
-        file_path.name, mime, payload,
+        {"pinataMetadata": json.dumps({"name": name or upload_name})},
+        upload_name, mime, payload,
     )
     result = _post(
         f"{PINATA_API}/pinning/pinFileToIPFS", body,

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/metadata.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/metadata.py
@@ -24,9 +24,11 @@ transaction lands and there is no second chance to attach the picture.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import mimetypes
 import os
+import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -71,20 +73,39 @@ class PinataError(RuntimeError):
 
 # ── finding a user-attached image ───────────────────────────────────────────
 # AgentOS never tells the model where an attachment lives. An image the user
-# drags into webchat reaches the model as pixels — a base64 image block — and
-# for anything under ~2 MB it is stored as base64 in the transcript row and
-# never touches the filesystem at all. Larger attachments (and everything
-# arriving through a channel adapter) are staged to disk, content-addressed:
+# drags into webchat reaches the model as pixels — an image content block — with
+# no filename and no path. But the bytes are not lost: every attachment is
+# recorded in the transcript database, in one of two shapes.
 #
-#     <media_root>/transcripts/<session_id>/<sha256 of the bytes>
+#   inline  {"type": "image/png", "name": "image.png", "data": "<base64>"}
+#   staged  {"sha256_ref": "<sha>", "name": …, "mime": …, "size": …}
+#           bytes at <media_root>/transcripts/<session_id>/<sha>
 #
-# with no file extension and no trace of the original filename. Nothing hands
-# the agent that sha, so the only way to locate a staged attachment is to look.
-# That is what `find_attachment_images` does — and when it finds nothing, that
-# is a real answer ("this image is not on disk"), not a failed search.
+# Anything under ~2 MB — which is most logos — is inline and never touches the
+# filesystem at all.
+#
+# The transcript is therefore the authority, and scanning the media directory is
+# not a substitute for it. An earlier version of this module did exactly that,
+# and it was actively dangerous: with no inline attachment on disk it returned
+# the newest *staged* blob, which belonged to an unrelated session three days
+# earlier, and offered it as the logo to pin into an immutable token. Ordering
+# by file mtime cannot tell "the image the user just sent" from "some image".
+# Message rows can, because they carry the message's own timestamp and session.
 
 _MEDIA_ROOT_ENV = "AGENTOS_ATTACHMENTS_MEDIA_ROOT"
 _STATE_DIR_ENV = "AGENTOS_STATE_DIR"
+
+# Past this, a candidate is almost certainly not what the user just attached.
+STALE_ATTACHMENT_SECONDS = 15 * 60
+
+
+def agentos_home() -> Path:
+    state_dir = os.environ.get(_STATE_DIR_ENV, "").strip()
+    return Path(state_dir).expanduser() if state_dir else Path.home() / ".agentos"
+
+
+def sessions_db_path() -> Path:
+    return agentos_home() / "state" / "sessions.db"
 
 
 def agentos_media_root() -> Path:
@@ -127,11 +148,11 @@ def sniff_image_mime(path: Path) -> str | None:
 
 def find_attachment_images(*, session: str | None = None, limit: int = 10,
                            media_root: Path | None = None) -> list[dict]:
-    """Staged attachment images, newest first.
+    """Staged attachment images on disk, newest first.
 
-    Returns ``[{path, session, bytes, mime, mtime}]``. An empty list means no
-    attachment was staged to disk — most often because the image was small
-    enough to travel inline.
+    A fallback only. Prefer :func:`find_chat_images`: file mtime says when bytes
+    were written, not which message they belong to, so this cannot distinguish
+    the image the user just sent from one staged days ago in another session.
     """
     root = (media_root or agentos_media_root()) / "transcripts"
     if not root.is_dir():
@@ -158,6 +179,128 @@ def find_attachment_images(*, session: str | None = None, limit: int = 10,
             })
     found.sort(key=lambda entry: entry["mtime"], reverse=True)
     return found[:limit]
+
+
+def find_chat_images(*, session: str | None = None, limit: int = 10,
+                     db_path: Path | None = None) -> list[dict]:
+    """Image attachments from the transcript, newest message first.
+
+    Each entry: ``{entry_id, index, session_key, sent_at, name, mime, bytes,
+    source}`` where ``source`` is ``"inline"`` or ``"staged"``. Ordering is by
+    the message's own timestamp, which is the only ordering that answers "what
+    did the user just send".
+
+    Returns an empty list if the database is missing or unreadable; the caller
+    falls back to a disk scan and says so.
+    """
+    import sqlite3
+
+    path = db_path or sessions_db_path()
+    if not path.is_file():
+        return []
+    query = """
+        SELECT e.id, a.key, e.session_key, e.created_at,
+               json_extract(a.value, '$.name'),
+               COALESCE(json_extract(a.value, '$.type'),
+                        json_extract(a.value, '$.mime')),
+               json_extract(a.value, '$.sha256_ref'),
+               json_extract(a.value, '$.size'),
+               length(json_extract(a.value, '$.data'))
+        FROM transcript_entries e, json_each(e.content, '$.attachments') a
+        WHERE e.role = 'user' AND json_valid(e.content)
+        ORDER BY e.created_at DESC
+        LIMIT 200
+    """
+    try:
+        # Read-only URI: the gateway may hold this database open for writes.
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5.0)
+    except sqlite3.Error:
+        return []
+    try:
+        rows = con.execute(query).fetchall()
+    except sqlite3.Error:
+        # Old schema, or no JSON1 support in this interpreter's sqlite.
+        return []
+    finally:
+        con.close()
+
+    out: list[dict] = []
+    for (entry_id, index, session_key, created_at, name, mime,
+         sha_ref, size, b64_len) in rows:
+        if session and session not in (session_key or ""):
+            continue
+        mime = (mime or "").strip()
+        # A missing mime on a staged ref is rare but recoverable from the name.
+        if not mime and name and "." in str(name):
+            mime = _IMAGE_MIME.get("." + str(name).rsplit(".", 1)[-1].lower(), "")
+        if not mime.startswith("image/"):
+            continue
+        out.append({
+            "entry_id": int(entry_id),
+            "index": int(index),
+            "session_key": session_key or "",
+            "sent_at": (int(created_at) / 1000.0) if created_at else 0.0,
+            "name": name or "attachment",
+            "mime": mime,
+            "bytes": int(size) if size else (b64_len or 0) * 3 // 4,
+            "source": "staged" if sha_ref else "inline",
+            "sha256_ref": sha_ref or "",
+        })
+        if len(out) >= limit:
+            break
+    return out
+
+
+def materialize_chat_image(entry: dict, *, dest_dir: Path | None = None,
+                           db_path: Path | None = None,
+                           media_root: Path | None = None) -> Path:
+    """Write a transcript image attachment to a real file and return its path.
+
+    This is the step that closes the gap: the bytes exist, they are simply not
+    on the filesystem where ``--image`` can reach them. Inline attachments are
+    base64-decoded out of the transcript row; staged ones are copied from the
+    content-addressed blob the row points at.
+    """
+    import sqlite3
+
+    target_dir = dest_dir or (Path(tempfile.gettempdir()) / "poolsfun-logos")
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    if entry["source"] == "staged":
+        session_id = (entry.get("session_key") or "").rsplit(":", 1)[-1]
+        blob = ((media_root or agentos_media_root()) / "transcripts" / session_id
+                / entry["sha256_ref"])
+        if not blob.is_file():
+            raise PinataError(
+                f"the transcript points at {entry['sha256_ref'][:12]}… but that blob is "
+                f"not under {agentos_media_root()}/transcripts. Ask the user for the "
+                "file path instead."
+            )
+        payload = blob.read_bytes()
+    else:
+        path = db_path or sessions_db_path()
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5.0)
+        try:
+            row = con.execute(
+                "SELECT json_extract(content, '$.attachments[' || ? || '].data') "
+                "FROM transcript_entries WHERE id = ?",
+                (entry["index"], entry["entry_id"]),
+            ).fetchone()
+        finally:
+            con.close()
+        if not row or not row[0]:
+            raise PinataError("the transcript row no longer carries the image data")
+        payload = base64.b64decode(row[0])
+
+    suffix = Path(str(entry.get("name") or "")).suffix.lower()
+    if suffix not in _IMAGE_MIME:
+        suffix = "." + (entry["mime"].split("/")[-1] or "png")
+    # Content-addressed so re-running does not pile up copies, and so the same
+    # image always lands at the same path.
+    digest = hashlib.sha256(payload).hexdigest()[:16]
+    out_path = target_dir / f"{digest}{suffix}"
+    out_path.write_bytes(payload)
+    return out_path
 
 
 def pinata_configured() -> bool:

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
@@ -330,6 +330,57 @@ def tier6_metadata() -> None:
         check("falls back to the extension", _guess_mime(Path("a.webp"), b"???"),
               "image/webp")
 
+        # Attachment discovery. AgentOS never surfaces a path, so this is the
+        # only way a skill can turn "the image I just sent" into a file.
+        from poolsfun.metadata import agentos_media_root, find_attachment_images, sniff_image_mime
+
+        saved_root = os.environ.pop("AGENTOS_ATTACHMENTS_MEDIA_ROOT", None)
+        saved_state = os.environ.pop("AGENTOS_STATE_DIR", None)
+        try:
+            check("media root defaults under ~/.agentos",
+                  str(agentos_media_root()).endswith("/.agentos/media"), True)
+            os.environ["AGENTOS_STATE_DIR"] = "/tmp/xyz"
+            check("AGENTOS_STATE_DIR relocates it",
+                  str(agentos_media_root()), "/tmp/xyz/media")
+            os.environ["AGENTOS_ATTACHMENTS_MEDIA_ROOT"] = "/tmp/explicit"
+            check("explicit media root wins", str(agentos_media_root()), "/tmp/explicit")
+        finally:
+            os.environ.pop("AGENTOS_ATTACHMENTS_MEDIA_ROOT", None)
+            os.environ.pop("AGENTOS_STATE_DIR", None)
+            if saved_root:
+                os.environ["AGENTOS_ATTACHMENTS_MEDIA_ROOT"] = saved_root
+            if saved_state:
+                os.environ["AGENTOS_STATE_DIR"] = saved_state
+
+        # Staged attachments have no extension, so the type must come from the
+        # bytes. A sha256-named PNG must still be recognised as a PNG.
+        root = Path(tempfile.mkdtemp())
+        staged = root / "transcripts" / "sess-1"
+        staged.mkdir(parents=True)
+        (staged / ("a" * 64)).write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+        (staged / ("b" * 64)).write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 64)
+        (staged / ("c" * 64)).write_bytes(b"just some text, not an image")
+        check("sniffs an extensionless PNG",
+              sniff_image_mime(staged / ("a" * 64)), "image/png")
+        check("non-image returns None", sniff_image_mime(staged / ("c" * 64)), None)
+        check("missing file returns None", sniff_image_mime(staged / "nope"), None)
+
+        found = find_attachment_images(media_root=root)
+        check("finds both staged images, skips the text blob", len(found), 2)
+        check("reports a usable absolute path",
+              all(Path(f["path"]).is_file() for f in found), True)
+        check("reports the session", {f["session"] for f in found}, {"sess-1"})
+        check("filters by session",
+              len(find_attachment_images(media_root=root, session="sess-1")), 2)
+        check("unknown session yields nothing",
+              find_attachment_images(media_root=root, session="nope"), [])
+        check("honours the limit",
+              len(find_attachment_images(media_root=root, limit=1)), 1)
+        # The empty case is the *common* one — a small webchat image is never
+        # written to disk — so it must return cleanly, not raise.
+        check("absent media root returns empty, does not raise",
+              find_attachment_images(media_root=Path("/nonexistent/xyz")), [])
+
         body, content_type = _multipart({"f": "v"}, "l.png", "image/png", b"data")
         boundary = content_type.split("boundary=")[1]
         check("multipart has 3 boundary occurrences", body.count(boundary.encode()), 3)
@@ -409,7 +460,8 @@ def tier8_cli_contract() -> None:
     read_mod = importlib.import_module("pools_read")
     write_mod = importlib.import_module("pools_write")
     check("read commands", sorted(read_mod.COMMANDS),
-          ["assets", "fees", "mine-salt", "preflight", "simulate", "token"])
+          ["assets", "fees", "find-image", "mine-salt", "preflight", "simulate",
+           "token"])
     check("write commands", sorted(write_mod.COMMANDS),
           ["approve", "claim", "collect", "collect-and-claim", "launch",
            "set-fee-recipient"])

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/selftest.py
@@ -365,6 +365,66 @@ def tier6_metadata() -> None:
         check("non-image returns None", sniff_image_mime(staged / ("c" * 64)), None)
         check("missing file returns None", sniff_image_mime(staged / "nope"), None)
 
+        # The transcript is the authority. Build a miniature sessions.db with a
+        # recent inline attachment and a much older staged one from a different
+        # session, and assert the recent one wins — the disk scan gets this
+        # exactly backwards, which is how an unrelated 3-day-old blob was once
+        # offered as a token logo.
+        import sqlite3
+
+        from poolsfun.metadata import find_chat_images, materialize_chat_image
+
+        db = root / "sessions.db"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE transcript_entries "
+                    "(id INTEGER PRIMARY KEY, session_key TEXT, role TEXT, "
+                    " content TEXT, created_at INTEGER)")
+        png = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x01" * 64).decode()
+        con.execute(
+            "INSERT INTO transcript_entries VALUES (1,'agent:main:webchat:old','user',?,?)",
+            (json.dumps({"text": "old", "attachments": [
+                {"sha256_ref": "f" * 64, "name": "old.png",
+                 "mime": "image/png", "size": 999}]}), 1_000_000_000_000))
+        con.execute(
+            "INSERT INTO transcript_entries VALUES (2,'agent:main:webchat:new','user',?,?)",
+            (json.dumps({"text": "logo", "attachments": [
+                {"type": "image/png", "name": "image.png", "data": png}]}),
+             2_000_000_000_000))
+        # A non-image attachment must not be offered as a logo.
+        con.execute(
+            "INSERT INTO transcript_entries VALUES (3,'agent:main:webchat:new','user',?,?)",
+            (json.dumps({"text": "doc", "attachments": [
+                {"type": "application/pdf", "name": "a.pdf", "data": "eA=="}]}),
+             2_100_000_000_000))
+        con.commit()
+        con.close()
+
+        chat = find_chat_images(db_path=db)
+        check("transcript lookup finds both images", len(chat), 2)
+        check("newest message wins, not newest file", chat[0]["session_key"],
+              "agent:main:webchat:new")
+        check("inline source is labelled", chat[0]["source"], "inline")
+        check("staged source is labelled", chat[1]["source"], "staged")
+        check("non-image attachments are excluded",
+              all(c["mime"].startswith("image/") for c in chat), True)
+        check("carries the message timestamp", chat[0]["sent_at"], 2_000_000_000.0)
+        check("filters by session",
+              len(find_chat_images(db_path=db, session="old")), 1)
+        check("missing database returns empty, does not raise",
+              find_chat_images(db_path=root / "nope.db"), [])
+
+        # Extraction must reproduce the exact bytes the user sent.
+        out = materialize_chat_image(chat[0], dest_dir=root / "out", db_path=db)
+        check("extracted file exists", out.is_file(), True)
+        check("extracted bytes round-trip", out.read_bytes(), base64.b64decode(png))
+        check("extension comes from the attachment", out.suffix, ".png")
+        check("extraction is idempotent",
+              materialize_chat_image(chat[0], dest_dir=root / "out", db_path=db), out)
+        raises("a staged ref with no blob on disk fails loudly",
+               lambda: materialize_chat_image(chat[1], dest_dir=root / "out",
+                                              db_path=db, media_root=root / "empty"),
+               contains="not under")
+
         found = find_attachment_images(media_root=root)
         check("finds both staged images, skips the text blob", len(found), 2)
         check("reports a usable absolute path",


### PR DESCRIPTION
Follow-up to #299 (merged). Two changes to `poolsdotfun-token-launcher`.

## 1. Flamingo mark

🎈 → 🦩. pools.fun's brand is a pink flamingo; the balloon was a placeholder.

A bundled skill's visual identity is its `metadata.agentos.emoji`. The `logo` field in `skills/types.py` belongs to `SkillPublisher`, which only resolves for ids on the server-side allowlist in `skills/publishers.py` and renders as partner styling and a trust signal — so it is deliberately not a skill's to set. Using it here would assert a partnership that does not exist.

## 2. Chat-attached logos were unfindable

Reported from a live webchat session: user attached an image, asked for it as the token logo, agent could not find the file.

It was not a search problem — **the file did not exist**, and SKILL.md was actively misleading:

> ~~In AgentOS webchat, an attached image lands on disk; pass that path here.~~

What actually happens (`engine/runtime.py:5885-6001`, `gateway/attachment_ingest.py`, `attachment_refs.py:23-39`):

- The model receives an **image content block** — pixels, no filename, no path, no placeholder.
- Attachments under ~2 MB, which is most logos, are kept **inline in the transcript row and never written to disk**.
- Larger ones are staged content-addressed at `<media_root>/transcripts/<session>/<sha256>` — no extension, no original filename — and the sha is never surfaced to the model either.

Verified against the reported session: it has **no material directory at all**, and the newest blob on disk predates the attachment by three days. So the agent was hunting for something that was never there, because the docs told it to.

### The fix

**New `pools_read.py find-image`.** Resolves the media root the way the gateway does (`AGENTOS_ATTACHMENTS_MEDIA_ROOT`, else `AGENTOS_STATE_DIR` or `~/.agentos`, + `/media`), scans staged attachments, identifies them by **magic bytes rather than extension**, and prints them newest-first with the exact `launch --image …` line:

```
=== attached images found on disk ===
  WHEN              TYPE     SIZE  SESSION       PATH
  2026-08-10 07:42  png   3088 KB  96f2478c-019  /Users/…/media/transcripts/96f2478c-…/8dfc15a6…
  2026-08-09 13:49  jpeg   137 KB  929335f1      /Users/…/media/transcripts/929335f1/36363c83…
```

When it finds nothing — the common case — it says so and lists the alternatives in preference order, rather than leaving the agent to guess again:

```
  none under /Users/…/.agentos/media/transcripts

  This usually means the image was never written to disk. AgentOS
  keeps attachments under ~2 MB inline in the transcript, so the
  model receives the pixels but no file exists to pin.

  To attach a logo anyway, pick one:
    - Ask the user for the image's path on their machine, then
      pass it to `pools_write.py launch --image <path>`.
    - If the logo is already hosted, skip Pinata entirely:
      `--metadata-uri ipfs://…` or an https URL.
    - Launch without a logo now; the metadata is inlined and the
      token still launches. Note it cannot be added later.
```

**SKILL.md** gains a *Getting the image when the user attached it in chat* section that states the mechanism up front and closes with the two rules that matter: never fabricate a path, and never silently launch without the image when the user asked for one.

**`pin_file`** now derives a filename from the sniffed mime for extensionless staged blobs, so a pinned logo is not named `68c79977460f28…`.

**description/triggers** pick up logo and image wording so the skill is reachable from "use this picture as the token logo".

## Verification

- selftest **187 checks, 0 failures** (was 174) — new coverage for media-root precedence, magic-byte sniffing of extensionless files, session filtering, and the empty case returning cleanly rather than raising.
- `ruff check src tests` clean; skills suite 439 passed (the one failure is the pre-existing `html-to-pdf` weasyprint issue).
- `find-image` exercised against the real `~/.agentos/media` on this machine — correctly identified 6 extensionless blobs as png/jpeg by magic bytes.

Note this documents a gap in the platform, not just the skill: **no bundled skill can currently receive a user-attached image as a file.** The general fix would be to emit `path:` / `read_full:` hints for `image/*` refs, mirroring `_render_preview_only_attachment_text` (`runtime.py:1292`) which already does exactly that for large text attachments. Worth a separate issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)