### PR TITLE
feat(scheduler): transient retry policy for channel/webhook delivery …

### DIFF
--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -28,9 +28,14 @@ SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
-_REPLY_DIRECTIVE_RE = re.compile(
-    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
-)
+
+# Transient delivery retry policy. A successful run whose *delivery* hit a
+# transient error (429/502/503, timeout, DNS/network hiccup) should not be
+# reported as ``delivery_failed`` forever — retry with exponential backoff
+# before giving up. Permanent errors (auth/config-style) fail immediately.
+_TRANSIENT_MAX_RETRIES = 3
+_TRANSIENT_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+_REPLY_DIRECTIVE_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
 
 
 def strip_reply_directives(text: str | None) -> str | None:
@@ -48,9 +53,7 @@ def validate_webhook_url(url: str) -> None:
     except ValueError as exc:
         raise ValueError(f"invalid webhook URL: {url!r}") from exc
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(
-            f"webhook URL must use http or https scheme, got {parsed.scheme!r}"
-        )
+        raise ValueError(f"webhook URL must use http or https scheme, got {parsed.scheme!r}")
     if not parsed.hostname:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
 
@@ -128,6 +131,45 @@ class DeliveryChain:
         self._channel_manager_ref = channel_manager_ref
         self._ws_emitter = ws_emitter
         self._session_forwarder = session_forwarder
+
+    @staticmethod
+    async def _retry_transient(
+        fn: Callable[[], Awaitable[Any]],
+        *,
+        job_id: str,
+    ) -> Any:
+        """Run ``fn`` with exponential-backoff retries on transient errors.
+
+        Error text is classified with ``scheduler.jobs.classify_error`` so
+        permanent failures (auth/config-style signatures such as 401/403 or
+        an invalid key) fail immediately, while transient ones (rate limits,
+        timeouts, 5xx, DNS/network issues) retry up to
+        ``_TRANSIENT_MAX_RETRIES`` times, sleeping ``_TRANSIENT_BACKOFF_SECONDS``
+        between attempts. Returns the first non-raising result; re-raises the
+        last error when every attempt is exhausted.
+        """
+        from agentos.scheduler.jobs import classify_error
+
+        last_error: Exception | None = None
+        for attempt in range(1, _TRANSIENT_MAX_RETRIES + 1):
+            try:
+                return await fn()
+            except Exception as exc:  # noqa: BLE001 - classification decides
+                last_error = exc
+                if classify_error(str(exc)) != "transient":
+                    raise
+                if attempt < _TRANSIENT_MAX_RETRIES:
+                    delay = _TRANSIENT_BACKOFF_SECONDS[attempt - 1]
+                    log.warning(
+                        "delivery.transient_retry",
+                        job_id=job_id,
+                        attempt=attempt,
+                        retry_delay_seconds=delay,
+                        error=str(exc)[:200],
+                    )
+                    await asyncio.sleep(delay)
+        assert last_error is not None
+        raise last_error
 
     @staticmethod
     def _is_script_job(job: CronJob) -> bool:
@@ -448,7 +490,11 @@ class DeliveryChain:
                     )
             else:
                 msg = OutgoingMessage(content=text, reply_to=channel_id or None)
-            await asyncio.wait_for(adapter.send(msg), timeout=30.0)
+
+            async def _send() -> None:
+                await asyncio.wait_for(adapter.send(msg), timeout=30.0)
+
+            await self._retry_transient(_send, job_id=job_id)
             log.info("delivery.channel_sent", job_id=job_id, channel=channel_name)
             return "delivered"
         except Exception as exc:
@@ -490,8 +536,12 @@ class DeliveryChain:
         }
         try:
             async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:
-                response = await client.post(url, json=payload, headers=headers)
-                response.raise_for_status()
+
+                async def _post() -> None:
+                    response = await client.post(url, json=payload, headers=headers)
+                    response.raise_for_status()
+
+                await self._retry_transient(_post, job_id=job_id)
             log.info("delivery.webhook_sent", job_id=job_id)
             return "delivered"
         except Exception as exc:

