### PR TITLE
feat(mcp): add Robinhood setup guide and mock integration tests #349

### DIFF
--- a/docs/features/agentic-trading.md
+++ b/docs/features/agentic-trading.md
@@ -25,30 +25,39 @@ Both run behind the same approval and sandbox layers as every other tool.
 
 The Web UI ships a featured preset for Robinhood Agentic Trading.
 
+> [!IMPORTANT]
+> **US Residency Requirement**: Opening a Robinhood account is restricted to US residents. You must have a valid Robinhood account to authenticate and connect this MCP server.
+
+### Setup Guide
+
+To connect the Robinhood MCP server to AgentOS:
+
+1. **Via the Web UI (Recommended)**:
+   - Navigate to **Settings > MCP Servers** in the Control UI.
+   - Select the **Robinhood Trading** preset.
+   - Click **Save**. This will automatically initiate the provider-hosted OAuth authorization flow in your browser.
+   - Complete the authentication on the Robinhood website to authorize AgentOS.
+2. **Via Configuration File**:
+   - For headless or scripted deployments, declare the server in your `agentos.toml` configuration:
+     ```toml
+     [mcp]
+     enabled = true
+     connect_timeout_seconds = 10
+
+     [[mcp.servers]]
+     name = "robinhood-trading"
+     transport = "streamable_http"
+     url = "https://agent.robinhood.com/mcp/trading"
+     oauth = true
+     tool_timeout_seconds = 30
+     ```
+   - When the gateway starts, open the Web UI or check the terminal to complete the pending OAuth authorization challenge.
+
 | Setting | Value |
 | --- | --- |
 | Endpoint | `https://agent.robinhood.com/mcp/trading` |
 | Transport | Streamable HTTP |
 | Authorization | Provider-hosted OAuth flow |
-
-Open **Settings > MCP Servers**, select the Robinhood Trading preset, and save
-it. Saving opens the provider authorization flow and loads the server's tools
-without a gateway restart.
-
-For scripted deployments, declare the same server in TOML:
-
-```toml
-[mcp]
-enabled = true
-connect_timeout_seconds = 10
-
-[[mcp.servers]]
-name = "robinhood-trading"
-transport = "streamable_http"
-url = "https://agent.robinhood.com/mcp/trading"
-oauth = true
-tool_timeout_seconds = 30
-```
 
 See [`../configuration.md`](../configuration.md) for the full MCP configuration
 reference and [`../web-ui.md`](../web-ui.md) for the connection UI.

--- a/tests/test_gateway/test_robinhood_mcp_mock.py
+++ b/tests/test_gateway/test_robinhood_mcp_mock.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.mcp.client import MCPClient
+from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.tools.registry import ToolRegistry
+
+
+class FakeRobinhoodMCPClient(MCPClient):
+    def __init__(self, config: MCPServerConfig) -> None:
+        super().__init__(config)
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def list_tools(self) -> list[MCPToolDef]:
+        return [
+            MCPToolDef(
+                name="get_accounts",
+                description="List accounts and identify dedicated Agentic account",
+                input_schema={"properties": {}, "required": []},
+            ),
+            MCPToolDef(
+                name="get_balances",
+                description="Get current buying power or account balances",
+                input_schema={
+                    "properties": {"account_id": {"type": "string"}},
+                    "required": ["account_id"],
+                },
+            ),
+            MCPToolDef(
+                name="get_positions",
+                description="Get current positions for an account",
+                input_schema={
+                    "properties": {"account_id": {"type": "string"}},
+                    "required": ["account_id"],
+                },
+            ),
+            MCPToolDef(
+                name="place_order",
+                description="Place a trade order in the dedicated Agentic account",
+                input_schema={
+                    "properties": {
+                        "account_id": {"type": "string"},
+                        "symbol": {"type": "string"},
+                        "side": {"type": "string"},
+                        "quantity": {"type": "number"},
+                        "price": {"type": "number"},
+                    },
+                    "required": ["account_id", "symbol", "side", "quantity"],
+                },
+            ),
+            MCPToolDef(
+                name="cancel_order",
+                description="Cancel a pending order",
+                input_schema={
+                    "properties": {"order_id": {"type": "string"}},
+                    "required": ["order_id"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
+        if name == "get_accounts":
+            return MCPToolResult(
+                content=(
+                    '[{"account_id": "RH_AGENTIC_123", '
+                    '"name": "Robinhood Agentic Account", "eligible": true}]'
+                )
+            )
+        elif name == "get_balances":
+            return MCPToolResult(content='{"buying_power": 5000.00, "cash": 5000.00}')
+        elif name == "get_positions":
+            return MCPToolResult(
+                content='[{"symbol": "AAPL", "quantity": 10, "market_value": 1750.00}]'
+            )
+        elif name == "place_order":
+            return MCPToolResult(
+                content=(
+                    '{"order_id": "ord_999", "status": "submitted", '
+                    '"symbol": "AAPL", "side": "buy"}'
+                )
+            )
+        elif name == "cancel_order":
+            return MCPToolResult(content='{"order_id": "ord_999", "status": "canceled"}')
+        return MCPToolResult(content="unknown")
+
+
+@pytest.mark.asyncio
+async def test_robinhood_mcp_mock_workflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agentos.mcp import discovery
+
+    config = MCPServerConfig(
+        name="robinhood-trading",
+        transport="streamable_http",
+        url="https://agent.robinhood.com/mcp/trading",
+        oauth=True,
+    )
+    client = FakeRobinhoodMCPClient(config)
+    monkeypatch.setattr(discovery, "create_client", lambda _config: client)
+
+    registry = ToolRegistry()
+    names = await discovery.discover_and_register(config, registry, owner="gateway")
+
+    # Assert that all expected tools are registered with prefix mcp_
+    assert "mcp_get_accounts" in names
+    assert "mcp_get_balances" in names
+    assert "mcp_get_positions" in names
+    assert "mcp_place_order" in names
+    assert "mcp_cancel_order" in names
+
+    # Call get_accounts and verify the response
+    accounts_tool = registry.get("mcp_get_accounts")
+    assert accounts_tool is not None
+    accounts_res = await accounts_tool.handler()
+    assert "RH_AGENTIC_123" in accounts_res
+
+    # Call get_balances and verify the response
+    balances_tool = registry.get("mcp_get_balances")
+    assert balances_tool is not None
+    balances_res = await balances_tool.handler(account_id="RH_AGENTIC_123")
+    assert "5000.00" in balances_res
+
+    # Call place_order and verify the response
+    place_tool = registry.get("mcp_place_order")
+    assert place_tool is not None
+    place_res = await place_tool.handler(
+        account_id="RH_AGENTIC_123", symbol="AAPL", side="buy", quantity=1.0
+    )
+    assert "ord_999" in place_res
+    assert "submitted" in place_res
+
+    # Call cancel_order and verify the response
+    cancel_tool = registry.get("mcp_cancel_order")
+    assert cancel_tool is not None
+    cancel_res = await cancel_tool.handler(order_id="ord_999")
+    assert "canceled" in cancel_res
+
+    await discovery.close_active_clients(owner="gateway")


### PR DESCRIPTION

Adds detailed setup documentation for the Robinhood Trading Model Context Protocol (MCP) server, highlighting step-by-step connection instructions via the Control Web UI/configuration TOML and documenting the US residency constraint for account registration. 

Also introduces mock integration test cases covering Robinhood MCP client connection, tool registration with the `mcp_` prefix (`get_accounts`, `get_balances`, `get_positions`, `place_order`, `cancel_order`), and verification of their execution within the gateway registry.

Closes #349
```