### PR TITLE
fix(gateway): remove query token fallback and disable uvicorn access log

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -26,13 +26,14 @@ before the gateway will bind to a public address (`0.0.0.0` / LAN): the startup
 guard refuses to serve an unauthenticated public bind, and a token is
 auto-generated when unset. See [`gateway.md`](gateway.md) for bind safety.
 
-When auth is enabled, send the token any one of these ways (checked in order):
+When auth is enabled, send the token via HTTP headers (checked in order):
 
 ```text
 Authorization: Bearer <token>
 X-Agentos-Token: <token>
-?token=<token>          # query parameter
 ```
+
+> **Note:** Query-string tokens (`?token=<token>`) are rejected (`401 Unauthorized`). Passing tokens in URL query parameters is not supported to prevent token leaks in access logs, browser history, and HTTP referrers.
 
 `/health` and `/ready` never require a token. Cross-origin browser requests are
 governed by CORS configuration regardless of auth mode.

--- a/src/agentos/gateway/app.py
+++ b/src/agentos/gateway/app.py
@@ -215,10 +215,7 @@ def create_gateway_app(
         auth_header = request.headers.get("authorization", "")
         if auth_header.startswith("Bearer "):
             return auth_header[7:]
-        token_header = request.headers.get("x-agentos-token")
-        if token_header:
-            return token_header
-        return request.query_params.get("token")
+        return request.headers.get("x-agentos-token")
 
     def _make_ctx(request: Request | None = None) -> RpcContext:
         from agentos.gateway.auth import denied_access, resolve_auth

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -2400,7 +2400,7 @@ async def start_gateway_server(
             "host": config.host,
             "port": config.port,
             "log_level": "info" if not config.debug else "debug",
-            "access_log": False,
+            "access_log": config.debug,
         }
         if config.tls.keyfile and config.tls.certfile:
             uvicorn_kwargs["ssl_keyfile"] = config.tls.keyfile

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -2400,6 +2400,7 @@ async def start_gateway_server(
             "host": config.host,
             "port": config.port,
             "log_level": "info" if not config.debug else "debug",
+            "access_log": False,
         }
         if config.tls.keyfile and config.tls.certfile:
             uvicorn_kwargs["ssl_keyfile"] = config.tls.keyfile

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -224,10 +224,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         auth_header = request.headers.get("authorization", "")
         if auth_header.startswith("Bearer "):
             return auth_header[7:]
-        token_header = request.headers.get("x-agentos-token")
-        if token_header:
-            return token_header
-        return request.query_params.get("token")
+        return request.headers.get("x-agentos-token")
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):

--- a/src/agentos/gateway/uploads.py
+++ b/src/agentos/gateway/uploads.py
@@ -278,11 +278,9 @@ class UploadStore:
 def _extract_authorization_token(request: Request) -> str | None:
     """Header-only token extraction.
 
-    The multipart upload endpoint deliberately rejects query-string token auth
-    (which the existing JSON-RPC routes accept for legacy convenience). A
-    cross-origin attacker can craft a multipart POST with a forged ``?token=…``
-    query but cannot set arbitrary headers on a plain ``<form>`` submission, so
-    requiring the ``Authorization`` header closes that surface.
+    Like all gateway endpoints, the multipart upload endpoint requires
+    header-based token auth (``Authorization: Bearer <token>`` or
+    ``x-agentos-token: <token>``) and rejects query-string tokens.
     """
 
     auth_header = request.headers.get("authorization", "")

--- a/tests/test_gateway/test_auth_no_query_token.py
+++ b/tests/test_gateway/test_auth_no_query_token.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from starlette.requests import Request
@@ -82,41 +82,90 @@ def test_gateway_endpoints_reject_query_token() -> None:
         assert res_header.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_boot_gateway_disables_uvicorn_access_log() -> None:
