### PR TITLE
fix(cron): let action=update repoint a job's delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Choosing a channel requires an interactive CLI or Web caller and a
   `session_target` other than `main`; webhook delivery and failure destinations
   remain CLI-, Web-, and RPC-only. (#310)
+- `cron(action="update")` accepts `delivery` too, so moving an existing job's
+  announcement is an edit rather than a rebuild. Refusing it left the model one
+  route to "post that job to Telegram instead" — remove the job and add a
+  replacement — which threw away the job id the user had just named along with
+  its whole run history, and in practice the refusal message pointed at the CLI,
+  the Web UI, and the RPC, none of which an agent in a chat can reach, so the
+  same failing call was retried until the turn was interrupted. A repoint keeps
+  the job's id, run history, `ws_topic` (so existing websocket subscribers stay
+  attached), and failure destination, and applies the same gates as `add`:
+  `mode='channel'` needs an interactive CLI or Web caller and a `session_target`
+  other than `main`, the recipient is validated at save time, and a chat caller
+  cannot repoint a job that already reports somewhere that chat cannot address.
+  (#310)
 - Sessions can be renamed. A new `sessions.rename` RPC sets (or clears) a
   session's `display_name`, and it is reachable from every surface:
   `agentos sessions rename <id> "<name>"` (`--clear` drops it), `/rename <name>`

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -272,8 +272,9 @@ in conversation can announce somewhere other than the chat it was asked for:
 }
 ```
 
-`mode` is `origin` (the calling conversation — identical to omitting
-`delivery`), `channel`, or `none`. `channel_id` follows the same recipient
+`delivery` is accepted on `add` and on `update`, so an existing job can be moved
+without being re-created. `mode` is `origin` (the calling conversation —
+identical to omitting `delivery` on `add`), `channel`, or `none`. `channel_id` follows the same recipient
 rules as above and is validated when the job is saved, so a session key or a
 non-numeric Telegram target fails immediately rather than at the next fire; an
 empty `channel_id` uses the channel's configured default chat. `channel_name`
@@ -378,11 +379,20 @@ alongside; the source keeps running:
 
 Delivery is one of the settings a clone inherits, so a clone announces wherever
 its source did unless it is given a `delivery` of its own — passing one
-redirects the clone and leaves the source alone. `update` does not take
-`delivery`: it is refused rather than accepted and ignored, since a job that
-kept reporting to its old destination while the caller was told the edit
-succeeded is the failure this argument exists to prevent. Repoint a live job
-from the CLI, the Web UI, or the `cron.update` RPC.
+redirects the clone and leaves the source alone. To move the existing job rather
+than derive a second one, pass `delivery` to `update`:
+
+```json
+{"action": "update", "job_id": "<job-id>",
+ "delivery": {"mode": "channel", "channel_name": "telegram", "channel_id": "-1001234567890"}}
+```
+
+A repoint keeps the job's id, its run history, and its websocket topic, so
+subscribers watching the job stay attached. The gates are the same ones `add`
+applies: `mode='channel'` needs an interactive CLI or Web caller and a session
+target other than `main`, the recipient is validated at save time, and a chat
+caller cannot repoint a job that already answers somewhere that chat cannot
+address. Webhook destinations and failure destinations remain CLI/Web/RPC-only.
 
 Both paths keep the operator gates. A job carrying a script or
 `tool_policy.elevated` can only be cloned or updated by an interactive CLI or

--- a/src/agentos/skills/bundled/cron/SKILL.md
+++ b/src/agentos/skills/bundled/cron/SKILL.md
@@ -132,11 +132,17 @@ instead of the channel it was reporting to.
 - Change in place: `cron(action="update", job_id="<job id>", task="<new prompt>")`
   patches only what you pass and keeps the job's id, schedule, timezone,
   delivery, kind, and policy. The same call accepts `schedule`, `tz`, `name`,
-  `job_kind`, `session_target`, `tool_policy`, `wake_mode`, and `enabled`.
+  `job_kind`, `session_target`, `tool_policy`, `wake_mode`, `delivery`, and
+  `enabled`.
+- Move where it announces: pass `delivery` to `update`. The job keeps its id and
+  its run history, which remove-and-re-create throws away.
 
 ```
 cron(action="update", job_id="<job id>", schedule={"kind": "cron", "expr": "30 7 * * 1-5"})
 cron(action="update", job_id="<job id>", enabled=False)
