### PR TITLE
fix(tools): stop a coarse clock stretching the x_search budget

### DIFF
--- a/src/agentos/tools/builtin/x_search.py
+++ b/src/agentos/tools/builtin/x_search.py
@@ -397,7 +397,11 @@ async def _post_with_retries(
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
-            attempt_timeout = min(_active_timeout_seconds, remaining)
+            # `remaining` comes from `deadline`, itself a rounded float sum, so it can
+            # exceed the total budget by an ulp when both `monotonic()` reads land in
+            # the same clock tick (Windows granularity is ~15.6ms). Cap on the budget
+            # itself so an attempt can never outlive it.
+            attempt_timeout = min(_active_timeout_seconds, remaining, _active_total_timeout_seconds)
             try:
                 response = await client.post(
                     f"{base_url}/responses",

--- a/tests/test_tools/test_x_search.py
+++ b/tests/test_tools/test_x_search.py
@@ -442,6 +442,27 @@ class TestFailureHandling:
         assert recorder.timeouts[0] <= 20.0
 
     @pytest.mark.asyncio
+    async def test_a_coarse_clock_cannot_stretch_the_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A same-tick clock must not hand an attempt more than the total budget.
+
+        Windows resolves ``monotonic()`` to ~15.6ms, so both reads routinely land
+        on the same tick and ``deadline - now`` collapses to ``(t + 20.0) - t`` —
+        which rounds *above* 20.0 for many values of ``t``. Pinning the clock
+        reproduces on any platform what CI hits intermittently on Windows.
+        """
+        stuck = 32754.452514458473  # (stuck + 20.0) - stuck == 20.000000000003638
+        assert (stuck + 20.0) - stuck > 20.0, "witness no longer rounds up"
+        monkeypatch.setattr(x_search_mod.time, "monotonic", lambda: stuck)
+        monkeypatch.setattr(x_search_mod, "_active_timeout_seconds", 180.0)
+        monkeypatch.setattr(x_search_mod, "_active_total_timeout_seconds", 20.0)
+        recorder = _Recorder([_response({"output_text": "ok"})])
+        recorder.install(monkeypatch)
+        await _call(query="grok")
+        assert recorder.timeouts[0] <= 20.0
+
+    @pytest.mark.asyncio
     async def test_an_error_body_is_bounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
         recorder = _Recorder([_response({"error": "x" * 5000}, 500)])
         recorder.install(monkeypatch)


### PR DESCRIPTION
## Problem

CI on `main` is red on the Windows job ([run 31806883794](https://github.com/use-agent-os/agent-os/actions/runs/31806883794)), with a single failure:

```
FAILED tests/test_tools/test_x_search.py::TestFailureHandling::test_an_attempt_never_outlives_the_total_budget
       - assert 20.000000000000057 <= 20.0
```

`_post_with_retries` derives the per-attempt timeout from `remaining = deadline - time.monotonic()` (`x_search.py:397`), where `deadline` is itself `time.monotonic() + total_timeout_seconds` (`x_search.py:575`).

On Linux `monotonic()` resolves to nanoseconds, so the second read is always strictly later and `remaining` lands below the budget. Windows resolves it to ~15.6ms, so both reads routinely fall in the **same tick** and the expression collapses to `(t + 20.0) - t`. Because the addition is rounded to the nearest double, that evaluates just *above* `20.0` for many values of `t` — and the attempt is handed a timeout fractionally larger than the total budget it is meant to fit inside.

This is a real (if microscopic) breach of the invariant the test names, not just a strict assertion. It is also genuinely intermittent: the same test passed on the Windows runner one commit earlier (`1e7c47c`) and failed on the next (`92febb4`) with no change to the tool or its tests.

## Change

Cap the per-attempt timeout on the total budget as well as on `remaining`:

```python
attempt_timeout = min(_active_timeout_seconds, remaining, _active_total_timeout_seconds)
```

## Regression test

`test_a_coarse_clock_cannot_stretch_the_budget` pins `monotonic()` to a value whose sum is known to round up, reproducing on any platform what CI hits only intermittently on Windows.

Without the source fix it fails with the same shape CI reported:

```
E       assert 20.000000000003638 <= 20.0
```

With the fix, the full file passes (52 passed).

## Verification

Ran the same gate CI runs:

- `uv run ruff check src tests` — All checks passed
- `uv run mypy src/agentos --show-error-codes` — only the pre-existing `mem0` `import-untyped` note, which is a locally-installed optional extra
- `uv run pytest tests/test_tools/test_x_search.py -q` — 52 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
