### PR TITLE
docs(cron): align cron elevation documentation and examples with bypass default

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -524,6 +524,11 @@ security_grading = false
 # paths. Use `agentos sandbox on|bypass|full|reset` to update this together
 # with the sandbox section.
 default_mode = "bypass"                 # off | on | bypass | full
+# Default permission mode for scheduled unattended agent_turn cron jobs.
+# Shipped default is "bypass", which lets scheduled jobs run shell-based tools
+# without interactive approval prompts while maintaining sensitive path checks.
+# Pass --no-elevated on the CLI or {"elevated": "off"} in tool_policy to opt out.
+# cron_default_mode = "bypass"          # off | bypass | full
 
 # [auth]
 # mode = "none"         # none | token | password

--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -31,10 +31,10 @@ For automation, prefer the narrowest profile that can complete the task.
 
 These profiles apply to interactive CLI and Web turns. For cron turns (unattended automation),
 the default elevated execution posture is controlled by `permissions.cron_default_mode` (which
-defaults to `bypass`). By default, cron jobs of kind `agent_run` run elevated (under `bypass`),
+defaults to `bypass`). By default, cron jobs of kind `agent_turn` run elevated (under `bypass`),
 whereas other job kinds (like reminders and script runs) are never elevated. You can explicitly
-override this default for any individual job by passing `--elevated=off` (or another mode)
-during job creation or update. See [`cli.md`](cli.md#letting-a-cron-job-run-shell-based-skills)
+override this default for any individual job by passing `--no-elevated` (or `--elevated-mode <mode>`)
+from the CLI, or `{"elevated": "off"}` in `tool_policy` via the tool/RPC. See [`cli.md`](cli.md#letting-a-cron-job-run-shell-based-skills)
 for details and security implications.
 
 ## Workspace Containment

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -683,7 +683,7 @@ delivery and failure destinations stay CLI/Web/RPC-only. See
 
 ### Letting a cron job run shell-based skills
 
-By default, cron jobs of kind `agent_run` run elevated under the `bypass` mode
+By default, cron jobs of kind `agent_turn` run elevated under the `bypass` mode
 (controlled globally by `permissions.cron_default_mode`). This allows them to
 run shell-based commands (like those in skills) without interactive approval prompts.
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -486,10 +486,10 @@ agentos cron output <id> [--run <run-id>] [--json]
 agentos cron add --every 10m --job-kind agent_turn --script watch_rss.py \
   --script-arg --url --script-arg https://example.com/feed.xml \
   --text "Summarize anything urgent."
-# Cron turns are read-only by default, so a job cannot run a shell-based skill.
-# --elevated opts one agent-turn job out of that: no approval, no sandbox, host
-# shell as the user. See docs/cli.md before suggesting it.
-agentos cron add --every 6h --agent main --elevated --name "LP check" --text "..."
+# Agent-turn cron jobs run elevated by default (`cron_default_mode = "bypass"`).
+# Pass --no-elevated to opt out and keep a job sandboxed / read-only.
+# See docs/cli.md and docs/approvals-and-permissions.md for details.
+agentos cron add --every 6h --agent main --no-elevated --name "LP check" --text "..."
 agentos cost                   # usage + estimated spend
 agentos diagnostics on         # runtime diagnostics logging
 agentos migrate hermes --source <dir> [--apply]   # dry-run first, then --apply


### PR DESCRIPTION
Closes #370

### Summary
- Rewrote the cron elevation commentary and example in `src/agentos/skills/bundled/agentos/SKILL.md` to reflect that scheduled `agent_turn` jobs run elevated by default (`bypass`) and document the `--no-elevated` opt-out.
- Fixed invalid job kind reference (`agent_run` → `agent_turn`) in `docs/cli.md` and `docs/approvals-and-permissions.md`.
- Fixed invalid CLI flag syntax (`--elevated=off` → `--no-elevated` / `tool_policy` structure) in `docs/approvals-and-permissions.md`.
- Added `cron_default_mode` to `[permissions]` in `agentos.toml.example`.

### Verification
- `uv run pytest tests/test_public_release_hygiene.py tests/test_gateway_config_legacy.py tests/test_scheduler/test_cron_default_elevation.py -vv` (Passed all 35 tests, 1 skipped)
- `uv run ruff check src tests` (Passed with 0 errors)
- `uv run mypy src/agentos --show-error-codes` (Passed with 0 issues across 612 source files)

