### PR TITLE
docs: expand troubleshooting with Windows, browser, router, memory, and Docker sections

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ root release README with task-oriented guides.
   authoring.
 - [`features/compaction-and-cache.md`](features/compaction-and-cache.md) -
   long-session compaction and prompt-cache continuity.
+- [`features/browser.md`](features/browser.md) - browser automation:
+  navigate, click, type, screenshot, and JavaScript execution via Chromium.
 
 ## Surfaces and Operations
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Start with:
+Stuff broke? Don't panic. Start here:
 
 ```sh
 agentos doctor
@@ -8,18 +8,21 @@ agentos doctor --json
 agentos gateway status
 ```
 
-The Web UI health view at <http://127.0.0.1:18791/control/> also reports
-readiness and recovery steps when the gateway is running.
+The Web UI health view at <http://127.0.0.1:18791/control/> also tells you
+what's going on when the gateway is running.
+
+---
 
 ## `agentos` Command Not Found
 
-After `uv tool install`, open a new terminal or run:
+After installing with `uv tool install`, your shell doesn't know about the new
+binary yet. Either open a fresh terminal or refresh your PATH:
 
 ```sh
 uv tool update-shell
 ```
 
-Check the executable:
+Verify it's there:
 
 ```sh
 command -v agentos
@@ -31,139 +34,290 @@ On Windows PowerShell:
 where.exe agentos
 ```
 
+If that still doesn't work, make sure `uv` itself is installed and on your
+PATH. Run `uv --version` to check.
+
+---
+
 ## Gateway Is Not Running
 
-Start it:
+The gateway needs to be up for most things to work. Start it:
 
 ```sh
 agentos gateway run
 ```
 
-Or use the managed background process:
+Or kick it off in the background:
 
 ```sh
 agentos gateway start --json
 agentos gateway status
 ```
 
-Open:
+Then open <http://127.0.0.1:18791/control/> in your browser.
 
-```text
-http://127.0.0.1:18791/control/
+If it crashes on startup, check the logs:
+
+```sh
+agentos gateway status --json
 ```
 
-For a focused gateway guide, see [`gateway.md`](gateway.md).
+A common reason: the config file has a typo or a provider isn't set up yet.
+Run `agentos doctor` — it usually points you right at the problem.
+
+For a deeper look at gateway lifecycle and config, see [`gateway.md`](gateway.md).
+
+---
 
 ## Port Already In Use
 
-Use another port:
+Something else is already listening on the default port. Either kill the
+other process, or just use a different port:
 
 ```sh
 agentos gateway run --port 18792
 ```
 
-Or stop the managed gateway:
+If you had a managed gateway running, stop it first:
 
 ```sh
 agentos gateway stop
 ```
 
+---
+
 ## Provider Not Configured
 
-Run:
+No provider set up means no model to talk to. Run onboarding:
 
 ```sh
 agentos onboard
+```
+
+Or configure one manually:
+
+```sh
 agentos providers list
 agentos providers configure openrouter
 ```
 
-Use environment-variable secrets:
+For secrets, always use environment variables instead of hardcoding keys:
 
 ```sh
 export OPENAI_API_KEY="sk-..."
 agentos configure provider --provider openai --api-key-env OPENAI_API_KEY
 ```
 
+If you're getting auth errors even after setting the key, double-check the
+variable name and that you exported it in the same shell session where you
+start the gateway. `.env` files are loaded at process start — changing one
+after the gateway is already running won't help until you restart.
+
+---
+
 ## Router Dependency Problems
 
-If Pilot Router cannot load, AgentOS can still run with direct model
-routing. To disable the router:
+Pilot Router is optional. If it can't load, AgentOS falls back to direct
+model routing — it still works, just without the cost optimization.
+
+If you want to disable it explicitly:
 
 ```sh
 agentos configure router --router disabled
 agentos gateway restart
 ```
 
-On Windows, ONNX Runtime may need the Visual C++ Redistributable for Visual
-Studio 2015-2022 x64. Install it, then restart the shell and gateway.
+### Windows: DLL Load Failed
+
+On Windows, Pilot Router needs the Visual C++ Redistributable (Visual Studio
+2015-2022 x64). The portable installer and the PowerShell source installer
+handle this for you via `winget`, but the `uv tool install` path does not.
+
+If you see a `DLL load failed` error in the logs:
+
+1. Download and install the
+   [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
+2. Restart your terminal.
+3. Restart the gateway.
+
+### Router Shows "Degraded" or Pins Everything to One Tier
+
+This usually means the ONNX model bundle is missing or incomplete. If you
+installed from source, make sure you pulled the LFS files:
+
+```sh
+git lfs pull --include="src/agentos/agentos_router/models/**"
+```
+
+Then rebuild and reinstall. If you're on a release install, this shouldn't
+happen — but a fresh `agentos upgrade` never hurts.
+
+You can also switch to the `llm_judge` strategy, which needs no local model
+files at all:
+
+```sh
+agentos configure router --strategy llm_judge
+agentos gateway restart
+```
+
+---
 
 ## Search Does Not Work
 
-Inspect search providers:
+Search is a separate capability from the LLM provider. Check what's set up:
 
 ```sh
 agentos search list
 agentos search status
 ```
 
-Use DuckDuckGo for a no-key path:
+### Quick fix: use DuckDuckGo (no API key needed)
 
 ```sh
 agentos configure search --search-provider duckduckgo
