### PR TITLE
feat(tools): add ask_user — structured questions with an end-turn contract

### DIFF
--- a/docs/tools-and-sandbox.md
+++ b/docs/tools-and-sandbox.md
@@ -25,6 +25,7 @@ For a focused permissions guide, see
 | Skills | `skill_list`, `skill_view`, `skill_create`, `skill_edit`, `install_skill_deps`, `meta_invoke`. |
 | Control | cron scheduling and gateway control operations. |
 | Channels/platforms | messaging, chat, and media helpers across supported channel adapters. |
+| User interaction | `ask_user` — structured questions with 2-4 options each. Presenting the question ends the turn; the answer arrives as the next user message. The Web UI renders a clickable card; the CLI and channels render a numbered list you answer by typing. Hidden on unattended surfaces (cron, subagents, heartbeats). |
 
 ## Permission Modes
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -230,6 +230,16 @@ Turn it off with `control_ui.show_thinking = false` (or
 thinking events nor serves reasoning bodies. This is WebUI-only either way:
 channel adapters (Slack, Telegram, …) never receive thinking.
 
+### Agent questions (ask_user)
+
+When the agent needs a decision that is genuinely yours — scope, a
+hard-to-reverse action, conflicting instructions — it can call the `ask_user`
+tool. The chat renders a question card with clickable options (plus a
+free-text field); picking an answer sends it as your next message and the
+agent continues from there. Asking ends the agent's turn, so nothing blocks
+while you decide, and typing a reply in the composer works exactly the same
+as clicking the card.
+
 ## Manual Compaction
 
 Long sessions can be compacted from chat. If no compaction is needed, the UI

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -248,6 +248,13 @@ export const chat = defineNamespace('chat', {
   toolViewFull: 'View full',
   toolResultTitle: 'Tool Result',
 
+  // ask_user question card.
+  askCardLabel: 'The agent is asking you',
+  askSend: 'Send answer',
+  askOtherPlaceholder: 'Or type your own answer…',
+  askMultiHint: 'Choose one or more',
+  askAnswered: 'Answered',
+
   // Transcript: router visualization.
   routerChoosing: 'Choosing a model',
   routerSuggested: 'Suggested model',

--- a/frontend/src/views/chat/chat-unified.css
+++ b/frontend/src/views/chat/chat-unified.css
@@ -1530,3 +1530,15 @@
     animation-iteration-count: 1 !important;
   }
 }
+
+/* ask_user question card — unified skin: product-facing prompt, so Inter for
+   the question text while options keep their mono base from chat.css. */
+.chat-ask-card {
+  font-family: var(--font-sans);
+}
+.chat-ask-title {
+  font-size: 0.84rem;
+}
+.chat-ask-option {
+  font-family: var(--font-sans);
+}

--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -3082,3 +3082,118 @@
     width: 100%;
   }
 }
