### PR TITLE
style(webui): redesign the ask_user and plan decision cards

### DIFF
--- a/frontend/src/views/chat/chat-unified.css
+++ b/frontend/src/views/chat/chat-unified.css
@@ -1531,14 +1531,9 @@
   }
 }
 
-/* ask_user question card — unified skin: product-facing prompt, so Inter for
-   the question text while options keep their mono base from chat.css. */
-.chat-ask-card {
-  font-family: var(--font-sans);
-}
-.chat-ask-title {
-  font-size: 0.84rem;
-}
-.chat-ask-option {
-  font-family: var(--font-sans);
+/* ask_user / plan cards — the base skin (chat.css) already sets Inter for
+   product-facing text and mono for the header chip; no unified override
+   needed beyond keeping machine data mono. */
+.chat-ask-card .chat-plan-body {
+  font-family: var(--font-mono);
 }

--- a/frontend/src/views/chat/chat.css
+++ b/frontend/src/views/chat/chat.css
@@ -3084,133 +3084,262 @@
 }
 
 /* ── ask_user question card (transcript/ask.ts) ─────────────────────────────
-   Rendered in the bubble body when the agent presents structured choices.
-   Signal-colored border marks it as the one element awaiting the user. */
+   The one element in the transcript waiting on the user. Lime stays
+   signal-only: a left rail + eyebrow carry the accent, the card body stays
+   neutral. Options are full-width rows with an explicit select indicator
+   (radio for single-select, square for multi) so state reads without
+   relying on border color alone. */
 .chat-ask-card {
   box-sizing: border-box;
-  max-width: 100%;
-  margin-top: 10px;
-  padding: 12px;
-  border: 1px solid color-mix(in srgb, var(--primary) 45%, transparent);
+  max-width: 560px;
+  margin-top: 12px;
+  padding: 14px 14px 12px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-left: 3px solid var(--primary);
   border-radius: var(--radius-compact);
-  background: color-mix(in srgb, var(--primary) 6%, transparent);
+  background: color-mix(in srgb, var(--foreground) 3%, var(--background));
 }
 .chat-ask-card--answered {
-  border-color: color-mix(in srgb, var(--foreground) 18%, transparent);
-  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  border-left-color: color-mix(in srgb, var(--foreground) 25%, transparent);
+  opacity: 0.78;
 }
 .chat-ask-eyebrow {
-  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
   color: var(--primary);
-  font-size: 0.62rem;
+  font-size: 0.64rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+.chat-ask-eyebrow svg {
+  flex: none;
+  width: 14px;
+  height: 14px;
 }
 .chat-ask-card--answered .chat-ask-eyebrow {
   color: var(--dim);
 }
 .chat-ask-question + .chat-ask-question {
-  margin-top: 12px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
 }
 .chat-ask-title {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 6px;
+  gap: 8px;
   color: var(--foreground);
-  font-size: 0.78rem;
+  font-family: var(--font-sans);
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1.45;
 }
 .chat-ask-header-chip {
-  padding: 1px 6px;
-  border-radius: var(--radius-compact);
-  background: color-mix(in srgb, var(--primary) 14%, transparent);
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary) 15%, transparent);
   color: var(--primary);
+  font-family: var(--font-mono);
   font-size: 0.62rem;
   font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 .chat-ask-multi-hint {
-  margin-top: 2px;
+  margin-top: 3px;
   color: var(--dim);
-  font-size: 0.64rem;
+  font-size: 0.68rem;
 }
 .chat-ask-options {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 6px;
-  margin-top: 8px;
+  margin-top: 10px;
 }
 .chat-ask-option {
   display: flex;
-  flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
-  max-width: 100%;
-  padding: 6px 10px;
-  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  gap: 10px;
+  width: 100%;
+  min-height: 40px;
+  padding: 9px 12px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
   border-radius: var(--radius-compact);
   background: transparent;
   color: var(--foreground);
-  font-family: inherit;
-  font-size: 0.72rem;
+  font-family: var(--font-sans);
   text-align: left;
   cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    transform 120ms ease;
 }
 .chat-ask-option:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--primary) 55%, transparent);
