### PR TITLE
fix(scheduler): make cron month and day-of-week names case-insensitive

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -99,11 +99,14 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
     for part in token.split(","):
         part = part.strip()
         if names:
-            # resolve names in ranges and steps too
+            # POSIX: month and day-of-week names are case-insensitive ("case
+            # doesn't matter"). Lowercase the token before substituting so
+            # Mon-Fri / JAN / jan all resolve; digits and the -, /, * ,
+            # separators are unaffected by lower().
+            part = part.lower()
             sub_parts = part.replace("/", "§").replace("-", "¶")
             for name, val in names.items():
-                sub_parts = sub_parts.replace(name.lower(), str(val))
-                sub_parts = sub_parts.replace(name.upper(), str(val))
+                sub_parts = sub_parts.replace(name, str(val))
             part = sub_parts.replace("§", "/").replace("¶", "-")
 
         if "/" in part:

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -20,6 +20,19 @@ def test_parse_cron_accepts_named_dow_and_month() -> None:
     assert parse_cron("30 8 1 jan *").raw == "30 8 1 jan *"
 
 
+def test_parse_cron_names_are_case_insensitive() -> None:
+    # POSIX: month and day-of-week names are case-insensitive. The parser used
+    # to substitute only all-lowercase and all-uppercase spellings, so the
+    # common "Mon-Fri" business-hours schedule was rejected outright.
+    assert parse_cron("0 9 * * Mon-Fri").day_of_week.values == frozenset({1, 2, 3, 4, 5})
+    assert parse_cron("0 9 * * MON-FRI").day_of_week.values == frozenset({1, 2, 3, 4, 5})
+    assert parse_cron("0 0 * * Mon,Wed,Fri").day_of_week.values == frozenset({1, 3, 5})
+    assert parse_cron("0 9 * Jan *").month.values == frozenset({1})
+    assert parse_cron("0 9 * JAN *").month.values == frozenset({1})
+    assert parse_cron("0 0 * Jan-Mar *").month.values == frozenset({1, 2, 3})
+    assert parse_cron("0 0 * JAN-MAR/2 *").month.values == frozenset({1, 3})
+
+
 def test_parse_cron_accepts_preset_alias() -> None:
     assert parse_cron("@hourly").raw == "0 * * * *"
 


### PR DESCRIPTION
## Linked issue

Fixes #481

## Summary

POSIX cron says month and day-of-week names are case-insensitive, but the parser only substituted all-lowercase and all-uppercase spellings. Mixed-case names — the common `Mon-Fri` business-hours schedule, `Jan`, `Sun` — were rejected with `Invalid value`, while the same schedule spelled `mon-fri` or `MON-FRI` parsed fine.

This change lowercases the token before name substitution in `_parse_field`. Digits and the `-`, `/`, `*`, `,` separators are unaffected by `lower()`, so every casing resolves identically.

## Tests

Added `test_parse_cron_names_are_case_insensitive` in `tests/test_scheduler/test_parser.py`, covering `Mon-Fri`, `MON-FRI`, `Mon,Wed,Fri`, `Jan`, `JAN`, `Jan-Mar`, and `JAN-MAR/2`. Confirmed digit-only and all-lowercase/all-uppercase schedules still parse.

Quality gate: `uv run ruff check` clean, `uv run mypy src/agentos/scheduler/parser.py` clean, `uv run pytest tests/test_scheduler/test_parser.py` 14 passed.