### PR TITLE
feat(scheduler): implement transient retry policy for webhook and cha…

### DIFF
--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -28,9 +28,7 @@ SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
-_REPLY_DIRECTIVE_RE = re.compile(
-    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
-)
+_REPLY_DIRECTIVE_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
 
 
 def strip_reply_directives(text: str | None) -> str | None:
@@ -48,11 +46,53 @@ def validate_webhook_url(url: str) -> None:
     except ValueError as exc:
         raise ValueError(f"invalid webhook URL: {url!r}") from exc
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(
-            f"webhook URL must use http or https scheme, got {parsed.scheme!r}"
-        )
+        raise ValueError(f"webhook URL must use http or https scheme, got {parsed.scheme!r}")
     if not parsed.hostname:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
+
+
+def _is_transient_delivery_error(exc: Exception) -> bool:
+    import asyncio
+
+    import httpx
+
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    if hasattr(httpx, "TimeoutException") and isinstance(exc, httpx.TimeoutException):
+        return True
+    if hasattr(httpx, "NetworkError") and isinstance(exc, httpx.NetworkError):
+        return True
+    if hasattr(httpx, "HTTPStatusError") and isinstance(exc, httpx.HTTPStatusError):
+        if exc.response.status_code in (429, 502, 503, 504):
+            return True
+
+    # Text-based fallback to match general socket/connection exceptions
+    msg = str(exc).lower()
+    transient_patterns = (
+        "rate limit",
+        "too many requests",
+        "resource exhausted",
+        "429",
+        "529",
+        "overload",
+        "timeout",
+        "timed out",
+        "econnreset",
+        "fetch failed",
+        "socket",
+        "network",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "502",
+        "503",
+        "504",
+        "cloudflare",
+    )
+    for pattern in transient_patterns:
+        if pattern in msg:
+            return True
+    return False
 
 
 # The origin webchat session a job was born in no longer exists. Deliberately
@@ -448,14 +488,39 @@ class DeliveryChain:
                     )
             else:
                 msg = OutgoingMessage(content=text, reply_to=channel_id or None)
-            await asyncio.wait_for(adapter.send(msg), timeout=30.0)
-            log.info("delivery.channel_sent", job_id=job_id, channel=channel_name)
-            return "delivered"
         except Exception as exc:
-            log.warning("delivery.channel_failed", job_id=job_id, exc_info=True)
-            # The provider's own words ("Bad Request: chat not found") are what
-            # make the run record actionable, so they go on the report too.
+            log.warning("delivery.channel_creation_failed", job_id=job_id, exc_info=True)
             return _failed(str(exc) or type(exc).__name__)
+
+        attempts = 3
+        delay = 1.0
+        for attempt in range(1, attempts + 1):
+            try:
+                await asyncio.wait_for(adapter.send(msg), timeout=30.0)
+                log.info("delivery.channel_sent", job_id=job_id, channel=channel_name)
+                return "delivered"
+            except Exception as exc:
+                is_transient = _is_transient_delivery_error(exc)
+                if attempt == attempts or not is_transient:
+                    log.warning(
+                        "delivery.channel_failed",
+                        job_id=job_id,
+                        attempt=attempt,
+                        is_transient=is_transient,
+                        exc_info=True,
+                    )
+                    # The provider's own words ("Bad Request: chat not found") are what
+                    # make the run record actionable, so they go on the report too.
+                    return _failed(str(exc) or type(exc).__name__)
+                log.info(
+                    "delivery.channel_retry",
+                    job_id=job_id,
+                    attempt=attempt,
+                    error=str(exc),
+                )
+                await asyncio.sleep(delay)
+                delay *= 2.0
+        return _failed("max delivery retries exceeded")
 
     async def _post_to_webhook(
         self,
@@ -488,15 +553,35 @@ class DeliveryChain:
             "summary": text,
             "deliveredAt": datetime.now(UTC).isoformat(),
         }
-        try:
-            async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:
-                response = await client.post(url, json=payload, headers=headers)
-                response.raise_for_status()
-            log.info("delivery.webhook_sent", job_id=job_id)
-            return "delivered"
-        except Exception as exc:
-            log.warning("delivery.webhook_failed", job_id=job_id, exc_info=True)
-            return _failed(str(exc) or type(exc).__name__)
+        attempts = 3
+        delay = 1.0
+        for attempt in range(1, attempts + 1):
+            try:
+                async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:
+                    response = await client.post(url, json=payload, headers=headers)
+                    response.raise_for_status()
+                log.info("delivery.webhook_sent", job_id=job_id)
+                return "delivered"
+            except Exception as exc:
+                is_transient = _is_transient_delivery_error(exc)
+                if attempt == attempts or not is_transient:
+                    log.warning(
+                        "delivery.webhook_failed",
+                        job_id=job_id,
+                        attempt=attempt,
+                        is_transient=is_transient,
+                        exc_info=True,
+                    )
+                    return _failed(str(exc) or type(exc).__name__)
+                log.info(
+                    "delivery.webhook_retry",
+                    job_id=job_id,
+                    attempt=attempt,
+                    error=str(exc),
+                )
+                await asyncio.sleep(delay)
+                delay *= 2.0
+        return _failed("max delivery retries exceeded")
 
     async def _deliver_webhook(self, job: CronJob, text: str) -> str:
         """Primary webhook delivery — POST to ``delivery.webhook_url``."""

