### PR TITLE
fix(web-ui): format chat.css to satisfy prettier

### DIFF
--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -289,7 +289,7 @@
    be clicked. Inherits `pointer-events` from the toolbar, so it stays inert
    while hidden (and while streaming). */
 .msg .msg-body > .msg-actions::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   bottom: 0;


### PR DESCRIPTION
## Problem

The `frontend` workflow's `check` job is failing on `main`
([run 31784644262](https://github.com/use-agent-os/agent-os/actions/runs/31784644262)):

```
> tsc --noEmit && eslint src && prettier --check src && vitest run
Checking formatting...
[warn] src/views/chat/chat.css
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
##[error]Process completed with exit code 1.
```

`tsc` and `eslint` pass; only the `prettier --check` stage fails, which short-circuits
the chain before `vitest` ever runs.

## Root cause

The hover-bridge pseudo-element added in 9332cdb (PR #305, fixing #304) was written as
`content: ""`. The repo's prettier config uses `singleQuote`, so the expected form is
`content: ''`. That PR was merged with an admin override that skipped CI, so the
formatting violation was never caught before it landed on `main`.

## Change

One character-pair swap in `frontend/src/views/chat/chat.css` — double quotes to single
quotes on the bridge's `content` declaration. No behavioural change: `content: ""` and
`content: ''` are the identical CSS empty string, so the hover-gap fix from #304 is
untouched.

## Verification

`npm run check` in `frontend/` locally:

- `tsc --noEmit` — pass
- `eslint src` — pass
- `prettier --check src` — pass (was the failing stage)
- `vitest run` — 90 files, 1900 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)