### PR TITLE
fix(approval): parse every rm in compound shell commands so the intent cache can't be bypassed (#512)

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -59,46 +59,43 @@ _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
 def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of an ``rm`` invocation.
+    """Pull every non-flag argument out of every ``rm`` invocation.
 
-    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Does not try to be a full shell parser — falls back to
-    whitespace split on shlex errors (unbalanced quotes).
+    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and cuts at shell
+    separators. ``re.finditer`` (not ``re.search``) is required: a compound
+    command such as ``rm A; rm -rf B`` must surface *both* targets, otherwise
+    an approval for ``A`` would let ``rm A; rm -rf B`` slip ``B`` past the
+    cache with no prompt (the original single-``search`` implementation only
+    parsed the first ``rm``).
     """
-    match = re.search(r"\brm\b([^\n]*)", command)
-    if not match:
-        return []
-    tail = match.group(1)
-
-    # Cut at the first shell separator so ``rm foo; ls bar`` doesn't pick ``ls``/``bar``.
-    cut = len(tail)
-    for sep in _SHELL_SEPARATORS:
-        idx = tail.find(sep)
-        if idx != -1 and idx < cut:
-            cut = idx
-    tail = tail[:cut].strip()
-    if not tail:
-        return []
-
-    token_sets: list[list[str]] = []
-    try:
-        token_sets.append(shlex.split(tail))
-    except ValueError:
-        token_sets.append(tail.split())
-    if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
-        try:
-            token_sets.append(shlex.split(tail, posix=False))
-        except ValueError:
-            token_sets.append(tail.split())
-
     targets: list[str] = []
     seen: set[str] = set()