+agentos gateway restart
 ```
 
-Use Brave with a key:
+### With Brave Search
 
 ```sh
 export BRAVE_SEARCH_API_KEY="..."
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+agentos gateway restart
 ```
+
+If search still fails, check your network. Some corporate proxies and VPNs
+block the search backend endpoints. Try `curl` against the search API directly
+to rule out network issues.
+
+---
+
+## Browser Tool Not Found or Not Working
+
+The browser tool is hidden by default until the `agent-browser` binary is
+installed. If the agent isn't offering browser actions, install it:
+
+```sh
+npm install -g agent-browser
+agent-browser install          # downloads Chromium
+```
+
+On Debian, Ubuntu, or Docker you'll also need system libraries:
+
+```sh
+agent-browser install --with-deps
+```
+
+Run `agentos doctor` — it tells you whether the binary and Chromium are
+present.
+
+### Headless Chromium Gets Blocked
+
+Some sites detect headless browsers and throw up CAPTCHAs or flat-out refuse
+to load. This is normal — headless Chromium is fingerprintable.
+
+The agent should not try to solve CAPTCHAs. If a site blocks you, switch to
+`web_search` / `web_fetch` instead, or use
+[attach mode](features/browser.md#attach-consent) with your own signed-in
+Chrome.
+
+### Attach Mode Won't Connect
+
+Attach mode requires your Chrome to be running with a debug port on
+localhost:
+
+```sh
+# macOS
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222
+
+# Linux
+google-chrome --remote-debugging-port=9222
+```
+
+Then set both the port and the consent flag in your config:
+
+```toml
+[browser]
+cdp_port = 9222
+attach_confirmed = true
+```
+
+The port alone isn't enough — you must also set `attach_confirmed = true`.
+This is on purpose, because attach mode can drive whatever your Chrome session
+is logged into.
+
+---
 
 ## Channel Config Saved but Channel Is Offline
 
-Restart the gateway after editing channel config:
+Saving a channel config writes it to disk, but the running gateway needs a
+restart to pick it up:
 
 ```sh
 agentos gateway restart
 agentos channels status <name> --json
 ```
 
-For webhook channels, confirm the gateway is reachable from the provider and
-that callback secrets match.
+For webhook-based channels (like Slack Events API), also make sure:
+
+- The gateway is reachable from the internet (or from Slack's servers).
+- The callback URL in your Slack app config points to the right port.
+- The signing secret matches what you configured in AgentOS.
+
+For Telegram, if the bot is online but messages aren't getting through, check
+that pairing is set up — see [`channels.md`](channels.md#telegram-account-pairing).
+
+---
 
 ## A Tool Was Denied
 
-Check sandbox and permission state:
+AgentOS has a layered sandbox. If a tool call gets rejected, check what's
+going on:
 
 ```sh
 agentos sandbox status
 agentos doctor
 ```
 
-For one-shot runs, choose an explicit permission posture:
+For one-shot runs, you can set an explicit permission level:
 
 ```sh
 agentos agent --permissions restricted -m "Read only"
 agentos agent --permissions full -m "Trusted local automation"
 ```
 
+If you keep hitting denials on something you trust, the workspace containment
+might be too strict. Check your workspace flags and sandbox posture in the
+Web UI under Agent Setup.
+
+---
+
 ## The Agent Seems to Forget Old Context
 
-Long sessions may compact old history. This is expected under context pressure.
+This is usually compaction at work. When a session gets long, AgentOS
+compresses older context to stay within the model's context window. It's
+expected behavior, not a bug.
 
-Inspect sessions:
+See what happened:
 
 ```sh
 agentos sessions show <session-key>
 agentos sessions export <session-key>
 ```
 
-If exact old text matters, keep it in a file, memory note, or exported session.
+If exact old text matters, keep it in a file, a memory note, or an exported
+transcript. The agent can always reference those when needed.
+
+To reduce how aggressively things get compacted, you can lower the
+compression threshold in your config — but that means higher token costs per
+turn.
+
+---
 
 ## A Turn Is Too Expensive or Too Slow
 
-Try:
+A few things to try:
 
 ```sh
 agentos configure router --router recommended
