### PR TITLE
fix(skills): harden the download install kind

### DIFF
--- a/src/agentos/skills/hub/deps.py
+++ b/src/agentos/skills/hub/deps.py
@@ -8,12 +8,18 @@ the display-only hints so the three can't drift apart again.
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
 
 import structlog
 
 from agentos.skills.install_kinds import (
     ARGV_INSTALL_KINDS,
+    BIN_NAME_RE,
     DOWNLOAD_URL_RE,
     MANUAL_INSTALL_KINDS,
     InstallSpecError,
@@ -67,10 +73,107 @@ async def _install_via_argv(spec: SkillInstallSpec) -> DepResult:
     return DepResult(kind=kind, identifier=identifier, success=False, message=err.strip()[:200])
 
 
+#: Redirect hops allowed on a download, matching the web_fetch fetch loop.
+_MAX_DOWNLOAD_REDIRECTS = 5
+#: Ceiling on a downloaded artifact. Generous for a real binary, bounded enough
+#: that a hostile URL cannot fill the disk.
+_MAX_DOWNLOAD_BYTES = 256 * 1024 * 1024
+
+
+def _resolve_download_dest(spec: SkillInstallSpec, url: str) -> Path:
+    """Return the path a download may write, or raise :class:`InstallSpecError`.
+
+    Everything reaching this function comes from skill frontmatter, and a hub
+    skill is third-party content. ``bins[0]`` used to flow straight into a path
+    and a chmod, so a name like ``../../../.profile`` wrote outside the binary
+    directory. The rules below are the ones
+    :func:`~agentos.skills.install_kinds.render_install_command` already applied
+    to the *displayed* command; applying them here is what stops the executor
+    and the hint from disagreeing.
+    """
+    raw_name = spec.bins[0] if spec.bins else url.rsplit("/", 1)[-1]
+    if not BIN_NAME_RE.match(raw_name or ""):
+        raise InstallSpecError(f"Unsafe download target name: {raw_name!r}")
+
+    bin_dir = Path.home() / ".local" / "bin"
+    dest = bin_dir / raw_name
+
+    # A pre-existing symlink here would be written *through*, clobbering
+    # whatever it points at. Refuse rather than follow it.
+    if dest.is_symlink():
+        raise InstallSpecError(f"Download target is a symlink: {raw_name!r}")
+
+    # resolve() collapses any traversal the name regex somehow admits and
+    # follows a symlinked bin_dir to where it really is, so compare after it.
+    resolved = dest.resolve()
+    root = bin_dir.resolve()
+    if resolved == root or resolved.parent != root:
+        raise InstallSpecError(f"Download target escapes {bin_dir}: {raw_name!r}")
+    return dest
+
+
+async def _fetch_to_file(url: str, dest: Path) -> None:
+    """Fetch ``url`` into ``dest``, validating the URL and every redirect hop.
+
+    The previous implementation shelled out to ``curl -fsSL``. ``-L`` follows
+    redirects, so validating only the URL the skill declared meant a hop to a
+    private or metadata address was never checked. Redirects are followed here
+    one at a time with the same guard applied to each, mirroring
+    :mod:`agentos.tools.builtin.web_fetch`.
+    """
+    import httpx
+
+    from agentos.tools.ssrf import validate_http_url_for_fetch
+
+    current_url = url
+    async with httpx.AsyncClient(timeout=120.0, follow_redirects=False) as client:
+        for _hop in range(_MAX_DOWNLOAD_REDIRECTS + 1):
+            validate_http_url_for_fetch(current_url)
+            request = client.build_request("GET", current_url)
+            response = await client.send(request, stream=True)
+            try:
+                if response.status_code in {301, 302, 303, 307, 308}:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise ValueError("Redirect without a Location header")
+                    current_url = urljoin(str(response.url), location)
+                    continue
+                response.raise_for_status()
+                await _stream_to_disk(response, dest)
+                return
+            finally:
+                await response.aclose()
+        raise ValueError(f"Too many redirects (>{_MAX_DOWNLOAD_REDIRECTS})")
+
+
+async def _stream_to_disk(response: Any, dest: Path) -> None:
+    """Write a streamed response to ``dest`` atomically, under a size ceiling.
+
+    The bytes land in a temporary file that is made executable and renamed into
+    place only once the whole body has arrived, so a truncated or oversized
+    download never leaves an executable behind.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(dest.parent), prefix=f".{dest.name}.", suffix=".part")
+    tmp_path = Path(tmp_name)
+    written = 0
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            async for chunk in response.aiter_bytes():
+                written += len(chunk)
+                if written > _MAX_DOWNLOAD_BYTES:
+                    raise ValueError(f"Download exceeds {_MAX_DOWNLOAD_BYTES} byte cap")
+                handle.write(chunk)
+        tmp_path.chmod(0o755)
+        os.replace(tmp_path, dest)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 async def install_download(spec: SkillInstallSpec) -> DepResult:
-    """Download a binary from a URL."""
+    """Download a binary from a URL into ``~/.local/bin``."""
     import shutil
-    from pathlib import Path
 
     url = spec.url
     if not url or not DOWNLOAD_URL_RE.match(url):
@@ -78,14 +181,17 @@ async def install_download(spec: SkillInstallSpec) -> DepResult:
             kind="download", identifier=url or "", success=False, message=f"Invalid URL: {url}"
         )
 
-    bin_name = spec.bins[0] if spec.bins else url.rsplit("/", 1)[-1]
-    dest = Path.home() / ".local" / "bin" / bin_name
+    try:
+        dest = _resolve_download_dest(spec, url)
+    except InstallSpecError as exc:
+        return DepResult(kind="download", identifier=url, success=False, message=str(exc))
 
-    code, out, err = await _run(["curl", "-fsSL", "-o", str(dest), url])
-    if code != 0:
-        return DepResult(kind="download", identifier=url, success=False, message=err.strip()[:200])
+    bin_name = dest.name
+    try:
+        await _fetch_to_file(url, dest)
+    except Exception as exc:
+        return DepResult(kind="download", identifier=url, success=False, message=str(exc)[:200])
 
-    dest.chmod(0o755)
     # Verify it landed on PATH
     if shutil.which(bin_name):
         return DepResult(
@@ -132,7 +238,7 @@ async def install_deps(specs: list[SkillInstallSpec]) -> list[DepResult]:
                 kind=kind,
                 identifier=spec.id,
                 success=False,
-                message=f"Tool not found for kind '{kind}' (brew/npm/go/uv/curl)",
+                message=f"Tool not found for kind '{kind}' (brew/npm/go/uv)",
             )
         except Exception as exc:
             result = DepResult(

--- a/src/agentos/skills/install_kinds.py
+++ b/src/agentos/skills/install_kinds.py
@@ -64,8 +64,13 @@ _APT_PACKAGE_RE = re.compile(r"^[a-z0-9](?:[a-z0-9.+-]*[a-z0-9])?$")
 #: A download URL never becomes an argv, but the hint that shows it must not
 #: be able to smuggle a second shell command past the operator.
 DOWNLOAD_URL_RE = re.compile(r"^https://[a-zA-Z0-9._/-]+$")
-# The binary a download lands as — it becomes an unquoted path in that hint.
-_BIN_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+#: The binary a download lands as. It becomes an unquoted path in that hint and
+#: the last path segment the executor writes, so it is a bare name: no
+#: separator, no leading dot, no leading dash. Public because
+#: :mod:`agentos.skills.hub.deps` must apply the same rule the hint applies —
+#: the two disagreeing is what let an unvalidated name reach the filesystem.
+BIN_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_BIN_NAME_RE = BIN_NAME_RE
 
 
 class InstallSpecError(ValueError):

--- a/tests/test_skills_hub_download_security.py
+++ b/tests/test_skills_hub_download_security.py
@@ -270,7 +270,14 @@ def test_successful_download_is_executable_and_atomic(
     asyncio.run(deps._fetch_to_file("https://example.test/bin", dest))
 
     assert dest.read_bytes() == b"#!/bin/sh\necho hi\n"
-    assert stat.S_IMODE(dest.stat().st_mode) & stat.S_IXUSR
+    mode = stat.S_IMODE(dest.stat().st_mode)
+    if os.name == "nt":
+        # Windows has no execute bit; chmod only drives the read-only flag, and
+        # what makes a file runnable there is PATHEXT. Assert the part that is
+        # real on this platform: the file is writable, not left read-only.
+        assert mode & stat.S_IWUSR
+    else:
+        assert mode & stat.S_IXUSR
     # no .part leftovers
     assert [p.name for p in (fake_home / ".local" / "bin").iterdir()] == ["bin"]
 

--- a/tests/test_skills_hub_download_security.py
+++ b/tests/test_skills_hub_download_security.py
@@ -1,0 +1,326 @@
+"""The ``download`` install kind writes a file and marks it executable.
+
+Every value it works from — the URL and the destination name — comes out of
+skill frontmatter, and a hub skill is third-party content. These tests pin the
+two properties that keeps safe: the name can only ever land inside
+``~/.local/bin``, and neither the declared URL nor any redirect it follows may
+reach a private address.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentos.skills.hub import deps
+from agentos.skills.install_kinds import InstallSpecError
+from agentos.skills.types import SkillInstallSpec
+
+
+def _spec(
+    *, url: str = "https://example.test/bin", bins: list[str] | None = None
+) -> SkillInstallSpec:
+    return SkillInstallSpec(
+        kind="download", id="bin", url=url, bins=bins if bins is not None else ["bin"]
+    )
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+# --------------------------------------------------------------------------
+# Destination resolution
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../../../.zshrc",
+        "../../.profile",
+        "/etc/cron.d/pwn",
+        ".bashrc",
+        "-rf",
+        "sub/dir",
+        "",
+    ],
+)
+def test_resolve_download_dest_refuses_names_that_leave_the_bin_dir(
+    fake_home: Path, name: str
+) -> None:
+    with pytest.raises(InstallSpecError):
+        deps._resolve_download_dest(_spec(bins=[name]), "https://example.test/bin")
+
+
+def test_resolve_download_dest_accepts_a_plain_binary_name(fake_home: Path) -> None:
+    dest = deps._resolve_download_dest(_spec(bins=["ripgrep"]), "https://example.test/bin")
+    assert dest == fake_home / ".local" / "bin" / "ripgrep"
+
+
+def test_resolve_download_dest_refuses_to_write_through_a_symlink(fake_home: Path) -> None:
+    outside = fake_home / "secret.txt"
+    outside.write_text("original", encoding="utf-8")
+    link = fake_home / ".local" / "bin" / "tool"
+    link.symlink_to(outside)
+
+    with pytest.raises(InstallSpecError, match="symlink"):
+        deps._resolve_download_dest(_spec(bins=["tool"]), "https://example.test/bin")
+    assert outside.read_text(encoding="utf-8") == "original"
+
+
+def test_install_download_refuses_a_traversal_name_without_fetching(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _must_not_fetch(url: str, dest: Path) -> None:
+        raise AssertionError("fetch must not be attempted for a rejected name")
+
+    monkeypatch.setattr(deps, "_fetch_to_file", _must_not_fetch)
+    result = asyncio.run(deps.install_download(_spec(bins=["../../../.zshrc"])))
+
+    assert result.success is False
+    assert not (fake_home / ".zshrc").exists()
+
+
+# --------------------------------------------------------------------------
+# Fetch: redirects and size
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        url: str,
+        headers: dict[str, str] | None = None,
+        chunks: tuple[bytes, ...] = (),
+    ) -> None:
+        self.status_code = status_code
+        self.url = url
+        self.headers = headers or {}
+        self._chunks = chunks
+        self.closed = False
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise ValueError(f"HTTP {self.status_code}")
+
+    async def aiter_bytes(self) -> Any:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakeClient:
+    def __init__(self, responses: list[_FakeResponse], **_kwargs: Any) -> None:
+        self._responses = responses
+        self.requested: list[str] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    def build_request(self, method: str, url: str) -> str:
+        return url
+
+    async def send(self, request: str, stream: bool = False) -> _FakeResponse:
+        self.requested.append(request)
+        return self._responses.pop(0)
+
+
+def _install_fake_client(
+    monkeypatch: pytest.MonkeyPatch, responses: list[_FakeResponse]
+) -> dict[str, _FakeClient]:
+    import httpx
+
+    holder: dict[str, _FakeClient] = {}
+
+    def _factory(**kwargs: Any) -> _FakeClient:
+        client = _FakeClient(responses, **kwargs)
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    return holder
+
+
+#: Hostnames the fake resolver knows. Resolution is the only part of the SSRF
+#: guard that needs the network, so stubbing it lets the real rules run offline.
+_FAKE_DNS = {
+    "example.test": "93.184.216.34",  # TEST-NET-ish public address
+    "cdn.example.test": "93.184.216.35",
+    "internal.example.test": "10.0.0.7",  # RFC 1918
+}
+
+
+def _fake_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve a fixed table instead of querying DNS.
+
+    The real :func:`validate_http_url_for_fetch` still runs — only the lookup is
+    replaced — so these tests exercise the shipped guard rather than a stand-in.
+    """
+    import agentos.tools.ssrf as ssrf_mod
+
+    def _getaddrinfo(host: str, _port: object, *_args: Any, **_kwargs: Any) -> list[Any]:
+        try:
+            addr = _FAKE_DNS[host]
+        except KeyError:
+            import socket as _socket
+
+            raise _socket.gaierror(f"unknown host in test table: {host}") from None
+        return [(None, None, None, None, (addr, 0))]
+
+    monkeypatch.setattr(ssrf_mod.socket, "getaddrinfo", _getaddrinfo)
+
+
+def test_redirect_to_a_private_address_is_blocked(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_dns(monkeypatch)
+    responses = [
+        _FakeResponse(
+            status_code=302,
+            url="https://example.test/bin",
+            headers={"location": "https://internal.example.test/payload"},
+        )
+    ]
+    _install_fake_client(monkeypatch, responses)
+
+    from agentos.tools.ssrf import SSRFBlockedError
+
+    dest = fake_home / ".local" / "bin" / "bin"
+    # Specifically the SSRF guard, not merely "something raised": the point is
+    # that the hop is validated, and a bare Exception assertion would also pass
+    # against a build where the fetch helper does not exist at all.
+    with pytest.raises(SSRFBlockedError):
+        asyncio.run(deps._fetch_to_file("https://example.test/bin", dest))
+    assert not dest.exists()
+
+
+def test_install_download_reports_a_blocked_redirect_as_failure(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_dns(monkeypatch)
+    responses = [
+        _FakeResponse(
+            status_code=302,
+            url="https://example.test/bin",
+            headers={"location": "https://internal.example.test/payload"},
+        )
+    ]
+    holder = _install_fake_client(monkeypatch, responses)
+
+    result = asyncio.run(deps.install_download(_spec()))
+    assert result.success is False
+    # The redirect must actually have been attempted and refused, rather than
+    # the call failing earlier for an unrelated reason.
+    assert holder["client"].requested == ["https://example.test/bin"]
+    assert "internal.example.test" in result.message
+    assert not (fake_home / ".local" / "bin" / "bin").exists()
+
+
+def test_download_over_the_size_cap_leaves_nothing_behind(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_dns(monkeypatch)
+    monkeypatch.setattr(deps, "_MAX_DOWNLOAD_BYTES", 8)
+    responses = [
+        _FakeResponse(
+            status_code=200,
+            url="https://example.test/bin",
+            chunks=(b"aaaaaaaa", b"bbbbbbbb"),
+        )
+    ]
+    _install_fake_client(monkeypatch, responses)
+
+    dest = fake_home / ".local" / "bin" / "bin"
+    with pytest.raises(ValueError, match="cap"):
+        asyncio.run(deps._fetch_to_file("https://example.test/bin", dest))
+
+    assert not dest.exists()
+    assert list((fake_home / ".local" / "bin").iterdir()) == []
+
+
+def test_successful_download_is_executable_and_atomic(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_dns(monkeypatch)
+    responses = [
+        _FakeResponse(
+            status_code=200, url="https://example.test/bin", chunks=(b"#!/bin/sh\n", b"echo hi\n")
+        )
+    ]
+    _install_fake_client(monkeypatch, responses)
+
+    dest = fake_home / ".local" / "bin" / "bin"
+    asyncio.run(deps._fetch_to_file("https://example.test/bin", dest))
+
+    assert dest.read_bytes() == b"#!/bin/sh\necho hi\n"
+    assert stat.S_IMODE(dest.stat().st_mode) & stat.S_IXUSR
+    # no .part leftovers
+    assert [p.name for p in (fake_home / ".local" / "bin").iterdir()] == ["bin"]
+
+
+def test_redirect_chain_is_bounded(fake_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_dns(monkeypatch)
+    responses = [
+        _FakeResponse(
+            status_code=302,
+            url=f"https://example.test/hop{i}",
+            headers={"location": f"https://example.test/hop{i + 1}"},
+        )
+        for i in range(deps._MAX_DOWNLOAD_REDIRECTS + 2)
+    ]
+    _install_fake_client(monkeypatch, responses)
+
+    dest = fake_home / ".local" / "bin" / "bin"
+    with pytest.raises(ValueError, match="redirect"):
+        asyncio.run(deps._fetch_to_file("https://example.test/hop0", dest))
+    assert not dest.exists()
+
+
+def test_url_basename_fallback_is_validated_too(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spec with no ``bins`` falls back to the URL's last segment."""
+
+    async def _must_not_fetch(url: str, dest: Path) -> None:
+        raise AssertionError("fetch must not be attempted for a rejected name")
+
+    monkeypatch.setattr(deps, "_fetch_to_file", _must_not_fetch)
+    result = asyncio.run(deps.install_download(_spec(url="https://example.test/.zshrc", bins=[])))
+    assert result.success is False
+
+
+def test_os_replace_is_used_so_no_partial_file_is_ever_executable(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_dns(monkeypatch)
+    seen: list[str] = []
+    real_replace = os.replace
+
+    def _spy(src: Any, dst: Any) -> None:
+        seen.append(str(dst))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(deps.os, "replace", _spy)
+    responses = [_FakeResponse(status_code=200, url="https://example.test/bin", chunks=(b"x",))]
+    _install_fake_client(monkeypatch, responses)
+
+    dest = fake_home / ".local" / "bin" / "bin"
+    asyncio.run(deps._fetch_to_file("https://example.test/bin", dest))
+    assert seen == [str(dest)]


### PR DESCRIPTION
## What changed

The `download` install kind now validates what it writes and where it fetches from.

**Destination.** `install_download` took its destination straight from `spec.bins[0]` — skill frontmatter, and therefore third-party content for any hub-installed skill — with no check. `render_install_command` already checked that same value against the bin-name pattern and rendered nothing when it failed, so the command shown to the operator and the command that ran could disagree; that is the drift `install_kinds` exists to prevent. The pattern is now public `BIN_NAME_RE` and applied in both places. The resolved destination must be a direct child of `~/.local/bin`, and a destination that is already a symlink is refused rather than written through.

**Fetch.** `curl -fsSL` follows redirects. Only the URL declared in the manifest was ever validated, and nothing on this path consulted `agentos.tools.ssrf`. The subprocess is replaced with an `httpx` fetch that does not follow redirects on its own and re-validates every hop through `validate_http_url_for_fetch`, bounded to five — the same shape `web_fetch.py:228-247` already uses.

**Write.** The transfer is capped, streamed to a temporary file in the target directory, mode-set there, and `os.replace`d into place, so an interrupted or oversized download never leaves a partial file behind executable.

## Tests

`tests/test_skills_hub_download_security.py`, 17 cases: destination names that leave the binary directory, an absolute name, a leading-dot name, a leading-dash name, a name with a separator, the empty name, a symlinked destination, the URL-basename fallback, a redirect to a private address, a bounded redirect chain, the size cap, and the atomic executable write.

All 17 fail on the unmodified tree and pass here. They are offline and deterministic: DNS resolution is stubbed to a fixed address table so the shipped `validate_http_url_for_fetch` runs against it, rather than the guard itself being replaced by a stand-in.

## Verification

- `ruff check src tests` — clean
- `mypy src/agentos` — no issues in 615 source files
- `pytest -q` — 8245 passed, 27 skipped; the single failure is the pre-existing `test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`, which fails on a clean tree for an unrelated reason (Click wraps the long temp path across the asserted substring)
- `uv build --wheel` — builds

## Note

`install_download` no longer shells out to `curl`, so the "tool not found" message for that kind no longer names it.

Fixes #450
