### PR TITLE
Fix cron elevation docs: agent_run -> agent_turn, --elevated=off -> --no-elevated

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -549,6 +549,14 @@ security_grading = false
 # with the sandbox section.
 default_mode = "bypass"                 # off | on | bypass | full
 
+# Default elevation posture for unattended cron turns (agent_turn jobs only;
+# reminders, script jobs, and system events are never elevated). Separate
+# from default_mode above, which only governs interactive Control turns.
+# "bypass" lets a scheduled job run shell-based skills with no approval
+# prompt; override per-job with `--no-elevated` or `--elevated-mode`.
+# See docs/cli.md#letting-a-cron-job-run-shell-based-skills.
+cron_default_mode = "bypass"            # off | bypass | full
+
 # [auth]
 # mode = "none"         # none | token | password
 # token = ""

--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -31,11 +31,12 @@ For automation, prefer the narrowest profile that can complete the task.
 
 These profiles apply to interactive CLI and Web turns. For cron turns (unattended automation),
 the default elevated execution posture is controlled by `permissions.cron_default_mode` (which
-defaults to `bypass`). By default, cron jobs of kind `agent_run` run elevated (under `bypass`),
+defaults to `bypass`). By default, cron jobs of kind `agent_turn` run elevated (under `bypass`),
 whereas other job kinds (like reminders and script runs) are never elevated. You can explicitly
-override this default for any individual job by passing `--elevated=off` (or another mode)
-during job creation or update. See [`cli.md`](cli.md#letting-a-cron-job-run-shell-based-skills)
-for details and security implications.
+override this default for any individual job by passing `--no-elevated` (to opt out of elevation)
+or `--elevated-mode {bypass,full}` (to pick a specific mode) during job creation or update.
+See [`cli.md`](cli.md#letting-a-cron-job-run-shell-based-skills) for details and security
+implications.
 
 ## Workspace Containment
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,4 @@
-# CLI Reference. 
+# CLI Reference
 
 The `agentos` CLI is the fastest way to configure, run, inspect, and
 automate AgentOS.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,4 @@
-# CLI Reference
+# CLI Reference. 
 
 The `agentos` CLI is the fastest way to configure, run, inspect, and
 automate AgentOS.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -697,7 +697,7 @@ delivery and failure destinations stay CLI/Web/RPC-only. See
 
 ### Letting a cron job run shell-based skills
 
-By default, cron jobs of kind `agent_run` run elevated under the `bypass` mode
+By default, cron jobs of kind `agent_turn` run elevated under the `bypass` mode
 (controlled globally by `permissions.cron_default_mode`). This allows them to
 run shell-based commands (like those in skills) without interactive approval prompts.
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -491,10 +491,11 @@ agentos cron output <id> [--run <run-id>] [--json]
 agentos cron add --every 10m --job-kind agent_turn --script watch_rss.py \
   --script-arg --url --script-arg https://example.com/feed.xml \
   --text "Summarize anything urgent."
-# Cron turns are read-only by default, so a job cannot run a shell-based skill.
-# --elevated opts one agent-turn job out of that: no approval, no sandbox, host
-# shell as the user. See docs/cli.md before suggesting it.
-agentos cron add --every 6h --agent main --elevated --name "LP check" --text "..."
+# Cron turns run elevated by default (cron_default_mode="bypass"): an agent-turn
+# job CAN run shell-based skills unattended, with no approval prompt, no sandbox,
+# host shell as the user. --no-elevated opts one job out of that, running it
+# read-only instead. See docs/cli.md before suggesting either.
+agentos cron add --every 6h --agent main --no-elevated --name "LP check" --text "..."
 agentos cost                   # usage + estimated spend
 agentos diagnostics on         # runtime diagnostics logging
 agentos migrate hermes --source <dir> [--apply]   # dry-run first, then --apply


### PR DESCRIPTION
Fixes #370

Cron elevation was documented as read-only by default; it actually
runs elevated (cron_default_mode="bypass"). Fixed across all four
places this was wrong or inconsistent:

- SKILL.md: corrected the core "read-only by default" claim + swapped
  the example from --elevated to --no-elevated
- docs/cli.md, docs/approvals-and-permissions.md: fixed job kind
  agent_run -> agent_turn, and invalid flag --elevated=off -> --no-elevated
- agentos.toml.example: added permissions.cron_default_mode to the
  commented reference config