### PR TITLE
fix(skills): enforce decompression caps and path safety on ClawHub zip downloads

### DIFF
--- a/src/agentos/skills/hub/clawhub.py
+++ b/src/agentos/skills/hub/clawhub.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import io
+import posixpath
+import zipfile
+
 import structlog
 
 from agentos.env import trust_env as _trust_env
@@ -11,13 +15,121 @@ log = structlog.get_logger(__name__)
 
 _DEFAULT_BASE_URL = "https://clawhub.ai"
 
+# Decompression security caps for untrusted zip downloads (prevent zip-bomb DoS).
+MAX_ZIP_ENTRIES: int = 500
+MAX_ZIP_ENTRY_BYTES: int = 5 * 1024 * 1024  # 5 MB per entry
+MAX_ZIP_TOTAL_BYTES: int = 25 * 1024 * 1024  # 25 MB total uncompressed
+_CHUNK_SIZE: int = 64 * 1024
+
+
+def _detect_root_prefix(infolist: list[zipfile.ZipInfo]) -> str:
+    """If all non-directory files are nested inside a single top-level folder,
+    return that folder prefix (e.g. 'slug/'). Otherwise return empty string."""
+    names = [
+        info.filename.replace("\\", "/").strip()
+        for info in infolist
+        if not info.is_dir() and not info.filename.replace("\\", "/").strip().endswith("/")
+    ]
+    if not names or "SKILL.md" in names:
+        return ""
+    first_parts = {name.split("/", 1)[0] for name in names if "/" in name}
+    if len(first_parts) == 1 and all("/" in name for name in names):
+        top = next(iter(first_parts))
+        if top and top != "." and top != "..":
+            return f"{top}/"
+    return ""
+
+
+def _normalize_zip_entry_path(name: str, root_prefix: str = "") -> str | None:
+    """Normalize and validate a zip entry path against zip-slip/traversal.
+
+    Handles POSIX and Windows separators, drive letters, and relative path escape.
+    Returns normalized relative path or None if unsafe.
+    """
+    clean = name.replace("\\", "/").strip()
+    if not clean or clean.endswith("/"):
+        return None
+
+    # Block absolute paths and Windows drive letters (e.g. /etc/passwd, C:\foo)
+    if clean.startswith("/"):
+        return None
+    segments = [s for s in clean.split("/") if s]
+    if any(len(s) >= 2 and s[1] == ":" and s[0].isalpha() for s in segments):
+        return None
+    # Block any directory traversal segments
+    if ".." in segments:
+        return None
+
+    # Strip single top-level archive directory if present
+    if root_prefix and clean.startswith(root_prefix):
+        clean = clean[len(root_prefix) :]
+    elif not root_prefix and "/" in clean and "SKILL.md" not in clean.split("/"):
+        # Fallback if single wrapper directory was not detected globally
+        parts = clean.split("/", 1)
+        if len(parts) > 1:
+            clean = parts[1]
+
+    normalized = posixpath.normpath(clean)
+    if (
+        normalized.startswith("..")
+        or normalized.startswith("/")
+        or ".." in normalized.split("/")
+        or normalized == "."
+    ):
+        return None
+    return normalized
+
+
+def _read_zip_entry_bounded(
+    zf: zipfile.ZipFile,
+    info: zipfile.ZipInfo,
+    *,
+    max_entry_bytes: int,
+    current_total_bytes: int,
+    max_total_bytes: int,
+) -> bytes | None:
+    """Read a zip entry with strict per-entry and total decompression ceilings.
+
+    Returns None if declared or streaming decompressed size exceeds the limits.
+    """
+    if info.file_size > max_entry_bytes:
+        return None
+    if current_total_bytes + info.file_size > max_total_bytes:
+        return None
+
+    chunks: list[bytes] = []
+    entry_read = 0
+    with zf.open(info) as stream:
+        while True:
+            chunk = stream.read(_CHUNK_SIZE)
+            if not chunk:
+                break
+            entry_read += len(chunk)
+            if entry_read > max_entry_bytes:
+                return None
+            if current_total_bytes + entry_read > max_total_bytes:
+                return None
+            chunks.append(chunk)
+    return b"".join(chunks)
+
 
 class ClawHubSource(SkillSource):
     """Skill source backed by the ClawHub community registry."""
 
