### PR TITLE
security(gateway): reject unimplemented auth modes at config load and…

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -60,7 +60,7 @@ class AuthConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="AGENTOS_AUTH_")
 
     token: str | None = None
-    password: str | None = None
+    password: str | None = None  # Deprecated and unused. Kept for schema compatibility.
     mode: str = "none"  # none | token | trusted-proxy
     trusted_proxy: str | None = None
 
@@ -2240,7 +2240,7 @@ class GatewayConfig(BaseSettings):
         auth_payload = auth_payload if isinstance(auth_payload, dict) else {}
         env_names = {
             "token": ("AGENTOS_AUTH_TOKEN", "AGENTOS_GATEWAY_AUTH__TOKEN"),
-            "password": ("AGENTOS_AUTH_PASSWORD", "AGENTOS_GATEWAY_AUTH__PASSWORD"),
+            "password": ("AGENTOS_AUTH_PASSWORD", "AGENTOS_GATEWAY_AUTH__PASSWORD"),  # Deprecated
         }
         for field_name, candidates in env_names.items():
             if field_name in auth_payload:

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -61,8 +61,19 @@ class AuthConfig(BaseSettings):
 
     token: str | None = None
     password: str | None = None
-    mode: str = "none"  # none | token | password | trusted-proxy
+    mode: str = "none"  # none | token | trusted-proxy
     trusted_proxy: str | None = None
+
+    @field_validator("mode")
+    @classmethod
+    def validate_mode(cls, v: str) -> str:
+        allowed = {"none", "token", "trusted-proxy"}
+        if v not in allowed:
+            raise ValueError(
+                f"Unsupported or unimplemented auth.mode: {v!r}. "
+                f"Allowed values are: {', '.join(sorted(allowed))}."
+            )
+        return v
 
 
 class CorsConfig(BaseSettings):
@@ -2304,7 +2315,6 @@ def _mode_protects_public_bind(auth: AuthConfig) -> bool:
     has a resolver in ``resolve_auth``. Every other mode is treated as
     unauthenticated for the public-bind guard:
 
-    * ``password`` has no HTTP-surface enforcement yet.
     * ``trusted-proxy`` only string-matches the client-supplied
       ``X-Forwarded-For`` header (trivially spoofable) and has no resolver in
       ``resolve_auth``, so it is not enforced end-to-end. Re-admit it here

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -358,6 +358,26 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
         if "allow_unauthenticated_public" in data.get("auth", {}):
             builder.removed_fields.append("auth.allow_unauthenticated_public")
 
+        mode = auth_section.get("mode")
+        if isinstance(mode, str) and mode.strip().lower() == "password":
+            auth_section["mode"] = "token"
+            builder.changes.append("auth.mode: password -> token (password auth was removed)")
+            warnings.warn(
+                "AgentOS: auth.mode = 'password' is no longer supported and has been "
+                "migrated to 'token' (fail-closed). Please configure token "
+                "authentication.",
+                DeprecationWarning,
+                stacklevel=6,
+            )
+            logging.getLogger(__name__).warning(
+                "AgentOS: auth.mode = 'password' is no longer supported and has been "
+                "migrated to 'token' (fail-closed). Please configure token "
+                "authentication."
+            )
+        if "password" in auth_section:
+            auth_section.pop("password")
+            builder.removed_fields.append("auth.password")
+
     if "channel_admin_senders" in builder.payload:
         builder.payload.pop("channel_admin_senders")
         builder.removed_fields.append("channel_admin_senders")

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -122,7 +122,9 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     RPC surface — the drive-by target — is gated.
     """
 
-    def __init__(self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool) -> None:
+    def __init__(
+        self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool
+    ) -> None:
         super().__init__(app)
         self._config = config
         self._cors_origins = [o for o in config.cors.allowed_origins if o != "*"]
@@ -154,7 +156,9 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
             )
 
             if not (
-                is_allowed_ws_origin(origin, self._config, bind_is_loopback=self._bind_is_loopback)
+                is_allowed_ws_origin(
+                    origin, self._config, bind_is_loopback=self._bind_is_loopback
+                )
                 or origin_in_allowlist(origin, self._cors_origins)
             ):
                 return PlainTextResponse("Origin not allowed", status_code=403)
@@ -175,7 +179,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._config = config
         base_path = (
-            config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
+            config.control_ui.base_path
+            if control_ui_base_path is None
+            else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
 
@@ -238,7 +244,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._config = config
         base_path = (
-            config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
+            config.control_ui.base_path
+            if control_ui_base_path is None
+            else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
         # {ip: [(timestamp, count), ...]}

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -122,9 +122,7 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     RPC surface — the drive-by target — is gated.
     """
 
-    def __init__(
-        self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool
-    ) -> None:
+    def __init__(self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool) -> None:
         super().__init__(app)
         self._config = config
         self._cors_origins = [o for o in config.cors.allowed_origins if o != "*"]
