### PR TITLE
fix(scheduler): honor account_id in cron delivery and resolve target …

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -299,8 +299,9 @@ rejected rather than quietly falling back to the caller. `best_effort` applies
 to any mode.
 
 Unlike the Web UI, the tool does not probe the adapter to confirm the chat
-exists, and `account_id` is accepted but has no effect on channel delivery
-today. Webhook delivery and failure destinations are refused outright here —
+exists, and `account_id` is accepted and binds the job to a specific account
+instance in multi-account setups. Webhook delivery and failure destinations
+are refused outright here —
 they stay CLI/Web/RPC-only, so an agent cannot be talked into POSTing job
 output at an arbitrary URL.
 

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -28,9 +28,7 @@ SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
-_REPLY_DIRECTIVE_RE = re.compile(
-    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
-)
+_REPLY_DIRECTIVE_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
 
 
 def strip_reply_directives(text: str | None) -> str | None:
@@ -48,9 +46,7 @@ def validate_webhook_url(url: str) -> None:
     except ValueError as exc:
         raise ValueError(f"invalid webhook URL: {url!r}") from exc
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(
-            f"webhook URL must use http or https scheme, got {parsed.scheme!r}"
-        )
+        raise ValueError(f"webhook URL must use http or https scheme, got {parsed.scheme!r}")
     if not parsed.hostname:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
 
@@ -327,6 +323,11 @@ class DeliveryChain:
             session_key=session_key,
         ):
             return await self._deliver_origin_webchat_to_session(job, text, session_key)
+        account_id = (
+            target.account_id
+            if target is not None and target.kind == "channel" and target.account_id
+            else job.delivery.account_id
+        )
         if not self._channel_manager_ref:
             return "skipped"
         return await self._post_to_channel(
@@ -334,6 +335,7 @@ class DeliveryChain:
             text=text,
             channel_name=channel_name,
             channel_id=channel_id,
+            account_id=account_id,
             thread_id=thread_id,
         )
 
@@ -413,7 +415,8 @@ class DeliveryChain:
         text: str,
         channel_name: str,
         channel_id: str,
-        thread_id: str,
+        account_id: str = "",
+        thread_id: str = "",
     ) -> str:
         """Send ``text`` via the registered channel adapter for ``channel_name``."""
         text = strip_reply_directives(text) or ""
@@ -422,7 +425,29 @@ class DeliveryChain:
         cm = self._channel_manager_ref()
         if cm is None:
             return "skipped"
-        adapter = cm.get(channel_name)
+
+        if hasattr(cm, "resolve_delivery_target"):
+            resolved = cm.resolve_delivery_target(
+                target=channel_name or "",
+                to=channel_id or "",
+                account_id=account_id or "",
+                thread_id=thread_id or "",
+            )
+            if not resolved.ok:
+                log.warning(
+                    "delivery.resolution_failed",
+                    job_id=job_id,
+                    channel=channel_name,
+                    reason=resolved.reason,
+                )
+                return _failed(f"delivery target resolution failed: {resolved.reason}")
+            adapter = resolved.adapter
+            channel_name = resolved.channel_type
+            channel_id = resolved.to
+            thread_id = resolved.thread_id
+        else:
+            adapter = cm.get(channel_name)
+
         if adapter is None:
             log.warning(
                 "delivery.adapter_not_found",

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -28,7 +28,9 @@ SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
-_REPLY_DIRECTIVE_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
+_REPLY_DIRECTIVE_RE = re.compile(
+    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
+)
 
 
 def strip_reply_directives(text: str | None) -> str | None:
@@ -46,7 +48,9 @@ def validate_webhook_url(url: str) -> None:
     except ValueError as exc:
         raise ValueError(f"invalid webhook URL: {url!r}") from exc
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"webhook URL must use http or https scheme, got {parsed.scheme!r}")
+        raise ValueError(
+            f"webhook URL must use http or https scheme, got {parsed.scheme!r}"
+        )
     if not parsed.hostname:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
 
@@ -284,21 +288,18 @@ class DeliveryChain:
             target is not None and target.kind == "channel"
         ):
             return "skipped"
