### PR TITLE
Log compaction-hook failures instead of swallowing them

### DIFF
--- a/src/agentos/engine/turn_runner/compaction_and_history_stage.py
+++ b/src/agentos/engine/turn_runner/compaction_and_history_stage.py
@@ -45,6 +45,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+import structlog
+
+log = structlog.get_logger(__name__)
+
 if TYPE_CHECKING:
     from agentos.engine.agent import Agent
     from agentos.engine.hooks.types import CompactionHook
@@ -339,13 +343,29 @@ class CompactionAndHistoryStage:
             try:
                 await hook.before_compact(state)
             except Exception:  # noqa: BLE001 — hook isolation contract
-                # A buggy hook MUST NOT break the turn. Swallow per
-                # protocol; observability is the runtime's concern.
-                pass
+                # A buggy hook MUST NOT break the turn. Still record it:
+                # during compaction a throwing hook can lose memory data,
+                # and "observability is the runtime's concern" means the
+                # runtime (here) must emit the trace, not swallow it.
+                log.warning(
+                    "compaction_hook_failed",
+                    hook=getattr(hook, "name", type(hook).__name__),
+                    phase="before_compact",
+                    session_key=getattr(state, "session_key", ""),
+                    agent_id=getattr(state, "agent_id", ""),
+                    exc_info=True,
+                )
 
     async def _fire_after_compact(self, state: Any, outcome: Any) -> None:
         for hook in self._compaction_hooks:
             try:
                 await hook.after_compact(state, outcome)
             except Exception:  # noqa: BLE001 — hook isolation contract
-                pass
+                log.warning(
+                    "compaction_hook_failed",
+                    hook=getattr(hook, "name", type(hook).__name__),
+                    phase="after_compact",
+                    session_key=getattr(state, "session_key", ""),
+                    agent_id=getattr(state, "agent_id", ""),
+                    exc_info=True,
+                )

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -796,7 +796,14 @@ class _CompactionHandler:
             try:
                 await hook.before_compact(state)
             except Exception:  # noqa: BLE001 - hook isolation contract
-                pass
+                log.warning(
+                    "compaction_hook_failed",
+                    hook=getattr(hook, "name", type(hook).__name__),
+                    phase="before_compact",
+                    session_key=state.session_key,
+                    agent_id=state.agent_id,
+                    exc_info=True,
+                )
 
     async def _fire_after_compact(
         self,
@@ -807,7 +814,14 @@ class _CompactionHandler:
             try:
                 await hook.after_compact(state, outcome)
             except Exception:  # noqa: BLE001 - hook isolation contract
-                pass
+                log.warning(
+                    "compaction_hook_failed",
+                    hook=getattr(hook, "name", type(hook).__name__),
+                    phase="after_compact",
+                    session_key=state.session_key,
+                    agent_id=state.agent_id,
+                    exc_info=True,
+                )
 
 # ---------------------------------------------------------------------------
 # Outer stage class


### PR DESCRIPTION
Part of #361

The turn/compaction hook surface is intentionally unpopulated today, but the
two stages that fire compaction hooks swallowed hook exceptions with a bare
`except Exception: pass`. Compaction is where memory capture/flush runs, so
a throwing hook would lose data with no trace.

This emits a structured `log.warning` on hook failure in both stages that fan
out compaction hooks, carrying hook name, phase, session_key, and agent_id:

- compaction_and_history_stage.py: add the missing structlog logger and log
  both `_fire_before_compact` / `_fire_after_compact` failures
- stream_consumer_stage.py: log the identical `_fire_before_compact` /
  `_fire_after_compact` pair (the logger already existed)

Hook isolation is preserved: a buggy hook still cannot break the turn, it
just no longer fails silently.

Out of scope (deliberately): the registration-path question in #361 — how
turn/compaction/tool hooks get populated on the service container — is a
design decision (config vs entry-point vs remove the surface) that should be
a maintainer's call, so this PR does not touch it.