### PR TITLE
fix(engine): let a tool declare its own transcript persistence ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   of the same ceiling rather than adding to it — at most half of it, with the
   opening taking what is left — and the index marks them as already shown.
   `skill_view.outlined` is now logged at INFO with a `pinned` count, because it
-  is the only event that says most of a skill did not reach the model. (#332)
+  is the only event that says most of a skill did not reach the model. Pinning
+  governs what one `skill_view` call returns; what survives into later turns is
+  the transcript's business, fixed separately in #334. (#332)
 
 ### Fixed
+
+- A tool may now declare the ceiling its own results are persisted under, and
+  `skill_view` sets one from `[skills].max_skill_view_chars`. Every tool result
+  was written to the transcript truncated to its first 2,000 characters, so a
+  skill body read on one turn came back on the next as an opening that stops
+  mid-sentence — and 40 of the 50 bundled skills are larger than that. A session
+  read `senior-unilp-manager`, saw the pinned directory rule from #332 in an
+  11,996-character result, and one turn later replayed 2,000 characters that did
+  not contain it and wrote the files flat. Nothing downstream could recover it:
+  the request builder compacts from what was persisted, not from the original,
+  so the layer under no pressure at all — writing one SQLite row — was cutting
+  harder, and more crudely, than the layer that has a budget to defend. The
+  ceiling is resolved when a result is persisted rather than at registration, so
+  it follows a config change, and a tool that declares nothing keeps the 2,000
+  characters that suit volatile output. (#334)
 
 - Web chat: copying an assistant message no longer prepends the collapsible
   reasoning block. `extractBubbleText()` cloned `.msg-body` and stripped only

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,6 +270,11 @@ gets what is left, and a section that does not fit is left in the index instead
 of being cut in half. Reserve it for invariants; pinning reference material
 spends the opening on it.
 
+A pinned section is worth little if it only lasts the turn that read it, so the
+transcript keeps a `skill_view` result up to this ceiling rather than the short
+preview it keeps of ordinary tool output. Raising `max_skill_view_chars` raises
+what is stored per view with it.
+
 ## First-Run Wizard
 
 ```sh

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -146,6 +146,7 @@ from agentos.provider import (
     classify_provider_error,
     decide_recovery_action,
 )
+from agentos.result_budget import persisted_result_max_chars
 from agentos.router_control import (
     RouterControlHoldStore,
     render_router_control_prompt_block,
@@ -897,9 +898,22 @@ def _persisted_tool_use_input(
 def _persisted_tool_result_segment(
     event: ToolResultEvent,
     *,
-    max_chars: int = _MAX_TOOL_RESULT_CHARS,
+    max_chars: int | None = None,
 ) -> dict[str, Any]:
-    """Create the transcript `tool_result` segment for a streamed event."""
+    """Create the transcript `tool_result` segment for a streamed event.
+
+    The ceiling comes from the tool unless the caller names one. Truncating here
+    cannot be undone by anything downstream — the request builder compacts from
+    whatever this wrote, not from the original — so a tool whose result is
+    instructions rather than output raises its own ceiling and keeps the loss at
+    the layer that has a budget to defend.
+    """
+
+    if max_chars is None:
+        max_chars = persisted_result_max_chars(
+            event.tool_name,
+            default=_MAX_TOOL_RESULT_CHARS,
+        )
 
     result = event.result
     segment: dict[str, Any] = {

--- a/src/agentos/result_budget.py
+++ b/src/agentos/result_budget.py
@@ -14,11 +14,17 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
+import structlog
+
 WEB_FETCH_MIN_MAX_CHARS = 100
+
+logger = structlog.get_logger(__name__)
 
 
 class ToolResultBudgetClass(StrEnum):
@@ -393,6 +399,59 @@ class ToolResultBudgetTracker:
                 returned_chars=returned_chars,
                 budget_class=budget_class,
             )
+
+
+# How much of a tool's result is written to the transcript.
+#
+# The default suits volatile output: a shell command's stdout is worth a
+# preview and nothing more, and keeping the whole of it would grow the session
+# store without ever being read again. Instructions are the opposite kind of
+# payload. A skill body is the reason the model knows how to do the task at
+# all, and a later turn that replays only its first characters is a turn
+# working from an instruction sheet with the ending torn off.
+#
+# So a tool may register the ceiling its own results are kept under. Nothing is
+# assumed about any tool that does not, which is every tool but one today.
+_PERSISTED_RESULT_BUDGETS: dict[str, Callable[[], int]] = {}
+
+
+def register_persisted_result_budget(tool_name: str, resolver: Callable[[], int]) -> None:
+    """Declare the ceiling ``tool_name``'s results are persisted under.
+
+    The resolver is called each time a result is persisted rather than once at
+    registration, for two reasons: the value usually comes from config, which is
+    not necessarily loaded when tools are registered, and config can be changed
+    while the gateway runs. A resolver returning ``0`` means the tool's results
+    are never truncated.
+    """
+
+    _PERSISTED_RESULT_BUDGETS[tool_name] = resolver
+
+
+def clear_persisted_result_budgets() -> None:
+    """Drop every registration. For tests, and for re-registering a tool set."""
+
+    _PERSISTED_RESULT_BUDGETS.clear()
+
+
+def persisted_result_max_chars(tool_name: str, *, default: int) -> int:
+    """The persistence ceiling for ``tool_name``, or ``default`` if it declared none."""
+
+    resolver = _PERSISTED_RESULT_BUDGETS.get(tool_name)
+    if resolver is None:
+        return default
+    try:
+        declared = resolver()
+    except Exception:  # pragma: no cover - persisting a turn is never worth failing on
+        logger.debug("persisted_result_budget.resolver_failed", tool=tool_name, exc_info=True)
+        return default
+    if not isinstance(declared, int):
+        return default
+    if declared == 0:
+        return sys.maxsize
+    if declared < 0:
+        return default
+    return declared
 
 
 def resolve_budget_class(tool_name: str, explicit: Any = None) -> ToolResultBudgetClass:

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -522,10 +522,11 @@ def create_skill_tools(loader: SkillLoader) -> None:
         is worse than not having read it, because it does not know that.
 
         The view ceiling bounds the body; the outline index, the directory note
-        and the configured-settings block are appended after it. The widest of
-        those across the bundled tree is around 1,300 characters, so the
-        headroom covers them with room to spare and still refuses an unbounded
-        row. A ceiling of 0 means the operator turned the read cap off, and
+        and the configured-settings block are appended after it. Measured over
+        the whole bundled tree at a 10,000 ceiling, the widest view runs 2,696
+        characters past it (`senior-unilp-manager`), and none reaches the
+        headroom below — which is what it is for, rather than a round number.
+        A ceiling of 0 means the operator turned the read cap off, and
         persistence follows rather than re-imposing one.
         """
 

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from agentos.result_budget import register_persisted_result_budget
 from agentos.skills.hub.defaults import (
     build_default_skill_installer,
     get_default_skill_router,
@@ -38,6 +39,8 @@ _MUTABLE_LAYERS = frozenset({SkillLayer.WORKSPACE})
 # Valid skill name pattern: lowercase alphanumeric + hyphens
 _SKILL_NAME_RE = re.compile(r"^[a-z][a-z0-9\-]{0,62}$")
 _INSTALL_OUTPUT_LIMIT = 4_000
+# Room after the view ceiling for the outline index and the trailing notes.
+_SKILL_VIEW_PERSIST_HEADROOM = 4_000
 _INSTALL_TIMEOUT_SECONDS = 120.0
 
 _BREW_FORMULA_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9/_@.+-]*$")
@@ -509,6 +512,29 @@ def create_skill_tools(loader: SkillLoader) -> None:
         except Exception:  # pragma: no cover — never block reading a skill
             logger.debug("skill_view.budget_lookup_failed", exc_info=True)
         return DEFAULT_MAX_SKILL_VIEW_CHARS
+
+    def _view_persist_budget() -> int:
+        """How much of a `skill_view` result is kept in the transcript.
+
+        A skill body is not output, it is instructions, and the turn that acts
+        on them is usually not the turn that read them. Persisting only the
+        opening leaves every later turn holding a skill it half-remembers, which
+        is worse than not having read it, because it does not know that.
+
+        The view ceiling bounds the body; the outline index, the directory note
+        and the configured-settings block are appended after it. The widest of
+        those across the bundled tree is around 1,300 characters, so the
+        headroom covers them with room to spare and still refuses an unbounded
+        row. A ceiling of 0 means the operator turned the read cap off, and
+        persistence follows rather than re-imposing one.
+        """
+
+        budget = _view_budget()
+        if budget <= 0:
+            return 0
+        return budget + _SKILL_VIEW_PERSIST_HEADROOM
+
+    register_persisted_result_budget("skill_view", _view_persist_budget)
 
     def _linked_files(skill: Any) -> list[str]:
         """Supporting files, relative to the skill directory, POSIX-style.

--- a/tests/test_engine/test_persisted_result_budget.py
+++ b/tests/test_engine/test_persisted_result_budget.py
@@ -1,0 +1,106 @@
+"""A tool may raise the ceiling its own results are persisted under.
+
+The default stays where it has always been, so a tool that says nothing keeps
+today's behaviour byte for byte. Only a tool that registers a resolver is
+treated differently, and the resolver is asked at persistence time so it
+follows a config change instead of freezing whatever was true at boot.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from agentos.engine.runtime import _MAX_TOOL_RESULT_CHARS, _persisted_tool_result_segment
+from agentos.engine.types import ToolResultEvent
+from agentos.result_budget import (
+    clear_persisted_result_budgets,
+    persisted_result_max_chars,
+    register_persisted_result_budget,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_persisted_result_budgets()
+    yield
+    clear_persisted_result_budgets()
+
+
+def _segment(tool_name: str, chars: int) -> dict:
+    return _persisted_tool_result_segment(
+        ToolResultEvent(
+            tool_use_id="call_1",
+            tool_name=tool_name,
+            result="x" * chars,
+            is_error=False,
+        )
+    )
+
+
+def test_unregistered_tool_keeps_the_default_ceiling() -> None:
+    assert persisted_result_max_chars("exec_command", default=_MAX_TOOL_RESULT_CHARS) == 2000
+
+
+def test_volatile_output_is_still_cut_at_two_thousand() -> None:
+    register_persisted_result_budget("skill_view", lambda: 14_000)
+
+    segment = _segment("exec_command", 9_000)
+
+    assert segment["result_truncated"] is True
+    assert len(segment["result"]) == 2000
+
+
+def test_registered_tool_persists_a_result_under_its_own_ceiling_whole() -> None:
+    register_persisted_result_budget("skill_view", lambda: 14_000)
+
+    segment = _segment("skill_view", 11_996)
+
+    assert segment["result"] == "x" * 11_996
+    assert "result_truncated" not in segment
+
+
+def test_registered_ceiling_is_a_ceiling_not_a_licence() -> None:
+    register_persisted_result_budget("skill_view", lambda: 14_000)
+
+    segment = _segment("skill_view", 20_000)
+
+    assert segment["result_truncated"] is True
+    assert len(segment["result"]) == 14_000
+
+
+def test_resolver_is_asked_at_persistence_time() -> None:
+    """A config change between two calls has to be visible to the second."""
+    ceiling = 14_000
+    register_persisted_result_budget("skill_view", lambda: ceiling)
+
+    assert "result_truncated" not in _segment("skill_view", 11_996)
+
+    ceiling = 3_000
+    later = _segment("skill_view", 11_996)
+
+    assert later["result_truncated"] is True
+    assert len(later["result"]) == 3_000
+
+
+def test_resolver_returning_zero_disables_truncation() -> None:
+    """`max_skill_view_chars = 0` turns the read ceiling off; persistence follows."""
+    register_persisted_result_budget("skill_view", lambda: 0)
+
+    segment = _segment("skill_view", 90_000)
+
+    assert segment["result"] == "x" * 90_000
+    assert "result_truncated" not in segment
+
+
+def test_a_failing_resolver_falls_back_to_the_default() -> None:
+    """Persisting a turn is never worth failing on."""
+
+    def _broken() -> int:
+        raise RuntimeError("config went away")
+
+    register_persisted_result_budget("skill_view", _broken)
+
+    segment = _segment("skill_view", 9_000)
+
+    assert segment["result_truncated"] is True
+    assert len(segment["result"]) == 2000

--- a/tests/test_tools/test_skill_view_budget.py
+++ b/tests/test_tools/test_skill_view_budget.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from agentos.engine.runtime import _persisted_tool_result_segment
+from agentos.engine.types import ToolResultEvent
+from agentos.result_budget import (
+    clear_persisted_result_budgets,
+    persisted_result_max_chars,
+)
 from agentos.skills.loader import SkillLoader
 from agentos.skills.outline import DEFAULT_MAX_SKILL_VIEW_CHARS
 from agentos.tools.builtin import control as control_module
@@ -86,6 +93,7 @@ def loaded(tmp_path: Path) -> Iterator[SkillLoader]:
     finally:
         skill_tools_module._loader = previous_loader
         control_module._gateway_config = previous_config
+        clear_persisted_result_budgets()
 
 
 def _set_budget(value: int | None) -> None:
@@ -330,3 +338,56 @@ async def test_pinning_does_not_push_the_view_past_its_ceiling(pinned: SkillLoad
     # characters came out of the head's allowance, not out of thin air.
     assert len(_body(result)) <= len(_body(unpinned)) + 400
     assert "Overview line." in result  # the head is still real content
+
+
+def test_skill_view_declares_a_persistence_ceiling(loaded: SkillLoader) -> None:
+    """Registering the tool set is what puts the ceiling in place.
+
+    Asserted through the public resolver rather than the closure, so the test
+    fails if the registration is ever dropped from ``create_skill_tools``.
+    """
+    _set_budget(10_000)
+
+    assert persisted_result_max_chars("skill_view", default=2_000) == 14_000
+
+
+def test_the_persistence_ceiling_follows_the_configured_budget(loaded: SkillLoader) -> None:
+    """One source of truth: lower the read ceiling and persistence lowers with it."""
+    _set_budget(4_000)
+
+    assert persisted_result_max_chars("skill_view", default=2_000) == 8_000
+
+
+def test_turning_the_read_ceiling_off_turns_off_persistence_truncation(
+    loaded: SkillLoader,
+) -> None:
+    _set_budget(0)
+
+    assert persisted_result_max_chars("skill_view", default=2_000) == sys.maxsize
+
+
+@pytest.mark.asyncio
+async def test_a_viewed_skill_survives_into_the_transcript_whole(loaded: SkillLoader) -> None:
+    """The bug this ceiling exists for: a skill read on one turn, gone by the next.
+
+    ``big-skill`` is far over the old flat 2,000-character persistence cap, and
+    the section index sits at the end of the view — exactly the part a head-only
+    truncation drops.
+    """
+    _set_budget(10_000)
+    viewed = await _skill_view("big-skill")
+    assert len(viewed) > 2_000
+    assert "Section 11" in viewed  # the index, at the tail
+
+    segment = _persisted_tool_result_segment(
+        ToolResultEvent(
+            tool_use_id="call_1",
+            tool_name="skill_view",
+            result=viewed,
+            is_error=False,
+        )
+    )
+
+    assert segment["result"] == viewed
+    assert "result_truncated" not in segment
+    assert "Section 11" in segment["result"]


### PR DESCRIPTION
Closes #334.

## What was wrong

`_persisted_tool_result_segment` truncated every tool result to `result[:2000]`
before writing it to the transcript — always, with no notion of budget class.
That is the right shape for a shell command's stdout and the wrong shape for a
skill body. 40 of the 50 bundled skills are larger than 2,000 characters.

Traced end to end on a real session. `skill_view` did its job:

```
15:36:28 skill_view.outlined skill=senior-unilp-manager returned=11851 budget=10000 pinned=1
```

The transcript is where it went:

| tool | returned to the model | persisted |
|---|---|---|
| `skill_view` | 11,996 | **2,000** |
| `skill_view` (section) | 8,797 | **2,000** |

The stored preview ends mid-sentence inside `## 1. How much liquidity does a
token have?`. Grepping the stored row for the directory rule returns nothing.
One turn later the model wrote the monitor flat and created a cron job pointing
at it — the exact failure #332 was merged to prevent.

## Why nothing downstream saved it

The two truncation paths are inverted:

| | persistence (`runtime.py`) | request build (`agent.py`) |
|---|---|---|
| when | always | only when the total is over budget |
| keeps | head only, 2,000 | head 65% + tail 35%, up to 4,000 |
| budget-class aware | no | yes |
| `keep_recent` | no | yes |
| recoverable | **never** | yes, the original is intact |

The request builder compacts from what persistence wrote, not from the
original. So the layer under no pressure at all — writing one SQLite row — was
cutting harder and more crudely than the layer that has a budget to defend, and
every bit of smarter compaction downstream was working on a payload already
reduced to its first 2,000 characters.

## The change

A tool may register the ceiling its own results are persisted under:

```python
register_persisted_result_budget("skill_view", _view_persist_budget)
```

- `skill_view`'s resolver derives from `[skills].max_skill_view_chars` plus
  headroom, so the ceiling stays one number rather than a second constant to
  keep in sync. Headroom is 4,000 against a widest measured overhead of 1,300
  across the bundled tree (outline index, directory note, settings block).
- The resolver is called **when a result is persisted**, not at registration, so
  it follows a config change and does not depend on boot ordering.
- A resolver returning `0` means the read ceiling is off and persistence follows
  rather than re-imposing one.
- A failing resolver falls back to the default; persisting a turn is never worth
  failing on.

**Any tool that declares nothing is unchanged, byte for byte.** `exec_command`,
`web_fetch`, `http_request` and the rest keep the flat 2,000 that suits volatile
output. One tool opts in today.

The principle: do not destroy data irreversibly at a layer with no budget
pressure. The loss moves to request-build time, where it is conditional,
budget-aware, and recoverable.

## Relationship to #332

#332 stays. They are consecutive layers and neither alone is sufficient:

```
SKILL.md (42,822)
   |  #332: pinning lifts the rule into the output
   v
skill_view returns 11,851  <- rule present
   |  #334: it survives into the transcript
   v
still present on later turns
```

#332 without this is the failure above. This without #332 would faithfully
persist an output that never contained the rule, since the section sits at 77%
of the file, outside the head. The CHANGELOG entry for #332 is amended here to
say pinning governs one call, not later turns.

## Tests

`tests/test_engine/test_persisted_result_budget.py` — the mechanism: default for
an unregistered tool, volatile output still cut at 2,000 with a registration
present, a registered result kept whole, the ceiling still being a ceiling,
resolution happening at persistence time, `0` disabling truncation, and a
throwing resolver falling back.

`tests/test_tools/test_skill_view_budget.py` — the wiring, asserted through the
public resolver so the test fails if the registration is dropped from
`create_skill_tools`: the ceiling exists, tracks the configured budget, follows
it to zero, and a real `skill_view` result over 2,000 characters survives
`_persisted_tool_result_segment` whole, section index included.

Full suite: 7,886 passed. Three failures are environmental and reproduce on a
clean `origin/main` in the same sandbox (`mem0` present because the run
installed all extras; `cairo` missing for `html_to_pdf`).

## Verification beyond the diff

Both bugs in this area lived outside the diff under review, so a diff read is
not the gate. Runtime check across two turns, results posted to this PR before
merge:

1. restart the gateway on this build
2. turn 1 — agent views a skill over 10,000 characters
3. turn 2 — ask it to set up a monitor
4. grep the persisted `tool_result` row for the directory rule
5. confirm the created job's `script` is `<skill>/<job_id>/tick.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
