### PR TITLE
fix(web-ui): keep the message hover toolbar reachable

### DIFF
--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -281,29 +281,50 @@
   background: var(--surface);
   opacity: 0;
   pointer-events: none;
-  transition:
-    opacity 120ms ease,
-    transform 120ms ease;
+  transition: opacity 120ms ease;
+}
+/* Transparent bridge across the gutter margin. The toolbar sits outside the
+   `.msg` box that carries `:hover`, so without this the 8px gap is a dead strip
+   the pointer cannot cross — hover drops and the buttons vanish before they can
+   be clicked. Inherits `pointer-events` from the toolbar, so it stays inert
+   while hidden (and while streaming). */
+.msg .msg-body > .msg-actions::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 10px; /* >= the 8px margin below */
 }
 .msg.assistant .msg-body > .msg-actions {
   left: 100%;
   margin-left: 8px;
-  transform: translateX(-3px);
+}
+.msg.assistant .msg-body > .msg-actions::before {
+  right: 100%;
 }
 .msg.user .msg-body > .msg-actions {
   right: 100%;
   margin-right: 8px;
-  transform: translateX(3px);
+}
+.msg.user .msg-body > .msg-actions::before {
+  left: 100%;
 }
 .msg:hover .msg-actions,
 .msg:focus-within .msg-actions {
   opacity: 1;
   pointer-events: auto;
-  transform: translateX(0);
 }
 .msg.streaming .msg-actions {
   opacity: 0 !important;
   pointer-events: none !important;
+}
+/* Where the toolbar is not gutter-positioned (narrow layouts drop it into flow)
+   or is always visible (touch), there is no gap to bridge — drop the strip so it
+   cannot swallow taps in the margin. */
+@media (max-width: 560px), (hover: none) {
+  .msg .msg-body > .msg-actions::before {
+    display: none;
+  }
 }
 .msg-action {
   display: inline-grid;


### PR DESCRIPTION
Closes #304

## Problem

The per-message hover toolbar (copy / regenerate / edit) is positioned in the outer gutter at `left: 100%` plus an `8px` margin — entirely outside the `.msg` box that carries the `:hover` state. Moving the pointer from the message text toward the buttons crosses that 8px dead strip, `.msg:hover` turns false, and the toolbar fades to `opacity: 0; pointer-events: none` before the cursor arrives. Copy and regenerate are unclickable with a normal mouse movement.

The reveal also animated `translateX(-3px) → translateX(0)`, sliding the group a further 3px *away* from the incoming cursor exactly while it appeared.

## Change

`frontend/src/views/chat/chat.css` only — no DOM changes.

- Add a transparent 10px `::before` on `.msg-actions` bridging the gutter margin back to the bubble edge, mirrored per role. It inherits `pointer-events` from the toolbar, so it is inert while the toolbar is hidden and while the message is streaming.
- Drop the `translateX` reveal animation so the target no longer moves away from the pointer; only `opacity` transitions now.
- Suppress the bridge at `≤560px` and under `hover: none`, where the toolbar is already in normal flow or permanently visible — there a strip in the margin would only swallow taps.

`.msg-actions` deliberately stays inside `.msg-body`: `extractBubbleText` (`transcript/message.ts:190-198`) strips it by selector when copying, so relocating the node would corrupt copied message text.

Visual placement is unchanged — the 8px gutter offset is preserved.

## Verification

`npm run build` passes and stays within the bundle budget.

Measured with `document.elementFromPoint` against the **built** stylesheet (`ChatPage-*.css`), walking pixel by pixel from the bubble edge to the copy button:

| Check | Result |
|---|---|
| Assistant path, bubble → copy button | **0** dead pixels |
| Same path with the bridge disabled (control) | **8** dead pixels — reproduces the reported bug |
| User side (mirrored) | 0 dead pixels, hit resolves to the `edit` button |
| Toolbar hidden / message streaming | fully inert, gutter point resolves to `.chat-thread` |
| Visible gap | still 8px — layout unchanged |
| Computed `transform` on reveal | `none` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