--- a/tests/test_scheduler/test_delivery_retry.py
+++ b/tests/test_scheduler/test_delivery_retry.py
@@ -1,0 +1,252 @@
+"""Transient retry policy for channel/webhook delivery (#430).
+
+A successful run whose *delivery* hit a transient error (429/502/503,
+timeout, DNS/network hiccup) must be retried with exponential backoff
+instead of being reported as ``delivery_failed`` forever. Permanent
+errors (auth/config-style signatures) fail immediately without retries.
+Both the primary delivery path and ``failure_destination`` alerts route
+through the same two methods, so retrying them covers both.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from agentos.scheduler import delivery as delivery_module
+from agentos.scheduler.delivery import (
+    _TRANSIENT_MAX_RETRIES,
+    DeliveryChain,
+)
+from agentos.scheduler.types import (
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    FailureDestination,
+    SessionTarget,
+)
+
+
+def _no_sleep() -> None:
+    """Tests must not wait on real backoff delays."""
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch) -> None:
+    monkeypatch.setattr(delivery_module, "_TRANSIENT_BACKOFF_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(
+        delivery_module,
+        "_TRANSIENT_MAX_RETRIES",
+        3,
+    )
+
+
+def _webhook_job(url: str, token: str = "") -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="hook",
+        cron_expr="*/5 * * * *",
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "x", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.WEBHOOK,
+            webhook_url=url,
+            webhook_token=token,
+        ),
+    )
+
+
+class _StatusResp:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _install_fake_httpx(
+    monkeypatch,
+    *,
+    failures: int = 0,
+    fail_text: str = "502 Bad Gateway",
+) -> type:
+    """Install a fake ``httpx`` module whose AsyncClient fails the first
+    ``failures`` POSTs with ``fail_text`` then succeeds.
+    """
+
+    class _FlakyClient:
+        instances: list[_FlakyClient] = []
+
+        def __init__(self, *, timeout=None, **_kw) -> None:
+            self.timeout = timeout
+            self.posts: list[dict] = []
+            _FlakyClient.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            self.posts.append({"url": url, "json": json, "headers": headers or {}})
+            if len(self.posts) <= failures:
+                raise RuntimeError(fail_text)
+            return _StatusResp(200)
+
+    class _FakeHttpx:
+        AsyncClient = _FlakyClient
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+    return _FlakyClient
+
+
+# --- webhook: transient ----------------------------------------------------
+
+
+async def test_webhook_transient_error_retries_then_delivers(monkeypatch) -> None:
+    client_cls = _install_fake_httpx(monkeypatch, failures=2)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(_webhook_job("https://hooks.example/cron"), text="x")
+
+    assert status == "delivered"
+    client = client_cls.instances[-1]
+    assert len(client.posts) == 3, "transient failure should be retried twice"
+
+
+async def test_webhook_transient_error_exhausts_retries(monkeypatch) -> None:
+    client_cls = _install_fake_httpx(monkeypatch, failures=99, fail_text="Connection timeout")
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(_webhook_job("https://hooks.example/cron"), text="x")
+
+    assert status == "delivery_failed"
+    client = client_cls.instances[-1]
+    assert len(client.posts) == _TRANSIENT_MAX_RETRIES
+
+
+async def test_webhook_rate_limit_error_is_transient(monkeypatch) -> None:
+    client_cls = _install_fake_httpx(monkeypatch, failures=1, fail_text="429 Too Many Requests")
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(_webhook_job("https://hooks.example/cron"), text="x")
+
+    assert status == "delivered"
+    client = client_cls.instances[-1]
+    assert len(client.posts) == 2
+
+
+# --- webhook: permanent ----------------------------------------------------
+
+
+async def test_webhook_permanent_error_does_not_retry(monkeypatch) -> None:
+    client_cls = _install_fake_httpx(monkeypatch, failures=99, fail_text="401 Unauthorized")
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(_webhook_job("https://hooks.example/cron"), text="x")
+
+    assert status == "delivery_failed"
+    client = client_cls.instances[-1]
+    assert len(client.posts) == 1, "permanent errors must fail fast"
+
+
+# --- channel ---------------------------------------------------------------
+
+
+class _FlakyAdapter:
+    def __init__(self, failures: int = 0, fail_text: str = "") -> None:
+        self.sends = 0
+        self.failures = failures
+        self.fail_text = fail_text
+
+    async def send(self, msg) -> None:
+        self.sends += 1
+        if self.sends <= self.failures:
+            raise RuntimeError(self.fail_text)
+
+
+class _FakeChannelManager:
+    def __init__(self, adapter) -> None:
+        self.adapter = adapter
+
+    def get(self, channel_name: str):
+        return self.adapter
+
+
+def _channel_job(channel_name: str = "telegram", channel_id: str = "C1") -> CronJob:
+    return CronJob(
+        id="job-2",
+        name="chan",
+        cron_expr="*/5 * * * *",
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "x", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        delivery=DeliveryConfig(
+            mode=DeliveryMode.CHANNEL,
+            channel_name=channel_name,
+            channel_id=channel_id,
+        ),
+    )
+
+
+async def test_channel_transient_error_retries_then_delivers() -> None:
+    adapter = _FlakyAdapter(failures=2, fail_text="429 Too Many Requests")
+    chain = DeliveryChain(
+        channel_manager_ref=lambda: _FakeChannelManager(adapter),
+    )
+
+    status = await chain._post_to_channel(
+        job_id="job-2",
+        text="x",
+        channel_name="telegram",
+        channel_id="C1",
+        thread_id="",
+    )
+
+    assert status == "delivered"
+    assert adapter.sends == 3, "transient failure should be retried twice"
+
+
+async def test_channel_permanent_error_does_not_retry() -> None:
+    adapter = _FlakyAdapter(failures=99, fail_text="403 Forbidden")
+    chain = DeliveryChain(
+        channel_manager_ref=lambda: _FakeChannelManager(adapter),
+    )
+
+    status = await chain._post_to_channel(
+        job_id="job-2",
+        text="x",
+        channel_name="telegram",
+        channel_id="C1",
+        thread_id="",
+    )
+
+    assert status == "delivery_failed"
+    assert adapter.sends == 1, "permanent errors must fail fast"
+
+
+# --- failure_destination shares the retry path -----------------------------
+
+
+async def test_failure_destination_webhook_gets_retried(monkeypatch) -> None:
+    client_cls = _install_fake_httpx(monkeypatch, failures=2)
+
+    job = _webhook_job("https://hooks.example/primary")
+    job.delivery.failure_destination = FailureDestination(
+        mode=DeliveryMode.WEBHOOK,
+        webhook_url="https://hooks.example/alerts",
+    )
+
+    chain = DeliveryChain()
+    status = await chain._deliver_to_failure_destination(
+        job, "alert text", job.delivery.failure_destination
+    )
+
+    assert status == "delivered"
+    client = client_cls.instances[-1]
+    assert len(client.posts) == 3
+    assert client.posts[0]["url"] == "https://hooks.example/alerts"


### PR DESCRIPTION
…(#430)

Add a retry loop with exponential backoff (3 attempts, 1s/2s/4s) to DeliveryChain._post_to_channel and _post_to_webhook, reusing the existing classify_error() / _TRANSIENT_ERROR_PATTERNS from scheduler/jobs.py so transient failures (429/502/503, timeout, DNS/network issues) are retried while permanent errors (401/403, invalid API key) fail immediately.

Both the primary delivery path and failure_destination alerts route through the same two methods, so the retry covers both.

Closes #430

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
