### PR TITLE
feat(provider): health-aware failover with a per-provider circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Provider failover is now health-aware. A circuit breaker counts consecutive
+  provider-health failures (overload / gateway 5xx, transport errors, rate
+  limits) per configured provider id; after
+  `llm.circuit_breaker.failure_threshold` failures (default 3) the provider is
+  skipped for a cooldown window (default 60s, doubling per consecutive trip up to
+  `max_cooldown_seconds`), and one half-open probe per window re-closes it when
+  the provider recovers. Failover used to be purely reactive and per-request —
+  every turn during an outage paid the full timeout on the dead primary before
+  falling back, because `ModelSelector` reset to the primary each turn. Breaker
+  state is shared across per-turn selector clones, so detection is paid once
+  per outage instead of once per turn. Request-shaped failures (unknown model,
+  bad request, context overflow, auth, billing) never trip the breaker, and if
+  every link in the chain is in cooldown the primary is still used. State is
+  surfaced in `agentos providers status` (new `circuit` column),
+  `agentos doctor` (`provider.circuit.open` / `provider.circuit.half_open`), and
+  `GET /api/system/status` (`circuitBreaker` / `circuitBreakers`). (#365)
+
 ### Fixed
 
 - Skill dependency installs work for every kind a skill can declare. Three

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -114,6 +114,16 @@ model = "openai/gpt-5.6-luna"
 base_url = "https://openrouter.ai/api/v1"
 # proxy = ""            # e.g. http://127.0.0.1:7890
 
+# Health-aware failover. Consecutive provider-health failures (overload,
+# transport, rate limit) open a circuit breaker so turns skip the dead
+# provider for a cooldown window instead of paying its timeout every turn.
+# One half-open probe per window re-closes it when the provider recovers.
+# [llm.circuit_breaker]
+# enabled = true
+# failure_threshold = 3       # consecutive failures before the breaker opens
+# cooldown_seconds = 60       # skip window; doubles per consecutive trip
+# max_cooldown_seconds = 600  # cap on the doubling
+
 # Provider quick reference. Support levels marked compat_mock_verified are
 # verified by local mocked-contract tests, not by live vendor calls.
 #

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -340,6 +340,10 @@ agentos providers configure openrouter
 agentos providers status
 ```
 
+`providers status` includes a `circuit` column with the active provider's
+failover circuit-breaker state (`closed`, `half_open`, or `open (42s)`); see
+[`providers-and-models.md`](providers-and-models.md#provider-health-circuit-breaker).
+
 Provider-specific setup examples, including OpenCAP, live in
 [`providers-and-models.md`](providers-and-models.md).
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -51,7 +51,7 @@ These require no auth and are safe for load balancers and container probes.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/config` | Effective gateway configuration. |
-| `GET` | `/api/system/status` | Version, uptime, active provider, auth mode. |
+| `GET` | `/api/system/status` | Version, uptime, active provider, auth mode, plus `circuitBreaker` (the active provider's breaker) and `circuitBreakers` (every tracked provider). |
 | `GET` | `/api/sessions` | List sessions. |
 | `POST` | `/api/chat` | Send a chat turn. Body: `message` (required), `sessionKey` (optional). |
 | `GET` | `/api/chat/history?sessionKey=<key>` | Fetch a session transcript. |

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -168,6 +168,11 @@ timeout on every turn.
   window.
 - If every provider in the chain is in cooldown, the primary is used anyway —
   a provider in cooldown still beats no provider at all.
+- A per-turn model override (an explicit `model`, or one picked by the router)
+  applies to the primary link. While the primary's breaker is open the turn
+  runs on the fallback's own configured model instead — the same semantics as
+  an ordinary failover, but now for the whole cooldown window rather than only
+  after a live failure.
 
 Tune or disable it in `agentos.toml`:
 

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -149,6 +149,46 @@ agentos configure router --router recommended
 For routing details, see
 [`features/agentos-router.md`](features/agentos-router.md).
 
+## Provider Health Circuit Breaker
+
+Failover is health-aware. When the active provider returns consecutive
+provider-health failures — overload / gateway 5xx, transport errors, or rate
+limits — AgentOS opens a circuit breaker for that provider and sends the next
+turns straight down the fallback chain instead of paying the dead provider's
+timeout on every turn.
+
+- `failure_threshold` consecutive failures open the breaker (default `3`).
+  Request-shaped failures (unknown model, bad request, context overflow, auth,
+  billing) never count — they say nothing about provider health.
+- While open, the provider is skipped for `cooldown_seconds` (default `60`).
+  Each consecutive trip doubles the window up to `max_cooldown_seconds`
+  (default `600`).
+- After the cooldown, exactly one turn is admitted as a half-open probe. A
+  clean turn closes the breaker; another failure re-opens it with the longer
+  window.
+- If every provider in the chain is in cooldown, the primary is used anyway —
+  a provider in cooldown still beats no provider at all.
+
+Tune or disable it in `agentos.toml`:
+
+```toml
+[llm.circuit_breaker]
+enabled = true
+failure_threshold = 3
+cooldown_seconds = 60
+max_cooldown_seconds = 600
+```
+
+Inspect the current state:
+
+```sh
+agentos providers status          # "circuit" column: closed | half_open | open (42s)
+agentos doctor                    # provider.circuit.open / provider.circuit.half_open
+curl localhost:8787/api/system/status   # circuitBreaker / circuitBreakers
+```
+
+Breaker state lives in the running gateway only; restarting clears it.
+
 ## Provider Troubleshooting
 
 Start with:
@@ -166,6 +206,7 @@ Check:
 - the base URL is correct for compatible APIs;
 - proxy settings match your network;
 - router is disabled when debugging one exact provider/model;
+- the provider's circuit breaker is not open (`agentos providers status`);
 - the gateway was restarted after config changes.
 
 ---

--- a/src/agentos/cli/providers_cmd.py
+++ b/src/agentos/cli/providers_cmd.py
@@ -53,6 +53,17 @@ def providers_list(
     console.print(table)
 
 
+def _circuit_cell(breaker: object) -> str:
+    """Render the failover breaker state, with cooldown left when open."""
+    if not isinstance(breaker, dict):
+        return "-"
+    state = str(breaker.get("state") or "closed")
+    remaining = breaker.get("cooldownRemainingSeconds")
+    if state == "open" and isinstance(remaining, int | float) and remaining > 0:
+        return f"open ({round(float(remaining))}s)"
+    return state
+
+
 @providers_app.command("status")
 def providers_status(
     provider: str | None = typer.Argument(None, help="Optional provider id"),
@@ -84,6 +95,7 @@ def providers_status(
     table.add_column("configured", no_wrap=True)
     table.add_column("buildable", no_wrap=True)
     table.add_column("model")
+    table.add_column("circuit", no_wrap=True)
     table.add_column("error")
     for row in payload.get("providers", []):
         table.add_row(
@@ -92,6 +104,7 @@ def providers_status(
             "yes" if row.get("configured") else "no",
             "yes" if row.get("buildable") else "no",
             str(row.get("model") or ""),
+            _circuit_cell(row.get("circuitBreaker")),
             str(row.get("error") or ""),
         )
     console.print(table)

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -142,10 +142,12 @@ from agentos.provider import (
     ErrorEvent as ProviderErrorEvent,
 )
 from agentos.provider import (
+    ProviderFailureKind,
     ProviderRecoveryAction,
     classify_provider_error,
     decide_recovery_action,
 )
+from agentos.provider.circuit_breaker import trips_breaker
 from agentos.result_budget import persisted_result_max_chars
 from agentos.router_control import (
     RouterControlHoldStore,
@@ -1025,17 +1027,24 @@ _SUBAGENT_TASK_PROTOCOL: Final[str] = (
 )
 
 
-def _should_use_selector_fallback(provider_name: str, event: ProviderErrorEvent) -> bool:
-    kind = classify_provider_error(
+def _classify_provider_event(provider_name: str, event: ProviderErrorEvent) -> ProviderFailureKind:
+    return classify_provider_error(
         provider_name=provider_name,
         status_code=int(event.code) if str(event.code).isdigit() else None,
         raw_code=event.code,
         message=event.message,
     )
+
+
+def _kind_uses_selector_fallback(kind: ProviderFailureKind) -> bool:
     return decide_recovery_action(kind) in {
         ProviderRecoveryAction.FALLBACK_PROVIDER,
         ProviderRecoveryAction.RETRY_THEN_FALLBACK,
     }
+
+
+def _should_use_selector_fallback(provider_name: str, event: ProviderErrorEvent) -> bool:
+    return _kind_uses_selector_fallback(_classify_provider_event(provider_name, event))
 
 
 def _normalize_heartbeat_text(
@@ -1085,7 +1094,12 @@ def _drop_unpaired_tool_use_segments(segments: list[dict[str, Any]]) -> list[dic
 
 
 class _SelectorFallbackProvider:
-    """Provider wrapper that switches to selector fallback on pre-content errors."""
+    """Provider wrapper that switches to selector fallback on pre-content errors.
+
+    Also feeds the selector's circuit breaker: provider-health failures are
+    counted so a sustained outage opens the breaker, and the first byte of
+    real content closes it again.
+    """
 
     def __init__(self, provider: Any, selector: Any) -> None:
         self._provider = provider
@@ -1097,6 +1111,24 @@ class _SelectorFallbackProvider:
     @property
     def provider_name(self) -> str:
         return getattr(self._provider, "provider_name", "")
+
+    def _record_failure(self, kind: ProviderFailureKind, reason: str) -> None:
+        recorder = getattr(self._selector, "record_provider_failure", None)
+        if recorder is None:
+            return
+        try:
+            recorder(kind, reason)
+        except Exception:  # pragma: no cover - breaker must never break a turn
+            log.debug("selector_fallback.breaker_failure_record_failed", exc_info=True)
+
+    def _record_success(self) -> None:
+        recorder = getattr(self._selector, "record_provider_success", None)
+        if recorder is None:
+            return
+        try:
+            recorder()
+        except Exception:  # pragma: no cover - breaker must never break a turn
+            log.debug("selector_fallback.breaker_success_record_failed", exc_info=True)
 
     def fallback_after_invalid_response(self, reason: str) -> bool:
         try:
@@ -1120,6 +1152,9 @@ class _SelectorFallbackProvider:
         config: Any = None,
     ) -> AsyncIterator[Any]:
         emitted_user_visible_content = False
+        saw_provider_error = False
+        recorded_success = False
+        recorded_failure = False
         pre_text_buffer: list[Any] = []
 
         def drain_pre_text_buffer() -> list[Any]:
@@ -1132,42 +1167,50 @@ class _SelectorFallbackProvider:
                 yield event
                 continue
 
-            if isinstance(event, ProviderErrorEvent) and _should_use_selector_fallback(
-                self.provider_name, event
-            ):
-                try:
-                    self._provider = self._selector.next_fallback_after_failure(
-                        RuntimeError(event.message)
-                    )
-                except Exception:
-                    for buffered_event in drain_pre_text_buffer():
-                        yield buffered_event
-                    yield event
+            if isinstance(event, ProviderErrorEvent):
+                saw_provider_error = True
+                kind = _classify_provider_event(self.provider_name, event)
+                if not recorded_failure:
+                    # One vote per stream: a provider that emits several error
+                    # events for one request is still a single failed turn.
+                    recorded_failure = trips_breaker(kind)
+                    self._record_failure(kind, event.message)
+                if _kind_uses_selector_fallback(kind):
+                    try:
+                        self._provider = self._selector.next_fallback_after_failure(
+                            RuntimeError(event.message)
+                        )
+                    except Exception:
+                        for buffered_event in drain_pre_text_buffer():
+                            yield buffered_event
+                        yield event
+                        return
+                    async for fallback_event in self._fallback_chat(messages, tools, config):
+                        yield fallback_event
                     return
-                async for fallback_event in self._provider.chat(
-                    messages,
-                    tools=tools,
-                    config=config,
-                ):
-                    yield fallback_event
-                return
+                for buffered_event in drain_pre_text_buffer():
+                    yield buffered_event
+                yield event
+                continue
 
             if _is_non_empty_provider_text_delta(event):
                 for buffered_event in drain_pre_text_buffer():
                     yield buffered_event
                 emitted_user_visible_content = True
+                if not recorded_success:
+                    recorded_success = True
+                    self._record_success()
                 yield event
                 continue
 
             if getattr(event, "kind", "") == "done":
                 for buffered_event in drain_pre_text_buffer():
                     yield buffered_event
-                yield event
-                continue
-
-            if isinstance(event, ProviderErrorEvent):
-                for buffered_event in drain_pre_text_buffer():
-                    yield buffered_event
+                # A clean stream proves the provider is healthy — including a
+                # tool-use-only turn that never emits user-visible text.
+                if not saw_provider_error and not recorded_success:
+                    recorded_success = True
+                    self._record_success()
                 yield event
                 continue
 
@@ -1175,6 +1218,31 @@ class _SelectorFallbackProvider:
 
         for buffered_event in drain_pre_text_buffer():
             yield buffered_event
+
+    async def _fallback_chat(
+        self,
+        messages: list[Any],
+        tools: Any,
+        config: Any,
+    ) -> AsyncIterator[Any]:
+        """Stream the post-failover provider, recording its own breaker outcome."""
+        saw_provider_error = False
+        recorded_success = False
+        recorded_failure = False
+        async for event in self._provider.chat(messages, tools=tools, config=config):
+            if isinstance(event, ProviderErrorEvent):
+                saw_provider_error = True
+                if not recorded_failure:
+                    kind = _classify_provider_event(self.provider_name, event)
+                    recorded_failure = trips_breaker(kind)
+                    self._record_failure(kind, event.message)
+            elif not recorded_success and (
+                _is_non_empty_provider_text_delta(event)
+                or (getattr(event, "kind", "") == "done" and not saw_provider_error)
+            ):
+                recorded_success = True
+                self._record_success()
+            yield event
 
     async def list_models(self) -> list[Any]:
         return list(await self._provider.list_models())

--- a/src/agentos/gateway/app.py
+++ b/src/agentos/gateway/app.py
@@ -187,6 +187,24 @@ def create_gateway_app(
                     provider_name = getattr(p, "name", None) or type(p).__name__
                 except Exception:
                     pass
+        # Operator-visible failover health: an open breaker explains why turns
+        # are running on a fallback provider rather than the configured one.
+        breakers: list[dict[str, Any]] = []
+        active_breaker: dict[str, Any] | None = None
+        if provider_selector is not None:
+            try:
+                from agentos.provider.circuit_breaker import snapshot_payload
+
+                breakers = snapshot_payload(
+                    getattr(provider_selector, "circuit_breaker", None)
+                )
+                if provider_name:
+                    active_breaker = next(
+                        (row for row in breakers if row.get("provider") == provider_name),
+                        None,
+                    )
+            except Exception:  # noqa: BLE001 - diagnostic surface only
+                breakers = []
         return JSONResponse(
             {
                 "version": __version__,
@@ -194,6 +212,8 @@ def create_gateway_app(
                 "status": "running",
                 "provider": provider_name,
                 "auth_mode": config.auth.mode,
+                "circuitBreaker": active_breaker,
+                "circuitBreakers": breakers,
             }
         )
 

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1498,6 +1498,10 @@ async def build_services(
     proxy = llm_runtime.proxy
     if provider_selector is None:
         if _should_build_provider_selector(provider=llm_runtime.provider, api_key=api_key):
+            from agentos.provider.circuit_breaker import (
+                BreakerSettings,
+                ProviderCircuitBreaker,
+            )
             from agentos.provider.selector import (
                 ModelSelector,
                 ProviderConfig,
@@ -1506,6 +1510,9 @@ async def build_services(
 
             if resolved_base.endswith("/v1"):
                 resolved_base = resolved_base[:-3]
+            breaker_settings = BreakerSettings.from_config(
+                getattr(getattr(config, "llm", None), "circuit_breaker", None)
+            )
             provider_selector = ModelSelector(
                 SelectorConfig(
                     primary=ProviderConfig(
@@ -1516,7 +1523,8 @@ async def build_services(
                         proxy=proxy,
                         provider_routing=llm_runtime.provider_routing,
                     )
-                )
+                ),
+                breaker=ProviderCircuitBreaker(breaker_settings),
             )
             log.info(
                 "build_services.provider_ready",

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -258,6 +258,21 @@ class TaskRuntimeConfig(BaseModel):
         return value
 
 
+class LlmCircuitBreakerConfig(BaseModel):
+    """Provider health breaker: skip a failing provider instead of retrying it.
+
+    ``failure_threshold`` consecutive provider-health failures (overload,
+    transport, rate limit) open the breaker for ``cooldown_seconds``; the
+    window doubles per consecutive trip up to ``max_cooldown_seconds``. One
+    half-open probe per window re-closes it when the provider recovers.
+    """
+
+    enabled: bool = True
+    failure_threshold: int = Field(default=3, ge=1)
+    cooldown_seconds: float = Field(default=60.0, gt=0)
+    max_cooldown_seconds: float = Field(default=600.0, gt=0)
+
+
 class LlmProviderConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="AGENTOS_LLM_")
 
@@ -275,6 +290,8 @@ class LlmProviderConfig(BaseSettings):
     # provider name. Mapped models send provider.order=[name] so the provider
     # is preferred without disabling OpenRouter fallback.
     provider_routing: dict[str, str] = Field(default_factory=dict)
+    # Health-aware failover: see LlmCircuitBreakerConfig.
+    circuit_breaker: LlmCircuitBreakerConfig = Field(default_factory=LlmCircuitBreakerConfig)
 
     @model_validator(mode="after")
     def _normalize_direct_deepseek_model(self) -> LlmProviderConfig:

--- a/src/agentos/gateway/rpc_tools.py
+++ b/src/agentos/gateway/rpc_tools.py
@@ -93,6 +93,18 @@ def _provider_base_url(provider_id: str, default_base_url: str, ctx: RpcContext)
     return default_base_url
 
 
+def _circuit_breaker_row(provider_id: str, ctx: RpcContext) -> dict[str, Any] | None:
+    """Side-effect-free breaker snapshot for one provider (None when absent)."""
+    selector = getattr(ctx, "provider_selector", None)
+    status_fn = getattr(selector, "circuit_breaker_status", None)
+    if status_fn is None:
+        return None
+    try:
+        return dict(status_fn(provider_id).to_dict())
+    except Exception:  # noqa: BLE001 - diagnostic surface
+        return None
+
+
 async def _model_probe(provider_id: str, ctx: RpcContext) -> dict[str, Any]:
     selector = getattr(ctx, "provider_selector", None)
     if selector is None:
@@ -182,6 +194,9 @@ async def _handle_providers_status(params: dict | None, ctx: RpcContext) -> dict
                 "baseUrlConfigured": base_url_configured,
                 "error": error,
                 "modelProbe": probe,
+                "circuitBreaker": _circuit_breaker_row(spec.provider_id, ctx)
+                if is_active
+                else None,
             }
         )
     return {"activeProvider": active, "providers": rows, "count": len(rows)}

--- a/src/agentos/health/evaluator.py
+++ b/src/agentos/health/evaluator.py
@@ -268,7 +268,86 @@ def evaluate_provider(payload: dict[str, Any]) -> list[HealthFinding]:
                 evidence={"providerId": provider_id, "model": active_row.get("model")},
             )
         )
+    findings.extend(_circuit_breaker_findings(provider_id, active_row))
     return findings
+
+
+def _circuit_breaker_findings(
+    provider_id: str,
+    active_row: dict[str, Any],
+) -> list[HealthFinding]:
+    """Report the active provider's failover breaker when it is not closed."""
+    breaker = active_row.get("circuitBreaker")
+    if not isinstance(breaker, dict):
+        return []
+    state = str(breaker.get("state") or "closed")
+    if state == "closed":
+        return []
+    failures = _int_from_payload(breaker, "consecutiveFailures")
+    threshold = _int_from_payload(breaker, "failureThreshold")
+    evidence = {
+        "providerId": provider_id,
+        "state": state,
+        "consecutiveFailures": failures,
+        "failureThreshold": threshold,
+        "cooldownRemainingSeconds": breaker.get("cooldownRemainingSeconds"),
+        "lastFailureKind": str(breaker.get("lastFailureKind") or ""),
+        "lastFailureReason": str(breaker.get("lastFailureReason") or ""),
+    }
+    if state == "half_open":
+        return [
+            HealthFinding(
+                id="provider.circuit.half_open",
+                severity="info",
+                readiness_impact="optional",
+                surface="provider",
+                title="Active provider is being probed after a cooldown",
+                detail=(
+                    f"{provider_id} tripped its failover circuit breaker and is now "
+                    "serving a single probe request. A successful turn closes the "
+                    "breaker; another failure re-opens it with a longer cooldown."
+                ),
+                evidence=evidence,
+                fix_steps=[
+                    FixStep(
+                        label="Inspect provider status",
+                        command="agentos providers status --json",
+                    )
+                ],
+            )
+        ]
+    remaining = breaker.get("cooldownRemainingSeconds")
+    cooldown_text = ""
+    if isinstance(remaining, int | float) and remaining > 0:
+        cooldown_text = f" Turns skip it for another {round(float(remaining))}s."
+    return [
+        HealthFinding(
+            id="provider.circuit.open",
+            severity="warn",
+            readiness_impact="degrades",
+            surface="provider",
+            title="Active provider is in failover cooldown",
+            detail=(
+                f"{provider_id} failed {failures} consecutive health checks "
+                f"(threshold {threshold}), so its circuit breaker is open."
+                f"{cooldown_text} Turns run on the fallback chain until it recovers."
+            ),
+            evidence=evidence,
+            fix_steps=[
+                FixStep(
+                    label="Inspect provider status",
+                    command="agentos providers status --json",
+                ),
+                FixStep(
+                    label="Check the provider's own status page",
+                    detail=(
+                        "The breaker re-probes automatically; it only stays open "
+                        "while the provider keeps failing."
+                    ),
+                ),
+            ],
+        )
+    ]
 
 
 def evaluate_memory(payload: dict[str, Any]) -> list[HealthFinding]:

--- a/src/agentos/provider/circuit_breaker.py
+++ b/src/agentos/provider/circuit_breaker.py
@@ -1,0 +1,364 @@
+"""Provider circuit breaker: outage-aware failover with cooldown + half-open probe.
+
+Reactive failover pays the full timeout on a dead provider *every* turn,
+because nothing remembers that the last N turns already failed there. This
+module adds that memory: consecutive provider-health failures trip a breaker,
+an open breaker is skipped by :class:`~agentos.provider.selector.ModelSelector`
+for a cooldown window, and a single half-open probe re-closes it once the
+provider recovers.
+
+State is keyed by the *configured* provider id (``"openrouter"``,
+``"deepseek"``), not the wire-protocol backend class, so an OpenRouter outage
+never mutes a separately-configured OpenAI fallback.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from .failures import ProviderFailureKind
+
+DEFAULT_FAILURE_THRESHOLD = 3
+DEFAULT_COOLDOWN_SECONDS = 60.0
+DEFAULT_MAX_COOLDOWN_SECONDS = 600.0
+
+_REASON_MAX_CHARS = 200
+
+
+class BreakerState(StrEnum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+#: Failure kinds that mean *this provider is unhealthy right now*.
+#:
+#: Deliberately narrow. ``MODEL_NOT_FOUND`` / ``UNSUPPORTED_FEATURE`` /
+#: ``BAD_REQUEST`` / ``CONTEXT_OVERFLOW`` are request-shaped, not
+#: provider-shaped — tripping on them would park a healthy provider because one
+#: model id was wrong. ``AUTH_INVALID`` and ``INSUFFICIENT_CREDITS`` are
+#: credential/billing faults that a cooldown cannot heal; they already route to
+#: ``FAIL_CONFIG`` / ``FALLBACK_PROVIDER`` and surface their own doctor
+#: findings.
+TRIPPING_FAILURE_KINDS: frozenset[ProviderFailureKind] = frozenset(
+    {
+        ProviderFailureKind.PROVIDER_OVERLOADED,
+        ProviderFailureKind.TRANSPORT_TRANSIENT,
+        ProviderFailureKind.RATE_LIMITED,
+    }
+)
+
+
+def trips_breaker(kind: ProviderFailureKind | None) -> bool:
+    """True when ``kind`` counts toward opening a provider's breaker."""
+    return kind is not None and kind in TRIPPING_FAILURE_KINDS
+
+
+@dataclass(frozen=True)
+class BreakerSettings:
+    """Tunables for :class:`ProviderCircuitBreaker`.
+
+    Values are clamped rather than rejected so a hand-edited config can never
+    take the runtime down: a nonsensical threshold degrades to the default
+    behavior instead of raising at boot.
+    """
+
+    enabled: bool = True
+    failure_threshold: int = DEFAULT_FAILURE_THRESHOLD
+    cooldown_seconds: float = DEFAULT_COOLDOWN_SECONDS
+    max_cooldown_seconds: float = DEFAULT_MAX_COOLDOWN_SECONDS
+
+    def __post_init__(self) -> None:
+        threshold = max(1, int(self.failure_threshold))
+        cooldown = max(1.0, float(self.cooldown_seconds))
+        max_cooldown = max(cooldown, float(self.max_cooldown_seconds))
+        object.__setattr__(self, "failure_threshold", threshold)
+        object.__setattr__(self, "cooldown_seconds", cooldown)
+        object.__setattr__(self, "max_cooldown_seconds", max_cooldown)
+
+    @classmethod
+    def from_config(cls, config: Any) -> BreakerSettings:
+        """Build settings from a config object exposing the same field names.
+
+        Missing attributes fall back to the defaults, so this accepts both the
+        real ``llm.circuit_breaker`` config model and ``None``.
+        """
+        if config is None:
+            return cls()
+        return cls(
+            enabled=bool(getattr(config, "enabled", True)),
+            failure_threshold=int(
+                getattr(config, "failure_threshold", DEFAULT_FAILURE_THRESHOLD)
+            ),
+            cooldown_seconds=float(
+                getattr(config, "cooldown_seconds", DEFAULT_COOLDOWN_SECONDS)
+            ),
+            max_cooldown_seconds=float(
+                getattr(config, "max_cooldown_seconds", DEFAULT_MAX_COOLDOWN_SECONDS)
+            ),
+        )
+
+
+@dataclass
+class _Entry:
+    """Mutable per-provider breaker state."""
+
+    consecutive_failures: int = 0
+    state: BreakerState = BreakerState.CLOSED
+    opened_at: float | None = None
+    probe_started_at: float | None = None
+    #: Consecutive open cycles; drives exponential cooldown backoff.
+    open_cycles: int = 0
+    total_failures: int = 0
+    total_trips: int = 0
+    last_failure_kind: str = ""
+    last_failure_reason: str = ""
+
+
+@dataclass(frozen=True)
+class ProviderBreakerStatus:
+    """Operator-facing snapshot of one provider's breaker."""
+
+    provider: str
+    state: BreakerState
+    consecutive_failures: int
+    failure_threshold: int
+    cooldown_remaining_seconds: float
+    cooldown_seconds: float
+    total_failures: int
+    total_trips: int
+    last_failure_kind: str = ""
+    last_failure_reason: str = ""
+
+    @property
+    def healthy(self) -> bool:
+        return self.state is BreakerState.CLOSED
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "state": str(self.state),
+            "consecutiveFailures": self.consecutive_failures,
+            "failureThreshold": self.failure_threshold,
+            "cooldownRemainingSeconds": round(self.cooldown_remaining_seconds, 3),
+            "cooldownSeconds": round(self.cooldown_seconds, 3),
+            "totalFailures": self.total_failures,
+            "totalTrips": self.total_trips,
+            "lastFailureKind": self.last_failure_kind,
+            "lastFailureReason": self.last_failure_reason,
+        }
+
+
+class ProviderCircuitBreaker:
+    """Per-provider consecutive-failure breaker with a half-open probe.
+
+    Lifecycle for one provider::
+
+        closed --(N tripping failures)--> open
+        open --(cooldown elapsed, one caller admitted)--> half_open
+        half_open --(success)--> closed
+        half_open --(failure)--> open   # with a longer cooldown
+
+    All methods are safe to call from multiple threads and from concurrent
+    turns; a single lock guards the whole table.
+    """
+
+    def __init__(
+        self,
+        settings: BreakerSettings | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._settings = settings or BreakerSettings()
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._entries: dict[str, _Entry] = {}
+
+    @property
+    def settings(self) -> BreakerSettings:
+        return self._settings
+
+    @property
+    def enabled(self) -> bool:
+        return self._settings.enabled
+
+    # ── decisions ────────────────────────────────────────────────────
+
+    def allow(self, provider: str) -> bool:
+        """True when a request may be sent to ``provider`` right now.
+
+        Admitting a half-open probe is a *state change*: exactly one caller
+        gets through per cooldown window, so callers must not use this as a
+        side-effect-free predicate. Use :meth:`status` for display.
+        """
+        if not self._settings.enabled or not provider:
+            return True
+        with self._lock:
+            entry = self._entries.get(provider)
+            if entry is None or entry.state is BreakerState.CLOSED:
+                return True
+            now = self._clock()
+            window = self._cooldown_for(entry)
+            if entry.state is BreakerState.OPEN:
+                if entry.opened_at is None or now - entry.opened_at >= window:
+                    entry.state = BreakerState.HALF_OPEN
+                    entry.probe_started_at = now
+                    return True
+                return False
+            # HALF_OPEN: one probe is already in flight. Re-admit only after a
+            # full window, so a turn that is abandoned mid-stream (no success
+            # and no failure recorded) cannot wedge the breaker forever.
+            if entry.probe_started_at is None or now - entry.probe_started_at >= window:
+                entry.probe_started_at = now
+                return True
+            return False
+
+    def record_success(self, provider: str) -> None:
+        """Close ``provider``'s breaker and clear its failure history."""
+        if not provider:
+            return
+        with self._lock:
+            entry = self._entries.get(provider)
+            if entry is None:
+                return
+            entry.consecutive_failures = 0
+            entry.state = BreakerState.CLOSED
+            entry.opened_at = None
+            entry.probe_started_at = None
+            entry.open_cycles = 0
+            entry.last_failure_kind = ""
+            entry.last_failure_reason = ""
+
+    def record_failure(
+        self,
+        provider: str,
+        kind: ProviderFailureKind | None = None,
+        reason: str = "",
+    ) -> BreakerState:
+        """Count a failure against ``provider`` and return the resulting state.
+
+        Failures whose ``kind`` is not in :data:`TRIPPING_FAILURE_KINDS` are
+        ignored — they say something about the request, not the provider.
+        Passing ``kind=None`` means "unclassified provider fault" and counts.
+        """
+        if not self._settings.enabled or not provider:
+            return BreakerState.CLOSED
+        if kind is not None and not trips_breaker(kind):
+            with self._lock:
+                entry = self._entries.get(provider)
+                return entry.state if entry else BreakerState.CLOSED
+        with self._lock:
+            entry = self._entries.setdefault(provider, _Entry())
+            now = self._clock()
+            entry.total_failures += 1
+            entry.consecutive_failures += 1
+            entry.last_failure_kind = str(kind) if kind is not None else ""
+            entry.last_failure_reason = (reason or "")[:_REASON_MAX_CHARS]
+            if entry.state is BreakerState.HALF_OPEN:
+                # The probe failed: reopen immediately with a longer window.
+                self._open(entry, now)
+                return entry.state
+            if entry.consecutive_failures >= self._settings.failure_threshold:
+                self._open(entry, now)
+            return entry.state
+
+    # ── introspection ────────────────────────────────────────────────
+
+    def state(self, provider: str) -> BreakerState:
+        with self._lock:
+            entry = self._entries.get(provider)
+            return entry.state if entry else BreakerState.CLOSED
+
+    def status(self, provider: str) -> ProviderBreakerStatus:
+        """Side-effect-free snapshot for one provider (closed when untracked)."""
+        with self._lock:
+            entry = self._entries.get(provider)
+            if entry is None:
+                return ProviderBreakerStatus(
+                    provider=provider,
+                    state=BreakerState.CLOSED,
+                    consecutive_failures=0,
+                    failure_threshold=self._settings.failure_threshold,
+                    cooldown_remaining_seconds=0.0,
+                    cooldown_seconds=self._settings.cooldown_seconds,
+                    total_failures=0,
+                    total_trips=0,
+                )
+            return self._status_locked(provider, entry)
+
+    def snapshot(self) -> list[ProviderBreakerStatus]:
+        """Snapshot of every tracked provider, ordered by provider id."""
+        with self._lock:
+            return [
+                self._status_locked(provider, entry)
+                for provider, entry in sorted(self._entries.items())
+            ]
+
+    def reset(self, provider: str | None = None) -> None:
+        """Clear breaker state for one provider, or all of them."""
+        with self._lock:
+            if provider is None:
+                self._entries.clear()
+            else:
+                self._entries.pop(provider, None)
+
+    # ── internals ────────────────────────────────────────────────────
+
+    def _open(self, entry: _Entry, now: float) -> None:
+        entry.state = BreakerState.OPEN
+        entry.opened_at = now
+        entry.probe_started_at = None
+        entry.open_cycles += 1
+        entry.total_trips += 1
+
+    def _cooldown_for(self, entry: _Entry) -> float:
+        """Exponential backoff across consecutive open cycles, capped."""
+        exponent = max(0, entry.open_cycles - 1)
+        # Cap the exponent before shifting so a very long outage cannot build
+        # an astronomically large intermediate float.
+        exponent = min(exponent, 32)
+        window = self._settings.cooldown_seconds * float(2**exponent)
+        return min(window, self._settings.max_cooldown_seconds)
+
+    def _status_locked(self, provider: str, entry: _Entry) -> ProviderBreakerStatus:
+        window = self._cooldown_for(entry)
+        remaining = 0.0
+        if entry.state is BreakerState.OPEN and entry.opened_at is not None:
+            remaining = max(0.0, window - (self._clock() - entry.opened_at))
+        return ProviderBreakerStatus(
+            provider=provider,
+            state=entry.state,
+            consecutive_failures=entry.consecutive_failures,
+            failure_threshold=self._settings.failure_threshold,
+            cooldown_remaining_seconds=remaining,
+            cooldown_seconds=window,
+            total_failures=entry.total_failures,
+            total_trips=entry.total_trips,
+            last_failure_kind=entry.last_failure_kind,
+            last_failure_reason=entry.last_failure_reason,
+        )
+
+
+def snapshot_payload(breaker: ProviderCircuitBreaker | None) -> list[dict[str, Any]]:
+    """JSON-ready breaker snapshot; ``[]`` when there is no breaker."""
+    if breaker is None:
+        return []
+    return [status.to_dict() for status in breaker.snapshot()]
+
+
+__all__ = [
+    "DEFAULT_COOLDOWN_SECONDS",
+    "DEFAULT_FAILURE_THRESHOLD",
+    "DEFAULT_MAX_COOLDOWN_SECONDS",
+    "TRIPPING_FAILURE_KINDS",
+    "BreakerSettings",
+    "BreakerState",
+    "ProviderBreakerStatus",
+    "ProviderCircuitBreaker",
+    "snapshot_payload",
+    "trips_breaker",
+]

--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -206,6 +206,10 @@ class ModelSelector:
         """
         if not self.has_fallback():
             raise IndexError("No more provider fallbacks available")
+        # Reactive failover needs a *strict* advance: the held admission belongs
+        # to the link that just failed, so re-checking it would hand back the
+        # same provider.
+        self._admitted_index = None
         self._index = self._first_admitted_index(self._index + 1)
         return _build_provider(self._chain[self._index])
 
@@ -240,7 +244,11 @@ class ModelSelector:
         if not chain:
             raise IndexError("No fallback chain available")
         self._chain = [self._chain[0], *chain]
-        self._index = self._first_admitted_index(1)
+        # Same strict-advance rule as ``next_fallback``: when ``resolve()``
+        # already skipped an open primary the active link is 1+, so restarting
+        # the search at 1 would re-pick the link this call is failing over from.
+        self._admitted_index = None
+        self._index = self._first_admitted_index(max(1, self._index + 1))
         return _build_provider(self._chain[self._index])
 
     def override_model(self, model: str) -> None:

--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .anthropic import AnthropicProvider
+from .circuit_breaker import (
+    BreakerState,
+    ProviderBreakerStatus,
+    ProviderCircuitBreaker,
+)
+from .failures import ProviderFailureKind
 from .ollama import OllamaProvider
 from .openai import OpenAIProvider
 from .openai_responses import OpenAIResponsesProvider
@@ -130,15 +136,52 @@ class ModelSelector:
         self,
         config: SelectorConfig,
         plugin: ProviderPlugin | None = None,
+        breaker: ProviderCircuitBreaker | None = None,
     ) -> None:
         self._config = config
         self._chain: list[ProviderConfig] = [config.primary, *config.fallbacks]
         self._index = 0
         self._plugin = plugin
+        # Breaker state has to outlive a single turn — ``clone()`` shares this
+        # instance so every turn sees the failures the previous ones recorded.
+        self._breaker = breaker if breaker is not None else ProviderCircuitBreaker()
+        # Chain index this selector already holds breaker admission for. A turn
+        # may call ``resolve()`` more than once (e.g. again after
+        # ``override_model``); re-asking the breaker would find the half-open
+        # probe this very turn was granted already in flight and wrongly skip
+        # to the fallback, burning a probe per turn so the primary never
+        # recovers.
+        self._admitted_index: int | None = None
+
+    @property
+    def circuit_breaker(self) -> ProviderCircuitBreaker:
+        """Shared per-provider health breaker (also shared with clones)."""
+        return self._breaker
 
     def resolve(self) -> LLMProvider:
-        """Return the current provider (primary on first call)."""
+        """Return the current provider, skipping links whose breaker is open.
+
+        This is the health-aware half of failover: during a provider outage a
+        fresh turn starts on the first chain link the breaker still admits
+        instead of paying the dead primary's timeout again.
+        """
+        self._index = self._first_admitted_index(self._index)
         return _build_provider(self._chain[self._index])
+
+    def _first_admitted_index(self, start: int) -> int:
+        """First index at or after ``start`` the breaker admits.
+
+        Falls back to ``start`` when every remaining link is in cooldown —
+        a provider in cooldown still beats no provider at all.
+        """
+        if self._admitted_index is not None and self._admitted_index >= start:
+            return self._admitted_index
+        for index in range(start, len(self._chain)):
+            if self._breaker.allow(self._chain[index].provider):
+                self._admitted_index = index
+                return index
+        self._admitted_index = start
+        return start
 
     @property
     def active_provider_id(self) -> str:
@@ -163,8 +206,28 @@ class ModelSelector:
         """
         if not self.has_fallback():
             raise IndexError("No more provider fallbacks available")
-        self._index += 1
+        self._index = self._first_admitted_index(self._index + 1)
         return _build_provider(self._chain[self._index])
+
+    def record_provider_failure(
+        self,
+        kind: ProviderFailureKind | None = None,
+        reason: str = "",
+    ) -> BreakerState:
+        """Count a failure against the currently-active chain link."""
+        return self._breaker.record_failure(self.active_provider_id, kind=kind, reason=reason)
+
+    def record_provider_success(self) -> None:
+        """Clear the currently-active chain link's failure history."""
+        self._breaker.record_success(self.active_provider_id)
+
+    def circuit_breaker_status(self, provider: str) -> ProviderBreakerStatus:
+        """Side-effect-free breaker snapshot for one provider id."""
+        return self._breaker.status(provider)
+
+    def circuit_breaker_snapshot(self) -> list[ProviderBreakerStatus]:
+        """Side-effect-free breaker snapshot for every tracked provider."""
+        return self._breaker.snapshot()
 
     def next_fallback_after_failure(self, primary_failure: Exception) -> LLMProvider:
         """Advance to the next fallback, consulting ``plugin.failover_hook``.
@@ -177,7 +240,7 @@ class ModelSelector:
         if not chain:
             raise IndexError("No fallback chain available")
         self._chain = [self._chain[0], *chain]
-        self._index = 1
+        self._index = self._first_admitted_index(1)
         return _build_provider(self._chain[self._index])
 
     def override_model(self, model: str) -> None:
@@ -200,16 +263,19 @@ class ModelSelector:
         self.reset()
 
     def reset(self) -> None:
-        """Reset to primary provider."""
+        """Reset to primary provider and drop any held breaker admission."""
         self._index = 0
+        self._admitted_index = None
 
     def clone(self) -> ModelSelector:
         """Return an independent copy for concurrent use.
 
         The clone starts at index 0 with its own chain list, so mutations
-        (override_model, next_fallback) don't affect the original.
+        (override_model, next_fallback) don't affect the original. The circuit
+        breaker is deliberately *shared*: provider health is a property of the
+        outage, not of one turn.
         """
-        return ModelSelector(self._config, plugin=self._plugin)
+        return ModelSelector(self._config, plugin=self._plugin, breaker=self._breaker)
 
     async def list_models(self) -> list[dict]:
         """Aggregate models from all configured providers in the chain."""

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -524,7 +524,10 @@ Full reference: `docs/http-api.md` (https://useagentos.dev/docs/http-api).
 - **Gateway won't bind publicly** → intentional auth guard; see the
   public-bind recipe above.
 - **Provider/model errors** → `agentos providers status`,
-  `agentos models list`, then `agentos providers configure …`.
+  `agentos models list`, then `agentos providers configure …`. The `circuit`
+  column shows the failover circuit breaker: `open (42s)` means recent
+  provider-health failures parked it and turns are on the fallback chain; it
+  re-probes itself, so tune `[llm.circuit_breaker]` rather than restarting.
 - **Skill missing from prompt** → do not guess from the layer. Ask the
   surface that knows: the `availability.reason` on a `skills.list` row, or the
   `[not offered] …` line the agent's own `skill_list` prints. Then act on the

--- a/tests/test_engine/test_selector_fallback_circuit_breaker.py
+++ b/tests/test_engine/test_selector_fallback_circuit_breaker.py
@@ -1,0 +1,243 @@
+"""``_SelectorFallbackProvider`` feeds the selector's provider circuit breaker."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from agentos.engine.runtime import _SelectorFallbackProvider
+from agentos.provider import DoneEvent as ProviderDone
+from agentos.provider import ErrorEvent as ProviderError
+from agentos.provider import TextDeltaEvent as ProviderText
+from agentos.provider.circuit_breaker import (
+    BreakerSettings,
+    BreakerState,
+    ProviderCircuitBreaker,
+)
+from agentos.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+pytestmark = pytest.mark.anyio
+
+
+class _StubProvider:
+    def __init__(self, name: str, streams: list[list[Any]]) -> None:
+        self.provider_name = name
+        self._streams = streams
+        self.calls = 0
+
+    def chat(self, messages: list[Any], tools: Any = None, config: Any = None) -> AsyncIterator:
+        index = min(self.calls, len(self._streams) - 1)
+        self.calls += 1
+        return self._stream(self._streams[index])
+
+    async def _stream(self, events: list[Any]) -> AsyncIterator[Any]:
+        for event in events:
+            yield event
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+class _StubSelector:
+    """Real breaker bookkeeping, stubbed provider construction."""
+
+    def __init__(self, breaker: ProviderCircuitBreaker, chain: list[str]) -> None:
+        self._breaker = breaker
+        self._chain = chain
+        self._index = 0
+        self.fallbacks: list[str] = []
+        self.providers: dict[str, _StubProvider] = {}
+
+    @property
+    def active_provider_id(self) -> str:
+        return self._chain[self._index]
+
+    def next_fallback_after_failure(self, failure: Exception) -> _StubProvider:
+        if self._index >= len(self._chain) - 1:
+            raise IndexError("No fallback chain available")
+        self._index += 1
+        self.fallbacks.append(str(failure))
+        return self.providers[self.active_provider_id]
+
+    def record_provider_failure(self, kind: Any = None, reason: str = "") -> BreakerState:
+        return self._breaker.record_failure(self.active_provider_id, kind=kind, reason=reason)
+
+    def record_provider_success(self) -> None:
+        self._breaker.record_success(self.active_provider_id)
+
+
+def _breaker(threshold: int = 2) -> ProviderCircuitBreaker:
+    return ProviderCircuitBreaker(
+        BreakerSettings(failure_threshold=threshold, cooldown_seconds=60.0)
+    )
+
+
+async def _drain(wrapper: _SelectorFallbackProvider) -> list[Any]:
+    return [event async for event in wrapper.chat([], tools=None, config=None)]
+
+
+async def test_overload_errors_accumulate_until_the_breaker_opens() -> None:
+    breaker = _breaker(threshold=2)
+    selector = _StubSelector(breaker, ["openrouter"])
+    provider = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+
+    for _ in range(2):
+        await _drain(_SelectorFallbackProvider(provider, selector))
+
+    assert breaker.state("openrouter") is BreakerState.OPEN
+    assert breaker.status("openrouter").last_failure_kind == "provider_overloaded"
+
+
+async def test_streamed_text_closes_the_breaker() -> None:
+    breaker = _breaker(threshold=2)
+    selector = _StubSelector(breaker, ["openrouter"])
+
+    failing = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+    await _drain(_SelectorFallbackProvider(failing, selector))
+    assert breaker.status("openrouter").consecutive_failures == 1
+
+    healthy = _StubProvider("openai", [[ProviderText(text="hi"), ProviderDone(stop_reason="stop")]])
+    await _drain(_SelectorFallbackProvider(healthy, selector))
+
+    assert breaker.status("openrouter").consecutive_failures == 0
+    assert breaker.state("openrouter") is BreakerState.CLOSED
+
+
+async def test_clean_tool_only_stream_counts_as_success() -> None:
+    """A turn that emits no user-visible text still proves the provider is up."""
+    breaker = _breaker(threshold=2)
+    selector = _StubSelector(breaker, ["openrouter"])
+
+    failing = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+    await _drain(_SelectorFallbackProvider(failing, selector))
+
+    quiet = _StubProvider("openai", [[ProviderDone(stop_reason="tool_use")]])
+    await _drain(_SelectorFallbackProvider(quiet, selector))
+
+    assert breaker.status("openrouter").consecutive_failures == 0
+
+
+async def test_request_shaped_error_does_not_count_against_the_provider() -> None:
+    breaker = _breaker(threshold=1)
+    selector = _StubSelector(breaker, ["openrouter"])
+    provider = _StubProvider(
+        "openai", [[ProviderError(code="400", message="model not found: bogus")]]
+    )
+
+    await _drain(_SelectorFallbackProvider(provider, selector))
+
+    assert breaker.state("openrouter") is BreakerState.CLOSED
+    assert breaker.status("openrouter").consecutive_failures == 0
+
+
+async def test_failover_records_the_primary_failure_and_the_fallback_success() -> None:
+    breaker = _breaker(threshold=1)
+    selector = _StubSelector(breaker, ["openrouter", "ollama"])
+    fallback = _StubProvider(
+        "ollama", [[ProviderText(text="hello"), ProviderDone(stop_reason="stop")]]
+    )
+    selector.providers["ollama"] = fallback
+    primary = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+
+    events = await _drain(_SelectorFallbackProvider(primary, selector))
+
+    assert [getattr(event, "text", None) for event in events if hasattr(event, "text")] == ["hello"]
+    assert breaker.state("openrouter") is BreakerState.OPEN
+    assert breaker.state("ollama") is BreakerState.CLOSED
+    assert breaker.status("ollama").consecutive_failures == 0
+
+
+async def test_fallback_failure_is_recorded_against_the_fallback() -> None:
+    breaker = _breaker(threshold=1)
+    selector = _StubSelector(breaker, ["openrouter", "ollama"])
+    selector.providers["ollama"] = _StubProvider(
+        "ollama", [[ProviderError(code="503", message="upstream 503")]]
+    )
+    primary = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+
+    await _drain(_SelectorFallbackProvider(primary, selector))
+
+    assert breaker.state("openrouter") is BreakerState.OPEN
+    assert breaker.state("ollama") is BreakerState.OPEN
+
+
+async def test_selector_without_breaker_hooks_is_tolerated() -> None:
+    """Older selector stand-ins (tests, plugins) must keep working."""
+
+    class _Bare:
+        def next_fallback_after_failure(self, failure: Exception) -> Any:
+            raise IndexError("none")
+
+    provider = _StubProvider(
+        "openai", [[ProviderText(text="ok"), ProviderDone(stop_reason="stop")]]
+    )
+    events = await _drain(_SelectorFallbackProvider(provider, _Bare()))
+
+    assert any(getattr(event, "text", "") == "ok" for event in events)
+
+
+async def test_real_selector_skips_the_open_primary_on_the_next_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a failure on turn 1 routes turn 2 straight to the fallback.
+
+    ``_build_provider`` is stubbed so the chain stays entirely offline — the
+    point under test is the breaker bookkeeping, not provider transports.
+    """
+    from agentos.provider import selector as selector_module
+
+    built: list[str] = []
+
+    def _fake_build(cfg: ProviderConfig) -> _StubProvider:
+        built.append(cfg.provider)
+        return _StubProvider(
+            cfg.provider, [[ProviderText(text="from fallback"), ProviderDone(stop_reason="stop")]]
+        )
+
+    monkeypatch.setattr(selector_module, "_build_provider", _fake_build)
+
+    breaker = _breaker(threshold=1)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig("openrouter", "openai/gpt-5.6-luna", api_key="k"),
+            fallbacks=[ProviderConfig("ollama", "llama3")],
+        ),
+        breaker=breaker,
+    )
+
+    turn_one = selector.clone()
+    primary = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+    events = await _drain(_SelectorFallbackProvider(primary, turn_one))
+
+    assert breaker.state("openrouter") is BreakerState.OPEN
+    assert built == ["ollama"]
+    assert any(getattr(event, "text", "") == "from fallback" for event in events)
+
+    turn_two = selector.clone()
+    turn_two.resolve()
+    assert turn_two.active_provider_id == "ollama"
+
+
+async def test_repeated_error_events_in_one_stream_count_once() -> None:
+    """One failed turn is one vote, however many error events it emitted."""
+    breaker = _breaker(threshold=2)
+    selector = _StubSelector(breaker, ["openrouter", "ollama"])
+    selector.providers["ollama"] = _StubProvider(
+        "ollama",
+        [
+            [
+                ProviderError(code="503", message="upstream 503"),
+                ProviderError(code="503", message="upstream 503 again"),
+                ProviderError(code="503", message="and again"),
+            ]
+        ],
+    )
+    primary = _StubProvider("openai", [[ProviderError(code="503", message="upstream 503")]])
+
+    await _drain(_SelectorFallbackProvider(primary, selector))
+
+    assert breaker.status("openrouter").consecutive_failures == 1
+    assert breaker.status("ollama").consecutive_failures == 1
+    assert breaker.state("ollama") is BreakerState.CLOSED

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -424,3 +424,55 @@ def test_reset_drops_the_held_admission() -> None:
     selector.reset()
     selector.resolve()
     assert selector.active_provider_id == "ollama"
+
+
+def _three_link_selector(breaker: ProviderCircuitBreaker) -> ModelSelector:
+    return ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig("openrouter", "openai/gpt-5.6-luna", api_key="k"),
+            fallbacks=[
+                ProviderConfig("deepseek", "deepseek-chat", api_key="k"),
+                ProviderConfig("anthropic", "claude-opus-5", api_key="k"),
+            ],
+        ),
+        breaker=breaker,
+    )
+
+
+def test_failover_after_a_skipped_primary_advances_past_the_failing_link() -> None:
+    """Breaker skips the primary, then link 1 fails mid-stream -> land on link 2."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2)
+    selector = _three_link_selector(breaker)
+
+    _fail(breaker, "openrouter", 2)
+    selector.resolve()
+    assert selector.active_provider_id == "deepseek"
+
+    selector.next_fallback_after_failure(RuntimeError("503"))
+    assert selector.active_provider_id == "anthropic"
+
+
+def test_next_fallback_after_a_skipped_primary_advances_past_the_failing_link() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2)
+    selector = _three_link_selector(breaker)
+
+    _fail(breaker, "openrouter", 2)
+    selector.resolve()
+    assert selector.active_provider_id == "deepseek"
+
+    selector.next_fallback()
+    assert selector.active_provider_id == "anthropic"
+
+
+def test_failover_from_the_primary_still_starts_at_the_first_fallback() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2)
+    selector = _three_link_selector(breaker)
+
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+
+    selector.next_fallback_after_failure(RuntimeError("503"))
+    assert selector.active_provider_id == "deepseek"

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -1,0 +1,426 @@
+"""Provider circuit breaker: cooldown, half-open probe, and selector skipping."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.provider.circuit_breaker import (
+    BreakerSettings,
+    BreakerState,
+    ProviderCircuitBreaker,
+    snapshot_payload,
+    trips_breaker,
+)
+from agentos.provider.failures import ProviderFailureKind
+from agentos.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _breaker(
+    clock: FakeClock,
+    *,
+    threshold: int = 3,
+    cooldown: float = 60.0,
+    max_cooldown: float = 600.0,
+    enabled: bool = True,
+) -> ProviderCircuitBreaker:
+    return ProviderCircuitBreaker(
+        BreakerSettings(
+            enabled=enabled,
+            failure_threshold=threshold,
+            cooldown_seconds=cooldown,
+            max_cooldown_seconds=max_cooldown,
+        ),
+        clock=clock,
+    )
+
+
+def _fail(breaker: ProviderCircuitBreaker, provider: str, times: int) -> BreakerState:
+    state = BreakerState.CLOSED
+    for _ in range(times):
+        state = breaker.record_failure(
+            provider, ProviderFailureKind.PROVIDER_OVERLOADED, "upstream 503"
+        )
+    return state
+
+
+# ── failure counting / opening ───────────────────────────────────────
+
+
+def test_breaker_opens_only_at_threshold() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=3)
+
+    assert _fail(breaker, "openrouter", 2) is BreakerState.CLOSED
+    assert breaker.allow("openrouter") is True
+
+    assert _fail(breaker, "openrouter", 1) is BreakerState.OPEN
+    assert breaker.allow("openrouter") is False
+
+
+def test_success_resets_the_failure_run() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=3)
+
+    _fail(breaker, "openrouter", 2)
+    breaker.record_success("openrouter")
+    assert breaker.status("openrouter").consecutive_failures == 0
+
+    # Two more failures must not open: the run restarted at zero.
+    assert _fail(breaker, "openrouter", 2) is BreakerState.CLOSED
+
+
+def test_request_shaped_failures_do_not_trip_the_breaker() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2)
+
+    for kind in (
+        ProviderFailureKind.MODEL_NOT_FOUND,
+        ProviderFailureKind.CONTEXT_OVERFLOW,
+        ProviderFailureKind.BAD_REQUEST,
+        ProviderFailureKind.AUTH_INVALID,
+        ProviderFailureKind.UNSUPPORTED_FEATURE,
+    ):
+        assert trips_breaker(kind) is False
+        breaker.record_failure("openrouter", kind, "nope")
+
+    assert breaker.state("openrouter") is BreakerState.CLOSED
+    assert breaker.allow("openrouter") is True
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        ProviderFailureKind.PROVIDER_OVERLOADED,
+        ProviderFailureKind.TRANSPORT_TRANSIENT,
+        ProviderFailureKind.RATE_LIMITED,
+    ],
+)
+def test_provider_health_failures_trip_the_breaker(kind: ProviderFailureKind) -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    assert trips_breaker(kind) is True
+    assert breaker.record_failure("openrouter", kind, "boom") is BreakerState.OPEN
+
+
+def test_unclassified_failure_counts() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2)
+    breaker.record_failure("openrouter")
+    assert breaker.record_failure("openrouter") is BreakerState.OPEN
+
+
+def test_breaker_state_is_per_provider() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    _fail(breaker, "openrouter", 1)
+
+    assert breaker.allow("openrouter") is False
+    assert breaker.allow("anthropic") is True
+
+
+# ── cooldown / half-open probe ───────────────────────────────────────
+
+
+def test_cooldown_admits_exactly_one_half_open_probe() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    clock.advance(59.0)
+    assert breaker.allow("openrouter") is False
+
+    clock.advance(1.0)
+    assert breaker.allow("openrouter") is True
+    assert breaker.state("openrouter") is BreakerState.HALF_OPEN
+    # A second concurrent turn must not also probe.
+    assert breaker.allow("openrouter") is False
+
+
+def test_successful_probe_closes_the_breaker() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True
+    breaker.record_success("openrouter")
+
+    assert breaker.state("openrouter") is BreakerState.CLOSED
+    assert breaker.allow("openrouter") is True
+    assert breaker.status("openrouter").cooldown_remaining_seconds == 0.0
+
+
+def test_failed_probe_reopens_with_a_longer_cooldown() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0, max_cooldown=600.0)
+    _fail(breaker, "openrouter", 1)
+
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True  # probe admitted
+    assert _fail(breaker, "openrouter", 1) is BreakerState.OPEN
+
+    # Backoff doubled: the old 60s window is no longer enough.
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is False
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True
+
+
+def test_cooldown_backoff_is_capped() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0, max_cooldown=120.0)
+    for _ in range(6):
+        _fail(breaker, "openrouter", 1)
+        clock.advance(10_000.0)
+        breaker.allow("openrouter")
+
+    assert breaker.status("openrouter").cooldown_seconds == 120.0
+
+
+def test_abandoned_probe_does_not_wedge_the_breaker() -> None:
+    """A turn that neither succeeds nor fails must not block future probes."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True  # probe admitted, never resolved
+    assert breaker.allow("openrouter") is False
+
+    clock.advance(60.0)
+    assert breaker.allow("openrouter") is True
+
+
+def test_disabled_breaker_always_admits() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, enabled=False)
+
+    assert breaker.record_failure("openrouter", ProviderFailureKind.RATE_LIMITED) is (
+        BreakerState.CLOSED
+    )
+    assert breaker.allow("openrouter") is True
+    assert breaker.snapshot() == []
+
+
+def test_settings_clamp_nonsense_values() -> None:
+    settings = BreakerSettings(
+        failure_threshold=0, cooldown_seconds=-5.0, max_cooldown_seconds=0.0
+    )
+    assert settings.failure_threshold == 1
+    assert settings.cooldown_seconds == 1.0
+    assert settings.max_cooldown_seconds == 1.0
+
+
+def test_reset_clears_state() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    _fail(breaker, "openrouter", 1)
+    _fail(breaker, "anthropic", 1)
+
+    breaker.reset("openrouter")
+    assert breaker.allow("openrouter") is True
+    assert breaker.allow("anthropic") is False
+
+    breaker.reset()
+    assert breaker.snapshot() == []
+
+
+# ── snapshots ────────────────────────────────────────────────────────
+
+
+def test_status_is_side_effect_free_while_open() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+
+    clock.advance(60.0)
+    assert breaker.status("openrouter").state is BreakerState.OPEN
+    # Reading status must not consume the probe slot.
+    assert breaker.allow("openrouter") is True
+
+
+def test_snapshot_payload_shape() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2, cooldown=60.0)
+    _fail(breaker, "openrouter", 2)
+    clock.advance(15.0)
+
+    rows = snapshot_payload(breaker)
+    assert [row["provider"] for row in rows] == ["openrouter"]
+    row = rows[0]
+    assert row["state"] == "open"
+    assert row["consecutiveFailures"] == 2
+    assert row["failureThreshold"] == 2
+    assert row["cooldownRemainingSeconds"] == 45.0
+    assert row["lastFailureKind"] == "provider_overloaded"
+    assert row["lastFailureReason"] == "upstream 503"
+    assert row["totalTrips"] == 1
+
+    assert snapshot_payload(None) == []
+
+
+def test_untracked_provider_reports_closed() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock)
+    status = breaker.status("anthropic")
+    assert status.state is BreakerState.CLOSED
+    assert status.healthy is True
+    assert status.to_dict()["provider"] == "anthropic"
+
+
+# ── selector integration ─────────────────────────────────────────────
+
+
+def _selector(breaker: ProviderCircuitBreaker) -> ModelSelector:
+    return ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig("openrouter", "openai/gpt-5.6-luna", api_key="k"),
+            fallbacks=[ProviderConfig("ollama", "llama3")],
+        ),
+        breaker=breaker,
+    )
+
+
+def test_resolve_skips_a_provider_in_cooldown() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=2)
+    selector = _selector(breaker)
+
+    assert selector.active_provider_id == "openrouter"
+
+    _fail(breaker, "openrouter", 2)
+    selector.resolve()
+    assert selector.active_provider_id == "ollama"
+
+
+def test_resolve_stays_on_the_primary_when_the_whole_chain_is_open() -> None:
+    """A provider in cooldown still beats having no provider at all."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    selector = _selector(breaker)
+
+    _fail(breaker, "openrouter", 1)
+    _fail(breaker, "ollama", 1)
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+
+
+def test_resolve_returns_to_the_primary_after_the_probe_succeeds() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    selector = _selector(breaker)
+
+    _fail(breaker, "openrouter", 1)
+    selector.resolve()
+    assert selector.active_provider_id == "ollama"
+
+    clock.advance(60.0)
+    probe = _selector(breaker)
+    probe.resolve()
+    assert probe.active_provider_id == "openrouter"
+    probe.record_provider_success()
+
+    later = _selector(breaker)
+    later.resolve()
+    assert later.active_provider_id == "openrouter"
+
+
+def test_breaker_state_survives_clone() -> None:
+    """Per-turn clones share breaker state — that is the whole point."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    selector = _selector(breaker)
+
+    turn_one = selector.clone()
+    turn_one.record_provider_failure(ProviderFailureKind.PROVIDER_OVERLOADED, "503")
+
+    turn_two = selector.clone()
+    turn_two.resolve()
+    assert turn_two.active_provider_id == "ollama"
+
+
+def test_selector_defaults_to_its_own_breaker() -> None:
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig("openrouter", "m", api_key="k"))
+    )
+    assert selector.circuit_breaker is not None
+    assert selector.clone().circuit_breaker is selector.circuit_breaker
+
+
+def test_record_provider_failure_targets_the_active_link() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    selector = _selector(breaker)
+
+    selector.next_fallback()
+    assert selector.active_provider_id == "ollama"
+    selector.record_provider_failure(ProviderFailureKind.TRANSPORT_TRANSIENT, "refused")
+
+    assert breaker.state("ollama") is BreakerState.OPEN
+    assert breaker.state("openrouter") is BreakerState.CLOSED
+
+
+def test_selector_snapshot_helpers() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    selector = _selector(breaker)
+    selector.record_provider_failure(ProviderFailureKind.RATE_LIMITED, "429")
+
+    assert selector.circuit_breaker_status("openrouter").state is BreakerState.OPEN
+    assert [s.provider for s in selector.circuit_breaker_snapshot()] == ["openrouter"]
+
+
+def test_repeated_resolve_keeps_the_probe_this_selector_was_granted() -> None:
+    """A turn resolves twice when a model override is in play (see
+    ``PromptAssemblerStage``). The second resolve must not see its own
+    half-open probe as "already in flight" and skip to the fallback."""
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+    clock.advance(60.0)
+
+    selector = _selector(breaker)
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"  # probe granted
+
+    selector.override_model("openai/other")
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+
+
+def test_a_different_turn_does_not_share_the_held_probe() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1, cooldown=60.0)
+    _fail(breaker, "openrouter", 1)
+    clock.advance(60.0)
+
+    prober = _selector(breaker)
+    prober.resolve()
+    assert prober.active_provider_id == "openrouter"
+
+    concurrent = _selector(breaker)
+    concurrent.resolve()
+    assert concurrent.active_provider_id == "ollama"
+
+
+def test_reset_drops_the_held_admission() -> None:
+    clock = FakeClock()
+    breaker = _breaker(clock, threshold=1)
+    selector = _selector(breaker)
+    selector.resolve()
+
+    _fail(breaker, "openrouter", 1)
+    selector.reset()
+    selector.resolve()
+    assert selector.active_provider_id == "ollama"