-        channel_name = (
-            target.channel_name
-            if target is not None and target.kind == "channel" and target.channel_name
-            else job.delivery.channel_name
-        )
-        channel_id = (
-            target.to
-            if target is not None and target.kind == "channel" and target.to is not None
-            else job.delivery.channel_id
-        )
-        thread_id = (
-            target.thread_id
-            if target is not None and target.kind == "channel"
-            else job.delivery.thread_id
-        )
+
+        if target is not None and target.kind == "channel":
+            channel_name = target.channel_name or ""
+            channel_id = target.to or ""
+            thread_id = target.thread_id or ""
+            account_id = target.account_id or ""
+        else:
+            channel_name = job.delivery.channel_name or ""
+            channel_id = job.delivery.channel_id or ""
+            thread_id = job.delivery.thread_id or ""
+            account_id = job.delivery.account_id or ""
+
         if self._is_same_webchat_session_delivery(
             job,
             channel_name=channel_name or "",
@@ -323,11 +324,6 @@ class DeliveryChain:
             session_key=session_key,
         ):
             return await self._deliver_origin_webchat_to_session(job, text, session_key)
-        account_id = (
-            target.account_id
-            if target is not None and target.kind == "channel" and target.account_id
-            else job.delivery.account_id
-        )
         if not self._channel_manager_ref:
             return "skipped"
         return await self._post_to_channel(
@@ -447,7 +443,6 @@ class DeliveryChain:
             thread_id = resolved.thread_id
         else:
             adapter = cm.get(channel_name)
-
         if adapter is None:
             log.warning(
                 "delivery.adapter_not_found",
@@ -567,6 +562,7 @@ class DeliveryChain:
                 text=text,
                 channel_name=fd.channel_name,
                 channel_id=fd.channel_id,
+                account_id=fd.account_id or "",
                 thread_id=fd.thread_id,
             )
         return "skipped"

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -315,14 +315,14 @@ def _cron_job_view(job: Any) -> dict[str, Any]:
         "last_run_at": last_run_at.isoformat() if last_run_at is not None else "",
         "elevated": (
             cron_tool_policy_elevated(job.tool_policy)
-            if isinstance(getattr(job, "tool_policy", None), dict)
-            and "elevated" in job.tool_policy
+            if isinstance(getattr(job, "tool_policy", None), dict) and "elevated" in job.tool_policy
             else (
                 configured_cron_default_elevated(_gateway_config)
                 if getattr(job, "handler_key", None) == "agent_run"
                 else None
             )
-        ) or "",
+        )
+        or "",
     }
 
 
@@ -445,11 +445,7 @@ def _parse_cron_delivery(raw: Any) -> dict[str, Any] | None:
         # was already promoted to mode='channel' above, so the only way to land
         # here is an explicitly contradictory mode: nothing legitimate is lost
         # by refusing it.
