### PR TITLE
fix(session): delete agent tasks and memory receipts with the session

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -640,24 +640,41 @@ class SessionStorage:
         session = await self.get_session(session_key)
         if session is None:
             return
-        await self.conn.execute(
-            "DELETE FROM transcript_entries WHERE session_id = ?",
-            (session.session_id,),
-        )
-        await self.conn.execute(
-            "DELETE FROM compacted_transcript_entries WHERE session_id = ?",
-            (session.session_id,),
-        )
-        await self.conn.execute(
-            "DELETE FROM session_summaries WHERE session_id = ?",
-            (session.session_id,),
-        )
-        await self.conn.execute(
-            "DELETE FROM session_context_states WHERE session_id = ?",
-            (session.session_id,),
-        )
-        await self.conn.execute("DELETE FROM sessions WHERE session_key = ?", (session_key,))
-        await self.conn.commit()
+        # Session keys are deterministic, so any row left behind here resurfaces
+        # in the next session that reuses the key. Delete every session-scoped
+        # table in one transaction: no table declares a foreign key, so a partial
+        # failure would otherwise orphan children under a deleted session.
+        await self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            await self.conn.execute(
+                "DELETE FROM transcript_entries WHERE session_id = ?",
+                (session.session_id,),
+            )
+            await self.conn.execute(
+                "DELETE FROM compacted_transcript_entries WHERE session_id = ?",
+                (session.session_id,),
+            )
+            await self.conn.execute(
+                "DELETE FROM session_summaries WHERE session_id = ?",
+                (session.session_id,),
+            )
+            await self.conn.execute(
+                "DELETE FROM session_context_states WHERE session_id = ?",
+                (session.session_id,),
+            )
+            await self.conn.execute(
+                "DELETE FROM agent_tasks WHERE session_key = ?",
+                (session_key,),
+            )
+            await self.conn.execute(
+                "DELETE FROM memory_durable_receipts WHERE session_key = ?",
+                (session_key,),
+            )
+            await self.conn.execute("DELETE FROM sessions WHERE session_key = ?", (session_key,))
+            await self.conn.commit()
+        except Exception:
+            await self.conn.rollback()
+            raise
 
     async def prune_stale_sessions(self, before_ms: int) -> int:
         """Delete sessions not updated since before_ms epoch ms. Returns count deleted."""

--- a/tests/test_session/test_delete_session_cleanup.py
+++ b/tests/test_session/test_delete_session_cleanup.py
@@ -1,0 +1,106 @@
+"""delete_session must remove every session-scoped row, not just transcripts."""
+
+from __future__ import annotations
+
+from agentos.session.models import (
+    AgentTaskRecord,
+    AgentTaskStatus,
+    MemoryDurableReceipt,
+    SessionNode,
+    TranscriptEntry,
+)
+from agentos.session.storage import SessionStorage
+
+# Fixed epoch ms so the tests never read the system clock.
+_T0 = 1_700_000_000_000
+
+SESSION_KEY = "agent:main:webchat:direct:peer-1"
+
+
+async def _seed(storage: SessionStorage, *, session_id: str, task_id: str) -> None:
+    await storage.upsert_session(
+        SessionNode(
+            session_key=SESSION_KEY,
+            session_id=session_id,
+            created_at=_T0,
+            updated_at=_T0,
+        )
+    )
+    await storage.append_transcript_entry(
+        TranscriptEntry(
+            session_id=session_id,
+            session_key=SESSION_KEY,
+            message_id=f"{task_id}-msg",
+            role="user",
+            content="secret question",
+            created_at=_T0,
+        )
+    )
+    await storage.create_agent_task(
+        AgentTaskRecord(
+            task_id=task_id,
+            session_key=SESSION_KEY,
+            source_kind="webui",
+            queue_mode="followup",
+            run_kind="web_turn",
+            status=AgentTaskStatus.SUCCEEDED,
+            created_at=_T0,
+            updated_at=_T0,
+            details={"metadata": {"channel": "webchat"}},
+        )
+    )
+    await storage.upsert_memory_durable_receipt(
+        MemoryDurableReceipt(
+            receipt_id=f"{task_id}-receipt",
+            session_key=SESSION_KEY,
+            session_id=session_id,
+            turn_id="turn-1",
+            scope="checkpoint",
+            content_hash="h1",
+            idempotency_key=f"checkpoint:{SESSION_KEY}:{task_id}",
+            status="checkpoint_saved",
+            created_at=_T0,
+            updated_at=_T0,
+        )
+    )
+
+
+async def test_delete_session_removes_tasks_and_memory_receipts() -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    try:
+        await _seed(storage, session_id="session-1", task_id="task-1")
+
+        await storage.delete_session(SESSION_KEY)
+
+        assert await storage.count_sessions() == 0
+        assert await storage.get_transcript("session-1") == []
+        assert await storage.list_agent_tasks(SESSION_KEY) == []
+        assert await storage.list_memory_durable_receipts(session_key=SESSION_KEY) == []
+    finally:
+        await storage.close()
+
+
+async def test_recreated_session_key_does_not_inherit_deleted_tasks() -> None:
+    """Session keys are deterministic, so a new chat reuses the deleted key."""
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    try:
+        await _seed(storage, session_id="session-1", task_id="task-1")
+        await storage.delete_session(SESSION_KEY)
+
+        # Same key, brand-new session id — what the next inbound message creates.
+        await storage.upsert_session(
+            SessionNode(
+                session_key=SESSION_KEY,
+                session_id="session-2",
+                created_at=_T0 + 1,
+                updated_at=_T0 + 1,
+            )
+        )
+
+        assert await storage.list_agent_tasks(SESSION_KEY) == []
+        grouped = await storage.list_agent_tasks_for_sessions([SESSION_KEY])
+        assert grouped[SESSION_KEY] == []
+    finally:
+        await storage.close()