--- a/tests/test_provider_circuit_breaker_surfaces.py
+++ b/tests/test_provider_circuit_breaker_surfaces.py
@@ -1,0 +1,181 @@
+"""Breaker state is visible to operators: doctor, providers.status, /api/system/status."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agentos.cli.providers_cmd import _circuit_cell
+from agentos.gateway.app import create_gateway_app
+from agentos.gateway.config import AuthConfig, GatewayConfig, LlmProviderConfig
+from agentos.gateway.rpc_tools import _circuit_breaker_row
+from agentos.health.evaluator import evaluate_provider
+from agentos.provider.circuit_breaker import (
+    BreakerSettings,
+    ProviderCircuitBreaker,
+)
+from agentos.provider.failures import ProviderFailureKind
+from agentos.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+
+def _selector(threshold: int = 1) -> ModelSelector:
+    return ModelSelector(
+        SelectorConfig(primary=ProviderConfig("openrouter", "m", api_key="k")),
+        breaker=ProviderCircuitBreaker(
+            BreakerSettings(failure_threshold=threshold, cooldown_seconds=60.0)
+        ),
+    )
+
+
+def _provider_row(breaker: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "activeProvider": "openrouter",
+        "providers": [
+            {
+                "providerId": "openrouter",
+                "active": True,
+                "configured": True,
+                "buildable": True,
+                "model": "m",
+                "circuitBreaker": breaker,
+            }
+        ],
+    }
+
+
+# ── doctor / health evaluator ────────────────────────────────────────
+
+
+def test_closed_breaker_adds_no_doctor_finding() -> None:
+    findings = evaluate_provider(_provider_row({"state": "closed"}))
+    assert [f.id for f in findings] == ["provider.active.ready"]
+
+
+def test_missing_breaker_field_adds_no_doctor_finding() -> None:
+    """Older gateways (or a selector without a breaker) must not break doctor."""
+    findings = evaluate_provider(_provider_row(None))
+    assert [f.id for f in findings] == ["provider.active.ready"]
+
+
+def test_open_breaker_degrades_readiness_with_cooldown_detail() -> None:
+    findings = evaluate_provider(
+        _provider_row(
+            {
+                "state": "open",
+                "consecutiveFailures": 3,
+                "failureThreshold": 3,
+                "cooldownRemainingSeconds": 42.4,
+                "lastFailureKind": "provider_overloaded",
+                "lastFailureReason": "upstream 503",
+            }
+        )
+    )
+    ids = [f.id for f in findings]
+    assert "provider.circuit.open" in ids
+
+    finding = next(f for f in findings if f.id == "provider.circuit.open")
+    assert finding.severity == "warn"
+    assert finding.readiness_impact == "degrades"
+    assert "42s" in finding.detail
+    assert finding.evidence["lastFailureKind"] == "provider_overloaded"
+    # Recoverable on its own — never tell the operator to restart for this.
+    assert finding.restart_required is False
+
+
+def test_half_open_breaker_is_informational_only() -> None:
+    findings = evaluate_provider(
+        _provider_row({"state": "half_open", "consecutiveFailures": 3, "failureThreshold": 3})
+    )
+    finding = next(f for f in findings if f.id == "provider.circuit.half_open")
+    assert finding.severity == "info"
+    assert finding.readiness_impact == "optional"
+
+
+# ── providers.status row ─────────────────────────────────────────────
+
+
+class _Ctx:
+    def __init__(self, provider_selector: Any) -> None:
+        self.provider_selector = provider_selector
+
+
+def test_providers_status_row_reports_breaker_state() -> None:
+    selector = _selector()
+    selector.record_provider_failure(ProviderFailureKind.PROVIDER_OVERLOADED, "upstream 503")
+
+    row = _circuit_breaker_row("openrouter", _Ctx(selector))
+    assert row is not None
+    assert row["state"] == "open"
+    assert row["consecutiveFailures"] == 1
+
+
+def test_providers_status_row_is_none_without_a_selector() -> None:
+    assert _circuit_breaker_row("openrouter", _Ctx(None)) is None
+
+
+def test_providers_status_row_is_side_effect_free() -> None:
+    """Rendering status must not consume the half-open probe slot."""
+    selector = _selector()
+    selector.record_provider_failure(ProviderFailureKind.PROVIDER_OVERLOADED, "503")
+
+    for _ in range(3):
+        _circuit_breaker_row("openrouter", _Ctx(selector))
+
+    assert selector.circuit_breaker.state("openrouter") == "open"
+
+
+@pytest.mark.parametrize(
+    ("breaker", "expected"),
+    [
+        (None, "-"),
+        ({"state": "closed"}, "closed"),
+        ({"state": "half_open"}, "half_open"),
+        ({"state": "open", "cooldownRemainingSeconds": 41.6}, "open (42s)"),
+        ({"state": "open", "cooldownRemainingSeconds": 0}, "open"),
+    ],
+)
+def test_cli_circuit_cell(breaker: dict[str, Any] | None, expected: str) -> None:
+    assert _circuit_cell(breaker) == expected
+
+
+# ── /api/system/status ───────────────────────────────────────────────
+
+
+def _client(selector: Any) -> TestClient:
+    config = GatewayConfig(
+        host="127.0.0.1",
+        auth=AuthConfig(mode="none"),
+        llm=LlmProviderConfig(provider="openrouter", model="m"),
+    )
+    return TestClient(
+        create_gateway_app(config, provider_selector=selector),
+        base_url="http://127.0.0.1",
+    )
+
+
+def test_system_status_exposes_breaker_state() -> None:
+    selector = _selector()
+    selector.record_provider_failure(ProviderFailureKind.RATE_LIMITED, "429 slow down")
+
+    payload = _client(selector).get("/api/system/status").json()
+
+    assert payload["provider"] == "openrouter"
+    assert payload["circuitBreaker"]["state"] == "open"
+    assert payload["circuitBreaker"]["provider"] == "openrouter"
+    assert [row["provider"] for row in payload["circuitBreakers"]] == ["openrouter"]
+
+
+def test_system_status_is_quiet_while_every_provider_is_healthy() -> None:
+    payload = _client(_selector()).get("/api/system/status").json()
+
+    assert payload["circuitBreaker"] is None
+    assert payload["circuitBreakers"] == []
+
+
+def test_system_status_without_a_selector() -> None:
+    payload = _client(None).get("/api/system/status").json()
+
+    assert payload["circuitBreaker"] is None
+    assert payload["circuitBreakers"] == []


### PR DESCRIPTION
Closes #365

## Problem

Failover was purely reactive and per-request. `_SelectorFallbackProvider` only advanced the chain once an error event arrived mid-stream, and `ModelSelector.reset()` put the *next* turn back on the failed primary. During a provider outage every turn paid the full timeout on the dead primary before falling back — for as long as the outage lasted.

## What this does

Adds `src/agentos/provider/circuit_breaker.py`: a per-provider consecutive-failure breaker with a cooldown and a half-open probe, keyed by the **configured provider id** (`openrouter`, `deepseek`) rather than the wire-protocol backend class — so an OpenRouter outage never mutes a separately-configured OpenAI fallback.

```
closed --(N tripping failures)--> open
open --(cooldown elapsed, one caller admitted)--> half_open
half_open --(clean turn)--> closed
half_open --(failure)--> open   # with a doubled cooldown, capped
```

- **Shared across turns.** `ModelSelector.clone()` passes the breaker through, so the per-turn clones accumulate one memory instead of forgetting each turn. That is what turns hours of per-turn timeout tax into one detection cost.
- **`resolve()` skips links in cooldown**, so a turn that starts during an outage goes straight to the fallback. If *every* link is in cooldown the primary is used anyway — a provider in cooldown still beats no provider at all.
- **Narrow trip set.** Only `PROVIDER_OVERLOADED`, `TRANSPORT_TRANSIENT`, `RATE_LIMITED` count. Request-shaped failures (unknown model, bad request, context overflow) and credential/billing faults (auth, insufficient credits) never trip it — a cooldown cannot heal them, and tripping on them would park a healthy provider because one model id was wrong.
- **One vote per stream.** A provider that emits several error events for one request is still a single failed turn.
- **Success closes it** on the first user-visible token, or on a clean `done` — so a tool-use-only turn that never emits text still counts as proof of health.
- **Abandoned probes cannot wedge it**: a turn admitted as the probe that never resolves releases the slot after one window.

## Operator surfaces

| Surface | What shows up |
|---|---|
| `agentos providers status` | new `circuit` column: `closed` / `half_open` / `open (42s)` |
| `agentos doctor` | `provider.circuit.open` (warn, degrades) and `provider.circuit.half_open` (info) |
| `GET /api/system/status` | `circuitBreaker` (active provider) and `circuitBreakers` (all tracked) |

All three read through a side-effect-free `status()` — rendering the dashboard never consumes the half-open probe slot.

## Config

Defaults are on; everything is tunable, and out-of-range values clamp rather than raise so a hand-edited config can't take the runtime down.

```toml
[llm.circuit_breaker]
enabled = true
failure_threshold = 3
cooldown_seconds = 60
max_cooldown_seconds = 600
```

## Tests

47 new tests across three files, all offline and deterministic (injected clock; `_build_provider` stubbed where a chain would otherwise reach the network):

- `tests/test_provider_circuit_breaker.py` — state machine, backoff cap, probe reservation, abandoned-probe release, selector skipping, clone sharing.
- `tests/test_engine/test_selector_fallback_circuit_breaker.py` — the runtime wrapper's failure/success recording, failover attribution to the right provider, and tolerance of selectors that lack the new hooks.
- `tests/test_provider_circuit_breaker_surfaces.py` — doctor findings, `providers.status` rows, `/api/system/status`, and the CLI cell.

Gate: `ruff check src tests`, `mypy src/agentos`, `pytest -q` (8112 passed, 30 skipped), `uv build --wheel`. No frontend changes.

## Notes for review

One bug found and fixed during self-review, worth a second pair of eyes: a turn can call `resolve()` twice (`TurnRunner._resolve_provider`, then again in `PromptAssemblerStage` when a model override is set). Consulting the breaker on each call meant the second resolve saw the half-open probe *it had just been granted* as already in flight and skipped to the fallback — burning one probe per turn so the primary could never recover. `ModelSelector` now remembers the admission it already holds (`_admitted_index`), cleared by `reset()` and never inherited by a clone. Regression tests cover both the held probe and the fact that a *different* turn does not share it.

Breaker state lives in the running gateway only; a restart clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)