### PR TITLE
fix(tools): keep edit_file's fuzzy matcher off the event loop

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import csv
 import fnmatch
+import functools
 import json
 import os
 import posixpath
@@ -840,7 +841,13 @@ async def edit_file(
     loop = asyncio.get_event_loop()
     original = await loop.run_in_executor(None, p.read_text, "utf-8")
 
-    match = _locate_edit(original, old_text, new_text, path=path)
+    # The matcher is the CPU-bound part of an edit, not the read or the write:
+    # a miss on a large file sweeps every window in it. Run it in the same
+    # executor so a slow match costs a worker thread, never the event loop.
+    match = await loop.run_in_executor(
+        None,
+        functools.partial(_locate_edit, original, old_text, new_text, path=path),
+    )
     updated = match.updated
 
     def _write() -> None:

--- a/src/agentos/tools/fuzzy_match.py
+++ b/src/agentos/tools/fuzzy_match.py
@@ -73,6 +73,17 @@ _BLOCK_ANCHOR_MIN_LINES = 3
 # percent against any pattern, and offering those as a hint misleads the model.
 _HINT_MIN_SIMILARITY = 0.40
 
+# ``block_anchor``, ``context_similarity`` and the failed-match hint all slide
+# the pattern's window down the whole file and score each position with
+# ``SequenceMatcher``, so their cost scales with lines × pattern lines. Past
+# this many cells the sweep is measured in tens of seconds — a 12,500-line file
+# against a 200-line pattern takes over a minute — and a model that gets a
+# prompt "not found" is better served than one that waits for a guess. The
+# bound still leaves every edit shape we actually see intact: a 2,000-line file
+# with a 50-line pattern, a 5,000-line file with a 20-line pattern, a
+# 10,000-line file with a 10-line pattern.
+_MAX_SWEEP_CELLS = 100_000
+
 _ESCAPE_SEQUENCES = (
     ("\\r\\n", "\n"),
     ("\\n", "\n"),
@@ -325,6 +336,12 @@ def _similarity(left: str, right: str) -> float:
     return SequenceMatcher(None, left, right).ratio()
 
 
+def _sweep_too_large(line_count: int, window: int) -> bool:
+    """True when a full similarity sweep over this input is not worth its cost."""
+
+    return line_count * window > _MAX_SWEEP_CELLS
+
+
 # ---------------------------------------------------------------------------
 # strategies
 # ---------------------------------------------------------------------------
@@ -391,7 +408,7 @@ def _strategy_block_anchor(content: str, pattern: str) -> list[tuple[int, int]]:
 
     lines, starts, ends = _content_lines(content)
     window = len(pattern_lines)
-    if window > len(lines):
+    if window > len(lines) or _sweep_too_large(len(lines), window):
         return []
 
     middle = "\n".join(line.strip() for line in pattern_lines[1:-1])
@@ -431,7 +448,7 @@ def _strategy_context_similarity(content: str, pattern: str) -> list[tuple[int, 
 
     lines, starts, ends = _content_lines(content)
     window = len(pattern_lines)
-    if window > len(lines):
+    if window > len(lines) or _sweep_too_large(len(lines), window):
         return []
 
     best_score = 0.0
@@ -549,6 +566,9 @@ def find_closest_lines(content: str, old_text: str, *, max_results: int = 3) -> 
     lines, _, _ = _content_lines(content)
     window = min(len(pattern_lines), len(lines))
     if window == 0 or not normalized_pattern.strip():
+        return ""
+    if _sweep_too_large(len(lines), window):
+        # No hint beats making a failed edit wait a minute for one.
         return ""
 
     scored: list[tuple[float, int]] = []

--- a/tests/test_tools/test_edit_file_offload.py
+++ b/tests/test_tools/test_edit_file_offload.py
@@ -1,0 +1,134 @@
+"""``edit_file`` must not do its matching work on the caller's event loop.
+
+The fuzzy matcher is the CPU-bound part of an edit: on a miss it slides the
+pattern's window down the whole file, twice — once looking for a match, once
+building the "closest match" hint. Run inline that blocks whatever loop called
+the tool, so two guards keep a failed edit cheap: the match runs in a worker
+thread, and the sweeping strategies decline outright on inputs too big to
+sweep.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.fuzzy_match import _MAX_SWEEP_CELLS, FuzzyMatchError, FuzzyMatchResult
+from agentos.tools.fuzzy_match import fuzzy_find_and_replace as real_fuzzy_find_and_replace
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    """Unwrap the @tool and @sandboxed decorators to reach the implementation."""
+
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+edit_file = _original_async(fs.edit_file)
+
+
+@contextmanager
+def tool_context(workspace: Path) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_matching_runs_off_the_calling_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text("value = 1\n", encoding="utf-8")
+
+    seen: list[threading.Thread] = []
+
+    def _record(content: str, old_text: str, new_text: str) -> FuzzyMatchResult:
+        seen.append(threading.current_thread())
+        return FuzzyMatchResult(
+            updated="value = 2\n",
+            match_count=1,
+            strategy="exact",
+            spans=((0, 9),),
+        )
+
+    monkeypatch.setattr(fs, "fuzzy_find_and_replace", _record)
+
+    caller = threading.current_thread()
+    with tool_context(tmp_path):
+        await edit_file(str(target), "value = 1", "value = 2")
+
+    assert seen, "the matcher was never called"
+    assert seen[0] is not caller, "the matcher ran on the calling (event loop) thread"
+    assert target.read_text(encoding="utf-8") == "value = 2\n"
+
+
+def _sweep_corpus(line_count: int) -> str:
+    return "".join(f"v_{index} = z({index})\n" for index in range(line_count))
+
+
+# Twelve lines keeps the pattern short enough that ``SequenceMatcher`` scores it
+# without its autojunk heuristic, so the hint below is a real one.
+_PATTERN_LINES = 12
+_PATTERN = "".join(f"qb_{index}: w({index})\n" for index in range(_PATTERN_LINES))
+
+
+def test_hint_survives_below_the_sweep_bound() -> None:
+    content = _sweep_corpus(_MAX_SWEEP_CELLS // _PATTERN_LINES - 500)
+
+    with pytest.raises(FuzzyMatchError) as excinfo:
+        real_fuzzy_find_and_replace(content, _PATTERN, "x = 1\n")
+
+    # Under the bound nothing changes: the sweep still runs and still reports
+    # the region that came closest.
+    assert excinfo.value.hint.startswith("line 1 (")
+
+
+def test_sweep_bound_drops_the_hint_on_oversized_input() -> None:
+    content = _sweep_corpus(_MAX_SWEEP_CELLS // _PATTERN_LINES + 500)
+
+    with pytest.raises(FuzzyMatchError) as excinfo:
+        real_fuzzy_find_and_replace(content, _PATTERN, "x = 1\n")
+
+    assert str(excinfo.value) == "old_text not found"
+    assert excinfo.value.hint == ""
+
+
+@pytest.mark.asyncio
+async def test_oversized_miss_fails_fast_without_a_hint(tmp_path: Path) -> None:
+    # 6_000 x 40 = 240_000 cells, comfortably past the bound: the resemblance
+    # strategies and the hint sweep must all decline rather than grind.
+    target = tmp_path / "big.py"
+    target.write_text(
+        "".join(f"alpha_{index} = compute_value({index}, flag=True)\n" for index in range(6_000)),
+        encoding="utf-8",
+    )
+    old_text = "".join(f"zulu_{index} = derive_other({index}, flag=False)\n" for index in range(40))
+
+    started = time.perf_counter()
+    with tool_context(tmp_path):
+        with pytest.raises(ValueError) as excinfo:
+            await edit_file(str(target), old_text, "x = 1\n")
+    elapsed = time.perf_counter() - started
+
+    message = str(excinfo.value)
+    assert "old_text not found" in message
+    assert "Closest match" not in message
+    # Coarse on purpose: the claim is "returns promptly", not a microbenchmark.
+    # Unbounded this same input runs for minutes.
+    assert elapsed < 5.0, f"oversized miss took {elapsed:.1f}s"


### PR DESCRIPTION
## What was broken

`edit_file` offloads its file read and its file write to the default executor, but ran the fuzzy matcher — the expensive part — inline on the calling event loop.

`src/agentos/tools/builtin/filesystem.py:840-843` (before):

```python
loop = asyncio.get_event_loop()
original = await loop.run_in_executor(None, p.read_text, "utf-8")

match = _locate_edit(original, old_text, new_text, path=path)
updated = match.updated
```

The matcher is quadratic on a miss. `src/agentos/tools/fuzzy_match.py:440-442` sweeps every window in the file with `SequenceMatcher`:

```python
for index in range(len(lines) - window + 1):
    candidate = "\n".join(line.strip() for line in lines[index : index + window])
    score = _similarity(candidate, normalized_pattern)
```

and `src/agentos/tools/fuzzy_match.py:622-625` runs a **second** full sweep purely to build a hint for the error string:

```python
raise FuzzyMatchError(
    "old_text not found",
    hint=find_closest_lines(content, old_text),
)
```

`_strategy_block_anchor` (`fuzzy_match.py:399`) sweeps the same way.

## Failure scenario

A model editing a large file drifts whitespace in `old_text` — precisely the case this matcher exists for — and the edit misses. Measured against a 12,504-line file with a non-matching `old_text`:

| `old_text` size | blocking time |
|---|---|
| 40 lines | 6.4 s |
| 100 lines | 24.3 s |
| 200 lines | 64.2 s |

All synchronous on the gateway loop. For that minute the process serves no WebSocket frames, no heartbeats, no approvals and no turn cancellation, and `execution_timeout_seconds` cannot fire either — its timer needs the loop that is blocked. Models retry failed edits, so this repeats.

## What changed

**1. The match runs in the executor** (`filesystem.py`). `_locate_edit` now joins the read and the write already offloaded three lines above, through `functools.partial` to carry the `path` keyword. The loop stays responsive, and the tool's own timeout can now fire.

**2. The sweeping strategies bow out on oversized input** (`fuzzy_match.py`). `_strategy_block_anchor`, `_strategy_context_similarity` and `find_closest_lines` return empty when `len(lines) * len(pattern_lines)` exceeds `_MAX_SWEEP_CELLS = 100_000`. The caller then gets a plain `old_text not found` with no hint. Offloading alone would still burn a worker thread for a minute; both halves are needed.

### Why 100,000 cells

Two constraints, measured on this checkout:

- **Realistic edits must keep their current behaviour.** Across the 1,020 source and docs files in this repo (`.py`/`.ts`/`.tsx`/`.md`) the line-count distribution is p50 = 159, p90 = 718, p99 = 1,949, max = 6,099. At 100,000 cells the p99 file still admits a 51-line `old_text`, the largest file in the tree still admits 16, a 5,000-line file admits 20 and a 10,000-line file admits 10. No plausible edit shape loses a strategy.
- **The cost at the bound is bounded.** Sweeping exactly at 100,000 cells against real Python source measures 3.1–6.0 s depending on shape (e.g. 5,000 × 20 → 3.1 s, 20,000 × 5 → 6.0 s). That is now worker-thread time, not loop time, and it is the ceiling rather than an unbounded ramp: the issue's 64 s case is 2.5 M cells, 25× the bound, and returns immediately.

A looser bound (say 250,000) would put ~15 s ceilings back on a thread for no coverage gain; a tighter one (50,000) would start cutting patterns of 25 lines on p99-sized files, which are ordinary.

Strategy order, `_BLOCK_ANCHOR_MIN_SIMILARITY`, `_CONTEXT_MIN_SIMILARITY`, `_CONTEXT_MIN_MARGIN` and `_HINT_MIN_SIMILARITY` are all unchanged, so match semantics do not move. The existing `tests/test_tools/test_fuzzy_match.py` and `tests/test_tools/test_edit_file_fuzzy.py` pass unmodified.

## How it is tested

New file `tests/test_tools/test_edit_file_offload.py`, four tests, all offline and deterministic:

- `test_matching_runs_off_the_calling_thread` — monkeypatches `filesystem.fuzzy_find_and_replace` with a stub that records `threading.current_thread()`, calls `edit_file`, and asserts the recorded thread is not the calling thread. Fails on `main` with `AssertionError: the matcher ran on the calling (event loop) thread`.
- `test_hint_survives_below_the_sweep_bound` — just under the bound the sweep still runs and still reports the closest region, so the guard is not silently swallowing hints.
- `test_sweep_bound_drops_the_hint_on_oversized_input` — just over the bound, `FuzzyMatchError` carries an empty hint. Both size cases are derived from `_MAX_SWEEP_CELLS` so they track the constant. Fails on `main`, where the hint is present in both.
- `test_oversized_miss_fails_fast_without_a_hint` — end-to-end through `edit_file` on a 6,000-line file with a 40-line pattern (240,000 cells): the error says `old_text not found`, carries no `Closest match`, and returns inside a deliberately coarse 5 s bound. Fails on `main` at 142 s.

The pattern length in the two bound tests is kept under 200 characters on purpose: past that `SequenceMatcher`'s autojunk heuristic drives the ratio toward zero and the hint disappears for unrelated reasons, which would make the assertion vacuous.

Full suite: `1 failed, 8212 passed, 27 skipped` — the single failure is the pre-existing, path-width-dependent `tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`, unchanged from a clean tree. `ruff check`, `mypy src/agentos` and `uv build --wheel` all pass.

## Not fixed here

Independent of this issue, the *linear* strategies are themselves slow on large files: `_map_unicode` and `_map_collapsed_whitespace` walk the content character by character in Python and build three parallel lists, costing ~1.3 s on a 740 KB file and ~4.6 s on 1.8 MB even when every sweeping strategy is skipped. That is now off the event loop too, so it is no longer a liveness bug, but it is worth its own change and is out of scope here.

Fixes #439