+  border-color: color-mix(in srgb, var(--primary) 50%, transparent);
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
+}
+.chat-ask-option:active:not(:disabled) {
+  transform: scale(0.985);
+}
+.chat-ask-option:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 .chat-ask-option:disabled {
   opacity: 0.55;
   cursor: default;
 }
+.chat-ask-option-check {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  border: 1.5px solid color-mix(in srgb, var(--foreground) 35%, transparent);
+  border-radius: 50%;
+  color: transparent;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+.chat-ask-option--multi .chat-ask-option-check {
+  border-radius: 4px;
+}
+.chat-ask-option-check svg {
+  width: 10px;
+  height: 10px;
+}
 .chat-ask-option--selected {
   border-color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+}
+.chat-ask-option--selected .chat-ask-option-check {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: var(--primary-foreground, #0a0a0a);
+}
+.chat-ask-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 .chat-ask-option-label {
+  font-size: 0.78rem;
   font-weight: 600;
+  line-height: 1.35;
 }
 .chat-ask-option-desc {
   color: var(--dim);
-  font-size: 0.64rem;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 .chat-ask-footer {
   display: flex;
-  gap: 6px;
-  margin-top: 10px;
+  gap: 8px;
+  align-items: center;
+  margin-top: 12px;
 }
 .chat-ask-other {
   flex: 1;
   min-width: 0;
-  padding: 6px 8px;
-  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
   border-radius: var(--radius-compact);
   background: var(--background);
   color: var(--foreground);
-  font-family: inherit;
-  font-size: 0.72rem;
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  transition: border-color 160ms ease;
+}
+.chat-ask-other:focus-visible {
+  border-color: var(--primary);
+  outline: none;
+}
+.chat-ask-other::placeholder {
+  color: color-mix(in srgb, var(--dim) 80%, transparent);
+}
+.chat-ask-send {
+  flex: none;
+  min-height: 34px;
+  padding: 7px 14px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-compact);
+  background: var(--primary);
+  color: var(--primary-foreground, #0a0a0a);
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    filter 160ms ease,
+    transform 120ms ease;
+}
+.chat-ask-send:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+.chat-ask-send:active:not(:disabled) {
+  transform: scale(0.97);
+}
+.chat-ask-send:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+.chat-ask-send:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 .chat-ask-answered {
-  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
   color: var(--dim);
-  font-size: 0.7rem;
+  font-size: 0.72rem;
   overflow-wrap: anywhere;
+}
+.chat-ask-answered svg {
+  flex: none;
+  width: 13px;
+  height: 13px;
+  color: var(--primary);
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-ask-option,
+  .chat-ask-option-check,
+  .chat-ask-other,
+  .chat-ask-send {
+    transition: none;
+  }
 }
 
 /* ── exit_plan_mode plan card (transcript/plan.ts) ──────────────────────────
-   Shares the ask-card frame (and its answered/locked state); adds a
-   scrollable plan body and the approve footer. */
+   Shares the ask-card frame, rail, and answered/locked state; the plan body
+   stays wide and scrollable, the Approve button is the shared primary CTA. */
+.chat-plan-card {
+  max-width: none;
+}
 .chat-plan-body {
-  max-height: 320px;
+  max-height: 340px;
   margin-top: 4px;
-  padding: 10px;
+  padding: 12px 14px;
   overflow-y: auto;
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
   border-radius: var(--radius-compact);
-  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  background: color-mix(in srgb, var(--foreground) 3%, transparent);
   color: var(--foreground);
-  font-size: 0.72rem;
-  line-height: 1.5;
+  font-size: 0.74rem;
+  line-height: 1.6;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
@@ -3219,5 +3348,5 @@
 }
 .chat-plan-refine-hint {
   color: var(--dim);
-  font-size: 0.66rem;
+  font-size: 0.68rem;
 }

--- a/frontend/src/views/chat/transcript/ask.ts
+++ b/frontend/src/views/chat/transcript/ask.ts
@@ -150,6 +150,28 @@ export function lockAnsweredAskCards(container: HTMLElement): void {
     })
 }
 
+/* ── SVG helpers (Lucide paths; stroke = currentColor, no emoji icons) ──── */
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/** Build a stroke-based icon svg from raw path/shape markup. */
+export function buildCardIconSVG(inner: string, viewBox = '0 0 24 24'): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg')
+  svg.setAttribute('viewBox', viewBox)
+  svg.setAttribute('fill', 'none')
+  svg.setAttribute('stroke', 'currentColor')
+  svg.setAttribute('stroke-width', '2')
+  svg.setAttribute('stroke-linecap', 'round')
+  svg.setAttribute('stroke-linejoin', 'round')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.innerHTML = inner
+  return svg
+}
+
+export const CARD_ICON_QUESTION =
+  '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>'
+export const CARD_ICON_CHECK = '<path d="M20 6 9 17l-5-5"/>'
+
 /* ── Imperative DOM builder (composed by the tool renderer) ─────────────── */
 
 export function buildAskCardDOM(
@@ -167,7 +189,8 @@ export function buildAskCardDOM(
 
   const eyebrow = document.createElement('div')
   eyebrow.className = 'chat-ask-eyebrow'
-  eyebrow.textContent = t('chat.askCardLabel')
+  eyebrow.appendChild(buildCardIconSVG(CARD_ICON_QUESTION))
+  eyebrow.appendChild(document.createTextNode(t('chat.askCardLabel')))
   card.appendChild(eyebrow)
 
   // One-question single-select cards send on click; everything else
@@ -192,7 +215,8 @@ export function buildAskCardDOM(
     })
     const done = document.createElement('div')
     done.className = 'chat-ask-answered'
-    done.textContent = `${t('chat.askAnswered')}: ${text}`
+    done.appendChild(buildCardIconSVG(CARD_ICON_CHECK))
+    done.appendChild(document.createTextNode(`${t('chat.askAnswered')}: ${text}`))
     card.appendChild(done)
   }
 