+
+/* ── ask_user question card (transcript/ask.ts) ─────────────────────────────
+   Rendered in the bubble body when the agent presents structured choices.
+   Signal-colored border marks it as the one element awaiting the user. */
+.chat-ask-card {
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 10px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--primary) 45%, transparent);
+  border-radius: var(--radius-compact);
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+}
+.chat-ask-card--answered {
+  border-color: color-mix(in srgb, var(--foreground) 18%, transparent);
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+}
+.chat-ask-eyebrow {
+  margin-bottom: 8px;
+  color: var(--primary);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.chat-ask-card--answered .chat-ask-eyebrow {
+  color: var(--dim);
+}
+.chat-ask-question + .chat-ask-question {
+  margin-top: 12px;
+}
+.chat-ask-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--foreground);
+  font-size: 0.78rem;
+}
+.chat-ask-header-chip {
+  padding: 1px 6px;
+  border-radius: var(--radius-compact);
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+  color: var(--primary);
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.chat-ask-multi-hint {
+  margin-top: 2px;
+  color: var(--dim);
+  font-size: 0.64rem;
+}
+.chat-ask-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.chat-ask-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  max-width: 100%;
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  border-radius: var(--radius-compact);
+  background: transparent;
+  color: var(--foreground);
+  font-family: inherit;
+  font-size: 0.72rem;
+  text-align: left;
+  cursor: pointer;
+}
+.chat-ask-option:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--primary) 55%, transparent);
+}
+.chat-ask-option:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.chat-ask-option--selected {
+  border-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
+.chat-ask-option-label {
+  font-weight: 600;
+}
+.chat-ask-option-desc {
+  color: var(--dim);
+  font-size: 0.64rem;
+}
+.chat-ask-footer {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+.chat-ask-other {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  border-radius: var(--radius-compact);
+  background: var(--background);
+  color: var(--foreground);
+  font-family: inherit;
+  font-size: 0.72rem;
+}
+.chat-ask-answered {
+  margin-top: 10px;
+  color: var(--dim);
+  font-size: 0.7rem;
+  overflow-wrap: anywhere;
+}

--- a/frontend/src/views/chat/transcript/ask.test.ts
+++ b/frontend/src/views/chat/transcript/ask.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for the ask_user card's pure helpers (transcript/ask.ts).
+// The DOM builder follows the tools.ts convention: verified by the
+// live-browser sweep, not RTL — only parse/compose logic is tested here.
+import { describe, expect, it } from 'vitest'
+
+import { composeAskAnswer, parseAskQuestions, type AskQuestion } from './ask'
+
+const presented = (questions: unknown): string =>
+  JSON.stringify({ status: 'question_presented', questions })
+
+const q = (over: Partial<Record<string, unknown>> = {}): Record<string, unknown> => ({
+  question: 'Deploy now?',
+  options: [{ label: 'Yes' }, { label: 'No', description: 'wait for CI' }],
+  multi_select: false,
+  ...over,
+})
+
+describe('parseAskQuestions', () => {
+  it('parses a presented ask_user result into normalized questions', () => {
+    const out = parseAskQuestions({
+      tool_name: 'ask_user',
+      result: presented([q({ header: 'Deploy' })]),
+    })
+    expect(out).toEqual([
+      {
+        question: 'Deploy now?',
+        header: 'Deploy',
+        options: [{ label: 'Yes' }, { label: 'No', description: 'wait for CI' }],
+        multiSelect: false,
+      },
+    ])
+  })
+
+  it('accepts the name alias and multi_select flag', () => {
+    const out = parseAskQuestions({
+      name: 'ask_user',
+      result: presented([q({ multi_select: true })]),
+    })
+    expect(out?.[0]?.multiSelect).toBe(true)
+  })
+
+  it('returns null for other tools, error results, and non-presented payloads', () => {
+    expect(parseAskQuestions({ tool_name: 'exec_command', result: presented([q()]) })).toBeNull()
+    expect(
+      parseAskQuestions({ tool_name: 'ask_user', is_error: true, result: presented([q()]) }),
+    ).toBeNull()
+    expect(
+      parseAskQuestions({ tool_name: 'ask_user', result: JSON.stringify({ status: 'error' }) }),
+    ).toBeNull()
+    expect(parseAskQuestions({ tool_name: 'ask_user', result: 'not json' })).toBeNull()
+  })
+
+  it('rejects malformed questions rather than rendering a partial card', () => {
+    expect(
+      parseAskQuestions({ tool_name: 'ask_user', result: presented([q({ question: '' })]) }),
+    ).toBeNull()
+    expect(
+      parseAskQuestions({
+        tool_name: 'ask_user',
+        result: presented([q({ options: [{ label: 'only one' }] })]),
+      }),
+    ).toBeNull()
+    expect(
+      parseAskQuestions({
+        tool_name: 'ask_user',
+        result: presented([q({ options: [{ label: 'a' }, { label: '' }] })]),
+      }),
+    ).toBeNull()
+    expect(parseAskQuestions({ tool_name: 'ask_user', result: presented([]) })).toBeNull()
+  })
+})
+
+describe('composeAskAnswer', () => {
+  const deployQuestion: AskQuestion = {
+    question: 'Deploy now?',
+    options: [{ label: 'Yes' }, { label: 'No' }],
+    multiSelect: false,
+  }
+  const single: AskQuestion[] = [deployQuestion]
+  const multi: AskQuestion[] = [
+    { ...deployQuestion, header: 'Deploy' },
+    {
+      question: 'Which environment?',
+      options: [{ label: 'staging' }, { label: 'prod' }],
+      multiSelect: true,
+    },
+  ]
+
+  it('returns just the answer for a single question', () => {
+    expect(composeAskAnswer(single, [['Yes']])).toBe('Yes')
+  })
+
+  it('prefixes header (or question) per line for multiple questions', () => {
+    expect(composeAskAnswer(multi, [['Yes'], ['staging', 'prod']])).toBe(
+      'Deploy: Yes\nWhich environment?: staging, prod',
+    )
+  })
+
+  it('skips unanswered questions and appends trimmed free text', () => {
+    expect(composeAskAnswer(multi, [[], ['staging']], '  canary first  ')).toBe(
+      'Which environment?: staging\ncanary first',
+    )
+  })
+
+  it('returns empty when nothing was chosen or typed', () => {
+    expect(composeAskAnswer(single, [[]], '   ')).toBe('')
+  })
+})

--- a/frontend/src/views/chat/transcript/ask.ts
+++ b/frontend/src/views/chat/transcript/ask.ts
@@ -120,6 +120,36 @@ export function composeAskAnswer(
   return lines.join('\n')
 }
 
+/**
+ * Mark ask cards that already have a user message after them as answered and
+ * disable their controls. History reconstruction rebuilds bubbles from
+ * persisted segments, so a card that was answered in a previous turn would
+ * otherwise come back active.
+ */
+export function lockAnsweredAskCards(container: HTMLElement): void {
+  container
+    .querySelectorAll<HTMLElement>('.chat-ask-card:not(.chat-ask-card--answered)')
+    .forEach((card) => {
+      const row = card.closest<HTMLElement>('.msg')
+      if (!row) return
+      let el = row.nextElementSibling
+      while (el) {
+        const isUserRow =
+          el.classList.contains('user') || el.getAttribute('data-history-role') === 'user'
+        if (isUserRow) {
+          card.classList.add('chat-ask-card--answered')
+          card
+            .querySelectorAll<HTMLButtonElement | HTMLInputElement>('button, input')
+            .forEach((c) => {
+              c.disabled = true
+            })
+          return
+        }
+        el = el.nextElementSibling
+      }
+    })
+}
+
 /* ── Imperative DOM builder (composed by the tool renderer) ─────────────── */
 
 export function buildAskCardDOM(

--- a/frontend/src/views/chat/transcript/ask.ts
+++ b/frontend/src/views/chat/transcript/ask.ts
@@ -1,0 +1,268 @@
+// Chat transcript — ask_user interactive question card.
+//
+// AgentOS-native (no legacy chat.js counterpart). The ask_user tool follows
+// an end-turn-and-resume contract: the backend terminates the turn after the
+// tool runs and the user's answer arrives as the next user message. This
+// module renders the presented questions as a clickable card in the live
+// stream bubble; clicking sends the composed answer through the same
+// `chat.send` path the composer uses (injected as `sendAnswer`). Typing a
+// free-text reply in the composer always works too — the card is a
+// convenience, not the mechanism.
+//
+// Split mirrors tools.ts: pure parse/compose helpers (unit-tested in
+// ask.test.ts) + an imperative DOM builder composed by the tool renderer.
+
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
+import type { StreamEventPayload } from '../types'
+
+export interface AskOption {
+  label: string
+  description?: string
+}
+
+export interface AskQuestion {
+  question: string
+  header?: string
+  options: AskOption[]
+  multiSelect: boolean
+}
+
+/* ── Pure helpers (unit-tested) ─────────────────────────────────────────── */
+
+const ASK_TOOL_NAME = 'ask_user'
+const ASK_STATUS_PRESENTED = 'question_presented'
+
+/**
+ * Parse presented questions from an ask_user `tool_result` stream frame.
+ * Returns null for other tools, error results, or malformed payloads —
+ * rendering keys off the RESULT (not the arguments) so a validation
+ * failure never draws a half-formed card.
+ */
+export function parseAskQuestions(payload: StreamEventPayload): AskQuestion[] | null {
+  const p = payload as {
+    name?: string
+    tool_name?: string
+    is_error?: boolean
+    isError?: boolean
+    result?: unknown
+  }
+  const toolName = p.name || p.tool_name || ''
+  if (toolName !== ASK_TOOL_NAME || p.is_error || p.isError) return null
+  let parsed: unknown = p.result
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      return null
+    }
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const body = parsed as { status?: unknown; questions?: unknown }
+  if (body.status !== ASK_STATUS_PRESENTED || !Array.isArray(body.questions)) return null
+
+  const questions: AskQuestion[] = []
+  for (const raw of body.questions) {
+    if (!raw || typeof raw !== 'object') return null
+    const q = raw as {
+      question?: unknown
+      header?: unknown
+      options?: unknown
+      multi_select?: unknown
+    }
+    const question = typeof q.question === 'string' ? q.question.trim() : ''
+    if (!question || !Array.isArray(q.options)) return null
+    const options: AskOption[] = []
+    for (const rawOpt of q.options) {
+      if (!rawOpt || typeof rawOpt !== 'object') return null
+      const opt = rawOpt as { label?: unknown; description?: unknown }
+      const label = typeof opt.label === 'string' ? opt.label.trim() : ''
+      if (!label) return null
+      const option: AskOption = { label }
+      if (typeof opt.description === 'string' && opt.description.trim()) {
+        option.description = opt.description.trim()
+      }
+      options.push(option)
+    }
+    if (options.length < 2) return null
+    const entry: AskQuestion = {
+      question,
+      options,
+      multiSelect: q.multi_select === true,
+    }
+    if (typeof q.header === 'string' && q.header.trim()) entry.header = q.header.trim()
+    questions.push(entry)
+  }
+  return questions.length > 0 ? questions : null
+}
+
+/**
+ * Compose the outgoing user message from per-question selections plus an
+ * optional free-text addition. Single question → just the answer text;
+ * multiple questions → one `Header: answer` line per answered question.
+ */
+export function composeAskAnswer(
+  questions: AskQuestion[],
+  selections: string[][],
+  freeText = '',
+): string {
+  const lines: string[] = []
+  const multi = questions.length > 1
+  questions.forEach((q, i) => {
+    const chosen = (selections[i] || []).filter(Boolean)
+    if (chosen.length === 0) return
+    const answer = chosen.join(', ')
+    lines.push(multi ? `${q.header || q.question}: ${answer}` : answer)
+  })
+  const extra = freeText.trim()
+  if (extra) lines.push(extra)
+  return lines.join('\n')
+}
+
+/* ── Imperative DOM builder (composed by the tool renderer) ─────────────── */
+
+export function buildAskCardDOM(
+  questions: AskQuestion[],
+  sendAnswer: ((text: string) => boolean) | undefined,
+): HTMLElement {
+  const card = document.createElement('div')
+  card.className = 'chat-ask-card'
+  card.setAttribute('role', 'group')
+  card.setAttribute('aria-label', t('chat.askCardLabel'))
+
+  // selections[qi] = list of selected labels for question qi.
+  const selections: string[][] = questions.map(() => [])
+  let answered = false
+
+  const eyebrow = document.createElement('div')
+  eyebrow.className = 'chat-ask-eyebrow'
+  eyebrow.textContent = t('chat.askCardLabel')
+  card.appendChild(eyebrow)
+
+  // One-question single-select cards send on click; everything else
+  // toggles selections and submits through the Send button.
+  const instantSend = questions.length === 1 && !questions[0]?.multiSelect && !!sendAnswer
+
+  // Free-text alternative, created in the footer below; declared ahead of
+  // `submit` so the closure reads the assigned input at click time.
+  let otherInput: HTMLInputElement | null = null
+
+  const submit = (): void => {
+    if (answered || !sendAnswer) return
+    const text = composeAskAnswer(questions, selections, otherInput ? otherInput.value : '')
+    if (!text) return
+    // The sender reports whether the message actually went out (false while
+    // the stream is still settling); only then does the card lock itself.
+    if (!sendAnswer(text)) return
+    answered = true
+    card.classList.add('chat-ask-card--answered')
+    card.querySelectorAll<HTMLButtonElement | HTMLInputElement>('button, input').forEach((el) => {
+      el.disabled = true
+    })
+    const done = document.createElement('div')
+    done.className = 'chat-ask-answered'
+    done.textContent = `${t('chat.askAnswered')}: ${text}`
+    card.appendChild(done)
+  }
+
+  questions.forEach((q, qi) => {
+    const block = document.createElement('div')
+    block.className = 'chat-ask-question'
+
+    const title = document.createElement('div')
+    title.className = 'chat-ask-title'
+    if (q.header) {
+      const chip = document.createElement('span')
+      chip.className = 'chat-ask-header-chip'
+      chip.textContent = q.header
+      title.appendChild(chip)
+    }
+    title.appendChild(document.createTextNode(q.question))
+    block.appendChild(title)
+
+    if (q.multiSelect) {
+      const hint = document.createElement('div')
+      hint.className = 'chat-ask-multi-hint'
+      hint.textContent = t('chat.askMultiHint')
+      block.appendChild(hint)
+    }
+
+    const optionRow = document.createElement('div')
+    optionRow.className = 'chat-ask-options'
+    q.options.forEach((opt) => {
+      const btn = document.createElement('button')
+      btn.type = 'button'
+      btn.className = 'chat-ask-option'
+      if (!sendAnswer) btn.disabled = true
+      const label = document.createElement('span')
+      label.className = 'chat-ask-option-label'
+      label.textContent = opt.label
+      btn.appendChild(label)
+      if (opt.description) {
+        const desc = document.createElement('span')
+        desc.className = 'chat-ask-option-desc'
+        desc.textContent = opt.description
+        btn.appendChild(desc)
+        btn.title = opt.description
+      }
+      btn.addEventListener('click', () => {
+        if (answered) return
+        if (instantSend) {
+          selections[qi] = [opt.label]
+          submit()
+          return
+        }
+        let current = selections[qi]
+        if (!current) {
+          current = []
+          selections[qi] = current
+        }
+        const at = current.indexOf(opt.label)
+        if (q.multiSelect) {
+          if (at >= 0) current.splice(at, 1)
+          else current.push(opt.label)
+          btn.classList.toggle('chat-ask-option--selected', at < 0)
+        } else {
+          selections[qi] = [opt.label]
+          optionRow
+            .querySelectorAll('.chat-ask-option--selected')
+            .forEach((el) => el.classList.remove('chat-ask-option--selected'))
+          btn.classList.add('chat-ask-option--selected')
+        }
+      })
+      optionRow.appendChild(btn)
+    })
+    block.appendChild(optionRow)
+    card.appendChild(block)
+  })
+
+  // Free-text alternative: always offered, so the card never traps the user
+  // in the listed options.
+  const footer = document.createElement('div')
+  footer.className = 'chat-ask-footer'
+  otherInput = document.createElement('input')
+  otherInput.type = 'text'
+  otherInput.className = 'chat-ask-other'
+  otherInput.placeholder = t('chat.askOtherPlaceholder')
+  if (!sendAnswer) otherInput.disabled = true
+  otherInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      submit()
+    }
+  })
+  footer.appendChild(otherInput)
+  if (!instantSend) {
+    const sendBtn = document.createElement('button')
+    sendBtn.type = 'button'
+    sendBtn.className = 'btn btn--sm chat-ask-send'
+    sendBtn.textContent = t('chat.askSend')
+    if (!sendAnswer) sendBtn.disabled = true
+    sendBtn.addEventListener('click', submit)
+    footer.appendChild(sendBtn)
+  }
+  card.appendChild(footer)
+
+  return card
+}

