### PR TITLE
fix(gateway): verify trusted proxy for X-Forwarded-For and bound rate limit dict (#354)

### DIFF
--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections import defaultdict
+from collections import OrderedDict
 from collections.abc import Callable
 from urllib.parse import urlsplit
 
@@ -122,9 +122,7 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     RPC surface — the drive-by target — is gated.
     """
 
-    def __init__(
-        self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool
-    ) -> None:
+    def __init__(self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool) -> None:
         super().__init__(app)
         self._config = config
         self._cors_origins = [o for o in config.cors.allowed_origins if o != "*"]
@@ -156,9 +154,7 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
             )
 
             if not (
-                is_allowed_ws_origin(
-                    origin, self._config, bind_is_loopback=self._bind_is_loopback
-                )
+                is_allowed_ws_origin(origin, self._config, bind_is_loopback=self._bind_is_loopback)
                 or origin_in_allowlist(origin, self._cors_origins)
             ):
                 return PlainTextResponse("Origin not allowed", status_code=403)
@@ -179,9 +175,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._config = config
         base_path = (
-            config.control_ui.base_path
-            if control_ui_base_path is None
-            else control_ui_base_path
+            config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
 
@@ -238,22 +232,60 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         app: ASGIApp,
         config: GatewayConfig,
         control_ui_base_path: str | None = None,
+        max_tracked_clients: int = 10_000,
     ) -> None:
         super().__init__(app)
         self._config = config
         base_path = (
-            config.control_ui.base_path
-            if control_ui_base_path is None
-            else control_ui_base_path
+            config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
-        # {ip: [(timestamp, count), ...]}
-        self._windows: dict[str, list[float]] = defaultdict(list)
+        # {ip: [timestamp, ...]} with LRU eviction ordering
+        self._windows: OrderedDict[str, list[float]] = OrderedDict()
+        self._max_tracked_clients = max_tracked_clients
+        self._last_sweep: float = 0.0
 
     def _is_ui_path(self, path: str) -> bool:
         if self._ui_prefix is None:
             return False
         return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")
+
+    def _is_trusted_proxy(self, peer_ip: str | None) -> bool:
+        if not peer_ip:
+            return False
+        trusted = self._config.auth.trusted_proxy
+        if not trusted:
+            return False
+        trusted_set = {p.strip().lower().strip("[]") for p in trusted.split(",") if p.strip()}
+        peer = peer_ip.strip().lower().strip("[]")
+        return peer in trusted_set
+
+    def _get_client_ip(self, request: Request) -> str:
+        peer_ip = request.client.host if request.client else None
+        if self._is_trusted_proxy(peer_ip):
+            forwarded = request.headers.get("x-forwarded-for")
+            if forwarded:
+                first_ip = forwarded.split(",")[0].strip()
+                if first_ip:
+                    return first_ip
+        if peer_ip:
+            return peer_ip
+        return "unknown"
+
+    def _sweep_expired(self, now: float, window: float) -> None:
+        self._last_sweep = now
+        expired = [
+            ip
+            for ip, timestamps in self._windows.items()
+            if not timestamps or (now - timestamps[-1] >= window)
+        ]
+        for ip in expired:
+            self._windows.pop(ip, None)
+
+    def _evict_excess(self, now: float, window: float) -> None:
+        self._sweep_expired(now, window)
+        while len(self._windows) > self._max_tracked_clients:
+            self._windows.popitem(last=False)
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if not self._config.rate_limit.enabled:
@@ -272,27 +304,32 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         client_ip = self._get_client_ip(request)
         now = time.time()
-        window = self._config.rate_limit.window_seconds
+        window = float(self._config.rate_limit.window_seconds)
         max_req = self._config.rate_limit.max_requests
+        sweep_interval = min(window, 60.0)
+
+        # Periodic sweep of expired windows
+        if now - self._last_sweep >= sweep_interval:
+            self._sweep_expired(now, window)
 
         # Prune old timestamps
-        self._windows[client_ip] = [t for t in self._windows[client_ip] if now - t < window]
+        timestamps = [t for t in self._windows.get(client_ip, []) if now - t < window]
 
-        if len(self._windows[client_ip]) >= max_req:
+        if len(timestamps) >= max_req:
+            self._windows[client_ip] = timestamps
+            self._windows.move_to_end(client_ip)
             return JSONResponse(
                 {"error": "Too Many Requests", "code": "RATE_LIMITED"}, status_code=429
             )
 
-        self._windows[client_ip].append(now)
-        return await call_next(request)  # type: ignore[no-any-return]
+        timestamps.append(now)
+        self._windows[client_ip] = timestamps
+        self._windows.move_to_end(client_ip)
 
-    def _get_client_ip(self, request: Request) -> str:
-        forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        if request.client:
-            return request.client.host
-        return "unknown"
+        if len(self._windows) > self._max_tracked_clients:
+            self._evict_excess(now, window)
+
+        return await call_next(request)  # type: ignore[no-any-return]
 
 
 class ErrorHandlingMiddleware(BaseHTTPMiddleware):

--- a/tests/test_gateway/test_rate_limit_trusted_proxy.py
+++ b/tests/test_gateway/test_rate_limit_trusted_proxy.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import time
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from agentos.gateway.config import AuthConfig, GatewayConfig, RateLimitConfig
+from agentos.gateway.middleware import RateLimitMiddleware
+
+
+def _create_app(
+    *,
+    max_requests: int = 2,
+    window_seconds: int = 60,
+    trusted_proxy: str | None = None,
+    max_tracked_clients: int = 10_000,
+) -> tuple[Starlette, list[RateLimitMiddleware]]:
+    app = Starlette()
+
+    async def api_endpoint(_request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app.add_route("/api/test", api_endpoint, methods=["GET"])
+
+    config = GatewayConfig(
+        auth=AuthConfig(trusted_proxy=trusted_proxy),
+        rate_limit=RateLimitConfig(
+            enabled=True,
+            max_requests=max_requests,
+            window_seconds=window_seconds,
+        ),
+    )
+
+    middleware_instance: list[RateLimitMiddleware] = []
+
+    def middleware_factory(inner_app):
+        mw = RateLimitMiddleware(
+            inner_app,
+            config=config,
+            max_tracked_clients=max_tracked_clients,
+        )
+        middleware_instance.append(mw)
+        return mw
+
+    app.add_middleware(middleware_factory)
+    return app, middleware_instance
+
+
+def test_untrusted_client_cannot_bypass_rate_limit_via_x_forwarded_for() -> None:
+    """An untrusted peer rotating X-Forwarded-For is rate limited by peer IP and does not bypass."""
+    app, mw_holder = _create_app(max_requests=2, window_seconds=60, trusted_proxy=None)
+
+    with TestClient(app, client=("198.51.100.1", 50000)) as client:
+        # Request 1: sends spoofed IP 1.1.1.1
+        resp1 = client.get("/api/test", headers={"x-forwarded-for": "1.1.1.1"})
+        assert resp1.status_code == 200
+
+        # Request 2: sends spoofed IP 2.2.2.2
+        resp2 = client.get("/api/test", headers={"x-forwarded-for": "2.2.2.2"})
+        assert resp2.status_code == 200
+
+        # Request 3: sends spoofed IP 3.3.3.3 -> must be 429 because peer IP
+        # (198.51.100.1) exceeded max_requests (2)
+        resp3 = client.get("/api/test", headers={"x-forwarded-for": "3.3.3.3"})
+        assert resp3.status_code == 429
+        assert resp3.json() == {"error": "Too Many Requests", "code": "RATE_LIMITED"}
+
+    # Memory check: only the peer IP was tracked, not the spoofed IPs
+    mw = mw_holder[0]
+    assert "198.51.100.1" in mw._windows
+    assert "1.1.1.1" not in mw._windows
+    assert "2.2.2.2" not in mw._windows
+    assert "3.3.3.3" not in mw._windows
+    assert len(mw._windows) == 1
+
+
+def test_trusted_proxy_honors_x_forwarded_for() -> None:
+    """When peer IP matches configured trusted_proxy, X-Forwarded-For is used as client identity."""
+    app, mw_holder = _create_app(
+        max_requests=2,
+        window_seconds=60,
+        trusted_proxy="10.0.0.1, 10.0.0.2",
+    )
+
+    with TestClient(app, client=("10.0.0.1", 50000)) as client:
+        # Client A makes 2 requests
+        assert (
+            client.get("/api/test", headers={"x-forwarded-for": "203.0.113.50"}).status_code == 200
+        )
+        assert (
+            client.get("/api/test", headers={"x-forwarded-for": "203.0.113.50"}).status_code == 200
+        )
+        # Client A is rate limited
+        assert (
+            client.get("/api/test", headers={"x-forwarded-for": "203.0.113.50"}).status_code == 429
+        )
+
+        # Client B sends through same trusted proxy -> not blocked
+        assert (
+            client.get("/api/test", headers={"x-forwarded-for": "203.0.113.51"}).status_code == 200
+        )
+
+    mw = mw_holder[0]
+    assert "203.0.113.50" in mw._windows
+    assert "203.0.113.51" in mw._windows
+    assert "10.0.0.1" not in mw._windows
+
+
+def test_trusted_proxy_x_forwarded_for_multiple_ips() -> None:
+    """X-Forwarded-For with multiple IPs takes the first (client) IP."""
+    app, mw_holder = _create_app(
+        max_requests=1,
+        window_seconds=60,
+        trusted_proxy="10.0.0.1",
+    )
+
+    with TestClient(app, client=("10.0.0.1", 50000)) as client:
+        resp = client.get(
+            "/api/test",
+            headers={"x-forwarded-for": "203.0.113.99, 10.0.0.5, 10.0.0.1"},
+        )
+        assert resp.status_code == 200
+
+    mw = mw_holder[0]
+    assert "203.0.113.99" in mw._windows
+    assert len(mw._windows) == 1
+
+
+def test_trusted_proxy_missing_or_blank_forwarded_for_falls_back_to_peer() -> None:
+    """If trusted proxy sends empty or missing X-Forwarded-For, fall back to peer IP."""
+    app, mw_holder = _create_app(
+        max_requests=1,
+        window_seconds=60,
+        trusted_proxy="10.0.0.1",
+    )
+
+    with TestClient(app, client=("10.0.0.1", 50000)) as client:
+        assert client.get("/api/test", headers={"x-forwarded-for": "  "}).status_code == 200
+        assert client.get("/api/test").status_code == 429
+
+    mw = mw_holder[0]
+    assert "10.0.0.1" in mw._windows
+
+
+def test_max_tracked_clients_evicts_lru() -> None:
+    """When number of distinct clients exceeds max_tracked_clients, oldest LRU entry is evicted."""
+    app, mw_holder = _create_app(
+        max_requests=5,
+        window_seconds=60,
+        trusted_proxy="10.0.0.1",
+        max_tracked_clients=3,
+    )
+
+    with TestClient(app, client=("10.0.0.1", 50000)) as client:
+        client.get("/api/test", headers={"x-forwarded-for": "1.1.1.1"})
+        client.get("/api/test", headers={"x-forwarded-for": "2.2.2.2"})
+        client.get("/api/test", headers={"x-forwarded-for": "3.3.3.3"})
+
+        mw = mw_holder[0]
+        assert len(mw._windows) == 3
+        assert list(mw._windows.keys()) == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+
+        # Accessing 1.1.1.1 again makes 2.2.2.2 the least recently used
+        client.get("/api/test", headers={"x-forwarded-for": "1.1.1.1"})
+        assert list(mw._windows.keys()) == ["2.2.2.2", "3.3.3.3", "1.1.1.1"]
+
+        # Adding 4.4.4.4 exceeds capacity (3), so 2.2.2.2 should be evicted
+        client.get("/api/test", headers={"x-forwarded-for": "4.4.4.4"})
+        assert len(mw._windows) == 3
+        assert list(mw._windows.keys()) == ["3.3.3.3", "1.1.1.1", "4.4.4.4"]
+        assert "2.2.2.2" not in mw._windows
+
+
+def test_sweep_expired_entries() -> None:
+    """Expired window timestamps are purged during periodic sweeps."""
+    app, mw_holder = _create_app(
+        max_requests=5,
+        window_seconds=1,
+        trusted_proxy="10.0.0.1",
+        max_tracked_clients=10,
+    )
+
+    with TestClient(app, client=("10.0.0.1", 50000)) as client:
+        client.get("/api/test", headers={"x-forwarded-for": "1.1.1.1"})
+        client.get("/api/test", headers={"x-forwarded-for": "2.2.2.2"})
+
+        mw = mw_holder[0]
+        assert len(mw._windows) == 2
+
+        # Wait for window to expire
+        time.sleep(1.1)
+
+        # Trigger next request after window has expired
+        client.get("/api/test", headers={"x-forwarded-for": "3.3.3.3"})
+
+        # Expired entries 1.1.1.1 and 2.2.2.2 should have been swept
+        assert "1.1.1.1" not in mw._windows
+        assert "2.2.2.2" not in mw._windows
+        assert "3.3.3.3" in mw._windows


### PR DESCRIPTION
## Summary
Fixes #354:
1. **Rate limit bypass via `X-Forwarded-For` spoofing**: `RateLimitMiddleware` extracted the client IP from `X-Forwarded-For` unconditionally without verifying whether the peer is a trusted proxy. Unauthenticated clients could rotate the header on each request to bypass rate limiting.
2. **Unbounded memory growth (DoS)**: `_windows` stored timestamps in a `defaultdict(list)` that was only pruned per-key on access and never evicted expired buckets or bounded capacity.

## Changes
- **Trusted Proxy Check**: `RateLimitMiddleware._get_client_ip()` now validates `request.client.host` against `config.auth.trusted_proxy` before trusting `X-Forwarded-For`. Untrusted clients are always rate-limited by their physical peer IP.
- **Bounded Storage & LRU Eviction**: Replaced `defaultdict(list)` with `OrderedDict[str, list[float]]` bounded by `max_tracked_clients` (default `10,000`).
- **Periodic Sweeping**: Periodically sweeps expired window buckets every `min(window, 60.0)` seconds and applies LRU eviction when capacity is exceeded to prevent memory exhaustion.
- **Regression Tests**: Added `tests/test_gateway/test_rate_limit_trusted_proxy.py` covering untrusted client header spoofing, trusted proxy forwarding, proxy chains, LRU eviction, and periodic expired bucket sweeping.

## Verification
- `uv run pytest tests/test_gateway/test_rate_limit_trusted_proxy.py tests/test_gateway/test_rate_limit_approvals.py` passed (7 tests)
- `uv run pytest tests/test_gateway/` passed (1,247 tests)
- `uv run ruff check src tests` passed
- `uv run mypy src/agentos --show-error-codes` passed (608 source files)

Closes #354
