### PR TITLE
refactor(identity): tidy system prompt sections and fix glued headings

### DIFF
--- a/src/agentos/identity/templates/system_prompt.j2
+++ b/src/agentos/identity/templates/system_prompt.j2
@@ -1,6 +1,6 @@
 {% if identity.name -%}
 # Agent: {{ identity.name }}
-{% endif -%}
+{% endif %}
 
 {% if prompt_mode != "none" -%}
 {% set product_identity_name = identity.name or "AgentOS" -%}
@@ -132,7 +132,7 @@ SOUL.md defines durable voice and persona guidance for this workspace. Treat it 
 - To create a new image, you MUST call the `image_generate` tool. Never claim to have generated, drawn, or produced an image without actually invoking the tool.
 {% if has_code_tool -%}
 - For charts or plots of data you already have, prefer `execute_code` to render matplotlib/SVG output, then describe the file you produced.
-{% endif -%}
+{% endif %}
 
 {% else -%}
 ## Image Generation
@@ -157,7 +157,7 @@ SOUL.md defines durable voice and persona guidance for this workspace. Treat it 
 - When memory evidence is useful to verify the answer, include the returned citation or path#line. Do not invent citations.
 {% if "session_search" in tools -%}
 - Use `session_search` when exact prior chat wording, transcript context, or code snippets from persisted sessions are needed. Ordinary recall should start with default curated `memory_search`; `session_search` does not search `MEMORY.md` or `memory/**/*.md`.
-{% endif -%}
+{% endif %}
 
 {% endif -%}
 
@@ -198,15 +198,6 @@ SOUL.md defines durable voice and persona guidance for this workspace. Treat it 
 
 {% endif -%}
 
-{% if prompt_mode == "full" -%}
-## AgentOS CLI Quick Reference
-
-- `agentos gateway run` — Start the ASGI gateway
-- `agentos chat` — Interactive CLI chat
-- Do not invent subcommands. Only use documented commands.
-
-{% endif -%}
-
 {% if memory and prompt_mode != "minimal" -%}
 ## Memory
 
@@ -228,13 +219,6 @@ Reference docs available at: {{ docs_path }}
 - {{ alias }}
 {% endfor %}
 Prefer aliases when overriding the model.
-
-{% endif -%}
-
-{% if prompt_mode != "minimal" and runtime_info and runtime_info.workspace_dir -%}
-## Workspace
-
-Working directory: {{ runtime_info.workspace_dir }}
 
 {% endif -%}
 
@@ -299,17 +283,23 @@ greetings like "hi". Always respond to direct user messages.
 
 {% endif -%}
 
-{% if runtime_info and prompt_mode == "full" -%}
+{% if runtime_info and (prompt_mode == "full" or (prompt_mode != "minimal" and runtime_info.get("workspace_dir"))) -%}
 ## Runtime
 
+{% if prompt_mode == "full" -%}
 - OS: {{ runtime_info.os }}
 - Shell: {{ runtime_info.shell }}
+{% endif -%}
+{% if runtime_info.get("workspace_dir") and prompt_mode != "minimal" -%}
+- Working directory: {{ runtime_info.workspace_dir }}
+{% endif %}
 
 {% endif -%}
 
 {% if prompt_mode == "full" -%}
 ## Reply Guidelines
 
+- Lead with the answer or outcome; keep supporting detail after it
 - Use the conversation's language for replies
 {% if tools and "ask_user" in tools -%}
 - When a decision is the user's to make, use `ask_user`; otherwise state your assumption and continue

--- a/tests/test_identity/test_system_prompt_sections.py
+++ b/tests/test_identity/test_system_prompt_sections.py
@@ -8,7 +8,7 @@ weakens a block fails loudly instead of shipping silently.
 from __future__ import annotations
 
 from agentos.identity.prompt import assemble_system_prompt
-from agentos.identity.types import AgentProfile
+from agentos.identity.types import AgentIdentity, AgentProfile
 
 _TOOLS = ["exec_command", "read_file", "write_file", "web_fetch"]
 
@@ -147,6 +147,65 @@ def test_heartbeat_prompt_implies_silent_replies() -> None:
 
     assert "## Heartbeats" in prompt
     assert "## Silent Replies" in prompt
