### PR TITLE
feat(gateway): add plan mode — research-only sessions with an approval gate

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,6 +87,7 @@ The most useful ones:
 | `/c0` … `/c3` | Pin the Pilot Router to a configured tier for this session. The pin appears in the bottom toolbar (e.g. `tier:c3`) and stays active until you exit or run `/auto`. |
 | `/use <model-id>` | Pin the route to a specific model, outside the configured tiers. The model must belong to the active provider. |
 | `/auto` | Restore automatic Pilot Router routing (clears the tier pin). |
+| `/plan [off]` | Toggle plan mode: the session becomes research-only (read, search, and analysis tools) until you approve the plan the agent presents via `exit_plan_mode`. `/plan off` leaves plan mode — from text surfaces it is also how you approve a presented plan before telling the agent to proceed. Gateway mode only. |
 | `/help` | List the commands available on the current surface. |
 | `/exit` / `/quit` | Leave the REPL. |
 

--- a/docs/tools-and-sandbox.md
+++ b/docs/tools-and-sandbox.md
@@ -25,7 +25,8 @@ For a focused permissions guide, see
 | Skills | `skill_list`, `skill_view`, `skill_create`, `skill_edit`, `install_skill_deps`, `meta_invoke`. |
 | Control | cron scheduling and gateway control operations. |
 | Channels/platforms | messaging, chat, and media helpers across supported channel adapters. |
