### PR TITLE
feat(channels): retry Slack and webhook POSTs when the network blips

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -22,7 +22,12 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from agentos.channels._reactions import NULL_STATUS_REACTOR, SlackStatusReactor
-from agentos.channels._util import ChannelAccessPolicy, EventDedupeCache, StreamThrottle
+from agentos.channels._util import (
+    ChannelAccessPolicy,
+    EventDedupeCache,
+    StreamThrottle,
+    retry_request,
+)
 from agentos.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
@@ -389,7 +394,7 @@ class SlackChannel:
             payload[key] = value
 
         client = self._get_client()
-        resp = await client.post("/chat.postMessage", json=payload)
+        resp = await retry_request(client.post, "/chat.postMessage", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
@@ -406,7 +411,8 @@ class SlackChannel:
         """Upload a local file to Slack using the external upload flow."""
         path = Path(file_path)
         client = self._get_client()
-        start_resp = await client.post(
+        start_resp = await retry_request(
+            client.post,
             "/files.getUploadURLExternal",
             json={"filename": path.name, "length": path.stat().st_size},
         )
@@ -419,8 +425,13 @@ class SlackChannel:
         if not upload_url or not file_id:
             raise RuntimeError("Slack file upload init response missing upload_url/file_id")
 
-        with path.open("rb") as f:
-            upload_resp = await client.post(upload_url, files={"file": (path.name, f)})
+        # Bytes, not an open handle: retry_request may POST again after a
+        # ReadTimeout, and a consumed file object would send an empty body.
+        upload_resp = await retry_request(
+            client.post,
+            upload_url,
+            files={"file": (path.name, path.read_bytes())},
+        )
         upload_resp.raise_for_status()
 
         complete_payload: dict[str, Any] = {
@@ -429,7 +440,8 @@ class SlackChannel:
         }
         if content:
             complete_payload["initial_comment"] = content
-        complete_resp = await client.post(
+        complete_resp = await retry_request(
+            client.post,
             "/files.completeUploadExternal",
             json=complete_payload,
         )
@@ -451,7 +463,7 @@ class SlackChannel:
             "text": content,
         }
         client = self._get_client()
-        resp = await client.post("/chat.update", json=payload)
+        resp = await retry_request(client.post, "/chat.update", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
@@ -466,7 +478,7 @@ class SlackChannel:
             "ts": message_id,
         }
         client = self._get_client()
-        resp = await client.post("/chat.delete", json=payload)
+        resp = await retry_request(client.post, "/chat.delete", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
@@ -513,7 +525,7 @@ class SlackChannel:
             }
             if thread_ts:
                 payload["thread_ts"] = thread_ts
-            resp = await client.post("/chat.postMessage", json=payload)
+            resp = await retry_request(client.post, "/chat.postMessage", json=payload)
             resp.raise_for_status()
             data = resp.json()
             if not data.get("ok"):
@@ -522,7 +534,8 @@ class SlackChannel:
             log.debug("slack.stream_start", ts=message_ts)
 
         async def _edit(text: str) -> None:
-            resp = await client.post(
+            resp = await retry_request(
+                client.post,
                 "/chat.update",
                 json={
                     "channel": target,

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -499,6 +499,8 @@ class DeliveryChain:
 
         import httpx
 
+        from agentos.channels._util import retry_request
+
         headers = {"Content-Type": "application/json"}
         if token:
             headers["Authorization"] = f"Bearer {token}"
@@ -510,7 +512,9 @@ class DeliveryChain:
         }
         try:
             async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:
-                response = await client.post(url, json=payload, headers=headers)
+                # Default retry_request budget (3 retries, 1s base) — do not
+                # raise it; this call holds the scheduler slot while it sleeps.
+                response = await retry_request(client.post, url, json=payload, headers=headers)
                 response.raise_for_status()
             log.info("delivery.webhook_sent", job_id=job_id)
             return "delivered"

--- a/tests/test_channels/test_slack.py
+++ b/tests/test_channels/test_slack.py
@@ -1,0 +1,202 @@
+"""Transient HTTP retries on Slack outbound calls.
+
+``retry_request`` is used as-is (same helper Discord already wraps). This
+file does not change the helper: a consumed file handle is avoided by
+sending bytes on the upload POST, not by seeking inside ``retry_request``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from agentos.channels.contract import ChannelSendStatus
+from agentos.channels.slack import SlackChannel
+from agentos.channels.types import OutgoingMessage
+
+
+class _FakeResp:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=httpx.Request("POST", "https://slack.com"),
+                response=httpx.Response(self.status_code),
+            )
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("agentos.channels._util.asyncio.sleep", _sleep)
+
+
+def _channel() -> SlackChannel:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C-default")
+    return channel
+
+
+@pytest.mark.asyncio
+async def test_slack_send_retries_on_503_then_succeeds() -> None:
+    calls = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                return _FakeResp(503, {"ok": False, "error": "server_error"})
+            return _FakeResp(200, {"ok": True, "ts": "123.456"})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    await channel.send(OutgoingMessage(content="Hello", reply_to="C-default"))
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_slack_send_retries_on_429() -> None:
+    calls = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return _FakeResp(429, {"ok": False, "error": "rate_limited"})
+            return _FakeResp(200, {"ok": True, "ts": "123.456"})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    await channel.send(OutgoingMessage(content="Hello", reply_to="C-default"))
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_slack_send_retries_on_read_timeout() -> None:
+    calls = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise httpx.ReadTimeout("Timeout")
+            return _FakeResp(200, {"ok": True, "ts": "123.456"})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    await channel.send(OutgoingMessage(content="Hello", reply_to="C-default"))
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_slack_send_does_not_retry_fatal_400() -> None:
+    calls = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal calls
+            calls += 1
+            return _FakeResp(400, {"ok": False, "error": "invalid_payload"})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await channel.send(OutgoingMessage(content="Hello", reply_to="C-default"))
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_send_does_not_retry_fatal_401() -> None:
+    calls = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal calls
+            calls += 1
+            return _FakeResp(401, {"ok": False, "error": "invalid_auth"})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await channel.send(OutgoingMessage(content="Hello", reply_to="C-default"))
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_edit_retries_on_503() -> None:
+    calls = 0
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return _FakeResp(503, {"ok": False})
+            return _FakeResp(200, {"ok": True})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    await channel.edit("111.222", "updated")
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_slack_send_file_retries_upload_with_bytes_body(tmp_path: Path) -> None:
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("file content", encoding="utf-8")
+    upload_attempts = 0
+    seen_bodies: list[bytes] = []
+
+    class FakeClient:
+        async def post(self, path: str, **kwargs: Any) -> _FakeResp:
+            nonlocal upload_attempts
+            if path == "/files.getUploadURLExternal":
+                return _FakeResp(
+                    200,
+                    {"ok": True, "upload_url": "https://upload.test", "file_id": "F1"},
+                )
+            if path == "https://upload.test":
+                upload_attempts += 1
+                body = kwargs["files"]["file"][1]
+                assert isinstance(body, bytes)
+                seen_bodies.append(body)
+                if upload_attempts == 1:
+                    raise httpx.ReadTimeout("Upload Timeout")
+                return _FakeResp(200, {"ok": True})
+            if path == "/files.completeUploadExternal":
+                return _FakeResp(200, {"ok": True, "files": [{"id": "F1"}]})
+            return _FakeResp(400, {"ok": False})
+
+    channel = _channel()
+    channel._client = FakeClient()  # type: ignore[assignment]
+
+    result = await channel.send_file("C-target", str(file_path), content="done")
+    assert result.status is ChannelSendStatus.SENT
+    assert upload_attempts == 2
+    assert seen_bodies == [b"file content", b"file content"]

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -20,8 +20,9 @@ def _mk(**kwargs: Any) -> SlackChannel:
 
 
 class _FakeResp:
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
         self._payload = payload
+        self.status_code = status_code
 
     def raise_for_status(self) -> None:
         return None

--- a/tests/test_scheduler/test_webhook_delivery.py
+++ b/tests/test_scheduler/test_webhook_delivery.py
@@ -97,7 +97,7 @@ async def test_ops_add_rejects_webhook_without_url(tmp_path: Path) -> None:
             await ops.add(
                 name="bad",
                 schedule_kind=ScheduleKind.CRON,
-            schedule_value="*/5 * * * *",
+                schedule_value="*/5 * * * *",
                 handler_key="agent_run",
                 payload=make_agent_turn_payload("x"),
                 session_target=SessionTarget.ISOLATED,
@@ -117,7 +117,7 @@ async def test_ops_add_rejects_webhook_with_bad_scheme(tmp_path: Path) -> None:
             await ops.add(
                 name="bad",
                 schedule_kind=ScheduleKind.CRON,
-            schedule_value="*/5 * * * *",
+                schedule_value="*/5 * * * *",
                 handler_key="agent_run",
                 payload=make_agent_turn_payload("x"),
                 session_target=SessionTarget.ISOLATED,
@@ -250,8 +250,21 @@ async def test_deliver_webhook_omits_authorization_when_no_token(monkeypatch) ->
 
 
 async def test_deliver_webhook_returns_failed_on_http_error(monkeypatch) -> None:
+    import asyncio
+
+    calls = 0
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr("agentos.channels._util.asyncio.sleep", fake_sleep)
+
     class _ErrorClient(_RecordingAsyncClient):
         async def post(self, url, json=None, headers=None):
+            nonlocal calls
+            calls += 1
+
             class _Resp:
                 status_code = 500
 
@@ -271,3 +284,81 @@ async def test_deliver_webhook_returns_failed_on_http_error(monkeypatch) -> None
         text="x",
     )
     assert status == "delivery_failed"
+    # 1 initial attempt + 3 retries
+    assert calls == 4
+
+
+async def test_deliver_webhook_retries_transient_error_and_recovers(monkeypatch) -> None:
+    calls = 0
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("agentos.channels._util.asyncio.sleep", fake_sleep)
+
+    class _RecoveringClient(_RecordingAsyncClient):
+        async def post(self, url, json=None, headers=None):
+            nonlocal calls
+            calls += 1
+
+            class _Resp:
+                def __init__(self, status_code: int) -> None:
+                    self.status_code = status_code
+
+                def raise_for_status(self):
+                    if self.status_code >= 400:
+                        raise RuntimeError(f"HTTP {self.status_code}")
+
+            if calls < 3:
+                return _Resp(503)
+            return _Resp(200)
+
+    class _FakeHttpx:
+        AsyncClient = _RecoveringClient
+
+    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("https://hooks.example/cron"),
+        text="x",
+    )
+    assert status == "delivered"
+    assert calls == 3
+
+
+async def test_deliver_webhook_does_not_retry_fatal_401(monkeypatch) -> None:
+    calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr("agentos.channels._util.asyncio.sleep", fake_sleep)
+
+    class _FatalErrorClient(_RecordingAsyncClient):
+        async def post(self, url, json=None, headers=None):
+            nonlocal calls
+            calls += 1
+
+            class _Resp:
+                status_code = 401
+
+                def raise_for_status(self):
+                    raise RuntimeError("HTTP 401 Unauthorized")
+
+            return _Resp()
+
+    class _FakeHttpx:
+        AsyncClient = _FatalErrorClient
+
+    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("https://hooks.example/cron"),
+        text="x",
+    )
+    assert status == "delivery_failed"
+    assert calls == 1
+    assert sleeps == []


### PR DESCRIPTION
## Linked issue

Fixes #469

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

Discord already wraps outbound HTTP in `retry_request` (429, 5xx, connect/read timeout, exponential backoff). Slack and cron webhook delivery did not — one dropped connection marked the send or the job as failed.

This routes Slack `send` / `send_file` / `edit` / `delete` / `send_streaming` and `_post_to_webhook` through that same helper. Defaults stay at 3 retries / 1s base so a webhook retry cannot sit on the scheduler slot for long.

`retry_request` itself is unchanged. File uploads send `path.read_bytes()` instead of an open handle, so a retry still has a body.

`_post_to_channel` is untouched on purpose — retry belongs on the adapter.

**Duplicate-delivery risk:** `chat.postMessage` and the file-upload sequence are not idempotent. A ReadTimeout often means Slack already accepted the request and the response was lost; retrying can post the same message twice. Discord already accepts that tradeoff. Callers can dedupe webhook payloads via `jobId`.

## Tests

```sh
uv run pytest tests/test_channels/test_slack.py tests/test_scheduler/test_webhook_delivery.py tests/test_channels/test_slack_socket_mode.py -q
```

43 passed. Covers 429 / 503 / ReadTimeout retry, 400 / 401 not retried, and a retried file upload still sending the original bytes.