@@ -171,14 +325,75 @@ agentos diagnostics on
 agentos cost
 ```
 
-For automation:
+Diagnostics will show you which tier each turn landed on and why. If the
+router keeps picking expensive models for simple tasks, check your tier
+configuration.
+
+For bounded automation runs, set limits:
 
 ```sh
 agentos agent --max-iterations 20 --timeout 600 -m "Bounded task"
 ```
 
-For large tool outputs, see
-[`features/tool-compression.md`](features/tool-compression.md).
+Large tool outputs are a common culprit. Tool compression helps:
+
+- [`features/tool-compression.md`](features/tool-compression.md)
+- [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+
+---
+
+## Memory or Embeddings Not Working
+
+Memory search uses local ONNX embeddings by default. If recall feels broken:
+
+```sh
+agentos memory status
+```
+
+If the embedding model isn't loaded, you might be missing the `recommended`
+install extra. Reinstall with:
+
+```sh
+uv tool install --force "use-agent-os[recommended]"
+```
+
+For source installs, make sure the model weights are actually present (they
+come via Git LFS):
+
+```sh
+git lfs pull --include="src/agentos/memory/models/**"
+```
+
+If the model files are pointer stubs instead of real weights, embeddings won't
+load. `agentos doctor` catches this.
+
+---
+
+## Docker-Specific Issues
+
+If you're running AgentOS in a container, a few things behave differently:
+
+- The gateway can't bind to `127.0.0.1` inside Docker — use `--listen 0.0.0.0`
+  and map the port with `-p`.
+- ONNX Runtime and Pilot Router may need extra system packages depending on
+  your base image. The Dockerfile in the repo handles this, but a custom
+  image might not.
+- Volume mounts for `~/.agentos` are needed if you want config and sessions
+  to persist across container restarts.
+
+---
+
+## Still Stuck?
+
+If nothing above helped:
+
+1. Run `agentos doctor` and read the output carefully — it's usually pretty
+   good about pointing at the real problem.
+2. Check the [docs index](README.md) for the feature you're trying to use.
+3. Open a
+   [documentation issue](https://github.com/use-agent-os/agent-os/issues/new?template=docs_report.yml)
+   or a [bug report](https://github.com/use-agent-os/agent-os/issues/new?template=bug_report.yml)
+   on GitHub.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Stuff broke? Don't panic. Start here:
+Start with:
 
 ```sh
 agentos doctor
@@ -8,21 +8,18 @@ agentos doctor --json
 agentos gateway status
 ```
 
-The Web UI health view at <http://127.0.0.1:18791/control/> also tells you
-what's going on when the gateway is running.
-
----
+The Web UI health view at <http://127.0.0.1:18791/control/> also reports
+readiness and recovery steps when the gateway is running.
 
 ## `agentos` Command Not Found
 
-After installing with `uv tool install`, your shell doesn't know about the new
-binary yet. Either open a fresh terminal or refresh your PATH:
+After `uv tool install`, open a new terminal or run:
 
 ```sh
 uv tool update-shell
 ```
 
-Verify it's there:
+Check the executable:
 
 ```sh
 command -v agentos
@@ -34,197 +31,151 @@ On Windows PowerShell:
 where.exe agentos
 ```
 
-If that still doesn't work, make sure `uv` itself is installed and on your
-PATH. Run `uv --version` to check.
-
----
-
 ## Gateway Is Not Running
 
-The gateway needs to be up for most things to work. Start it:
+Start it:
 
 ```sh
 agentos gateway run
 ```
 
-Or kick it off in the background:
+Or use the managed background process:
 
 ```sh
 agentos gateway start --json
 agentos gateway status
 ```
 
-Then open <http://127.0.0.1:18791/control/> in your browser.
+Open:
 
-If it crashes on startup, check the logs:
-
-```sh
-agentos gateway status --json
+```text
+http://127.0.0.1:18791/control/
 ```
 