@@ -156,9 +154,7 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
             )
 
             if not (
-                is_allowed_ws_origin(
-                    origin, self._config, bind_is_loopback=self._bind_is_loopback
-                )
+                is_allowed_ws_origin(origin, self._config, bind_is_loopback=self._bind_is_loopback)
                 or origin_in_allowlist(origin, self._cors_origins)
             ):
                 return PlainTextResponse("Origin not allowed", status_code=403)
@@ -179,9 +175,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._config = config
         base_path = (
-            config.control_ui.base_path
-            if control_ui_base_path is None
-            else control_ui_base_path
+            config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
 
@@ -209,16 +203,18 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )
+            return await call_next(request)  # type: ignore[no-any-return]
 
-        elif auth_mode == "trusted-proxy":
+        if auth_mode == "trusted-proxy":
             proxy = self._config.auth.trusted_proxy
             forwarded_for = request.headers.get("x-forwarded-for", "")
             if proxy and proxy not in forwarded_for:
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )
+            return await call_next(request)  # type: ignore[no-any-return]
 
-        return await call_next(request)  # type: ignore[no-any-return]
+        return JSONResponse({"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401)
 
     def _extract_token(self, request: Request) -> str | None:
         auth_header = request.headers.get("authorization", "")
@@ -242,9 +238,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._config = config
         base_path = (
-            config.control_ui.base_path
-            if control_ui_base_path is None
-            else control_ui_base_path
+            config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
         # {ip: [(timestamp, count), ...]}

--- a/tests/test_cli/test_gateway_auth_prompt.py
+++ b/tests/test_cli/test_gateway_auth_prompt.py
@@ -86,17 +86,15 @@ def test_warning_names_the_specific_lan_host_not_only_wildcard(tmp_path) -> None
     config = _config(tmp_path, host="192.168.1.50")
     emitted: list[str] = []
 
-    provision_public_bind_auth(
-        config, interactive=True, prompt=lambda _m: "2", emit=emitted.append
-    )
+    provision_public_bind_auth(config, interactive=True, prompt=lambda _m: "2", emit=emitted.append)
 
     output = "\n".join(emitted)
     assert "192.168.1.50" in output
     assert "non-loopback" in output
 
 
-def test_unsupported_auth_mode_can_only_be_cancelled_or_replaced(tmp_path) -> None:
-    config = _config(tmp_path, auth=AuthConfig(mode="password"))
+def test_trusted_proxy_auth_mode_can_only_be_cancelled_or_replaced(tmp_path) -> None:
+    config = _config(tmp_path, auth=AuthConfig(mode="trusted-proxy"))
 
     outcome, result = provision_public_bind_auth(
         config, interactive=True, prompt=lambda _m: "2", emit=lambda _m: None
@@ -104,7 +102,7 @@ def test_unsupported_auth_mode_can_only_be_cancelled_or_replaced(tmp_path) -> No
 
     assert outcome is AuthProvisionOutcome.CANCEL
     assert result is config
-    assert result.auth.mode == "password"
+    assert result.auth.mode == "trusted-proxy"
 
 
 def test_public_bind_with_token_mode_is_unchanged(tmp_path) -> None:
@@ -287,7 +285,7 @@ def test_choice_2_cancels_without_mutating_or_persisting(tmp_path) -> None:
 
 
 def test_choice_2_cancel_does_not_add_auth_runtime_overrides(tmp_path) -> None:
-    config = _config(tmp_path, auth=AuthConfig(mode="password"))
+    config = _config(tmp_path, auth=AuthConfig(mode="trusted-proxy"))
     set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
 
     outcome, _ = provision_public_bind_auth(

--- a/tests/test_gateway/test_auth_mode_security.py
+++ b/tests/test_gateway/test_auth_mode_security.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from starlette.requests import Request
+from starlette.responses import Response
+
+from agentos.gateway.config import AuthConfig, GatewayConfig
+from agentos.gateway.middleware import AuthMiddleware
+
+
+def test_invalid_auth_mode_raises_validation_error() -> None:
+    # Reject unknown/unimplemented modes at config validation time
+    with pytest.raises(ValidationError) as excinfo:
+        AuthConfig(mode="password")
+    assert "Unsupported or unimplemented auth.mode" in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        AuthConfig(mode="tokn")  # typo
+    assert "Unsupported or unimplemented auth.mode" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_fails_closed_for_unimplemented_mode() -> None:
+    # Build a config that has an bypassed or unimplemented mode
+    # Since Pydantic prevents direct validation bypass at init, we can test middleware
+    # dispatch directly using a mock request.
+    from starlette.types import Scope
+
+    async def dummy_app(scope: Scope, receive: Any, send: Any) -> None:
+        pass
+
+    config = GatewayConfig()
+    # Bypass validation by mutating the private model fields or using model_construct
+    config.auth = AuthConfig.model_construct(mode="password")
+
+    middleware = AuthMiddleware(dummy_app, config=config)
+
+    # Mock request targeting a non-public route
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/v1/sessions",
+        "headers": [],
+    }
+    request = Request(scope)
+
+    async def mock_call_next(req: Request) -> Response:
+        return Response("OK")
+
+    response = await middleware.dispatch(request, mock_call_next)
+    assert response.status_code == 401

--- a/tests/test_gateway/test_auth_mode_security.py
+++ b/tests/test_gateway/test_auth_mode_security.py
@@ -52,3 +52,32 @@ async def test_auth_middleware_fails_closed_for_unimplemented_mode() -> None:
 
     response = await middleware.dispatch(request, mock_call_next)
     assert response.status_code == 401
+
+
+def test_password_auth_mode_migration(tmp_path) -> None:
+    # A legacy config carrying mode="password" and password="foo" should migrate to token mode
+    config_file = tmp_path / "agentos.toml"
+    config_file.write_text(
+        '[auth]\nmode = "password"\npassword = "hunter2"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.warns(DeprecationWarning, match="auth.mode = 'password' is no longer supported"):
+        cfg = GatewayConfig.load(config_file)
+
+    assert cfg.auth.mode == "token"
+    # Ensure that it rewrote the file on disk (mode="token" and password popped)
+    import tomllib
+
+    with open(config_file, "rb") as f:
+        migrated_data = tomllib.load(f)
+    assert migrated_data["auth"]["mode"] == "token"
+    assert "password" not in migrated_data["auth"]
+
+    # Ensure a backup was created
+    backups = [p for p in tmp_path.iterdir() if "backup" in p.name]
+    assert len(backups) == 1
+    with open(backups[0], "rb") as f:
+        backup_data = tomllib.load(f)
+    assert backup_data["auth"]["mode"] == "password"
+    assert backup_data["auth"]["password"] == "hunter2"

--- a/tests/test_gateway/test_config_persist_no_freeze_rpc.py
+++ b/tests/test_gateway/test_config_persist_no_freeze_rpc.py
@@ -215,17 +215,17 @@ async def test_config_apply_baseline_diff_persists_deliberate_auth_mode_edit(tmp
     impossible; the snapshot-baseline diff restores the ability to persist a
     deliberate YAML edit of an overridden field.
 
-    Distinguishing setup: the on-disk original (password), the running echo
+    Distinguishing setup: the on-disk original (trusted-proxy), the running echo
     (none, runtime override), and the deliberate edit (token) are all different, so
-    the two strategies give different final states — round-2 restores password
+    the two strategies give different final states — round-2 restores trusted-proxy
     (wrong), baseline-diff persists token (correct)."""
     import yaml
 
     cfg_path = tmp_path / "config.toml"
-    _seed_disk(cfg_path, {"auth": {"mode": "password", "token": "existing-token"}})
+    _seed_disk(cfg_path, {"auth": {"mode": "trusted-proxy", "token": "existing-token"}})
 
     # The runtime map recorded the on-disk auth original; running is mode=none.
-    set_runtime_overrides({"auth.mode": "password"})
+    set_runtime_overrides({"auth.mode": "trusted-proxy"})
     cfg = _running_config(
         cfg_path,
         auth=AuthConfig(

--- a/tests/test_gateway/test_config_persist_runtime_only.py
+++ b/tests/test_gateway/test_config_persist_runtime_only.py
@@ -102,11 +102,11 @@ def test_explicit_change_without_overrides_persists_verbatim(tmp_path):
 def test_local_auth_mode_override_is_restorable(tmp_path):
     cfg_path = tmp_path / "config.toml"
     with open(cfg_path, "wb") as f:
-        tomli_w.dump({"auth": {"mode": "password"}}, f)
+        tomli_w.dump({"auth": {"mode": "trusted-proxy"}}, f)
 
     # A local run forced mode=none; boot recorded the on-disk auth value so a
     # later writer cannot freeze the transient posture.
-    set_runtime_overrides({"auth.mode": "password"})
+    set_runtime_overrides({"auth.mode": "trusted-proxy"})
     runtime = GatewayConfig(
         auth=AuthConfig(mode="none"),
         config_path=str(cfg_path),
@@ -114,7 +114,7 @@ def test_local_auth_mode_override_is_restorable(tmp_path):
     persist_config(runtime)
 
     saved = _read(cfg_path)
-    assert saved["auth"]["mode"] == "password"
+    assert saved["auth"]["mode"] == "trusted-proxy"
 
 
 def test_missing_original_drops_the_field_so_defaults_apply(tmp_path):


### PR DESCRIPTION

### Description
Fixes a security issue where configuring an unimplemented `auth.mode` (such as `"password"` or typos) allowed requests to silently bypass `AuthMiddleware` and pass unauthenticated. 

Adds strict Pydantic `@field_validator("mode")` on `AuthConfig.mode` to reject unsupported or unimplemented modes at config load/validation time. Also hardens `AuthMiddleware.dispatch` to fail closed and return `401 Unauthorized` for any modes that do not match `"none"`, `"token"`, or `"trusted-proxy"`. Legacy placeholder tests using `"password"` have been transitioned to `"trusted-proxy"`.

Closes #352
```