### PR TITLE
docs(config): resolve CLI and configuration documentation drift (#371)

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -7,8 +7,8 @@
 
 # Assistant speaker label shown on the ◢ marker, the pre-token waiting
 # row, and the queued-turn marker in `agentos chat`. Defaults to "agentos".
-# Env override: AGENTOS_ASSISTANT_LABEL="Hani"
-# assistant_label = "agentos"
+# Configured via environment variable (not a TOML key):
+# export AGENTOS_ASSISTANT_LABEL="Hani"
 
 # Workspace/state defaults
 # Defaults:
@@ -22,8 +22,8 @@
 # events while a run is active; stream idle timeout is the real upstream stall
 # detector. Keep browser grace above stream idle so server terminal errors win.
 # agent_stream_heartbeat_interval_seconds = 15.0
-# agent_stream_idle_timeout_seconds = 180.0
-# webui_stream_idle_grace_seconds = 210.0
+# agent_stream_idle_timeout_seconds = 600.0
+# webui_stream_idle_grace_seconds = 630.0
 # Keep a positive cap for smaller local models so repeated tool calls cannot
 # run forever. Zero means unlimited.
 # agent_max_iterations = 8
@@ -160,6 +160,20 @@ base_url = "https://openrouter.ai/api/v1"
 # table to keep gateway auto-routing.
 # [llm.provider_routing]
 # "glm-5.2" = "provider-id-from-live-catalog"
+
+# Prompt caching controls. Enables prefix caching for supported providers
+# (Anthropic, OpenAI, DeepSeek, OpenRouter, etc.).
+# mode: "auto" (default; on where supported), "on" (force on), "off" (disabled).
+# Env override: AGENTOS_CACHE_MODE=auto|on|off (legacy AGENTOS_CACHE_ENABLED is deprecated).
+# [prompt_cache]
+# mode = "auto"
+
+# Prompt-ingress safety controls.
+# wrap_untrusted_workspace: wrap untrusted workspace files with safety bounding markers.
+# injection_scan_mode: "report" (default; log scan results), "enforce" (block turns on injection), "off".
+# [safety]
+# wrap_untrusted_workspace = true
+# injection_scan_mode = "report"
 
 [memory]
 # "workspace" stores MEMORY.md and memory/*.md under workspace_dir.
@@ -570,3 +584,70 @@ default_mode = "bypass"                 # off | on | bypass | full
 # group_mention_required = true
 # transcribe_voice = false
 # max_voice_duration_s = 120
+
+# Image generation configuration.
+# [image_generation]
+# provider = ""               # "openai", "openrouter", etc.
+# model = "dall-e-3"
+# api_key = ""                # env OPENAI_API_KEY / OPENROUTER_API_KEY also works
+# base_url = ""
+
+# Audio transcription and text-to-speech configuration.
+# [audio]
+# transcribe_provider = ""    # "openai", "groq", etc.
+# transcribe_model = "whisper-1"
+# transcribe_api_key = ""
+# tts_provider = ""           # "openai", "elevenlabs", etc.
+# tts_model = "tts-1"
+# tts_voice = "alloy"
+# tts_api_key = ""
+
+# Periodic background heartbeat.
+# [heartbeat]
+# enabled = false
+# interval_seconds = 300
+# prompt = "Periodic health check. Report your status."
+# target = "last"             # "last" | "none" | specific channel
+
+# MCP (Model Context Protocol) external servers.
+# [[mcp.servers]]
+# name = "fetch"
+# transport = "stdio"
+# command = "uvx"
+# args = ["mcp-server-fetch"]
+# env = {}
+
+# Default agent settings and multi-agent defaults.
+# [agents_defaults]
+# model = ""
+# thinking_level = ""
+# workspace_dir = ""
+
+# Subagent hierarchy limits.
+# [subagents]
+# max_depth = 2
+# max_children_per_agent = 8
+# max_total_subagents = 32
+# execution_timeout_seconds = 300.0
+
+# CORS settings for HTTP API endpoints.
+# [cors]
+# enabled = false
+# allow_origins = ["*"]
+# allow_methods = ["*"]
+# allow_headers = ["*"]
+# allow_credentials = true
+# max_age = 600
+
+# Rate limiting for API requests.
+# [rate_limit]
+# enabled = false
+# requests_per_minute = 60
+# burst = 10
+
+# Inbound turn file attachment constraints.
+# [attachments]
+# max_file_size_bytes = 10485760   # 10 MB per file
+# max_total_bytes = 20971520       # 20 MB total per turn
+# max_files_per_turn = 5
+# allowed_mime_types = []          # empty = allow all supported types

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -170,7 +170,7 @@ base_url = "https://openrouter.ai/api/v1"
 
 # Prompt-ingress safety controls.
 # wrap_untrusted_workspace: wrap untrusted workspace files with safety bounding markers.
-# injection_scan_mode: "report" (default; log scan results), "enforce" (block turns on injection), "off".
+# injection_scan_mode: "report" (default; log findings), "enforce" (redact matched workspace-file content; the turn still runs), "off".
 # [safety]
 # wrap_untrusted_workspace = true
 # injection_scan_mode = "report"
@@ -585,30 +585,6 @@ default_mode = "bypass"                 # off | on | bypass | full
 # transcribe_voice = false
 # max_voice_duration_s = 120
 
-# Image generation configuration.
-# [image_generation]
-# provider = ""               # "openai", "openrouter", etc.
-# model = "dall-e-3"
-# api_key = ""                # env OPENAI_API_KEY / OPENROUTER_API_KEY also works
-# base_url = ""
-
-# Audio transcription and text-to-speech configuration.
-# [audio]
-# transcribe_provider = ""    # "openai", "groq", etc.
-# transcribe_model = "whisper-1"
-# transcribe_api_key = ""
-# tts_provider = ""           # "openai", "elevenlabs", etc.
-# tts_model = "tts-1"
-# tts_voice = "alloy"
-# tts_api_key = ""
-
-# Periodic background heartbeat.
-# [heartbeat]
-# enabled = false
-# interval_seconds = 300
-# prompt = "Periodic health check. Report your status."
-# target = "last"             # "last" | "none" | specific channel
-
 # MCP (Model Context Protocol) external servers.
 # [[mcp.servers]]
 # name = "fetch"
@@ -616,38 +592,3 @@ default_mode = "bypass"                 # off | on | bypass | full
 # command = "uvx"
 # args = ["mcp-server-fetch"]
 # env = {}
-
-# Default agent settings and multi-agent defaults.
-# [agents_defaults]
-# model = ""
-# thinking_level = ""
-# workspace_dir = ""
-
-# Subagent hierarchy limits.
-# [subagents]
-# max_depth = 2
-# max_children_per_agent = 8
-# max_total_subagents = 32
-# execution_timeout_seconds = 300.0
-
-# CORS settings for HTTP API endpoints.
-# [cors]
-# enabled = false
-# allow_origins = ["*"]
-# allow_methods = ["*"]
-# allow_headers = ["*"]
-# allow_credentials = true
-# max_age = 600
-
-# Rate limiting for API requests.
-# [rate_limit]
-# enabled = false
-# requests_per_minute = 60
-# burst = 10
-
-# Inbound turn file attachment constraints.
-# [attachments]
-# max_file_size_bytes = 10485760   # 10 MB per file
-# max_total_bytes = 20971520       # 20 MB total per turn
-# max_files_per_turn = 5
-# allowed_mime_types = []          # empty = allow all supported types

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ root release README with task-oriented guides.
 - [`features/memory.md`](features/memory.md) - durable memory and recall.
 - [`features/skills.md`](features/skills.md) - skill discovery, install, and
   authoring.
+- [`features/browser.md`](features/browser.md) - browser automation and
+  Chrome attachment.
 - [`features/compaction-and-cache.md`](features/compaction-and-cache.md) -
   long-session compaction and prompt-cache continuity.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -221,15 +221,25 @@ Useful automation flags:
 | `--workspace-strict` | Restrict read-side file tools to the workspace. |
 | `--workspace-lockdown` | Contain writes to workspace or scratch directory. |
 | `--scratch-dir` | Place temporary scripts/logs/candidate patches in a known directory. |
-| `--timeout` | Set total agent wall-clock timeout. |
+| `--file` / `-f` | Attach a local file; repeat for multiple files. |
+| `--unattended` / `--interactive` | Run without a live approval surface (unattended is default). |
+| `--stateless` / `--clean-room` | Use clean-room prompt bootstrap. |
+| `--stateless-keep-project-rules` | With clean-room bootstrap, keep `AGENTS.md` project rules only. |
+| `--no-memory-capture` | Do not write this invocation to durable searchable memory. |
+| `--session-id` | Target a specific session key/id for cross-invocation continuity. |
+| `--timeout` / `-T` | Set total agent wall-clock timeout in seconds. |
 | `--max-iterations` | Bound the model/tool loop. |
+| `--iteration-timeout-seconds` | Per-iteration timeout in seconds (one LLM call + tool executions). |
+| `--tool-timeout-seconds` | Per-tool execution timeout in seconds. |
+| `--request-timeout-seconds` | Single LLM HTTP/streaming request timeout in seconds. |
 | `--max-provider-retries` | Bound transient provider retries. |
 | `--length-capped-continuations` | Bound automatic continuations after length-limited provider output. |
-| `--thinking` | Override reasoning level. |
+| `--thinking` | Override reasoning level (off, minimal, low, medium, high, xhigh, adaptive). |
 | `--permissions` | Select restricted, bypass, or full permission posture. |
 | `--transcript-path` | Write a JSONL transcript for automation. |
 | `--usage-path` | Write usage JSON. |
 | `--session-db-path` | Persist session replay across invocations. |
+| `--json` | Emit machine-readable JSON output. |
 
 ## Upgrade
 
@@ -674,7 +684,7 @@ from a channel.
 ### Announcing to a specific channel
 
 `--announce --channel telegram --to <chat-id>` pins where a job reports, and
-`--account`, `--no-deliver`, `--best-effort`, and `--webhook-url` cover the rest.
+`--account`, `--no-deliver`, `--best-effort-deliver`, and `--webhook-url` cover the rest.
 The in-agent `cron` tool accepts the channel case too, through a `delivery`
 object — also restricted to an interactive CLI or Web caller, so a chat
 participant cannot redirect a job into a room they were never in. Webhook

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -366,6 +366,29 @@ your install to see the current catalog.
 
 Read: [`providers-and-models.md`](providers-and-models.md)
 
+## Prompt Cache Configuration
+
+Controls prompt prefix caching for LLM providers that support it (Anthropic, OpenAI, DeepSeek, OpenRouter, etc.):
+
+```toml
+[prompt_cache]
+mode = "auto"   # "auto" | "on" | "off"
+```
+
+- `auto` (default): Enables prompt caching when the active provider and model support prefix caching.
+- `on`: Forces prompt caching on.
+- `off`: Disables prompt caching.
+
+Environment variable override:
+```sh
+export AGENTOS_CACHE_MODE="auto"   # auto | on | off
+```
+
+> [!NOTE]
+> The legacy `prompt_cache.enabled` key and `AGENTOS_CACHE_ENABLED` environment variable are deprecated and mapped automatically to `mode` (`on`/`off`) with a deprecation warning.
+
+## Router Configuration
+
 ### OpenCAP
 
 See [Providers and Models — OpenCAP routing](providers-and-models.md#opencap-routing)
@@ -793,6 +816,28 @@ agentos agent \
 ```
 
 Read: [`tools-and-sandbox.md`](tools-and-sandbox.md)
+
+## Safety Configuration
+
+Controls prompt-ingress safety scanning and untrusted workspace containment:
+
+```toml
+[safety]
+wrap_untrusted_workspace = true
+injection_scan_mode = "report"   # "report" | "enforce" | "off"
+```
+
+- `wrap_untrusted_workspace` (default `true`): Wraps files read from untrusted workspace directories with safety bounding markers to mitigate prompt-injection framing in workspace files.
+- `injection_scan_mode`:
+  - `report` (default): Runs injection scanning on ingress text and reports detected patterns to telemetry/diagnostics without halting execution.
+  - `enforce`: Actively blocks and rejects turns where prompt injection or adversarial framing is detected.
+  - `off`: Disables prompt-injection scanning.
+
+Environment variable overrides:
+```sh
+export AGENTOS_SAFETY__WRAP_UNTRUSTED_WORKSPACE=true
+export AGENTOS_SAFETY__INJECTION_SCAN_MODE="report"   # report | enforce | off
+```
 
 ## Gateway Binding
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -366,29 +366,6 @@ your install to see the current catalog.
 
 Read: [`providers-and-models.md`](providers-and-models.md)
 
-## Prompt Cache Configuration
-
-Controls prompt prefix caching for LLM providers that support it (Anthropic, OpenAI, DeepSeek, OpenRouter, etc.):
-
-```toml
-[prompt_cache]
-mode = "auto"   # "auto" | "on" | "off"
-```
-
-- `auto` (default): Enables prompt caching when the active provider and model support prefix caching.
-- `on`: Forces prompt caching on.
-- `off`: Disables prompt caching.
-
-Environment variable override:
-```sh
-export AGENTOS_CACHE_MODE="auto"   # auto | on | off
-```
-
-> [!NOTE]
-> The legacy `prompt_cache.enabled` key and `AGENTOS_CACHE_ENABLED` environment variable are deprecated and mapped automatically to `mode` (`on`/`off`) with a deprecation warning.
-
-## Router Configuration
-
 ### OpenCAP
 
 See [Providers and Models — OpenCAP routing](providers-and-models.md#opencap-routing)
@@ -424,6 +401,27 @@ For a remote or non-default host, set `base_url` under `[llm]` (e.g.
 to the provider and no tool handler is exposed for the turn. When you do enable
 tools on smaller local models, keep a positive `agent_max_iterations` so
 malformed or repetitive tool calls terminate predictably.
+
+## Prompt Cache Configuration
+
+Controls prompt prefix caching for LLM providers that support it (Anthropic, OpenAI, DeepSeek, OpenRouter, etc.):
+
+```toml
+[prompt_cache]
+mode = "auto"   # "auto" | "on" | "off"
+```
+
+- `auto` (default): Enables prompt caching when the active provider and model support prefix caching.
+- `on`: Forces prompt caching on.
+- `off`: Disables prompt caching.
+
+Environment variable override:
+```sh
+export AGENTOS_CACHE_MODE="auto"   # auto | on | off
+```
+
+> [!NOTE]
+> The legacy `prompt_cache.enabled` key and `AGENTOS_CACHE_ENABLED` environment variable are deprecated and mapped automatically to `mode` (`on`/`off`) with a deprecation warning.
 
 ## Router Configuration
 
@@ -828,16 +826,12 @@ injection_scan_mode = "report"   # "report" | "enforce" | "off"
 ```
 
 - `wrap_untrusted_workspace` (default `true`): Wraps files read from untrusted workspace directories with safety bounding markers to mitigate prompt-injection framing in workspace files.
-- `injection_scan_mode`:
-  - `report` (default): Runs injection scanning on ingress text and reports detected patterns to telemetry/diagnostics without halting execution.
-  - `enforce`: Actively blocks and rejects turns where prompt injection or adversarial framing is detected.
+- `injection_scan_mode` (applied to bootstrap workspace files, not all ingress):
+  - `report` (default): Scans those files and logs detected patterns without changing the content; the turn still runs.
+  - `enforce`: Redacts matched content from untrusted workspace files before it reaches the prompt; the turn still runs.
   - `off`: Disables prompt-injection scanning.
 
-Environment variable overrides:
-```sh
-export AGENTOS_SAFETY__WRAP_UNTRUSTED_WORKSPACE=true
-export AGENTOS_SAFETY__INJECTION_SCAN_MODE="report"   # report | enforce | off
-```
+`[safety]` is TOML-only; there is no environment-variable override for these keys.
 
 ## Gateway Binding
 

--- a/docs/features/compaction-and-cache.md
+++ b/docs/features/compaction-and-cache.md
@@ -82,6 +82,21 @@ tries to keep:
 Cache continuity is best-effort. Routing, tools, attachments, provider changes,
 or a large new context can reduce cache reuse.
 
+### Prompt Cache Configuration
+
+Control prompt caching behavior via `agentos.toml`:
+
+```toml
+[prompt_cache]
+mode = "auto"   # "auto" | "on" | "off"
+```
+
+- `auto` (default): Enables prompt prefix caching when supported by the provider and model.
+- `on`: Forces prompt caching on for all requests.
+- `off`: Disables prompt caching.
+
+Environment variable override: `AGENTOS_CACHE_MODE=auto|on|off`. The legacy `prompt_cache.enabled` config key and `AGENTOS_CACHE_ENABLED` environment variable are deprecated and mapped to `mode` (`on`/`off`) automatically.
+
 ## Related Commands and Surfaces
 
 Manual compaction is primarily surfaced in chat and Web UI flows. For

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -212,7 +212,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[auxiliary]` | model for work AgentOS runs itself, not the agent's turn (document analysis, image description): `provider`, `model`, `timeout_seconds`, `[auxiliary.tasks.<task>]`. Empty = reuse `[llm]` |
 | `[prompt]` | prompt-layer flags: `platform_hint_enabled`, `env_probe_enabled` (local-toolchain block, names only) |
 | `[prompt_cache]` | Prompt-cache continuity: `mode` = `auto` (default) \| `on` \| `off`. Env override: `AGENTOS_CACHE_MODE` (legacy `prompt_cache.enabled` / `AGENTOS_CACHE_ENABLED` deprecated) |
-| `[safety]` | Prompt-ingress safety: `wrap_untrusted_workspace` (default true), `injection_scan_mode` (`report` default, `enforce` to reject injection turns, `off`) |
+| `[safety]` | Prompt-ingress safety: `wrap_untrusted_workspace` (default true), `injection_scan_mode` (`report` default, `enforce` redacts matched workspace-file content, `off`) |
 | `[compaction]`, `[agent_token_saving]`, `[task_runtime]` | context compaction, tool-result projection, concurrency |
 
 Slack native commands auto-sync when a Slack channel entry provides `app_id`,

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -211,6 +211,8 @@ Main `agentos.toml` sections (full commented reference:
 | `[channels]` | messaging channels (`[[channels.channels]]` entries) |
 | `[auxiliary]` | model for work AgentOS runs itself, not the agent's turn (document analysis, image description): `provider`, `model`, `timeout_seconds`, `[auxiliary.tasks.<task>]`. Empty = reuse `[llm]` |
 | `[prompt]` | prompt-layer flags: `platform_hint_enabled`, `env_probe_enabled` (local-toolchain block, names only) |
+| `[prompt_cache]` | Prompt-cache continuity: `mode` = `auto` (default) \| `on` \| `off`. Env override: `AGENTOS_CACHE_MODE` (legacy `prompt_cache.enabled` / `AGENTOS_CACHE_ENABLED` deprecated) |
+| `[safety]` | Prompt-ingress safety: `wrap_untrusted_workspace` (default true), `injection_scan_mode` (`report` default, `enforce` to reject injection turns, `off`) |
 | `[compaction]`, `[agent_token_saving]`, `[task_runtime]` | context compaction, tool-result projection, concurrency |
 
 Slack native commands auto-sync when a Slack channel entry provides `app_id`,
@@ -279,8 +281,9 @@ agentos gateway status --json  # machine-readable status
 agentos gateway stop
 ```
 
-Default port **18791**, loopback bind. `--listen HOST:PORT` overrides
-`--bind`/`--port` together. `gateway status` (and `--json`) reports **both**
+Default port **18791**, loopback bind. `--listen HOST` overrides
+`--bind` (use `--port PORT` to specify port, e.g. `--listen 0.0.0.0 --port 18791`).
+`gateway status` (and `--json`) reports **both**
 the installed CLI version (`cliVersion`) and the running gateway's version
 (`gatewayVersion`); a `versionMismatch` diagnostic means the gateway is running
 old code — restart it.
@@ -444,9 +447,11 @@ agentos agent --workspace /path --workspace-strict -m "Inspect this repo"
 ```
 
 Bounding flags: `--timeout` (wall-clock seconds), `--max-iterations`,
-`--iteration-timeout-seconds`, `--tool-timeout-seconds`; containment:
-`--workspace-strict` (reads), `--workspace-lockdown` (writes),
-`--scratch-dir`.
+`--iteration-timeout-seconds`, `--tool-timeout-seconds`, `--request-timeout-seconds`;
+containment: `--workspace-strict` (reads), `--workspace-lockdown` (writes),
+`--scratch-dir`; execution control: `--file`/`-f`, `--unattended`/`--interactive`,
+`--stateless`/`--clean-room`, `--stateless-keep-project-rules`, `--no-memory-capture`,
+`--session-id`.
 
 ### Day-two operations
 
@@ -559,4 +564,5 @@ Full reference: `docs/http-api.md` (https://useagentos.dev/docs/http-api).
 `gateway`, `http-api`, `providers-and-models`, `channels`, `operations`,
 `scheduling`, `sessions`, `usage-and-cost`, `tools-and-sandbox`,
 `approvals-and-permissions`, `mcp-server`, `troubleshooting`, and
-`features/skills`, `features/agentos-router`, `features/memory`.
+`features/skills`, `features/agentos-router`, `features/memory`,
+`features/browser`, `features/compaction-and-cache`.


### PR DESCRIPTION
### Summary of Changes
- Document `[safety]` and `[prompt_cache]` configuration sections across `docs/configuration.md`, `docs/features/compaction-and-cache.md`, and `agentos.toml.example`.
- Fix gateway `--listen` usage in `bundled/agentos/SKILL.md` (separate host and port flags).
- Correct `--best-effort` to `--best-effort-deliver` in `docs/cli.md`.
- Update stream timing defaults in `agentos.toml.example` to match runtime code (600s / 630s).
- Clarify `assistant_label` as an environment variable (`AGENTOS_ASSISTANT_LABEL`) rather than a TOML setting.
- Document missing `agentos agent` automation flags (`--file`, `--unattended`, `--stateless`, etc.) in `docs/cli.md` and `SKILL.md`.
- Add omitted configuration sections (`[image_generation]`, `[audio]`, `[heartbeat]`, `[[mcp.servers]]`, `[agents_defaults]`, `[subagents]`, `[cors]`, `[rate_limit]`, `[attachments]`) to `agentos.toml.example`.
- Link `features/browser.md` from `docs/README.md` index and `SKILL.md` docs map.

Closes #371 