### PR TITLE
fix(gateway): resolve bootstrap info disclosure and restrict cross-or…

### DIFF
--- a/frontend/src/lib/bootstrap.ts
+++ b/frontend/src/lib/bootstrap.ts
@@ -1,4 +1,5 @@
 import { controlBasePath, controlPath } from './control-base'
+import { authenticatedHeaders } from './http-auth'
 
 export interface Bootstrap {
   version: string
@@ -15,7 +16,9 @@ export function bootstrapUrl(basePath = controlBasePath()): string {
 }
 
 export async function fetchBootstrap(): Promise<Bootstrap> {
-  const resp = await fetch(bootstrapUrl())
+  const resp = await fetch(bootstrapUrl(), {
+    headers: authenticatedHeaders(),
+  })
   if (!resp.ok) throw new Error(`bootstrap failed: ${resp.status}`)
   return (await resp.json()) as Bootstrap
 }

--- a/src/agentos/gateway/control_ui.py
+++ b/src/agentos/gateway/control_ui.py
@@ -81,14 +81,44 @@ def _request_ws_url(request: Request, config: GatewayConfig) -> str:
     return f"{ws_scheme}://{host}/ws"
 
 
-def _build_bootstrap_context(config: GatewayConfig, request: Request) -> dict:
+def _is_authenticated_request(request: Request, config: GatewayConfig) -> bool:
+    """Check if the request is authenticated based on config settings."""
+    auth_mode = config.auth.mode
+    if auth_mode == "none":
+        return True
+
+    if auth_mode == "token":
+        auth_header = request.headers.get("authorization", "")
+        token = None
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+        else:
+            token = request.headers.get("x-agentos-token")
+            if not token:
+                token = request.query_params.get("token")
+        configured_token = config.auth.token
+        return bool(configured_token and token == configured_token)
+
+    if auth_mode == "trusted-proxy":
+        proxy = config.auth.trusted_proxy
+        forwarded_for = request.headers.get("x-forwarded-for", "")
+        if proxy and proxy not in forwarded_for:
+            return False
+        return True
+
+    return False
+
+
+def _build_bootstrap_context(
+    config: GatewayConfig, request: Request, *, authenticated: bool = False
+) -> dict:
     """Build the public bootstrap payload consumed by the React application."""
     return {
         "version": f"{__version__}+{_TEMPLATE_VERSION_SUFFIX}",
         "ws_url": _request_ws_url(request, config),
         "auth_mode": config.auth.mode,
         "base_path": config.control_ui.base_path,
-        "config_path": config.config_path or "",
+        "config_path": (config.config_path or "") if authenticated else "",
         "features": {
             "diagnostics": config.diagnostics_enabled,
         },
@@ -156,7 +186,8 @@ def create_control_ui_routes(config: GatewayConfig) -> list[Route | Mount]:
         )
 
     async def serve_bootstrap(request: Request) -> JSONResponse:
-        ctx = _build_bootstrap_context(config, request)
+        authenticated = _is_authenticated_request(request, config)
+        ctx = _build_bootstrap_context(config, request, authenticated=authenticated)
         return JSONResponse(ctx, headers={"Cache-Control": _INDEX_CACHE_CONTROL})
 
     routes: list[Route | Mount] = []

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -138,6 +138,10 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     def _is_ui_path(self, path: str) -> bool:
         if self._ui_prefix is None:
             return False
+        # The bootstrap JSON API is not a served UI page/asset, so it must
+        # not be exempt from the origin guard.
+        if path == f"{self._ui_prefix}/api/bootstrap":
+            return False
         # Exact shell ("/control") or anything under it ("/control/..."),
         # never a bare-prefix match that would swallow sibling routes.
         return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")

--- a/tests/test_gateway/test_control_ui_bootstrap.py
+++ b/tests/test_gateway/test_control_ui_bootstrap.py
@@ -148,10 +148,63 @@ def test_bootstrap_includes_config_path(dist_dir: Path, tmp_path: Path) -> None:
     config = GatewayConfig()
     config.config_path = str(tmp_path / "AgentOS Config.toml")
 
+    # Default auth.mode="none", so it should return config_path
     response = _client(config).get("/control/api/bootstrap")
-
     assert response.status_code == 200
     assert response.json()["config_path"] == str(config.config_path)
+
+    # auth.mode="token"
+    config_token = GatewayConfig(auth={"mode": "token", "token": "secret-token"})
+    config_token.config_path = str(tmp_path / "AgentOS Config.toml")
+    client_token = _client(config_token)
+
+    # 1. Unauthenticated request -> config_path should be empty
+    response = client_token.get("/control/api/bootstrap")
+    assert response.status_code == 200
+    assert response.json()["config_path"] == ""
+
+    # 2. Authenticated request with Bearer token -> config_path should be returned
+    response = client_token.get(
+        "/control/api/bootstrap", headers={"authorization": "Bearer secret-token"}
+    )
+    assert response.status_code == 200
+    assert response.json()["config_path"] == str(config_token.config_path)
+
+    # 3. Authenticated request with custom header -> config_path should be returned
+    response = client_token.get(
+        "/control/api/bootstrap", headers={"x-agentos-token": "secret-token"}
+    )
+    assert response.status_code == 200
+    assert response.json()["config_path"] == str(config_token.config_path)
+
+    # 4. Authenticated request with query parameter -> config_path should be returned
+    response = client_token.get("/control/api/bootstrap?token=secret-token")
+    assert response.status_code == 200
+    assert response.json()["config_path"] == str(config_token.config_path)
+
+    # 5. Invalid token request -> config_path should be empty
+    response = client_token.get(
+        "/control/api/bootstrap", headers={"authorization": "Bearer bad-token"}
+    )
+    assert response.status_code == 200
+    assert response.json()["config_path"] == ""
+
+    # auth.mode="trusted-proxy"
+    config_proxy = GatewayConfig(auth={"mode": "trusted-proxy", "trusted_proxy": "10.0.0.1"})
+    config_proxy.config_path = str(tmp_path / "AgentOS Config.toml")
+    client_proxy = _client(config_proxy)
+
+    # 1. Non-matching proxy -> config_path empty
+    response = client_proxy.get("/control/api/bootstrap")
+    assert response.status_code == 200
+    assert response.json()["config_path"] == ""
+
+    # 2. Matching proxy -> config_path returned
+    response = client_proxy.get(
+        "/control/api/bootstrap", headers={"x-forwarded-for": "10.0.0.1, 192.168.1.1"}
+    )
+    assert response.status_code == 200
+    assert response.json()["config_path"] == str(config_proxy.config_path)
 
 
 def test_bootstrap_ws_url_uses_client_reachable_wildcard_host(dist_dir: Path) -> None:

--- a/tests/test_gateway/test_middleware_ui_exemptions.py
+++ b/tests/test_gateway/test_middleware_ui_exemptions.py
@@ -86,3 +86,28 @@ def test_http_token_auth_without_configured_token_fails_closed(tmp_path) -> None
         response = client.get("/api/config")
 
     assert response.status_code == 401
+
+
+def test_origin_guard_enforced_on_bootstrap_but_exempts_other_ui_paths(tmp_path) -> None:
+    config = GatewayConfig(
+        config_path=str(tmp_path / "config.toml"),
+        auth={"mode": "none"},
+        control_ui={"base_path": "/control"},
+    )
+    # create_gateway_app sets up the full middleware stack including LoopbackOriginMiddleware.
+    # LoopbackOriginMiddleware is active on loopback binds (TestClient has localhost
+    # base_url which triggers it). Since auth.mode="none", bootstrap is accessible.
+    with TestClient(create_gateway_app(config), base_url="http://localhost") as client:
+        # 1. Accessing control UI shell with foreign origin is allowed (exempt)
+        response_ui = client.get("/control/", headers={"origin": "http://evil.com"})
+        # (It returns 200 or 503 depending on whether dist dir is built, but not 403)
+        assert response_ui.status_code != 403
+
+        # 2. Accessing bootstrap endpoint with same-origin or loopback origin is allowed
+        response_bootstrap_ok = client.get("/control/api/bootstrap", headers={"origin": "http://localhost"})
+        assert response_bootstrap_ok.status_code == 200
+
+        # 3. Accessing bootstrap endpoint with foreign origin is rejected with 403
+        response_bootstrap_evil = client.get("/control/api/bootstrap", headers={"origin": "http://evil.com"})
+        assert response_bootstrap_evil.status_code == 403
+        assert response_bootstrap_evil.text == "Origin not allowed"


### PR DESCRIPTION


> This pull request resolves the cross-origin information disclosure vulnerability on the `/control/api/bootstrap` endpoint. It strips the host-identifying `config_path` field from the unauthenticated payload unless a valid token is provided. Additionally, it removes the bootstrap JSON API route from the UI path exceptions in `LoopbackOriginMiddleware` to reject cross-origin fetch requests from foreign origins. Fixes #351