### PR TITLE
fix(gateway): gate bootstrap endpoint behind Origin guard (#351)

### DIFF
--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -138,6 +138,11 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     def _is_ui_path(self, path: str) -> bool:
         if self._ui_prefix is None:
             return False
+        # The bootstrap endpoint is served under the UI prefix but is an RPC
+        # payload (it leaks the host config path and auth mode), not a served
+        # page — it must stay behind the origin guard like any other /api/*.
+        if path == f"{self._ui_prefix}/api/bootstrap":
+            return False
         # Exact shell ("/control") or anything under it ("/control/..."),
         # never a bare-prefix match that would swallow sibling routes.
         return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")

--- a/tests/test_gateway/test_bootstrap_origin_guard.py
+++ b/tests/test_gateway/test_bootstrap_origin_guard.py
@@ -1,0 +1,54 @@
+"""The Control UI bootstrap endpoint must stay behind the Origin guard.
+
+/control/api/bootstrap is served under the UI prefix but is an RPC payload:
+it leaks the host config path and the auth mode to any cross-origin page that
+can fetch it. The UI-shell exemption exists for served pages (guarded by CSP),
+not for JSON RPC sinks — so the bootstrap route is carved out of it.
+"""
+
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agentos.gateway.config import GatewayConfig
+from agentos.gateway.middleware import LoopbackOriginMiddleware
+
+
+def _bootstrap(request):
+    return JSONResponse({"config_path": "/home/operator/.agentos/config.toml"})
+
+
+def _app() -> TestClient:
+    inner = Starlette(
+        routes=[
+            Route("/control/api/bootstrap", _bootstrap),
+            Route("/control", _bootstrap),
+        ]
+    )
+    config = GatewayConfig()
+    mw = LoopbackOriginMiddleware(inner, config=config, bind_is_loopback=True)
+    return TestClient(mw)
+
+
+def test_bootstrap_rejects_foreign_origin():
+    resp = _app().get(
+        "/control/api/bootstrap",
+        headers={"origin": "https://evil.example"},
+    )
+    assert resp.status_code == 403
+    assert b"config.toml" not in resp.content
+
+
+def test_bootstrap_allows_requests_without_origin():
+    # CLI/curl/browser navigations send no Origin — pass through.
+    resp = _app().get("/control/api/bootstrap")
+    assert resp.status_code == 200
+
+
+def test_ui_shell_still_exempt():
+    # The served shell itself remains exempt (CSP-guarded page, not RPC).
+    resp = _app().get("/control", headers={"origin": "https://evil.example"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

`/control/api/bootstrap` was exempt from the loopback Origin guard because the Control UI prefix exemption (`_is_ui_path`) covered everything under `/control/*`. But the bootstrap endpoint is not a served page — it's a JSON RPC payload that leaks the host `config_path` (an absolute filesystem path) and the `auth_mode`. With the default any-origin-readable posture, a malicious cross-origin page in the victim's browser could fetch it and learn where the config lives and how the gateway is secured.

## Changes

- **Carve `/control/api/bootstrap` out of the UI-shell exemption** in `LoopbackOriginMiddleware._is_ui_path` — it now goes through the same Origin guard as every other `/api/*` route
- The served shell and static assets stay exempt (they're CSP-guarded pages, not RPC sinks)

## Regression tests

Add `tests/test_gateway/test_bootstrap_origin_guard.py` covering:
- Foreign Origin gets 403 on the bootstrap endpoint, with no config-path leak
- Requests without an Origin header (CLI, curl, navigations) still pass
- The UI shell itself remains exempt

## Verification

```bash
uv run pytest tests/test_gateway/test_bootstrap_origin_guard.py -q
# 3 passed

uv run ruff check src tests
# All checks passed!
```

Refs #351