+def test_boot_gateway_disables_uvicorn_access_log(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Gateway boot sequence configures uvicorn with access_log=False to prevent URL leaks."""
-    from agentos.gateway.boot import start_gateway_server
+    import asyncio
+    from types import SimpleNamespace
 
-    config = GatewayConfig(host="127.0.0.1", port=18791)
+    from agentos.gateway import boot
 
     captured_config: dict[str, Any] = {}
 
-    with (
-        patch("uvicorn.Config") as mock_uv_config,
-        patch("uvicorn.Server") as mock_uv_server,
-        patch("agentos.gateway.boot.create_background_task") as mock_bg_task,
-        patch("agentos.gateway.boot.preload_agentos_router_runtime") as _,
-    ):
-        mock_server_instance = MagicMock()
-
-        async def _dummy_serve() -> None:
+    class FakeTurnRunner:
+        def __init__(self, **_kwargs: Any) -> None:
             pass
 
-        mock_server_instance.serve = _dummy_serve
-        mock_uv_server.return_value = mock_server_instance
-        def _dummy_bg_task(coro: Any) -> Any:
-            if hasattr(coro, "close"):
-                coro.close()
-            return MagicMock()
+        def set_session_lock_provider(self, _provider: Any) -> None:
+            pass
 
-        mock_bg_task.side_effect = _dummy_bg_task
-
-        def _capture_config(*args: Any, **kwargs: Any) -> Any:
+    class FakeUvicornConfig:
+        def __init__(self, **kwargs: Any) -> None:
             captured_config.update(kwargs)
-            return MagicMock()
 
-        mock_uv_config.side_effect = _capture_config
+    class FakeServer:
+        def __init__(self, _config: Any) -> None:
+            self.should_exit = False
 
-        handle = await start_gateway_server(config=config, run=True)
-        assert handle is not None
-        assert captured_config.get("access_log") is False
+        async def serve(self) -> None:
+            return None
+
+    async def fake_build_services(**kwargs: Any) -> Any:
+        config = kwargs["config"]
+
+        async def close() -> None:
+            return None
+
+        return SimpleNamespace(
+            provider_selector=object(),
+            tool_registry=object(),
+            session_manager=object(),
+            skill_loader=object(),
+            usage_tracker=object(),
+            config=config,
+            memory_sync_managers={},
+            model_catalog=None,
+            memory_retrievers={},
+            turn_capture_services={},
+            cron_scheduler=None,
+            task_runtime=None,
+            agent_registry=None,
+            memory_managers={},
+            memory_stores={},
+            _turn_runner_ref=[],
+            close=close,
+        )
+
+    def fake_create_background_task(coro: Any) -> Any:
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        return asyncio.create_task(asyncio.sleep(0))
+
+    monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr(boot, "build_services", fake_build_services)
+    monkeypatch.setattr(boot, "_setup_file_logging", lambda config: None)
+    monkeypatch.setattr(boot, "emit_skill_filter_banner", lambda config: None)
+    monkeypatch.setattr(boot, "create_background_task", fake_create_background_task)
+    monkeypatch.setattr(boot.uvicorn, "Config", FakeUvicornConfig)
+    monkeypatch.setattr(boot.uvicorn, "Server", FakeServer)
+    monkeypatch.setattr("agentos.gateway.pidlock.GatewayPidLock.acquire", lambda self: None)
+    monkeypatch.setattr("agentos.gateway.pidlock.GatewayPidLock.release", lambda self: None)
+
+    config = GatewayConfig(
+        state_dir=str(tmp_path / "state"),
+        workspace_dir=str(tmp_path / "workspace"),
+        control_ui={"enabled": False},
+        channels={"channels": []},
+    )
+
+    async def run_case() -> None:
+        server = await boot.start_gateway_server(config=config, run=True)
+        try:
+            assert captured_config.get("access_log") is False
+        finally:
+            await server.close()
+
+    asyncio.run(run_case())

--- a/tests/test_gateway/test_auth_no_query_token.py
+++ b/tests/test_gateway/test_auth_no_query_token.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from agentos.gateway.app import create_gateway_app
+from agentos.gateway.config import AuthConfig, GatewayConfig
+from agentos.gateway.middleware import AuthMiddleware
+
+
+def test_auth_middleware_extract_token_rejects_query_param() -> None:
+    """AuthMiddleware._extract_token extracts from headers only, not query params."""
+    middleware = AuthMiddleware(
+        app=MagicMock(),
+        config=GatewayConfig(auth=AuthConfig(mode="token", token="my-secret")),
+    )
+
+    # 1. Query parameter only -> None
+    scope_query: dict[str, Any] = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/sessions",
+        "query_string": b"token=my-secret",
+        "headers": [],
+    }
+    req_query = Request(scope_query)
+    assert middleware._extract_token(req_query) is None
+
+    # 2. Authorization: Bearer header -> extracted
+    scope_bearer: dict[str, Any] = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/sessions",
+        "query_string": b"",
+        "headers": [(b"authorization", b"Bearer my-secret")],
+    }
+    req_bearer = Request(scope_bearer)
+    assert middleware._extract_token(req_bearer) == "my-secret"
+
+    # 3. x-agentos-token header -> extracted
+    scope_custom: dict[str, Any] = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/sessions",
+        "query_string": b"",
+        "headers": [(b"x-agentos-token", b"my-secret")],
+    }
+    req_custom = Request(scope_custom)
+    assert middleware._extract_token(req_custom) == "my-secret"
+
+
+def test_gateway_endpoints_reject_query_token() -> None:
+    """REST and RPC endpoints reject ?token= query parameter and require headers."""
+    config = GatewayConfig(auth=AuthConfig(mode="token", token="secret-123"))
+    app = create_gateway_app(config=config)
+
+    with TestClient(app, base_url="http://localhost") as client:
+        # 1. Query token is rejected with 401 Unauthorized
+        res_query = client.get("/api/sessions?token=secret-123")
+        assert res_query.status_code == 401
+        assert res_query.json().get("code") == "UNAUTHORIZED"
+
+        res_config_query = client.get("/api/config?token=secret-123")
+        assert res_config_query.status_code == 401
+
+        # 2. Bearer header is accepted
+        res_bearer = client.get(
+            "/api/sessions",
+            headers={"Authorization": "Bearer secret-123"},
+        )
+        assert res_bearer.status_code == 200
+
+        # 3. x-agentos-token header is accepted
+        res_header = client.get(
+            "/api/sessions",
+            headers={"x-agentos-token": "secret-123"},
+        )
+        assert res_header.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_boot_gateway_disables_uvicorn_access_log() -> None:
+    """Gateway boot sequence configures uvicorn with access_log=False to prevent URL leaks."""
+    from agentos.gateway.boot import start_gateway_server
+
+    config = GatewayConfig(host="127.0.0.1", port=18791)
+
+    captured_config: dict[str, Any] = {}
+
+    with (
+        patch("uvicorn.Config") as mock_uv_config,
+        patch("uvicorn.Server") as mock_uv_server,
+        patch("agentos.gateway.boot.create_background_task") as mock_bg_task,
+        patch("agentos.gateway.boot.preload_agentos_router_runtime") as _,
+    ):
+        mock_server_instance = MagicMock()
+
+        async def _dummy_serve() -> None:
+            pass
+
+        mock_server_instance.serve = _dummy_serve
+        mock_uv_server.return_value = mock_server_instance
+        def _dummy_bg_task(coro: Any) -> Any:
+            if hasattr(coro, "close"):
+                coro.close()
+            return MagicMock()
+
+        mock_bg_task.side_effect = _dummy_bg_task
+
+        def _capture_config(*args: Any, **kwargs: Any) -> Any:
+            captured_config.update(kwargs)
+            return MagicMock()
+
+        mock_uv_config.side_effect = _capture_config
+
+        handle = await start_gateway_server(config=config, run=True)
+        assert handle is not None
+        assert captured_config.get("access_log") is False

--- a/tests/test_gateway/test_auth_no_query_token.py
+++ b/tests/test_gateway/test_auth_no_query_token.py
@@ -82,11 +82,11 @@ def test_gateway_endpoints_reject_query_token() -> None:
         assert res_header.status_code == 200
 
 
-def test_boot_gateway_disables_uvicorn_access_log(
+def test_boot_gateway_access_log_reflects_debug_mode(
     tmp_path: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Gateway boot sequence configures uvicorn with access_log=False to prevent URL leaks."""
+    """Gateway boot sequence configures uvicorn access_log to follow config.debug."""
     import asyncio
     from types import SimpleNamespace
 
@@ -154,18 +154,35 @@ def test_boot_gateway_disables_uvicorn_access_log(
     monkeypatch.setattr("agentos.gateway.pidlock.GatewayPidLock.acquire", lambda self: None)
     monkeypatch.setattr("agentos.gateway.pidlock.GatewayPidLock.release", lambda self: None)
 
-    config = GatewayConfig(
-        state_dir=str(tmp_path / "state"),
-        workspace_dir=str(tmp_path / "workspace"),
-        control_ui={"enabled": False},
-        channels={"channels": []},
-    )
-
-    async def run_case() -> None:
-        server = await boot.start_gateway_server(config=config, run=True)
+    async def run_cases() -> None:
+        # Default / debug=False -> access_log is False
+        config_default = GatewayConfig(
+            state_dir=str(tmp_path / "state1"),
+            workspace_dir=str(tmp_path / "workspace1"),
+            control_ui={"enabled": False},
+            channels={"channels": []},
+            debug=False,
+        )
+        server_default = await boot.start_gateway_server(config=config_default, run=True)
         try:
             assert captured_config.get("access_log") is False
         finally:
-            await server.close()
+            await server_default.close()
 
-    asyncio.run(run_case())
+        captured_config.clear()
+
+        # debug=True -> access_log is True
+        config_debug = GatewayConfig(
+            state_dir=str(tmp_path / "state2"),
+            workspace_dir=str(tmp_path / "workspace2"),
+            control_ui={"enabled": False},
+            channels={"channels": []},
+            debug=True,
+        )
+        server_debug = await boot.start_gateway_server(config=config_debug, run=True)
+        try:
+            assert captured_config.get("access_log") is True
+        finally:
+            await server_debug.close()
+
+    asyncio.run(run_cases())

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -550,13 +550,7 @@ def test_upload_unauthenticated_rejected() -> None:
 
 
 def test_upload_rejects_query_token_when_disallowed_for_multipart() -> None:
-    """Query-string tokens are rejected for the multipart upload endpoint.
-
-    The existing JSON-RPC routes accept ``?token=…`` as a convenience for
-    browser-side consumers, but a multipart POST is the kind of request a
-    malicious cross-origin page can craft, so we force the Authorization header
-    for /api/v1/files/upload specifically.
-    """
+    """Query-string tokens are rejected for all endpoints including multipart uploads."""
     pytest.importorskip("starlette.testclient")
     from starlette.applications import Starlette
     from starlette.testclient import TestClient
@@ -572,12 +566,11 @@ def test_upload_rejects_query_token_when_disallowed_for_multipart() -> None:
     app.add_middleware(AuthMiddleware, config=config)
 
     with TestClient(app) as client:
-        # Auth mode passes the AuthMiddleware via the query token (legacy
-        # convenience) but the upload handler MUST refuse it.
+        # Query-string token is rejected by AuthMiddleware with 401
         response = client.post(
             "/api/v1/files/upload?token=secret",
             files={"file": ("x.pdf", b"%PDF-1.4\n", "application/pdf")},
         )
     assert response.status_code == 401, response.text
     body: dict[str, Any] = response.json()
-    assert "Authorization" in body.get("error", "") or "header" in body.get("error", "").lower()
+    assert body.get("code") == "UNAUTHORIZED" or "Authorization" in body.get("error", "")

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -36,9 +36,12 @@ def test_onboarding_finish_output_separates_summary_from_commands():
     assert "uv run" not in text
 
 
-def test_onboarding_finish_output_summarizes_all_capability_sections():
+def test_onboarding_finish_output_summarizes_all_capability_sections(monkeypatch):
     from agentos.gateway.config import GatewayConfig, LlmProviderConfig
     from agentos.onboarding.next_steps import format_next_steps
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
 
     cfg = GatewayConfig()
     cfg.llm = LlmProviderConfig(

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -36,12 +36,9 @@ def test_onboarding_finish_output_separates_summary_from_commands():
     assert "uv run" not in text
 
 
-def test_onboarding_finish_output_summarizes_all_capability_sections(monkeypatch):
+def test_onboarding_finish_output_summarizes_all_capability_sections():
     from agentos.gateway.config import GatewayConfig, LlmProviderConfig
     from agentos.onboarding.next_steps import format_next_steps
-
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
 
     cfg = GatewayConfig()
     cfg.llm = LlmProviderConfig(


### PR DESCRIPTION
Closes #350

### Summary
- Dropped `request.query_params.get("token")` fallback in `AuthMiddleware._extract_token` (`src/agentos/gateway/middleware.py`) and `_extract_http_token` (`src/agentos/gateway/app.py`), requiring header-based authentication (`Authorization: Bearer <token>` or `x-agentos-token: <token>`) across all HTTP endpoints.
- Configured uvicorn with `access_log=False` in `src/agentos/gateway/boot.py` to prevent query strings from leaking into stdout access logs.
- Added comprehensive unit tests in `tests/test_gateway/test_auth_no_query_token.py`.

### Testing
- `tests/test_gateway/test_auth_no_query_token.py` (all tests passed)
- Full `tests/test_gateway` suite (1,244 passed, 1 skipped)
- `ruff check` and `mypy` passed with zero errors.