-| User interaction | `ask_user` — structured questions with 2-4 options each. Presenting the question ends the turn; the answer arrives as the next user message. The Web UI renders a clickable card; the CLI and channels render a numbered list you answer by typing. Hidden on unattended surfaces (cron, subagents, heartbeats). |
+| User interaction | `ask_user` — structured questions with 2-4 options each. Presenting the question ends the turn; the answer arrives as the next user message. The Web UI renders a clickable card; the CLI and channels render a numbered list you answer by typing. Hidden on surfaces with nobody to reply (cron, subagents, heartbeats); channel DMs count as having a responder. |
+| Plan mode | `/plan` flips the session into research-only planning: the turn's tool surface narrows to a read/search/analysis allowlist and the agent presents its finished plan via `exit_plan_mode` (which ends the turn, like `ask_user`). Approval is out of band — the Web UI plan card's Approve button or `/plan off` — so the model cannot talk itself out of plan mode. State is per-session gateway memory; a gateway restart clears it. |
 
 ## Permission Modes
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -230,6 +230,17 @@ Turn it off with `control_ui.show_thinking = false` (or
 thinking events nor serves reasoning bodies. This is WebUI-only either way:
 channel adapters (Slack, Telegram, …) never receive thinking.
 
+### Plan mode
+
+Flip **Plan mode** in the run-modes popover (or type `/plan`) to make the
+session research-only: the agent keeps its read, search, and analysis tools
+but every mutating tool is withheld until you approve a plan. When the agent
+finishes planning it calls `exit_plan_mode`, its turn ends, and the chat
+shows the plan in a card with an **Approve plan** button. Approving turns
+plan mode off and sends the go-ahead; typing feedback instead keeps plan
+mode on and refines the plan. Plan mode is per-session and lives in gateway
+memory — a gateway restart clears it.
+
 ### Agent questions (ask_user)
 
 When the agent needs a decision that is genuinely yours — scope, a

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -255,6 +255,14 @@ export const chat = defineNamespace('chat', {
   askMultiHint: 'Choose one or more',
   askAnswered: 'Answered',
 
+  // exit_plan_mode plan card + toolbar row.
+  planCardLabel: 'Proposed plan',
+  planApprove: 'Approve plan',
+  planApproved: 'Plan approved — implementation starting',
+  planRefineHint: 'or keep chatting to refine the plan',
+  planApprovedMessage: 'Plan approved — proceed with the implementation.',
+  toolbarPlanMode: 'Plan mode',
+
   // Transcript: router visualization.
   routerChoosing: 'Choosing a model',
   routerSuggested: 'Suggested model',

--- a/frontend/src/views/chat/Toolbar.tsx
+++ b/frontend/src/views/chat/Toolbar.tsx
@@ -166,6 +166,37 @@ export function Toolbar({
 
   // chat.js:1395-1417 — patch agentos_router.enabled + rollout_phase, revert on
   // failure.
+  // ── Plan mode ─────────────────────────────────────────────────────────────
+  // Per-session flag in gateway process memory (PlanModeStore); read back on
+  // mount so a reopened popover reflects the real state, not a guess.
+  const planQuery = useQuery<{ planMode?: boolean }>({
+    queryKey: ['plan.mode.get', sessionKey],
+    queryFn: async () => {
+      await rpc.waitForConnection()
+      return rpc.call<{ planMode?: boolean }>('plan.mode.get', { key: sessionKey })
+    },
+    enabled: !!sessionKey,
+    retry: false,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+  })
+  const planChecked = !!planQuery.data?.planMode
+
+  const onPlanToggle = useCallback(
+    async (next: boolean) => {
+      if (!sessionKey) return
+      try {
+        await rpc.call('plan.mode.set', { key: sessionKey, mode: next ? 'on' : 'off' })
+        toast.info('Plan mode: ' + (next ? 'ON' : 'OFF'))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        toast.error('Failed to toggle plan mode: ' + message, { duration: 3500 })
+      }
+      await queryClient.invalidateQueries({ queryKey: ['plan.mode.get', sessionKey] })
+    },
+    [rpc, sessionKey, queryClient],
+  )
+
   const onRouterToggle = useCallback(
     async (next: boolean) => {
       setRouterPending(next)
@@ -267,6 +298,20 @@ export function Toolbar({
               type="checkbox"
               checked={routerChecked}
               onChange={(e) => void onRouterToggle(e.target.checked)}
+            />
+            <span className="chat-toggle-track" aria-hidden="true">
+              <span className="chat-toggle-thumb" />
+            </span>
+          </label>
+        </div>
+
+        <div className="chat-toolbar-row">
+          <span className="chat-toolbar-row-label t-label">{t('chat.toolbarPlanMode')}</span>
+          <label className="chat-toggle" aria-label={t('chat.toolbarPlanMode')}>
+            <input
+              type="checkbox"
+              checked={planChecked}
+              onChange={(e) => void onPlanToggle(e.target.checked)}
             />
             <span className="chat-toggle-track" aria-hidden="true">
               <span className="chat-toggle-thumb" />

--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -3197,3 +3197,27 @@
   font-size: 0.7rem;
   overflow-wrap: anywhere;
 }
+
+/* ── exit_plan_mode plan card (transcript/plan.ts) ──────────────────────────
+   Shares the ask-card frame (and its answered/locked state); adds a
+   scrollable plan body and the approve footer. */
+.chat-plan-body {
+  max-height: 320px;
+  margin-top: 4px;
+  padding: 10px;
+  overflow-y: auto;
+  border-radius: var(--radius-compact);
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  color: var(--foreground);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.chat-plan-footer {
+  align-items: center;
+}
+.chat-plan-refine-hint {
+  color: var(--dim);
+  font-size: 0.66rem;
+}

--- a/frontend/src/views/chat/transcript/plan.test.ts
+++ b/frontend/src/views/chat/transcript/plan.test.ts
@@ -1,0 +1,40 @@
+// Unit tests for the plan card's pure helper (transcript/plan.ts). The DOM
+// builder follows the tools.ts convention: live-browser sweep, not RTL.
+import { describe, expect, it } from 'vitest'
+
+import { parsePlanFromToolResult } from './plan'
+
+const presented = (plan: unknown): string => JSON.stringify({ status: 'plan_presented', plan })
+
+describe('parsePlanFromToolResult', () => {
+  it('extracts the plan from a presented exit_plan_mode result', () => {
+    expect(
+      parsePlanFromToolResult({ tool_name: 'exit_plan_mode', result: presented('## Plan\n1. X') }),
+    ).toBe('## Plan\n1. X')
+  })
+
+  it('accepts the name alias', () => {
+    expect(parsePlanFromToolResult({ name: 'exit_plan_mode', result: presented('X') })).toBe('X')
+  })
+
+  it('returns null for other tools, errors, and malformed payloads', () => {
+    expect(parsePlanFromToolResult({ tool_name: 'ask_user', result: presented('X') })).toBeNull()
+    expect(
+      parsePlanFromToolResult({
+        tool_name: 'exit_plan_mode',
+        is_error: true,
+        result: presented('X'),
+      }),
+    ).toBeNull()
+    expect(parsePlanFromToolResult({ tool_name: 'exit_plan_mode', result: 'not json' })).toBeNull()
+    expect(
+      parsePlanFromToolResult({
+        tool_name: 'exit_plan_mode',
+        result: JSON.stringify({ status: 'error' }),
+      }),
+    ).toBeNull()
+    expect(
+      parsePlanFromToolResult({ tool_name: 'exit_plan_mode', result: presented('   ') }),
+    ).toBeNull()
+  })
+})

--- a/frontend/src/views/chat/transcript/plan.ts
+++ b/frontend/src/views/chat/transcript/plan.ts
@@ -1,0 +1,107 @@
+// Chat transcript — exit_plan_mode plan card.
+//
+// AgentOS-native. Follows the ask-card end-turn contract (transcript/ask.ts):
+// the backend terminates the turn after exit_plan_mode presents the plan, and
+// approval is OUT OF BAND — the Approve button turns plan mode off via
+// `plan.mode.set` and then sends the go-ahead as the next user message
+// (injected as `approvePlan`). Typed feedback in the composer keeps plan mode
+// on and refines the plan instead.
+//
+// The card carries the `.chat-ask-card` base class ON PURPOSE: the history
+// renderer's lockAnsweredAskCards pass (ask.ts) then locks a plan card that
+// already has a user message after it, the same way it locks answered
+// questions — including this card in that sweep is what keeps a stale
+// Approve button from inviting a click.
+
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
+import type { StreamEventPayload } from '../types'
+
+const PLAN_TOOL_NAME = 'exit_plan_mode'
+const PLAN_STATUS_PRESENTED = 'plan_presented'
+
+/* ── Pure helper (unit-tested) ──────────────────────────────────────────── */
+
+/**
+ * Extract the presented plan from an exit_plan_mode `tool_result` frame.
+ * Returns null for other tools, error results, or malformed payloads.
+ */
+export function parsePlanFromToolResult(payload: StreamEventPayload): string | null {
+  const p = payload as {
+    name?: string
+    tool_name?: string
+    is_error?: boolean
+    isError?: boolean
+    result?: unknown
+  }
+  const toolName = p.name || p.tool_name || ''
+  if (toolName !== PLAN_TOOL_NAME || p.is_error || p.isError) return null
+  let parsed: unknown = p.result
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      return null
+    }
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const body = parsed as { status?: unknown; plan?: unknown }
+  if (body.status !== PLAN_STATUS_PRESENTED) return null
+  const plan = typeof body.plan === 'string' ? body.plan.trim() : ''
+  return plan || null
+}
+
+/* ── Imperative DOM builder (composed by the tool renderer) ─────────────── */
+
+export function buildPlanCardDOM(
+  plan: string,
+  approvePlan: (() => boolean) | undefined,
+): HTMLElement {
+  const card = document.createElement('div')
+  card.className = 'chat-ask-card chat-plan-card'
+  card.setAttribute('role', 'group')
+  card.setAttribute('aria-label', t('chat.planCardLabel'))
+
+  const eyebrow = document.createElement('div')
+  eyebrow.className = 'chat-ask-eyebrow'
+  eyebrow.textContent = t('chat.planCardLabel')
+  card.appendChild(eyebrow)
+
+  const body = document.createElement('div')
+  body.className = 'chat-plan-body'
+  body.textContent = plan
+  card.appendChild(body)
+
+  const footer = document.createElement('div')
+  footer.className = 'chat-ask-footer chat-plan-footer'
+  const approveBtn = document.createElement('button')
+  approveBtn.type = 'button'
+  approveBtn.className = 'btn btn--sm chat-ask-send chat-plan-approve'
+  approveBtn.textContent = t('chat.planApprove')
+  if (!approvePlan) approveBtn.disabled = true
+  let answered = false
+  approveBtn.addEventListener('click', () => {
+    if (answered || !approvePlan) return
+    // The approver reports whether the approval actually went out (false
+    // while the ended turn's stream is still settling).
+    if (!approvePlan()) return
+    answered = true
+    card.classList.add('chat-ask-card--answered')
+    card.querySelectorAll<HTMLButtonElement>('button').forEach((el) => {
+      el.disabled = true
+    })
+    const done = document.createElement('div')
+    done.className = 'chat-ask-answered'
+    done.textContent = t('chat.planApproved')
+    card.appendChild(done)
+  })
+  footer.appendChild(approveBtn)
+  const hint = document.createElement('span')
+  hint.className = 'chat-plan-refine-hint'
+  hint.textContent = t('chat.planRefineHint')
+  footer.appendChild(hint)
+  card.appendChild(footer)
+
+  return card
+}

--- a/frontend/src/views/chat/transcript/stream.ts
+++ b/frontend/src/views/chat/transcript/stream.ts
@@ -342,6 +342,8 @@ export interface StreamControllerDeps {
   openModal?: (title: string, html: string, buttons: Array<Record<string, unknown>>) => void
   /** ask_user card → send the composed answer via the composer's chat.send path. */
   sendUserAnswer?: (text: string) => boolean
+  /** exit_plan_mode card → approve: plan mode off via RPC + go-ahead message. */
+  approvePlan?: () => boolean
   /**
    * chat.js:7814 `_addMessage` with provenance options — append the subagent
    * completion system row. Distinct from `addMessage` above (which is the
@@ -1503,6 +1505,7 @@ export function createStreamController(
     pushMessage,
     openModal,
     sendUserAnswer: deps.sendUserAnswer,
+    approvePlan: deps.approvePlan,
     diag,
   })
 

--- a/frontend/src/views/chat/transcript/tools.ts
+++ b/frontend/src/views/chat/transcript/tools.ts
@@ -22,6 +22,7 @@ import '@/i18n/en/chat'
 
 import type { StreamEventPayload } from '../types'
 import { buildAskCardDOM, parseAskQuestions } from './ask'
+import { buildPlanCardDOM, parsePlanFromToolResult } from './plan'
 
 /* ── Constants (ported from chat.js, modernized to vector icon keys) ────── */
 
@@ -418,6 +419,12 @@ export interface ToolRendererDeps {
    * Absent → the card renders read-only.
    */
   sendUserAnswer?: (text: string) => boolean
+  /**
+   * exit_plan_mode card → approve the plan: turn plan mode off via RPC and
+   * send the go-ahead as the next user message. Returns false when the
+   * approval did not go out yet. Absent → the card renders read-only.
+   */
+  approvePlan?: () => boolean
   /** chat.js `_chatDiag` — the diagnostics ring. Default: no-op. */
   diag?: (event: string, detail: Record<string, unknown>) => void
 }
@@ -719,6 +726,21 @@ export function createToolRenderer(deps: ToolRendererDeps) {
       }
     }
 
+    // exit_plan_mode: render the plan card with the out-of-band Approve
+    // button. Same end-turn contract and same dual-path rendering rule as
+    // the ask card (live + reconstruct below).
+    if (toolName === 'exit_plan_mode' && !isError) {
+      const plan = parsePlanFromToolResult(payload)
+      if (plan && body && !body.querySelector(`[data-ask-for="${toolId}"]`)) {
+        const planCard = buildPlanCardDOM(plan, deps.approvePlan)
+        if (toolId) planCard.setAttribute('data-ask-for', toolId)
+        deps.flushPendingTextSegment()
+        body.appendChild(planCard)
+        deps.newTextSegment()
+        diag('tool_result.plan_card', { toolId, planChars: plan.length })
+      }
+    }
+
     // Only show result preview if non-empty.
     const resultDiv = buildToolResultDOM(content, isError, toolResultIsTruncated(payload), toolName)
     if (!resultDiv) {
@@ -846,6 +868,19 @@ export function createToolRenderer(deps: ToolRendererDeps) {
               const askCard = buildAskCardDOM(questions, deps.sendUserAnswer)
               if (toolId) askCard.setAttribute('data-ask-for', toolId)
               body.appendChild(askCard)
+            }
+          }
+
+          // exit_plan_mode: same resync-survival rule as the ask card.
+          if (resultToolName === 'exit_plan_mode' && !isError) {
+            const plan = parsePlanFromToolResult({
+              tool_name: 'exit_plan_mode',
+              result: content,
+            } as StreamEventPayload)
+            if (plan && !body.querySelector(`[data-ask-for="${toolId}"]`)) {
+              const planCard = buildPlanCardDOM(plan, deps.approvePlan)
+              if (toolId) planCard.setAttribute('data-ask-for', toolId)
+              body.appendChild(planCard)
             }
           }
         }

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -348,6 +348,7 @@ export function useTranscript(opts: {
   // controller exists, so the card reaches it through a ref (same
   // late-binding pattern as openModalRef).
   const sendUserAnswerRef = useRef<((text: string) => boolean) | null>(null)
+  const approvePlanRef = useRef<(() => boolean) | null>(null)
   const messageActionsRef = useRef({
     onEdit: opts.onEditMessage,
     onRegenerate: opts.onRegenerateMessage,
@@ -503,6 +504,7 @@ export function useTranscript(opts: {
       historyHydrating: () => historyHydratingRef.current,
       openModal: (title, html, buttons) => openModalRef.current?.(title, html, buttons),
       sendUserAnswer: (text) => sendUserAnswerRef.current?.(text) ?? false,
+      approvePlan: () => approvePlanRef.current?.() ?? false,
       // Artifact preview/download URLs + download Authorization header
       // (chat.js:7575/7657 `App.getAuthToken()`).
       getAuthToken,
@@ -999,7 +1001,24 @@ export function useTranscript(opts: {
       send(text)
       return true
     }
-  }, [controller, send])
+    // Plan approval is out of band by design: turn plan mode off via RPC
+    // FIRST, then send the go-ahead so the next turn already has its full
+    // tool surface back. The card locks optimistically; an RPC failure
+    // surfaces as an error message in the transcript via the send path.
+    approvePlanRef.current = () => {
+      if (controller.isStreaming()) return false
+      const key = sessionKeyRef.current
+      if (!key) return false
+      void rpc
+        .call('plan.mode.set', { key, mode: 'off' })
+        .then(() => send(t('chat.planApprovedMessage')))
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err)
+          messageRendererRef.current?.addMessage('error', t('chat.sendFailed', { message }))
+        })
+      return true
+    }
+  }, [controller, rpc, send])
 
   // chat.js:8439-8450 `_onStop`. Abort only while streaming; set the abort flag,
   // fire `chat.abort` with `{ sessionKey, source }` (chat.js:8444), and end the

--- a/src/agentos/channels/command_replies.py
+++ b/src/agentos/channels/command_replies.py
@@ -74,6 +74,10 @@ def format_channel_success_reply(*, name: str, method: str, payload: Any) -> str
         return "Automatic model routing is already active."
     if method == "router.hold.set":
         return _format_router_hold(payload)
+    if method == "plan.mode.set" and isinstance(payload, dict) and "planMode" in payload:
+        if payload["planMode"]:
+            return "Plan mode on: research only until the plan is approved."
+        return "Plan mode off."
     if method == "commands.list_for_surface":
         return _format_help(payload)
     if method == "chat.history":

--- a/src/agentos/cli/chat/turn_stream.py
+++ b/src/agentos/cli/chat/turn_stream.py
@@ -17,6 +17,7 @@ from agentos.ask_user import format_questions_as_text, questions_from_tool_resul
 from agentos.cli.chat.output import ChatOutputHandle
 from agentos.cli.chat.turn import TurnResult, UsageSummary
 from agentos.execution_status import derive_is_error
+from agentos.plan_mode import format_plan_as_text, plan_from_tool_result
 from agentos.session.terminal_reply import build_terminal_reply
 
 _DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS = 15.0
@@ -513,6 +514,14 @@ async def stream_response_gateway(
                                 await renderer.aappend_text(
                                     "\n\n" + format_questions_as_text(ask_questions)
                                 )
+                            plan_text = plan_from_tool_result(
+                                event.get("tool_name") or event.get("toolName"),
+                                event.get("result"),
+                            )
+                            if plan_text:
+                                await renderer.aappend_text(
+                                    "\n\n" + format_plan_as_text(plan_text)
+                                )
                     elif event_name == "session.event.artifact":
                         artifact = artifact_event_payload(event)
                         artifacts.append(artifact)
@@ -657,6 +666,14 @@ async def stream_response_turnrunner(
                             if ask_questions:
                                 await renderer.aappend_text(
                                     "\n\n" + format_questions_as_text(ask_questions)
+                                )
+                            plan_text = plan_from_tool_result(
+                                event.tool_name,
+                                event.result,
+                            )
+                            if plan_text:
+                                await renderer.aappend_text(
+                                    "\n\n" + format_plan_as_text(plan_text)
                                 )
                     elif isinstance(event, ArtifactEvent):
                         artifact = artifact_event_payload(event)

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -51,6 +51,7 @@ GATEWAY_SLASH_HANDLER_WORDS = frozenset(
         "/new",
         "/path",
         "/permissions",
+        "/plan",
         "/quit",
         "/rename",
         "/reset",
@@ -199,9 +200,9 @@ async def handle_gateway_slash_command(
             # resolve is authoritative for the persisted display name and
             # the active router hold, so prefer its view over the local
             # title arg (covers the titled-session resume path too).
-            state.display_name = _resolved.get("displayName") or _resolved.get(
-                "display_name"
-            ) or state.display_name
+            state.display_name = (
+                _resolved.get("displayName") or _resolved.get("display_name") or state.display_name
+            )
             tier = _resolved.get("router_hold_tier")
             state.router_hold_tier = tier if isinstance(tier, str) and tier else None
         except Exception:  # noqa: BLE001 - network/timeout; non-fatal
@@ -409,6 +410,24 @@ async def handle_gateway_slash_command(
         state.router_hold_tier = tier
         sync_session_chrome_from_state(state)
         console.print(f"[{ACCENT}]router pinned to tier {tier}[/]{suffix}")
+        return True
+
+    if cmd == "/plan" or cmd.startswith("/plan "):
+        arg = cmd[len("/plan") :].strip().lower()
+        mode = "off" if arg in {"off", "exit", "stop"} else "on"
+        try:
+            res = await client.call(
+                "plan.mode.set",
+                {"key": state.session_key, "mode": mode},
+            )
+        except Exception as exc:  # noqa: BLE001 - keep chat alive on RPC error
+            console.print(f"[yellow]{exc}[/yellow]")
+            return True
+        enabled = bool(isinstance(res, dict) and res.get("planMode"))
+        if enabled:
+            console.print(f"[{ACCENT}]plan mode on[/] — research only until the plan is approved")
+        else:
+            console.print(f"[{ACCENT}]plan mode off[/]")
         return True
 
     if cmd == "/auto":
@@ -834,8 +853,7 @@ async def _handle_elevated_command(
         )
     elif arg == "on":
         console.print(
-            f"[yellow]permissions: on[/yellow] - exec on host, approvals required. "
-            f"{revoked_suffix}"
+            f"[yellow]permissions: on[/yellow] - exec on host, approvals required. {revoked_suffix}"
         )
     elif arg == "bypass":
         console.print(

--- a/src/agentos/engine/commands.py
+++ b/src/agentos/engine/commands.py
@@ -216,6 +216,13 @@ def _model_hold(envelope: Any, args: str = "") -> dict[str, str]:
     return {"key": envelope.session_key, "model": args.strip()}
 
 
+def _plan_mode(envelope: Any, args: str = "") -> dict[str, str]:
+    """`/plan [off]` — enter plan mode, or leave it with the `off` argument."""
+
+    mode = "off" if args.strip().lower() in {"off", "exit", "stop"} else "on"
+    return {"key": envelope.session_key, "mode": mode}
+
+
 def _session_name(envelope: Any, args: str = "") -> dict[str, str]:
     """`/rename <name>` — label the current session so it is easy to find.
 
@@ -471,6 +478,21 @@ _COMMANDS: tuple[CommandDef, ...] = (
             _S: _local("session.rename"),
             _C: _rpc("sessions.rename", _session_name),
         },
+    ),
+    # ---- Plan mode (web + cli-gateway + channel) --------------------------
+    # /plan flips the session into research-only planning; /plan off leaves
+    # it (and is how a presented plan gets approved from text surfaces).
+    # Standalone CLI has no gateway store, so the command is absent there.
+    CommandDef(
+        name="/plan",
+        usage="/plan [off]",
+        description="Toggle plan mode: research-only until the plan is approved.",
+        execution={
+            _W: _rpc("plan.mode.set", _plan_mode),
+            _T: _rpc("plan.mode.set", _plan_mode),
+            _C: _rpc("plan.mode.set", _plan_mode),
+        },
+        argument_choices=(ArgumentChoice("off", "Leave plan mode"),),
     ),
     CommandDef(
         name="/exit",

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -4294,6 +4294,7 @@ class TurnRunner:
             apply_prompt_cache,
             filter_skills,
             inject_env_probe,
+            inject_plan_mode,
             inject_platform_hint,
             inject_subagent_grounding,
             observe_reasoning_hint,
@@ -4404,6 +4405,7 @@ class TurnRunner:
                 inject_subagent_grounding,
                 inject_env_probe,
                 inject_platform_hint,
+                inject_plan_mode,
                 apply_prompt_cache,
             ],
         )

--- a/src/agentos/engine/steps/__init__.py
+++ b/src/agentos/engine/steps/__init__.py
@@ -2,6 +2,7 @@
 
 from agentos.engine.pipeline import TurnContext
 from agentos.engine.steps.inject_env_probe import inject_env_probe
+from agentos.engine.steps.inject_plan_mode import inject_plan_mode
 from agentos.engine.steps.inject_platform_hint import inject_platform_hint
 from agentos.engine.steps.inject_subagent_grounding import inject_subagent_grounding
 from agentos.engine.steps.prompt_cache import apply_prompt_cache
@@ -22,6 +23,7 @@ __all__ = [
     "apply_agentos_router",
     "filter_skills",
     "inject_env_probe",
+    "inject_plan_mode",
     "inject_platform_hint",
     "inject_subagent_grounding",
     "observe_reasoning_hint",

--- a/src/agentos/engine/steps/inject_plan_mode.py
+++ b/src/agentos/engine/steps/inject_plan_mode.py
@@ -1,0 +1,47 @@
+"""Inject the plan-mode block into the dynamic prompt suffix when active.
+
+Plan mode toggles mid-session, so the block lives in the uncached suffix
+(the ``inject_platform_hint`` pattern), never in the cacheable base.
+"""
+
+from __future__ import annotations
+
+from agentos.engine.pipeline import TurnContext
+
+_PLAN_MODE_BLOCK = """## Plan Mode (Active)
+
+This session is in plan mode: research and design only.
+- Mutating tools (file writes, shell, code execution, messaging, publishing,
+  scheduling) are disabled for now; read, search, and analysis tools remain
+  available. Never try to work around a disabled tool.
+- Explore the code and context as deeply as needed, then produce ONE concrete
+  implementation plan: what changes, file by file, in execution order, with
+  verification steps.
+- Present the finished plan by calling `exit_plan_mode` with the full plan
+  text. That ends your turn; the user reviews it.
+- Plan mode ends only when the user approves out of band (the plan card or
+  `/plan off`). A typed "yes" does NOT end plan mode — refine if asked and
+  call `exit_plan_mode` again.
+- Use `ask_user` for decisions that shape the plan and are genuinely the
+  user's to make."""
+
+
+async def inject_plan_mode(ctx: TurnContext) -> TurnContext:
+    """Append the plan-mode instructions to the uncached suffix when on."""
+    from agentos.plan_mode import get_plan_mode_store
+
+    if not get_plan_mode_store().is_enabled(ctx.session_key):
+        ctx.metadata["inject_plan_mode__applied"] = False
+        return ctx
+
+    if isinstance(ctx.system_prompt, str):
+        base, suffix = ctx.system_prompt, ""
+    else:
+        base, suffix = ctx.system_prompt
+
+    ctx.system_prompt = (
+        base,
+        f"{suffix}\n\n{_PLAN_MODE_BLOCK}" if suffix else _PLAN_MODE_BLOCK,
+    )
+    ctx.metadata["inject_plan_mode__applied"] = True
+    return ctx

--- a/src/agentos/gateway/access.py
+++ b/src/agentos/gateway/access.py
@@ -37,6 +37,7 @@ CHANNEL_RPC_METHODS: frozenset[str] = frozenset(
         "commands.list_for_surface",
         "doctor.memory.status",
         "models.list",
+        "plan.mode.set",
         "router.hold.clear",
         "router.hold.set",
         "sessions.abort",

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -63,6 +63,7 @@ from agentos.gateway.attachment_ingest import AttachmentIngestResult, ingest_att
 from agentos.gateway.session_events import build_sessions_changed_payload
 from agentos.paths import media_root_from_config
 from agentos.permissions import configured_default_elevated
+from agentos.plan_mode import format_plan_as_text, plan_from_tool_result
 from agentos.session.keys import canonicalize_session_key as _canonicalize_session_key
 from agentos.session.terminal_reply import build_terminal_reply
 
@@ -1743,9 +1744,12 @@ def _ask_user_reply_text(event: Any) -> str | None:
     if is_error:
         return None
     questions = questions_from_tool_result(tool_name, content)
-    if questions is None:
-        return None
-    return format_questions_as_text(questions)
+    if questions is not None:
+        return format_questions_as_text(questions)
+    plan = plan_from_tool_result(tool_name, content)
+    if plan is not None:
+        return format_plan_as_text(plan)
+    return None
 
 
 def _text_delta_from_event(event: Any) -> str:

--- a/src/agentos/gateway/routing.py
+++ b/src/agentos/gateway/routing.py
@@ -385,6 +385,23 @@ def tool_context_from_envelope(
         denied_tools = set(cron_baseline_deny)
     elif caller_kind is CallerKind.SUBAGENT:
         denied_tools = set(SUBAGENT_TOOL_DENY)
+    if caller_kind not in {CallerKind.CRON, CallerKind.SUBAGENT}:
+        # Plan mode: the session is research-only until the plan is approved.
+        # Applied as an ALLOWLIST intersection so a tool added later is never
+        # granted to plan mode by omission, and enforced both at tool-list
+        # time (visibility) and at dispatch time (policy chain allowlist
+        # check). Cron and subagent turns keep their own surfaces — plan mode
+        # is a property of the user-facing session, not of background work.
+        # Channel turns count as user-facing even though they are marked
+        # unattended: a human is on the other end to approve the plan.
+        from agentos.plan_mode import PLAN_MODE_TOOL_ALLOW, get_plan_mode_store
+
+        if get_plan_mode_store().is_enabled(envelope.session_key):
+            allowed_tools = (
+                set(PLAN_MODE_TOOL_ALLOW)
+                if allowed_tools is None
+                else allowed_tools & PLAN_MODE_TOOL_ALLOW
+            )
     source_kind = envelope.metadata.get("tool_source_kind") or envelope.source_kind.value
     source_name = envelope.metadata.get("tool_source_name") or envelope.source_name
     channel_admission = envelope.runtime_state.channel_admission

--- a/src/agentos/gateway/rpc/__init__.py
+++ b/src/agentos/gateway/rpc/__init__.py
@@ -65,6 +65,7 @@ import agentos.gateway.rpc_mcp  # noqa: E402, F401
 import agentos.gateway.rpc_memory  # noqa: E402, F401
 import agentos.gateway.rpc_models  # noqa: E402, F401
 import agentos.gateway.rpc_onboarding  # noqa: E402, F401
+import agentos.gateway.rpc_plan  # noqa: E402, F401
 import agentos.gateway.rpc_router  # noqa: E402, F401
 import agentos.gateway.rpc_secrets  # noqa: E402, F401
 import agentos.gateway.rpc_sessions  # noqa: E402, F401

--- a/src/agentos/gateway/rpc_plan.py
+++ b/src/agentos/gateway/rpc_plan.py
@@ -1,0 +1,56 @@
+"""RPC handlers for session plan mode.
+
+Backs the /plan slash command, the chat composer's plan pill, and the plan
+card's Approve button. The store is process memory (``PlanModeStore``), so
+``plan.mode.get`` exists for reconnecting clients to read the flag back
+rather than guessing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.plan_mode import get_plan_mode_store
+from agentos.session.keys import canonicalize_session_key
+
+_d = get_dispatcher()
+
+
+def _require_key(params: dict | None) -> str:
+    if not isinstance(params, dict) or "key" not in params:
+        raise ValueError("params.key is required")
+    key = params["key"]
+    if not isinstance(key, str) or not key.strip():
+        raise ValueError("params.key must be a non-empty string")
+    return canonicalize_session_key(key)
+
+
+def _payload(key: str) -> dict[str, Any]:
+    return {"key": key, "planMode": get_plan_mode_store().is_enabled(key)}
+
+
+@_d.method("plan.mode.set", CONTROL_AND_CHANNEL)
+async def _handle_plan_mode_set(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    """Turn plan mode on or off for a session.
+
+    ``mode`` accepts "on"/"off". Turning it off is also how a plan gets
+    approved: the plan card's Approve button and ``/plan off`` both land
+    here — approval is out of band by design, never an in-band model call.
+    """
+    key = _require_key(params)
+    mode = str((params or {}).get("mode") or "").strip().lower()
+    if mode not in {"on", "off"}:
+        raise ValueError("params.mode must be 'on' or 'off'")
+    store = get_plan_mode_store()
+    if mode == "on":
+        store.enable(key)
+    else:
+        store.disable(key)
+    return _payload(key)
+
+
+@_d.method("plan.mode.get", CONTROL_ONLY)
+async def _handle_plan_mode_get(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    return _payload(_require_key(params))

--- a/src/agentos/plan_mode.py
+++ b/src/agentos/plan_mode.py
@@ -1,0 +1,194 @@
+"""Plan mode: per-session research-only state with an approval gate.
+
+While plan mode is on for a session, the gateway builds the turn's
+ToolContext from a read-only allowlist — the model can explore, search, and
+analyze but cannot mutate anything. The model presents its finished plan by
+calling ``exit_plan_mode``, which follows the same end-turn-and-resume
+contract as ``ask_user`` (see ``agentos.ask_user``): presenting the plan
+terminates the turn, and approval arrives out of band (the Web UI plan card
+or ``/plan off``), never as an in-band model decision.
+
+This module is deliberately side-effect free (no registry imports) so the
+gateway routing layer, the dispatch finalizer, RPC handlers, and text
+surfaces can all import it without pulling in tool registration — the same
+split as ``agentos.router_control`` and ``agentos.ask_user``.
+
+State is in-memory and per-gateway, like ``RouterControlHoldStore``: a
+gateway restart clears plan mode (the session falls back to normal tools,
+which the operator can re-enable with ``/plan``).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+EXIT_PLAN_TOOL_NAME = "exit_plan_mode"
+
+# Status stamped on a successful exit_plan_mode payload. The dispatch
+# finalizer keys terminates_turn off this value; renderers key off it too.
+PLAN_STATUS_PRESENTED = "plan_presented"
+
+_MAX_PLAN_CHARS = 40_000
+
+# Read/research surface available while plan mode is on. This is an
+# ALLOWLIST on purpose (the cron-surface precedent): a tool added later is
+# never granted to plan mode by omission. Everything that writes files,
+# runs code, sends messages, publishes, schedules, or spawns is absent.
+PLAN_MODE_TOOL_ALLOW: frozenset[str] = frozenset(
+    {
+        # The exit door + the question tool.
+        EXIT_PLAN_TOOL_NAME,
+        "ask_user",
+        # Filesystem reads.
+        "read_file",
+        "list_dir",
+        "glob_search",
+        "grep_search",
+        "read_spreadsheet",
+        "pdf",
+        "image",
+        # Git reads.
+        "git_status",
+        "git_diff",
+        "git_log",
+        # Web research.
+        "web_search",
+        "web_fetch",
+        "http_request",
+        "x_search",
+        # Memory / session reads.
+        "memory_search",
+        "memory_get",
+        "session_search",
+        "session_status",
+        "sessions_list",
+        "sessions_history",
+        "sessions_yield",
+        # Skill / environment reads.
+        "skill_list",
+        "skill_view",
+        "skill_search_community",
+        "env_list",
+        "agents_list",
+        # Routing stays available: pinning a tier does not mutate the world.
+        "router_control",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PlanModeState:
+    """Plan-mode record for one session."""
+
+    enabled_at: float
+
+
+class PlanModeStore:
+    """In-memory per-session plan-mode flags. No TTL by design: a mode that
+    silently expires mid-plan hands write tools back without the user's
+    say-so, which is the worst possible failure for this feature. Only an
+    explicit disable (approval, ``/plan off``) or a gateway restart clears it.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, PlanModeState] = {}
+
+    def enable(self, session_key: str) -> None:
+        key = (session_key or "").strip()
+        if not key:
+            raise ValueError("session_key is required")
+        self._sessions.setdefault(key, PlanModeState(enabled_at=time.time()))
+
+    def disable(self, session_key: str) -> bool:
+        """Turn plan mode off. Returns True when it was on."""
+        return self._sessions.pop((session_key or "").strip(), None) is not None
+
+    def is_enabled(self, session_key: str) -> bool:
+        return (session_key or "").strip() in self._sessions
+
+    def get(self, session_key: str) -> PlanModeState | None:
+        return self._sessions.get((session_key or "").strip())
+
+
+_store: PlanModeStore | None = None
+
+
+def get_plan_mode_store() -> PlanModeStore:
+    global _store
+    if _store is None:
+        _store = PlanModeStore()
+    return _store
+
+
+def reset_plan_mode_store() -> None:
+    """Test hook: drop the module singleton."""
+    global _store
+    _store = None
+
+
+def validate_plan(raw: object) -> str:
+    """Normalize and validate the plan text; raises ValueError on violation."""
+    plan = str(raw or "").strip()
+    if not plan:
+        raise ValueError("'plan' must be a non-empty string describing the plan")
+    if len(plan) > _MAX_PLAN_CHARS:
+        raise ValueError(f"'plan' exceeds {_MAX_PLAN_CHARS} characters")
+    return plan
+
+
+def build_plan_presented_payload(plan: str) -> dict[str, Any]:
+    """Build the tool-result payload for a successfully presented plan."""
+    return {
+        "status": PLAN_STATUS_PRESENTED,
+        "plan": plan,
+        "message": (
+            "The plan was presented to the user. This turn ends now; wait for "
+            "their approval or feedback, which arrives as the next user message. "
+            "Plan mode stays on until the user approves."
+        ),
+    }
+
+
+def _presented_payload(content: object) -> dict[str, Any] | None:
+    if isinstance(content, dict):
+        payload: Any = content
+    elif isinstance(content, str):
+        try:
+            payload = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    else:
+        return None
+    if isinstance(payload, dict) and payload.get("status") == PLAN_STATUS_PRESENTED:
+        return payload
+    return None
+
+
+def exit_plan_payload_terminates_turn(content: object) -> bool:
+    """True when a tool-result payload is a successfully presented plan."""
+    return _presented_payload(content) is not None
+
+
+def plan_from_tool_result(tool_name: object, content: object) -> str | None:
+    """Extract the presented plan from an exit_plan_mode result, else None."""
+    if tool_name != EXIT_PLAN_TOOL_NAME:
+        return None
+    payload = _presented_payload(content)
+    if payload is None:
+        return None
+    plan = str(payload.get("plan") or "").strip()
+    return plan or None
+
+
+def format_plan_as_text(plan: str) -> str:
+    """Render a presented plan for plain-text surfaces (channels, CLI)."""
+    return (
+        "--- Proposed plan ---\n"
+        f"{plan}\n"
+        "---------------------\n"
+        "Reply with feedback to refine the plan, or send /plan off and tell "
+        "me to proceed."
+    )

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -77,6 +77,9 @@ in both gateway and `--standalone` modes:
   thinking level and pricing baseline. Distinct from `/model`, whose argument
   filters the listing rather than switching.
 - `/auto` — restore automatic Pilot Router routing (clear the pin).
+- `/plan [off]` — toggle plan mode (gateway mode only): the session becomes
+  research-only until the plan the agent presents via `exit_plan_mode` is
+  approved (Web UI plan card, or `/plan off` + telling it to proceed).
 
 A pin withdraws the model's own `router_control` tool, so it cannot route
 around the choice. Image turns still go to a vision tier (they are routed

--- a/src/agentos/tools/builtin/__init__.py
+++ b/src/agentos/tools/builtin/__init__.py
@@ -21,6 +21,7 @@ _NAMES = [
     "messaging",
     "nodes",
     "patch",
+    "plan",
     "router_control",
     "sessions",
     "session_search",

--- a/src/agentos/tools/builtin/ask.py
+++ b/src/agentos/tools/builtin/ask.py
@@ -14,6 +14,7 @@ import json
 from agentos.ask_user import build_presented_payload, validate_questions
 from agentos.tools.registry import tool
 from agentos.tools.types import (
+    CallerKind,
     InteractionMode,
     SafeToolError,
     UnsupportedSurfaceError,
@@ -82,10 +83,16 @@ from agentos.tools.types import (
 )
 async def ask_user(questions: list[object]) -> str:
     ctx = current_tool_context.get()
-    if ctx is not None and ctx.interaction_mode is InteractionMode.UNATTENDED:
+    if (
+        ctx is not None
+        and ctx.interaction_mode is InteractionMode.UNATTENDED
+        and ctx.caller_kind is not CallerKind.CHANNEL
+    ):
         # Runtime-surface resolution already denies the tool on unattended
-        # surfaces; this guard keeps the contract even for contexts built
-        # outside that path.
+        # surfaces without a human on the other end; this guard keeps the
+        # contract even for contexts built outside that path. Channel turns
+        # are marked unattended (no approval operator) but DO have a human
+        # responder, so they pass.
         raise UnsupportedSurfaceError(
             "ask_user requires a live user, but this run is unattended. "
             "Choose a sensible default and state the assumption instead."

--- a/src/agentos/tools/builtin/plan.py
+++ b/src/agentos/tools/builtin/plan.py
@@ -1,0 +1,74 @@
+"""exit_plan_mode tool: present the finished plan and end the turn.
+
+Only visible while plan mode is on (it is absent from the default surface
+and enters through the plan-mode allowlist). Like ask_user, it never
+blocks: presenting the plan terminates the turn via the dispatch finalizer,
+and the user's approval or feedback arrives as the next user message.
+Approval itself is out of band — the Web UI plan card or ``/plan off`` —
+so the model can never talk itself out of plan mode.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agentos.plan_mode import (
+    build_plan_presented_payload,
+    get_plan_mode_store,
+    validate_plan,
+)
+from agentos.tools.registry import tool
+from agentos.tools.types import (
+    CallerKind,
+    InteractionMode,
+    SafeToolError,
+    UnsupportedSurfaceError,
+    current_tool_context,
+)
+
+
+@tool(
+    name="exit_plan_mode",
+    description=(
+        "Present your finished implementation plan to the user for approval. "
+        "Call this once your research is complete and the plan is concrete; the "
+        "turn ends and the user reviews the plan. Plan mode stays on until the "
+        "user explicitly approves — a typed 'yes' in chat does not end plan "
+        "mode, so call this tool again after refining if asked."
+    ),
+    params={
+        "plan": {
+            "type": "string",
+            "description": (
+                "The complete implementation plan, in markdown: what will change, "
+                "file by file, in execution order, with verification steps."
+            ),
+        },
+    },
+    required=["plan"],
+    exposed_by_default=False,
+)
+async def exit_plan_mode(plan: str) -> str:
+    ctx = current_tool_context.get()
+    if (
+        ctx is not None
+        and ctx.interaction_mode is InteractionMode.UNATTENDED
+        and ctx.caller_kind is not CallerKind.CHANNEL
+    ):
+        # Channel turns are marked unattended (no approval operator) but a
+        # human responder is on the other end — the same exception ask_user
+        # makes.
+        raise UnsupportedSurfaceError(
+            "exit_plan_mode requires a live user to approve the plan, but this run is unattended."
+        )
+    session_key = getattr(ctx, "session_key", None) or ""
+    if not get_plan_mode_store().is_enabled(session_key):
+        raise SafeToolError(
+            "Plan mode is not active for this session, so there is no plan "
+            "gate to exit. Proceed with the work directly."
+        )
+    try:
+        normalized = validate_plan(plan)
+    except ValueError as exc:
+        raise SafeToolError(str(exc)) from exc
+    return json.dumps(build_plan_presented_payload(normalized))

--- a/src/agentos/tools/policy/finalize.py
+++ b/src/agentos/tools/policy/finalize.py
@@ -25,6 +25,7 @@ from agentos.execution_status import (
     mark_execution_status_truncated,
     normalize_execution_status,
 )
+from agentos.plan_mode import exit_plan_payload_terminates_turn
 from agentos.result_budget import (
     ToolResultBudgetTracker,
     ToolRunBudgetExceededError,
@@ -271,5 +272,12 @@ async def finalize(
             call.tool_name == "ask_user"
             and not is_error
             and ask_user_payload_terminates_turn(content)
+        )
+        or (
+            # exit_plan_mode shares that contract: presenting the plan ends
+            # the turn; approval arrives out of band.
+            call.tool_name == "exit_plan_mode"
+            and not is_error
+            and exit_plan_payload_terminates_turn(content)
         ),
     )

--- a/src/agentos/tools/policy_runtime.py
+++ b/src/agentos/tools/policy_runtime.py
@@ -18,9 +18,11 @@ _SESSION_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset(
     {"sessions_send", "sessions_spawn", "sessions_yield"}
 )
 _CHANNEL_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"message"})
-_INTERACTIVE_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset(
-    {"agents_list", "ask_user", "subagents"}
-)
+_INTERACTIVE_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"agents_list", "subagents"})
+# Tools that need a human on the other end to answer, not an approval
+# operator: a channel DM qualifies even though the turn is marked
+# unattended, while cron/heartbeat/one-shot runs have nobody to reply.
+_HUMAN_REPLY_TOOL_NAMES: frozenset[str] = frozenset({"ask_user", "exit_plan_mode"})
 _GATEWAY_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"gateway"})
 _SCHEDULER_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"cron"})
 
@@ -148,6 +150,7 @@ def resolve_runtime_tool_surface(
     if ctx.interaction_mode is InteractionMode.UNATTENDED:
         if not caps.channel_backing:
             denied_tools |= set(_CHANNEL_RUNTIME_TOOL_NAMES)
+            denied_tools |= set(_HUMAN_REPLY_TOOL_NAMES)
         denied_tools |= set(_INTERACTIVE_RUNTIME_TOOL_NAMES)
     if private_memory_read_tools_blocked(ctx):
         denied_tools |= set(_PRIVATE_MEMORY_READ_TOOL_NAMES)

--- a/tests/test_engine/test_inject_plan_mode.py
+++ b/tests/test_engine/test_inject_plan_mode.py
@@ -1,0 +1,63 @@
+"""The plan-mode prompt block rides the uncached suffix, only when active."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps.inject_plan_mode import inject_plan_mode
+from agentos.plan_mode import get_plan_mode_store, reset_plan_mode_store
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store() -> None:
+    reset_plan_mode_store()
+    yield
+    reset_plan_mode_store()
+
+
+def _ctx(session_key: str, system_prompt: str | tuple[str, str] = "base") -> TurnContext:
+    return TurnContext(
+        message="hello",
+        session_key=session_key,
+        config=None,
+        provider=None,
+        model="",
+        tool_defs=[],
+        system_prompt=system_prompt,
+    )
+
+
+@pytest.mark.asyncio
+async def test_appends_block_to_uncached_suffix_when_active() -> None:
+    key = "agent:main:step-plan"
+    get_plan_mode_store().enable(key)
+
+    out = await inject_plan_mode(_ctx(key, system_prompt=("base", "existing suffix")))
+
+    assert out.metadata["inject_plan_mode__applied"] is True
+    base, suffix = out.system_prompt
+    assert base == "base"
+    assert suffix.startswith("existing suffix")
+    assert "## Plan Mode (Active)" in suffix
+    assert "exit_plan_mode" in suffix
+
+
+@pytest.mark.asyncio
+async def test_splits_a_string_prompt_into_base_and_suffix() -> None:
+    key = "agent:main:step-plan-str"
+    get_plan_mode_store().enable(key)
+
+    out = await inject_plan_mode(_ctx(key, system_prompt="base"))
+
+    base, suffix = out.system_prompt
+    assert base == "base"
+    assert "## Plan Mode (Active)" in suffix
+
+
+@pytest.mark.asyncio
+async def test_noop_when_mode_is_off() -> None:
+    out = await inject_plan_mode(_ctx("agent:main:step-noplan"))
+
+    assert out.metadata["inject_plan_mode__applied"] is False
+    assert out.system_prompt == "base"

--- a/tests/test_gateway/test_plan_mode_routing.py
+++ b/tests/test_gateway/test_plan_mode_routing.py
@@ -1,0 +1,99 @@
+"""Plan-mode enforcement in the gateway tool-context builder + RPC surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.channels.types import IncomingMessage
+from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.routing import (
+    build_channel_route_envelope,
+    build_cron_route_envelope,
+    build_web_route_envelope,
+    tool_context_from_envelope,
+)
+from agentos.gateway.rpc import RpcContext, get_dispatcher
+from agentos.plan_mode import (
+    PLAN_MODE_TOOL_ALLOW,
+    get_plan_mode_store,
+    reset_plan_mode_store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store() -> None:
+    reset_plan_mode_store()
+    yield
+    reset_plan_mode_store()
+
+
+class TestRoutingEnforcement:
+    def test_web_turn_gets_the_plan_allowlist_when_mode_is_on(self) -> None:
+        key = "agent:main:web-plan"
+        get_plan_mode_store().enable(key)
+        ctx = tool_context_from_envelope(build_web_route_envelope(session_key=key))
+        assert ctx.allowed_tools == set(PLAN_MODE_TOOL_ALLOW)
+        assert "write_file" not in ctx.allowed_tools
+        assert "exit_plan_mode" in ctx.allowed_tools
+
+    def test_web_turn_is_unrestricted_when_mode_is_off(self) -> None:
+        ctx = tool_context_from_envelope(
+            build_web_route_envelope(session_key="agent:main:web-noplan")
+        )
+        assert ctx.allowed_tools is None
+
+    def test_channel_turn_gets_the_allowlist_despite_unattended_mark(self) -> None:
+        key = "telegram:dm:u1"
+        get_plan_mode_store().enable(key)
+        msg = IncomingMessage(sender_id="u1", channel_id="c1", content="hi")
+        ctx = tool_context_from_envelope(
+            build_channel_route_envelope(msg, session_key=key, session_prefix="telegram")
+        )
+        assert ctx.allowed_tools == set(PLAN_MODE_TOOL_ALLOW)
+
+    def test_cron_surface_is_never_narrowed_by_plan_mode(self) -> None:
+        from types import SimpleNamespace
+
+        key = "cron:job-1"
+        get_plan_mode_store().enable(key)
+        job = SimpleNamespace(id="job-1", name="demo")
+        ctx = tool_context_from_envelope(build_cron_route_envelope(job, session_key=key))
+        # Cron keeps its own allowlist; plan mode must not intersect it.
+        assert "exit_plan_mode" not in (ctx.allowed_tools or set())
+
+
+class TestPlanRpc:
+    def test_audiences(self) -> None:
+        set_entry = get_dispatcher().get_entry("plan.mode.set")
+        get_entry = get_dispatcher().get_entry("plan.mode.get")
+        assert set_entry is not None and set_entry.audiences == CONTROL_AND_CHANNEL
+        assert get_entry is not None and get_entry.audiences == CONTROL_ONLY
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_roundtrip(self) -> None:
+        ctx = RpcContext(conn_id="test", config=GatewayConfig())
+        key = "agent:main:rpc-plan"
+
+        on = await get_dispatcher().dispatch("r1", "plan.mode.set", {"key": key, "mode": "on"}, ctx)
+        assert on.ok is True and on.payload["planMode"] is True
+        assert get_plan_mode_store().is_enabled(key) is True
+
+        got = await get_dispatcher().dispatch("r2", "plan.mode.get", {"key": key}, ctx)
+        assert got.ok is True and got.payload["planMode"] is True
+
+        off = await get_dispatcher().dispatch(
+            "r3", "plan.mode.set", {"key": key, "mode": "off"}, ctx
+        )
+        assert off.ok is True and off.payload["planMode"] is False
+        assert get_plan_mode_store().is_enabled(key) is False
+
+    @pytest.mark.asyncio
+    async def test_set_rejects_bad_params(self) -> None:
+        ctx = RpcContext(conn_id="test", config=GatewayConfig())
+        bad_mode = await get_dispatcher().dispatch(
+            "r4", "plan.mode.set", {"key": "agent:main:x", "mode": "maybe"}, ctx
+        )
+        assert bad_mode.ok is False
+        no_key = await get_dispatcher().dispatch("r5", "plan.mode.set", {"mode": "on"}, ctx)
+        assert no_key.ok is False

--- a/tests/test_plan_mode.py
+++ b/tests/test_plan_mode.py
@@ -1,0 +1,99 @@
+"""Unit tests for the side-effect-free plan-mode helpers (agentos.plan_mode)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.plan_mode import (
+    PLAN_MODE_TOOL_ALLOW,
+    PLAN_STATUS_PRESENTED,
+    PlanModeStore,
+    build_plan_presented_payload,
+    exit_plan_payload_terminates_turn,
+    format_plan_as_text,
+    plan_from_tool_result,
+    validate_plan,
+)
+
+
+class TestPlanModeStore:
+    def test_enable_disable_roundtrip(self) -> None:
+        store = PlanModeStore()
+        key = "agent:main:t"
+        assert store.is_enabled(key) is False
+        store.enable(key)
+        assert store.is_enabled(key) is True
+        # No TTL: still on until an explicit disable.
+        assert store.get(key) is not None
+        assert store.disable(key) is True
+        assert store.is_enabled(key) is False
+        assert store.disable(key) is False
+
+    def test_enable_requires_a_key(self) -> None:
+        with pytest.raises(ValueError, match="session_key"):
+            PlanModeStore().enable("  ")
+
+    def test_sessions_are_independent(self) -> None:
+        store = PlanModeStore()
+        store.enable("agent:main:a")
+        assert store.is_enabled("agent:main:b") is False
+
+
+class TestAllowlist:
+    def test_contains_only_read_research_tools(self) -> None:
+        forbidden = {
+            "write_file",
+            "edit_file",
+            "apply_patch",
+            "exec_command",
+            "execute_code",
+            "background_process",
+            "git_commit",
+            "message",
+            "publish_artifact",
+            "cron",
+            "gateway",
+            "memory",
+            "memory_save",
+            "sessions_send",
+            "sessions_spawn",
+            "skill_create",
+            "skill_edit",
+            "skill_delete",
+            "image_generate",
+        }
+        assert not (PLAN_MODE_TOOL_ALLOW & forbidden)
+
+    def test_contains_the_exit_door_and_the_question_tool(self) -> None:
+        assert "exit_plan_mode" in PLAN_MODE_TOOL_ALLOW
+        assert "ask_user" in PLAN_MODE_TOOL_ALLOW
+
+
+class TestPayloadHelpers:
+    def test_validate_plan_normalizes_and_rejects(self) -> None:
+        assert validate_plan("  do X  ") == "do X"
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_plan("   ")
+        with pytest.raises(ValueError, match="exceeds"):
+            validate_plan("x" * 40_001)
+
+    def test_presented_payload_terminates_turn(self) -> None:
+        payload = build_plan_presented_payload("## Plan\n1. Do X")
+        assert payload["status"] == PLAN_STATUS_PRESENTED
+        assert exit_plan_payload_terminates_turn(json.dumps(payload)) is True
+        assert exit_plan_payload_terminates_turn(payload) is True
+        assert exit_plan_payload_terminates_turn("not json") is False
+        assert exit_plan_payload_terminates_turn(json.dumps({"status": "error"})) is False
+
+    def test_plan_from_tool_result_gates_on_tool_and_status(self) -> None:
+        payload = json.dumps(build_plan_presented_payload("Do X"))
+        assert plan_from_tool_result("exit_plan_mode", payload) == "Do X"
+        assert plan_from_tool_result("ask_user", payload) is None
+        assert plan_from_tool_result("exit_plan_mode", '{"status": "error"}') is None
+
+    def test_format_plan_as_text_carries_the_approval_hint(self) -> None:
+        text = format_plan_as_text("1. Do X")
+        assert "1. Do X" in text
+        assert "/plan off" in text

--- a/tests/test_tools/test_exit_plan_mode_tool.py
+++ b/tests/test_tools/test_exit_plan_mode_tool.py
@@ -1,0 +1,107 @@
+"""exit_plan_mode tool: dispatch behavior, end-turn contract, and gating."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentos.plan_mode import get_plan_mode_store, reset_plan_mode_store
+from agentos.tool_boundary import ToolCall
+from agentos.tools import get_default_registry
+from agentos.tools.dispatch import build_tool_handler
+from agentos.tools.types import CallerKind, InteractionMode, ToolContext
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store() -> None:
+    reset_plan_mode_store()
+    yield
+    reset_plan_mode_store()
+
+
+def _call(plan: str = "## Plan\n1. Do X") -> ToolCall:
+    return ToolCall(
+        tool_use_id="plan-1",
+        tool_name="exit_plan_mode",
+        arguments={"plan": plan},
+    )
+
+
+@pytest.mark.asyncio
+async def test_exit_plan_mode_presents_and_terminates_turn() -> None:
+    key = "agent:main:t-plan"
+    get_plan_mode_store().enable(key)
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key=key)
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call())
+
+    assert result.is_error is False
+    # Same end-turn-and-resume contract as ask_user: presenting ends the turn.
+    assert result.terminates_turn is True
+    payload = json.loads(result.content)
+    assert payload["status"] == "plan_presented"
+    assert payload["plan"] == "## Plan\n1. Do X"
+
+
+@pytest.mark.asyncio
+async def test_exit_plan_mode_refused_outside_plan_mode() -> None:
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key="agent:main:t-noplan")
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call())
+
+    assert result.is_error is True
+    assert result.terminates_turn is False
+    assert "not active" in result.content
+
+
+@pytest.mark.asyncio
+async def test_exit_plan_mode_rejects_an_empty_plan() -> None:
+    key = "agent:main:t-plan-empty"
+    get_plan_mode_store().enable(key)
+    ctx = ToolContext(caller_kind=CallerKind.AGENT, session_key=key)
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call(plan="   "))
+
+    assert result.is_error is True
+    assert result.terminates_turn is False
+    assert "non-empty" in result.content
+
+
+@pytest.mark.asyncio
+async def test_exit_plan_mode_refuses_unattended_non_channel_surfaces() -> None:
+    key = "agent:main:t-plan-unattended"
+    get_plan_mode_store().enable(key)
+    ctx = ToolContext(
+        caller_kind=CallerKind.CLI,
+        interaction_mode=InteractionMode.UNATTENDED,
+        session_key=key,
+    )
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call())
+
+    assert result.is_error is True
+    assert "unattended" in result.content
+
+
+@pytest.mark.asyncio
+async def test_exit_plan_mode_allows_channel_turns_despite_unattended_mark() -> None:
+    # Channel turns carry UNATTENDED (no approval operator) but a human
+    # responder is on the other end — the ask_user exception applies here too.
+    key = "telegram:dm:u1"
+    get_plan_mode_store().enable(key)
+    ctx = ToolContext(
+        caller_kind=CallerKind.CHANNEL,
+        interaction_mode=InteractionMode.UNATTENDED,
+        session_key=key,
+    )
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(_call())
+
+    assert result.is_error is False
+    assert result.terminates_turn is True


### PR DESCRIPTION
## What

`/plan` (or the Plan mode toggle in the Web UI run-modes popover) flips a session into **plan mode**: the agent keeps its read, search, and analysis tools but every mutating tool is withheld until the user approves the plan it presents. The companion to #324 — together they close the "runs straight through" gap: `ask_user` hands single decisions back mid-work, plan mode gates a whole implementation behind an explicit go-ahead.

## Design

**Allowlist, not denylist.** While plan mode is on, `tool_context_from_envelope` intersects the turn's tool surface with `PLAN_MODE_TOOL_ALLOW` (the cron-surface precedent): a tool added later is never granted to plan mode by omission. Enforcement is double-layered — the model never sees withheld tools (visibility), and the dispatch policy chain rejects them anyway (allowlist check).

**Exit reuses the #324 end-turn contract.** `exit_plan_mode(plan)` presents the plan and terminates the turn via the same `terminates_turn` finalizer path as `ask_user` — nothing blocks, nothing races the tool timeout. **Approval is out of band by design**: the Web UI plan card's Approve button (plan mode off via RPC, then the go-ahead message) or `/plan off` from text surfaces. A typed "yes" keeps plan mode on — the model cannot talk itself out of it, and the prompt block says so.

**No TTL.** A mode that silently expires mid-plan hands write tools back without the user's say-so — the worst failure this feature could have. Only explicit disable or a gateway restart clears it (in-memory per-gateway store, the `RouterControlHoldStore` precedent; documented).

**Prompt rides the uncached suffix** (`inject_plan_mode` engine step, the `inject_platform_hint` pattern) because the mode toggles mid-session.

## Surface-semantics fix folded in (applies to #324's ask_user too)

Channel turns are marked `UNATTENDED` (no approval operator), so the interactive-only deny from #324 silently hid `ask_user` on real channel adapters. The requirement is a human **responder**, not an approval operator — a Telegram DM qualifies. Both tools now key off the existing `channel_backing` capability: cron, subagents, heartbeats, and one-shot runs stay excluded; channel DMs get the tools, rendered as the numbered list / text plan with the `/plan off` approval hint.

## Included

- `agentos/plan_mode.py` — store + allowlist + payload predicates + text formatting, side-effect free (the `router_control` split)
- `tools/builtin/plan.py` — `exit_plan_mode`, hidden by default, enters through the allowlist, refuses when mode is off
- RPC `plan.mode.set/get`, `/plan [off]` slash command (web, cli-gateway, channel + channel reply formatting), TUI handler
- Web UI: plan card (Approve + "keep chatting to refine" hint) with the **dual-path rendering** the #324 live test mandated (`appendToolResult` AND `reconstructToolCalls`), locked after answering by the shared `lockAnsweredAskCards` sweep; Plan mode toggle in the run-modes popover
- Docs: `tools-and-sandbox.md`, `web-ui.md`, `cli.md`, bundled `agentos` SKILL.md

## Tests

Unit + integration: store/validation/predicates, dispatch (`terminates_turn` only on success, refusal outside mode, channel exception), routing enforcement per caller kind, RPC audiences + roundtrip, prompt step, frontend parse helper. Full gates: pytest **7856 passed**, repo-wide mypy clean, ruff clean, `npm run check` (the one failure is the pre-existing AppShell g-chord focus test, broken on clean `main`).

**Live E2E** against an isolated gateway (opencap, real model): plan mode on → the model used only `list_dir`/`read_file`/`glob_search` despite being asked to create a file, presented a real 5-step plan via `exit_plan_mode`, the turn ended at the presentation; approve → `apply_patch` ran and the file existed. Repeated in Chrome against the real Web UI: popover toggle → plan card (surviving the post-stream history resync) → Approve → implementation turn wrote the file.

## Known limits (deliberate)

- Standalone CLI (`--standalone`) has no gateway store; `/plan` is absent there (documented).
- Plan-mode state does not survive a gateway restart (falls back to normal tools; re-enable with `/plan`).
- The plan body renders as pre-wrapped text, not markdown — a rendering upgrade is a clean follow-up.