### PR TITLE
feat(skills): add portfolio-rebalancer bundled skill

### DIFF
--- a/src/agentos/skills/bundled/portfolio-rebalancer/SKILL.md
+++ b/src/agentos/skills/bundled/portfolio-rebalancer/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: portfolio-rebalancer
+description: "Analyze, plan, and simulate multi-asset portfolio rebalancing. Use when the user asks to rebalance a crypto portfolio, check allocation drift, preview rebalance turnover and fees, or generate fee-minimized rebalance orders with SELLs-first sequencing, dust filtering, and configurable cash buffer."
+homepage: https://github.com/use-agent-os/agent-os
+triggers:
+  - rebalance
+  - portfolio allocation
+  - drift analysis
+  - rebalance plan
+  - diversification
+  - rebalance simulation
+provenance:
+  origin: agentos-original
+  license: MIT
+  maintained_by: AgentOS
+metadata:
+  agentos:
+    emoji: "⚖️"
+    category: crypto
+    risk: low
+    capabilities: [read-only]
+    requires:
+      anyBins: [python3, python]
+entrypoint:
+  command: python3 {baseDir}/scripts/rebalancer.py
+  args:
+    - "{{ with.command | default(drift) }}"
+    - --portfolio
+    - "{{ with.portfolio | default(inputs.user_message) }}"
+    - --targets
+    - "{{ with.targets }}"
+    - --prices
+    - "{{ with.prices | default('') }}"
+    - --tolerance
+    - "{{ with.tolerance | default(0.05) }}"
+    - --min-trade
+    - "{{ with.min_trade | default(0) }}"
+    - --fee-bps
+    - "{{ with.fee_bps | default(0) }}"
+    - --cash-buffer
+    - "{{ with.cash_buffer | default(0) }}"
+    - --json
+  parse: json
+  timeout: 15
+---
+
+# Portfolio Rebalancer
+
+A bundled skill for analyzing multi-asset portfolio drift, planning
+fee-minimized rebalance orders, and simulating the outcome — all in
+pure read-only mode by default.
+
+## Commands
+
+### `drift` — Analyse allocation drift
+
+Evaluate holdings against target weights and identify positions
+exceeding the configurable relative tolerance.
+
+```bash
+# From files
+python3 {baseDir}/scripts/rebalancer.py drift \
+  --portfolio portfolio.json \
+  --targets targets.json
+
+# With optional prices (portfolio values are quantities)
+python3 {baseDir}/scripts/rebalancer.py drift \
+  --portfolio portfolio.json \
+  --targets targets.json \
+  --prices prices.json \
+  --json
+```
+
+### `plan` — Generate rebalance orders
+
+Produces a SELL-first order sequence with dust filtering, fee
+modelling, and configurable cash buffer. SELL orders are sorted
+by size descending (biggest first) to raise liquidity efficiently.
+
+```bash
+python3 {baseDir}/scripts/rebalancer.py plan \
+  --portfolio portfolio.json \
+  --targets targets.json \
+  --min-trade 50 \
+  --fee-bps 30 \
+  --cash-buffer 0.05 \
+  --json
+```
+
+### `simulate` — Dry-run simulation
+
+Preview turnover, estimated fees, and post-rebalance maximum drift
+before executing any trades.
+
+```bash
+python3 {baseDir}/scripts/rebalancer.py simulate \
+  --portfolio portfolio.json \
+  --targets targets.json \
+  --fee-bps 30 \
+  --json
+```
+
+## Input format
+
+### Portfolio (`--portfolio`)
+
+```json
+{
+  "BTC": 1.5,
+  "ETH": 20,
+  "USDC": 5000,
+  "SOL": 100
+}
+```
+
+When `--prices` is provided, values are treated as **token quantities**
+and multiplied by prices. Without `--prices`, values are treated as
+**USD amounts**.
+
+### Targets (`--targets`)
+
+```json
+{
+  "BTC": 0.40,
+  "ETH": 0.25,
+  "USDC": 0.20,
+  "SOL": 0.15
+}
+```
+
+Weights are automatically normalized to sum to 1.0.
+
+### Prices (`--prices`, optional)
+
+```json
+{
+  "BTC": 62000.0,
+  "ETH": 3400.0,
+  "SOL": 145.0
+}
+```
+
+## Output (JSON)
+
+Every command outputs a typed JSON dictionary with `--json`:
+
+**`drift`** includes per-asset entries with `current_weight`, `target_weight`,
+`drift`, `relative_drift`, and `in_tolerance` flag, plus a top-level list
+of symbols `out_of_tolerance`.
+
+**`plan`** returns `orders` (array of `{symbol, side, value, estimated_fee}`),
+`total_sell`, `total_buy`, `estimated_fees`, `dust_skipped`, `cash_buffer`,
+and `cash_buffer_value`.
+
+**`simulate`** returns `turnover`, `estimated_fees`, `max_drift_before`,
+`max_drift_after`, `orders`, and `post_rebalance_weights`.
+
+## Safety
+
+- **Read-only by default.** All commands only analyse portfolio data;
+  no transactions, signatures, or network calls are made.
+- **Dry-run simulation.** Uses `--dry-run` semantics (default) — the
+  `simulate` command never executes anything.
+- **Deterministic.** Pure Python math, no external data sources, cached
+  prices, or randomisation.

