### PR TITLE
fix(cli): send the gateway token from every CLI connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `agentos chat`, `agentos sessions`, `agentos skills`, and `agentos env` now
+  send the resolved gateway token when they open their own WebSocket
+  connection, and honour `AGENTOS_GATEWAY_URL` consistently. `resolve_auth`
+  grants no loopback exemption in token mode, so setting `auth.mode = "token"`
+  previously broke all four commands even on a purely local install — the
+  token resolver existed (`default_gateway_token`) but these call sites never
+  used it. `chat` additionally ignored `AGENTOS_GATEWAY_URL` entirely and
+  always dialled the hardcoded `ws://localhost:18791/ws`.
+
 - Bankr catalog cards all wear the Bankr brand mark again. `aero-stock-lp` is
   the one entry in `BankrBot/skills` whose `catalog.json` ships a `logo`, so it
   rendered that artwork while every other card in the partner tab showed the

--- a/src/agentos/cli/chat/gateway_runtime.py
+++ b/src/agentos/cli/chat/gateway_runtime.py
@@ -148,9 +148,10 @@ async def run_gateway_chat(
 ) -> None:
     """Run gateway chat without owning a concrete terminal application."""
     from agentos.cli.gateway_client import GatewayClient, GatewayRPCError
+    from agentos.cli.gateway_rpc import default_gateway_token, default_gateway_url
 
     client = GatewayClient()
-    await client.connect()
+    await client.connect(default_gateway_url(), token=default_gateway_token())
 
     elevated_state: dict[str, str | None] = {"mode": None}
 

--- a/src/agentos/cli/env_cmd.py
+++ b/src/agentos/cli/env_cmd.py
@@ -17,7 +17,11 @@ from typing import Any
 
 import typer
 
-from agentos.cli.gateway_rpc import default_gateway_url, rpc_error_exit_code
+from agentos.cli.gateway_rpc import (
+    default_gateway_token,
+    default_gateway_url,
+    rpc_error_exit_code,
+)
 from agentos.cli.output import emit_error, print_json
 from agentos.cli.ui import console
 
