### PR TITLE
feat(engine): wire turn, compaction, and tool hooks and log hook fail…

### DIFF
--- a/src/agentos/cli/agent_cmd.py
+++ b/src/agentos/cli/agent_cmd.py
@@ -7,6 +7,7 @@ import copy
 import getpass
 import json
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -114,6 +115,9 @@ async def run_agent_once(
     scratch_dir: str | None = None,
     workspace_lockdown: bool = False,
     permissions: str | None = None,
+    turn_hooks: Sequence[Any] | None = None,
+    compaction_hooks: Sequence[Any] | None = None,
+    tool_hooks: Sequence[Any] | None = None,
 ) -> AgentRunResult:
     """Run a single agent turn through build_services() and TurnRunner.run()."""
     from agentos.agents.scope import resolve_agent_workspace_dir
@@ -185,6 +189,9 @@ async def run_agent_once(
         session_db_path=session_db_path,
         extra_agent_ids=extra_agents,
         seed_agent_workspaces=seed_agent_workspaces,
+        turn_hooks=turn_hooks,
+        compaction_hooks=compaction_hooks,
+        tool_hooks=tool_hooks,
     )
     assert svc.session_manager is not None
     session_key = canonicalize_session_key(session_id or f"agent:{agent_id}:main")

--- a/src/agentos/cli/tui/adapters/runtime_bridge.py
+++ b/src/agentos/cli/tui/adapters/runtime_bridge.py
@@ -8,7 +8,7 @@ or standalone runtime dependencies.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from typing import Any, Protocol
 
 import agentos.cli.tui.adapters.terminal_bridge as _terminal_bridge