@@ -223,19 +247,27 @@ export function buildAskCardDOM(
     q.options.forEach((opt) => {
       const btn = document.createElement('button')
       btn.type = 'button'
-      btn.className = 'chat-ask-option'
+      btn.className = 'chat-ask-option' + (q.multiSelect ? ' chat-ask-option--multi' : '')
+      btn.setAttribute('aria-pressed', 'false')
       if (!sendAnswer) btn.disabled = true
+      const check = document.createElement('span')
+      check.className = 'chat-ask-option-check'
+      check.setAttribute('aria-hidden', 'true')
+      check.appendChild(buildCardIconSVG(CARD_ICON_CHECK))
+      btn.appendChild(check)
+      const textCol = document.createElement('span')
+      textCol.className = 'chat-ask-option-text'
       const label = document.createElement('span')
       label.className = 'chat-ask-option-label'
       label.textContent = opt.label
-      btn.appendChild(label)
+      textCol.appendChild(label)
       if (opt.description) {
         const desc = document.createElement('span')
         desc.className = 'chat-ask-option-desc'
         desc.textContent = opt.description
-        btn.appendChild(desc)
-        btn.title = opt.description
+        textCol.appendChild(desc)
       }
+      btn.appendChild(textCol)
       btn.addEventListener('click', () => {
         if (answered) return
         if (instantSend) {
@@ -253,12 +285,15 @@ export function buildAskCardDOM(
           if (at >= 0) current.splice(at, 1)
           else current.push(opt.label)
           btn.classList.toggle('chat-ask-option--selected', at < 0)
+          btn.setAttribute('aria-pressed', at < 0 ? 'true' : 'false')
         } else {
           selections[qi] = [opt.label]
-          optionRow
-            .querySelectorAll('.chat-ask-option--selected')
-            .forEach((el) => el.classList.remove('chat-ask-option--selected'))
+          optionRow.querySelectorAll('.chat-ask-option--selected').forEach((el) => {
+            el.classList.remove('chat-ask-option--selected')
+            el.setAttribute('aria-pressed', 'false')
+          })
           btn.classList.add('chat-ask-option--selected')
+          btn.setAttribute('aria-pressed', 'true')
         }
       })
       optionRow.appendChild(btn)
@@ -286,7 +321,7 @@ export function buildAskCardDOM(
   if (!instantSend) {
     const sendBtn = document.createElement('button')
     sendBtn.type = 'button'
-    sendBtn.className = 'btn btn--sm chat-ask-send'
+    sendBtn.className = 'chat-ask-send'
     sendBtn.textContent = t('chat.askSend')
     if (!sendAnswer) sendBtn.disabled = true
     sendBtn.addEventListener('click', submit)

--- a/frontend/src/views/chat/transcript/plan.ts
+++ b/frontend/src/views/chat/transcript/plan.ts
@@ -17,6 +17,7 @@ import { t } from '@/i18n'
 import '@/i18n/en/chat'
 
 import type { StreamEventPayload } from '../types'
+import { buildCardIconSVG, CARD_ICON_CHECK } from './ask'
 
 const PLAN_TOOL_NAME = 'exit_plan_mode'
 const PLAN_STATUS_PRESENTED = 'plan_presented'
@@ -65,7 +66,14 @@ export function buildPlanCardDOM(
 
   const eyebrow = document.createElement('div')
   eyebrow.className = 'chat-ask-eyebrow'
-  eyebrow.textContent = t('chat.planCardLabel')
+  eyebrow.appendChild(
+    buildCardIconSVG(
+      '<rect x="8" y="2" width="8" height="4" rx="1"/>' +
+        '<path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>' +
+        '<path d="m9 14 2 2 4-4"/>',
+    ),
+  )
+  eyebrow.appendChild(document.createTextNode(t('chat.planCardLabel')))
   card.appendChild(eyebrow)
 
   const body = document.createElement('div')
@@ -77,7 +85,7 @@ export function buildPlanCardDOM(
   footer.className = 'chat-ask-footer chat-plan-footer'
   const approveBtn = document.createElement('button')
   approveBtn.type = 'button'
-  approveBtn.className = 'btn btn--sm chat-ask-send chat-plan-approve'
+  approveBtn.className = 'chat-ask-send chat-plan-approve'
   approveBtn.textContent = t('chat.planApprove')
   if (!approvePlan) approveBtn.disabled = true
   let answered = false
@@ -93,7 +101,8 @@ export function buildPlanCardDOM(
     })
     const done = document.createElement('div')
     done.className = 'chat-ask-answered'
-    done.textContent = t('chat.planApproved')
+    done.appendChild(buildCardIconSVG(CARD_ICON_CHECK))
+    done.appendChild(document.createTextNode(t('chat.planApproved')))
     card.appendChild(done)
   })
   footer.appendChild(approveBtn)


### PR DESCRIPTION
## Why

The first-pass cards from #324/#330 read as debug output: wrapped chip buttons whose only selected-state signal was a border tint, 10px descriptions, a full lime border wash, and a generic ghost button for the one primary action on screen.

## What changed

| Before | After |
|---|---|
| Wrapped chip buttons | Full-width stacked option rows, min-height 40px |
| Selected = border tint only | Explicit indicator: **radio circle** (single-select) vs **square** (multi-select), filled lime + check when chosen; `aria-pressed` mirrors it |
| Full lime border wash | 3px lime **left rail** on a neutral body — lime stays signal-only, matching the chat design language |
| Text-only eyebrow | SVG icon (question / clipboard — Lucide paths, no emoji) |
| Ghost `.btn` for Send/Approve | Filled lime primary CTA |
| 10px descriptions | 0.7rem with real line-height; question titles 0.86rem Inter |
| No motion/focus discipline | Hover states, active-press scale, `:focus-visible` rings on every control, 120–160ms transitions, `prefers-reduced-motion` guard |

Multi-question cards get dividers; ask card width capped at 560px for scanability (plan card stays wide); answered state gains a lime check and locked cards dim as a whole.

## Contracts untouched

DOM/behavior contracts are unchanged — class names, `data-ask-for` dedupe, the `lockAnsweredAskCards` sweep, and the `sendAnswer`/`approvePlan` boolean protocol. Pure helpers and all existing tests pass as-is.

## Verified

- `npm run check` green (the one failure is the pre-existing AppShell g-chord focus test, broken on clean `main`); bundle budget 137.9 KiB / 180 KiB.
- Live in Chrome against a running gateway: radio vs checkbox selection states, multi-select toggling, free-text field, send → answer message → locked reconstruction after the history resync.