@@ -42,7 +46,7 @@ async def _try_gateway(method: str, params: dict[str, Any], *, json_output: bool
 
     client = gateway_client_module.GatewayClient()
     try:
-        await client.connect(default_gateway_url())
+        await client.connect(default_gateway_url(), token=default_gateway_token())
     except (SystemExit, ConnectionError, OSError):
         await client.close()
         return None

--- a/src/agentos/cli/sessions_cmd.py
+++ b/src/agentos/cli/sessions_cmd.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -13,10 +12,9 @@ import typer
 from rich.table import Table
 
 from agentos.cli.chat.session_state import messages_to_markdown
-from agentos.cli.gateway_rpc import run_gateway_sync
+from agentos.cli.gateway_rpc import default_gateway_token, default_gateway_url, run_gateway_sync
 from agentos.cli.output import print_json
 from agentos.cli.ui import ACCENT, ACCENT_HEADER, console, error_panel, markup_escape
-from agentos.cli.url_utils import normalize_gateway_url
 
 app = typer.Typer(help="Manage chat sessions.")
 
@@ -135,9 +133,7 @@ async def _with_client(action):
 
     client = GatewayClient()
     try:
-        await client.connect(
-            normalize_gateway_url(os.environ.get("AGENTOS_GATEWAY_URL", "ws://localhost:18791/ws"))
-        )
+        await client.connect(default_gateway_url(), token=default_gateway_token())
         return await action(client)
     except SystemExit as exc:
         console.print(f"[dim]{exc}[/dim]")

--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -13,6 +13,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from agentos.cli.gateway_rpc import (
+    default_gateway_token,
     default_gateway_url,
     rpc_error_exit_code,
     run_gateway_sync,
@@ -43,7 +44,7 @@ async def _try_gateway_skill_mutation(
 
     client = gateway_client_module.GatewayClient()
     try:
-        await client.connect(default_gateway_url())
+        await client.connect(default_gateway_url(), token=default_gateway_token())
     except (SystemExit, ConnectionError, OSError):
         await client.close()
         return None

--- a/tests/test_cli/test_chat_cmd.py
+++ b/tests/test_cli/test_chat_cmd.py
@@ -1299,7 +1299,7 @@ class _FakeGatewayClient:
         self.closed = False
         type(self).instances.append(self)
 
-    async def connect(self) -> None:
+    async def connect(self, url: str, *, token: str | None = None) -> None:
         self.connected = True
 
     async def create_session(

--- a/tests/test_cli/test_gateway_client_auth.py
+++ b/tests/test_cli/test_gateway_client_auth.py
@@ -1,0 +1,101 @@
+"""Every CLI surface that opens its own gateway connection must send the token.
+
+Regression guard. ``resolve_auth`` grants no loopback exemption in token mode:
+once ``auth.mode = "token"`` is set, a connection that omits the token is
+refused even on a purely local install. ``chat``, ``sessions``, ``skills``, and
+``env`` each opened a connection by hand and skipped the token that
+``default_gateway_token`` already resolves — so turning auth on broke four
+commands that had nothing to do with remote access.
+
+The fake client below takes ``url`` as a *required* positional argument on
+purpose: the original ``chat`` bug was a bare ``client.connect()`` that
+silently fell back to the hardcoded ``ws://localhost:18791/ws`` default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.cli import env_cmd, gateway_client, sessions_cmd, skills_cmd
+from agentos.cli.chat import gateway_runtime
+
+_TOKEN = "token-from-env"
+_HOST = "10.0.0.5"
+
+
+class _StopError(Exception):
+    """Unwind a runtime once the connection under test has been recorded."""
+
+
+@pytest.fixture
+def connections(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    seen: list[dict[str, Any]] = []
+
+    class _FakeClient:
+        async def connect(self, url: str, *, token: str | None = None) -> None:
+            seen.append({"url": url, "token": token})
+
+        async def call(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+            return {}
+
+        async def create_session(self, **kwargs: Any) -> str:
+            raise _StopError
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setenv("AGENTOS_GATEWAY_URL", f"ws://{_HOST}:18791/ws")
+    monkeypatch.setenv("AGENTOS_GATEWAY_TOKEN", _TOKEN)
+    monkeypatch.setattr(gateway_client, "GatewayClient", _FakeClient)
+    return seen
+
+
+def _assert_authenticated(seen: list[dict[str, Any]]) -> None:
+    assert len(seen) == 1
+    assert _HOST in seen[0]["url"]
+    assert seen[0]["token"] == _TOKEN
+
+
+class TestGatewayConnectionsCarryTheToken:
+    def test_env_cmd(self, connections: list[dict[str, Any]]) -> None:
+        import asyncio
+
+        asyncio.run(env_cmd._try_gateway("env.list", {}, json_output=False))
+
+        _assert_authenticated(connections)
+
+    def test_skills_cmd(self, connections: list[dict[str, Any]]) -> None:
+        import asyncio
+
+        asyncio.run(skills_cmd._try_gateway_skill_mutation("skills.list", {}, json_output=False))
+
+        _assert_authenticated(connections)
+
+    def test_sessions_cmd(self, connections: list[dict[str, Any]]) -> None:
+        import asyncio
+
+        async def _action(client: Any) -> dict[str, Any]:
+            return await client.call("sessions.list", {})
+
+        asyncio.run(sessions_cmd._with_client(_action))
+
+        _assert_authenticated(connections)
+
+    def test_chat_runtime(self, connections: list[dict[str, Any]]) -> None:
+        import asyncio
+
+        deps = gateway_runtime.GatewayRuntimeDependencies(
+            stream_response=None,  # type: ignore[arg-type]
+            handle_slash_command=None,  # type: ignore[arg-type]
+            run_input_loop=None,  # type: ignore[arg-type]
+            get_tui_output=lambda scope: None,
+            is_exit_command=lambda text: False,
+            notify=lambda notice: None,
+        )
+
+        with pytest.raises(_StopError):
+            asyncio.run(gateway_runtime.run_gateway_chat(model=None, session_id=None, deps=deps))
+
+        _assert_authenticated(connections)

--- a/tests/unit/cli/repl/test_gateway_runtime.py
+++ b/tests/unit/cli/repl/test_gateway_runtime.py
@@ -72,7 +72,7 @@ async def test_gateway_runtime_dispatches_messages_slash_commands_and_exit(
             self.abort_calls: list[str] = []
             _FakeGatewayClient.instances.append(self)
 
-        async def connect(self) -> None:
+        async def connect(self, url: str, *, token: str | None = None) -> None:
             self.connected = True
 
         async def create_session(self, model: str | None = None) -> str:
@@ -220,7 +220,7 @@ async def test_gateway_abort_targets_active_turn_session_after_session_changes(
             self.abort_calls: list[str] = []
             _FakeGatewayClient.instances.append(self)
 
-        async def connect(self) -> None:
+        async def connect(self, url: str, *, token: str | None = None) -> None:
             return None
 
         async def create_session(self, model: str | None = None) -> str:


### PR DESCRIPTION
Setting `auth.mode = "token"` breaks four CLI commands on a **purely local install** — no remote access involved.

`resolve_auth` grants no loopback exemption in token mode: a loopback peer still has to present the token. But `chat`, `sessions`, `skills`, and `env` each open their own WebSocket and skip the token that `default_gateway_token()` already resolves.

```
cli/chat/gateway_runtime.py:153   await client.connect()
cli/sessions_cmd.py:138           connect(normalize_gateway_url(os.environ.get(...)))
cli/skills_cmd.py:46              connect(default_gateway_url())          # no token
cli/env_cmd.py:45                 connect(default_gateway_url())          # no token
```

`chat` is the worst of the four: a bare `connect()` falls back to the hardcoded `ws://localhost:18791/ws` default, so it ignores `AGENTOS_GATEWAY_URL` entirely.

All four now route through `default_gateway_url()` + `default_gateway_token()`, matching what `run_gateway_call` in `gateway_rpc.py` has always done. `sessions_cmd` drops its hand-rolled env read for the shared resolver.

**No effect on the default install.** `GatewayClient.connect` only puts `auth` in the handshake params when the token is truthy, and `resolve_auth` ignores `auth_params` in `mode = "none"` — so passing a resolved token to a no-auth gateway is inert.

## Tests

`tests/test_cli/test_gateway_client_auth.py` covers all four surfaces: each must connect to the `AGENTOS_GATEWAY_URL` host and pass `AGENTOS_GATEWAY_TOKEN`. The fake client takes `url` as a **required positional** argument on purpose — that is what catches the bare `connect()` regression rather than silently recording the default. Verified failing 4/4 on the pre-fix tree.

Three existing test doubles (`tests/unit/cli/repl/test_gateway_runtime.py`, `tests/test_cli/test_chat_cmd.py`) defined `connect(self)` and needed the real signature.

## Gate

`ruff` clean, `mypy` clean (615 files), `pytest` 8293 passed / 1 failed. The single failure — `tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force` — reproduces on a clean `upstream/main` with this branch stashed, so it is not from this change.

Rebased on `8312719`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)