-A common reason: the config file has a typo or a provider isn't set up yet.
-Run `agentos doctor` — it usually points you right at the problem.
-
-For a deeper look at gateway lifecycle and config, see [`gateway.md`](gateway.md).
-
----
+For a focused gateway guide, see [`gateway.md`](gateway.md).
 
 ## Port Already In Use
 
-Something else is already listening on the default port. Either kill the
-other process, or just use a different port:
+Use another port:
 
 ```sh
 agentos gateway run --port 18792
 ```
 
-If you had a managed gateway running, stop it first:
+Or stop the managed gateway:
 
 ```sh
 agentos gateway stop
 ```
 
----
-
 ## Provider Not Configured
 
-No provider set up means no model to talk to. Run onboarding:
+Run:
 
 ```sh
 agentos onboard
-```
-
-Or configure one manually:
-
-```sh
 agentos providers list
 agentos providers configure openrouter
 ```
 
-For secrets, always use environment variables instead of hardcoding keys:
+Use environment-variable secrets:
 
 ```sh
 export OPENAI_API_KEY="sk-..."
 agentos configure provider --provider openai --api-key-env OPENAI_API_KEY
 ```
 
-If you're getting auth errors even after setting the key, double-check the
-variable name and that you exported it in the same shell session where you
-start the gateway. `.env` files are loaded at process start — changing one
-after the gateway is already running won't help until you restart.
-
----
-
 ## Router Dependency Problems
 
-Pilot Router is optional. If it can't load, AgentOS falls back to direct
-model routing — it still works, just without the cost optimization.
-
-If you want to disable it explicitly:
+If Pilot Router cannot load, AgentOS can still run with direct model
+routing. To disable the router:
 
 ```sh
 agentos configure router --router disabled
 agentos gateway restart
 ```
 
-### Windows: DLL Load Failed
+On Windows, ONNX Runtime may need the Visual C++ Redistributable for Visual
+Studio 2015-2022 x64. The portable installer and the PowerShell source
+installer install it via `winget`; the `uv tool install` path does not.
 
-On Windows, Pilot Router needs the Visual C++ Redistributable (Visual Studio
-2015-2022 x64). The portable installer and the PowerShell source installer
-handle this for you via `winget`, but the `uv tool install` path does not.
+If logs show `DLL load failed`:
 
