### PR TITLE
fix(gateway): cap multipart uploads before the body is buffered

### DIFF
--- a/src/agentos/gateway/audio_transcription.py
+++ b/src/agentos/gateway/audio_transcription.py
@@ -13,7 +13,13 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from agentos.gateway.config import GatewayConfig
-from agentos.gateway.uploads import _extract_authorization_token
+from agentos.gateway.uploads import (
+    _MULTIPART_FRAMING_ALLOWANCE,
+    RequestBodyTooLargeError,
+    _extract_authorization_token,
+    bounded_request,
+    declared_content_length,
+)
 from agentos.provider.audio import (
     ElevenLabsAudioProductionProvider,
     ElevenLabsSpeechToTextRequest,
@@ -66,6 +72,18 @@ async def transcribe_audio_bytes(
     )
 
 
+def _transcription_too_large() -> JSONResponse:
+    """Build the shared 413 body used by every transcription size guard."""
+
+    return JSONResponse(
+        {
+            "error": "audio upload exceeds transcription size limit",
+            "code": "TOO_LARGE",
+        },
+        status_code=413,
+    )
+
+
 def register_audio_transcription_routes(
     app: Starlette,
     *,
@@ -93,8 +111,18 @@ def register_audio_transcription_routes(
                 status_code=503,
             )
 
+        # Bound the body before it is parsed: Starlette spools file parts to
+        # disk unbounded, so the size check has to run while the bytes are
+        # still arriving rather than after they are all resident.
+        stream_budget = _MAX_TRANSCRIPTION_BYTES + _MULTIPART_FRAMING_ALLOWANCE
+        declared = declared_content_length(request)
+        if declared is not None and declared > stream_budget:
+            return _transcription_too_large()
+
         try:
-            form = await request.form()
+            form = await bounded_request(request, stream_budget).form()
+        except RequestBodyTooLargeError:
+            return _transcription_too_large()
         except Exception as exc:
             if config.debug:
                 from agentos.redact import redact_sensitive_text
@@ -117,17 +145,13 @@ def register_audio_transcription_routes(
                 status_code=415,
             )
 
-        payload = await upload.read()
+        # One byte past the cap is enough to detect an oversize upload without
+        # ever buffering it whole.
+        payload = await upload.read(_MAX_TRANSCRIPTION_BYTES + 1)
         if not isinstance(payload, bytes) or len(payload) == 0:
             return JSONResponse({"error": "empty upload"}, status_code=400)
         if len(payload) > _MAX_TRANSCRIPTION_BYTES:
-            return JSONResponse(
-                {
-                    "error": "audio upload exceeds transcription size limit",
-                    "code": "TOO_LARGE",
-                },
-                status_code=413,
-            )
+            return _transcription_too_large()
 
         provider_cfg = config.audio.providers.elevenlabs
         model_id = str(

--- a/src/agentos/gateway/uploads.py
+++ b/src/agentos/gateway/uploads.py
@@ -32,6 +32,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
+from starlette.types import Message, Receive
 
 from agentos.contracts.attachments import (
     ALLOWED_MEDIA_TYPES,
@@ -47,6 +48,12 @@ _ALLOWED_MIMES: frozenset[str] = ALLOWED_MEDIA_TYPES
 
 _DEFAULT_MAX_FILE_BYTES = 30 * 1024 * 1024
 _DEFAULT_TTL_SECONDS = 10 * 60
+
+# Multipart framing (boundaries, part headers, sibling text fields) inflates
+# the request body past the file bytes themselves. Allow for it so a body that
+# is exactly at the cap is not refused on its Content-Length alone, while an
+# obviously abusive body still never reaches the parser.
+_MULTIPART_FRAMING_ALLOWANCE = 64 * 1024
 
 
 class UploadStoreError(Exception):
@@ -70,6 +77,56 @@ class AttachmentLostInRestartError(UploadStoreError):
 
     Concrete UX hook for "uploaded file lost in restart".
     """
+
+
+class RequestBodyTooLargeError(Exception):
+    """The request body exceeded the byte budget granted to its endpoint."""
+
+
+# ---------------------------------------------------------------------------
+# Request-size guards, shared with the audio transcription route.
+# ---------------------------------------------------------------------------
+
+
+def declared_content_length(request: Request) -> int | None:
+    """Return the declared body size, or ``None`` when absent or unparseable.
+
+    A missing or malformed header means "unknown", never zero: chunked and
+    lying clients must fall through to the streaming guard below.
+    """
+
+    raw = request.headers.get("content-length")
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def bounded_request(request: Request, limit: int) -> Request:
+    """Return a view of ``request`` whose body stream stops after ``limit``.
+
+    Starlette's ``max_part_size`` only guards non-file parts -- a file part
+    streams unbounded into a ``SpooledTemporaryFile`` before the handler runs
+    (``MultiPartParser.on_part_data`` skips the check when the part has a
+    file). Raising out of ``receive`` aborts the parse while the body is still
+    arriving, so an abusive upload never lands on disk in full either.
+    """
+
+    remaining = limit
+
+    async def receive() -> Message:
+        nonlocal remaining
+        message = await request.receive()
+        if message.get("type") == "http.request":
+            remaining -= len(message.get("body", b""))
+            if remaining < 0:
+                raise RequestBodyTooLargeError(f"request body exceeds {limit} bytes")
+        return message
+
+    return Request(request.scope, cast(Receive, receive))
 
 
 @dataclass
@@ -289,6 +346,16 @@ def _extract_authorization_token(request: Request) -> str | None:
     return request.headers.get("x-agentos-token")
 
 
+def _too_large(max_bytes: int, *, mime: str | None = None) -> JSONResponse:
+    """Build the shared 413 body used by every upload size guard."""
+
+    suffix = f" for {mime}" if mime else ""
+    return JSONResponse(
+        {"error": f"upload exceeds {max_bytes} byte cap{suffix}", "code": "TOO_LARGE"},
+        status_code=413,
+    )
+
+
 def register_upload_routes(
     app: Starlette,
     *,
@@ -311,8 +378,18 @@ def register_upload_routes(
                     status_code=401,
                 )
 
+        # The per-mime cap is only known once the part headers are parsed, so
+        # bound the body by the store's absolute ceiling first and tighten it
+        # below. Without this the whole body spools to disk before any check.
+        stream_budget = store.max_file_bytes + _MULTIPART_FRAMING_ALLOWANCE
+        declared = declared_content_length(request)
+        if declared is not None and declared > stream_budget:
+            return _too_large(store.max_file_bytes)
+
         try:
-            form = await request.form()
+            form = await bounded_request(request, stream_budget).form()
+        except RequestBodyTooLargeError:
+            return _too_large(store.max_file_bytes)
         except Exception as exc:
             return JSONResponse(
                 {"error": f"multipart/form-data required: {exc}"}, status_code=400
@@ -336,11 +413,19 @@ def register_upload_routes(
                 {"error": "missing or invalid 'mime' / content-type"}, status_code=400
             )
 
-        payload = await upload.read()
+        # Read one byte past the cap: enough to detect an oversize part, never
+        # enough to materialise it. ``store.put`` re-checks as defence in depth.
+        cap = min(
+            store.max_file_bytes,
+            attachment_size_limit_for_mime(normalized_mime, staged=True),
+        )
+        payload = await upload.read(cap + 1)
         if not isinstance(payload, bytes) or len(payload) == 0:
             return JSONResponse(
                 {"error": "empty upload"}, status_code=400
             )
+        if len(payload) > cap:
+            return _too_large(cap, mime=normalized_mime)
 
         try:
             file_uuid = await store.put(filename, normalized_mime, payload)

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -574,3 +574,160 @@ def test_upload_rejects_query_token_when_disallowed_for_multipart() -> None:
     assert response.status_code == 401, response.text
     body: dict[str, Any] = response.json()
     assert body.get("code") == "UNAUTHORIZED" or "Authorization" in body.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Size-cap tests: the body must never be fully buffered before the cap runs.
+#
+# The transcription case lives here rather than next to the other audio-route
+# tests so the whole size-cap surface is covered in one place.
+# ---------------------------------------------------------------------------
+
+
+def test_upload_route_reads_bounded_and_skips_store_on_oversize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversize part is caught by a bounded read, never handed to the store.
+
+    ``UploadFile.read`` must be given an explicit ceiling (never the unbounded
+    default of ``-1``) so the whole body is not materialised in the process.
+    """
+
+    pytest.importorskip("starlette.testclient")
+    from starlette.applications import Starlette
+    from starlette.datastructures import UploadFile
+    from starlette.testclient import TestClient
+
+    from agentos.gateway.config import GatewayConfig
+    from agentos.gateway.uploads import UploadStore, register_upload_routes
+
+    read_sizes: list[int] = []
+    original_read = UploadFile.read
+
+    async def recording_read(self: UploadFile, size: int = -1) -> bytes:
+        read_sizes.append(size)
+        return await original_read(self, size)
+
+    monkeypatch.setattr(UploadFile, "read", recording_read)
+
+    store = UploadStore(marker_dir=None, ttl_seconds=600, max_file_bytes=30 * 1024 * 1024)
+    put_sizes: list[int] = []
+    original_put = store.put
+
+    async def recording_put(name: str, mime: str, payload: bytes) -> str:
+        put_sizes.append(len(payload))
+        return await original_put(name, mime, payload)
+
+    monkeypatch.setattr(store, "put", recording_put)
+
+    app = Starlette(debug=False)
+    register_upload_routes(app, config=GatewayConfig(), store=store)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/files/upload",
+            files={"file": ("big.txt", b"a" * (TEXT_ATTACHMENT_BYTES + 1), "text/plain")},
+        )
+
+    assert response.status_code == 413, response.text
+    assert response.json()["code"] == "TOO_LARGE"
+    assert put_sizes == [], "oversize payload must never reach the store"
+    assert read_sizes, "handler never read the upload"
+    assert all(0 < size <= TEXT_ATTACHMENT_BYTES + 1 for size in read_sizes), read_sizes
+
+
+def test_upload_route_rejects_declared_content_length_without_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Content-Length above the cap is refused before the form is parsed."""
+
+    pytest.importorskip("starlette.testclient")
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+
+    from agentos.gateway.config import GatewayConfig
+    from agentos.gateway.uploads import UploadStore, register_upload_routes
+
+    def exploding_form(self: Request, **kwargs: Any) -> Any:
+        raise AssertionError("form() must not be awaited for an oversize Content-Length")
+
+    monkeypatch.setattr(Request, "form", exploding_form)
+
+    store = UploadStore(marker_dir=None, ttl_seconds=600, max_file_bytes=1024)
+    app = Starlette(debug=False)
+    register_upload_routes(app, config=GatewayConfig(), store=store)
+    handler = app.router.routes[-1].endpoint  # type: ignore[attr-defined]
+
+    async def receive() -> Any:
+        raise AssertionError("request body must not be consumed")
+
+    scope: dict[str, Any] = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/v1/files/upload",
+        "raw_path": b"/api/v1/files/upload",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"content-type", b"multipart/form-data; boundary=testboundary"),
+            (b"content-length", str(8 * 1024 * 1024 * 1024).encode("ascii")),
+        ],
+    }
+
+    response = asyncio.run(handler(Request(scope, receive)))
+
+    assert response.status_code == 413
+    assert json.loads(bytes(response.body))["code"] == "TOO_LARGE"
+
+
+def test_transcribe_route_reads_bounded_and_skips_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The transcription route applies the same bounded read as uploads."""
+
+    pytest.importorskip("starlette.testclient")
+    from starlette.applications import Starlette
+    from starlette.datastructures import UploadFile
+    from starlette.testclient import TestClient
+
+    from agentos.gateway import audio_transcription
+    from agentos.gateway.config import GatewayConfig
+
+    monkeypatch.setattr(audio_transcription, "_MAX_TRANSCRIPTION_BYTES", 64)
+
+    read_sizes: list[int] = []
+    original_read = UploadFile.read
+
+    async def recording_read(self: UploadFile, size: int = -1) -> bytes:
+        read_sizes.append(size)
+        return await original_read(self, size)
+
+    monkeypatch.setattr(UploadFile, "read", recording_read)
+
+    provider_calls: list[int] = []
+
+    class _RefusingProvider:
+        async def transcribe_audio(self, request: Any) -> Any:
+            provider_calls.append(len(request.audio_bytes))
+            raise AssertionError("provider must not see an oversize upload")
+
+    config = GatewayConfig()
+    config.audio.enabled = True
+    app = Starlette(debug=False)
+    audio_transcription.register_audio_transcription_routes(
+        app, config=config, provider_factory=lambda _cfg: _RefusingProvider()
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/audio/transcribe",
+            files={"file": ("voice.webm", b"a" * 4096, "audio/webm")},
+        )
+
+    assert response.status_code == 413, response.text
+    assert response.json()["code"] == "TOO_LARGE"
+    assert provider_calls == []
+    assert read_sizes, "handler never read the upload"
+    assert all(0 < size <= 65 for size in read_sizes), read_sizes


### PR DESCRIPTION
## What was broken

`POST /api/v1/files/upload` and `POST /api/audio/transcribe` buffered the entire
multipart body — to disk, then into process memory — **before** any size limit
was consulted.

- `src/agentos/gateway/uploads.py:315,339-352` (pre-fix): `form = await request.form()`,
  then `payload = await upload.read()` with no bound, then `await store.put(...)`.
  `store.put` (`uploads.py:170-176`, `max_bytes = min(self.max_file_bytes, mime_limit)`)
  was the only size gate, and it ran after the bytes were already resident.
- `src/agentos/gateway/audio_transcription.py:120-129` had the identical shape
  against `_MAX_TRANSCRIPTION_BYTES`.

Nothing upstream capped it. In the pinned Starlette (1.0.0),
`MultiPartParser.on_part_data` guards the `max_part_size` check with
`if self._current_part.file is None:` — file parts fall to the `else:` branch and
stream unbounded into a `SpooledTemporaryFile`:

```python
def on_part_data(self, data: bytes, start: int, end: int) -> None:
    message_bytes = data[start:end]
    if self._current_part.file is None:
        if len(self._current_part.data) + len(message_bytes) > self.max_part_size:
            raise MultiPartException(...)
        self._current_part.data.extend(message_bytes)
    else:
        self._file_parts_to_write.append((self._current_part, message_bytes))
```

## Failure scenario

One request with an 8 GB file part:

1. Starlette spools ~8 GB into the temp dir → disk exhaustion.
2. `await upload.read()` materialises all of it in the gateway process → OOM kill.

The gateway is a single process serving every session, channel and cron job, so
this takes all of them down. The rate limiter (100 req / 60 s) is irrelevant —
one request is enough — and the route is reachable by any admitted client,
including a loopback peer under the default `auth.mode = "none"`. For contrast
the inline attachment path *is* capped (`attachment_ingest.MAX_TOTAL_ATTACHMENT_BYTES`);
only the HTTP multipart sink was uncapped.

## What changed

Three guards, applied to both routes, so the bytes never accumulate:

1. **Declared-length pre-check.** `declared_content_length(request)` parses
   `Content-Length`; when it already exceeds the endpoint's ceiling the handler
   returns 413 *before* `request.form()` is touched. A missing or unparseable
   header is treated as **unknown**, not as zero, so it falls through to (2).
2. **Bounded body stream.** `bounded_request(request, limit)` returns a `Request`
   view whose ASGI `receive` counts bytes and raises `RequestBodyTooLargeError`
   once the budget is spent, aborting the multipart parse while the body is still
   arriving. This is what keeps an oversize body off **disk**, not just out of memory.
3. **Bounded read.** `payload = await upload.read(cap + 1)` where
   `cap = min(store.max_file_bytes, attachment_size_limit_for_mime(mime, staged=True))`
   (`_MAX_TRANSCRIPTION_BYTES + 1` for the audio route). One byte past the cap is
   enough to detect an oversize part and never enough to materialise it.

The per-mime cap is only knowable after the part headers are parsed, so (1) and (2)
use the store's absolute ceiling (`store.max_file_bytes`) plus a
`_MULTIPART_FRAMING_ALLOWANCE` of 64 KiB, which covers boundaries, part headers and
sibling text fields so a body exactly at the cap is not refused on its declared
length alone. (3) then applies the exact per-mime cap.

`store.put` keeps its own oversize check as defence in depth, and the 413 response
still carries `code: "TOO_LARGE"`.

## How it is tested

`tests/test_gateway/test_uploads_endpoint.py`, three new tests — each confirmed to
fail on the unmodified tree for the right reason:

- `test_upload_route_reads_bounded_and_skips_store_on_oversize` — records every
  `UploadFile.read` size argument and every `store.put` payload. Pre-fix:
  `AssertionError: assert [2000001] == []` (the oversize payload reached the store)
  and the recorded read size was the unbounded default. Post-fix: read is called
  with `TEXT_ATTACHMENT_BYTES + 1`, `put` is never called, 413 / `TOO_LARGE`.
- `test_upload_route_rejects_declared_content_length_without_parsing` — patches
  `Request.form` to raise and `receive` to raise, then drives the handler with a
  hand-built scope whose `content-length` is 8 GiB. Pre-fix: `assert 400 == 413`
  (the form was parsed and the `AssertionError` was swallowed by the 400 branch).
  Post-fix: 413 with neither `form()` nor `receive()` reached.
- `test_transcribe_route_reads_bounded_and_skips_provider` — same shape for the
  audio route, with `_MAX_TRANSCRIPTION_BYTES` monkeypatched down to 64 bytes so
  the test stays small. Pre-fix: `AssertionError: [-1]` (unbounded read).

The transcription test lives in `test_uploads_endpoint.py` rather than beside the
other audio-route tests so the whole size-cap surface reads as one section.

The pre-existing `test_upload_route_rejects_oversize_text_family` still passes
unchanged.

Manual check of the streaming guard (not committed, needs a large body): a 64 MiB
chunked multipart body with **no** `Content-Length`, against a store configured
with `max_file_bytes=1024`, returns 413 with **0 bytes** written to the spool file.

Gate on the branch: `ruff check src tests` clean, `mypy src/agentos` clean
(615 files), `uv build --wheel` succeeds, `pytest -q` →
`1 failed, 8210 passed, 28 skipped`. The single failure is the pre-existing,
environment-dependent `tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`
(Click wraps the long temp path across a newline), unrelated to this change.

## Known limitation

Guard (2) bounds what this process accepts, but the ASGI server upstream may still
have read some of the request off the socket before `receive` refuses it, and the
connection is closed without draining the rest. Bounding the body at the server
level (a global body-size limit in the ASGI stack) would close that remaining
window; it is deliberately out of scope here to keep the change to the two
affected routes.

Fixes #436
