### PR TITLE
fix(skills): keep Bankr catalog cards on the Bankr brand mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Bankr catalog cards all wear the Bankr brand mark again. `aero-stock-lp` is
+  the one entry in `BankrBot/skills` whose `catalog.json` ships a `logo`, so it
+  rendered that artwork while every other card in the partner tab showed the
+  Bankr symbol. The Bankr source now ignores the payload's logo entirely —
+  membership in the catalog is the brand, and a repository-side edit can no
+  longer repaint a partner card's identity.
+
 - The Control UI bootstrap endpoint no longer leaks host details to any website
   the operator visits. `{control_ui.base_path}/api/bootstrap` sat inside the
   prefix that is exempt from the loopback Origin guard, so with the default

--- a/src/agentos/skills/hub/bankr.py
+++ b/src/agentos/skills/hub/bankr.py
@@ -475,12 +475,6 @@ class BankrSource(SkillSource):
             return None
 
         provider = str(catalog.get("provider") or "")
-        logo_name = catalog.get("logo")
-        logo = (
-            f"{self._raw_base}/{slug}/{logo_name}"
-            if isinstance(logo_name, str) and logo_name
-            else ""
-        )
 
         setup_raw = catalog.get("setup")
         setup = [str(s) for s in setup_raw] if isinstance(setup_raw, list) else []
@@ -499,7 +493,14 @@ class BankrSource(SkillSource):
             identifier=self._skill_url(slug),
             homepage=str(catalog.get("providerUrl") or self._skill_url(slug)),
             provider=provider,
-            logo=logo,
+            # The catalog's own ``logo`` is deliberately ignored. This is a
+            # curated partner catalog: every card in it is Bankr-distributed,
+            # so it wears the Bankr brand mark the tab and catalog header wear
+            # (``LogoBadge`` falls back to it on an empty logo). Honouring the
+            # payload's artwork made ``aero-stock-lp`` — the one entry that
+            # ships a ``logo.svg`` — the odd card out, and would let a
+            # repository-side edit repaint a partner card's identity.
+            logo="",
             emoji=emoji,
             category=infer_category(slug, provider),
             setup=setup,

--- a/tests/test_skills_hub_bankr.py
+++ b/tests/test_skills_hub_bankr.py
@@ -150,7 +150,7 @@ async def test_search_empty_query_lists_all_bankr_skills(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_builds_provider_logo_and_identifier(monkeypatch) -> None:
+async def test_search_builds_provider_and_identifier_without_payload_logo(monkeypatch) -> None:
     import httpx
 
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
@@ -160,13 +160,13 @@ async def test_search_builds_provider_logo_and_identifier(monkeypatch) -> None:
 
     alchemy = by_name["alchemy"]
     assert alchemy.provider == "Alchemy"
-    assert alchemy.logo == (
-        "https://raw.githubusercontent.com/BankrBot/skills/main/alchemy/alchemy.svg"
-    )
+    # A catalog-declared logo is ignored: partner-catalog cards wear the Bankr
+    # brand mark the tab wears, not whatever artwork the repository ships.
+    assert alchemy.logo == ""
     assert alchemy.identifier == "https://github.com/BankrBot/skills/tree/main/alchemy"
 
-    # Null logo in the catalog → empty logo, but the Bankr brand emoji fills in
-    # as the avatar so cards never render a bare initials box.
+    # Same for a null logo; the Bankr brand emoji fills in as the avatar so
+    # cards never render a bare initials box.
     assert by_name["bankr"].logo == ""
     assert by_name["bankr"].emoji == "📺"
     assert by_name["alchemy"].emoji == "📺"


### PR DESCRIPTION
## Problem

In the Skills → Bankr partner catalog, `aero-stock-lp` rendered a chart icon while `bankr` and `bankr-token-scam-analysis` rendered the Bankr brand mark. It is the one entry in `BankrBot/skills` whose `catalog.json` ships `"logo": "logo.svg"` — the others ship `logo: null` — and `BankrSource._meta_from_catalog` turned that field into a `raw.githubusercontent.com` URL.

## Fix

The Bankr source no longer reads the payload's `logo`; catalog metas are built with `logo=""`. The frontend `LogoBadge` already falls back to the bundled `bankr-symbol.svg` when `source === "bankr"`, so all three cards are now consistent with the tab and the catalog header.

This is deliberately the payload-independent branch: the catalog is a curated, server-side allowlist, so membership is the brand. Honouring repository-side artwork would let an upstream edit repaint a partner card's identity — the same reasoning the user-skill path already applies where it sets `logo=""`.

## Verification

- `pytest tests/test_skills_hub_bankr.py` → 34 passed
- `pytest tests -k "skills_hub or skills_registry"` → 90 passed, 2 skipped
- `ruff check`, `ruff format --check`, `mypy` clean on the touched files
- Live against the real `BankrBot/skills` catalog: all three skills return `logo=''`, emoji `📺`; `aero-stock-lp` still resolves to category `defi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THHfJpFv1FZsv9Vhj7Rb23