### PR TITLE
Fix #359: thread cron delivery.account_id to channel adapter

### DIFF
--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -298,6 +298,11 @@ class DeliveryChain:
             if target is not None and target.kind == "channel" and target.to is not None
             else job.delivery.channel_id
         )
+        account_id = (
+            target.account_id
+            if target is not None and target.kind == "channel" and target.account_id
+            else job.delivery.account_id
+        )
         thread_id = (
             target.thread_id
             if target is not None and target.kind == "channel"
@@ -334,6 +339,7 @@ class DeliveryChain:
             text=text,
             channel_name=channel_name,
             channel_id=channel_id,
+            account_id=account_id,
             thread_id=thread_id,
         )
 
@@ -412,17 +418,56 @@ class DeliveryChain:
         job_id: str,
         text: str,
         channel_name: str,
-        channel_id: str,
-        thread_id: str,
+        channel_id: str = "",
+        account_id: str = "",
+        thread_id: str = "",
     ) -> str:
-        """Send ``text`` via the registered channel adapter for ``channel_name``."""
+        """Send ``text`` via the registered channel adapter for ``channel_name``.
+
+        When ``account_id`` is provided on a multi-account channel, resolve the
+        specific adapter instance instead of falling back to the first match.
+        """
         text = strip_reply_directives(text) or ""
         if not self._channel_manager_ref:
             return "skipped"
         cm = self._channel_manager_ref()
         if cm is None:
             return "skipped"
-        adapter = cm.get(channel_name)
+
+        # Resolve the adapter, honouring account_id for multi-account channels.
+        if account_id:
+            resolution = cm.resolve_delivery_target(
+                target=channel_name,
+                to=channel_id,
+                account_id=account_id,
+                thread_id=thread_id,
+            )
+            if not resolution.ok:
+                log.warning(
+                    "delivery.account_resolution_failed",
+                    job_id=job_id,
+                    channel=channel_name,
+                    account_id=account_id,
+                    reason=resolution.reason,
+                )
+                # Fall back to the default adapter for the channel type
+                # so we never silently drop delivery when an account binding
+                # cannot be resolved.
+                adapter = cm.get(channel_name)
+            else:
+                adapter = resolution.adapter
+                channel_id = resolution.to or channel_id
+                thread_id = resolution.thread_id or thread_id
+                log.info(
+                    "delivery.account_resolved",
+                    job_id=job_id,
+                    channel=channel_name,
+                    account_id=account_id,
+                    adapter_name=resolution.adapter_name,
+                )
+        else:
+            adapter = cm.get(channel_name)
+
         if adapter is None:
             log.warning(
                 "delivery.adapter_not_found",
@@ -542,6 +587,7 @@ class DeliveryChain:
                 text=text,
                 channel_name=fd.channel_name,
                 channel_id=fd.channel_id,
+                account_id=fd.account_id,
                 thread_id=fd.thread_id,
             )
         return "skipped"

--- a/src/agentos/scheduler/types.py
+++ b/src/agentos/scheduler/types.py
@@ -96,7 +96,7 @@ class DeliveryConfig:
     mode: DeliveryMode = DeliveryMode.NONE
     channel_name: str = ""  # adapter key: "slack", "discord", "telegram"
     channel_id: str = ""  # target channel/chat ID
-    account_id: str = ""  # optional account binding for multi-account channels
+    account_id: str = ""  # optional account binding; threaded to adapter for multi-account channels
     thread_id: str = ""  # optional thread ID
     ws_topic: str = ""  # WS targeted push topic, default "cron:{job_id}"
     originating_reply_target: ReplyTargetSnapshot | None = None

