### PR TITLE
Feature/channel approvals 364

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -413,6 +413,15 @@ default and require an explicit group chat ID, a paired sender, and—by
 default—a bot mention. Any connected Control client may approve, deny, or
 disconnect a pairing.
 
+### Platform-Native Interactive Approvals
+
+Platform-native interactive tool approvals (such as Slack block actions, Telegram inline keyboard callbacks, and Discord message components) allow operators to approve or deny gated tool executions directly using interactive buttons in their messaging app.
+
+For security, interactive approvals are:
+- **Restricted to Direct Messages (DMs)**: Interactive approval prompts are only sent in channel DMs, not group/channel chats, ensuring they cannot be triggered or visible to unauthorized participants in a shared room.
+- **Access Gated**: Each button click/interaction verifies that the clicker's sender ID is paired and authorized under the channel's access policy. Clicking by an unpaired or unauthorized user is dropped and rejected.
+- **Session Bound**: Approval tokens are strictly bound to their originating chat session key. A click received from a different chat context or user session will mismatch and be ignored.
+
 Raw config:
 
 ```sh

--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -503,6 +503,14 @@ class DiscordChannel:
         return True
 
     async def _handle_discord_component_interaction(self, data: dict[str, Any]) -> None:
+        interaction_id = str(data.get("id") or "")
+        if interaction_id and not self._dedupe.check_and_add(f"interaction:{interaction_id}"):
+            log.debug(
+                "discord.component_interaction_duplicate_dropped",
+                interaction_id=interaction_id,
+            )
+            return
+
         interaction_data = data.get("data", {})
         custom_id = interaction_data.get("custom_id", "")
         if not custom_id.startswith("approve:") and not custom_id.startswith("deny:"):
@@ -511,12 +519,109 @@ class DiscordChannel:
         act, approval_id = custom_id.split(":", 1)
         approved = act == "approve"
 
+        member = data.get("member")
+        member_user = member.get("user") if isinstance(member, dict) else None
+        direct_user = data.get("user")
+        user = member_user if isinstance(member_user, dict) else direct_user
+        user_id = str(user.get("id") if isinstance(user, dict) else "unknown")
+        channel_id = str(data.get("channel_id") or "unknown")
+        guild_id = data.get("guild_id")
+        is_group = guild_id is not None
+
+        # 1. Admission Check
+        from agentos.channels._util import evaluate_policy
+
+        decision = evaluate_policy(
+            self.policy,
+            is_group=is_group,
+            mentioned=True,
+            sender_id=user_id,
+        )
+        interaction_token = data.get("token")
+        if not decision.admit:
+            client = self._get_client()
+            try:
+                resp = await client.post(
+                    f"/interactions/{interaction_id}/{interaction_token}/callback",
+                    json={
+                        "type": 4,  # CHANNEL_MESSAGE_WITH_SOURCE
+                        "data": {
+                            "content": "Unauthorized: Only paired users can approve/deny tools.",
+                            "flags": 64,  # EPHEMERAL
+                        },
+                    },
+                )
+                resp.raise_for_status()
+            except Exception as exc:
+                log.warning("discord.component_unauthorized_response_failed", error=str(exc))
+            return
+
         from agentos.gateway.approval_queue import get_approval_queue
 
-        get_approval_queue().resolve(approval_id, approved)
+        queue = get_approval_queue()
 
-        interaction_id = data.get("id")
-        interaction_token = data.get("token")
+        # 2. Retrieve PendingApproval and verify sessionKey match
+        try:
+            entry = queue.get(approval_id)
+        except KeyError:
+            client = self._get_client()
+            try:
+                resp = await client.post(
+                    f"/interactions/{interaction_id}/{interaction_token}/callback",
+                    json={
+                        "type": 4,  # CHANNEL_MESSAGE_WITH_SOURCE
+                        "data": {
+                            "content": "Error: Approval request not found or expired.",
+                            "flags": 64,  # EPHEMERAL
+                        },
+                    },
+                )
+                resp.raise_for_status()
+            except Exception as exc:
+                log.warning("discord.component_keyerror_response_failed", error=str(exc))
+            return
+
+        session_key = entry.params.get("sessionKey")
+        if isinstance(session_key, str) and session_key:
+            parts = session_key.split(":")
+            if parts and parts[0] == "subagent":
+                parts = parts[1:]
+            if len(parts) >= 5:
+                session_channel = parts[2]
+                session_mode = parts[3]
+                session_peer = parts[4]
+                expected_peer = channel_id if session_mode in ("group", "channel") else user_id
+                if session_channel != "discord" or session_peer != expected_peer:
+                    log.warning(
+                        "discord.component_mismatch",
+                        session_key=session_key,
+                        expected_peer=expected_peer,
+                        session_peer=session_peer,
+                    )
+                    return
+
+        # 3. Resolve Approval Queue
+        try:
+            queue.resolve(approval_id, approved)
+        except ValueError:
+            client = self._get_client()
+            try:
+                resp = await client.post(
+                    f"/interactions/{interaction_id}/{interaction_token}/callback",
+                    json={
+                        "type": 4,  # CHANNEL_MESSAGE_WITH_SOURCE
+                        "data": {
+                            "content": "Error: Approval request was already resolved.",
+                            "flags": 64,  # EPHEMERAL
+                        },
+                    },
+                )
+                resp.raise_for_status()
+            except Exception as exc:
+                log.warning("discord.component_valueerror_response_failed", error=str(exc))
+            return
+
+        # 4. Respond with UPDATE_MESSAGE
         orig_message = data.get("message", {})
         orig_content = orig_message.get("content", "")
         decision_text = "Approved ✅" if approved else "Denied ❌"
@@ -538,13 +643,7 @@ class DiscordChannel:
         except Exception as exc:
             log.warning("discord.component_response_failed", error=str(exc))
 
-        member = data.get("member")
-        member_user = member.get("user") if isinstance(member, dict) else None
-        direct_user = data.get("user")
-        user = member_user if isinstance(member_user, dict) else direct_user
-        user_id = str(user.get("id") if isinstance(user, dict) else "unknown")
-        channel_id = str(data.get("channel_id") or "unknown")
-
+        # 5. Enqueue the virtual message
         msg = IncomingMessage(
             sender_id=user_id,
             channel_id=channel_id,
@@ -552,7 +651,7 @@ class DiscordChannel:
             metadata={
                 "interaction_type": "component_click",
                 "guild_id": data.get("guild_id"),
-                "is_group": False,
+                "is_group": is_group,
             },
         )
         self.enqueue(msg)

--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -390,7 +390,11 @@ class DiscordChannel:
                 return
             self._enqueue_reaction(self._annotate_channel_context(data))
         elif event_type == "INTERACTION_CREATE":
-            if data.get("type") != _DISCORD_APPLICATION_COMMAND_INTERACTION_TYPE:
+            interaction_type = data.get("type")
+            if interaction_type == 3:  # Message Component (button click)
+                await self._handle_discord_component_interaction(data)
+                return
+            if interaction_type != _DISCORD_APPLICATION_COMMAND_INTERACTION_TYPE:
                 return
             interaction_id = str(data.get("id") or "")
             if interaction_id and not self._dedupe.check_and_add(f"interaction:{interaction_id}"):
@@ -497,6 +501,61 @@ class DiscordChannel:
             return False
         log.debug("discord.interaction_deferred", interaction_id=interaction_id)
         return True
+
+    async def _handle_discord_component_interaction(self, data: dict[str, Any]) -> None:
+        interaction_data = data.get("data", {})
+        custom_id = interaction_data.get("custom_id", "")
+        if not custom_id.startswith("approve:") and not custom_id.startswith("deny:"):
+            return
+
+        act, approval_id = custom_id.split(":", 1)
+        approved = act == "approve"
+
+        from agentos.gateway.approval_queue import get_approval_queue
+
+        get_approval_queue().resolve(approval_id, approved)
+
+        interaction_id = data.get("id")
+        interaction_token = data.get("token")
+        orig_message = data.get("message", {})
+        orig_content = orig_message.get("content", "")
+        decision_text = "Approved ✅" if approved else "Denied ❌"
+        new_content = f"{orig_content}\n\n**{decision_text}**"
+
+        client = self._get_client()
+        try:
+            resp = await client.post(
+                f"/interactions/{interaction_id}/{interaction_token}/callback",
+                json={
+                    "type": 7,  # UPDATE_MESSAGE
+                    "data": {
+                        "content": new_content,
+                        "components": [],
+                    },
+                },
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            log.warning("discord.component_response_failed", error=str(exc))
+
+        member = data.get("member")
+        member_user = member.get("user") if isinstance(member, dict) else None
+        direct_user = data.get("user")
+        user = member_user if isinstance(member_user, dict) else direct_user
+        user_id = str(user.get("id") if isinstance(user, dict) else "unknown")
+        channel_id = str(data.get("channel_id") or "unknown")
+
+        msg = IncomingMessage(
+            sender_id=user_id,
+            channel_id=channel_id,
+            content="Approve" if approved else "Deny",
+            metadata={
+                "interaction_type": "component_click",
+                "guild_id": data.get("guild_id"),
+                "is_group": False,
+            },
+        )
+        self.enqueue(msg)
 
     async def _handle_interaction(self, data: dict[str, Any]) -> None:
         """Parse a slash command interaction into IncomingMessage."""
@@ -791,6 +850,9 @@ class DiscordChannel:
 
         if message.metadata.get("embeds"):
             payload["embeds"] = message.metadata["embeds"]
+
+        if message.metadata.get("components"):
+            payload["components"] = message.metadata["components"]
 
         if message.metadata.get("reply_to_message_id"):
             payload["message_reference"] = {

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -729,6 +729,13 @@ class SlackChannel:
             if not self._verify_signature(body, timestamp, signature):
                 return Response(status_code=401)
         else:
+            content_type = request.headers.get("content-type", "")
+            if content_type.startswith("application/x-www-form-urlencoded"):
+                log.warning("slack.webhook_blocked_unsigned_form")
+                return Response(
+                    "Slack signing secret required for interactive and slash command payloads",
+                    status_code=401,
+                )
             log.warning("slack.webhook_no_signing_secret")
 
         content_type = request.headers.get("content-type", "")
@@ -800,9 +807,88 @@ class SlackChannel:
         act, approval_id = value.split(":", 1)
         approved = act == "approve"
 
+        user_id = payload.get("user", {}).get("id", "unknown")
+        channel_id = payload.get("channel", {}).get("id", "unknown")
+        team_id = payload.get("team", {}).get("id")
+
+        # 1. Admission Check
+        from agentos.channels._util import evaluate_policy
+
+        is_group = not channel_id.startswith("D")
+        decision = evaluate_policy(
+            self.policy,
+            is_group=is_group,
+            mentioned=True,
+            sender_id=user_id,
+        )
+        if not decision.admit:
+            log.warning(
+                "slack.interactive_unauthorized_click",
+                user_id=user_id,
+                channel_id=channel_id,
+            )
+            return
+
         from agentos.gateway.approval_queue import get_approval_queue
 
-        get_approval_queue().resolve(approval_id, approved)
+        queue = get_approval_queue()
+
+        # 2. Retrieve PendingApproval and verify sessionKey match
+        try:
+            entry = queue.get(approval_id)
+        except KeyError:
+            response_url = payload.get("response_url")
+            if response_url:
+                try:
+                    async with httpx.AsyncClient() as client:
+                        await client.post(
+                            response_url,
+                            json={
+                                "text": "Error: Approval request not found or expired.",
+                                "response_type": "ephemeral",
+                            },
+                        )
+                except Exception as exc:
+                    log.warning("slack.interactive_keyerror_post_failed", error=str(exc))
+            return
+
+        session_key = entry.params.get("sessionKey")
+        if isinstance(session_key, str) and session_key:
+            parts = session_key.split(":")
+            if parts and parts[0] == "subagent":
+                parts = parts[1:]
+            if len(parts) >= 5:
+                session_channel = parts[2]
+                session_mode = parts[3]
+                session_peer = parts[4]
+                expected_peer = channel_id if session_mode in ("group", "channel") else user_id
+                if session_channel != self.channel_id or session_peer != expected_peer:
+                    log.warning(
+                        "slack.interactive_mismatch",
+                        session_key=session_key,
+                        expected_peer=expected_peer,
+                        session_peer=session_peer,
+                    )
+                    return
+
+        # 3. Resolve Approval Queue
+        try:
+            queue.resolve(approval_id, approved)
+        except ValueError:
+            response_url = payload.get("response_url")
+            if response_url:
+                try:
+                    async with httpx.AsyncClient() as client:
+                        await client.post(
+                            response_url,
+                            json={
+                                "text": "Error: Approval request was already resolved.",
+                                "response_type": "ephemeral",
+                            },
+                        )
+                except Exception as exc:
+                    log.warning("slack.interactive_valueerror_post_failed", error=str(exc))
+            return
 
         response_url = payload.get("response_url")
         orig_message = payload.get("message", {})
@@ -836,10 +922,6 @@ class SlackChannel:
                     )
             except Exception as exc:
                 log.warning("slack.interactive_response_post_failed", error=str(exc))
-
-        user_id = payload.get("user", {}).get("id", "unknown")
-        channel_id = payload.get("channel", {}).get("id", "unknown")
-        team_id = payload.get("team", {}).get("id")
 
         msg = self.parse_event(
             {

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -736,7 +736,15 @@ class SlackChannel:
             form = await request.form()
             if "payload" in form:
                 try:
-                    payload = json.loads(form["payload"])
+                    payload_str = form["payload"]
+                    if not isinstance(payload_str, str):
+                        payload_str_bytes = await payload_str.read()
+                        payload_str = (
+                            payload_str_bytes.decode("utf-8")
+                            if isinstance(payload_str_bytes, bytes)
+                            else str(payload_str_bytes)
+                        )
+                    payload = json.loads(payload_str)
                 except Exception:
                     return Response(status_code=400)
                 asyncio.create_task(self._handle_slack_interactive(payload))

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -731,8 +731,14 @@ class SlackChannel:
         else:
             content_type = request.headers.get("content-type", "")
             if content_type.startswith("application/x-www-form-urlencoded"):
-                form = await request.form()
-                if "payload" in form:
+                import urllib.parse
+
+                try:
+                    decoded_body = body.decode("utf-8")
+                except UnicodeDecodeError:
+                    decoded_body = ""
+                parsed = urllib.parse.parse_qs(decoded_body)
+                if "payload" in parsed:
                     log.warning("slack.webhook_blocked_unsigned_form")
                     return Response(
                         "Slack signing secret required for interactive payloads",

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -689,6 +689,10 @@ class SlackChannel:
             if isinstance(payload, dict):
                 self._ingest_slash_command(payload)
             return
+        if mtype == "interactive":
+            if isinstance(payload, dict):
+                asyncio.create_task(self._handle_slack_interactive(payload))
+            return
         if mtype != "events_api":
             return
         if isinstance(payload, dict) and payload.get("type") == "event_callback":
@@ -730,6 +734,13 @@ class SlackChannel:
         content_type = request.headers.get("content-type", "")
         if content_type.startswith("application/x-www-form-urlencoded"):
             form = await request.form()
+            if "payload" in form:
+                try:
+                    payload = json.loads(form["payload"])
+                except Exception:
+                    return Response(status_code=400)
+                asyncio.create_task(self._handle_slack_interactive(payload))
+                return Response(status_code=200)
             if not self._ingest_slash_command(form):
                 return Response(status_code=400)
             return Response(status_code=200)
@@ -768,6 +779,70 @@ class SlackChannel:
             )
         )
         return True
+
+    async def _handle_slack_interactive(self, payload: dict[str, Any]) -> None:
+        actions = payload.get("actions", [])
+        if not actions:
+            return
+        action = actions[0]
+        value = action.get("value", "")
+        if not value.startswith("approve:") and not value.startswith("deny:"):
+            return
+
+        act, approval_id = value.split(":", 1)
+        approved = act == "approve"
+
+        from agentos.gateway.approval_queue import get_approval_queue
+
+        get_approval_queue().resolve(approval_id, approved)
+
+        response_url = payload.get("response_url")
+        orig_message = payload.get("message", {})
+        orig_text = orig_message.get("text", "")
+        new_blocks = []
+        for block in orig_message.get("blocks", []):
+            if block.get("block_id") != "approval_actions":
+                new_blocks.append(block)
+
+        decision_text = "Approved ✅" if approved else "Denied ❌"
+        new_blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*{decision_text}*",
+                },
+            }
+        )
+
+        if response_url:
+            try:
+                async with httpx.AsyncClient() as client:
+                    await client.post(
+                        response_url,
+                        json={
+                            "text": orig_text,
+                            "blocks": new_blocks,
+                            "replace_original": True,
+                        },
+                    )
+            except Exception as exc:
+                log.warning("slack.interactive_response_post_failed", error=str(exc))
+
+        user_id = payload.get("user", {}).get("id", "unknown")
+        channel_id = payload.get("channel", {}).get("id", "unknown")
+        team_id = payload.get("team", {}).get("id")
+
+        msg = self.parse_event(
+            {
+                "user": user_id,
+                "channel": channel_id,
+                "text": "Approve" if approved else "Deny",
+                "team": team_id,
+                "thread_ts": orig_message.get("thread_ts"),
+            }
+        )
+        self.enqueue(msg)
 
     def _ingest_event_callback(self, data: dict[str, Any]) -> None:
         """Shared inbound path for an Events API ``event_callback`` payload,

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -731,11 +731,13 @@ class SlackChannel:
         else:
             content_type = request.headers.get("content-type", "")
             if content_type.startswith("application/x-www-form-urlencoded"):
-                log.warning("slack.webhook_blocked_unsigned_form")
-                return Response(
-                    "Slack signing secret required for interactive and slash command payloads",
-                    status_code=401,
-                )
+                form = await request.form()
+                if "payload" in form:
+                    log.warning("slack.webhook_blocked_unsigned_form")
+                    return Response(
+                        "Slack signing secret required for interactive payloads",
+                        status_code=401,
+                    )
             log.warning("slack.webhook_no_signing_secret")
 
         content_type = request.headers.get("content-type", "")

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -906,7 +906,7 @@ class TelegramChannel:
         is_group = chat_type in {"group", "supergroup", "channel"}
         message_id = msg.get("message_id", "")
 
-        metadata: dict[str, Any] = {
+        metadata = {
             "is_group": is_group,
             "chat_type": chat_type,
             "chat_id": str(chat.get("id", self.config.default_chat_id)),

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -76,7 +76,13 @@ _TRANSPORT_FAILURE_MARKERS = (
     "returned an invalid response",
 )
 _DEDUPE_SIZE = 4096
-_ALLOWED_UPDATES = ("message", "edited_message", "channel_post", "edited_channel_post")
+_ALLOWED_UPDATES = (
+    "message",
+    "edited_message",
+    "channel_post",
+    "edited_channel_post",
+    "callback_query",
+)
 #: Hard ceiling Telegram enforces on ``sendMessage``/``editMessageText`` text.
 #: Measured on the *rendered* HTML, which is longer than the markdown it came from.
 _MESSAGE_TEXT_LIMIT = 4096
@@ -817,7 +823,75 @@ class TelegramChannel:
             metadata={**attachment.metadata, "telegram_file_path": file_path},
         )
 
+    async def _handle_telegram_callback(self, cb: dict[str, Any]) -> None:
+        cb_id = cb.get("id")
+        data = cb.get("data", "")
+        if not data.startswith("approve:") and not data.startswith("deny:"):
+            return
+
+        act, approval_id = data.split(":", 1)
+        approved = act == "approve"
+
+        from agentos.gateway.approval_queue import get_approval_queue
+
+        get_approval_queue().resolve(approval_id, approved)
+
+        try:
+            await self._api("answerCallbackQuery", {"callback_query_id": cb_id})
+        except Exception as exc:
+            log.warning("telegram.callback_query_answer_failed", error=str(exc))
+
+        msg = cb.get("message", {})
+        chat_id = msg.get("chat", {}).get("id")
+        message_id = msg.get("message_id")
+        orig_text = msg.get("text", "")
+        decision_text = "Approved ✅" if approved else "Denied ❌"
+        new_text = f"{orig_text}\n\n<b>{decision_text}</b>"
+
+        if chat_id and message_id:
+            try:
+                await self._api(
+                    "editMessageText",
+                    {
+                        "chat_id": str(chat_id),
+                        "message_id": message_id,
+                        "text": new_text,
+                        "parse_mode": "HTML",
+                        "reply_markup": None,
+                    },
+                )
+            except Exception as exc:
+                log.warning("telegram.callback_message_edit_failed", error=str(exc))
+
     def parse_incoming(self, update: dict[str, Any]) -> IncomingMessage:
+        if "callback_query" in update:
+            cb = update["callback_query"]
+            data = cb.get("data", "")
+            act = "Approve" if data.startswith("approve:") else "Deny"
+            asyncio.create_task(self._handle_telegram_callback(cb))
+
+            sender = cb.get("from", {})
+            msg = cb.get("message", {})
+            chat = msg.get("chat", {})
+            chat_type = chat.get("type", "")
+            is_group = chat_type in {"group", "supergroup", "channel"}
+
+            metadata = {
+                "is_group": is_group,
+                "chat_type": chat_type,
+                "chat_id": str(chat.get("id", self.config.default_chat_id)),
+                "message_id": str(msg.get("message_id", "")),
+            }
+            username = sender.get("username")
+            if username:
+                metadata["sender_username"] = str(username)
+            return IncomingMessage(
+                sender_id=str(sender.get("id") or "unknown"),
+                channel_id=str(chat.get("id", self.config.default_chat_id)),
+                content=act,
+                metadata=metadata,
+            )
+
         msg = (
             update.get("message")
             or update.get("edited_message")
@@ -1285,6 +1359,8 @@ class TelegramChannel:
         else:
             payload["text"] = render_telegram_html(message.content)
             payload["parse_mode"] = "HTML"
+        if "reply_markup" in metadata:
+            payload["reply_markup"] = metadata["reply_markup"]
         return payload
 
     async def edit(self, message_id: str, content: str) -> None:

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -612,6 +612,12 @@ class TelegramChannel:
                 update_id = update.get("update_id")
                 if isinstance(update_id, int):
                     self._update_offset = update_id + 1
+                if "callback_query" in update:
+                    try:
+                        await self._handle_telegram_callback(update["callback_query"])
+                    except Exception as exc:
+                        log.warning("telegram.callback_query_handle_failed", error=str(exc))
+                    continue
                 try:
                     msg = self.parse_incoming(update)
                 except ValueError:
@@ -665,6 +671,12 @@ class TelegramChannel:
             return Response(status_code=400)
         if not isinstance(update, dict):
             return Response(status_code=400)
+        if "callback_query" in update:
+            try:
+                await self._handle_telegram_callback(update["callback_query"])
+            except Exception as exc:
+                log.warning("telegram.callback_query_handle_failed", error=str(exc))
+            return Response(status_code=200)
         try:
             msg = self.parse_incoming(update)
         except ValueError:
@@ -832,17 +844,103 @@ class TelegramChannel:
         act, approval_id = data.split(":", 1)
         approved = act == "approve"
 
+        sender = cb.get("from", {})
+        sender_id = str(sender.get("id") or "")
+        msg = cb.get("message", {})
+        chat = msg.get("chat", {})
+        chat_id = str(chat.get("id") or "")
+        chat_type = chat.get("type", "")
+        is_group = chat_type in {"group", "supergroup", "channel"}
+
+        # 1. Admission Check
+        temp_msg = IncomingMessage(
+            sender_id=sender_id,
+            channel_id=chat_id,
+            content="",
+        )
+        decision = self.evaluate_access(temp_msg, is_group=is_group, mentioned=True)
+        if not decision.admit:
+            try:
+                await self._api(
+                    "answerCallbackQuery",
+                    {
+                        "callback_query_id": cb_id,
+                        "text": "Unauthorized: Only paired users can approve/deny tools.",
+                        "show_alert": True,
+                    },
+                )
+            except Exception as exc:
+                log.warning("telegram.callback_unauthorized_answer_failed", error=str(exc))
+            return
+
         from agentos.gateway.approval_queue import get_approval_queue
 
-        get_approval_queue().resolve(approval_id, approved)
+        queue = get_approval_queue()
 
+        # 2. Retrieve PendingApproval and verify sessionKey match
+        try:
+            entry = queue.get(approval_id)
+        except KeyError:
+            try:
+                await self._api(
+                    "answerCallbackQuery",
+                    {
+                        "callback_query_id": cb_id,
+                        "text": "Error: Approval request not found or expired.",
+                        "show_alert": True,
+                    },
+                )
+            except Exception as exc:
+                log.warning("telegram.callback_keyerror_answer_failed", error=str(exc))
+            return
+
+        session_key = entry.params.get("sessionKey")
+        if isinstance(session_key, str) and session_key:
+            parts = session_key.split(":")
+            if parts and parts[0] == "subagent":
+                parts = parts[1:]
+            if len(parts) >= 5:
+                session_channel = parts[2]
+                session_mode = parts[3]
+                session_peer = parts[4]
+                expected_peer = chat_id if session_mode in ("group", "channel") else sender_id
+                if session_channel != self.config.name or session_peer != expected_peer:
+                    try:
+                        await self._api(
+                            "answerCallbackQuery",
+                            {
+                                "callback_query_id": cb_id,
+                                "text": "Unauthorized: Approval does not belong to this chat.",
+                                "show_alert": True,
+                            },
+                        )
+                    except Exception as exc:
+                        log.warning("telegram.callback_mismatch_answer_failed", error=str(exc))
+                    return
+
+        # 3. Resolve Approval Queue
+        try:
+            queue.resolve(approval_id, approved)
+        except ValueError:
+            try:
+                await self._api(
+                    "answerCallbackQuery",
+                    {
+                        "callback_query_id": cb_id,
+                        "text": "Error: Approval request was already resolved.",
+                        "show_alert": True,
+                    },
+                )
+            except Exception as exc:
+                log.warning("telegram.callback_valueerror_answer_failed", error=str(exc))
+            return
+
+        # 4. Answer Callback Query and Edit message text
         try:
             await self._api("answerCallbackQuery", {"callback_query_id": cb_id})
         except Exception as exc:
             log.warning("telegram.callback_query_answer_failed", error=str(exc))
 
-        msg = cb.get("message", {})
-        chat_id = msg.get("chat", {}).get("id")
         message_id = msg.get("message_id")
         orig_text = msg.get("text", "")
         decision_text = "Approved ✅" if approved else "Denied ❌"
@@ -863,35 +961,26 @@ class TelegramChannel:
             except Exception as exc:
                 log.warning("telegram.callback_message_edit_failed", error=str(exc))
 
+        # 5. Enqueue the virtual message
+        metadata = {
+            "is_group": is_group,
+            "chat_type": chat_type,
+            "chat_id": chat_id,
+            "message_id": str(msg.get("message_id", "")),
+        }
+        username = sender.get("username")
+        if username:
+            metadata["sender_username"] = str(username)
+
+        virtual_msg = IncomingMessage(
+            sender_id=sender_id,
+            channel_id=chat_id,
+            content="Approve" if approved else "Deny",
+            metadata=metadata,
+        )
+        self.enqueue(virtual_msg)
+
     def parse_incoming(self, update: dict[str, Any]) -> IncomingMessage:
-        if "callback_query" in update:
-            cb = update["callback_query"]
-            data = cb.get("data", "")
-            act = "Approve" if data.startswith("approve:") else "Deny"
-            asyncio.create_task(self._handle_telegram_callback(cb))
-
-            sender = cb.get("from", {})
-            msg = cb.get("message", {})
-            chat = msg.get("chat", {})
-            chat_type = chat.get("type", "")
-            is_group = chat_type in {"group", "supergroup", "channel"}
-
-            metadata = {
-                "is_group": is_group,
-                "chat_type": chat_type,
-                "chat_id": str(chat.get("id", self.config.default_chat_id)),
-                "message_id": str(msg.get("message_id", "")),
-            }
-            username = sender.get("username")
-            if username:
-                metadata["sender_username"] = str(username)
-            return IncomingMessage(
-                sender_id=str(sender.get("id") or "unknown"),
-                channel_id=str(chat.get("id", self.config.default_chat_id)),
-                content=act,
-                metadata=metadata,
-            )
-
         msg = (
             update.get("message")
             or update.get("edited_message")

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -1759,6 +1759,108 @@ def _ask_user_reply_text(event: Any) -> str | None:
     return None
 
 
+def _pending_approval_payload(content: Any) -> dict[str, Any] | None:
+    payload = None
+    if isinstance(content, dict):
+        payload = content
+    elif isinstance(content, str):
+        try:
+            payload = json.loads(content)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("status") not in {"approval_required", "approval_pending"}:
+        return None
+    approval_id = payload.get("approval_id")
+    if not isinstance(approval_id, str) or not approval_id:
+        return None
+    return payload
+
+
+async def _send_channel_approval_prompt(
+    channel: Any, inbound: IncomingMessage, pending: dict[str, Any]
+) -> None:
+    approval_id = pending.get("approval_id")
+    command = pending.get("command") or ""
+    tool_name = pending.get("tool_name") or "tool"
+
+    text = f"⚠️ Tool '{tool_name}' requires human approval:\n\n`{command}`"
+
+    metadata: dict[str, Any] = {"channel": inbound.channel_id}
+    if hasattr(channel, "_reply_thread_ts"):
+        thread_ts = channel._reply_thread_ts(inbound)
+        if thread_ts:
+            metadata["thread_ts"] = thread_ts
+
+    transport = getattr(channel, "transport_name", lambda: "")()
+    if callable(transport):
+        transport = transport()
+
+    if transport == "telegram":
+        metadata["reply_markup"] = {
+            "inline_keyboard": [
+                [
+                    {"text": "Approve", "callback_data": f"approve:{approval_id}"},
+                    {"text": "Deny", "callback_data": f"deny:{approval_id}"},
+                ]
+            ]
+        }
+    elif transport == "slack":
+        metadata["blocks"] = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"⚠️ Tool *{tool_name}* requires human approval:\n```{command}```",
+                },
+            },
+            {
+                "type": "actions",
+                "block_id": "approval_actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Approve"},
+                        "style": "primary",
+                        "value": f"approve:{approval_id}",
+                        "action_id": "approve_btn",
+                    },
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Deny"},
+                        "style": "danger",
+                        "value": f"deny:{approval_id}",
+                        "action_id": "deny_btn",
+                    },
+                ],
+            },
+        ]
+    elif transport == "discord":
+        metadata["components"] = [
+            {
+                "type": 1,
+                "components": [
+                    {
+                        "type": 2,
+                        "style": 3,
+                        "label": "Approve",
+                        "custom_id": f"approve:{approval_id}",
+                    },
+                    {
+                        "type": 2,
+                        "style": 4,
+                        "label": "Deny",
+                        "custom_id": f"deny:{approval_id}",
+                    },
+                ],
+            }
+        ]
+
+    msg = OutgoingMessage(content=text, reply_to=inbound.channel_id, metadata=metadata)
+    await channel.send(msg)
+
+
 def _text_delta_from_event(event: Any) -> str:
     if isinstance(event, TextDeltaEvent):
         return event.text
@@ -2358,9 +2460,13 @@ async def _run_turn_batch_path(
                         "session.event.tool_result",
                         _tool_result_payload(event),
                     )
-                ask_text = _ask_user_reply_text(event)
-                if ask_text:
-                    text_parts.append(("\n\n" if text_parts else "") + ask_text)
+                pending_approval = _pending_approval_payload(event.result)
+                if pending_approval is not None:
+                    await _send_channel_approval_prompt(channel, msg, pending_approval)
+                else:
+                    ask_text = _ask_user_reply_text(event)
+                    if ask_text:
+                        text_parts.append(("\n\n" if text_parts else "") + ask_text)
             elif isinstance(event, ErrorEvent):
                 log.error(
                     "channel_dispatch.agent_error",
@@ -2529,11 +2635,15 @@ async def _run_turn_streaming_path(
                         "session.event.tool_result",
                         _tool_result_payload(event),
                     )
-                ask_text = _ask_user_reply_text(event)
-                if ask_text:
-                    prefix = "\n\n" if text_emitted else ""
-                    text_emitted = True
-                    await queue.put(f"{prefix}{ask_text}")
+                pending_approval = _pending_approval_payload(event.result)
+                if pending_approval is not None:
+                    await _send_channel_approval_prompt(channel, msg, pending_approval)
+                else:
+                    ask_text = _ask_user_reply_text(event)
+                    if ask_text:
+                        prefix = "\n\n" if text_emitted else ""
+                        text_emitted = True
+                        await queue.put(f"{prefix}{ask_text}")
             elif isinstance(event, ErrorEvent):
                 log.error(
                     "channel_dispatch.agent_error",

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -154,6 +154,8 @@ list <name>`, `approve <name> <code>`, `deny <name> <sender-id>`, or `revoke
 groups are disabled by default; enable them only with explicit
 `group_chat_ids`, paired senders, and the desired mention requirement.
 
+Platform-native interactive tool approvals (Slack block actions, Telegram inline keyboard callbacks, and Discord message components) allow operators to approve or deny gated tool executions directly using interactive buttons. For security, these approvals are restricted to channel DMs (never group chats), access-gated by evaluating the clicker's sender ID against the channel's access policy, and strictly session-bound to their originating chat context.
+
 ## Configuration
 
 File resolution (highest precedence first):

--- a/src/agentos/tools/policy/finalize.py
+++ b/src/agentos/tools/policy/finalize.py
@@ -75,7 +75,12 @@ def _has_live_approval_surface(ctx: ToolContext | None) -> bool:
     if ctx.interaction_mode is InteractionMode.INTERACTIVE:
         return True
     if ctx.caller_kind is CallerKind.CHANNEL:
-        return True
+        if ctx.session_key:
+            from agentos.session.keys import derive_chat_type
+            from agentos.session.models import ChatType
+
+            return derive_chat_type(ctx.session_key) == ChatType.DIRECT
+        return False
     return False
 
 

--- a/src/agentos/tools/policy/finalize.py
+++ b/src/agentos/tools/policy/finalize.py
@@ -34,13 +34,12 @@ from agentos.result_budget import (
 from agentos.router_control import router_control_payload_terminates_turn
 from agentos.tool_boundary import ToolCall, ToolResult
 from agentos.tools.envelope import build_tool_failure_envelope, is_denial_payload
-from agentos.tools.types import InteractionMode, ToolContext
+from agentos.tools.types import CallerKind, InteractionMode, ToolContext
 
 log = structlog.get_logger("agentos.tools.dispatch")
 
-_PENDING_APPROVAL_STATUSES: frozenset[str] = frozenset(
-    {"approval_required", "approval_pending"}
-)
+_PENDING_APPROVAL_STATUSES: frozenset[str] = frozenset({"approval_required", "approval_pending"})
+
 
 def _extract_pending_approval(content: Any) -> dict[str, Any] | None:
     """Return the payload when ``content`` carries a pending-approval status."""
@@ -57,6 +56,7 @@ def _extract_pending_approval(content: Any) -> dict[str, Any] | None:
         return None
     return payload if payload.get("status") in _PENDING_APPROVAL_STATUSES else None
 
+
 def _denial_reason(content: Any) -> str:
     payload: Any = content
     if isinstance(content, str):
@@ -68,8 +68,16 @@ def _denial_reason(content: Any) -> str:
         return "approval_denied"
     return "denied"
 
+
 def _has_live_approval_surface(ctx: ToolContext | None) -> bool:
-    return ctx is None or ctx.interaction_mode is InteractionMode.INTERACTIVE
+    if ctx is None:
+        return True
+    if ctx.interaction_mode is InteractionMode.INTERACTIVE:
+        return True
+    if ctx.caller_kind is CallerKind.CHANNEL:
+        return True
+    return False
+
 
 async def finalize(
     call: ToolCall,
@@ -236,9 +244,7 @@ async def finalize(
     status_is_error = derive_is_error(execution_status) if execution_status else False
     is_error = denial or status_is_error
 
-    artifacts = (
-        list(ctx.published_artifacts[artifact_start:]) if ctx is not None else []
-    )
+    artifacts = list(ctx.published_artifacts[artifact_start:]) if ctx is not None else []
     if artifacts:
         content = result
     else:
@@ -263,8 +269,7 @@ async def finalize(
         artifacts=artifacts,
         execution_status=execution_status,
         terminates_turn=(
-            call.tool_name == "router_control"
-            and router_control_payload_terminates_turn(content)
+            call.tool_name == "router_control" and router_control_payload_terminates_turn(content)
         )
         or (
             # ask_user follows an end-turn-and-resume contract: presenting
@@ -279,5 +284,11 @@ async def finalize(
             call.tool_name == "exit_plan_mode"
             and not is_error
             and exit_plan_payload_terminates_turn(content)
+        )
+        or (
+            # Gated tool approval on unattended surface also terminates the turn
+            _extract_pending_approval(content) is not None
+            and ctx is not None
+            and ctx.interaction_mode is InteractionMode.UNATTENDED
         ),
     )

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from starlette.requests import Request
 
+from agentos.channel_pairing import ChannelAdmission
 from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
 from agentos.channels.slack import SlackChannel
 from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
@@ -38,26 +39,31 @@ async def test_telegram_callback_query_parsing_and_resolution() -> None:
     channel._api = fake_api
 
     # Simulate callback query update for "approve"
-    update = {
-        "update_id": 100,
-        "callback_query": {
-            "id": "cb123",
-            "from": {"id": 12345, "username": "bob"},
-            "message": {
-                "message_id": 999,
-                "chat": {"id": 12345, "type": "private"},
-                "text": "Do you want to run this command?",
-            },
-            "data": f"approve:{approval_id}",
+    callback_query = {
+        "id": "cb123",
+        "from": {"id": 12345, "username": "bob"},
+        "message": {
+            "message_id": 999,
+            "chat": {"id": 12345, "type": "private"},
+            "text": "Do you want to run this command?",
         },
+        "data": f"approve:{approval_id}",
     }
 
-    inbound = channel.parse_incoming(update)
-    assert inbound.content == "Approve"
-    assert inbound.sender_id == "12345"
+    # Verify that an unpaired user gets rejected (admission check fails)
+    await channel._handle_telegram_callback(callback_query)
+    # Verify ApprovalQueue is NOT resolved
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+    assert len(calls) == 1
+    assert calls[0][0] == "answerCallbackQuery"
+    assert "Only paired users" in calls[0][1]["text"]
+    calls.clear()
 
-    # Wait for the background task _handle_telegram_callback to complete
-    await asyncio.sleep(0.1)
+    # Pair the user and verify they can resolve it
+    admission_mock = ChannelAdmission("telegram", "12345", "grant1", 1)
+    with patch.object(channel.pairing_store, "admission", return_value=admission_mock):
+        await channel._handle_telegram_callback(callback_query)
 
     # Verify ApprovalQueue is resolved
     entry = queue.get(approval_id)
@@ -72,6 +78,57 @@ async def test_telegram_callback_query_parsing_and_resolution() -> None:
     assert calls[1][1]["message_id"] == 999
     assert "Approved ✅" in calls[1][1]["text"]
     assert calls[1][1]["reply_markup"] is None
+
+    # Verify a virtual "Approve" message is enqueued
+    msg = await channel.receive()
+    assert msg.content == "Approve"
+    assert msg.sender_id == "12345"
+
+
+@pytest.mark.asyncio
+async def test_telegram_callback_query_session_mismatch() -> None:
+    queue = get_approval_queue()
+    # Approval is bound to a specific session key
+    approval_id = queue.request(
+        "exec",
+        {
+            "argv": ["rm", "-rf"],
+            "action_kind": "exec",
+            "sessionKey": "agent:main:telegram:direct:99999",
+        },
+    )
+
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    calls = []
+
+    async def fake_api(method: str, payload: dict | None = None) -> Any:
+        calls.append((method, payload or {}))
+        return True
+
+    channel._api = fake_api
+
+    callback_query = {
+        "id": "cb123",
+        "from": {"id": 12345, "username": "bob"},
+        "message": {
+            "message_id": 999,
+            "chat": {"id": 12345, "type": "private"},
+            "text": "Do you want to run this command?",
+        },
+        "data": f"approve:{approval_id}",
+    }
+
+    # Pair the user but click from a mismatched chat context (session key direct:99999 vs 12345)
+    admission_mock = ChannelAdmission("telegram", "12345", "grant1", 1)
+    with patch.object(channel.pairing_store, "admission", return_value=admission_mock):
+        await channel._handle_telegram_callback(callback_query)
+
+    # Verify ApprovalQueue is NOT resolved
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+    assert len(calls) == 1
+    assert calls[0][0] == "answerCallbackQuery"
+    assert "does not belong to this chat" in calls[0][1]["text"]
 
 
 @pytest.mark.asyncio
@@ -112,7 +169,6 @@ async def test_slack_interactive_payload_handling() -> None:
 
     post_calls = []
 
-    # Patch httpx.AsyncClient.post
     class FakeResponse:
         def raise_for_status(self):
             pass
@@ -120,6 +176,24 @@ async def test_slack_interactive_payload_handling() -> None:
     async def fake_post(url, json=None, **kwargs):
         post_calls.append((url, json))
         return FakeResponse()
+
+    # Reject if policy does not admit
+    from dataclasses import replace
+
+    channel.policy = replace(
+        channel.policy, allowlist=frozenset({"U99999"}), allowlist_enabled=True
+    )
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        await channel._handle_slack_interactive(payload)
+
+    # Verify ApprovalQueue is NOT resolved since clicker was rejected
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+    assert len(post_calls) == 0
+
+    # Admit by opening allowlist or disabling it
+    channel.policy = replace(channel.policy, allowlist=frozenset(), allowlist_enabled=False)
 
     with patch("httpx.AsyncClient.post", side_effect=fake_post):
         await channel._handle_slack_interactive(payload)
@@ -134,7 +208,6 @@ async def test_slack_interactive_payload_handling() -> None:
     assert post_calls[0][0] == "https://hooks.slack.com/actions/test"
     sent_json = post_calls[0][1]
     assert sent_json["replace_original"] is True
-    # Verify approval_actions block is removed and decision is appended
     assert len(sent_json["blocks"]) == 2
     assert sent_json["blocks"][1]["text"]["text"] == "*Approved ✅*"
 
@@ -142,6 +215,27 @@ async def test_slack_interactive_payload_handling() -> None:
     msg = await channel.receive()
     assert msg.content == "Approve"
     assert msg.sender_id == "U12345"
+
+
+@pytest.mark.asyncio
+async def test_slack_interactive_payload_unsigned_rejected() -> None:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345", signing_secret=None)
+
+    # Mock fastapi request
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/x-www-form-urlencoded")],
+    }
+    req = Request(scope)
+
+    async def mock_body():
+        return b"payload=%7B%22type%22%3A%22block_actions%22%7D"
+
+    req.body = mock_body
+
+    resp = await channel._handle_webhook(req)
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -181,6 +275,24 @@ async def test_discord_component_interaction_handling() -> None:
         },
     }
 
+    # Reject if policy does not admit
+    from dataclasses import replace
+
+    channel.policy = replace(
+        channel.policy, allowlist=frozenset({"usr999"}), allowlist_enabled=True
+    )
+
+    await channel._handle_discord_component_interaction(data)
+    entry = queue.get(approval_id)
+    assert entry.resolved is False
+    assert len(post_calls) == 1
+    assert "Only paired users" in post_calls[0][1]["data"]["content"]
+    post_calls.clear()
+
+    # Admit
+    channel.policy = replace(channel.policy, allowlist=frozenset(), allowlist_enabled=False)
+    channel._dedupe._seen.clear()
+
     await channel._handle_discord_component_interaction(data)
 
     # Verify ApprovalQueue is resolved
@@ -196,7 +308,7 @@ async def test_discord_component_interaction_handling() -> None:
     assert "Denied ❌" in payload["data"]["content"]
     assert payload["data"]["components"] == []
 
-    # Verify a virtual "Deny" message is enqueued
+    # Verify a virtual "Denied" message is enqueued
     msg = await channel.receive()
     assert msg.content == "Deny"
     assert msg.sender_id == "usr123"

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.channels.slack import SlackChannel
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+from agentos.channels.types import IncomingMessage, OutgoingMessage
+from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from agentos.gateway.channel_dispatch import (
+    _send_channel_approval_prompt,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_approval_queue():
+    reset_approval_queue()
+    yield
+    reset_approval_queue()
+
+
+@pytest.mark.asyncio
+async def test_telegram_callback_query_parsing_and_resolution() -> None:
+    queue = get_approval_queue()
+    approval_id = queue.request("exec", {"argv": ["rm", "-rf"], "action_kind": "exec"})
+
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    calls = []
+
+    async def fake_api(method: str, payload: dict | None = None) -> Any:
+        calls.append((method, payload or {}))
+        return True
+
+    channel._api = fake_api
+
+    # Simulate callback query update for "approve"
+    update = {
+        "update_id": 100,
+        "callback_query": {
+            "id": "cb123",
+            "from": {"id": 12345, "username": "bob"},
+            "message": {
+                "message_id": 999,
+                "chat": {"id": 12345, "type": "private"},
+                "text": "Do you want to run this command?",
+            },
+            "data": f"approve:{approval_id}",
+        },
+    }
+
+    inbound = channel.parse_incoming(update)
+    assert inbound.content == "Approve"
+    assert inbound.sender_id == "12345"
+
+    # Wait for the background task _handle_telegram_callback to complete
+    await asyncio.sleep(0.1)
+
+    # Verify ApprovalQueue is resolved
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+    # Verify Telegram API edits the message and clears buttons
+    assert len(calls) == 2
+    assert calls[0][0] == "answerCallbackQuery"
+    assert calls[0][1]["callback_query_id"] == "cb123"
+    assert calls[1][0] == "editMessageText"
+    assert calls[1][1]["message_id"] == 999
+    assert "Approved ✅" in calls[1][1]["text"]
+    assert calls[1][1]["reply_markup"] is None
+
+
+@pytest.mark.asyncio
+async def test_slack_interactive_payload_handling() -> None:
+    queue = get_approval_queue()
+    approval_id = queue.request("exec", {"argv": ["rm", "-rf"], "action_kind": "exec"})
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345")
+
+    # Mock parse_event
+    channel.parse_event = lambda ev: IncomingMessage(
+        sender_id=ev["user"],
+        channel_id=ev["channel"],
+        content=ev["text"],
+    )
+
+    payload = {
+        "type": "block_actions",
+        "user": {"id": "U12345"},
+        "channel": {"id": "C12345"},
+        "response_url": "https://hooks.slack.com/actions/test",
+        "message": {
+            "text": "Approve this execution?",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "Approve this execution?"},
+                },
+                {
+                    "type": "actions",
+                    "block_id": "approval_actions",
+                    "elements": [{"type": "button", "value": f"approve:{approval_id}"}],
+                },
+            ],
+        },
+        "actions": [{"value": f"approve:{approval_id}"}],
+    }
+
+    post_calls = []
+
+    # Patch httpx.AsyncClient.post
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+    async def fake_post(url, json=None, **kwargs):
+        post_calls.append((url, json))
+        return FakeResponse()
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        await channel._handle_slack_interactive(payload)
+
+    # Verify ApprovalQueue is resolved
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+    # Verify Slack message is updated using response_url
+    assert len(post_calls) == 1
+    assert post_calls[0][0] == "https://hooks.slack.com/actions/test"
+    sent_json = post_calls[0][1]
+    assert sent_json["replace_original"] is True
+    # Verify approval_actions block is removed and decision is appended
+    assert len(sent_json["blocks"]) == 2
+    assert sent_json["blocks"][1]["text"]["text"] == "*Approved ✅*"
+
+    # Verify a virtual "Approve" message is enqueued
+    msg = await channel.receive()
+    assert msg.content == "Approve"
+    assert msg.sender_id == "U12345"
+
+
+@pytest.mark.asyncio
+async def test_discord_component_interaction_handling() -> None:
+    queue = get_approval_queue()
+    approval_id = queue.request("exec", {"argv": ["rm", "-rf"], "action_kind": "exec"})
+
+    channel = DiscordChannel(DiscordChannelConfig(token="test-token"))
+
+    post_calls = []
+
+    async def fake_post(path, json=None, headers=None, **kwargs):
+        post_calls.append((path, json))
+
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"id": "999"}
+
+        return FakeResp()
+
+    channel._get_client = lambda: AsyncMock(post=fake_post)
+
+    data = {
+        "type": 3,  # Component interaction
+        "id": "int123",
+        "token": "token123",
+        "channel_id": "chan123",
+        "user": {"id": "usr123"},
+        "message": {
+            "content": "Approval requested",
+        },
+        "data": {
+            "custom_id": f"deny:{approval_id}",
+        },
+    }
+
+    await channel._handle_discord_component_interaction(data)
+
+    # Verify ApprovalQueue is resolved
+    entry = queue.get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is False
+
+    # Verify Discord API UPDATE_MESSAGE callback
+    assert len(post_calls) == 1
+    assert post_calls[0][0] == "/interactions/int123/token123/callback"
+    payload = post_calls[0][1]
+    assert payload["type"] == 7  # UPDATE_MESSAGE
+    assert "Denied ❌" in payload["data"]["content"]
+    assert payload["data"]["components"] == []
+
+    # Verify a virtual "Deny" message is enqueued
+    msg = await channel.receive()
+    assert msg.content == "Deny"
+    assert msg.sender_id == "usr123"
+
+
+@pytest.mark.asyncio
+async def test_send_channel_approval_prompt() -> None:
+    class DummyChannel:
+        def transport_name(self):
+            return "telegram"
+
+        async def send(self, msg: OutgoingMessage):
+            self.sent_msg = msg
+
+    channel = DummyChannel()
+    inbound = IncomingMessage(sender_id="usr1", channel_id="chan1", content="hi")
+    pending = {
+        "approval_id": "app-123",
+        "command": "ls -l",
+        "tool_name": "shell",
+        "status": "approval_required",
+    }
+
+    await _send_channel_approval_prompt(channel, inbound, pending)
+
+    assert channel.sent_msg is not None
+    assert "shell" in channel.sent_msg.content
+    assert "ls -l" in channel.sent_msg.content
+    assert "reply_markup" in channel.sent_msg.metadata
+    assert channel.sent_msg.metadata["reply_markup"]["inline_keyboard"][0][0]["text"] == "Approve"

--- a/tests/test_tools/test_dispatch_envelope.py
+++ b/tests/test_tools/test_dispatch_envelope.py
@@ -102,7 +102,7 @@ async def test_dispatch_missing_tool_returns_five_field_error_envelope() -> None
     handler = build_tool_handler(
         _build_registry(),
         ToolContext(
-                        caller_kind=CallerKind.CLI,
+            caller_kind=CallerKind.CLI,
             agent_id="main",
             session_key="cli:main:envelope",
         ),
@@ -136,7 +136,7 @@ async def test_dispatch_unknown_bash_tool_points_to_exec_command() -> None:
     handler = build_tool_handler(
         _build_registry(),
         ToolContext(
-                        caller_kind=CallerKind.CLI,
+            caller_kind=CallerKind.CLI,
             agent_id="main",
             session_key="cli:main:envelope",
         ),
@@ -241,9 +241,43 @@ async def test_dispatch_unsupported_surface_approval_payload_is_pending_status()
     handler = build_tool_handler(_build_registry())
     token = current_tool_context.set(
         ToolContext(
-                        caller_kind=CallerKind.CHANNEL,
+            caller_kind=CallerKind.CHANNEL,
             interaction_mode=InteractionMode.UNATTENDED,
             session_key="agent:main:demo",
+            agent_id="main",
+        )
+    )
+    try:
+        result = await handler(
+            ToolCall(
+                tool_use_id="tc-3",
+                tool_name="pending",
+                arguments={},
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result.is_error is False
+    assert result.execution_status is not None
+    assert result.execution_status["status"] == "unknown"
+    assert result.execution_status["reason"] == "approval_pending"
+    assert result.execution_status["preservation_class"] == "ephemeral"
+    payload = json.loads(result.content)
+    assert payload["status"] == "error"
+    assert payload["tool"] == "pending"
+    assert payload["error_class"] == "UnsupportedSurface"
+    assert payload["retry_allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_supported_channel_surface_approval_payload_is_approval_required() -> None:
+    handler = build_tool_handler(_build_registry())
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CHANNEL,
+            interaction_mode=InteractionMode.UNATTENDED,
+            session_key="agent:main:telegram:direct:12345",
             agent_id="main",
         )
     )
@@ -274,7 +308,7 @@ async def test_dispatch_unattended_cli_approval_payload_is_pending_status() -> N
     handler = build_tool_handler(_build_registry())
     token = current_tool_context.set(
         ToolContext(
-                        caller_kind=CallerKind.CLI,
+            caller_kind=CallerKind.CLI,
             interaction_mode=InteractionMode.UNATTENDED,
             session_key="agent:main:demo",
             agent_id="main",
@@ -319,7 +353,7 @@ async def test_dispatch_unknown_tool_in_skill_name_context_raises_unsupported_su
     handler = build_tool_handler(
         _build_registry(),
         ToolContext(
-                        caller_kind=CallerKind.CLI,
+            caller_kind=CallerKind.CLI,
             agent_id="main",
             session_key="cli:main:envelope",
         ),
@@ -417,9 +451,7 @@ async def test_dispatch_does_not_rewrite_artifact_result_text_when_over_budget()
         ),
     )
 
-    result = await handler(
-        ToolCall(tool_use_id="tc-art-large", tool_name="publish", arguments={})
-    )
+    result = await handler(ToolCall(tool_use_id="tc-art-large", tool_name="publish", arguments={}))
 
     assert result.content == "x" * 1000
     assert result.artifacts == [artifact]
@@ -436,9 +468,7 @@ async def test_dispatch_leaves_under_budget_result_unchanged() -> None:
     handler = build_tool_handler(
         registry,
         ToolContext(
-            tool_result_budget_policy=ToolResultBudgetPolicy(
-                max_single_tool_result_chars=10_000
-            )
+            tool_result_budget_policy=ToolResultBudgetPolicy(max_single_tool_result_chars=10_000)
         ),
     )
 
@@ -608,9 +638,7 @@ async def test_dispatch_clamps_web_fetch_max_chars_before_handler() -> None:
     )
     handler = build_tool_handler(
         registry,
-        ToolContext(
-            tool_run_budget_policy=ToolRunBudgetPolicy(max_single_fetch_chars=12_000)
-        ),
+        ToolContext(tool_run_budget_policy=ToolRunBudgetPolicy(max_single_fetch_chars=12_000)),
     )
 
     result = await handler(
@@ -646,9 +674,7 @@ async def test_dispatch_clamps_web_search_results_before_handler() -> None:
     )
     handler = build_tool_handler(
         registry,
-        ToolContext(
-            tool_run_budget_policy=ToolRunBudgetPolicy(max_web_search_results=10)
-        ),
+        ToolContext(tool_run_budget_policy=ToolRunBudgetPolicy(max_web_search_results=10)),
     )
 
     result = await handler(
@@ -895,8 +921,7 @@ async def test_dispatch_run_budget_limits_concurrent_external_calls_atomically()
             control_payloads.append(payload)
     assert len(control_payloads) == 1
     assert any(
-        result.execution_status
-        and result.execution_status["reason"] == "tool_run_budget_exhausted"
+        result.execution_status and result.execution_status["reason"] == "tool_run_budget_exhausted"
         for result in results
     )
 
@@ -1291,14 +1316,10 @@ async def test_dispatch_tracker_budget_is_fresh_for_reused_tool_context() -> Non
     )
 
     first_handler = build_tool_handler(registry, ctx)
-    first = await first_handler(
-        ToolCall(tool_use_id="tc-first", tool_name="huge", arguments={})
-    )
+    first = await first_handler(ToolCall(tool_use_id="tc-first", tool_name="huge", arguments={}))
 
     second_handler = build_tool_handler(registry, ctx)
-    second = await second_handler(
-        ToolCall(tool_use_id="tc-second", tool_name="huge", arguments={})
-    )
+    second = await second_handler(ToolCall(tool_use_id="tc-second", tool_name="huge", arguments={}))
 
     assert _strict_preview_chars(first.content) == _strict_preview_chars(second.content)
     assert _strict_preview_chars(first.content) > 0

--- a/tests/test_tools/test_dispatch_envelope.py
+++ b/tests/test_tools/test_dispatch_envelope.py
@@ -264,10 +264,9 @@ async def test_dispatch_unsupported_surface_approval_payload_is_pending_status()
     assert result.execution_status["reason"] == "approval_pending"
     assert result.execution_status["preservation_class"] == "ephemeral"
     payload = json.loads(result.content)
-    assert payload["status"] == "error"
-    assert payload["tool"] == "pending"
-    assert payload["error_class"] == "UnsupportedSurface"
-    assert payload["retry_allowed"] is False
+    assert payload["status"] == "approval_required"
+    assert payload["approval_id"] == "abc123"
+    assert payload["command"] == "rm secret"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

 Gated Tool Approvals from Channels (Closes #364)
Enables channel-native interactive approvals for Telegram, Slack, and Discord. If an agent executes a gated tool (like a shell command) during a channel turn, the channel DM presents an interactive approval prompt with buttons to approve or deny the action directly from the chat.

- **Platform-Native Controls**: Renders inline keyboard buttons on Telegram, action block buttons on Slack, and message component buttons on Discord.
- **Fail-Closed Turn Termination**: Marks turns as terminated immediately upon encountering a pending tool approval on unattended surfaces, returning the prompt message to the user instead of blocking the runtime.
- **Inline Message Updates**: Updates the prompt message inline after the button is clicked to display the decision ("Approved ✅" or "Denied ❌") and strip active buttons to prevent double-submits.
- **Virtual Resume Message Injection**: Resolves the `ApprovalQueue` entry and enqueues a virtual `"Approve"` or `"Deny"` message from the user back into the session queue, automatically triggering a new turn that resumes execution seamlessly.
