### PR TITLE
fix(tools): redact secrets in file content handed back to the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- `read_file`, `read_spreadsheet` and `grep_search` now mask credentials in the
+  content they hand back to the model, and so do the two channels that quote
+  file content alongside them: `edit_file`'s closest-match hint, and terminal
+  output from a command that reads a credential file (`cat ~/.aws/credentials`).
+  Previously the sensitive-path denylist was the only thing protecting a secrets
+  file, and that denylist is lifted entirely under elevated-full mode — which
+  cron `agent_turn` jobs run by default — so `read_file ~/.aws/credentials`
+  returned the raw keys into the persisted transcript. Masking uses a
+  non-reusable `«redacted:…»` sentinel, DSN and URL passwords included, so a
+  value read out of a config file cannot be written back over the working one.
+
+  How much of the pass runs depends on the file. Shape-matched credentials
+  (`sk-…`, JWTs, PEM blocks) are masked everywhere; the name-driven pass, the
+  only one that catches a shapeless secret like `aws_secret_access_key`, runs
+  everywhere except source code, where it would mask identifiers and hand back
+  code that no longer matches the file. Closes #355.
+
+### Fixed
+
+- Credential masking no longer rewrites ordinary source code. The
+  `Authorization` / `x-api-key` header names matched as substrings
+  (`"requiresApiKey": False`), their value ran past the closing bracket
+  (`{"xi-api-key": api_key}` lost its `}`), a bare number was masked as a
+  credential, a vendor prefix matched mid-base64 (`AKIA…` inside an embedded
+  font blob), and a PEM block spanning two adjacent string literals swallowed
+  the code between them. Header names now match on a segment boundary, values
+  stop at the punctuation that closes them and skip numbers and `<placeholder>`
+  forms, prefixes need a left boundary, and a PEM span must have a base64 body.
+  A PEM block in a `read_file` window is masked line by line, so the line
+  numbers the reader computes its next `offset=` from stay correct.
+
+- The `NAME=value` pass now recognises quoted keys (`"client_secret": "…"`), so
+  credentials in JSON and YAML config are masked as the docstring always said
+  they were.
+
 ## [2026.8.24] - 2026-08-24
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,27 @@ headers, JWTs, private keys and DSN passwords are masked. Set
 `AGENTOS_REDACT_SECRETS=0` before starting AgentOS to turn this off; it is read
 once at startup, so a command the agent runs cannot switch it off mid-session.
 
+File content is scanned the same way: `read_file`, `read_spreadsheet`,
+`grep_search` and `edit_file`'s closest-match hint mask credentials on their way
+back to the model, using a `«redacted:sk-…»` sentinel that cannot be mistaken
+for a usable key and written back over the real one. This layer stays on even
+under `/elevated full`, where the sensitive-path denylist is lifted, so an
+elevated read of a secrets file does not put the secrets verbatim into the
+persisted transcript. Reading one through the shell (`cat ~/.aws/credentials`)
+gets the same treatment.
+
+How hard the pass looks depends on the file. Credentials recognisable from their
+own text — vendor-prefixed keys, JWTs, PEM private keys — are masked in every
+file, source code included. The name-driven pass (`NAME=value`, `"name": value`,
+`Authorization:` headers, DSN and URL passwords) is the only one that catches a
+shapeless secret such as `aws_secret_access_key`, and it runs everywhere
+**except** source code, where `api_key=self._api_key` is an identifier and
+`apiKey: NotRequired[str]` a type: masking those would hand back code that no
+longer matches the file. Configuration data — `.env`, `~/.aws/credentials`,
+`~/.kube/config`, `.netrc`, `.ini`, JSON and YAML — gets the full pass.
+`grep_search` judges each matched line by the path it came from, so one search
+can span both kinds of file.
+
 ### What the outbound guard refuses
 
 `http_request`, `exec_command` and `execute_code` refuse to put credential

