### PR TITLE
fix(security): block credential material in URL userinfo at the egress guard (#499)

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -8,7 +8,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import parse_qsl, unquote, urlparse
 
 import httpx
 
@@ -53,8 +53,17 @@ def _sensitive_body_marker(body: str | None) -> str | None:
 
 def _sensitive_url_marker(url: str) -> str | None:
     parsed = urlparse(url)
+    # URL userinfo is a legitimate credential carrier (RFC 3986), and the
+    # HTTP client underneath converts it into an ``Authorization: Basic``
+    # header on the wire — so a credential placed there egresses to whatever
+    # host the URL names without ever appearing in the path or query. Check
+    # both components percent-decoded: the client decodes userinfo before
+    # sending, so ``sk%2Dant-…`` reaches the wire as ``sk-ant-…``.
+    for part in (parsed.username, parsed.password):
+        if part and secret_literal_marker(unquote(part)) is not None:
+            return "sensitive_url_userinfo"
     for segment in parsed.path.split("/"):
-        if secret_literal_marker(segment) is not None:
+        if secret_literal_marker(unquote(segment)) is not None:
             return "sensitive_url_path"
     if not parsed.query:
         return None

--- a/tests/test_tools/test_credential_egress_guard.py
+++ b/tests/test_tools/test_credential_egress_guard.py
@@ -193,3 +193,68 @@ class TestShellCommands:
         blocked = shell._sensitive_shell_block("exec_command", command)
         assert blocked is not None
         assert json.loads(blocked)["sensitive_payload"] == "credential_literal"
+
+
+# Assembled at run time like the PEM above, so the tracked file carries no
+# literal that matches a shipped vendor key shape.
+_VENDOR_KEY = "sk-ant-api03-" + "A" * 20
+
+
+class TestUrlUserinfo:
+    """A credential in URL userinfo egresses as an Authorization header.
+
+    The HTTP client converts ``https://user:***@host/`` into
+    ``Authorization: Basic base64(user:key)`` on the wire, so userinfo is an
+    exfiltration channel the path/query checks never saw.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_vendor_key_in_userinfo_is_blocked(self, ok_response: None) -> None:
+        url = f"https://user:{_VENDOR_KEY}@api.example.test/v1/quote"
+        payload = json.loads(await _http_request()(url=url))
+        assert payload["status"] == "blocked"
+        assert payload["sensitive_payload"] == "sensitive_url_userinfo"
+
+    @pytest.mark.asyncio
+    async def test_a_vendor_key_as_username_is_blocked(self, ok_response: None) -> None:
+        url = f"https://{_VENDOR_KEY}@api.example.test/v1/quote"
+        payload = json.loads(await _http_request()(url=url))
+        assert payload["status"] == "blocked"
+        assert payload["sensitive_payload"] == "sensitive_url_userinfo"
+
+    @pytest.mark.asyncio
+    async def test_a_percent_encoded_key_in_userinfo_is_blocked(
+        self, ok_response: None
+    ) -> None:
+        """The client percent-decodes userinfo before sending, so the guard must too."""
+        from urllib.parse import quote
+
+        url = f"https://user:{quote(_VENDOR_KEY, safe='')}@api.example.test/v1"
+        payload = json.loads(await _http_request()(url=url))
+        assert payload["status"] == "blocked"
+        assert payload["sensitive_payload"] == "sensitive_url_userinfo"
+
+    @pytest.mark.asyncio
+    async def test_a_plain_userinfo_password_is_sent(self, ok_response: None) -> None:
+        """Opaque userinfo credentials are normal HTTP Basic auth, not exfiltration."""
+        payload = json.loads(
+            await _http_request()(url="https://user:***@api.example.test/v1")
+        )
+        assert payload.get("status") != "blocked"
+
+    def test_the_marker_covers_userinfo_username_password_and_encoding(self) -> None:
+        from urllib.parse import quote
+
+        assert web._sensitive_url_marker(f"https://u:{_VENDOR_KEY}@h.example/x") == (
+            "sensitive_url_userinfo"
+        )
+        assert web._sensitive_url_marker(f"https://{_VENDOR_KEY}@h.example/x") == (
+            "sensitive_url_userinfo"
+        )
+        encoded = quote(_VENDOR_KEY, safe="")
+        assert web._sensitive_url_marker(f"https://u:{encoded}@h.example/x") == (
+            "sensitive_url_userinfo"
+        )
+        # Benign userinfo and plain URLs stay unmarked.
+        assert web._sensitive_url_marker("https://user:***@h.example/x") is None
+        assert web._sensitive_url_marker("https://h.example/x?k=***") is None


### PR DESCRIPTION
Fixes #499

## What

The sensitive-payload egress guard scans URLs via `_sensitive_url_marker`, which checked **path segments and query values only** — never the URL **userinfo** component. The HTTP client (httpx) converts userinfo into an `Authorization: Basic *** header on the wire, so a vendor-shaped credential placed in userinfo bypassed the guard and egressed to whatever host the URL names.

Verified against a mock transport: `GET https://user:sk-ant-…@api.example.com` sends `Authorization: Basic *** decoding to `user:sk-ant-…`.

The same marker guards three surfaces: `http_request`, `web_fetch` (every redirect hop), and the media `image` tool — all were exposed.

## Changes

`src/agentos/tools/builtin/web.py` — `_sensitive_url_marker`:
- Check `parsed.username` and `parsed.password` percent-decoded, returning a new `sensitive_url_userinfo` marker. Percent-decoding matters: the client decodes userinfo before sending, so `sk%2Dant-…` reaches the wire as `sk-ant-…`.
- Percent-decode path segments too, for consistency with the same encoding blind spot.

## Tests

`tests/test_tools/test_credential_egress_guard.py` — new `TestUrlUserinfo` class:
- vendor key in userinfo password blocked (`sensitive_url_userinfo`)
- vendor key as username blocked
- percent-encoded key in userinfo blocked
- plain userinfo password still sent (normal HTTP Basic auth is not exfiltration)
- marker-level coverage of username/password/encoding plus benign cases

Credentials are assembled at run time (like the existing PEM fixture) so the tracked file carries no literal vendor-key shape.

## Verification

- `uv run ruff check` — clean
- `uv run mypy src/agentos/tools/builtin/web.py` — clean
- `uv run pytest tests/test_tools/test_credential_egress_guard.py` — 36 passed
- `uv run pytest tests/test_tools -k "web or fetch or media or egress or ssrf or sensitive"` — 113 passed
- full offline suite run before opening