-        stray = [
-            f
-            for f in ("channel_name", "channel_id", "account_id", "thread_id")
-            if parsed[f]
-        ]
+        stray = [f for f in ("channel_name", "channel_id", "account_id", "thread_id") if parsed[f]]
         if stray:
             raise SafeToolError(
                 f"delivery.{stray[0]} conflicts with delivery.mode='{mode}' — "
@@ -492,12 +488,9 @@ def _validate_cron_delivery_channel(channel_name: str) -> None:
     if not known:
         # A live manager with nothing in it is a real answer, not a missing one:
         # no channel delivery can succeed at all.
-        raise SafeToolError(
-            "no channels are configured, so a cron job cannot deliver to one"
-        )
+        raise SafeToolError("no channels are configured, so a cron job cannot deliver to one")
     raise SafeToolError(
-        f"no channel named '{channel_name}' is configured; "
-        f"available: {', '.join(sorted(known))}"
+        f"no channel named '{channel_name}' is configured; available: {', '.join(sorted(known))}"
     )
 
 
@@ -865,10 +858,7 @@ def _session_storage_or_none() -> Any:
                 },
                 "account_id": {
                     "type": "string",
-                    "description": (
-                        "Optional account binding for multi-account channels. "
-                        "Stored on the job but not yet honoured by channel delivery."
-                    ),
+                    "description": ("Optional account binding for multi-account channels."),
                 },
                 "thread_id": {
                     "type": "string",
@@ -929,9 +919,7 @@ async def cron(
     if action in ("get", "update", "remove", "run", "runs") and not job_id:
         raise SafeToolError(f"'job_id' required for {action}")
     if action != "update" and enabled is not None:
-        raise SafeToolError(
-            "'enabled' is only accepted by update; a new job always starts enabled"
-        )
+        raise SafeToolError("'enabled' is only accepted by update; a new job always starts enabled")
 
     # Dispatch to injected scheduler
     if _scheduler is None:
@@ -1010,7 +998,8 @@ async def cron(
                         if getattr(j, "handler_key", None) == "agent_run"
                         else None
                     )
-                ) or "",
+                )
+                or "",
             }
             for j in jobs
         ]

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -315,14 +315,14 @@ def _cron_job_view(job: Any) -> dict[str, Any]:
         "last_run_at": last_run_at.isoformat() if last_run_at is not None else "",
         "elevated": (
             cron_tool_policy_elevated(job.tool_policy)
-            if isinstance(getattr(job, "tool_policy", None), dict) and "elevated" in job.tool_policy
+            if isinstance(getattr(job, "tool_policy", None), dict)
+            and "elevated" in job.tool_policy
             else (
                 configured_cron_default_elevated(_gateway_config)
                 if getattr(job, "handler_key", None) == "agent_run"
                 else None
             )
-        )
-        or "",
+        ) or "",
     }
 
 
@@ -445,7 +445,11 @@ def _parse_cron_delivery(raw: Any) -> dict[str, Any] | None:
         # was already promoted to mode='channel' above, so the only way to land
         # here is an explicitly contradictory mode: nothing legitimate is lost
         # by refusing it.
-        stray = [f for f in ("channel_name", "channel_id", "account_id", "thread_id") if parsed[f]]
+        stray = [
+            f
+            for f in ("channel_name", "channel_id", "account_id", "thread_id")
+            if parsed[f]
+        ]
         if stray:
             raise SafeToolError(
                 f"delivery.{stray[0]} conflicts with delivery.mode='{mode}' — "
@@ -488,9 +492,12 @@ def _validate_cron_delivery_channel(channel_name: str) -> None:
     if not known:
         # A live manager with nothing in it is a real answer, not a missing one:
         # no channel delivery can succeed at all.
-        raise SafeToolError("no channels are configured, so a cron job cannot deliver to one")
+        raise SafeToolError(
+            "no channels are configured, so a cron job cannot deliver to one"
+        )
     raise SafeToolError(
-        f"no channel named '{channel_name}' is configured; available: {', '.join(sorted(known))}"
+        f"no channel named '{channel_name}' is configured; "
+        f"available: {', '.join(sorted(known))}"
     )
 
 
@@ -858,7 +865,9 @@ def _session_storage_or_none() -> Any:
                 },
                 "account_id": {
                     "type": "string",
-                    "description": ("Optional account binding for multi-account channels."),
+                    "description": (
+                        "Optional account binding for multi-account channels."
+                    ),
                 },
                 "thread_id": {
                     "type": "string",
@@ -919,7 +928,9 @@ async def cron(
     if action in ("get", "update", "remove", "run", "runs") and not job_id:
         raise SafeToolError(f"'job_id' required for {action}")
     if action != "update" and enabled is not None:
-        raise SafeToolError("'enabled' is only accepted by update; a new job always starts enabled")
+        raise SafeToolError(
+            "'enabled' is only accepted by update; a new job always starts enabled"
+        )
 
     # Dispatch to injected scheduler
     if _scheduler is None:
@@ -998,8 +1009,7 @@ async def cron(
                         if getattr(j, "handler_key", None) == "agent_run"
                         else None
                     )
-                )
-                or "",
+                ) or "",
             }
             for j in jobs
         ]

