### PR TITLE
fix(gateway): compare auth tokens in constant time

### DIFF
--- a/src/agentos/gateway/audio_transcription.py
+++ b/src/agentos/gateway/audio_transcription.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from agentos.gateway.auth import token_matches
 from agentos.gateway.config import GatewayConfig
 from agentos.gateway.uploads import (
     _MULTIPART_FRAMING_ALLOWANCE,
@@ -94,7 +95,9 @@ def register_audio_transcription_routes(
 
     async def transcribe_handler(request: Request) -> JSONResponse:
         if config.auth.mode == "token":
-            if config.auth.token and _extract_authorization_token(request) != config.auth.token:
+            if config.auth.token and not token_matches(
+                _extract_authorization_token(request), config.auth.token
+            ):
                 return JSONResponse(
                     {
                         "error": (

--- a/src/agentos/gateway/auth.py
+++ b/src/agentos/gateway/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,21 @@ def denied_access(surface: ConnectionSurface = ConnectionSurface.CONTROL) -> Acc
     """Build a fail-closed context for a rejected connection."""
 
     return AccessContext(surface=surface, admitted=False, credential_verified=False)
+
+
+def token_matches(provided: str | None, configured: str | None) -> bool:
+    """Return True iff ``provided`` equals the configured gateway token.
+
+    Uses ``hmac.compare_digest`` so a remote caller cannot walk the secret a
+    byte at a time from response latency. Missing or empty configured values
+    fail closed; the attacker-controlled side is never short-circuited with
+    ``==`` / ``!=``.
+    """
+
+    if not isinstance(configured, str) or not configured:
+        return False
+    candidate = provided if isinstance(provided, str) else ""
+    return hmac.compare_digest(candidate.encode("utf-8"), configured.encode("utf-8"))
 
 
 def _surface(value: str | ConnectionSurface | None) -> ConnectionSurface:
@@ -67,8 +83,7 @@ def resolve_auth(
 
     if config.auth.mode == "token":
         provided = (auth_params or {}).get("token")
-        configured = config.auth.token
-        if not configured or provided != configured:
+        if not token_matches(provided, config.auth.token):
             log.warning("auth.failed", mode=config.auth.mode, error="invalid token")
             return None
         return AccessContext(
@@ -96,4 +111,4 @@ def resolve_auth(
     return None
 
 
-__all__ = ["AccessContext", "denied_access", "resolve_auth"]
+__all__ = ["AccessContext", "denied_access", "resolve_auth", "token_matches"]

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -15,6 +15,7 @@ from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.types import ASGIApp
 
 from agentos.gateway.access import is_loopback_address
+from agentos.gateway.auth import token_matches
 from agentos.gateway.config import GatewayConfig
 
 log = structlog.get_logger(__name__)
@@ -243,8 +244,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         if auth_mode == "token":
             token = self._extract_token(request)
-            configured_token = self._config.auth.token
-            if not configured_token or token != configured_token:
+            if not token_matches(token, self._config.auth.token):
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )

--- a/src/agentos/gateway/uploads.py
+++ b/src/agentos/gateway/uploads.py
@@ -39,6 +39,7 @@ from agentos.contracts.attachments import (
     attachment_size_limit_for_mime,
     normalize_attachment_mime,
 )
+from agentos.gateway.auth import token_matches
 from agentos.gateway.config import GatewayConfig
 
 log = logging.getLogger(__name__)
@@ -366,7 +367,9 @@ def register_upload_routes(
 
     async def upload_handler(request: Request) -> JSONResponse:
         if config.auth.mode == "token":
-            if config.auth.token and _extract_authorization_token(request) != config.auth.token:
+            if config.auth.token and not token_matches(
+                _extract_authorization_token(request), config.auth.token
+            ):
                 return JSONResponse(
                     {
                         "error": (

--- a/tests/test_gateway/test_audio_transcription_route.py
+++ b/tests/test_gateway/test_audio_transcription_route.py
@@ -63,6 +63,20 @@ def test_audio_transcription_route_requires_token_header() -> None:
     assert fake.requests == []
 
 
+def test_audio_transcription_route_rejects_wrong_token() -> None:
+    fake = _FakeProvider()
+    client = _client(fake)
+
+    response = client.post(
+        "/api/audio/transcribe",
+        headers={"Authorization": "Bearer nope"},
+        files={"file": ("voice.webm", b"spoken", "audio/webm")},
+    )
+
+    assert response.status_code == 401
+    assert fake.requests == []
+
+
 def test_audio_transcription_route_transcribes_multipart_audio() -> None:
     fake = _FakeProvider()
     client = _client(fake)

--- a/tests/test_gateway/test_auth_control_access.py
+++ b/tests/test_gateway/test_auth_control_access.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import hmac
+from typing import Any
+
 from agentos.gateway.access import ConnectionSurface
-from agentos.gateway.auth import resolve_auth
+from agentos.gateway.auth import resolve_auth, token_matches
 from agentos.gateway.config import AuthConfig, GatewayConfig
 
 
@@ -51,3 +54,48 @@ def test_token_auth_without_configured_token_fails_closed() -> None:
     config = GatewayConfig(auth=AuthConfig(mode="token", token=None))
 
     assert resolve_auth(config, {}, "control", peer_ip="127.0.0.1") is None
+
+
+def test_token_auth_rejects_wrong_token() -> None:
+    config = GatewayConfig(
+        host="0.0.0.0",
+        auth=AuthConfig(mode="token", token="secret"),
+    )
+
+    assert resolve_auth(config, {"token": "nope"}, "control", peer_ip="203.0.113.7") is None
+    assert resolve_auth(config, {"token": 123}, "control", peer_ip="203.0.113.7") is None
+    assert resolve_auth(config, {}, "control", peer_ip="203.0.113.7") is None
+
+
+def test_token_matches_accepts_equal_strings() -> None:
+    assert token_matches("secret", "secret") is True
+
+
+def test_token_matches_rejects_mismatch_missing_empty_and_non_string() -> None:
+    assert token_matches("secret", "secret!") is False
+    assert token_matches("secre", "secret") is False
+    assert token_matches(None, "secret") is False
+    assert token_matches("", "secret") is False
+    assert token_matches("secret", None) is False
+    assert token_matches("secret", "") is False
+    assert token_matches(None, None) is False
+    bogus: Any = 123
+    assert token_matches(bogus, "secret") is False
+    assert token_matches("secret", bogus) is False
+
+
+def test_token_matches_uses_compare_digest(monkeypatch) -> None:
+    calls: list[tuple[bytes | str, bytes | str]] = []
+    original = hmac.compare_digest
+
+    def _capture(left: bytes | str, right: bytes | str) -> bool:
+        calls.append((left, right))
+        return original(left, right)
+
+    monkeypatch.setattr("agentos.gateway.auth.hmac.compare_digest", _capture)
+
+    assert token_matches("secret", "secret") is True
+    assert calls == [(b"secret", b"secret")]
+    calls.clear()
+    assert token_matches("nope", "secret") is False
+    assert calls == [(b"nope", b"secret")]

--- a/tests/test_gateway/test_middleware_ui_exemptions.py
+++ b/tests/test_gateway/test_middleware_ui_exemptions.py
@@ -86,3 +86,19 @@ def test_http_token_auth_without_configured_token_fails_closed(tmp_path) -> None
         response = client.get("/api/config")
 
     assert response.status_code == 401
+
+
+def test_http_token_auth_rejects_wrong_token(tmp_path) -> None:
+    config = GatewayConfig(
+        config_path=str(tmp_path / "config.toml"),
+        auth={"mode": "token", "token": "test-token"},
+    )
+
+    with TestClient(create_gateway_app(config), base_url="http://localhost") as client:
+        response = client.get(
+            "/api/config",
+            headers={"authorization": "Bearer nope"},
+        )
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "UNAUTHORIZED"

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -521,6 +521,34 @@ def test_upload_route_rejects_oversize_text_family() -> None:
     assert response.json()["code"] == "TOO_LARGE"
 
 
+def test_upload_route_rejects_wrong_token_without_middleware() -> None:
+    """The upload handler itself rejects a mismatched bearer token.
+
+    AuthMiddleware is the primary HTTP gate; this covers the in-route check
+    that still runs if the handler is registered without that middleware.
+    """
+    pytest.importorskip("starlette.testclient")
+    from starlette.applications import Starlette
+    from starlette.testclient import TestClient
+
+    from agentos.gateway.config import AuthConfig, GatewayConfig
+    from agentos.gateway.uploads import UploadStore, register_upload_routes
+
+    config = GatewayConfig(auth=AuthConfig(mode="token", token="secret"))
+    store = UploadStore(marker_dir=None, ttl_seconds=600, max_file_bytes=30 * 1024 * 1024)
+    app = Starlette(debug=False)
+    register_upload_routes(app, config=config, store=store)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/files/upload",
+            headers={"Authorization": "Bearer nope"},
+            files={"file": ("x.pdf", b"%PDF-1.4\n", "application/pdf")},
+        )
+    assert response.status_code == 401
+    assert response.json()["code"] == "UNAUTHORIZED"
+
+
 def test_upload_unauthenticated_rejected() -> None:
     """The HTTP route returns 401 when no token is supplied (auth=token mode).
 


### PR DESCRIPTION
## Linked issue

Fixes #498

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

Gateway token auth compared the caller-supplied value to the configured secret with `==` / `!=`, which short-circuits on the first differing byte. The Slack adapter already uses `hmac.compare_digest`; the four gateway token gates did not.

This adds a shared `token_matches` helper (fail closed on a missing/empty configured token, `compare_digest` on UTF-8 bytes) and routes every gateway token comparison through it:

- `resolve_auth` (WebSocket / RPC)
- `AuthMiddleware.dispatch` (HTTP)
- upload route
- audio transcription route

No change to the auth contract: missing/empty configured tokens still fail closed on the `resolve_auth` and middleware paths, and the upload/transcribe in-route checks still only run when a token is configured.

## Tests

```sh
uv run ruff check src/agentos/gateway/auth.py src/agentos/gateway/middleware.py src/agentos/gateway/uploads.py src/agentos/gateway/audio_transcription.py tests/test_gateway/test_auth_control_access.py tests/test_gateway/test_middleware_ui_exemptions.py tests/test_gateway/test_audio_transcription_route.py tests/test_gateway/test_uploads_endpoint.py
uv run mypy src/agentos/gateway/auth.py src/agentos/gateway/middleware.py src/agentos/gateway/uploads.py src/agentos/gateway/audio_transcription.py --show-error-codes
uv run pytest tests/test_gateway/test_auth_control_access.py tests/test_gateway/test_middleware_ui_exemptions.py tests/test_gateway/test_audio_transcription_route.py tests/test_gateway/test_uploads_endpoint.py -q
```

47 passed. Coverage includes match / mismatch / missing / empty / non-string input, that the helper calls `hmac.compare_digest`, and a wrong-token 401 on each of the four gates.