@@ -369,6 +369,9 @@ async def run_standalone_chat(
     timeout: float | None = None,
     output_console: Any | None = None,
     error_panel_factory: Callable[[str], Any] | None = None,
+    turn_hooks: Sequence[Any] | None = None,
+    compaction_hooks: Sequence[Any] | None = None,
+    tool_hooks: Sequence[Any] | None = None,
 ) -> None:
     repl_runner = (
         globals()["run_concurrent_repl"] if run_concurrent_repl is None else run_concurrent_repl
@@ -398,6 +401,9 @@ async def run_standalone_chat(
         workspace=workspace,
         workspace_strict=workspace_strict,
         timeout=timeout,
+        turn_hooks=turn_hooks,
+        compaction_hooks=compaction_hooks,
+        tool_hooks=tool_hooks,
         deps=_standalone_runtime.StandaloneRuntimeDependencies(
             stream_response=active_stream_response,
             image_command_handler=active_image_command_handler,
@@ -416,6 +422,9 @@ async def standalone_chat_runner(
     workspace: str | None = None,
     workspace_strict: bool | None = None,
     timeout: float | None = None,
+    turn_hooks: Sequence[Any] | None = None,
+    compaction_hooks: Sequence[Any] | None = None,
+    tool_hooks: Sequence[Any] | None = None,
 ) -> None:
     await run_standalone_chat(
         model=model,
@@ -423,4 +432,7 @@ async def standalone_chat_runner(
         workspace=workspace,
         workspace_strict=workspace_strict,
         timeout=timeout,
+        turn_hooks=turn_hooks,
+        compaction_hooks=compaction_hooks,
+        tool_hooks=tool_hooks,
     )

--- a/src/agentos/cli/tui/standalone_runtime.py
+++ b/src/agentos/cli/tui/standalone_runtime.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import getpass
 import os
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 from uuid import uuid4
@@ -181,13 +181,20 @@ async def run_standalone_chat(
     workspace: str | None = None,
     workspace_strict: bool | None = None,
     timeout: float | None = None,
+    turn_hooks: Sequence[Any] | None = None,
+    compaction_hooks: Sequence[Any] | None = None,
+    tool_hooks: Sequence[Any] | None = None,
 ) -> None:
     """Run standalone chat without owning a concrete terminal application."""
     from agentos.cli.agent_cmd import _resolve_workspace_strict
     from agentos.gateway import build_services, build_turn_runner_from_services
     from agentos.gateway.routing import build_cli_route_envelope, tool_context_from_envelope
 
-    svc = await build_services()
+    svc = await build_services(
+        turn_hooks=turn_hooks,
+        compaction_hooks=compaction_hooks,
+        tool_hooks=tool_hooks,
+    )
     session_manager = svc.session_manager
     if session_manager is None:
         raise RuntimeError("standalone chat requires session manager")

--- a/src/agentos/engine/hooks/__init__.py
+++ b/src/agentos/engine/hooks/__init__.py
@@ -23,6 +23,8 @@ from agentos.engine.hooks.defaults import (
     NoopToolHook,
     NoopTurnHook,
     build_default_turn_hooks,
+    fire_after_compact,
+    fire_before_compact,
 )
 from agentos.engine.hooks.types import (
     CompactionHook,
@@ -53,4 +55,6 @@ __all__ = [
     "TurnHookContext",
     "TurnHookResult",
     "build_default_turn_hooks",
+    "fire_after_compact",
+    "fire_before_compact",
 ]

--- a/src/agentos/engine/hooks/defaults.py
+++ b/src/agentos/engine/hooks/defaults.py
@@ -8,6 +8,9 @@ hook path with these defaults registered.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
 import structlog
 
 from agentos.engine.hooks.types import (
@@ -29,6 +32,7 @@ log = structlog.get_logger("agentos.engine.hooks")
 # No-op hooks — used in tests + as the safe registration default
 # ---------------------------------------------------------------------------
 
+
 class NoopTurnHook:
     """TurnHook that does nothing. Useful as a base class or test double."""
 
@@ -46,6 +50,7 @@ class NoopTurnHook:
     def on_event(self, ctx: TurnHookContext, event: TurnEvent) -> None:
         return None
 
+
 class NoopToolHook:
     """ToolHook that does nothing."""
 
@@ -56,6 +61,7 @@ class NoopToolHook:
 
     def after_tool(self, call: ToolHookCall, outcome: ToolHookResult) -> None:
         return None
+
 
 class NoopCompactionHook:
     """CompactionHook that does nothing."""
@@ -68,9 +74,11 @@ class NoopCompactionHook:
     async def after_compact(self, state: CompactionState, outcome: object) -> None:
         return None
 
+
 # ---------------------------------------------------------------------------
 # Default trace emitter — reproduces TurnRunner._write_trace_event verbatim
 # ---------------------------------------------------------------------------
+
 
 class DefaultTraceEmitterHook:
     """``TurnHook.on_event`` implementation that emits a trace event.
@@ -110,9 +118,11 @@ class DefaultTraceEmitterHook:
         except Exception as exc:  # pragma: no cover — observability must not break turns
             log.debug("trace_event.write_failed", kind=event.kind, error=str(exc))
 
+
 # ---------------------------------------------------------------------------
 # Default transcript hook — placeholder; production persistence stays inline
 # ---------------------------------------------------------------------------
+
 
 class DefaultTranscriptHook:
     """``TurnHook.after_turn`` implementation reserved for transcript persist.
@@ -138,9 +148,11 @@ class DefaultTranscriptHook:
     def on_event(self, ctx: TurnHookContext, event: TurnEvent) -> None:
         return None
 
+
 # ---------------------------------------------------------------------------
 # Default memory flush hook — placeholder; production flush stays inline
 # ---------------------------------------------------------------------------
+
 
 class DefaultMemoryFlushHook:
     """``TurnHook.after_turn`` implementation reserved for memory flush.
@@ -164,9 +176,11 @@ class DefaultMemoryFlushHook:
     def on_event(self, ctx: TurnHookContext, event: TurnEvent) -> None:
         return None
 
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
+
 
 def build_default_turn_hooks() -> tuple[TurnHook, ...]:
     """Return the canonical default ``TurnHook`` chain.
@@ -183,6 +197,7 @@ def build_default_turn_hooks() -> tuple[TurnHook, ...]:
         DefaultMemoryFlushHook(),
     )
 
+
 __all__ = [
     "DefaultMemoryFlushHook",
     "DefaultTraceEmitterHook",
@@ -191,6 +206,8 @@ __all__ = [
     "NoopToolHook",
     "NoopTurnHook",
     "build_default_turn_hooks",
+    "fire_before_compact",
+    "fire_after_compact",
 ]
 
 # Static checks: defaults satisfy the protocols.
@@ -208,3 +225,33 @@ del (
     _check_tool,
     _check_compact,
 )
+
+
+async def fire_before_compact(hooks: Sequence[CompactionHook], state: CompactionState) -> None:
+    for hook in hooks:
+        try:
+            await hook.before_compact(state)
+        except Exception as exc:  # noqa: BLE001 — hook isolation contract
+            log.warning(
+                "compaction_hook.before_compact_failed",
+                hook_name=getattr(hook, "name", type(hook).__name__),
+                session_key=state.session_key,
+                agent_id=state.agent_id,
+                error=str(exc),
+            )
+
+
+async def fire_after_compact(
+    hooks: Sequence[CompactionHook], state: CompactionState, outcome: Any
+) -> None:
+    for hook in hooks:
+        try:
+            await hook.after_compact(state, outcome)
+        except Exception as exc:  # noqa: BLE001 — hook isolation contract
+            log.warning(
+                "compaction_hook.after_compact_failed",
+                hook_name=getattr(hook, "name", type(hook).__name__),
+                session_key=state.session_key,
+                agent_id=state.agent_id,
+                error=str(exc),
+            )

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -52,6 +52,7 @@ from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.engine.hooks import (
     CompactionHook,
     DefaultTraceEmitterHook,
+    ToolHook,
     TurnEvent,
     TurnHook,
     TurnHookContext,
@@ -608,8 +609,9 @@ def _summarize_memory_write(arguments: Any) -> str:
     target = str(arguments.get("target") or "memory")
     operations = arguments.get("operations")
     if isinstance(operations, list) and operations:
-        actions = ",".join(sorted({str(op.get("action", "?")) for op in operations
-                                   if isinstance(op, dict)}))
+        actions = ",".join(
+            sorted({str(op.get("action", "?")) for op in operations if isinstance(op, dict)})
+        )
         return f"{target}/batch[{len(operations)} ops: {actions or '?'}]"
     action = str(arguments.get("action") or "?")
     content = str(arguments.get("content") or arguments.get("old_text") or "").strip()
@@ -1477,6 +1479,7 @@ class TurnRunner:
         diagnostics_state: Any | None = None,
         turn_hooks: Sequence[TurnHook] | None = None,
         compaction_hooks: Sequence[CompactionHook] | None = None,
+        tool_hooks: Sequence[ToolHook] | None = None,
     ) -> None:
         self._provider_selector = provider_selector
         self._tool_registry = tool_registry
@@ -1508,6 +1511,8 @@ class TurnRunner:
         self._compaction_hooks: tuple[CompactionHook, ...] = (
             tuple(compaction_hooks) if compaction_hooks else ()
         )
+        # ToolHook surface. build_tool_handler uses these to wrap tool execution.
+        self._tool_hooks: tuple[ToolHook, ...] = tuple(tool_hooks) if tool_hooks else ()
         # Per-session lock provider.
         # Gateway path: task_runtime._get_session_lock_for_turn (wired in boot.py).
         # CLI/standalone path: _standalone_lock_provider from build_turn_runner_from_services.
@@ -2830,9 +2835,7 @@ class TurnRunner:
 
             # 11. Observability: best-effort DecisionEntry for this turn.
             #     Must never break turn execution — wrap in try/except.
-            turn.metadata.update(
-                {}
-            )
+            turn.metadata.update({})
             prompt_report_for_decision = build_prompt_report(
                 turn_id=turn_id,
                 session_key=session_key,
@@ -3670,6 +3673,7 @@ class TurnRunner:
             self._tool_registry,
             ctx,
             known_skill_names=known_skill_names,
+            tool_hooks=self._tool_hooks,
         )
         return tool_defs, tool_handler
 
@@ -4060,9 +4064,7 @@ class TurnRunner:
         # heartbeat config are boot-time) or for the session kind
         # (bootstrap_context_mode keys the snapshot), so gating on them does
         # not churn the cacheable base.
-        channels_enabled = bool(
-            getattr(getattr(self._config, "channels", None), "channels", None)
-        )
+        channels_enabled = bool(getattr(getattr(self._config, "channels", None), "channels", None))
         unattended_context = bool(
             getattr(getattr(self._config, "heartbeat", None), "enabled", False)
         ) or bootstrap_context_mode in {"heartbeat_light", "unattended"}
@@ -4521,7 +4523,6 @@ class TurnRunner:
             final_prompt = "\n\n".join(final_prompt)
 
         return final_prompt, cache_breakpoints, request_context_prompt
-
 
     async def _record_checkpoint_before_compaction(
         self,
@@ -5374,8 +5375,6 @@ class TurnRunner:
                 ),
             )
 
-
-
     def _pre_compaction_flush_timeout_seconds(self) -> float:
         memory_cfg = getattr(self._config, "memory", None)
         raw_timeout = getattr(memory_cfg, "flush_timeout_seconds", 15.0)
@@ -5393,7 +5392,6 @@ class TurnRunner:
         except (TypeError, ValueError):
             return 120.0
         return max(timeout, 0.0)
-
 
     def _consume_pre_compaction_flush_task(
         self,

--- a/src/agentos/engine/turn_runner/compaction_and_history_stage.py
+++ b/src/agentos/engine/turn_runner/compaction_and_history_stage.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from agentos.engine.agent import Agent
-    from agentos.engine.hooks.types import CompactionHook
+    from agentos.engine.hooks.types import CompactionHook, CompactionState
     from agentos.engine.turn_runner.outcome import StageOutcome
 
 # Internal sentinels mirroring the runtime.py module-level constants. The
@@ -59,6 +59,7 @@ _T3_FLUSH_FAILED: str = "flush_failed"
 # ---------------------------------------------------------------------------
 # Ports — four narrow Protocols
 # ---------------------------------------------------------------------------
+
 
 @runtime_checkable
 class T3UpgradeCompactionPort(Protocol):
@@ -93,6 +94,7 @@ class T3UpgradeCompactionPort(Protocol):
         compaction_model: str | None,
     ) -> str: ...
 
+
 @runtime_checkable
 class PreflightCompactionPort(Protocol):
     """Wraps ``TurnRunner._maybe_preflight_compact``.
@@ -116,6 +118,7 @@ class PreflightCompactionPort(Protocol):
         compaction_provider: Any | None,
         compaction_model: str | None,
     ) -> None: ...
+
 
 @runtime_checkable
 class HistoryLoaderPort(Protocol):
@@ -142,6 +145,7 @@ class HistoryLoaderPort(Protocol):
         trim_last_user: bool,
     ) -> str | None: ...
 
+
 @runtime_checkable
 class RequestContextPrependPort(Protocol):
     """Wraps ``_prepend_request_context_prompt`` (module-level pure helper).
@@ -164,9 +168,11 @@ class RequestContextPrependPort(Protocol):
         prepended: str | None,
     ) -> str | None: ...
 
+
 # ---------------------------------------------------------------------------
 # Stage I/O dataclasses (frozen)
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class CompactionAndHistoryStageInput:
@@ -191,6 +197,7 @@ class CompactionAndHistoryStageInput:
     session_key: str
     agent_id: str
     history_has_persisted_user: bool
+
 
 @dataclass(frozen=True)
 class CompactionAndHistoryStageOutput:
@@ -219,9 +226,11 @@ class CompactionAndHistoryStageOutput:
     compaction_summary_context: str | None
     final_request_context_prompt: str | None
 
+
 # ---------------------------------------------------------------------------
 # Stage
 # ---------------------------------------------------------------------------
+
 
 class CompactionAndHistoryStage:
     """Compact (if needed), load history, prepend compaction context.
@@ -334,18 +343,12 @@ class CompactionAndHistoryStage:
             )
         )
 
-    async def _fire_before_compact(self, state: Any) -> None:
-        for hook in self._compaction_hooks:
-            try:
-                await hook.before_compact(state)
-            except Exception:  # noqa: BLE001 — hook isolation contract
-                # A buggy hook MUST NOT break the turn. Swallow per
-                # protocol; observability is the runtime's concern.
-                pass
+    async def _fire_before_compact(self, state: CompactionState) -> None:
+        from agentos.engine.hooks import fire_before_compact
 
-    async def _fire_after_compact(self, state: Any, outcome: Any) -> None:
-        for hook in self._compaction_hooks:
-            try:
-                await hook.after_compact(state, outcome)
-            except Exception:  # noqa: BLE001 — hook isolation contract
-                pass
+        await fire_before_compact(self._compaction_hooks, state)
+
+    async def _fire_after_compact(self, state: CompactionState, outcome: Any) -> None:
+        from agentos.engine.hooks import fire_after_compact
+
+        await fire_after_compact(self._compaction_hooks, state, outcome)

--- a/src/agentos/engine/turn_runner/compaction_and_history_stage.py
+++ b/src/agentos/engine/turn_runner/compaction_and_history_stage.py
@@ -344,11 +344,13 @@ class CompactionAndHistoryStage:
         )
 
     async def _fire_before_compact(self, state: CompactionState) -> None:
+        # Imported inline to avoid import cycle
         from agentos.engine.hooks import fire_before_compact
 
         await fire_before_compact(self._compaction_hooks, state)
 
     async def _fire_after_compact(self, state: CompactionState, outcome: Any) -> None:
+        # Imported inline to avoid import cycle
         from agentos.engine.hooks import fire_after_compact
 
         await fire_after_compact(self._compaction_hooks, state, outcome)

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -61,6 +61,7 @@ _SUPPRESS: Final = object()
 # Ports -- five narrow Protocols + one callable
 # ---------------------------------------------------------------------------
 
+
 @runtime_checkable
 class AgentRunPort(Protocol):
     """Wrap ``agent.run_turn(turn_input, extra_messages=..., **kwargs)``.
@@ -80,6 +81,7 @@ class AgentRunPort(Protocol):
         extra_messages: list[Any] | None,
         semantic_message: str | None,
     ) -> AsyncIterator[AgentEvent]: ...
+
 
 @runtime_checkable
 class CompactionPersistPort(Protocol):
@@ -107,6 +109,7 @@ class CompactionPersistPort(Protocol):
         compaction_id: str | None = None,
     ) -> None: ...
 
+
 @runtime_checkable
 class MemorySnapshotRefreshPort(Protocol):
     """Refresh ``_memory_snapshots[(agent_id, session_key)]`` after compaction.
@@ -129,6 +132,7 @@ class MemorySnapshotRefreshPort(Protocol):
         session_key: str,
         private_memory_allowed: bool,
     ) -> None: ...
+
 
 @runtime_checkable
 class SystemPromptRefreshPort(Protocol):
@@ -155,6 +159,7 @@ class SystemPromptRefreshPort(Protocol):
         bootstrap_context_mode: str | None,
     ) -> None: ...
 
+
 @runtime_checkable
 class MemorySyncNotifyPort(Protocol):
     """Notify ``sync_manager.notify_message(byte_count)`` post-stream.
@@ -170,6 +175,7 @@ class MemorySyncNotifyPort(Protocol):
         runtime_message: str,
     ) -> None: ...
 
+
 # Callable signature for runtime warning transformation. Implemented as a
 # plain callable rather than a Protocol because it is a single-method
 # contract and the recording-fake discipline applies identically.
@@ -178,6 +184,7 @@ WarningTransformer = Callable[["WarningEvent"], "WarningEvent"]
 # ---------------------------------------------------------------------------
 # Stream state -- four owned + four pass-by-reference accumulators
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class _StreamState:
@@ -201,9 +208,7 @@ class _StreamState:
     error_message: str | None = None
     pending_error_event: ErrorEvent | None = None
     done_event: DoneEvent | None = None
-    protocol_text_guard: ProtocolTextLeakGuard = field(
-        default_factory=ProtocolTextLeakGuard
-    )
+    protocol_text_guard: ProtocolTextLeakGuard = field(default_factory=ProtocolTextLeakGuard)
 
     # PASSED IN by the harness -- references, not copies.
     final_text_parts: list[str] = field(default_factory=list)
@@ -211,9 +216,11 @@ class _StreamState:
     turn_artifacts: list[dict[str, Any]] = field(default_factory=list)
     artifact_delivery_failures: list[str] = field(default_factory=list)
 
+
 # ---------------------------------------------------------------------------
 # Stage I/O dataclass
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class StreamConsumerStageInput:
@@ -260,9 +267,11 @@ class StreamConsumerStageInput:
     # Original input provenance for runtime-generated disclosures.
     input_provenance: dict[str, Any] | None = None
 
+
 # ---------------------------------------------------------------------------
 # Per-event handler classes
 # ---------------------------------------------------------------------------
+
 
 class _TextDeltaHandler:
     """Accumulate streamed text deltas into the final-text and current-text buffers."""
@@ -277,6 +286,7 @@ class _TextDeltaHandler:
             state.final_text_parts.append(cleaned_delta)
             state.current_text_parts.append(cleaned_delta)
         return replace(event, text=cleaned_delta)
+
 
 class _ToolUseStartHandler:
     """Strip synthetic-tool-call text, flush the current text segment, append tool_use segment.
@@ -322,13 +332,9 @@ class _ToolUseStartHandler:
                             event.tool_name,
                         )
                     ]
-                state.current_text_parts[:] = (
-                    [cleaned_current_text] if cleaned_current_text else []
-                )
+                state.current_text_parts[:] = [cleaned_current_text] if cleaned_current_text else []
         if state.current_text_parts:
-            state.turn_segments.append(
-                {"type": "text", "text": "".join(state.current_text_parts)}
-            )
+            state.turn_segments.append({"type": "text", "text": "".join(state.current_text_parts)})
             state.current_text_parts[:] = []
         state.turn_segments.append(
             {
@@ -339,6 +345,7 @@ class _ToolUseStartHandler:
             }
         )
         return event
+
 
 class _ToolResultHandler:
     """Capture artifact-delivery failures and append the tool_result segment."""
@@ -374,6 +381,7 @@ class _ToolResultHandler:
         state.turn_segments.append(_persisted_tool_result_segment(event))
         return event
 
+
 class _ArtifactHandler:
     """Append an artifact payload to the per-turn artifact list."""
 
@@ -386,6 +394,7 @@ class _ArtifactHandler:
 
         state.turn_artifacts.append(artifact_payload(event))
         return event
+
 
 class _ErrorHandler:
     """Rewrite timeout envelopes, drop unpaired tool_use, capture pending error.
@@ -412,12 +421,11 @@ class _ErrorHandler:
                 code=_LLM_TIMEOUT_ENVELOPE["error_class"],
             )
         if event.code in {"incomplete_tool_stream", "provider_output_truncated"}:
-            state.turn_segments[:] = _drop_unpaired_tool_use_segments(
-                state.turn_segments
-            )
+            state.turn_segments[:] = _drop_unpaired_tool_use_segments(state.turn_segments)
         state.error_message = event.message or "Unknown error"
         state.pending_error_event = event
         return _SUPPRESS
+
 
 class _WarningHandler:
     """Forward warnings to the runner's runtime-warning transformer."""
@@ -427,6 +435,7 @@ class _WarningHandler:
 
     def handle(self, event: WarningEvent) -> WarningEvent:
         return self._transformer(event)
+
 
 class _DoneHandler:
     """Apply routing-tier metadata, savings, normalize text, emit notices.
@@ -545,9 +554,7 @@ class _DoneHandler:
             artifact_event = _ArtifactEvent(**artifact)
             state.turn_artifacts.append(artifact)
             extra_yields.append(artifact_event)
-        state.artifact_delivery_failures.extend(
-            omitted_publish_result.failure_summaries
-        )
+        state.artifact_delivery_failures.extend(omitted_publish_result.failure_summaries)
 
         if _should_add_artifact_delivery_failure_notice(
             failure_summaries=state.artifact_delivery_failures,
@@ -574,9 +581,7 @@ class _DoneHandler:
             extra_yields.append(notice_event)
 
         accumulated_text = "".join(state.final_text_parts)
-        if _claims_image_without_tool_use(
-            accumulated_text, turn.tool_defs, state.turn_segments
-        ):
+        if _claims_image_without_tool_use(accumulated_text, turn.tool_defs, state.turn_segments):
             extra_yields.append(
                 _WarningEvent(
                     code="image_generate_claimed_without_call",
@@ -682,6 +687,7 @@ def _int_value(value: Any) -> int:
         return int(value or 0)
     except (TypeError, ValueError):
         return 0
+
 
 class _CompactionHandler:
     """Persist compaction and refresh memory snapshot + system prompt.
