### PR TITLE
fix(security): cap web_fetch downloads at a hard byte limit (#502)

### DIFF
--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -261,15 +261,13 @@ async def web_fetch(
                 if marker is not None:
                     raise ValueError("Blocked redirect URL containing sensitive data")
 
-                response = await client.send(
-                    client.build_request("GET", current_url), stream=True
-                )
+                response = await client.send(client.build_request("GET", current_url), stream=True)
                 if response.status_code not in {301, 302, 303, 307, 308}:
                     break
                 location = response.headers.get("location")
-                await response.aclose()
                 if not location:
                     break
+                await response.aclose()
                 current_url = urljoin(str(response.url), location)
             else:
                 raise ValueError(f"Too many redirects (>{_MAX_REDIRECTS})")

--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -54,6 +54,17 @@ _WEB_FETCH_DEFAULT_MAX_CHARS = 20_000
 _WEB_FETCH_MAX_CHARS_ENV = "AGENTOS_WEB_FETCH_MAX_CHARS"
 _MAX_REDIRECTS = 5
 
+# Hard ceiling on the number of response bytes web_fetch will buffer into
+# memory, independent of the display cap (max_chars). max_chars only truncates
+# what the model sees; without a download cap, a single unbounded response
+# body (chunked encoding with no content-length, or a lying content-length) is
+# read fully into RAM via response.text, so one malicious URL can exhaust the
+# process. 1 MiB covers every realistic page; the display cap then decides how
+# much of that is returned.
+_WEB_FETCH_DOWNLOAD_LIMIT_BYTES = 1_048_576
+_WEB_FETCH_DOWNLOAD_LIMIT_ENV = "AGENTOS_WEB_FETCH_DOWNLOAD_LIMIT"
+_STREAM_CHUNK_BYTES = 65_536
+
 
 def _check_ssrf(url: str) -> None:
     """Raise ValueError if the URL resolves to a private/internal address."""
@@ -132,6 +143,18 @@ def _resolve_default_max_chars() -> int:
     except ValueError:
         return _WEB_FETCH_DEFAULT_MAX_CHARS
     return value if value >= 100 else _WEB_FETCH_DEFAULT_MAX_CHARS
+
+
+def _resolve_download_limit_bytes() -> int:
+    """Resolve the hard download cap from env or the built-in default."""
+    raw = os.environ.get(_WEB_FETCH_DOWNLOAD_LIMIT_ENV, "").strip()
+    if not raw:
+        return _WEB_FETCH_DOWNLOAD_LIMIT_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _WEB_FETCH_DOWNLOAD_LIMIT_BYTES
+    return value if value >= 65_536 else _WEB_FETCH_DOWNLOAD_LIMIT_BYTES
 
 
 def _resolve_effective_max_chars(max_chars: int | None) -> int | None:
@@ -219,8 +242,9 @@ async def web_fetch(
     final_url = url
     status = 0
     raw_html = ""
+    body_truncated = False
 
-    async def _do_fetch(user_agent: str) -> tuple[int, str, str, str]:
+    async def _do_fetch(user_agent: str) -> tuple[int, str, str, str, bool]:
         headers = dict(_DEFAULT_HEADERS)
         headers["User-Agent"] = user_agent
         async with httpx.AsyncClient(
@@ -230,33 +254,63 @@ async def web_fetch(
             headers=headers,
         ) as client:
             current_url = url
+            response: httpx.Response | None = None
             for _redirect_count in range(_MAX_REDIRECTS + 1):
                 _check_ssrf(current_url)
                 marker = _sensitive_url_marker(current_url)
                 if marker is not None:
                     raise ValueError("Blocked redirect URL containing sensitive data")
 
-                response = await client.get(current_url)
+                response = await client.send(
+                    client.build_request("GET", current_url), stream=True
+                )
                 if response.status_code not in {301, 302, 303, 307, 308}:
                     break
                 location = response.headers.get("location")
+                await response.aclose()
                 if not location:
                     break
                 current_url = urljoin(str(response.url), location)
             else:
                 raise ValueError(f"Too many redirects (>{_MAX_REDIRECTS})")
 
-            return (
-                response.status_code,
-                str(response.url),
-                response.headers.get("content-type", ""),
-                response.text,
-            )
+            assert response is not None
+            try:
+                # Stream the body with a hard byte ceiling so an unbounded
+                # response can never be buffered fully into memory; max_chars
+                # only caps what is returned to the model, not what is
+                # downloaded.
+                download_limit = _resolve_download_limit_bytes()
+                total = 0
+                chunks: list[bytes] = []
+                truncated = False
+                async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+                    chunks.append(chunk)
+                    total += len(chunk)
+                    if total >= download_limit:
+                        truncated = True
+                        break
+
+                raw_body = b"".join(chunks)
+                try:
+                    raw_text = raw_body.decode("utf-8")
+                except UnicodeDecodeError:
+                    raw_text = raw_body.decode("utf-8", errors="replace")
+
+                return (
+                    response.status_code,
+                    str(response.url),
+                    response.headers.get("content-type", ""),
+                    raw_text,
+                    truncated,
+                )
+            finally:
+                await response.aclose()
 
     last_error: str | None = None
     for attempt_idx, user_agent in enumerate((_UA_PRIMARY, _UA_FALLBACK)):
         try:
-            status, final_url, content_type, raw_html = await _do_fetch(user_agent)
+            status, final_url, content_type, raw_html, body_truncated = await _do_fetch(user_agent)
         except SSRFBlockedError:
             raise
         except httpx.TimeoutException:
@@ -299,7 +353,7 @@ async def web_fetch(
             "title": "",
             "extract_mode": extract_mode,
             "extractor": "raw",
-            "truncated": False,
+            "truncated": body_truncated,
             "length": len(raw_html),
             "text": _wrap_content(final_url, raw_html),
         }
@@ -374,7 +428,7 @@ async def web_fetch(
         "title": title,
         "extract_mode": extract_mode,
         "extractor": extractor_used,
-        "truncated": False,
+        "truncated": body_truncated,
         "length": len(extracted_content),
         "text": _wrap_content(final_url, extracted_content),
     }

--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -279,6 +279,12 @@ async def web_fetch(
                 # only caps what is returned to the model, not what is
                 # downloaded.
                 download_limit = _resolve_download_limit_bytes()
+                # Snapshot the charset advertised in Content-Type before we
+                # start streaming — httpx derives response.encoding from
+                # those headers, and we have to honour the server's charset
+                # (e.g. text/plain; charset=iso-8859-1) instead of assuming
+                # UTF-8. Falling back to utf-8 matches httpx's own default.
+                response_encoding = response.encoding or "utf-8"
                 total = 0
                 chunks: list[bytes] = []
                 truncated = False
@@ -290,10 +296,7 @@ async def web_fetch(
                         break
 
                 raw_body = b"".join(chunks)
-                try:
-                    raw_text = raw_body.decode("utf-8")
-                except UnicodeDecodeError:
-                    raw_text = raw_body.decode("utf-8", errors="replace")
+                raw_text = raw_body.decode(response_encoding, errors="replace")
 
                 return (
                     response.status_code,

--- a/tests/test_tools/test_web_fetch_download_cap.py
+++ b/tests/test_tools/test_web_fetch_download_cap.py
@@ -46,16 +46,53 @@ def _e2e_resolver(addr: str) -> Any:
     return resolver
 
 
-def _install_transport(
-    monkeypatch: pytest.MonkeyPatch, handler: Any
+def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)
+        return real_async_client(*args, transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr("socket.getaddrinfo", _e2e_resolver("93.184.216.34"))
+    monkeypatch.setattr(wf.httpx, "AsyncClient", fake_async_client)
+
+
+class _StreamingBody(httpx.AsyncByteStream):
+    """A body served as an async iterator, not a pre-buffered blob."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def __aiter__(self) -> Any:
+        yield self._data
+
+
+class _StreamingTransport(httpx.AsyncBaseTransport):
+    """A genuinely streaming transport.
+
+    Unlike ``httpx.MockTransport`` (which hands back a fully-buffered stream),
+    this one streams the body, so reading a closed response actually raises.
+    """
+
+    def __init__(self, status: int, headers: dict[str, str], body: bytes) -> None:
+        self._status = status
+        self._headers = headers
+        self._body = body
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            self._status, headers=self._headers, stream=_StreamingBody(self._body)
+        )
+
+
+def _install_streaming_transport(
+    monkeypatch: pytest.MonkeyPatch, transport: _StreamingTransport
 ) -> None:
     real_async_client = httpx.AsyncClient
 
     def fake_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
         kwargs.pop("transport", None)
-        return real_async_client(
-            *args, transport=httpx.MockTransport(handler), **kwargs
-        )
+        return real_async_client(*args, transport=transport, **kwargs)
 
     monkeypatch.setattr("socket.getaddrinfo", _e2e_resolver("93.184.216.34"))
     monkeypatch.setattr(wf.httpx, "AsyncClient", fake_async_client)
@@ -111,9 +148,7 @@ async def test_web_fetch_small_body_not_truncated(
     """A small body passes through without download truncation."""
 
     def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200, headers={"content-type": "text/plain"}, content=b"hello world"
-        )
+        return httpx.Response(200, headers={"content-type": "text/plain"}, content=b"hello world")
 
     _install_transport(monkeypatch, handler)
     wf._cache.clear()
@@ -124,3 +159,29 @@ async def test_web_fetch_small_body_not_truncated(
     assert result["truncated"] is False
     assert result["length"] == len("hello world")
     assert "hello world" in str(result["text"])
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_redirect_without_location_returns_body(
+    monkeypatch: pytest.MonkeyPatch,
+    sandbox_off: Any,
+) -> None:
+    """A 3xx response with no Location header is the final response.
+
+    The body must be returned, not an error about a closed stream. Uses a
+    genuinely streaming transport: a buffered MockTransport cannot catch the
+    read-after-aclose regression.
+    """
+    transport = _StreamingTransport(
+        302,
+        {"content-type": "text/plain"},
+        b"moved, but nowhere",
+    )
+    _install_streaming_transport(monkeypatch, transport)
+    wf._cache.clear()
+
+    result = json.loads(await wf.web_fetch(url="https://example.com/no-location"))
+
+    assert result["status"] == 302
+    assert "closed" not in str(result.get("error", ""))
+    assert "moved, but nowhere" in str(result["text"])

--- a/tests/test_tools/test_web_fetch_download_cap.py
+++ b/tests/test_tools/test_web_fetch_download_cap.py
@@ -185,3 +185,34 @@ async def test_web_fetch_redirect_without_location_returns_body(
     assert result["status"] == 302
     assert "closed" not in str(result.get("error", ""))
     assert "moved, but nowhere" in str(result["text"])
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_honors_response_charset(
+    monkeypatch: pytest.MonkeyPatch,
+    sandbox_off: Any,
+) -> None:
+    """Non-UTF-8 (ISO-8859-1) pages must be decoded with the server's charset.
+
+    Mirrors ``test_http_request_honors_response_charset`` from the #509 fix
+    on the sibling ``http_request`` tool: the streaming transport serves an
+    ISO-8859-1 body, the Content-Type advertises ``charset=iso-8859-1``, and
+    the returned text must contain the real ``café`` character — not the
+    U+FFFD replacement character that a hard-coded UTF-8 decode would emit.
+    """
+    body_bytes = b"caf\xe9 na\xefve r\xe9sum\xe9 ..."
+    transport = _StreamingTransport(
+        200,
+        {"content-type": "text/plain; charset=iso-8859-1"},
+        body_bytes,
+    )
+    _install_streaming_transport(monkeypatch, transport)
+    wf._cache.clear()
+
+    result = json.loads(await wf.web_fetch(url="https://example.com/latin1"))
+
+    assert result["status"] == 200
+    assert result["content_type"] == "text/plain; charset=iso-8859-1"
+    inner_text = str(result["text"])
+    assert "café" in inner_text
+    assert "\ufffd" not in inner_text

--- a/tests/test_tools/test_web_fetch_download_cap.py
+++ b/tests/test_tools/test_web_fetch_download_cap.py
@@ -1,0 +1,126 @@
+"""Tests: web_fetch downloads are capped at a hard byte limit.
+
+The display cap (max_chars) only controls what the model sees. Without a
+download ceiling, a single response with an unbounded body (chunked encoding,
+no content-length, or a lying content-length) is buffered fully into memory
+before any truncation is applied, so one URL can exhaust the process.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+from agentos.sandbox.config import SandboxSettings
+from agentos.sandbox.integration import configure_runtime, reset_runtime
+from agentos.tools.builtin import web_fetch as wf
+from agentos.tools.builtin.web_fetch import (
+    _WEB_FETCH_DOWNLOAD_LIMIT_BYTES,
+    _resolve_download_limit_bytes,
+)
+
+
+@pytest.fixture
+def sandbox_off(tmp_path: Any) -> Any:
+    """Configure a sandbox-off runtime so the @sandboxed tool runs inline."""
+    from pathlib import Path
+
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=Path(tmp_path),
+    )
+    yield
+    reset_runtime()
+
+
+def _e2e_resolver(addr: str) -> Any:
+    """Return a socket.getaddrinfo replacement resolving any host to addr."""
+
+    def resolver(host: Any, port: Any, **_kw: Any) -> list[tuple[Any, ...]]:
+        return [(2, 1, 6, "", (addr, 0))]
+
+    return resolver
+
+
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch, handler: Any
+) -> None:
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)
+        return real_async_client(
+            *args, transport=httpx.MockTransport(handler), **kwargs
+        )
+
+    monkeypatch.setattr("socket.getaddrinfo", _e2e_resolver("93.184.216.34"))
+    monkeypatch.setattr(wf.httpx, "AsyncClient", fake_async_client)
+
+
+def test_download_limit_default_and_env_override() -> None:
+    assert _resolve_download_limit_bytes() == _WEB_FETCH_DOWNLOAD_LIMIT_BYTES
+
+    with mock.patch.dict("os.environ", {"AGENTOS_WEB_FETCH_DOWNLOAD_LIMIT": "131072"}):
+        assert _resolve_download_limit_bytes() == 131_072
+
+    with mock.patch.dict("os.environ", {"AGENTOS_WEB_FETCH_DOWNLOAD_LIMIT": "100"}):
+        # Values below the 64 KiB floor fall back to the default.
+        assert _resolve_download_limit_bytes() == _WEB_FETCH_DOWNLOAD_LIMIT_BYTES
+
+    with mock.patch.dict("os.environ", {"AGENTOS_WEB_FETCH_DOWNLOAD_LIMIT": "notanint"}):
+        assert _resolve_download_limit_bytes() == _WEB_FETCH_DOWNLOAD_LIMIT_BYTES
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_caps_unbounded_response_body(
+    monkeypatch: pytest.MonkeyPatch,
+    sandbox_off: Any,
+) -> None:
+    """A 2 MiB response is buffered only up to the download limit."""
+    limit = 128 * 1024
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Non-HTML so the raw body is returned and its length is measurable.
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/plain"},
+            content=b"A" * (2 * 1024 * 1024),
+        )
+
+    _install_transport(monkeypatch, handler)
+    monkeypatch.setattr(wf, "_WEB_FETCH_DOWNLOAD_LIMIT_BYTES", limit)
+    wf._cache.clear()
+
+    result = json.loads(await wf.web_fetch(url="https://example.com/huge"))
+
+    assert result["status"] == 200
+    assert result["truncated"] is True
+    # The buffered body must not exceed the download limit.
+    assert result["length"] <= limit
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_small_body_not_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+    sandbox_off: Any,
+) -> None:
+    """A small body passes through without download truncation."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, headers={"content-type": "text/plain"}, content=b"hello world"
+        )
+
+    _install_transport(monkeypatch, handler)
+    wf._cache.clear()
+
+    result = json.loads(await wf.web_fetch(url="https://example.com/small"))
+
+    assert result["status"] == 200
+    assert result["truncated"] is False
+    assert result["length"] == len("hello world")
+    assert "hello world" in str(result["text"])


### PR DESCRIPTION
Fixes #502

## Problem

`web_fetch` buffered the entire HTTP response body into memory (`response.text` on a non-streamed response) before applying the `max_chars` display cap. `max_chars` and the run-budget policy only truncate what is returned to the model — they run after the whole body is already in RAM. A single unbounded response (chunked encoding with no content-length, a lying content-length, or a multi-GB body) could exhaust process memory and crash the agent/gateway. The 30s timeout bounds time, not bytes.

## Fix

Stream the response via `client.send(..., stream=True)` and iterate `response.aiter_bytes(chunk)`, accumulating only up to a hard `_WEB_FETCH_DOWNLOAD_LIMIT_BYTES` (default 1 MiB, env-overridable via `AGENTOS_WEB_FETCH_DOWNLOAD_LIMIT`, floor 64 KiB), then stop reading. `truncated` is set to `True` when the cap is hit (both the raw non-HTML path and the HTML extraction path). 1 MiB covers every realistic page; the existing `max_chars` display cap then decides how much of that is returned.

Redirect handling is preserved: each hop is still SSRF-checked and scanned by the sensitive-URL marker before the body is read, and redirect responses are closed before following.

## Tests

New `tests/test_tools/test_web_fetch_download_cap.py`:
- default limit + env override + sub-floor/invalid fallback
- a 2 MiB response is buffered only up to the limit (`truncated=True`, `length <= limit`)
- a small body passes through untruncated

## Verification

- `uv run ruff check` — clean
- `uv run mypy src/agentos/tools/builtin/web_fetch.py` — clean
- `uv run pytest tests/test_tools/test_web_fetch_download_cap.py tests/test_tools/test_web_fetch.py` — 8 passed
- `uv run pytest tests/test_tools -k "web or fetch or egress or ssrf or sensitive"` — 107 passed
- Full offline suite (`pytest -q -m "not llm"`): 8380 passed; the 8 failures + 3 errors are pre-existing environment-dependent ones (pilot encoder/wheelhouse/shell process isolation/pilot benchmark) that fail identically on clean main.

Confirmed REAL / HIGH by independent review.