+cron(action="update", job_id="<job id>",
+     delivery={"mode": "channel", "channel_name": "telegram",
+               "channel_id": "-1001234567890"})
 ```
 
 ## Cloning a job
@@ -164,9 +170,10 @@ cloning it would be authoring content for somebody else's destination.
 short readable name while its prompt is long.
 
 Passing `delivery` alongside `clone_from` redirects the clone: the explicit
-destination wins over the one the source carried. `delivery` is not accepted by
-`action="update"` — an existing job's destination is changed from the CLI, the
-Web UI, or the cron RPC.
+destination wins over the one the source carried. To move the *existing* job
+instead of making a second one, pass `delivery` to `action="update"` — the same
+operator rules apply, and `mode="channel"` still needs an interactive CLI or Web
+caller.
 
 Other actions:
 

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -501,6 +501,85 @@ def _cron_delivery_summary(config: Any) -> dict[str, Any]:
     return summary
 
 
+async def _cron_update_delivery(
+    override: dict[str, Any],
+    target_job: Any,
+    ctx: Any,
+    caller_session_key: str,
+    session_target: str,
+) -> DeliveryConfig:
+    """The delivery config an ``action=update`` repoint should persist.
+
+    ``ws_topic`` is per-job, not per-destination, so it is carried across the
+    move: dropping it would orphan every websocket subscriber already watching
+    the job. A failure destination cannot be set from the tool, so whatever the
+    job carries survives the edit rather than being silently cleared.
+    """
+    existing = getattr(target_job, "delivery", None)
+    ws_topic = str(getattr(existing, "ws_topic", "") or "") or f"cron:{target_job.id}"
+    mode = override["mode"]
+
+    config: DeliveryConfig
+    if mode == "none":
+        config = DeliveryConfig(mode=DeliveryMode.NONE, ws_topic=ws_topic)
+    elif mode == "channel":
+        config = DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name=override["channel_name"],
+            channel_id=override["channel_id"],
+            account_id=override["account_id"],
+            thread_id=override["thread_id"],
+            ws_topic=ws_topic,
+        )
+    else:
+        # mode='origin' means "report back to the conversation asking for this",
+        # which is the calling session — the same inference a bare add makes.
+        from agentos.scheduler.delivery import infer_delivery
+
+        config = await infer_delivery(
+            session_storage=_session_storage_or_none(),
+            session_key=caller_session_key,
+            user_overrides=None,
+        )
+        config.ws_topic = ws_topic
+        if (
+            config.mode == DeliveryMode.NONE
+            and ctx is not None
+            and getattr(ctx, "channel_kind", None)
+        ):
+            # Session storage has no routing target yet (a fresh session before
+            # last_channel was written); the live context still knows one.
+            config.mode = DeliveryMode.ORIGIN
+            config.channel_name = ctx.channel_kind or ""
+            config.channel_id = ctx.channel_id or ""
+        if (
+            config.mode == DeliveryMode.ORIGIN
+            and config.channel_name
+            and config.originating_reply_target is None
+        ):
+            config.originating_reply_target = ReplyTargetSnapshot(
+                channel_name=config.channel_name,
+                channel_type=config.channel_name,
+                to=config.channel_id,
+                account_id=config.account_id,
+                thread_id=config.thread_id,
+            )
+        if session_target == "main":
+            # Persistence forces NONE for main; the snapshot is what pins the
+            # reply target, so it is the only part worth keeping.
+            config = DeliveryConfig(
+                mode=DeliveryMode.NONE,
+                ws_topic=ws_topic,
+                originating_reply_target=config.originating_reply_target,
+            )
+
+    if override["best_effort"]:
+        config.best_effort = True
+    if existing is not None and getattr(existing, "failure_destination", None) is not None:
+        config.failure_destination = existing.failure_destination
+    return config
+
+
 def _session_storage_or_none() -> Any:
     """The session store ``infer_delivery`` reads, or ``None`` when unavailable."""
     try:
@@ -728,6 +807,8 @@ def _session_storage_or_none() -> Any:
                 "'remind me' wants. Pass it only when the user names a different "
                 "destination: mode='channel' with channel_name and channel_id "
                 "posts to that chat instead, mode='none' keeps the run silent. "
+                "Works on update too, so moving a job's announcement is an edit "
+                "— never remove the job and add a replacement to change it. "
                 "channel_id is the id the provider uses (a Telegram numeric chat "
                 "id, negative for groups, or @username), never an AgentOS session "
                 "key; leave it empty to use the channel's configured default chat. "
@@ -1321,15 +1402,12 @@ async def cron(
 
     if action == "update":
         assert job_id is not None
-        if delivery:
-            # Repointing a live job is not implemented here, and silently
-            # dropping the argument would leave the job announcing where it
-            # always did while the caller believes it was moved — the discard
-            # this parameter exists to stop.
-            raise SafeToolError(
-                "delivery cannot be changed with action='update'; set it when the "
-                "job is created, or change it from the CLI, the Web UI, or the cron RPC"
-            )
+        # Repointing a live job used to be refused here, which left the model no
+        # way to move an announcement except remove + re-create — losing the job
+        # id the user named and its whole run history. The CLI, the Web UI and
+        # the cron RPC have always been able to do it; the checks below are the
+        # same grants ``add`` applies, not a weaker path to the same write.
+        delivery_override = _parse_cron_delivery(delivery)
         target_job = await sched.get_job(job_id)
         if target_job is None:
             raise SafeToolError(f"Job not found: {job_id}")
@@ -1367,6 +1445,49 @@ async def cron(
                     "so its content can only be edited by an interactive CLI or Web caller"
                 )
 
+        # Moving where a job announces is the same grant as rewriting what it
+        # says, and is checked before anything is written: `enabled` below
+        # pauses/resumes as a side effect, so a rejected destination must not
+        # leave a half-applied edit behind.
+        new_delivery: DeliveryConfig | None = None
+        if delivery_override is not None:
+            if delivery_override["mode"] == "channel":
+                caller_kind = getattr(ctx, "caller_kind", None) if ctx is not None else None
+                if caller_kind not in (CallerKind.CLI, CallerKind.WEB):
+                    raise SafeToolError(
+                        "delivery.mode='channel' requires an interactive CLI or Web caller; "
+                        "from a chat a job delivers back to the calling conversation"
+                    )
+                if new_target == "main":
+                    raise SafeToolError(
+                        "delivery.mode='channel' is unavailable for session_target=main; "
+                        "use session_target=isolated"
+                    )
+                _validate_cron_delivery_channel(delivery_override["channel_name"])
+                try:
+                    validate_channel_target(
+                        delivery_override["channel_name"],
+                        delivery_override["channel_id"],
+                    )
+                except ValueError as exc:
+                    # Caught at save time on purpose: an unusable recipient is
+                    # otherwise only discovered when the job fires.
+                    raise SafeToolError(str(exc)) from exc
+            if channel_caller and not _delivery_targets_caller(
+                getattr(target_job, "delivery", None), ctx
+            ):
+                raise SafeToolError(
+                    "that job reports to a destination this chat cannot address, "
+                    "so its delivery can only be changed by an interactive CLI or Web caller"
+                )
+            new_delivery = await _cron_update_delivery(
+                delivery_override,
+                target_job,
+                ctx,
+                caller_session_key,
+                new_target,
+            )
+
         if task is not None:
             blocked, reason = _scan_cron_prompt(task)
             if blocked:
@@ -1377,6 +1498,8 @@ async def cron(
                 raise SafeToolError(script_error)
 
         patch: dict[str, Any] = {}
+        if new_delivery is not None:
+            patch["delivery"] = new_delivery
         if name is not None and name.strip():
             patch["name"] = name.strip()
         if enabled is not None:
@@ -1489,7 +1612,8 @@ async def cron(
         if not patch:
             raise SafeToolError(
                 "update needs at least one field to change (schedule, task, name, "
-                "job_kind, session_target, tool_policy, wake_mode, tz, or enabled)"
+                "job_kind, session_target, tool_policy, wake_mode, tz, delivery, "
+                "or enabled)"
             )
         try:
             updated = await sched.update_job(job_id, **patch)

--- a/tests/test_tools/test_cron_tool_update_clone.py
+++ b/tests/test_tools/test_cron_tool_update_clone.py
@@ -74,6 +74,13 @@ def _channel_delivery() -> DeliveryConfig:
     )
 
 
+def _channel_delivery_with_topic() -> DeliveryConfig:
+    """A job that already has websocket subscribers watching it."""
+    config = _channel_delivery()
+    config.ws_topic = "cron:seeded"
+    return config
+
+
 async def _seed_agent_turn(sched: _OpsScheduler, **overrides: Any) -> Any:
     """A job with every setting a naive re-create would silently drop."""
     defaults: dict[str, Any] = {
@@ -920,9 +927,131 @@ async def test_delivery_none_silences_a_clone_that_inherited_a_channel(
     assert clone.delivery.channel_id == ""
 
 
+# ---------------------------------------------------------------------------
+# update: delivery
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_update_refuses_delivery_rather_than_dropping_it(tmp_path: Path) -> None:
-    """Accepting and ignoring it would report success while the job stayed put."""
+async def test_update_repoints_delivery_to_a_named_channel(tmp_path: Path) -> None:
+    """The edit the model reached for; refusing it drove remove + re-create."""
+    store, sched = await _open(tmp_path)
+    try:
+        job = await _seed_agent_turn(sched, delivery=_channel_delivery_with_topic())
+        payload = await _call(
+            sched,
+            _cli_ctx(),
+            action="update",
+            job_id=job.id,
+            delivery={
+                "mode": "channel",
+                "channel_name": "telegram",
+                "channel_id": "-100777",
+            },
+        )
+        stored = await sched.get_job(job.id)
+    finally:
+        await store.close()
+
+    assert stored is not None and stored.delivery is not None
+    assert stored.delivery.mode == DeliveryMode.CHANNEL
+    assert stored.delivery.channel_name == "telegram"
+    assert stored.delivery.channel_id == "-100777"
+    # The websocket topic is per-job, not per-destination: repointing must not
+    # orphan the subscribers already watching this job.
+    assert stored.delivery.ws_topic == "cron:seeded"
+    assert payload["job"]["delivery"]["channel_id"] == "-100777"
+    # The rest of the job is untouched by a delivery-only edit.
+    assert stored.tz == "Asia/Bangkok"
+    assert stored.tool_policy == {"profile": "messaging"}
+
+
+@pytest.mark.asyncio
+async def test_update_delivery_alone_is_a_change(tmp_path: Path) -> None:
+    """It must not trip the "needs at least one field" guard."""
+    store, sched = await _open(tmp_path)
+    try:
+        job = await _seed_agent_turn(sched)
+        payload = await _call(
+            sched,
+            _cli_ctx(),
+            action="update",
+            job_id=job.id,
+            delivery={"mode": "none"},
+        )
+        stored = await sched.get_job(job.id)
+    finally:
+        await store.close()
+
+    assert payload["job"]["delivery"]["mode"] == "none"
+    assert stored is not None and stored.delivery is not None
+    assert stored.delivery.mode == DeliveryMode.NONE
+    assert stored.delivery.channel_id == ""
+
+
+@pytest.mark.asyncio
+async def test_update_delivery_channel_needs_an_operator_caller(tmp_path: Path) -> None:
+    """A chat participant must not aim a job at a room they were never in."""
+    store, sched = await _open(tmp_path)
+    try:
+        job = await _seed_agent_turn(
+            sched,
+            delivery=DeliveryConfig(
+                mode=DeliveryMode.CHANNEL,
+                channel_name="telegram",
+                channel_id="42",
+            ),
+            tool_policy={},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await _call(
+                sched,
+                _channel_ctx(),
+                action="update",
+                job_id=job.id,
+                delivery={
+                    "mode": "channel",
+                    "channel_name": "telegram",
+                    "channel_id": "-100777",
+                },
+            )
+        stored = await sched.get_job(job.id)
+    finally:
+        await store.close()
+
+    assert "interactive CLI or Web caller" in str(excinfo.value)
+    assert stored is not None and stored.delivery is not None
+    assert stored.delivery.channel_id == "42"
+
+
+@pytest.mark.asyncio
+async def test_update_delivery_refused_when_the_job_answers_elsewhere(
+    tmp_path: Path,
+) -> None:
+    """Silencing a job that reports to another room is the same grant as editing it."""
+    store, sched = await _open(tmp_path)
+    try:
+        job = await _seed_agent_turn(sched, tool_policy={})
+        with pytest.raises(ToolError) as excinfo:
+            await _call(
+                sched,
+                _channel_ctx(),
+                action="update",
+                job_id=job.id,
+                delivery={"mode": "none"},
+            )
+        stored = await sched.get_job(job.id)
+    finally:
+        await store.close()
+
+    assert "cannot address" in str(excinfo.value)
+    assert stored is not None and stored.delivery is not None
+    assert stored.delivery.channel_id == "-100999"
+
+
+@pytest.mark.asyncio
+async def test_update_delivery_rejects_an_unusable_recipient(tmp_path: Path) -> None:
+    """Caught at save time rather than at every fire."""
     store, sched = await _open(tmp_path)
     try:
         job = await _seed_agent_turn(sched)
@@ -932,12 +1061,16 @@ async def test_update_refuses_delivery_rather_than_dropping_it(tmp_path: Path) -
                 _cli_ctx(),
                 action="update",
                 job_id=job.id,
-                delivery={"mode": "none"},
+                delivery={
+                    "mode": "channel",
+                    "channel_name": "telegram",
+                    "channel_id": "agent:main:telegram:42",
+                },
             )
         stored = await sched.get_job(job.id)
     finally:
         await store.close()
 
-    assert "delivery cannot be changed" in str(excinfo.value)
+    assert "session key" in str(excinfo.value).lower()
     assert stored is not None and stored.delivery is not None
     assert stored.delivery.channel_id == "-100999"


### PR DESCRIPTION
## Problem

A webchat session asked its agent to make an existing cron job announce to a Telegram channel. Every attempt failed with:

```
delivery cannot be changed with action='update'; set it when the job is created,
or change it from the CLI, the Web UI, or the cron RPC
```

Two things went wrong from there:

1. **Dead end.** `delivery` shipped in #310 for `action="add"` only, and `update` refused it outright. The refusal message points at the CLI, the Web UI, and the cron RPC — none of which an agent running inside a chat can reach. There was no route to the thing the user asked for.
2. **The workaround is destructive.** The model's escape was `add(clone_from=...)` + `remove(...)`, which discarded the job id the user had just named along with its entire run history. Before landing on that it retried the identical failing call about twenty times (the repeat-call guard fired, and it kept going anyway) until the turn was interrupted.

`cron.update` over RPC (`rpc_cron.py`) has always been able to repoint a live job. Only the tool was blocked, so this is the tool catching up rather than a new capability.

## Change

`cron(action="update", job_id=..., delivery={...})` now repoints the job.

- **Same gates as `add`.** `mode='channel'` requires an interactive CLI or Web caller and a `session_target` other than `main`; the channel name is checked against the configured channels and the recipient against the provider's shape, both at save time rather than at the next fire.
- **One gate `add` has no reason to need.** A chat caller cannot repoint a job that already reports somewhere that chat cannot address — the same grant that already governs rewriting such a job's text. Otherwise a participant in one room could silence, or take over, a job answering in another.
- **Checked before anything is written.** `enabled` pauses/resumes as a side effect, so a rejected destination must not leave a half-applied edit behind.
- **`ws_topic` survives the move.** It is per-job, not per-destination; dropping it would orphan every websocket subscriber already watching the job. So does the job's `failure_destination` — the tool cannot set one, so clearing it silently would be a downgrade nobody asked for.
- `mode='origin'` re-infers the calling conversation the way a bare `add` does, including the live-context fallback for a session whose `last_channel` has not been written yet.

Also: `delivery` is listed in the "update needs at least one field" error, and the parameter description now says it works on `update` — the model was reading a schema that told it to rebuild the job.

## Tests

Five tests replace the one that asserted the refusal, in `tests/test_tools/test_cron_tool_update_clone.py` — driven through the real `SchedulerOps` over a real store, so the assertions are about what is persisted:

- repoint to a named channel keeps `tz`, `tool_policy`, and `ws_topic`
- `delivery` on its own is enough of a change (does not trip the min-field guard)
- a chat caller is refused `mode='channel'` and the stored destination is unchanged
- a chat caller is refused any repoint of a job answering elsewhere
- a session key passed where a Telegram chat id belongs is refused at save time

## Verification

- `tests/test_tools/test_cron_tool_update_clone.py` — 40 passed
- `tests/test_tools tests/test_scheduler tests/test_gateway` — all green
- Full suite — 7806 passed. Three failures (`test_mem0_provider.py`, `test_provider_config.py`, `test_skill_html_to_pdf.py`) reproduce identically on a clean tree via `git stash`: they are local environment artifacts (mem0 present in the venv, weasyprint's native lib missing), not regressions from this change.
- `ruff check src tests` clean; `mypy src/agentos/tools/builtin/control.py` clean

Docs updated in the same change: `src/agentos/skills/bundled/cron/SKILL.md`, `docs/scheduling.md`, `CHANGELOG.md`.

Follow-up to #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