-    def __init__(self, base_url: str = _DEFAULT_BASE_URL, token: str | None = None) -> None:
+    def __init__(
+        self,
+        base_url: str = _DEFAULT_BASE_URL,
+        token: str | None = None,
+        *,
+        max_zip_entries: int = MAX_ZIP_ENTRIES,
+        max_zip_entry_bytes: int = MAX_ZIP_ENTRY_BYTES,
+        max_zip_total_bytes: int = MAX_ZIP_TOTAL_BYTES,
+    ) -> None:
         self._base_url = base_url.rstrip("/")
         self._token = token
+        self.max_zip_entries = max_zip_entries
+        self.max_zip_entry_bytes = max_zip_entry_bytes
+        self.max_zip_total_bytes = max_zip_total_bytes
 
     @property
     def source_id(self) -> str:
@@ -75,9 +187,6 @@ class ClawHubSource(SkillSource):
         return results[:limit]
 
     async def fetch(self, identifier: str) -> SkillBundle | None:
-        import io
-        import zipfile
-
         import httpx
 
         url = f"{self._base_url}/api/v1/download"
@@ -107,31 +216,79 @@ class ClawHubSource(SkillSource):
         files: dict[str, str | bytes] = {}
         try:
             with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
-                import posixpath
+                infolist = zf.infolist()
+                if len(infolist) > self.max_zip_entries:
+                    log.warning(
+                        "clawhub.fetch_zip_entries_exceeded",
+                        identifier=identifier,
+                        count=len(infolist),
+                        max_entries=self.max_zip_entries,
+                    )
+                    return None
 
-                for name in zf.namelist():
-                    if name.endswith("/"):
+                declared_total = sum(info.file_size for info in infolist if not info.is_dir())
+                if declared_total > self.max_zip_total_bytes:
+                    log.warning(
+                        "clawhub.fetch_declared_size_exceeded",
+                        identifier=identifier,
+                        declared_size=declared_total,
+                        max_size=self.max_zip_total_bytes,
+                    )
+                    return None
+
+                root_prefix = _detect_root_prefix(infolist)
+                total_decompressed = 0
+                for info in infolist:
+                    if info.is_dir() or info.filename.endswith("/") or info.filename.endswith("\\"):
                         continue
-                    parts = name.split("/", 1)
-                    rel = parts[1] if len(parts) > 1 else parts[0]
-                    rel = posixpath.normpath(rel)
-                    if rel.startswith("..") or rel.startswith("/"):
+
+                    rel = _normalize_zip_entry_path(info.filename, root_prefix=root_prefix)
+                    if rel is None:
+                        log.warning(
+                            "clawhub.fetch_unsafe_path_skipped",
+                            identifier=identifier,
+                            filename=info.filename,
+                        )
                         continue
-                    try:
-                        raw = zf.read(name)
-                        if rel == "SKILL.md":
-                            files[rel] = raw.decode("utf-8")
-                        else:
-                            try:
-                                files[rel] = raw.decode("utf-8")
-                            except UnicodeDecodeError:
-                                files[rel] = raw
-                    except UnicodeDecodeError:
-                        log.warning("clawhub.fetch_bad_skill_encoding", identifier=identifier)
+
+                    raw = _read_zip_entry_bounded(
+                        zf,
+                        info,
+                        max_entry_bytes=self.max_zip_entry_bytes,
+                        current_total_bytes=total_decompressed,
+                        max_total_bytes=self.max_zip_total_bytes,
+                    )
+                    if raw is None:
+                        log.warning(
+                            "clawhub.fetch_decompression_limit_exceeded",
+                            identifier=identifier,
+                            filename=info.filename,
+                        )
                         return None
