### PR TITLE
fix(gateway): fail closed on auth modes the gateway does not enforce (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   single carve-out for `/api/bootstrap` itself, which the console must read
   before it holds a token. Fixes #351.
 
+- `auth.mode = "password"` no longer admits the gateway unauthenticated. The
+  mode was advertised and env-bound (`AGENTOS_AUTH_PASSWORD`) but had no branch
+  in `AuthMiddleware.dispatch`, so it fell through to the unauthenticated pass
+  and left the whole non-RPC surface — `/api/system/status`, `/api/config`,
+  `/api/v1/files/upload`, `/api/audio/transcribe` — open on a loopback bind. Any
+  typo'd mode did the same. `auth.mode` now validates against the modes the
+  gateway actually implements (`none`, `token`, `trusted-proxy`) and refuses
+  anything else at load time with a message naming the fix, and the middleware
+  fails closed with `401` on any mode without an enforcement branch — the config
+  object is read live, so a runtime mutation cannot reopen the hole. `auth.mode`
+  is also case- and whitespace-normalized now (`" TOKEN "` loads as `token`), and
+  `agentos.toml.example` plus the setup guide no longer list `password` as a
+  choice. Closes #352.
+
 ## [2026.8.24] - 2026-08-24
 
 ### Added

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -557,7 +557,7 @@ default_mode = "bypass"                 # off | on | bypass | full
 cron_default_mode = "bypass"            # off | bypass | full
 
 # [auth]
-# mode = "none"         # none | token | password
+# mode = "none"         # none | token | trusted-proxy
 # token = ""
 # Startup guard: with mode = "none" the gateway refuses to bind a non-loopback
 # host (0.0.0.0, a LAN IP, ...). Enable token auth or keep the loopback bind.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -35,6 +35,11 @@ X-Agentos-Token: <token>
 
 > **Note:** Query-string tokens (`?token=<token>`) are rejected (`401 Unauthorized`). Passing tokens in URL query parameters is not supported to prevent token leaks in access logs, browser history, and HTTP referrers.
 
+The gateway implements exactly three auth modes — `none`, `token`, and
+`trusted-proxy`. Any other value (including the never-implemented `"password"`,
+or a typo like `"tokenn"`) is refused when the config loads rather than silently
+admitting every request; the startup error names the supported modes.
+
 `/health` and `/ready` never require a token. Cross-origin browser requests are
 governed by CORS configuration regardless of auth mode.
 

--- a/docs/setup-guide.html
+++ b/docs/setup-guide.html
@@ -647,7 +647,7 @@ default_mode = "bypass"     # off | on | bypass | full
 cron_default_mode = "bypass" # off | bypass | full
 
 # [auth]
-# mode  = "token"           # none | token | password - enable before binding 0.0.0.0
+# mode  = "token"           # none | token | trusted-proxy - enable before binding 0.0.0.0
 # token = "your-long-random-token"</pre>
       </div>
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -189,7 +189,8 @@ configuration.
 in Advanced. The WebSocket config mutation RPCs reject attempts to retarget the
 active config file or replace runtime-owned authentication credentials. Other
 authentication settings, such as `auth.mode`, remain editable and may require a
-gateway restart.
+gateway restart — `auth.mode` accepts only `none`, `token`, or `trusted-proxy`,
+and any other value is rejected by the mutation RPC rather than saved.
 
 Restart reporting is deliberately conservative. Mutation responses expose
 `restartRequired`; subsequent snapshots expose cumulative `pendingRestart` and

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -56,13 +56,53 @@ class ContextOverflowPolicy(StrEnum):
     REFUSE = "refuse"
 
 
+# The auth modes the gateway actually implements. Every entry here has an
+# enforcement branch in ``AuthMiddleware.dispatch``; anything else — the
+# never-implemented ``"password"``, or a typo like ``"tokenn"`` — is rejected at
+# validation time so a mode can never silently no-op into an unauthenticated
+# gateway (#352). Enforced end-to-end is a stricter bar still: see
+# ``_mode_protects_public_bind``, which admits only ``token`` on a public bind.
+SUPPORTED_AUTH_MODES: tuple[str, ...] = ("none", "token", "trusted-proxy")
+
+
 class AuthConfig(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="AGENTOS_AUTH_")
+    model_config = SettingsConfigDict(env_prefix="AGENTOS_AUTH_", validate_assignment=True)
 
     token: str | None = None
+    # Reserved: no auth mode consumes this today. ``auth.mode="password"`` is
+    # rejected (see the ``mode`` validator); the field is kept so an existing
+    # config that carries the value still loads.
     password: str | None = None
-    mode: str = "none"  # none | token | password | trusted-proxy
+    mode: str = "none"  # none | token | trusted-proxy
     trusted_proxy: str | None = None
+
+    @field_validator("mode")
+    @classmethod
+    def _validate_mode(cls, value: str) -> str:
+        """Fail closed on any mode the middleware does not enforce.
+
+        ``"password"`` was advertised and env-bound but never implemented: it
+        fell through ``AuthMiddleware.dispatch`` and admitted every non-RPC
+        request unauthenticated. Refusing it (and every typo) at load time is
+        the only posture that cannot be mistaken for "auth is on".
+        """
+        normalized = value.strip().lower()
+        if normalized in SUPPORTED_AUTH_MODES:
+            return normalized
+        supported = ", ".join(repr(mode) for mode in SUPPORTED_AUTH_MODES)
+        extra = (
+            " It was advertised but never implemented: it admitted every request "
+            "unauthenticated instead of asking for a credential."
+            if normalized == "password"
+            else ""
+        )
+        raise ValueError(
+            f"auth.mode={value!r} is not an implemented auth mode; supported modes are "
+            f"{supported}.{extra} Fix it in the [auth] section of your agentos.toml "
+            "(or in AGENTOS_AUTH_MODE / AGENTOS_GATEWAY_AUTH__MODE if the value comes "
+            'from the environment): mode = "token" enforces a credential, mode = "none" '
+            "accepts an unauthenticated loopback-only gateway."
+        )
 
 
 class CorsConfig(BaseSettings):
@@ -2314,7 +2354,8 @@ def _mode_protects_public_bind(auth: AuthConfig) -> bool:
     has a resolver in ``resolve_auth``. Every other mode is treated as
     unauthenticated for the public-bind guard:
 
-    * ``password`` has no HTTP-surface enforcement yet.
+    * ``password`` is refused outright by ``AuthConfig`` — it was advertised
+      but never implemented (#352).
     * ``trusted-proxy`` only string-matches the client-supplied
       ``X-Forwarded-For`` header (trivially spoofable) and has no resolver in
       ``resolve_auth``, so it is not enforced end-to-end. Re-admit it here

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -209,6 +209,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
+        # Modes already reported by the fail-closed branch. A gateway stuck in
+        # that posture would otherwise log once per request.
+        self._reported_unsupported_modes: set[str] = set()
 
     def _is_ui_path(self, path: str) -> bool:
         """True for the served Control UI surface that carries no credentials.
@@ -253,6 +256,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )
+
+        else:
+            # Fail closed on any mode without an enforcement branch above
+            # (#352). ``AuthConfig`` rejects those at validation time, but this
+            # middleware reads the config object live — a runtime mutation must
+            # never fall through to an unauthenticated pass, which is exactly
+            # how ``auth.mode="password"`` silently admitted every request.
+            if auth_mode not in self._reported_unsupported_modes:
+                self._reported_unsupported_modes.add(auth_mode)
+                log.warning("gateway.auth.unsupported_mode", mode=auth_mode)
+            return JSONResponse({"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401)
 
         return await call_next(request)  # type: ignore[no-any-return]
 

--- a/tests/test_cli/test_gateway_auth_prompt.py
+++ b/tests/test_cli/test_gateway_auth_prompt.py
@@ -95,8 +95,8 @@ def test_warning_names_the_specific_lan_host_not_only_wildcard(tmp_path) -> None
     assert "non-loopback" in output
 
 
-def test_unsupported_auth_mode_can_only_be_cancelled_or_replaced(tmp_path) -> None:
-    config = _config(tmp_path, auth=AuthConfig(mode="password"))
+def test_unenforced_auth_mode_can_only_be_cancelled_or_replaced(tmp_path) -> None:
+    config = _config(tmp_path, auth=AuthConfig(mode="trusted-proxy", trusted_proxy="10.0.0.1"))
 
     outcome, result = provision_public_bind_auth(
         config, interactive=True, prompt=lambda _m: "2", emit=lambda _m: None
@@ -104,7 +104,7 @@ def test_unsupported_auth_mode_can_only_be_cancelled_or_replaced(tmp_path) -> No
 
     assert outcome is AuthProvisionOutcome.CANCEL
     assert result is config
-    assert result.auth.mode == "password"
+    assert result.auth.mode == "trusted-proxy"
 
 
 def test_public_bind_with_token_mode_is_unchanged(tmp_path) -> None:
@@ -287,7 +287,7 @@ def test_choice_2_cancels_without_mutating_or_persisting(tmp_path) -> None:
 
 
 def test_choice_2_cancel_does_not_add_auth_runtime_overrides(tmp_path) -> None:
-    config = _config(tmp_path, auth=AuthConfig(mode="password"))
+    config = _config(tmp_path, auth=AuthConfig(mode="trusted-proxy", trusted_proxy="10.0.0.1"))
     set_runtime_overrides({"host": "127.0.0.1", "port": 18791, "debug": False})
 
     outcome, _ = provision_public_bind_auth(

--- a/tests/test_gateway/test_auth_mode_enforcement.py
+++ b/tests/test_gateway/test_auth_mode_enforcement.py
@@ -1,0 +1,166 @@
+"""Every ``auth.mode`` value either enforces credentials or is refused (#352).
+
+``auth.mode="password"`` was an advertised, env-bound mode with no branch in
+``AuthMiddleware.dispatch``: it fell through to ``call_next`` and admitted the
+whole non-RPC surface unauthenticated. So did any typo'd mode. The fix is two
+layers — validation refuses an unimplemented mode at load time, and the
+middleware fails closed on anything that reaches it anyway (the config object
+is read live, so a runtime mutation must not reopen the hole).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from starlette.testclient import TestClient
+
+from agentos.gateway.app import create_gateway_app
+from agentos.gateway.config import SUPPORTED_AUTH_MODES, AuthConfig, GatewayConfig
+
+
+class TestAuthModeValidation:
+    @pytest.mark.parametrize("mode", list(SUPPORTED_AUTH_MODES))
+    def test_supported_modes_are_accepted(self, mode: str) -> None:
+        assert AuthConfig(mode=mode).mode == mode
+
+    def test_password_mode_is_refused(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AuthConfig(mode="password")
+        message = str(exc_info.value)
+        assert "password" in message
+        assert "token" in message
+
+    @pytest.mark.parametrize("mode", ["tokenn", "on", "", "basic", "Password"])
+    def test_unknown_modes_are_refused(self, mode: str) -> None:
+        with pytest.raises(ValidationError):
+            AuthConfig(mode=mode)
+
+    def test_mode_is_normalized(self) -> None:
+        assert AuthConfig(mode=" TOKEN ").mode == "token"
+
+    def test_assignment_is_validated(self) -> None:
+        auth = AuthConfig(mode="token", token="secret")
+        with pytest.raises(ValidationError):
+            auth.mode = "password"
+        assert auth.mode == "token"
+
+    def test_password_field_still_loads(self) -> None:
+        """An existing config carrying auth.password must not fail to parse."""
+        assert AuthConfig(password="hunter2").password == "hunter2"
+
+    @pytest.mark.parametrize(
+        "env_name",
+        ["AGENTOS_AUTH_MODE", "AGENTOS_GATEWAY_AUTH__MODE"],
+    )
+    def test_env_bound_password_mode_is_refused(
+        self, env_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``AGENTOS_AUTH_PASSWORD`` made this an env-bound mode; both env
+        spellings of ``mode`` must be refused, not just the TOML one."""
+        monkeypatch.setenv(env_name, "password")
+        monkeypatch.setenv("AGENTOS_AUTH_PASSWORD", "hunter2")
+        with pytest.raises(ValidationError):
+            GatewayConfig()
+
+    @pytest.mark.parametrize(
+        "env_name",
+        ["AGENTOS_AUTH_MODE", "AGENTOS_GATEWAY_AUTH__MODE"],
+    )
+    def test_env_bound_token_mode_still_loads(
+        self, env_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(env_name, "token")
+        monkeypatch.setenv("AGENTOS_AUTH_TOKEN", "secret-123")
+        assert GatewayConfig().auth.mode == "token"
+
+    def test_toml_with_password_mode_is_refused(self, tmp_path) -> None:
+        path = tmp_path / "agentos.toml"
+        path.write_text('[auth]\nmode = "password"\npassword = "hunter2"\n')
+        with pytest.raises(ValidationError):
+            GatewayConfig.load_from_toml(path)
+
+
+def _unenforced_config(mode: str = "password") -> GatewayConfig:
+    """A gateway whose live config carries a mode with no enforcement branch.
+
+    ``model_construct`` bypasses validation on purpose: this is the runtime
+    posture the middleware must fail closed on, not the load-time one.
+    """
+
+    return GatewayConfig(
+        host="127.0.0.1",
+        auth=AuthConfig.model_construct(mode=mode, password="hunter2"),
+    )
+
+
+class TestUnenforcedModeFailsClosed:
+    @pytest.mark.parametrize(
+        "path",
+        ["/api/sessions", "/api/config", "/api/system/status"],
+    )
+    def test_non_rpc_surface_is_denied(self, path: str) -> None:
+        app = create_gateway_app(config=_unenforced_config())
+        with TestClient(app, base_url="http://localhost") as client:
+            response = client.get(path)
+            assert response.status_code == 401
+            assert response.json().get("code") == "UNAUTHORIZED"
+
+    @pytest.mark.parametrize("mode", ["password", "tokenn", "", "basic"])
+    def test_every_unenforced_mode_is_denied(self, mode: str) -> None:
+        """A typo must fail closed exactly like the advertised mode did."""
+        app = create_gateway_app(config=_unenforced_config(mode))
+        with TestClient(app, base_url="http://localhost") as client:
+            assert client.get("/api/sessions").status_code == 401
+
+    def test_post_route_is_denied(self) -> None:
+        """The fall-through admitted writes, not just reads — /api/chat runs a
+        turn with the operator's provider credentials."""
+        app = create_gateway_app(config=_unenforced_config())
+        with TestClient(app, base_url="http://localhost") as client:
+            response = client.post("/api/chat", json={"message": "hi"})
+            assert response.status_code == 401
+            assert response.json().get("code") == "UNAUTHORIZED"
+
+    def test_upload_route_is_denied(self) -> None:
+        app = create_gateway_app(config=_unenforced_config())
+        with TestClient(app, base_url="http://localhost") as client:
+            response = client.post(
+                "/api/v1/files/upload",
+                files={"file": ("a.txt", b"hello", "text/plain")},
+            )
+            assert response.status_code == 401
+
+    def test_transcribe_route_is_denied(self) -> None:
+        app = create_gateway_app(config=_unenforced_config())
+        with TestClient(app, base_url="http://localhost") as client:
+            response = client.post(
+                "/api/audio/transcribe",
+                files={"file": ("a.webm", b"audio", "audio/webm")},
+            )
+            assert response.status_code == 401
+
+    def test_health_probe_stays_public(self) -> None:
+        """Fail-closed must not take the credential-free health surface down."""
+        app = create_gateway_app(config=_unenforced_config())
+        with TestClient(app, base_url="http://localhost") as client:
+            assert client.get("/health").status_code == 200
+
+
+class TestSupportedModesStillWork:
+    def test_none_mode_admits_loopback(self) -> None:
+        app = create_gateway_app(config=GatewayConfig(auth=AuthConfig(mode="none")))
+        with TestClient(app, base_url="http://localhost") as client:
+            assert client.get("/api/system/status").status_code == 200
+
+    def test_token_mode_enforces(self) -> None:
+        config = GatewayConfig(auth=AuthConfig(mode="token", token="secret-123"))
+        app = create_gateway_app(config=config)
+        with TestClient(app, base_url="http://localhost") as client:
+            assert client.get("/api/system/status").status_code == 401
+            assert (
+                client.get(
+                    "/api/system/status",
+                    headers={"Authorization": "Bearer secret-123"},
+                ).status_code
+                == 200
+            )

--- a/tests/test_gateway/test_config_persist_no_freeze_rpc.py
+++ b/tests/test_gateway/test_config_persist_no_freeze_rpc.py
@@ -215,17 +215,17 @@ async def test_config_apply_baseline_diff_persists_deliberate_auth_mode_edit(tmp
     impossible; the snapshot-baseline diff restores the ability to persist a
     deliberate YAML edit of an overridden field.
 
-    Distinguishing setup: the on-disk original (password), the running echo
+    Distinguishing setup: the on-disk original (trusted-proxy), the running echo
     (none, runtime override), and the deliberate edit (token) are all different, so
-    the two strategies give different final states — round-2 restores password
+    the two strategies give different final states — round-2 restores trusted-proxy
     (wrong), baseline-diff persists token (correct)."""
     import yaml
 
     cfg_path = tmp_path / "config.toml"
-    _seed_disk(cfg_path, {"auth": {"mode": "password", "token": "existing-token"}})
+    _seed_disk(cfg_path, {"auth": {"mode": "trusted-proxy", "token": "existing-token"}})
 
     # The runtime map recorded the on-disk auth original; running is mode=none.
-    set_runtime_overrides({"auth.mode": "password"})
+    set_runtime_overrides({"auth.mode": "trusted-proxy"})
     cfg = _running_config(
         cfg_path,
         auth=AuthConfig(
@@ -253,7 +253,7 @@ async def test_config_apply_baseline_diff_persists_deliberate_auth_mode_edit(tmp
 
     saved = _read(cfg_path)
     # Deliberate edit (none in baseline -> token submitted) persisted; NOT
-    # restored to the on-disk password original the way round-2 would.
+    # restored to the on-disk trusted-proxy original the way round-2 would.
     assert saved["auth"]["mode"] == "token"
     assert saved["auth"]["token"] == "existing-token"
 

--- a/tests/test_gateway/test_config_persist_runtime_only.py
+++ b/tests/test_gateway/test_config_persist_runtime_only.py
@@ -102,11 +102,11 @@ def test_explicit_change_without_overrides_persists_verbatim(tmp_path):
 def test_local_auth_mode_override_is_restorable(tmp_path):
     cfg_path = tmp_path / "config.toml"
     with open(cfg_path, "wb") as f:
-        tomli_w.dump({"auth": {"mode": "password"}}, f)
+        tomli_w.dump({"auth": {"mode": "trusted-proxy"}}, f)
 
     # A local run forced mode=none; boot recorded the on-disk auth value so a
     # later writer cannot freeze the transient posture.
-    set_runtime_overrides({"auth.mode": "password"})
+    set_runtime_overrides({"auth.mode": "trusted-proxy"})
     runtime = GatewayConfig(
         auth=AuthConfig(mode="none"),
         config_path=str(cfg_path),
@@ -114,7 +114,7 @@ def test_local_auth_mode_override_is_restorable(tmp_path):
     persist_config(runtime)
 
     saved = _read(cfg_path)
-    assert saved["auth"]["mode"] == "password"
+    assert saved["auth"]["mode"] == "trusted-proxy"
 
 
 def test_missing_original_drops_the_field_so_defaults_apply(tmp_path):

--- a/tests/test_gateway/test_public_bind_auth_guard.py
+++ b/tests/test_gateway/test_public_bind_auth_guard.py
@@ -77,9 +77,19 @@ class TestEnforcePublicBindAuthGuard:
     def test_refuses_public_bind_with_unenforced_auth_mode(self, mode: str) -> None:
         """[P1b] Only token is enforced end-to-end. password/trusted-proxy are
         not enforced on the HTTP surface, and a typo must never be read as
-        "auth is on"."""
+        "auth is on".
+
+        ``AuthConfig`` now refuses every one of these but ``trusted-proxy`` at
+        validation time (#352), so the unvalidated ``model_construct`` posture
+        is what actually exercises this guard — it must stay closed even if a
+        mode reaches it by some other path.
+        """
+        config = GatewayConfig(
+            host="0.0.0.0",
+            auth=AuthConfig.model_construct(mode=mode, trusted_proxy=None),
+        )
         with pytest.raises(ValueError, match="auth.mode"):
-            enforce_public_bind_auth_guard(_config("0.0.0.0", auth_mode=mode))
+            enforce_public_bind_auth_guard(config)
 
     def test_refuses_trusted_proxy_even_with_proxy_configured(self) -> None:
         """[P1] AuthMiddleware only string-matches the client-controlled


### PR DESCRIPTION
Closes #352.

## The hole

`AuthMiddleware.dispatch` handled `none`, `token` and `trusted-proxy`, then unconditionally `return await call_next(request)`. `auth.mode = "password"` — an advertised mode with an env binding (`AGENTOS_AUTH_PASSWORD`) — hit that fall-through, so the entire non-RPC HTTP surface was admitted unauthenticated: `/api/system/status`, `/api/config`, `/api/chat`, `/api/v1/files/upload`, `/api/audio/transcribe`. Any typo'd mode (`"tokenn"`, `""`) behaved identically. An operator on a loopback bind who set `password` believing it protected the gateway got a `none`-equivalent posture with no signal.

## The fix

The issue offered two options; this takes the second (fail closed at validation), because implementing `password` would add a second HTTP credential mode that duplicates `token` while needing its own resolver, WS handshake path and UI — and `_mode_protects_public_bind` already documents `token` as the only mode enforced end-to-end.

Two layers:

1. **`AuthConfig.mode` validates against `SUPPORTED_AUTH_MODES`** (`none`, `token`, `trusted-proxy` — every mode with an enforcement branch) and refuses anything else at load time. The error names the `[auth]` section of `agentos.toml` and both env spellings, and says which mode to pick.
2. **`AuthMiddleware.dispatch` gains an `else` branch** that logs (once per mode) and returns `401`. This is not redundant: the middleware reads the config object live, and `model_copy(update=…)` / `update_config_in_place` bypass field validation. Validation alone would not keep the fall-through closed.

`resolve_auth` already failed closed for the WS/RPC surface. The upload and transcribe routes self-check only when `mode == "token"`, so they are covered by the middleware's default-deny — asserted by the new tests.

`auth.password` is retained as a *field* so an existing config still parses; the mode that consumed it is gone.

## On hard-failing rather than migrating

`migrate_config_payload` exists so a legacy value never bricks boot, so the obvious question is why `mode = "password"` is not rewritten to `"none"`. Because the repo already distinguishes dead keys from security-relevant ones: retired channels and `memory.*` leftovers are stripped with a warning, but `auth.allow_unauthenticated_public` and a limited `auth.token_scopes` both `raise` rather than migrate — precisely so a human decides the security posture. A silent rewrite to `"none"` would also preserve the thing the issue is about: an operator who believes auth is on while it is not. Recovery is a one-line hand edit, named in the error text.

Known wrinkle: `agentos config set auth.mode token --config …` cannot repair such a config — it loads (and validates) before it writes, so it surfaces the `ValidationError` as a traceback. That is pre-existing behaviour shared with the two hard-failing auth keys above; happy to fold a friendly-error wrapper for `config get`/`config set` into this PR if you'd like it here rather than separately.

## Tests

New `tests/test_gateway/test_auth_mode_enforcement.py` (30 cases):

- validation: `password`, typos, both env spellings (`AGENTOS_AUTH_MODE` and `AGENTOS_GATEWAY_AUTH__MODE`), TOML load, assignment, normalization, and that `auth.password` still parses.
- middleware: `password` and typo'd modes are `401` on GET routes, the `/api/chat` POST route, the upload route and the transcribe route — built via `model_construct` so the unvalidated runtime posture is what is exercised.
- non-regression: `/health` stays public; `none` and `token` behave as before.

Adversarially verified: reverting the middleware branch fails 10 of them, with `/api/system/status`, `/api/config`, `/api/chat`, upload and transcribe all returning `200` unauthenticated.

Four pre-existing tests used `"password"` as a stand-in value and were updated: three now use `trusted-proxy` (same `_mode_protects_public_bind` branch, same "three distinct values" property), and `test_public_bind_auth_guard` now builds its unvalidated config with `model_construct` outside the `pytest.raises` block — otherwise it would have started passing on the construction error instead of on the guard.

Docs: `agentos.toml.example` and `docs/setup-guide.html` no longer list `password` as a choice (they were instructing operators toward a now-fatal value); `docs/http-api.md` and `docs/web-ui.md` state the supported set.

## Gate

`ruff check` clean, `mypy src/agentos` clean (615 files), `uv run pytest -q` = 8276 passed, 27 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzMXMPYXLDin7PDvFyZiPo

