### PR TITLE
fix(tools): redact credentials in git output before it reaches the model

### DIFF
--- a/src/agentos/redact.py
+++ b/src/agentos/redact.py
@@ -278,6 +278,7 @@ _ASSIGNMENT_RE = re.compile(
     r"""(?ix)
     (?:^|[\s"'{,(])                     # start of a token
     (?:\d+\t)?                          # grep -n line prefix
+    (?:[+\-])?                          # unified-diff add/remove line marker
     ([A-Za-z][A-Za-z0-9_.\-]{0,64})     # name
     ['\"]?                              # closing quote of a JSON/YAML key
     \s*[:=]\s*

--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -38,6 +38,22 @@ def _reject_foreign_git_path(path: str) -> None:
     reject_foreign_host_path(path, platform=os.name, workspace=workspace)
 
 
+def _redact_git_output(output: str) -> str:
+    """Mask credentials in git output before it reaches the model.
+
+    ``git diff`` / ``log -p`` / ``show`` surface committed and working-tree file
+    content, which routinely includes ``.env`` files and credentials. Like
+    ``execute_code``, this is arbitrary file content, so the assignment pass runs
+    unconditionally (``code_file=False``) — a deliberate divergence from
+    ``redact_terminal_output``, which gates that pass on env-dump /
+    credential-file commands and would leave named secrets in a diff unmasked.
+    """
+    from agentos.redact import redact_sensitive_text
+
+    redacted = redact_sensitive_text(output, force=True, code_file=False)
+    return redacted if redacted is not None else output
+
+
 async def _run_git(*args: str, cwd: str | None = None) -> str:
     runtime = get_runtime()
     if runtime is not None and runtime.effective.sandbox_enabled:
@@ -67,7 +83,7 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
             build_request_for_git(args, workspace, action_kind, policy),
             runtime=runtime,
         )
-        output = result.stdout + result.stderr
+        output = _redact_git_output(result.stdout + result.stderr)
         if result.returncode != 0:
             raise RuntimeError(f"git {' '.join(args)} failed (exit {result.returncode}):\n{output}")
         return output
@@ -79,7 +95,7 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
         cwd=cwd,
     )
     stdout, _ = await proc.communicate()
-    output = stdout.decode("utf-8", errors="replace")
+    output = _redact_git_output(stdout.decode("utf-8", errors="replace"))
     if proc.returncode != 0:
         raise RuntimeError(f"git {' '.join(args)} failed (exit {proc.returncode}):\n{output}")
     return output

--- a/tests/test_security/test_redact.py
+++ b/tests/test_security/test_redact.py
@@ -185,6 +185,26 @@ class TestRedaction:
         assert redact.redact_sensitive_text(code, code_file=True) == code
         assert redact.redact_sensitive_text(code, code_file=False) != code
 
+    def test_masks_named_secret_on_unified_diff_added_line(self) -> None:
+        """A named credential on a ``+`` diff line must not escape the assignment pass.
+
+        ``_ASSIGNMENT_RE`` allows a leading unified-diff marker so the name
+        anchor matches on add/remove lines. Without it, the marker is not in
+        the token-start character class and the named secret passes through
+        unmasked. Vendor-prefixed keys (sk-ant-... etc.) are still caught by
+        the separate shape pass but non-vendor named secrets (e.g.
+        DB_PASSWORD=...) leak.
+        """
+        added = "+MY_CUSTOM_SECRET=supersecretvalue123"
+        removed = "-MY_CUSTOM_SECRET=supersecretvalue123"
+        assert redact.redact_sensitive_text(added, force=True) != added
+        assert redact.redact_sensitive_text(removed, force=True) != removed
+        # Label must survive the mask.
+        out = redact.redact_sensitive_text(added, force=True)
+        assert out is not None
+        assert "+MY_CUSTOM_SECRET=" in out
+        assert "supersecretvalue123" not in out
+
 
 class TestTerminalOutput:
     def test_env_dump_output_is_masked(self) -> None:

--- a/tests/test_tools/test_git_output_redaction.py
+++ b/tests/test_tools/test_git_output_redaction.py
@@ -1,0 +1,113 @@
+"""git tools must redact credentials in their output before it reaches the model.
+
+``git diff`` / ``log -p`` / ``show`` surface committed and working-tree file
+content, which routinely includes ``.env`` files and credentials. The other
+output surfaces (read_file, execute_code) all route through the redaction
+layer; git must too.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from agentos.tools.builtin import git
+
+_ANTHROPIC_KEY = (
+    "sk-ant-api03-A1b2C3d4E5f6G7h8A1b2C3d4E5f6G7h8A1b2C3d4E5f6G7h8"
+)
+_GITHUB_TOKEN = "ghp_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"
+_NAMED_SECRET = "supersecretvalue123"
+
+
+def _write_env(repo: Path, extra: str = "") -> None:
+    content = (
+        f"ANTHROPIC_KEY={_ANTHROPIC_KEY}\n"
+        f"GITHUB_TOKEN={_GITHUB_TOKEN}\n"
+        f"MY_CUSTOM_SECRET={_NAMED_SECRET}\n"
+        f"{extra}"
+    )
+    repo.joinpath(".env").write_text(content, encoding="utf-8")
+
+
+def _init_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+
+
+def _make_repo_with_secrets(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_env(repo)
+    _init_repo(repo)
+    subprocess.run(["git", "add", ".env"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "add env"], cwd=repo, check=True)
+    return repo
+
+
+def _git_repo_with_history(tmp_path: Path) -> Path:
+    """Real repo with the secret committed, then a second commit so `git log -p` shows it."""
+    repo = _make_repo_with_secrets(tmp_path)
+    _write_env(repo, extra="EXTRA_KEY=moresecretvalue456\n")
+    subprocess.run(["git", "add", ".env"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "edit env"], cwd=repo, check=True)
+    return repo
+
+
+def test_run_git_redacts_committed_secret_in_log_p(tmp_path: Path) -> None:
+    repo = _git_repo_with_history(tmp_path)
+    out = subprocess.run(  # noqa: S603
+        ["git", "log", "-p", "-3"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+    # Precondition: the raw git output really contains the secrets.
+    assert _NAMED_SECRET in out
+    # _run_git must not hand them to the model raw.
+    redacted = git._redact_git_output(out)
+    assert _ANTHROPIC_KEY not in redacted
+    assert _GITHUB_TOKEN not in redacted
+    assert _NAMED_SECRET not in redacted
+    # Structure is preserved, not dropped.
+    assert "ANTHROPIC_KEY=" in redacted
+    assert "GITHUB_TOKEN=" in redacted
+    assert "MY_CUSTOM_SECRET=" in redacted
+
+
+def test_run_git_redacts_working_tree_secret_in_diff(tmp_path: Path) -> None:
+    repo = _make_repo_with_secrets(tmp_path)
+    # Modify the working tree so `git diff` shows the added line only.
+    _write_env(repo, extra="EXTRA_SECRET=moresecretvalue456\n")
+    # Precondition: the raw diff shows an added line carrying a named secret.
+    raw = subprocess.run(  # noqa: S603
+        ["git", "diff"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+    assert "+EXTRA_SECRET=moresecretvalue456" in raw
+    # The unified-diff `+` marker must not let the named secret escape redaction.
+    redacted = git._redact_git_output(raw)
+    assert "moresecretvalue456" not in redacted
+    # Diff marker and label are preserved so the agent still reads the change.
+    assert "+EXTRA_SECRET=" in redacted
+
+
+def test_git_diff_added_lines_do_not_leak_named_secret(tmp_path: Path) -> None:
+    repo = _make_repo_with_secrets(tmp_path)
+    # Every line is an added line (+...) via a no-index diff against /dev/null.
+    raw = subprocess.run(  # noqa: S603
+        [
+            "git",
+            "diff",
+            "--no-index",
+            "/dev/null",
+            str(repo / ".env"),
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "+ANTHROPIC_KEY=" in raw
+    redacted = git._redact_git_output(raw)
+    assert _ANTHROPIC_KEY not in redacted
+    assert _GITHUB_TOKEN not in redacted
+    assert _NAMED_SECRET not in redacted
+    # Assignment pass still masks non-vendor named secrets even with the + marker.
+    assert "MY_CUSTOM_SECRET=" in redacted


### PR DESCRIPTION
Fixes #496

## What

Two related credential-leak gaps, fixed together because the second makes the first's fix incomplete on its own:

1. **git tools return output with no redaction.** `_run_git` in `src/agentos/tools/builtin/git.py` returned `result.stdout + result.stderr` (sandboxed path) and the subprocess decode raw. `git diff` / `log -p` / `show` surface committed and working-tree file content that routinely includes `.env` files and credentials. Both paths (success and error) now route through `redact_sensitive_text(..., force=True, code_file=False)`.

2. **Named credentials on unified-diff `+`/`-` lines escaped the assignment pass.** `_ASSIGNMENT_RE`'s token-start anchor `(?:^|[\s"'{,(])` does not include the diff marker, so `+MY_CUSTOM_SECRET=*** never matched. Added an optional `(?:[+\-])?` after the grep prefix. Vendor-prefixed keys were already caught by the shape pass; this closes the non-vendor named-secret gap (DB passwords, internal API keys, custom tokens).

`code_file=False` is a deliberate divergence from `redact_terminal_output` (which gates the assignment pass on env-dump / credential-file commands): git output is arbitrary file content, so the assignment pass must run unconditionally — same rationale as the `execute_code` fix in #490.

## Verification

Reproduced the leak on `main` first, then confirmed the fix closes it:

- Committed `.env` with `ANTHROPIC_KEY=sk-ant-...`, `GITHUB_TOKEN=ghp_...`, `MY_CUSTOM_SECRET=...` → `git log -p` and `git diff` previously returned all three raw; now all masked, labels and `+` markers preserved.
- Isolated the diff-marker gap on `redact_sensitive_text` directly: `+MY_CUSTOM_SECRET=...` previously leaked, now masked.
- Regex change validated against 19 cases (diff +/-/context, plain, export, yaml, json, arithmetic, `+++`/`---`/`@@` headers) — zero false positives, zero regressions.

## Tests

- New `tests/test_tools/test_git_output_redaction.py` — real temp repos, committed + working-tree secrets through `log -p`, `diff`, and no-index added-line diffs.
- New case in `tests/test_security/test_redact.py` — named secret on `+`/`-` diff lines.

Quality gate: `ruff check` clean, `mypy` clean, `pytest tests/test_security tests/test_tools -m "not llm"` → 996 passed (the 3 `test_shell_process_isolation.py` failures are pre-existing environment-dependent and fail on clean `main` too).
