### PR TITLE
fix(scheduler): reject reversed ranges in stepped cron fields

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -121,6 +121,11 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
                 start_str, end_str = range_part.split("-", 1)
                 start = _to_int(start_str, field_name, lo, hi)
                 end = _to_int(end_str, field_name, lo, hi)
+                # Same rule the plain-range branch applies. Without it a
+                # reversed range silently yields an empty step sequence, so the
+                # expression parses, stores, and then matches no instant at all.
+                if start > end:
+                    raise CronParseError(f"Range start > end in field '{field_name}'")
             else:
                 start = _to_int(range_part, field_name, lo, hi)
                 end = hi

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -39,6 +39,11 @@ def test_parse_cron_rejects_garbage() -> None:
         parse_cron("not-a-cron")
 
 
+def test_parse_cron_rejects_unknown_preset() -> None:
+    with pytest.raises(CronParseError, match="Unknown preset"):
+        parse_cron("@bogus")
+
+
 def test_parse_cron_rejects_reversed_range_with_step() -> None:
     # A reversed range in the step branch used to parse into an *empty* field
     # set, so the expression validated, stored, and then matched nothing —
@@ -51,11 +56,6 @@ def test_parse_cron_rejects_reversed_range_with_step() -> None:
         parse_cron("0 0 * * FRI-TUE/2")
     with pytest.raises(CronParseError, match="Range start > end"):
         parse_cron("0 0 * dec-feb/2 *")
-
-
-def test_parse_cron_rejects_unknown_preset() -> None:
-    with pytest.raises(CronParseError, match="Unknown preset"):
-        parse_cron("@bogus")
 
 
 # --- parse_iso_at --------------------------------------------------------

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -39,6 +39,20 @@ def test_parse_cron_rejects_garbage() -> None:
         parse_cron("not-a-cron")
 
 
+def test_parse_cron_rejects_reversed_range_with_step() -> None:
+    # A reversed range in the step branch used to parse into an *empty* field
+    # set, so the expression validated, stored, and then matched nothing —
+    # _next_run would burn through its whole scan window and raise
+    # "No valid next run found" at job creation. Reject it up front like the
+    # plain-range branch already does.
+    with pytest.raises(CronParseError, match="Range start > end"):
+        parse_cron("5-3/2 * * * *")
+    with pytest.raises(CronParseError, match="Range start > end"):
+        parse_cron("0 0 * * FRI-TUE/2")
+    with pytest.raises(CronParseError, match="Range start > end"):
+        parse_cron("0 0 * dec-feb/2 *")
+
+
 def test_parse_cron_rejects_unknown_preset() -> None:
     with pytest.raises(CronParseError, match="Unknown preset"):
         parse_cron("@bogus")


### PR DESCRIPTION
## Linked issue

Fixes #479

## Summary

A stepped cron range with `start > end` (e.g. `5-3/2`, `FRI-TUE/2`) parsed into an **empty** field set because `range(start, end+1, step)` is empty when `start > end`, while the validation only checked `start <= end` in the plain (non-stepped) branch. Such an expression validated and stored cleanly but then matched no instant at all — the job's first next-run scan burnt through the full 2,102,400-minute window (~3s CPU per create) and raised `ValueError: No valid next run found for expression '...'` at creation time.

This change adds the same `start <= end` guard the non-stepped branch already applies to the stepped branch, so the schedule fails validation up front instead of creating a job that can never fire. The error message matches the existing one (`Range start > end in field '...'`), keeping the two branches consistent.

## Tests

Added `test_parse_cron_rejects_reversed_range_with_step` in `tests/test_scheduler/test_parser.py`, asserting rejection of `5-3/2 * * * *`, `0 0 * * FRI-TUE/2`, and `0 0 * dec-feb/2 *`. Confirmed valid stepped ranges (`0-30/5`, `*/5`, `1-10/2`, `0 0 * * 1-5/2`) still parse.

Quality gate: `uv run ruff check` clean, `uv run mypy src/agentos/scheduler/parser.py` clean, `uv run pytest tests/test_scheduler/test_parser.py` 14 passed.