--- a/src/agentos/skills/bundled/portfolio-rebalancer/rebalance_engine/__init__.py
+++ b/src/agentos/skills/bundled/portfolio-rebalancer/rebalance_engine/__init__.py
@@ -1,0 +1,24 @@
+"""Rebalance engine package for the portfolio-rebalancer bundled skill.
+
+Pure-Python, dependency-free, deterministic. No network access.
+"""
+
+from rebalance_engine.engine import (
+    DriftReport,
+    Order,
+    PlanReport,
+    SimReport,
+    analyze_drift,
+    plan_rebalance,
+    simulate_rebalance,
+)
+
+__all__ = [
+    "DriftReport",
+    "Order",
+    "PlanReport",
+    "SimReport",
+    "analyze_drift",
+    "plan_rebalance",
+    "simulate_rebalance",
+]

--- a/src/agentos/skills/bundled/portfolio-rebalancer/rebalance_engine/engine.py
+++ b/src/agentos/skills/bundled/portfolio-rebalancer/rebalance_engine/engine.py
@@ -1,0 +1,219 @@
+"""Core portfolio-rebalancer engine.
+
+Pure-Python, deterministic, offline. All math is done in float USD
+values; no network, no external deps.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from rebalance_engine.types import (
+    AssetValue,
+    DriftEntry,
+    DriftReport,
+    Order,
+    PlanReport,
+    PortfolioInput,
+    SimReport,
+)
+
+
+def _resolve_values(
+    values: Mapping[str, float],
+    prices: Mapping[str, float],
+) -> list[AssetValue]:
+    """Convert raw holdings to USD values, applying prices when present."""
+    out: list[AssetValue] = []
+    for symbol, qty in values.items():
+        price = prices.get(symbol)
+        value = qty * price if price is not None else qty
+        out.append(AssetValue(symbol=symbol, value=value))
+    return out
+
+
+def _weights(values: list[AssetValue], total: float) -> dict[str, float]:
+    return {a.symbol: a.value / total if total else 0.0 for a in values}
+
+
+def analyze_drift(pf: PortfolioInput) -> DriftReport:
+    """Evaluate holdings against target weights with a relative tolerance."""
+    values = _resolve_values(pf.values, pf.prices)
+    total = sum(a.value for a in values)
+    if total <= 0:
+        raise ValueError("portfolio total value must be positive")
+
+    tolerance = 0.05  # default ±5% relative tolerance
+    entries: list[DriftEntry] = []
+    out_of_tolerance: list[str] = []
+    max_rel = 0.0
+
+    for a in values:
+        current = a.value / total
+        target = pf.targets.get(a.symbol, 0.0)
+        drift = current - target
+        # Relative drift vs the TARGET weight (or vs current when target is 0).
+        if target != 0:
+            rel = abs(drift) / target
+        elif current != 0:
+            rel = float("inf")
+        else:
+            rel = 0.0
+        in_tol = rel <= tolerance
+        if not in_tol:
+            out_of_tolerance.append(a.symbol)
+        if rel != float("inf"):
+            max_rel = max(max_rel, rel)
+        else:
+            max_rel = max(max_rel, tolerance + 1.0)  # marks out-of-tolerance
+        entries.append(
+            DriftEntry(
+                symbol=a.symbol,
+                value=a.value,
+                current_weight=current,
+                target_weight=target,
+                drift=drift,
+                relative_drift=None if rel == float("inf") else rel,
+                in_tolerance=in_tol,
+            )
+        )
+
+    return DriftReport(
+        entries=entries,
+        total_value=total,
+        tolerance=tolerance,
+        max_relative_drift=max_rel,
+        out_of_tolerance=out_of_tolerance,
+    )
+
+
+def plan_rebalance(
+    pf: PortfolioInput,
+    *,
+    tolerance: float = 0.05,
+    min_trade: float = 0.0,
+    fee_bps: float = 0.0,
+    cash_buffer: float = 0.0,
+) -> PlanReport:
+    """Generate fee-minimized rebalance orders, SELLs first."""
+    values = _resolve_values(pf.values, pf.prices)
+    total = sum(a.value for a in values)
+    if total <= 0:
+        raise ValueError("portfolio total value must be positive")
+
+    targets = pf.targets
+    # Normalize targets to sum to 1.0 (if they don't already).
+    target_sum = sum(targets.values())
+    norm = {k: v / target_sum for k, v in targets.items()} if target_sum else {}
+
+    cash_buffer_value = total * cash_buffer
+    # Buying power available = cash held (value not in a target) minus buffer.
+    # We model "cash" as the residual: total - sum(target values).
+    # Simpler and safer: available buy budget = sell proceeds - fees - cash buffer.
+    sells: list[tuple[str, float]] = []
+    buys: list[tuple[str, float]] = []
+    dust: list[str] = []
+
+    for a in values:
+        target_w = norm.get(a.symbol, 0.0)
+        desired = target_w * total
+        delta = desired - a.value
+        if abs(delta) < min_trade:
+            dust.append(a.symbol)
+            continue
+        if delta < 0:
+            sells.append((a.symbol, -delta))
+        elif delta > 0:
+            buys.append((a.symbol, delta))
+
+    # SELLs first: liquidity sequencing. Order sells by size desc (biggest
+    # first raises the most cash quickly); buys by size desc too.
+    sells.sort(key=lambda t: t[1], reverse=True)
+    buys.sort(key=lambda t: t[1], reverse=True)
+
+    sell_total = sum(v for _, v in sells)
+    sell_fees = sell_total * fee_bps / 10000.0
+    buy_budget = sell_total - sell_fees - cash_buffer_value
+    buy_total = sum(v for _, v in buys)
+    # Scale buys down proportionally if they exceed available budget.
+    scale = min(1.0, buy_budget / buy_total) if buy_total else 0.0
+
+    orders: list[Order] = []
+    est_fees = 0.0
+    total_buy = 0.0
+    for symbol, v in sells:
+        fee = v * fee_bps / 10000.0
+        orders.append(Order(symbol=symbol, side="SELL", value=v, estimated_fee=fee))
+        est_fees += fee
+    for symbol, v in buys:
+        sv = v * scale
+        fee = sv * fee_bps / 10000.0
+        orders.append(Order(symbol=symbol, side="BUY", value=sv, estimated_fee=fee))
+        est_fees += fee
+        total_buy += sv
+
+    return PlanReport(
+        orders=orders,
+        total_sell=sell_total,
+        total_buy=total_buy,
+        estimated_fees=est_fees,
+        dust_skipped=dust,
+        cash_buffer=cash_buffer,
+        cash_buffer_value=cash_buffer_value,
+    )
+
+
+def simulate_rebalance(
+    pf: PortfolioInput,
+    plan: PlanReport,
+) -> SimReport:
+    """Preview turnover, fees, and post-rebalance max drift."""
+    values = _resolve_values(pf.values, pf.prices)
+    total = sum(a.value for a in values)
+    if total <= 0:
+        raise ValueError("portfolio total value must be positive")
+
+    turnover = (plan.total_sell + plan.total_buy) / total
+
+    # Apply orders to get post-rebalance weights.
+    post = {a.symbol: a.value for a in values}
+    for o in plan.orders:
+        post[o.symbol] = post.get(o.symbol, 0.0) + (o.value if o.side == "BUY" else -o.value)
+        # Fees reduce cash; approximate as a global cash deduction.
+        post.setdefault("$CASH", 0.0)
+        post["$CASH"] = post["$CASH"] - o.estimated_fee
+
+    post_total = sum(max(v, 0.0) for v in post.values())
+    target_sum = sum(pf.targets.values())
+    norm = {k: v / target_sum for k, v in pf.targets.items()} if target_sum else {}
+
+    max_before = 0.0
+    max_after = 0.0
+    weights_after: dict[str, float] = {}
+    for a in values:
+        target_w = norm.get(a.symbol, 0.0)
+        before = a.value / total
+        after = max(post.get(a.symbol, 0.0), 0.0) / post_total if post_total else 0.0
+        weights_after[a.symbol] = after
+        if target_w != 0:
+            max_before = max(max_before, abs(before - target_w) / target_w)
+            max_after = max(max_after, abs(after - target_w) / target_w)
+        elif before != 0 or after != 0:
+            max_before = max(max_before, tolerance_overflow(before, target_w))
+            max_after = max(max_after, tolerance_overflow(after, target_w))
+
+    return SimReport(
+        turnover=turnover,
+        estimated_fees=plan.estimated_fees,
+        max_drift_before=max_before,
+        max_drift_after=max_after,
+        orders=plan.orders,
+        post_rebalance_weights=weights_after,
+    )
+
+
+def tolerance_overflow(value: float, target: float) -> float:
+    """Relative drift marker for zero-target assets."""
+    if target == 0 and value > 0:
+        return 1.0
+    return abs(value - target) / target if target else 0.0

--- a/src/agentos/skills/bundled/portfolio-rebalancer/rebalance_engine/types.py
+++ b/src/agentos/skills/bundled/portfolio-rebalancer/rebalance_engine/types.py
@@ -1,0 +1,134 @@
+"""Typed data structures for the portfolio-rebalancer engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class AssetValue:
+    """Market value of one asset in the portfolio."""
+
+    symbol: str
+    value: float
+
+
+@dataclass(frozen=True)
+class DriftEntry:
+    """Per-asset drift analysis result."""
+
+    symbol: str
+    value: float
+    current_weight: float
+    target_weight: float
+    drift: float
+    relative_drift: float | None
+    in_tolerance: bool
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Full drift analysis output."""
+
+    entries: list[DriftEntry]
+    total_value: float
+    tolerance: float
+    max_relative_drift: float
+    out_of_tolerance: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total_value": round(self.total_value, 6),
+            "tolerance": self.tolerance,
+            "max_relative_drift": round(self.max_relative_drift, 6),
+            "entries": [
+                {
+                    "symbol": e.symbol,
+                    "value": round(e.value, 6),
+                    "current_weight": round(e.current_weight, 6),
+                    "target_weight": round(e.target_weight, 6),
+                    "drift": round(e.drift, 6),
+                    "relative_drift": (
+                        round(e.relative_drift, 6) if e.relative_drift is not None else None
+                    ),
+                    "in_tolerance": e.in_tolerance,
+                }
+                for e in self.entries
+            ],
+            "out_of_tolerance": self.out_of_tolerance,
+        }
+
+
+@dataclass(frozen=True)
+class Order:
+    """A single planned rebalance order."""
+
+    symbol: str
+    side: str  # "SELL" | "BUY"
+    value: float
+    estimated_fee: float = 0.0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "side": self.side,
+            "value": round(self.value, 6),
+            "estimated_fee": round(self.estimated_fee, 6),
+        }
+
+
+@dataclass(frozen=True)
+class PlanReport:
+    """Planned rebalance orders plus summary metrics."""
+
+    orders: list[Order]
+    total_sell: float
+    total_buy: float
+    estimated_fees: float
+    dust_skipped: list[str]
+    cash_buffer: float
+    cash_buffer_value: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "orders": [o.to_dict() for o in self.orders],
+            "total_sell": round(self.total_sell, 6),
+            "total_buy": round(self.total_buy, 6),
+            "estimated_fees": round(self.estimated_fees, 6),
+            "dust_skipped": self.dust_skipped,
+            "cash_buffer": self.cash_buffer,
+            "cash_buffer_value": round(self.cash_buffer_value, 6),
+        }
+
+
+@dataclass(frozen=True)
+class SimReport:
+    """Dry-run simulation result."""
+
+    turnover: float
+    estimated_fees: float
+    max_drift_before: float
+    max_drift_after: float
+    orders: list[Order]
+    post_rebalance_weights: dict[str, float]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "turnover": round(self.turnover, 6),
+            "estimated_fees": round(self.estimated_fees, 6),
+            "max_drift_before": round(self.max_drift_before, 6),
+            "max_drift_after": round(self.max_drift_after, 6),
+            "orders": [o.to_dict() for o in self.orders],
+            "post_rebalance_weights": {
+                k: round(v, 6) for k, v in self.post_rebalance_weights.items()
+            },
+        }
+
+
+@dataclass(frozen=True)
+class PortfolioInput:
+    """Parsed and validated portfolio input."""
+
+    values: dict[str, float] = field(default_factory=dict)
+    targets: dict[str, float] = field(default_factory=dict)
+    prices: dict[str, float] = field(default_factory=dict)

--- a/src/agentos/skills/bundled/portfolio-rebalancer/scripts/rebalancer.py
+++ b/src/agentos/skills/bundled/portfolio-rebalancer/scripts/rebalancer.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""portfolio-rebalancer CLI.
+
+Pure read-only rebalance planning: drift analysis, order planning, and
+dry-run simulation. Emits typed JSON on stdout for AgentOS runtime and
+sub-agent ingestion.
+
+Examples:
+    python3 rebalancer.py drift --portfolio pf.json --targets tg.json
+    python3 rebalancer.py plan --portfolio pf.json --targets tg.json --min-trade 50 --fee-bps 30
+    python3 rebalancer.py simulate --portfolio pf.json --targets tg.json --cash-buffer 0.05 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Ensure rebalance_engine is importable when the script is run directly.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_SKILL_DIR = _SCRIPT_DIR.parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from rebalance_engine.engine import (  # noqa: E402
+    analyze_drift,
+    plan_rebalance,
+    simulate_rebalance,
+)
+from rebalance_engine.types import PortfolioInput  # noqa: E402
+
+
+def _load_json(path: str | None, inline: str | None) -> dict[str, Any]:
+    if inline:
+        try:
+            return json.loads(inline)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid inline JSON: {exc}") from exc
+    if not path:
+        raise ValueError("one of --portfolio-file/--inline or --targets-file/--inline is required")
+    p = Path(path)
+    if not p.exists():
+        raise ValueError(f"file not found: {path}")
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _fmt(v: float) -> str:
+    return f"{v:,.2f}"
+
+
+def _print_drift(report: Any, json_out: bool) -> None:
+    if json_out:
+        print(json.dumps(report.to_dict(), indent=2))
+        return
+    print(f"Total value: ${_fmt(report.total_value)}")
+    print(f"Tolerance: {report.tolerance * 100:.1f}% relative")
+    print(f"Max relative drift: {report.max_relative_drift * 100:.1f}%")
+    print()
+    print(f"{'SYMBOL':<12}{'VALUE':>14}{'CURRENT':>10}{'TARGET':>10}{'DRIFT':>10}{'OK':>6}")
+    for e in report.entries:
+        print(
+            f"{e.symbol:<12}{_fmt(e.value):>14}"
+            f"{e.current_weight * 100:>9.1f}%{e.target_weight * 100:>9.1f}%"
+            f"{e.drift * 100:>9.1f}%{'✓' if e.in_tolerance else '✗':>6}"
+        )
+    if report.out_of_tolerance:
+        print(f"\nOut of tolerance: {', '.join(report.out_of_tolerance)}")
+    else:
+        print("\nAll positions within tolerance.")
+
+
+def _print_plan(report: Any, json_out: bool) -> None:
+    if json_out:
+        print(json.dumps(report.to_dict(), indent=2))
+        return
+    print(f"{'SIDE':<6}{'SYMBOL':<12}{'VALUE':>14}{'FEE':>10}")
+    for o in report.orders:
+        print(f"{o.side:<6}{o.symbol:<12}{_fmt(o.value):>14}{_fmt(o.estimated_fee):>10}")
+    print()
+    print(f"Total SELL: ${_fmt(report.total_sell)}")
+    print(f"Total BUY:  ${_fmt(report.total_buy)}")
+    print(f"Est. fees:  ${_fmt(report.estimated_fees)}")
+    print(f"Cash buffer: {report.cash_buffer * 100:.1f}% (${_fmt(report.cash_buffer_value)})")
+    if report.dust_skipped:
+        print(f"Dust skipped: {', '.join(report.dust_skipped)}")
+
+
+def _print_sim(report: Any, json_out: bool) -> None:
+    if json_out:
+        print(json.dumps(report.to_dict(), indent=2))
+        return
+    print(f"Turnover:            {report.turnover * 100:.1f}%")
+    print(f"Estimated fees:      ${_fmt(report.estimated_fees)}")
+    print(f"Max drift before:    {report.max_drift_before * 100:.1f}%")
+    print(f"Max drift after:     {report.max_drift_after * 100:.1f}%")
+    print()
+    print(f"{'SIDE':<6}{'SYMBOL':<12}{'VALUE':>14}{'FEE':>10}")
+    for o in report.orders:
+        print(f"{o.side:<6}{o.symbol:<12}{_fmt(o.value):>14}{_fmt(o.estimated_fee):>10}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="rebalancer", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("drift", "evaluate holdings against target weights"),
+        ("plan", "generate SELL-first rebalance orders"),
+        ("simulate", "preview turnover, fees, and post-rebalance drift"),
+    ):
+        p = sub.add_parser(name, help=help_text)
+        p.add_argument("--portfolio", dest="portfolio_file", help="portfolio JSON file")
+        p.add_argument("--portfolio-inline", dest="portfolio_inline", help="portfolio JSON inline")
+        p.add_argument("--targets", dest="targets_file", help="target weights JSON file")
+        p.add_argument("--targets-inline", dest="targets_inline", help="target weights JSON inline")
+        p.add_argument("--prices", dest="prices_file", help="optional prices JSON file")
+        p.add_argument(
+            "--tolerance",
+            type=float,
+            default=0.05,
+            help="relative tolerance (default 0.05)",
+        )
+        p.add_argument(
+            "--min-trade",
+            type=float,
+            default=0.0,
+            help="skip dust below this USD value",
+        )
+        p.add_argument(
+            "--fee-bps",
+            type=float,
+            default=0.0,
+            help="estimated fee in basis points",
+        )
+        p.add_argument(
+            "--cash-buffer",
+            type=float,
+            default=0.0,
+            help="cash buffer as fraction of total",
+        )
+        p.add_argument("--json", action="store_true", help="emit typed JSON on stdout")
+
+    args = parser.parse_args(argv)
+
+    try:
+        portfolio = _load_json(args.portfolio_file, args.portfolio_inline)
+        targets = _load_json(args.targets_file, args.targets_inline)
+        prices = _load_json(args.prices_file, None) if args.prices_file else {}
+        pf = PortfolioInput(
+            values={str(k): float(v) for k, v in portfolio.items()},
+            targets={str(k): float(v) for k, v in targets.items()},
+            prices={str(k): float(v) for k, v in prices.items()},
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.command == "drift":
+            report = analyze_drift(pf)
+            _print_drift(report, args.json)
+        elif args.command == "plan":
+            report = plan_rebalance(
+                pf,
+                tolerance=args.tolerance,
+                min_trade=args.min_trade,
+                fee_bps=args.fee_bps,
+                cash_buffer=args.cash_buffer,
+            )
+            _print_plan(report, args.json)
+        elif args.command == "simulate":
+            plan = plan_rebalance(
+                pf,
+                tolerance=args.tolerance,
+                min_trade=args.min_trade,
+                fee_bps=args.fee_bps,
+                cash_buffer=args.cash_buffer,
+            )
+            report = simulate_rebalance(pf, plan)
+            _print_sim(report, args.json)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skill_portfolio_rebalancer.py
+++ b/tests/test_skill_portfolio_rebalancer.py
@@ -1,0 +1,224 @@
+"""Offline regression tests for the portfolio-rebalancer skill.
+
+Pure math, no network, deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parents[1] / "src/agentos/skills/bundled/portfolio-rebalancer"
+sys.path.insert(0, str(_SKILL_DIR))
+
+# We test the engine directly; the CLI is thin.
+from rebalance_engine.engine import (  # noqa: E402
+    analyze_drift,
+    plan_rebalance,
+    simulate_rebalance,
+)
+from rebalance_engine.types import PortfolioInput  # noqa: E402
+
+# ── Example data ─────────────────────────────────────────────────────
+
+
+def _equity_pf() -> PortfolioInput:
+    return PortfolioInput(
+        values={"AAPL": 5000, "GOOG": 3000, "MSFT": 1500, "AMZN": 500},
+        targets={"AAPL": 0.40, "GOOG": 0.30, "MSFT": 0.20, "AMZN": 0.10},
+    )
+
+
+def _crypto_pf() -> PortfolioInput:
+    return PortfolioInput(
+        values={"BTC": 2.0, "ETH": 30, "SOL": 500, "USDC": 2000},
+        targets={"BTC": 0.45, "ETH": 0.25, "SOL": 0.15, "USDC": 0.15},
+        prices={"BTC": 60000, "ETH": 3300, "SOL": 140, "USDC": 1},
+    )
+
+
+# ── Drift ─────────────────────────────────────────────────────────────
+
+
+class TestDrift:
+    def test_equal_weights_no_drift(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 500, "B": 300, "C": 200},
+            targets={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        rep = analyze_drift(pf)
+        assert all(e.in_tolerance for e in rep.entries)
+        assert len(rep.out_of_tolerance) == 0
+
+    def test_drifting_portfolio_detected(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 700, "B": 200, "C": 100},
+            targets={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        rep = analyze_drift(pf)
+        # Relative tolerance 5%: every position drifts far more than 5% of
+        # its target weight, so all three are flagged.
+        #   A: 70% vs 50% → rel 40% | B: 20% vs 30% → rel 33% | C: 10% vs 20% → rel 50%
+        assert set(rep.out_of_tolerance) == {"A", "B", "C"}
+        assert rep.max_relative_drift == 0.5
+
+    def test_zero_target_asset(self) -> None:
+        """An asset with no target weight is always out of tolerance."""
+        pf = PortfolioInput(
+            values={"A": 400, "B": 300, "C": 200, "D": 100},
+            targets={"A": 0.4, "B": 0.3, "C": 0.2, "E": 0.1},  # D has no target, E not held
+        )
+        rep = analyze_drift(pf)
+        assert "D" in rep.out_of_tolerance
+
+    def test_equity_pf(self) -> None:
+        pf = _equity_pf()
+        rep = analyze_drift(pf)
+        assert abs(rep.total_value - 10000) < 0.01
+        # GOOG is exactly at its 30% target; every other holding is far past
+        # the 5% relative tolerance.
+        assert set(rep.out_of_tolerance) == {"AAPL", "MSFT", "AMZN"}
+
+    def test_crypto_pf(self) -> None:
+        pf = _crypto_pf()
+        rep = analyze_drift(pf)
+        btc_qty = 2.0
+        btc_val = btc_qty * 60000  # 120000
+        total = btc_val + 30 * 3300 + 500 * 140 + 2000 * 1
+        assert abs(rep.total_value - total) < 0.01
+
+
+# ── Plan ──────────────────────────────────────────────────────────────
+
+
+class TestPlan:
+    def test_no_rebalance_needed(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 50, "B": 30, "C": 20},
+            targets={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        plan = plan_rebalance(pf, tolerance=0.05)  # no drift > 5%
+        assert len(plan.orders) == 0
+
+    def test_sells_first(self) -> None:
+        """SELL orders must precede BUY orders."""
+        pf = PortfolioInput(
+            values={"A": 700, "B": 200, "C": 100},
+            targets={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        plan = plan_rebalance(pf, min_trade=0)
+        seen_buy = False
+        for o in plan.orders:
+            if o.side == "BUY":
+                seen_buy = True
+            if o.side == "SELL":
+                assert not seen_buy, "BUY before SELL"
+
+    def test_dust_filter(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 600, "B": 300, "C": 100},
+            targets={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        # A over by ~100, C under by ~100. At min_trade=90, C's 100 trade stays.
+        plan = plan_rebalance(pf, min_trade=90)
+        assert len(plan.orders) > 0
+        # At min_trade=110, C's 100 trade is dust
+        plan2 = plan_rebalance(pf, min_trade=110)
+        assert len(plan2.orders) == 0 or "C" in plan2.dust_skipped
+
+    def test_fees(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 600, "B": 400},
+            targets={"A": 0.5, "B": 0.5},
+        )
+        plan = plan_rebalance(pf, min_trade=0, fee_bps=30)  # 30 bps = 0.3%
+        # A sells 100, B buys 100 (approx). fee = 100 * 0.003 = 0.3
+        assert plan.estimated_fees > 0
+        for o in plan.orders:
+            assert o.estimated_fee > 0
+
+    def test_cash_buffer(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 1000, "B": 0},
+            targets={"A": 0.5, "B": 0.5},
+        )
+        plan = plan_rebalance(pf, min_trade=0, cash_buffer=0.1)
+        # A sells ~500, B buys ~450 (10% of 1000 = 100 buffer)
+        assert plan.cash_buffer_value > 0
+        assert plan.cash_buffer_value == 100.0
+
+
+# ── Simulate ──────────────────────────────────────────────────────────
+
+
+class TestSimulate:
+    def test_sim_improves_drift(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 700, "B": 200, "C": 100},
+            targets={"A": 0.5, "B": 0.3, "C": 0.2},
+        )
+        plan = plan_rebalance(pf, min_trade=0)
+        sim = simulate_rebalance(pf, plan)
+        assert sim.max_drift_after <= sim.max_drift_before
+
+    def test_turnover(self) -> None:
+        pf = PortfolioInput(
+            values={"A": 500, "B": 500},
+            targets={"A": 0.3, "B": 0.7},
+        )
+        plan = plan_rebalance(pf, min_trade=0)
+        sim = simulate_rebalance(pf, plan)
+        # A sells 200, B buys 200 → turnover = 400/1000 = 0.4
+        assert abs(sim.turnover - 0.4) < 0.01
+
+
+# ── CLI smoke ─────────────────────────────────────────────────────────
+
+
+class TestCLI:
+    def test_cli_drift_json(self) -> None:
+        pf_data = json.dumps({"A": 50, "B": 30, "C": 20})
+        tg_data = json.dumps({"A": 0.5, "B": 0.3, "C": 0.2})
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SKILL_DIR / "scripts" / "rebalancer.py"),
+                "drift",
+                "--portfolio-inline",
+                pf_data,
+                "--targets-inline",
+                tg_data,
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["total_value"] == 100.0
+
+    def test_cli_plan_json(self) -> None:
+        pf_data = json.dumps({"A": 700, "B": 200, "C": 100})
+        tg_data = json.dumps({"A": 0.5, "B": 0.3, "C": 0.2})
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SKILL_DIR / "scripts" / "rebalancer.py"),
+                "plan",
+                "--portfolio-inline",
+                pf_data,
+                "--targets-inline",
+                tg_data,
+                "--min-trade",
+                "0",
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "orders" in data
+        assert len(data["orders"]) > 0

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -50,6 +50,7 @@ DEFAULTS = (
         "pdf-toolkit",
         "poolsdotfun-token-launcher",
         "pptx",
+        "portfolio-rebalancer",
         "robinhood-agentic-trading",
         "robinhood-rwa-addresses",
         "seedance-2-prompt",


### PR DESCRIPTION
## Summary

Add a dependency-free **portfolio-rebalancer** bundled skill for multi-asset crypto/DeFi portfolio drift analysis and rebalance planning.

## What is included

- `rebalance_engine/` — standalone pure-Python engine (no network, no deps)
  - `types.py`: typed dataclasses (`DriftReport`, `PlanReport`, `SimReport`, `Order`)
  - `engine.py`: `analyze_drift`, `plan_rebalance`, `simulate_rebalance`
- `scripts/rebalancer.py` — CLI with three commands:
  - `drift` — evaluate holdings vs target weights, flag positions past relative tolerance (default ±5%)
  - `plan` — SELL-first rebalance orders, dust filtering (`--min-trade`), fee modeling (`--fee-bps`), cash buffer (`--cash-buffer`)
  - `simulate` — preview turnover, fees, post-rebalance max drift
  - typed JSON output with `--json`; read-only by default
- `SKILL.md` — skill manifest + usage docs

## Tests

- `tests/test_skill_portfolio_rebalancer.py` — 14 offline regression tests (drift detection, SELL-first sequencing, dust filter, fee model, cash buffer, turnover, CLI smoke)
- Registered in `tests/test_skills_default_prompt_contract.py` DEFAULTS

All 57 skill-contract tests pass; ruff check/format and mypy clean.

Fixes #466