### PR TITLE
fix(memory): remove dead daily-note config keys (#405)

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -619,8 +619,6 @@ class MemoryConfig(BaseSettings):
     )
     capture_max_chars: int = 2000
     capture_roll_max_chars: int = Field(default=50_000, ge=0)
-    daily_note_max_chars: int = Field(default=4000, ge=0)
-    daily_notes_total_max_chars: int = Field(default=8000, ge=0)
 
     # Retriever tuning
     temporal_decay_enabled: bool = False
@@ -2154,8 +2152,6 @@ class GatewayConfig(BaseSettings):
             "mode": "stable",
             "prompt_cache_mode": self.prompt_cache.effective_mode,
             "query_embedding_cache": self.memory.cost.query_embedding_cache,
-            "daily_note_max_chars": str(self.memory.daily_note_max_chars),
-            "daily_notes_total_max_chars": str(self.memory.daily_notes_total_max_chars),
             "auto_capture_enabled": str(self.memory.auto_capture_enabled).lower(),
             "capture_effective_enabled": str(capture_effective_enabled).lower(),
             "capture_mode": self.memory.capture_mode,

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -68,6 +68,12 @@ DEPRECATED_MEMORY_FIELDS: frozenset[str] = frozenset(
         "memory.repair_enabled",
         "memory.repair_interval_seconds",
         "memory.repair_max_items_per_tick",
+        # Daily-note char budgets were removed in PR #111; the config keys
+        # were left behind as dead weight. MemoryConfig forbids extras, so an
+        # existing agentos.toml carrying these would fail validation at boot
+        # without this migration entry.
+        "memory.daily_note_max_chars",
+        "memory.daily_notes_total_max_chars",
     }
 )
 

--- a/tests/test_memory_daily_notes_removal.py
+++ b/tests/test_memory_daily_notes_removal.py
@@ -1,0 +1,54 @@
+"""Removing daily-note char budgets must not break installs that were using them.
+
+Two things outlive the code: the `memory.daily_note_max_chars` and
+`memory.daily_notes_total_max_chars` keys in a user's agentos.toml, and the
+memory-mode fingerprint that reported them as live knobs. `MemoryConfig` forbids
+extra keys, so the first would fail validation at boot; the second would keep
+attribution logs lying about which knobs shape behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.gateway.config import GatewayConfig
+
+# -- config -------------------------------------------------------------------
+
+
+def test_an_existing_config_with_daily_note_keys_still_loads(tmp_path: Path):
+    """The decisive case: MemoryConfig forbids extras, so this would 500 at boot."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[memory]\n"
+        "inject_limit = 6400\n"
+        "daily_note_max_chars = 8000\n"
+        "daily_notes_total_max_chars = 16000\n",
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.memory.inject_limit == 6400
+    assert not hasattr(config.memory, "daily_note_max_chars")
+    assert not hasattr(config.memory, "daily_notes_total_max_chars")
+
+
+def test_the_dropped_keys_are_reported_not_silently_eaten():
+    from agentos.gateway.config_migration import DEPRECATED_MEMORY_FIELDS
+
+    assert "memory.daily_note_max_chars" in DEPRECATED_MEMORY_FIELDS
+    assert "memory.daily_notes_total_max_chars" in DEPRECATED_MEMORY_FIELDS
+
+
+def test_a_config_without_daily_note_keys_is_unaffected(tmp_path: Path):
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text("[memory]\ninject_limit = 5000\n", encoding="utf-8")
+
+    assert GatewayConfig.load(config_path).memory.inject_limit == 5000
+
+
+def test_the_fingerprint_no_longer_carries_daily_note_keys():
+    fingerprint = GatewayConfig().memory_mode_fingerprint()
+    assert "daily_note_max_chars" not in fingerprint
+    assert "daily_notes_total_max_chars" not in fingerprint


### PR DESCRIPTION
## Summary

Remove `daily_note_max_chars` and `daily_notes_total_max_chars` from `MemoryConfig` and `memory_mode_fingerprint()`. These keys were left behind from PR #111 which stopped reading daily notes entirely, and are never consumed anywhere in the codebase.

## Changes

- **Remove** both fields from `MemoryConfig` (src/agentos/gateway/config.py:622-623)
- **Remove** both keys from `memory_mode_fingerprint()` (src/agentos/gateway/config.py:2157-2158)
- **Add** both keys to `DEPRECATED_MEMORY_FIELDS` (src/agentos/gateway/config_migration.py) so existing `agentos.toml` files carrying them still load and are rewritten without them, instead of failing validation at boot

## Regression tests

Add `tests/test_memory_daily_notes_removal.py` covering:
- Config with the keys still loads and drops them (decisive case: MemoryConfig forbids extras)
- Keys are reported in `DEPRECATED_MEMORY_FIELDS`
- Config without the keys is unaffected
- Fingerprint no longer carries the keys

## Verification

```bash
uv run pytest tests/test_memory_daily_notes_removal.py -v
# 4 passed

uv run ruff check src tests
# All checks passed!
```

Refs #405
