### PR TITLE
fix(security): cap GitHub skill-hub blob downloads at a hard byte limit (#510)

### DIFF
--- a/src/agentos/skills/hub/github.py
+++ b/src/agentos/skills/hub/github.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import quote, unquote, urlparse
 
 import structlog
@@ -124,6 +125,47 @@ def _decode_file(path: str, content: bytes) -> str | bytes:
         return content.decode("utf-8")
     except UnicodeDecodeError:
         return content
+
+
+# Remote skill blobs are community-controlled — bound what we will buffer.
+# Without a ceiling, a single oversized blob (or a tree full of them) is read
+# fully into RAM via ``raw_resp.content`` and can OOM the installer. These sit
+# far above any real skill file and far below what it takes to exhaust memory.
+_MAX_BLOB_BYTES = 8 * 1024 * 1024  # uncompressed, per blob
+_MAX_TOTAL_BYTES = 32 * 1024 * 1024  # whole skill directory
+_STREAM_CHUNK_BYTES = 64 * 1024
+
+
+async def _read_capped(resp: Any, limit: int) -> bytes | None:
+    """Read a streamed blob response, returning ``None`` once it exceeds *limit*.
+
+    ``Content-Length`` and ``info.file_size`` are attacker-controlled metadata,
+    so they are only a first filter; this running total is what actually stops a
+    blob that lies about how much it expands to.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in resp.aiter_bytes(_STREAM_CHUNK_BYTES):
+        total += len(chunk)
+        if total > limit:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _fetch_blob(
+    client: Any, raw_url: str, headers: dict[str, str], limit: int
+) -> bytes | None:
+    # stream=True is essential: a plain client.get() would buffer the entire
+    # blob into response.content BEFORE _read_capped could stop the read, so
+    # the cap would only truncate what we keep, not what we download.
+    request = client.build_request("GET", raw_url, headers=headers)
+    raw_resp = await client.send(request, stream=True)
+    raw_resp.raise_for_status()
+    try:
+        return await _read_capped(raw_resp, limit)
+    finally:
+        await raw_resp.aclose()
 
 
 # YAML block-scalar indicator: > or |, one optional chomping/indentation
@@ -265,6 +307,7 @@ class GitHubSource(SkillSource):
                     return None
 
                 files: dict[str, str | bytes] = {}
+                budget = _MAX_TOTAL_BYTES
                 for item in tree_data.get("tree", []):
                     path = str(item.get("path") or "")
                     if item.get("type") != "blob":
@@ -276,9 +319,18 @@ class GitHubSource(SkillSource):
                         f"https://raw.githubusercontent.com/{ref.repo_full}/"
                         f"{quote(ref.ref, safe='')}/{quote(path, safe='/')}"
                     )
-                    raw_resp = await client.get(raw_url, headers=self._headers())
-                    raw_resp.raise_for_status()
-                    files[rel_path] = _decode_file(rel_path, raw_resp.content)
+                    blob_limit = min(_MAX_BLOB_BYTES, budget)
+                    raw = await _fetch_blob(client, raw_url, self._headers(), blob_limit)
+                    if raw is None:
+                        log.warning(
+                            "github.fetch_blob_over_cap",
+                            identifier=identifier,
+                            path=path,
+                            limit=blob_limit,
+                        )
+                        return None
+                    budget -= len(raw)
+                    files[rel_path] = _decode_file(rel_path, raw)
         except Exception as exc:
             log.warning("github.fetch_failed", identifier=identifier, error=str(exc))
             return None

--- a/tests/test_skills_hub_github.py
+++ b/tests/test_skills_hub_github.py
@@ -16,7 +16,7 @@ class _Response:
         status_code: int = 200,
     ) -> None:
         self._json_data = json_data or {}
-        self.content = content
+        self._content = content
         self.text = content.decode("utf-8", errors="replace")
         self.status_code = status_code
 
@@ -26,6 +26,16 @@ class _Response:
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise RuntimeError(f"HTTP {self.status_code}")
+
+    async def aiter_bytes(self, chunk_size: int = 64 * 1024) -> Any:
+        pos = 0
+        while pos < len(self._content):
+            end = pos + chunk_size
+            yield self._content[pos:end]
+            pos = end
+
+    async def aclose(self) -> None:
+        return None
 
 
 class _AsyncClient:
@@ -51,7 +61,16 @@ class _AsyncClient:
     async def __aexit__(self, *args: Any) -> None:
         return None
 
+    def build_request(
+        self, method: str, url: str, **kwargs: Any
+    ) -> tuple[str, dict[str, Any]]:
+        return (url, kwargs)
+
     async def get(self, url: str, **kwargs: Any) -> _Response:
+        return await self.send((url, kwargs), stream=False)
+
+    async def send(self, request: tuple[str, dict[str, Any]], stream: bool = False) -> _Response:
+        url, kwargs = request
         self.requests.append((url, kwargs))
         if "/git/trees/" in url:
             return _Response(json_data={"tree": self.tree_entries, "truncated": False})
@@ -191,3 +210,65 @@ def test_frontmatter_handles_crlf_line_endings() -> None:
 
     skill_md = "---\r\ndescription: On-chain data\r\n---\r\n# Body\r\n"
     assert _frontmatter_field(skill_md, "description") == "On-chain data"
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_blob_over_per_blob_cap_is_rejected(monkeypatch) -> None:
+    """A single oversized blob must not be buffered fully into RAM.
+
+    A hostile repo can return a 60 MB blob for what should be a small skill
+    file. The streaming fetch must stop near the per-blob cap and return None
+    instead of buffering the full body.
+    """
+    import httpx
+
+    from agentos.skills.hub import github as gh_mod
+
+    class _OversizedAsyncClient(_AsyncClient):
+        async def send(self, request: tuple[str, dict[str, Any]], stream: bool = False) -> Any:
+            url, _ = request
+            if "/git/trees/" in url:
+                return await _AsyncClient.send(self, request, stream=stream)
+            return _Response(content=b"x" * (60 * 1024 * 1024))
+
+    monkeypatch.setattr(httpx, "AsyncClient", _OversizedAsyncClient)
+    monkeypatch.setattr(gh_mod, "_MAX_BLOB_BYTES", 1024)
+
+    bundle = await GitHubSource().fetch(
+        "https://github.com/acme/skillpack/tree/main/skills/demo"
+    )
+
+    assert bundle is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_total_budget_blocks_after_exhausted(monkeypatch) -> None:
+    """The whole skill directory must respect a cumulative size budget.
+
+    Even when every individual blob sits under the per-blob cap, a tree of many
+    blobs must not be allowed to sum past the total budget. We craft a tree
+    with two mid-size blobs and a tiny total budget, and assert the fetch is
+    abandoned before both blobs land in RAM.
+    """
+    import httpx
+
+    from agentos.skills.hub import github as gh_mod
+
+    class _TwoBlobAsyncClient(_AsyncClient):
+        tree_entries = [
+            {"path": "skills/demo/SKILL.md", "type": "blob"},
+            {"path": "skills/demo/notes.md", "type": "blob"},
+        ]
+        raw_payloads = {
+            "skills/demo/SKILL.md": b"---\nname: demo\n---\n# body\n",
+            "skills/demo/notes.md": b"x" * 2048,
+        }
+
+    monkeypatch.setattr(httpx, "AsyncClient", _TwoBlobAsyncClient)
+    monkeypatch.setattr(gh_mod, "_MAX_TOTAL_BYTES", 200)
+
+    bundle = await GitHubSource().fetch(
+        "https://github.com/acme/skillpack/tree/main/skills/demo"
+    )
+
+    assert bundle is None


### PR DESCRIPTION
Fixes #510

`GitHubSource.fetch()` downloaded every blob of a skill directory with a non-streaming `await client.get(...)`, so httpx buffered each blob fully into `response.content` before any check. There was no per-blob cap and no total budget, so a hostile repo could ship an oversized blob (or a tree of many blobs) and the installer would buffer it all into RAM. The 15s timeout bounds time, not bytes.

Empirical proof before the fix: a 60 MB blob served through a streaming mock transport was buffered fully into RAM (`bundle.files["SKILL.md"]` len = 62,914,560). After the fix the read stops at the per-blob ceiling and the fetch fails closed (served to the tool = 8,650,752 bytes, bundle = None).

Changes:
- Stream each blob with `client.send(client.build_request(...), stream=True)` and accumulate `aiter_bytes(chunk)` up to a per-blob ceiling (default 8 MiB) and a cumulative total budget (default 32 MiB), stopping the read past either.
- Close the streamed response in a `finally` so the connection is released even when the ceiling is hit.
- Fail closed (return None) when a blob exceeds its cap, logging `github.fetch_blob_over_cap`.
- Add regression tests: an oversized blob must be rejected, and a tree whose blobs sum past the total budget must be abandoned.

This completes the skill-hub download hardening: the ClawHub source got caps in #357 and the `download` install kind streams with `_MAX_DOWNLOAD_BYTES`; the GitHub source was the last uncapped path.

Quality gate: `uv run ruff check` and `uv run mypy src/agentos/skills/hub/github.py` clean; `tests/test_skills_hub_github.py` 11 passed; sibling hub suites (bankr, capminal, aeon, installer, clawhub) 81 passed.
