### PR TITLE
fix(gateway): rate limiter XFF trust + unbounded buckets (#354)

### DIFF
--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -270,8 +270,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if request.method == "GET" and path == "/api/approvals":
             return await call_next(request)  # type: ignore[no-any-return]
 
-        client_ip = self._get_client_ip(request)
         now = time.time()
+        self._prune_windows(now)
+        client_ip = self._get_client_ip(request)
         window = self._config.rate_limit.window_seconds
         max_req = self._config.rate_limit.max_requests
 
@@ -286,13 +287,40 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._windows[client_ip].append(now)
         return await call_next(request)  # type: ignore[no-any-return]
 
+    # Cap the number of tracked client buckets. Without a bound, an attacker
+    # (or a botnet behind rotating IPs) grows _windows forever — a memory DoS
+    # on a long-lived gateway. 10k buckets is far above any legitimate LAN /
+    # small-team deployment while keeping memory bounded (~a few MB worst case).
+    _MAX_TRACKED_CLIENTS = 10_000
+
     def _get_client_ip(self, request: Request) -> str:
-        forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
+        # X-Forwarded-For is client-controlled on a direct (non-proxied)
+        # connection: trusting it unconditionally lets any caller rotate the
+        # header and bypass the rate limit entirely. Only honor it when the
+        # immediate peer is the configured trusted proxy.
+        peer = request.client.host if request.client else ""
+        trusted_proxy = self._config.auth.trusted_proxy
+        if trusted_proxy and peer == trusted_proxy:
+            forwarded = request.headers.get("x-forwarded-for")
+            if forwarded:
+                return forwarded.split(",")[0].strip()
         if request.client:
             return request.client.host
         return "unknown"
+
+    def _prune_windows(self, now: float) -> None:
+        """Drop fully-expired buckets and bound the tracked-client count."""
+        window = self._config.rate_limit.window_seconds
+        expired = [ip for ip, ts in self._windows.items() if not ts or now - ts[-1] >= window]
+        for ip in expired:
+            self._windows.pop(ip, None)
+        if len(self._windows) > self._MAX_TRACKED_CLIENTS:
+            # Evict oldest-seen buckets first (LRU-ish) to stay under the cap.
+            by_last_seen = sorted(
+                self._windows.items(), key=lambda kv: kv[1][-1] if kv[1] else 0.0
+            )
+            for ip, _ in by_last_seen[: len(self._windows) - self._MAX_TRACKED_CLIENTS]:
+                self._windows.pop(ip, None)
 
 
 class ErrorHandlingMiddleware(BaseHTTPMiddleware):

--- a/tests/test_gateway/test_rate_limit_middleware.py
+++ b/tests/test_gateway/test_rate_limit_middleware.py
@@ -1,0 +1,91 @@
+"""Rate limiter must not trust client-supplied X-Forwarded-For or grow unbounded.
+
+Two failure modes, one fix:
+
+1. Bypass: on a direct (non-proxied) connection, X-Forwarded-For is fully
+   client-controlled. Trusting it lets a caller rotate the header and get a
+   fresh bucket per request. It is only honored when the immediate peer is
+   the configured trusted proxy.
+
+2. DoS: _windows was an unbounded dict keyed by client IP — rotating source
+   IPs grew it forever on a long-lived gateway. Buckets are now pruned and
+   the tracked-client count is capped.
+"""
+
+from __future__ import annotations
+
+import time
+
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agentos.gateway.config import AuthConfig, GatewayConfig, RateLimitConfig
+from agentos.gateway.middleware import RateLimitMiddleware
+
+
+def _ok(request):
+    return PlainTextResponse("ok")
+
+
+def _app(config: GatewayConfig) -> tuple[TestClient, RateLimitMiddleware]:
+    inner = Starlette(routes=[Route("/", _ok)])
+    mw = RateLimitMiddleware(inner, config=config)
+    return TestClient(mw), mw
+
+
+def test_x_forwarded_for_is_ignored_without_trusted_proxy():
+    config = GatewayConfig(
+        rate_limit=RateLimitConfig(enabled=True, max_requests=2, window_seconds=60),
+    )
+    client, mw = _app(config)
+
+    for i in range(3):
+        resp = client.get("/", headers={"x-forwarded-for": f"10.0.0.{i}"})
+    # All three requests share one bucket (the real peer / testclient), so the
+    # third one is limited — rotating XFF must not bypass.
+    assert resp.status_code == 429
+    assert len(mw._windows) <= 2  # "unknown" or the single peer bucket
+
+
+def test_x_forwarded_for_honored_from_trusted_proxy():
+    config = GatewayConfig(
+        auth=AuthConfig(mode="trusted-proxy", trusted_proxy="testclient"),
+        rate_limit=RateLimitConfig(enabled=True, max_requests=1, window_seconds=60),
+    )
+    client, mw = _app(config)
+
+    # Peer's host under TestClient is "testclient"; when it matches the
+    # configured trusted proxy, distinct XFF values get distinct buckets.
+    client.get("/", headers={"x-forwarded-for": "10.0.0.1"})
+    resp = client.get("/", headers={"x-forwarded-for": "10.0.0.2"})
+    assert resp.status_code == 200
+    assert "10.0.0.1" in mw._windows and "10.0.0.2" in mw._windows
+
+
+def test_windows_dict_is_bounded():
+    config = GatewayConfig(
+        rate_limit=RateLimitConfig(enabled=True, max_requests=100, window_seconds=60),
+    )
+    _, mw = _app(config)
+
+    now = time.time()
+    # Simulate a flood from many distinct IPs.
+    for i in range(RateLimitMiddleware._MAX_TRACKED_CLIENTS + 500):
+        mw._windows[f"192.0.{i // 256}.{i % 256}"] = [now]
+
+    mw._prune_windows(now)
+    assert len(mw._windows) <= RateLimitMiddleware._MAX_TRACKED_CLIENTS
+
+
+def test_expired_buckets_are_pruned():
+    config = GatewayConfig(
+        rate_limit=RateLimitConfig(enabled=True, max_requests=1, window_seconds=1),
+    )
+    _, mw = _app(config)
+
+    stale = time.time() - 3600
+    mw._windows["192.0.2.1"] = [stale]
+    mw._prune_windows(time.time())
+    assert "192.0.2.1" not in mw._windows


### PR DESCRIPTION
## Summary

The gateway rate limiter had two holes:

1. **Bypass via `X-Forwarded-For`**: `_get_client_ip` trusted the header unconditionally. On a direct (non-proxied) connection the header is fully client-controlled — rotating it gave every request a fresh bucket, so the limiter never fired.

2. **Memory DoS via unbounded `_windows`**: the per-IP sliding-window dict grew forever. Rotating source IPs (or a botnet) on a long-lived gateway grew it without bound.

## Changes

- **Only honor `X-Forwarded-For` when the immediate peer is the configured `auth.trusted_proxy`** — otherwise use the real peer host
- **Prune fully-expired buckets** on every limited request
- **Cap tracked clients at 10,000** with LRU-ish eviction (oldest-seen first) — far above any legitimate LAN/small-team deployment while keeping memory bounded

## Regression tests

Add `tests/test_gateway/test_rate_limit_middleware.py` covering:
- XFF rotation without a trusted proxy does not bypass the limit
- XFF honored when the peer is the configured trusted proxy
- `_windows` stays under the cap under a simulated IP flood
- Expired buckets are pruned

## Verification

```bash
uv run pytest tests/test_gateway/test_rate_limit_middleware.py -q
# 4 passed

uv run ruff check src tests
# All checks passed!
```

Refs #354