@@ -792,26 +798,24 @@ class _CompactionHandler:
         )
 
     async def _fire_before_compact(self, state: CompactionState) -> None:
-        for hook in self._compaction_hooks:
-            try:
-                await hook.before_compact(state)
-            except Exception:  # noqa: BLE001 - hook isolation contract
-                pass
+        from agentos.engine.hooks import fire_before_compact
+
+        await fire_before_compact(self._compaction_hooks, state)
 
     async def _fire_after_compact(
         self,
         state: CompactionState,
         outcome: dict[str, Any],
     ) -> None:
-        for hook in self._compaction_hooks:
-            try:
-                await hook.after_compact(state, outcome)
-            except Exception:  # noqa: BLE001 - hook isolation contract
-                pass
+        from agentos.engine.hooks import fire_after_compact
+
+        await fire_after_compact(self._compaction_hooks, state, outcome)
+
 
 # ---------------------------------------------------------------------------
 # Outer stage class
 # ---------------------------------------------------------------------------
+
 
 class StreamConsumerStage:
     """Consume the agent stream and yield events; persist mid-stream side effects.
@@ -913,9 +917,7 @@ class StreamConsumerStage:
             elif isinstance(event, WarningEvent):
                 transformed = self._warning_handler.handle(event)
             elif isinstance(event, DoneEvent):
-                transformed, extra_yields = self._done_handler.handle(
-                    event, inp, state
-                )
+                transformed, extra_yields = self._done_handler.handle(event, inp, state)
             elif isinstance(event, CompactionEvent):
                 await self._compaction_handler.handle(event, inp)
                 transformed = _SUPPRESS

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -798,6 +798,7 @@ class _CompactionHandler:
         )
 
     async def _fire_before_compact(self, state: CompactionState) -> None:
+        # Imported inline to avoid import cycle
         from agentos.engine.hooks import fire_before_compact
 
         await fire_before_compact(self._compaction_hooks, state)
@@ -807,6 +808,7 @@ class _CompactionHandler:
         state: CompactionState,
         outcome: dict[str, Any],
     ) -> None:
+        # Imported inline to avoid import cycle
         from agentos.engine.hooks import fire_after_compact
 
         await fire_after_compact(self._compaction_hooks, state, outcome)

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1919,11 +1919,8 @@ def build_turn_runner_from_services(
         memory_provider_managers=getattr(svc, "memory_provider_managers", None) or None,
         session_lock_provider=_standalone_lock_provider,
         diagnostics_state=diagnostics_state,
-        # Hook registries forwarded from services when present so any future
-        # user-registered TurnHook / CompactionHook / ToolHook instance flows through to
-        # TurnRunner without another boot edit.
-        # None today (no production services expose either registry); the
-        # plumbing stays here so the path is wired end-to-end.
+        # Hook registries forwarded from services when present so any user-registered
+        # TurnHook / CompactionHook / ToolHook instance flows through to TurnRunner.
         turn_hooks=getattr(svc, "turn_hooks", None),
         compaction_hooks=getattr(svc, "compaction_hooks", None),
         tool_hooks=getattr(svc, "tool_hooks", None),
@@ -1940,6 +1937,9 @@ async def start_gateway_server(
     channel_manager: Any = None,
     usage_tracker: Any = None,
     run: bool = True,
+    turn_hooks: Sequence[Any] | None = None,
+    compaction_hooks: Sequence[Any] | None = None,
+    tool_hooks: Sequence[Any] | None = None,
 ) -> GatewayServer:
     """
     Boot sequence:
