### PR TITLE
fix(router): apply the cost-aware override after the routing decision

### DIFF
--- a/src/agentos/engine/steps/agentos_router.py
+++ b/src/agentos/engine/steps/agentos_router.py
@@ -537,7 +537,8 @@ def _requires_history(strategy: object) -> bool:
     """History-aware strategies declare ``requires_history = True``.
 
     Gates history load/accumulation and the deterministic guards
-    (confidence gate, complaint upgrade, kv-cache anti-downgrade).
+    (confidence gate, complaint upgrade, kv-cache anti-downgrade, cost-aware
+    override) — every one of them lives in ``_finalize_decision``.
     """
     return bool(getattr(strategy, "requires_history", False))
 
@@ -1228,6 +1229,8 @@ def _finalize_decision(
     if router_cfg is not None:
         cost_aware = getattr(router_cfg, "cost_aware", True)
 
+    pre_cost_aware_tier = final_tier
+    cost_aware_override_applied = False
     if cost_aware:
         cheapest_tier = _get_cheapest_compatible_tier(final_tier, tiers, valid_tiers)
         if cheapest_tier != final_tier:
@@ -1239,6 +1242,21 @@ def _finalize_decision(
                 cheapest_model=tiers[cheapest_tier].get("model"),
             )
             final_tier = cheapest_tier
+            cost_aware_override_applied = True
+
+    # The override is the last step that can move the tier, so the ``final_*``
+    # fields are rewritten from it: ``_reconcile_controller_with_final_tier``
+    # and the routing-history entry must see the tier that actually chose the
+    # model. ``base_tier`` / ``route_class`` deliberately keep the classifier's
+    # own decision — the override is a substitution, not a classification.
+    extra.update(
+        {
+            "final_tier": final_tier,
+            "final_route_class": _route_class_for_tier(final_tier),
+            "cost_aware_override_applied": cost_aware_override_applied,
+            "pre_cost_aware_tier": pre_cost_aware_tier,
+        }
+    )
 
     return RoutingDecision(
         tier=final_tier,
@@ -1519,14 +1537,10 @@ async def apply_agentos_router(ctx: TurnContext) -> TurnContext:
         source = "default"
         probs = synthetic_one_hot(tier_name)
 
-    cost_aware = True
-    if ctx.config and ctx.config.agentos_router:
-        cost_aware = getattr(ctx.config.agentos_router, "cost_aware", True)
-
-    if cost_aware:
-        cheapest_tier = _get_cheapest_compatible_tier(tier_name, tiers, valid_tiers)
-        if cheapest_tier != tier_name:
-            tier_name = cheapest_tier
+    # NOTE: the cost-aware substitution is deliberately NOT applied here. It
+    # runs once, at the end of ``_finalize_decision``, so the complaint
+    # upgrade, the anti-downgrade and the telemetry all start from the tier the
+    # classifier actually returned.
     decision = RoutingDecision(
         tier=tier_name,
         model=tiers[tier_name].get("model", ctx.model),

--- a/tests/test_engine/test_router_cost_aware_override.py
+++ b/tests/test_engine/test_router_cost_aware_override.py
@@ -1,0 +1,120 @@
+"""Cost-aware tier substitution must run last, not before the decision exists.
+
+The substitution picks the cheapest tier at or above the classified capability.
+It has to be the *final* step: the complaint upgrade, the kv-cache
+anti-downgrade and the routing-history record all reason about the tier the
+classifier actually chose. Applying it up front made the complaint upgrade step
+off an already-substituted tier (c1 -> c2 -> c3 on the shipped defaults, i.e. a
+far more expensive model on exactly the turns users complain on) and made
+``base_tier`` / ``route_class`` report a tier no classifier ever returned.
+
+Default OpenRouter tier prices (USD/M, input + output) put c2 (0.561) below c1
+(1.45), so ``_get_cheapest_compatible_tier("c1")`` is ``"c2"`` out of the box —
+which is what makes the ordering observable here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.steps import agentos_router as agentos_router_step
+from agentos.engine.steps.agentos_router import apply_agentos_router
+from agentos.gateway.config import GatewayConfig
+
+
+@pytest.fixture(autouse=True)
+def reset_agentos_router_state(monkeypatch: pytest.MonkeyPatch):
+    # Offline pricing only: the cheapest-tier lookup must read the baked-in
+    # table, never the live OpenRouter/OpenCAP catalogues.
+    monkeypatch.setenv("AGENTOS_OPENROUTER_LIVE_PRICING", "0")
+    monkeypatch.setenv("AGENTOS_OPENCAP_LIVE_PRICING", "0")
+    agentos_router_step._history_store.clear()
+    agentos_router_step._strategy = None
+    agentos_router_step._strategy_key = None
+    yield
+    agentos_router_step._history_store.clear()
+    agentos_router_step._strategy = None
+    agentos_router_step._strategy_key = None
+    monkeypatch.undo()
+
+
+class _FixedStrategy:
+    """History-aware strategy pinned to one tier, so no judge/model is needed."""
+
+    requires_history = True
+
+    def __init__(self, tier: str) -> None:
+        self._tier = tier
+
+    async def classify(self, message, valid_tiers, routing_history=None):
+        return self._tier, 0.99, "llm_judge", {}
+
+
+def _pin_strategy(monkeypatch: pytest.MonkeyPatch, tier: str) -> None:
+    monkeypatch.setattr(
+        agentos_router_step,
+        "_get_strategy",
+        lambda _config, _llm_cfg=None: _FixedStrategy(tier),
+    )
+
+
+def _make_context(message: str) -> TurnContext:
+    config = GatewayConfig()
+    config.agentos_router.rollout_phase = "full"
+    assert config.agentos_router.cost_aware is True
+    return TurnContext(
+        message=message,
+        session_key="cost-aware-session",
+        config=config,
+        provider=None,
+        model=config.llm.model,
+        tool_defs=[],
+        system_prompt="system",
+        raw_message=None,
+        attachments=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_cost_aware_override_does_not_inflate_the_complaint_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context("that's not right, try again")
+
+    routed = await apply_agentos_router(ctx)
+
+    # The complaint upgrade steps up from the classified c1 -> c2, and the
+    # cost-aware pass then keeps c2 (already the cheapest at/above c2).
+    # Stepping off a pre-substituted c2 would land on c3 (claude-opus-5).
+    assert routed.metadata["routed_tier"] == "c2"
+
+    extra = ctx.metadata["routing_extra"]
+    assert extra["complaint_detected"] is True
+    assert extra["complaint_upgrade_applied"] is True
+    assert extra["base_tier"] == "c1"
+    assert extra["route_class"] == "R1"
+    assert extra["final_tier"] == routed.metadata["routed_tier"]
+
+
+@pytest.mark.asyncio
+async def test_cost_aware_override_keeps_the_classified_tier_in_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _pin_strategy(monkeypatch, "c1")
+    ctx = _make_context("Summarize this paragraph for me.")
+
+    routed = await apply_agentos_router(ctx)
+
+    # c2 is cheaper than c1 on the shipped defaults, so the override fires.
+    assert routed.metadata["routed_tier"] == "c2"
+
+    extra = ctx.metadata["routing_extra"]
+    # ...but the classification the telemetry reports stays the real one.
+    assert extra["base_tier"] == "c1"
+    assert extra["route_class"] == "R1"
+    assert extra["cost_aware_override_applied"] is True
+    assert extra["pre_cost_aware_tier"] == "c1"
+    assert extra["final_tier"] == "c2"
+    assert extra["final_route_class"] == "R2"

--- a/tests/test_engine/test_router_local_provider_degrade.py
+++ b/tests/test_engine/test_router_local_provider_degrade.py
@@ -55,7 +55,6 @@ def _pin_strategy(monkeypatch: pytest.MonkeyPatch, tier: str) -> None:
 
 def _make_context(config: GatewayConfig, message: str = "Do something.") -> TurnContext:
     config.agentos_router.rollout_phase = "full"
-    config.agentos_router.cost_aware = False
     return TurnContext(
         message=message,
         session_key="degrade-session",


### PR DESCRIPTION
## What was broken

The cost-aware tier substitution was applied to the raw classification *before*
`RoutingDecision` was built, at `src/agentos/engine/steps/agentos_router.py:1522`:

```python
if cost_aware:
    cheapest_tier = _get_cheapest_compatible_tier(tier_name, tiers, valid_tiers)
    if cheapest_tier != tier_name:
        tier_name = cheapest_tier
decision = RoutingDecision(tier=tier_name, ...)
```

Everything downstream therefore reasoned about a tier the classifier never chose:

- `agentos_router.py:1180` — the complaint upgrade in `_finalize_decision` takes
  `upgrade_start_tier = final_tier`, i.e. the already-substituted tier.
- `agentos_router.py:1211` — `extra["final_tier"]` / `extra["final_route_class"]`
  were written *before* the second application, so they never reflected the
  override that actually chose the model.

## Concrete failure scenario

Verified against `GatewayConfig()` defaults with live pricing off. Default
OpenRouter tier prices (USD/M, input + output): c0 0.42, **c1 1.45**, **c2 0.561**,
c3 30.0 — c2 is cheaper than c1, so `_get_cheapest_compatible_tier("c1") == "c2"`
out of the box.

For a turn classified **c1**:

| | `cost_aware = False` | `cost_aware = True` (default) |
|---|---|---|
| ordinary turn | c1 | c2, and telemetry reported `base_tier` c2, `route_class` R2 |
| complaint turn | c2 (0.132 / 0.429 per M) | **c3, `anthropic/claude-opus-5`** (5 / 25 per M) |

So a feature named "cost aware" made every complaint turn roughly **38x more
expensive per input token**, and the routing history recorded a classification
that never happened.

## What changed

- Removed the pre-decision application, so `RoutingDecision` carries the
  classifier's tier and `_finalize_decision` computes `base_tier`, the complaint
  upgrade and the kv-cache anti-downgrade from the real classification.
- Kept exactly one application, at the end of `_finalize_decision`.
- After it, `extra["final_tier"]` / `extra["final_route_class"]` are rewritten and
  two markers added — `cost_aware_override_applied` and `pre_cost_aware_tier` — so
  `_reconcile_controller_with_final_tier` and the routing-history entry see the
  tier that actually chose the model, while `base_tier` / `route_class` keep the
  classifier's own decision.
- Dropped the `cost_aware = False` line in
  `tests/test_engine/test_router_local_provider_degrade.py`, which existed only to
  dodge this ordering; both degrade tests pass without it.

Tiers still select a **model** only — `tier.provider` stays metadata and no
provider selection changed.

Note on scope: the override now lives entirely inside `_finalize_decision`, which
runs for history-aware strategies. Every strategy `_get_strategy` can build
(`LLMJudgeStrategy`, `PilotStrategy`, `_UnavailableJudgeStrategy`) declares
`requires_history = True`, so no shipped routing path loses the override — it
joins the other deterministic guards that already live there.

## How it is tested

New `tests/test_engine/test_router_cost_aware_override.py`: a fixed history-aware
strategy pinned to c1, default `GatewayConfig`, live pricing disabled by env so the
cheapest-tier lookup reads the baked-in table (offline, no network). It asserts

- a complaint message routes to **c2**, not c3;
- `base_tier == "c1"` and `route_class == "R1"` even when the override fires;
- `final_tier` / `final_route_class` equal the tier actually routed to, plus the
  `cost_aware_override_applied` / `pre_cost_aware_tier` markers.

Both tests fail on the unmodified tree (`assert 'c3' == 'c2'` and
`assert 'c2' == 'c1'`) and pass with the fix.

Gate: `ruff format` (edited files only), `ruff check src tests`,
`mypy src/agentos` (615 files clean), full `pytest` (8210 passed, 27 skipped;
only the pre-existing, environment-dependent
`tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`
failure, unrelated to this change), `uv build --wheel`.

Fixes #438
