### PR TITLE
fix(onboarding): isolate capability summary test from ambient OpenAI keys

### DIFF
--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -36,9 +36,12 @@ def test_onboarding_finish_output_separates_summary_from_commands():
     assert "uv run" not in text
 
 
-def test_onboarding_finish_output_summarizes_all_capability_sections():
+def test_onboarding_finish_output_summarizes_all_capability_sections(monkeypatch):
     from agentos.gateway.config import GatewayConfig, LlmProviderConfig
     from agentos.onboarding.next_steps import format_next_steps
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
 
     cfg = GatewayConfig()
     cfg.llm = LlmProviderConfig(


### PR DESCRIPTION

Closes #372 

### Summary of Changes
- Added `monkeypatch` fixture to `test_onboarding_finish_output_summarizes_all_capability_sections` in `tests/test_onboarding/test_next_steps.py`.
- Cleared ambient `OPENAI_API_KEY` and `OPENAI_EMBEDDINGS_API_KEY` environment variables so the test deterministically verifies the unconfigured capability status (`Needs action`) regardless of local environment credentials.

### Verification
- `uv run pytest tests/test_onboarding/test_next_steps.py -vv` (11 passed)
- `uv run pytest tests/test_onboarding/ -q` (352 passed)
- `uv run ruff check tests/test_onboarding/test_next_steps.py` (All checks passed)
