### PR TITLE
feat(skills): add Bankr's `aero-stock-lp` to the hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `aero-stock-lp` joins the Bankr skill hub. The skill range-LPs Coinbase
+  tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome
+  Slipstream (Base) — opening, recentering, and exiting concentrated-liquidity
+  positions, reporting pool status, NAV, yields, and P&L, and routing each
+  position to whichever side pays more at this epoch, staked for AERO emissions
+  or unstaked for trading fees. It is published as a directory in
+  `BankrBot/skills`, so it browses and installs through the existing repo half
+  of the Bankr source with no new code path.
+
+### Changed
+
+- The Bankr user-skill allowlist — the half that carries skills published from
+  a wallet on bankr.bot — is now empty. `stock-premium-lp-manager` was retired
+  from it in favour of `aero-stock-lp`, which covers the same tokenized-equity
+  LP workflow from the repository. Copies already installed keep working; the
+  slug is no longer offered for browse or install.
+
 ### Fixed
 
 - The Control UI bootstrap endpoint no longer leaks host details to any website

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -571,9 +571,9 @@ allowlist and must never be rendered with a logo or read as a trust signal;
 `publisher` is the only field that answers "who vouches for this". It is empty
 only when it would repeat the resolved brand, so a partner skill is credited
 once rather than twice — a *different* credit survives. That is the
-`stock-premium-lp-manager` case: written from a wallet on bankr.bot but named in
-the wheel's user-skill allowlist, so it carries Bankr's `publisher` and
-`@igoryuzo` as its `author`.
+wallet-published case: a skill written from a wallet on bankr.bot but named in
+the wheel's user-skill allowlist carries Bankr's `publisher` and the author's
+handle (e.g. `@igoryuzo`) as its `author`.
 
 There is deliberately **no `availability` key** in CLI output. Whether the
 agent is currently being offered a skill depends on a chat session's tool

--- a/docs/features/agentic-trading.md
+++ b/docs/features/agentic-trading.md
@@ -116,13 +116,15 @@ while a look-alike dropped on disk does not — see
 | Skill | Publisher | What it does |
 | --- | --- | --- |
 | `bankr` | Bankr | Natural-language crypto trading, tokenized stocks and ETFs (spot or leveraged), portfolio balances with P&L, transfers, token deploys, and automated trading across Base, Ethereum, Polygon, Solana, Unichain, Arbitrum, BNB Chain, and Robinhood Chain. Also fronts the Bankr LLM gateway. |
+| `aero-stock-lp` | Bankr | Range-LP Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome Slipstream (Base): open, recenter, and exit concentrated-liquidity positions, check pool status, NAV, and yields, and get a portfolio pass with P&L and projected APR. Routes each position to the higher-yielding side — staked for AERO emissions vs unstaked for trading fees — at entry and on every manage pass. Writes go through the Bankr arbitrary-transaction flow. |
 | `capminal` | Capminal | Cap Wallet operations: deploy tokens via Clanker, Liquid, or Virtuals, claim rewards, manage limit, stop-loss, TWAP, and DCA orders, bridge between Base and Robinhood Chain, and discover x402 APIs. |
 
 Each publisher carries further skills in the same catalog; browse the Community
 tab to see the current list.
 
-`bankr` needs the `@bankr/cli` install and a Bankr login; `capminal` needs
-`CAP_API_KEY`. Both authorize spending — treat them as credentials and read
+`bankr` needs the `@bankr/cli` install and a Bankr login; `aero-stock-lp` runs
+on top of that same Bankr wallet, funded with USDC on Base; `capminal` needs
+`CAP_API_KEY`. All three authorize spending — treat them as credentials and read
 [`skills.md`](skills.md) for how requirements are surfaced before an install.
 
 ## Local by default

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -23,7 +23,10 @@ served as JSON by ``api.bankr.bot/public/skills/<wallet>/<slug>`` — body and a
 Those are carried by a second allowlist, ``_ALLOWED_USER_SKILLS``, and take a
 separate load/fetch path: there is no repository to clone and no
 ``catalog.json``, so the SKILL.md is synthesized from the API payload instead of
