### PR TITLE
Remove dead sandbox key: network_default

### DIFF
--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -534,7 +534,6 @@ security_grading = false
 # default_level = "STANDARD"            # DISABLED | STANDARD | STRICT | LOCKED
 # backend = "auto"                       # auto | bubblewrap | seatbelt | noop
 # allow_legacy_mode = false              # required for default_level = DISABLED
-# network_default = "none"               # none | proxy_allowlist
 # denial_threshold = 3                   # pause autonomous runs after N denials
 # extra_ro_mounts = []
 # extra_rw_mounts = []

--- a/src/agentos/sandbox/config.py
+++ b/src/agentos/sandbox/config.py
@@ -25,7 +25,6 @@ from agentos.sandbox.types import SecurityLevel
 log = logging.getLogger(__name__)
 
 BackendName = Literal["auto", "bubblewrap", "seatbelt", "noop"]
-NetworkDefault = Literal["none", "proxy_allowlist"]
 
 
 @dataclass(frozen=True)
@@ -78,7 +77,6 @@ class SandboxSettings(BaseSettings):
     backend: BackendName = "auto"
     allow_legacy_mode: bool = False
 
-    network_default: NetworkDefault = "none"
     denial_threshold: int = 3
 
     extra_ro_mounts: list[str] = Field(default_factory=list)
@@ -157,6 +155,5 @@ class SandboxSettings(BaseSettings):
 __all__ = [
     "BackendName",
     "EffectiveMode",
-    "NetworkDefault",
     "SandboxSettings",
 ]


### PR DESCRIPTION
Fixes #360

`sandbox.network_default` is defined on SandboxSettings and advertised in
agentos.toml.example, but no code reads it: `_resolve_network` never receives
it, and both sandbox backends raise SandboxBackendError on PROXY_ALLOWLIST.
Setting it is a silent no-op.

- Remove the network_default field and the now-unused NetworkDefault alias
  (zero external users) from sandbox/config.py
- Remove the # network_default line from agentos.toml.example

No deprecated-key migration needed: SandboxSettings uses Pydantic's default
extra="ignore", so existing toml files carrying the key are ignored, not
rejected at boot (unlike MemoryConfig's extra="forbid"). The full
proxy_allowlist egress proxy is a separate enhancement, per the issue.