### PR TITLE
fix(security): close DNS-rebinding TOCTOU in SSRF guard with a validating network backend (#516)

### DIFF
--- a/src/agentos/skills/hub/deps.py
+++ b/src/agentos/skills/hub/deps.py
@@ -121,12 +121,12 @@ async def _fetch_to_file(url: str, dest: Path) -> None:
     one at a time with the same guard applied to each, mirroring
     :mod:`agentos.tools.builtin.web_fetch`.
     """
-    import httpx
-
-    from agentos.tools.ssrf import validate_http_url_for_fetch
+    from agentos.tools.ssrf import ssrf_guarded_client, validate_http_url_for_fetch
 
     current_url = url
-    async with httpx.AsyncClient(timeout=120.0, follow_redirects=False) as client:
+    async with ssrf_guarded_client(
+        timeout=120.0, follow_redirects=False
+    ) as client:
         for _hop in range(_MAX_DOWNLOAD_REDIRECTS + 1):
             validate_http_url_for_fetch(current_url)
             request = client.build_request("GET", current_url)

--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -48,7 +48,7 @@ from agentos.provider.image_generation import (
 from agentos.tools.path_aliases import resolve_workspace_alias
 from agentos.tools.path_policy import reject_foreign_host_path
 from agentos.tools.registry import tool
-from agentos.tools.ssrf import validate_http_url_for_fetch
+from agentos.tools.ssrf import ssrf_guarded_client, validate_http_url_for_fetch
 from agentos.tools.types import (
     CallerKind,
     SafeToolError,
@@ -277,8 +277,6 @@ def _sensitive_media_url_block(tool_name: str, url: str) -> dict | None:
 
 
 async def _fetch_image_url(url: str) -> tuple[bytes, str]:
-    import httpx
-
     def _check_image_url(candidate_url: str) -> None:
         marker = _sensitive_media_url_block("image", candidate_url)
         if marker is not None:
@@ -293,7 +291,7 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
             raise ToolError(str(exc)) from exc
 
     try:
-        async with httpx.AsyncClient(
+        async with ssrf_guarded_client(
             timeout=30.0, follow_redirects=False, trust_env=_trust_env()
         ) as client:
             current_url = url

--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
+import httpx
+
 from agentos.artifacts import (
     DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
     DEFAULT_ARTIFACT_MAX_BYTES,

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -248,11 +248,14 @@ async def http_request(
     async with ssrf_guarded_client(
         timeout=timeout, trust_env=_trust_env(), metadata_only=True
     ) as client:
-        response = await client.request(
-            method=method_upper,
-            url=url,
-            headers=headers or {},
-            content=content,
+        response = await client.send(
+            client.build_request(
+                method=method_upper,
+                url=url,
+                headers=headers or {},
+                content=content,
+            ),
+            stream=True,
         )
         try:
             # Stream the body with a hard byte ceiling so an unbounded response

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -18,7 +18,7 @@ from agentos.sandbox.integration import sandboxed
 from agentos.search.types import SearchProviderError, SearchResult
 from agentos.tools.path_policy import reject_foreign_host_path
 from agentos.tools.registry import tool
-from agentos.tools.ssrf import assert_not_metadata_endpoint
+from agentos.tools.ssrf import assert_not_metadata_endpoint, ssrf_guarded_client
 from agentos.tools.types import ToolError, UnsupportedURLSchemeError, current_tool_context
 
 
@@ -239,21 +239,20 @@ async def http_request(
         return _sensitive_body_block("http_request", marker)
 
     try:
-        import httpx
+        import httpx  # noqa: F401 - availability check
     except ImportError:
         return "[error] httpx not installed. Run: pip install httpx"
 
     content: bytes | None = body.encode() if body else None
 
-    async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:
-        response = await client.send(
-            client.build_request(
-                method=method_upper,
-                url=url,
-                headers=headers or {},
-                content=content,
-            ),
-            stream=True,
+    async with ssrf_guarded_client(
+        timeout=timeout, trust_env=_trust_env(), metadata_only=True
+    ) as client:
+        response = await client.request(
+            method=method_upper,
+            url=url,
+            headers=headers or {},
+            content=content,
         )
         try:
             # Stream the body with a hard byte ceiling so an unbounded response

--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -19,7 +19,7 @@ from agentos.result_budget import (
 )
 from agentos.sandbox.integration import sandboxed
 from agentos.tools.registry import tool
-from agentos.tools.ssrf import validate_http_url_for_fetch
+from agentos.tools.ssrf import ssrf_guarded_client, validate_http_url_for_fetch
 from agentos.tools.types import SSRFBlockedError, current_tool_context
 
 log = structlog.get_logger(__name__)
@@ -223,7 +223,7 @@ async def web_fetch(
     async def _do_fetch(user_agent: str) -> tuple[int, str, str, str]:
         headers = dict(_DEFAULT_HEADERS)
         headers["User-Agent"] = user_agent
-        async with httpx.AsyncClient(
+        async with ssrf_guarded_client(
             timeout=30.0,
             follow_redirects=False,
             trust_env=_trust_env(),

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import ipaddress
 import socket
 from collections.abc import Iterable
+from typing import Any
 from urllib.parse import urlparse
+
+from httpcore._backends.base import SOCKET_OPTION, AsyncNetworkBackend
 
 from agentos.tools.types import SSRFBlockedError, UnsupportedURLSchemeError
 
@@ -218,3 +221,207 @@ def _is_trusted_fake_ip(addr: IPAddress, trusted_networks: tuple[IPNetwork, ...]
 
 def _blocked_message(hostname: str, addr: IPAddress, reason: str) -> str:
     return f"Blocked: {hostname} resolves to {addr} ({reason})"
+
+
+def _unwrap_mapped(addr: IPAddress) -> IPAddress:
+    """Return the IPv4 an IPv4-mapped IPv6 address stands for, else *addr*."""
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    return addr
+
+
+def _fetch_block_reason(
+    addr: IPAddress, *, trusted_networks: tuple[IPNetwork, ...]
+) -> str | None:
+    """Return why *addr* may not be fetched, or None when it may."""
+    hard = _hard_block_reason(addr)
+    if hard is not None:
+        return hard
+    if _is_trusted_fake_ip(addr, trusted_networks):
+        return None
+    if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+        return (
+            f"reserved/private range; configure [tools].trusted_fake_ip_cidrs "
+            f"with {RFC2544_FAKE_IP_NETWORK} only if this is fake-IP DNS"
+            if addr in RFC2544_FAKE_IP_NETWORK
+            else "private/internal range"
+        )
+    return None
+
+
+def _trusted_networks(
+    trusted_fake_ip_cidrs: Iterable[str] | None,
+) -> tuple[IPNetwork, ...]:
+    if trusted_fake_ip_cidrs is not None:
+        return tuple(
+            ipaddress.ip_network(value)
+            for value in validate_trusted_fake_ip_cidrs(trusted_fake_ip_cidrs)
+        )
+    return _trusted_fake_ip_cidrs
+
+
+def resolve_safe_addresses(
+    hostname: str,
+    *,
+    metadata_only: bool = False,
+    trusted_fake_ip_cidrs: Iterable[str] | None = None,
+) -> list[str]:
+    """Resolve *hostname* and return every safe address as an IP literal.
+
+    Every address the name resolves to is validated before any of them is
+    returned, so a caller that connects to one of the returned literals is
+    guaranteed the validated address is the connected address. This is what
+    closes the DNS-rebinding window: a guard that resolves once while the HTTP
+    stack resolves again at connect time can be shown a public address first
+    and a metadata address second.
+
+    Raises :class:`SSRFBlockedError` when any resolved address is blocked and
+    ``ValueError`` when the name does not resolve.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
+
+    trusted_networks = _trusted_networks(trusted_fake_ip_cidrs)
+    safe: list[str] = []
+    seen: set[str] = set()
+    for info in infos:
+        try:
+            addr = ipaddress.ip_address(info[4][0])
+        except ValueError:  # pragma: no cover - getaddrinfo returned a non-address
+            continue
+        check = _unwrap_mapped(addr)
+        reason = (
+            f"metadata endpoint {check}"
+            if metadata_only and _is_metadata_address(check)
+            else None
+        )
+        if reason is None and not metadata_only:
+            reason = _fetch_block_reason(check, trusted_networks=trusted_networks)
+        if reason is not None:
+            raise SSRFBlockedError(_blocked_message(hostname, addr, reason))
+        literal = str(addr)
+        if literal not in seen:
+            seen.add(literal)
+            safe.append(literal)
+    if not safe:
+        raise ValueError(f"Cannot resolve hostname: {hostname}")
+    return safe
+
+
+class ValidatingNetworkBackend(AsyncNetworkBackend):
+    """httpcore network backend that pins TCP connections to validated IPs.
+
+    The URL-level guards in this module resolve a hostname and check the
+    result, but httpx/httpcore then resolve the same hostname *again* when
+    opening the connection. With a short-TTL (rebinding) domain the two
+    resolutions can differ, so the guard validates one address and the socket
+    connects to another — e.g. ``169.254.169.254``.
+
+    This backend removes the second resolution: it resolves the target itself,
+    validates every address, and connects to one of the validated literals.
+    TLS is unaffected — httpcore still performs the handshake against the
+    origin hostname (SNI and certificate verification), only the TCP endpoint
+    changes.
+    """
+
+    def __init__(self, *, metadata_only: bool = False, inner: Any = None) -> None:
+        from httpcore._backends.auto import AutoBackend
+
+        self._inner = inner if inner is not None else AutoBackend()
+        self._metadata_only = metadata_only
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> Any:
+        try:
+            literal = ipaddress.ip_address(host.strip("[]"))
+        except ValueError:
+            literal = None
+
+        if literal is not None:
+            check = _unwrap_mapped(literal)
+            blocked = _is_metadata_address(check) if self._metadata_only else (
+                _fetch_block_reason(check, trusted_networks=_trusted_fake_ip_cidrs)
+                is not None
+            )
+            if blocked:
+                raise SSRFBlockedError(
+                    f"Blocked: {host} is a private/internal or metadata address"
+                )
+            candidates = [str(literal)]
+        else:
+            if host.strip().lower().rstrip(".") in _METADATA_HOSTNAMES:
+                raise SSRFBlockedError(
+                    f"Blocked request to {host}: cloud metadata endpoints serve "
+                    "instance credentials and are never a valid agent target."
+                )
+            candidates = resolve_safe_addresses(host, metadata_only=self._metadata_only)
+
+        last_exc: Exception | None = None
+        for candidate in candidates:
+            try:
+                return await self._inner.connect_tcp(
+                    candidate,
+                    port,
+                    timeout=timeout,
+                    local_address=local_address,
+                    socket_options=socket_options,
+                )
+            except Exception as exc:  # try the next resolved address
+                last_exc = exc
+        assert last_exc is not None  # candidates is never empty
+        raise last_exc
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> Any:
+        return await self._inner.connect_unix_socket(
+            path, timeout=timeout, socket_options=socket_options
+        )
+
+    async def sleep(self, seconds: float) -> None:
+        await self._inner.sleep(seconds)
+
+
+def ssrf_guarded_client(
+    *,
+    metadata_only: bool = False,
+    **client_kwargs: Any,
+) -> Any:
+    """Return an ``httpx.AsyncClient`` whose connections are pinned to validated IPs.
+
+    The client is constructed normally (so env-proxy mounts and every other
+    httpx default stay intact) and then the default connection pool's network
+    backend is swapped for :class:`ValidatingNetworkBackend`. That backend
+    resolves and validates the destination itself at connect time, closing the
+    DNS-rebinding window between the URL-level guard and the actual socket —
+    without rewriting the URL, so TLS SNI, the Host header, and relative
+    redirects are unaffected.
+
+    ``metadata_only=True`` keeps ordinary private addresses reachable (the
+    ``http_request`` flavour, which is pointed at localhost on purpose) while
+    still blocking cloud metadata endpoints at connect time.
+    """
+    import httpx
+
+    client = httpx.AsyncClient(**client_kwargs)
+    try:
+        pool = client._transport._pool  # type: ignore[attr-defined]  # httpx 0.28 layout
+        pool._network_backend = ValidatingNetworkBackend(  # type: ignore[attr-defined]  # noqa: SLF001
+            metadata_only=metadata_only
+        )
+    except AttributeError:
+        # A test fake (or a future httpx layout) without the expected pool
+        # structure falls back to the URL-level guard only.
+        pass
+    return client

--- a/tests/test_security/test_ssrf_rebinding.py
+++ b/tests/test_security/test_ssrf_rebinding.py
@@ -1,0 +1,147 @@
+"""Tests for the DNS-rebinding TOCTOU guard (ValidatingNetworkBackend).
+
+The URL-level guard (validate_http_url_for_fetch) resolves a hostname and
+checks the result, but httpx/httpcore then resolve the same hostname AGAIN at
+connect time. With a short-TTL (rebinding) domain the two resolutions can
+differ, so the guard validates one address and the socket connects to another
+(e.g. 169.254.169.254). ValidatingNetworkBackend closes that window by
+resolving and validating the destination itself at connect time.
+"""
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from agentos.tools import ssrf
+from agentos.tools.types import SSRFBlockedError
+
+
+def _fake_getaddrinfo(ip: str):
+    def resolver(hostname: str, port: int | None, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port or 443))]
+
+    return resolver
+
+
+@pytest.fixture(autouse=True)
+def reset_trusted_fake_ip_cidrs():
+    ssrf.configure_trusted_fake_ip_cidrs([])
+    yield
+    ssrf.configure_trusted_fake_ip_cidrs([])
+
+
+# --- resolve_safe_addresses -------------------------------------------------
+
+
+def test_resolve_safe_addresses_blocks_metadata(monkeypatch):
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254"))
+    with pytest.raises(SSRFBlockedError):
+        ssrf.resolve_safe_addresses("rebind.example")
+
+
+def test_resolve_safe_addresses_blocks_private(monkeypatch):
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.5"))
+    with pytest.raises(SSRFBlockedError):
+        ssrf.resolve_safe_addresses("rebind.example")
+
+
+def test_resolve_safe_addresses_returns_public_ip(monkeypatch):
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    assert ssrf.resolve_safe_addresses("example.com") == ["93.184.216.34"]
+
+
+def test_resolve_safe_addresses_metadata_only_allows_private(monkeypatch):
+    # metadata_only flavour (http_request) keeps ordinary private reachable.
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.5"))
+    assert ssrf.resolve_safe_addresses("internal.example", metadata_only=True) == ["10.0.0.5"]
+
+
+def test_resolve_safe_addresses_metadata_only_still_blocks_metadata(monkeypatch):
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254"))
+    with pytest.raises(SSRFBlockedError):
+        ssrf.resolve_safe_addresses("rebind.example", metadata_only=True)
+
+
+# --- ValidatingNetworkBackend.connect_tcp -----------------------------------
+
+
+class _RecordingBackend:
+    """Fake inner backend that records the IP it was asked to connect to."""
+
+    def __init__(self) -> None:
+        self.connected: list[str] = []
+
+    async def connect_tcp(self, host, port, timeout=None, local_address=None, socket_options=None):
+        self.connected.append(host)
+        return object()
+
+    async def connect_unix_socket(self, path, timeout=None, socket_options=None):
+        return object()
+
+    async def sleep(self, seconds):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_backend_blocks_rebinding_to_metadata(monkeypatch):
+    """The core TOCTOU: URL guard saw a public IP, but connect-time resolution
+    returns the metadata endpoint. The backend must block at connect time."""
+    inner = _RecordingBackend()
+    backend = ssrf.ValidatingNetworkBackend(inner=inner)
+    # connect-time resolution returns the metadata address.
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254"))
+    with pytest.raises(SSRFBlockedError):
+        await backend.connect_tcp("rebind.example", 443)
+    assert inner.connected == []  # never reached the socket
+
+
+@pytest.mark.asyncio
+async def test_backend_connects_to_validated_public_ip(monkeypatch):
+    inner = _RecordingBackend()
+    backend = ssrf.ValidatingNetworkBackend(inner=inner)
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    await backend.connect_tcp("example.com", 443)
+    # The backend connects to the validated IP literal, not the hostname.
+    assert inner.connected == ["93.184.216.34"]
+
+
+@pytest.mark.asyncio
+async def test_backend_blocks_metadata_ip_literal():
+    inner = _RecordingBackend()
+    backend = ssrf.ValidatingNetworkBackend(inner=inner)
+    with pytest.raises(SSRFBlockedError):
+        await backend.connect_tcp("169.254.169.254", 80)
+    assert inner.connected == []
+
+
+@pytest.mark.asyncio
+async def test_backend_metadata_only_allows_private_literal():
+    inner = _RecordingBackend()
+    backend = ssrf.ValidatingNetworkBackend(metadata_only=True, inner=inner)
+    await backend.connect_tcp("10.0.0.5", 80)
+    assert inner.connected == ["10.0.0.5"]
+
+
+@pytest.mark.asyncio
+async def test_backend_blocks_metadata_hostname_by_name():
+    inner = _RecordingBackend()
+    backend = ssrf.ValidatingNetworkBackend(inner=inner)
+    with pytest.raises(SSRFBlockedError):
+        await backend.connect_tcp("metadata.google.internal", 80)
+    assert inner.connected == []
+
+
+# --- ssrf_guarded_client ----------------------------------------------------
+
+
+def test_guarded_client_swaps_backend_on_default_pool():
+    client = ssrf.ssrf_guarded_client(timeout=5.0)
+    backend = client._transport._pool._network_backend
+    assert isinstance(backend, ssrf.ValidatingNetworkBackend)
+
+
+def test_guarded_client_metadata_only_flag():
+    client = ssrf.ssrf_guarded_client(timeout=5.0, metadata_only=True)
+    backend = client._transport._pool._network_backend
+    assert backend._metadata_only is True


