### PR TITLE
Remove dead subagents key: archive_after_minutes

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1757,10 +1757,6 @@ class SubagentsGatewayConfig(BaseModel):
     """Number of slots in ``task_runtime.max_concurrency`` reserved for
     non-subagent tasks so a fan-out parent never starves itself."""
 
-    archive_after_minutes: int = Field(default=60, ge=0)
-    """Minutes after a subagent session goes terminal before its transcript
-    is archived. ``0`` disables auto-archive."""
-
     prompt_compact: bool = False
     """When enabled, subagent bootstrap prompts keep only AGENTS.md and TOOLS.md."""
 

--- a/tests/test_gateway/test_agent_subagent_defaults_serde.py
+++ b/tests/test_gateway/test_agent_subagent_defaults_serde.py
@@ -51,7 +51,6 @@ def test_gateway_config_exposes_agents_defaults_and_subagents_subtree() -> None:
     assert isinstance(cfg.subagents, SubagentsGatewayConfig)
     assert cfg.subagents.enforce_disabled_agents is False
     assert cfg.subagents.subagent_reserved_slots == 2
-    assert cfg.subagents.archive_after_minutes == 60
 
 
 def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
@@ -60,11 +59,9 @@ def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
         subagents=SubagentsGatewayConfig(
             enforce_disabled_agents=True,
             subagent_reserved_slots=4,
-            archive_after_minutes=0,
         ),
     )
     assert cfg.agents_defaults.subagents is not None
     assert cfg.agents_defaults.subagents.model == "haiku"
     assert cfg.subagents.enforce_disabled_agents is True
     assert cfg.subagents.subagent_reserved_slots == 4
-    assert cfg.subagents.archive_after_minutes == 0


### PR DESCRIPTION
Fixes #407

`subagents.archive_after_minutes` is defined on `SubagentsGatewayConfig` and
documented as driving a post-terminal auto-archive timer, but nothing reads
it: there is no auto-archive timer anywhere, and the machinery it would drive
(`SubagentRegistry.archive()` / `get_archived()`, and the `archived` handle
status) has zero callers. An operator tuning the key gets a silent no-op.

- Remove the field from `SubagentsGatewayConfig`
- Update the serde test that asserted its default/explicit values

No deprecated-key migration needed: `SubagentsGatewayConfig` is a plain
BaseModel with Pydantic's default `extra="ignore"` (the `extra="forbid"`
nearby belongs to `UpdatesConfig`), so an existing agentos.toml carrying the
key is silently ignored rather than rejected at boot. The unused
`SubagentRegistry.archive()`/`get_archived()` surface is left in place as a
future API; wiring an actual auto-archive timer is a separate enhancement.