### PR TITLE
fix(tools): refresh wizard model choices and clarify stub/profile subsystems

### DIFF
--- a/src/agentos/application/wizard.py
+++ b/src/agentos/application/wizard.py
@@ -171,11 +171,13 @@ _ONBOARD_AGENT_STEPS: list[WizardStep] = [
                 field_type="select",
                 required=True,
                 choices=[
-                    "anthropic/claude-3-5-sonnet",
-                    "anthropic/claude-3-5-haiku",
-                    "openai/gpt-4o",
-                    "openai/gpt-4o-mini",
+                    "openai/gpt-5.6-luna",
+                    "openai/gpt-5.6-luna-pro",
+                    "anthropic/claude-3-7-sonnet",
+                    "deepseek/deepseek-chat",
+                    "deepseek/deepseek-reasoner",
                 ],
+                default="openai/gpt-5.6-luna",
                 description="Provider/model pair used when a turn does not override it.",
             ),
             WizardField(

--- a/src/agentos/tools/builtin/nodes.py
+++ b/src/agentos/tools/builtin/nodes.py
@@ -1,4 +1,8 @@
-"""Canvas and node helper functions for deployments with a node runtime."""
+"""Reserved node runtime and canvas tool stubs.
+
+These built-ins are unexposed by default (`exposed_by_default=False`) and serve
+as reserved tool signatures for environments with an external node execution runtime.
+"""
 
 from __future__ import annotations
 

--- a/src/agentos/tools/visibility.py
+++ b/src/agentos/tools/visibility.py
@@ -34,6 +34,11 @@ def filter_by_profile(
     profile: ToolProfile | str,
     ctx: ToolContext | None = None,
 ) -> list[ToolDefinition]:
+    """Compatibility pass-through for tool definitions under a profile.
+
+    Fine-grained tool visibility and filtering are centrally enforced by
+    :func:`is_tool_visible` and :mod:`agentos.tools.policy_config`.
+    """
     del ctx
     ToolProfile(profile)
     return list(tools)
@@ -45,6 +50,11 @@ def profile_allows_tool(
     *,
     explicitly_allowed: set[str] | frozenset[str] | None = None,
 ) -> bool:
+    """Compatibility check for tool allowance under a profile.
+
+    Fine-grained tool policy evaluation is centrally handled in
+    :mod:`agentos.tools.policy_config` and :mod:`agentos.tools.policy.checks`.
+    """
     del tool_name, explicitly_allowed
     ToolProfile(profile)
     return True

--- a/tests/test_application/test_wizard.py
+++ b/tests/test_application/test_wizard.py
@@ -34,7 +34,7 @@ def test_wizard_registry_advances_and_applies_schema_defaults() -> None:
     assert second.next_step is not None
     assert second.next_step.step_id == "defaults"
 
-    final = registry.advance(wizard_id, {"default_model": "openai/gpt-4o-mini"})
+    final = registry.advance(wizard_id, {"default_model": "openai/gpt-5.6-luna"})
     assert final.completed is True
     assert final.next_step is None
     assert final.result == {
@@ -43,7 +43,7 @@ def test_wizard_registry_advances_and_applies_schema_defaults() -> None:
             "agent_name": "cora",
             "system_prompt": "Help with release work",
             "persona_tone": "professional",
-            "default_model": "openai/gpt-4o-mini",
+            "default_model": "openai/gpt-5.6-luna",
             "temperature": 7,
         },
     }


### PR DESCRIPTION
Closes #362

### Summary
- Updated `onboard_agent` wizard in `src/agentos/application/wizard.py` to modern default model options (`openai/gpt-5.6-luna`, `openai/gpt-5.6-luna-pro`, `anthropic/claude-3-7-sonnet`, `deepseek/deepseek-chat`, `deepseek/deepseek-reasoner`).
- Clarified docstrings and status for `nodes`/`canvas` reserved tool stubs in `src/agentos/tools/builtin/nodes.py`.
- Clarified tool profile compatibility contracts in `src/agentos/tools/visibility.py` relative to centralized policy evaluation.
- Updated application wizard tests in `tests/test_application/test_wizard.py`.

### Verification
- `uv run pytest tests/test_application tests/test_gateway/test_rpc_wizard.py tests/test_tools/test_node_runtime_stubs.py tests/test_tools/test_registry_visibility.py tests/test_tools/test_registry_visibility_boundary.py -vv` (Passed all 42 tests)
- `uv run ruff check src tests` (Passed with 0 errors)
- `uv run mypy src/agentos --show-error-codes` (Passed with 0 issues across 612 source files)
