### PR TITLE
feat(channels): add transient HTTP retries for Slack and webhooks

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -282,6 +282,21 @@ async def retry_request(
     last_exc: Exception | None = None
     for attempt in range(max_retries + 1):
         try:
+            if attempt > 0 and "files" in kwargs:
+                files = kwargs["files"]
+                if isinstance(files, dict):
+                    for file_val in files.values():
+                        fileobj = None
+                        if isinstance(file_val, tuple):
+                            if len(file_val) > 1:
+                                fileobj = file_val[1]
+                        else:
+                            fileobj = file_val
+                        if fileobj and hasattr(fileobj, "seek") and callable(fileobj.seek):
+                            try:
+                                fileobj.seek(0)
+                            except Exception:
+                                pass
             resp = await func(*args, **kwargs)
             if resp.status_code == 429:
                 retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))

--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -298,14 +298,16 @@ async def retry_request(
                             except Exception:
                                 pass
             resp = await func(*args, **kwargs)
-            if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+            status_code = getattr(resp, "status_code", 200)
+            if status_code == 429:
+                headers = getattr(resp, "headers", {})
+                retry_after = float(headers.get("Retry-After", base_delay * (2**attempt)))
                 log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
                 await asyncio.sleep(retry_after)
                 continue
-            if resp.status_code in {500, 502, 503, 504} and attempt < max_retries:
+            if status_code in {500, 502, 503, 504} and attempt < max_retries:
                 delay = base_delay * (2**attempt) + random.random()
-                log.warning("transient_error", status=resp.status_code, delay=delay)
+                log.warning("transient_error", status=status_code, delay=delay)
                 await asyncio.sleep(delay)
                 continue
             return resp

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -22,7 +22,12 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from agentos.channels._reactions import NULL_STATUS_REACTOR, SlackStatusReactor
-from agentos.channels._util import ChannelAccessPolicy, EventDedupeCache, StreamThrottle
+from agentos.channels._util import (
+    ChannelAccessPolicy,
+    EventDedupeCache,
+    StreamThrottle,
+    retry_request,
+)
 from agentos.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
@@ -389,7 +394,7 @@ class SlackChannel:
             payload[key] = value
 
         client = self._get_client()
-        resp = await client.post("/chat.postMessage", json=payload)
+        resp = await retry_request(client.post, "/chat.postMessage", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
@@ -406,7 +411,8 @@ class SlackChannel:
         """Upload a local file to Slack using the external upload flow."""
         path = Path(file_path)
         client = self._get_client()
-        start_resp = await client.post(
+        start_resp = await retry_request(
+            client.post,
             "/files.getUploadURLExternal",
             json={"filename": path.name, "length": path.stat().st_size},
         )
@@ -420,7 +426,11 @@ class SlackChannel:
             raise RuntimeError("Slack file upload init response missing upload_url/file_id")
 
         with path.open("rb") as f:
-            upload_resp = await client.post(upload_url, files={"file": (path.name, f)})
+            upload_resp = await retry_request(
+                client.post,
+                upload_url,
+                files={"file": (path.name, f)},
+            )
         upload_resp.raise_for_status()
 
         complete_payload: dict[str, Any] = {
@@ -429,7 +439,8 @@ class SlackChannel:
         }
         if content:
             complete_payload["initial_comment"] = content
-        complete_resp = await client.post(
+        complete_resp = await retry_request(
+            client.post,
             "/files.completeUploadExternal",
             json=complete_payload,
         )
@@ -451,7 +462,7 @@ class SlackChannel:
             "text": content,
         }
         client = self._get_client()
-        resp = await client.post("/chat.update", json=payload)
+        resp = await retry_request(client.post, "/chat.update", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
@@ -466,7 +477,7 @@ class SlackChannel:
             "ts": message_id,
         }
         client = self._get_client()
-        resp = await client.post("/chat.delete", json=payload)
+        resp = await retry_request(client.post, "/chat.delete", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
@@ -513,7 +524,7 @@ class SlackChannel:
             }
             if thread_ts:
                 payload["thread_ts"] = thread_ts
-            resp = await client.post("/chat.postMessage", json=payload)
+            resp = await retry_request(client.post, "/chat.postMessage", json=payload)
             resp.raise_for_status()
             data = resp.json()
             if not data.get("ok"):
@@ -522,7 +533,8 @@ class SlackChannel:
             log.debug("slack.stream_start", ts=message_ts)
 
         async def _edit(text: str) -> None:
-            resp = await client.post(
+            resp = await retry_request(
+                client.post,
                 "/chat.update",
                 json={
                     "channel": target,

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -28,9 +28,7 @@ SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
-_REPLY_DIRECTIVE_RE = re.compile(
-    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
-)
+_REPLY_DIRECTIVE_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
 
 
 def strip_reply_directives(text: str | None) -> str | None:
@@ -48,9 +46,7 @@ def validate_webhook_url(url: str) -> None:
     except ValueError as exc:
         raise ValueError(f"invalid webhook URL: {url!r}") from exc
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(
-            f"webhook URL must use http or https scheme, got {parsed.scheme!r}"
-        )
+        raise ValueError(f"webhook URL must use http or https scheme, got {parsed.scheme!r}")
     if not parsed.hostname:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
 
@@ -479,6 +475,8 @@ class DeliveryChain:
 
         import httpx
 
+        from agentos.channels._util import retry_request
+
         headers = {"Content-Type": "application/json"}
         if token:
             headers["Authorization"] = f"Bearer {token}"
@@ -490,7 +488,7 @@ class DeliveryChain:
         }
         try:
             async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:
-                response = await client.post(url, json=payload, headers=headers)
+                response = await retry_request(client.post, url, json=payload, headers=headers)
                 response.raise_for_status()
             log.info("delivery.webhook_sent", job_id=job_id)
             return "delivered"

--- a/tests/test_channels/test_slack.py
+++ b/tests/test_channels/test_slack.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from agentos.channels.contract import ChannelSendStatus
+from agentos.channels.slack import SlackChannel
+from agentos.channels.types import OutgoingMessage
+
+
+class _FakeResp:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=httpx.Request("POST", "https://slack.com"),
+                response=httpx.Response(self.status_code),
+            )
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def mock_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+
+@pytest.mark.asyncio
+async def test_slack_send_retries_on_transient_http_errors() -> None:
+    call_count = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return _FakeResp(503, {"ok": False, "error": "server_error"})
+            return _FakeResp(200, {"ok": True, "ts": "123.456"})
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C-default")
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    msg = OutgoingMessage(content="Hello", reply_to="C-default")
+    await channel.send(msg)
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_slack_send_retries_on_rate_limit() -> None:
+    call_count = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _FakeResp(429, {"ok": False, "error": "rate_limited"})
+            return _FakeResp(200, {"ok": True, "ts": "123.456"})
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C-default")
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    msg = OutgoingMessage(content="Hello", reply_to="C-default")
+    await channel.send(msg)
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_slack_send_retries_on_read_timeout() -> None:
+    call_count = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ReadTimeout("Timeout")
+            return _FakeResp(200, {"ok": True, "ts": "123.456"})
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C-default")
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    msg = OutgoingMessage(content="Hello", reply_to="C-default")
+    await channel.send(msg)
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_slack_send_raises_fatal_error_immediately() -> None:
+    call_count = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal call_count
+            call_count += 1
+            return _FakeResp(400, {"ok": False, "error": "bad_payload"})
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C-default")
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    msg = OutgoingMessage(content="Hello", reply_to="C-default")
+    with pytest.raises(httpx.HTTPStatusError):
+        await channel.send(msg)
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_send_file_resets_file_pointer_on_retry(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("file content", encoding="utf-8")
+
+    upload_attempts = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal upload_attempts
+            if path == "/files.getUploadURLExternal":
+                return _FakeResp(
+                    200,
+                    {"ok": True, "upload_url": "https://upload.test", "file_id": "F1"},
+                )
+            elif path == "https://upload.test":
+                upload_attempts += 1
+                files = kwargs.get("files")
+                assert files is not None
+                fileobj = files["file"][1]
+                content = fileobj.read()
+                if upload_attempts == 1:
+                    raise httpx.ReadTimeout("Upload Timeout")
+                assert content == b"file content"
+                return _FakeResp(200, {"ok": True})
+            elif path == "/files.completeUploadExternal":
+                return _FakeResp(200, {"ok": True, "files": [{"id": "F1"}]})
+            return _FakeResp(400, {"ok": False})
+
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C-default")
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    result = await channel.send_file("C-target", str(file_path), content="done")
+    assert result.status == ChannelSendStatus.SENT
+    assert upload_attempts == 2

--- a/tests/test_scheduler/test_webhook_delivery.py
+++ b/tests/test_scheduler/test_webhook_delivery.py
@@ -97,7 +97,7 @@ async def test_ops_add_rejects_webhook_without_url(tmp_path: Path) -> None:
             await ops.add(
                 name="bad",
                 schedule_kind=ScheduleKind.CRON,
-            schedule_value="*/5 * * * *",
+                schedule_value="*/5 * * * *",
                 handler_key="agent_run",
                 payload=make_agent_turn_payload("x"),
                 session_target=SessionTarget.ISOLATED,
@@ -117,7 +117,7 @@ async def test_ops_add_rejects_webhook_with_bad_scheme(tmp_path: Path) -> None:
             await ops.add(
                 name="bad",
                 schedule_kind=ScheduleKind.CRON,
-            schedule_value="*/5 * * * *",
+                schedule_value="*/5 * * * *",
                 handler_key="agent_run",
                 payload=make_agent_turn_payload("x"),
                 session_target=SessionTarget.ISOLATED,
@@ -250,6 +250,13 @@ async def test_deliver_webhook_omits_authorization_when_no_token(monkeypatch) ->
 
 
 async def test_deliver_webhook_returns_failed_on_http_error(monkeypatch) -> None:
+    import asyncio
+
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
     class _ErrorClient(_RecordingAsyncClient):
         async def post(self, url, json=None, headers=None):
             class _Resp:
@@ -271,3 +278,125 @@ async def test_deliver_webhook_returns_failed_on_http_error(monkeypatch) -> None
         text="x",
     )
     assert status == "delivery_failed"
+
+
+async def test_deliver_webhook_retries_transient_error_and_fails(monkeypatch) -> None:
+    import asyncio
+
+    calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    class _TransientErrorClient(_RecordingAsyncClient):
+        async def post(self, url, json=None, headers=None):
+            nonlocal calls
+            calls += 1
+
+            class _Resp:
+                status_code = 500
+
+                def raise_for_status(self):
+                    raise RuntimeError("HTTP 500")
+
+            return _Resp()
+
+    class _FakeHttpx:
+        AsyncClient = _TransientErrorClient
+
+    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("https://hooks.example/cron"),
+        text="x",
+    )
+    assert status == "delivery_failed"
+    # 1 initial attempt + 3 retries = 4 total calls
+    assert calls == 4
+    assert len(sleeps) == 3
+
+
+async def test_deliver_webhook_retries_transient_error_and_recovers(monkeypatch) -> None:
+    import asyncio
+
+    calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    class _RecoveringClient(_RecordingAsyncClient):
+        async def post(self, url, json=None, headers=None):
+            nonlocal calls
+            calls += 1
+
+            class _Resp:
+                def __init__(self, status_code: int) -> None:
+                    self.status_code = status_code
+
+                def raise_for_status(self):
+                    if self.status_code >= 400:
+                        raise RuntimeError(f"HTTP {self.status_code}")
+
+            if calls < 3:
+                return _Resp(503)
+            return _Resp(200)
+
+    class _FakeHttpx:
+        AsyncClient = _RecoveringClient
+
+    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("https://hooks.example/cron"),
+        text="x",
+    )
+    assert status == "delivered"
+    assert calls == 3
+    assert len(sleeps) == 2
+
+
+async def test_deliver_webhook_does_not_retry_fatal_errors(monkeypatch) -> None:
+    import asyncio
+
+    calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    class _FatalErrorClient(_RecordingAsyncClient):
+        async def post(self, url, json=None, headers=None):
+            nonlocal calls
+            calls += 1
+
+            class _Resp:
+                status_code = 401
+
+                def raise_for_status(self):
+                    raise RuntimeError("HTTP 401 Unauthorized")
+
+            return _Resp()
+
+    class _FakeHttpx:
+        AsyncClient = _FatalErrorClient
+
+    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("https://hooks.example/cron"),
+        text="x",
+    )
+    assert status == "delivery_failed"
+    assert calls == 1
+    assert len(sleeps) == 0


### PR DESCRIPTION

## Description
This PR integrates the existing `retry_request` helper utility into the Slack channel adapter and the scheduler's webhook delivery system to gracefully handle transient HTTP failures (e.g. rate limit `429`s, server `5xx` errors, connection issues, and read timeouts).

### Non-Idempotent Duplicate-Delivery Tradeoff
> [!WARNING]
> **Duplicate Delivery Risk (Non-Idempotent Outbound Slack Requests)**
> Slack's `chat.postMessage` and the `files.upload` sequence (`/files.getUploadURLExternal`, uploading file blocks, `/files.completeUploadExternal`) are non-idempotent operations. If a transient error or a `ReadTimeout` occurs after Slack has successfully processed the request but before sending a response, the request will be retried.
>
> This may result in duplicate messages or files being delivered/posted to Slack. This behavior is consistent with the existing Discord adapter implementation and has been accepted to achieve parity in resiliency against intermittent network blips.

---

### Key Changes
1. **Utility Update (`src/agentos/channels/_util.py`)**
   - Modified `retry_request` to detect seekable file objects in the `files` parameter (e.g. within multipart request parameters) and reset their file pointers (`seek(0)`) on subsequent retry attempts.

2. **Slack Channel (`src/agentos/channels/slack.py`)**
   - Wrapped `send`, `send_file`, `edit`, `delete`, and both nested functions (`_post` and `_edit`) in `send_streaming` using the `retry_request` utility.

3. **Scheduler Webhook (`src/agentos/scheduler/delivery.py`)**
   - Wrapped `_post_to_webhook` with the default `retry_request` parameters (`max_retries=3`, `base_delay=1.0`), ensuring transient error retries are capped within a ~7s delay window to stay within the job's execution budget.

4. **Testing**
   - Created [`test_slack.py`](file:///c:/Users/SHATTER/.vscode/agent-os/tests/test_channels/test_slack.py) to assert retry behavior on transient errors (`503`, `429`, `ReadTimeout`), verify that fatal errors (e.g. `400`) do not retry, and assert seek pointer recovery on retried file uploads.
   - Extended [`test_webhook_delivery.py`](file:///c:/Users/SHATTER/.vscode/agent-os/tests/test_scheduler/test_webhook_delivery.py) to assert retry counts, recovery, and fatal error bypass.
   -closes #469 