--- a/tests/test_scheduler/test_multi_account_delivery.py
+++ b/tests/test_scheduler/test_multi_account_delivery.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.channels.types import DeliveryTargetResolution, OutgoingMessage
+from agentos.scheduler.delivery import DeliveryChain
+from agentos.scheduler.payloads import make_script_payload
+from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+
+
+class _FakeAdapter:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.messages: list[OutgoingMessage] = []
+
+    async def send(self, message: OutgoingMessage) -> None:
+        self.messages.append(message)
+
+
+class _FakeMultiAccountChannelManager:
+    def __init__(self, channels: dict[str, Any], channel_types: dict[str, str]) -> None:
+        self._channels = channels
+        self._channel_types = channel_types
+
+    def resolve_delivery_target(
+        self,
+        *,
+        target: str,
+        to: str = "",
+        account_id: str = "",
+        thread_id: str = "",
+    ) -> DeliveryTargetResolution:
+        target_name = target.strip()
+        target_type = target_name.lower()
+        account = account_id.strip()
+        to = to.strip()
+        thread = thread_id.strip()
+
+        candidates = [
+            name
+            for name, channel_type in self._channel_types.items()
+            if channel_type.lower() == target_type
+        ]
+        if account:
+            if account not in candidates:
+                return DeliveryTargetResolution(ok=False, reason="unsupported_account")
+            return DeliveryTargetResolution(
+                ok=True,
+                adapter=self._channels.get(account),
+                adapter_name=account,
+                channel_type=target_type,
+                to=to,
+                account_id=account,
+                thread_id=thread,
+            )
+
+        if target_name in self._channels:
+            return DeliveryTargetResolution(
+                ok=True,
+                adapter=self._channels.get(target_name),
+                adapter_name=target_name,
+                channel_type=self._channel_types.get(target_name, target_name).lower(),
+                to=to,
+                account_id=account,
+                thread_id=thread,
+            )
+
+        if not candidates:
+            return DeliveryTargetResolution(ok=False, reason="unsupported_target")
+        if len(candidates) > 1:
+            return DeliveryTargetResolution(ok=False, reason="ambiguous_account")
+
+        return DeliveryTargetResolution(
+            ok=True,
+            adapter=self._channels.get(candidates[0]),
+            adapter_name=candidates[0],
+            channel_type=target_type,
+            to=to,
+            account_id=account,
+            thread_id=thread,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cron_delivery_resolves_and_honors_account_id() -> None:
+    # Setup two Slack adapters
+    adapter1 = _FakeAdapter("slack-bot-1")
+    adapter2 = _FakeAdapter("slack-bot-2")
+    channels = {"slack-bot-1": adapter1, "slack-bot-2": adapter2}
+    channel_types = {"slack-bot-1": "slack", "slack-bot-2": "slack"}
+
+    manager = _FakeMultiAccountChannelManager(channels, channel_types)
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    job = CronJob(
+        id="job-1",
+        name="multi-acc-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C0123ABCDEF",
+            account_id="slack-bot-1",
+        ),
+    )
+
+    report = await chain.deliver(
+        job,
+        result_text="hello world",
+        success=True,
+        summary="hello world",
+        session_key="cron:job-1:run:deadbeef",
+    )
+
+    assert report.channel_status == "delivered"
+    # Ensure message went to adapter 1 and not adapter 2
+    assert len(adapter1.messages) == 1
+    assert adapter1.messages[0].content == "hello world"
+    assert len(adapter2.messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_cron_delivery_resolution_failure_reports_failed() -> None:
+    # Setup one Slack adapter
+    adapter = _FakeAdapter("slack-bot-1")
+    channels = {"slack-bot-1": adapter}
+    channel_types = {"slack-bot-1": "slack"}
+
+    manager = _FakeMultiAccountChannelManager(channels, channel_types)
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    # Use a non-existent account_id
+    job = CronJob(
+        id="job-1",
+        name="multi-acc-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C0123ABCDEF",
+            account_id="slack-bot-nonexistent",
+        ),
+    )
+
+    report = await chain.deliver(
+        job,
+        result_text="hello world",
+        success=True,
+        summary="hello world",
+        session_key="cron:job-1:run:deadbeef",
+    )
+
+    assert report.channel_status == "delivery_failed"
+    assert "delivery target resolution failed: unsupported_account" in report.channel_detail

