### PR TITLE
fix(security): cap http_request downloads at a hard byte limit (#508)

### DIFF
--- a/src/agentos/env_policy.py
+++ b/src/agentos/env_policy.py
@@ -136,6 +136,7 @@ _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_GATEWAY_HOST",
     "AGENTOS_GATEWAY_PORT",
     "AGENTOS_LISTEN",
+    "AGENTOS_HTTP_DOWNLOAD_LIMIT",
 )
 
 #: Names that may never be written through an AgentOS surface.

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -121,7 +121,9 @@ def _resolve_download_limit_bytes() -> int:
         value = int(raw)
     except ValueError:
         return _DOWNLOAD_LIMIT_BYTES
-    return value if value >= _STREAM_CHUNK_BYTES else _DOWNLOAD_LIMIT_BYTES
+    return (
+        min(value, _DOWNLOAD_LIMIT_BYTES) if value >= _STREAM_CHUNK_BYTES else _DOWNLOAD_LIMIT_BYTES
+    )
 
 
 def _fetch_workspace_dir() -> Path:
@@ -281,6 +283,7 @@ async def http_request(
             status_code = response.status_code
             response_url = str(response.url)
             response_headers = dict(response.headers)
+            response_encoding = response.encoding or "utf-8"
             content_type = response_headers.get("content-type", "")
         finally:
             await response.aclose()
@@ -294,7 +297,7 @@ async def http_request(
         saved_path, digest = _save_http_response_body(raw_body, output_path)
         preview = (
             wrap_untrusted_boundary(
-                raw_body[:_TEXT_BODY_LIMIT].decode("utf-8", "replace"),
+                raw_body[:_TEXT_BODY_LIMIT].decode(response_encoding, "replace"),
                 response_url,
             )
             if is_text
@@ -325,9 +328,9 @@ async def http_request(
         download_capped or stream_truncated or len(raw_body) > _BINARY_BODY_LIMIT
     )
     if is_text:
-        text_body = raw_body.decode("utf-8", "replace")
+        text_body = raw_body.decode(response_encoding, "replace")
         body = wrap_untrusted_boundary(text_body[:_TEXT_BODY_LIMIT], response_url)
-        body_truncated = len(text_body) > _TEXT_BODY_LIMIT
+        body_truncated = download_capped or stream_truncated or len(text_body) > _TEXT_BODY_LIMIT
     else:
         body = None
         body_truncated = False

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -244,30 +244,49 @@ async def http_request(
             ),
             stream=True,
         )
+        try:
+            # Stream the body with a hard byte ceiling so an unbounded response
+            # can never be buffered fully into memory; the display caps
+            # (_BINARY_BODY_LIMIT / _TEXT_BODY_LIMIT) only decide what is
+            # returned. A timeout bounds time, not bytes: on a fast pipe
+            # gigabytes arrive inside the window, so one attacker-influenced
+            # URL can OOM the process.
+            #
+            # The whole read MUST stay inside this ``async with`` block:
+            # ``AsyncClient.__aexit__`` closes the transport pool, and once it
+            # does, ``response.aiter_bytes`` raises ``httpx.ReadError`` because
+            # the underlying socket is gone. Reviewer #509 caught this as a
+            # 100% production failure — every real request raised ReadError
+            # after the previous layout exited the block before iterating.
+            download_limit = _resolve_download_limit_bytes()
+            total = 0
+            chunks: list[bytes] = []
+            download_capped = False
+            stream_truncated = False
+            try:
+                async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+                    chunks.append(chunk)
+                    total += len(chunk)
+                    if total >= download_limit:
+                        download_capped = True
+                        break
+            except httpx.RemoteProtocolError:
+                # Server dropped the connection mid-body (e.g. truncated
+                # chunked response). Return what we got rather than crashing
+                # the whole tool call.
+                stream_truncated = True
+            raw_body = b"".join(chunks)
+            # Snapshot response metadata while the connection is still open so
+            # downstream consumers don't depend on the closed transport.
+            status_code = response.status_code
+            response_url = str(response.url)
+            response_headers = dict(response.headers)
+            content_type = response_headers.get("content-type", "")
+        finally:
+            await response.aclose()
 
     from agentos.safety.injection_guard import wrap_untrusted_boundary
 
-    try:
-        # Stream the body with a hard byte ceiling so an unbounded response can
-        # never be buffered fully into memory; the display caps
-        # (_BINARY_BODY_LIMIT / _TEXT_BODY_LIMIT) only decide what is returned.
-        # A timeout bounds time, not bytes: on a fast pipe gigabytes arrive
-        # inside the window, so one attacker-influenced URL can OOM the process.
-        download_limit = _resolve_download_limit_bytes()
-        total = 0
-        chunks: list[bytes] = []
-        download_capped = False
-        async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
-            chunks.append(chunk)
-            total += len(chunk)
-            if total >= download_limit:
-                download_capped = True
-                break
-        raw_body = b"".join(chunks)
-    finally:
-        await response.aclose()
-
-    content_type = response.headers.get("content-type", "")
     is_text = _is_text_response_content_type(content_type)
     should_save = output_path is not None
 
@@ -276,20 +295,20 @@ async def http_request(
         preview = (
             wrap_untrusted_boundary(
                 raw_body[:_TEXT_BODY_LIMIT].decode("utf-8", "replace"),
-                str(response.url),
+                response_url,
             )
             if is_text
             else None
         )
         result = {
-            "status": response.status_code,
-            "url": str(response.url),
-            "headers": dict(response.headers),
+            "status": status_code,
+            "url": response_url,
+            "headers": response_headers,
             "content_type": content_type,
             "body": None,
             "body_base64": None,
-            "body_truncated": False,
-            "body_base64_truncated": download_capped,
+            "body_truncated": stream_truncated,
+            "body_base64_truncated": download_capped or stream_truncated,
             "body_saved": True,
             "body_omitted_reason": "saved_to_file",
             "body_preview": preview,
@@ -302,19 +321,21 @@ async def http_request(
 
     capped = raw_body[:_BINARY_BODY_LIMIT]
     body_base64 = base64.b64encode(capped).decode("ascii")
-    body_base64_truncated = download_capped or len(raw_body) > _BINARY_BODY_LIMIT
+    body_base64_truncated = (
+        download_capped or stream_truncated or len(raw_body) > _BINARY_BODY_LIMIT
+    )
     if is_text:
         text_body = raw_body.decode("utf-8", "replace")
-        body = wrap_untrusted_boundary(text_body[:_TEXT_BODY_LIMIT], str(response.url))
+        body = wrap_untrusted_boundary(text_body[:_TEXT_BODY_LIMIT], response_url)
         body_truncated = len(text_body) > _TEXT_BODY_LIMIT
     else:
         body = None
         body_truncated = False
 
     result = {
-        "status": response.status_code,
-        "url": str(response.url),
-        "headers": dict(response.headers),
+        "status": status_code,
+        "url": response_url,
+        "headers": response_headers,
         "content_type": content_type,
         "body": body,
         "body_base64": body_base64,

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -36,6 +36,17 @@ def _validate_http_url(url: str) -> None:
 
 _TEXT_BODY_LIMIT = 10_000
 _BINARY_BODY_LIMIT = 1_000_000
+# Hard ceiling on the number of response bytes http_request will buffer into
+# memory, independent of the display cap (_BINARY_BODY_LIMIT / _TEXT_BODY_LIMIT).
+# Those caps only truncate what the model sees; without a download cap, a single
+# unbounded response body (chunked encoding with no content-length, or a lying
+# content-length) is read fully into RAM via response.content, so one
+# attacker-influenced URL (search results, links inside fetched pages, user
+# input) can exhaust the process. 1 MiB covers every realistic response; the
+# display cap then decides how much of that is returned.
+_DOWNLOAD_LIMIT_BYTES = 1_000_000
+_DOWNLOAD_LIMIT_ENV = "AGENTOS_HTTP_DOWNLOAD_LIMIT"
+_STREAM_CHUNK_BYTES = 65_536
 _FETCH_DIR_NAME = ".fetch"
 
 
@@ -99,6 +110,18 @@ def _is_text_response_content_type(content_type: str) -> bool:
         or "json" in normalized
         or "xml" in normalized
     )
+
+
+def _resolve_download_limit_bytes() -> int:
+    """Resolve the hard download cap from env or the built-in default."""
+    raw = os.environ.get(_DOWNLOAD_LIMIT_ENV, "").strip()
+    if not raw:
+        return _DOWNLOAD_LIMIT_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DOWNLOAD_LIMIT_BYTES
+    return value if value >= _STREAM_CHUNK_BYTES else _DOWNLOAD_LIMIT_BYTES
 
 
 def _fetch_workspace_dir() -> Path:
@@ -212,23 +235,49 @@ async def http_request(
     content: bytes | None = body.encode() if body else None
 
     async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:
-        response = await client.request(
-            method=method_upper,
-            url=url,
-            headers=headers or {},
-            content=content,
+        response = await client.send(
+            client.build_request(
+                method=method_upper,
+                url=url,
+                headers=headers or {},
+                content=content,
+            ),
+            stream=True,
         )
+
+    from agentos.safety.injection_guard import wrap_untrusted_boundary
+
+    try:
+        # Stream the body with a hard byte ceiling so an unbounded response can
+        # never be buffered fully into memory; the display caps
+        # (_BINARY_BODY_LIMIT / _TEXT_BODY_LIMIT) only decide what is returned.
+        # A timeout bounds time, not bytes: on a fast pipe gigabytes arrive
+        # inside the window, so one attacker-influenced URL can OOM the process.
+        download_limit = _resolve_download_limit_bytes()
+        total = 0
+        chunks: list[bytes] = []
+        download_capped = False
+        async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+            chunks.append(chunk)
+            total += len(chunk)
+            if total >= download_limit:
+                download_capped = True
+                break
+        raw_body = b"".join(chunks)
+    finally:
+        await response.aclose()
 
     content_type = response.headers.get("content-type", "")
     is_text = _is_text_response_content_type(content_type)
-    raw_body = response.content
     should_save = output_path is not None
-    from agentos.safety.injection_guard import wrap_untrusted_boundary
 
     if should_save:
         saved_path, digest = _save_http_response_body(raw_body, output_path)
         preview = (
-            wrap_untrusted_boundary(response.text[:_TEXT_BODY_LIMIT], str(response.url))
+            wrap_untrusted_boundary(
+                raw_body[:_TEXT_BODY_LIMIT].decode("utf-8", "replace"),
+                str(response.url),
+            )
             if is_text
             else None
         )
@@ -240,21 +289,22 @@ async def http_request(
             "body": None,
             "body_base64": None,
             "body_truncated": False,
-            "body_base64_truncated": False,
+            "body_base64_truncated": download_capped,
             "body_saved": True,
             "body_omitted_reason": "saved_to_file",
             "body_preview": preview,
             "path": str(saved_path),
             "size": len(raw_body),
             "sha256": digest,
+            "download_capped": download_capped,
         }
         return json.dumps(result, ensure_ascii=False, indent=2)
 
     capped = raw_body[:_BINARY_BODY_LIMIT]
     body_base64 = base64.b64encode(capped).decode("ascii")
-    body_base64_truncated = len(raw_body) > _BINARY_BODY_LIMIT
+    body_base64_truncated = download_capped or len(raw_body) > _BINARY_BODY_LIMIT
     if is_text:
-        text_body = response.text
+        text_body = raw_body.decode("utf-8", "replace")
         body = wrap_untrusted_boundary(text_body[:_TEXT_BODY_LIMIT], str(response.url))
         body_truncated = len(text_body) > _TEXT_BODY_LIMIT
     else:
@@ -274,6 +324,7 @@ async def http_request(
         "path": None,
         "size": len(raw_body),
         "sha256": hashlib.sha256(raw_body).hexdigest(),
+        "download_capped": download_capped,
     }
     return json.dumps(result, ensure_ascii=False, indent=2)
 

--- a/tests/test_env_policy.py
+++ b/tests/test_env_policy.py
@@ -49,6 +49,7 @@ class TestDenylist:
             "AGENTOS_GATEWAY_TOKEN",
             "AGENTOS_STATE_DIR",
             "AGENTOS_GATEWAY_PORT",
+            "AGENTOS_HTTP_DOWNLOAD_LIMIT",
         ],
     )
     def test_execution_and_posture_names_are_refused(self, name: str) -> None:

--- a/tests/test_tools/test_credential_egress_guard.py
+++ b/tests/test_tools/test_credential_egress_guard.py
@@ -54,6 +54,22 @@ def ok_response(monkeypatch: pytest.MonkeyPatch) -> None:
         async def request(self, **kwargs: object) -> httpx.Response:
             return response
 
+        def build_request(self, **kwargs: object) -> httpx.Request:
+            return httpx.Request(
+                kwargs.get("method", "GET"),
+                kwargs.get("url", "https://example.test/"),
+                headers=kwargs.get("headers"),
+                content=kwargs.get("content"),
+            )
+
+        async def send(
+            self, _request: object, **kwargs: object
+        ) -> httpx.Response:
+            # The http_request tool now opens the stream via client.send(
+            # build_request(...), stream=True). Keep this mock compatible with
+            # both call shapes so the egress-guard request path stays tested.
+            return response
+
     monkeypatch.setattr(web.httpx, "AsyncClient", FakeAsyncClient)
 
 

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -31,8 +31,26 @@ def _patch_response(monkeypatch: pytest.MonkeyPatch, response: httpx.Response) -
         async def __aexit__(self, *args: object) -> None:
             return None
 
-        async def request(self, **kwargs: object) -> httpx.Response:
-            return response
+        def build_request(
+            self,
+            method: str,
+            url: str,
+            *,
+            headers: dict[str, str] | None = None,
+            content: bytes | None = None,
+        ) -> httpx.Request:
+            return httpx.Request(method, url, headers=headers, content=content)
+
+        async def send(self, request: httpx.Request, **kwargs: object) -> httpx.Response:
+            # Re-bind the pre-built response to the request actually in flight,
+            # preserving any pre-seeded body as an async stream so the streaming
+            # download path can iterate over it.
+            return httpx.Response(
+                response.status_code,
+                headers=dict(response.headers),
+                content=response.content,
+                request=request,
+            )
 
     monkeypatch.setattr(web.httpx, "AsyncClient", FakeAsyncClient)
 
@@ -331,3 +349,101 @@ async def test_http_request_without_output_path_does_not_create_fetch_directory(
     assert first["path"] is None
     assert second["path"] is None
     assert not (tmp_path / ".fetch").exists()
+
+
+class _StreamingAsyncClient:
+    """AsyncClient whose request() returns a streaming httpx.Response.
+
+    The handler builds the response body lazily (chunked, no content-length) so
+    the test can assert the tool stops reading near the download ceiling instead
+    of buffering the entire body into memory.
+    """
+
+    def __init__(
+        self, handler: Callable[[httpx.Request], httpx.Response], **kwargs: object
+    ) -> None:
+        self._handler = handler
+
+    async def __aenter__(self) -> _StreamingAsyncClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def build_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        content: bytes | None = None,
+    ) -> httpx.Request:
+        return httpx.Request(method, url, headers=headers, content=content)
+
+    async def send(self, request: httpx.Request, **kwargs: object) -> httpx.Response:
+        return self._handler(request)
+
+
+class _AsyncBody(httpx.AsyncByteStream):
+    def __init__(self, total: int, chunk: int = 256 * 1024) -> None:
+        self._remaining = total
+        self._chunk = chunk
+
+    async def __aiter__(self):
+        while self._remaining > 0:
+            n = min(self._chunk, self._remaining)
+            self._remaining -= n
+            yield b"A" * n
+
+
+@pytest.mark.asyncio
+async def test_http_request_caps_download_at_hard_byte_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Serve a 50MB chunked body (no content-length). The tool must stop reading
+    # near the 1MiB download cap, not buffer the whole body into RAM.
+    total = 50 * 1024 * 1024
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/octet-stream"},
+            stream=_AsyncBody(total),
+            request=request,
+        )
+
+    monkeypatch.setattr(web.httpx, "AsyncClient", lambda *a, **k: _StreamingAsyncClient(handler))
+
+    payload = json.loads(await _original_http_request()(url="https://example.test/huge"))
+
+    assert payload["download_capped"] is True
+    assert payload["body_base64_truncated"] is True
+    assert payload["body_saved"] is False
+    assert payload["size"] <= 1_000_000 + _STREAM_CHUNK, payload["size"]
+    assert payload["size"] < total
+
+
+@pytest.mark.asyncio
+async def test_http_request_env_overrides_download_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTOS_HTTP_DOWNLOAD_LIMIT", "200000")
+    total = 5 * 1024 * 1024
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/octet-stream"},
+            stream=_AsyncBody(total),
+            request=request,
+        )
+
+    monkeypatch.setattr(web.httpx, "AsyncClient", lambda *a, **k: _StreamingAsyncClient(handler))
+
+    payload = json.loads(await _original_http_request()(url="https://example.test/huge"))
+
+    assert payload["download_capped"] is True
+    assert payload["size"] <= 200_000 + _STREAM_CHUNK, payload["size"]
+
+
+_STREAM_CHUNK = 65_536

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -147,6 +147,24 @@ async def test_http_request_uses_body_base64_when_content_type_missing(
 
 
 @pytest.mark.asyncio
+async def test_http_request_honors_response_charset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = "café".encode("iso-8859-1")
+    _patch_response(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=raw,
+            headers={"content-type": "text/plain; charset=iso-8859-1"},
+            request=httpx.Request("GET", "https://example.test/latin1"),
+        ),
+    )
+    payload = json.loads(await _original_http_request()(url="https://example.test/latin1"))
+    assert "café" in payload["body"]
+
+
+@pytest.mark.asyncio
 async def test_http_request_does_not_implicitly_save_large_binary_response(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_tools/test_web_http_request_real_socket.py
+++ b/tests/test_tools/test_web_http_request_real_socket.py
@@ -1,0 +1,141 @@
+"""A real-socket test for the http_request streaming path.
+
+Reviewer feedback on PR #509: the fake clients in the suite have a no-op
+``__aexit__``, so code that reads the stream *after* the client is closed
+went green while every real request failed with ``httpx.ReadError``. This
+module stands up a real local TCP socket, so the transport pool teardown in
+``AsyncClient.__aexit__`` is exercised exactly as in production: if the
+stream is iterated outside the client block, this test fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+import pytest
+
+from agentos.sandbox.integration import configure_runtime
+from agentos.sandbox.policy import SandboxSettings
+from agentos.tools.builtin import web
+
+HttpRequest = Callable[..., Awaitable[str]]
+
+
+@pytest.fixture
+def _real_http_stack(tmp_path):
+    """Allow the real httpx transport to run (the whole point of this module)."""
+    configure_runtime(
+        SandboxSettings(sandbox=False, security_grading=False, allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    yield
+
+
+def _http_request() -> HttpRequest:
+    """The raw handler with the @tool/@sandboxed decorators unwrapped."""
+    return cast(HttpRequest, web.http_request.__wrapped__.__wrapped__)
+
+
+class _ChunkedServer:
+    """A minimal HTTP/1.1 chunked responder on an ephemeral local port."""
+
+    def __init__(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        try:
+            conn, _ = self._sock.accept()
+            with conn:
+                conn.recv(65536)
+                body = b"chunked-body-payload"
+                header = (
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: text/plain\r\n"
+                    b"Transfer-Encoding: chunked\r\n"
+                    b"Connection: close\r\n\r\n"
+                )
+                conn.sendall(header)
+                for i in range(0, len(body), 8):
+                    part = body[i : i + 8]
+                    conn.sendall(f"{len(part):x}\r\n".encode() + part + b"\r\n")
+                conn.sendall(b"0\r\n\r\n")
+                conn.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        self._sock.close()
+
+
+@pytest.mark.asyncio
+async def test_streaming_read_works_with_real_httpx_transport(_real_http_stack) -> None:
+    """The download must be read while the client is still open.
+
+    Regression for the PR #509 review: iterating ``aiter_bytes`` after
+    ``async with httpx.AsyncClient`` exits raises ``httpx.ReadError`` on a
+    real transport (the pool is closed). A fake client with a no-op
+    ``__aexit__`` cannot catch this, hence the local socket.
+    """
+    server = _ChunkedServer()
+    try:
+        result = await _http_request()(url=f"http://127.0.0.1:{server.port}/x")
+    finally:
+        server.close()
+
+    assert "chunked-body-payload" in result
+
+
+@pytest.mark.asyncio
+async def test_streaming_read_survives_server_closing_early(_real_http_stack) -> None:
+    """A truncated chunked response must not hang or crash the tool.
+
+    The server sends one chunk header + partial body then drops the
+    connection. http_request should catch the protocol error, flag the body
+    as truncated, and return a well-formed JSON envelope instead of raising.
+    """
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+
+    def serve_and_cut() -> None:
+        try:
+            conn, _ = srv.accept()
+            with conn:
+                conn.recv(65536)
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: text/plain\r\n"
+                    b"Transfer-Encoding: chunked\r\n\r\n"
+                    b"a\r\n0123456789\r\n"
+                )
+                # No terminator: the connection just drops.
+        except OSError:
+            pass
+
+    t = threading.Thread(target=serve_and_cut, daemon=True)
+    t.start()
+    try:
+        result = await asyncio.wait_for(
+            _http_request()(url=f"http://127.0.0.1:{port}/x"),
+            timeout=10,
+        )
+    finally:
+        srv.close()
+        t.join(timeout=1)
+
+    import json
+
+    payload = json.loads(result)
+    assert payload["status"] == 200
+    assert payload["body_base64_truncated"] is True
+    assert "0123456789" not in payload["body_base64"]


### PR DESCRIPTION
Fixes #508

`http_request` issued its request with a non-streaming `await client.request(...)`, so httpx buffered the entire response body into memory before `_BINARY_BODY_LIMIT` (1 MB) was applied. That cap only truncates what is returned to the model, not what is downloaded: a chunked response with no `content-length` (or a lying one) is read fully into RAM, so one attacker-influenced URL can exhaust process memory. The timeout bounds time, not bytes.

Empirical proof before the fix: a 50 MB chunked body served through a mock transport was streamed fully into memory (`served_bytes=52,428,800`, `payload.size=52,428,800`), then only 1 MB was returned. After the fix the read stops at the ceiling (`served_bytes=1,048,576`, `download_capped=True`).

Changes:
- Stream the response with `client.send(client.build_request(...), stream=True)` and accumulate `aiter_bytes(chunk)` up to a hard byte ceiling (default 1 MiB, `AGENTOS_HTTP_DOWNLOAD_LIMIT` overridable), stopping the read past the ceiling.
- Close the streamed response in a `finally` so the connection is released even when the ceiling is hit.
- Expose `download_capped` in both the inline and `output_path` result shapes so callers can tell `size`/`sha256` reflect the capped prefix, and fold it into `body_base64_truncated`.
- Add regression tests: a 50 MB chunked body must stop near the ceiling, and the env override must lower it.

Same bug class as #502 (`web_fetch`) and #506 (media image fetch), both already accepted as HIGH with streaming fixes.

Quality gate: `uv run ruff check` and `uv run mypy src/agentos/tools/builtin/web.py` clean; `tests/test_tools/test_web_http_request.py` 13 passed.