-being downloaded through :class:`GitHubSource`.
+being downloaded through :class:`GitHubSource`. That allowlist is empty at the
+moment — the one skill it carried, ``stock-premium-lp-manager``, was superseded
+by ``aero-stock-lp`` in the repository — but the path is live and is what a
+future bankr.bot-published skill is added to.
 """
 
 from __future__ import annotations
@@ -49,13 +52,13 @@ _DEFAULT_REF = "main"
 # Only these skills are loaded from BankrBot/skills. Fetching the whole repo tree
 # and every skill's catalog.json + SKILL.md (~100 skills) trips GitHub's rate
 # limit (429); since the slugs are fixed we fetch just these directly.
-_ALLOWED_SLUGS: tuple[str, ...] = ("bankr", "bankr-token-scam-analysis")
+_ALLOWED_SLUGS: tuple[str, ...] = ("bankr", "bankr-token-scam-analysis", "aero-stock-lp")
 # Bankr-hosted skills published from bankr.bot rather than into the repository,
 # as ``<wallet>/<slug>``. Same reasoning as the repo allowlist — the registry has
-# no public index, so the entries are named here rather than crawled.
-_ALLOWED_USER_SKILLS: tuple[str, ...] = (
-    "0xd4fd8d6f0f64f3d0ba015b645ca8f8c13355c24a/stock-premium-lp-manager",
-)
+# no public index, so the entries are named here rather than crawled. Empty for
+# now: ``stock-premium-lp-manager`` was retired in favour of the repo-published
+# ``aero-stock-lp`` above, which covers the same tokenized-equity LP workflow.
+_ALLOWED_USER_SKILLS: tuple[str, ...] = ()
 _USER_API_BASE = "https://api.bankr.bot/public/skills"
 _USER_PAGE_BASE = "https://bankr.bot/skills"
 _USER_HOSTS = {"bankr.bot", "www.bankr.bot"}

--- a/src/agentos/skills/hub/source.py
+++ b/src/agentos/skills/hub/source.py
@@ -23,7 +23,10 @@ _TOKEN_RE = re.compile(r"[a-z0-9]+")
 # category for its whole catalog collapses the chip row into a no-op.
 _CATEGORY_KEYWORDS: list[tuple[str, frozenset[str]]] = [
     ("trading", frozenset({"trade", "trading", "swap", "uniswap", "dex", "perp", "hyperliquid"})),
-    ("defi", frozenset({"defi", "aave", "lend", "yield", "vault", "stake", "liquidity", "token"})),
+    (
+        "defi",
+        frozenset({"defi", "aave", "lend", "yield", "vault", "stake", "liquidity", "lp", "token"}),
+    ),
     ("wallet", frozenset({"wallet", "account", "erc4337", "signer", "sign", "custody"})),
     ("markets", frozenset({"polymarket", "kalshi", "prediction", "bet", "market", "odds"})),
     (
@@ -49,9 +52,9 @@ def infer_category(slug: str, provider: str, tags: Sequence[str] = ()) -> str:
     """Return a coarse category for browse filters, or "other" when unknown.
 
     ``tags`` is folded into the same token set as the slug and provider, so a