### PR DESCRIPTION
## What was broken

`SessionStorage.delete_session` (`src/agentos/session/storage.py:638-660`) cleaned five
session-scoped tables and missed two:

- `agent_tasks` (`storage.py:253`)
- `memory_durable_receipts` (`storage.py:284`)

Neither table declares a foreign key, so nothing else removed those rows.

## Concrete failure scenario

Session keys are deterministic (`src/agentos/session/keys.py:60-107` — e.g. `agent:main:main`,
`agent:main:<channel>:direct:<peer>`), so deleting a conversation and then sending another
message re-creates the **same** key. `list_agent_tasks_for_sessions` (`storage.py:895`) then
returns the deleted conversation's task rows to the session the user believes is new. Those
rows carry `details.metadata` / `details.input_provenance`
(`src/agentos/gateway/task_runtime.py:424-431`, including channel and source attribution) and
`error_message` — exactly the data the user asked to delete.

Every delete path inherited it: `agentos sessions delete`
(`src/agentos/cli/sessions_cmd.py:342`), the Web UI RPC (`src/agentos/gateway/rpc_sessions.py:1891`),
the scheduler reaper (`src/agentos/scheduler/reaper.py:67`), and `prune_stale_sessions`
(`storage.py:662-672`), which loops over `delete_session`. Since nothing else pruned these two
tables, they also grew without bound.

Reproduced with an in-memory `SessionStorage` seeded with one session, one `AgentTaskRecord`
and one `MemoryDurableReceipt`: after `delete_session(key)`, `count_sessions()` is `0` but
`list_agent_tasks(key)` and `list_memory_durable_receipts(session_key=key)` each still return
one row.

## What changed

`delete_session` now deletes `agent_tasks` and `memory_durable_receipts` by the already
canonicalized `session_key` (both tables key on `session_key`, not `session_id`), and the whole
delete runs inside a single `BEGIN IMMEDIATE` transaction with rollback on failure — the same
idiom `rewrite_compacted_session` already uses in this file. Without a foreign key, a partial
failure could previously drop the `sessions` row while leaving its children behind.

All seven tables in this schema are now accounted for: `sessions`, `transcript_entries`,
`compacted_transcript_entries`, `session_summaries`, `session_context_states`, `agent_tasks`
and `memory_durable_receipts`. The `transcript_fts` virtual table is an external-content FTS5
index over `transcript_entries` and is kept in sync by the existing `transcript_fts_ad`
delete trigger, so it needs no explicit statement.

## How it is tested

New `tests/test_session/test_delete_session_cleanup.py`, pure in-memory SQLite, fixed epoch-ms
constant, no clock or network:

- `test_delete_session_removes_tasks_and_memory_receipts` — seeds a session, a transcript entry,
  an `AgentTaskRecord` and a `MemoryDurableReceipt`; asserts all of them are gone after the
  delete.
- `test_recreated_session_key_does_not_inherit_deleted_tasks` — re-creates a session under the
  identical key with a fresh `session_id` and asserts both `list_agent_tasks` and
  `list_agent_tasks_for_sessions` come back empty. This is the user-facing symptom.

Both tests fail on the unmodified tree (`AssertionError: assert [AgentTaskRecord(...)] == []`)
and pass with the fix. Full suite: 8209 passed, 1 failed, 28 skipped — the single failure is
the pre-existing, environment-dependent
`tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`. `ruff check`,
`mypy src/agentos` and `uv build --wheel` are clean.

Fixes #440