--- a/frontend/src/views/chat/transcript/history.ts
+++ b/frontend/src/views/chat/transcript/history.ts
@@ -13,6 +13,7 @@ import { t } from '@/i18n'
 import '@/i18n/en/chat'
 
 import type { ChatMessage } from '../types'
+import { lockAnsweredAskCards } from './ask'
 import type { Artifact } from './artifacts'
 import type { TurnMeta, TurnUsage } from './message'
 import type { TranscriptHeaderStateRef } from './stream'
@@ -694,6 +695,11 @@ export function createHistoryRenderer(deps: HistoryRenderDeps) {
     ) {
       deps.clearPendingFinalizedAssistantBubble()
     }
+
+    // Ask cards rebuilt above come back active; lock the ones a later user
+    // message already answered so only a genuinely pending question invites
+    // a click.
+    lockAnsweredAskCards(th)
 
     renderHistoryScopeRow(state)
 

--- a/frontend/src/views/chat/transcript/stream.ts
+++ b/frontend/src/views/chat/transcript/stream.ts
@@ -340,6 +340,8 @@ export interface StreamControllerDeps {
    * injects the React modal bridge; default no-op keeps tool cards standalone.
    */
   openModal?: (title: string, html: string, buttons: Array<Record<string, unknown>>) => void
+  /** ask_user card → send the composed answer via the composer's chat.send path. */
+  sendUserAnswer?: (text: string) => boolean
   /**
    * chat.js:7814 `_addMessage` with provenance options — append the subagent
    * completion system row. Distinct from `addMessage` above (which is the
@@ -1500,6 +1502,7 @@ export function createStreamController(
     addMessage: addMessageWithOptions,
     pushMessage,
     openModal,
+    sendUserAnswer: deps.sendUserAnswer,
     diag,
   })
 

--- a/frontend/src/views/chat/transcript/tools.ts
+++ b/frontend/src/views/chat/transcript/tools.ts
@@ -21,6 +21,7 @@ import { t } from '@/i18n'
 import '@/i18n/en/chat'
 
 import type { StreamEventPayload } from '../types'
+import { buildAskCardDOM, parseAskQuestions } from './ask'
 
 /* ── Constants (ported from chat.js, modernized to vector icon keys) ────── */
 
@@ -410,6 +411,13 @@ export interface ToolRendererDeps {
   pushMessage: (message: Record<string, unknown>) => void
   /** chat.js `UI.modal` — open the "View full" result modal. Default: no-op. */
   openModal?: (title: string, html: string, buttons: Array<Record<string, unknown>>) => void
+  /**
+   * ask_user card → send the composed answer as the next user message
+   * (the composer's chat.send path). Returns false when the send did not go
+   * out (e.g. the stream is still settling) so the card stays active.
+   * Absent → the card renders read-only.
+   */
+  sendUserAnswer?: (text: string) => boolean
   /** chat.js `_chatDiag` — the diagnostics ring. Default: no-op. */
   diag?: (event: string, detail: Record<string, unknown>) => void
 }
@@ -693,6 +701,22 @@ export function createToolRenderer(deps: ToolRendererDeps) {
       if (deps.getAutoScroll()) deps.scrollToBottom()
       diag('tool_result.append.skip_duplicate', { toolId, toolName })
       return
+    }
+
+    // ask_user: render the interactive question card in the bubble body
+    // (outside the collapsed tool details). The answer goes out through the
+    // injected chat.send path; the turn has already been terminated
+    // server-side, so the send lands as the next user message.
+    if (toolName === 'ask_user' && !isError) {
+      const questions = parseAskQuestions(payload)
+      if (questions && body && !body.querySelector(`[data-ask-for="${toolId}"]`)) {
+        const askCard = buildAskCardDOM(questions, deps.sendUserAnswer)
+        if (toolId) askCard.setAttribute('data-ask-for', toolId)
+        deps.flushPendingTextSegment()
+        body.appendChild(askCard)
+        deps.newTextSegment()
+        diag('tool_result.ask_card', { toolId, questions: questions.length })
+      }
     }
 
     // Only show result preview if non-empty.

--- a/frontend/src/views/chat/transcript/tools.ts
+++ b/frontend/src/views/chat/transcript/tools.ts
@@ -831,6 +831,23 @@ export function createToolRenderer(deps: ToolRendererDeps) {
               }
             }
           }
