### PR TITLE
fix(gateway): stop the Control UI bootstrap leaking host details cross-origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Control UI bootstrap endpoint no longer leaks host details to any website
+  the operator visits. `{control_ui.base_path}/api/bootstrap` sat inside the
+  prefix that is exempt from the loopback Origin guard, so with the default
+  `cors.allowed_origins = ["*"]` any page could `fetch()` it cross-origin and
+  read the absolute config file path (which reveals the OS username) along with
+  the configured `auth_mode`. The bootstrap payload no longer carries
+  `config_path` at all — the console reads it from the authenticated
+  `doctor.status` RPC instead — and the Origin guard's Control UI exemption now
+  stops at `{base_path}/api/`, so the shell and its fingerprinted assets stay
+  exempt while every JSON route under the prefix is fenced on the loopback
+  binds the guard covers. `AuthMiddleware` gets the same narrowing, with a
+  single carve-out for `/api/bootstrap` itself, which the console must read
+  before it holds a token. Fixes #351.
+
 ## [2026.8.24] - 2026-08-24
 
 ### Added

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -23,7 +23,6 @@ let mockBootstrap: Bootstrap = {
   ws_url: 'ws://localhost/ws',
   auth_mode: '',
   base_path: '/control',
-  config_path: '',
   features: { diagnostics: false },
 }
 

--- a/frontend/src/app/locale-switch.test.tsx
+++ b/frontend/src/app/locale-switch.test.tsx
@@ -31,7 +31,6 @@ const mockBootstrap: Bootstrap = {
   ws_url: 'ws://localhost/ws',
   auth_mode: '',
   base_path: '/control',
-  config_path: '',
   features: { diagnostics: false },
 }
 

--- a/frontend/src/app/providers.test.tsx
+++ b/frontend/src/app/providers.test.tsx
@@ -30,7 +30,6 @@ const BOOTSTRAP = {
   ws_url: 'ws://127.0.0.1:18791/ws',
   auth_mode: 'token',
   base_path: '/control',
-  config_path: '/tmp/agentos.toml',
   features: { diagnostics: true },
 }
 

--- a/frontend/src/lib/bootstrap.ts
+++ b/frontend/src/lib/bootstrap.ts
@@ -5,7 +5,6 @@ export interface Bootstrap {
   ws_url: string
   auth_mode: string
   base_path: string
-  config_path: string
   features: { diagnostics: boolean }
 }
 
@@ -68,7 +67,6 @@ export function fallbackBootstrap(): Bootstrap {
     ws_url: defaultWsUrl(),
     auth_mode: '',
     base_path: controlBasePath(),
-    config_path: '',
     features: { diagnostics: false },
   }
 }

--- a/frontend/src/views/agents/AgentsPage.test.tsx
+++ b/frontend/src/views/agents/AgentsPage.test.tsx
@@ -48,7 +48,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/approvals/ApprovalsPage.test.tsx
+++ b/frontend/src/views/approvals/ApprovalsPage.test.tsx
@@ -35,7 +35,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/channels/ChannelsPage.test.tsx
+++ b/frontend/src/views/channels/ChannelsPage.test.tsx
@@ -44,7 +44,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/chat/ChatPage.test.tsx
+++ b/frontend/src/views/chat/ChatPage.test.tsx
@@ -71,7 +71,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/chat/Toolbar.test.tsx
+++ b/frontend/src/views/chat/Toolbar.test.tsx
@@ -26,7 +26,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/cron/CronPage.test.tsx
+++ b/frontend/src/views/cron/CronPage.test.tsx
@@ -49,7 +49,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/health/HealthPage.test.tsx
+++ b/frontend/src/views/health/HealthPage.test.tsx
@@ -22,7 +22,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: { diagnostics: true },
   }),
 }))
@@ -137,19 +136,25 @@ describe('HealthPage', () => {
     await waitFor(() => expect(screen.getAllByText('Still good').length).toBeGreaterThan(0))
   })
 