--- a/tests/test_scheduler/test_delivery_retry.py
+++ b/tests/test_scheduler/test_delivery_retry.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from agentos.channels.types import OutgoingMessage
+from agentos.scheduler.delivery import DeliveryChain, _is_transient_delivery_error
+
+
+def test_is_transient_delivery_error() -> None:
+    # Timeout
+    assert _is_transient_delivery_error(TimeoutError()) is True
+    assert _is_transient_delivery_error(httpx.TimeoutException("timeout")) is True
+
+    # NetworkError
+    assert _is_transient_delivery_error(httpx.NetworkError("network error")) is True
+
+    # HTTPStatusError - transient
+    resp_503 = httpx.Response(503, request=httpx.Request("POST", "https://example.com"))
+    err_503 = httpx.HTTPStatusError("503", request=resp_503.request, response=resp_503)
+    assert _is_transient_delivery_error(err_503) is True
+
+    resp_429 = httpx.Response(429, request=httpx.Request("POST", "https://example.com"))
+    err_429 = httpx.HTTPStatusError("429", request=resp_429.request, response=resp_429)
+    assert _is_transient_delivery_error(err_429) is True
+
+    # HTTPStatusError - permanent
+    resp_403 = httpx.Response(403, request=httpx.Request("POST", "https://example.com"))
+    err_403 = httpx.HTTPStatusError("403", request=resp_403.request, response=resp_403)
+    assert _is_transient_delivery_error(err_403) is False
+
+    # Text based pattern
+    assert _is_transient_delivery_error(Exception("Rate limit exceeded")) is True
+    assert _is_transient_delivery_error(Exception("Connection reset by peer econnreset")) is True
+    assert _is_transient_delivery_error(Exception("Unauthorized access")) is False
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.raise_transient = True
+
+    async def send(self, message: OutgoingMessage) -> None:
+        self.call_count += 1
+        if self.raise_transient and self.call_count == 1:
+            raise httpx.NetworkError("temporary connection failure")
+
+
+class _FakeChannelManager:
+    def __init__(self, adapter: _FakeAdapter | None) -> None:
+        self.adapter = adapter
+
+    def get(self, name: str) -> _FakeAdapter | None:
+        return self.adapter
+
+
+@pytest.mark.asyncio
+async def test_post_to_webhook_retry_success() -> None:
+    chain = DeliveryChain(channel_manager_ref=lambda: None)
+
+    call_count = 0
+
+    async def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        req = httpx.Request("POST", "https://hooks.example.com")
+        if call_count == 1:
+            resp_503 = httpx.Response(503, request=req)
+            raise httpx.HTTPStatusError("503", request=req, response=resp_503)
+        return httpx.Response(200, request=req)
+
+    # Use patch to mock httpx.AsyncClient.post with a custom async function
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_client_post:
+        mock_client_post.side_effect = mock_post
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            res = await chain._post_to_webhook(
+                job_id="job-1",
+                job_name="test-job",
+                text="hello",
+                url="https://hooks.example.com",
+                token="",
+            )
+            assert res == "delivered"
+            assert call_count == 2
+            mock_sleep.assert_called_once_with(1.0)
+
+
+@pytest.mark.asyncio
+async def test_post_to_webhook_permanent_failure_no_retry() -> None:
+    chain = DeliveryChain(channel_manager_ref=lambda: None)
+
+    call_count = 0
+
+    async def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        req = httpx.Request("POST", "https://hooks.example.com")
+        resp_403 = httpx.Response(403, request=req)
+        raise httpx.HTTPStatusError("403", request=req, response=resp_403)
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_client_post:
+        mock_client_post.side_effect = mock_post
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            res = await chain._post_to_webhook(
+                job_id="job-1",
+                job_name="test-job",
+                text="hello",
+                url="https://hooks.example.com",
+                token="",
+            )
+            assert res == "delivery_failed"
+            assert res.detail == "403"
+            assert call_count == 1
+            mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_to_channel_retry_success() -> None:
+    adapter = _FakeAdapter()
+    manager = _FakeChannelManager(adapter)
+    chain = DeliveryChain(channel_manager_ref=lambda: manager)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        res = await chain._post_to_channel(
+            job_id="job-1",
+            text="hello",
+            channel_name="slack",
+            channel_id="C123",
+            thread_id="",
+        )
+        assert res == "delivered"
+        assert adapter.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)


### PR DESCRIPTION
closes #430 

### Description
Currently, when the scheduler runs a cron job, any temporary network hiccup, HTTP 502/503/504 error, or 429 rate limit during primary delivery or `failure_destination` alerts causes the delivery to fail permanently without retrying.

This PR implements a transient retry policy in `DeliveryChain` for both webhook and channel adapters:
* Classifies errors as transient if they represent connection issues, timeouts, or specific HTTP status codes (`429`, `502`, `503`, `504`).
* Automatically retries transient errors up to 3 times with exponential backoff starting at `1.0s` (doubling on each retry).
* Unchanged delivery configurations are preserved and behave normally on permanent errors (e.g. `403 Forbidden` or `401 Unauthorized`), failing immediately.

### Proposed Changes
* **[`delivery.py`](file:///c:/Users/SHATTER/.vscode/agent-os/src/agentos/scheduler/delivery.py)**: Added transient classifier `_is_transient_delivery_error(exc: Exception) -> bool` and wrapped both `_post_to_channel` and `_post_to_webhook` in a retry loop.
* **[`test_delivery_retry.py`](file:///c:/Users/SHATTER/.vscode/agent-os/tests/test_scheduler/test_delivery_retry.py)**: Added unit test cases covering transient/permanent classification, successful retries on webhook/channel delivery, and immediate failures on permanent status codes.

### Testing
Ran all scheduler delivery tests successfully:
```sh
uv run pytest tests/test_scheduler/test_webhook_delivery.py tests/test_scheduler/test_delivery_retry.py -q
```
* **Result**: `15 passed`