--- a/src/agentos/redact.py
+++ b/src/agentos/redact.py
@@ -41,11 +41,13 @@ from __future__ import annotations
 import os
 import re
 import shlex
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 
 __all__ = [
     "is_env_dump_command",
     "mask_secret",
+    "reads_credential_file",
+    "redact_file_output",
     "redact_sensitive_text",
     "redact_terminal_output",
     "secret_literal_marker",
@@ -109,7 +111,14 @@ _PREFIX_PATTERNS: tuple[str, ...] = (
     r"ntn_[A-Za-z0-9]{16,}",  # Notion
     r"SG\.[A-Za-z0-9_-]{16,}",  # SendGrid
 )
-_PREFIX_RE = re.compile("|".join(_PREFIX_PATTERNS))
+#: Anchored on the left so ``AKIA…`` inside a base64 blob is not mistaken for
+#: a key — masking it corrupts the blob on a read-then-write round trip.
+_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9])(?:" + "|".join(_PREFIX_PATTERNS) + ")")
+
+#: ``https://user:token@host`` — userinfo in a web URL is a credential the
+#: same way a DSN password is. Redaction-only: the payload guard keeps its
+#: narrower connection-string vocabulary.
+_URL_USERINFO_RE = re.compile(r"(https?://[^:\s/]+:)([^@\s/]+)(@)", re.IGNORECASE)
 
 _PEM_PRIVATE_KEY_RE = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE)
 _PEM_PRIVATE_KEY_BLOCK_RE = re.compile(
@@ -270,6 +279,7 @@ _ASSIGNMENT_RE = re.compile(
     (?:^|[\s"'{,(])                     # start of a token
     (?:\d+\t)?                          # grep -n line prefix
     ([A-Za-z][A-Za-z0-9_.\-]{0,64})     # name
+    ['\"]?                              # closing quote of a JSON/YAML key
     \s*[:=]\s*
     (?:
         "([^"\n]{1,4096})"
@@ -279,15 +289,24 @@ _ASSIGNMENT_RE = re.compile(
     """
 )
 
+#: A header value ends at whitespace, at a quote, or at the punctuation that
+#: closes the structure carrying it. Running past ``}``/``)``/``]``/``;`` is
+#: what turned ``{"xi-api-key": api_key}`` into unbalanced source code.
+_HEADER_VALUE = r"[^\s\"',;)}\]`]+"
+#: Names are matched on a segment boundary, never as a substring, for the same
+#: reason as :func:`_is_credential_name`: ``requiresApiKey`` is a field name.
+_NAME_START = r"(?<![A-Za-z0-9_])"
 _AUTH_HEADER_RE = re.compile(
-    r"((?:Proxy-)?Authorization['\"]?\s*:\s*['\"]?)([A-Za-z][\w.+-]*\s+)?([^\s\"',]+)",
+    rf"({_NAME_START}(?:Proxy-)?Authorization['\"]?\s*:\s*['\"]?)"
+    rf"([A-Za-z][\w.+-]*\s+)?({_HEADER_VALUE})",
     re.IGNORECASE,
 )
 _SECRET_HEADER_NAMES = (
     r"(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)"
 )
 _SECRET_HEADER_RE = re.compile(
-    rf"({_SECRET_HEADER_NAMES}['\"]?\s*:\s*['\"]?)([^\s\"',]+)", re.IGNORECASE
+    rf"({_NAME_START}{_SECRET_HEADER_NAMES}['\"]?\s*:\s*['\"]?)({_HEADER_VALUE})",
+    re.IGNORECASE,
 )
 
 
@@ -446,6 +465,8 @@ def redact_sensitive_text(
     and ``"apiKey": "test"`` fixtures are not leaks. ``file_read=True`` is for
     file content handed back to the agent: secrets are still masked, but with
     the non-reusable sentinel so the agent cannot write a corrupted value back.
+    The two are orthogonal — file content is often source code, and
+    :func:`redact_file_output` decides which of the two a given path is.
     """
     if text is None:
         return None
@@ -454,31 +475,153 @@ def redact_sensitive_text(
     if not text or not (force or _REDACT_ENABLED):
         return text
 
-    if file_read:
-        code_file = True
+    mask = _mask_nonreusable if file_read else _mask_token
+    text = _redact_value_shapes(text, mask=mask)
+    return _redact_named_credentials(text, mask=mask, assignments=not code_file)
 
+
+def _redact_value_shapes(text: str, *, mask: Callable[[str], str], line_safe: bool = False) -> str:
+    """Mask credentials recognisable from their own text alone.
+
+    PEM blocks, vendor-prefixed keys and JWTs carry the match without any help
+    from a surrounding name, which makes this pass safe to run on anything —
+    source code included. ``line_safe`` keeps a collapsed PEM block from
+    swallowing the line numbers around it in a ``read_file`` window.
+    """
     if "-----BEGIN" in text:
-        text = _PEM_PRIVATE_KEY_BLOCK_RE.sub("«redacted:private-key»", text)
-
-    mask_value = _mask_nonreusable if file_read else _mask_token
+        text = _redact_pem_blocks(text, line_safe=line_safe)
     if _has_known_prefix(text):
-        text = _PREFIX_RE.sub(lambda m: mask_value(m.group(0)), text)
+        text = _PREFIX_RE.sub(lambda m: mask(m.group(0)), text)
     if "eyJ" in text:
-        text = _JWT_RE.sub(lambda m: mask_value(m.group(0)), text)
-    if "://" in text:
-        text = _DB_CONNSTR_RE.sub(lambda m: f"{m.group(1)}{_MASK}{m.group(3)}", text)
-    if ":" in text:
-        text = _AUTH_HEADER_RE.sub(
-            lambda m: f"{m.group(1)}{m.group(2) or ''}{_mask_token(m.group(3))}", text
-        )
-        text = _SECRET_HEADER_RE.sub(lambda m: f"{m.group(1)}{_mask_token(m.group(2))}", text)
-
-    if not code_file and ("=" in text or ":" in text):
-        text = _redact_assignments(text)
+        text = _JWT_RE.sub(lambda m: mask(m.group(0)), text)
     return text
 
 
-def _redact_assignments(text: str) -> str:
+def _redact_named_credentials(
+    text: str,
+    *,
+    mask: Callable[[str], str],
+    assignments: bool,
+    dsn_mask: str = _MASK,
+) -> str:
+    """Mask values that are credentials because of the *name* next to them.
+
+    Unlike :func:`_redact_value_shapes` this pass reads structure, not shape,
+    so it cannot tell ``apiKey: NotRequired[str]`` from ``apiKey: <secret>``.
+    Callers holding source code keep it off.
+    """
+    if "://" in text:
+        text = _URL_USERINFO_RE.sub(
+            lambda m: (
+                f"{m.group(1)}{dsn_mask}{m.group(3)}"
+                if not _is_reference_value(m.group(2))
+                else m.group(0)
+            ),
+            text,
+        )
+        text = _DB_CONNSTR_RE.sub(
+            lambda m: (
+                f"{m.group(1)}{dsn_mask}{m.group(3)}"
+                if not _is_reference_value(m.group(2))
+                else m.group(0)
+            ),
+            text,
+        )
+    if ":" in text:
+        text = _AUTH_HEADER_RE.sub(
+            lambda m: (
+                f"{m.group(1)}{m.group(2) or ''}{mask(m.group(3))}"
+                if _is_maskable_header_value(m.group(3))
+                else m.group(0)
+            ),
+            text,
+        )
+        text = _SECRET_HEADER_RE.sub(
+            lambda m: (
+                f"{m.group(1)}{mask(m.group(2))}"
+                if _is_maskable_header_value(m.group(2))
+                else m.group(0)
+            ),
+            text,
+        )
+    if assignments and ("=" in text or ":" in text):
+        text = _redact_assignments(text, mask=mask)
+    return text
+
+
+#: A bare integer is a count or an id, never a credential. ``"authorization":
+#: 20104`` is a token-vocabulary entry in a tokenizer, not a header.
+_NUMERIC_VALUE_RE = re.compile(r"^[-+]?\d+(?:\.\d+)?$")
+
+
+def _is_maskable_header_value(value: str) -> bool:
+    """Return whether a header value is worth masking.
+
+    Deliberately *not* :func:`_is_secret_literal_value`: a short opaque session
+    token is still a credential, and applying that predicate's length floor here
+    would un-mask values this has always masked. This only drops the two shapes
+    that provably carry nothing — a number, and a placeholder like
+    ``Bearer <token>`` in documentation.
+    """
+    stripped = value.strip().strip("\"'")
+    if not stripped or _NUMERIC_VALUE_RE.match(stripped):
+        return False
+    return not _is_reference_value(stripped)
+
+
+#: ``12\tMIIEow…`` — the line-number prefix ``read_file`` puts on every line.
+_LINE_NUMBER_PREFIX_RE = re.compile(r"^(\d+\t)?")
+
+
+#: A PEM body is base64, optionally preceded by ``Proc-Type:``-style headers.
+#: Anything else between the markers means they are two string literals in a
+#: source file, not one key — masking that span destroys the code between them.
+_PEM_BODY_LINE_RE = re.compile(r"^(?:\d+\t)?(?:[A-Za-z0-9+/=.…]*|[A-Za-z][A-Za-z-]*: .*)$")
+
+
+def _is_pem_key_block(block: str) -> bool:
+    """Return whether a BEGIN/END span is one key rather than two literals.
+
+    A ``_SK_START = b"…OPENSSH PRIVATE KEY…"`` marker constant on one line and
+    ``_SK_END = …`` on the next is a match with no body: real code that masking
+    would eat. A key on a single line is the JSON-escaped form
+    (``"private_key": "…BEGIN…\\nMIIE…"``) and does carry a secret.
+    """
+    lines = block.split("\n")
+    if len(lines) == 1:
+        return True
+    body = [line.strip("\r") for line in lines[1:-1]]
+    if not any(body):
+        return False
+    return all(_PEM_BODY_LINE_RE.match(line) for line in body)
+
+
+def _redact_pem_blocks(text: str, *, line_safe: bool) -> str:
+    """Mask PEM private-key blocks, optionally one line at a time.
+
+    Collapsing the block to a single token is right for a log line and wrong
+    for a numbered file window: the reader sees line 12 followed by line 41 and
+    computes the next ``offset=`` from a file that looks shorter than it is.
+    """
+    if not line_safe:
+        return _PEM_PRIVATE_KEY_BLOCK_RE.sub(
+            lambda m: "«redacted:private-key»" if _is_pem_key_block(m.group(0)) else m.group(0),
+            text,
+        )
+
+    def _mask_block(match: re.Match[str]) -> str:
+        if not _is_pem_key_block(match.group(0)):
+            return match.group(0)
+        masked = []
+        for line in match.group(0).split("\n"):
+            prefix = _LINE_NUMBER_PREFIX_RE.match(line)
+            masked.append(f"{prefix.group(1) or '' if prefix else ''}«redacted:private-key»")
+        return "\n".join(masked)
+
+    return _PEM_PRIVATE_KEY_BLOCK_RE.sub(_mask_block, text)
+
+
+def _redact_assignments(text: str, *, mask: Callable[[str], str] = _mask_token) -> str:
     """Mask the value half of ``NAME=secret`` / ``"name": "secret"`` pairs."""
 
     def _replace(match: re.Match[str]) -> str:
@@ -486,7 +629,7 @@ def _redact_assignments(text: str) -> str:
         value = match.group(2) or match.group(3) or match.group(4) or ""
         if not _is_credential_name(name) or not _is_secret_literal_value(value):
             return match.group(0)
-        return match.group(0).replace(value, _mask_token(value))
+        return match.group(0).replace(value, mask(value))
 
     return _ASSIGNMENT_RE.sub(_replace, text)
 
@@ -539,21 +682,170 @@ def is_env_dump_command(command: str | None) -> bool:
     return False
 
 
+def reads_credential_file(command: str | None) -> bool:
+    """Return whether *command* names a credential file as an operand.
+
+    ``cat ~/.aws/credentials`` is the same disclosure as ``read_file`` on it,
+    and blocking only the tool just moves the agent to the shell. Any operand
+    that is not source code by :func:`_is_source_code_path` and is either a
+    known credential file or lives in a credential directory counts.
+    """
+    if not command or not isinstance(command, str):
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    for token in tokens:
+        if token.startswith("-"):
+            continue
+        name = os.path.basename(token).lower()
+        parts = {part.lower() for part in token.replace("\\", "/").split("/")[:-1]}
+        if name in _CREDENTIAL_FILE_NAMES or name.startswith(".env"):
+            return True
+        if parts & _CREDENTIAL_DIR_NAMES:
+            return True
+    return False
+
+
 def redact_terminal_output(output: str, command: str | None = None, *, force: bool = False) -> str:
     """Mask credentials in command output before it reaches the model.
 
     One policy for every terminal surface — foreground ``exec_command`` and
     background process polling alike — so the two cannot drift. ``env`` and
     friends get the assignment pass, because that is exactly the shape their
-    output has; everything else skips it, because ordinary output is source
-    code and config dumps where the assignment pass is mostly false positives.
+    output has, and so does a command that reads a credential file, whose
+    output is that file. Everything else skips it, because ordinary output is
+    source code and config dumps where the assignment pass is mostly false
+    positives.
     """
     if not output:
         return output
-    redacted = redact_sensitive_text(
-        output, force=force, code_file=not is_env_dump_command(command or "")
-    )
+    assignments = is_env_dump_command(command or "") or reads_credential_file(command)
+    redacted = redact_sensitive_text(output, force=force, code_file=not assignments)
     return redacted if redacted is not None else output
+
+
+#: Suffixes whose content is source code. The name-driven pass is kept off
+#: these: it cannot tell ``apiKey: NotRequired[str]`` or
+#: ``api_key=self._api_key`` from a real secret, and a masked identifier is
+#: code the agent can no longer match with ``edit_file`` — or worse, writes
+#: back with the sentinel in it. Shape-matched credentials (``sk-…``, JWTs, PEM
+#: blocks) are still masked here; those carry their own evidence.
+_SOURCE_CODE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".bash",
+        ".c",
+        ".cc",
+        ".cjs",
+        ".cpp",
+        ".cs",
+        ".css",
+        ".dart",
+        ".erl",
+        ".ex",
+        ".exs",
+        ".fish",
+        ".go",
+        ".h",
+        ".hpp",
+        ".hs",
+        ".java",
+        ".js",
+        ".jsx",
+        ".kt",
+        ".kts",
+        ".lua",
+        ".m",
+        ".mjs",
+        ".mm",
+        ".php",
+        ".pl",
+        ".proto",
+        ".ps1",
+        ".py",
+        ".pyi",
+        ".r",
+        ".rb",
+        ".rs",
+        ".scala",
+        ".sh",
+        ".sql",
+        ".svelte",
+        ".swift",
+        ".ts",
+        ".tsx",
+        ".vue",
+        ".zsh",
+    }
+)
+
+#: Files that are nothing but credentials, matched whole because they carry no
+#: suffix. ``~/.aws/credentials`` is the case #355 was filed about.
+_CREDENTIAL_FILE_NAMES: frozenset[str] = frozenset(
+    {
+        ".dockercfg",
+        ".git-credentials",
+        ".htpasswd",
+        ".netrc",
+        ".npmrc",
+        ".pgpass",
+        ".pypirc",
+        "_netrc",
+        "credentials",
+    }
+)
+
+#: Directories whose every file is credential material, for the ones that name
+#: their config plainly (``~/.kube/config``, ``~/.docker/config.json``).
+_CREDENTIAL_DIR_NAMES: frozenset[str] = frozenset(
+    {".aws", ".docker", ".gnupg", ".kube", ".ssh", "gcloud"}
+)
+
+
+def _is_source_code_path(path: str | os.PathLike[str] | None) -> bool:
+    """Return whether *path* is source code rather than configuration data."""
+    if path is None:
+        return False
+    text = os.fspath(path)
+    name = os.path.basename(text).lower()
+    if name in _CREDENTIAL_FILE_NAMES or name.startswith(".env"):
+        return False
+    parts = {part.lower() for part in text.replace("\\", "/").split("/")[:-1]}
+    if parts & _CREDENTIAL_DIR_NAMES:
+        return False
+    return os.path.splitext(name)[1] in _SOURCE_CODE_SUFFIXES
+
+
+def redact_file_output(text: str, *, path: str | os.PathLike[str] | None = None) -> str:
+    """Mask credentials in file content before it reaches the model.
+
+    One policy for every file-read surface — ``read_file``, ``read_spreadsheet``,
+    ``grep_search`` and ``edit_file``'s closest-match hint alike — so they
+    cannot drift. This sits *behind* the sensitive-path denylist rather than
+    replacing it: the denylist is switched off entirely under elevated-full
+    mode, so it cannot be the only thing standing between ``~/.aws/credentials``
+    and the persisted transcript.
+
+    Masking uses the non-reusable sentinel (see :func:`_mask_nonreusable`): an
+    agent that reads a config file and writes it back must not silently replace
+    a working key with a truncated one that fails a request hours later.
+
+    *path* decides how much of the pass runs. Shape-matched credentials — PEM
+    blocks, vendor-prefixed keys, JWTs — are masked in every file. The
+    name-driven pass, which is the only one that catches a shapeless secret like
+    ``aws_secret_access_key``, runs everywhere **except** source code, where it
+    would mask identifiers and hand back code that no longer matches the file.
+    Without a path, the conservative source-code reading applies.
+    """
+    if not text or not _REDACT_ENABLED:
+        return text
+    masked = _redact_value_shapes(text, mask=_mask_nonreusable, line_safe=True)
+    if _is_source_code_path(path) or path is None:
+        return masked
+    return _redact_named_credentials(
+        masked, mask=_mask_nonreusable, assignments=True, dsn_mask="«redacted»"
+    )
 
 
 #: CDP endpoint URLs (``ws(s)://…/devtools/browser/<token>``) carry a

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -17,6 +17,7 @@ from xml.etree import ElementTree as ET
 import structlog
 
 from agentos.identity.workspace import BOOTSTRAP_FILENAMES
+from agentos.redact import redact_file_output
 from agentos.sandbox.integration import get_runtime, sandboxed
 from agentos.tools.fuzzy_match import (
     AmbiguousMatchError,
@@ -313,8 +314,7 @@ def _workspace_strict_read_block(
             "workspace": str(roots[0]),
             "allowed_roots": [str(root) for root in roots],
             "message": (
-                f"{tool_name} blocked: {candidate} is outside active read roots "
-                f"({root_labels})."
+                f"{tool_name} blocked: {candidate} is outside active read roots ({root_labels})."
             ),
             "retryable": False,
         }
@@ -515,7 +515,9 @@ async def read_file(path: str, offset: int | None = None, limit: int | None = No
 
     return await loop.run_in_executor(
         None,
-        lambda: _stream_numbered_lines_from_file(p, path, offset=offset, limit=limit),
+        lambda: redact_file_output(
+            _stream_numbered_lines_from_file(p, path, offset=offset, limit=limit), path=p
+        ),
     )
 
 
@@ -575,7 +577,13 @@ async def read_spreadsheet(
         )
 
     selected = _select_spreadsheet_sheets(sheets, sheet)
-    return _format_spreadsheet(path=p, sheets=selected, offset=row_offset, limit=row_limit)
+    return await loop.run_in_executor(
+        None,
+        lambda: redact_file_output(
+            _format_spreadsheet(path=p, sheets=selected, offset=row_offset, limit=row_limit),
+            path=p,
+        ),
+    )
 
 
 def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[list[str]]]]:
@@ -738,8 +746,7 @@ def _format_spreadsheet(
         if start + limit < len(rows):
             end = start + len(selected)
             parts.append(
-                f"(Showing rows {offset}-{end} of {len(rows)}. "
-                f"Use offset={end + 1} to continue.)"
+                f"(Showing rows {offset}-{end} of {len(rows)}. Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)
 
@@ -801,7 +808,10 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
             " be more specific"
         ) from exc
     except FuzzyMatchError as exc:
-        detail = f" Closest match: {exc.hint}" if exc.hint else ""
+        # The hint quotes real file lines back at the model, so it is a file-read
+        # channel like any other and gets the same mask.
+        hint = redact_file_output(exc.hint, path=path) if exc.hint else ""
+        detail = f" Closest match: {hint}" if hint else ""
         raise ValueError(f"old_text not found in {path}.{detail}") from exc
 
 
@@ -828,9 +838,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:
@@ -1008,7 +1016,8 @@ async def grep_search(
                 text = fp.read_text(encoding="utf-8", errors="replace")
                 for lineno, line in enumerate(text.splitlines(), 1):
                     if regex.search(line):
-                        results.append(f"{fp}:{lineno}: {line.rstrip()}")
+                        shown = redact_file_output(line.rstrip(), path=fp)
+                        results.append(f"{fp}:{lineno}: {shown}")
                         if len(results) >= max_results:
                             return
             except (PermissionError, OSError):

--- a/tests/test_security/test_file_read_redaction.py
+++ b/tests/test_security/test_file_read_redaction.py
@@ -1,0 +1,299 @@
+"""File-read surfaces must mask credentials, denylist bypassed or not.
+
+The sensitive-path denylist is switched off under elevated-full mode, so it
+cannot be the only thing between ``~/.aws/credentials`` and the transcript.
+These tests pin the redaction layer that stays on behind it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.redact import redact_file_output
+from agentos.sandbox.sensitive_paths import sensitive_path_marker
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+OPENAI_KEY = "sk-proj-" + "A" * 24
+GITHUB_PAT = "ghp_" + "B" * 20
+AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+DB_PASSWORD = "sup3rSecretPassw0rdValue"
+#: Split so the repo's own secret-shape hygiene check does not flag the fixture.
+PEM_BEGIN = "-----" + "BEGIN"
+
+
+@contextmanager
+def tool_context(*, elevated: str | None = None) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            elevated=elevated,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_redact_file_output_uses_the_non_reusable_sentinel() -> None:
+    out = redact_file_output(f"api_key: {GITHUB_PAT}")
+
+    assert GITHUB_PAT not in out
+    assert "«redacted:" in out
+
+
+def test_redact_file_output_passes_empty_text_through() -> None:
+    assert redact_file_output("") == ""
+
+
+@pytest.mark.asyncio
+async def test_read_file_masks_a_vendor_key(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    target.write_text(f'api_key = "{OPENAI_KEY}"\n', encoding="utf-8")
+
+    with tool_context():
+        out = await fs.read_file(str(target))
+
+    assert OPENAI_KEY not in out
+    assert "«redacted:" in out
+    assert out.startswith("1\t")
+
+
+@pytest.mark.asyncio
+async def test_read_file_leaves_ordinary_source_untouched(tmp_path: Path) -> None:
+    target = tmp_path / "settings.py"
+    target.write_text('MAX_TOKENS = 4096\nAPI_KEY = "test-value"\n', encoding="utf-8")
+
+    with tool_context():
+        out = await fs.read_file(str(target))
+
+    assert out == '1\tMAX_TOKENS = 4096\n2\tAPI_KEY = "test-value"\n'
+
+
+@pytest.mark.asyncio
+async def test_read_file_redacts_a_sensitive_path_under_elevated_full(tmp_path: Path) -> None:
+    """Elevation drops the hard block; the mask behind it must still apply."""
+    target = tmp_path / ".env"
+    target.write_text(f"OPENAI_API_KEY={OPENAI_KEY}\n", encoding="utf-8")
+    assert sensitive_path_marker(str(target)) is not None
+
+    with tool_context(elevated="full"):
+        out = await fs.read_file(str(target))
+
+    assert OPENAI_KEY not in out
+    assert "«redacted:" in out
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_masks_a_vendor_key(tmp_path: Path) -> None:
+    target = tmp_path / "keys.csv"
+    target.write_text(f"name,value\nopenai,{OPENAI_KEY}\n", encoding="utf-8")
+
+    with tool_context():
+        out = await fs.read_spreadsheet(str(target))
+
+    assert OPENAI_KEY not in out
+    assert "«redacted:" in out
+
+
+@pytest.mark.asyncio
+async def test_grep_search_masks_a_vendor_key_in_the_matched_line(tmp_path: Path) -> None:
+    target = tmp_path / "notes.txt"
+    target.write_text(f"token: {GITHUB_PAT}\n", encoding="utf-8")
+
+    with tool_context():
+        out = await fs.grep_search("token", path=str(target))
+
+    assert GITHUB_PAT not in out
+    assert "«redacted:" in out
+
+
+def test_redact_file_output_sentinels_an_auth_header_too() -> None:
+    """Every mask on the file path is non-reusable, headers included."""
+    out = redact_file_output("Authorization: Bearer abcdefghijklmnopqrstuvwxyz", path="notes.txt")
+
+    assert "abcdefghijklmnopqrstuvwxyz" not in out
+    assert "Authorization: Bearer «redacted:" in out
+
+
+def test_redact_file_output_sentinels_a_dsn_password() -> None:
+    """``***`` reads as a value worth writing back; the sentinel does not."""
+    out = redact_file_output("postgres://app:s3cretpassword@db/app", path="/app/.env")
+
+    assert "s3cretpassword" not in out
+    assert "postgres://app:«redacted»@db/app" == out
+
+
+# Source lines that a name-only guard mangles: the value half is an identifier,
+# a type annotation or a literal, and rewriting it hands the model broken code.
+CODE_LINES = [
+    'return {"xi-api-key": api_key}',
+    '    "Authorization": f"Bearer {self._api_key}",',
+    '    "requiresApiKey": False,',
+    "def sign(authorization: MandateAuthorization | None = None) -> None:",
+    "    client = Client(api_key=self._api_key)",
+]
+
+
+@pytest.mark.parametrize("line", CODE_LINES)
+def test_redact_file_output_leaves_source_code_intact(line: str) -> None:
+    assert redact_file_output(line, path="src/agentos/provider/openai.py") == line
+
+
+@pytest.mark.asyncio
+async def test_read_file_does_not_rewrite_source_code(tmp_path: Path) -> None:
+    """A mangled read is an edit the agent can no longer make."""
+    target = tmp_path / "provider.py"
+    body = "\n".join(CODE_LINES) + "\n"
+    target.write_text(body, encoding="utf-8")
+
+    with tool_context():
+        out = await fs.read_file(str(target))
+
+    assert out == "".join(f"{i}\t{line}\n" for i, line in enumerate(CODE_LINES, 1))
+
+
+@pytest.mark.asyncio
+async def test_read_file_masks_an_opaque_secret_in_a_credentials_file(tmp_path: Path) -> None:
+    """The headline case: the AWS secret carries no vendor prefix to match on."""
+    target = tmp_path / "credentials"
+    target.write_text(
+        "[default]\n"
+        "aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n"
+        f"aws_secret_access_key = {AWS_SECRET}\n",
+        encoding="utf-8",
+    )
+
+    with tool_context(elevated="full"):
+        out = await fs.read_file(str(target))
+
+    assert AWS_SECRET not in out
+    assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+
+@pytest.mark.asyncio
+async def test_read_file_masks_an_opaque_password_in_a_dotenv(tmp_path: Path) -> None:
+    target = tmp_path / ".env.local"
+    target.write_text(f"DB_PASSWORD={DB_PASSWORD}\nMAX_TOKENS=4096\n", encoding="utf-8")
+
+    with tool_context(elevated="full"):
+        out = await fs.read_file(str(target))
+
+    assert DB_PASSWORD not in out
+    assert "MAX_TOKENS=4096" in out
+
+
+@pytest.mark.asyncio
+async def test_grep_search_judges_each_file_by_its_own_path(tmp_path: Path) -> None:
+    """One search spans both kinds of file, and each gets its own policy."""
+    (tmp_path / "app.ini").write_text(f"db_password = {DB_PASSWORD}\n", encoding="utf-8")
+    (tmp_path / "db.py").write_text("db_password = settings.db_password\n", encoding="utf-8")
+
+    with tool_context():
+        out = await fs.grep_search("db_password", path=str(tmp_path))
+
+    assert "db_password = «redacted:" in out
+    assert DB_PASSWORD not in out
+    assert "db_password = settings.db_password" in out
+
+
+def test_edit_file_failed_match_hint_does_not_quote_a_secret(tmp_path: Path) -> None:
+    """The closest-match hint quotes real file lines, so it is a read channel."""
+    target = tmp_path / "credentials"
+    original = f"aws_secret_access_key = {AWS_SECRET}\n"
+
+    with pytest.raises(ValueError) as excinfo:
+        fs._locate_edit(original, "aws_secret_access_key = NOPE", "x", path=str(target))
+
+    message = str(excinfo.value)
+    assert "Closest match:" in message
+    assert AWS_SECRET not in message
+
+
+# ── Passes chosen by path ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "text"),
+    [
+        # A type annotation, a keyword map and an f-string template: all shapes
+        # the name-driven pass reads as ``name: secret``.
+        ("api.py", "apiKey: NotRequired[str]"),
+        ("lexer.py", "    'AUTHORIZATION': tokens.Keyword,"),
+        ("db.py", 'DSN = f"postgres://{user}:{password}@{host}/db"'),
+        # Two string literals, not one key: masking the span eats the code.
+        (
+            "ssh.py",
+            f'_SK_START = b"{PEM_BEGIN} OPENSSH PRIVATE KEY-----"\n'
+            '_SK_END = b"-----END OPENSSH PRIVATE KEY-----"',
+        ),
+        # A vocabulary entry, and a documentation placeholder.
+        ("tokenizer.json", '"authorization": 20104,'),
+        ("api.md", "Send it as `Authorization: Bearer <token>`."),
+    ],
+)
+def test_redact_file_output_leaves_non_credentials_alone(path: str, text: str) -> None:
+    assert redact_file_output(text, path=path) == text
+
+
+def test_redact_file_output_masks_a_pem_block_line_by_line() -> None:
+    """A collapsed block desyncs the line numbers read_file just emitted."""
+    numbered = (
+        f"1\t{PEM_BEGIN} RSA PRIVATE KEY-----\n"
+        "2\tMIIEowIBAAKCAQEA0Y\n"
+        "3\t-----END RSA PRIVATE KEY-----\n"
+        "4\tafter\n"
+    )
+
+    out = redact_file_output(numbered, path="/home/u/.ssh/id_rsa")
+
+    assert "MIIEowIBAAKCAQEA0Y" not in out
+    assert [line.split("\t")[0] for line in out.splitlines()] == ["1", "2", "3", "4"]
+    assert out.endswith("4\tafter\n")
+
+
+def test_redact_file_output_does_not_match_a_prefix_inside_base64() -> None:
+    """``AKIA`` mid-blob is a font, not a key; masking it corrupts the blob."""
+    blob = "AAAwAaAKIAABCDEFGHIJKLMNOAQAAAAAABQA8"
+
+    assert redact_file_output(blob, path="ImageFont.py") == blob
+
+
+def test_redact_file_output_masks_userinfo_in_a_git_credentials_file() -> None:
+    out = redact_file_output(
+        "https://user:opaquepassword123@github.com", path="/home/u/.git-credentials"
+    )
+
+    assert "opaquepassword123" not in out
+
+
+def test_redact_file_output_masks_a_secret_dir_config() -> None:
+    """``~/.kube/config`` is credential material whatever its name says."""
+    out = redact_file_output('"password": "b3BhcXVlYmFzZTY0dmFs"', path="/home/u/.kube/config")
+
+    assert "b3BhcXVlYmFzZTY0dmFs" not in out
+
+
+def test_redact_terminal_output_covers_a_credential_file_read() -> None:
+    """Blocking only read_file would just move the agent to the shell."""
+    from agentos.redact import redact_terminal_output
+
+    out = redact_terminal_output(f"aws_secret_access_key = {AWS_SECRET}", "cat ~/.aws/credentials")
+
+    assert AWS_SECRET not in out
+
+
+def test_redact_terminal_output_still_masks_a_short_header_value() -> None:
+    """The file-read work must not un-mask what the terminal already masked."""
+    from agentos.redact import redact_terminal_output
+
+    out = redact_terminal_output("Authorization: Bearer abc123def45", "curl -v https://x")
+
+    assert "abc123def45" not in out


### PR DESCRIPTION
## Summary

`redact_sensitive_text(file_read=True)` — the redaction path built for file content — had **no production caller**. `read_file` relied solely on the sensitive-path denylist, and that denylist is disabled entirely under elevated-full mode, which cron `agent_turn` jobs run by default. So `read_file ~/.aws/credentials` put raw credentials into the persisted transcript and back into the model's context.

`redact_file_output()` is now wired into `read_file`, `read_spreadsheet` and `grep_search` as a layer that stays on when the denylist is bypassed, plus the two channels that quote file content next to them:

- `edit_file`'s closest-match hint, which returns up to three real file lines on a failed match — a near-miss `old_text` otherwise reads a secrets file one line at a time.
- terminal output from a command that reads a credential file. Blocking only the tool just moves the agent to `cat ~/.aws/credentials`.

## How much of the pass runs depends on the file

Credentials recognisable from their own text — PEM blocks, vendor-prefixed keys, JWTs — are masked in **every** file. The name-driven pass (`NAME=value`, `Authorization:` headers, DSN and URL passwords) is the only one that catches a shapeless secret like `aws_secret_access_key`, and it runs everywhere **except source code**, where `api_key=self._api_key` is an identifier and `apiKey: NotRequired[str]` is a type — masking those hands the model code that no longer matches the file, and `edit_file` can no longer touch it. `grep_search` judges each matched line by the path it came from, so one search can span both kinds of file.

Masks use the non-reusable `«redacted:…»` sentinel, DSN and URL passwords included, so a value read out of a config file cannot be written back over the working one.

## Masks fixed along the way

Running the existing masks on every file read exposed how loose two of them were. All of these were verified against real files and are fixed here (they also affected `exec_command` output, which runs the same masks):

| Input | Before | Now |
| --- | --- | --- |
| `{"xi-api-key": api_key}` | `{"xi-api-key": ***` (lost its `}`) | unchanged |
| `"requiresApiKey": False,` | `"requiresApiKey": ***,` | unchanged |
| `"authorization": 20104,` | masked | unchanged |
| `Authorization: Bearer <token>` (docs) | masked | unchanged |
| `AKIA…` inside embedded base64 | masked, blob corrupted | unchanged |
| `_SK_START = b"…BEGIN OPENSSH PRIVATE KEY…"` + `_SK_END` next line | code between them eaten | unchanged |
| PEM block in a `read_file` window | collapsed, line numbers desync | masked line by line, numbering intact |
| `"client_secret": "…"` in JSON | not masked | masked |

Header names now match on a segment boundary, values stop at the punctuation that closes them and skip numbers and `<placeholder>` forms, vendor prefixes need a left boundary, and a PEM span must have a base64 body to be treated as a key.

## Verification

- New `tests/test_security/test_file_read_redaction.py` (28 cases): the `~/.aws/credentials` case under elevated-full, `.env`/`.kube/config`/`.git-credentials`, per-file policy in `grep_search`, the `edit_file` hint, the sentinel on DSN passwords, PEM line-numbering, and one case per source-code shape above. Verified failing before the change.
- Whole-tree false-positive sweep over 10,882 files (repo + installed site-packages): 14 files change, every one of them a credential-shaped literal in a test fixture or a real key in package metadata — no structural corruption.
- Full gate: `ruff check`, `mypy` (615 files clean), `pytest` 8277 passed / 27 skipped.

Closes #355.