### PR TITLE
fix(scheduler): honour cron delivery account_id in channel send

### DIFF
--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -335,6 +335,7 @@ class DeliveryChain:
             channel_name=channel_name,
             channel_id=channel_id,
             thread_id=thread_id,
+            account_id=job.delivery.account_id,
         )
 
     async def _deliver_origin_webchat_to_session(
@@ -414,15 +415,46 @@ class DeliveryChain:
         channel_name: str,
         channel_id: str,
         thread_id: str,
+        account_id: str = "",
     ) -> str:
-        """Send ``text`` via the registered channel adapter for ``channel_name``."""
+        """Send ``text`` via the registered channel adapter for ``channel_name``.
+
+        When ``account_id`` is set, the channel manager resolves the concrete
+        account/adapter instance authoritatively; an unknown or ambiguous
+        account fails loudly instead of silently delivering from the wrong one.
+        """
         text = strip_reply_directives(text) or ""
         if not self._channel_manager_ref:
             return "skipped"
         cm = self._channel_manager_ref()
         if cm is None:
             return "skipped"
-        adapter = cm.get(channel_name)
+        adapter = None
+        if account_id.strip():
+            resolved = cm.resolve_delivery_target(
+                target=channel_name,
+                to=channel_id,
+                account_id=account_id,
+                thread_id=thread_id,
+            )
+            if not resolved.ok:
+                log.warning(
+                    "delivery.account_resolution_failed",
+                    job_id=job_id,
+                    channel=channel_name,
+                    account_id=account_id,
+                    reason=resolved.reason,
+                )
+                return _failed(
+                    f"account {account_id!r} cannot serve channel {channel_name!r}: "
+                    f"{resolved.reason}"
+                )
+            adapter = resolved.adapter
+            channel_name = resolved.channel_type or channel_name
+            channel_id = resolved.to or channel_id
+            thread_id = resolved.thread_id or ""
+        else:
+            adapter = cm.get(channel_name)
         if adapter is None:
             log.warning(
                 "delivery.adapter_not_found",

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -867,7 +867,8 @@ def _session_storage_or_none() -> Any:
                     "type": "string",
                     "description": (
                         "Optional account binding for multi-account channels. "
-                        "Stored on the job but not yet honoured by channel delivery."
+                        "Channel delivery resolves the named account's adapter "
+                        "and fails loudly when the account is unknown."
                     ),
                 },
                 "thread_id": {

--- a/tests/test_scheduler/test_delivery_account_binding.py
+++ b/tests/test_scheduler/test_delivery_account_binding.py
@@ -1,0 +1,149 @@
+"""Cron delivery honours ``delivery.account_id`` (issue #359).
+
+Before the fix, ``_post_to_channel`` resolved the adapter from the channel
+name alone: a job pinned to a specific account on a multi-account channel
+silently delivered from the wrong one. The schema even documented the gap
+("Stored on the job but not yet honoured by channel delivery").
+
+These tests pin the new behaviour: the account binding is threaded into
+``ChannelManager.resolve_delivery_target`` and a bad binding fails loudly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.channels.types import DeliveryTargetResolution
+from agentos.scheduler.delivery import DeliveryChain
+from agentos.scheduler.payloads import make_script_payload
+from agentos.scheduler.types import CronJob, DeliveryConfig, DeliveryMode, SessionTarget
+
+
+class _RecordingAdapter:
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def send(self, message: Any) -> None:
+        self.sent.append(message)
+
+
+class _MultiAccountChannelManager:
+    """Stands in for ChannelManager with two accounts on one channel type."""
+
+    def __init__(self, adapters: dict[str, Any], channel_type: str = "telegram") -> None:
+        self._adapters = adapters
+        self._channel_type = channel_type
+        self.resolution_calls: list[dict[str, str]] = []
+
+    def get(self, name: str) -> Any:
+        return self._adapters.get(name)
+
+    def resolve_delivery_target(
+        self,
+        *,
+        target: str,
+        to: str = "",
+        account_id: str = "",
+        thread_id: str = "",
+    ) -> DeliveryTargetResolution:
+        self.resolution_calls.append(
+            {"target": target, "to": to, "account_id": account_id, "thread_id": thread_id}
+        )
+        account = account_id.strip()
+        if account:
+            adapter = self._adapters.get(account)
+            if adapter is None:
+                return DeliveryTargetResolution(ok=False, reason="unsupported_account")
+            return DeliveryTargetResolution(
+                ok=True,
+                adapter=adapter,
+                adapter_name=account,
+                channel_type=self._channel_type,
+                to=to,
+                account_id=account,
+                thread_id=thread_id,
+            )
+        adapter = self._adapters.get(target)
+        if adapter is None:
+            return DeliveryTargetResolution(ok=False, reason="unsupported_target")
+        return DeliveryTargetResolution(
+            ok=True,
+            adapter=adapter,
+            adapter_name=target,
+            channel_type=self._channel_type,
+            to=to,
+            account_id="",
+            thread_id=thread_id,
+        )
+
+
+def _job(account_id: str = "") -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="watch-memory",
+        handler_key="script_run",
+        payload=make_script_payload("watch-memory.sh"),
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="telegram",
+            channel_id="1245463966",
+            account_id=account_id,
+        ),
+    )
+
+
+async def _deliver(chain: DeliveryChain, job: CronJob) -> str:
+    report = await chain.deliver(
+        job,
+        result_text="3 alerts pending",
+        success=True,
+        summary="3 alerts pending",
+        session_key="cron:job-1:run:deadbeef",
+    )
+    return report.channel_status + (f": {report.channel_detail}" if report.channel_detail else "")
+
+
+@pytest.mark.asyncio
+async def test_account_id_selects_the_bound_account_adapter() -> None:
+    default_adapter = _RecordingAdapter()
+    pinned_adapter = _RecordingAdapter()
+    manager = _MultiAccountChannelManager(
+        {"telegram": default_adapter, "telegram-alerts": pinned_adapter}
+    )
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    result = await _deliver(chain, _job(account_id="telegram-alerts"))
+
+    assert result == "delivered"
+    assert manager.resolution_calls[0]["account_id"] == "telegram-alerts"
+    assert pinned_adapter.sent, "the pinned account's adapter must send the message"
+    assert not default_adapter.sent, "the default adapter must not be used"
+
+
+@pytest.mark.asyncio
+async def test_unknown_account_fails_loudly_instead_of_using_the_default() -> None:
+    default_adapter = _RecordingAdapter()
+    manager = _MultiAccountChannelManager({"telegram": default_adapter})
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    result = await _deliver(chain, _job(account_id="telegram-missing"))
+
+    assert "failed" in result, result
+    assert "unsupported_account" in result
+    assert not default_adapter.sent, "a bad binding must never fall back to the default"
+
+
+@pytest.mark.asyncio
+async def test_empty_account_id_keeps_the_legacy_name_only_path() -> None:
+    default_adapter = _RecordingAdapter()
+    manager = _MultiAccountChannelManager({"telegram": default_adapter})
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    result = await _deliver(chain, _job())
+
+    assert result == "delivered"
+    assert manager.resolution_calls == [], "no account binding, no account resolution"
+    assert default_adapter.sent


### PR DESCRIPTION
## Summary

Fixes the silent correctness bug from #359: a cron job's `delivery.account_id` flowed through the tool schema, `DeliveryConfig`, persistence, and the RPC round-trip — then was dropped before the actual channel send. On a multi-account channel, a job pinned to a specific account silently delivered from the wrong one.

## Change

- **`scheduler/delivery.py`** — `_post_to_channel` now accepts `account_id` and, when set, resolves the concrete account/adapter authoritatively via `ChannelManager.resolve_delivery_target()` (the same pattern `heartbeat_service` already uses). An unknown or unservable account **fails loudly** on the run record (`account 'x' cannot serve channel 'y': unsupported_account`) instead of silently falling back to the default adapter. Jobs without a binding keep the legacy name-only path — fully backward compatible.
- **`tools/builtin/control.py`** — the schema note ("Stored on the job but not yet honoured by channel delivery") is updated to describe the now-honoured behaviour.
- **`tests/test_scheduler/test_delivery_account_binding.py`** — new regression coverage: bound-account selection, unknown-account fail-loud, and the legacy unbound path.

## Verification

- Static checks pass; the new tests use the same `DeliveryChain` harness style as the existing delivery tests.
- I could not execute the pytest suite locally (sandbox runs Python 3.11; the repo requires ≥3.12 — same pre-existing environment mismatch noted in CI configs). Relying on CI to confirm; will address any failure immediately.

Refs #359. (Note: this was claimed by another contributor in the issue thread; I had the fix ready and am submitting it for consideration — happy to rebase, collaborate, or close if parallel work lands first.)