--- a/src/agentos/tools/builtin/control.py
+++ b/src/agentos/tools/builtin/control.py
@@ -867,7 +867,8 @@ def _session_storage_or_none() -> Any:
                     "type": "string",
                     "description": (
                         "Optional account binding for multi-account channels. "
-                        "Stored on the job but not yet honoured by channel delivery."
+                        "When set, the delivery resolves the specific account "
+                        "adapter instead of falling back to the channel default."
                     ),
                 },
                 "thread_id": {

--- a/tests/test_scheduler/test_cron_delivery_account_id.py
+++ b/tests/test_scheduler/test_cron_delivery_account_id.py
@@ -1,0 +1,307 @@
+"""Cron delivery must thread account_id to the channel adapter.
+
+Bug: a cron job's delivery.account_id was stored and validated but silently
+dropped before the actual channel send. On a multi-account channel, a job bound
+to a specific account delivered from the wrong one — no error, just silent
+misrouting.
+
+Fix: _post_to_channel now accepts and uses account_id via
+ChannelManager.resolve_delivery_target, and _deliver_channel +
+_deliver_to_failure_destination thread it through.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentos.channels.types import DeliveryTargetResolution
+from agentos.scheduler.delivery import DeliveryChain
+from agentos.scheduler.types import (
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    FailureDestination,
+    SessionTarget,
+)
+
+# --- Helpers ----------------------------------------------------------------
+
+
+class _RecordingAdapter:
+    """Minimal adapter that records send calls."""
+
+    def __init__(self, name: str = "telegram") -> None:
+        self.name = name
+        self.sent: list[Any] = []
+
+    async def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+
+class _RecordingChannelManager:
+    """Channel manager that tracks resolve_delivery_target calls."""
+
+    def __init__(self) -> None:
+        self.adapters: dict[str, _RecordingAdapter] = {}
+        self.resolve_calls: list[dict[str, Any]] = []
+
+    def register(self, name: str) -> _RecordingAdapter:
+        adapter = _RecordingAdapter(name=name)
+        self.adapters[name] = adapter
+        return adapter
+
+    def get(self, name: str) -> _RecordingAdapter | None:
+        return self.adapters.get(name)
+
+    def resolve_delivery_target(
+        self,
+        *,
+        target: str,
+        to: str = "",
+        account_id: str = "",
+        thread_id: str = "",
+    ) -> DeliveryTargetResolution:
+        """Record the call and resolve to the named adapter if possible."""
+        self.resolve_calls.append(
+            {
+                "target": target,
+                "to": to,
+                "account_id": account_id,
+                "thread_id": thread_id,
+            }
+        )
+        # If we have an account_id, require an exact adapter match.
+        if account_id:
+            if account_id not in self.adapters:
+                return DeliveryTargetResolution(
+                    ok=False, reason="unsupported_account"
+                )
+            adapter = self.adapters[account_id]
+            return DeliveryTargetResolution(
+                ok=True,
+                adapter=adapter,
+                adapter_name=account_id,
+                channel_type=target.lower(),
+                to=to,
+                account_id=account_id,
+                thread_id=thread_id,
+            )
+        # Without account_id, fall back to type lookup.
+        adapter = self.adapters.get(target)
+        if adapter is None:
+            return DeliveryTargetResolution(ok=False, reason="unsupported_target")
+        return DeliveryTargetResolution(
+            ok=True,
+            adapter=adapter,
+            adapter_name=target,
+            channel_type=target.lower(),
+            to=to,
+            account_id="",
+            thread_id=thread_id,
+        )
+
+
+class _FakeSessionStorage:
+    """Minimal session storage for _deliver_channel code path."""
+
+    async def get_session(self, key: str) -> None:
+        return None
+
+    async def list_sessions(self, **kw: Any) -> list[Any]:
+        return []
+
+
+def _job_with_channel_delivery(
+    *,
+    account_id: str = "",
+    channel_name: str = "telegram",
+    channel_id: str = "12345",
+) -> CronJob:
+    return CronJob(
+        id="job-acct",
+        name="test-account-delivery",
+        cron_expr="* * * * *",
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "hello", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name=channel_name,
+            channel_id=channel_id,
+            account_id=account_id,
+        ),
+    )
+
+
+# --- Tests ------------------------------------------------------------------
+
+
+async def test_post_to_channel_passes_account_id_to_resolve() -> None:
+    """When account_id is set, _post_to_channel must call
+    resolve_delivery_target with that account_id instead of
+    falling back to cm.get(channel_name)."""
+    cm = _RecordingChannelManager()
+    # Register two accounts for "telegram" type:
+    # "telegram" (default) and "telegram-business" (named account).
+    default_adapter = cm.register("telegram")
+    business_adapter = cm.register("telegram-business")
+
+    chain = DeliveryChain(channel_manager_ref=lambda: cm)
+
+    job = _job_with_channel_delivery(account_id="telegram-business")
+    # Build a route envelope with the channel target so _deliver_channel
+    # reaches _post_to_channel.
+    from agentos.scheduler.routing import build_cron_route_envelope
+
+    envelope = build_cron_route_envelope(
+        job,
+        session_key="agent:main",
+        delivery=job.delivery,
+    )
+
+    result = await chain._deliver_channel(
+        job, "test message", envelope, session_key="agent:main:isolated:job-acct"
+    )
+
+    assert result == "delivered"
+    # resolve_delivery_target must have been called with account_id.
+    assert len(cm.resolve_calls) >= 1
+    resolve = cm.resolve_calls[0]
+    assert resolve["account_id"] == "telegram-business"
+    # The business adapter must have received the message, not the default.
+    assert len(business_adapter.sent) == 1
+    assert business_adapter.sent[0].content == "test message"
+    # Default adapter must NOT have received it.
+    assert len(default_adapter.sent) == 0
+
+
+async def test_post_to_channel_without_account_id_uses_get() -> None:
+    """When account_id is empty, _post_to_channel should fall back to the
+    simple cm.get(channel_name) path without calling resolve_delivery_target."""
+    cm = _RecordingChannelManager()
+    default_adapter = cm.register("telegram")
+
+    chain = DeliveryChain(channel_manager_ref=lambda: cm)
+
+    job = _job_with_channel_delivery(account_id="")
+    from agentos.scheduler.routing import build_cron_route_envelope
+
+    envelope = build_cron_route_envelope(
+        job,
+        session_key="agent:main",
+        delivery=job.delivery,
+    )
+
+    result = await chain._deliver_channel(
+        job, "plain message", envelope, session_key="agent:main:isolated:job-acct"
+    )
+
+    assert result == "delivered"
+    # Without account_id, resolve should NOT be called.
+    assert len(cm.resolve_calls) == 0
+    # The default adapter gets it via cm.get().
+    assert len(default_adapter.sent) == 1
+    assert default_adapter.sent[0].content == "plain message"
+
+
+async def test_post_to_channel_falls_back_on_bad_account_id() -> None:
+    """If resolve_delivery_target rejects an unknown account_id,
+    _post_to_channel must fall back to cm.get(channel_name) rather than
+    silently failing delivery."""
+    cm = _RecordingChannelManager()
+    default_adapter = cm.register("telegram")
+
+    chain = DeliveryChain(channel_manager_ref=lambda: cm)
+
+    # Request a non-existent account.
+    job = _job_with_channel_delivery(account_id="no-such-account")
+    from agentos.scheduler.routing import build_cron_route_envelope
+
+    envelope = build_cron_route_envelope(
+        job,
+        session_key="agent:main",
+        delivery=job.delivery,
+    )
+
+    result = await chain._deliver_channel(
+        job, "fallback message", envelope, session_key="agent:main:isolated:job-acct"
+    )
+
+    # Delivery must still succeed via the fallback adapter.
+    assert result == "delivered"
+    assert len(default_adapter.sent) == 1
+    assert default_adapter.sent[0].content == "fallback message"
+
+
+async def test_failure_destination_threads_account_id() -> None:
+    """FailureDestination.account_id must be threaded through to
+    _post_to_channel for multi-account failure alerting."""
+    cm = _RecordingChannelManager()
+    cm.register("slack")
+    ops_adapter = cm.register("slack-ops")
+
+    chain = DeliveryChain(channel_manager_ref=lambda: cm)
+
+    job = CronJob(
+        id="job-fd-acct",
+        name="test",
+        cron_expr="* * * * *",
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "x", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.NONE,
+            failure_destination=FailureDestination(
+                mode=DeliveryMode.CHANNEL,
+                channel_name="slack",
+                channel_id="C-ops",
+                account_id="slack-ops",
+            ),
+        ),
+    )
+
+    status = await chain.dispatch_failure_alert(job, "heartbeat dead")
+
+    assert status == "delivered"
+    # resolve_delivery_target should have been called with account_id.
+    assert len(cm.resolve_calls) >= 1
+    assert cm.resolve_calls[0]["account_id"] == "slack-ops"
+    # The ops adapter should have received the alert.
+    assert len(ops_adapter.sent) == 1
+    assert ops_adapter.sent[0].content == "heartbeat dead"
+
+
+async def test_deliver_channel_prefers_reply_target_account_id() -> None:
+    """When the route envelope's reply_target carries an account_id,
+    _deliver_channel must prefer it over job.delivery.account_id."""
+    cm = _RecordingChannelManager()
+    cm.register("telegram")
+    biz_adapter = cm.register("telegram-biz")
+
+    job = _job_with_channel_delivery(account_id="telegram")
+    # Simulate a reply_target with a different account_id.
+    from agentos.scheduler.routing import build_cron_route_envelope
+
+    envelope = build_cron_route_envelope(
+        job,
+        session_key="agent:main",
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name="telegram",
+            channel_id="12345",
+            account_id="telegram-biz",
+        ),
+    )
+
+    chain = DeliveryChain(channel_manager_ref=lambda: cm)
+
+    result = await chain._deliver_channel(
+        job, "routed message", envelope, session_key="agent:main:isolated:job-acct"
+    )
+
+    assert result == "delivered"
+    # The account_id from the delivery config used to build the envelope
+    # should be threaded — in this case "telegram-biz".
+    assert len(cm.resolve_calls) >= 1
+    assert cm.resolve_calls[0]["account_id"] == "telegram-biz"
+    assert len(biz_adapter.sent) == 1


### PR DESCRIPTION
## Summary

Cron `delivery.account_id` was stored on the job, validated in the tool schema, persisted, and serialized through RPC — then silently dropped before the actual channel send. On a multi-account channel (e.g., two Telegram bots), a job explicitly pinned to a specific account would deliver from the wrong one with no error.

Fixes #359.

## Changes

### `src/agentos/scheduler/delivery.py`
- **`_post_to_channel`** now accepts an `account_id` parameter. When set, it calls `ChannelManager.resolve_delivery_target()` with the account binding to select the correct adapter instance for multi-account channels. Falls back to `cm.get(channel_name)` when `account_id` is empty or resolution fails.
- **`_deliver_channel`** extracts `account_id` from the route envelope's `reply_target` (preferred) or `job.delivery` (fallback) and threads it to `_post_to_channel`.
- **`_deliver_to_failure_destination`** threads `fd.account_id` to `_post_to_channel` so failure alerts also honour account bindings.

### `src/agentos/scheduler/types.py`
- Updated `DeliveryConfig.account_id` comment to note it is now threaded to the channel adapter.

### `src/agentos/tools/builtin/control.py`
- Updated the `account_id` schema description from "Stored on the job but not yet honoured by channel delivery" to document the now-functional behaviour.

### `tests/test_scheduler/test_cron_delivery_account_id.py` (new)
- `test_post_to_channel_passes_account_id_to_resolve` — verifies specific account resolution.
- `test_post_to_channel_without_account_id_uses_get` — verifies empty account_id fallback.
- `test_post_to_channel_falls_back_on_bad_account_id` — graceful fallback on unknown account.
- `test_failure_destination_threads_account_id` — failure alerts honour account bindings.
- `test_deliver_channel_prefers_reply_target_account_id` — route envelope takes precedence.

## Quality gate
- `ruff check` → all checks passed
- `mypy` → success, no issues found
- `pytest` → 436 passed (full scheduler suite + 5 new tests)