-If you see a `DLL load failed` error in the logs:
+1. Install the
+   [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
+   (2015-2022 x64).
+2. Restart the shell and gateway.
 
-1. Download and install the
-   [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
-2. Restart your terminal.
-3. Restart the gateway.
+### Router Degraded or Pinned to One Tier
 
-### Router Shows "Degraded" or Pins Everything to One Tier
-
-This usually means the ONNX model bundle is missing or incomplete. If you
-installed from source, make sure you pulled the LFS files:
+A missing or incomplete ONNX model bundle is the usual cause. From a source
+checkout:
 
 ```sh
 git lfs pull --include="src/agentos/agentos_router/models/**"
 ```
 
-Then rebuild and reinstall. If you're on a release install, this shouldn't
-happen — but a fresh `agentos upgrade` never hurts.
+Then rebuild and reinstall. Release installs ship the bundle in the wheel.
 
-You can also switch to the `llm_judge` strategy, which needs no local model
-files at all:
+To use the `llm_judge` strategy instead (no local model files), pick it during
+onboarding or set:
 
-```sh
-agentos configure router --strategy llm_judge
-agentos gateway restart
+```toml
+[agentos_router]
+strategy = "llm_judge"
 ```
 
----
+Restart the gateway after changing the file. See
+[`configuration.md`](configuration.md#router-strategy).
 
 ## Search Does Not Work
 
-Search is a separate capability from the LLM provider. Check what's set up:
+Inspect search providers:
 
 ```sh
 agentos search list
 agentos search status
 ```
 
-### Quick fix: use DuckDuckGo (no API key needed)
+Use DuckDuckGo for a no-key path:
 
 ```sh
 agentos configure search --search-provider duckduckgo
-agentos gateway restart
 ```
 
-### With Brave Search
+Use Brave with a key:
 
 ```sh
 export BRAVE_SEARCH_API_KEY="..."
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
-agentos gateway restart
 ```
-
-If search still fails, check your network. Some corporate proxies and VPNs
-block the search backend endpoints. Try `curl` against the search API directly
-to rule out network issues.
-
----
 
 ## Browser Tool Not Found or Not Working
 
-The browser tool is hidden by default until the `agent-browser` binary is
-installed. If the agent isn't offering browser actions, install it:
+The browser tool stays hidden until the `agent-browser` binary is installed:
 
 ```sh
 npm install -g agent-browser
 agent-browser install          # downloads Chromium
 ```
 
-On Debian, Ubuntu, or Docker you'll also need system libraries:
+On Debian, Ubuntu, or Docker, also install system libraries:
 
 ```sh
 agent-browser install --with-deps
 ```
 
-Run `agentos doctor` — it tells you whether the binary and Chromium are
-present.
+`agentos doctor` reports whether the binary and Chromium are present.
 
 ### Headless Chromium Gets Blocked
 
-Some sites detect headless browsers and throw up CAPTCHAs or flat-out refuse
-to load. This is normal — headless Chromium is fingerprintable.
+Some sites detect headless Chromium and serve CAPTCHAs or refuse to load.
+Do not try to solve CAPTCHAs. Switch to `web_search` / `web_fetch`, or use
+[attach mode](features/browser.md#attach-consent) with a signed-in Chrome.
 
-The agent should not try to solve CAPTCHAs. If a site blocks you, switch to
-`web_search` / `web_fetch` instead, or use
-[attach mode](features/browser.md#attach-consent) with your own signed-in
-Chrome.
+### Attach Mode Will Not Connect
 
-### Attach Mode Won't Connect
-
-Attach mode requires your Chrome to be running with a debug port on
-localhost:
+Start Chrome with a debug port on localhost:
 
 ```sh
 # macOS
@@ -235,7 +186,7 @@ localhost:
 google-chrome --remote-debugging-port=9222
 ```
 
-Then set both the port and the consent flag in your config:
+Then set both the port and the consent flag:
 
 ```toml
 [browser]
@@ -243,81 +194,53 @@ cdp_port = 9222
 attach_confirmed = true
 ```
 
-The port alone isn't enough — you must also set `attach_confirmed = true`.
-This is on purpose, because attach mode can drive whatever your Chrome session
-is logged into.
-
----
+The port alone is not enough. `attach_confirmed = true` is required because
+attach mode can drive whatever the Chrome session is logged into.
 
 ## Channel Config Saved but Channel Is Offline
 
-Saving a channel config writes it to disk, but the running gateway needs a
-restart to pick it up:
+Restart the gateway after editing channel config:
 
 ```sh
 agentos gateway restart
 agentos channels status <name> --json
 ```
 
-For webhook-based channels (like Slack Events API), also make sure:
-
-- The gateway is reachable from the internet (or from Slack's servers).
-- The callback URL in your Slack app config points to the right port.
-- The signing secret matches what you configured in AgentOS.
-
-For Telegram, if the bot is online but messages aren't getting through, check
-that pairing is set up — see [`channels.md`](channels.md#telegram-account-pairing).
-
----
+For webhook channels, confirm the gateway is reachable from the provider and
+that callback secrets match.
 
 ## A Tool Was Denied
 
-AgentOS has a layered sandbox. If a tool call gets rejected, check what's
-going on:
+Check sandbox and permission state:
 
 ```sh
 agentos sandbox status
 agentos doctor
 ```
 
-For one-shot runs, you can set an explicit permission level:
+For one-shot runs, choose an explicit permission posture:
 
 ```sh
 agentos agent --permissions restricted -m "Read only"
 agentos agent --permissions full -m "Trusted local automation"
 ```
 
-If you keep hitting denials on something you trust, the workspace containment
-might be too strict. Check your workspace flags and sandbox posture in the
-Web UI under Agent Setup.
-
----
-
 ## The Agent Seems to Forget Old Context
 
-This is usually compaction at work. When a session gets long, AgentOS
-compresses older context to stay within the model's context window. It's
-expected behavior, not a bug.
+Long sessions may compact old history. This is expected under context pressure.
 
-See what happened:
+Inspect sessions:
 
 ```sh
 agentos sessions show <session-key>
 agentos sessions export <session-key>
 ```
 
-If exact old text matters, keep it in a file, a memory note, or an exported
-transcript. The agent can always reference those when needed.
-
-To reduce how aggressively things get compacted, you can lower the
-compression threshold in your config — but that means higher token costs per
-turn.
-
----
+If exact old text matters, keep it in a file, memory note, or exported session.
 
 ## A Turn Is Too Expensive or Too Slow
 
-A few things to try:
+Try:
 
 ```sh
 agentos configure router --router recommended
@@ -325,71 +248,53 @@ agentos diagnostics on
 agentos cost
 ```
 
-Diagnostics will show you which tier each turn landed on and why. If the
-router keeps picking expensive models for simple tasks, check your tier
-configuration.
-
-For bounded automation runs, set limits:
+For automation:
 
 ```sh
 agentos agent --max-iterations 20 --timeout 600 -m "Bounded task"
 ```
 
-Large tool outputs are a common culprit. Tool compression helps:
-
-- [`features/tool-compression.md`](features/tool-compression.md)
-- [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
-
----
+For large tool outputs, see
+[`features/tool-compression.md`](features/tool-compression.md).
 
 ## Memory or Embeddings Not Working
 
-Memory search uses local ONNX embeddings by default. If recall feels broken:
+Memory search uses local ONNX embeddings by default. Inspect:
 
 ```sh
 agentos memory status
 ```
 
-If the embedding model isn't loaded, you might be missing the `recommended`
-install extra. Reinstall with:
+If the embedding model is not loaded, the `recommended` extra may be missing:
 
 ```sh
 uv tool install --force "use-agent-os[recommended]"
 ```
 
-For source installs, make sure the model weights are actually present (they
-come via Git LFS):
+For source installs, pull the Git LFS weights:
 
 ```sh
 git lfs pull --include="src/agentos/memory/models/**"
 ```
 
-If the model files are pointer stubs instead of real weights, embeddings won't
-load. `agentos doctor` catches this.
-
----
+If the model files are pointer stubs instead of real weights, embeddings will
+not load. `agentos doctor` will report memory embeddings as FTS-only.
 
 ## Docker-Specific Issues
 
-If you're running AgentOS in a container, a few things behave differently:
+The shipped `Dockerfile` already sets `AGENTOS_LISTEN=0.0.0.0`. Custom images
+must bind `0.0.0.0` (`--listen 0.0.0.0` or `AGENTOS_LISTEN=0.0.0.0`) so the
+port mapping reaches the gateway. Binding `127.0.0.1` inside the container is
+valid, but the process is then unreachable from the host.
 
-- The gateway can't bind to `127.0.0.1` inside Docker — use `--listen 0.0.0.0`
-  and map the port with `-p`.
 - ONNX Runtime and Pilot Router may need extra system packages depending on
-  your base image. The Dockerfile in the repo handles this, but a custom
-  image might not.
-- Volume mounts for `~/.agentos` are needed if you want config and sessions
-  to persist across container restarts.
-
----
+  the base image. The repo Dockerfile handles this; a custom image may not.
+- Mount `~/.agentos` if config and sessions should persist across restarts.
 
 ## Still Stuck?
 
-If nothing above helped:
-
-1. Run `agentos doctor` and read the output carefully — it's usually pretty
-   good about pointing at the real problem.
-2. Check the [docs index](README.md) for the feature you're trying to use.
+1. Run `agentos doctor` and read the findings.
+2. Check the [docs index](README.md) for the feature you are using.
 3. Open a
    [documentation issue](https://github.com/use-agent-os/agent-os/issues/new?template=docs_report.yml)
    or a [bug report](https://github.com/use-agent-os/agent-os/issues/new?template=bug_report.yml)


### PR DESCRIPTION
Closes #403

Expands the troubleshooting page with the failure modes that show up after install. Existing sections keep their original terse voice.

**Changes:**
- Expand Windows DLL / Visual C++ Redistributable notes (`winget` vs `uv tool install`)
- Add **browser tool** install, headless blocked, and attach mode troubleshooting
- Add **router degraded** / missing model bundle / LFS pull, with `llm_judge` as `[agentos_router] strategy`
- Add **memory and embeddings** troubleshooting (`recommended` extra, LFS weights; doctor reports FTS-only)
- Add **Docker-specific issues** (bind `0.0.0.0` so the port mapping reaches the gateway; shipped Dockerfile already sets `AGENTOS_LISTEN`)
- Add **Still stuck** section with issue template links
- Add missing `features/browser.md` link to `docs/README.md` feature guides list