-  it('uses config-target fix steps when the stored wsUrl equals the default (health.js:227-238)', async () => {
-    // Legacy saveConnectionSettings stores the default URL itself (app.js:210):
-    // a stored-but-equal URL must still count as "uses default".
+  it('uses gateway-target fix steps even when the stored wsUrl equals the default', async () => {
+    // Legacy read the host config path off the inlined bootstrap and produced
+    // --config fix steps here. /api/bootstrap is unauthenticated, so it no
+    // longer carries that path: the synthetic offline report must fall back to
+    // the gateway/bind target and must not render a Config context row.
     localStorage.setItem('agentos.wsUrl', 'ws://127.0.0.1:18791/ws')
     mockRpc.call.mockRejectedValue(new Error('boom'))
     renderPage()
     await waitFor(() =>
       expect(screen.getAllByText('Gateway health report unavailable').length).toBeGreaterThan(0),
     )
-    expect(screen.getByText('agentos doctor --config /tmp/agentos.toml --json')).toBeInTheDocument()
-    expect(screen.getByText('agentos gateway start --config /tmp/agentos.toml')).toBeInTheDocument()
-    // Config context row present in the synthetic error report.
-    expect(screen.getByText('Config')).toBeInTheDocument()
+    expect(
+      screen.getByText('agentos doctor --gateway ws://127.0.0.1:18791/ws --json'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('agentos gateway start --bind 127.0.0.1 --port 18791'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Config')).not.toBeInTheDocument()
+    expect(screen.queryByText('/tmp/agentos.toml')).not.toBeInTheDocument()
   })
 
   it('uses gateway-target fix steps when the stored wsUrl differs from the default', async () => {

--- a/frontend/src/views/health/HealthPage.tsx
+++ b/frontend/src/views/health/HealthPage.tsx
@@ -15,9 +15,7 @@ import {
   gatewayUnavailableFixSteps,
   impactCountsFromSeverity,
   impactValue,
-  isLocalGatewayUrl,
   statusLabel,
-  usesDefaultGatewayUrl,
   visibleEvidenceEntries,
   type Finding,
   type GroupKind,
@@ -422,7 +420,6 @@ export function HealthPage() {
     /* blocked storage: fall back to bootstrap */
   }
   const gatewayUrl = storedWsUrl || bootstrap.ws_url || ''
-  const configPath = bootstrap.config_path || ''
 
   const query = useQuery<HealthReport>({
     queryKey: ['doctor.status', 'main'],
@@ -468,12 +465,12 @@ export function HealthPage() {
     findingsNode = <article className="health-empty">{t('health.findingsLoading')}</article>
   } else if (query.isError) {
     // health.js:86-115 — synthetic gateway.unavailable report + finding.
-    // health.js:227-238 — usesDefault is URL-equality against the default RPC
-    // URL (bootstrap ws_url stands in for legacy App.getDefaultRpcUrl()), not
-    // mere absence of the localStorage override: legacy saveConnectionSettings
-    // stores the default URL itself on save (app.js:210).
-    const usesDefault = usesDefaultGatewayUrl(gatewayUrl, bootstrap.ws_url || '')
-    const errorConfigPath = usesDefault && isLocalGatewayUrl(gatewayUrl) ? configPath : ''
+    // Legacy read the host config path off the inlined bootstrap and, when the
+    // gateway URL was the default one, produced --config fix steps from it
+    // (health.js:227-238). /api/bootstrap is unauthenticated, so it no longer
+    // carries that path: the offline report has no config path to target and
+    // falls back to the gateway/bind pair. The live report is unaffected — its
+    // configPath comes from the authenticated doctor.status RPC.
     const errorReport: HealthReport = {
       status: 'unavailable',
       ready: false,
@@ -484,7 +481,7 @@ export function HealthPage() {
       // distinct "Health report unavailable" per health.js:89.)
       summary: t('health.gatewayUnavailableTitle'),
       gatewayUrl,
-      configPath: errorConfigPath,
+      configPath: '',
       counts: { error: 1, warn: 0, info: 0, ok: 0 },
       impactCounts: { blocks_ready: 1, degrades: 0, optional: 0, none: 0 },
     }
@@ -495,8 +492,8 @@ export function HealthPage() {
       surface: 'gateway',
       title: t('health.gatewayUnavailableTitle'),
       detail: gatewayUnavailableDetail(gatewayUrl, query.error),
-      evidence: errorConfigPath ? { gatewayUrl, configPath: errorConfigPath } : { gatewayUrl },
-      fixSteps: gatewayUnavailableFixSteps(gatewayUrl, errorConfigPath, usesDefault),
+      evidence: { gatewayUrl },
+      fixSteps: gatewayUnavailableFixSteps(gatewayUrl, '', false),
       restartRequired: false,
     }
     railNode = <StatusRail report={errorReport} fallbackGatewayUrl={gatewayUrl} />

--- a/frontend/src/views/logs/LogsPage.test.tsx
+++ b/frontend/src/views/logs/LogsPage.test.tsx
@@ -19,7 +19,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/mcp/McpPage.test.tsx
+++ b/frontend/src/views/mcp/McpPage.test.tsx
@@ -29,7 +29,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/overview/OverviewPage.test.tsx
+++ b/frontend/src/views/overview/OverviewPage.test.tsx
@@ -49,7 +49,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/sessions/SessionsPage.test.tsx
+++ b/frontend/src/views/sessions/SessionsPage.test.tsx
@@ -45,7 +45,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/setup/SetupPage.test.tsx
+++ b/frontend/src/views/setup/SetupPage.test.tsx
@@ -28,7 +28,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/skills/SkillsPage.test.tsx
+++ b/frontend/src/views/skills/SkillsPage.test.tsx
@@ -48,7 +48,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/frontend/src/views/usage/UsagePage.test.tsx
+++ b/frontend/src/views/usage/UsagePage.test.tsx
@@ -31,7 +31,6 @@ vi.mock('@/app/providers', () => ({
     ws_url: 'ws://127.0.0.1:18791/ws',
     auth_mode: 'none',
     base_path: '/control',
-    config_path: '/tmp/agentos.toml',
     features: {},
   }),
 }))

--- a/src/agentos/gateway/control_ui.py
+++ b/src/agentos/gateway/control_ui.py
@@ -82,13 +82,19 @@ def _request_ws_url(request: Request, config: GatewayConfig) -> str:
 
 
 def _build_bootstrap_context(config: GatewayConfig, request: Request) -> dict:
-    """Build the public bootstrap payload consumed by the React application."""
+    """Build the public bootstrap payload consumed by the React application.
+
+    This route is reachable before the console holds a token, so the payload
+    must stay free of host-identifying data: ``config_path`` is an absolute
+    filesystem path that reveals the OS username, and the console already
+    receives it over the authenticated ``doctor.status`` / ``config.get`` RPCs.
+    Keep new fields to what an unauthenticated caller may safely learn.
+    """
     return {
         "version": f"{__version__}+{_TEMPLATE_VERSION_SUFFIX}",
         "ws_url": _request_ws_url(request, config),
         "auth_mode": config.auth.mode,
         "base_path": config.control_ui.base_path,
-        "config_path": config.config_path or "",
         "features": {
             "diagnostics": config.diagnostics_enabled,
         },

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -28,6 +28,21 @@ _PUBLIC_PATHS = frozenset({"/health", "/healthz", "/ready", "/readyz"})
 # that overlaps this must NOT be trusted as an exemption prefix.
 _API_PREFIX = "/api"
 
+# The one JSON route under the Control UI prefix that must answer before the
+# console holds a token: the SPA fetches it to learn its WS URL and auth mode.
+# Everything else under ``{base_path}/api/`` is Control surface and is treated
+# like the root ``/api/*`` routes.
+_UI_BOOTSTRAP_SUFFIX = f"{_API_PREFIX}/bootstrap"
+
+
+def _is_under(prefix: str, path: str) -> bool:
+    """True for the prefix itself or anything below it — never a bare-prefix match.
+
+    ``/control`` and ``/control/chat`` match ``/control``; ``/controlpanel``
+    does not, so a sibling route can never be swallowed by the exemption.
+    """
+    return path == prefix or path.startswith(prefix + "/")
+
 
 def _safe_ui_exempt_prefix(base_path: str) -> str | None:
     """Return the Control UI prefix safe to exempt from the Origin guard, or None.
@@ -124,6 +139,15 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     and the Control UI shell is a served page (guarded by CSP /
     ``SecurityHeadersMiddleware``), not an RPC sink. Only the ``/api/*`` and
     RPC surface — the drive-by target — is gated.
+
+    The UI prefix exemption stops at ``{base_path}/api/`` (``_is_ui_path``
+    below): the shell and its fingerprinted assets are top-level navigations
+    and subresource loads, but the JSON routes mounted under the UI prefix
+    (``/control/api/bootstrap``) are fetch-only and therefore exactly the
+    drive-by target this guard exists for — with ``cors.allowed_origins``
+    defaulting to ``["*"]``, any page the operator visits could read the
+    response. Un-exempting the whole ``/api/`` subtree rather than that one
+    path keeps future JSON routes gated by default (#351).
     """
 
     def __init__(self, app: ASGIApp, config: GatewayConfig, bind_is_loopback: bool) -> None:
@@ -140,9 +164,12 @@ class LoopbackOriginMiddleware(BaseHTTPMiddleware):
     def _is_ui_path(self, path: str) -> bool:
         if self._ui_prefix is None:
             return False
-        # Exact shell ("/control") or anything under it ("/control/..."),
-        # never a bare-prefix match that would swallow sibling routes.
-        return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")
+        if not _is_under(self._ui_prefix, path):
+            return False
+        # ...except the JSON surface mounted under the prefix: a cross-origin
+        # page cannot read the shell it navigates to, but it *can* read
+        # fetch("/control/api/bootstrap"). Those stay gated.
+        return not _is_under(self._ui_prefix + _API_PREFIX, path)
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         path = request.url.path
@@ -184,9 +211,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
 
     def _is_ui_path(self, path: str) -> bool:
+        """True for the served Control UI surface that carries no credentials.
+
+        The shell and its assets are exempt. The JSON surface under
+        ``{base_path}/api/`` is not — it is Control surface and gets the same
+        token gate as the root ``/api/*`` routes — with one carve-out for
+        ``/api/bootstrap``, which the console must read before it has a token.
+        """
         if self._ui_prefix is None:
             return False
-        return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")
+        if not _is_under(self._ui_prefix, path):
+            return False
+        if path == self._ui_prefix + _UI_BOOTSTRAP_SUFFIX:
+            return True
+        return not _is_under(self._ui_prefix + _API_PREFIX, path)
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         # Skip auth for public endpoints and WebSocket upgrades (WS handles own auth)
@@ -249,7 +287,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     def _is_ui_path(self, path: str) -> bool:
         if self._ui_prefix is None:
             return False
-        return path == self._ui_prefix or path.startswith(self._ui_prefix + "/")
+        return _is_under(self._ui_prefix, path)
 
     def _is_trusted_proxy(self, peer_ip: str | None) -> bool:
         if not peer_ip:

--- a/tests/test_gateway/test_control_ui_api_guards.py
+++ b/tests/test_gateway/test_control_ui_api_guards.py
@@ -1,0 +1,191 @@
+"""Origin + auth guard coverage for the JSON surface under the Control UI prefix (#351).
+
+``LoopbackOriginMiddleware`` exempts the Control UI prefix because the shell
+and its fingerprinted assets are navigations/subresources, not RPC sinks. The
+JSON routes mounted under that prefix are a different animal: any page the
+operator visits can ``fetch("http://127.0.0.1:18791/control/api/bootstrap")``
+cross-origin and read the response (CORS defaults to ``["*"]``). Those routes
+must stay behind the guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agentos.gateway.app import create_gateway_app
+from agentos.gateway.config import AuthConfig, ControlUiConfig, GatewayConfig
+from agentos.gateway.middleware import AuthMiddleware, LoopbackOriginMiddleware
+
+_EVIL = "https://evil.example"
+
+
+def _client(base_path: str = "/control", *, bind_is_loopback: bool = True) -> TestClient:
+    config = GatewayConfig(control_ui=ControlUiConfig(base_path=base_path))
+
+    async def ok(_request: Request) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[
+            Route(f"{base_path}/", ok),
+            Route(f"{base_path}/api/bootstrap", ok),
+            Route(f"{base_path}/chat", ok),
+            Route(f"{base_path}/static/dist/assets/app-a1b2c3.js", ok),
+            Route("/api/config", ok),
+        ]
+    )
+    app.add_middleware(
+        LoopbackOriginMiddleware,
+        config=config,
+        bind_is_loopback=bind_is_loopback,
+    )
+    return TestClient(app)
+
+
+def test_cross_origin_fetch_of_ui_bootstrap_is_rejected() -> None:
+    response = _client().get("/control/api/bootstrap", headers={"origin": _EVIL})
+
+    assert response.status_code == 403
+    assert "Origin not allowed" in response.text
+
+
+def test_cross_origin_fetch_of_ui_bootstrap_is_rejected_on_custom_base_path() -> None:
+    response = _client("/console").get("/console/api/bootstrap", headers={"origin": _EVIL})
+
+    assert response.status_code == 403
+
+
+def test_same_origin_and_originless_bootstrap_requests_pass() -> None:
+    client = _client()
+
+    assert client.get("/control/api/bootstrap").status_code == 200
+    same_origin = client.get("/control/api/bootstrap", headers={"origin": "http://127.0.0.1:18791"})
+    assert same_origin.status_code == 200
+
+
+def test_ui_shell_and_assets_stay_exempt_for_cross_origin_navigations() -> None:
+    client = _client()
+    headers = {"origin": _EVIL}
+
+    # A cross-site navigation to the shell sends an Origin on some browsers; the
+    # page it lands on is same-origin-isolated, so it must keep rendering.
+    assert client.get("/control/", headers=headers).status_code == 200
+    assert client.get("/control/chat", headers=headers).status_code == 200
+    assert (
+        client.get("/control/static/dist/assets/app-a1b2c3.js", headers=headers).status_code == 200
+    )
+
+
+def test_root_api_surface_stays_guarded() -> None:
+    assert _client().get("/api/config", headers={"origin": _EVIL}).status_code == 403
+
+
+def test_guard_is_a_noop_on_a_public_bind() -> None:
+    """The guard is loopback-only by design, matching the WS handshake guard.
+
+    Note that auth does NOT cover the gap for this one route: ``/api/bootstrap``
+    is deliberately carved out of ``AuthMiddleware`` so the console can read it
+    before it holds a token. What makes that tolerable is the payload itself —
+    with ``config_path`` gone it carries nothing an unauthenticated cross-origin
+    reader may not learn. Any field added back to ``_build_bootstrap_context``
+    has to clear that bar.
+    """
+    client = _client(bind_is_loopback=False)
+
+    assert client.get("/control/api/bootstrap", headers={"origin": _EVIL}).status_code == 200
+
+
+class TestAuthExemptionScope:
+    """``AuthMiddleware`` exempts the served UI, not the JSON surface under it.
+
+    ``/api/bootstrap`` is the single carve-out: the console fetches it before it
+    holds a token, and (with ``config_path`` removed) it carries nothing an
+    unauthenticated caller may not learn. Any other JSON route mounted under
+    the UI prefix must fail closed onto the same token gate as ``/api/*``.
+    """
+
+    @staticmethod
+    def _auth_client(base_path: str = "/control") -> TestClient:
+        config = GatewayConfig(
+            auth=AuthConfig(mode="token", token="secret-123"),
+            control_ui=ControlUiConfig(base_path=base_path),
+        )
+
+        async def ok(_request: Request) -> PlainTextResponse:
+            return PlainTextResponse("ok")
+
+        app = Starlette(
+            routes=[
+                Route(f"{base_path}/", ok),
+                Route(f"{base_path}/api/bootstrap", ok),
+                Route(f"{base_path}/api/secrets", ok),
+                Route("/api/config", ok),
+            ]
+        )
+        app.add_middleware(AuthMiddleware, config=config)
+        return TestClient(app)
+
+    def test_bootstrap_stays_reachable_without_a_token(self) -> None:
+        assert self._auth_client().get("/control/api/bootstrap").status_code == 200
+
+    def test_shell_stays_reachable_without_a_token(self) -> None:
+        assert self._auth_client().get("/control/").status_code == 200
+
+    def test_other_ui_json_routes_require_a_token(self) -> None:
+        client = self._auth_client()
+
+        assert client.get("/control/api/secrets").status_code == 401
+        assert (
+            client.get(
+                "/control/api/secrets", headers={"authorization": "Bearer secret-123"}
+            ).status_code
+            == 200
+        )
+
+    def test_root_api_still_requires_a_token(self) -> None:
+        assert self._auth_client().get("/api/config").status_code == 401
+
+
+class TestAssembledGatewayApp:
+    """The guard only works because of where it sits in the real middleware stack.
+
+    ``create_gateway_app`` installs ``LoopbackOriginMiddleware`` *before*
+    ``CORSMiddleware`` (app.py). Reorder those two and CORS answers the
+    preflight first, reflecting the wildcard origin and reopening #351 — with
+    every unit test above still green. These exercise the assembled app so the
+    ordering itself is covered.
+    """
+
+    @staticmethod
+    def _app_client(auth_mode: str) -> TestClient:
+        config = GatewayConfig(
+            host="127.0.0.1",
+            port=18791,
+            auth=AuthConfig(mode=auth_mode, token="secret-123" if auth_mode == "token" else None),
+        )
+        return TestClient(create_gateway_app(config=config), base_url="http://127.0.0.1:18791")
+
+    @pytest.mark.parametrize("auth_mode", ("none", "token"))
+    def test_console_still_boots_without_a_token(self, auth_mode: str) -> None:
+        """The SPA fetches bootstrap same-origin (no Origin header) before it has a token."""
+        response = self._app_client(auth_mode).get("/control/api/bootstrap")
+
+        assert response.status_code == 200
+        assert "config_path" not in response.json()
+
+    @pytest.mark.parametrize("auth_mode", ("none", "token"))
+    def test_cross_origin_page_cannot_read_bootstrap(self, auth_mode: str) -> None:
+        client = self._app_client(auth_mode)
+
+        assert client.get("/control/api/bootstrap", headers={"origin": _EVIL}).status_code == 403
+        preflight = client.options(
+            "/control/api/bootstrap",
+            headers={"origin": _EVIL, "access-control-request-method": "GET"},
+        )
+        assert preflight.status_code == 403
+        assert "access-control-allow-origin" not in preflight.headers

--- a/tests/test_gateway/test_control_ui_bootstrap.py
+++ b/tests/test_gateway/test_control_ui_bootstrap.py
@@ -50,7 +50,6 @@ def test_bootstrap_returns_json_context(dist_dir: Path) -> None:
         "ws_url",
         "auth_mode",
         "base_path",
-        "config_path",
         "features",
     }
     assert data["base_path"] == "/control"
@@ -144,14 +143,16 @@ def test_runtime_base_injection_escapes_attribute_content(dist_dir: Path) -> Non
     assert "<script>alert(1)</script>" not in shell
 
 
-def test_bootstrap_includes_config_path(dist_dir: Path, tmp_path: Path) -> None:
+def test_bootstrap_omits_host_identifying_config_path(dist_dir: Path, tmp_path: Path) -> None:
+    """The route is reachable pre-auth, so it must not leak the host FS path (#351)."""
     config = GatewayConfig()
     config.config_path = str(tmp_path / "AgentOS Config.toml")
 
     response = _client(config).get("/control/api/bootstrap")
 
     assert response.status_code == 200
-    assert response.json()["config_path"] == str(config.config_path)
+    assert "config_path" not in response.json()
+    assert str(tmp_path) not in response.text
 
 
 def test_bootstrap_ws_url_uses_client_reachable_wildcard_host(dist_dir: Path) -> None:


### PR DESCRIPTION
Fixes #351

## The bug

`{control_ui.base_path}/api/bootstrap` is registered inside the Control UI base path (`control_ui.py`), and `_safe_ui_exempt_prefix` exempts that whole prefix from **both** `AuthMiddleware` and the loopback Origin guard. The exemption's reasoning — "the shell is a top-level navigation and sends no Origin" — holds for the HTML shell and the fingerprinted assets: a cross-origin page can navigate to those but cannot read them.

It does not hold for `/api/bootstrap`, which is a fetch-only JSON route. With the default `cors.allowed_origins = ["*"]` plus `allow_credentials=True`, any website the operator visits could `fetch()` it and read back `config_path` (an absolute host path, so the OS username) and `auth_mode` — even under `auth.mode="token"`.

## The fix

Both halves of the issue's suggested fix, because they close different parts of the surface.

**1. `config_path` is gone from the bootstrap payload.** This is the half that closes the disclosure on *every* bind. The route has to answer before the console holds a token (`AppProviders` fetches it unauthenticated and the token only reaches `sessionStorage` later), so it cannot simply be auth-gated; the right move is for the pre-auth payload to carry nothing host-identifying. `_build_bootstrap_context` now documents that bar for future fields.

The console already gets the config path from the authenticated `doctor.status` RPC, so the live health report is unchanged. The one consumer of the bootstrap copy was the *synthetic* "gateway unavailable" report, which used it to emit `--config <path>` fix steps; with no config path available offline it falls back to the `--gateway` / `--bind` target that the non-default-URL branch already used. `HealthPage.test.tsx` is updated to pin that.

**2. The Origin guard's UI exemption now stops at `{base_path}/api/`.** The shell and assets stay exempt; the JSON surface under the prefix is fenced on the loopback binds the guard covers. Un-exempting the whole `/api/` subtree rather than that one path means any JSON route added under the UI prefix later is gated by default. `AuthMiddleware` gets the same narrowing, with a single carve-out for `/api/bootstrap` itself.

The rate limiter deliberately keeps exempting the whole prefix — the SPA pulls ~30 files per page load, and that exemption is a throughput knob rather than a confidentiality one.

## What I checked

- **The console still boots** in `auth.mode="none"` and `auth.mode="token"`, on loopback and public binds, against the real `create_gateway_app`. The SPA's bootstrap fetch is same-origin, so it sends no `Origin` header and passes through untouched.
- **The Vite dev flow is unaffected**: the page at `localhost:5173/control/` fetches the relative `/control/api/bootstrap` same-origin, so again no `Origin`; and had one been sent, `is_allowed_ws_origin` admits any loopback host on any port.
- **No SPA route is shadowed.** The fallback route `{base}/{path:path}` still matches `/control/api/<anything>`, which now returns 401 in token mode instead of the shell. The React router has no `api` route and every REST call the console makes goes to the gateway root (`/api/approvals`, `/api/sessions`, …), so nothing reachable regresses — this fails closed on purpose.
- **Path edge cases**: `ControlUiConfig` already validates `base_path` (canonical, single leading slash, restricted segment charset, `/api` and `/ws` rejected), so `_is_under` can't produce `//` or a boundary mismatch. `/controlapi` never matches prefix `/control`.

## Tests

New `tests/test_gateway/test_control_ui_api_guards.py`:

- cross-origin `fetch()` of `/control/api/bootstrap` → 403, on the default and a custom `base_path`
- same-origin and Origin-less requests → 200; shell and assets stay exempt for cross-origin navigations
- `AuthMiddleware` exempts the shell and `/api/bootstrap` but token-gates any other JSON route under the prefix
- the same behaviour against the **assembled** `create_gateway_app`, including the `OPTIONS` preflight — the fix depends on `LoopbackOriginMiddleware` sitting ahead of `CORSMiddleware`, and reordering those two would silently reopen this issue with the isolated unit tests still green

`test_control_ui_bootstrap.py` now asserts the payload has no `config_path` and that the host path appears nowhere in the response body. Each of the five guard assertions was verified load-bearing by reverting `middleware.py` and watching them fail.

## Quality gate

`ruff` clean · `mypy` clean (615 files) · `uv run pytest -q` → 8260 passed, 27 skipped · `npm --prefix frontend run check` → tsc/eslint/prettier clean, 1958 vitest tests passed.

## Note on scope

`usesDefaultGatewayUrl` is now only referenced by its own unit tests (its single app caller was the dead config-target branch). I left it and the `configPath` parameter on `gatewayUnavailableFixSteps` in place rather than widen a security fix into a health-view cleanup — happy to strip both if you'd prefer.

Also: @Preciousuche asked on the issue about picking this up. The issue isn't assigned, so I went ahead — glad to close this in favour of their PR if they already have one in flight.