+
+
+def test_cli_quick_reference_stays_removed() -> None:
+    # The bundled agentos skill is the canonical CLI reference; a two-line
+    # in-prompt copy only drifts from the real CLI.
+    prompt = _full_prompt()
+
+    assert "AgentOS CLI Quick Reference" not in prompt
+
+
+def test_runtime_section_carries_os_shell_and_working_directory() -> None:
+    prompt = assemble_system_prompt(
+        AgentProfile(agent_id="main", prompt_mode="full"),
+        tools=_TOOLS,
+        runtime_info={"os": "Darwin", "shell": "/bin/zsh", "workspace_dir": "<WS>"},
+    )
+
+    assert prompt.count("## Runtime") == 1
+    assert "## Workspace" not in prompt
+    assert "- OS: Darwin" in prompt
+    assert "- Shell: /bin/zsh" in prompt
+    assert "- Working directory: <WS>" in prompt
+
+
+def test_runtime_section_omits_workspace_line_when_unset() -> None:
+    prompt = assemble_system_prompt(
+        AgentProfile(agent_id="main", prompt_mode="full"),
+        tools=_TOOLS,
+        runtime_info={"os": "Darwin", "shell": "/bin/zsh"},
+    )
+
+    assert "- OS: Darwin" in prompt
+    assert "Working directory:" not in prompt
+
+
+def test_reply_guidelines_lead_with_the_answer() -> None:
+    prompt = _full_prompt()
+
+    assert "## Reply Guidelines" in prompt
+    assert "Lead with the answer or outcome" in prompt
+
+
+def test_section_headings_always_follow_a_blank_line() -> None:
+    # Sections that end with a conditional bullet used to glue onto the next
+    # heading: a trailing `{% endif -%}` swallowed the separator blank line.
+    prompt = assemble_system_prompt(
+        AgentProfile(agent_id="main", prompt_mode="full", identity=AgentIdentity(name="Bin")),
+        tools=[*_TOOLS, "image_generate", "execute_code", "memory_search", "session_search"],
+        memory="MEMORY (your personal notes)\n\n- example",
+        runtime_info={"os": "Darwin", "shell": "/bin/zsh", "workspace_dir": "<WS>"},
+        heartbeat_prompt="Heartbeat polls arrive as system events.",
+        channels_enabled=True,
+        unattended_context=True,
+    )
+
+    lines = prompt.split("\n")
+    for i, line in enumerate(lines):
+        if line.startswith("## ") and i > 0:
+            assert lines[i - 1] == "", f"heading glued to content: {lines[i - 1]!r} -> {line!r}"
 
 
 def test_minimal_mode_omits_gated_sections_regardless_of_flags() -> None:


### PR DESCRIPTION
Closes #343. Final cosmetics pass of the prompt-modernization arc (#336 → #338 → #340). One cache break, net **−124 chars (~31 tokens)** on a full-mode render.

## What

- **Drop `## AgentOS CLI Quick Reference`** — two hardcoded commands that drift from the real CLI; the bundled `agentos` skill and `docs/cli.md` are the canonical references. (No CLI surface changes, so no skill/docs updates are due.)
- **Fold `## Workspace` into `## Runtime`** — OS, shell, and working directory are one environment concern; now one section, three bullets. Gating is preserved per line: OS/shell stay full-mode-only, the working-directory line keeps its old non-minimal + workspace_dir-set condition, and `runtime_info.get("workspace_dir")` guards StrictUndefined for callers that omit the key.
- **Reply Guidelines opens with "Lead with the answer or outcome; keep supporting detail after it".**
- **Fix glued section headings (pre-existing rendering defect).** Any section whose last line is conditional ended with `{% endif -%}`; the right-trim dash swallows the blank line separating it from the next heading. Every shipped full-mode prompt today renders `# Agent` glued onto `## Product Identity`, `## Image Generation` onto `## Memory Recall`, and `## Memory Recall` onto `## Memory Write Guidance`. Those closing tags (plus the new Runtime block's) drop the dash — safe in all prompt modes because each sits inside its section's outer `{% if %}`.

## Tests

Five new cases in `tests/test_identity/test_system_prompt_sections.py`: CLI quick-reference stays removed; merged Runtime carries OS/shell/working-directory with `## Workspace` gone; the working-directory line vanishes when unset; Reply Guidelines leads with the answer; and a regression walk over a fully-populated render (identity name, image/code/memory/session tools, memory, heartbeat, both gating flags) asserting **every** heading follows a blank line.

## Verification

`ruff`, `mypy`, full offline suite: **7913 passed, 23 skipped**. Render-level verification is the whole change (no runtime wiring touched), so no live E2E this time: before/after renders diff exactly as intended — sections merged, separator lines restored, headings never glued.