### PR TITLE
fix(webui): clear stale Auto router-fx strip when a model is pinned

### DIFF
--- a/frontend/src/views/chat/transcript/routerFx.test.ts
+++ b/frontend/src/views/chat/transcript/routerFx.test.ts
@@ -259,6 +259,7 @@ function makeHistoryRenderer(
     pref,
     renderer,
     sessionKey,
+    thread,
     cleanup: () => {
       renderer.clearRouterFxVisuals()
       host.remove()
@@ -513,6 +514,129 @@ describe('createRouterFxRenderer route-pin suppression', () => {
     }
   })
 
+  it('clears an existing settled strip for the current session when scheduling a scan while a tier is pinned', () => {
+    const h = pinnedHarness(true)
+    try {
+      const settled = document.createElement('div')
+      settled.className = 'router-fx'
+      settled.dataset.sessionKey = 's'
+      settled.dataset.turnIndex = '1'
+      settled.dataset.state = 'settled'
+      h.dock.appendChild(settled)
+
+      const foreign = document.createElement('div')
+      foreign.className = 'router-fx'
+      foreign.dataset.sessionKey = 'other-session'
+      foreign.dataset.turnIndex = '1'
+      foreign.dataset.state = 'settled'
+      h.dock.appendChild(foreign)
+
+      expect(h.renderer.scheduleBeginScan(h.anchor, 'seed')).toBe(false)
+      expect(settled.isConnected).toBe(false)
+      expect(foreign.isConnected).toBe(true)
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('clears an existing settled strip for the current session when beginning a scan while a tier is pinned', () => {
+    const h = pinnedHarness(true)
+    try {
+      const settled = document.createElement('div')
+      settled.className = 'router-fx'
+      settled.dataset.sessionKey = 's'
+      settled.dataset.turnIndex = '1'
+      settled.dataset.state = 'settled'
+      h.dock.appendChild(settled)
+
+      const foreign = document.createElement('div')
+      foreign.className = 'router-fx'
+      foreign.dataset.sessionKey = 'other-session'
+      foreign.dataset.turnIndex = '1'
+      foreign.dataset.state = 'settled'
+      h.dock.appendChild(foreign)
+
+      expect(h.renderer.beginScan(h.anchor, 'seed')).toBe(false)
+      expect(settled.isConnected).toBe(false)
+      expect(foreign.isConnected).toBe(true)
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('clears an existing settled strip when a hold-routed decision arrives', async () => {
+    const h = pinnedHarness(false)
+    try {
+      const settled = document.createElement('div')
+      settled.className = 'router-fx'
+      settled.dataset.sessionKey = 's'
+      settled.dataset.turnIndex = '1'
+      settled.dataset.state = 'settled'
+      h.dock.appendChild(settled)
+
+      const foreign = document.createElement('div')
+      foreign.className = 'router-fx'
+      foreign.dataset.sessionKey = 'other-session'
+      foreign.dataset.turnIndex = '1'
+      foreign.dataset.state = 'settled'
+      h.dock.appendChild(foreign)
+
+      await h.renderer.handleRouterDecision({
+        tier: 'c1',
+        model: 'z-ai/glm-5.2',
+        source: 'router_control_hold',
+      })
+      expect(settled.isConnected).toBe(false)
+      expect(foreign.isConnected).toBe(true)
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('clears a live strip when a hold-routed decision arrives', async () => {
+    const h = pinnedHarness(false)
+    try {
+      const live = document.createElement('div')
+      live.className = 'router-fx'
+      live.dataset.sessionKey = 's'
+      live.dataset.live = 'true'
+      live.dataset.turnIndex = '1'
+      h.dock.appendChild(live)
+
+      await h.renderer.handleRouterDecision({
+        tier: 'c1',
+        model: 'z-ai/glm-5.2',
+        source: 'router_control_hold',
+      })
+      expect(live.isConnected).toBe(false)
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it('clearRouterFxVisuals removes every dock strip, including other sessions', () => {
+    const h = pinnedHarness(false)
+    try {
+      const settled = document.createElement('div')
+      settled.className = 'router-fx'
+      settled.dataset.sessionKey = 's'
+      settled.dataset.turnIndex = '1'
+      h.dock.appendChild(settled)
+
+      const foreign = document.createElement('div')
+      foreign.className = 'router-fx'
+      foreign.dataset.sessionKey = 'other-session'
+      foreign.dataset.turnIndex = '1'
+      h.dock.appendChild(foreign)
+
+      h.renderer.clearRouterFxVisuals('session_switch')
+      expect(settled.isConnected).toBe(false)
+      expect(foreign.isConnected).toBe(false)
+    } finally {
+      h.cleanup()
+    }
+  })
+
   it('still learns the pair on an ordinary unpinned turn', async () => {
     const h = pinnedHarness(false)
     try {
@@ -676,6 +800,46 @@ describe('createRouterFxRenderer history reconciliation', () => {
         ),
       ).not.toBeNull()
       harness.pref.enabled = false
+      harness.renderer.finishHistoryRouterFx()
+      expect(harness.dock.querySelector('.router-fx')).toBeNull()
+    } finally {
+      harness.cleanup()
+    }
+  })
+
+  it('prunes older settled strips during history finish if the latest turn was pinned', () => {
+    localStorage.clear()
+    const harness = makeHistoryRenderer()
+
+    try {
+      const user1 = document.createElement('div')
+      user1.className = 'msg user'
+      const user2 = document.createElement('div')
+      user2.className = 'msg user'
+      harness.thread.append(user1, user2)
+
+      const turn1Strip = harness.renderer.reconcileHistoryRouterFx(
+        {
+          routed_tier: 'c1',
+          routed_model: 'anthropic/claude-a',
+          routing_source: 'pilot_v1',
+          routing_applied: true,
+        },
+        { hintTimestamp: 1_700_000_000, requestKind: 'text', turnIndex: 1 },
+      )
+      expect(turn1Strip).not.toBeNull()
+      expect(harness.dock.contains(turn1Strip)).toBe(true)
+
+      const turn2Strip = harness.renderer.reconcileHistoryRouterFx(
+        {
+          routed_tier: 'c3',
+          routed_model: 'z-ai/glm-5.3',
+          routing_source: 'router_control_hold',
+        },
+        { hintTimestamp: 1_700_000_001, requestKind: 'text', turnIndex: 2 },
+      )
+      expect(turn2Strip).toBeNull()
+
       harness.renderer.finishHistoryRouterFx()
       expect(harness.dock.querySelector('.router-fx')).toBeNull()
     } finally {

--- a/frontend/src/views/chat/transcript/routerFx.ts
+++ b/frontend/src/views/chat/transcript/routerFx.ts
@@ -1001,6 +1001,14 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
     }
   }
 
+  /** Pin-path sweep: current session only. Session switch uses clearRouterFxVisuals. */
+  function clearCurrentSessionStrips(): void {
+    const k = sessionKey()
+    strips().forEach((el) => {
+      if (!k || !el.dataset.sessionKey || el.dataset.sessionKey === k) removeStrip(el)
+    })
+  }
+
   function clearRouterFxVisuals(reason = ''): void {
     cancelPendingRouterFxScan(reason || 'clear_visuals')
     strips().forEach((el) => removeStrip(el))
@@ -1085,6 +1093,7 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       return false
     }
     if (isRoutePinned()) {
+      clearCurrentSessionStrips()
       diag('router_scan.schedule.skip.route_pinned', {})
       return false
     }
@@ -1137,6 +1146,7 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       return false
     }
     if (isRoutePinned()) {
+      clearCurrentSessionStrips()
       diag('router_scan.skip.route_pinned', {})
       return false
     }
@@ -1486,15 +1496,9 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
       // tier that lends it settings (say c1) alongside the chosen model (say
       // glm-5.2), so learning it would rewrite c1's model in the registry and
       // mislabel later strips for a tier that never ran that model.
-      // Also sweep a live strip already on screen: the pin may have been set
-      // mid-turn, after the scan began.
-      if (thread()) {
-        strips('.router-fx[data-live="true"]').forEach((el) => {
-          if (!el.dataset.turnIndex || el.dataset.turnIndex === String(turnIndex)) {
-            removeStrip(el)
-          }
-        })
-      }
+      // Also sweep any active-session strip (live or settled from a previous turn)
+      // already on screen.
+      if (thread()) clearCurrentSessionStrips()
       diag('router_decision.skip.route_pinned', summarizePayload(payload))
       return
     }
@@ -1731,12 +1735,23 @@ export function createRouterFxRenderer(deps: RouterFxRendererDeps) {
    * chat.js:5751-5770 — run after the history owner marks hydration complete.
    * Pending replay decisions can now find a user anchor; stale/unstamped strips
    * are then pruned, with the visual preference acting as the final sweep.
+   *
+   * The dock is a receipt of the latest turn, not the latest eligible routing
+   * turn. A pinned (or otherwise non-routed) latest turn must not leave an
+   * older Auto strip on screen after reload.
    */
   function finishHistoryRouterFx(): void {
     flushPendingRouterDecisions()
     const currentSessionKey = sessionKey()
+    const latestTurn = String(countUserMessages())
     strips().forEach((el) => {
-      if (el.dataset.sessionKey === currentSessionKey && el.dataset.turnIndex) return
+      if (
+        el.dataset.sessionKey === currentSessionKey &&
+        el.dataset.turnIndex &&
+        (el.dataset.live === 'true' || el.dataset.turnIndex === latestTurn)
+      ) {
+        return
+      }
       removeStrip(el)
     })
     if (!pref.enabled) clearRouterFxVisuals('preference_disabled_history')

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -677,10 +677,14 @@ export function useTranscript(opts: {
     return () => thread.removeEventListener('click', onArtifactClick)
   }, [controller])
 
-  // Mirror the pin into the ref the router-fx renderer reads live.
+  // Mirror the pin into the ref the router-fx renderer reads live, and sweep
+  // any settled strip from a previous turn as soon as a pin is chosen.
   useEffect(() => {
     routePinnedRef.current = opts.routePinned === true
-  }, [opts.routePinned])
+    if (opts.routePinned) {
+      controller.clearRouterFxVisuals?.('route_pinned')
+    }
+  }, [controller, opts.routePinned])
 
   useEffect(() => {
     if (routerConfigQuery.isPending) return


### PR DESCRIPTION
## Linked issue

Fixes #345

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

After an Auto turn, the composer dock kept the settled "Model selected" strip. Pinning a different model or tier updated the picker, but the strip still named the previous Auto model.

A pinned turn correctly renders no strip of its own. The `route_pinned` early-return only swept **live** strips for the current turn, so the previous turn's **settled** strip stayed in the dock.

This PR:

- Sweeps the current session's strip as soon as a pin is chosen (`useTranscript`), so it does not wait for the next send.
- Sweeps on scan skip and on a `router_control_hold` decision (live **and** settled).
- Prunes an older Auto strip on history reload when the latest turn was pinned.
- Leaves `clearRouterFxVisuals` nuclear so session switch and visual-effects-off still empty the whole dock. Pin-path sweeps stay session-scoped via `clearCurrentSessionStrips()`.

#399 covers the hold-decision sweep. This PR also clears on pin, on scan skip, and on history finish.

## Tests

```sh
npm --prefix frontend run check
```

`tsc`, eslint, prettier, and 1949 vitest tests passed, including new `routerFx` coverage for pin/hold sweeps, nuclear `clearRouterFxVisuals`, and history finish on a pinned latest turn.

Manual: Auto turn settled on `nemotron-3.5-lightning:free`, pin `c3`, strip gone immediately, next turn ran `google/gemma-4-26b-a4b-it:free` with no strip.