### PR TITLE
fix(sandbox): remove dead network_default config key (#360)

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -534,7 +534,6 @@ security_grading = false
 # default_level = "STANDARD"            # DISABLED | STANDARD | STRICT | LOCKED
 # backend = "auto"                       # auto | bubblewrap | seatbelt | noop
 # allow_legacy_mode = false              # required for default_level = DISABLED
-# network_default = "none"               # none | proxy_allowlist
 # denial_threshold = 3                   # pause autonomous runs after N denials
 # extra_ro_mounts = []
 # extra_rw_mounts = []

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -134,6 +134,19 @@ RETIRED_CHANNEL_TYPE_ALIASES: dict[str, str] = {
     "wecom": "wecom",
 }
 
+DEPRECATED_SANDBOX_FIELDS: frozenset[str] = frozenset(
+    {
+        # sandbox.network_default was a silent no-op: no code read it, and its
+        # only non-default value (proxy_allowlist) is unimplemented on both
+        # sandbox backends. Dropped so existing agentos.toml files carrying it
+        # keep loading instead of silently doing nothing.
+        "sandbox.network_default",
+    }
+)
+DEPRECATED_SANDBOX_LEAVES: frozenset[str] = frozenset(
+    k.removeprefix("sandbox.") for k in DEPRECATED_SANDBOX_FIELDS
+)
+
 DEPRECATED_AGENT_TOKEN_SAVING_FIELDS: frozenset[str] = frozenset(
     {
         "agent_token_saving.tool_result_compression_enabled",
@@ -527,6 +540,19 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
         if deprecated:
             builder.removed_fields.extend(sorted(deprecated))
             handle_deprecated_memory_fields(deprecated, "config_migration")
+
+    sandbox_section = builder.payload.get("sandbox")
+    if isinstance(sandbox_section, dict):
+        deprecated_sandbox: dict[str, object] = {}
+        for leaf in list(sandbox_section):
+            if leaf in DEPRECATED_SANDBOX_LEAVES:
+                deprecated_sandbox[f"sandbox.{leaf}"] = sandbox_section.pop(leaf)
+        if deprecated_sandbox:
+            builder.removed_fields.extend(sorted(deprecated_sandbox))
+            builder.warnings.append(
+                "sandbox.network_default was removed; no code read it and "
+                "proxy_allowlist is unimplemented on both sandbox backends"
+            )
 
     token_saving = builder.payload.get("agent_token_saving")
     if isinstance(token_saving, dict):

--- a/src/agentos/sandbox/config.py
+++ b/src/agentos/sandbox/config.py
@@ -25,7 +25,6 @@ from agentos.sandbox.types import SecurityLevel
 log = logging.getLogger(__name__)
 
 BackendName = Literal["auto", "bubblewrap", "seatbelt", "noop"]
-NetworkDefault = Literal["none", "proxy_allowlist"]
 
 
 @dataclass(frozen=True)
@@ -78,7 +77,6 @@ class SandboxSettings(BaseSettings):
     backend: BackendName = "auto"
     allow_legacy_mode: bool = False
 
-    network_default: NetworkDefault = "none"
     denial_threshold: int = 3
 
     extra_ro_mounts: list[str] = Field(default_factory=list)
@@ -157,6 +155,5 @@ class SandboxSettings(BaseSettings):
 __all__ = [
     "BackendName",
     "EffectiveMode",
-    "NetworkDefault",
     "SandboxSettings",
 ]

--- a/tests/test_sandbox_network_default_removal.py
+++ b/tests/test_sandbox_network_default_removal.py
@@ -1,0 +1,46 @@
+"""Removing sandbox.network_default must not break installs that set it.
+
+The key was a silent no-op: no code read it, and its only non-default value
+(proxy_allowlist) is unimplemented on both sandbox backends (seatbelt and
+bubblewrap raise SandboxBackendError on PROXY_ALLOWLIST). The deprecated-field
+migration drops the key so existing agentos.toml files keep loading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.gateway.config import GatewayConfig
+
+
+def test_an_existing_config_with_network_default_still_loads(tmp_path: Path):
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[sandbox]\n"
+        "sandbox = true\n"
+        "network_default = \"proxy_allowlist\"\n",
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.sandbox.sandbox is True
+    assert not hasattr(config.sandbox, "network_default")
+
+
+def test_the_dropped_key_is_reported_not_silently_eaten():
+    from agentos.gateway.config_migration import DEPRECATED_SANDBOX_FIELDS
+
+    assert "sandbox.network_default" in DEPRECATED_SANDBOX_FIELDS
+
+
+def test_a_config_without_the_key_is_unaffected(tmp_path: Path):
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[sandbox]\nsandbox = true\ndenial_threshold = 5\n",
+        encoding="utf-8",
+    )
+
+    cfg = GatewayConfig.load(config_path)
+    assert cfg.sandbox.sandbox is True
+    assert cfg.sandbox.denial_threshold == 5


### PR DESCRIPTION
## Summary

Remove `sandbox.network_default` from `SandboxSettings`. The key was a silent no-op: no code ever read it (`_resolve_network` in sandbox/policy.py never receives it), and its only non-default value (`proxy_allowlist`) is unimplemented on both sandbox backends — `seatbelt.py` and `bubblewrap.py` both raise `SandboxBackendError` on `NetworkMode.PROXY_ALLOWLIST`. `agentos.toml.example` advertised the key, so an operator setting it got a silent no-op today — and a crash if the value ever reached a backend.

## Changes

- **Remove** the `network_default` field and the `NetworkDefault` literal type from `SandboxSettings` (src/agentos/sandbox/config.py)
- **Remove** the example line from `agentos.toml.example`
- **Add** `sandbox.network_default` to a new `DEPRECATED_SANDBOX_FIELDS` set (src/agentos/gateway/config_migration.py) and drop it in `migrate_config_payload()` with a warning, so existing `agentos.toml` files carrying the key keep loading instead of silently doing nothing

The full domain-allowlisted egress proxy implementation stays tracked as a separate enhancement — this PR only removes the dead abstraction so it can't silently no-op.

## Regression tests

Add `tests/test_sandbox_network_default_removal.py` covering:
- Config with the key still loads and drops it
- Key is reported in `DEPRECATED_SANDBOX_FIELDS`
- Config without the key is unaffected

## Verification

```bash
uv run pytest tests/test_sandbox_network_default_removal.py -q
# 3 passed

uv run ruff check src tests
# All checks passed!
```

Refs #360
