### PR TITLE
feat(budgets): spend ceilings with a hard stop and alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Spend budgets. A new `[budgets]` config section sets money ceilings per
+  session, per UTC day, per agent, and per channel. A turn that starts at or
+  above a hard limit is refused before any provider call with a
+  `budget_exceeded` error naming the scope and the number; a matching
+  `*_warn` threshold raises a one-shot `budget_warning` without stopping the
+  turn. Ceilings are re-checked between iterations within a turn as well, so a
+  single turn with a long tool loop cannot run past one. Spend is persisted to
+  `~/.agentos/state/spend_ledger.db`, so a ceiling survives a gateway restart —
+  a runaway overnight loop cannot be reset by a crash-and-respawn. Nothing is
+  enforced until an operator sets a number.
+
 - `aero-stock-lp` joins the Bankr skill hub. The skill range-LPs Coinbase
   tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome
   Slipstream (Base) — opening, recentering, and exiting concentrated-liquidity
@@ -43,6 +54,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `BUNDLED_TOOLS` resolves to a module under `agentos.tools.builtin`.
 
 ### Changed
+
+- `UsageTracker.check_warning()` is removed. It had no callers; the
+  `[budgets]` session ceilings replace it with a configurable, enforced
+  equivalent.
 
 - The Bankr user-skill allowlist — the half that carries skills published from
   a wallet on bankr.bot — is now empty. `stock-premium-lp-manager` was retired

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -609,3 +609,23 @@ cron_default_mode = "bypass"            # off | bypass | full
 # command = "uvx"
 # args = ["mcp-server-fetch"]
 # env = {}
+
+# [budgets]
+# Money spend ceilings, in US dollars of estimated (or provider-billed) model
+# spend. Nothing is enforced until a ceiling is set. Daily ceilings are keyed
+# by UTC day and persist in the session DB, so a restart does not reset them.
+# A turn that would run past a hard limit is refused with a clear error; a
+# `*_warn` threshold surfaces a one-shot warning instead of stopping the turn.
+# enabled = true                         # suspend every ceiling without deleting the numbers
+# session_limit = 5.0                    # hard stop per session
+# session_warn = 4.0                     # warn once per session
+# daily_limit = 50.0                     # hard stop for gateway-wide spend today
+# daily_warn = 40.0                      # warn once per day
+# [budgets.agent_daily_limit]
+# main = 20.0
+# [budgets.agent_daily_warn]
+# main = 15.0
+# [budgets.channel_daily_limit]
+# telegram = 10.0
+# [budgets.channel_daily_warn]
+# telegram = 8.0

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -612,10 +612,12 @@ cron_default_mode = "bypass"            # off | bypass | full
 
 # [budgets]
 # Money spend ceilings, in US dollars of estimated (or provider-billed) model
-# spend. Nothing is enforced until a ceiling is set. Daily ceilings are keyed
-# by UTC day and persist in the session DB, so a restart does not reset them.
+# spend. Nothing is enforced until a ceiling is set. Spend persists in its own
+# state file (`spend_ledger.db`) — keyed by UTC day for the daily ceilings and
+# by session for the session ceiling — so a restart does not reset them.
 # A turn that would run past a hard limit is refused with a clear error; a
 # `*_warn` threshold surfaces a one-shot warning instead of stopping the turn.
+# Changing any of these requires a gateway restart to take effect.
 # enabled = true                         # suspend every ceiling without deleting the numbers
 # session_limit = 5.0                    # hard stop per session
 # session_warn = 4.0                     # warn once per session

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -901,8 +901,11 @@ their `*_limit` counterparts.
 - Subagent turns run through the same gate, and their spend is attributed to
   the parent agent id, so a fan-out is bounded by the agent and daily
   ceilings rather than multiplying past them.
-- Budgets are hot-applied: changing them through `agentos config` takes effect
-  on the next turn without a gateway restart.
+- Changing a ceiling requires a gateway restart to take effect. `budgets.*` is
+  not on the live-reload allowlist, so both `agentos config` and the Web UI
+  report `restart_required` when you change one. Restart before relying on a
+  new ceiling — a limit written while the gateway is running is not yet
+  enforcing.
 - Enforcement fails open. If the ledger cannot be read or written, the
   shortfall is logged (`usage_tracker.ledger_*`) and turns keep running: a
   budget check is never the reason a gateway stops working. Reads reconcile

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -854,6 +854,64 @@ injection_scan_mode = "report"   # "report" | "enforce" | "off"
 
 `[safety]` is TOML-only; there is no environment-variable override for these keys.
 
+## Spend Budgets
+
+Money ceilings with a hard stop, so a runaway loop or subagent fan-out cannot
+burn an unbounded amount overnight. Every value is US dollars of estimated
+model spend (or the provider-billed figure, when the provider reports one).
+
+```toml
+[budgets]
+enabled = true          # master switch; keeps the numbers but suspends enforcement when false
+session_limit = 5.0     # hard stop once one session reaches this
+session_warn = 4.0      # one-shot warning for that session
+daily_limit = 50.0      # hard stop for gateway-wide spend on the current UTC day
+daily_warn = 40.0       # one-shot warning for that day
+
+[budgets.agent_daily_limit]
+main = 20.0
+
+[budgets.channel_daily_limit]
+telegram = 10.0
+```
+
+`agent_daily_warn` and `channel_daily_warn` take the same per-key shape as
+their `*_limit` counterparts.
+
+- Nothing is enforced by default: every ceiling is unset on a fresh install,
+  and `enabled = true` only means "apply the ceilings you have configured".
+- A turn that starts at or above a hard limit is refused before any provider
+  call, with a `budget_exceeded` error naming the scope and the number. The
+  refusal is recorded in the session transcript, and the user message that
+  triggered it is rolled back rather than left as a reply-less turn.
+- Ceilings are re-checked between iterations *within* a turn as well, so a
+  single turn with a long tool loop stops at the ceiling instead of running
+  to completion past it.
+- A `*_warn` threshold does not stop the turn. It surfaces a
+  `budget_warning` once per session (session scope) or once per UTC day
+  (daily scopes), so a long session does not repeat the same alert every turn.
+- A warn threshold above its own hard limit is rejected at load time — it
+  could never fire. So are two spellings of one scope key (`default` and
+  `main`, `Telegram` and `telegram`), which would otherwise silently drop one
+  of the two numbers.
+- Spend is tracked in a ledger persisted at
+  `~/.agentos/state/spend_ledger.db` (keyed per UTC day for the daily scopes,
+  per session for the session scope), so a ceiling survives a gateway restart
+  — a runaway overnight loop cannot be reset by a crash-and-respawn.
+- Subagent turns run through the same gate, and their spend is attributed to
+  the parent agent id, so a fan-out is bounded by the agent and daily
+  ceilings rather than multiplying past them.
+- Budgets are hot-applied: changing them through `agentos config` takes effect
+  on the next turn without a gateway restart.
+- Enforcement fails open. If the ledger cannot be read or written, the
+  shortfall is logged (`usage_tracker.ledger_*`) and turns keep running: a
+  budget check is never the reason a gateway stops working. Reads reconcile
+  the persisted row against in-process accounting by taking the larger of the
+  two, so a dropped write cannot quietly retire a ceiling within a run.
+
+`[budgets]` is TOML-only; there is no environment-variable override for these
+keys.
+
 ## Gateway Binding
 
 Foreground:

--- a/docs/usage-and-cost.md
+++ b/docs/usage-and-cost.md
@@ -76,6 +76,28 @@ For simple one-shot automation, bound the run:
 agentos agent --max-iterations 20 --timeout 600 -m "Bounded task"
 ```
 
+## Cap Spend with a Hard Stop
+
+Cost views are after the fact. To bound spend while it happens, set ceilings in
+`[budgets]`:
+
+```toml
+[budgets]
+session_limit = 5.0
+daily_limit = 50.0
+daily_warn = 40.0
+```
+
+A turn that starts at or above a hard limit is refused before any provider call
+with a `budget_exceeded` error, and ceilings are re-checked between iterations
+so a long tool loop stops at the ceiling too. A `*_warn` threshold raises a
+one-shot warning without stopping the turn. Spend is persisted to
+`~/.agentos/state/spend_ledger.db`, so a ceiling survives a gateway restart.
+Per-agent and per-channel ceilings use `[budgets.agent_daily_limit]` and
+`[budgets.channel_daily_limit]`.
+
+See [`configuration.md`](configuration.md#spend-budgets) for the full key list.
+
 ## Notes and Limits
 
 - Cost is an estimate based on recorded runtime usage and configured pricing.

--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -11,7 +11,7 @@ import hashlib
 import json
 import time
 import uuid
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -668,6 +668,7 @@ class Agent:
         memory_sync_manager: Any | None = None,
         tool_registry: ToolRegistry | None = None,
         tool_context: ToolContext | None = None,
+        spend_budget_guard: Callable[[str], tuple[bool, str | None]] | None = None,
     ) -> None:
         self.provider = provider
         self.config = config or AgentConfig()
@@ -680,6 +681,11 @@ class Agent:
         self._turn_call_logger = turn_call_logger
         self._tool_registry: ToolRegistry | None = tool_registry
         self._tool_context: ToolContext | None = tool_context
+        # Cumulative spend ceilings, re-read between iterations. The turn-start
+        # gate alone would let one turn with an unbounded tool loop run
+        # arbitrarily far past a ceiling, which is the shape a runaway
+        # actually takes.
+        self._spend_budget_guard = spend_budget_guard
         self._pending_warnings: list[WarningEvent] = []
 
         self._state: AgentState = AgentState.IDLE
@@ -1957,6 +1963,19 @@ class Agent:
                     ),
                     code="turn_billed_cost_budget_exceeded",
                 )
+            if self._spend_budget_guard is not None and self._session_key:
+                try:
+                    spend_stop, spend_message = self._spend_budget_guard(self._session_key)
+                except Exception as exc:  # noqa: BLE001 - a budget check never fails a turn
+                    logger.warning("agent.spend_budget_check_failed", error=str(exc))
+                else:
+                    if spend_stop:
+                        return ErrorEvent(
+                            message=(
+                                spend_message or "A configured spend budget limit has been reached."
+                            ),
+                            code="budget_exceeded",
+                        )
             max_tool_errors = self._positive_int(getattr(self.config, "max_turn_tool_errors", 0))
             if max_tool_errors is not None and turn_tool_errors >= max_tool_errors:
                 return ErrorEvent(

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -2491,6 +2491,49 @@ class TurnRunner:
                 "attachment_count": len(attachments),
             },
         )
+
+        # ── Spend budget gate ────────────────────────────────────────────
+        # Checked before any provider work so a runaway loop or fan-out stops
+        # costing money at the ceiling rather than one turn past it. Subagent
+        # turns run through this same path, so a fan-out is bounded too.
+        budget_stop, budget_message = self._check_spend_budget(session_key)
+        if budget_stop:
+            # The refusal hinges on the decision, never on the presentation
+            # string: a tracker that reports a stop without a message must
+            # still stop the turn.
+            budget_error = ErrorEvent(
+                message=budget_message or "A configured spend budget limit has been reached.",
+                code="budget_exceeded",
+            )
+            log.warning(
+                "turn_runner.budget_exceeded",
+                session_key=session_key,
+                agent_id=agent_id,
+                message=budget_error.message,
+            )
+            self._emit_turn_event(
+                "turn_error",
+                trace_context,
+                session_key=session_key,
+                agent_id=agent_id,
+                turn_id=turn_id,
+                run_kind=run_kind,
+                input_mode=input_mode,
+                seq=2,
+                payload={
+                    "error_type": "BudgetExceeded",
+                    "error_code": budget_error.code,
+                    "error_chars": len(budget_error.message),
+                },
+            )
+            await self._persist_turn_error(session_key, budget_error)
+            yield budget_error
+            return
+        if budget_message:
+            yield self._handle_runtime_warning(
+                WarningEvent(code="budget_warning", message=budget_message)
+            )
+
         try:
             input_out = await self._input_stage.run(
                 InputStageInput(
@@ -3188,6 +3231,33 @@ class TurnRunner:
             return None, None
         cloned = self._provider_selector.clone()
         return cloned.resolve(), cloned
+
+    def _check_spend_budget(self, session_key: str) -> tuple[bool, str | None]:
+        """Evaluate configured ``[budgets]`` ceilings for this session.
+
+        Returns ``(hard_stop, message)``. A budget check must never be the
+        reason a turn fails, so any unexpected error fails open with a log
+        line rather than blocking work the operator did not ask to block.
+        """
+        tracker = self._usage_tracker
+        if tracker is None:
+            return False, None
+        budgets = getattr(self._config, "budgets", None) if self._config else None
+        if budgets is None:
+            return False, None
+        check = getattr(tracker, "check_budget_limits", None)
+        if not callable(check):
+            return False, None
+        try:
+            hard_stop, message = check(session_key, budgets)
+        except Exception as exc:  # noqa: BLE001 - budget checks must fail open
+            log.warning(
+                "turn_runner.budget_check_failed",
+                session_key=session_key,
+                error=str(exc),
+            )
+            return False, None
+        return bool(hard_stop), message
 
     def _handle_runtime_warning(self, event: WarningEvent) -> WarningEvent:
         return event

--- a/src/agentos/engine/turn_runner/harness.py
+++ b/src/agentos/engine/turn_runner/harness.py
@@ -563,6 +563,7 @@ class _TurnRunnerAgentFactoryAdapter(AgentFactoryPort):
             memory_sync_manager=memory_sync_manager,
             tool_registry=self._runner._tool_registry,
             tool_context=tool_context,
+            spend_budget_guard=self._runner._check_spend_budget,
         )
 
 

--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -467,17 +467,6 @@ class UsageTracker:
             with conn:
                 conn.execute(
                     """
-                    CREATE TABLE IF NOT EXISTS spend_ledger (
-                        day TEXT,
-                        scope_kind TEXT,
-                        scope_id TEXT,
-                        cost_usd REAL NOT NULL DEFAULT 0.0,
-                        PRIMARY KEY (day, scope_kind, scope_id)
-                    )
-                    """
-                )
-                conn.execute(
-                    """
                     CREATE TABLE IF NOT EXISTS usage_records (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         session_key TEXT NOT NULL,

--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -42,6 +42,19 @@ def parse_session_key_scope(session_key: str) -> tuple[str, str]:
     return agent_id, channel
 
 
+def _scope_ceiling(config: Any, field: str, scope_id: str) -> float | None:
+    """Read one per-scope ceiling from a budgets config, tolerating absence.
+
+    ``config`` is typed loosely because the engine must not import gateway
+    config; anything exposing the documented ``[budgets]`` field names works.
+    """
+    mapping = getattr(config, field, None)
+    if not isinstance(mapping, dict):
+        return None
+    amount = mapping.get(scope_id)
+    return float(amount) if amount is not None else None
+
+
 _current_usage_scope: ContextVar[str | None] = ContextVar(
     "agentos_usage_scope",
     default=None,
@@ -358,19 +371,93 @@ _global_usage_tracker: UsageTracker | None = None
 class UsageTracker:
     """Tracks per-session token usage and cost."""
 
-    def __init__(self, default_provider_id: str = "", db_path: str | None = None) -> None:
+    def __init__(
+        self,
+        default_provider_id: str = "",
+        db_path: str | None = None,
+        *,
+        ledger_db_path: str | None = None,
+    ) -> None:
+        """
+        ``db_path`` backs the detailed ``usage_records`` history.
+
+        ``ledger_db_path`` backs the spend ledger that budget ceilings read.
+        It is deliberately a *separate* file from the session database: the
+        ledger is written synchronously from the turn hot path, and sharing a
+        file with the session store's async writer would make every ledger
+        commit contend for that write lock on the event loop. The tracker owns
+        this file's schema outright, so it is also not a second schema owner
+        inside a migration-managed database.
+        """
         global _global_usage_tracker
         self._sessions: dict[str, SessionUsage] = {}
         self._scopes: dict[tuple[str, str], SessionUsage] = {}
         self._default_provider_id = str(default_provider_id or "").strip().lower()
         self._db_path = db_path
+        self._ledger_db_path = ledger_db_path
         self._session_metadata: dict[str, tuple[str, str]] = {}
         self._warned_keys: set[str] = set()
+        # In-process mirror of the persisted ledger. Reads take the larger of
+        # the two: a dropped write (sqlite busy, disk full) must not be able to
+        # under-report spend and silently retire a ceiling.
+        self._daily_spend: dict[tuple[str, str, str], float] = {}
+        self._daily_spend_day = ""
+        self._session_spend: dict[str, float] = {}
         self._session_active_skill: dict[str, str] = {}
         _global_usage_tracker = self
 
         if self._db_path:
             self._init_db()
+        if self._ledger_db_path:
+            self._init_ledger_db()
+
+    def _connect(self, path: str) -> sqlite3.Connection:
+        """Open a short-lived connection tuned for hot-path writes.
+
+        WAL keeps readers off the write lock and ``synchronous=NORMAL`` drops
+        the per-commit fsync, so a ledger write costs well under a
+        millisecond. ``busy_timeout`` is deliberately short: this runs on the
+        event loop, and blocking every session for seconds to record a cost
+        row is worse than dropping the row (the in-process mirror covers it).
+        """
+        conn = sqlite3.connect(path, timeout=0.25)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA busy_timeout=250")
+        except Exception as e:  # noqa: BLE001 - pragmas are best-effort
+            log.warning("usage_tracker.pragma_failed", error=str(e))
+        return conn
+
+    def _init_ledger_db(self) -> None:
+        if not self._ledger_db_path:
+            return
+        conn = self._connect(self._ledger_db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS spend_ledger (
+                        day TEXT,
+                        scope_kind TEXT,
+                        scope_id TEXT,
+                        cost_usd REAL NOT NULL DEFAULT 0.0,
+                        PRIMARY KEY (day, scope_kind, scope_id)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS session_spend (
+                        session_key TEXT PRIMARY KEY,
+                        cost_usd REAL NOT NULL DEFAULT 0.0
+                    )
+                    """
+                )
+        except Exception as e:
+            log.warning("usage_tracker.ledger_init_failed", error=str(e))
+        finally:
+            conn.close()
 
     def _init_db(self) -> None:
         if not self._db_path:
@@ -415,32 +502,37 @@ class UsageTracker:
         finally:
             conn.close()
 
-    def _update_spend_ledger(
+    def _bump_daily_mirror(
         self, day: str, scope_kind: str, scope_id: str, incremental_cost: float
     ) -> None:
-        if not self._db_path or incremental_cost <= 0.0:
+        """Accumulate one scope's spend in the in-process ledger mirror."""
+        if incremental_cost <= 0.0:
             return
-        conn = sqlite3.connect(self._db_path)
-        try:
-            with conn:
-                conn.execute(
-                    """
-                    INSERT INTO spend_ledger (day, scope_kind, scope_id, cost_usd)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(day, scope_kind, scope_id) DO UPDATE SET
-                        cost_usd = cost_usd + excluded.cost_usd
-                    """,
-                    (day, scope_kind, scope_id, incremental_cost),
-                )
-        except Exception as e:
-            log.warning("usage_tracker.db_update_failed", error=str(e))
-        finally:
-            conn.close()
+        if day != self._daily_spend_day:
+            # Day rolled over. Yesterday's mirror can never be read again
+            # (every lookup is keyed by the current UTC day), so drop it
+            # rather than let a long-lived gateway accumulate one entry per
+            # scope per day forever. The warn-once bookkeeping is dropped with
+            # it: daily keys are dead, and a session that spans midnight is
+            # worth re-warning about once on the new day.
+            self._daily_spend.clear()
+            self._warned_keys.clear()
+            self._daily_spend_day = day
+        ledger_key = (day, scope_kind, scope_id)
+        self._daily_spend[ledger_key] = self._daily_spend.get(ledger_key, 0.0) + incremental_cost
 
     def get_spend(self, day: str, scope_kind: str, scope_id: str) -> float:
-        if not self._db_path:
-            return 0.0
-        conn = sqlite3.connect(self._db_path)
+        """Return accumulated spend for one ledger scope on one UTC day.
+
+        The persisted row and the in-process mirror are reconciled by taking
+        the larger of the two. They diverge only when a write was dropped, and
+        in that direction the persisted row under-reports — which would retire
+        a ceiling rather than enforce it.
+        """
+        mirror = self._daily_spend.get((day, scope_kind, scope_id), 0.0)
+        if not self._ledger_db_path:
+            return mirror
+        conn = self._connect(self._ledger_db_path)
         try:
             cursor = conn.cursor()
             cursor.execute(
@@ -449,35 +541,47 @@ class UsageTracker:
                 (day, scope_kind, scope_id),
             )
             row = cursor.fetchone()
-            return row[0] if row else 0.0
+            return max(mirror, float(row[0])) if row else mirror
         except Exception as e:
-            log.warning("usage_tracker.db_query_failed", error=str(e))
-            return 0.0
+            log.warning("usage_tracker.ledger_query_failed", error=str(e))
+            return mirror
         finally:
             conn.close()
 
     def get_session_db_cost(self, session_key: str) -> float:
-        if not self._db_path:
+        """Return the persisted lifetime cost recorded for one session."""
+        if not self._ledger_db_path:
             return 0.0
-        conn = sqlite3.connect(self._db_path)
+        conn = self._connect(self._ledger_db_path)
         try:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT total_cost_usd FROM sessions WHERE session_key = ?",
+                "SELECT cost_usd FROM session_spend WHERE session_key = ?",
                 (session_key,),
             )
             row = cursor.fetchone()
-            return row[0] if row else 0.0
-        except Exception:
+            return float(row[0]) if row else 0.0
+        except Exception as e:
+            log.warning("usage_tracker.session_spend_query_failed", error=str(e))
             return 0.0
         finally:
             conn.close()
 
     def get_effective_session_cost(self, session_key: str) -> float:
+        """Best known lifetime cost for a session.
+
+        The in-process total covers only what this process has seen. After a
+        restart a resumed session starts from zero in memory while the ledger
+        still holds what it spent before, so a session ceiling must compare
+        against the larger of the two — otherwise a crash-and-respawn hands
+        the session a fresh allowance.
+        """
+        persisted = self._session_spend.get(session_key)
+        if persisted is None:
+            persisted = self.get_session_db_cost(session_key)
         mem_usage = self._sessions.get(session_key)
-        if mem_usage is not None:
-            return mem_usage.total_cost
-        return self.get_session_db_cost(session_key)
+        in_memory = mem_usage.total_cost if mem_usage is not None else 0.0
+        return max(in_memory, persisted)
 
     def get_session_scope(self, session_key: str) -> tuple[str, str]:
         meta = self._session_metadata.get(session_key)
@@ -487,122 +591,115 @@ class UsageTracker:
         return meta
 
     def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
-        """Check budget limits and return (exceeded_hard_stop, alert_message)."""
-        if config is None:
+        """Evaluate every configured spend ceiling for ``session_key``.
+
+        Returns ``(hard_stop, message)``. ``hard_stop`` True means the caller
+        must refuse the work; ``message`` carries operator-facing text for
+        either that refusal or — with ``hard_stop`` False — a one-shot warning.
+
+        Hard stops are evaluated across all scopes before warnings, so a
+        breached ceiling is never masked by a warning from an earlier scope.
+        Warnings fire at most once per scope per day/session so a long-running
+        session does not repeat the same alert on every turn.
+        """
+        if config is None or not getattr(config, "enabled", True):
             return False, None
 
         agent_id, channel = self.get_session_scope(session_key)
         day = datetime.now(UTC).strftime("%Y-%m-%d")
 
-        # 1. Session cost check
-        sess_cost = self.get_effective_session_cost(session_key)
-        if config.session_limit is not None and sess_cost >= config.session_limit:
-            return (
-                True,
-                f"Session cost ${sess_cost:,.4f} exceeds limit of ${config.session_limit:,.4f}.",
-            )
-        if config.session_warn is not None and sess_cost >= config.session_warn:
-            warn_key = f"{session_key}:session_warn"
-            if warn_key not in self._warned_keys:
-                self._warned_keys.add(warn_key)
-                log.warning(
-                    "budget.session_warning",
-                    session_key=session_key,
-                    cost=sess_cost,
-                    limit=config.session_warn,
-                )
-                return (
-                    False,
-                    (
-                        f"Session cost ${sess_cost:,.4f} exceeds warning threshold "
-                        f"of ${config.session_warn:,.4f}."
-                    ),
-                )
+        # (log_event, label, warn_key, spend, limit, warn). Spend is only read
+        # for scopes that actually have a ceiling configured, so the default
+        # all-None config costs four dict lookups and no SQLite queries.
+        checks: list[tuple[str, str, str, float, float | None, float | None]] = []
 
-        # 2. Daily global cost check
-        daily_cost = self.get_spend(day, "gateway", "global")
-        if config.daily_limit is not None and daily_cost >= config.daily_limit:
-            return (
-                True,
+        session_limit = getattr(config, "session_limit", None)
+        session_warn = getattr(config, "session_warn", None)
+        if session_limit is not None or session_warn is not None:
+            checks.append(
                 (
-                    f"Daily global cost ${daily_cost:,.4f} exceeds limit "
-                    f"of ${config.daily_limit:,.4f}."
-                ),
+                    "session",
+                    "Session cost",
+                    f"session:{session_key}",
+                    self.get_effective_session_cost(session_key),
+                    session_limit,
+                    session_warn,
+                )
             )
-        if config.daily_warn is not None and daily_cost >= config.daily_warn:
-            warn_key = f"{day}:daily_warn"
-            if warn_key not in self._warned_keys:
-                self._warned_keys.add(warn_key)
-                log.warning("budget.daily_warning", cost=daily_cost, limit=config.daily_warn)
-                return (
-                    False,
-                    (
-                        f"Daily global cost ${daily_cost:,.4f} exceeds warning threshold "
-                        f"of ${config.daily_warn:,.4f}."
-                    ),
-                )
 
-        # 3. Agent daily cost check
-        agent_limit = config.agent_daily_limit.get(agent_id)
-        agent_warn = config.agent_daily_warn.get(agent_id)
+        daily_limit = getattr(config, "daily_limit", None)
+        daily_warn = getattr(config, "daily_warn", None)
+        if daily_limit is not None or daily_warn is not None:
+            checks.append(
+                (
+                    "daily",
+                    "Daily gateway cost",
+                    f"daily:{day}",
+                    self.get_spend(day, "gateway", "global"),
+                    daily_limit,
+                    daily_warn,
+                )
+            )
+
+        agent_limit = _scope_ceiling(config, "agent_daily_limit", agent_id)
+        agent_warn = _scope_ceiling(config, "agent_daily_warn", agent_id)
         if agent_limit is not None or agent_warn is not None:
-            agent_cost = self.get_spend(day, "agent", agent_id)
-            if agent_limit is not None and agent_cost >= agent_limit:
-                return (
-                    True,
-                    (
-                        f"Daily cost for agent '{agent_id}' (${agent_cost:,.4f}) "
-                        f"exceeds limit of ${agent_limit:,.4f}."
-                    ),
+            checks.append(
+                (
+                    "agent_daily",
+                    f"Daily cost for agent '{agent_id}'",
+                    f"agent:{day}:{agent_id}",
+                    self.get_spend(day, "agent", agent_id),
+                    agent_limit,
+                    agent_warn,
                 )
-            if agent_warn is not None and agent_cost >= agent_warn:
-                warn_key = f"{day}:agent_warn:{agent_id}"
-                if warn_key not in self._warned_keys:
-                    self._warned_keys.add(warn_key)
-                    log.warning(
-                        "budget.agent_warning",
-                        agent_id=agent_id,
-                        cost=agent_cost,
-                        limit=agent_warn,
-                    )
-                    return (
-                        False,
-                        (
-                            f"Daily cost for agent '{agent_id}' (${agent_cost:,.4f}) "
-                            f"exceeds warning threshold of ${agent_warn:,.4f}."
-                        ),
-                    )
+            )
 
-        # 4. Channel daily cost check
-        channel_limit = config.channel_daily_limit.get(channel)
-        channel_warn = config.channel_daily_warn.get(channel)
+        channel_limit = _scope_ceiling(config, "channel_daily_limit", channel)
+        channel_warn = _scope_ceiling(config, "channel_daily_warn", channel)
         if channel_limit is not None or channel_warn is not None:
-            channel_cost = self.get_spend(day, "channel", channel)
-            if channel_limit is not None and channel_cost >= channel_limit:
+            checks.append(
+                (
+                    "channel_daily",
+                    f"Daily cost for channel '{channel}'",
+                    f"channel:{day}:{channel}",
+                    self.get_spend(day, "channel", channel),
+                    channel_limit,
+                    channel_warn,
+                )
+            )
+
+        for scope, label, _warn_key, spend, limit, _warn in checks:
+            if limit is not None and spend >= limit:
+                log.warning(
+                    "budget.limit_exceeded",
+                    scope=scope,
+                    session_key=session_key,
+                    spend=spend,
+                    limit=limit,
+                )
                 return (
                     True,
-                    (
-                        f"Daily cost for channel '{channel}' (${channel_cost:,.4f}) "
-                        f"exceeds limit of ${channel_limit:,.4f}."
-                    ),
+                    f"{label} ${spend:,.4f} has reached the ${limit:,.4f} budget limit.",
                 )
-            if channel_warn is not None and channel_cost >= channel_warn:
-                warn_key = f"{day}:channel_warn:{channel}"
-                if warn_key not in self._warned_keys:
-                    self._warned_keys.add(warn_key)
-                    log.warning(
-                        "budget.channel_warning",
-                        channel=channel,
-                        cost=channel_cost,
-                        limit=channel_warn,
-                    )
-                    return (
-                        False,
-                        (
-                            f"Daily cost for channel '{channel}' (${channel_cost:,.4f}) "
-                            f"exceeds warning threshold of ${channel_warn:,.4f}."
-                        ),
-                    )
+
+        for scope, label, warn_key, spend, _limit, warn in checks:
+            if warn is None or spend < warn:
+                continue
+            if warn_key in self._warned_keys:
+                continue
+            self._warned_keys.add(warn_key)
+            log.warning(
+                "budget.warning",
+                scope=scope,
+                session_key=session_key,
+                spend=spend,
+                threshold=warn,
+            )
+            return (
+                False,
+                f"{label} ${spend:,.4f} has reached the ${warn:,.4f} budget warning threshold.",
+            )
 
         return False, None
 
@@ -668,60 +765,115 @@ class UsageTracker:
         )
         effective_cost = billed_cost if billed_cost > 0.0 else cost
 
-        # Persistence to Daily Ledger & usage records
-        if self._db_path:
-            agent_id, channel = self.get_session_scope(session_key)
-            day = datetime.now(UTC).strftime("%Y-%m-%d")
-            if effective_cost > 0.0:
-                self._update_spend_ledger(day, "gateway", "global", effective_cost)
-                self._update_spend_ledger(day, "agent", agent_id, effective_cost)
-                self._update_spend_ledger(day, "channel", channel, effective_cost)
+        # Spend ledger — mirrored in memory with or without a DB so budget
+        # ceilings apply to an in-memory tracker too.
+        agent_id, channel = self.get_session_scope(session_key)
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        ledger_scopes = (("gateway", "global"), ("agent", agent_id), ("channel", channel))
+        if effective_cost > 0.0:
+            for scope_kind, scope_id in ledger_scopes:
+                self._bump_daily_mirror(day, scope_kind, scope_id, effective_cost)
+            if session_key not in self._session_spend:
+                # Seed from the ledger so a session resumed after a restart
+                # keeps counting from what it already spent.
+                self._session_spend[session_key] = self.get_session_db_cost(session_key)
+            self._session_spend[session_key] += effective_cost
+            self._persist_ledger(day, ledger_scopes, session_key, effective_cost)
 
-            # Record detailed usage row
-            tool_name = _current_tool_name.get()
-            scope_key = _current_usage_scope.get()
-            if not tool_name and scope_key:
-                tool_name = scope_key
+        if not self._db_path:
+            return
 
-            skill = _current_skill_name.get()
-            if not skill:
-                skill = self._session_active_skill.get(session_key)
+        tool_name = _current_tool_name.get()
+        scope_key = _current_usage_scope.get()
+        if not tool_name and scope_key:
+            tool_name = scope_key
 
-            created_at = int(time.time() * 1000)
+        skill = _current_skill_name.get()
+        if not skill:
+            skill = self._session_active_skill.get(session_key)
 
-            conn = sqlite3.connect(self._db_path)
-            try:
-                with conn:
-                    conn.execute(
-                        """
-                        INSERT INTO usage_records (
-                            session_key, agent_id, channel_type, tool_name, skill,
-                            model, provider, input_tokens, output_tokens,
-                            cache_read_tokens, cache_write_tokens, cost_usd, billed_cost_usd,
-                            created_at
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            session_key,
-                            agent_id,
-                            channel,
-                            tool_name,
-                            skill,
-                            model_id,
-                            effective_provider_id,
-                            input_tokens,
-                            output_tokens,
-                            cache_read_tokens,
-                            cache_write_tokens,
-                            cost,
-                            billed_cost,
-                            created_at,
-                        ),
-                    )
-            except Exception as e:
-                log.warning("usage_tracker.insert_usage_record_failed", error=str(e))
-            finally:
-                conn.close()
+        created_at = int(time.time() * 1000)
+
+        conn = self._connect(self._db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO usage_records (
+                        session_key, agent_id, channel_type, tool_name, skill,
+                        model, provider, input_tokens, output_tokens,
+                        cache_read_tokens, cache_write_tokens, cost_usd, billed_cost_usd,
+                        created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_key,
+                        agent_id,
+                        channel,
+                        tool_name,
+                        skill,
+                        model_id,
+                        effective_provider_id,
+                        input_tokens,
+                        output_tokens,
+                        cache_read_tokens,
+                        cache_write_tokens,
+                        cost,
+                        billed_cost,
+                        created_at,
+                    ),
+                )
+        except Exception as e:
+            log.warning("usage_tracker.insert_usage_record_failed", error=str(e))
+        finally:
+            conn.close()
+
+    def _persist_ledger(
+        self,
+        day: str,
+        ledger_scopes: tuple[tuple[str, str], ...],
+        session_key: str,
+        incremental_cost: float,
+    ) -> None:
+        """Write one turn's spend into the durable ledger.
+
+        All four upserts share one connection and one transaction: this runs
+        on the turn hot path and sqlite3 is synchronous, so every extra
+        connect/commit is event-loop time. A failure here is logged and
+        swallowed — the in-process mirror still holds the spend, and
+        ``get_spend`` takes the larger of the two, so a dropped write costs
+        durability across a restart but never retires a live ceiling.
+        """
+        if not self._ledger_db_path:
+            return
+        conn = self._connect(self._ledger_db_path)
+        try:
+            with conn:
+                conn.executemany(
+                    """
+                    INSERT INTO spend_ledger (day, scope_kind, scope_id, cost_usd)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(day, scope_kind, scope_id) DO UPDATE SET
+                        cost_usd = cost_usd + excluded.cost_usd
+                    """,
+                    [
+                        (day, scope_kind, scope_id, incremental_cost)
+                        for scope_kind, scope_id in ledger_scopes
+                    ],
+                )
+                conn.execute(
+                    """
+                    INSERT INTO session_spend (session_key, cost_usd)
+                    VALUES (?, ?)
+                    ON CONFLICT(session_key) DO UPDATE SET
+                        cost_usd = cost_usd + excluded.cost_usd
+                    """,
+                    (session_key, incremental_cost),
+                )
+        except Exception as e:
+            log.warning("usage_tracker.ledger_write_failed", error=str(e))
+        finally:
+            conn.close()
 
     def get(self, session_key: str) -> SessionUsage | None:
         """Return accumulated usage for a session, or None."""
@@ -832,15 +984,6 @@ class UsageTracker:
     def all_sessions(self) -> dict[str, SessionUsage]:
         """Return all tracked sessions."""
         return dict(self._sessions)
-
-    def check_warning(self, session_key: str, threshold: float = 5.0) -> str | None:
-        """Return a warning if session cost exceeds threshold, else None."""
-        usage = self._sessions.get(session_key)
-        if usage is None:
-            return None
-        if usage.cost >= threshold:
-            return f"Session cost ${usage.cost:,.2f} has exceeded the ${threshold:,.2f} threshold."
-        return None
 
     def query_usage(
         self,

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -611,6 +611,10 @@ async def dispatch_task_runtime_turn(
             "provider_request_budget_exhausted",
             "provider_request_too_large",
             "current_turn_context_exhausted",
+            # A budget-refused turn never reached the model, so the user
+            # message persisted ahead of the run would otherwise linger as a
+            # reply-less turn and feed back into later context.
+            "budget_exceeded",
         }:
             message_id = getattr(run, "persisted_user_message_id", None)
             remove_message = getattr(session_manager, "remove_message", None)
@@ -1794,8 +1798,27 @@ async def build_services(
         log.warning("build_services.cron_scheduler_failed", error=str(e))
 
     # ── Usage tracker ───────────────────────────────────────────────
+    # The spend ledger that budget ceilings read lives in its own state file,
+    # not in the session DB: it is written synchronously from the turn hot
+    # path, and sharing a file with the session store's async writer would put
+    # every ledger commit behind that write lock on the event loop. An
+    # in-memory session DB (CLI standalone / tests) means no durable state
+    # directory is in play, so the tracker stays in-memory too.
     if usage_tracker is None:
-        usage_tracker = _UsageTracker(default_provider_id=config.llm.provider)
+        ledger_db_path: str | None = None
+        if session_db_path != ":memory:":
+            ledger_db = _state_path(config, "spend_ledger.db")
+            try:
+                ledger_db.parent.mkdir(parents=True, exist_ok=True)
+                ledger_db_path = str(ledger_db)
+            except OSError as e:
+                # A ledger we cannot create must not stop the gateway; budgets
+                # fall back to in-process accounting for this run.
+                log.warning("build_services.spend_ledger_unavailable", error=str(e))
+        usage_tracker = _UsageTracker(
+            default_provider_id=config.llm.provider,
+            ledger_db_path=ledger_db_path,
+        )
 
     # ── Auxiliary LLM client (needs the tracker above to bill side tasks) ──
     try:

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -37,6 +37,7 @@ from agentos.router_tiers import (
     normalize_tier_mapping,
 )
 from agentos.sandbox.config import SandboxSettings
+from agentos.session.keys import normalize_agent_id
 from agentos.skills.injector import DEFAULT_MAX_SKILLS_PROMPT_CHARS
 from agentos.skills.outline import DEFAULT_MAX_SKILL_VIEW_CHARS
 
@@ -1814,6 +1815,129 @@ class UpdatesConfig(BaseModel):
     notify: bool = True
 
 
+class BudgetsConfig(BaseModel):
+    """Money spend ceilings — hard stop plus warn thresholds.
+
+    Every ceiling is US dollars of estimated (or provider-billed, when the
+    provider reports one) model spend. ``None`` means "no ceiling for this
+    scope", which is the default for all of them: a fresh install enforces
+    nothing until an operator sets a number.
+
+    Session ceilings are measured against the session's own accumulated cost.
+    The ``*_daily_*`` ceilings are measured against a persisted per-UTC-day
+    ledger, so they survive a gateway restart — the point of the feature is
+    that a runaway overnight loop cannot be reset by a crash-and-respawn.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    """Master switch. Left on so setting a ceiling is enough to enforce it;
+    set ``false`` to suspend every ceiling without deleting the numbers."""
+
+    session_limit: float | None = Field(default=None, ge=0.0)
+    """Hard stop once one session's accumulated cost reaches this."""
+
+    session_warn: float | None = Field(default=None, ge=0.0)
+    """Warn (once per session) at this session cost. Must not exceed
+    ``session_limit`` when both are set."""
+
+    daily_limit: float | None = Field(default=None, ge=0.0)
+    """Hard stop once gateway-wide spend for the current UTC day reaches this."""
+
+    daily_warn: float | None = Field(default=None, ge=0.0)
+    """Warn (once per day) at this gateway-wide daily spend."""
+
+    agent_daily_limit: dict[str, float] = Field(default_factory=dict)
+    """Per-agent daily hard stops, keyed by agent id."""
+
+    agent_daily_warn: dict[str, float] = Field(default_factory=dict)
+    """Per-agent daily warn thresholds, keyed by agent id."""
+
+    channel_daily_limit: dict[str, float] = Field(default_factory=dict)
+    """Per-channel daily hard stops, keyed by channel name (``telegram``,
+    ``slack``, ``webchat``, ``system``, ...)."""
+
+    channel_daily_warn: dict[str, float] = Field(default_factory=dict)
+    """Per-channel daily warn thresholds, keyed by channel name."""
+
+    @staticmethod
+    def _normalized_keys(value: Any, normalize: Any) -> Any:
+        """Rewrite scope keys to their canonical form, refusing collisions.
+
+        Two spellings of one scope (``default`` and ``main``, ``Telegram`` and
+        ``telegram``) would otherwise collapse into a single entry and one of
+        the operator's two numbers would vanish with no error.
+        """
+        if not isinstance(value, dict):
+            return value
+        normalized: dict[str, Any] = {}
+        seen: dict[str, str] = {}
+        for key, amount in value.items():
+            canonical = normalize(str(key))
+            if canonical in seen:
+                raise ValueError(
+                    f"budget keys '{seen[canonical]}' and '{key}' both refer to "
+                    f"'{canonical}' — keep only one"
+                )
+            seen[canonical] = str(key)
+            normalized[canonical] = amount
+        return normalized
+
+    @field_validator("agent_daily_limit", "agent_daily_warn", mode="before")
+    @classmethod
+    def _normalize_agent_keys(cls, value: Any) -> Any:
+        return cls._normalized_keys(value, normalize_agent_id)
+
+    @field_validator("channel_daily_limit", "channel_daily_warn", mode="before")
+    @classmethod
+    def _normalize_channel_keys(cls, value: Any) -> Any:
+        return cls._normalized_keys(value, lambda key: key.strip().lower())
+
+    @field_validator(
+        "agent_daily_limit",
+        "agent_daily_warn",
+        "channel_daily_limit",
+        "channel_daily_warn",
+    )
+    @classmethod
+    def _reject_negative_ceilings(cls, value: dict[str, float]) -> dict[str, float]:
+        for key, amount in value.items():
+            if amount < 0:
+                raise ValueError(f"budget ceiling for '{key}' must be >= 0 (got {amount})")
+        return value
+
+    @model_validator(mode="after")
+    def _warn_below_limit(self) -> BudgetsConfig:
+        """A warn threshold above its hard stop can never fire — reject it.
+
+        Silently accepting it would leave the operator believing they have an
+        early-warning signal that the hard stop always pre-empts.
+        """
+        pairs: list[tuple[str, float | None, float | None]] = [
+            ("session", self.session_warn, self.session_limit),
+            ("daily", self.daily_warn, self.daily_limit),
+        ]
+        for scope, warn, limit in pairs:
+            if warn is not None and limit is not None and warn > limit:
+                raise ValueError(
+                    f"budgets.{scope}_warn ({warn}) must not exceed budgets.{scope}_limit ({limit})"
+                )
+        scoped = [
+            ("agent_daily", self.agent_daily_warn, self.agent_daily_limit),
+            ("channel_daily", self.channel_daily_warn, self.channel_daily_limit),
+        ]
+        for scope, warns, limits in scoped:
+            for key, warn_amount in warns.items():
+                limit_amount = limits.get(key)
+                if limit_amount is not None and warn_amount > limit_amount:
+                    raise ValueError(
+                        f"budgets.{scope}_warn['{key}'] ({warn_amount}) must not exceed "
+                        f"budgets.{scope}_limit['{key}'] ({limit_amount})"
+                    )
+        return self
+
+
 class TlsConfig(BaseSettings):
     """Optional TLS termination at the gateway itself.
 
@@ -1896,6 +2020,7 @@ class GatewayConfig(BaseSettings):
     agents: list[AgentEntryConfig] = Field(default_factory=list)
     agents_defaults: AgentDefaults = Field(default_factory=AgentDefaults)
     subagents: SubagentsGatewayConfig = Field(default_factory=SubagentsGatewayConfig)
+    budgets: BudgetsConfig = Field(default_factory=BudgetsConfig)
 
     updates: UpdatesConfig = Field(default_factory=UpdatesConfig)
 

--- a/src/agentos/session/terminal_reply.py
+++ b/src/agentos/session/terminal_reply.py
@@ -63,6 +63,11 @@ def build_terminal_reply(
         return "The task was cancelled before it finished."
     if status == AgentTaskStatus.ABANDONED.value or reason == "shutdown_timeout":
         return "The task stopped before it could finish."
+    if error_class == "budget_exceeded" or reason == "budget_exceeded":
+        # A spend ceiling is a deliberate refusal, not a failure. Keep the
+        # message that names the scope and the number instead of collapsing it
+        # into generic failure text the operator cannot act on.
+        return error_message or "The task stopped because a spend budget limit was reached."
     if status == AgentTaskStatus.FAILED.value or reason in {"error", "tool_error"}:
         return "The task failed before it could finish."
     if status == AgentTaskStatus.SUCCEEDED.value or reason in {"completed", "done"}:

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -215,6 +215,7 @@ Main `agentos.toml` sections (full commented reference:
 | `[prompt]` | prompt-layer flags: `platform_hint_enabled`, `env_probe_enabled` (local-toolchain block, names only) |
 | `[prompt_cache]` | Prompt-cache continuity: `mode` = `auto` (default) \| `on` \| `off`. Env override: `AGENTOS_CACHE_MODE` (legacy `prompt_cache.enabled` / `AGENTOS_CACHE_ENABLED` deprecated) |
 | `[safety]` | Prompt-ingress safety: `wrap_untrusted_workspace` (default true), `injection_scan_mode` (`report` default, `enforce` redacts matched workspace-file content, `off`) |
+| `[budgets]` | money spend ceilings (USD): `session_limit`/`session_warn`, `daily_limit`/`daily_warn` (per UTC day, persisted across restarts), and per-key `[budgets.agent_daily_limit]` / `[budgets.channel_daily_limit]` (plus `*_warn`). A turn at or above a hard limit is refused with `budget_exceeded`; a warn threshold raises a one-shot `budget_warning`. Nothing is enforced until a ceiling is set |
 | `[compaction]`, `[agent_token_saving]`, `[task_runtime]` | context compaction, tool-result projection, concurrency |
 
 Slack native commands auto-sync when a Slack channel entry provides `app_id`,

--- a/tests/test_engine/test_spend_budgets.py
+++ b/tests/test_engine/test_spend_budgets.py
@@ -1,0 +1,447 @@
+"""Spend budgets: ledger accumulation, ceiling evaluation, and turn-loop enforcement."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.engine.types import ErrorEvent, WarningEvent
+from agentos.engine.usage import UsageTracker
+from agentos.gateway.config import BudgetsConfig
+
+SESSION = "agent:main:telegram:acct:peer"
+
+
+def _spend(tracker: UsageTracker, session_key: str, cost: float) -> None:
+    """Record ``cost`` dollars of provider-billed spend on ``session_key``."""
+    tracker.add(
+        session_key,
+        input_tokens=100,
+        output_tokens=10,
+        model_id="test-model",
+        billed_cost=cost,
+        provider_id="test",
+    )
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+# ── Ledger ──────────────────────────────────────────────────────────────
+
+
+def test_daily_ledger_accumulates_without_a_database() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 1.25)
+    _spend(tracker, SESSION, 0.75)
+
+    day = _today()
+    assert tracker.get_spend(day, "gateway", "global") == pytest.approx(2.0)
+    assert tracker.get_spend(day, "agent", "main") == pytest.approx(2.0)
+    assert tracker.get_spend(day, "channel", "telegram") == pytest.approx(2.0)
+
+
+def test_daily_ledger_survives_a_restart(tmp_path: Path) -> None:
+    db = str(tmp_path / "spend_ledger.db")
+    first = UsageTracker(ledger_db_path=db)
+    _spend(first, SESSION, 3.0)
+
+    # A fresh tracker on the same DB stands in for a gateway restart: the
+    # whole point of the ledger is that a crash cannot reset a daily ceiling.
+    restarted = UsageTracker(ledger_db_path=db)
+    assert restarted.get_spend(_today(), "gateway", "global") == pytest.approx(3.0)
+    hard_stop, _ = restarted.check_budget_limits(SESSION, BudgetsConfig(daily_limit=3.0))
+    assert hard_stop is True
+
+
+def test_session_ceiling_survives_a_restart(tmp_path: Path) -> None:
+    """A crash-and-respawn must not hand a session a fresh allowance."""
+    db = str(tmp_path / "spend_ledger.db")
+    first = UsageTracker(ledger_db_path=db)
+    _spend(first, SESSION, 4.0)
+
+    restarted = UsageTracker(ledger_db_path=db)
+    assert restarted.get_effective_session_cost(SESSION) == pytest.approx(4.0)
+
+    config = BudgetsConfig(session_limit=5.0)
+    assert restarted.check_budget_limits(SESSION, config) == (False, None)
+    # The post-restart turn's own spend adds to the pre-restart total rather
+    # than starting the count over.
+    _spend(restarted, SESSION, 1.0)
+    assert restarted.check_budget_limits(SESSION, config)[0] is True
+
+
+def test_a_dropped_ledger_write_cannot_retire_a_ceiling(tmp_path: Path) -> None:
+    """The persisted row can only under-report; reads take the larger value."""
+    db = str(tmp_path / "spend_ledger.db")
+    tracker = UsageTracker(ledger_db_path=db)
+    _spend(tracker, SESSION, 6.0)
+
+    # Simulate a write that never landed (sqlite busy, disk full): the row
+    # lags behind what this process has actually spent.
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE spend_ledger SET cost_usd = 1.0")
+
+    assert tracker.get_spend(_today(), "gateway", "global") == pytest.approx(6.0)
+    assert tracker.check_budget_limits(SESSION, BudgetsConfig(daily_limit=5.0))[0] is True
+
+
+def test_ledger_ignores_zero_cost_usage() -> None:
+    tracker = UsageTracker()
+    tracker.add(SESSION, input_tokens=0, output_tokens=0, model_id="test-model")
+
+    assert tracker.get_spend(_today(), "gateway", "global") == 0.0
+
+
+# ── Ceiling evaluation ──────────────────────────────────────────────────
+
+
+def test_no_config_and_empty_config_enforce_nothing() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 100.0)
+
+    assert tracker.check_budget_limits(SESSION, None) == (False, None)
+    assert tracker.check_budget_limits(SESSION, BudgetsConfig()) == (False, None)
+
+
+def test_disabled_switch_suspends_configured_ceilings() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 10.0)
+
+    config = BudgetsConfig(enabled=False, session_limit=1.0, session_warn=0.5)
+    assert tracker.check_budget_limits(SESSION, config) == (False, None)
+
+
+def test_session_limit_hard_stops_at_the_ceiling() -> None:
+    tracker = UsageTracker()
+    config = BudgetsConfig(session_limit=2.0)
+
+    _spend(tracker, SESSION, 1.5)
+    assert tracker.check_budget_limits(SESSION, config) == (False, None)
+
+    _spend(tracker, SESSION, 0.5)
+    hard_stop, message = tracker.check_budget_limits(SESSION, config)
+    assert hard_stop is True
+    assert message is not None
+    assert "Session cost" in message
+    assert "$2.0000" in message
+
+
+def test_session_warning_fires_once_and_does_not_stop_the_turn() -> None:
+    tracker = UsageTracker()
+    config = BudgetsConfig(session_warn=1.0, session_limit=10.0)
+
+    _spend(tracker, SESSION, 1.0)
+    hard_stop, message = tracker.check_budget_limits(SESSION, config)
+    assert hard_stop is False
+    assert message is not None
+    assert "warning threshold" in message
+
+    _spend(tracker, SESSION, 1.0)
+    assert tracker.check_budget_limits(SESSION, config) == (False, None)
+
+
+def test_daily_limit_hard_stops_across_sessions() -> None:
+    tracker = UsageTracker()
+    config = BudgetsConfig(daily_limit=5.0)
+
+    _spend(tracker, "agent:main:telegram:a:1", 3.0)
+    _spend(tracker, "agent:main:webchat:b:2", 2.0)
+
+    hard_stop, message = tracker.check_budget_limits("agent:main:webchat:b:2", config)
+    assert hard_stop is True
+    assert message is not None
+    assert "Daily gateway cost" in message
+
+
+def test_agent_and_channel_daily_ceilings_are_scoped() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, "agent:trader:telegram:a:1", 4.0)
+    _spend(tracker, "agent:writer:webchat:b:2", 1.0)
+
+    config = BudgetsConfig(agent_daily_limit={"trader": 3.0})
+    assert tracker.check_budget_limits("agent:trader:telegram:a:1", config)[0] is True
+    assert tracker.check_budget_limits("agent:writer:webchat:b:2", config) == (False, None)
+
+    channel_config = BudgetsConfig(channel_daily_limit={"telegram": 3.0})
+    assert tracker.check_budget_limits("agent:trader:telegram:a:1", channel_config)[0] is True
+    assert tracker.check_budget_limits("agent:writer:webchat:b:2", channel_config) == (False, None)
+
+
+def test_subagent_spend_is_attributed_to_the_parent_agent() -> None:
+    """A fan-out must count against the spawning agent's daily ceiling."""
+    tracker = UsageTracker()
+    _spend(tracker, "subagent:agent:trader:subagent:child-1", 2.0)
+    _spend(tracker, "subagent:agent:trader:subagent:child-2", 2.0)
+
+    config = BudgetsConfig(agent_daily_limit={"trader": 3.0})
+    hard_stop, message = tracker.check_budget_limits("agent:trader:telegram:a:1", config)
+    assert hard_stop is True
+    assert message is not None
+    assert "agent 'trader'" in message
+
+
+def test_hard_stop_wins_over_an_earlier_scope_warning() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 6.0)
+
+    # Session is only at its warn threshold, but the daily ceiling is breached.
+    config = BudgetsConfig(session_warn=5.0, session_limit=20.0, daily_limit=6.0)
+    hard_stop, message = tracker.check_budget_limits(SESSION, config)
+    assert hard_stop is True
+    assert message is not None
+    assert "Daily gateway cost" in message
+
+
+# ── Config validation ───────────────────────────────────────────────────
+
+
+def test_warn_above_its_own_limit_is_rejected() -> None:
+    with pytest.raises(ValueError, match="session_warn"):
+        BudgetsConfig(session_warn=10.0, session_limit=5.0)
+    with pytest.raises(ValueError, match="daily_warn"):
+        BudgetsConfig(daily_warn=10.0, daily_limit=5.0)
+    with pytest.raises(ValueError, match="agent_daily_warn"):
+        BudgetsConfig(agent_daily_warn={"main": 10.0}, agent_daily_limit={"main": 5.0})
+
+
+def test_negative_ceilings_are_rejected() -> None:
+    with pytest.raises(ValueError):
+        BudgetsConfig(session_limit=-1.0)
+    with pytest.raises(ValueError, match="must be >= 0"):
+        BudgetsConfig(agent_daily_limit={"main": -1.0})
+
+
+def test_colliding_scope_keys_are_rejected() -> None:
+    """Two spellings of one scope would silently drop one of the numbers."""
+    with pytest.raises(ValueError, match="both refer to"):
+        BudgetsConfig(agent_daily_limit={"default": 5.0, "main": 100.0})
+    with pytest.raises(ValueError, match="both refer to"):
+        BudgetsConfig(channel_daily_limit={"Telegram": 5.0, "telegram": 100.0})
+
+
+def test_scope_keys_are_normalized() -> None:
+    config = BudgetsConfig(
+        agent_daily_limit={"Default": 5.0},
+        channel_daily_limit={"Telegram": 5.0},
+    )
+    assert config.agent_daily_limit == {"main": 5.0}
+    assert config.channel_daily_limit == {"telegram": 5.0}
+
+
+def test_unknown_budget_keys_are_rejected() -> None:
+    with pytest.raises(ValueError):
+        BudgetsConfig(sesion_limit=5.0)  # type: ignore[call-arg]
+
+
+# ── Turn-loop enforcement ───────────────────────────────────────────────
+
+
+class _RecordingSessionManager:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str, str]] = []
+
+    async def append_message(self, session_key: str, *, role: str, content: str) -> None:
+        self.messages.append((session_key, role, content))
+
+
+def _runner(tracker: Any, budgets: Any, manager: Any) -> Any:
+    from agentos.engine.runtime import TurnRunner
+
+    return TurnRunner(
+        provider_selector=None,
+        session_manager=manager,
+        usage_tracker=tracker,
+        config=SimpleNamespace(budgets=budgets, context_window_tokens=100_000),
+    )
+
+
+async def _collect(runner: Any) -> list[Any]:
+    return [event async for event in runner._run_turn("hi", SESSION, "main", None, [])]
+
+
+@pytest.mark.asyncio
+async def test_turn_is_refused_at_the_hard_limit() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 5.0)
+    manager = _RecordingSessionManager()
+    runner = _runner(tracker, BudgetsConfig(session_limit=5.0), manager)
+
+    events = await _collect(runner)
+
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ErrorEvent)
+    assert error.code == "budget_exceeded"
+    assert "budget limit" in error.message
+    # The refusal is auditable in the transcript, not only in the log.
+    assert manager.messages and manager.messages[0][1] == "system"
+
+
+@pytest.mark.asyncio
+async def test_turn_warns_but_continues_below_the_hard_limit() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 4.0)
+    runner = _runner(tracker, BudgetsConfig(session_warn=4.0, session_limit=10.0), None)
+
+    events = await _collect(runner)
+
+    assert isinstance(events[0], WarningEvent)
+    assert events[0].code == "budget_warning"
+    # The turn was not refused — it proceeded and failed later on the absent
+    # provider, which is the pre-existing behavior for this stub runner.
+    assert not any(
+        isinstance(event, ErrorEvent) and event.code == "budget_exceeded" for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_runs_when_no_budgets_are_configured() -> None:
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 100.0)
+    runner = _runner(tracker, BudgetsConfig(), None)
+
+    events = await _collect(runner)
+
+    assert not any(
+        isinstance(event, ErrorEvent) and event.code == "budget_exceeded" for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_without_a_message_still_refuses_the_turn() -> None:
+    """The refusal must hinge on the decision, not on the presentation text."""
+
+    class _TerseTracker:
+        def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
+            return True, None
+
+    runner = _runner(_TerseTracker(), BudgetsConfig(session_limit=1.0), None)
+
+    events = await _collect(runner)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ErrorEvent)
+    assert events[0].code == "budget_exceeded"
+    assert events[0].message
+
+
+@pytest.mark.asyncio
+async def test_budget_check_failure_fails_open() -> None:
+    """A broken budget check must never be the reason a turn is refused."""
+
+    class _ExplodingTracker:
+        def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
+            raise RuntimeError("ledger unavailable")
+
+    runner = _runner(_ExplodingTracker(), BudgetsConfig(session_limit=0.0), None)
+
+    events = await _collect(runner)
+
+    assert not any(
+        isinstance(event, ErrorEvent) and event.code == "budget_exceeded" for event in events
+    )
+
+
+# ── Intra-turn enforcement ──────────────────────────────────────────────
+
+
+class _LoopingToolProvider:
+    """A provider that never stops calling a tool — a runaway turn."""
+
+    provider_name = "fake"
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def chat(
+        self,
+        messages: list[Any],
+        tools: list[Any] | None = None,
+        config: Any | None = None,
+    ) -> Any:
+        self.calls.append(messages)
+        return self._stream(len(self.calls))
+
+    async def _stream(self, call_number: int) -> Any:
+        from agentos.provider import DoneEvent as ProviderDone
+        from agentos.provider import ToolUseEndEvent as ProviderToolUseEnd
+        from agentos.provider import ToolUseStartEvent as ProviderToolUseStart
+
+        tool_id = f"tool-{call_number}"
+        yield ProviderToolUseStart(tool_use_id=tool_id, tool_name="echo")
+        yield ProviderToolUseEnd(
+            tool_use_id=tool_id, tool_name="echo", arguments={"value": "again"}
+        )
+        yield ProviderDone(stop_reason="tool_use", input_tokens=1, output_tokens=1)
+
+
+@pytest.mark.asyncio
+async def test_spend_guard_stops_a_runaway_loop_inside_one_turn() -> None:
+    """The turn-start gate alone leaves an unbounded tool loop unbounded."""
+    from agentos.engine import Agent, AgentConfig, ToolResult
+    from agentos.provider import ToolDefinition, ToolInputSchema
+
+    async def _echo(call: Any) -> Any:
+        return ToolResult(tool_use_id=call.tool_use_id, tool_name=call.tool_name, content="ok")
+
+    seen: list[str] = []
+
+    def guard(session_key: str) -> tuple[bool, str | None]:
+        seen.append(session_key)
+        # Under the ceiling for the first iteration, over it after that.
+        return len(seen) > 1, "Daily gateway cost $50.0000 has reached the $50.0000 budget limit."
+
+    provider = _LoopingToolProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(max_iterations=0),  # unbounded, as the shipped default is
+        tool_definitions=[
+            ToolDefinition(
+                name="echo",
+                description="Echo.",
+                input_schema=ToolInputSchema(
+                    properties={"value": {"type": "string"}}, required=["value"]
+                ),
+            )
+        ],
+        tool_handler=_echo,
+        session_key=SESSION,
+        spend_budget_guard=guard,
+    )
+
+    events = [event async for event in agent.run_turn("go")]
+
+    assert any(
+        getattr(event, "code", "") == "budget_exceeded" and event.kind == "error"
+        for event in events
+    )
+    # It stopped early rather than looping to exhaustion.
+    assert len(provider.calls) <= 3
+    assert seen == [SESSION] * len(seen)
+
+
+@pytest.mark.asyncio
+async def test_a_broken_guard_does_not_stop_the_turn() -> None:
+    from agentos.engine import Agent, AgentConfig
+
+    def guard(session_key: str) -> tuple[bool, str | None]:
+        raise RuntimeError("ledger unavailable")
+
+    provider = _LoopingToolProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(max_iterations=2),
+        session_key=SESSION,
+        spend_budget_guard=guard,
+    )
+
+    events = [event async for event in agent.run_turn("go")]
+
+    assert not any(getattr(event, "code", "") == "budget_exceeded" for event in events)

--- a/tests/test_engine/turn_runner/test_harness_agent_factory_adapter.py
+++ b/tests/test_engine/turn_runner/test_harness_agent_factory_adapter.py
@@ -22,10 +22,15 @@ def test_agent_factory_adapter_passes_runner_tool_registry(monkeypatch) -> None:
     monkeypatch.setattr(agent_module, "Agent", RecordingAgent)
 
     registry = object()
+
+    def _check_spend_budget(session_key: str) -> tuple[bool, str | None]:
+        return False, None
+
     runner = SimpleNamespace(
         _tool_registry=registry,
         _usage_tracker=None,
         _session_flush_service=None,
+        _check_spend_budget=_check_spend_budget,
     )
     adapter = _TurnRunnerAgentFactoryAdapter(runner)
 
@@ -41,3 +46,6 @@ def test_agent_factory_adapter_passes_runner_tool_registry(monkeypatch) -> None:
     )
 
     assert captured["tool_registry"] is registry
+    # The constructed Agent re-checks spend ceilings between iterations, so the
+    # runner's guard has to reach it.
+    assert captured["spend_budget_guard"] is _check_spend_budget


### PR DESCRIPTION
Closes #363.

## Problem

Nothing capped money. Usage was tracked but there was no spend ceiling anywhere: `check_warning` had zero callers, `check_budget_limits` was never wired to a config or an enforcement point, and the daily ledger it read from was never given a database — so every one of its queries returned `$0.00`. A runaway loop or subagent fan-out could burn an unbounded amount overnight.

## What this adds

A `[budgets]` config section with ceilings per **session**, per **UTC day**, per **agent**, and per **channel**, each with an optional warn threshold:

```toml
[budgets]
session_limit = 5.0
session_warn  = 4.0
daily_limit   = 50.0
daily_warn    = 40.0