+
+                    total_decompressed += len(raw)
+
+                    if rel == "SKILL.md":
+                        try:
+                            files[rel] = raw.decode("utf-8")
+                        except UnicodeDecodeError:
+                            log.warning("clawhub.fetch_bad_skill_encoding", identifier=identifier)
+                            return None
+                    else:
+                        try:
+                            files[rel] = raw.decode("utf-8")
+                        except UnicodeDecodeError:
+                            files[rel] = raw
         except zipfile.BadZipFile:
             # Might be raw SKILL.md content — validate it has frontmatter
             if resp.text.strip().startswith("---"):
+                if len(resp.content) > self.max_zip_entry_bytes:
+                    log.warning(
+                        "clawhub.fetch_raw_skill_too_large",
+                        identifier=identifier,
+                        size=len(resp.content),
+                    )
+                    return None
                 files["SKILL.md"] = resp.text
             else:
                 log.warning(

--- a/tests/test_skills_hub_clawhub.py
+++ b/tests/test_skills_hub_clawhub.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Any
+
+import pytest
+
+from agentos.skills.hub.clawhub import (
+    ClawHubSource,
+    _normalize_zip_entry_path,
+)
+
+
+class _MockResponse:
+    def __init__(
+        self,
+        *,
+        content: bytes = b"",
+        status_code: int = 200,
+        json_data: dict[str, Any] | list[Any] | None = None,
+    ) -> None:
+        self.content = content
+        self.text = content.decode("utf-8", errors="replace")
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self) -> Any:
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _create_zip_bytes(files: dict[str, bytes | str]) -> bytes:
+    bio = io.BytesIO()
+    with zipfile.ZipFile(bio, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, content in files.items():
+            if isinstance(content, str):
+                zf.writestr(name, content.encode("utf-8"))
+            else:
+                zf.writestr(name, content)
+    return bio.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("path", "root_prefix", "expected"),
+    [
+        ("SKILL.md", "", "SKILL.md"),
+        ("skill-slug/SKILL.md", "skill-slug/", "SKILL.md"),
+        ("skill-slug/scripts/run.py", "skill-slug/", "scripts/run.py"),
+        ("skill-slug/scripts/sub/run.py", "skill-slug/", "scripts/sub/run.py"),
+        ("skill-slug/scripts/sub\\run.py", "skill-slug/", "scripts/sub/run.py"),
+        ("../outside.txt", "", None),
+        ("skill-slug/../outside.txt", "skill-slug/", None),
+        ("skill-slug/sub/../../outside.txt", "skill-slug/", None),
+        ("skill-slug/sub\\..\\..\\outside.txt", "skill-slug/", None),
+        ("C:\\Windows\\system32\\cmd.exe", "", None),
+        ("C:outside.txt", "", None),
+        ("/etc/passwd", "", None),
+        ("skill-slug/", "", None),
+        ("", "", None),
+    ],
+)
+def test_normalize_zip_entry_path(path: str, root_prefix: str, expected: str | None) -> None:
+    assert _normalize_zip_entry_path(path, root_prefix=root_prefix) == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_valid_zip_extracts_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    zip_bytes = _create_zip_bytes(
+        {
+            "my-skill/SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n# My Skill\n",
+            "my-skill/scripts/helper.py": "print('hello')",
+            "my-skill/assets/logo.bin": b"\x00\xff\xfe",
+        }
+    )
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=zip_bytes)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    source = ClawHubSource()
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is not None
+    assert bundle.name == "my-skill"
+    assert "SKILL.md" in bundle.files
+    assert bundle.files["SKILL.md"].startswith("---")
+    assert bundle.files["scripts/helper.py"] == "print('hello')"
+    assert bundle.files["assets/logo.bin"] == b"\x00\xff\xfe"
+
+
+@pytest.mark.asyncio
+async def test_fetch_raw_skill_md_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    raw_content = b"---\nname: my-skill\ndescription: Raw SKILL.md\n---\n# Raw\n"
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=raw_content)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    source = ClawHubSource()
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is not None
+    assert bundle.name == "my-skill"
+    assert "SKILL.md" in bundle.files
+    assert "Raw SKILL.md" in bundle.files["SKILL.md"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_blocks_excessive_entry_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    files = {
+        "my-skill/SKILL.md": "---\nname: my-skill\n---\n",
+        "my-skill/file1.txt": "a",
+        "my-skill/file2.txt": "b",
+        "my-skill/file3.txt": "c",
+    }
+    zip_bytes = _create_zip_bytes(files)
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=zip_bytes)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    source = ClawHubSource(max_zip_entries=3)
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_blocks_declared_size_exceeding_total_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    files = {
+        "my-skill/SKILL.md": "---\nname: my-skill\n---\n" + ("x" * 1000),
+        "my-skill/data.txt": "y" * 1000,
+    }
+    zip_bytes = _create_zip_bytes(files)
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=zip_bytes)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    source = ClawHubSource(max_zip_total_bytes=1500)
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_blocks_decompression_bomb_single_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    # Highly compressible stream (deflate bomb pattern)
+    bomb_data = b"0" * (100 * 1024)
+    files = {
+        "my-skill/SKILL.md": "---\nname: my-skill\n---\n",
+        "my-skill/bomb.txt": bomb_data,
+    }
+    zip_bytes = _create_zip_bytes(files)
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=zip_bytes)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    # Allow total size but restrict single entry size
+    source = ClawHubSource(max_zip_entry_bytes=10 * 1024, max_zip_total_bytes=500 * 1024)
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_blocks_decompression_bomb_cumulative_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    files = {
+        "my-skill/SKILL.md": "---\nname: my-skill\n---\n",
+        "my-skill/part1.txt": b"1" * (5 * 1024),
+        "my-skill/part2.txt": b"2" * (5 * 1024),
+    }
+    zip_bytes = _create_zip_bytes(files)
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=zip_bytes)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    # Entry cap is 6KB (each part passes), but total cap is 8KB (combined parts fail)
+    source = ClawHubSource(max_zip_entry_bytes=6 * 1024, max_zip_total_bytes=8 * 1024)
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_filters_zip_slip_and_preserves_safe_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    files = {
+        "my-skill/SKILL.md": "---\nname: my-skill\n---\n# Title\n",
+        "my-skill/../evil.txt": "malicious",
+        "my-skill/sub/..\\..\\evil_win.txt": "malicious_win",
+        "my-skill/safe.txt": "safe content",
+    }
+    zip_bytes = _create_zip_bytes(files)
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _MockResponse:
+            return _MockResponse(content=zip_bytes)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    source = ClawHubSource()
+    bundle = await source.fetch("my-skill")
+
+    assert bundle is not None
+    assert "SKILL.md" in bundle.files
+    assert "safe.txt" in bundle.files
+    assert "../evil.txt" not in bundle.files
+    assert "evil.txt" not in bundle.files
+    assert "evil_win.txt" not in bundle.files


### PR DESCRIPTION
Closes #357

### Summary of Changes
- Enforced decompression caps on ClawHub zip downloads:
  - `max_zip_entries` ceiling (default 500 entries).
  - `max_zip_entry_bytes` per-file ceiling (default 5 MB).
  - `max_zip_total_bytes` total uncompressed size ceiling (default 25 MB).
  - Chunked stream reading (`_read_zip_entry_bounded`) to guard against deceptive declared header sizes in zip bombs.
- Hardened zip-slip protection in `_normalize_zip_entry_path` to block `..`, `/`, and Windows drive letters across both POSIX and Windows separators.
- Added comprehensive unit tests in `tests/test_skills_hub_clawhub.py`.

### Verification
- `uv run pytest tests/test_skills_hub_clawhub.py -vv` (21 passed)
- `uv run pytest tests/test_skills_hub_installer_security.py -vv` (7 passed)
- `uv run ruff check src/agentos/skills/hub/clawhub.py tests/test_skills_hub_clawhub.py` (All checks passed)
- `uv run mypy src/agentos/skills/hub/clawhub.py --show-error-codes` (No issues found)