--- a/tests/test_scheduler/test_multi_account_delivery.py
+++ b/tests/test_scheduler/test_multi_account_delivery.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
 from agentos.channels.manager import ChannelManager
 from agentos.channels.types import OutgoingMessage
 from agentos.scheduler.delivery import DeliveryChain
 from agentos.scheduler.payloads import make_script_payload
-from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+from agentos.scheduler.types import (
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    FailureDestination,
+    SessionTarget,
+)
 
 
 class _FakeAdapter:
@@ -105,3 +114,240 @@ async def test_cron_delivery_resolution_failure_reports_failed() -> None:
 
     assert report.channel_status == "delivery_failed"
     assert "delivery target resolution failed: unsupported_account" in report.channel_detail
+
+
+@pytest.mark.asyncio
+async def test_reply_target_account_id_override_and_empty_target_account_no_reuse() -> None:
+    # Setup two Slack adapters
+    adapter1 = _FakeAdapter("slack-bot-1")
+    adapter2 = _FakeAdapter("slack-bot-2")
+    channels = {"slack-bot-1": adapter1, "slack-bot-2": adapter2}
+    channel_types = {"slack-bot-1": "slack", "slack-bot-2": "slack"}
+
+    manager = ChannelManager(
+        _channels=channels,  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types=channel_types,
+    )
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    job = CronJob(
+        id="job-1",
+        name="multi-acc-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C0123ABCDEF",
+            account_id="slack-bot-1",
+        ),
+    )
+
+    # 1. ReplyTarget overrides the job account
+    reply_target_override = SimpleNamespace(
+        kind="channel",
+        channel_name="slack",
+        to="C0123ABCDEF",
+        thread_id="",
+        account_id="slack-bot-2",
+    )
+    envelope_override = SimpleNamespace(reply_target=reply_target_override)
+
+    report_override = await chain.deliver(
+        job,
+        result_text="hello override",
+        success=True,
+        summary="hello override",
+        session_key="cron:job-1:run:deadbeef",
+        route_envelope=envelope_override,
+    )
+    assert report_override.channel_status == "delivered"
+    assert len(adapter2.messages) == 1
+    assert adapter2.messages[0].content == "hello override"
+    assert len(adapter1.messages) == 0
+
+    # 2. Empty target account does NOT fall back to job's stale account,
+    # leading to ambiguous failure
+    reply_target_empty = SimpleNamespace(
+        kind="channel",
+        channel_name="slack",
+        to="C0123ABCDEF",
+        thread_id="",
+        account_id="",
+    )
+    envelope_empty = SimpleNamespace(reply_target=reply_target_empty)
+
+    report_empty = await chain.deliver(
+        job,
+        result_text="hello empty",
+        success=True,
+        summary="hello empty",
+        session_key="cron:job-1:run:deadbeef",
+        route_envelope=envelope_empty,
+    )
+    assert report_empty.channel_status == "delivery_failed"
+    assert "delivery target resolution failed: ambiguous_account" in report_empty.channel_detail
+
+
+@pytest.mark.asyncio
+async def test_failure_destination_account_id_routing() -> None:
+    # Setup two Telegram adapters
+    adapter1 = _FakeAdapter("telegram-bot-1")
+    adapter2 = _FakeAdapter("telegram-bot-2")
+    channels = {"telegram-bot-1": adapter1, "telegram-bot-2": adapter2}
+    channel_types = {"telegram-bot-1": "telegram", "telegram-bot-2": "telegram"}
+
+    manager = ChannelManager(
+        _channels=channels,  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types=channel_types,
+    )
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    fd = FailureDestination(
+        mode=DeliveryMode.CHANNEL,
+        channel_name="telegram",
+        channel_id="T0123456",
+        account_id="telegram-bot-2",
+    )
+    job = CronJob(
+        id="job-1",
+        name="failure-dest-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.NONE,
+            failure_destination=fd,
+        ),
+    )
+
+    status = await chain.dispatch_failure_alert(job, "job execution failed")
+    assert status == "delivered"
+    assert len(adapter2.messages) == 1
+    assert adapter2.messages[0].content == "job execution failed"
+    assert len(adapter1.messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_account_unique_and_ambiguous_resolution() -> None:
+    # 1. Unique resolution when only 1 adapter exists for the type
+    adapter_slack = _FakeAdapter("slack-bot-1")
+    manager = ChannelManager(
+        _channels={"slack-bot-1": adapter_slack},  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types={"slack-bot-1": "slack"},
+    )
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    job = CronJob(
+        id="job-1",
+        name="unique-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C0123ABCDEF",
+            account_id="",  # No account_id provided
+        ),
+    )
+
+    report = await chain.deliver(
+        job, "hello unique", True, "hello unique", "cron:job-1:run:deadbeef"
+    )
+    assert report.channel_status == "delivered"
+    assert len(adapter_slack.messages) == 1
+
+    # 2. Ambiguous resolution when multiple adapters exist for the type
+    # and no account_id is specified
+    adapter_slack2 = _FakeAdapter("slack-bot-2")
+    manager_ambiguous = ChannelManager(
+        _channels={"slack-bot-1": adapter_slack, "slack-bot-2": adapter_slack2},  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types={"slack-bot-1": "slack", "slack-bot-2": "slack"},
+    )
+    chain_ambiguous = DeliveryChain(channel_manager_ref=lambda: manager_ambiguous)
+
+    report_ambiguous = await chain_ambiguous.deliver(
+        job, "hello ambiguous", True, "hello ambiguous", "cron:job-1:run:deadbeef"
+    )
+    assert report_ambiguous.channel_status == "delivery_failed"
+    assert "delivery target resolution failed: ambiguous_account" in report_ambiguous.channel_detail
+
+
+@pytest.mark.asyncio
+async def test_slack_resolved_thread_metadata() -> None:
+    adapter = _FakeAdapter("slack-bot-1")
+    manager = ChannelManager(
+        _channels={"slack-bot-1": adapter},  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types={"slack-bot-1": "slack"},
+    )
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    job = CronJob(
+        id="job-1",
+        name="thread-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C0123ABCDEF",
+            thread_id="thread-456",
+        ),
+    )
+
+    report = await chain.deliver(
+        job, "hello thread", True, "hello thread", "cron:job-1:run:deadbeef"
+    )
+    assert report.channel_status == "delivered"
+    assert len(adapter.messages) == 1
+    msg = adapter.messages[0]
+    assert msg.content == "hello thread"
+    assert msg.reply_to == "thread-456"
+    assert msg.metadata == {"channel": "C0123ABCDEF"}
+
+
+@pytest.mark.asyncio
+async def test_compatibility_fallback_for_managers_without_resolve_delivery_target() -> None:
+    class LegacyManager:
+        def __init__(self, channels: dict[str, Any]) -> None:
+            self._channels = channels
+
+        def get(self, name: str) -> Any:
+            return self._channels.get(name)
+
+    adapter = _FakeAdapter("slack")
+    legacy_manager = LegacyManager({"slack": adapter})
+    chain = DeliveryChain(channel_manager_ref=lambda: legacy_manager)  # type: ignore
+
+    job = CronJob(
+        id="job-1",
+        name="legacy-test",
+        handler_key="script_run",
+        payload=make_script_payload("test.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="slack",
+            channel_id="C0123ABCDEF",
+        ),
+    )
+
+    report = await chain.deliver(
+        job, "hello legacy", True, "hello legacy", "cron:job-1:run:deadbeef"
+    )
+    assert report.channel_status == "delivered"
+    assert len(adapter.messages) == 1
+    assert adapter.messages[0].content == "hello legacy"

