### PR TITLE
fix(tools): redact file contents on read_file, grep_search, and read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -16,6 +16,7 @@ from xml.etree import ElementTree as ET
 import structlog
 
 from agentos.identity.workspace import BOOTSTRAP_FILENAMES
+from agentos.redact import redact_sensitive_text
 from agentos.sandbox.integration import get_runtime, sandboxed
 from agentos.tools.fuzzy_match import (
     AmbiguousMatchError,
@@ -512,10 +513,11 @@ async def read_file(path: str, offset: int | None = None, limit: int | None = No
     if binary_reason:
         raise _binary_file_error(path, p, reason=binary_reason)
 
-    return await loop.run_in_executor(
+    raw = await loop.run_in_executor(
         None,
         lambda: _stream_numbered_lines_from_file(p, path, offset=offset, limit=limit),
     )
+    return redact_sensitive_text(raw, file_read=True) or ""
 
 
 @tool(
@@ -574,7 +576,8 @@ async def read_spreadsheet(
         )
 
     selected = _select_spreadsheet_sheets(sheets, sheet)
-    return _format_spreadsheet(path=p, sheets=selected, offset=row_offset, limit=row_limit)
+    formatted = _format_spreadsheet(path=p, sheets=selected, offset=row_offset, limit=row_limit)
+    return redact_sensitive_text(formatted, file_read=True) or ""
 
 
 def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[list[str]]]]:
@@ -1032,4 +1035,4 @@ async def grep_search(
     matches = await loop.run_in_executor(None, _search)
     if not matches:
         return f"No matches for '{pattern}'"
-    return "\n".join(matches)
+    return redact_sensitive_text("\n".join(matches), file_read=True) or ""

--- a/tests/test_security/test_filesystem_elevation_redaction.py
+++ b/tests/test_security/test_filesystem_elevation_redaction.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@contextmanager
+def tool_context(
+    workspace: Path,
+    *,
+    strict: bool = False,
+    elevated_mode: str | None = None,
+) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+            workspace_strict=strict,
+            elevated=elevated_mode,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_read_file_redacts_credentials_even_in_elevated_full_mode(tmp_path: Path) -> None:
+    fake_token = "sk-proj-" + "A" * 32
+    target = tmp_path / "credentials"
+    target.write_text(f"[default]\napi_key = {fake_token}\n", encoding="utf-8")
+
+    with tool_context(tmp_path, strict=False, elevated_mode="full"):
+        content = await fs.read_file(str(target))
+
+    assert fake_token not in content
+    assert "«redacted:sk-p…»" in content or "«redacted»" in content
+    assert "api_key =" in content
+
+
+@pytest.mark.asyncio
+async def test_grep_search_redacts_credentials(tmp_path: Path) -> None:
+    fake_token = "sk-ant-" + "B" * 32
+    target = tmp_path / "config.env"
+    target.write_text(f"ANTHROPIC_KEY={fake_token}\nDEBUG=true\n", encoding="utf-8")
+
+    with tool_context(tmp_path, strict=False, elevated_mode="full"):
+        result = await fs.grep_search("ANTHROPIC_KEY", path=str(target))
+
+    assert fake_token not in result
+    assert "«redacted:sk-a…»" in result or "«redacted»" in result
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_redacts_credentials(tmp_path: Path) -> None:
+    fake_token = "sk-or-v1-" + "C" * 40
+    target = tmp_path / "keys.csv"
+    target.write_text(f"service,key\nopenrouter,{fake_token}\n", encoding="utf-8")
+
+    with tool_context(tmp_path, strict=False, elevated_mode="full"):
+        result = await fs.read_spreadsheet(str(target))
+
+    assert fake_token not in result
+    assert "«redacted:sk-o…»" in result or "«redacted»" in result
+    assert "openrouter" in result


### PR DESCRIPTION
Closes #355

### Summary
- Wired `redact_sensitive_text(..., file_read=True)` into `read_file`, `read_spreadsheet`, and `grep_search` in `src/agentos/tools/builtin/filesystem.py`.
- Ensures defense-in-depth credential masking for file content returned to the agent even when running under elevated modes that bypass the path blocklist.
- Added comprehensive unit tests in `tests/test_security/test_filesystem_elevation_redaction.py`.

### Verification
- `uv run pytest tests/test_security/test_filesystem_elevation_redaction.py tests/test_tools/test_filesystem_read_workspace.py tests/test_public_release_hygiene.py -vv` (Passed all 34 tests)
- `uv run ruff check src tests` (Passed with 0 errors)
- `uv run mypy src/agentos --show-error-codes` (Passed with 0 issues across 612 source files)
