### PR TITLE
ci: stop an unresolvable PR sha from failing the whole pipeline

### DIFF
--- a/.github/scripts/list-ci-changed-files.sh
+++ b/.github/scripts/list-ci-changed-files.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Write the list of files a CI run should classify to <output-file>.
+#
+# For a pull_request event that means the base..head diff. Everything else
+# (push, workflow_dispatch, anything new) writes the `.ci/run-all` sentinel
+# that classify-ci-changes.sh reads as "run every job".
+#
+# The diff is best-effort by design. `actions/checkout` fetches only
+# `refs/heads/*` and `refs/tags/*`; when it cannot resolve `refs/pull/<n>/merge`
+# — a fork PR whose workflow run is released after the PR was merged and
+# closed, for one — it silently falls back to the default branch and the head
+# sha is nowhere in the local object database. Classification is an
+# optimisation, so an unresolvable sha must widen the run to everything rather
+# than exit 128 and fail CI on a step that decides nothing.
+set -euo pipefail
+
+event_name="${1-}"
+base_sha="${2-}"
+head_sha="${3-}"
+output_file="${4:?usage: list-ci-changed-files.sh <event> <base-sha> <head-sha> <output-file>}"
+
+run_all() {
+  printf '.ci/run-all\n' > "${output_file}"
+}
+
+# Is the object present locally *and* a commit we can diff?
+have_commit() {
+  local sha="${1}"
+  [[ -n "${sha}" ]] || return 1
+  git cat-file -e "${sha}^{commit}" 2>/dev/null
+}
+
+# Pull a single commit the checkout did not fetch. Harmless when it fails —
+# the caller falls back to running everything.
+try_fetch_commit() {
+  local sha="${1}"
+  [[ -n "${sha}" ]] || return 1
+  git fetch --no-tags --quiet origin "${sha}" 2>/dev/null || return 1
+  have_commit "${sha}"
+}
+
+resolve_commit() {
+  local sha="${1}"
+  have_commit "${sha}" || try_fetch_commit "${sha}"
+}
+
+if [[ "${event_name}" != "pull_request" ]]; then
+  run_all
+else
+  # A plain string, not an array: bash 3.2 treats an empty array as unset
+  # under `set -u`, and these scripts also run under the Windows Git Bash.
+  missing=""
+  for sha in "${base_sha}" "${head_sha}"; do
+    resolve_commit "${sha}" || missing="${missing} ${sha:-<empty>}"
+  done
+
+  if [[ -n "${missing}" ]]; then
+    echo "::warning::Cannot resolve pull request commit(s):${missing}." \
+      "Running every CI job instead of classifying the diff."
+    run_all
+  elif ! git diff --name-only "${base_sha}" "${head_sha}" > "${output_file}"; then
+    echo "::warning::git diff ${base_sha}..${head_sha} failed." \
+      "Running every CI job instead of classifying the diff."
+    run_all
+  fi
+fi
+
+echo "Changed files:"
+sed 's/^/  /' "${output_file}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,26 +33,17 @@ jobs:
 
       - name: List changed files
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           changed_files="${RUNNER_TEMP}/changed-files.txt"
 
-          case "${{ github.event_name }}" in
-            pull_request)
-              git diff --name-only \
-                "${{ github.event.pull_request.base.sha }}" \
-                "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
-              ;;
-            push)
-              printf '.ci/run-all\n' > "${changed_files}"
-              ;;
-            *)
-              printf '.ci/run-all\n' > "${changed_files}"
-              ;;
-          esac
+          bash .github/scripts/list-ci-changed-files.sh \
+            "${EVENT_NAME}" "${BASE_SHA}" "${HEAD_SHA}" "${changed_files}"
 
-          echo "Changed files:"
-          sed 's/^/  /' "${changed_files}"
           printf 'CHANGED_FILES=%s\n' "${changed_files}" >> "${GITHUB_ENV}"
 
       - name: Classify changed files

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -12,6 +12,7 @@ import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
 CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
+LISTER = ".github/scripts/list-ci-changed-files.sh"
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
 
