### PR TITLE
docs(skills): default the unilp ratchet monitor to a script cron job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `senior-unilp-manager` now defaults the ratchet monitor to a `script` cron
+  job. "Wiring it to cron" leads with the `job_kind="script"` shape and states
+  the rule outright: if the user did not say which shape they want, schedule
+  the script job. `agent_turn` is documented as the explicit opt-in for when a
+  model is wanted in the loop — to summarize or escalate in its own words —
+  with its cost named, a full turn on every tick of a job that is almost always
+  a no-op. `tick` already reconciles and fires in one process, so the script
+  shape costs no model call, takes no `tool_policy`, and with `--alert-only`
+  stays quiet on a healthy ratchet. Instructions only; no behaviour changed.
+  (#325)
+
 ## [2026.8.17] - 2026-08-17
 
 ### Added

--- a/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
@@ -596,15 +596,12 @@ conversation — a cron task string, a script on disk — has to carry the full 
 `{baseDir}/scripts/ratchet.py`, spelled out. This is the one place the `"$S"` form above is
 wrong.
 
-```
-cron(action="add", schedule={"kind": "cron", "expr": "*/5 * * * *"},
-     task="python3 {baseDir}/scripts/ratchet.py tick --all --broadcast --json — report the "
-          "result, and raise the alarm if any state is NEEDS_ATTENTION",
-     job_kind="agent_turn", session_target="isolated")
-```
+Two shapes can carry it, and they are not equal. **If the user did not say which one they
+want, schedule the script job.** Reach for `agent_turn` only when they explicitly ask for a
+model in the loop.
 
 `tick` does the reconcile and the fire in one process on purpose: no agent judgement sits
-between deciding and sending — which is why the model in the loop is optional. Put the same
+between deciding and sending — which is why the model in the loop is optional. Put the
 command in a script under `~/.agentos/scripts/` (again with the path spelled out) and the
 ticks cost no model call and no tokens; stdout is delivered verbatim, and a tick that prints
 nothing stays silent:
@@ -632,6 +629,17 @@ mandate sitting in `NEEDS_ATTENTION`, on **every** tick until a human clears it:
 reports the same `noop` as a healthy mandate, and going quiet on it would be the one silence
 that costs money. `--alert-only` only changes `--json` output; run by hand without it and the
 command prints exactly what it always did.
+
+The other shape puts a model on every tick. Use it **only** when the user explicitly asks
+for one — so it can summarize the result or escalate in its own words — and know what it
+costs: a full turn every five minutes for a job that is almost always a no-op.
+
+```
+cron(action="add", schedule={"kind": "cron", "expr": "*/5 * * * *"},
+     task="python3 {baseDir}/scripts/ratchet.py tick --all --broadcast --json — report the "
+          "result, and raise the alarm if any state is NEEDS_ATTENTION",
+     job_kind="agent_turn", session_target="isolated")
+```
 
 A script job runs the file itself and never starts an agent turn, so it takes **no**
 `tool_policy` — `tool_policy.elevated` belongs to the `agent_turn` shape above and is


### PR DESCRIPTION
## Summary

`senior-unilp-manager`'s "Wiring it to cron" section led with the `agent_turn` shape and offered the script job only afterwards ("Put the same command in a script … and the ticks cost no model call"). An agent asked to set up ratchet monitoring, without being told which shape to use, picked `agent_turn` — a full model turn every five minutes for a job that is almost always a no-op.

This reorders that section and states the default outright. Instructions only; no code changed.

## Changes

- Lead with the `job_kind="script"` example, followed by the existing `ratchet-tick.sh` body with `--json --alert-only` and the `--alert-only` rationale (both unchanged).
- Add the explicit rule: **if the user did not say which shape they want, schedule the script job**; reach for `agent_turn` only when they explicitly ask for a model in the loop.
- Demote the `agent_turn` example below the `--alert-only` explanation, framed as the opt-in for when a model should summarize or escalate in its own words, with its cost named.
- Keep both examples' constraints intact: the full `{baseDir}/scripts/ratchet.py` path rule, `tool_policy.elevated` belonging only to the `agent_turn` shape, the interactive CLI-or-Web caller requirement, and the `UNIV4_LP_PRIVATE_KEY` visibility check for script jobs.
- CHANGELOG entry under `[Unreleased]`.

## Scope

Two files: `src/agentos/skills/bundled/senior-unilp-manager/SKILL.md` and `CHANGELOG.md`. No Python, no behaviour change, no other skill or doc touched — `grep` found no ratchet cron examples elsewhere in `docs/`.

## Testing

`tests/test_public_release_hygiene.py` passes (15). The four failures in `tests/test_skills_default_prompt_contract.py` are pre-existing on `upstream/main` in this environment — verified identical before and after the change.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)