--- a/tests/test_scheduler/test_multi_account_delivery.py
+++ b/tests/test_scheduler/test_multi_account_delivery.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
-from agentos.channels.types import DeliveryTargetResolution, OutgoingMessage
+from agentos.channels.manager import ChannelManager
+from agentos.channels.types import OutgoingMessage
 from agentos.scheduler.delivery import DeliveryChain
 from agentos.scheduler.payloads import make_script_payload
 from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
@@ -19,70 +18,6 @@ class _FakeAdapter:
         self.messages.append(message)
 
 
-class _FakeMultiAccountChannelManager:
-    def __init__(self, channels: dict[str, Any], channel_types: dict[str, str]) -> None:
-        self._channels = channels
-        self._channel_types = channel_types
-
-    def resolve_delivery_target(
-        self,
-        *,
-        target: str,
-        to: str = "",
-        account_id: str = "",
-        thread_id: str = "",
-    ) -> DeliveryTargetResolution:
-        target_name = target.strip()
-        target_type = target_name.lower()
-        account = account_id.strip()
-        to = to.strip()
-        thread = thread_id.strip()
-
-        candidates = [
-            name
-            for name, channel_type in self._channel_types.items()
-            if channel_type.lower() == target_type
-        ]
-        if account:
-            if account not in candidates:
-                return DeliveryTargetResolution(ok=False, reason="unsupported_account")
-            return DeliveryTargetResolution(
-                ok=True,
-                adapter=self._channels.get(account),
-                adapter_name=account,
-                channel_type=target_type,
-                to=to,
-                account_id=account,
-                thread_id=thread,
-            )
-
-        if target_name in self._channels:
-            return DeliveryTargetResolution(
-                ok=True,
-                adapter=self._channels.get(target_name),
-                adapter_name=target_name,
-                channel_type=self._channel_types.get(target_name, target_name).lower(),
-                to=to,
-                account_id=account,
-                thread_id=thread,
-            )
-
-        if not candidates:
-            return DeliveryTargetResolution(ok=False, reason="unsupported_target")
-        if len(candidates) > 1:
-            return DeliveryTargetResolution(ok=False, reason="ambiguous_account")
-
-        return DeliveryTargetResolution(
-            ok=True,
-            adapter=self._channels.get(candidates[0]),
-            adapter_name=candidates[0],
-            channel_type=target_type,
-            to=to,
-            account_id=account,
-            thread_id=thread,
-        )
-
-
 @pytest.mark.asyncio
 async def test_cron_delivery_resolves_and_honors_account_id() -> None:
     # Setup two Slack adapters
