### PR TITLE
fix(subagents): remove dead archive_after_minutes config key (#407)

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1757,10 +1757,6 @@ class SubagentsGatewayConfig(BaseModel):
     """Number of slots in ``task_runtime.max_concurrency`` reserved for
     non-subagent tasks so a fan-out parent never starves itself."""
 
-    archive_after_minutes: int = Field(default=60, ge=0)
-    """Minutes after a subagent session goes terminal before its transcript
-    is archived. ``0`` disables auto-archive."""
-
     prompt_compact: bool = False
     """When enabled, subagent bootstrap prompts keep only AGENTS.md and TOOLS.md."""
 

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -134,6 +134,19 @@ RETIRED_CHANNEL_TYPE_ALIASES: dict[str, str] = {
     "wecom": "wecom",
 }
 
+DEPRECATED_SUBAGENTS_FIELDS: frozenset[str] = frozenset(
+    {
+        # Auto-archive was never wired: SubagentRegistry.archive() has zero
+        # callers, so this key was a silent no-op. SubagentsGatewayConfig
+        # forbids extras, so an existing agentos.toml carrying it would fail
+        # validation at boot without this migration entry.
+        "subagents.archive_after_minutes",
+    }
+)
+DEPRECATED_SUBAGENTS_LEAVES: frozenset[str] = frozenset(
+    k.removeprefix("subagents.") for k in DEPRECATED_SUBAGENTS_FIELDS
+)
+
 DEPRECATED_AGENT_TOKEN_SAVING_FIELDS: frozenset[str] = frozenset(
     {
         "agent_token_saving.tool_result_compression_enabled",
@@ -527,6 +540,19 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
         if deprecated:
             builder.removed_fields.extend(sorted(deprecated))
             handle_deprecated_memory_fields(deprecated, "config_migration")
+
+    subagents_section = builder.payload.get("subagents")
+    if isinstance(subagents_section, dict):
+        deprecated_subagents: dict[str, object] = {}
+        for leaf in list(subagents_section):
+            if leaf in DEPRECATED_SUBAGENTS_LEAVES:
+                deprecated_subagents[f"subagents.{leaf}"] = subagents_section.pop(leaf)
+        if deprecated_subagents:
+            builder.removed_fields.extend(sorted(deprecated_subagents))
+            builder.warnings.append(
+                "subagents.archive_after_minutes was removed; no auto-archive timer "
+                "exists, so the key was a silent no-op"
+            )
 
     token_saving = builder.payload.get("agent_token_saving")
     if isinstance(token_saving, dict):

--- a/tests/test_gateway/test_agent_subagent_defaults_serde.py
+++ b/tests/test_gateway/test_agent_subagent_defaults_serde.py
@@ -51,7 +51,6 @@ def test_gateway_config_exposes_agents_defaults_and_subagents_subtree() -> None:
     assert isinstance(cfg.subagents, SubagentsGatewayConfig)
     assert cfg.subagents.enforce_disabled_agents is False
     assert cfg.subagents.subagent_reserved_slots == 2
-    assert cfg.subagents.archive_after_minutes == 60
 
 
 def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
@@ -60,11 +59,9 @@ def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
         subagents=SubagentsGatewayConfig(
             enforce_disabled_agents=True,
             subagent_reserved_slots=4,
-            archive_after_minutes=0,
         ),
     )
     assert cfg.agents_defaults.subagents is not None
     assert cfg.agents_defaults.subagents.model == "haiku"
     assert cfg.subagents.enforce_disabled_agents is True
     assert cfg.subagents.subagent_reserved_slots == 4
-    assert cfg.subagents.archive_after_minutes == 0

--- a/tests/test_subagents_archive_key_removal.py
+++ b/tests/test_subagents_archive_key_removal.py
@@ -1,0 +1,44 @@
+"""Removing subagents.archive_after_minutes must not break installs that set it.
+
+The key was a silent no-op: no auto-archive timer exists anywhere, and
+SubagentRegistry.archive() has zero callers. SubagentsGatewayConfig forbids
+extra keys, so an existing agentos.toml carrying the key would fail validation
+at boot without the deprecated-field migration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.gateway.config import GatewayConfig
+
+
+def test_an_existing_config_with_archive_after_minutes_still_loads(tmp_path: Path):
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[subagents]\n"
+        "enforce_disabled_agents = true\n"
+        "archive_after_minutes = 120\n",
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.subagents.enforce_disabled_agents is True
+    assert not hasattr(config.subagents, "archive_after_minutes")
+
+
+def test_the_dropped_key_is_reported_not_silently_eaten():
+    from agentos.gateway.config_migration import DEPRECATED_SUBAGENTS_FIELDS
+
+    assert "subagents.archive_after_minutes" in DEPRECATED_SUBAGENTS_FIELDS
+
+
+def test_a_config_without_the_key_is_unaffected(tmp_path: Path):
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[subagents]\nsubagent_reserved_slots = 4\n",
+        encoding="utf-8",
+    )
+
+    assert GatewayConfig.load(config_path).subagents.subagent_reserved_slots == 4


### PR DESCRIPTION
## Summary

Remove `subagents.archive_after_minutes` from `SubagentsGatewayConfig`. The key documented an auto-archive timer that was never wired: nothing reads it, and the only machinery it could drive — `SubagentRegistry.archive()` / `get_archived()` in engine/subagent.py — has zero callers. Terminal subagent handles stay in `_runs` for the lifetime of the registry regardless of the setting, so tuning the key in `agentos.toml` is a silent no-op.

## Changes

- **Remove** the field from `SubagentsGatewayConfig` (src/agentos/gateway/config.py)
- **Add** `subagents.archive_after_minutes` to a new `DEPRECATED_SUBAGENTS_FIELDS` set (src/agentos/gateway/config_migration.py) and drop it in `migrate_config_payload()` with a warning, so existing `agentos.toml` files carrying the key still load instead of failing validation at boot
- **Update** the serde test in tests/test_gateway/test_agent_subagent_defaults_serde.py

## Regression tests

Add `tests/test_subagents_archive_key_removal.py` covering:
- Config with the key still loads and drops it (decisive case: strict schema)
- Key is reported in `DEPRECATED_SUBAGENTS_FIELDS`
- Config without the key is unaffected

## Verification

```bash
uv run pytest tests/test_subagents_archive_key_removal.py tests/test_gateway/test_agent_subagent_defaults_serde.py -q
# 8 passed

uv run ruff check src tests
# All checks passed!
```

Refs #407
