### PR TITLE
fix(config): remove dead subagents.archive_after_minutes key

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1757,10 +1757,6 @@ class SubagentsGatewayConfig(BaseModel):
     """Number of slots in ``task_runtime.max_concurrency`` reserved for
     non-subagent tasks so a fan-out parent never starves itself."""
 
-    archive_after_minutes: int = Field(default=60, ge=0)
-    """Minutes after a subagent session goes terminal before its transcript
-    is archived. ``0`` disables auto-archive."""
-
     prompt_compact: bool = False
     """When enabled, subagent bootstrap prompts keep only AGENTS.md and TOOLS.md."""
 

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -149,9 +149,11 @@ DEPRECATED_AGENT_TOKEN_SAVING_LEAVES: frozenset[str] = frozenset(
     k.removeprefix("agent_token_saving.") for k in DEPRECATED_AGENT_TOKEN_SAVING_FIELDS
 )
 
-# Auto-archive was removed; SubagentsGatewayConfig rejects unknown keys, so an
-# existing agentos.toml carrying `subagents.archive_after_minutes` would fail
-# validation at boot without this.
+# Auto-archive was removed. SubagentsGatewayConfig is a plain BaseModel and
+# Pydantic's default extra="ignore" means a toml carrying the key would still
+# load — but the dead key would silently linger in the user's file. This
+# migration strips it, rewrites the toml with a backup, and warns the user
+# that the setting is now a no-op.
 DEPRECATED_SUBAGENTS_FIELDS: frozenset[str] = frozenset(
     {
         "subagents.archive_after_minutes",

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -149,12 +149,27 @@ DEPRECATED_AGENT_TOKEN_SAVING_LEAVES: frozenset[str] = frozenset(
     k.removeprefix("agent_token_saving.") for k in DEPRECATED_AGENT_TOKEN_SAVING_FIELDS
 )
 
+# Auto-archive was removed; SubagentsGatewayConfig rejects unknown keys, so an
+# existing agentos.toml carrying `subagents.archive_after_minutes` would fail
+# validation at boot without this.
+DEPRECATED_SUBAGENTS_FIELDS: frozenset[str] = frozenset(
+    {
+        "subagents.archive_after_minutes",
+    }
+)
+DEPRECATED_SUBAGENTS_LEAVES: frozenset[str] = frozenset(
+    k.removeprefix("subagents.") for k in DEPRECATED_SUBAGENTS_FIELDS
+)
+
 _LEGACY_MEMORY_FIELDS_WARN_LOCK = threading.Lock()
 _LEGACY_MEMORY_FIELDS_WARNED = False
 _LEGACY_MEMORY_FIELDS_SEEN: set[str] = set()
 _LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARN_LOCK = threading.Lock()
 _LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARNED = False
 _LEGACY_AGENT_TOKEN_SAVING_FIELDS_SEEN: set[str] = set()
+_LEGACY_SUBAGENTS_FIELDS_WARN_LOCK = threading.Lock()
+_LEGACY_SUBAGENTS_FIELDS_WARNED = False
+_LEGACY_SUBAGENTS_FIELDS_SEEN: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -270,6 +285,51 @@ def handle_deprecated_agent_token_saving_fields(
             "AgentOS: %d legacy agent_token_saving.tool_result_compression_* "
             "config field(s) migrated or ignored (e.g. %s); see %s for details. "
             "Tokenjuice projection is now the built-in tool-result path.",
+            n,
+            first_three,
+            log_ref,
+        )
+
+
+def handle_deprecated_subagents_fields(
+    found: dict[str, object],
+    source: str,
+) -> None:
+    """Record and warn once for deprecated subagents fields removed from config data."""
+    global _LEGACY_SUBAGENTS_FIELDS_WARNED
+
+    if not found:
+        return
+
+    with _LEGACY_SUBAGENTS_FIELDS_WARN_LOCK:
+        _LEGACY_SUBAGENTS_FIELDS_SEEN.update(found.keys())
+        should_warn = not _LEGACY_SUBAGENTS_FIELDS_WARNED
+        if should_warn:
+            _LEGACY_SUBAGENTS_FIELDS_WARNED = True
+            warning_fields = sorted(_LEGACY_SUBAGENTS_FIELDS_SEEN)
+        else:
+            warning_fields = []
+
+    _write_legacy_field_log(found, source)
+
+    if should_warn:
+        n = len(warning_fields)
+        first_three = ", ".join(warning_fields[:3])
+        try:
+            logs_dir = default_agentos_home() / "logs"
+            log_ref = str(logs_dir)
+        except Exception:
+            log_ref = "~/.agentos/logs"
+        warnings.warn(
+            f"AgentOS: {n} legacy subagents.* config field(s) ignored "
+            f"(e.g. {first_three}); see {log_ref} for details. "
+            "These fields will be removed in 0.2.0.",
+            DeprecationWarning,
+            stacklevel=6,
+        )
+        logging.getLogger(__name__).warning(
+            "AgentOS: %d legacy subagents.* config field(s) ignored (e.g. %s); "
+            "see %s for details. These fields will be removed in 0.2.0.",
             n,
             first_three,
             log_ref,
@@ -560,6 +620,17 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
                     "agent_token_saving.tool_result_compression_* was removed; "
                     "tokenjuice projection is now the built-in tool-result path"
                 )
+
+    subagents_section = builder.payload.get("subagents")
+    if isinstance(subagents_section, dict):
+        deprecated_subagents: dict[str, object] = {}
+        for leaf in list(subagents_section):
+            if leaf in DEPRECATED_SUBAGENTS_LEAVES:
+                deprecated_subagents[f"subagents.{leaf}"] = subagents_section.pop(leaf)
+
+        if deprecated_subagents:
+            builder.removed_fields.extend(sorted(deprecated_subagents))
+            handle_deprecated_subagents_fields(deprecated_subagents, "config_migration")
 
     # 2026-07: the skills-block budget default rose from 8000 to 24000 once the
     # block stopped emitting a filesystem path per skill. 8000 could not fit the

--- a/tests/test_gateway/test_agent_subagent_defaults_serde.py
+++ b/tests/test_gateway/test_agent_subagent_defaults_serde.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from agentos.gateway.config import (
     AgentDefaults,
     AgentEntryConfig,
@@ -51,7 +53,6 @@ def test_gateway_config_exposes_agents_defaults_and_subagents_subtree() -> None:
     assert isinstance(cfg.subagents, SubagentsGatewayConfig)
     assert cfg.subagents.enforce_disabled_agents is False
     assert cfg.subagents.subagent_reserved_slots == 2
-    assert cfg.subagents.archive_after_minutes == 60
 
 
 def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
@@ -60,11 +61,41 @@ def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
         subagents=SubagentsGatewayConfig(
             enforce_disabled_agents=True,
             subagent_reserved_slots=4,
-            archive_after_minutes=0,
         ),
     )
     assert cfg.agents_defaults.subagents is not None
     assert cfg.agents_defaults.subagents.model == "haiku"
     assert cfg.subagents.enforce_disabled_agents is True
     assert cfg.subagents.subagent_reserved_slots == 4
-    assert cfg.subagents.archive_after_minutes == 0
+
+
+def test_legacy_subagents_config_with_archive_after_minutes_still_loads(
+    tmp_path: Path,
+) -> None:
+    """SubagentsGatewayConfig does not set extra='forbid', but the migration
+    should still strip the dead key and rewrite the file with a backup."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[subagents]\n"
+        "archive_after_minutes = 60\n"
+        "enforce_disabled_agents = true\n",
+        encoding="utf-8",
+    )
+
+    cfg = GatewayConfig.load(config_path)
+
+    assert cfg.subagents.enforce_disabled_agents is True
+    assert not hasattr(cfg.subagents, "archive_after_minutes")
+    backups = sorted(tmp_path.glob("agentos.toml.backup.*"))
+    assert backups
+    backup_text = backups[-1].read_text(encoding="utf-8")
+    assert "archive_after_minutes" in backup_text
+    text = config_path.read_text(encoding="utf-8")
+    assert "archive_after_minutes" not in text
+    assert "enforce_disabled_agents" in text
+
+
+def test_the_dropped_archive_key_is_reported_not_silently_eaten():
+    from agentos.gateway.config_migration import DEPRECATED_SUBAGENTS_FIELDS
+
+    assert "subagents.archive_after_minutes" in DEPRECATED_SUBAGENTS_FIELDS

--- a/tests/test_gateway/test_agent_subagent_defaults_serde.py
+++ b/tests/test_gateway/test_agent_subagent_defaults_serde.py
@@ -76,9 +76,7 @@ def test_legacy_subagents_config_with_archive_after_minutes_still_loads(
     should still strip the dead key and rewrite the file with a backup."""
     config_path = tmp_path / "agentos.toml"
     config_path.write_text(
-        "[subagents]\n"
-        "archive_after_minutes = 60\n"
-        "enforce_disabled_agents = true\n",
+        "[subagents]\narchive_after_minutes = 60\nenforce_disabled_agents = true\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary

`subagents.archive_after_minutes` (default `60`) is defined in `SubagentsGatewayConfig` but nothing reads it — there is no auto-archive timer anywhere, `SubagentRegistry.archive()` has zero callers, and terminal subagent handles stay in `_runs` forever regardless of this setting.

## Changes

- Drop `archive_after_minutes` from `SubagentsGatewayConfig`
- Add `DEPRECATED_SUBAGENTS_FIELDS` + `handle_deprecated_subagents_fields()` so existing configs carrying the key are stripped with a deprecation warning instead of failing validation at boot (mirrors the `memory.*` / `agent_token_saving.*` patterns)
- Wire the subagents section through `migrate_config_payload()`

## Tests

- `test_agent_subagent_defaults_serde.py`: removed stale `archive_after_minutes` assertions; added regression coverage — a legacy toml carrying the key still loads, the file is rewritten without it, a backup is created, and the key is in the deprecated list

Fixes #407