@@ -2016,6 +2016,9 @@ async def start_gateway_server(
         tool_registry=tool_registry,
         usage_tracker=usage_tracker,
         session_db_path=str(_state_path(config, "sessions.db")),
+        turn_hooks=turn_hooks,
+        compaction_hooks=compaction_hooks,
+        tool_hooks=tool_hooks,
     )
 
     # Record boot time for uptime calculation (gateway-specific)

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -8,7 +8,7 @@ import logging
 import os
 import secrets
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -268,6 +268,9 @@ class ServiceContainer:
     heartbeat_loop: Any = None
     heartbeat_watcher: Any = None
     _compaction_listener_remove: Callable[[], None] | None = None
+    turn_hooks: Sequence[Any] | None = None
+    compaction_hooks: Sequence[Any] | None = None
+    tool_hooks: Sequence[Any] | None = None
 
     # Backward-compat alias — returns the "main" store (or None).
     @property
@@ -1379,6 +1382,9 @@ async def build_services(
     session_db_path: str = ":memory:",
     extra_agent_ids: list[str] | None = None,
     seed_agent_workspaces: bool = True,
+    turn_hooks: Sequence[Any] | None = None,
+    compaction_hooks: Sequence[Any] | None = None,
+    tool_hooks: Sequence[Any] | None = None,
 ) -> ServiceContainer:
     """Initialize reusable services without any gateway-specific side effects.
 
@@ -1864,6 +1870,9 @@ async def build_services(
         memory_retrievers=memory_retrievers,
         turn_capture_services=turn_capture_services,
         memory_provider_managers=memory_provider_managers,
+        turn_hooks=turn_hooks,
+        compaction_hooks=compaction_hooks,
+        tool_hooks=tool_hooks,
     )
     # Attach deferred callback ref so start_gateway_server can wire TurnRunner
     svc._turn_runner_ref = _turn_runner_ref  # type: ignore[attr-defined]
@@ -1911,12 +1920,13 @@ def build_turn_runner_from_services(
         session_lock_provider=_standalone_lock_provider,
         diagnostics_state=diagnostics_state,
         # Hook registries forwarded from services when present so any future
-        # user-registered TurnHook / CompactionHook instance flows through to
+        # user-registered TurnHook / CompactionHook / ToolHook instance flows through to
         # TurnRunner without another boot edit.
         # None today (no production services expose either registry); the
         # plumbing stays here so the path is wired end-to-end.
         turn_hooks=getattr(svc, "turn_hooks", None),
         compaction_hooks=getattr(svc, "compaction_hooks", None),
+        tool_hooks=getattr(svc, "tool_hooks", None),
     )
 
 

--- a/tests/test_cli/test_chat_cmd.py
+++ b/tests/test_cli/test_chat_cmd.py
@@ -725,7 +725,7 @@ async def test_standalone_repl_forwards_timeout(monkeypatch) -> None:
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return _FakeServices()
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -765,7 +765,7 @@ async def test_standalone_chat_uses_workspace_in_tool_context(
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return _FakeServices()
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -806,7 +806,7 @@ async def test_standalone_path_command_runs_as_plain_message(
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return _FakeServices()
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -881,7 +881,7 @@ async def test_standalone_repl_wires_memory_services_into_turnrunner(monkeypatch
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return services
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -1084,7 +1084,7 @@ async def test_standalone_repl_uses_exact_slash_tokens(monkeypatch) -> None:
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return services
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -1123,7 +1123,7 @@ async def test_standalone_slash_compact_passes_provider_config(monkeypatch) -> N
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return services
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -1168,7 +1168,7 @@ async def test_standalone_reset_truncates_non_empty_transcript(
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return services
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -1209,7 +1209,7 @@ async def test_standalone_compact_missing_flush_service_does_not_block_compactio
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return services
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)
@@ -1244,7 +1244,7 @@ async def test_standalone_slash_compact_keeps_legacy_compact_manager_compatible(
     async def fake_prompt_user(prefix: str = "[you] ", **kwargs):
         return next(inputs)
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args, **kwargs) -> _FakeServices:
         return services
 
     monkeypatch.setattr("agentos.engine.runtime.TurnRunner", FakeTurnRunner)

--- a/tests/test_engine/test_hook_surface_equivalence.py
+++ b/tests/test_engine/test_hook_surface_equivalence.py
@@ -514,12 +514,14 @@ async def test_build_services_wires_hooks(tmp_path) -> None:
         tool_hooks=[toh],
         seed_agent_workspaces=False,
     )
+    try:
+        assert svc.turn_hooks == [th]
+        assert svc.compaction_hooks == [ch]
+        assert svc.tool_hooks == [toh]
 
-    assert svc.turn_hooks == [th]
-    assert svc.compaction_hooks == [ch]
-    assert svc.tool_hooks == [toh]
-
-    runner = build_turn_runner_from_services(svc, config=config)
-    assert th in runner._turn_hooks
-    assert runner._compaction_hooks == (ch,)
-    assert runner._tool_hooks == (toh,)
+        runner = build_turn_runner_from_services(svc, config=config)
+        assert th in runner._turn_hooks
+        assert runner._compaction_hooks == (ch,)
+        assert runner._tool_hooks == (toh,)
+    finally:
+        await svc.close()

--- a/tests/test_engine/test_hook_surface_equivalence.py
+++ b/tests/test_engine/test_hook_surface_equivalence.py
@@ -123,14 +123,36 @@ def _hook_emit(
 @pytest.mark.parametrize(
     ("kind", "seq", "attrs", "payload"),
     [
-        ("turn_start", 1, {"input_mode": "user", "run_kind": "default"},
-         {"message_chars": 12, "attachment_count": 0}),
-        ("turn_error", 2, None,
-         {"error_type": "ProviderResolutionError", "error_code": "no_provider", "error_chars": 19}),
-        ("turn_end", 2, {"provider": "openrouter", "model": "gpt-x"},
-         {"final_text_chars": 5, "segment_count": 0, "artifact_count": 0,
-          "error": False, "tool_projection_applied": False,
-          "tool_projection_calls": 0, "tool_projection_tokens_saved": 0}),
+        (
+            "turn_start",
+            1,
+            {"input_mode": "user", "run_kind": "default"},
+            {"message_chars": 12, "attachment_count": 0},
+        ),
+        (
+            "turn_error",
+            2,
+            None,
+            {
+                "error_type": "ProviderResolutionError",
+                "error_code": "no_provider",
+                "error_chars": 19,
+            },
+        ),
+        (
+            "turn_end",
+            2,
+            {"provider": "openrouter", "model": "gpt-x"},
+            {
+                "final_text_chars": 5,
+                "segment_count": 0,
+                "artifact_count": 0,
+                "error": False,
+                "tool_projection_applied": False,
+                "tool_projection_calls": 0,
+                "tool_projection_tokens_saved": 0,
+            },
+        ),
         ("turn_cancelled", 2, None, {"partial_text_chars": 3}),
     ],
 )
@@ -312,13 +334,15 @@ def _emit_through_runtime(
 @pytest.mark.parametrize(
     ("kind", "seq", "attrs", "payload"),
     [
-        ("turn_start", 1, {"input_mode": "user", "run_kind": "default"},
-         {"message_chars": 12, "attachment_count": 0}),
-        ("turn_end", 2, {"provider": "p", "model": "m"},
-         {"final_text_chars": 5}),
+        (
+            "turn_start",
+            1,
+            {"input_mode": "user", "run_kind": "default"},
+            {"message_chars": 12, "attachment_count": 0},
+        ),
+        ("turn_end", 2, {"provider": "p", "model": "m"}, {"final_text_chars": 5}),
         ("turn_cancelled", 2, None, {"partial_text_chars": 3}),
-        ("turn_error", 2, None,
-         {"error_type": "RuntimeError", "error_chars": 7}),
+        ("turn_error", 2, None, {"error_type": "RuntimeError", "error_chars": 7}),
     ],
 )
 def test_emit_turn_event_legacy_matches_new(
@@ -335,15 +359,11 @@ def test_emit_turn_event_legacy_matches_new(
     runner = _make_runtime_with_default_hook()
 
     monkeypatch.setenv("AGENTOS_HOOKS", "legacy")
-    _emit_through_runtime(
-        runner, trace_context, kind=kind, seq=seq, attrs=attrs, payload=payload
-    )
+    _emit_through_runtime(runner, trace_context, kind=kind, seq=seq, attrs=attrs, payload=payload)
     legacy = captured_events.pop()
 
     monkeypatch.setenv("AGENTOS_HOOKS", "new")
-    _emit_through_runtime(
-        runner, trace_context, kind=kind, seq=seq, attrs=attrs, payload=payload
-    )
+    _emit_through_runtime(runner, trace_context, kind=kind, seq=seq, attrs=attrs, payload=payload)
     new = captured_events.pop()
 
     assert legacy.kind == new.kind
@@ -414,9 +434,92 @@ def test_runtime_hook_failure_does_not_break_emission(
         provider_selector=None,
         turn_hooks=(_RaisingHook(), DefaultTraceEmitterHook()),
     )
-    _emit_through_runtime(
-        runner, trace_context, kind="turn_start", seq=1, attrs=None, payload=None
-    )
+    _emit_through_runtime(runner, trace_context, kind="turn_start", seq=1, attrs=None, payload=None)
     # The default emitter still wrote the event despite the prior hook raising.
     event = captured_events.pop()
     assert event.kind == "turn_start"
+
+
+@pytest.mark.asyncio
+async def test_compaction_hooks_failure_logged(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agentos.engine.hooks.defaults as hooks_defaults
+    from agentos.engine.hooks import CompactionState
+    from agentos.engine.hooks.defaults import fire_after_compact, fire_before_compact
+
+    warnings = []
+
+    def mock_warn(event, **kwargs):
+        warnings.append((event, kwargs))
+
+    monkeypatch.setattr(hooks_defaults.log, "warning", mock_warn)
+
+    class BuggyCompactionHook:
+        name = "buggy"
+
+        async def before_compact(self, state: CompactionState) -> None:
+            raise ValueError("before fail")
+
+        async def after_compact(self, state: CompactionState, outcome: Any) -> None:
+            raise ValueError("after fail")
+
+    state = CompactionState(session_key="sess-1", agent_id="agent-1")
+
+    await fire_before_compact([BuggyCompactionHook()], state)
+    await fire_after_compact([BuggyCompactionHook()], state, {"ok": True})
+
+    assert len(warnings) == 2
+    assert warnings[0][0] == "compaction_hook.before_compact_failed"
+    assert warnings[0][1]["hook_name"] == "buggy"
+    assert warnings[0][1]["error"] == "before fail"
+
+    assert warnings[1][0] == "compaction_hook.after_compact_failed"
+    assert warnings[1][1]["hook_name"] == "buggy"
+    assert warnings[1][1]["error"] == "after fail"
+
+
+def test_turn_runner_wires_tool_hooks() -> None:
+    from agentos.engine.hooks import NoopToolHook
+
+    my_hook = NoopToolHook()
+    runner = TurnRunner(
+        provider_selector=None,
+        tool_hooks=(my_hook,),
+    )
+
+    assert runner._tool_hooks == (my_hook,)
+
+
+@pytest.mark.asyncio
+async def test_build_services_wires_hooks(tmp_path) -> None:
+    from agentos.engine.hooks import NoopCompactionHook, NoopToolHook, NoopTurnHook
+    from agentos.gateway.boot import build_services, build_turn_runner_from_services
+    from agentos.gateway.config import GatewayConfig
+
+    th = NoopTurnHook()
+    ch = NoopCompactionHook()
+    toh = NoopToolHook()
+
+    config = GatewayConfig(
+        state_dir=str(tmp_path / "state"),
+        workspace_dir=str(tmp_path / "workspace"),
+        control_ui={"enabled": False},
+        channels={"channels": []},
+        mcp={"enabled": False},
+    )
+
+    svc = await build_services(
+        config=config,
+        turn_hooks=[th],
+        compaction_hooks=[ch],
+        tool_hooks=[toh],
+        seed_agent_workspaces=False,
+    )
+
+    assert svc.turn_hooks == [th]
+    assert svc.compaction_hooks == [ch]
+    assert svc.tool_hooks == [toh]
+
+    runner = build_turn_runner_from_services(svc, config=config)
+    assert th in runner._turn_hooks
+    assert runner._compaction_hooks == (ch,)
+    assert runner._tool_hooks == (toh,)

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -1203,3 +1203,44 @@ async def test_task_runtime_turn_honours_cron_job_elevation() -> None:
     assert tool_context.elevated == "bypass"
     assert "exec_command" in (tool_context.allowed_tools or set())
     assert "cron" in tool_context.denied_tools
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_server_wires_hooks(tmp_path) -> None:
+    from agentos.engine.hooks import NoopCompactionHook, NoopToolHook, NoopTurnHook
+    from agentos.gateway.boot import start_gateway_server
+
+    th = NoopTurnHook()
+    ch = NoopCompactionHook()
+    toh = NoopToolHook()
+
+    config = GatewayConfig(
+        state_dir=str(tmp_path / "state"),
+        workspace_dir=str(tmp_path / "workspace"),
+        control_ui={"enabled": False},
+        channels={"channels": []},
+        mcp={"enabled": False},
+    )
+
+    server = await start_gateway_server(
+        config=config,
+        run=False,
+        turn_hooks=[th],
+        compaction_hooks=[ch],
+        tool_hooks=[toh],
+    )
+    try:
+        svc = server._services
+        assert svc is not None
+        assert svc.turn_hooks == [th]
+        assert svc.compaction_hooks == [ch]
+        assert svc.tool_hooks == [toh]
+
+        assert hasattr(svc, "_turn_runner_ref")
+        runner = svc._turn_runner_ref[0]
+        assert th in runner._turn_hooks
+        assert runner._compaction_hooks == (ch,)
+        assert runner._tool_hooks == (toh,)
+    finally:
+        await server.close()
+

--- a/tests/test_gateway/test_structlog_reaches_debug_log.py
+++ b/tests/test_gateway/test_structlog_reaches_debug_log.py
@@ -14,7 +14,7 @@ import logging
 
 import structlog
 
-from agentos.gateway.boot import _setup_file_logging
+from agentos.gateway.boot import _remove_structlog_tee, _setup_file_logging
 from agentos.gateway.config import GatewayConfig
 
 
@@ -36,6 +36,7 @@ def _enable_file_logging(tmp_path, monkeypatch) -> None:
 
 
 def test_a_structlog_warning_lands_in_the_debug_log(tmp_path, monkeypatch) -> None:
+    _remove_structlog_tee()
     original = structlog.get_config()
     try:
         _enable_file_logging(tmp_path, monkeypatch)
@@ -56,6 +57,7 @@ def test_a_structlog_warning_lands_in_the_debug_log(tmp_path, monkeypatch) -> No
 
 
 def test_the_level_is_preserved_so_filters_still_work(tmp_path, monkeypatch) -> None:
+    _remove_structlog_tee()
     original = structlog.get_config()
     try:
         _enable_file_logging(tmp_path, monkeypatch)
@@ -74,6 +76,7 @@ def test_the_level_is_preserved_so_filters_still_work(tmp_path, monkeypatch) -> 
 def test_turning_file_logging_off_restores_the_previous_structlog_config(
     tmp_path, monkeypatch
 ) -> None:
+    _remove_structlog_tee()
     original = structlog.get_config()
     try:
         _enable_file_logging(tmp_path, monkeypatch)

--- a/tests/unit/cli/repl/test_standalone_runtime.py
+++ b/tests/unit/cli/repl/test_standalone_runtime.py
@@ -97,7 +97,7 @@ async def test_standalone_runtime_mirrors_turn_model_update_to_legacy_scope(
     output = cast(TuiOutputHandle, object())
     captured: dict[str, Any] = {}
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args: Any, **kwargs: Any) -> _FakeServices:
         return services
 
     def fake_build_turn_runner_from_services(_services: object) -> object:
@@ -206,7 +206,7 @@ async def test_standalone_runtime_matches_exit_with_standalone_surface(
         surfaces.append(surface)
         return value == "/exit"
 
-    async def fake_build_services() -> _FakeServices:
+    async def fake_build_services(*args: Any, **kwargs: Any) -> _FakeServices:
         return _FakeServices()
 
     async def fake_run_concurrent_repl(


### PR DESCRIPTION
 Description
Wires the engine-level turn, compaction, and tool hook extension surface to the `ServiceContainer` and `TurnRunner` to make them reachable in production.

Also de-duplicates the identical compaction hook invocation patterns across `CompactionAndHistoryStage` and `StreamConsumerStage` into reusable `fire_before_compact` and `fire_after_compact` helper functions. These helpers are equipped with safe exception isolation and emit `log.warning(...)` messages upon hook failure so that buggy hooks are logged instead of failing silently.

Closes #361
```
