### PR TITLE
feat(cron,skills): name a job's directory in one add, and let a skill pin a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- A cron job's `script` path may contain `{job_id}`, which the scheduler
+  replaces with the created job's own id before the job is persisted, and the
+  `cron` tool's add result now reports the resolved path as `script_path`. A
+  job that keeps its files in a directory named after itself could not name that
+  directory at creation time, because the id is minted by the create: the only
+  route there was to stage the script elsewhere, add the job against the staging
+  path, move the file, and repoint the job — four steps during which a live job
+  points at a path it will not keep, and any run abandoned midway leaves files
+  behind that nothing can attribute to a job. One `add` now does it. Works for
+  a `script` job and for an `agent_turn` job's pre-run script, from the tool,
+  the CLI, and the RPC surface alike, because the substitution happens in
+  `SchedulerOps`. A stored path that somehow still holds the placeholder refuses
+  to run rather than creating a directory called `{job_id}`. (#332)
+- Skills can pin a section so `skill_view` returns it wherever it sits in the
+  file: `<!-- always -->` on the line directly above a heading. Over the read
+  ceiling `skill_view` returns a skill's opening sections plus an index of the
+  rest, so position in the file decided what a model actually read — and a rule
+  written into a large skill's tail was never seen unless the model thought to
+  ask for that section. `senior-unilp-manager` is 44k characters against a 10k
+  ceiling, and two merged fixes wrote their rules past the cut; neither reached
+  the model, and the next run repeated both mistakes. Pinned sections come out
+  of the same ceiling rather than adding to it — at most half of it, with the
+  opening taking what is left — and the index marks them as already shown.
+  `skill_view.outlined` is now logged at INFO with a `pinned` count, because it
+  is the only event that says most of a skill did not reach the model. (#332)
+
 ### Fixed
 
 - Web chat: copying an assistant message no longer prepends the collapsible
@@ -18,6 +46,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `senior-unilp-manager`'s monitor layout is now one `cron` call and one pinned
+  section. "Files on disk for a monitor" became "Setting up a monitor", shrank
+  from 4 238 characters to roughly 2 100 — the stage-add-move-repoint sequence
+  it existed to explain is replaced by `script="senior-unilp-manager/{job_id}/
+  tick.sh"` — and carries `<!-- always -->`, so it reaches the model whatever
+  the read ceiling is. The rule that a monitor is a `script` job unless a model
+  in the loop was asked for moved into that section for the same reason: it sat
+  past the cut too, and the run that motivated this shipped an agent task the
+  user had to correct by hand. (#332)
 - `senior-unilp-manager` now defaults the ratchet monitor to a `script` cron
   job. "Wiring it to cron" leads with the `job_kind="script"` shape and states
   the rule outright: if the user did not say which shape they want, schedule

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -618,8 +618,10 @@ agentos cron add --every 15m --script watch_rss.py --name hn \
 
 `--script` implies `--job-kind script` and resolves relative to
 `~/.agentos/scripts/`; absolute paths, `~`, and `..` are refused, and so is a
-symlink out of that directory. `.sh`/`.bash` run under bash, anything else under
-python. `--script-arg` (repeatable) passes argv straight to the script — never
+symlink out of that directory. Subdirectories are allowed, and `{job_id}`
+anywhere in the path is replaced with the created job's own id, so a job can own
+a directory named after itself in one `add`. `.sh`/`.bash` run under bash,
+anything else under python. `--script-arg` (repeatable) passes argv straight to the script — never
 through a shell. Non-empty stdout is delivered verbatim, empty stdout is a silent
 run, and a non-zero exit or `--timeout` delivers the error and fails the job.
 Secrets are masked in the output, and the gateway token is withheld from the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -621,8 +621,8 @@ agentos cron add --every 15m --script watch_rss.py --name hn \
 symlink out of that directory. Subdirectories are allowed, and `{job_id}`
 anywhere in the path is replaced with the created job's own id, so a job can own
 a directory named after itself in one `add`. `.sh`/`.bash` run under bash,
-anything else under python. `--script-arg` (repeatable) passes argv straight to the script — never
-through a shell. Non-empty stdout is delivered verbatim, empty stdout is a silent
+anything else under python. `--script-arg` (repeatable) passes argv straight to
+the script — never through a shell. Non-empty stdout is delivered verbatim, empty stdout is a silent
 run, and a non-zero exit or `--timeout` delivers the error and fails the job.
 Secrets are masked in the output, and the gateway token is withheld from the
 child process. The bundled `cron-watchers` skill ships scripts for RSS, JSON

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,29 @@ Two cases are deliberately left whole: a body with no headings, because there
 would be no way to ask for the rest, and a body only slightly over the ceiling,
 where the index would cost more than it saves. Set `0` to switch it off.
 
+### Pinning a section
+
+Which sections survive the cut is otherwise decided by where they sit in the
+file, so a rule written into a large skill's tail is invisible and nothing says
+so. A skill can mark a section to be returned wherever it sits, by writing
+`<!-- always -->` on the line directly above its heading:
+
+```markdown
+<!-- always -->
+## Rules
+
+Every file this job needs lives in its own directory.
+```
+
+It is an HTML comment, so it renders as nothing anywhere the file is read as
+markdown, and it only counts as a marker when it is the nearest non-blank line
+above the heading — a skill that documents the marker does not pin whatever
+heading follows the explanation. Pinned sections come out of the same ceiling
+rather than adding to it: together they may take at most half of it, the opening
+gets what is left, and a section that does not fit is left in the index instead
+of being cut in half. Reserve it for invariants; pinning reference material
+spends the opening on it.
+
 ```sh
 agentos config get skills.max_skills_prompt_chars
 agentos config set skills.max_skills_prompt_chars 32000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,12 @@ Two cases are deliberately left whole: a body with no headings, because there
 would be no way to ask for the rest, and a body only slightly over the ceiling,
 where the index would cost more than it saves. Set `0` to switch it off.
 
+```sh
+agentos config get skills.max_skills_prompt_chars
+agentos config set skills.max_skills_prompt_chars 32000
+agentos gateway restart
+```
+
 ### Pinning a section
 
 Which sections survive the cut is otherwise decided by where they sit in the
@@ -263,12 +269,6 @@ rather than adding to it: together they may take at most half of it, the opening
 gets what is left, and a section that does not fit is left in the index instead
 of being cut in half. Reserve it for invariants; pinning reference material
 spends the opening on it.
-
-```sh
-agentos config get skills.max_skills_prompt_chars
-agentos config set skills.max_skills_prompt_chars 32000
-agentos gateway restart
-```
 
 ## First-Run Wizard
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -124,9 +124,9 @@ agentos cron add --every 10m --script 'lp-monitor/{job_id}/tick.sh' --name lp-ra
 That gives a job a directory named after itself in a single `add` — the id does
 not exist until the job does, so the alternative is to create the job against a
 staging path and repoint it afterwards, leaving a live job pointing at a path it
-will not keep. The command prints the resolved path; write the script there. A
-job whose stored path somehow still holds `{job_id}` refuses to run rather than
-creating a directory by that name.
+will not keep. The job it prints back carries the resolved path in its `script`
+field; write the file there. A job whose stored path somehow still holds
+`{job_id}` refuses to run rather than creating a directory by that name.
 
 Arguments go through `--script-arg`, repeated once per argument:
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -114,6 +114,20 @@ time — the directory is the trust boundary. `.sh` and `.bash` run under bash;
 every other extension runs under the same Python interpreter as the gateway.
 Pass `--workdir` to run somewhere other than the script's own directory.
 
+Subdirectories under `~/.agentos/scripts/` are allowed, and `{job_id}` anywhere
+in the path is replaced with the created job's own id:
+
+```sh
+agentos cron add --every 10m --script 'lp-monitor/{job_id}/tick.sh' --name lp-ratchet
+```
+
+That gives a job a directory named after itself in a single `add` — the id does
+not exist until the job does, so the alternative is to create the job against a
+staging path and repoint it afterwards, leaving a live job pointing at a path it
+will not keep. The command prints the resolved path; write the script there. A
+job whose stored path somehow still holds `{job_id}` refuses to run rather than
+creating a directory by that name.
+
 Arguments go through `--script-arg`, repeated once per argument:
 
 ```sh

--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -13,8 +13,14 @@ from agentos.tools.policy_config import normalize_tool_profile
 from .delivery import validate_webhook_url
 from .jobs import _next_run
 from .parser import parse_cron, parse_iso_at, validate_tz
-from .payloads import normalize_contract, normalize_origin_session_key, payload_agent_id
+from .payloads import (
+    normalize_contract,
+    normalize_origin_session_key,
+    payload_agent_id,
+    payload_script,
+)
 from .persistence import JobStore
+from .scripts import JOB_ID_PLACEHOLDER, substitute_job_id
 from .stagger import compute_jitter
 from .types import (
     CronJob,
@@ -26,6 +32,21 @@ from .types import (
     ScheduleKind,
     SessionTarget,
 )
+
+
+def _resolve_script_placeholder(job: CronJob) -> None:
+    """Replace ``{job_id}`` in the job's script path with the job's own id.
+
+    A monitor that keeps its files in a directory named after its job cannot
+    write that name when it creates the job, because the id is minted by the
+    create. Substituting here — the last thing before the job is persisted, on
+    the path every surface takes — means no store ever holds the placeholder,
+    so there is no window in which a live job points at a path it will not keep.
+    """
+    script = payload_script(job.payload)
+    if JOB_ID_PLACEHOLDER not in script:
+        return
+    job.payload = {**job.payload, "script": substitute_job_id(script, job.id)}
 
 
 def _normalized_tool_policy(
@@ -280,6 +301,7 @@ class SchedulerOps:
             # CRON or EVERY with cron expression: scan forward
             job.next_run_at = _next_run(job, now)
 
+        _resolve_script_placeholder(job)
         await self._store.save(job)
         return job
 
@@ -400,6 +422,7 @@ class SchedulerOps:
         )
 
         job.updated_at = now
+        _resolve_script_placeholder(job)
         await self._store.save(job)
         return job
 

--- a/src/agentos/scheduler/scripts.py
+++ b/src/agentos/scheduler/scripts.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -46,6 +47,25 @@ log = structlog.get_logger(__name__)
 MAX_SCRIPT_OUTPUT_CHARS = 16_000
 
 _SHELL_SUFFIXES = frozenset({".sh", ".bash"})
+
+#: Stands in for the owning job's id inside a script path. A job that keeps its
+#: files in a directory named after itself cannot write that name at creation
+#: time, because the id is minted by the create. Without the placeholder the
+#: only way there is to stage the script somewhere else, create the job against
+#: the staging path, move the file, and repoint the job — four steps during
+#: which a live job points at a path it will not keep, and any abandoned run
+#: leaves files behind that nothing can attribute.
+JOB_ID_PLACEHOLDER = "{job_id}"
+
+#: What the placeholder resolves to while a path is being validated, before any
+#: job exists. Shaped like a real id so containment is checked against a path
+#: the same length and depth as the one that will actually run.
+_PLACEHOLDER_PROBE = "00000000-0000-0000-0000-000000000000"
+
+#: A job id becomes a path segment, so it may only hold characters that cannot
+#: reshape the path. Real ids are uuid4; this is the backstop for the one place
+#: a value is spliced into a path rather than resolved as one.
+_JOB_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class ScriptPathError(ValueError):
@@ -71,6 +91,23 @@ def normalize_script_value(script: str | None) -> str:
     return raw
 
 
+def substitute_job_id(script: str, job_id: str) -> str:
+    """Return *script* with every :data:`JOB_ID_PLACEHOLDER` replaced by *job_id*.
+
+    A path with no placeholder is returned as written, so this is safe to run
+    over every script path rather than only the ones that opted in.
+
+    Raises:
+        ScriptPathError: *job_id* is not id-shaped, and splicing it into a path
+            would change that path's shape rather than name a directory in it.
+    """
+    if JOB_ID_PLACEHOLDER not in (script or ""):
+        return script
+    if not _JOB_ID_RE.match(job_id or ""):
+        raise ScriptPathError(f"Blocked: {job_id!r} cannot name a directory in a script path")
+    return script.replace(JOB_ID_PLACEHOLDER, job_id)
+
+
 def resolve_script_path(script: str) -> Path:
     """Resolve *script* to an absolute path inside :func:`scripts_dir`.
 
@@ -80,11 +117,20 @@ def resolve_script_path(script: str) -> Path:
     escapes do not.
 
     Raises:
-        ScriptPathError: the path is empty or resolves outside the scripts dir.
+        ScriptPathError: the path is empty, still holds an unresolved
+            :data:`JOB_ID_PLACEHOLDER`, or resolves outside the scripts dir.
     """
     raw = normalize_script_value(script)
     if not raw:
         raise ScriptPathError("script path is required")
+    if JOB_ID_PLACEHOLDER in raw:
+        # Resolving it literally would make a directory actually called
+        # "{job_id}" and then report the file missing, which reads as a typo
+        # rather than as a job that was persisted before substitution ran.
+        raise ScriptPathError(
+            f"Blocked: script path still holds {JOB_ID_PLACEHOLDER}; it is replaced "
+            f"with the job's id when the job is created: {raw!r}"
+        )
 
     base = scripts_dir()
     base.mkdir(parents=True, exist_ok=True)
@@ -113,6 +159,10 @@ def validate_script_path(script: str | None) -> str | None:
 
     Existence is deliberately not checked — a job may be scheduled before its
     script is written, and a missing file surfaces as a delivered run error.
+
+    A :data:`JOB_ID_PLACEHOLDER` is allowed and stands in for one path segment
+    while the containment check runs: the path has to pass this gate before any
+    job exists to substitute into it.
     """
     raw = normalize_script_value(script)
     if not raw:
@@ -124,7 +174,7 @@ def validate_script_path(script: str | None) -> str | None:
             "place the script in that directory and pass just the file name."
         )
     try:
-        resolve_script_path(raw)
+        resolve_script_path(raw.replace(JOB_ID_PLACEHOLDER, _PLACEHOLDER_PROBE))
     except ScriptPathError as exc:
         return str(exc)
     return None
@@ -337,6 +387,7 @@ def has_actionable_output(output: str) -> bool:
 
 
 __all__ = [
+    "JOB_ID_PLACEHOLDER",
     "MAX_SCRIPT_OUTPUT_CHARS",
     "ScriptPathError",
     "has_actionable_output",
@@ -344,5 +395,6 @@ __all__ = [
     "resolve_script_path",
     "run_job_script",
     "scripts_dir",
+    "substitute_job_id",
     "validate_script_path",
 ]

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -463,6 +463,8 @@ agentos cron add --every 1h --job-kind agent_turn --text "Summarize updates"
 # script jobs run a file in ~/.agentos/scripts/ and deliver its stdout — no
 # model, no tokens. Empty stdout = silent; non-zero exit delivers the error and
 # fails the job. Relative paths only; CLI/Web callers only (never a channel).
+# Subdirectories are fine, and '{job_id}' in the path becomes the new job's id,
+# so a job can own a directory named after itself in a single add.
 agentos cron add --every 5m --script watch-memory.sh --name memory-watchdog
 # ...but a job added from the CLI has no chat to deliver into, so that stdout
 # only reaches the run record. --session-key names the chat it reports into

--- a/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
@@ -605,21 +605,21 @@ model in the loop.
 
 `tick` does the reconcile and the fire in one process on purpose: no agent judgement sits
 between deciding and sending — which is why the model in the loop is optional. Put the
-command in a script under `~/.agentos/scripts/senior-unilp-manager/<cron_id>/` (again with
+command in a script under `~/.agentos/scripts/senior-unilp-manager/{job_id}/` (again with
 the path spelled out) and the ticks cost no model call and no tokens; stdout is delivered
 verbatim, and a tick that prints nothing stays silent:
 
 ```
-# the shape a wired-up monitor ends in — <cron_id> is this job's own id,
-# so it is reached by the staging sequence below, not typed at add time
 cron(action="add", schedule={"kind": "every", "every_seconds": 600},
-     job_kind="script", script="senior-unilp-manager/<cron_id>/tick.sh",
-     session_target="isolated")
+     job_kind="script", name="<something a human will recognise>",
+     script="senior-unilp-manager/{job_id}/tick.sh", session_target="isolated")
 ```
 
-Do not copy that `add` verbatim: a job created against a literal `<cron_id>` finds no file and
-retires itself in five ticks. **Files on disk for a monitor** below is the layout that path
-belongs to, and the sequence that fills the id in. Read it before wiring one up.
+`{job_id}` is written literally: `cron` replaces it with the id of the job it just created,
+and reports the resolved location as `script_path`. Write `tick.sh` there straight away — the
+job is live from the moment it is added, and five failing ticks retire it. Pass `name`, or
+the job carries its script path as its name for the rest of its life, including in every
+failure alert. **Setting up a monitor** below is the layout that path belongs to.
 
 Write `--alert-only` into `tick.sh`, alongside `--json`. Without it every tick delivers the
 full result of every mandate, which on a healthy ratchet is a block of JSON saying nothing
@@ -658,66 +658,39 @@ from a chat channel. The script inherits the gateway process environment, so con
 `UNIV4_LP_PRIVATE_KEY` is visible there before arming: a missing key fails every tick, and
 five consecutive failures retire the job.
 
-## Files on disk for a monitor
+<!-- always -->
+## Setting up a monitor
+
+**Schedule the script shape unless the user asked for a model in the loop.** `job_kind="script"`
+runs `tick.sh` itself and costs no model call and no tokens; `agent_turn` puts a whole turn on
+every tick of a job that is almost always a no-op. **Wiring it to cron** above has both.
 
 One monitor, one directory:
 
 ```
-~/.agentos/scripts/senior-unilp-manager/<cron_id>/
+~/.agentos/scripts/senior-unilp-manager/{job_id}/
 ```
 
-`<cron_id>` is the id of the cron job that owns the monitor, so the mapping is one-to-one and
-mechanical: delete the job, delete the directory. Everything that monitor needs lives there
-and nowhere else — `tick.sh`, any Python helper you write for it, any scratch or output the
-run keeps. Never drop a file for it at the top of `~/.agentos/scripts/`: that directory is
-shared with every other skill's jobs, and a file with no owner in its path is a file nothing
+Everything that monitor needs lives there and nowhere else — `tick.sh`, any helper you write
+for it, any scratch or output the run keeps. The directory is named by the cron **job** that
+owns it, so the mapping is one-to-one and mechanical: delete the job, delete the directory.
+It is the job id rather than a mandate id because a tick script runs `--all` — one job covers
+every mandate, and naming its directory after one of them would be a lie about what it
+watches. Never drop a file for a monitor at the top of `~/.agentos/scripts/`: that directory
+is shared with every other skill's jobs, and a file with no owner in its path is one nothing
 can ever safely clean up.
 
-The cron **job** id, not a mandate id, is what names the directory. A tick script runs
-`--all`, so it is not per-mandate: one job covers every mandate in the state directory, and
-naming its directory after one of them would be a lie about what it watches.
+`{job_id}` is literal, and `cron` fills it in — see **Wiring it to cron** above for the one
+`add` that creates the job and names its directory in the same call. `script=` is the one
+path in this skill that is *not* spelled out in full: it is relative to
+`~/.agentos/scripts/`, and an absolute or `~`-prefixed value is refused outright even when it
+points inside that directory.
 
 **Mandate state does not go here.** The mandate JSON, the `.log.jsonl` write-ahead log, and
 the `.lock` stay where **State on disk** above puts them — `$UNILP_STATE_DIR`, else
 `$AGENTOS_HOME/state/unilp`, else `~/.agentos/state/unilp` — because that is where
-`ratchet.py` writes them and where it looks for them. The scripts directory holds the
-executable and its helpers; it is not a state directory, and a mandate written there is a
-mandate the runner never finds.
-
-### Getting the id into the path
-
-The job needs a script path at creation time, and the cron id only exists once the job has
-been created. Stage the script, then repoint:
-
-1. `mkdir -p ~/.agentos/scripts/senior-unilp-manager/pending/<stage>/` — only the base
-   `~/.agentos/scripts/` is created for you — and write the real, finished `tick.sh` there.
-   `<stage>` is any string unique to this monitor; see below.
-2. `cron(action="add", job_kind="script", name="<something a human will recognise>",
-   script="senior-unilp-manager/pending/<stage>/tick.sh", …)` and read `job_id` off the
-   result — that is `<cron_id>`. Pass `name` here: without one the job is named after
-   whatever `script` said at creation, and it would carry the staging path as its name for
-   the rest of its life, including in every failure alert.
-3. `mkdir -p ~/.agentos/scripts/senior-unilp-manager/<cron_id>/`, move `tick.sh` into it, and
-   remove the now-empty staging directory.
-4. `cron(action="update", job_id="<cron_id>", script="senior-unilp-manager/<cron_id>/tick.sh")`
-   to repoint the job at its final home. `action="update"` can repoint a live job's script, so
-   this keeps the id the user was just told, along with the job's whole run history.
-
-Stage a working script rather than a placeholder, and do steps 3 and 4 straight away: between
-the add and the repoint the job is already live, and a tick that fires at a path with no file
-behind it delivers `Script not found` — five consecutive failures retire the job.
-
-`<stage>` is a nonce, and it has to be one per monitor. Wiring a second monitor while the
-first is still between its add and its repoint, a shared `pending/tick.sh` does not merely
-clobber a file: job A still points at that path, so its next tick runs **B's** script. The id
-of the mandate you just armed is a unique string already to hand — use it, and it is gone
-again by step 4.
-
-Two things about the `script=` argument itself. It is relative to `~/.agentos/scripts/`, and
-an absolute or `~`-prefixed value is refused outright even when it points inside that
-directory — this is the one path in the skill that is *not* spelled out in full. Within that,
-subdirectories need no special handling: only paths escaping the scripts directory are
-rejected.
+`ratchet.py` writes them and where it looks for them. A mandate written into the scripts
+directory is a mandate the runner never finds.
 
 ### Tearing one down
 
@@ -730,10 +703,8 @@ directory down together:
 rm -rf ~/.agentos/scripts/senior-unilp-manager/<cron_id>
 ```
 
-That is the whole point of the layout: the directory name is the job id, so there is never a
-question of which files belonged to the job you just removed. Leave the state directory
-alone — `disarm` has already settled the mandate there, and the log is the record of what the
-monitor did.
+Leave the state directory alone — `disarm` has already settled the mandate there, and the log
+is the record of what the monitor did.
 
 ## Before arming anything real
 

--- a/src/agentos/skills/outline.py
+++ b/src/agentos/skills/outline.py
@@ -36,6 +36,19 @@ _OUTLINE_DEPTH = 2
 #: every heading, and asking for a parent indexes its children.
 _MAX_OUTLINE_ENTRIES = 30
 
+#: Written on its own line directly above a heading, this pins that section:
+#: ``skill_view`` returns it whether or not the budget reaches that far. It is
+#: an HTML comment so it renders as nothing wherever the file is read as
+#: markdown. Position in the file otherwise decides what a model sees, which
+#: makes a rule added to a large skill invisible for no reason the author can
+#: tell from reading their own change.
+ALWAYS_MARKER = "<!-- always -->"
+
+#: The share of the view budget pinned sections may take between them. Pinning
+#: everything would leave no head, and a skill that opens on its index reads as
+#: a table of contents rather than as a skill.
+_ALWAYS_BUDGET_SHARE = 0.5
+
 _HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(\S.*?)[ \t]*#*[ \t]*$")
 _FENCE_RE = re.compile(r"^[ \t]*(```+|~~~+)")
 
@@ -120,6 +133,58 @@ def parse_sections(body: str) -> list[Section]:
             Section(level=level, title=title, start=start, end=end, ancestors=ancestors)
         )
     return sections
+
+
+def always_sections(body: str, sections: list[Section]) -> list[Section]:
+    """The sections marked with :data:`ALWAYS_MARKER`, in document order.
+
+    The marker is the nearest non-blank line above the heading. Requiring it to
+    be the nearest line is what keeps a skill that *documents* the marker from
+    pinning whatever heading happens to follow the discussion — and a marker
+    shown inside a code fence pins nothing at all, because the heading under it
+    is not a section in the first place.
+    """
+    pinned: list[Section] = []
+    for section in sections:
+        # rstrip drops the blank lines an author leaves between the marker and
+        # the heading, so what remains ends on the nearest non-blank line.
+        preceding = body[: section.start].rstrip()
+        nearest = preceding[preceding.rfind("\n") + 1 :].strip()
+        if nearest == ALWAYS_MARKER:
+            pinned.append(section)
+    return pinned
+
+
+def within_always_budget(pinned: list[Section], limit: int) -> list[Section]:
+    """The pinned sections that fit their share of *limit*, in document order.
+
+    A section that would push the total past the share is dropped rather than
+    truncated: half a rule is worse than a line in the index saying where the
+    whole one is.
+    """
+    if limit <= 0:
+        return []
+    share = int(limit * _ALWAYS_BUDGET_SHARE)
+    kept: list[Section] = []
+    used = 0
+    for section in pinned:
+        if used + section.size > share:
+            continue
+        kept.append(section)
+        used += section.size
+    return kept
+
+
+def render_pinned(body: str, pinned: list[Section]) -> str:
+    """Render pinned sections verbatim, under a line saying why they are here."""
+    if not pinned:
+        return ""
+    parts = [
+        "Marked by the skill as rules rather than reference, and so returned in "
+        "full wherever they sit in it:"
+    ]
+    parts.extend(body[section.start : section.end].strip() for section in pinned)
+    return "\n\n".join(parts)
 
 
 def _base_level(sections: list[Section]) -> int:
@@ -218,16 +283,24 @@ def render_outline(
     *,
     shown_through: int,
     skill_name: str,
+    also_shown: list[Section] | None = None,
 ) -> str:
-    """Render the index of sections, marking the ones already returned."""
+    """Render the index of sections, marking the ones already returned.
+
+    *also_shown* names sections returned out of order — pinned ones, which sit
+    past the cut but were rendered anyway. Without it the index would invite a
+    second tool call for text the model is already holding.
+    """
     entries = indexable(sections)
     if not entries:
         return ""
     base = _base_level(sections)
+    pinned_starts = {section.start for section in (also_shown or [])}
     lines = ["Sections:"]
     for section in entries:
         indent = "  " * (section.level - base)
-        note = " (shown above)" if section.end <= shown_through else ""
+        shown = section.end <= shown_through or section.start in pinned_starts
+        note = " (shown above)" if shown else ""
         lines.append(f"- {indent}{section.title} — {_human(section.size)} chars{note}")
     lines.append("")
     lines.append(

--- a/src/agentos/skills/outline.py
+++ b/src/agentos/skills/outline.py
@@ -143,6 +143,10 @@ def always_sections(body: str, sections: list[Section]) -> list[Section]:
     pinning whatever heading happens to follow the discussion — and a marker
     shown inside a code fence pins nothing at all, because the heading under it
     is not a section in the first place.
+
+    A section already inside a pinned one is dropped: a section owns its
+    subsections, so marking both a parent and a child would render the child
+    twice and charge the budget for it twice.
     """
     pinned: list[Section] = []
     for section in sections:
@@ -150,8 +154,11 @@ def always_sections(body: str, sections: list[Section]) -> list[Section]:
         # the heading, so what remains ends on the nearest non-blank line.
         preceding = body[: section.start].rstrip()
         nearest = preceding[preceding.rfind("\n") + 1 :].strip()
-        if nearest == ALWAYS_MARKER:
-            pinned.append(section)
+        if nearest != ALWAYS_MARKER:
+            continue
+        if any(outer.start <= section.start and section.end <= outer.end for outer in pinned):
+            continue
+        pinned.append(section)
     return pinned
 
 

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -27,7 +27,12 @@ from agentos.scheduler.payloads import (
 )
 from agentos.scheduler.prompt_safety import scan_cron_prompt as _scan_cron_prompt
 from agentos.scheduler.schedule_normalizer import coerce_schedule_from_params
-from agentos.scheduler.scripts import normalize_script_value, validate_script_path
+from agentos.scheduler.scripts import (
+    ScriptPathError,
+    normalize_script_value,
+    resolve_script_path,
+    validate_script_path,
+)
 from agentos.scheduler.types import (
     DeliveryConfig,
     DeliveryMode,
@@ -720,7 +725,10 @@ def _session_storage_or_none() -> Any:
                 "job_kind='agent_turn' it is a pre-run collector: its stdout is "
                 "given to the agent as context, and no output means the turn is "
                 "skipped entirely. Either way it needs an interactive CLI or Web "
-                "caller."
+                "caller. Subdirectories are allowed, and '{job_id}' anywhere in "
+                "the path is replaced with the created job's own id — use it to "
+                "give a job its own directory in one call, then write the file "
+                "to the 'script_path' the result reports."
             ),
         },
         "script_args": {
@@ -1385,7 +1393,11 @@ async def cron(
             "schedule_kind": _enum_value(schedule_kind),
             "schedule_value": schedule_value,
             "task": task,
-            "script": script or "",
+            # Read back off the created job rather than echoed from the
+            # argument: a `{job_id}` in the path was resolved by the scheduler
+            # against the id this same result reports, and the caller needs the
+            # resolved form to know where to write the file.
+            "script": payload_script(job.payload),
             "payload_kind": job_kind,
             "session_target": session_target,
             "wake_mode": wake_mode,
@@ -1396,6 +1408,15 @@ async def cron(
             "delivery": _cron_delivery_summary(job.delivery),
             "status": "scheduled",
         }
+        created_script = payload_script(job.payload)
+        if created_script:
+            # Spelled out in full on purpose: `script` is relative to a
+            # directory the caller is not told the location of, and a job whose
+            # script does not exist yet is one the caller is about to write.
+            try:
+                added["script_path"] = str(resolve_script_path(created_script))
+            except ScriptPathError:
+                pass
         if source_job is not None:
             added["cloned_from"] = clone_from
         return json.dumps(added)

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -1413,8 +1413,12 @@ async def cron(
             # Spelled out in full on purpose: `script` is relative to a
             # directory the caller is not told the location of, and a job whose
             # script does not exist yet is one the caller is about to write.
+            # Forward slashes on every platform, for the same reason skill_view
+            # reports its linked files that way: the model quotes this straight
+            # back as a `write_file` path, where a backslash is a JSON escape.
+            # Windows accepts a forward-slash path everywhere this one is used.
             try:
-                added["script_path"] = str(resolve_script_path(created_script))
+                added["script_path"] = resolve_script_path(created_script).as_posix()
             except ScriptPathError:
                 pass
         if source_job is not None:

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -536,10 +536,13 @@ def create_skill_tools(loader: SkillLoader) -> None:
     def _skill_body_within_budget(skill: Any, raw: str) -> str:
         """Return the body whole, or its opening plus an index of the rest."""
         from agentos.skills.outline import (
+            always_sections,
             head_sections,
             parse_sections,
             render_linked_files,
             render_outline,
+            render_pinned,
+            within_always_budget,
         )
 
         budget = _view_budget()
@@ -559,8 +562,23 @@ def create_skill_tools(loader: SkillLoader) -> None:
             )
             return raw
 
-        head, shown_through = head_sections(raw, sections, budget)
-        outline = render_outline(sections, shown_through=shown_through, skill_name=skill.name)
+        # Pinned sections are taken out of the budget before the head, so a
+        # rule the skill marked as one survives no matter how far down it sits.
+        pinned = within_always_budget(always_sections(raw, sections), budget)
+        head, shown_through = head_sections(
+            raw, sections, budget - sum(section.size for section in pinned)
+        )
+        # One the head already reached needs no second copy. The head keeps the
+        # reduced budget rather than being recomputed against the freed space:
+        # the cost is a slightly shorter opening, and a single pass is easier to
+        # reason about than a loop that re-decides what it has already shown.
+        pinned = [section for section in pinned if section.end > shown_through]
+        outline = render_outline(
+            sections,
+            shown_through=shown_through,
+            skill_name=skill.name,
+            also_shown=pinned,
+        )
         linked = render_linked_files(_linked_files(skill), skill.name)
         parts = [
             head,
@@ -570,6 +588,7 @@ def create_skill_tools(loader: SkillLoader) -> None:
                 "its opening sections. The rest is indexed below — read only what the task "
                 "needs rather than the whole skill."
             ),
+            render_pinned(raw, pinned),
             outline,
         ]
         if linked:
@@ -582,12 +601,16 @@ def create_skill_tools(loader: SkillLoader) -> None:
         if len(outlined) >= len(raw):
             return raw
 
-        logger.debug(
+        # INFO, not DEBUG: this is the event that says most of a skill did not
+        # reach the model. A rule written into the indexed tail is invisible
+        # until someone asks for it, and nothing else reports that.
+        logger.info(
             "skill_view.outlined",
             skill=skill.name,
             chars=len(raw),
             returned=len(outlined),
             budget=budget,
+            pinned=len(pinned),
         )
         return outlined
 

--- a/tests/test_scheduler/test_cron_tool_script_path.py
+++ b/tests/test_scheduler/test_cron_tool_script_path.py
@@ -1,0 +1,158 @@
+"""What the ``cron`` tool reports back about a script job's path.
+
+The caller writes the script *after* the job exists — that is the whole point of
+``{job_id}`` — so the add result has to say where. It reports the path the job
+actually carries, not the argument it was handed, and spells it out in full:
+``script`` is relative to a directory the tool never names.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+import agentos.tools.builtin.control as control_mod
+from agentos.scheduler.ops import _resolve_script_placeholder
+from agentos.scheduler.types import CronJob, DeliveryConfig
+from agentos.tools.builtin.control import cron as cron_tool
+from agentos.tools.types import (
+    CallerKind,
+    InteractionMode,
+    ToolContext,
+    current_tool_context,
+)
+
+
+@contextmanager
+def _with_ctx(ctx: ToolContext):
+    token = current_tool_context.set(ctx)
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+class _FakeScheduler:
+    """Stands in for the engine, but resolves the placeholder the way ops does.
+
+    The substitution itself belongs to ``SchedulerOps`` and is covered against a
+    real store in ``test_script_job_id_placeholder``. Calling the same helper
+    here keeps this stub from quietly diverging from it — a fake that skipped
+    the step would let the tool look correct while reporting a path holding an
+    unresolved placeholder.
+    """
+
+    def __init__(self) -> None:
+        self.jobs: list[CronJob] = []
+
+    async def list_jobs(self) -> list[CronJob]:
+        return list(self.jobs)
+
+    async def add_job(self, **kwargs: Any) -> CronJob:
+        job = CronJob(
+            id="1f3c9d2a-0000-4000-8000-00000000abcd",
+            name=kwargs["name"],
+            cron_expr=kwargs.get("schedule_value", ""),
+            schedule_raw=kwargs.get("schedule_value", ""),
+            handler_key=kwargs["handler_key"],
+            payload=kwargs["payload"],
+            session_target=kwargs["session_target"],
+            session_key=kwargs["session_key"],
+            delivery=kwargs.get("delivery") or DeliveryConfig(),
+        )
+        _resolve_script_placeholder(job)
+        self.jobs.append(job)
+        return job
+
+    async def update_job(self, job_id: str, **patch: Any) -> CronJob | None:
+        for job in self.jobs:
+            if job.id == job_id:
+                for key, value in patch.items():
+                    setattr(job, key, value)
+                return job
+        return None
+
+    async def get_job(self, job_id: str) -> CronJob | None:
+        return next((job for job in self.jobs if job.id == job_id), None)
+
+    async def remove_job(self, job_id: str) -> bool:
+        return False
+
+    async def get_runs(self, job_id: str, limit: int = 20) -> list[Any]:
+        return []
+
+
+@pytest.fixture
+def scheduler(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path))
+    sched = _FakeScheduler()
+    control_mod.set_scheduler(sched)
+
+    from agentos.tools.builtin import sessions as sessions_mod
+
+    class _Storage:
+        async def get_session(self, session_key: str) -> None:
+            return None
+
+    class _Manager:
+        _storage = _Storage()
+
+    monkeypatch.setattr(sessions_mod, "_get_session_manager", lambda: _Manager())
+    yield sched
+    control_mod.set_scheduler(None)  # type: ignore[arg-type]
+
+
+def _web_ctx() -> ToolContext:
+    return ToolContext(
+        caller_kind=CallerKind.WEB,
+        interaction_mode=InteractionMode.INTERACTIVE,
+        session_key="agent:main:webchat:u1",
+        agent_id="main",
+    )
+
+
+async def _add(script: str) -> dict[str, Any]:
+    with _with_ctx(_web_ctx()):
+        raw = await cron_tool(
+            action="add",
+            name="monitor",
+            schedule={"kind": "every", "every_seconds": 600},
+            job_kind="script",
+            script=script,
+            session_target="isolated",
+        )
+    return json.loads(raw)
+
+
+async def test_add_reports_the_resolved_script_and_its_full_path(scheduler) -> None:
+    result = await _add("unilp/{job_id}/tick.sh")
+
+    job_id = result["job_id"]
+    assert result["script"] == f"unilp/{job_id}/tick.sh"
+    assert result["script_path"].endswith(f"scripts/unilp/{job_id}/tick.sh")
+    assert "{job_id}" not in result["script"]
+    assert "{job_id}" not in result["script_path"]
+
+
+async def test_a_plain_script_still_reports_where_it_lives(scheduler) -> None:
+    result = await _add("watch.sh")
+
+    assert result["script"] == "watch.sh"
+    assert result["script_path"].endswith("scripts/watch.sh")
+
+
+async def test_a_job_with_no_script_reports_no_path(scheduler) -> None:
+    with _with_ctx(_web_ctx()):
+        raw = await cron_tool(
+            action="add",
+            name="ping",
+            schedule={"kind": "every", "every_seconds": 600},
+            job_kind="agent_turn",
+            task="say hi",
+            session_target="isolated",
+        )
+
+    assert "script_path" not in json.loads(raw)

--- a/tests/test_scheduler/test_cron_tool_script_path.py
+++ b/tests/test_scheduler/test_cron_tool_script_path.py
@@ -132,7 +132,10 @@ async def test_add_reports_the_resolved_script_and_its_full_path(scheduler) -> N
 
     job_id = result["job_id"]
     assert result["script"] == f"unilp/{job_id}/tick.sh"
+    # Forward slashes on every platform: the model quotes this back as a
+    # `write_file` path, where a backslash is a JSON escape.
     assert result["script_path"].endswith(f"scripts/unilp/{job_id}/tick.sh")
+    assert "\\" not in result["script_path"]
     assert "{job_id}" not in result["script"]
     assert "{job_id}" not in result["script_path"]
 

--- a/tests/test_scheduler/test_script_job_id_placeholder.py
+++ b/tests/test_scheduler/test_script_job_id_placeholder.py
@@ -1,0 +1,152 @@
+"""``{job_id}`` in a cron job's script path.
+
+A job that owns a directory named after itself cannot name that directory at
+creation time: the id does not exist until the job does. The placeholder closes
+that gap, so one ``add`` replaces the stage-add-move-repoint sequence that left
+a live job pointing at a staging path for as long as the sequence took.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.scheduler.ops import SchedulerOps
+from agentos.scheduler.payloads import (
+    make_agent_turn_payload,
+    make_script_payload,
+    payload_script,
+)
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.scripts import (
+    JOB_ID_PLACEHOLDER,
+    ScriptPathError,
+    resolve_script_path,
+    substitute_job_id,
+    validate_script_path,
+)
+from agentos.scheduler.types import ScheduleKind, SessionTarget
+
+
+@pytest.fixture
+def agentos_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path))
+    (tmp_path / "scripts").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+async def _open_ops(tmp_path: Path) -> tuple[JobStore, SchedulerOps]:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    return store, SchedulerOps(store)
+
+
+def test_the_placeholder_is_replaced_with_the_job_id() -> None:
+    assert substitute_job_id("unilp/{job_id}/tick.sh", "abc-123") == "unilp/abc-123/tick.sh"
+
+
+def test_a_path_without_the_placeholder_is_returned_unchanged() -> None:
+    assert substitute_job_id("watch.sh", "abc-123") == "watch.sh"
+
+
+def test_every_occurrence_is_replaced() -> None:
+    """A helper directory and the file under it can both name the job."""
+    assert substitute_job_id("{job_id}/{job_id}.sh", "j1") == "j1/j1.sh"
+
+
+@pytest.mark.parametrize("job_id", ["../escape", "a/b", "", "  ", "with space"])
+def test_a_job_id_that_could_reshape_the_path_is_refused(job_id: str) -> None:
+    """The id becomes a path segment, so only an id-shaped string may land in it.
+
+    Real ids are uuid4, but the substitution is the one place a caller-supplied
+    value is spliced into a path, and a backstop there costs nothing.
+    """
+    with pytest.raises(ScriptPathError):
+        substitute_job_id("unilp/{job_id}/tick.sh", job_id)
+
+
+def test_a_path_holding_the_placeholder_passes_validation(agentos_home) -> None:
+    """It has to survive the add-time gate to ever reach substitution."""
+    assert validate_script_path("unilp/{job_id}/tick.sh") is None
+
+
+def test_the_placeholder_cannot_be_used_to_escape_the_scripts_dir(agentos_home) -> None:
+    assert validate_script_path("../{job_id}/tick.sh") is not None
+
+
+def test_an_unresolved_placeholder_never_resolves_to_a_path(agentos_home) -> None:
+    """The backstop: a stored path that kept the placeholder must not run.
+
+    Resolving it literally would create a directory called ``{job_id}`` and
+    report a missing file, which reads as a typo rather than as the bug it is.
+    """
+    with pytest.raises(ScriptPathError) as excinfo:
+        resolve_script_path(f"unilp/{JOB_ID_PLACEHOLDER}/tick.sh")
+
+    assert "{job_id}" in str(excinfo.value)
+
+
+async def test_add_resolves_the_placeholder_before_the_job_is_persisted(
+    tmp_path: Path, agentos_home
+) -> None:
+    """No window: what reaches the store already names the job."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await ops.add(
+            name="monitor",
+            handler_key="script_run",
+            payload=make_script_payload("unilp/{job_id}/tick.sh"),
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.EVERY,
+            schedule_value="600",
+        )
+
+        assert payload_script(job.payload) == f"unilp/{job.id}/tick.sh"
+        reloaded = await store.get(job.id)
+        assert reloaded is not None
+        assert payload_script(reloaded.payload) == f"unilp/{job.id}/tick.sh"
+    finally:
+        await store.close()
+
+
+async def test_add_resolves_the_placeholder_in_a_pre_run_script(
+    tmp_path: Path, agentos_home
+) -> None:
+    """An agent_turn job's pre-run script takes the same field."""
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await ops.add(
+            name="briefing",
+            handler_key="agent_run",
+            payload=make_agent_turn_payload("report it", "main", "unilp/{job_id}/probe.py"),
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.EVERY,
+            schedule_value="600",
+        )
+
+        assert payload_script(job.payload) == f"unilp/{job.id}/probe.py"
+    finally:
+        await store.close()
+
+
+async def test_update_resolves_the_placeholder_against_the_existing_id(
+    tmp_path: Path, agentos_home
+) -> None:
+    store, ops = await _open_ops(tmp_path)
+    try:
+        job = await ops.add(
+            name="monitor",
+            handler_key="script_run",
+            payload=make_script_payload("staging/tick.sh"),
+            session_target=SessionTarget.ISOLATED,
+            schedule_kind=ScheduleKind.EVERY,
+            schedule_value="600",
+        )
+
+        updated = await ops.update(job.id, payload=make_script_payload("unilp/{job_id}/tick.sh"))
+
+        assert updated is not None
+        assert payload_script(updated.payload) == f"unilp/{job.id}/tick.sh"
+    finally:
+        await store.close()

--- a/tests/test_skills_outline.py
+++ b/tests/test_skills_outline.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from agentos.skills.outline import (
+    always_sections,
     find_section,
     head_sections,
     indexable,
     parse_sections,
     render_outline,
+    render_pinned,
 )
 
 
@@ -183,3 +185,91 @@ def test_the_index_marks_what_the_head_already_returned() -> None:
 def test_a_body_without_headings_has_nothing_to_index() -> None:
     assert parse_sections("just prose, no headings\n") == []
     assert indexable([]) == []
+
+
+def test_a_marked_section_is_pinned_wherever_it_sits() -> None:
+    """The rule a skill cannot afford to have truncated.
+
+    Section order otherwise decides what a model reads, so a rule added to a
+    large skill lands in the indexed tail and is never seen unless the model
+    thinks to ask for it.
+    """
+    body = _body(
+        "# T",
+        "intro",
+        "## One",
+        "x" * 400,
+        "<!-- always -->",
+        "## Rules",
+        "never do that",
+    )
+    sections = parse_sections(body)
+
+    pinned = always_sections(body, sections)
+
+    assert [s.title for s in pinned] == ["Rules"]
+
+
+def test_an_unmarked_skill_pins_nothing() -> None:
+    body = _body("# T", "i", "## One", "x" * 400, "## Two", "y" * 400)
+
+    assert always_sections(body, parse_sections(body)) == []
+
+
+def test_the_marker_is_read_through_blank_lines() -> None:
+    body = _body("# T", "i", "<!-- always -->", "", "## Rules", "r")
+
+    assert [s.title for s in always_sections(body, parse_sections(body))] == ["Rules"]
+
+
+def test_a_marker_that_is_not_the_nearest_line_pins_nothing() -> None:
+    """A marker with prose between it and the heading marks nothing.
+
+    Otherwise the word appearing anywhere above a heading would pin it, and a
+    skill discussing the marker would pin sections it never meant to.
+    """
+    body = _body("# T", "<!-- always -->", "some prose", "## Rules", "r")
+
+    assert always_sections(body, parse_sections(body)) == []
+
+
+def test_a_marker_inside_a_fence_pins_nothing() -> None:
+    """A skill documenting the marker shows it in a code block."""
+    body = _body(
+        "# T",
+        "```md",
+        "<!-- always -->",
+        "## Not a section",
+        "```",
+        "",
+        "## Real",
+        "r",
+    )
+
+    assert always_sections(body, parse_sections(body)) == []
+
+
+def test_the_index_marks_a_pinned_section_as_already_shown() -> None:
+    body = _body("# T", "i", "## One", "x" * 200, "<!-- always -->", "## Rules", "r")
+    sections = parse_sections(body)
+    pinned = always_sections(body, sections)
+
+    rendered = render_outline(
+        sections,
+        shown_through=0,
+        skill_name="demo",
+        also_shown=pinned,
+    )
+
+    lines = [line for line in rendered.splitlines() if "Rules" in line]
+    assert lines and lines[0].endswith("(shown above)")
+
+
+def test_pinned_text_is_rendered_under_a_heading_that_says_why() -> None:
+    body = _body("# T", "i", "<!-- always -->", "## Rules", "never do that")
+    sections = parse_sections(body)
+
+    rendered = render_pinned(body, always_sections(body, sections))
+
+    assert "## Rules" in rendered
+    assert "never do that" in rendered

--- a/tests/test_skills_outline.py
+++ b/tests/test_skills_outline.py
@@ -273,3 +273,21 @@ def test_pinned_text_is_rendered_under_a_heading_that_says_why() -> None:
 
     assert "## Rules" in rendered
     assert "never do that" in rendered
+
+
+def test_a_pinned_subsection_of_a_pinned_section_is_not_pinned_twice() -> None:
+    """A section owns its subsections, so pinning both would render it twice."""
+    body = _body(
+        "# T",
+        "i",
+        "<!-- always -->",
+        "## Rules",
+        "outer",
+        "<!-- always -->",
+        "### Detail",
+        "inner",
+    )
+
+    pinned = always_sections(body, parse_sections(body))
+
+    assert [s.title for s in pinned] == ["Rules"]

--- a/tests/test_tools/test_cron_tool_strict.py
+++ b/tests/test_tools/test_cron_tool_strict.py
@@ -29,6 +29,9 @@ class _ToolFakeScheduler:
 
         return SimpleNamespace(
             id="job-strict",
+            # The real scheduler returns the job it persisted, and the tool
+            # reads the stored payload back rather than echoing its argument.
+            payload=kwargs.get("payload") or {},
             delivery=SimpleNamespace(ws_topic=""),
         )
 

--- a/tests/test_tools/test_skill_view_budget.py
+++ b/tests/test_tools/test_skill_view_budget.py
@@ -252,3 +252,81 @@ async def test_the_hub_is_not_suggested_to_a_session_that_cannot_reach_it(
     assert "skill_search_community" not in result
     assert "skill_install_community" not in result
     assert "skill_list" in result
+
+
+def _pinned_skill(dir_: Path, name: str) -> None:
+    """A skill whose rule sits at the very end, past any budget cut.
+
+    The shape that motivated pinning: `senior-unilp-manager` grew to 44k
+    characters, and two merged fixes wrote their rules into the last quarter of
+    it, where a 10k budget never reached. Both were silently ignored.
+    """
+    body = ["# Big", "", "Overview line.", ""]
+    for index in range(12):
+        body += [f"## Section {index}", "", "w" * 3_000, ""]
+    body += [
+        "<!-- always -->",
+        "## Rules",
+        "",
+        "Put every file under its own directory.",
+        "",
+    ]
+    skill_dir = dir_ / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Use when testing pinned sections.\n---\n"
+        + "\n".join(body),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def pinned(tmp_path: Path) -> Iterator[SkillLoader]:
+    bundled = tmp_path / "bundled"
+    _pinned_skill(bundled, "pinned-skill")
+    _long_skill(bundled, "unpinned-skill", sections=12, section_chars=3_000)
+
+    loader = SkillLoader(
+        bundled_dir=bundled,
+        workspace_dir=tmp_path / "workspace",
+        managed_dir=tmp_path / "managed",
+        personal_agents_dir=tmp_path / "personal",
+        project_agents_dir=tmp_path / "project",
+        snapshot_path=tmp_path / "skills.snapshot.json",
+    )
+    previous_loader = skill_tools_module._loader
+    previous_config = control_module._gateway_config
+    skill_tools_module.create_skill_tools(loader)
+    try:
+        yield loader
+    finally:
+        skill_tools_module._loader = previous_loader
+        control_module._gateway_config = previous_config
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_section_survives_the_cut(pinned: SkillLoader) -> None:
+    _set_budget(None)
+
+    result = await _skill_view("pinned-skill")
+
+    assert "Put every file under its own directory." in result
+    # And the index does not send the model back for what it just received.
+    rules_line = next(
+        line for line in result.splitlines() if line.strip().startswith("- ") and "Rules" in line
+    )
+    assert rules_line.endswith("(shown above)")
+
+
+@pytest.mark.asyncio
+async def test_pinning_does_not_push_the_view_past_its_ceiling(pinned: SkillLoader) -> None:
+    """The head gives up room for the rule; the total does not grow."""
+    _set_budget(None)
+    unpinned = await _skill_view("unpinned-skill")
+
+    result = await _skill_view("pinned-skill")
+
+    # Only the sentence introducing the pinned block is new: the rule's own
+    # characters came out of the head's allowance, not out of thin air.
+    assert len(_body(result)) <= len(_body(unpinned)) + 400
+    assert "Overview line." in result  # the head is still real content


### PR DESCRIPTION
Closes #332.

## Why

A merged, docs-only fix to a large skill can have no effect at all. Once a
SKILL.md is over `max_skill_view_chars`, `skill_view` returns its opening
sections plus an index of the rest — so **where a rule sits in the file decides
whether a model ever reads it**, and nothing says otherwise.

`senior-unilp-manager` is 44,639 characters against a 10,000 ceiling. #327 and
#328 both wrote their rules into the last quarter of it. Reproducing what the
model actually received:

```
shown_through: 9,701 of 45,609 chars
head contains the layout rule: False
index line: '-   Files on disk for a monitor — 4,238 chars'
```

The session that motivated this called `skill_view` three times, got the outline
each time, never asked for a section, and then did exactly what both merged
fixes existed to prevent — scheduled an agent task where a script job was the
rule, and dropped the monitor's files flat into `~/.agentos/scripts/`.

## What changed

Two changes, in this order, because the first is what makes the second fit.

### 1. `{job_id}` in a cron job's script path

```
cron(action="add", job_kind="script",
     script="senior-unilp-manager/{job_id}/tick.sh", …)
```

A job that keeps its files in a directory named after itself could not name that
directory at creation time — the id is minted by the create. The only route
there was to stage the script elsewhere, add the job against the staging path,
move the file, and repoint with `action="update"`: four steps, during which a
live job points at a path it will not keep, and any run abandoned midway leaves
files behind that nothing can attribute to a job.

- Substitution happens in `SchedulerOps`, last thing before the job is
  persisted, so the tool, the CLI, and the RPC surface all get it and **no store
  ever holds the placeholder** — there is no window to race.
- Works for a `script` job and for an `agent_turn` job's pre-run script.
- The add result reports the resolved absolute path as `script_path`, because
  `script` is relative to a directory the tool never names.
- `resolve_script_path` refuses a path that still holds the placeholder rather
  than creating a directory called `{job_id}` and reporting a missing file.
- `substitute_job_id` refuses an id that is not id-shaped. Real ids are uuid4,
  but this is the one place a value is spliced into a path rather than resolved
  as one, so containment is not doing the work there.
- `validate_script_path` substitutes a probe id before its containment check, so
  `../{job_id}/tick.sh` is still refused for the right reason.

### 2. `<!-- always -->` pins a section

Written on the line directly above a heading, it makes `skill_view` return that
section wherever it sits.

- Pinned sections come out of the **same** ceiling rather than adding to it: at
  most half of it between them, the opening takes what is left, and one that
  does not fit stays in the index rather than being cut in half.
- The index marks them `(shown above)`, so the model does not spend a second
  call on text it already holds.
- The marker only counts as the nearest non-blank line above a heading, so a
  skill that *documents* the marker does not pin whatever follows the
  explanation. Inside a fence it pins nothing, because the heading under it is
  not a section.
- `skill_view.outlined` moves DEBUG → INFO and gains a `pinned` count. It is the
  only event that reports most of a skill did not reach the model.

### 3. `senior-unilp-manager` shrinks and pins

"Files on disk for a monitor" → "Setting up a monitor": 4,238 → 2,329
characters, because the stage-add-move-repoint procedure it existed to explain
is now one `add`. It absorbs the script-vs-`agent_turn` rule from #327, which
had fallen past the cut too, and carries the marker.

Verified against the real file at the shipped 10k ceiling:

```
pinned: [('Setting up a monitor', 2329)]
head: 7374 chars   →   total returned ~11.6k, versus 11,561 before
```

The rule now reaches the model for ~50 characters more than the old truncated
view cost.

## Testing

- `tests/test_scheduler/test_script_job_id_placeholder.py` (new) — substitution,
  the id-shape refusal, validation, the run-time backstop, and `ops.add` /
  `ops.update` against a **real `JobStore`**, asserting the reloaded job never
  holds the placeholder.
- `tests/test_scheduler/test_cron_tool_script_path.py` (new) — what the add
  result reports. Its stub calls the same `_resolve_script_placeholder` the real
  ops path does, so it cannot drift into passing while production fails.
- `tests/test_skills_outline.py` — marker detection including the blank-line,
  not-nearest-line, and inside-a-fence cases; index marking; rendering.
- `tests/test_tools/test_skill_view_budget.py` — a pinned section survives the
  cut end to end, and pinning does not push the view past its ceiling.
- `tests/test_tools/test_cron_tool_strict.py` — its fake `add_job` returned a
  `SimpleNamespace` with no `payload`; the real scheduler returns the job it
  persisted, and the tool now reads the stored payload back rather than echoing
  its argument.

Full gate green: `ruff check src tests`, `mypy src/agentos` (608 files),
`pytest -q` (7876 passed, 27 skipped), `uv build --wheel`. No frontend changes.

## Docs

`docs/scheduling.md`, `docs/cli.md`, and the bundled `agentos` SKILL.md cover
`{job_id}`; `docs/configuration.md` documents the pin marker under the skill
read ceiling, including that pinning spends the opening's budget and is for
invariants rather than reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
