### PR TITLE
fix(tools): make download install hint agree with executor when bins is absent

### DIFF
--- a/src/agentos/skills/install_kinds.py
+++ b/src/agentos/skills/install_kinds.py
@@ -153,7 +153,10 @@ def render_install_command(spec: SkillInstallSpec) -> str:
         url = spec.url
         if not url or not DOWNLOAD_URL_RE.match(url):
             return ""
-        bin_name = spec.bins[0] if spec.bins else spec.id
+        # Must agree with deps._resolve_download_dest: when bins is absent the
+        # executor falls back to the URL's last path segment, not the spec id
+        # (an id is a label, e.g. "mytool", and would name the binary wrong).
+        bin_name = spec.bins[0] if spec.bins else url.rsplit("/", 1)[-1]
         if not _BIN_NAME_RE.match(bin_name or ""):
             return ""
         dest = f"~/.local/bin/{bin_name}"

--- a/tests/test_skill_install_kinds.py
+++ b/tests/test_skill_install_kinds.py
@@ -237,6 +237,26 @@ def test_download_hint_rejects_a_url_the_executor_would_refuse() -> None:
     assert render_install_command(evil) == ""
 
 
+def test_download_hint_matches_executor_when_bins_is_absent() -> None:
+    # No bins declared: the executor falls back to the URL's last path segment,
+    # so the displayed command must name the same file. Using spec.id (a label)
+    # would render a command that writes the wrong filename on disk.
+    from agentos.skills.hub import deps
+
+    spec = SkillInstallSpec(
+        kind="download", id="mytool", url="https://example.com/releases/v1.2.3/mytool-binary"
+    )
+    hint = render_install_command(spec)
+    assert hint == (
+        "curl -fsSL -o ~/.local/bin/mytool-binary "
+        "https://example.com/releases/v1.2.3/mytool-binary && chmod +x ~/.local/bin/mytool-binary"
+    )
+    # The name the executor resolves must be exactly what the hint writes.
+    resolved = deps._resolve_download_dest(spec, spec.url)
+    assert resolved.name == "mytool-binary"
+    assert resolved.name in hint
+
+
 def test_apt_is_hint_only_for_the_agent_tool() -> None:
     assert _render_install_command(SPECS["apt"]) == "sudo apt-get install -y gh"
     with pytest.raises(ToolError, match="elevated privileges"):


### PR DESCRIPTION
## Summary

For a `download` install spec without `bins`, `render_install_command` fell back to `spec.id` (a label) for the destination filename while the executor in `deps._resolve_download_dest` falls back to the URL's last path segment. The rendered command the operator copies wrote a different filename than the executor does.

Fix: use the URL's last path segment in both, matching the executor. Adds a regression test pinning the two paths to the same name.

## Changes

- `src/agentos/skills/install_kinds.py`: change the download fallback from `spec.id` to `url.rsplit('/', 1)[-1]`
- `tests/test_skill_install_kinds.py`: add `test_download_hint_matches_executor_when_bins_is_absent`

## Testing

- `ruff check`: clean
- `mypy`: clean  
- 38/38 tests pass (`test_skill_install_kinds.py`)

Fixes #464.