### PR TITLE
fix(webui): export inline token chart as image instead of json on download (#247)

### DIFF
--- a/frontend/src/views/chat/chat-unified.css
+++ b/frontend/src/views/chat/chat-unified.css
@@ -327,10 +327,14 @@
 
 .chat-surface .msg-artifact-chart__download {
   flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: 0.6875rem;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .chat-surface .msg-artifact-chart__download:hover {

--- a/frontend/src/views/chat/transcript/artifacts.test.ts
+++ b/frontend/src/views/chat/transcript/artifacts.test.ts
@@ -283,29 +283,18 @@ describe('createArtifactRenderer chart artifacts', () => {
     )
   })
 
-  it('keeps the download on the anchor, which the click handler steps aside for', () => {
+  it('renders a download button rather than a raw-json anchor', () => {
     const { deps } = chartRendererDeps()
 
     const container = document.createElement('div')
     container.innerHTML = createArtifactRenderer(deps).renderArtifacts([CHART_ARTIFACT])
 
-    const link = container.querySelector<HTMLElement>('.msg-artifact-chart__download')
-    // Resolving to itself and being an anchor is exactly what makes the
-    // delegated handler leave it to the browser's native download.
-    expect(link?.closest('[data-artifact-download]')).toBe(link)
-    expect(link?.tagName).toBe('A')
-  })
-
-  it('still offers the raw payload as a download', () => {
-    const { deps } = chartRendererDeps()
-
-    const container = document.createElement('div')
-    container.innerHTML = createArtifactRenderer(deps).renderArtifacts([CHART_ARTIFACT])
-
-    expect(container.querySelector('.msg-artifact-chart__download')).toHaveAttribute(
-      'download',
-      'bonk.chart.json',
-    )
+    const button = container.querySelector<HTMLElement>('.msg-artifact-chart__download')
+    expect(button?.tagName).toBe('BUTTON')
+    expect(button?.getAttribute('type')).toBe('button')
+    // No data-artifact-download, so the delegated handler does not fetch JSON.
+    expect(button?.hasAttribute('data-artifact-download')).toBe(false)
+    expect(button?.textContent).toBe('Download')
   })
 
   it('hands a streamed chart artifact to the mounter as soon as it lands', () => {

--- a/frontend/src/views/chat/transcript/artifacts.ts
+++ b/frontend/src/views/chat/transcript/artifacts.ts
@@ -307,16 +307,15 @@ export function createArtifactRenderer(deps: ArtifactRendererDeps) {
         // `data-chart-src` and draws into `__canvas`. Geometry is reserved in
         // CSS so the transcript does not jump when the chart lands.
         //
-        // `data-artifact-download` stays OFF the host and lives only on the
-        // Download anchor below — same as the audio card. The transcript's
-        // delegated click handler downloads any non-anchor element carrying
-        // that attribute, so stamping it here would turn every pan, zoom and
-        // crosshair click on the canvas into a file download.
+        // The download button exports the rendered chart as an image (PNG) via
+        // chart.takeScreenshot(). `data-artifact-download` stays OFF both the
+        // host and the button so delegated transcript download handling does
+        // not intercept it or fetch the raw JSON artifact payload.
         const payloadUrl = artifactPreviewUrl(artifact || {}, { sessionKey, token })
         html += `<div class="msg-artifact-chart" data-chart-src="${escAttr(payloadUrl)}" data-artifact-category="${escAttr(category)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}">
           <div class="msg-artifact-chart__header">
             <span class="msg-artifact-chart__name">${esc(name)}</span>
-            <a class="msg-artifact-chart__download" href="${escAttr(downloadHref)}" download="${escAttr(name)}" data-artifact-download="${escAttr(downloadUrl)}">${escAttr(t('chat.artifactDownload'))}</a>
+            <button type="button" class="msg-artifact-chart__download" aria-label="${escAttr(t('chat.artifactDownload'))}">${escAttr(t('chat.artifactDownload'))}</button>
           </div>
           <div class="msg-artifact-chart__readout"></div>
           <div class="msg-artifact-chart__canvas"></div>

--- a/frontend/src/views/chat/transcript/chart.test.ts
+++ b/frontend/src/views/chat/transcript/chart.test.ts
@@ -13,9 +13,11 @@ import { createArtifactRenderer } from './artifacts'
 import {
   CHART_ARTIFACT_MIME,
   candleReadout,
+  chartImageFilename,
   chartTheme,
   compactNumber,
   createChartMounter,
+  exportChartAsImage,
   formatCandleTime,
   hasVolume,
   isChartArtifact,
@@ -41,6 +43,7 @@ interface FakeChart {
   remove: ReturnType<typeof vi.fn>
   subscribeCrosshairMove: ReturnType<typeof vi.fn>
   unsubscribeCrosshairMove: ReturnType<typeof vi.fn>
+  takeScreenshot: ReturnType<typeof vi.fn>
   series: FakeSeries[]
   crosshair: CrosshairHandler[]
 }
@@ -57,6 +60,8 @@ vi.mock('lightweight-charts', () => ({
 function makeFakeChart(): FakeChart {
   const series: FakeSeries[] = []
   const crosshair: CrosshairHandler[] = []
+  const fakeCanvas = document.createElement('canvas')
+  fakeCanvas.toDataURL = vi.fn(() => 'data:image/png;base64,fake')
   return {
     series,
     crosshair,
@@ -76,6 +81,7 @@ function makeFakeChart(): FakeChart {
       const at = crosshair.indexOf(handler)
       if (at >= 0) crosshair.splice(at, 1)
     }),
+    takeScreenshot: vi.fn(() => fakeCanvas),
   }
 }
 
@@ -89,14 +95,16 @@ function createdCharts(): FakeChart[] {
  * the real renderer in artifacts.test.ts; this builds the same shape so the
  * mounter can be exercised on its own.
  */
-function placeholder(url: string): HTMLElement {
+function placeholder(url: string, name = 'bonk.chart.json'): HTMLElement {
   const host = document.createElement('div')
   host.className = 'msg-artifact-chart'
   if (url) host.dataset.chartSrc = url
   else host.setAttribute('data-chart-src', '')
+  host.dataset.artifactName = name
   host.innerHTML =
     '<div class="msg-artifact-chart__header">' +
-    '<span class="msg-artifact-chart__name">bonk.chart.json</span>' +
+    `<span class="msg-artifact-chart__name">${name}</span>` +
+    '<button type="button" class="msg-artifact-chart__download">Download</button>' +
     '</div>' +
     '<div class="msg-artifact-chart__readout"></div>' +
     '<div class="msg-artifact-chart__canvas"></div>' +
@@ -724,5 +732,91 @@ describe('createChartMounter readout', () => {
     const unsubOrder = chart?.unsubscribeCrosshairMove.mock.invocationCallOrder[0] ?? 0
     const removeOrder = chart?.remove.mock.invocationCallOrder[0] ?? 0
     expect(unsubOrder).toBeLessThan(removeOrder)
+  })
+
+  it('wires the download button to export the chart as a PNG image', async () => {
+    const host = placeholder('/api/v1/artifacts/art-1', 'bonk.chart.json')
+    const root = mountRoot(host)
+    const mounter = createChartMounter({
+      fetchPayload: async () => payloadBody(),
+      getTheme: () => 'dark',
+    })
+
+    mounter.mountCharts(root)
+
+    await vi.waitFor(() => expect(createdCharts()).toHaveLength(1))
+    const downloadBtn = host.querySelector<HTMLButtonElement>('.msg-artifact-chart__download')
+    expect(downloadBtn).not.toBeNull()
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    downloadBtn?.click()
+
+    expect(createdCharts()[0]?.takeScreenshot).toHaveBeenCalled()
+    expect(clickSpy).toHaveBeenCalled()
+    clickSpy.mockRestore()
+  })
+})
+
+/* ── chartImageFilename ─────────────────────────────────────────────────── */
+
+describe('chartImageFilename', () => {
+  it('replaces .json with .png', () => {
+    expect(chartImageFilename('bonk.chart.json')).toBe('bonk.chart.png')
+    expect(chartImageFilename('chart.json')).toBe('chart.png')
+    expect(chartImageFilename('sol-usd.JSON')).toBe('sol-usd.png')
+  })
+
+  it('preserves existing .png extensions', () => {
+    expect(chartImageFilename('chart.png')).toBe('chart.png')
+    expect(chartImageFilename('preview.PNG')).toBe('preview.PNG')
+  })
+
+  it('appends .png when no extension is provided', () => {
+    expect(chartImageFilename('bonk-chart')).toBe('bonk-chart.png')
+  })
+
+  it('defaults to chart.png when empty or nullish', () => {
+    expect(chartImageFilename('')).toBe('chart.png')
+    expect(chartImageFilename(null)).toBe('chart.png')
+    expect(chartImageFilename(undefined)).toBe('chart.png')
+  })
+})
+
+/* ── exportChartAsImage ─────────────────────────────────────────────────── */
+
+describe('exportChartAsImage', () => {
+  it('takes a screenshot from the chart and triggers anchor download', () => {
+    const fakeCanvas = document.createElement('canvas')
+    fakeCanvas.toDataURL = vi.fn(() => 'data:image/png;base64,sample')
+    const fakeChart = {
+      takeScreenshot: vi.fn(() => fakeCanvas),
+    }
+
+    let downloadedHref = ''
+    let downloadedName = ''
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadedHref = this.href
+      downloadedName = this.download
+    })
+
+    const ok = exportChartAsImage(fakeChart, 'solana.chart.json')
+    expect(ok).toBe(true)
+    expect(fakeChart.takeScreenshot).toHaveBeenCalled()
+    expect(fakeCanvas.toDataURL).toHaveBeenCalledWith('image/png')
+    expect(downloadedHref).toBe('data:image/png;base64,sample')
+    expect(downloadedName).toBe('solana.chart.png')
+
+    clickSpy.mockRestore()
+  })
+
+  it('returns false when takeScreenshot or toDataURL fails', () => {
+    const brokenChart = {
+      takeScreenshot: vi.fn(() => {
+        throw new Error('Screenshot failed')
+      }),
+    }
+    expect(exportChartAsImage(brokenChart, 'chart')).toBe(false)
   })
 })

--- a/frontend/src/views/chat/transcript/chart.ts
+++ b/frontend/src/views/chat/transcript/chart.ts
@@ -273,6 +273,45 @@ export function candleReadout(candle: ChartCandle, decimals: number): CandleRead
   }
 }
 
+/**
+ * Derive the PNG filename for a chart image export.
+ *
+ * Replaces `.json` (e.g. `bonk.chart.json` -> `bonk.chart.png`) or appends
+ * `.png` if not already an image filename.
+ */
+export function chartImageFilename(name: string | null | undefined): string {
+  const trimmed = (name || '').trim()
+  if (!trimmed) return 'chart.png'
+  if (trimmed.toLowerCase().endsWith('.png')) return trimmed
+  if (trimmed.toLowerCase().endsWith('.json')) {
+    return `${trimmed.slice(0, -5)}.png`
+  }
+  return `${trimmed}.png`
+}
+
+/**
+ * Export a chart instance as a downloaded PNG image.
+ */
+export function exportChartAsImage(
+  chart: { takeScreenshot: () => HTMLCanvasElement },
+  filename: string,
+): boolean {
+  try {
+    const canvas = chart.takeScreenshot()
+    if (!canvas || typeof canvas.toDataURL !== 'function') return false
+    const dataUrl = canvas.toDataURL('image/png')
+    const a = document.createElement('a')
+    a.href = dataUrl
+    a.download = chartImageFilename(filename)
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    return true
+  } catch {
+    return false
+  }
+}
+
 /* ── Injected mounter dependencies ──────────────────────────────────────── */
 
 /**
@@ -534,9 +573,24 @@ export function createChartMounter(deps: ChartMounterDeps) {
       observer.observe(canvasHost)
     }
 
+    const downloadBtn = host.querySelector<HTMLElement>('.msg-artifact-chart__download')
+    let downloadClickListener: ((event: MouseEvent) => void) | null = null
+    if (downloadBtn) {
+      const filename = chartImageFilename(host.dataset.artifactName || payload.title || 'chart')
+      downloadClickListener = (event: MouseEvent): void => {
+        event.preventDefault()
+        event.stopPropagation()
+        exportChartAsImage(chart, filename)
+      }
+      downloadBtn.addEventListener('click', downloadClickListener)
+    }
+
     const entry: LiveChart = {
       applyTheme,
       dispose: () => {
+        if (downloadClickListener && downloadBtn) {
+          downloadBtn.removeEventListener('click', downloadClickListener)
+        }
         // Unsubscribe before remove(): the chart tears its internals down and
         // will not accept the call afterwards.
         crosshairUnsubscribe?.()


### PR DESCRIPTION
### Summary of Changes
- Fix Inline Token Chart download button exporting `.json` instead of `.png` image (#247).
- Implemented `exportChartAsImage` and `chartImageFilename` in `chart.ts` using lightweight-charts' `takeScreenshot()` API.
- Updated chart placeholder markup in `artifacts.ts` to render a download `<button>` instead of an `<a>` tag.
- Added button reset and pointer styling in `chat-unified.css`.
- Added unit tests in `chart.test.ts` and updated `artifacts.test.ts`.

Closes #247