### PR TITLE
feat(scheduler): make every agent_run cron job elevated by default

### DIFF
--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -29,12 +29,13 @@ Practical meaning:
 
 For automation, prefer the narrowest profile that can complete the task.
 
-These profiles apply to interactive CLI and Web turns. A cron turn is
-unattended, so none of them reach it — a scheduled job runs under a read-only
-tool allowlist regardless of `permissions.default_mode`, and the only way to
-give one a shell is the per-job `agentos cron add --elevated` opt-in described
-in [`cli.md`](cli.md#letting-a-cron-job-run-shell-based-skills). Read the
-consequences there before turning it on.
+These profiles apply to interactive CLI and Web turns. For cron turns (unattended automation),
+the default elevated execution posture is controlled by `permissions.cron_default_mode` (which
+defaults to `bypass`). By default, cron jobs of kind `agent_run` run elevated (under `bypass`),
+whereas other job kinds (like reminders and script runs) are never elevated. You can explicitly
+override this default for any individual job by passing `--elevated=off` (or another mode)
+during job creation or update. See [`cli.md`](cli.md#letting-a-cron-job-run-shell-based-skills)
+for details and security implications.
 
 ## Workspace Containment
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -671,18 +671,20 @@ delivery and failure destinations stay CLI/Web/RPC-only. See
 
 ### Letting a cron job run shell-based skills
 
-A cron turn runs under a read-only tool allowlist, so a job that is shown a
-skill can read `SKILL.md` and never carry it out — nearly every skill body is a
-block of shell. `--elevated` opts one job out of that:
+By default, cron jobs of kind `agent_run` run elevated under the `bypass` mode
+(controlled globally by `permissions.cron_default_mode`). This allows them to
+run shell-based commands (like those in skills) without interactive approval prompts.
+
+If you wish to opt out a job from elevated execution, pass `--no-elevated`:
 
 ```sh
-agentos cron add --every 6h --agent main --elevated \
+agentos cron add --every 6h --agent main --no-elevated \
   --name "LP check" --text "Use the senior-unilp-manager skill to review my LP positions"
 agentos cron list                       # the Elevated column shows the mode
-agentos cron update <job-id> --no-elevated
+agentos cron update <job-id> --elevated-mode bypass
 ```
 
-Related flags: `--elevated-mode {bypass,full}` (default `bypass`) and
+Related flags: `--elevated` (which sets the job to explicitly run elevated), `--elevated-mode {bypass,full}`, and
 `--tool-policy '<json>'` (`profile`, `allow`, `alsoAllow`, `deny` — can only
 narrow the cron baseline). `profile` must be one of `coding`, `full`,
 `memory_only`, `messaging`, `minimal`; omit the key to inherit rather than

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -644,6 +644,7 @@ source = "workspace"        # MEMORY.md + memory/*.md under the workspace
 
 [permissions]
 default_mode = "bypass"     # off | on | bypass | full
+cron_default_mode = "bypass" # off | bypass | full
 
 # [auth]
 # mode  = "token"           # none | token | password - enable before binding 0.0.0.0

--- a/frontend/src/views/cron/CronPage.test.tsx
+++ b/frontend/src/views/cron/CronPage.test.tsx
@@ -260,8 +260,8 @@ describe('CronPage', () => {
   it('shows no elevated badge on a default read-only job', async () => {
     wireRpc()
     renderPage()
-    await waitFor(() => expect(screen.getByText('Health check')).toBeInTheDocument())
-    const card = screen.getByLabelText('Cron job Health check')
+    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
+    const card = screen.getByLabelText('Cron job Daily standup')
     expect(within(card).queryByText(/elevated/i)).toBeNull()
   })
 

--- a/frontend/src/views/cron/CronPage.test.tsx
+++ b/frontend/src/views/cron/CronPage.test.tsx
@@ -260,8 +260,8 @@ describe('CronPage', () => {
   it('shows no elevated badge on a default read-only job', async () => {
     wireRpc()
     renderPage()
-    await waitFor(() => expect(screen.getByText('Daily standup')).toBeInTheDocument())
-    const card = screen.getByLabelText('Cron job Daily standup')
+    await waitFor(() => expect(screen.getByText('Health check')).toBeInTheDocument())
+    const card = screen.getByLabelText('Cron job Health check')
     expect(within(card).queryByText(/elevated/i)).toBeNull()
   })
 

--- a/frontend/src/views/cron/logic.test.ts
+++ b/frontend/src/views/cron/logic.test.ts
@@ -987,6 +987,7 @@ describe('jobElevated', () => {
   })
   it('reads the top-level wire field', () => {
     expect(jobElevated({ id: 'x', elevated: 'bypass' })).toBe('bypass')
+    expect(jobElevated({ id: 'x', effectiveElevated: 'bypass' })).toBe('bypass')
   })
   it('falls back to the policy blob the mode is stored in', () => {
     expect(jobElevated({ id: 'x', toolPolicy: { elevated: 'full' } })).toBe('full')

--- a/frontend/src/views/cron/logic.ts
+++ b/frontend/src/views/cron/logic.ts
@@ -53,6 +53,8 @@ export interface RawJob {
   created_from?: string
   /** 'bypass' | 'full' when the job may run shell-based skills unattended. */
   elevated?: string | null
+  effectiveElevated?: string | null
+  effective_elevated?: string | null
   [key: string]: unknown
 }
 
@@ -139,7 +141,7 @@ export function jobKindClass(job: RawJob): 'is-reminder' | 'is-agent' {
  */
 export function jobElevated(job: RawJob | null | undefined): string {
   if (!job) return ''
-  const direct = job.elevated
+  const direct = job.effectiveElevated || job.effective_elevated || job.elevated
   if (typeof direct === 'string' && direct) return direct
   const policy = job.toolPolicy as { elevated?: unknown } | undefined
   const nested = policy?.elevated

--- a/frontend/src/views/cron/logic.ts
+++ b/frontend/src/views/cron/logic.ts
@@ -54,7 +54,6 @@ export interface RawJob {
   /** 'bypass' | 'full' when the job may run shell-based skills unattended. */
   elevated?: string | null
   effectiveElevated?: string | null
-  effective_elevated?: string | null
   [key: string]: unknown
 }
 
@@ -141,7 +140,7 @@ export function jobKindClass(job: RawJob): 'is-reminder' | 'is-agent' {
  */
 export function jobElevated(job: RawJob | null | undefined): string {
   if (!job) return ''
-  const direct = job.effectiveElevated || job.effective_elevated || job.elevated
+  const direct = job.effectiveElevated || job.elevated
   if (typeof direct === 'string' && direct) return direct
   const policy = job.toolPolicy as { elevated?: unknown } | undefined
   const nested = policy?.elevated

--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -431,7 +431,7 @@ def _render_jobs(rows: list[dict[str, Any]], *, title: str = "Cron jobs") -> Non
             str(row.get("expression") or row.get("schedule_raw") or ""),
             str(row.get("payloadKind") or row.get("payload_kind") or ""),
             str(row.get("agentId") or row.get("agent_id") or ""),
-            str(row.get("elevated") or ""),
+            str(row.get("effectiveElevated") or row.get("effective_elevated") or row.get("elevated") or ""),
             str(row.get("next_run") or ""),
             str(row.get("last_run") or ""),
             str(row.get("error_count") or row.get("consecutive_errors") or 0),

--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -433,7 +433,6 @@ def _render_jobs(rows: list[dict[str, Any]], *, title: str = "Cron jobs") -> Non
             str(row.get("agentId") or row.get("agent_id") or ""),
             str(
                 row.get("effectiveElevated")
-                or row.get("effective_elevated")
                 or row.get("elevated")
                 or ""
             ),

--- a/src/agentos/cli/cron_cmd.py
+++ b/src/agentos/cli/cron_cmd.py
@@ -431,7 +431,12 @@ def _render_jobs(rows: list[dict[str, Any]], *, title: str = "Cron jobs") -> Non
             str(row.get("expression") or row.get("schedule_raw") or ""),
             str(row.get("payloadKind") or row.get("payload_kind") or ""),
             str(row.get("agentId") or row.get("agent_id") or ""),
-            str(row.get("effectiveElevated") or row.get("effective_elevated") or row.get("elevated") or ""),
+            str(
+                row.get("effectiveElevated")
+                or row.get("effective_elevated")
+                or row.get("elevated")
+                or ""
+            ),
             str(row.get("next_run") or ""),
             str(row.get("last_run") or ""),
             str(row.get("error_count") or row.get("consecutive_errors") or 0),

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -53,7 +53,7 @@ from agentos.gateway.session_services import get_session_storage
 from agentos.gateway.session_streams import get_session_streams
 from agentos.gateway.websocket import get_registry
 from agentos.paths import default_agentos_home
-from agentos.permissions import configured_default_elevated
+from agentos.permissions import configured_cron_default_elevated, configured_default_elevated
 from agentos.router_tiers import DEFAULT_ROUTER_STRATEGY
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 
@@ -2295,6 +2295,7 @@ async def start_gateway_server(
             task_runtime_ref=lambda: task_runtime,
             workspace_resolver=_cron_workspace_resolver,
             default_elevated=lambda: configured_default_elevated(config),
+            cron_default_elevated=lambda: configured_cron_default_elevated(config),
         )
         system_handler = make_system_event_handler(
             delivery_chain=delivery_chain,
@@ -2305,6 +2306,7 @@ async def start_gateway_server(
             heartbeat_loop_ref=lambda: heartbeat_loop,
             workspace_resolver=_cron_workspace_resolver,
             default_elevated=lambda: configured_default_elevated(config),
+            cron_default_elevated=lambda: configured_cron_default_elevated(config),
         )
         static_handler = make_static_message_handler(delivery_chain=delivery_chain)
         script_handler = make_script_run_handler(delivery_chain=delivery_chain)

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -192,6 +192,7 @@ class PermissionsConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     default_mode: Literal["off", "on", "bypass", "full"] = "bypass"
+    cron_default_mode: Literal["off", "bypass", "full"] = "bypass"
 
 
 class TaskRuntimeConfig(BaseModel):

--- a/src/agentos/gateway/routing.py
+++ b/src/agentos/gateway/routing.py
@@ -255,6 +255,9 @@ def build_cron_route_envelope(
     job_name = str(getattr(job, "name", ""))
     sender_id = f"cron-job-{job_id}"
     metadata: dict[str, Any] = {"job_id": job_id, "job_name": job_name}
+    handler_key = getattr(job, "handler_key", None)
+    if handler_key:
+        metadata["handler_key"] = str(handler_key)
     tool_policy = getattr(job, "tool_policy", None)
     if isinstance(tool_policy, dict) and tool_policy:
         metadata["tool_policy"] = dict(tool_policy)
@@ -357,6 +360,7 @@ def tool_context_from_envelope(
     workspace_dir: str | None = None,
     workspace_strict: bool = False,
     default_elevated: str | None = None,
+    cron_default_elevated: str | None = None,
 ) -> ToolContext:
     """Build the runtime ToolContext from the canonical route envelope."""
     caller_kind = _caller_kind(envelope.source_kind)
@@ -367,7 +371,19 @@ def tool_context_from_envelope(
     cron_baseline_allow = CRON_AGENT_ALLOW
     cron_baseline_deny = CRON_AGENT_DENY
     if caller_kind is CallerKind.CRON:
-        cron_elevated = cron_tool_policy_elevated(envelope.metadata.get("tool_policy"))
+        tool_policy = envelope.metadata.get("tool_policy")
+        handler_key = envelope.metadata.get("handler_key")
+        has_explicit = isinstance(tool_policy, dict) and "elevated" in tool_policy
+        if has_explicit:
+            cron_elevated = cron_tool_policy_elevated(tool_policy)
+            cron_source = "job"
+        elif handler_key == "agent_run":
+            cron_elevated = cron_default_elevated
+            cron_source = "config"
+        else:
+            cron_elevated = None
+            cron_source = None
+
         if cron_elevated is not None:
             cron_baseline_allow = CRON_ELEVATED_ALLOW
             cron_baseline_deny = CRON_ELEVATED_DENY
@@ -380,6 +396,7 @@ def tool_context_from_envelope(
                 job_name=envelope.metadata.get("job_name"),
                 agent_id=envelope.agent_id,
                 mode=cron_elevated,
+                source=cron_source,
             )
         allowed_tools = set(cron_baseline_allow)
         denied_tools = set(cron_baseline_deny)
@@ -395,10 +412,7 @@ def tool_context_from_envelope(
     if not callable(channel_admission_validator):
         channel_admission_validator = None
     elevated = envelope.metadata.get("elevated") or default_elevated
-    if cron_elevated is not None:
-        # A per-job opt-in is the only way a cron turn is ever elevated. The
-        # clamp below stays intact so the global permissions.default_mode still
-        # cannot reach cron on its own.
+    if caller_kind is CallerKind.CRON:
         elevated = cron_elevated
     elif (
         elevated not in ("on", "bypass", "full")

--- a/src/agentos/gateway/routing.py
+++ b/src/agentos/gateway/routing.py
@@ -11,7 +11,7 @@ import structlog
 
 from agentos.channel_pairing import ChannelAdmission
 from agentos.channels.types import IncomingMessage
-from agentos.permissions import cron_tool_policy_elevated
+from agentos.permissions import CRON_ELEVATED_MODES, cron_tool_policy_elevated
 from agentos.session.keys import normalize_agent_id, parse_agent_id
 from agentos.tools.policy import apply_tool_policy_layer
 from agentos.tools.types import (
@@ -384,7 +384,7 @@ def tool_context_from_envelope(
             cron_elevated = None
             cron_source = None
 
-        if cron_elevated is not None:
+        if cron_elevated in CRON_ELEVATED_MODES:
             cron_baseline_allow = CRON_ELEVATED_ALLOW
             cron_baseline_deny = CRON_ELEVATED_DENY
             # An unattended turn is about to get a real shell. Logged here
@@ -413,7 +413,7 @@ def tool_context_from_envelope(
         channel_admission_validator = None
     elevated = envelope.metadata.get("elevated") or default_elevated
     if caller_kind is CallerKind.CRON:
-        elevated = cron_elevated
+        elevated = cron_elevated if cron_elevated in CRON_ELEVATED_MODES else None
     elif (
         elevated not in ("on", "bypass", "full")
         or caller_kind not in {CallerKind.CLI, CallerKind.WEB}

--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -8,7 +8,11 @@ from dataclasses import asdict
 from typing import Any, TypeGuard
 
 from agentos.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
-from agentos.permissions import cron_tool_policy_elevated, normalize_cron_elevated
+from agentos.permissions import (
+    configured_cron_default_elevated,
+    cron_tool_policy_elevated,
+    normalize_cron_elevated,
+)
 from agentos.scheduler.delivery_targets import validate_channel_target
 from agentos.scheduler.payloads import (
     AGENT_TURN_KIND,
@@ -53,7 +57,7 @@ def _require_scheduler(ctx: RpcContext) -> Any:
     return scheduler
 
 
-def _job_to_wire(j: Any) -> dict[str, Any]:
+def _job_to_wire(j: Any, config: Any = None) -> dict[str, Any]:
     """Map internal CronJob (dataclass or dict) to the wire format the Cron UI expects."""
     d = asdict(j) if hasattr(j, "__dataclass_fields__") else dict(j)
     status = d.get("status", "pending")
@@ -86,6 +90,18 @@ def _job_to_wire(j: Any) -> dict[str, Any]:
         if hasattr(schedule_kind_value, "value")
         else str(schedule_kind_value)
     )
+    tool_policy = d.get("tool_policy")
+    handler_key = d.get("handler_key") or getattr(j, "handler_key", None)
+    has_explicit = isinstance(tool_policy, dict) and "elevated" in tool_policy
+    if has_explicit:
+        effective_elevated = cron_tool_policy_elevated(tool_policy)
+    elif handler_key == "agent_run":
+        effective_elevated = (
+            configured_cron_default_elevated(config) if config is not None else "bypass"
+        )
+    else:
+        effective_elevated = None
+
     return {  # noqa: PIE810 — wire schema favors flat literal dict
         "id": d.get("id"),
         "name": d.get("name", ""),
@@ -131,6 +147,8 @@ def _job_to_wire(j: Any) -> dict[str, Any]:
         # Elevation lives inside tool_policy on the job, but it is toggled
         # independently of allow/deny, so it gets its own top-level wire field.
         "elevated": cron_tool_policy_elevated(d.get("tool_policy")),
+        "effectiveElevated": effective_elevated,
+        "effective_elevated": effective_elevated,
     }
 
 
@@ -168,9 +186,7 @@ def _delivery_to_wire(delivery: Any) -> dict[str, Any]:
             "threadId": delivery.get("thread_id", ""),
             "webhookUrl": delivery.get("webhook_url", "") or "",
             "bestEffort": bool(delivery.get("best_effort", False)),
-            "failureDestination": _failure_destination_to_wire(
-                delivery.get("failure_destination")
-            ),
+            "failureDestination": _failure_destination_to_wire(delivery.get("failure_destination")),
         }
     return {
         "mode": (
@@ -409,9 +425,7 @@ def _build_failure_destination(raw: Any) -> FailureDestination | None:
     if mode_norm == "webhook":
         url = raw.get("webhookUrl") or raw.get("to") or ""
         if not url:
-            raise ValueError(
-                "failureDestination mode='webhook' requires webhookUrl"
-            )
+            raise ValueError("failureDestination mode='webhook' requires webhookUrl")
         validate_webhook_url(str(url))
         return FailureDestination(
             mode=DeliveryMode.WEBHOOK,
@@ -435,9 +449,7 @@ def _build_webhook_delivery(delivery_raw: dict[str, Any]) -> DeliveryConfig:
     token = delivery_raw.get("webhookToken") or delivery_raw.get("token") or ""
     best_effort = bool(delivery_raw.get("bestEffort", False))
     validate_webhook_url(str(url))
-    failure_destination = _build_failure_destination(
-        delivery_raw.get("failureDestination")
-    )
+    failure_destination = _build_failure_destination(delivery_raw.get("failureDestination"))
     return DeliveryConfig(
         mode=DeliveryMode.WEBHOOK,
         webhook_url=str(url),
@@ -651,7 +663,7 @@ async def _handle_cron_list(params: dict | None, ctx: RpcContext) -> list[dict]:
     if scheduler is None:
         return []
     jobs = await scheduler.list_jobs()
-    result = [_job_to_wire(j) for j in jobs]
+    result = [_job_to_wire(j, config=ctx.config) for j in jobs]
     agent_id = (params or {}).get("agentId")
     if agent_id:
         result = [j for j in result if j.get("agentId") == agent_id]
@@ -666,7 +678,7 @@ async def _handle_cron_status(params: dict | None, ctx: RpcContext) -> dict[str,
     job = await scheduler.get_job(params["id"])
     if job is None:
         raise KeyError(f"Cron job not found: {params['id']}")
-    return _job_to_wire(job)
+    return _job_to_wire(job, config=ctx.config)
 
 
 @_d.method("cron.add")
@@ -700,6 +712,7 @@ async def _handle_cron_add(params: dict | None, ctx: RpcContext) -> dict[str, An
             schedule_kind=schedule_kind,
             schedule_value=schedule_value,
             schedule_tz=schedule_tz,
+            config=ctx.config,
         )
 
     # Infer or parse delivery config
@@ -756,6 +769,7 @@ async def _handle_cron_add(params: dict | None, ctx: RpcContext) -> dict[str, An
         schedule_kind=schedule_kind,
         schedule_value=schedule_value,
         schedule_tz=schedule_tz,
+        config=ctx.config,
     )
 
 
@@ -773,6 +787,7 @@ async def _finalize_cron_add(
     schedule_kind: ScheduleKind,
     schedule_value: str,
     schedule_tz: str,
+    config: Any = None,
 ) -> dict[str, Any]:
     tz_value = (
         schedule_tz
@@ -811,7 +826,7 @@ async def _finalize_cron_add(
             await scheduler.update_job(job.id, delivery=job.delivery)
         except Exception:
             pass
-    return _job_to_wire(job)
+    return _job_to_wire(job, config=config)
 
 
 # Alias: cron.js sends cron.create for new jobs
@@ -834,9 +849,7 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         patch["schedule_kind"] = sched_kind
         patch["schedule_value"] = sched_value
         schedule_raw = params.get("schedule")
-        schedule_tz_was_supplied = (
-            isinstance(schedule_raw, dict) and "tz" in schedule_raw
-        )
+        schedule_tz_was_supplied = isinstance(schedule_raw, dict) and "tz" in schedule_raw
         if sched_kind == ScheduleKind.CRON and (
             sched_tz or tz_was_supplied or schedule_tz_was_supplied
         ):
@@ -900,7 +913,8 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         # display), so it must not be inherited as prompt text when a job is
         # converted away from script.
         current_text = (
-            "" if current_kind == SCRIPT_KIND
+            ""
+            if current_kind == SCRIPT_KIND
             else payload_text(current_job.payload, current_job.session_target)
         )
         merged_params = {
@@ -998,10 +1012,7 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
                     delivery_raw.get("failureDestination")
                 ),
             )
-        elif (
-            isinstance(delivery_raw, dict)
-            and delivery_raw.get("failureDestination") is not None
-        ):
+        elif isinstance(delivery_raw, dict) and delivery_raw.get("failureDestination") is not None:
             # Standalone FD patch: keep the existing primary delivery target,
             # only update the failure_destination side.
             existing = current_job.delivery
@@ -1016,9 +1027,7 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
                 webhook_url=existing.webhook_url,
                 webhook_token=existing.webhook_token,
                 best_effort=existing.best_effort,
-                failure_destination=_build_failure_destination(
-                    delivery_raw["failureDestination"]
-                ),
+                failure_destination=_build_failure_destination(delivery_raw["failureDestination"]),
             )
 
     if "toolPolicy" in params or "tool_policy" in params:
@@ -1040,7 +1049,7 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         job = current_job
     if job is None:
         raise KeyError(f"Cron job not found: {params['id']}")
-    return _job_to_wire(job)
+    return _job_to_wire(job, config=ctx.config)
 
 
 @_d.method("cron.remove")

--- a/src/agentos/gateway/rpc_cron.py
+++ b/src/agentos/gateway/rpc_cron.py
@@ -96,9 +96,7 @@ def _job_to_wire(j: Any, config: Any = None) -> dict[str, Any]:
     if has_explicit:
         effective_elevated = cron_tool_policy_elevated(tool_policy)
     elif handler_key == "agent_run":
-        effective_elevated = (
-            configured_cron_default_elevated(config) if config is not None else "bypass"
-        )
+        effective_elevated = configured_cron_default_elevated(config)
     else:
         effective_elevated = None
 
@@ -148,7 +146,6 @@ def _job_to_wire(j: Any, config: Any = None) -> dict[str, Any]:
         # independently of allow/deny, so it gets its own top-level wire field.
         "elevated": cron_tool_policy_elevated(d.get("tool_policy")),
         "effectiveElevated": effective_elevated,
-        "effective_elevated": effective_elevated,
     }
 
 
@@ -186,7 +183,9 @@ def _delivery_to_wire(delivery: Any) -> dict[str, Any]:
             "threadId": delivery.get("thread_id", ""),
             "webhookUrl": delivery.get("webhook_url", "") or "",
             "bestEffort": bool(delivery.get("best_effort", False)),
-            "failureDestination": _failure_destination_to_wire(delivery.get("failure_destination")),
+            "failureDestination": _failure_destination_to_wire(
+                delivery.get("failure_destination")
+            ),
         }
     return {
         "mode": (
@@ -425,7 +424,9 @@ def _build_failure_destination(raw: Any) -> FailureDestination | None:
     if mode_norm == "webhook":
         url = raw.get("webhookUrl") or raw.get("to") or ""
         if not url:
-            raise ValueError("failureDestination mode='webhook' requires webhookUrl")
+            raise ValueError(
+                "failureDestination mode='webhook' requires webhookUrl"
+            )
         validate_webhook_url(str(url))
         return FailureDestination(
             mode=DeliveryMode.WEBHOOK,
@@ -449,7 +450,9 @@ def _build_webhook_delivery(delivery_raw: dict[str, Any]) -> DeliveryConfig:
     token = delivery_raw.get("webhookToken") or delivery_raw.get("token") or ""
     best_effort = bool(delivery_raw.get("bestEffort", False))
     validate_webhook_url(str(url))
-    failure_destination = _build_failure_destination(delivery_raw.get("failureDestination"))
+    failure_destination = _build_failure_destination(
+        delivery_raw.get("failureDestination")
+    )
     return DeliveryConfig(
         mode=DeliveryMode.WEBHOOK,
         webhook_url=str(url),
@@ -849,7 +852,9 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         patch["schedule_kind"] = sched_kind
         patch["schedule_value"] = sched_value
         schedule_raw = params.get("schedule")
-        schedule_tz_was_supplied = isinstance(schedule_raw, dict) and "tz" in schedule_raw
+        schedule_tz_was_supplied = (
+            isinstance(schedule_raw, dict) and "tz" in schedule_raw
+        )
         if sched_kind == ScheduleKind.CRON and (
             sched_tz or tz_was_supplied or schedule_tz_was_supplied
         ):
@@ -913,8 +918,7 @@ async def _handle_cron_update(params: dict | None, ctx: RpcContext) -> dict[str,
         # display), so it must not be inherited as prompt text when a job is
         # converted away from script.
         current_text = (
-            ""
-            if current_kind == SCRIPT_KIND
+            "" if current_kind == SCRIPT_KIND
             else payload_text(current_job.payload, current_job.session_target)
         )
         merged_params = {

--- a/src/agentos/permissions.py
+++ b/src/agentos/permissions.py
@@ -33,12 +33,16 @@ def normalize_cron_elevated(value: Any) -> str | None:
     to be asked for by name because it also disables the sensitive-path block.
     """
 
-    if value is None or value is False:
+    if value is None:
         return None
+    if value is False:
+        return "off"
     if value is True:
         return "bypass"
     mode = str(value).strip().lower()
-    if mode in ("", "off", "false", "none"):
+    if mode in ("off", "false", "none"):
+        return "off"
+    if mode == "":
         return None
     if mode == "on":
         raise ValueError(
@@ -62,7 +66,8 @@ def cron_tool_policy_elevated(tool_policy: Any) -> str | None:
     if not isinstance(tool_policy, Mapping):
         return None
     try:
-        return normalize_cron_elevated(tool_policy.get("elevated"))
+        mode = normalize_cron_elevated(tool_policy.get("elevated"))
+        return None if mode == "off" else mode
     except ValueError:
         return None
 

--- a/src/agentos/permissions.py
+++ b/src/agentos/permissions.py
@@ -74,3 +74,12 @@ def configured_default_elevated(config: Any) -> str | None:
         default="off",
     )
     return mode if mode in ELEVATED_PERMISSION_MODES else None
+
+
+def configured_cron_default_elevated(config: Any) -> str | None:
+    permissions = getattr(config, "permissions", None)
+    if permissions is None:
+        return "bypass"
+    cron_default_mode = getattr(permissions, "cron_default_mode", "bypass")
+    mode = normalize_permission_mode(cron_default_mode, default="bypass")
+    return mode if mode in CRON_ELEVATED_MODES else None

--- a/src/agentos/scheduler/handlers.py
+++ b/src/agentos/scheduler/handlers.py
@@ -676,7 +676,7 @@ def make_system_event_handler(
                     "kind": "cron",
                     "source_tool": f"cron:{job.id}",
                 },
-            )
+        )
 
         await delivery_chain.notify_start(job, text)
         heartbeat_loop = heartbeat_loop_ref() if heartbeat_loop_ref else None
@@ -728,7 +728,6 @@ def make_system_event_handler(
             heartbeat_kwargs["delivery_override"] = delivery_override
         run_once_now = getattr(heartbeat_loop, "run_once_now", None)
         if callable(run_once_now):
-
             async def _run_once():
                 run_once_kwargs: dict[str, Any] = {
                     "reason": reason,
@@ -743,7 +742,6 @@ def make_system_event_handler(
                 return await run_once_now(**run_once_kwargs)
 
         else:
-
             async def _run_once():
                 return await heartbeat_service.run_once(**heartbeat_kwargs)
 

--- a/src/agentos/scheduler/handlers.py
+++ b/src/agentos/scheduler/handlers.py
@@ -152,6 +152,7 @@ def _build_cron_tool_context(
     session_key: str | None = None,
     workspace_resolver: WorkspaceResolver | None = None,
     default_elevated: str | DefaultElevatedResolver | None = None,
+    cron_default_elevated: str | DefaultElevatedResolver | None = None,
 ) -> ToolContext:
     from agentos.scheduler.routing import build_cron_route_envelope, tool_context_from_envelope
 
@@ -179,6 +180,7 @@ def _build_cron_tool_context(
         workspace_dir=workspace_dir,
         workspace_strict=workspace_strict,
         default_elevated=_resolve_default_elevated(default_elevated),
+        cron_default_elevated=_resolve_default_elevated(cron_default_elevated),
     )
 
 
@@ -239,6 +241,7 @@ def make_agent_run_handler(
     task_runtime_ref: Callable[[], Any] | None = None,
     workspace_resolver: WorkspaceResolver | None = None,
     default_elevated: str | DefaultElevatedResolver | None = None,
+    cron_default_elevated: str | DefaultElevatedResolver | None = None,
 ) -> Callable:
     """Factory: creates an agent_run_handler with explicit DI.
 
@@ -387,6 +390,7 @@ def make_agent_run_handler(
                     session_key=session_key,
                     workspace_resolver=workspace_resolver,
                     default_elevated=default_elevated,
+                    cron_default_elevated=cron_default_elevated,
                 )
                 async for event in wrap_stream(
                     turn_runner.run(
@@ -642,6 +646,7 @@ def make_system_event_handler(
     heartbeat_loop_ref: Callable[[], Any] | None = None,
     workspace_resolver: WorkspaceResolver | None = None,
     default_elevated: str | DefaultElevatedResolver | None = None,
+    cron_default_elevated: str | DefaultElevatedResolver | None = None,
     wake_now_busy_max_wait_seconds: float = 120.0,
     wake_now_busy_retry_delay_seconds: float = 0.25,
 ) -> Callable:
@@ -671,7 +676,7 @@ def make_system_event_handler(
                     "kind": "cron",
                     "source_tool": f"cron:{job.id}",
                 },
-        )
+            )
 
         await delivery_chain.notify_start(job, text)
         heartbeat_loop = heartbeat_loop_ref() if heartbeat_loop_ref else None
@@ -708,6 +713,7 @@ def make_system_event_handler(
             session_key=session_key,
             workspace_resolver=workspace_resolver,
             default_elevated=default_elevated,
+            cron_default_elevated=cron_default_elevated,
         )
         heartbeat_kwargs: dict[str, Any] = {
             "reason": reason,
@@ -722,6 +728,7 @@ def make_system_event_handler(
             heartbeat_kwargs["delivery_override"] = delivery_override
         run_once_now = getattr(heartbeat_loop, "run_once_now", None)
         if callable(run_once_now):
+
             async def _run_once():
                 run_once_kwargs: dict[str, Any] = {
                     "reason": reason,
@@ -736,6 +743,7 @@ def make_system_event_handler(
                 return await run_once_now(**run_once_kwargs)
 
         else:
+
             async def _run_once():
                 return await heartbeat_service.run_once(**heartbeat_kwargs)
 

--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from agentos.permissions import normalize_cron_elevated
+from agentos.permissions import CRON_ELEVATED_MODES, normalize_cron_elevated
 from agentos.session.keys import normalize_agent_id
 from agentos.tools.policy_config import normalize_tool_profile
 
@@ -61,7 +61,7 @@ def _normalized_tool_policy(
     if mode is None:
         policy.pop("elevated")
         return policy
-    if handler_key != "agent_run":
+    if mode in CRON_ELEVATED_MODES and handler_key != "agent_run":
         raise ValueError(
             "cron elevation is only supported for agent_turn jobs; reminder, "
             "system_event and script jobs never run an agent turn with the job's "

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -200,7 +200,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[tools]` | model-visible tools and policy; `enabled = false` runs providers in plain-text mode; `profile` (`full` \| `coding` \| `messaging` \| `memory_only` \| `minimal`) sets the base allowlist — `agentos context` prices each one |
 | `[memory]` | memory source and embedding model, `[memory.nudge]` (periodic memory review) |
 | `[sandbox]` | `sandbox`, `default_level` (DISABLED/STANDARD/STRICT/LOCKED), `backend`, network/mounts |
-| `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`) |
+| `[permissions]` | `default_mode` = `off` \| `on` \| `bypass` \| `full` (pair with `agentos sandbox …`); `cron_default_mode` = `off` \| `bypass` \| `full` (default `bypass`) |
 | `[auth]` | gateway admission: `mode` (`none` on loopback or `token`), `token` |
 | `[control_ui]` | `allowed_origins` for reverse-proxy setups; `show_thinking` (default true) streams model reasoning to the WebUI as collapsible blocks — WebUI-only, channels never receive it |
 | `[updates]` | `notify` (default true) — the once-per-24h "new release available" notice |

--- a/src/agentos/skills/bundled/cron/SKILL.md
+++ b/src/agentos/skills/bundled/cron/SKILL.md
@@ -117,6 +117,10 @@ has not given one, ask, or leave it empty for the channel default.
 The `add` response echoes the resolved `delivery`, so confirm the destination
 from that rather than assuming it.
 
+## Elevation and Security
+
+By default, scheduled `agent_turn` jobs run elevated under the `bypass` mode (controlled globally by `permissions.cron_default_mode`), allowing them to execute shell commands. Other job kinds (like reminders and script runs) are never elevated. You can explicitly override this default for any individual job by passing `"elevated": "off"` (or another elevated mode like `"full"`) inside `tool_policy`.
+
 ## Editing an existing job
 
 Never re-create a job to change it. `cron(action="add", ...)` builds a fresh job

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -309,19 +309,15 @@ def _cron_job_view(job: Any) -> dict[str, Any]:
         "next_run_at": next_run_at.isoformat() if next_run_at is not None else "",
         "last_run_at": last_run_at.isoformat() if last_run_at is not None else "",
         "elevated": (
-            (
-                cron_tool_policy_elevated(job.tool_policy)
-                if cron_tool_policy_elevated(job.tool_policy)
-                else ""
-            )
-            if isinstance(getattr(job, "tool_policy", None), dict) and "elevated" in job.tool_policy
+            cron_tool_policy_elevated(job.tool_policy)
+            if isinstance(getattr(job, "tool_policy", None), dict)
+            and "elevated" in job.tool_policy
             else (
                 configured_cron_default_elevated(_gateway_config)
-                if getattr(job, "handler_key", None) == "agent_run" and _gateway_config is not None
-                else ("bypass" if getattr(job, "handler_key", None) == "agent_run" else "")
+                if getattr(job, "handler_key", None) == "agent_run"
+                else None
             )
-        )
-        or "",
+        ) or "",
     }
 
 
@@ -444,7 +440,11 @@ def _parse_cron_delivery(raw: Any) -> dict[str, Any] | None:
         # was already promoted to mode='channel' above, so the only way to land
         # here is an explicitly contradictory mode: nothing legitimate is lost
         # by refusing it.
-        stray = [f for f in ("channel_name", "channel_id", "account_id", "thread_id") if parsed[f]]
+        stray = [
+            f
+            for f in ("channel_name", "channel_id", "account_id", "thread_id")
+            if parsed[f]
+        ]
         if stray:
             raise SafeToolError(
                 f"delivery.{stray[0]} conflicts with delivery.mode='{mode}' — "
@@ -487,9 +487,12 @@ def _validate_cron_delivery_channel(channel_name: str) -> None:
     if not known:
         # A live manager with nothing in it is a real answer, not a missing one:
         # no channel delivery can succeed at all.
-        raise SafeToolError("no channels are configured, so a cron job cannot deliver to one")
+        raise SafeToolError(
+            "no channels are configured, so a cron job cannot deliver to one"
+        )
     raise SafeToolError(
-        f"no channel named '{channel_name}' is configured; available: {', '.join(sorted(known))}"
+        f"no channel named '{channel_name}' is configured; "
+        f"available: {', '.join(sorted(known))}"
     )
 
 
@@ -918,7 +921,9 @@ async def cron(
     if action in ("get", "update", "remove", "run", "runs") and not job_id:
         raise SafeToolError(f"'job_id' required for {action}")
     if action != "update" and enabled is not None:
-        raise SafeToolError("'enabled' is only accepted by update; a new job always starts enabled")
+        raise SafeToolError(
+            "'enabled' is only accepted by update; a new job always starts enabled"
+        )
 
     # Dispatch to injected scheduler
     if _scheduler is None:
@@ -989,21 +994,15 @@ async def cron(
                 "agent_id": _cron_job_agent_id(j),
                 "created_from": getattr(j, "creator_session_key", "") or "",
                 "elevated": (
-                    (
-                        cron_tool_policy_elevated(j.tool_policy)
-                        if cron_tool_policy_elevated(j.tool_policy)
-                        else ""
-                    )
+                    cron_tool_policy_elevated(j.tool_policy)
                     if isinstance(getattr(j, "tool_policy", None), dict)
                     and "elevated" in j.tool_policy
                     else (
                         configured_cron_default_elevated(_gateway_config)
                         if getattr(j, "handler_key", None) == "agent_run"
-                        and _gateway_config is not None
-                        else ("bypass" if getattr(j, "handler_key", None) == "agent_run" else "")
+                        else None
                     )
-                )
-                or "",
+                ) or "",
             }
             for j in jobs
         ]

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -276,6 +276,8 @@ def _cron_job_view(job: Any) -> dict[str, Any]:
     "clone it but change the prompt" request can be answered by reading the
     source rather than guessing at defaults.
     """
+    from agentos.permissions import configured_cron_default_elevated, cron_tool_policy_elevated
+
     payload = job.payload if isinstance(getattr(job, "payload", None), dict) else {}
     session_target = getattr(job, "session_target", "")
     kind = payload_kind(payload, session_target)
@@ -306,6 +308,20 @@ def _cron_job_view(job: Any) -> dict[str, Any]:
         "created_from": str(getattr(job, "creator_session_key", "") or ""),
         "next_run_at": next_run_at.isoformat() if next_run_at is not None else "",
         "last_run_at": last_run_at.isoformat() if last_run_at is not None else "",
+        "elevated": (
+            (
+                cron_tool_policy_elevated(job.tool_policy)
+                if cron_tool_policy_elevated(job.tool_policy)
+                else ""
+            )
+            if isinstance(getattr(job, "tool_policy", None), dict) and "elevated" in job.tool_policy
+            else (
+                configured_cron_default_elevated(_gateway_config)
+                if getattr(job, "handler_key", None) == "agent_run" and _gateway_config is not None
+                else ("bypass" if getattr(job, "handler_key", None) == "agent_run" else "")
+            )
+        )
+        or "",
     }
 
 
@@ -428,11 +444,7 @@ def _parse_cron_delivery(raw: Any) -> dict[str, Any] | None:
         # was already promoted to mode='channel' above, so the only way to land
         # here is an explicitly contradictory mode: nothing legitimate is lost
         # by refusing it.
-        stray = [
-            f
-            for f in ("channel_name", "channel_id", "account_id", "thread_id")
-            if parsed[f]
-        ]
+        stray = [f for f in ("channel_name", "channel_id", "account_id", "thread_id") if parsed[f]]
         if stray:
             raise SafeToolError(
                 f"delivery.{stray[0]} conflicts with delivery.mode='{mode}' — "
@@ -475,12 +487,9 @@ def _validate_cron_delivery_channel(channel_name: str) -> None:
     if not known:
         # A live manager with nothing in it is a real answer, not a missing one:
         # no channel delivery can succeed at all.
-        raise SafeToolError(
-            "no channels are configured, so a cron job cannot deliver to one"
-        )
+        raise SafeToolError("no channels are configured, so a cron job cannot deliver to one")
     raise SafeToolError(
-        f"no channel named '{channel_name}' is configured; "
-        f"available: {', '.join(sorted(known))}"
+        f"no channel named '{channel_name}' is configured; available: {', '.join(sorted(known))}"
     )
 
 
@@ -909,9 +918,7 @@ async def cron(
     if action in ("get", "update", "remove", "run", "runs") and not job_id:
         raise SafeToolError(f"'job_id' required for {action}")
     if action != "update" and enabled is not None:
-        raise SafeToolError(
-            "'enabled' is only accepted by update; a new job always starts enabled"
-        )
+        raise SafeToolError("'enabled' is only accepted by update; a new job always starts enabled")
 
     # Dispatch to injected scheduler
     if _scheduler is None:
@@ -948,6 +955,8 @@ async def cron(
     # Elevation hands an unattended job a real shell, so it stays an operator
     # decision. Subagents and agent-kind callers already cannot reach `cron` at
     # all — this makes the rule explicit rather than emergent from two denylists.
+    # Note: This gate only blocks explicit per-job tool_policy.elevated requests.
+    # Unattended default elevation from cron_default_mode is handled at routing time.
     if tool_policy and isinstance(tool_policy, dict) and tool_policy.get("elevated"):
         if not _operator_caller(ctx):
             raise SafeToolError("tool_policy.elevated requires an interactive CLI or Web caller")
@@ -961,6 +970,8 @@ async def cron(
         raise SafeToolError("scheduling a script requires an interactive CLI or Web caller")
 
     if action == "list":
+        from agentos.permissions import configured_cron_default_elevated, cron_tool_policy_elevated
+
         jobs = [
             job for job in await sched.list_jobs() if _cron_job_agent_id(job) == current_agent_id
         ]
@@ -977,6 +988,22 @@ async def cron(
                 "status": j.status.value if hasattr(j.status, "value") else str(j.status),
                 "agent_id": _cron_job_agent_id(j),
                 "created_from": getattr(j, "creator_session_key", "") or "",
+                "elevated": (
+                    (
+                        cron_tool_policy_elevated(j.tool_policy)
+                        if cron_tool_policy_elevated(j.tool_policy)
+                        else ""
+                    )
+                    if isinstance(getattr(j, "tool_policy", None), dict)
+                    and "elevated" in j.tool_policy
+                    else (
+                        configured_cron_default_elevated(_gateway_config)
+                        if getattr(j, "handler_key", None) == "agent_run"
+                        and _gateway_config is not None
+                        else ("bypass" if getattr(j, "handler_key", None) == "agent_run" else "")
+                    )
+                )
+                or "",
             }
             for j in jobs
         ]
@@ -1430,6 +1457,7 @@ async def cron(
             raise SafeToolError(
                 "updating a scheduled script requires an interactive CLI or Web caller"
             )
+        # Note: This gate only blocks updates to jobs with explicit per-job elevation requests.
         if dict(getattr(target_job, "tool_policy", None) or {}).get("elevated"):
             if not _operator_caller(ctx):
                 raise SafeToolError(

--- a/tests/test_gateway/test_rpc_cron_current_session.py
+++ b/tests/test_gateway/test_rpc_cron_current_session.py
@@ -410,7 +410,7 @@ async def test_rpc_update_can_clear_elevation_without_touching_the_lists() -> No
         RpcContext(conn_id="test", cron_scheduler=scheduler),
     )
 
-    assert scheduler.updated["tool_policy"] == {"deny": ["web_fetch"]}
+    assert scheduler.updated["tool_policy"] == {"deny": ["web_fetch"], "elevated": "off"}
 
 
 async def test_rpc_update_applies_other_fields_to_a_paused_job() -> None:

--- a/tests/test_scheduler/test_cron_default_elevation.py
+++ b/tests/test_scheduler/test_cron_default_elevation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from agentos.gateway.routing import build_cron_route_envelope, tool_context_from_envelope
+from agentos.scheduler.types import CronJob
+
+
+def _cron_ctx(handler_key: str, tool_policy: dict | None = None, **kwargs):
+    job = CronJob(
+        id="elev",
+        name="Elevated",
+        handler_key=handler_key,
+        tool_policy=tool_policy if tool_policy is not None else {},
+    )
+    envelope = build_cron_route_envelope(
+        job,
+        session_key="cron:elev:run:1",
+        agent_id="main",
+    )
+    return tool_context_from_envelope(envelope, **kwargs)
+
+
+def test_cron_agent_run_elevated_by_default() -> None:
+    # 1. agent_run job with no explicit tool_policy.elevated runs elevated by default (bypass)
+    result = _cron_ctx("agent_run", cron_default_elevated="bypass")
+    assert result.elevated == "bypass"
+    assert "exec_command" in (result.allowed_tools or set())
+
+
+def test_cron_other_jobs_not_elevated_by_default() -> None:
+    # 2. reminder, system_event and script_run jobs are unaffected and still reject elevation
+    for handler in ("system_event", "static_message", "script_run"):
+        result = _cron_ctx(handler, cron_default_elevated="bypass")
+        assert result.elevated is None
+        assert "exec_command" not in (result.allowed_tools or set())
+
+
+def test_cron_explicit_off_override() -> None:
+    # 3. Explicitly setting elevated: "off" on an agent_run job overrides
+    # the default and does not run elevated
+    result = _cron_ctx("agent_run", {"elevated": "off"}, cron_default_elevated="bypass")
+    assert result.elevated is None
+
+
+def test_cron_explicit_full_override() -> None:
+    # 4. Explicitly setting elevated: "full" overrides the bypass default
+    result = _cron_ctx("agent_run", {"elevated": "full"}, cron_default_elevated="bypass")
+    assert result.elevated == "full"
+
+
+def test_cron_default_mode_off() -> None:
+    # 5. Setting cron_default_mode: "off" globally restores the previous
+    # behavior exactly (unelevated by default)
+    result = _cron_ctx("agent_run", cron_default_elevated=None)
+    assert result.elevated is None
+
+
+def test_cron_default_mode_on_does_not_leak_into_cron() -> None:
+    # 6. Interactive setting default_mode: "on" does not leak into a cron turn
+    result = _cron_ctx("agent_run", default_elevated="on", cron_default_elevated=None)
+    assert result.elevated is None

--- a/tests/test_scheduler/test_cron_default_elevation.py
+++ b/tests/test_scheduler/test_cron_default_elevation.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from agentos.gateway.config import PermissionsConfig
 from agentos.gateway.routing import build_cron_route_envelope, tool_context_from_envelope
-from agentos.scheduler.types import CronJob
+from agentos.gateway.rpc_cron import _job_to_wire
+from agentos.scheduler.ops import SchedulerOps
+from agentos.scheduler.payloads import make_agent_turn_payload
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import CronJob, ScheduleKind, SessionTarget
 
 
 def _cron_ctx(handler_key: str, tool_policy: dict | None = None, **kwargs):
@@ -58,3 +65,79 @@ def test_cron_default_mode_on_does_not_leak_into_cron() -> None:
     # 6. Interactive setting default_mode: "on" does not leak into a cron turn
     result = _cron_ctx("agent_run", default_elevated="on", cron_default_elevated=None)
     assert result.elevated is None
+
+
+def test_permissions_config_round_trip() -> None:
+    config = PermissionsConfig(cron_default_mode="off")
+    data = config.model_dump()
+    assert data["cron_default_mode"] == "off"
+    loaded = PermissionsConfig(**data)
+    assert loaded.cron_default_mode == "off"
+
+
+async def test_cron_write_path_explicit_off_override(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    ops = SchedulerOps(store)
+    try:
+        # Create a job with elevated=False on the real write path
+        job = await ops.add(
+            name="optout-job",
+            handler_key="agent_run",
+            payload=make_agent_turn_payload("ping"),
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.CRON,
+            schedule_value="*/5 * * * *",
+            tool_policy={"elevated": False},
+        )
+        assert job.tool_policy == {"elevated": "off"}
+
+        # Loaded job still carries elevated="off"
+        loaded = await store.get(job.id)
+        assert loaded is not None
+        assert loaded.tool_policy == {"elevated": "off"}
+
+        # Routing with bypass default still keeps the explicit override off
+        envelope = build_cron_route_envelope(loaded, session_key="cron:run:1", agent_id="main")
+        result = tool_context_from_envelope(envelope, cron_default_elevated="bypass")
+        assert result.elevated is None
+    finally:
+        await store.close()
+
+
+async def test_cron_list_wire_surfacing(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    ops = SchedulerOps(store)
+    try:
+        # Create one default job and one explicit opt-out job
+        job_default = await ops.add(
+            name="default-job",
+            handler_key="agent_run",
+            payload=make_agent_turn_payload("ping"),
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.CRON,
+            schedule_value="*/5 * * * *",
+        )
+        job_off = await ops.add(
+            name="off-job",
+            handler_key="agent_run",
+            payload=make_agent_turn_payload("ping"),
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.CRON,
+            schedule_value="*/5 * * * *",
+            tool_policy={"elevated": "off"},
+        )
+
+        from types import SimpleNamespace
+
+        fake_config = SimpleNamespace(permissions=SimpleNamespace(cron_default_mode="bypass"))
+
+        # Wire mapping surfaces effectiveElevated properly
+        wire_default = _job_to_wire(job_default, config=fake_config)
+        assert wire_default["effectiveElevated"] == "bypass"
+
+        wire_off = _job_to_wire(job_off, config=fake_config)
+        assert wire_off["effectiveElevated"] is None
+    finally:
+        await store.close()

--- a/tests/test_scheduler/test_cron_elevation.py
+++ b/tests/test_scheduler/test_cron_elevation.py
@@ -90,12 +90,12 @@ async def test_ops_add_rejects_the_on_elevation_mode(tmp_path: Path) -> None:
         await store.close()
 
 
-async def test_ops_add_drops_a_falsy_elevation_key(tmp_path: Path) -> None:
-    """An unelevated job stores the same empty policy it always did."""
+async def test_ops_add_maps_a_falsy_elevation_key_to_off(tmp_path: Path) -> None:
+    """An explicitly unelevated job stores the 'off' policy."""
     store, ops = await _open_ops(tmp_path)
     try:
         job = await _add(ops, tool_policy={"elevated": False})
-        assert job.tool_policy == {}
+        assert job.tool_policy == {"elevated": "off"}
     finally:
         await store.close()
 

--- a/tests/test_scheduler/test_cron_elevation.py
+++ b/tests/test_scheduler/test_cron_elevation.py
@@ -122,3 +122,19 @@ async def test_persisted_elevation_survives_a_store_round_trip(tmp_path: Path) -
 
     assert loaded is not None
     assert loaded.tool_policy == {"elevated": "full", "deny": ["web_fetch"]}
+
+
+async def test_ops_add_accepts_falsy_elevation_on_non_agent_job(tmp_path: Path) -> None:
+    """An explicit opt-out (False or 'off') on a non-agent job is accepted and stores 'off'."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await _add(
+            ops,
+            handler_key="system_event",
+            payload=make_system_event_payload("wake"),
+            session_target=SessionTarget.MAIN,
+            tool_policy={"elevated": False},
+        )
+        assert job.tool_policy == {"elevated": "off"}
+    finally:
+        await store.close()


### PR DESCRIPTION

### Summary
This PR implements **Issue #311**, making scheduled agent turns (`agent_run` cron jobs) elevated by default (running in `bypass` mode) instead of requiring a per-job opt-in. Other unattended automation kinds (reminders, system events, and script runs) remain strictly unelevated.

### Key Changes
- **Configuration**: Added the global `cron_default_mode` field to `PermissionsConfig` (defaulting to `"bypass"`).
- **Routing & Policy**: Injected `handler_key` into cron envelopes and updated the router's tool context resolution to enforce default elevation rules at execution time.
- **Logging**: Added `source="config"` / `source="job"` metadata to elevated warnings to indicate how elevation was granted.
- **CLI & Web UI**:
  - Surfaced calculated effective elevation on Web UI job cards and the CLI `cron list` table view.
  - Kept the top-level `elevated` wire field mapped strictly to explicit overrides to ensure backward compatibility.
- **Tests**: Added full unit test coverage in `tests/test_scheduler/test_cron_default_elevation.py` and updated frontend tests.
```Closes #311 