-    skill whose slug says nothing useful ("stock-premium-lp-manager") still
-    lands in a real bucket. Sources that parse ``tags`` out of frontmatter
-    should pass them; those that have none can omit the argument.
+    skill whose slug says little on its own still lands in a real bucket.
+    Sources that parse ``tags`` out of frontmatter should pass them; those that
+    have none can omit the argument.
     """
     haystack = " ".join([slug, provider, *tags]).lower()
     tokens = set(_TOKEN_RE.findall(haystack))

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -287,16 +287,21 @@ async def test_all_entries_failing_returns_empty_without_raising(monkeypatch) ->
 
 
 class _DefaultAllowlistClient(_AsyncClient):
-    """Serves the real default slugs plus the default registry skill."""
+    """Serves the real default slugs, and any registry skill that is asked for."""
 
     catalogs = {
         "bankr": _catalog("bankr", logo=None),
         "bankr-token-scam-analysis": _catalog("bankr-token-scam-analysis", logo=None),
+        "aero-stock-lp": _catalog("aero-stock-lp", logo="logo.svg"),
     }
     skill_mds = {
         "bankr": b"---\nname: bankr\ndescription: Trading agent\n---\n# Bankr\n",
         "bankr-token-scam-analysis": (
             b"---\nname: scam\ndescription: Scans tokens for scams\n---\n# Scan\n"
+        ),
+        "aero-stock-lp": (
+            b"---\nname: aero-stock-lp\ndescription: LP tokenized stocks onchain\n"
+            b"---\n# Aero stock LP\n"
         ),
     }
 
@@ -308,28 +313,29 @@ class _DefaultAllowlistClient(_AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_default_allowlist_loads_the_shipped_repo_and_registry_skills(monkeypatch) -> None:
+async def test_default_allowlist_loads_exactly_the_shipped_repo_skills(monkeypatch) -> None:
     import httpx
 
     monkeypatch.setattr(httpx, "AsyncClient", _DefaultAllowlistClient)
 
-    # Defaults (no allowlist args) → exactly these, nothing else.
-    assert _ALLOWED_SLUGS == ("bankr", "bankr-token-scam-analysis")
-    assert _ALLOWED_USER_SKILLS == (
-        "0xd4fd8d6f0f64f3d0ba015b645ca8f8c13355c24a/stock-premium-lp-manager",
-    )
+    # Defaults (no allowlist args) → exactly these, nothing else. The registry
+    # half ships empty: ``stock-premium-lp-manager`` was retired in favour of
+    # the repo-published ``aero-stock-lp``.
+    assert _ALLOWED_SLUGS == ("bankr", "bankr-token-scam-analysis", "aero-stock-lp")
+    assert _ALLOWED_USER_SKILLS == ()
 
     results = await BankrSource().search("")
 
     assert {r.name for r in results} == {
         "bankr",
         "bankr-token-scam-analysis",
-        "stock-premium-lp-manager",
+        "aero-stock-lp",
     }
-    # Two repo skills → two catalog.json + two SKILL.md fetches, no tree crawl.
-    # The registry skill needs neither: its payload carries the body inline.
-    assert _DefaultAllowlistClient.catalog_calls == 2
-    assert _DefaultAllowlistClient.skill_md_calls == 2
+    # Three repo skills → three catalog.json + three SKILL.md fetches, no tree
+    # crawl. No registry skill is allowlisted, so the client's api.bankr.bot
+    # branch is never reached.
+    assert _DefaultAllowlistClient.catalog_calls == 3
+    assert _DefaultAllowlistClient.skill_md_calls == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -269,7 +269,7 @@ def test_a_branded_hub_install_is_not_credited_twice(tmp_path: Path) -> None:
 
 
 def test_a_branded_install_keeps_an_author_credit_that_is_not_the_brand(tmp_path: Path) -> None:
-    """``stock-premium-lp-manager``: Bankr-distributed, wallet-written.
+    """A wallet-published bankr.bot skill: Bankr-distributed, wallet-written.
 
     Suppression exists to stop a card saying "Bankr" twice, not to erase the
     human behind a brand-distributed skill. The credit survives precisely


### PR DESCRIPTION
Closes #456

## What

Bankr publishes [`aero-stock-lp`](https://github.com/BankrBot/skills/tree/main/aero-stock-lp) — range-LP for Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome Slipstream (Base), routing each position to whichever side pays more at the current epoch: staked for AERO emissions, or unstaked for trading fees.

`BankrSource` browses the Bankr catalog live but lists only the slugs named in the two hard-coded allowlists in `src/agentos/skills/hub/bankr.py`. That is deliberate — it keeps a browse from crawling ~100 skills and tripping GitHub's rate limit, and it stops an install from being pointed at an arbitrary repo under Bankr's brand. A skill absent from the allowlist is invisible in **Skills > Bankr** and refused by `agentos skills install … -s bankr`.

## Changes

- **`skills/hub/bankr.py`** — `aero-stock-lp` added to `_ALLOWED_SLUGS`. It is a repo directory with `catalog.json` (`install.type: "bankr"`) + `SKILL.md`, exactly the shape `bankr/catalog.json` already has, so the existing repo half of the source handles it with **no new code path**.
- **`skills/hub/bankr.py`** — `0xd4fd…/stock-premium-lp-manager` removed from `_ALLOWED_USER_SKILLS`, which is now empty. It is the same author's earlier stock-LP skill, published from a wallet on bankr.bot; `aero-stock-lp` supersedes it, and carrying both would put two near-duplicate stock-LP cards in the hub. The bankr.bot code path stays live and fully tested — only its current occupant goes, and the module docstring says so, so the path does not read as dead code. Copies already installed keep working; only browse and install of that slug go away.
- **`skills/hub/source.py`** — `lp` added to the `defi` keyword set. Without it `infer_category("aero-stock-lp", "Bankr")` returned `"other"` and the skill was unreachable from the `defi` browse filter chip. Whole-token matching means this cannot fire on a substring; the three existing `infer_category` assertions are unchanged.
- **Tests** — the shipped-defaults test in `tests/test_skills_hub_bankr.py` pins both allowlists literally, the resulting name set, and the HTTP call counts. Fixtures, expected names, and counts (2 → 3) updated, and the test renamed since no registry skill is shipped any more. The bankr.bot tests build their own source with an explicit `user_allowlist=`, so that half stays covered.
- **Docs** — new partner-skill row in `docs/features/agentic-trading.md`; `docs/cli.md` and one test docstring stop naming the retired slug in their author-credit example; `CHANGELOG.md` Added + Changed entries.

## Nothing else changes

No new bundled directory, no packaging change (wheel artifacts only cover `bundled/**`), no frontend change (`SHOW_BANKR` / `PARTNER_BRANDS.bankr` / the `source: 'bankr'` snapshot query are per-catalog, not per-skill), no `publishers.py` change — `RECOGNIZED_PUBLISHERS["bankr"]` already exists.

## Verification

Live browse against the real catalog:

```
aero-stock-lp | Bankr | defi | https://raw.githubusercontent.com/BankrBot/skills/main/aero-stock-lp/logo.svg
      LP tokenized stocks onchain — range-LP Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on …
bankr | BankrBot | other |
bankr-token-scam-analysis | BankrBot | defi |
```

- `fetch()` on the new identifier downloads `SKILL.md`, `catalog.json`, `logo.svg`, and all 7 `scripts/*.mjs` files.
- Both `inspect()` and `fetch()` on the retired bankr.bot identifier return `None` and log `bankr.identifier_rejected`.
- Quality gate clean on the touched files (`ruff check`, `ruff format --check`, `mypy src`).
- Full suite: **8244 passed**. Three failures are pre-existing and environment-caused — verified by stashing this diff and reproducing them on `main`: two mem0 provider tests (mem0 is installed in the venv while the tests assume it is absent) and `test_render_html_to_pdf` (renderer `OSError`).
- Frontend `src/views/skills`: 130 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gnUfGFgWGoSok4LTogBLx