### PR TITLE
fix(gateway): resolve channel kind for approval prompts

### DIFF
--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -1778,6 +1778,63 @@ def _pending_approval_payload(content: Any) -> dict[str, Any] | None:
     return payload
 
 
+def _channel_kind(channel: Any) -> str:
+    """Resolve the platform an adapter speaks for, e.g. ``telegram``.
+
+    ``transport_name`` is NOT it: on the real adapters it is a property whose
+    value is the wire transport (``polling``/``webhook``/``websocket``), and
+    Discord does not expose it at all. The platform lives on the capability
+    profile; the class name is the fallback for duck-typed adapters.
+    """
+    profile = getattr(channel, "capability_profile", None)
+    channel_type = getattr(profile, "channel_type", None)
+    if isinstance(channel_type, str) and channel_type:
+        return channel_type.lower()
+    return type(channel).__name__.removesuffix("Channel").lower()
+
+
+def _channel_approval_prompt_text(pending: dict[str, Any]) -> str:
+    command = pending.get("command") or ""
+    tool_name = pending.get("tool_name") or "tool"
+    return f"⚠️ Tool '{tool_name}' requires human approval:\n\n`{command}`"
+
+
+async def _deliver_channel_approval_prompt(
+    channel: Any, inbound: IncomingMessage, pending: dict[str, Any]
+) -> None:
+    """Send the approval prompt, degrading to plain text if rendering fails.
+
+    The turn loops around this call only catch ``TimeoutError``, so anything
+    raised while building the platform's interactive payload would unwind the
+    whole turn and leave the user with silence.
+    """
+    try:
+        await _send_channel_approval_prompt(channel, inbound, pending)
+        return
+    except Exception as exc:  # noqa: BLE001 - a dead prompt must not kill the turn
+        log.warning(
+            "channel_dispatch.approval_prompt_failed",
+            channel_type=type(channel).__name__,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+    try:
+        await channel.send(
+            OutgoingMessage(
+                content=_channel_approval_prompt_text(pending),
+                reply_to=inbound.channel_id,
+                metadata={"channel": inbound.channel_id},
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - nothing left to fall back to
+        log.warning(
+            "channel_dispatch.approval_prompt_fallback_failed",
+            channel_type=type(channel).__name__,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
 async def _send_channel_approval_prompt(
     channel: Any, inbound: IncomingMessage, pending: dict[str, Any]
 ) -> None:
@@ -1785,7 +1842,7 @@ async def _send_channel_approval_prompt(
     command = pending.get("command") or ""
     tool_name = pending.get("tool_name") or "tool"
 
-    text = f"⚠️ Tool '{tool_name}' requires human approval:\n\n`{command}`"
+    text = _channel_approval_prompt_text(pending)
 
     metadata: dict[str, Any] = {"channel": inbound.channel_id}
     if hasattr(channel, "_reply_thread_ts"):
@@ -1793,11 +1850,9 @@ async def _send_channel_approval_prompt(
         if thread_ts:
             metadata["thread_ts"] = thread_ts
 
-    transport = getattr(channel, "transport_name", lambda: "")()
-    if callable(transport):
-        transport = transport()
+    kind = _channel_kind(channel)
 
-    if transport == "telegram":
+    if kind == "telegram":
         metadata["reply_markup"] = {
             "inline_keyboard": [
                 [
@@ -1806,7 +1861,7 @@ async def _send_channel_approval_prompt(
                 ]
             ]
         }
-    elif transport == "slack":
+    elif kind == "slack":
         metadata["blocks"] = [
             {
                 "type": "section",
@@ -1836,7 +1891,7 @@ async def _send_channel_approval_prompt(
                 ],
             },
         ]
-    elif transport == "discord":
+    elif kind == "discord":
         metadata["components"] = [
             {
                 "type": 1,
@@ -2462,7 +2517,7 @@ async def _run_turn_batch_path(
                     )
                 pending_approval = _pending_approval_payload(event.result)
                 if pending_approval is not None:
-                    await _send_channel_approval_prompt(channel, msg, pending_approval)
+                    await _deliver_channel_approval_prompt(channel, msg, pending_approval)
                 else:
                     ask_text = _ask_user_reply_text(event)
                     if ask_text:
@@ -2637,7 +2692,7 @@ async def _run_turn_streaming_path(
                     )
                 pending_approval = _pending_approval_payload(event.result)
                 if pending_approval is not None:
-                    await _send_channel_approval_prompt(channel, msg, pending_approval)
+                    await _deliver_channel_approval_prompt(channel, msg, pending_approval)
                 else:
                     ask_text = _ask_user_reply_text(event)
                     if ask_text:

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -11,8 +13,10 @@ from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
 from agentos.channels.slack import SlackChannel
 from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
 from agentos.channels.types import IncomingMessage, OutgoingMessage
+from agentos.engine.types import DoneEvent, TextDeltaEvent, ToolResultEvent
 from agentos.gateway.approval_queue import get_approval_queue, reset_approval_queue
 from agentos.gateway.channel_dispatch import (
+    _run_turn_batch_path,
     _send_channel_approval_prompt,
 )
 
@@ -314,28 +318,131 @@ async def test_discord_component_interaction_handling() -> None:
     assert msg.sender_id == "usr123"
 
 
+_PENDING_APPROVAL: dict[str, Any] = {
+    "approval_id": "app-123",
+    "command": "ls -l",
+    "tool_name": "shell",
+    "status": "approval_required",
+}
+
+
+def _capture_sends(channel: Any) -> list[OutgoingMessage]:
+    """Stub the adapter's outbound send and collect the messages it emits."""
+    sent: list[OutgoingMessage] = []
+
+    async def fake_send(message: OutgoingMessage) -> None:
+        sent.append(message)
+
+    channel.send = fake_send
+    return sent
+
+
+def _inbound() -> IncomingMessage:
+    return IncomingMessage(sender_id="usr1", channel_id="chan1", content="hi")
+
+
 @pytest.mark.asyncio
-async def test_send_channel_approval_prompt() -> None:
-    class DummyChannel:
-        def transport_name(self):
-            return "telegram"
+async def test_send_channel_approval_prompt_telegram() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    sent = _capture_sends(channel)
 
-        async def send(self, msg: OutgoingMessage):
-            self.sent_msg = msg
+    await _send_channel_approval_prompt(channel, _inbound(), dict(_PENDING_APPROVAL))
 
-    channel = DummyChannel()
-    inbound = IncomingMessage(sender_id="usr1", channel_id="chan1", content="hi")
-    pending = {
-        "approval_id": "app-123",
-        "command": "ls -l",
-        "tool_name": "shell",
-        "status": "approval_required",
+    assert len(sent) == 1
+    assert "shell" in sent[0].content
+    assert "ls -l" in sent[0].content
+    row = sent[0].metadata["reply_markup"]["inline_keyboard"][0]
+    assert [button["text"] for button in row] == ["Approve", "Deny"]
+    assert [button["callback_data"] for button in row] == ["approve:app-123", "deny:app-123"]
+
+
+@pytest.mark.asyncio
+async def test_send_channel_approval_prompt_slack() -> None:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345")
+    sent = _capture_sends(channel)
+
+    await _send_channel_approval_prompt(channel, _inbound(), dict(_PENDING_APPROVAL))
+
+    assert len(sent) == 1
+    elements = sent[0].metadata["blocks"][1]["elements"]
+    assert [element["text"]["text"] for element in elements] == ["Approve", "Deny"]
+    assert [element["value"] for element in elements] == ["approve:app-123", "deny:app-123"]
+
+
+@pytest.mark.asyncio
+async def test_send_channel_approval_prompt_discord() -> None:
+    channel = DiscordChannel(DiscordChannelConfig(token="test-token"))
+    sent = _capture_sends(channel)
+
+    await _send_channel_approval_prompt(channel, _inbound(), dict(_PENDING_APPROVAL))
+
+    assert len(sent) == 1
+    components = sent[0].metadata["components"][0]["components"]
+    assert [component["label"] for component in components] == ["Approve", "Deny"]
+    assert [component["custom_id"] for component in components] == [
+        "approve:app-123",
+        "deny:app-123",
+    ]
+
+
+class _ApprovalTurnRunner:
+    """Yield a gated tool result followed by the assistant's closing text."""
+
+    async def run(self, message: str, session_key: str, **kwargs: Any) -> Any:
+        yield ToolResultEvent(
+            tool_use_id="call-1",
+            tool_name="shell",
+            result=json.dumps(_PENDING_APPROVAL),
+        )
+        yield TextDeltaEvent(text="waiting for approval")
+        yield DoneEvent()
+
+
+def _batch_turn_kwargs() -> dict[str, Any]:
+    return {
+        "turn_runner": _ApprovalTurnRunner(),
+        "msg": _inbound(),
+        "session_key": "agent:main:telegram:direct:chan1",
+        "tool_ctx": SimpleNamespace(agent_id="main"),
+        "event_bridge": None,
+        "semantic_message": None,
+        "config": SimpleNamespace(
+            agent_stream_heartbeat_interval_seconds=60.0,
+            agent_stream_idle_timeout_seconds=5.0,
+        ),
     }
 
-    await _send_channel_approval_prompt(channel, inbound, pending)
 
-    assert channel.sent_msg is not None
-    assert "shell" in channel.sent_msg.content
-    assert "ls -l" in channel.sent_msg.content
-    assert "reply_markup" in channel.sent_msg.metadata
-    assert channel.sent_msg.metadata["reply_markup"]["inline_keyboard"][0][0]["text"] == "Approve"
+@pytest.mark.asyncio
+async def test_channel_turn_delivers_approval_prompt_and_completes() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    sent = _capture_sends(channel)
+
+    await _run_turn_batch_path(channel, **_batch_turn_kwargs())
+
+    keyboard = sent[0].metadata["reply_markup"]["inline_keyboard"][0]
+    assert [button["callback_data"] for button in keyboard] == [
+        "approve:app-123",
+        "deny:app-123",
+    ]
+    assert "waiting for approval" in sent[-1].content
+
+
+@pytest.mark.asyncio
+async def test_channel_turn_survives_approval_prompt_rendering_failure() -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    sent = _capture_sends(channel)
+
+    async def broken_prompt(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("prompt rendering blew up")
+
+    with patch(
+        "agentos.gateway.channel_dispatch._send_channel_approval_prompt",
+        broken_prompt,
+    ):
+        await _run_turn_batch_path(channel, **_batch_turn_kwargs())
+
+    assert "shell" in sent[0].content
+    assert "ls -l" in sent[0].content
+    assert "reply_markup" not in sent[0].metadata
+    assert "waiting for approval" in sent[-1].content


### PR DESCRIPTION
## What was broken

`src/agentos/gateway/channel_dispatch.py:1796` probed `transport_name` as if it
were a method:

```python
transport = getattr(channel, "transport_name", lambda: "")()
if callable(transport):
    transport = transport()

if transport == "telegram":
```

On every real adapter `transport_name` is a **property returning a `str`**, and
its value is the wire transport, never the platform:

- `src/agentos/channels/telegram.py:365-367` → `"polling"` / `"webhook"`
- `src/agentos/channels/slack.py:126-129` → `"websocket"` / `"webhook"`
- `DiscordChannel` does not expose `transport_name` at all

So `getattr(...)()` called a `str` → `TypeError: 'str' object is not callable`,
and every branch of the `if transport == ...` chain was unreachable in
production.

## Failure scenario

1. A user DMs the bot and the turn calls a gated tool, which returns
   `approval_required`; `finalize` lets it through because
   `_has_live_approval_surface` is true for a CHANNEL + DIRECT session
   (`src/agentos/tools/policy/finalize.py:70-83`).
2. `channel_dispatch.py:2465` (batch path) or `:2640` (streaming path) calls
   `_send_channel_approval_prompt` → `TypeError`.
3. The `try:` around each turn loop catches only `TimeoutError`, so the
   exception unwinds the whole turn: **no approval prompt, no buttons, no
   reply**. The user sees silence and the approval sits pending until it
   expires.
4. On Discord the call did not raise, but the kind resolved to `""`, so the
   message went out with no Approve/Deny components — a dead prompt.

The existing test passed only because its `DummyChannel` exposed
`transport_name` as a *method returning `"telegram"`*
(`tests/test_channels/test_channel_approvals.py:318-322`) — a shape no real
adapter has.

## What changed

- New `_channel_kind()` resolves the platform from
  `channel.capability_profile.channel_type`, which is `"telegram"` /
  `"slack"` / `"discord"` on all three adapters
  (`telegram.py:372`, `slack.py:134`, `discord.py:159`), with
  `type(channel).__name__` as the fallback for duck-typed adapters. The
  `callable()` re-invocation is gone.
- Both call sites now go through `_deliver_channel_approval_prompt()`, which
  logs and falls back to a plain-text approval prompt if rendering raises, so a
  prompt bug can never abort a turn again.
- The prompt text is factored into `_channel_approval_prompt_text()` so the
  fallback sends the same message without the interactive payload.

## How it is tested

`DummyChannel` is gone. The prompt tests are rebuilt on the three real adapter
classes (constructed with placeholder tokens, `send` stubbed and captured):

- `test_send_channel_approval_prompt_telegram` — asserts
  `metadata["reply_markup"]["inline_keyboard"][0]` carries
  `approve:<id>` / `deny:<id>`.
- `test_send_channel_approval_prompt_slack` — asserts
  `metadata["blocks"][1]["elements"]`.
- `test_send_channel_approval_prompt_discord` — asserts
  `metadata["components"][0]["components"]`.
- `test_channel_turn_delivers_approval_prompt_and_completes` — drives
  `_run_turn_batch_path` end to end with a real `TelegramChannel`: the prompt
  goes out with buttons **and** the turn still delivers its closing text.
- `test_channel_turn_survives_approval_prompt_rendering_failure` — makes prompt
  rendering raise and asserts the turn completes with a plain-text prompt
  instead.

On the unmodified tree these fail with `TypeError: 'str' object is not
callable` (Telegram, Slack, batch path), `KeyError: 'components'` (Discord) and
the raised `RuntimeError` escaping the turn (fallback case).

Full gate on the branch: `ruff format`, `ruff check src tests`,
`mypy src/agentos`, `uv build --wheel` all clean;
`pytest -q` → `1 failed, 8212 passed, 27 skipped`, the single failure being the
pre-existing, environment-dependent
`tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`
(also present on `main`).

## Out of scope

`build_channel_route_envelope` hardcodes `interaction_mode=InteractionMode.UNATTENDED`
(`src/agentos/gateway/routing.py:407`) and `src/agentos/tools/builtin/shell.py:1446`
raises `UnsupportedSurfaceError` on UNATTENDED, so `shell` specifically still
cannot reach the channel-approval surface. That is a separate defect and is not
touched here.

Fixes #435
