### PR TITLE
fix(config): remove dead memory.daily_note_max_chars / daily_notes_total_max_chars

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -619,8 +619,6 @@ class MemoryConfig(BaseSettings):
     )
     capture_max_chars: int = 2000
     capture_roll_max_chars: int = Field(default=50_000, ge=0)
-    daily_note_max_chars: int = Field(default=4000, ge=0)
-    daily_notes_total_max_chars: int = Field(default=8000, ge=0)
 
     # Retriever tuning
     temporal_decay_enabled: bool = False
@@ -2154,8 +2152,6 @@ class GatewayConfig(BaseSettings):
             "mode": "stable",
             "prompt_cache_mode": self.prompt_cache.effective_mode,
             "query_embedding_cache": self.memory.cost.query_embedding_cache,
-            "daily_note_max_chars": str(self.memory.daily_note_max_chars),
-            "daily_notes_total_max_chars": str(self.memory.daily_notes_total_max_chars),
             "auto_capture_enabled": str(self.memory.auto_capture_enabled).lower(),
             "capture_effective_enabled": str(capture_effective_enabled).lower(),
             "capture_mode": self.memory.capture_mode,

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -68,6 +68,9 @@ DEPRECATED_MEMORY_FIELDS: frozenset[str] = frozenset(
         "memory.repair_enabled",
         "memory.repair_interval_seconds",
         "memory.repair_max_items_per_tick",
+        # Daily-note size limits were removed (PR #111); no consumer reads them.
+        "memory.daily_note_max_chars",
+        "memory.daily_notes_total_max_chars",
     }
 )
 

--- a/tests/test_gateway_config_legacy.py
+++ b/tests/test_gateway_config_legacy.py
@@ -43,6 +43,8 @@ _ALL_DEPRECATED_MEMORY_FIELDS = {
     "memory.eviction_policy": "lru",
     "memory.summary_model": "gpt-4o-mini",
     "memory.summary_max_tokens": "256",
+    "memory.daily_note_max_chars": "4000",
+    "memory.daily_notes_total_max_chars": "8000",
 }
 
 

--- a/tests/test_memory_dream_removal.py
+++ b/tests/test_memory_dream_removal.py
@@ -56,6 +56,39 @@ def test_the_fingerprint_no_longer_carries_dream_keys():
     assert not [key for key in fingerprint if "dream" in key]
 
 
+def test_the_fingerprint_no_longer_carries_daily_note_keys():
+    """Daily-note size knobs were removed (PR #111); the fingerprint must not
+    advertise them as live memory knobs."""
+    fingerprint = GatewayConfig().memory_mode_fingerprint()
+    assert "daily_note_max_chars" not in fingerprint
+    assert "daily_notes_total_max_chars" not in fingerprint
+
+
+def test_an_existing_config_with_daily_note_keys_still_loads(tmp_path: Path):
+    """MemoryConfig forbids extras, so a leftover [memory] daily-note block
+    would fail validation at boot without the deprecated-key migration."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[memory]\n"
+        "inject_limit = 6400\n"
+        "daily_note_max_chars = 4000\n"
+        "daily_notes_total_max_chars = 8000\n",
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.memory.inject_limit == 6400
+    assert not hasattr(config.memory, "daily_note_max_chars")
+
+
+def test_the_dropped_daily_note_keys_are_reported_not_silently_eaten():
+    from agentos.gateway.config_migration import DEPRECATED_MEMORY_FIELDS
+
+    assert "memory.daily_note_max_chars" in DEPRECATED_MEMORY_FIELDS
+    assert "memory.daily_notes_total_max_chars" in DEPRECATED_MEMORY_FIELDS
+
+
 # -- scheduler ----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

`memory.daily_note_max_chars` and `memory.daily_notes_total_max_chars` are dead config keys — defined on `MemoryConfig` and exported by `memory_mode_fingerprint()`, but nothing consumes them. The only intended consumer (`load_daily_notes()`) has zero callers since PR #111 stopped reading daily notes.

## Changes

- Drop both fields from `MemoryConfig`
- Remove both entries from `memory_mode_fingerprint()`
- Add both to `DEPRECATED_MEMORY_FIELDS` so existing configs carrying them are rewritten with a deprecation warning instead of failing validation at boot

## Tests

- `test_memory_dream_removal.py`: fingerprint no longer carries the keys; a toml with the keys still loads and drops them; keys are in the deprecated list
- `test_gateway_config_legacy.py`: both keys added to the all-deprecated-fields fixture

Fixes #405