### PR TITLE
feat(channels): transcribe inbound Telegram voice messages

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -546,3 +546,5 @@ default_mode = "bypass"                 # off | on | bypass | full
 # groups_enabled = false
 # group_chat_ids = ["-1001234567890"]
 # group_mention_required = true
+# transcribe_voice = false
+# max_voice_duration_s = 120

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -126,6 +126,16 @@ agentos channels add telegram --name personal --token <bot-token> \
   --field group_mention_required=true
 ```
 
+### Voice Transcription
+
+Telegram channels can automatically transcribe inbound voice messages, audio files, and video notes before routing them to the model. This requires global audio features to be enabled (with valid ElevenLabs Speech-to-Text credentials) and the following fields set:
+
+```sh
+agentos channels add telegram --name personal --token <bot-token> \
+  --field transcribe_voice=true \
+  --field max_voice_duration_s=120
+```
+
 Pairing is sender-level: the same paired sender may use direct messages and
 explicitly configured groups. Removing the pairing disconnects that sender
 from both surfaces immediately.

--- a/src/agentos/channels/_attachment_io.py
+++ b/src/agentos/channels/_attachment_io.py
@@ -33,8 +33,6 @@ def attachment_limit_for_mime(mime: str | None) -> int:
     normalized = normalize_attachment_mime(mime)
     if normalized in ALLOWED_MEDIA_TYPES:
         return attachment_size_limit_for_mime(normalized, staged=True)
-    if normalized and (normalized.startswith("audio/") or normalized.startswith("video/")):
-        return 30 * 1024 * 1024  # 30 MB transcription limit
     return MAX_ATTACHMENT_BYTES
 
 

--- a/src/agentos/channels/_attachment_io.py
+++ b/src/agentos/channels/_attachment_io.py
@@ -33,6 +33,8 @@ def attachment_limit_for_mime(mime: str | None) -> int:
     normalized = normalize_attachment_mime(mime)
     if normalized in ALLOWED_MEDIA_TYPES:
         return attachment_size_limit_for_mime(normalized, staged=True)
+    if normalized and (normalized.startswith("audio/") or normalized.startswith("video/")):
+        return 30 * 1024 * 1024  # 30 MB transcription limit
     return MAX_ATTACHMENT_BYTES
 
 

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -123,6 +123,8 @@ class TelegramChannelConfig(BaseModel):
     groups_enabled: bool = False
     group_chat_ids: list[str] = Field(default_factory=list)
     group_mention_required: bool = True
+    transcribe_voice: bool = False
+    max_voice_duration_s: int = 120
 
     model_config = {}
 
@@ -212,10 +214,7 @@ class TelegramChannel:
 
     def record_access_denial(self, message: IncomingMessage, reason: str) -> None:
         """Create a durable pairing request for an unauthorized Telegram DM."""
-        if (
-            reason != "not_paired"
-            or bool(message.metadata.get("is_group"))
-        ):
+        if reason != "not_paired" or bool(message.metadata.get("is_group")):
             return
         profile = self._sender_profile(message)
         sender_id = profile["sender_id"]
@@ -685,11 +684,17 @@ class TelegramChannel:
             name = f"{default_name}-{suffix}"
         mime = media.get("mime_type") if isinstance(media.get("mime_type"), str) else default_mime
         size = media.get("file_size") if isinstance(media.get("file_size"), int) else None
+        duration = (
+            media.get("duration") if isinstance(media.get("duration"), (int, float)) else None
+        )
+        metadata = {"telegram_file_id": file_id, "telegram_media_kind": media_kind}
+        if duration is not None:
+            metadata["duration"] = duration
         return Attachment(
             name=name,
             mime_type=mime,
             size=size,
-            metadata={"telegram_file_id": file_id, "telegram_media_kind": media_kind},
+            metadata=metadata,
         )
 
     def _telegram_media_attachments(self, msg: dict[str, Any]) -> list[Attachment]:
@@ -730,6 +735,7 @@ class TelegramChannel:
             ("audio", "telegram-audio"),
             ("voice", "telegram-voice"),
             ("sticker", "telegram-sticker"),
+            ("video_note", "telegram-video-note"),
         ):
             media = msg.get(key)
             if isinstance(media, dict):
@@ -827,6 +833,13 @@ class TelegramChannel:
             if key in msg:
                 metadata[key] = msg[key]
 
+        reply_to_message = msg.get("reply_to_message")
+        if isinstance(reply_to_message, dict):
+            reply_to_from = reply_to_message.get("from") or {}
+            metadata["reply_to_message_id"] = str(reply_to_message.get("message_id", ""))
+            metadata["reply_to_message_from_id"] = str(reply_to_from.get("id", ""))
+            metadata["reply_to_message_from_username"] = str(reply_to_from.get("username", ""))
+
         content = msg.get("text") or msg.get("caption") or ""
         content_entity_key = "entities" if msg.get("text") else "caption_entities"
         content_entities = msg.get(content_entity_key)
@@ -834,7 +847,15 @@ class TelegramChannel:
             metadata["content_entities"] = content_entities
         attachments = self._telegram_media_attachments(msg)
         if not content:
-            for media_key in ("document", "photo", "video", "audio", "voice", "sticker"):
+            for media_key in (
+                "document",
+                "photo",
+                "video",
+                "audio",
+                "voice",
+                "sticker",
+                "video_note",
+            ):
                 if media_key in msg:
                     content = f"[{media_key}]"
                     break
@@ -853,6 +874,16 @@ class TelegramChannel:
         username = self.bot_username
         if not username:
             return False
+
+        # If this message is a reply to the bot, count it as a mention.
+        reply_to_from_id = msg.metadata.get("reply_to_message_from_id")
+        reply_to_from_username = msg.metadata.get("reply_to_message_from_username")
+        if (reply_to_from_id and str(reply_to_from_id) == str(self.bot_user_id or "")) or (
+            reply_to_from_username
+            and reply_to_from_username.casefold() == username.lstrip("@").casefold()
+        ):
+            return True
+
         mention = f"@{username}".lower()
         text = msg.content or ""
         entities = msg.metadata.get("content_entities")

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -43,6 +43,7 @@ from agentos.channels.contract import (
 from agentos.channels.types import Attachment, ChannelHealth, IncomingMessage, OutgoingMessage
 from agentos.engine.native_commands import telegram_bot_commands
 from agentos.env import trust_env as _trust_env
+from agentos.gateway.audio_transcription import MAX_TRANSCRIPTION_BYTES
 
 log = structlog.get_logger(__name__)
 
@@ -124,7 +125,7 @@ class TelegramChannelConfig(BaseModel):
     group_chat_ids: list[str] = Field(default_factory=list)
     group_mention_required: bool = True
     transcribe_voice: bool = False
-    max_voice_duration_s: int = 120
+    max_voice_duration_s: int = Field(default=120, gt=0)
 
     model_config = {}
 
@@ -759,7 +760,29 @@ class TelegramChannel:
         file_id = attachment.metadata.get("telegram_file_id")
         if not isinstance(file_id, str) or not file_id:
             return attachment
-        limit = attachment_limit_for_mime(attachment.mime_type)
+
+        media_kind = attachment.metadata.get("telegram_media_kind")
+        is_transcription_kind = media_kind in ("voice", "audio", "video_note")
+        transcribe_enabled = getattr(self.config, "transcribe_voice", False)
+
+        if transcribe_enabled and is_transcription_kind:
+            # Check duration limit pre-download
+            duration = attachment.metadata.get("duration")
+            max_duration = getattr(self.config, "max_voice_duration_s", 120)
+            if duration is not None and duration > max_duration:
+                raise ValueError(
+                    f"Audio clip exceeds the maximum duration of {max_duration} "
+                    "seconds and could not be transcribed."
+                )
+            # Check size limit pre-download
+            if attachment.size is not None and attachment.size > MAX_TRANSCRIPTION_BYTES:
+                raise ValueError(
+                    "Audio clip exceeds the maximum size of 30 MB and could not be transcribed."
+                )
+            limit = MAX_TRANSCRIPTION_BYTES
+        else:
+            limit = attachment_limit_for_mime(attachment.mime_type)
+
         ensure_declared_size_within_limit(attachment.size, name=attachment.name, limit=limit)
         file_info = await self._api("getFile", {"file_id": file_id})
         if not isinstance(file_info, dict):

--- a/src/agentos/gateway/audio_transcription.py
+++ b/src/agentos/gateway/audio_transcription.py
@@ -18,7 +18,8 @@ from agentos.provider.audio import (
     ElevenLabsSpeechToTextResult,
 )
 
-_MAX_TRANSCRIPTION_BYTES = 30 * 1024 * 1024
+MAX_TRANSCRIPTION_BYTES = 30 * 1024 * 1024
+_MAX_TRANSCRIPTION_BYTES = MAX_TRANSCRIPTION_BYTES
 
 
 def _default_provider_factory(config: GatewayConfig) -> ElevenLabsAudioProductionProvider:

--- a/src/agentos/gateway/audio_transcription.py
+++ b/src/agentos/gateway/audio_transcription.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -15,6 +15,7 @@ from agentos.gateway.uploads import _extract_authorization_token
 from agentos.provider.audio import (
     ElevenLabsAudioProductionProvider,
     ElevenLabsSpeechToTextRequest,
+    ElevenLabsSpeechToTextResult,
 )
 
 _MAX_TRANSCRIPTION_BYTES = 30 * 1024 * 1024
@@ -26,6 +27,37 @@ def _default_provider_factory(config: GatewayConfig) -> ElevenLabsAudioProductio
         api_key=getattr(provider_cfg, "api_key", ""),
         api_key_env=getattr(provider_cfg, "api_key_env", "ELEVENLABS_API_KEY"),
         base_url=getattr(provider_cfg, "base_url", "https://api.elevenlabs.io"),
+    )
+
+
+async def transcribe_audio_bytes(
+    config: GatewayConfig,
+    payload: bytes,
+    *,
+    filename: str = "voice.webm",
+    mime_type: str = "audio/webm",
+    model_id: str | None = None,
+    language_code: str | None = None,
+    provider_factory: Callable[[GatewayConfig], Any] = _default_provider_factory,
+) -> ElevenLabsSpeechToTextResult:
+    """Helper to call speech-to-text using the configured provider."""
+    if not getattr(config.audio, "enabled", False):
+        raise RuntimeError("Audio transcription is disabled")
+
+    provider_cfg = config.audio.providers.elevenlabs
+    actual_model_id = (
+        model_id or getattr(provider_cfg, "speech_to_text_model", "scribe_v2") or "scribe_v2"
+    )
+
+    provider = cast(ElevenLabsAudioProductionProvider, provider_factory(config))
+    return await provider.transcribe_audio(
+        ElevenLabsSpeechToTextRequest(
+            audio_bytes=payload,
+            filename=filename,
+            mime_type=mime_type,
+            model_id=actual_model_id,
+            language_code=language_code or None,
+        )
     )
 
 
@@ -43,8 +75,7 @@ def register_audio_transcription_routes(
                 return JSONResponse(
                     {
                         "error": (
-                            "Authorization header (Bearer ...) required for "
-                            "/api/audio/transcribe"
+                            "Authorization header (Bearer ...) required for /api/audio/transcribe"
                         ),
                         "code": "UNAUTHORIZED",
                     },
@@ -60,9 +91,7 @@ def register_audio_transcription_routes(
         try:
             form = await request.form()
         except Exception as exc:
-            return JSONResponse(
-                {"error": f"multipart/form-data required: {exc}"}, status_code=400
-            )
+            return JSONResponse({"error": f"multipart/form-data required: {exc}"}, status_code=400)
 
         upload = form.get("file")
         if upload is None or not hasattr(upload, "read"):
@@ -98,14 +127,14 @@ def register_audio_transcription_routes(
         language_code = language_code_value if isinstance(language_code_value, str) else None
 
         try:
-            result = await provider_factory(config).transcribe_audio(
-                ElevenLabsSpeechToTextRequest(
-                    audio_bytes=payload,
-                    filename=str(filename),
-                    mime_type=mime_type,
-                    model_id=model_id,
-                    language_code=language_code or None,
-                )
+            result = await transcribe_audio_bytes(
+                config=config,
+                payload=payload,
+                filename=str(filename),
+                mime_type=mime_type,
+                model_id=model_id,
+                language_code=language_code,
+                provider_factory=provider_factory,
             )
         except Exception as exc:
             return JSONResponse(

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -59,6 +59,7 @@ from agentos.engine.types import (
 )
 from agentos.execution_status import normalize_execution_status
 from agentos.gateway.attachment_ingest import AttachmentIngestResult, ingest_attachments
+from agentos.gateway.audio_transcription import MAX_TRANSCRIPTION_BYTES
 from agentos.gateway.session_events import build_sessions_changed_payload
 from agentos.paths import media_root_from_config
 from agentos.permissions import configured_default_elevated
@@ -1857,7 +1858,7 @@ async def _ingest_channel_message_attachments(
 
     if audio_enabled and transcribe_voice:
         non_audio_materialized = []
-        has_changes = False
+        successfully_transcribed_file_ids = set()
         for att in materialized:
             is_audio = False
             # Resolve fields check if att is dict (from failure) or Attachment object
@@ -1869,9 +1870,7 @@ async def _ingest_channel_message_attachments(
                 att.get("mime_type") if isinstance(att, dict) else None
             )
 
-            if media_kind in ("voice", "audio", "video_note") or (
-                mime_type and (mime_type.startswith("audio/") or mime_type.startswith("video/"))
-            ):
+            if media_kind in ("voice", "audio", "video_note"):
                 is_audio = True
 
             if is_audio:
@@ -1881,18 +1880,17 @@ async def _ingest_channel_message_attachments(
                 data = getattr(att, "data", None) or (
                     att.get("data") if isinstance(att, dict) else None
                 )
-                size = getattr(att, "size", None) or (
-                    att.get("size") if isinstance(att, dict) else None
-                )
-                if size is None and data is not None:
-                    size = len(data)
 
                 # Check if there was an ingest/materialization error
                 ingest_error = att.get("_ingest_error") if isinstance(att, dict) else None
                 if ingest_error:
                     error_msg = (
-                        "Voice message could not be transcribed "
-                        f"(download failed: {ingest_error})."
+                        ingest_error
+                        if "exceeds" in ingest_error
+                        else (
+                            "Voice message could not be transcribed "
+                            f"(download failed: {ingest_error})."
+                        )
                     )
                     if route_envelope is not None:
                         try:
@@ -1927,11 +1925,10 @@ async def _ingest_channel_message_attachments(
                     continue
 
                 # Check size limit
-                max_size_bytes = 30 * 1024 * 1024
+                max_size_bytes = MAX_TRANSCRIPTION_BYTES
                 if len(data) > max_size_bytes:
                     error_msg = (
-                        "Audio clip exceeds the maximum size of 30 MB "
-                        "and could not be transcribed."
+                        "Audio clip exceeds the maximum size of 30 MB and could not be transcribed."
                     )
                     if route_envelope is not None:
                         try:
@@ -1958,7 +1955,7 @@ async def _ingest_channel_message_attachments(
                     # Update msg.content
                     media_placeholder = f"[{media_kind or 'voice'}]"
                     if media_placeholder in msg.content:
-                        msg.content = msg.content.replace(media_placeholder, transcript)
+                        msg.content = msg.content.replace(media_placeholder, transcript, 1)
                     else:
                         if msg.content:
                             msg.content = f"{msg.content}\n\n{transcript}"
@@ -1972,16 +1969,13 @@ async def _ingest_channel_message_attachments(
                     file_id = metadata.get("telegram_file_id")
                     if file_id:
                         msg.metadata["telegram_file_id"] = file_id
+                        successfully_transcribed_file_ids.add(file_id)
                     if stt_result.language_code:
                         msg.metadata["language_code"] = stt_result.language_code
 
-                    has_changes = True
                 except Exception as exc:
                     log.warning("channel.transcribe_audio_failed", error=str(exc))
-                    error_msg = (
-                        "Voice message could not be transcribed "
-                        "(provider error)."
-                    )
+                    error_msg = "Voice message could not be transcribed (provider error)."
                     if route_envelope is not None:
                         try:
                             await channel.send(
@@ -1993,21 +1987,14 @@ async def _ingest_channel_message_attachments(
             else:
                 non_audio_materialized.append(att)
 
-        if has_changes:
+        if successfully_transcribed_file_ids:
             materialized = non_audio_materialized
             # Clean up matching attachments from msg.attachments
-            transcribed_file_ids = set()
-            for att in msg.attachments:
-                metadata = getattr(att, "metadata", {})
-                media_kind = metadata.get("telegram_media_kind")
-                if media_kind in ("voice", "audio", "video_note"):
-                    file_id = metadata.get("telegram_file_id")
-                    if file_id:
-                        transcribed_file_ids.add(file_id)
             msg.attachments = [
                 att
                 for att in msg.attachments
-                if getattr(att, "metadata", {}).get("telegram_file_id") not in transcribed_file_ids
+                if getattr(att, "metadata", {}).get("telegram_file_id")
+                not in successfully_transcribed_file_ids
             ]
 
     result = await ingest_attachments(

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -464,7 +464,12 @@ async def run_channel_dispatch(
                 route_envelope=route_envelope,
             )
 
-        ingested = await _ingest_channel_message_attachments(channel=channel, msg=msg)
+        ingested = await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
 
         async with _maybe_lock(session_lock):
             await _record_delivery_context(
@@ -749,11 +754,7 @@ async def _dispatch_channel_new_command(
 
     ctx = context_factory(route_envelope)
     access = getattr(ctx, "access", None)
-    if (
-        access is None
-        or not access.admitted
-        or access.surface is not ConnectionSurface.CHANNEL
-    ):
+    if access is None or not access.admitted or access.surface is not ConnectionSurface.CHANNEL:
         return _route_envelope_reply_message(
             "/new denied: paired channel connection required",
             route_envelope,
@@ -822,7 +823,12 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
         if _should_skip_unmentioned(channel, msg, session_key, route_envelope):
             return
 
-    ingested = await _ingest_channel_message_attachments(channel=channel, msg=msg)
+    ingested = await _ingest_channel_message_attachments(
+        channel=channel,
+        msg=msg,
+        config=config,
+        route_envelope=route_envelope,
+    )
 
     async with _maybe_lock(session_lock):
         await _record_delivery_context(session_manager, session_key, msg, session_prefix, route_envelope=route_envelope)  # noqa: E501
@@ -1832,11 +1838,178 @@ async def _ingest_channel_message_attachments(
     *,
     channel: Any,
     msg: IncomingMessage,
+    config: Any = None,
+    route_envelope: Any = None,
 ) -> AttachmentIngestResult:
     materialized = await _materialize_channel_attachments(
         channel,
         list(getattr(msg, "attachments", []) or []),
     )
+
+    # Check if voice transcription is enabled on this channel & globally
+    transcribe_voice = False
+    if hasattr(channel, "config"):
+        transcribe_voice = getattr(channel.config, "transcribe_voice", False)
+
+    audio_enabled = False
+    if config is not None and getattr(config, "audio", None) is not None:
+        audio_enabled = getattr(config.audio, "enabled", False)
+
+    if audio_enabled and transcribe_voice:
+        non_audio_materialized = []
+        has_changes = False
+        for att in materialized:
+            is_audio = False
+            # Resolve fields check if att is dict (from failure) or Attachment object
+            metadata = getattr(att, "metadata", None) or (
+                att.get("metadata", {}) if isinstance(att, dict) else {}
+            )
+            media_kind = metadata.get("telegram_media_kind")
+            mime_type = getattr(att, "mime_type", None) or (
+                att.get("mime_type") if isinstance(att, dict) else None
+            )
+
+            if media_kind in ("voice", "audio", "video_note") or (
+                mime_type and (mime_type.startswith("audio/") or mime_type.startswith("video/"))
+            ):
+                is_audio = True
+
+            if is_audio:
+                name = getattr(att, "name", None) or (
+                    att.get("name") if isinstance(att, dict) else "audio"
+                )
+                data = getattr(att, "data", None) or (
+                    att.get("data") if isinstance(att, dict) else None
+                )
+                size = getattr(att, "size", None) or (
+                    att.get("size") if isinstance(att, dict) else None
+                )
+                if size is None and data is not None:
+                    size = len(data)
+
+                # Check if there was an ingest/materialization error
+                ingest_error = att.get("_ingest_error") if isinstance(att, dict) else None
+                if ingest_error:
+                    error_msg = (
+                        "Voice message could not be transcribed "
+                        f"(download failed: {ingest_error})."
+                    )
+                    if route_envelope is not None:
+                        try:
+                            await channel.send(
+                                _route_envelope_reply_message(error_msg, route_envelope)
+                            )
+                        except Exception:
+                            log.exception("channel.transcribe_reply_failed")
+                    non_audio_materialized.append(att)
+                    continue
+
+                if not data:
+                    non_audio_materialized.append(att)
+                    continue
+
+                # Check duration limit
+                duration = metadata.get("duration")
+                max_duration = getattr(channel.config, "max_voice_duration_s", 120)
+                if duration is not None and duration > max_duration:
+                    error_msg = (
+                        f"Audio clip exceeds the maximum duration of {max_duration} "
+                        "seconds and could not be transcribed."
+                    )
+                    if route_envelope is not None:
+                        try:
+                            await channel.send(
+                                _route_envelope_reply_message(error_msg, route_envelope)
+                            )
+                        except Exception:
+                            log.exception("channel.transcribe_reply_failed")
+                    non_audio_materialized.append(att)
+                    continue
+
+                # Check size limit
+                max_size_bytes = 30 * 1024 * 1024
+                if len(data) > max_size_bytes:
+                    error_msg = (
+                        "Audio clip exceeds the maximum size of 30 MB "
+                        "and could not be transcribed."
+                    )
+                    if route_envelope is not None:
+                        try:
+                            await channel.send(
+                                _route_envelope_reply_message(error_msg, route_envelope)
+                            )
+                        except Exception:
+                            log.exception("channel.transcribe_reply_failed")
+                    non_audio_materialized.append(att)
+                    continue
+
+                # Call STT
+                from agentos.gateway.audio_transcription import transcribe_audio_bytes
+
+                try:
+                    stt_result = await transcribe_audio_bytes(
+                        config=config,
+                        payload=data,
+                        filename=str(name),
+                        mime_type=mime_type or "audio/ogg",
+                    )
+                    transcript = stt_result.text
+
+                    # Update msg.content
+                    media_placeholder = f"[{media_kind or 'voice'}]"
+                    if media_placeholder in msg.content:
+                        msg.content = msg.content.replace(media_placeholder, transcript)
+                    else:
+                        if msg.content:
+                            msg.content = f"{msg.content}\n\n{transcript}"
+                        else:
+                            msg.content = transcript
+
+                    # Set metadata
+                    msg.metadata["transcribed_from"] = media_kind or "voice"
+                    if duration is not None:
+                        msg.metadata["duration"] = duration
+                    file_id = metadata.get("telegram_file_id")
+                    if file_id:
+                        msg.metadata["telegram_file_id"] = file_id
+                    if stt_result.language_code:
+                        msg.metadata["language_code"] = stt_result.language_code
+
+                    has_changes = True
+                except Exception as exc:
+                    log.warning("channel.transcribe_audio_failed", error=str(exc))
+                    error_msg = (
+                        "Voice message could not be transcribed "
+                        "(provider error)."
+                    )
+                    if route_envelope is not None:
+                        try:
+                            await channel.send(
+                                _route_envelope_reply_message(error_msg, route_envelope)
+                            )
+                        except Exception:
+                            log.exception("channel.transcribe_reply_failed")
+                    non_audio_materialized.append(att)
+            else:
+                non_audio_materialized.append(att)
+
+        if has_changes:
+            materialized = non_audio_materialized
+            # Clean up matching attachments from msg.attachments
+            transcribed_file_ids = set()
+            for att in msg.attachments:
+                metadata = getattr(att, "metadata", {})
+                media_kind = metadata.get("telegram_media_kind")
+                if media_kind in ("voice", "audio", "video_note"):
+                    file_id = metadata.get("telegram_file_id")
+                    if file_id:
+                        transcribed_file_ids.add(file_id)
+            msg.attachments = [
+                att
+                for att in msg.attachments
+                if getattr(att, "metadata", {}).get("telegram_file_id") not in transcribed_file_ids
+            ]
+
     result = await ingest_attachments(
         msg.content,
         materialized,

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1593,6 +1593,8 @@ class TelegramChannelEntry(ConfiguredChannelEntry):
     groups_enabled: bool = False
     group_chat_ids: list[str] = Field(default_factory=list)
     group_mention_required: bool = True
+    transcribe_voice: bool = False
+    max_voice_duration_s: int = 120
 
     @field_validator("group_chat_ids", mode="before")
     @classmethod

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1594,7 +1594,7 @@ class TelegramChannelEntry(ConfiguredChannelEntry):
     group_chat_ids: list[str] = Field(default_factory=list)
     group_mention_required: bool = True
     transcribe_voice: bool = False
-    max_voice_duration_s: int = 120
+    max_voice_duration_s: int = Field(default=120, gt=0)
 
     @field_validator("group_chat_ids", mode="before")
     @classmethod

--- a/tests/test_channels/test_telegram_transcription.py
+++ b/tests/test_channels/test_telegram_transcription.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+from agentos.channels.types import Attachment, IncomingMessage, OutgoingMessage
+from agentos.gateway.channel_dispatch import _ingest_channel_message_attachments
+
+
+def test_telegram_voice_and_video_note_parsing() -> None:
+    # 1. Test voice parsing with duration
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    msg = channel.parse_incoming({
+        "message": {
+            "message_id": 101,
+            "chat": {"id": 123, "type": "private"},
+            "from": {"id": 456, "first_name": "Alice"},
+            "voice": {
+                "file_id": "voice-file-id",
+                "file_unique_id": "voice-unique",
+                "duration": 45,
+                "mime_type": "audio/ogg",
+                "file_size": 2048,
+            }
+        }
+    })
+    assert msg.content == "[voice]"
+    assert len(msg.attachments) == 1
+    assert msg.attachments[0].metadata["telegram_media_kind"] == "voice"
+    assert msg.attachments[0].metadata["duration"] == 45
+    assert msg.attachments[0].metadata["telegram_file_id"] == "voice-file-id"
+
+    # 2. Test video_note parsing with duration
+    msg_vn = channel.parse_incoming({
+        "message": {
+            "message_id": 102,
+            "chat": {"id": 123, "type": "private"},
+            "from": {"id": 456, "first_name": "Alice"},
+            "video_note": {
+                "file_id": "vn-file-id",
+                "file_unique_id": "vn-unique",
+                "duration": 12,
+                "file_size": 4096,
+            }
+        }
+    })
+    assert msg_vn.content == "[video_note]"
+    assert len(msg_vn.attachments) == 1
+    assert msg_vn.attachments[0].metadata["telegram_media_kind"] == "video_note"
+    assert msg_vn.attachments[0].metadata["duration"] == 12
+    assert msg_vn.attachments[0].metadata["telegram_file_id"] == "vn-file-id"
+
+    # 3. Test reply metadata parsing
+    msg_reply = channel.parse_incoming({
+        "message": {
+            "message_id": 103,
+            "chat": {"id": 123, "type": "private"},
+            "from": {"id": 456, "first_name": "Alice"},
+            "text": "Hello",
+            "reply_to_message": {
+                "message_id": 99,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 789, "username": "bot_user"},
+                "text": "Prior message",
+            }
+        }
+    })
+    assert msg_reply.metadata["reply_to_message_id"] == "99"
+    assert msg_reply.metadata["reply_to_message_from_id"] == "789"
+    assert msg_reply.metadata["reply_to_message_from_username"] == "bot_user"
+
+
+def test_telegram_is_group_mentioned_on_reply() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    channel.bot_user_id = "789"
+    channel.bot_username = "my_bot"
+
+    # Reply to bot by ID
+    msg_reply_id = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        metadata={
+            "is_group": True,
+            "reply_to_message_from_id": "789",
+        }
+    )
+    assert channel.is_group_mentioned(msg_reply_id) is True
+
+    # Reply to bot by username
+    msg_reply_username = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        metadata={
+            "is_group": True,
+            "reply_to_message_from_username": "my_bot",
+        }
+    )
+    assert channel.is_group_mentioned(msg_reply_username) is True
+
+    # Unrelated message - no mention
+    msg_no_mention = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        metadata={
+            "is_group": True,
+        }
+    )
+    assert channel.is_group_mentioned(msg_no_mention) is False
+
+
+@pytest.mark.asyncio
+async def test_channel_dispatch_transcription_success() -> None:
+    channel = MagicMock()
+    channel.config = TelegramChannelConfig(token="test-token", transcribe_voice=True)
+    channel.resolve_inbound_attachment = AsyncMock(
+        side_effect=lambda att: att.model_copy(update={"data": b"fake-ogg-bytes"})
+    )
+
+    msg = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        attachments=[
+            Attachment(
+                name="voice.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id",
+                    "duration": 10,
+                }
+            )
+        ]
+    )
+
+    config = MagicMock()
+    config.audio.enabled = True
+    route_envelope = MagicMock()
+    route_envelope.channel_id = "123"
+
+    with patch(
+        "agentos.gateway.audio_transcription.transcribe_audio_bytes",
+        new_callable=AsyncMock,
+    ) as mock_stt:
+        mock_stt.return_value = MagicMock(
+            text="hello from voice note",
+            provider="elevenlabs",
+            model="scribe_v2",
+            language_code="en",
+        )
+
+        await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
+
+        # Assert voice attachment transcribed and removed from attachments list
+        assert msg.content == "hello from voice note"
+        assert len(msg.attachments) == 0
+        assert msg.metadata["transcribed_from"] == "voice"
+        assert msg.metadata["duration"] == 10
+        assert msg.metadata["telegram_file_id"] == "voice-id"
+        assert msg.metadata["language_code"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_channel_dispatch_transcription_success_with_caption() -> None:
+    channel = MagicMock()
+    channel.config = TelegramChannelConfig(token="test-token", transcribe_voice=True)
+    channel.resolve_inbound_attachment = AsyncMock(
+        side_effect=lambda att: att.model_copy(update={"data": b"fake-ogg-bytes"})
+    )
+
+    msg = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="This is the caption",
+        attachments=[
+            Attachment(
+                name="voice.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id",
+                    "duration": 10,
+                }
+            )
+        ]
+    )
+
+    config = MagicMock()
+    config.audio.enabled = True
+    route_envelope = MagicMock()
+
+    with patch(
+        "agentos.gateway.audio_transcription.transcribe_audio_bytes",
+        new_callable=AsyncMock,
+    ) as mock_stt:
+        mock_stt.return_value = MagicMock(
+            text="hello from voice note",
+            provider="elevenlabs",
+            model="scribe_v2",
+            language_code="en",
+        )
+
+        await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
+
+        # Caption and voice note combined
+        assert msg.content == "This is the caption\n\nhello from voice note"
+        assert len(msg.attachments) == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_dispatch_transcription_provider_failure() -> None:
+    channel = MagicMock()
+    channel.config = TelegramChannelConfig(token="test-token", transcribe_voice=True)
+    channel.resolve_inbound_attachment = AsyncMock(
+        side_effect=lambda att: att.model_copy(update={"data": b"fake-ogg-bytes"})
+    )
+    channel.send = AsyncMock()
+
+    msg = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        attachments=[
+            Attachment(
+                name="voice.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id",
+                    "duration": 10,
+                }
+            )
+        ]
+    )
+
+    config = MagicMock()
+    config.audio.enabled = True
+    route_envelope = MagicMock()
+    route_envelope.channel_id = "123"
+    route_envelope.thread_id = None
+
+    with patch(
+        "agentos.gateway.audio_transcription.transcribe_audio_bytes",
+        new_callable=AsyncMock,
+    ) as mock_stt:
+        mock_stt.side_effect = RuntimeError("STT provider is down")
+
+        await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
+
+        # Check content is unchanged (placeholder) and error message sent to user
+        assert msg.content == "[voice]"
+        channel.send.assert_called_once()
+        sent_msg = channel.send.call_args[0][0]
+        assert isinstance(sent_msg, OutgoingMessage)
+        assert "provider error" in sent_msg.content
+
+
+@pytest.mark.asyncio
+async def test_channel_dispatch_transcription_oversized_duration() -> None:
+    channel = MagicMock()
+    # 5s max duration config
+    channel.config = TelegramChannelConfig(
+        token="test-token", transcribe_voice=True, max_voice_duration_s=5
+    )
+    channel.resolve_inbound_attachment = AsyncMock(
+        side_effect=lambda att: att.model_copy(update={"data": b"fake-ogg-bytes"})
+    )
+    channel.send = AsyncMock()
+
+    msg = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        attachments=[
+            Attachment(
+                name="voice.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id",
+                    "duration": 10,  # exceeds 5s max
+                }
+            )
+        ]
+    )
+
+    config = MagicMock()
+    config.audio.enabled = True
+    route_envelope = MagicMock()
+    route_envelope.channel_id = "123"
+    route_envelope.thread_id = None
+
+    with patch(
+        "agentos.gateway.audio_transcription.transcribe_audio_bytes",
+        new_callable=AsyncMock,
+    ) as mock_stt:
+        await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
+
+        # No transcription should be called
+        mock_stt.assert_not_called()
+        assert msg.content == "[voice]"
+        channel.send.assert_called_once()
+        sent_msg = channel.send.call_args[0][0]
+        assert "exceeds the maximum duration" in sent_msg.content
+
+
+@pytest.mark.asyncio
+async def test_channel_dispatch_transcription_disabled() -> None:
+    channel = MagicMock()
+    # transcribe_voice is False by default
+    channel.config = TelegramChannelConfig(token="test-token")
+    channel.resolve_inbound_attachment = AsyncMock(
+        side_effect=lambda att: att.model_copy(update={"data": b"fake-ogg-bytes"})
+    )
+
+    msg = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice]",
+        attachments=[
+            Attachment(
+                name="voice.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id",
+                    "duration": 10,
+                }
+            )
+        ]
+    )
+
+    config = MagicMock()
+    config.audio.enabled = True
+    route_envelope = MagicMock()
+
+    with patch(
+        "agentos.gateway.audio_transcription.transcribe_audio_bytes",
+        new_callable=AsyncMock,
+    ) as mock_stt:
+        await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
+
+        mock_stt.assert_not_called()
+        assert msg.content == "[voice]"

--- a/tests/test_channels/test_telegram_transcription.py
+++ b/tests/test_channels/test_telegram_transcription.py
@@ -12,20 +12,22 @@ from agentos.gateway.channel_dispatch import _ingest_channel_message_attachments
 def test_telegram_voice_and_video_note_parsing() -> None:
     # 1. Test voice parsing with duration
     channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
-    msg = channel.parse_incoming({
-        "message": {
-            "message_id": 101,
-            "chat": {"id": 123, "type": "private"},
-            "from": {"id": 456, "first_name": "Alice"},
-            "voice": {
-                "file_id": "voice-file-id",
-                "file_unique_id": "voice-unique",
-                "duration": 45,
-                "mime_type": "audio/ogg",
-                "file_size": 2048,
+    msg = channel.parse_incoming(
+        {
+            "message": {
+                "message_id": 101,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 456, "first_name": "Alice"},
+                "voice": {
+                    "file_id": "voice-file-id",
+                    "file_unique_id": "voice-unique",
+                    "duration": 45,
+                    "mime_type": "audio/ogg",
+                    "file_size": 2048,
+                },
             }
         }
-    })
+    )
     assert msg.content == "[voice]"
     assert len(msg.attachments) == 1
     assert msg.attachments[0].metadata["telegram_media_kind"] == "voice"
@@ -33,19 +35,21 @@ def test_telegram_voice_and_video_note_parsing() -> None:
     assert msg.attachments[0].metadata["telegram_file_id"] == "voice-file-id"
 
     # 2. Test video_note parsing with duration
-    msg_vn = channel.parse_incoming({
-        "message": {
-            "message_id": 102,
-            "chat": {"id": 123, "type": "private"},
-            "from": {"id": 456, "first_name": "Alice"},
-            "video_note": {
-                "file_id": "vn-file-id",
-                "file_unique_id": "vn-unique",
-                "duration": 12,
-                "file_size": 4096,
+    msg_vn = channel.parse_incoming(
+        {
+            "message": {
+                "message_id": 102,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 456, "first_name": "Alice"},
+                "video_note": {
+                    "file_id": "vn-file-id",
+                    "file_unique_id": "vn-unique",
+                    "duration": 12,
+                    "file_size": 4096,
+                },
             }
         }
-    })
+    )
     assert msg_vn.content == "[video_note]"
     assert len(msg_vn.attachments) == 1
     assert msg_vn.attachments[0].metadata["telegram_media_kind"] == "video_note"
@@ -53,20 +57,22 @@ def test_telegram_voice_and_video_note_parsing() -> None:
     assert msg_vn.attachments[0].metadata["telegram_file_id"] == "vn-file-id"
 
     # 3. Test reply metadata parsing
-    msg_reply = channel.parse_incoming({
-        "message": {
-            "message_id": 103,
-            "chat": {"id": 123, "type": "private"},
-            "from": {"id": 456, "first_name": "Alice"},
-            "text": "Hello",
-            "reply_to_message": {
-                "message_id": 99,
+    msg_reply = channel.parse_incoming(
+        {
+            "message": {
+                "message_id": 103,
                 "chat": {"id": 123, "type": "private"},
-                "from": {"id": 789, "username": "bot_user"},
-                "text": "Prior message",
+                "from": {"id": 456, "first_name": "Alice"},
+                "text": "Hello",
+                "reply_to_message": {
+                    "message_id": 99,
+                    "chat": {"id": 123, "type": "private"},
+                    "from": {"id": 789, "username": "bot_user"},
+                    "text": "Prior message",
+                },
             }
         }
-    })
+    )
     assert msg_reply.metadata["reply_to_message_id"] == "99"
     assert msg_reply.metadata["reply_to_message_from_id"] == "789"
     assert msg_reply.metadata["reply_to_message_from_username"] == "bot_user"
@@ -85,7 +91,7 @@ def test_telegram_is_group_mentioned_on_reply() -> None:
         metadata={
             "is_group": True,
             "reply_to_message_from_id": "789",
-        }
+        },
     )
     assert channel.is_group_mentioned(msg_reply_id) is True
 
@@ -97,7 +103,7 @@ def test_telegram_is_group_mentioned_on_reply() -> None:
         metadata={
             "is_group": True,
             "reply_to_message_from_username": "my_bot",
-        }
+        },
     )
     assert channel.is_group_mentioned(msg_reply_username) is True
 
@@ -108,7 +114,7 @@ def test_telegram_is_group_mentioned_on_reply() -> None:
         content="[voice]",
         metadata={
             "is_group": True,
-        }
+        },
     )
     assert channel.is_group_mentioned(msg_no_mention) is False
 
@@ -134,9 +140,9 @@ async def test_channel_dispatch_transcription_success() -> None:
                     "telegram_media_kind": "voice",
                     "telegram_file_id": "voice-id",
                     "duration": 10,
-                }
+                },
             )
-        ]
+        ],
     )
 
     config = MagicMock()
@@ -192,9 +198,9 @@ async def test_channel_dispatch_transcription_success_with_caption() -> None:
                     "telegram_media_kind": "voice",
                     "telegram_file_id": "voice-id",
                     "duration": 10,
-                }
+                },
             )
-        ]
+        ],
     )
 
     config = MagicMock()
@@ -246,9 +252,9 @@ async def test_channel_dispatch_transcription_provider_failure() -> None:
                     "telegram_media_kind": "voice",
                     "telegram_file_id": "voice-id",
                     "duration": 10,
-                }
+                },
             )
-        ]
+        ],
     )
 
     config = MagicMock()
@@ -303,9 +309,9 @@ async def test_channel_dispatch_transcription_oversized_duration() -> None:
                     "telegram_media_kind": "voice",
                     "telegram_file_id": "voice-id",
                     "duration": 10,  # exceeds 5s max
-                }
+                },
             )
-        ]
+        ],
     )
 
     config = MagicMock()
@@ -355,9 +361,9 @@ async def test_channel_dispatch_transcription_disabled() -> None:
                     "telegram_media_kind": "voice",
                     "telegram_file_id": "voice-id",
                     "duration": 10,
-                }
+                },
             )
-        ]
+        ],
     )
 
     config = MagicMock()
@@ -377,3 +383,131 @@ async def test_channel_dispatch_transcription_disabled() -> None:
 
         mock_stt.assert_not_called()
         assert msg.content == "[voice]"
+
+
+def test_telegram_config_validation_max_voice_duration() -> None:
+    from pydantic import ValidationError
+
+    # 0 should raise validation error
+    with pytest.raises(ValidationError):
+        TelegramChannelConfig(token="test", max_voice_duration_s=0)
+
+    # Negative value should raise validation error
+    with pytest.raises(ValidationError):
+        TelegramChannelConfig(token="test", max_voice_duration_s=-5)
+
+    # Positive value should succeed
+    cfg = TelegramChannelConfig(token="test", max_voice_duration_s=10)
+    assert cfg.max_voice_duration_s == 10
+
+
+@pytest.mark.asyncio
+async def test_resolve_inbound_attachment_predownload_limits() -> None:
+    channel = TelegramChannel(
+        TelegramChannelConfig(token="test", transcribe_voice=True, max_voice_duration_s=5)
+    )
+
+    # 1. Test duration check pre-download
+    att_duration = Attachment(
+        name="voice.ogg",
+        mime_type="audio/ogg",
+        size=1024,
+        metadata={
+            "telegram_media_kind": "voice",
+            "telegram_file_id": "voice-id",
+            "duration": 10,
+        },
+    )
+    with pytest.raises(ValueError) as excinfo:
+        await channel.resolve_inbound_attachment(att_duration)
+    assert "exceeds the maximum duration of 5 seconds" in str(excinfo.value)
+
+    # 2. Test size check pre-download
+    from agentos.gateway.audio_transcription import MAX_TRANSCRIPTION_BYTES
+
+    att_size = Attachment(
+        name="voice.ogg",
+        mime_type="audio/ogg",
+        size=MAX_TRANSCRIPTION_BYTES + 100,
+        metadata={
+            "telegram_media_kind": "voice",
+            "telegram_file_id": "voice-id",
+            "duration": 3,
+        },
+    )
+    with pytest.raises(ValueError) as excinfo:
+        await channel.resolve_inbound_attachment(att_size)
+    assert "exceeds the maximum size of 30 MB" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_channel_dispatch_transcription_partial_failure() -> None:
+    channel = MagicMock()
+    channel.config = TelegramChannelConfig(token="test-token", transcribe_voice=True)
+    channel.resolve_inbound_attachment = AsyncMock(
+        side_effect=lambda att: att.model_copy(update={"data": b"fake-ogg-bytes"})
+    )
+
+    msg = IncomingMessage(
+        sender_id="456",
+        channel_id="123",
+        content="[voice] and [voice]",
+        attachments=[
+            Attachment(
+                name="voice1.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id-1",
+                    "duration": 10,
+                },
+            ),
+            Attachment(
+                name="voice2.ogg",
+                mime_type="audio/ogg",
+                size=120,
+                metadata={
+                    "telegram_media_kind": "voice",
+                    "telegram_file_id": "voice-id-2",
+                    "duration": 10,
+                },
+            ),
+        ],
+    )
+
+    config = MagicMock()
+    config.audio.enabled = True
+    route_envelope = MagicMock()
+    route_envelope.channel_id = "123"
+    route_envelope.thread_id = None
+
+    with patch(
+        "agentos.gateway.audio_transcription.transcribe_audio_bytes",
+        new_callable=AsyncMock,
+    ) as mock_stt:
+
+        def side_effect(config, payload, filename, mime_type):
+            if "voice1" in filename:
+                return MagicMock(
+                    text="hello",
+                    provider="elevenlabs",
+                    model="scribe_v2",
+                    language_code="en",
+                )
+            else:
+                raise RuntimeError("STT failed for voice2")
+
+        mock_stt.side_effect = side_effect
+
+        await _ingest_channel_message_attachments(
+            channel=channel,
+            msg=msg,
+            config=config,
+            route_envelope=route_envelope,
+        )
+
+        assert "hello" in msg.content
+        assert "[voice]" in msg.content
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0].metadata["telegram_file_id"] == "voice-id-2"


### PR DESCRIPTION

### Description

This PR implements automatic transcription for inbound Telegram voice messages, audio files, and round video notes (`video_note`) before the turn is built, mapping the speech-to-text output onto the message text content.

#### Key Changes:
- **Transcription Wiring**: refactored the ElevenLabs STT call in `audio_transcription.py` to a shared helper and integrated it into the channel message ingestion flow in `channel_dispatch.py`.
- **Media Support**: Added support for parsing and transcribing `voice`, `audio`, and `video_note` payloads.
- **Group Mention Detection**: Updated group mention checks (`is_group_mentioned`) to detect replies targeting the bot (either by user ID or username) to satisfy admission checks.
- **Limits & Safeguards**:
  - Enforces a default 120-second duration limit (configurable via `max_voice_duration_s`) and a 30 MB size limit.
  - Notifies the user via a channel reply if a limit is exceeded or STT fails, falling back safely to the placeholder text (`[voice]`, etc.) to prevent dropping the message.
- **MIME Limits**: Relaxed the channel-level download limit for `audio/` and `video/` types to 30 MB while keeping the global attachment whitelist strict by stripping raw audio attachments after transcription.

Closes #312