### PR TITLE
docs(scheduling): fix stale read-only tool surface claim

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -202,9 +202,11 @@ Per tick:
 
 Same directory rule, same argv handling, and the same operator gate as a script
 job. The script's stdout is untrusted input arriving inside a prompt — the
-header says so to the model, and a cron turn's read-only tool surface is the
-real containment. Think twice before combining a pre-run script that reads the
-open internet with `--elevated`.
+header says so to the model, but the turn still runs elevated by default
+(`cron_default_mode="bypass"`), so that output can drive real shell-based skill
+calls with no approval prompt. Pass `--no-elevated` to drop a job back to a
+read-only tool surface, and prefer that whenever a pre-run script reads the
+open internet.
 
 ## Choose the Session Target
 


### PR DESCRIPTION
Follow-up to #413 (which this text predates).

The paragraph at `docs/scheduling.md` described the cron turn surface as read-only and framed `--elevated` as the dangerous opt-in. Both are stale since `cron_default_mode="bypass"` landed: the turn runs **elevated by default**, and `--no-elevated` is the opt-out.

This updates the paragraph to match the behavior already documented in `SKILL.md` and `cli.md`:

- script stdout is still untrusted input, but it now arrives in an elevated-by-default turn, so it can drive real shell-based skill calls with no approval prompt
- `--no-elevated` restores the read-only tool surface; prefer it when a pre-run script reads the open internet

Docs-only change.