+
+          // ask_user: rebuild the interactive question card. The post-stream
+          // history resync replaces the live bubble with this reconstruction,
+          // so without this branch the card only exists for the seconds
+          // between the tool result and the resync. Cards answered in earlier
+          // turns are locked afterwards by lockAnsweredAskCards (history.ts).
+          if (resultToolName === 'ask_user' && !isError) {
+            const questions = parseAskQuestions({
+              tool_name: 'ask_user',
+              result: content,
+            } as StreamEventPayload)
+            if (questions && !body.querySelector(`[data-ask-for="${toolId}"]`)) {
+              const askCard = buildAskCardDOM(questions, deps.sendUserAnswer)
+              if (toolId) askCard.setAttribute('data-ask-for', toolId)
+              body.appendChild(askCard)
+            }
+          }
         }
       }
     } catch {

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -344,6 +344,10 @@ export function useTranscript(opts: {
   // change across renders. Route it through a ref so every View-full click sees
   // the latest callback without rebuilding the imperative transcript controller.
   const openModalRef = useRef(opts.openModal)
+  // ask_user card → composer send path. `send` is defined after the
+  // controller exists, so the card reaches it through a ref (same
+  // late-binding pattern as openModalRef).
+  const sendUserAnswerRef = useRef<((text: string) => boolean) | null>(null)
   const messageActionsRef = useRef({
     onEdit: opts.onEditMessage,
     onRegenerate: opts.onRegenerateMessage,
@@ -498,6 +502,7 @@ export function useTranscript(opts: {
       historyHasRendered: () => historyHasRenderedRef.current,
       historyHydrating: () => historyHydratingRef.current,
       openModal: (title, html, buttons) => openModalRef.current?.(title, html, buttons),
+      sendUserAnswer: (text) => sendUserAnswerRef.current?.(text) ?? false,
       // Artifact preview/download URLs + download Authorization header
       // (chat.js:7575/7657 `App.getAuthToken()`).
       getAuthToken,
@@ -983,6 +988,18 @@ export function useTranscript(opts: {
     },
     [rpc, controller, routerConfigGate],
   )
+
+  // Late-bind the ask_user card's answer path to the freshest `send` so a
+  // card built mid-stream still sends through the current session wiring.
+  // Reports success so the card only locks itself once the answer went out
+  // (send() is a no-op while the ended turn's stream is still settling).
+  useEffect(() => {
+    sendUserAnswerRef.current = (text) => {
+      if (controller.isStreaming()) return false
+      send(text)
+      return true
+    }
+  }, [controller, send])
 
   // chat.js:8439-8450 `_onStop`. Abort only while streaming; set the abort flag,
   // fire `chat.abort` with `{ sessionKey, source }` (chat.js:8444), and end the

--- a/src/agentos/ask_user.py
+++ b/src/agentos/ask_user.py
@@ -1,0 +1,175 @@
+"""Shared helpers for the ``ask_user`` tool.
+
+This module is deliberately side-effect free (no registry imports) so the
+tool-dispatch finalizer, the gateway channel renderer, and the CLI turn
+stream can all import it without pulling in the tool registration path —
+the same split as ``agentos.router_control`` vs
+``agentos.tools.builtin.router_control``.
+
+The tool follows an end-turn-and-resume contract: presenting a question
+terminates the turn (via ``ToolResult.terminates_turn``), and the user's
+answer arrives as the next user message. Nothing blocks waiting for the
+answer, so the tool never races the engine's tool-execution timeout.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+ASK_USER_TOOL_NAME = "ask_user"
+
+# Status stamped on a successful ask_user payload. The dispatch finalizer
+# keys terminates_turn off this value, so renderers can rely on it too.
+ASK_STATUS_PRESENTED = "question_presented"
+
+MAX_QUESTIONS = 4
+MIN_OPTIONS = 2
+MAX_OPTIONS = 4
+_MAX_QUESTION_CHARS = 500
+_MAX_LABEL_CHARS = 100
+_MAX_DESCRIPTION_CHARS = 300
+_MAX_HEADER_CHARS = 24
+
+
+def validate_questions(raw: object) -> list[dict[str, Any]]:
+    """Normalize and validate the ``questions`` argument.
+
+    Returns a list of ``{question, header?, options: [{label, description?}],
+    multi_select}`` dicts with whitespace stripped and unknown keys dropped.
+    Raises ``ValueError`` with an operator-readable message on any violation;
+    the tool layer converts that into a ToolError the model can act on.
+    """
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("'questions' must be a non-empty array of question objects")
+    if len(raw) > MAX_QUESTIONS:
+        raise ValueError(f"'questions' allows at most {MAX_QUESTIONS} questions per call")
+
+    normalized: list[dict[str, Any]] = []
+    for qi, item in enumerate(raw, 1):
+        if not isinstance(item, dict):
+            raise ValueError(f"questions[{qi}] must be an object")
+        question = str(item.get("question") or "").strip()
+        if not question:
+            raise ValueError(f"questions[{qi}].question must be a non-empty string")
+        if len(question) > _MAX_QUESTION_CHARS:
+            raise ValueError(f"questions[{qi}].question exceeds {_MAX_QUESTION_CHARS} characters")
+
+        raw_options = item.get("options")
+        if not isinstance(raw_options, list):
+            raise ValueError(f"questions[{qi}].options must be an array")
+        if not (MIN_OPTIONS <= len(raw_options) <= MAX_OPTIONS):
+            raise ValueError(
+                f"questions[{qi}].options must contain between {MIN_OPTIONS} and "
+                f"{MAX_OPTIONS} options"
+            )
+        options: list[dict[str, str]] = []
+        seen_labels: set[str] = set()
+        for oi, opt in enumerate(raw_options, 1):
+            if not isinstance(opt, dict):
+                raise ValueError(f"questions[{qi}].options[{oi}] must be an object")
+            label = str(opt.get("label") or "").strip()
+            if not label:
+                raise ValueError(f"questions[{qi}].options[{oi}].label must be a non-empty string")
+            if len(label) > _MAX_LABEL_CHARS:
+                raise ValueError(
+                    f"questions[{qi}].options[{oi}].label exceeds {_MAX_LABEL_CHARS} characters"
+                )
+            if label.casefold() in seen_labels:
+                raise ValueError(f"questions[{qi}] has duplicate option label: {label!r}")
+            seen_labels.add(label.casefold())
+            normalized_option: dict[str, str] = {"label": label}
+            description = str(opt.get("description") or "").strip()
+            if description:
+                normalized_option["description"] = description[:_MAX_DESCRIPTION_CHARS]
+            options.append(normalized_option)
+
+        entry: dict[str, Any] = {
+            "question": question,
+            "options": options,
+            "multi_select": bool(item.get("multi_select")),
+        }
+        header = str(item.get("header") or "").strip()
+        if header:
+            entry["header"] = header[:_MAX_HEADER_CHARS]
+        normalized.append(entry)
+    return normalized
+
+
+def build_presented_payload(questions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the tool-result payload for a successfully presented question."""
+    return {
+        "status": ASK_STATUS_PRESENTED,
+        "questions": questions,
+        "message": (
+            "The question was presented to the user. This turn ends now; "
+            "the user's answer will arrive as the next user message."
+        ),
+    }
+
+
+def _presented_payload(content: object) -> dict[str, Any] | None:
+    if isinstance(content, dict):
+        payload: Any = content
+    elif isinstance(content, str):
+        try:
+            payload = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    else:
+        return None
+    if isinstance(payload, dict) and payload.get("status") == ASK_STATUS_PRESENTED:
+        return payload
+    return None
+
+
+def ask_user_payload_terminates_turn(content: object) -> bool:
+    """True when a tool-result payload is a successfully presented question."""
+    return _presented_payload(content) is not None
+
+
+def questions_from_tool_result(
+    tool_name: object,
+    content: object,
+) -> list[dict[str, Any]] | None:
+    """Extract presented questions from an ask_user tool result, else None.
+
+    Used by text surfaces (channels, CLI) to render the question after the
+    tool executed; they key off the result rather than the arguments so a
+    validation failure never renders a half-formed question.
+    """
+    if tool_name != ASK_USER_TOOL_NAME:
+        return None
+    payload = _presented_payload(content)
+    if payload is None:
+        return None
+    questions = payload.get("questions")
+    if not isinstance(questions, list) or not questions:
+        return None
+    return questions
+
+
+def format_questions_as_text(questions: list[dict[str, Any]]) -> str:
+    """Render questions as a numbered list for plain-text surfaces.
+
+    Channels and the CLI have no buttons; the user answers by typing an
+    option number or free text as their next message.
+    """
+    lines: list[str] = []
+    multi_question = len(questions) > 1
+    for qi, question in enumerate(questions, 1):
+        header = str(question.get("header") or "").strip()
+        title = str(question.get("question") or "").strip()
+        prefix = f"Q{qi}. " if multi_question else ""
+        heading = f"{prefix}{header}: {title}" if header else f"{prefix}{title}"
+        lines.append(heading)
+        options = question.get("options")
+        for oi, option in enumerate(options if isinstance(options, list) else [], 1):
+            label = str(option.get("label") or "").strip()
+            description = str(option.get("description") or "").strip()
+            suffix = f" — {description}" if description else ""
+            lines.append(f"  {oi}. {label}{suffix}")
+        if question.get("multi_select"):
+            lines.append("  (choose one or more)")
+    lines.append("Reply with the option number(s) or your own answer.")
+    return "\n".join(lines)

--- a/src/agentos/cli/chat/turn_stream.py
+++ b/src/agentos/cli/chat/turn_stream.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, cast
 
+from agentos.ask_user import format_questions_as_text, questions_from_tool_result
 from agentos.cli.chat.output import ChatOutputHandle
 from agentos.cli.chat.turn import TurnResult, UsageSummary
 from agentos.execution_status import derive_is_error
@@ -501,6 +502,17 @@ async def stream_response_gateway(
                                     ),
                                 ),
                             )
+                            ask_questions = questions_from_tool_result(
+                                event.get("tool_name") or event.get("toolName"),
+                                event.get("result"),
+                            )
+                            if ask_questions:
+                                # No buttons on this surface: show the numbered
+                                # list; the user types the answer as their next
+                                # message.
+                                await renderer.aappend_text(
+                                    "\n\n" + format_questions_as_text(ask_questions)
+                                )
                     elif event_name == "session.event.artifact":
                         artifact = artifact_event_payload(event)
                         artifacts.append(artifact)
@@ -638,6 +650,14 @@ async def stream_response_turnrunner(
                                     legacy_is_error=event.is_error,
                                 ),
                             )
+                            ask_questions = questions_from_tool_result(
+                                event.tool_name,
+                                event.result,
+                            )
+                            if ask_questions:
+                                await renderer.aappend_text(
+                                    "\n\n" + format_questions_as_text(ask_questions)
+                                )
                     elif isinstance(event, ArtifactEvent):
                         artifact = artifact_event_payload(event)
                         artifacts.append(artifact)

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -26,6 +26,7 @@ import structlog
 
 from agentos.agents.scope import resolve_agent_model
 from agentos.artifacts import artifact_payload
+from agentos.ask_user import format_questions_as_text, questions_from_tool_result
 from agentos.channels._util import ChannelAccessPolicy, evaluate_policy
 from agentos.channels.artifact_delivery import (
     artifact_delivery_key as _artifact_delivery_key,
@@ -1615,6 +1616,12 @@ class _RuntimeChannelStreamRelay:
         if artifact is not None:
             self._artifacts.append(artifact)
             return
+        ask_text = _ask_user_reply_text(event)
+        if ask_text is not None:
+            prefix = "\n\n" if self.text_emitted else ""
+            self.text_emitted = True
+            await self._queue.put(f"{prefix}{ask_text}")
+            return
         text = _text_delta_from_event(event)
         if not text:
             return
@@ -1715,6 +1722,30 @@ class _RuntimeChannelStreamRelay:
                         self._inbound,
                     )
                 )
+
+
+def _ask_user_reply_text(event: Any) -> str | None:
+    """Render a presented ask_user question for a text-only channel reply.
+
+    Channels have no clickable options; the question is appended to the
+    reply as a numbered list and the user answers by typing a number or
+    free text as their next message. Duck-typed so both ToolResultEvent
+    instances and dict-shaped runtime events work.
+    """
+    if isinstance(event, dict):
+        tool_name = event.get("tool_name")
+        content = event.get("result")
+        is_error = bool(event.get("is_error"))
+    else:
+        tool_name = getattr(event, "tool_name", None)
+        content = getattr(event, "result", None)
+        is_error = bool(getattr(event, "is_error", False))
+    if is_error:
+        return None
+    questions = questions_from_tool_result(tool_name, content)
+    if questions is None:
+        return None
+    return format_questions_as_text(questions)
 
 
 def _text_delta_from_event(event: Any) -> str:
@@ -2163,6 +2194,9 @@ async def _run_turn_batch_path(
                         "session.event.tool_result",
                         _tool_result_payload(event),
                     )
+                ask_text = _ask_user_reply_text(event)
+                if ask_text:
+                    text_parts.append(("\n\n" if text_parts else "") + ask_text)
             elif isinstance(event, ErrorEvent):
                 log.error(
                     "channel_dispatch.agent_error",
@@ -2331,6 +2365,11 @@ async def _run_turn_streaming_path(
                         "session.event.tool_result",
                         _tool_result_payload(event),
                     )
+                ask_text = _ask_user_reply_text(event)
+                if ask_text:
+                    prefix = "\n\n" if text_emitted else ""
+                    text_emitted = True
+                    await queue.put(f"{prefix}{ask_text}")
             elif isinstance(event, ErrorEvent):
                 log.error(
                     "channel_dispatch.agent_error",

--- a/src/agentos/identity/templates/system_prompt.j2
+++ b/src/agentos/identity/templates/system_prompt.j2
@@ -76,6 +76,16 @@ SOUL.md defines durable voice and persona guidance for this workspace. Treat it 
 
 {% endif -%}
 
+{% if tools and "ask_user" in tools and prompt_mode == "full" -%}
+## Asking The User
+
+- Use `ask_user` only when a decision is genuinely the user's to make and different answers lead to materially different work: scope choices, hard-to-reverse actions, conflicting instructions, or missing values you cannot look up.
+- Do not ask when a sensible default exists. Pick it, state the assumption in your reply, and continue.
+- Do not ask anything you can resolve yourself with the available tools or context.
+- Batch every open question into ONE `ask_user` call instead of asking one at a time, and finish all work that does not depend on the answers BEFORE asking.
+- Calling `ask_user` ends your turn; the user's answer arrives as their next message. Never call `ask_user` again for a question you already asked, and never block on questions the user has declined to answer — proceed with stated assumptions instead.
+
+{% endif -%}
 {% set has_sessions_send = tools and "sessions_send" in tools -%}
 {% set has_channel_message = tools and "message" in tools -%}
 {% if has_sessions_send and has_channel_message and prompt_mode == "full" -%}
@@ -287,7 +297,11 @@ greetings like "hi". Always respond to direct user messages.
 ## Reply Guidelines
 
 - Use the conversation's language for replies
-- When uncertain, ask for clarification rather than guessing
+{% if tools and "ask_user" in tools -%}
+- When a decision is the user's to make, use `ask_user`; otherwise state your assumption and continue
+{% else -%}
+- When uncertain, state the interpretation you are acting on rather than silently guessing
+{% endif -%}
 - Prefer concise replies unless detail is requested
 
 {% endif -%}

--- a/src/agentos/tools/builtin/__init__.py
+++ b/src/agentos/tools/builtin/__init__.py
@@ -10,6 +10,7 @@ _FATAL_MODULES = frozenset({"shell", "patch", "filesystem"})
 _NAMES = [
     "agents",
     "artifacts",
+    "ask",
     "code_exec",
     "control",
     "env_tools",

--- a/src/agentos/tools/builtin/ask.py
+++ b/src/agentos/tools/builtin/ask.py
@@ -1,0 +1,99 @@
+"""ask_user tool: present structured choices to the user and end the turn.
+
+The tool never blocks waiting for the answer. Presenting the question is
+the whole job: the dispatch finalizer marks the result ``terminates_turn``
+(see ``agentos.tools.policy.finalize``), the turn ends, and the user's
+answer arrives as the next user message. Interactive surfaces render the
+questions as clickable options; plain-text surfaces render a numbered list.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agentos.ask_user import build_presented_payload, validate_questions
+from agentos.tools.registry import tool
+from agentos.tools.types import (
+    InteractionMode,
+    SafeToolError,
+    UnsupportedSurfaceError,
+    current_tool_context,
+)
+
+
+@tool(
+    name="ask_user",
+    description=(
+        "Ask the user up to 4 structured questions, each with 2-4 options, when a "
+        "decision is genuinely theirs to make and different answers lead to "
+        "materially different work. The turn ends after asking; the answer arrives "
+        "as the next user message. The user can always reply with their own text "
+        "instead of an option, so never add an 'Other' option yourself. Do not ask "
+        "when a sensible default exists — pick it and state the assumption."
+    ),
+    params={
+        "questions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 4,
+            "description": "Questions to ask; batch every open question into one call.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The complete question, ending with a question mark.",
+                    },
+                    "header": {
+                        "type": "string",
+                        "description": "Optional short topic label (max 24 chars).",
+                    },
+                    "options": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 4,
+                        "description": "Distinct answer choices.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "label": {
+                                    "type": "string",
+                                    "description": "Concise choice text (1-5 words).",
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "What choosing this option means.",
+                                },
+                            },
+                            "required": ["label"],
+                        },
+                    },
+                    "multi_select": {
+                        "type": "boolean",
+                        "description": "Allow choosing multiple options.",
+                        "default": False,
+                    },
+                },
+                "required": ["question", "options"],
+            },
+        },
+    },
+    required=["questions"],
+)
+async def ask_user(questions: list[object]) -> str:
+    ctx = current_tool_context.get()
+    if ctx is not None and ctx.interaction_mode is InteractionMode.UNATTENDED:
+        # Runtime-surface resolution already denies the tool on unattended
+        # surfaces; this guard keeps the contract even for contexts built
+        # outside that path.
+        raise UnsupportedSurfaceError(
+            "ask_user requires a live user, but this run is unattended. "
+            "Choose a sensible default and state the assumption instead."
+        )
+    try:
+        normalized = validate_questions(questions)
+    except ValueError as exc:
+        # SafeToolError keeps the validation detail visible to the model so it
+        # can correct the call instead of retrying blind.
+        raise SafeToolError(str(exc)) from exc
+    return json.dumps(build_presented_payload(normalized))

--- a/src/agentos/tools/policy/finalize.py
+++ b/src/agentos/tools/policy/finalize.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import structlog
 
+from agentos.ask_user import ask_user_payload_terminates_turn
 from agentos.execution_status import (
     derive_is_error,
     execution_status_for_tool_result,
@@ -29,7 +30,6 @@ from agentos.result_budget import (
     ToolRunBudgetExceededError,
     resolve_budget_class,
 )
-from agentos.ask_user import ask_user_payload_terminates_turn
 from agentos.router_control import router_control_payload_terminates_turn
 from agentos.tool_boundary import ToolCall, ToolResult
 from agentos.tools.envelope import build_tool_failure_envelope, is_denial_payload

--- a/src/agentos/tools/policy/finalize.py
+++ b/src/agentos/tools/policy/finalize.py
@@ -29,6 +29,7 @@ from agentos.result_budget import (
     ToolRunBudgetExceededError,
     resolve_budget_class,
 )
+from agentos.ask_user import ask_user_payload_terminates_turn
 from agentos.router_control import router_control_payload_terminates_turn
 from agentos.tool_boundary import ToolCall, ToolResult
 from agentos.tools.envelope import build_tool_failure_envelope, is_denial_payload
@@ -263,5 +264,12 @@ async def finalize(
         terminates_turn=(
             call.tool_name == "router_control"
             and router_control_payload_terminates_turn(content)
+        )
+        or (
+            # ask_user follows an end-turn-and-resume contract: presenting
+            # the question ends the turn; the answer is the next user message.
+            call.tool_name == "ask_user"
+            and not is_error
+            and ask_user_payload_terminates_turn(content)
         ),
     )

--- a/src/agentos/tools/policy_config.py
+++ b/src/agentos/tools/policy_config.py
@@ -34,6 +34,9 @@ _TOOL_GROUPS: Mapping[str, frozenset[str]] = {
     "group:memory": frozenset({"memory_search", "memory_get"}),
     "group:web": frozenset({"web_search", "web_fetch", "http_request", "x_search"}),
     "group:messaging": frozenset({"message"}),
+    # Structured user questions. Interactive surfaces only — the runtime
+    # capability layer hides ask_user on unattended runs regardless of profile.
+    "group:interaction": frozenset({"ask_user"}),
     "channel:chat": frozenset(
         {
             "message",
@@ -115,8 +118,12 @@ _TOOL_PROFILES: Mapping[str, frozenset[str] | None] = {
         | _TOOL_GROUPS["group:runtime"]
         | _TOOL_GROUPS["group:sessions"]
         | _TOOL_GROUPS["group:memory"]
+        # Coding turns hit the most decisions that are genuinely the user's
+        # (scope, destructive steps); the ask tool belongs on this surface.
+        | _TOOL_GROUPS["group:interaction"]
     ),
     "messaging": _TOOL_GROUPS["group:messaging"]
+    | _TOOL_GROUPS["group:interaction"]
     | frozenset(
         {
             "sessions_list",

--- a/src/agentos/tools/policy_runtime.py
+++ b/src/agentos/tools/policy_runtime.py
@@ -18,7 +18,9 @@ _SESSION_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset(
     {"sessions_send", "sessions_spawn", "sessions_yield"}
 )
 _CHANNEL_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"message"})
-_INTERACTIVE_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"agents_list", "subagents"})
+_INTERACTIVE_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset(
+    {"agents_list", "ask_user", "subagents"}
+)
 _GATEWAY_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"gateway"})
 _SCHEDULER_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"cron"})
 

--- a/src/agentos/tools/types.py
+++ b/src/agentos/tools/types.py
@@ -95,6 +95,7 @@ current_tool_context: contextvars.ContextVar[ToolContext | None] = contextvars.C
 
 SUBAGENT_TOOL_DENY: frozenset[str] = frozenset(
     {
+        "ask_user",
         "cron",
         "gateway",
         "agents_list",

--- a/tests/test_ask_user.py
+++ b/tests/test_ask_user.py
@@ -1,0 +1,110 @@
+"""Unit tests for the side-effect-free ask_user helpers (agentos.ask_user)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.ask_user import (
+    ASK_STATUS_PRESENTED,
+    ask_user_payload_terminates_turn,
+    build_presented_payload,
+    format_questions_as_text,
+    questions_from_tool_result,
+    validate_questions,
+)
+
+
+def _question(**overrides: object) -> dict:
+    base: dict = {
+        "question": "Deploy now?",
+        "options": [{"label": "Yes"}, {"label": "No", "description": "wait for CI"}],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidateQuestions:
+    def test_normalizes_a_valid_question(self) -> None:
+        out = validate_questions([_question(header="  Deploy  ", multi_select=1)])
+        assert out == [
+            {
+                "question": "Deploy now?",
+                "options": [
+                    {"label": "Yes"},
+                    {"label": "No", "description": "wait for CI"},
+                ],
+                "multi_select": True,
+                "header": "Deploy",
+            }
+        ]
+
+    def test_rejects_non_list_and_empty(self) -> None:
+        for bad in (None, "x", {}, []):
+            with pytest.raises(ValueError, match="non-empty array"):
+                validate_questions(bad)  # type: ignore[arg-type]
+
+    def test_rejects_more_than_four_questions(self) -> None:
+        with pytest.raises(ValueError, match="at most 4"):
+            validate_questions([_question() for _ in range(5)])
+
+    def test_rejects_empty_question_text(self) -> None:
+        with pytest.raises(ValueError, match="question must be a non-empty string"):
+            validate_questions([_question(question="   ")])
+
+    def test_rejects_option_count_out_of_bounds(self) -> None:
+        with pytest.raises(ValueError, match="between 2 and 4"):
+            validate_questions([_question(options=[{"label": "only"}])])
+        with pytest.raises(ValueError, match="between 2 and 4"):
+            validate_questions([_question(options=[{"label": f"o{i}"} for i in range(5)])])
+
+    def test_rejects_blank_and_duplicate_labels(self) -> None:
+        with pytest.raises(ValueError, match="label must be a non-empty string"):
+            validate_questions([_question(options=[{"label": "a"}, {"label": " "}])])
+        with pytest.raises(ValueError, match="duplicate option label"):
+            validate_questions([_question(options=[{"label": "A"}, {"label": "a"}])])
+
+
+class TestPayloadHelpers:
+    def test_presented_payload_terminates_turn(self) -> None:
+        payload = build_presented_payload(validate_questions([_question()]))
+        assert payload["status"] == ASK_STATUS_PRESENTED
+        assert ask_user_payload_terminates_turn(json.dumps(payload)) is True
+        assert ask_user_payload_terminates_turn(payload) is True
+
+    def test_non_presented_content_does_not_terminate(self) -> None:
+        assert ask_user_payload_terminates_turn("not json") is False
+        assert ask_user_payload_terminates_turn(json.dumps({"status": "error"})) is False
+        assert ask_user_payload_terminates_turn(None) is False
+
+    def test_questions_from_tool_result_gates_on_tool_and_status(self) -> None:
+        payload = json.dumps(build_presented_payload(validate_questions([_question()])))
+        assert questions_from_tool_result("ask_user", payload) is not None
+        assert questions_from_tool_result("exec_command", payload) is None
+        assert questions_from_tool_result("ask_user", '{"status": "error"}') is None
+
+
+class TestFormatQuestionsAsText:
+    def test_single_question_layout(self) -> None:
+        text = format_questions_as_text(validate_questions([_question(header="Deploy")]))
+        assert text.splitlines() == [
+            "Deploy: Deploy now?",
+            "  1. Yes",
+            "  2. No — wait for CI",
+            "Reply with the option number(s) or your own answer.",
+        ]
+
+    def test_multi_question_numbering_and_multi_select_hint(self) -> None:
+        text = format_questions_as_text(
+            validate_questions(
+                [
+                    _question(),
+                    _question(question="Which env?", multi_select=True),
+                ]
+            )
+        )
+        lines = text.splitlines()
+        assert lines[0] == "Q1. Deploy now?"
+        assert "Q2. Which env?" in lines
+        assert "  (choose one or more)" in lines

--- a/tests/test_tools/test_ask_user_tool.py
+++ b/tests/test_tools/test_ask_user_tool.py
@@ -1,0 +1,112 @@
+"""ask_user tool: dispatch behavior, end-turn contract, and surface gating."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.tool_boundary import ToolCall
+from agentos.tools import get_default_registry
+from agentos.tools.dispatch import build_tool_handler
+from agentos.tools.types import CallerKind, InteractionMode, ToolContext
+from agentos.tools.visibility import effective_tool_context, is_tool_visible
+
+
+def _call(arguments: dict | None = None) -> ToolCall:
+    return ToolCall(
+        tool_use_id="ask-1",
+        tool_name="ask_user",
+        arguments=arguments
+        if arguments is not None
+        else {
+            "questions": [
+                {
+                    "question": "Deploy now?",
+                    "options": [{"label": "Yes"}, {"label": "No"}],
+                }
+            ]
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_user_presents_and_terminates_turn() -> None:
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key="agent:main:t-ask")
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call())
+
+    assert result.is_error is False
+    # The end-turn-and-resume contract: presenting the question ends the turn.
+    assert result.terminates_turn is True
+    payload = json.loads(result.content)
+    assert payload["status"] == "question_presented"
+    assert payload["questions"][0]["question"] == "Deploy now?"
+    assert [o["label"] for o in payload["questions"][0]["options"]] == ["Yes", "No"]
+
+
+@pytest.mark.asyncio
+async def test_ask_user_rejects_invalid_questions_without_ending_turn() -> None:
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key="agent:main:t-ask-bad")
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(
+        _call({"questions": [{"question": "x?", "options": [{"label": "only one"}]}]})
+    )
+
+    assert result.is_error is True
+    assert result.terminates_turn is False
+    assert "between 2 and 4" in result.content
+
+
+@pytest.mark.asyncio
+async def test_ask_user_refuses_unattended_surfaces() -> None:
+    ctx = ToolContext(
+        caller_kind=CallerKind.AGENT,
+        interaction_mode=InteractionMode.UNATTENDED,
+        session_key="agent:main:t-ask-unattended",
+    )
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call())
+
+    assert result.is_error is True
+    assert result.terminates_turn is False
+    assert "unattended" in result.content
+
+
+def _registered_ask_user():
+    rt = get_default_registry().get("ask_user")
+    assert rt is not None
+    return rt
+
+
+def test_ask_user_hidden_from_cron_and_subagent_surfaces() -> None:
+    rt = _registered_ask_user()
+    cron_ctx = effective_tool_context(session_key="cron:job-1", caller_kind=CallerKind.CRON)
+    subagent_ctx = effective_tool_context(
+        session_key="subagent:main:x", caller_kind=CallerKind.SUBAGENT
+    )
+    assert is_tool_visible(rt, cron_ctx) is False
+    assert is_tool_visible(rt, subagent_ctx) is False
+
+
+def test_ask_user_hidden_when_interactive_surface_is_unattended() -> None:
+    rt = _registered_ask_user()
+    ctx = effective_tool_context(
+        session_key="agent:main:t-ask-vis",
+        caller_kind=CallerKind.AGENT,
+        interaction_mode=InteractionMode.UNATTENDED,
+    )
+    assert is_tool_visible(rt, ctx) is False
+
+
+def test_ask_user_visible_on_interactive_agent_surface() -> None:
+    rt = _registered_ask_user()
+    ctx = effective_tool_context(
+        session_key="agent:main:t-ask-vis2",
+        caller_kind=CallerKind.AGENT,
+        interaction_mode=InteractionMode.INTERACTIVE,
+    )
+    assert is_tool_visible(rt, ctx) is True


### PR DESCRIPTION
## Why

The agent has no way to hand a decision back to the user. Nothing in the tool surface can present options, so every ambiguity gets resolved by running straight through — the exact gap other harnesses close with an ask-the-user tool.

## Design: end-turn-and-resume, not a blocking wait

A blocking ask tool cannot work in this engine: every tool is killed at `tool_timeout` (60s default, `engine/types.py:286`), and even the shell approval wait only survives by padding its own timeout and falling back to a retry payload. A user answering a design question routinely takes minutes-to-hours.

So `ask_user` never waits. Presenting the question **is** the whole job:

1. The tool validates and returns a `question_presented` payload.
2. The dispatch finalizer marks the result `terminates_turn` — the same mechanism `sessions_yield` and `router_control` already use — and the turn ends cleanly.
3. The user's answer arrives as their next message (card click, typed text, or a channel reply), and the next turn continues with full history.

Nothing races the engine timeout, no watchdog interactions, and the answer can come seconds or days later.

## What's included

- **`agentos/ask_user.py`** — side-effect-free helpers (validation, payload predicate, numbered-list formatting), importable by dispatch/gateway/CLI without touching registration (the `router_control.py` split).
- **`tools/builtin/ask.py`** — the tool: 1–4 questions × 2–4 options, `multi_select`, validation detail surfaced via `SafeToolError`, `UnsupportedSurfaceError` on unattended contexts.
- **Gating** — hidden for cron/subagent/unattended via `_INTERACTIVE_RUNTIME_TOOL_NAMES` + `SUBAGENT_TOOL_DENY`; added to the `coding` and `messaging` tool profiles as `group:interaction`.
- **Web UI** — a clickable question card (`transcript/ask.ts`, imperative-DOM like the rest of the transcript renderer) built from the `tool_result` frame; answers go out through the composer's `chat.send` path and the card only locks after the send actually left (guards the stream-settling race). Free-text field included, so the card never traps the user in the listed options.
- **CLI (gateway + standalone) and channels** — the question renders as a numbered list; the user replies with a number or free text. Covers the relay, batch, and streaming channel paths.
- **Prompt** — an "Asking The User" block, gated on the tool being present, teaching when to ask vs decide (ask only when answers change the work; batch into one call; do independent work first; never re-ask). The vague "ask for clarification rather than guessing" line is replaced.
- **Docs** — `docs/tools-and-sandbox.md`, `docs/web-ui.md`.

## Tests

- `tests/test_ask_user.py` — validation, payload predicates, text formatting.
- `tests/test_tools/test_ask_user_tool.py` — dispatch integration (`terminates_turn` on success and only on success), unattended refusal, cron/subagent/unattended visibility.
- `frontend .../ask.test.ts` — parse/compose helpers (DOM builder follows the tools.ts convention: live-browser sweep, not RTL).
- Full gates: `pytest` 7826 passed, repo-wide `mypy` clean, `ruff` clean, frontend `npm run check` — the only failure is the pre-existing `AppShell` g-chord focus test, which fails identically on a clean `main` checkout.

## Known limits (deliberate v1 scope)

- The no-relay runtime channel fallback (transcript-text delivery) doesn't render the options; the model's own text still carries the ask.
- History reload shows the ask as a regular tool card, not an interactive one — typing the answer always works, the card is a convenience.
- CLI shows the numbered list rather than an interactive selector (the in-REPL approval-surface machinery makes that a clean follow-up).