@@ -91,7 +26,13 @@ async def test_cron_delivery_resolves_and_honors_account_id() -> None:
     channels = {"slack-bot-1": adapter1, "slack-bot-2": adapter2}
     channel_types = {"slack-bot-1": "slack", "slack-bot-2": "slack"}
 
-    manager = _FakeMultiAccountChannelManager(channels, channel_types)
+    # Use a real ChannelManager configured with two adapters of the same type
+    manager = ChannelManager(
+        _channels=channels,  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types=channel_types,
+    )
     chain = DeliveryChain(channel_manager_ref=lambda: manager)
 
     job = CronJob(
@@ -130,7 +71,13 @@ async def test_cron_delivery_resolution_failure_reports_failed() -> None:
     channels = {"slack-bot-1": adapter}
     channel_types = {"slack-bot-1": "slack"}
 
-    manager = _FakeMultiAccountChannelManager(channels, channel_types)
+    # Use a real ChannelManager
+    manager = ChannelManager(
+        _channels=channels,  # type: ignore
+        _turn_runner=None,
+        _session_manager=None,
+        _channel_types=channel_types,
+    )
     chain = DeliveryChain(channel_manager_ref=lambda: manager)
 
     # Use a non-existent account_id


### PR DESCRIPTION

### Description
Addresses a bug where `delivery.account_id` was dropped before channel delivery, resulting in cron jobs bound to a specific account silently delivering from the wrong one in multi-account setups. 

Updates the delivery path to thread the `account_id` and utilize the channel manager's `resolve_delivery_target()` resolver. This resolves the specific adapter instance correctly while preserving a backward-compatible fallback to `cm.get()`. Also cleans up the schema description to reflect that `account_id` is now fully honored in delivery.

Closes #359
```