### PR TITLE
fix(sandbox): run the command when the resource module is missing

### DIFF
--- a/src/agentos/safety/sandbox.py
+++ b/src/agentos/safety/sandbox.py
@@ -1,9 +1,11 @@
 """Subprocess execution sandbox with CPU / memory / wall / network limits.
 
-POSIX-only: uses :mod:`resource` via ``preexec_fn`` to apply
-``setrlimit`` before the child process begins. On platforms where
-``resource`` is unavailable (notably Windows), :func:`run_sandboxed`
-returns a :class:`SandboxResult` with ``reason='unsupported_platform'``.
+CPU / memory caps are POSIX-only: they use :mod:`resource` via
+``preexec_fn`` to apply ``setrlimit`` before the child process begins. On
+platforms where ``resource`` is unavailable (notably Windows) the command
+still runs — the wall-clock timeout is cross-platform — but the rlimits are
+skipped and :data:`NOTE_NO_RLIMITS` is attached to
+:attr:`SandboxResult.notes` so the degradation is never silent.
 
 Environment whitelist: by default the sandboxed command sees only
 ``HOME``, ``PATH`` and ``LANG`` — a deliberate narrow whitelist so
@@ -44,6 +46,11 @@ REASON_NETWORK_DENY: Final[str] = "network_deny"
 REASON_UNSUPPORTED: Final[str] = "unsupported_platform"
 REASON_EXEC_FAILED: Final[str] = "exec_failed"
 
+NOTE_NO_RLIMITS: Final[str] = (
+    "rlimits not applied on this platform: the POSIX 'resource' module is "
+    "unavailable, so only the wall-clock timeout is enforced"
+)
+
 _DEFAULT_ENV_WHITELIST: Final[tuple[str, ...]] = ("HOME", "PATH", "LANG")
 
 
@@ -67,6 +74,10 @@ class SandboxResult:
     stderr: str
     reason: str = REASON_OK
     limits: SandboxLimits = field(default_factory=SandboxLimits)
+    #: Advisory degradations that applied to this run — e.g. the caps in
+    #: ``limits`` could not be enforced. Non-fatal, but callers must surface
+    #: them: a user who turned the sandbox on has to know what is missing.
+    notes: tuple[str, ...] = ()
 
 
 def _preexec(limits: SandboxLimits):  # pragma: no cover — runs in child
@@ -111,20 +122,15 @@ def run_sandboxed(
     * Network scope ``'deny'`` is recorded and returned verbatim on
       result — the child is expected to consult the limit (tests assert
       this by round-tripping the limits).
-    * On POSIX platforms without :mod:`resource` (Windows) the function
-      short-circuits with ``reason='unsupported_platform'``.
+    * On platforms without :mod:`resource` (Windows) the command still
+      runs under the wall limit; only the rlimits are skipped, and
+      :data:`NOTE_NO_RLIMITS` is added to ``notes`` to say so.
     """
 
     effective = limits or SandboxLimits()
-
-    if not HAS_RESOURCE:
-        return SandboxResult(
-            returncode=-1,
-            stdout="",
-            stderr="resource module unavailable",
-            reason=REASON_UNSUPPORTED,
-            limits=effective,
-        )
+    # ``_preexec`` returns ``None`` without ``resource``, so the same call
+    # works everywhere; the note is what keeps the degradation visible.
+    notes: tuple[str, ...] = () if HAS_RESOURCE else (NOTE_NO_RLIMITS,)
 
     env = _filtered_env(effective.env_whitelist)
 
