### PR TITLE
fix(scheduler): accept day-of-week 7 as Sunday in cron expressions

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -26,7 +26,7 @@ _FIELD_RANGES = {
     "hour": (0, 23),
     "day_of_month": (1, 31),
     "month": (1, 12),
-    "day_of_week": (0, 6),  # 0=Sunday
+    "day_of_week": (0, 7),  # 0=Sunday, 7=Sunday too (POSIX permits 0 and 7)
 }
 
 _MONTH_NAMES = {
@@ -140,6 +140,14 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
 
         else:
             values.add(_to_int(part, field_name, lo, hi))
+
+    if field_name == "day_of_week" and 7 in values:
+        # POSIX: day-of-week may use either 0 or 7 to mean Sunday. Our matcher
+        # normalizes Python's Monday==0 to Sunday==0 via (weekday+1) % 7, so a
+        # literal 7 must collide onto 0 or a plain "0 0 * * 7" schedule would
+        # never fire (and "SAT-SUN" would be a dead range).
+        values.remove(7)
+        values.add(0)
 
     return CronField(frozenset(values))
 

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -39,6 +39,32 @@ def test_parse_cron_rejects_garbage() -> None:
         parse_cron("not-a-cron")
 
 
+def test_parse_cron_accepts_dow_7_as_sunday() -> None:
+    # POSIX permits either 0 or 7 to mean Sunday in the day-of-week field.
+    expr = parse_cron("0 0 * * 7")
+    assert expr.day_of_week.values == frozenset({0})
+
+
+def test_parse_cron_dow_ranges_may_end_at_7() -> None:
+    # With Sunday spellable as 7, a "WED-SUN" style range is valid and must
+    # resolve to the same weekday set as its 0-terminated equivalent.
+    expr = parse_cron("0 0 * * WED-7")
+    assert expr.day_of_week.values == frozenset({0, 3, 4, 5, 6})
+
+
+def test_parse_cron_dow_7_dedups_with_0_and_names() -> None:
+    assert parse_cron("0 0 * * 0,7").day_of_week.values == frozenset({0})
+    assert parse_cron("0 0 * * MON,7").day_of_week.values == frozenset({0, 1})
+
+
+def test_parse_cron_dow_7_matches_sunday_not_monday() -> None:
+    expr = parse_cron("0 0 * * 7")
+    sunday = datetime(2026, 8, 30, 0, 0)  # a Sunday
+    monday = datetime(2026, 8, 31, 0, 0)  # the next Monday
+    assert expr.matches(sunday)
+    assert not expr.matches(monday)
+
+
 def test_parse_cron_rejects_unknown_preset() -> None:
     with pytest.raises(CronParseError, match="Unknown preset"):
         parse_cron("@bogus")


### PR DESCRIPTION
## Linked issue

Fixes #477

## Summary

POSIX cron allows either `0` or `7` to mean Sunday in the day-of-week field, but the parser pinned the range to `(0, 6)`, so valid expressions like `0 0 * * 7` (the classic weekly-Sunday job), `0 0 * * 0,7`, and `WED-7` ranges were rejected before any job could be stored.

This change:

- widens the day-of-week range to `(0, 7)` in `_FIELD_RANGES`
- folds a literal `7` onto `0` at parse time in `_parse_field`, matching the matcher's existing `(weekday + 1) % 7` normalization in `CronExpression.matches`

So `0 0 * * 7` now fires on Sunday exactly like `0 0 * * 0`, and `0,7` / `MON,7` dedupe to a single Sunday entry. No other code assumes the old `(0, 6)` bound (grep across `src/`, `frontend/`, `docs/` found no other day-of-week range consumers).

## Tests

Added regression tests in `tests/test_scheduler/test_parser.py`:

- acceptance of `0 0 * * 7` resolving to `{0}`
- ranges ending at 7 (`WED-7` == `{0, 3, 4, 5, 6}`)
- dedup of `0,7` and `MON,7`
- match assertion: a 7-schedule fires on a Sunday, not the following Monday

Quality gate: `uv run ruff check` clean, `uv run mypy src/agentos/scheduler/parser.py` clean, `uv run pytest tests/test_scheduler -q` 442 passed, full offline suite `uv run pytest -q -m "not llm"` 8348 passed (the 8 failures + 3 errors are the pre-existing environment-dependent ones documented in AGENTS.md: pilot MiniLM model files, wheel build, shell sandbox isolation — none touch the scheduler).
