### PR TITLE
fix(webui): keep the reasoning block out of the chat copy action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Web chat: copying an assistant message no longer prepends the collapsible
+  reasoning block. `extractBubbleText()` cloned `.msg-body` and stripped only
+  `.msg-actions` and `.msg-meta`, so the `Thinking` summary label — and the
+  full reasoning body once the block had been expanded — landed in the
+  clipboard ahead of the reply. `.thinking-block` now joins the strip list, so
+  copy yields the reply text alone whether the block is collapsed or expanded.
+  (#322)
+
 ### Changed
 
 - `senior-unilp-manager` now defaults the ratchet monitor to a `script` cron

--- a/frontend/src/views/chat/transcript/message.test.ts
+++ b/frontend/src/views/chat/transcript/message.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMessageRenderer, historyTurnMeta } from './message'
+import { createThinkingBlock } from './thinking'
 
 const chatCss = readFileSync('src/views/chat/chat.css', 'utf8')
 
@@ -114,6 +115,31 @@ describe('message renderer', () => {
     expect(row.querySelector('.msg-meta')).toHaveTextContent(
       'model↑1.3k ↓42cache:500think:12$0.00125',
     )
+  })
+
+  it('copies only the reply text when the bubble carries a reasoning block', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    const { renderer } = makeRenderer()
+    const row = renderer.addMessage('assistant', 'the reply', '2026-07-22T12:34:00Z')!
+    const body = row.querySelector<HTMLElement>('.msg-body')!
+    const parts = createThinkingBlock({ open: false })
+    body.insertAdjacentElement('afterbegin', parts.details)
+
+    // Collapsed: the `Thinking` summary label must not leak into the clipboard.
+    expect(renderer.extractBubbleText(row)).toBe('the reply')
+
+    // Expanded: neither does the reasoning body fetched on first expand.
+    parts.details.open = true
+    parts.content.textContent = 'chain of thought that must stay private'
+    expect(renderer.extractBubbleText(row)).toBe('the reply')
+
+    row.querySelector<HTMLButtonElement>('.msg-action[data-action="copy"]')!.click()
+    await Promise.resolve()
+    expect(writeText).toHaveBeenCalledWith('the reply')
   })
 
   it('does not render the retired savings or combo UI from usage payloads', () => {

--- a/frontend/src/views/chat/transcript/message.ts
+++ b/frontend/src/views/chat/transcript/message.ts
@@ -193,7 +193,12 @@ export function createMessageRenderer(deps: MessageRendererDeps) {
     const attachmentText = body.querySelector('.msg-attachment-text')
     if (attachmentText) return (attachmentText.textContent || '').trim()
     const clone = body.cloneNode(true) as HTMLElement
-    clone.querySelectorAll('.msg-actions, .msg-meta').forEach((node) => node.remove())
+    // `.thinking-block` is the collapsible reasoning disclosure the history and
+    // stream renderers prepend inside `.msg-body`; its summary label and lazily
+    // fetched body are chrome, not reply text, so they never reach the clipboard.
+    clone
+      .querySelectorAll('.msg-actions, .msg-meta, .thinking-block')
+      .forEach((node) => node.remove())
     return (clone.textContent || '').trim()
   }
 


### PR DESCRIPTION
Closes #322

## Problem

Copying an assistant message in the web chat put the collapsible reasoning block on the clipboard ahead of the reply: `Thinking` when collapsed, and the full reasoning body once the block had been expanded.

`extractBubbleText()` clones `.msg-body` and stripped only `.msg-actions` and `.msg-meta`. The reasoning disclosure lives in that same body — `history.ts` prepends it as `details.thinking-block` for rows flagged `has_thinking`, and `stream.ts` appends the identical element into the streaming bubble — so it survived the clone and ended up in the copied text.

## Fix

Add `.thinking-block` to the strip list in `extractBubbleText()`.

`extractBubbleText()` is the only place bubble text is extracted, and both renderers use the same class, so the single selector covers history rows, live streaming rows, and the edit/regenerate paths that share the helper.

## Test

`message.test.ts` renders an assistant row, prepends a real `createThinkingBlock()`, and asserts the extracted text is the reply alone in both states — collapsed (summary label only) and expanded (with reasoning text set) — then clicks the copy action and asserts what reached `navigator.clipboard.writeText`.

Verified the test fails on the pre-fix code (`expected 'Thinkingthe reply' to be 'the reply'`) and passes with it.

## Gate

`npm --prefix frontend run check` equivalent, all clean:

- `tsc --noEmit` — no output
- `eslint src` — clean
- `prettier --check` on the changed files — clean
- `vitest run` — 91 files, 1940 tests passed