### PR TITLE
fix(gateway): stop leaking raw exceptions in 500 responses (#353)

### DIFF
--- a/src/agentos/gateway/app.py
+++ b/src/agentos/gateway/app.py
@@ -564,7 +564,7 @@ def create_gateway_app(
     # ── Middleware ───────────────────────────────────────────────────────────
 
     middleware = [
-        Middleware(ErrorHandlingMiddleware),
+        Middleware(ErrorHandlingMiddleware, debug=config.debug),
         # DNS-rebinding guard: reject foreign Host headers on a loopback bind
         # (no-op ["*"] on a public bind, which is already auth-gated).
         Middleware(LoopbackHostMiddleware, allowed_hosts=resolve_trusted_hosts(config)),

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections import defaultdict
 from collections.abc import Callable
@@ -14,6 +15,8 @@ from starlette.types import ASGIApp
 
 from agentos.gateway.access import is_loopback_address
 from agentos.gateway.config import GatewayConfig
+
+log = logging.getLogger(__name__)
 
 # Endpoints that carry no credentials and expose no Control surface; exempt from
 # both token auth and the cross-origin guard. Kept module-level so the origin
@@ -296,14 +299,26 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
 
 class ErrorHandlingMiddleware(BaseHTTPMiddleware):
-    """Catch unhandled exceptions and return structured JSON errors."""
+    """Catch unhandled exceptions and return structured JSON errors.
+
+    Raw ``str(exc)`` can leak internal paths, SQL fragments, provider URLs,
+    and other host details to any client that can reach the gateway. Only
+    include the raw message when the gateway runs in debug mode; production
+    clients get a generic message while the full exception stays in the log.
+    """
+
+    def __init__(self, app: ASGIApp, debug: bool = False) -> None:
+        super().__init__(app)
+        self._debug = debug
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         try:
             return await call_next(request)  # type: ignore[no-any-return]
         except Exception as exc:
+            log.exception("unhandled gateway error on %s %s", request.method, request.url.path)
+            detail = str(exc) if self._debug else "internal server error"
             return JSONResponse(
-                {"error": str(exc), "code": "INTERNAL_ERROR"},
+                {"error": detail, "code": "INTERNAL_ERROR"},
                 status_code=500,
             )
 

--- a/tests/test_gateway/test_error_handling_middleware.py
+++ b/tests/test_gateway/test_error_handling_middleware.py
@@ -1,0 +1,45 @@
+"""Unhandled-exception responses must not leak internals outside debug mode.
+
+Raw str(exc) can contain host paths, SQL fragments, provider URLs, and other
+internals. Any client that can reach the gateway could harvest them from a
+500 response. The full exception belongs in the server log; production
+clients get a generic message.
+"""
+
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agentos.gateway.middleware import ErrorHandlingMiddleware
+
+
+def _boom(request):
+    raise RuntimeError("secret path /home/operator/.agentos/config.toml")
+
+
+def _app(debug: bool) -> TestClient:
+    app = Starlette(routes=[Route("/boom", _boom)])
+    app.add_middleware(ErrorHandlingMiddleware, debug=debug)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_production_mode_returns_generic_error():
+    resp = _app(debug=False).get("/boom")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["code"] == "INTERNAL_ERROR"
+    assert body["error"] == "internal server error"
+    assert "/home/operator" not in body["error"]
+    assert "secret" not in body["error"]
+
+
+def test_debug_mode_returns_raw_exception():
+    resp = _app(debug=True).get("/boom")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["code"] == "INTERNAL_ERROR"
+    assert "/home/operator/.agentos/config.toml" in body["error"]


### PR DESCRIPTION
## Summary

`ErrorHandlingMiddleware` returned raw `str(exc)` on every unhandled exception, regardless of debug mode. Exception strings can contain host paths, SQL fragments, provider URLs, and other internals — any client that can reach the gateway could harvest them from a 500 response.

## Changes

- **Pass `debug` into `ErrorHandlingMiddleware`** (wired from `config.debug` in app.py)
- **Production mode** (`debug=False`, the default): return generic `"internal server error"` and log the full exception server-side with traceback
- **Debug mode** (`debug=True`): keep the raw exception message for local development

## Regression tests

Add `tests/test_gateway/test_error_handling_middleware.py` covering:
- Production mode returns generic error, no internals leak
- Debug mode returns the raw exception message

## Verification

```bash
uv run pytest tests/test_gateway/test_error_handling_middleware.py -q
# 2 passed

uv run ruff check src tests
# All checks passed!
```

Refs #353
