### PR TITLE
fix(config): remove dead subagents.archive_after_minutes key

### DIFF
--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1757,10 +1757,6 @@ class SubagentsGatewayConfig(BaseModel):
     """Number of slots in ``task_runtime.max_concurrency`` reserved for
     non-subagent tasks so a fan-out parent never starves itself."""
 
-    archive_after_minutes: int = Field(default=60, ge=0)
-    """Minutes after a subagent session goes terminal before its transcript
-    is archived. ``0`` disables auto-archive."""
-
     prompt_compact: bool = False
     """When enabled, subagent bootstrap prompts keep only AGENTS.md and TOOLS.md."""
 

--- a/src/agentos/gateway/config_migration.py
+++ b/src/agentos/gateway/config_migration.py
@@ -561,6 +561,23 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
                     "tokenjuice projection is now the built-in tool-result path"
                 )
 
+    # Subagent auto-archive: the `archive_after_minutes` config key in
+    # `SubagentsGatewayConfig` had no timer or registry consumer, so it is
+    # removed (see issue #407). Existing configs carrying it are reported.
+    subagents = builder.payload.get("subagents")
+    if isinstance(subagents, dict):
+        deprecated_subagent: dict[str, object] = {}
+        if "archive_after_minutes" in subagents:
+            deprecated_subagent["subagents.archive_after_minutes"] = subagents.pop(
+                "archive_after_minutes"
+            )
+        if deprecated_subagent:
+            builder.removed_fields.extend(sorted(deprecated_subagent))
+            builder.warnings.append(
+                "subagents.archive_after_minutes was removed; auto-archive was never "
+                "implemented (issue #407)"
+            )
+
     # 2026-07: the skills-block budget default rose from 8000 to 24000 once the
     # block stopped emitting a filesystem path per skill. 8000 could not fit the
     # descriptions for the shipped set, so every install that saved a config was

--- a/tests/test_gateway/test_agent_subagent_defaults_serde.py
+++ b/tests/test_gateway/test_agent_subagent_defaults_serde.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from agentos.gateway.config import (
     AgentDefaults,
     AgentEntryConfig,
@@ -9,6 +11,7 @@ from agentos.gateway.config import (
     GatewayConfig,
     SubagentsGatewayConfig,
 )
+from agentos.gateway.config_migration import migrate_config_payload
 
 
 def test_subagent_defaults_optional_fields_default_to_none() -> None:
@@ -51,7 +54,6 @@ def test_gateway_config_exposes_agents_defaults_and_subagents_subtree() -> None:
     assert isinstance(cfg.subagents, SubagentsGatewayConfig)
     assert cfg.subagents.enforce_disabled_agents is False
     assert cfg.subagents.subagent_reserved_slots == 2
-    assert cfg.subagents.archive_after_minutes == 60
 
 
 def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
@@ -67,4 +69,41 @@ def test_gateway_config_accepts_explicit_subagent_defaults() -> None:
     assert cfg.agents_defaults.subagents.model == "haiku"
     assert cfg.subagents.enforce_disabled_agents is True
     assert cfg.subagents.subagent_reserved_slots == 4
-    assert cfg.subagents.archive_after_minutes == 0
+    assert "archive_after_minutes" not in SubagentsGatewayConfig.model_fields
+
+
+def test_an_existing_config_with_archive_after_minutes_still_loads(tmp_path: Path) -> None:
+    """The decisive case: an old agentos.toml carrying the dead key must load cleanly."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text(
+        "[subagents]\n"
+        "enforce_disabled_agents = true\n"
+        "archive_after_minutes = 99\n",
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.subagents.enforce_disabled_agents is True
+    assert "archive_after_minutes" not in SubagentsGatewayConfig.model_fields
+
+
+def test_migration_reports_the_dropped_key_not_silently_eaten() -> None:
+    result = migrate_config_payload(
+        {"subagents": {"enforce_disabled_agents": True, "archive_after_minutes": 99}}
+    )
+
+    assert "subagents.archive_after_minutes" in result.removed_fields
+    assert result.changed is True
+    assert any("archive_after_minutes" in w for w in result.warnings)
+    # the key must be stripped from the payload handed to validation
+    assert "archive_after_minutes" not in result.payload["subagents"]
+
+
+def test_migration_leaves_live_subagent_keys_untouched() -> None:
+    payload = {"subagents": {"enforce_disabled_agents": True, "subagent_reserved_slots": 4}}
+    result = migrate_config_payload(payload)
+
+    assert result.removed_fields == ()
+    assert result.warnings == ()
+    assert result.payload["subagents"]["subagent_reserved_slots"] == 4


### PR DESCRIPTION
## Summary

subagents.archive_after_minutes was documented as 'minutes after a subagent session goes terminal before its transcript is archived' but nothing ever read it:
- No auto-archive timer exists anywhere in the codebase
- SubagentRegistry.archive() / get_archived() have zero callers

Fixes #407.

## Changes

- config.py: drop archive_after_minutes field from SubagentsGatewayConfig
- config_migration.py: strip the key in migrate_config_payload with an explicit warning so existing agentos.toml files carrying it are reported, not silently eaten
- test_agent_subagent_defaults_serde.py: update serde tests + add migration behavior coverage

## Testing

- ruff check: clean
- mypy: clean
- 8/8 tests pass