### PR TITLE
Remove dead memory keys: daily_note_max_chars / daily_notes_total_max_chars

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -619,8 +619,6 @@ class MemoryConfig(BaseSettings):
     )
     capture_max_chars: int = 2000
     capture_roll_max_chars: int = Field(default=50_000, ge=0)
-    daily_note_max_chars: int = Field(default=4000, ge=0)
-    daily_notes_total_max_chars: int = Field(default=8000, ge=0)
 
     # Retriever tuning
     temporal_decay_enabled: bool = False
@@ -2154,8 +2152,6 @@ class GatewayConfig(BaseSettings):
             "mode": "stable",
             "prompt_cache_mode": self.prompt_cache.effective_mode,
             "query_embedding_cache": self.memory.cost.query_embedding_cache,
-            "daily_note_max_chars": str(self.memory.daily_note_max_chars),
-            "daily_notes_total_max_chars": str(self.memory.daily_notes_total_max_chars),
             "auto_capture_enabled": str(self.memory.auto_capture_enabled).lower(),
             "capture_effective_enabled": str(capture_effective_enabled).lower(),
             "capture_mode": self.memory.capture_mode,

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -68,6 +68,13 @@ DEPRECATED_MEMORY_FIELDS: frozenset[str] = frozenset(
         "memory.repair_enabled",
         "memory.repair_interval_seconds",
         "memory.repair_max_items_per_tick",
+        # Daily notes stopped being read in PR #111 (perf: stop reading daily
+        # notes that are always discarded); these two budget keys were left
+        # behind and are silently no-op. MemoryConfig forbids extras, so an
+        # existing agentos.toml carrying them would fail validation at boot
+        # without this. Dropped with the standard warning.
+        "memory.daily_note_max_chars",
+        "memory.daily_notes_total_max_chars",
     }
 )
 

--- a/tests/test_gateway_config_legacy.py
+++ b/tests/test_gateway_config_legacy.py
@@ -43,6 +43,8 @@ _ALL_DEPRECATED_MEMORY_FIELDS = {
     "memory.eviction_policy": "lru",
     "memory.summary_model": "gpt-4o-mini",
     "memory.summary_max_tokens": "256",
+    "memory.daily_note_max_chars": "4000",
+    "memory.daily_notes_total_max_chars": "8000",
 }
 
 


### PR DESCRIPTION
Fixes #405

`memory.daily_note_max_chars` and `memory.daily_notes_total_max_chars` are dead config keys: defined on `MemoryConfig` and exported by `memory_mode_fingerprint()`, but nothing consumes them (PR #111 stopped reading daily notes; `load_daily_notes()` has zero callers). An operator tuning either key gets a silent no-op, and the fingerprint advertises them as live memory knobs.

- Drop both fields from `MemoryConfig` (config.py)
- Drop both from `memory_mode_fingerprint()` so they stop reporting as live
- Register both in `DEPRECATED_MEMORY_FIELDS` (config_migration.py) so existing agentos.toml files drop them with a warning instead of failing validation at boot (the `memory.dream` / `memory.flush_*` precedent; `MemoryConfig` is `extra="forbid"`)
- Add both to the deprecated-fields fixture in test_gateway_config_legacy.py so the existing load-without-raising / aggregated-warning / per-field-log tests cover them