[budgets.agent_daily_limit]
main = 20.0

[budgets.channel_daily_limit]
telegram = 10.0
```

- **Hard stop.** A turn that starts at or above a limit is refused before any provider call with a `budget_exceeded` error naming the scope and the number. The refusal is recorded in the transcript, and the user message persisted ahead of the run is rolled back rather than left as a reply-less turn.
- **Mid-turn too.** Ceilings are re-checked between agent iterations. `max_iterations` defaults to unlimited, so a turn-start-only gate would let one turn with a long tool loop run arbitrarily far past a ceiling — which is the shape a runaway actually takes.
- **Alerts.** A `*_warn` threshold emits a one-shot `budget_warning` (`WarningEvent`) and lets the turn continue — once per session for the session scope, once per UTC day for the daily scopes.
- **Survives a restart.** Spend is persisted to `spend_ledger.db` under the state dir, keyed per UTC day for the daily scopes and per session for the session scope. The premise of the feature is that a crash-and-respawn cannot hand a runaway a fresh allowance.
- **Nothing is enforced until an operator sets a number.** Every ceiling is unset by default; `enabled = true` only means "apply the ceilings you configured".

Subagent turns run through the same gate and their spend is attributed to the parent agent id, so a fan-out is bounded by the agent and daily ceilings rather than multiplying past them.

## Notes for review

**The ledger lives in its own file, not the session DB.** It is written synchronously from the turn hot path; sharing a file with the session store's async writer would put every ledger commit behind that write lock on the event loop. Its own file also means the tracker owns the schema outright rather than being a second schema owner inside the yoyo-managed session database. Connections are WAL + `synchronous=NORMAL` with a deliberately short (250 ms) busy timeout — blocking every session for seconds to record a cost row is worse than dropping the row.

**Enforcement fails open, but cannot be quietly retired.** A budget check is never the reason a gateway stops working: a broken tracker or an unreadable ledger logs and lets the turn run. But reads reconcile the persisted row against in-process accounting by taking the larger of the two, so a *dropped write* — the direction that would under-report spend — cannot silently disable a ceiling within a run.

**Config validation refuses two footguns** rather than accepting them silently: a warn threshold above its own hard limit (it could never fire), and two spellings of one scope key (`default`/`main`, `Telegram`/`telegram`) that would collapse into one entry and drop one of the operator's numbers.

**Removes `UsageTracker.check_warning()`.** It had no callers anywhere in `src/`; the configurable session ceilings supersede it.

## Testing

- New `tests/test_engine/test_spend_budgets.py` (25 tests): ledger accumulation with and without a DB, daily *and* session ceilings surviving a simulated restart, a dropped ledger write not retiring a ceiling, per-agent/per-channel scoping, subagent spend attributed to the parent, hard stops winning over earlier-scope warnings, warn-once semantics, config validation, turn-loop refusal and warning events, mid-turn stop of a runaway tool loop, and fail-open on a broken guard.
- Extended `test_harness_agent_factory_adapter.py` to assert the guard reaches the constructed `Agent`.
- Full gate green on the rebased branch: `ruff check` clean, `mypy src/agentos` clean (615 files), `pytest` **8382 passed, 27 skipped**.

Docs updated in `docs/configuration.md`, `docs/usage-and-cost.md`, `agentos.toml.example`, the bundled `agentos` SKILL.md config table, and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBCPHKecAQbq38S9yidPqS