### PR TITLE
fix(skills): cap decompression when unpacking a ClawHub skill zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- Installing a skill from ClawHub no longer unpacks the downloaded zip
+  unbounded. `ClawHubSource.fetch` read every entry into memory with no cap on
+  entry count or uncompressed size, so a few tens of KB of nested deflate — a
+  classic zip bomb — could exhaust the gateway's memory and take the process
+  down. The download is now streamed against a size ceiling — httpx gunzips a
+  `Content-Encoding` body with no limit of its own, so a buffered read could
+  have been filled before any zip cap got a say — and the archive is refused
+  past an entry count, a per-entry size, and a total uncompressed size. Each
+  entry is decompressed in chunks against a running total, so an archive that
+  understates `ZipInfo.file_size` is caught mid-read rather than trusted. A
+  hostile archive also fails closed rather than raising through the installer:
+  an entry flagged encrypted, an unsupported compression method, or a truncated
+  deflate stream reaches the caller as "no bundle", not as an exception that
+  aborts a whole lockfile sync. Entry paths are also checked against
+  Windows-style escapes (`..\`, `C:\`), which
+  `posixpath.normpath` leaves intact; previously only the installer's resolve
+  check caught those. Closes #357.
+
 - `read_file`, `read_spreadsheet` and `grep_search` now mask credentials in the
   content they hand back to the model, and so do the two channels that quote
   file content alongside them: `edit_file`'s closest-match hint, and terminal

--- a/src/agentos/skills/hub/clawhub.py
+++ b/src/agentos/skills/hub/clawhub.py
@@ -2,14 +2,68 @@
 
 from __future__ import annotations
 
+import ntpath
+import posixpath
+from typing import TYPE_CHECKING
+
 import structlog
 
 from agentos.env import trust_env as _trust_env
 from agentos.skills.hub.source import SkillBundle, SkillMeta, SkillSource
 
+if TYPE_CHECKING:  # pragma: no cover - import kept lazy at runtime
+    import zipfile
+
 log = structlog.get_logger(__name__)
 
 _DEFAULT_BASE_URL = "https://clawhub.ai"
+
+# Decompression caps for a downloaded skill archive. A skill bundle is a handful
+# of text files plus the odd asset, so these ceilings sit far above any real
+# skill and far below what it takes to OOM the gateway. Without them a few tens
+# of KB of nested deflate (a zip bomb) expands into memory unbounded.
+_MAX_ARCHIVE_BYTES = 16 * 1024 * 1024  # compressed bytes accepted off the wire
+_MAX_ZIP_ENTRIES = 2_000
+_MAX_ENTRY_BYTES = 8 * 1024 * 1024  # uncompressed, per entry
+_MAX_TOTAL_BYTES = 32 * 1024 * 1024  # uncompressed, whole archive
+_ZIP_READ_CHUNK = 64 * 1024
+
+
+def _safe_rel_path(name: str) -> str | None:
+    """Strip a zip entry's wrapper directory, or return ``None`` to skip it.
+
+    The archive names come from a community registry, so they are untrusted.
+    ``posixpath.normpath`` alone does not neutralize Windows-style escapes
+    (``..\\``, ``C:\\``) — those are rejected outright rather than normalized.
+    """
+    rel = name.split("/", 1)[1] if "/" in name else name
+    if not rel or "\\" in rel or ntpath.splitdrive(rel)[0]:
+        return None
+    rel = posixpath.normpath(rel)
+    if rel in (".", "..") or rel.startswith(("../", "/")):
+        return None
+    return rel
+
+
+def _read_capped(zf: zipfile.ZipFile, info: zipfile.ZipInfo, limit: int) -> bytes | None:
+    """Decompress one entry, returning ``None`` once it exceeds ``limit`` bytes.
+
+    ``ZipInfo.file_size`` is attacker-controlled metadata, so the declared sizes
+    checked by the caller are only a first filter; this running total is what
+    actually stops an archive that lies about how much it expands to.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    with zf.open(info) as fh:
+        while True:
+            chunk = fh.read(_ZIP_READ_CHUNK)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > limit:
+                return None
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 class ClawHubSource(SkillSource):
@@ -77,25 +131,43 @@ class ClawHubSource(SkillSource):
     async def fetch(self, identifier: str) -> SkillBundle | None:
         import io
         import zipfile
+        import zlib
 
         import httpx
 
         url = f"{self._base_url}/api/v1/download"
         try:
             async with httpx.AsyncClient(timeout=30, trust_env=_trust_env()) as client:
-                resp = await client.get(url, params={"slug": identifier}, headers=self._headers())
-                resp.raise_for_status()
+                # Streamed, not buffered: httpx transparently gunzips a
+                # Content-Encoding body with no ceiling of its own, so a small
+                # gzipped response could otherwise fill memory before a single
+                # zip cap below gets a say.
+                async with client.stream(
+                    "GET", url, params={"slug": identifier}, headers=self._headers()
+                ) as resp:
+                    resp.raise_for_status()
+                    chunks: list[bytes] = []
+                    size = 0
+                    async for chunk in resp.aiter_bytes():
+                        size += len(chunk)
+                        if size > _MAX_ARCHIVE_BYTES:
+                            log.warning(
+                                "clawhub.fetch_archive_too_large",
+                                identifier=identifier,
+                                limit=_MAX_ARCHIVE_BYTES,
+                            )
+                            return None
+                        chunks.append(chunk)
+                    content = b"".join(chunks)
         except Exception as exc:
             log.warning("clawhub.fetch_failed", identifier=identifier, error=str(exc))
             return None
 
+        text_body = content.decode("utf-8", errors="replace")
+
         # Detect error responses disguised as 200 (e.g. rate limiting)
-        if (
-            len(resp.content) < 50
-            and not resp.content.startswith(b"PK")
-            and not resp.content.startswith(b"---")
-        ):
-            text = resp.text.strip()
+        if len(content) < 50 and not content.startswith(b"PK") and not content.startswith(b"---"):
+            text = text_body.strip()
             if (
                 "rate limit" in text.lower()
                 or "error" in text.lower()
@@ -106,36 +178,68 @@ class ClawHubSource(SkillSource):
 
         files: dict[str, str | bytes] = {}
         try:
-            with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
-                import posixpath
+            with zipfile.ZipFile(io.BytesIO(content)) as zf:
+                infos = zf.infolist()
+                if len(infos) > _MAX_ZIP_ENTRIES:
+                    log.warning(
+                        "clawhub.fetch_zip_too_many_entries",
+                        identifier=identifier,
+                        entries=len(infos),
+                        limit=_MAX_ZIP_ENTRIES,
+                    )
+                    return None
+                if sum(info.file_size for info in infos) > _MAX_TOTAL_BYTES:
+                    log.warning(
+                        "clawhub.fetch_zip_declared_size_too_large",
+                        identifier=identifier,
+                        limit=_MAX_TOTAL_BYTES,
+                    )
+                    return None
 
-                for name in zf.namelist():
-                    if name.endswith("/"):
+                budget = _MAX_TOTAL_BYTES
+                for info in infos:
+                    name = info.filename
+                    if info.is_dir() or name.endswith("/"):
                         continue
-                    parts = name.split("/", 1)
-                    rel = parts[1] if len(parts) > 1 else parts[0]
-                    rel = posixpath.normpath(rel)
-                    if rel.startswith("..") or rel.startswith("/"):
+                    rel = _safe_rel_path(name)
+                    if rel is None:
+                        log.warning("clawhub.fetch_zip_unsafe_path", identifier=identifier)
                         continue
-                    try:
-                        raw = zf.read(name)
-                        if rel == "SKILL.md":
-                            files[rel] = raw.decode("utf-8")
-                        else:
-                            try:
-                                files[rel] = raw.decode("utf-8")
-                            except UnicodeDecodeError:
-                                files[rel] = raw
-                    except UnicodeDecodeError:
-                        log.warning("clawhub.fetch_bad_skill_encoding", identifier=identifier)
+                    if info.file_size > _MAX_ENTRY_BYTES:
+                        log.warning(
+                            "clawhub.fetch_zip_entry_too_large",
+                            identifier=identifier,
+                            entry=rel,
+                            limit=_MAX_ENTRY_BYTES,
+                        )
                         return None
-        except zipfile.BadZipFile:
-            # Might be raw SKILL.md content — validate it has frontmatter
-            if resp.text.strip().startswith("---"):
-                files["SKILL.md"] = resp.text
+                    raw = _read_capped(zf, info, min(_MAX_ENTRY_BYTES, budget))
+                    if raw is None:
+                        log.warning(
+                            "clawhub.fetch_zip_bomb_blocked", identifier=identifier, entry=rel
+                        )
+                        return None
+                    budget -= len(raw)
+                    try:
+                        files[rel] = raw.decode("utf-8")
+                    except UnicodeDecodeError:
+                        if rel == "SKILL.md":
+                            log.warning("clawhub.fetch_bad_skill_encoding", identifier=identifier)
+                            return None
+                        files[rel] = raw
+        except (zipfile.BadZipFile, NotImplementedError, RuntimeError, zlib.error, EOFError) as exc:
+            # A hostile archive must fail closed, not raise through the installer:
+            # an unsupported compress_type, an entry flagged encrypted, or a
+            # truncated deflate stream each surface as something other than
+            # BadZipFile. Might also be raw SKILL.md content — validate frontmatter.
+            if text_body.strip().startswith("---"):
+                files["SKILL.md"] = text_body
             else:
                 log.warning(
-                    "clawhub.fetch_invalid_content", identifier=identifier, size=len(resp.content)
+                    "clawhub.fetch_invalid_content",
+                    identifier=identifier,
+                    size=len(content),
+                    error=str(exc),
                 )
                 return None
 

--- a/tests/test_skills_hub_clawhub_zip_security.py
+++ b/tests/test_skills_hub_clawhub_zip_security.py
@@ -1,0 +1,238 @@
+"""A ClawHub download is untrusted input, and unpacking it must stay bounded.
+
+``ClawHubSource.fetch`` reads a downloaded zip straight into memory. Without
+caps a small nested-deflate archive expands until the gateway dies, so these
+tests pin the decompression ceilings (entry count, per-entry size, total size)
+and the path rules that keep a bundle inside its own directory on every OS.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from agentos.skills.hub import clawhub
+from agentos.skills.hub.clawhub import ClawHubSource
+
+_SKILL_MD = "---\nname: demo\ndescription: demo skill\n---\n# Demo\n"
+
+
+class _StreamResponse:
+    """Stands in for an httpx streaming response, counting chunks handed over."""
+
+    def __init__(self, content: bytes, chunk_size: int = 4096) -> None:
+        self._content = content
+        self._chunk_size = chunk_size
+        self.chunks_yielded = 0
+
+    async def __aenter__(self) -> _StreamResponse:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        for start in range(0, max(len(self._content), 1), self._chunk_size):
+            self.chunks_yielded += 1
+            yield self._content[start : start + self._chunk_size]
+
+
+def _client_returning(content: bytes, sink: list[_StreamResponse]) -> type:
+    class _AsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _AsyncClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        def stream(self, method: str, url: str, **kwargs: Any) -> _StreamResponse:
+            resp = _StreamResponse(content)
+            sink.append(resp)
+            return resp
+
+    return _AsyncClient
+
+
+def _zip(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+async def _fetch(
+    monkeypatch: pytest.MonkeyPatch, content: bytes, sink: list[_StreamResponse] | None = None
+) -> Any:
+    import httpx
+
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_returning(content, sink if sink is not None else [])
+    )
+    return await ClawHubSource().fetch("demo")
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_an_ordinary_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    content = _zip({"demo/SKILL.md": _SKILL_MD.encode(), "demo/scripts/run.sh": b"echo hi\n"})
+
+    bundle = await _fetch(monkeypatch, content)
+
+    assert bundle is not None
+    assert bundle.files["SKILL.md"] == _SKILL_MD
+    assert bundle.files["scripts/run.sh"] == "echo hi\n"
+
+
+@pytest.mark.asyncio
+async def test_fetch_keeps_undecodable_non_skill_files_as_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = _zip({"demo/SKILL.md": _SKILL_MD.encode(), "demo/logo.png": b"\x89PNG\xff\xfe"})
+
+    bundle = await _fetch(monkeypatch, content)
+
+    assert bundle is not None
+    assert bundle.files["logo.png"] == b"\x89PNG\xff\xfe"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_a_skill_md_that_is_not_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    content = _zip({"demo/SKILL.md": b"\xff\xfe not utf-8"})
+
+    assert await _fetch(monkeypatch, content) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_an_archive_that_expands_past_the_total_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The classic bomb: highly compressible zeros that dwarf the archive itself."""
+    monkeypatch.setattr(clawhub, "_MAX_TOTAL_BYTES", 64 * 1024)
+    monkeypatch.setattr(clawhub, "_MAX_ENTRY_BYTES", 64 * 1024)
+    content = _zip({"demo/SKILL.md": _SKILL_MD.encode(), "demo/bomb.bin": b"\0" * (256 * 1024)})
+    assert len(content) < 8 * 1024  # tiny on the wire, large in memory
+
+    assert await _fetch(monkeypatch, content) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_an_entry_that_lies_about_its_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ZipInfo.file_size`` is attacker-controlled, so the running total decides."""
+    monkeypatch.setattr(clawhub, "_MAX_ENTRY_BYTES", 32 * 1024)
+    monkeypatch.setattr(clawhub, "_MAX_TOTAL_BYTES", 64 * 1024)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("demo/SKILL.md", _SKILL_MD)
+        info = zipfile.ZipInfo("demo/bomb.bin")
+        info.compress_type = zipfile.ZIP_DEFLATED
+        zf.writestr(info, b"\0" * (256 * 1024))
+        # Understate the declared size so only the streaming cap can catch it.
+        zf.filelist[-1].file_size = 1
+    content = buf.getvalue()
+
+    assert await _fetch(monkeypatch, content) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_an_archive_with_too_many_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(clawhub, "_MAX_ZIP_ENTRIES", 4)
+    entries = {"demo/SKILL.md": _SKILL_MD.encode()}
+    entries.update({f"demo/f{i}.txt": b"x" for i in range(10)})
+
+    assert await _fetch(monkeypatch, _zip(entries)) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_stops_reading_an_oversized_download_mid_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The body is capped while it streams, so a decoded gzip bomb never lands in RAM."""
+    monkeypatch.setattr(clawhub, "_MAX_ARCHIVE_BYTES", 4096)
+    content = b"PK" + b"\0" * (64 * 4096)
+    sink: list[_StreamResponse] = []
+
+    assert await _fetch(monkeypatch, content, sink) is None
+    # 4096-byte chunks against a 4096-byte cap: it gives up on the second one.
+    assert sink[0].chunks_yielded == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_an_archive_flagged_encrypted_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """zipfile answers an encrypted entry with RuntimeError, not BadZipFile.
+
+    Anything but a clean ``None`` escapes ``fetch`` and aborts the caller — a
+    lockfile sync stops dead on the first poisoned archive.
+    """
+    content = bytearray(_zip({"demo/SKILL.md": _SKILL_MD.encode()}))
+    # Set the "encrypted" general-purpose bit on every central-directory record.
+    idx = content.find(b"PK\x01\x02")
+    while idx != -1:
+        content[idx + 8] |= 0x01
+        idx = content.find(b"PK\x01\x02", idx + 4)
+
+    assert await _fetch(monkeypatch, bytes(content)) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_still_accepts_a_raw_skill_md_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = await _fetch(monkeypatch, _SKILL_MD.encode())
+
+    assert bundle is not None
+    assert bundle.files["SKILL.md"] == _SKILL_MD
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "demo/../../etc/passwd",
+        "demo/..\\..\\windows\\system32\\evil.dll",
+        "demo/C:/Windows/evil.dll",
+        "demo//etc/passwd",
+        "..",
+        "demo/",
+    ],
+)
+def test_unsafe_zip_paths_are_refused(name: str) -> None:
+    assert clawhub._safe_rel_path(name) is None
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("demo/SKILL.md", "SKILL.md"),
+        ("demo/scripts/run.sh", "scripts/run.sh"),
+        ("demo/./scripts/../SKILL.md", "SKILL.md"),
+        ("SKILL.md", "SKILL.md"),
+    ],
+)
+def test_ordinary_zip_paths_are_kept(name: str, expected: str) -> None:
+    assert clawhub._safe_rel_path(name) == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_drops_a_traversing_entry_but_keeps_the_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = _zip({"demo/SKILL.md": _SKILL_MD.encode(), "demo/../../evil.sh": b"rm -rf /"})
+
+    bundle = await _fetch(monkeypatch, content)
+
+    assert bundle is not None
+    assert set(bundle.files) == {"SKILL.md"}


### PR DESCRIPTION
Closes #357.

## Problem

`ClawHubSource.fetch` read every entry of a downloaded skill archive into an in-memory dict with no cap on entry count, per-entry size, or total uncompressed size. A few tens of KB of nested deflate — a classic zip bomb — could exhaust the gateway's memory and take the process down. Zip-slip was already guarded; the decompression dimension was not.

## What changed

`src/agentos/skills/hub/clawhub.py`:

- **Streamed download with a ceiling.** The body is read with `client.stream(...)` against `_MAX_ARCHIVE_BYTES` (16 MiB) and abandoned mid-stream past it. This matters on its own: httpx transparently gunzips a `Content-Encoding` body with no limit of its own, so a buffered `resp.content` was its own OOM vector before any zip cap could get a say.
- **Archive-level caps.** Entry count (`_MAX_ZIP_ENTRIES`), declared total uncompressed size, per-entry size (`_MAX_ENTRY_BYTES`), and total uncompressed size (`_MAX_TOTAL_BYTES`) are all checked before/while reading.
- **Streaming per-entry read.** `_read_capped` decompresses in 64 KiB chunks against a running total, so an archive that understates `ZipInfo.file_size` — attacker-controlled metadata — is caught mid-read rather than trusted.

Two hardening fixes fall out of the same rewrite, both flagged in the issue's note or found while reviewing it:

- **Windows-style path escapes.** `_safe_rel_path` rejects `..\`, `C:\`, and drive-qualified names, which `posixpath.normpath` leaves intact; previously only the installer's `_is_relative_to` resolve check saved that case.
- **Fail closed on a hostile archive.** Only `BadZipFile` was caught, so an entry flagged encrypted (`RuntimeError`), an unsupported compression method (`NotImplementedError`), or a truncated deflate stream (`zlib.error`/`EOFError`) raised straight out of `fetch` — and `sync_from_lockfile` stops dead on the first poisoned archive rather than skipping it. These now reach the caller as "no bundle".

Decode behavior is unchanged: `SKILL.md` must be UTF-8 or the bundle is rejected; other entries fall back to bytes.

## Tests

New `tests/test_skills_hub_clawhub_zip_security.py` (20 tests, offline and deterministic) covers the happy path, the byte fallback, each cap (total, per-entry, entry count, download size, and an entry that lies about `file_size`), the mid-stream abort, the encrypted-archive fail-closed path, the raw-`SKILL.md` fallback, and the path rules in both directions. Every cap test fails against the pre-fix code.

## Verification

```
uv run ruff check src tests      # All checks passed
uv run mypy src/agentos          # Success: no issues found in 615 source files
uv run pytest -q                 # 8357 passed, 27 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PDbe8euhD5sjDnJeUbUNv