### PR TITLE
chore(release): bump version to 2026.8.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to AgentOS will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [2026.8.28] - 2026-08-28
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-agent-os"
-version = "2026.8.27"
+version = "2026.8.28"
 description = "Local-first agentic trading AI agent with on-device Pilot Router"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]


### PR DESCRIPTION
Version bump to 2026.8.28 for release. Rolls the Unreleased Projects feature into the 2026.8.28 changelog section.

- Version bump: Pulled latest main, bumped pyproject.toml to 2026.8.28, and rolled the Unreleased changelog section into ## [2026.8.28] on branch release/2026.8.28.

- PR #505: Created and merged into main with a merge commit.  
  No tests run, per instruction.

- Tag: Switched back to main, pulled the merge, and pushed tag v2026.8.28.

- PyPI: The Publish workflow paused at the PyPI environment gate. It was approved and completed successfully.  
  Verified live on PyPI: use-agent-os 2026.8.28 is published with both a wheel and source distribution.

- Release notes: Published at [v2026.8.28](https://github.com/use-agent-os/agent-os/releases/tag/v2026.8.28) (https://github.com/use-agent-os/agent-os/releases/tag/v2026.8.28).

  Highlights the Projects feature:
  - Cross-agent session groups
  - Per-project knowledge injected on every turn
  - Web UI, CLI, RPC, and tools support
  - V011 migration