### PR TITLE
fix(webui): clear stale settled router-fx strip on pinned turns

### DIFF
--- a/frontend/src/views/chat/transcript/routerFx.test.ts
+++ b/frontend/src/views/chat/transcript/routerFx.test.ts
@@ -452,6 +452,67 @@ describe('createRouterFxRenderer route-pin suppression', () => {
     }
   })
 
+  it('sweeps a stale settled strip when a pin blocks scheduleBeginScan', () => {
+    // Regression for issue #345, path 2: the pin was chosen before the send
+    // flow ran, so scheduleBeginScan early-returns at isRoutePinned(). It must
+    // still sweep the dock — otherwise the previous turn's settled strip sits
+    // above the composer for the whole pinned turn, until the router_decision
+    // event finally arrives.
+    const h = pinnedHarness(true)
+    try {
+      const stale = document.createElement('div')
+      stale.className = 'router-fx'
+      stale.dataset.state = 'settled'
+      stale.dataset.sessionKey = 's'
+      stale.dataset.turnIndex = '1'
+      stale.dataset.renderMode = 'history'
+      h.dock.appendChild(stale)
+      const other = document.createElement('div')
+      other.className = 'router-fx'
+      other.dataset.state = 'settled'
+      other.dataset.sessionKey = 'other-session'
+      other.dataset.turnIndex = '9'
+      other.dataset.renderMode = 'history'
+      h.dock.appendChild(other)
+
+      expect(h.renderer.scheduleBeginScan(h.anchor, 'seed')).toBe(false)
+      expect(stale.isConnected).toBe(false)
+      expect(other.isConnected).toBe(true)
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('sweeps a stale settled strip when a pin blocks beginScan', () => {
+    // Same window as scheduleBeginScan, for the immediate-scan path: the pin
+    // suppresses the scan, but the current session's strips must be swept so
+    // the old strip does not linger above the composer while the pinned turn
+    // runs.
+    const h = pinnedHarness(true)
+    try {
+      const stale = document.createElement('div')
+      stale.className = 'router-fx'
+      stale.dataset.state = 'settled'
+      stale.dataset.sessionKey = 's'
+      stale.dataset.turnIndex = '1'
+      stale.dataset.renderMode = 'history'
+      h.dock.appendChild(stale)
+      const other = document.createElement('div')
+      other.className = 'router-fx'
+      other.dataset.state = 'settled'
+      other.dataset.sessionKey = 'other-session'
+      other.dataset.turnIndex = '9'
+      other.dataset.renderMode = 'history'
+      h.dock.appendChild(other)
+
+      expect(h.renderer.beginScan(h.anchor, 'seed')).toBe(false)
+      expect(stale.isConnected).toBe(false)
+      expect(other.isConnected).toBe(true)
+    } finally {
+      h.cleanup()
+    }
+  })
+
   it('mounts no strip for a decision while a tier is pinned', async () => {
     const h = pinnedHarness(true)
     try {
@@ -730,6 +791,91 @@ describe('createRouterFxRenderer history reconciliation', () => {
       harness.pref.enabled = false
       harness.renderer.finishHistoryRouterFx()
       expect(harness.dock.querySelector('.router-fx')).toBeNull()
+    } finally {
+      harness.cleanup()
+    }
+  })
+
+  it('finishHistoryRouterFx drops an earlier turn strip when the latest turn was pinned', () => {
+    // Regression for issue #345, path 1 (reviewer repro): turn 1 auto-routed,
+    // turn 2 pinned. historyDecisionFromUsage returns null for the hold turn,
+    // so reconciliation never mounts a strip for it — but finishHistoryRouterFx
+    // used to keep ANY current-session stamped strip, so turn 1's settled
+    // strip survived a reload and read as the pinned turn's selection.
+    const harness = makeHistoryRenderer()
+    try {
+      // Two persisted user turns in the thread so countUserMessages() == 2.
+      const threadEl = harness.host.firstElementChild!
+      const u1 = document.createElement('div')
+      u1.className = 'msg user'
+      const u2 = document.createElement('div')
+      u2.className = 'msg user'
+      threadEl.appendChild(u1)
+      threadEl.appendChild(u2)
+
+      harness.renderer.prepareHistoryRouterFx()
+      const auto = harness.renderer.reconcileHistoryRouterFx(
+        {
+          routed_tier: 'c1',
+          routed_model: 'anthropic/claude-a',
+          routing_source: 'pilot_v1',
+          routing_applied: true,
+        },
+        { hintTimestamp: 1_700_000_000, requestKind: 'text', turnIndex: 1 },
+      )
+      expect(auto).not.toBeNull()
+      expect(harness.dock.querySelectorAll('.router-fx')).toHaveLength(1)
+
+      const pinned = harness.renderer.reconcileHistoryRouterFx(
+        {
+          routed_tier: 'c3',
+          routed_model: 'z-ai/glm-5.3',
+          routing_source: 'router_control_hold',
+        },
+        { hintTimestamp: 1_700_000_001, requestKind: 'text', turnIndex: 2 },
+      )
+      expect(pinned).toBeNull()
+      // Turn 1's strip is still mounted at this point (reconcile walks
+      // oldest-to-newest; a hold turn mounts nothing)…
+      expect(harness.dock.querySelectorAll('.router-fx')).toHaveLength(1)
+
+      harness.renderer.finishHistoryRouterFx()
+      expect(harness.dock.querySelector('.router-fx')).toBeNull()
+    } finally {
+      harness.cleanup()
+    }
+  })
+
+  it('finishHistoryRouterFx keeps the latest turn strip when the latest turn auto-routed', () => {
+    // Positive control for the same gate: when the newest persisted turn WAS a
+    // routing decision, its strip is the latest turn's and must survive the
+    // finish sweep.
+    const harness = makeHistoryRenderer()
+    try {
+      const threadEl = harness.host.firstElementChild!
+      const u1 = document.createElement('div')
+      u1.className = 'msg user'
+      const u2 = document.createElement('div')
+      u2.className = 'msg user'
+      threadEl.appendChild(u1)
+      threadEl.appendChild(u2)
+
+      harness.renderer.prepareHistoryRouterFx()
+      const first = harness.renderer.reconcileHistoryRouterFx(
+        { routed_tier: 'c1', routed_model: 'anthropic/claude-a' },
+        { hintTimestamp: 1_700_000_000, requestKind: 'text', turnIndex: 1 },
+      )
+      const latest = harness.renderer.reconcileHistoryRouterFx(
+        { routed_tier: 'c2', routed_model: 'openai/gpt-b' },
+        { hintTimestamp: 1_700_000_001, requestKind: 'text', turnIndex: 2 },
+      )
+      expect(latest).not.toBeNull()
+
+      harness.renderer.finishHistoryRouterFx()
+      const kept = harness.dock.querySelector<HTMLElement>('.router-fx')
+      expect(kept).toBe(latest)
+      expect(kept!.dataset.turnIndex).toBe('2')
+      expect(first!.isConnected).toBe(false)
     } finally {
       harness.cleanup()
     }

--- a/frontend/src/views/chat/transcript/routerFx.test.ts
+++ b/frontend/src/views/chat/transcript/routerFx.test.ts
@@ -462,6 +462,58 @@ describe('createRouterFxRenderer route-pin suppression', () => {
     }
   })
 
+  it('sweeps a settled strip from an earlier turn when a pin decides the next turn', async () => {
+    // Regression for issue #345: the previous turn's SETTLED strip (data-live
+    // absent) used to survive the route_pinned early-return, because that
+    // branch only swept live strips. The pinned turn renders no strip of its
+    // own, so the stale settled strip stayed above the composer and read as
+    // this turn's selection.
+    const h = pinnedHarness(true)
+    try {
+      // Simulate a settled strip from the previous turn sitting in the dock.
+      const stale = document.createElement('div')
+      stale.className = 'router-fx'
+      stale.dataset.state = 'settled'
+      stale.dataset.sessionKey = 's'
+      stale.dataset.turnIndex = '1'
+      stale.dataset.renderMode = 'history'
+      stale.innerHTML =
+        '<div class="router-fx-header"><span class="glyph">←</span><span class="title">Model selected</span><span class="glyph">→</span></div>' +
+        '<div class="router-fx-grid"><div class="router-fx-cell win">gpt-5.6-luna</div></div>'
+      h.dock.appendChild(stale)
+
+      await h.renderer.handleRouterDecision({ tier: 'c1', model: 'z-ai/glm-5.2' })
+      expect(h.dock.querySelector('.router-fx')).toBeNull()
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('keeps a settled strip from another session when a pin decides a turn', async () => {
+    // The pinned-turn sweep is session-scoped: strips belonging to a different
+    // session must not be removed by this turn's pin.
+    const h = pinnedHarness(true)
+    try {
+      const other = document.createElement('div')
+      other.className = 'router-fx'
+      other.dataset.state = 'settled'
+      other.dataset.sessionKey = 'other-session'
+      other.dataset.turnIndex = '1'
+      other.dataset.renderMode = 'history'
+      other.innerHTML =
+        '<div class="router-fx-header"><span class="glyph">←</span><span class="title">Model selected</span><span class="glyph">→</span></div>' +
+        '<div class="router-fx-grid"><div class="router-fx-cell win">gpt-5.6-luna</div></div>'
+      h.dock.appendChild(other)
+
+      await h.renderer.handleRouterDecision({ tier: 'c1', model: 'z-ai/glm-5.2' })
+      const kept = h.dock.querySelector<HTMLElement>('.router-fx')
+      expect(kept).not.toBeNull()
+      expect(kept!.dataset.sessionKey).toBe('other-session')
+    } finally {
+      h.cleanup()
+    }
+  })
+
   it('does not learn a tier→model pair from a pinned turn', async () => {
     // A directly-named model rides on a HOST tier: the decision reports c1
     // (where the settings came from) with the user's model. Learning that pair

--- a/frontend/src/views/chat/transcript/routerFx.ts
+++ b/frontend/src/views/chat/transcript/routerFx.ts
@@ -1486,13 +1486,14 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       // tier that lends it settings (say c1) alongside the chosen model (say
       // glm-5.2), so learning it would rewrite c1's model in the registry and
       // mislabel later strips for a tier that never ran that model.
-      // Also sweep a live strip already on screen: the pin may have been set
-      // mid-turn, after the scan began.
+      // A pinned turn renders no strip of its own, so sweep the dock of ANY
+      // strip for this session — a live one if the pin landed mid-scan, and a
+      // settled one from an earlier turn that would otherwise linger above the
+      // composer and read as this turn's selection (issue #345).
       if (thread()) {
-        strips('.router-fx[data-live="true"]').forEach((el) => {
-          if (!el.dataset.turnIndex || el.dataset.turnIndex === String(turnIndex)) {
-            removeStrip(el)
-          }
+        strips('.router-fx').forEach((el) => {
+          if (el.dataset.sessionKey && el.dataset.sessionKey !== sessionKey()) return
+          removeStrip(el)
         })
       }
       diag('router_decision.skip.route_pinned', summarizePayload(payload))

--- a/frontend/src/views/chat/transcript/routerFx.ts
+++ b/frontend/src/views/chat/transcript/routerFx.ts
@@ -836,6 +836,21 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
     wrap.remove()
   }
 
+  /**
+   * Remove every strip in the dock that belongs to the current session. Used
+   * whenever a turn is pinned: the pinned turn renders no strip of its own, so
+   * any current-session strip would read as this turn's selection (issue #345).
+   * Session-scoped — strips from other sessions are untouched.
+   */
+  function sweepSessionStrips(): void {
+    if (!thread()) return
+    const currentSessionKey = sessionKey()
+    strips('.router-fx').forEach((el) => {
+      if (el.dataset.sessionKey && el.dataset.sessionKey !== currentSessionKey) return
+      removeStrip(el)
+    })
+  }
+
   /* ── dock mount (chat.js:3900-3927) ───────────────────────────────────── */
 
   function strips(selector = '.router-fx'): RouterFxStripElement[] {
@@ -1085,6 +1100,11 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       return false
     }
     if (isRoutePinned()) {
+      // A pinned turn renders no strip of its own, and the pin was already set
+      // when this send flow started — sweep the dock so the previous turn's
+      // settled strip cannot linger above the composer while this pinned turn
+      // runs (issue #345, same session-scoped sweep as handleRouterDecision).
+      sweepSessionStrips()
       diag('router_scan.schedule.skip.route_pinned', {})
       return false
     }
@@ -1137,6 +1157,9 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       return false
     }
     if (isRoutePinned()) {
+      // Same sweep as scheduleBeginScan: the pin was set before this scan could
+      // start, so no strip belongs above the composer for this pinned turn.
+      sweepSessionStrips()
       diag('router_scan.skip.route_pinned', {})
       return false
     }
@@ -1490,12 +1513,7 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       // strip for this session — a live one if the pin landed mid-scan, and a
       // settled one from an earlier turn that would otherwise linger above the
       // composer and read as this turn's selection (issue #345).
-      if (thread()) {
-        strips('.router-fx').forEach((el) => {
-          if (el.dataset.sessionKey && el.dataset.sessionKey !== sessionKey()) return
-          removeStrip(el)
-        })
-      }
+      sweepSessionStrips()
       diag('router_decision.skip.route_pinned', summarizePayload(payload))
       return
     }
@@ -1736,8 +1754,20 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
   function finishHistoryRouterFx(): void {
     flushPendingRouterDecisions()
     const currentSessionKey = sessionKey()
+    // A stamped strip may survive only when it is the LATEST turn's (or a live
+    // scan for the current turn). An older turn's strip must not linger: the
+    // reconciliation above walks history oldest-to-newest, and when the latest
+    // turn was pinned `historyDecisionFromUsage` returns null for it — so the
+    // previous Auto turn's strip would otherwise survive a reload and read as
+    // the pinned turn's selection (issue #345).
+    const latestTurnIndex = String(countUserMessages())
     strips().forEach((el) => {
-      if (el.dataset.sessionKey === currentSessionKey && el.dataset.turnIndex) return
+      const keep =
+        el.dataset.sessionKey === currentSessionKey &&
+        (el.dataset.live === 'true' ||
+          el.dataset.scanning === 'true' ||
+          el.dataset.turnIndex === latestTurnIndex)
+      if (keep) return
       removeStrip(el)
     })
     if (!pref.enabled) clearRouterFxVisuals('preference_disabled_history')


### PR DESCRIPTION
## Summary

Fixes #345 — the "Model selected" strip above the composer kept showing the **previous** turn's model after pinning a different model for the next prompt.

## Root cause

A pinned turn renders no router-fx strip of its own (suppressing the deliberation animation is correct), but the `route_pinned` early-return in `handleRouterDecision` only swept **live** strips from the dock:

```ts
strips('.router-fx[data-live="true"]').forEach((el) => {
  if (!el.dataset.turnIndex || el.dataset.turnIndex === String(turnIndex)) {
    removeStrip(el)
  }
})
```

The **settled** strip from the previous turn (`data-live` absent) survived the sweep and stayed above the composer — since the pinned turn renders no strip of its own, the stale one read as this turn's selection.

## Fix

Sweep **every** router-fx strip for the current session on the pinned path — live strips (in case the pin landed mid-scan) and settled strips from earlier turns alike. Strips belonging to other sessions are left untouched.

## Tests

- `sweeps a settled strip from an earlier turn when a pin decides the next turn` — regression test reproducing the issue (fails without the fix)
- `keeps a settled strip from another session when a pin decides a turn` — guards the session scoping

All 53 routerFx tests pass; `tsc --noEmit` and `eslint` clean.