@@ -121,7 +122,7 @@ def test_default_ci_blocks_pull_requests_and_main_and_dev_pushes() -> None:
     assert "Windows compatibility tests" in text
     assert "Release packaging contracts" in text
     assert "CI result" in text
-    assert 'push)\n              printf \'.ci/run-all\\n\' > "${changed_files}"' in text
+    assert LISTER in text
     assert "runtime_changed" in text
     assert "test_changed" in text
     assert "ci_changed" in text
@@ -577,3 +578,160 @@ def test_release_hydration_checks_guard_pilot_v1_bundle() -> None:
         assert "pilot_v1" in text
         assert "model.onnx" in text
         assert "manifest.json" in text
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def _repo_with_two_commits(tmp_path: Path) -> tuple[Path, str, str]:
+    """Build a throwaway repo and return ``(path, base_sha, head_sha)``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "ci@example.test")
+    _git(repo, "config", "user.name", "CI Test")
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "base")
+    base_sha = _git(repo, "rev-parse", "HEAD")
+
+    (repo / "src").mkdir()
+    (repo / "src" / "thing.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "src/thing.py")
+    _git(repo, "commit", "-qm", "head")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    return repo, base_sha, head_sha
+
+
+def _list_changed_files(
+    repo: Path,
+    tmp_path: Path,
+    *,
+    event_name: str,
+    base_sha: str = "",
+    head_sha: str = "",
+) -> tuple[list[str], subprocess.CompletedProcess[str]]:
+    changed_file = tmp_path / "changed-files.txt"
+    lister = Path(LISTER).resolve()
+
+    result = subprocess.run(
+        [
+            _bash_executable(),
+            lister.as_posix(),
+            event_name,
+            base_sha,
+            head_sha,
+            changed_file.as_posix(),
+        ],
+        cwd=repo,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if not changed_file.exists():
+        return [], result
+    listed = [line for line in changed_file.read_text(encoding="utf-8").splitlines() if line]
+    return listed, result
+
+
+def test_changed_file_lister_diffs_a_pull_request_range(tmp_path: Path) -> None:
+    repo, base_sha, head_sha = _repo_with_two_commits(tmp_path)
+
+    listed, result = _list_changed_files(
+        repo,
+        tmp_path,
+        event_name="pull_request",
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert listed == ["src/thing.py"]
+
+
+def test_changed_file_lister_runs_everything_for_a_push(tmp_path: Path) -> None:
+    repo, _base_sha, _head_sha = _repo_with_two_commits(tmp_path)
+
+    listed, result = _list_changed_files(repo, tmp_path, event_name="push")
+
+    assert result.returncode == 0, result.stderr
+    assert listed == [".ci/run-all"]
+
+
+def test_changed_file_lister_runs_everything_when_the_head_sha_is_unreachable(
+    tmp_path: Path,
+) -> None:
+    """A head sha that is not in the object DB must not hard-fail the pipeline.
+
+    Reproduces CI run #830: a fork PR whose workflow was released only after the
+    PR had been merged. ``refs/pull/<n>/merge`` was already gone, so
+    ``actions/checkout`` silently fell back to ``origin/main`` and the head sha
+    lived only in the contributor's fork. ``git diff`` then exited 128 with
+    ``fatal: bad object`` and failed CI on a classification step.
+    """
+    repo, base_sha, _head_sha = _repo_with_two_commits(tmp_path)
+    missing_sha = "da1445ade0d8d94a55002a298d5bcb2e78baaca3"
+
+    listed, result = _list_changed_files(
+        repo,
+        tmp_path,
+        event_name="pull_request",
+        base_sha=base_sha,
+        head_sha=missing_sha,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert listed == [".ci/run-all"]
+
+
+def test_changed_file_lister_runs_everything_when_the_base_sha_is_unreachable(
+    tmp_path: Path,
+) -> None:
+    repo, _base_sha, head_sha = _repo_with_two_commits(tmp_path)
+    missing_sha = "0000000000000000000000000000000000000001"
+
+    listed, result = _list_changed_files(
+        repo,
+        tmp_path,
+        event_name="pull_request",
+        base_sha=missing_sha,
+        head_sha=head_sha,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert listed == [".ci/run-all"]
+
+
+def test_changed_file_lister_runs_everything_when_a_pull_request_sha_is_blank(
+    tmp_path: Path,
+) -> None:
+    repo, _base_sha, head_sha = _repo_with_two_commits(tmp_path)
+
+    listed, result = _list_changed_files(
+        repo,
+        tmp_path,
+        event_name="pull_request",
+        base_sha="",
+        head_sha=head_sha,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert listed == [".ci/run-all"]
+
+
+def test_ci_lists_changed_files_through_the_shared_script() -> None:
+    """ci.yml must not inline an unguarded ``git diff`` of the PR range."""
+    text = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
+
+    assert LISTER in text
+    assert "git diff --name-only" not in text


### PR DESCRIPTION
Closes #474.

## The failure

CI run [#830](https://github.com/use-agent-os/agent-os/actions/runs/32986267543) on PR #472:

```
fatal: bad object da1445ade0d8d94a55002a298d5bcb2e78baaca3
##[error]Process completed with exit code 128.
```

`classify-changes` → `List changed files` diffed the pull_request range inline with an unguarded `git diff base head`. `ci-result` requires `classify-changes` to succeed, so the run failed on a step that only decides *which jobs to run* — nothing was actually tested.

## Root cause

Traced through the run logs rather than guessed. Fork-PR workflow runs need maintainer approval; #830 was released only **after** the PR had been merged and closed, so `refs/pull/472/merge` no longer existed. The checkout step then did:

```
git fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
git checkout --progress --force -B main refs/remotes/origin/main
```

Only `refs/heads/*` and `refs/tags/*`, then a silent fallback to `origin/main`. The head sha lives only in the contributor's fork, so it was never in the object database. Any fork PR whose run is released or retried after the branch is gone reproduces this.

## The fix

Move the listing into `.github/scripts/list-ci-changed-files.sh`, next to the `classify-ci-changes.sh` it feeds — same convention, and shell logic that is now testable instead of untested YAML.

It resolves each sha, fetches one the checkout missed, and when a sha still cannot be resolved emits a `::warning::` and falls back to the `.ci/run-all` sentinel that `classify-ci-changes.sh` already reads as "run every job". Classification is an optimisation, so an unknown range widens the run rather than failing it — matching how the script already treats an empty changed-file list.

Behaviour for a resolvable PR range and for push / workflow_dispatch is unchanged.

## Tests

Six new cases in `tests/test_ci/test_workflows.py`, driving the real script against throwaway git repos:

- a resolvable PR range still produces the exact diff
- push still produces `.ci/run-all`
- **unreachable head sha** → `.ci/run-all`, exit 0 (reproduces #830 with that literal sha)
- unreachable base sha → `.ci/run-all`, exit 0
- blank sha → `.ci/run-all`, exit 0
- ci.yml no longer inlines `git diff --name-only`

All five behavioural tests fail on `main` and pass here. One existing assertion in `test_default_ci_blocks_pull_requests_and_main_and_dev_pushes` pinned the inline `push)` branch text; it now asserts the script is wired in, and the behaviour it guarded is covered directly by the new test.

## Quality gate

```
actionlint v1.7.12       clean
ruff check src tests     All checks passed!
mypy src/agentos         Success: no issues found in 610 source files
pytest -q                8363 passed, 27 skipped
```

## Not in this PR

Runs [#828](https://github.com/use-agent-os/agent-os/actions/runs/32985725675) (stuck `queued`) and [#829](https://github.com/use-agent-os/agent-os/actions/runs/32985818679) (`startup_failure`, 0s, no jobs) on `main` @ `4986998` are a GitHub Actions infrastructure hiccup, not a repo defect — ci.yml is unchanged since `ee83482` and the identical file passed in [#827](https://github.com/use-agent-os/agent-os/actions/runs/32982504070). #829 cannot be re-run and #828 needs a manual cancel to free the `CI-refs/heads/main` concurrency group; I did not have permission to cancel it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuH22Vgc5waYKj76SSwnQW