### PR TITLE
fix(sandbox): wire network_default into policy resolution and warn on reserved proxy_allowlist

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -510,7 +510,7 @@ security_grading = false
 # default_level = "STANDARD"            # DISABLED | STANDARD | STRICT | LOCKED
 # backend = "auto"                       # auto | bubblewrap | seatbelt | noop
 # allow_legacy_mode = false              # required for default_level = DISABLED
-# network_default = "none"               # none | proxy_allowlist
+# network_default = "none"               # none (proxy_allowlist is reserved/unimplemented)
 # denial_threshold = 3                   # pause autonomous runs after N denials
 # extra_ro_mounts = []
 # extra_rw_mounts = []

--- a/src/agentos/sandbox/config.py
+++ b/src/agentos/sandbox/config.py
@@ -144,6 +144,13 @@ class SandboxSettings(BaseSettings):
             if not self.allow_legacy_mode:
                 notes.append("legacy_flag_missing")
 
+        if self.network_default == "proxy_allowlist":
+            log.warning(
+                "sandbox.network_default_reserved: network_default='proxy_allowlist' is "
+                "reserved and not yet implemented on sandbox backends"
+            )
+            notes.append("network_default_proxy_allowlist_reserved")
+
         return EffectiveMode(
             sandbox_enabled=sandbox_enabled,
             grading_enabled=grading_enabled,

--- a/src/agentos/sandbox/policy.py
+++ b/src/agentos/sandbox/policy.py
@@ -145,13 +145,19 @@ def _resolve_limits(level: SecurityLevel, settings: SandboxSettings) -> Resource
     )
 
 
-def _resolve_network(level: SecurityLevel, action_kind: str) -> NetworkMode:
+def _resolve_network(
+    level: SecurityLevel,
+    action_kind: str,
+    settings: SandboxSettings | None = None,
+) -> NetworkMode:
     if level == SecurityLevel.DISABLED:
         return NetworkMode.HOST
     if action_kind in _NETWORK_TAGS and level == SecurityLevel.STANDARD:
         # STANDARD + explicit network tag: operators running `web.fetch` at
         # L1 expect egress; isolation still applies to FS/process state.
         return NetworkMode.HOST
+    if settings is not None and settings.network_default == "proxy_allowlist":
+        return NetworkMode.PROXY_ALLOWLIST
     return NetworkMode.NONE
 
 
@@ -221,7 +227,7 @@ def build_policy(
 
     mounts, workspace_rw = _collect_mounts(level, workspace, settings)
     limits = _resolve_limits(level, settings)
-    network = _resolve_network(level, action_kind)
+    network = _resolve_network(level, action_kind, settings)
     tmp_writable = level != SecurityLevel.LOCKED
 
     require_approval = level >= SecurityLevel.STRICT and (

--- a/tests/test_sandbox/test_policy_network.py
+++ b/tests/test_sandbox/test_policy_network.py
@@ -39,3 +39,68 @@ def test_standard_shell_and_code_exec_keep_network_none(tmp_path: Path) -> None:
 
     assert shell_policy.network is NetworkMode.NONE
     assert code_policy.network is NetworkMode.NONE
+
+
+def test_network_default_proxy_allowlist_resolves_policy(tmp_path: Path) -> None:
+    settings = SandboxSettings(network_default="proxy_allowlist")
+
+    shell_policy = build_policy(
+        SecurityLevel.STANDARD,
+        "shell.exec",
+        tmp_path,
+        settings,
+        trusted=True,
+    )
+    strict_policy = build_policy(
+        SecurityLevel.STRICT,
+        "shell.exec",
+        tmp_path,
+        settings,
+        trusted=True,
+    )
+    locked_policy = build_policy(
+        SecurityLevel.LOCKED,
+        "shell.exec",
+        tmp_path,
+        settings,
+        trusted=True,
+    )
+
+    assert shell_policy.network is NetworkMode.PROXY_ALLOWLIST
+    assert strict_policy.network is NetworkMode.PROXY_ALLOWLIST
+    assert locked_policy.network is NetworkMode.PROXY_ALLOWLIST
+
+
+def test_disabled_level_keeps_host_even_with_proxy_allowlist_default(tmp_path: Path) -> None:
+    settings = SandboxSettings(network_default="proxy_allowlist", allow_legacy_mode=True)
+
+    disabled_policy = build_policy(
+        SecurityLevel.DISABLED,
+        "shell.exec",
+        tmp_path,
+        settings,
+        trusted=True,
+    )
+
+    assert disabled_policy.network is NetworkMode.HOST
+
+
+def test_standard_network_tag_keeps_host_even_with_proxy_allowlist_default(tmp_path: Path) -> None:
+    settings = SandboxSettings(network_default="proxy_allowlist")
+
+    policy = build_policy(
+        SecurityLevel.STANDARD,
+        "network.http",
+        tmp_path,
+        settings,
+        trusted=True,
+    )
+
+    assert policy.network is NetworkMode.HOST
+
+
+def test_validate_combination_warns_on_reserved_proxy_allowlist() -> None:
+    settings = SandboxSettings(network_default="proxy_allowlist")
+    effective = settings.validate_combination()
+
+    assert "network_default_proxy_allowlist_reserved" in effective.notes


### PR DESCRIPTION
Closes #360

### Summary
- Wired `settings.network_default` into `_resolve_network` and `build_policy` in `src/agentos/sandbox/policy.py`.
- Updated `SandboxSettings.validate_combination()` to log an explicit warning and record `network_default_proxy_allowlist_reserved` in `EffectiveMode.notes` when `proxy_allowlist` is configured.
- Clarified in `agentos.toml.example` that `proxy_allowlist` is currently reserved and unimplemented on sandbox backends.
- Added comprehensive regression tests in `tests/test_sandbox/test_policy_network.py`.

### Verification
- `uv run pytest tests/test_sandbox -vv` (Passed all 22 active tests)
- `uv run ruff check src tests` (Passed with 0 errors)
- `uv run mypy src/agentos --show-error-codes` (Passed with 0 issues across 612 source files)
- `python scripts/build_control_ui.py build` (Passed, UI bundle and license ledger verified)
- `uv build --wheel` (Passed, wheel built successfully)