@@ -134,8 +140,18 @@ def run_sandboxed(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
-            preexec_fn=_preexec(effective),  # noqa: PLW1509 — POSIX setrlimit
+            preexec_fn=_preexec(effective),  # noqa: PLW1509 — None off POSIX
             text=True,
+        )
+    except NotImplementedError as exc:
+        # Hosts without process creation at all (WASI / Emscripten builds).
+        return SandboxResult(
+            returncode=-1,
+            stdout="",
+            stderr=str(exc),
+            reason=REASON_UNSUPPORTED,
+            limits=effective,
+            notes=notes,
         )
     except (OSError, ValueError) as exc:
         return SandboxResult(
@@ -144,6 +160,7 @@ def run_sandboxed(
             stderr=str(exc),
             reason=REASON_EXEC_FAILED,
             limits=effective,
+            notes=notes,
         )
 
     try:
@@ -157,16 +174,21 @@ def run_sandboxed(
             stderr=stderr or "",
             reason=REASON_WALL_LIMIT,
             limits=effective,
+            notes=notes,
         )
 
     # Translate exit signals into structured reasons. On POSIX a hard
     # RLIMIT_CPU exceed produces SIGKILL (returncode == -9); RLIMIT_AS
-    # typically surfaces as SIGSEGV / allocation-error exits.
+    # typically surfaces as SIGSEGV / allocation-error exits. Only a
+    # negative returncode is a signal exit, so the mapping never fires on
+    # platforms that have no signals.
     reason = REASON_OK
-    if proc.returncode in {-_signal(9), -_signal(24)}:  # SIGKILL / SIGXCPU
-        reason = REASON_CPU_LIMIT
-    elif proc.returncode == -_signal(11):  # SIGSEGV
-        reason = REASON_MEMORY_LIMIT
+    if proc.returncode < 0:
+        signalled = -proc.returncode
+        if signalled in {_signal(9), _signal(24)}:  # SIGKILL / SIGXCPU
+            reason = REASON_CPU_LIMIT
+        elif signalled == _signal(11):  # SIGSEGV
+            reason = REASON_MEMORY_LIMIT
 
     return SandboxResult(
         returncode=proc.returncode,
@@ -174,6 +196,7 @@ def run_sandboxed(
         stderr=stderr or "",
         reason=reason,
         limits=effective,
+        notes=notes,
     )
 
 
@@ -187,6 +210,7 @@ def _signal(num: int) -> int:
 
 __all__ = [
     "HAS_RESOURCE",
+    "NOTE_NO_RLIMITS",
     "REASON_CPU_LIMIT",
     "REASON_EXEC_FAILED",
     "REASON_MEMORY_LIMIT",

--- a/src/agentos/sandbox/backend/noop.py
+++ b/src/agentos/sandbox/backend/noop.py
@@ -4,7 +4,9 @@ Runs the request in-process via :mod:`asyncio` subprocess APIs with no
 namespace isolation. Resource caps from the policy are still honoured by
 reusing :func:`agentos.safety.sandbox.run_sandboxed` for rlimits + wall
 timeout. Every invocation emits a ``WARNING`` so the bypass is visible in
-logs; disabling the sandbox must never be silent.
+logs; disabling the sandbox must never be silent. A second ``WARNING`` is
+emitted when the run reports degraded caps (no ``resource`` module, so no
+rlimits) for the same reason.
 """
 
 from __future__ import annotations
@@ -60,6 +62,17 @@ class NoopBackend(Backend):
             functools.partial(run_sandboxed, list(request.argv), limits),
         )
         elapsed = time.monotonic() - started
+        if result.notes:
+            # Deliberately NOT ``backend_notes``: that field means "the
+            # backend refused something", and both shell.py and code_exec.py
+            # answer it by escalating for approval and re-running the command
+            # unsandboxed — which would double-execute every command that ran
+            # fine here. A warning keeps the missing caps visible instead.
+            log.warning(
+                "sandbox.rlimits_unavailable: cpu/memory caps not enforced action=%s notes=%s",
+                request.action_kind,
+                "; ".join(result.notes),
+            )
         timed_out = result.reason == "wall_limit"
         return SandboxResult(
             returncode=result.returncode,

--- a/tests/test_sandbox/test_run_sandboxed_without_resource.py
+++ b/tests/test_sandbox/test_run_sandboxed_without_resource.py
@@ -1,0 +1,106 @@
+"""``run_sandboxed`` must still run the command when :mod:`resource` is absent.
+
+``resource`` is POSIX-only. Its absence means "rlimits cannot be applied",
+not "the command cannot run" — the wall-clock timeout is cross-platform and
+must keep working. These tests monkeypatch the feature flag rather than
+gating on ``sys.platform`` so they are meaningful on every CI runner.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from agentos.safety import sandbox as sandbox_mod
+from agentos.safety.sandbox import (
+    REASON_OK,
+    REASON_WALL_LIMIT,
+    SandboxLimits,
+    run_sandboxed,
+)
+from agentos.sandbox.backend.noop import NoopBackend
+from agentos.sandbox.types import (
+    MountSpec,
+    NetworkMode,
+    ResourceLimits,
+    SandboxPolicy,
+    SandboxRequest,
+    SecurityLevel,
+)
+
+
+@pytest.fixture
+def without_resource(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate a host where ``import resource`` failed (e.g. Windows)."""
+    monkeypatch.setattr(sandbox_mod, "HAS_RESOURCE", False)
+    monkeypatch.setattr(sandbox_mod, "_resource", None)
+
+
+def _policy(workspace: Path) -> SandboxPolicy:
+    return SandboxPolicy(
+        level=SecurityLevel.STANDARD,
+        network=NetworkMode.NONE,
+        mounts=(MountSpec(host_path=workspace, sandbox_path=Path("/workspace"), mode="rw"),),
+        workspace_rw=True,
+        tmp_writable=True,
+        limits=ResourceLimits(),
+        env_allowlist=("PATH",),
+        require_approval=False,
+    )
+
+
+def test_child_still_runs_without_resource_module(without_resource: None) -> None:
+    result = run_sandboxed([sys.executable, "-c", "print('ok')"])
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+    assert result.reason == REASON_OK
+
+
+def test_wall_limit_still_fires_without_resource_module(without_resource: None) -> None:
+    result = run_sandboxed(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        SandboxLimits(wall_seconds=1),
+    )
+
+    assert result.reason == REASON_WALL_LIMIT
+    assert result.returncode != 0
+
+
+def test_missing_rlimits_are_reported_on_the_result(without_resource: None) -> None:
+    result = run_sandboxed([sys.executable, "-c", "print('ok')"])
+
+    assert sandbox_mod.NOTE_NO_RLIMITS in result.notes
+
+
+def test_rlimits_are_applied_note_absent_when_resource_is_available() -> None:
+    if not sandbox_mod.HAS_RESOURCE:  # pragma: no cover — Windows CI only
+        pytest.skip("host has no resource module")
+
+    result = run_sandboxed([sys.executable, "-c", "print('ok')"])
+
+    assert result.notes == ()
+
+
+@pytest.mark.asyncio
+async def test_noop_backend_surfaces_the_degradation(
+    without_resource: None,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request = SandboxRequest(
+        argv=(sys.executable, "-c", "print('ok')"),
+        cwd=tmp_path,
+        action_kind="code.exec",
+        policy=_policy(tmp_path),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agentos.sandbox.backend.noop"):
+        result = await NoopBackend().run(request)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+    assert any("sandbox.rlimits_unavailable" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## What was broken

`resource` is POSIX-only, and `run_sandboxed` treated its absence as "cannot run" instead of "cannot apply rlimits".

`src/agentos/safety/sandbox.py:120-127` short-circuited before any subprocess was spawned:

```python
if not HAS_RESOURCE:
    return SandboxResult(
        returncode=-1,
        stdout="",
        stderr="resource module unavailable",
        reason=REASON_UNSUPPORTED,
        limits=effective,
    )
```

`src/agentos/sandbox/backend/noop.py:58-61` shows `NoopBackend.run` *is* `run_sandboxed`, with no fallback.

## Failure scenario

Windows is a supported platform (`install.ps1`, `windows-latest` in CI) and `agentos sandbox on` is documented at `docs/configuration.md:793`. `configure_runtime` already degrades `sandbox=true, backend="auto"` to sandbox-off on Windows (`src/agentos/sandbox/integration.py:178-192`), but an explicit `backend = "noop"` with `sandbox = true` keeps `sandbox_enabled` true and routes every action through `run_sandboxed`. On Windows that meant:

- `git_status` / `git_diff` / `git_commit` raise `RuntimeError: git status --short --branch failed (exit -1): resource module unavailable` (`src/agentos/tools/builtin/git.py:66-71`).
- `code_exec` returns `exit_code=-1` with the same stderr (`src/agentos/tools/builtin/code_exec.py:362-370`).
- `NoopBackend` left `backend_notes` empty (`src/agentos/sandbox/types.py:205`), so `src/agentos/tools/builtin/shell.py:766` never took its escalation fallback either.

The wall-clock timeout from `communicate(timeout=...)` is fully cross-platform; only the rlimit application is POSIX-specific.

## What changed

`src/agentos/safety/sandbox.py`

- Dropped the early return. `_preexec` already returns `None` without `resource`, so the same `Popen` call works on every platform — only the `setrlimit` step is skipped, and the existing `communicate(timeout=...)` wall limit still applies.
- Added `NOTE_NO_RLIMITS` and a `SandboxResult.notes` tuple so the degradation is reported, not silent. A user who turned the sandbox on must not believe caps are enforced when they are not.
- Kept `REASON_UNSUPPORTED` for the genuinely unrunnable case: hosts with no process creation at all (WASI / Emscripten builds) raise `NotImplementedError` from `Popen`.
- The signal-to-reason mapping now only runs when `returncode < 0`. Previously, on a platform where `_signal()` returns `0`, a clean `returncode == 0` would have matched `{-_signal(9), -_signal(24)}` and been reported as `cpu_limit`. That path was unreachable behind the early return and becomes reachable without this guard.

`src/agentos/sandbox/backend/noop.py`

- Logs a `WARNING` (`sandbox.rlimits_unavailable`) when a run reports degraded caps, alongside the existing per-invocation bypass warning.
- The note is deliberately **not** copied into `SandboxResult.backend_notes`. That field currently means "the backend refused something": `shell.py:767` and `code_exec.py:379` both answer a non-empty `backend_notes` by calling `escalate_backend_denial` and then re-running the command unsandboxed. Routing an advisory "rlimits unavailable" note there would prompt for approval on every call and double-execute commands that had already succeeded. Splitting `backend_notes` into denial notes vs. advisory notes belongs in `tools/` and is left as a follow-up.

POSIX behaviour is unchanged — same env whitelist, same `preexec_fn`, same reasons.

## How it is tested

New `tests/test_sandbox/test_run_sandboxed_without_resource.py`. It monkeypatches `HAS_RESOURCE = False` / `_resource = None` rather than gating on `sys.platform`, so it is meaningful on Linux CI:

- the child actually runs (`returncode == 0`, `"ok" in stdout`, `reason == "ok"`);
- the wall timeout still fires (`reason == "wall_limit"`) with no `resource` module;
- `NOTE_NO_RLIMITS` reaches `SandboxResult.notes`, and is absent when `resource` *is* available;
- `NoopBackend` runs the command and emits the `sandbox.rlimits_unavailable` warning.

All five fail on the unmodified tree (`AssertionError: resource module unavailable / assert -1 == 0`, `assert 'unsupported_platform' == 'wall_limit'`) and pass after the change.

Gate: `ruff format` (edited files only), `ruff check src tests`, `mypy src/agentos`, full `pytest`, `uv build --wheel` — all green.

## Known follow-up, not fixed here

`src/agentos/tools/builtin/shell.py:757` hardcodes `argv=("sh", "-lc", command)`, which still will not resolve on Windows. Out of scope for this change.

Fixes #437
