### PR TITLE
docs(senior-unilp-manager): give LP monitor files a folder under scripts/senior-unilp-manager/<cron_id>/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   shape costs no model call, takes no `tool_policy`, and with `--alert-only`
   stays quiet on a healthy ratchet. Instructions only; no behaviour changed.
   (#325)
+- `senior-unilp-manager` now has a file layout for the monitors it sets up.
+  Every file a ratchet monitor needs — `tick.sh`, any helper the agent writes
+  for it, any scratch the run keeps — lives under
+  `~/.agentos/scripts/senior-unilp-manager/<cron_id>/` and nowhere else, so the
+  mapping from job to files is one-to-one: delete the job, delete the
+  directory. Previously the skill said only "a script under
+  `~/.agentos/scripts/`", and each run invented its own names in a directory
+  shared with every other skill's jobs, which left nothing that could be
+  cleaned up when a mandate was disarmed. The skill now also says explicitly
+  that mandate state is not part of that directory — the mandate JSON, the
+  write-ahead log, and the lock stay under `$UNILP_STATE_DIR` /
+  `$AGENTOS_HOME/state/unilp` / `~/.agentos/state/unilp` — and spells out the
+  stage-then-repoint ordering, since a cron id does not exist until its job
+  does, and the teardown that the layout is there to make possible: remove the
+  job, then remove its directory. Skill instructions only; subdirectories under
+  the scripts directory were already supported. (#326)
 
 ## [2026.8.17] - 2026-08-17
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
@@ -483,6 +483,9 @@ safe and idempotent: identical terms print `already armed as <id>` and change no
 each try to burn the same NFT — so `disarm` the old one first if the new terms are the ones
 you want. Do not work around this by re-labelling: `--label` is only a display string.
 
+Disarming settles the mandate but leaves any cron monitor and its files standing. If nothing
+else needs the ticker, take those down too — see **Tearing one down**.
+
 ## One transaction, and why that matters
 
 A fire is a single `modifyLiquidities` call:
@@ -602,16 +605,23 @@ model in the loop.
 
 `tick` does the reconcile and the fire in one process on purpose: no agent judgement sits
 between deciding and sending — which is why the model in the loop is optional. Put the
-command in a script under `~/.agentos/scripts/` (again with the path spelled out) and the
-ticks cost no model call and no tokens; stdout is delivered verbatim, and a tick that prints
-nothing stays silent:
+command in a script under `~/.agentos/scripts/senior-unilp-manager/<cron_id>/` (again with
+the path spelled out) and the ticks cost no model call and no tokens; stdout is delivered
+verbatim, and a tick that prints nothing stays silent:
 
 ```
+# the shape a wired-up monitor ends in — <cron_id> is this job's own id,
+# so it is reached by the staging sequence below, not typed at add time
 cron(action="add", schedule={"kind": "every", "every_seconds": 600},
-     job_kind="script", script="ratchet-tick.sh", session_target="isolated")
+     job_kind="script", script="senior-unilp-manager/<cron_id>/tick.sh",
+     session_target="isolated")
 ```
 
-Write `--alert-only` into that script, alongside `--json`. Without it every tick delivers the
+Do not copy that `add` verbatim: a job created against a literal `<cron_id>` finds no file and
+retires itself in five ticks. **Files on disk for a monitor** below is the layout that path
+belongs to, and the sequence that fills the id in. Read it before wiring one up.
+
+Write `--alert-only` into `tick.sh`, alongside `--json`. Without it every tick delivers the
 full result of every mandate, which on a healthy ratchet is a block of JSON saying nothing
 happened, every ten minutes, until nobody reads it any more. With it a tick that found
 nothing still prints the whole payload — the run history keeps it — but ends on the line
@@ -647,6 +657,83 @@ rejected here. Both shapes need an interactive CLI or Web caller; neither can be
 from a chat channel. The script inherits the gateway process environment, so confirm
 `UNIV4_LP_PRIVATE_KEY` is visible there before arming: a missing key fails every tick, and
 five consecutive failures retire the job.
+
+## Files on disk for a monitor
+
+One monitor, one directory:
+
+```
+~/.agentos/scripts/senior-unilp-manager/<cron_id>/
+```
+
+`<cron_id>` is the id of the cron job that owns the monitor, so the mapping is one-to-one and
+mechanical: delete the job, delete the directory. Everything that monitor needs lives there
+and nowhere else — `tick.sh`, any Python helper you write for it, any scratch or output the
+run keeps. Never drop a file for it at the top of `~/.agentos/scripts/`: that directory is
+shared with every other skill's jobs, and a file with no owner in its path is a file nothing
+can ever safely clean up.
+
+The cron **job** id, not a mandate id, is what names the directory. A tick script runs
+`--all`, so it is not per-mandate: one job covers every mandate in the state directory, and
+naming its directory after one of them would be a lie about what it watches.
+
+**Mandate state does not go here.** The mandate JSON, the `.log.jsonl` write-ahead log, and
+the `.lock` stay where **State on disk** above puts them — `$UNILP_STATE_DIR`, else
+`$AGENTOS_HOME/state/unilp`, else `~/.agentos/state/unilp` — because that is where
+`ratchet.py` writes them and where it looks for them. The scripts directory holds the
+executable and its helpers; it is not a state directory, and a mandate written there is a
+mandate the runner never finds.
+
+### Getting the id into the path
+
+The job needs a script path at creation time, and the cron id only exists once the job has
+been created. Stage the script, then repoint:
+
+1. `mkdir -p ~/.agentos/scripts/senior-unilp-manager/pending/<stage>/` — only the base
+   `~/.agentos/scripts/` is created for you — and write the real, finished `tick.sh` there.
+   `<stage>` is any string unique to this monitor; see below.
+2. `cron(action="add", job_kind="script", name="<something a human will recognise>",
+   script="senior-unilp-manager/pending/<stage>/tick.sh", …)` and read `job_id` off the
+   result — that is `<cron_id>`. Pass `name` here: without one the job is named after
+   whatever `script` said at creation, and it would carry the staging path as its name for
+   the rest of its life, including in every failure alert.
+3. `mkdir -p ~/.agentos/scripts/senior-unilp-manager/<cron_id>/`, move `tick.sh` into it, and
+   remove the now-empty staging directory.
+4. `cron(action="update", job_id="<cron_id>", script="senior-unilp-manager/<cron_id>/tick.sh")`
+   to repoint the job at its final home. `action="update"` can repoint a live job's script, so
+   this keeps the id the user was just told, along with the job's whole run history.
+
+Stage a working script rather than a placeholder, and do steps 3 and 4 straight away: between
+the add and the repoint the job is already live, and a tick that fires at a path with no file
+behind it delivers `Script not found` — five consecutive failures retire the job.
+
+`<stage>` is a nonce, and it has to be one per monitor. Wiring a second monitor while the
+first is still between its add and its repoint, a shared `pending/tick.sh` does not merely
+clobber a file: job A still points at that path, so its next tick runs **B's** script. The id
+of the mandate you just armed is a unique string already to hand — use it, and it is gone
+again by step 4.
+
+Two things about the `script=` argument itself. It is relative to `~/.agentos/scripts/`, and
+an absolute or `~`-prefixed value is refused outright even when it points inside that
+directory — this is the one path in the skill that is *not* spelled out in full. Within that,
+subdirectories need no special handling: only paths escaping the scripts directory are
+rejected.
+
+### Tearing one down
+
+A monitor's files outlive the mandate that motivated it, and nothing removes them for you.
+When a mandate is disarmed and no other mandate needs the ticker, take the job and its
+directory down together:
+
+```bash
+# cron(action="remove", job_id="<cron_id>") first, then:
+rm -rf ~/.agentos/scripts/senior-unilp-manager/<cron_id>
+```
+
+That is the whole point of the layout: the directory name is the job id, so there is never a
+question of which files belonged to the job you just removed. Leave the state directory
+alone — `disarm` has already settled the mandate there, and the log is the record of what the
+monitor did.
 
 ## Before arming anything real
 


### PR DESCRIPTION
Closes #326.

## What

`senior-unilp-manager` told the agent to put a monitor's tick script "under `~/.agentos/scripts/`" and stopped there. That directory is shared with every other skill's cron jobs, so each run invented its own file names and dropped shell scripts, ad-hoc Python helpers, and scratch state into it side by side with files belonging to nothing in particular. Nothing recorded which file served which monitor, so disarming a mandate or deleting a cron job left its files behind with no safe way to identify them.

Instructions only. No code change: relative subdirectories under the scripts directory were already supported (`resolve_script_path()` resolves any path under the base and rejects only escapes), and `action="update"` has been able to repoint a live job's script since ac3f215.

## The layout

```
~/.agentos/scripts/senior-unilp-manager/<cron_id>/
```

Everything a monitor needs lives there and nowhere else — `tick.sh`, any helper the agent writes for it, any scratch the run keeps. The mapping is one-to-one and mechanical: delete the job, delete the directory.

**Cron job id, not mandate id.** The issue left this open. A tick script runs `--all`, so it is not per-mandate — one job covers every mandate in the state directory, and naming its directory after one of them would be a lie about what it watches. The cron id also survives the mandates it outlives.

**Mandate state is explicitly excluded.** The mandate JSON, the `.log.jsonl` write-ahead log, and the `.lock` stay under `$UNILP_STATE_DIR` / `$AGENTOS_HOME/state/unilp` / `~/.agentos/state/unilp`, where `ratchet.py` writes them and where it looks for them. The skill now says so outright, because today the agent puts them in the scripts directory too.

## The ordering

The cron id does not exist until the job does, so the skill spells out the sequence: `mkdir` a staging directory and write the finished `tick.sh` there, `add` the job against the staging path (with an explicit `name`), read `job_id` back, move the file into `senior-unilp-manager/<job_id>/`, and repoint with `action="update"`.

Three details the section is explicit about, because each is a real failure:

- Stage a **working** script, not a placeholder, and repoint straight away — the job is live between the add and the repoint, and a tick against a missing file delivers `Script not found`; five consecutive failures retire it.
- Pass `name` at add time. Without one the job takes its name from `script`, so it would carry the staging path forever, including in every failure alert.
- The staging name must be unique per monitor. A shared `pending/tick.sh` does not just clobber a file: a job still pointing there runs the *other* monitor's script on its next tick.

## Teardown

The layout only pays off if something acts on it, so the skill now has a **Tearing one down** step — `cron(action="remove", job_id=…)`, then `rm -rf` the directory — and the disarm section points at it.

## Also updated

- `script=` is documented as relative-only: an absolute or `~`-prefixed value is refused even when it points inside the scripts directory. This is the one path in the skill that is deliberately *not* spelled out in full, which reads as a contradiction next to the `{baseDir}/scripts/ratchet.py` rule right above it.
- The primary script-job `cron(action="add")` example is marked as the end state a wired-up monitor reaches, with a warning not to copy it verbatim — a job added against a literal `<cron_id>` retires itself in five ticks.

Existing constraints are untouched: full `{baseDir}/scripts/ratchet.py` path inside the script, `--json --alert-only`, no `tool_policy` on a script job, interactive CLI or Web caller, and the `UNIV4_LP_PRIVATE_KEY` visibility check.

## Not in scope

#325 (default the monitor to a script cron job rather than an `agent_turn`) touches the same section. This change does not reorder the two examples or state a default — it leaves that decision to #325 so the two do not collide.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean, 602 files
- `uv run pytest -q` — 7809 passed, 27 skipped
- Every load-bearing claim in the new text checked against the code: `resolve_script_path` / `validate_script_path` (`src/agentos/scheduler/scripts.py`), `MAX_CONSECUTIVE_ERRORS = 5` and the transient classification of `Script not found` (`src/agentos/scheduler/jobs.py`), and the `add` → `job_id` / `update` → script-repoint path (`src/agentos/tools/builtin/control.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)