### PR TITLE
fix(memory): remove dead daily-note size-limit config keys

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -619,8 +619,6 @@ class MemoryConfig(BaseSettings):
     )
     capture_max_chars: int = 2000
     capture_roll_max_chars: int = Field(default=50_000, ge=0)
-    daily_note_max_chars: int = Field(default=4000, ge=0)
-    daily_notes_total_max_chars: int = Field(default=8000, ge=0)
 
     # Retriever tuning
     temporal_decay_enabled: bool = False
@@ -2154,8 +2152,6 @@ class GatewayConfig(BaseSettings):
             "mode": "stable",
             "prompt_cache_mode": self.prompt_cache.effective_mode,
             "query_embedding_cache": self.memory.cost.query_embedding_cache,
-            "daily_note_max_chars": str(self.memory.daily_note_max_chars),
-            "daily_notes_total_max_chars": str(self.memory.daily_notes_total_max_chars),
             "auto_capture_enabled": str(self.memory.auto_capture_enabled).lower(),
             "capture_effective_enabled": str(capture_effective_enabled).lower(),
             "capture_mode": self.memory.capture_mode,

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -68,6 +68,14 @@ DEPRECATED_MEMORY_FIELDS: frozenset[str] = frozenset(
         "memory.repair_enabled",
         "memory.repair_interval_seconds",
         "memory.repair_max_items_per_tick",
+        # Daily-note injection was removed (PR #111 stopped reading daily notes
+        # that are always discarded), but the size-limit keys survived in
+        # ``MemoryConfig`` and ``memory_mode_fingerprint()`` without any
+        # consumer. MemoryConfig forbids extras, so an existing agentos.toml
+        # carrying them would fail validation at boot once the fields are
+        # dropped; they join the deprecated set instead.
+        "memory.daily_note_max_chars",
+        "memory.daily_notes_total_max_chars",
     }
 )
 

--- a/tests/test_gateway_config_legacy.py
+++ b/tests/test_gateway_config_legacy.py
@@ -33,6 +33,8 @@ _ALL_DEPRECATED_MEMORY_FIELDS = {
     "memory.multi_hop_max_depth": "3",
     "memory.multi_hop_score_threshold": "0.7",
     "memory.recall_frequency": "always",
+    "memory.daily_note_max_chars": "4000",
+    "memory.daily_notes_total_max_chars": "8000",
     "memory.recall_top_k_default": "10",
     "memory.auto_recall_enabled": "true",
     "memory.prefetch_enabled": "true",

--- a/tests/test_memory_daily_note_keys_removal.py
+++ b/tests/test_memory_daily_note_keys_removal.py
@@ -1,0 +1,57 @@
+"""Removing the dead daily-note size keys must not break installs carrying them.
+
+`memory.daily_note_max_chars` and `memory.daily_notes_total_max_chars`
+survived the daily-note removal (PR #111) with no consumer, so they are
+dropped from `MemoryConfig` and `memory_mode_fingerprint()`. Because
+`MemoryConfig` forbids extras, an existing agentos.toml carrying either key
+would fail validation at boot without the deprecated-field migration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.gateway.config import GatewayConfig
+
+# -- config -------------------------------------------------------------------
+
+
+def test_an_existing_config_with_daily_note_keys_still_loads(tmp_path: Path) -> None:
+    """The decisive case: MemoryConfig forbids extras, so this would 500 at boot."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[memory]\n"
+        "inject_limit = 6400\n"
+        "daily_note_max_chars = 4000\n"
+        "daily_notes_total_max_chars = 8000\n",
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.memory.inject_limit == 6400
+    assert not hasattr(config.memory, "daily_note_max_chars")
+    assert not hasattr(config.memory, "daily_notes_total_max_chars")
+
+
+def test_the_dropped_keys_are_reported_not_silently_eaten() -> None:
+    from agentos.gateway.config_migration import DEPRECATED_MEMORY_FIELDS
+
+    assert "memory.daily_note_max_chars" in DEPRECATED_MEMORY_FIELDS
+    assert "memory.daily_notes_total_max_chars" in DEPRECATED_MEMORY_FIELDS
+
+
+def test_the_fingerprint_no_longer_carries_daily_note_keys() -> None:
+    fingerprint = GatewayConfig().memory_mode_fingerprint()
+    assert "daily_note_max_chars" not in fingerprint
+    assert "daily_notes_total_max_chars" not in fingerprint
+
+
+def test_the_keys_are_not_configurable() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GatewayConfig(memory={"daily_note_max_chars": 4000})
+    with pytest.raises(ValidationError):
+        GatewayConfig(memory={"daily_notes_total_max_chars": 8000})


### PR DESCRIPTION
## Linked issue

Fixes #405

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

`memory.daily_note_max_chars` and `memory.daily_notes_total_max_chars` were leftovers from #111 (`perf(memory): stop reading daily notes that are always discarded`): the fields and their `memory_mode_fingerprint()` exports survived on `MemoryConfig` with no consumer anywhere — the only function that would accept them, `identity/workspace.load_daily_notes()`, has zero callers repo-wide, and `engine/runtime.py` still documents the permanent-omit policy. Operators tuning these keys got a silent no-op while attribution/decision logs advertised them as live memory knobs.

This removes both fields and their fingerprint exports. Since `MemoryConfig` is `extra="forbid"`, the keys are registered in `DEPRECATED_MEMORY_FIELDS` (`config_migration.py`) so an existing `agentos.toml` carrying them loads with the standard legacy-field warning instead of failing validation at boot — the same pattern already used for the `memory.dream` and `memory.flush_*` removals.

Changes:
- `src/agentos/gateway/config.py` — drop the two fields (MemoryConfig) and their two lines in `memory_mode_fingerprint()`.
- `src/agentos/gateway/config_migration.py` — add both keys to `DEPRECATED_MEMORY_FIELDS` with a comment on why.
- `tests/test_memory_daily_note_keys_removal.py` — new regression file mirroring `test_memory_dream_removal.py`: toml with the keys still loads, keys are in the deprecated set, fingerprint no longer carries them, constructor now rejects them.
- `tests/test_gateway_config_legacy.py` — extend the all-deprecated-fields fixture with both keys.

Out of scope (noted in #405 discussion): the now-orphaned `load_daily_notes()` helper itself — I kept this PR limited to the config keys so review stays small.

## Tests

```
uv run pytest tests/test_memory_daily_note_keys_removal.py tests/test_gateway_config_legacy.py \
  tests/test_memory_dream_removal.py tests/test_gateway/test_config_memory_defaults.py -q
# 45 passed in 9.48s

uv run pytest tests/test_gateway/ tests/test_memory_user_md_notify.py tests/test_memory_dream_removal.py \
  tests/test_skills_config_vars.py -q
# 1292 passed in 90.68s

uv run ruff check <changed files>   # All checks passed
uv run mypy src/agentos/gateway/config.py src/agentos/gateway/config_migration.py --show-error-codes
# Success: no issues found in 2 source files
```

The migration test emits the expected one-shot `DeprecationWarning: AgentOS: 2 legacy memory.* config field(s) ignored (e.g. memory.daily_note_max_chars, memory.daily_notes_total_max_chars)`, confirming the toml path works. Full quality gate (Control UI build + full pytest) will run in CI; local verification covered every test touching memory config, migration, and the fingerprint.

## Third-party origin

none