### PR DESCRIPTION
Fixes #516

## What

The SSRF guard validates a URL by resolving the hostname once, but httpx/httpcore resolve the same hostname AGAIN when opening the connection. With a short-TTL (rebinding) domain the two resolutions differ, so the guard validates one address and the socket connects to another (e.g. 169.254.169.254). Empirically confirmed: one validate+fetch sequence triggers 2 independent getaddrinfo calls for the same host.

## Fix

- New `ValidatingNetworkBackend` in `ssrf.py`: an httpcore network backend that resolves and validates the destination itself at connect time, then connects to one of the validated IP literals. The validated address IS the connected address, so the rebinding window is gone. TLS is unaffected — httpcore still handshakes against the origin hostname (SNI + cert verification); only the TCP endpoint changes.
- New `ssrf_guarded_client()` helper: builds a normal `httpx.AsyncClient` (env-proxy mounts and all httpx defaults intact) and swaps the backend onto the default pool. `metadata_only=True` keeps ordinary private addresses reachable for the `http_request` flavour while still blocking metadata endpoints at connect time.
- Wired into every URL-fetching site: `web_fetch`, `media` image fetch, `http_request`, and skill-dependency downloads (`skills/hub/deps.py`).

## Tests

New `tests/test_security/test_ssrf_rebinding.py` (12 tests): rebinding-to-metadata blocked at connect time, validated public IP is the connected IP, metadata IP literal blocked, metadata_only allows private but not metadata, metadata hostname blocked by name, guarded client swaps the backend.

- `uv run pytest tests/test_security/ tests/test_tools/test_web_http_request.py tests/test_tools/test_web_fetch.py tests/test_tools/test_media_image.py tests/test_skills_hub_download_security.py tests/test_tools/test_credential_egress_guard.py tests/test_tools/test_browser_tool.py -q` → 101 passed
- `uv run ruff check` + `uv run mypy src/agentos` → clean