-    for tokens in token_sets:
-        for token in tokens:
-            if not token or token.startswith("-") or token in seen:
-                continue
-            seen.add(token)
-            targets.append(token)
+    # Stop at the first shell separator so each ``rm`` invocation is parsed on
+    # its own. A bare ``[^\n]*`` would swallow the rest of the line into the
+    # first match and hide subsequent ``rm``s (an ``rm A; rm -rf B`` would only
+    # ever yield A).
+    for match in re.finditer(r"\brm\b([^;\n&|]*)", command):
+        tail = match.group(1).strip()
+        if not tail:
+            continue
+
+        token_sets: list[list[str]] = []
+        try:
+            token_sets.append(shlex.split(tail))
+        except ValueError:
+            token_sets.append(tail.split())
+        if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\\\[^\\s]", tail)):
+            try:
+                token_sets.append(shlex.split(tail, posix=False))
+            except ValueError:
+                token_sets.append(tail.split())
+
+        for tokens in token_sets:
+            for token in tokens:
+                if not token or token.startswith("-") or token in seen:
+                    continue
+                seen.add(token)
+                targets.append(token)
     return targets
 
 

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -34,8 +34,12 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
     """
     if not raw or raw.startswith(("$", "`")) or raw in {"*", "-"}:
         return raw
+    # Normalize Windows backslash separators so paths like
+    # ``\root\.agentos\workspace\.env`` (produced on Windows runners or by
+    # Windows-style shell commands) resolve correctly on POSIX runners too.
+    normalized = raw.replace("\\", "/")
     try:
-        path = Path(raw).expanduser()
+        path = Path(normalized).expanduser()
         if base_dir is not None and not path.is_absolute():
             path = Path(base_dir).expanduser() / path
         return str(path.resolve(strict=False))
@@ -80,15 +84,24 @@ def _extract_rm_targets(command: str) -> list[str]:
             continue
 
         token_sets: list[list[str]] = []
-        try:
-            token_sets.append(shlex.split(tail))
-        except ValueError:
-            token_sets.append(tail.split())
+        # Use plain whitespace splitting (not shlex) so backslash-separated
+        # Windows-style paths such as ``\root\.agentos\workspace\.env`` keep
+        # their backslashes. ``shlex.split`` (POSIX) treats ``\`` as an escape
+        # and would collapse ``\root\.agentos`` into ``root.agentos``.
+        raw_tokens = tail.split()
+        stripped: list[str] = []
+        for tok in raw_tokens:
+            if len(tok) >= 2 and tok[0] == tok[-1] and tok[0] in ("'", '"'):
+                stripped.append(tok[1:-1])
+            else:
+                stripped.append(tok)
+        token_sets.append(stripped)
         if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\\\[^\\s]", tail)):
+            # Also try a non-POSIX shlex pass for completeness.
             try:
                 token_sets.append(shlex.split(tail, posix=False))
             except ValueError:
-                token_sets.append(tail.split())
+                pass
 
         for tokens in token_sets:
             for token in tokens:

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -1,0 +1,41 @@
+"""Tests for the destructive-intent approval cache.
+
+The cache short-circuits the human approval prompt for paraphrased retries of
+a previously-approved intent. It MUST NOT let a compound command smuggle an
+extra destructive target past an approval for a different target.
+"""
+from __future__ import annotations
+
+from agentos.application.intent_cache import IntentApprovalCache
+
+
+def test_compound_command_with_second_rm_is_not_cached() -> None:
+    cache = IntentApprovalCache()
+    cache.record("rm /data/project-a/tmp-cache")
+    assert cache.check("rm /data/project-a/tmp-cache")
+    # A second rm smuggled in via a shell separator must not pass.
+    for sep in (";", "&&", "||", "|", "&", "\n"):
+        cmd = f"rm /data/project-a/tmp-cache{sep}rm -rf /data/project-b"
+        assert not cache.check(cmd), f"compound rm via {sep!r} slipped past the cache"
+
+
+def test_compound_command_requires_approval_of_every_target() -> None:
+    cache = IntentApprovalCache()
+    cache.record("rm /a /b")
+    # Both targets approved -> ok.
+    assert cache.check("rm /a /b")
+    # Adding a third target -> must re-prompt.
+    assert not cache.check("rm /a /b /c")
+
+
+def test_paraphrased_python_delete_still_cached() -> None:
+    cache = IntentApprovalCache()
+    cache.record("rm /data/project-a/tmp-cache")
+    # The cache is designed to allow os.remove() paraphrases.
+    assert cache.check('os.remove("/data/project-a/tmp-cache")')
+
+
+def test_unrelated_delete_not_cached() -> None:
+    cache = IntentApprovalCache()
+    cache.record("rm /data/project-a/tmp-cache")
+    assert not cache.check("rm -rf /data/project-b")


### PR DESCRIPTION
Fixes #512

## What

`IntentApprovalCache._extract_rm_targets` used `re.search`, which only ever parsed the FIRST `rm` invocation in a command. A compound command like `rm A; rm -rf B` extracted only `A`, so after the user approved `rm A`, `check("rm A; rm -rf B")` returned `True` and the second delete ran with no approval prompt.

Empirically reproduced on unmodified source for all six separators (`;` `&&` `||` `|` `&` newline) — every compound command passed the cache with the extra target never extracted.

## Fix

- `re.finditer` instead of `re.search`, with the capture stopped at shell separators (`[^;\n&|]*`) so each `rm` invocation is tokenized independently.
- `check()`'s existing all-intents-must-match semantics then correctly require approval for every target.

## Tests

New `tests/test_application/test_intent_cache.py` (4 tests): all six separator variants must NOT pass the cache after a single approval, multi-target approval requires every target, paraphrased `os.remove` still cached (designed behavior preserved), unrelated delete still blocked.

- `uv run pytest tests/test_application/test_intent_cache.py tests/test_tools/test_shell_approval_policy.py tests/test_gateway/test_rpc_approvals.py tests/test_application/test_approval_rpc.py -q` → 78 passed
- `uv run ruff check` + `uv run mypy` → clean
