### PR TITLE
fix(scheduler): honor the timezone alias on the legacy expression schedule

### DIFF
--- a/src/agentos/scheduler/schedule_normalizer.py
+++ b/src/agentos/scheduler/schedule_normalizer.py
@@ -25,8 +25,17 @@ def coerce_schedule_from_params(params: dict[str, Any]) -> tuple[ScheduleKind, s
         return coerce_schedule(schedule)
     expression = params.get("expression")
     if isinstance(expression, str) and expression.strip():
+        # Honour the `timezone` alias the same way the structured path does
+        # via _top_level_tz — otherwise a legacy caller passing
+        # {"expression": "...", "timezone": "Asia/Shanghai"} silently dropped
+        # the tz while {"expression": "...", "tz": "..."} kept it.
+        top_tz = _top_level_tz(params)
         return coerce_schedule(
-            {"kind": "cron", "expr": expression, "tz": params.get("tz", "") or ""}
+            {
+                "kind": "cron",
+                "expr": expression.strip(),
+                "tz": top_tz,
+            }
         )
     raise ValueError("params required: schedule (object) or expression (string)")
 

--- a/tests/test_scheduler/test_schedule_normalizer.py
+++ b/tests/test_scheduler/test_schedule_normalizer.py
@@ -85,6 +85,30 @@ def test_normalizer_wraps_legacy_expression() -> None:
     assert tz == "America/Los_Angeles"
 
 
+def test_normalizer_expression_accepts_timezone_alias() -> None:
+    # The expression-shorthand path must honour the `timezone` alias exactly
+    # like the structured path does via _top_level_tz. A legacy caller passing
+    # {"expression": "...", "timezone": "Asia/Shanghai"} used to silently drop
+    # the tz while the "tz" key kept it.
+    kind, value, tz = coerce_schedule_from_params(
+        {"expression": "*/5 * * * *", "timezone": "Asia/Shanghai"}
+    )
+    assert kind == ScheduleKind.CRON
+    assert value == "*/5 * * * *"
+    assert tz == "Asia/Shanghai"
+
+
+def test_normalizer_expression_rejects_conflicting_tz_and_timezone() -> None:
+    with pytest.raises(ValueError, match="tz conflicts with timezone"):
+        coerce_schedule_from_params(
+            {
+                "expression": "*/5 * * * *",
+                "tz": "Asia/Shanghai",
+                "timezone": "America/Los_Angeles",
+            }
+        )
+
+
 def test_normalizer_rejects_invalid_tz() -> None:
     with pytest.raises(ValueError, match="schedule.tz invalid"):
         coerce_schedule_from_params(


### PR DESCRIPTION
## Linked issue

Fixes #484

## Summary

`coerce_schedule_from_params` had an alias drift between the two input shapes it accepts. The structured path honors both `tz` and the `timezone` alias via `_top_level_tz`, but the legacy expression-shorthand path only read `"tz"` — so a caller passing `{"expression": "0 9 * * *", "timezone": "Asia/Shanghai"}` silently lost the tz, while the same shape with `"tz"` kept it.

That drift also hit `cron.update`, which builds `schedule_tz` from the result and would wipe an existing `job.tz`.

This resolves the top-level tz through `_top_level_tz` on the expression-shorthand path, the same way the structured path does, so the `timezone` alias is honored and a `tz`/`timezone` conflict still raises.

## Tests

Added `test_normalizer_expression_accepts_timezone_alias` and `test_normalizer_expression_rejects_conflicting_tz_and_timezone` in `tests/test_scheduler/test_schedule_normalizer.py`. Confirmed digit-only and `tz`-only expression schedules still parse.

Quality gate: `uv run ruff check` clean, `uv run mypy src/agentos/scheduler/schedule_normalizer.py` clean, `uv run pytest tests/test_scheduler/test_schedule_normalizer.py` 11 passed.