### PR TITLE
fix(provider): add OpenCAP x-api-key header and preserve Gemini thought_signature

### DIFF
--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -1375,6 +1375,7 @@ class Agent:
                             block.name,
                             block.input,
                         ),
+                        thought_signature=block.thought_signature,
                     )
                     continue
 
@@ -1399,6 +1400,7 @@ class Agent:
                         id=block.id,
                         name=block.name,
                         input=legacy_projected_input,
+                        thought_signature=block.thought_signature,
                     )
 
         if not replacements:
@@ -2350,6 +2352,7 @@ class Agent:
                                         tool_name=raw_ev.tool_name,
                                         arguments=arguments,
                                         synthetic_from_text=synthetic_from_text,
+                                        thought_signature=raw_ev.thought_signature,
                                     )
                                 )
 
@@ -3182,6 +3185,7 @@ class Agent:
                             id=tc.tool_use_id,
                             name=tc.tool_name,
                             input=tc.arguments,
+                            thought_signature=tc.thought_signature,
                         )
                     )
                 if assistant_content:
@@ -3503,6 +3507,7 @@ class Agent:
                         is_error=projected_result.is_error,
                         arguments=tc.arguments,
                         execution_status=projected_result.execution_status,
+                        thought_signature=tc.thought_signature,
                     )
                     replay_event = router_control_replay_event_from_payload(result.content)
                     if replay_event is not None:
@@ -3521,6 +3526,7 @@ class Agent:
                             arguments=retry_arguments,
                             synthetic_from_text=tc.synthetic_from_text,
                             origin_trace=tc.origin_trace,
+                            thought_signature=tc.thought_signature,
                         )
                         result = await _run_one(retry_call)
                         result_tool_call = retry_call
@@ -3537,6 +3543,7 @@ class Agent:
                             is_error=projected_result.is_error,
                             arguments=retry_arguments,
                             execution_status=projected_result.execution_status,
+                            thought_signature=retry_call.thought_signature,
                         )
                         replay_event = router_control_replay_event_from_payload(result.content)
                         if replay_event is not None:

--- a/src/agentos/engine/history.py
+++ b/src/agentos/engine/history.py
@@ -249,6 +249,7 @@ def reconstruct_messages_from_entry(
                     id=tool_use_id,
                     name=name,
                     input=_coerce_tool_input(seg.get("input")),
+                    thought_signature=seg.get("thought_signature") or seg.get("thoughtSignature"),
                 )
             )
         elif seg_type == "tool_result":

--- a/src/agentos/engine/session_sanitize.py
+++ b/src/agentos/engine/session_sanitize.py
@@ -26,7 +26,7 @@ from agentos.provider.types import ContentBlockDocument, ContentBlockImage
 
 _BLOCK_FIELDS: dict[str, set[str]] = {
     "text": {"type", "text"},
-    "tool_use": {"type", "id", "name", "input"},
+    "tool_use": {"type", "id", "name", "input", "thought_signature", "thoughtSignature"},
     "tool_result": {"type", "tool_use_id", "content", "is_error", "execution_status"},
     "image": {"type", "source_type", "media_type", "data"},
     "document": {"type", "source_type", "media_type", "data", "title"},
@@ -254,7 +254,12 @@ def _project_historical_tool_use(
         changed = True
 
     return (
-        ContentBlockToolUse(id=block.id, name=block.name, input=projected_input),
+        ContentBlockToolUse(
+            id=block.id,
+            name=block.name,
+            input=projected_input,
+            thought_signature=block.thought_signature,
+        ),
         changed,
     )
 

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -365,18 +365,21 @@ class _ToolResultHandler:
         failure_summary = _artifact_delivery_failure_summary(event)
         if failure_summary is not None:
             state.artifact_delivery_failures.append(failure_summary)
-        if event.arguments is not None:
+        if event.arguments is not None or getattr(event, "thought_signature", None) is not None:
             for segment in reversed(state.turn_segments):
                 if (
                     segment.get("type") == "tool_use"
                     and segment.get("tool_use_id") == event.tool_use_id
                 ):
-                    segment["name"] = event.tool_name
-                    segment["input"] = _persisted_tool_use_input(
-                        event.tool_name,
-                        event.tool_use_id,
-                        event.arguments,
-                    )
+                    if event.arguments is not None:
+                        segment["name"] = event.tool_name
+                        segment["input"] = _persisted_tool_use_input(
+                            event.tool_name,
+                            event.tool_use_id,
+                            event.arguments,
+                        )
+                    if getattr(event, "thought_signature", None):
+                        segment["thought_signature"] = event.thought_signature
                     break
         state.turn_segments.append(_persisted_tool_result_segment(event))
         return event

--- a/src/agentos/engine/types.py
+++ b/src/agentos/engine/types.py
@@ -86,6 +86,7 @@ class ToolResultEvent:
     is_error: bool = False
     arguments: dict[str, Any] | None = None
     execution_status: ExecutionStatus | None = None
+    thought_signature: str | None = None
 
 
 @dataclass

--- a/src/agentos/provider/openai.py
+++ b/src/agentos/provider/openai.py
@@ -277,6 +277,22 @@ def _parse_plain_json_tool_call(text: str) -> tuple[str, dict[str, Any]] | None:
     return _parse_trailing_plain_json_tool_call(text)
 
 
+def _extract_thought_signature(tc: Mapping[str, Any]) -> str | None:
+    raw_fn = tc.get("function")
+    function: Mapping[str, Any] = raw_fn if isinstance(raw_fn, Mapping) else {}
+    raw_extra = tc.get("extra_content")
+    extra_content: Mapping[str, Any] = raw_extra if isinstance(raw_extra, Mapping) else {}
+    sig = (
+        tc.get("thought_signature")
+        or tc.get("thoughtSignature")
+        or function.get("thought_signature")
+        or function.get("thoughtSignature")
+        or extra_content.get("thought_signature")
+        or extra_content.get("thoughtSignature")
+    )
+    return str(sig) if sig else None
+
+
 def _coerce_int(value: Any) -> int:
     try:
         return int(value or 0)
@@ -541,6 +557,7 @@ def _build_openai_messages(
     *,
     include_reasoning_content: bool = True,
     require_assistant_reasoning_content: bool = False,
+    provider_kind: str | None = None,
 ) -> list[dict[str, Any]]:
     """Convert a agentos Message into one or more OpenAI-format message dicts.
 
@@ -569,16 +586,20 @@ def _build_openai_messages(
         if block.type == "text":
             parts.append({"type": "text", "text": block.text})
         elif block.type == "tool_use":
-            tool_calls.append(
-                {
-                    "id": block.id,
-                    "type": "function",
-                    "function": {
-                        "name": block.name,
-                        "arguments": json.dumps(block.input),
-                    },
-                }
-            )
+            tool_call_dict: dict[str, Any] = {
+                "id": block.id,
+                "type": "function",
+                "function": {
+                    "name": block.name,
+                    "arguments": json.dumps(block.input),
+                },
+            }
+            thought_sig = getattr(block, "thought_signature", None)
+            if thought_sig:
+                tool_call_dict["thought_signature"] = thought_sig
+            elif provider_kind == "gemini":
+                tool_call_dict["thought_signature"] = "skip_thought_signature_validator"
+            tool_calls.append(tool_call_dict)
         elif block.type == "image":
             if block.source_type == "url":
                 parts.append({"type": "image_url", "image_url": {"url": block.data}})
@@ -751,6 +772,7 @@ class OpenAIProvider:
                     require_assistant_reasoning_content=(
                         _is_direct_deepseek_v4_request(self._provider_kind, self._model)
                     ),
+                    provider_kind=self._provider_kind,
                 )
             )
 
@@ -813,9 +835,7 @@ class OpenAIProvider:
                 payload["reasoning_effort"] = effort
             elif reasoning_format == "deepseek":
                 payload["thinking"] = {"type": "enabled"}
-                payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(
-                    cfg.thinking_level
-                )
+                payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(cfg.thinking_level)
             elif reasoning_format == "gemini":
                 payload["reasoning_effort"] = effort
             elif reasoning_format == "zai":
@@ -840,10 +860,15 @@ class OpenAIProvider:
             payload["thinking"] = {"type": "disabled"}
         elif caps and caps.supports_reasoning and caps.reasoning_format == "dashscope":
             payload["enable_thinking"] = False
-        elif caps and caps.supports_reasoning and caps.reasoning_format in {
-            "moonshot",
-            "volcengine",
-        }:
+        elif (
+            caps
+            and caps.supports_reasoning
+            and caps.reasoning_format
+            in {
+                "moonshot",
+                "volcengine",
+            }
+        ):
             payload["thinking"] = {"type": "disabled"}
         elif (
             self._provider_kind == "openrouter"
@@ -899,6 +924,8 @@ class OpenAIProvider:
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
         }
+        if self._provider_kind in {"opencap", "bankr"}:
+            headers["x-api-key"] = self._api_key
         headers.update(openrouter_app_headers(self._base_url))
         if self._org_id:
             headers["OpenAI-Organization"] = self._org_id
@@ -983,11 +1010,13 @@ class OpenAIProvider:
                         # to keep memory low.
                         _body_text = (
                             body.decode("utf-8", errors="replace")
-                            if isinstance(body, bytes) else str(body)
+                            if isinstance(body, bytes)
+                            else str(body)
                         )
                         try:
                             _payload_head = json.dumps(
-                                payload, ensure_ascii=False,
+                                payload,
+                                ensure_ascii=False,
                             )[:4000]
                         except Exception:  # noqa: BLE001
                             _payload_head = repr(payload)[:4000]
@@ -1085,11 +1114,13 @@ class OpenAIProvider:
                                     provider_kind=self._provider_kind,
                                 )
                                 function = tc.get("function") or {}
+                                thought_sig = _extract_thought_signature(tc)
                                 if idx not in pending_calls:
                                     pending_calls[idx] = {
                                         "id": tc.get("id") or f"call_{uuid4().hex[:12]}",
                                         "name": function.get("name") or "",
                                         "parts": [],
+                                        "thought_signature": thought_sig,
                                     }
                                     emitted_stream_event = True
                                     yield ToolUseStartEvent(
@@ -1103,6 +1134,10 @@ class OpenAIProvider:
                                     fname = function.get("name") or ""
                                     if fname:
                                         pending_calls[idx]["name"] = fname
+                                    if thought_sig and not pending_calls[idx].get(
+                                        "thought_signature"
+                                    ):
+                                        pending_calls[idx]["thought_signature"] = thought_sig
 
                                 fragment = function.get("arguments") or ""
                                 if fragment:
@@ -1136,6 +1171,7 @@ class OpenAIProvider:
                             tool_use_id=call["id"],
                             tool_name=call["name"],
                             arguments=args,
+                            thought_signature=call.get("thought_signature"),
                         )
 
                     # Last-resort MiniMax compatibility: some OpenRouter
@@ -1294,6 +1330,7 @@ class OpenAIProvider:
                 tool_use_id = tc.get("id") or f"call_{uuid4().hex[:12]}"
                 tool_name = function.get("name") or ""
                 arguments_text = function.get("arguments") or ""
+                thought_sig = _extract_thought_signature(tc)
                 emitted_structured_tool = True
                 yield ToolUseStartEvent(tool_use_id=tool_use_id, tool_name=tool_name)
                 if arguments_text:
@@ -1309,6 +1346,7 @@ class OpenAIProvider:
                     tool_use_id=tool_use_id,
                     tool_name=tool_name,
                     arguments=arguments,
+                    thought_signature=thought_sig,
                 )
 
         if not emitted_structured_tool and tools and assistant_text_parts:
@@ -1338,6 +1376,8 @@ class OpenAIProvider:
 
     async def list_models(self) -> list[ModelInfo]:
         headers = {"Authorization": f"Bearer {self._api_key}"}
+        if self._provider_kind in {"opencap", "bankr"}:
+            headers["x-api-key"] = self._api_key
         headers.update(openrouter_app_headers(self._base_url))
         try:
             async with httpx.AsyncClient(

--- a/src/agentos/provider/types.py
+++ b/src/agentos/provider/types.py
@@ -56,6 +56,7 @@ class ToolUseEndEvent:
     tool_name: str = ""
     arguments: dict[str, Any] = field(default_factory=dict)
     synthetic_from_text: bool = False
+    thought_signature: str | None = None
 
 
 @dataclass
@@ -233,6 +234,7 @@ class ContentBlockToolUse(BaseModel):
     id: str
     name: str
     input: dict[str, Any]
+    thought_signature: str | None = None
 
 
 class ContentBlockToolResult(BaseModel):

--- a/src/agentos/tool_boundary.py
+++ b/src/agentos/tool_boundary.py
@@ -19,6 +19,7 @@ class ToolCall:
     # Populated by the agent when available; consulted by tools.dispatch to
     # refuse calls whose origin lies inside an <untrusted> envelope.
     origin_trace: str | None = None
+    thought_signature: str | None = None
 
 
 @dataclass

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -392,12 +392,13 @@ def _collect_events(
     provider: OpenAIProvider,
     cfg: ChatConfig,
     tools: list[ToolDefinition] | None = None,
+    messages: list[Message] | None = None,
 ) -> list[Any]:
     async def _run() -> list[Any]:
         return [
             event
             async for event in provider.chat(
-                [Message(role="user", content="hi")],
+                messages or [Message(role="user", content="hi")],
                 config=cfg,
                 tools=tools,
             )
@@ -1637,3 +1638,212 @@ def test_stream_survives_a_null_function_object_inside_a_tool_call(monkeypatch: 
     assert [(event.tool_use_id, event.tool_name, event.arguments) for event in tool_ends] == [
         ("call_a", "lookup", {"q": "hi"}),
     ]
+
+
+def test_gemini_stream_tool_call_extracts_thought_signature(monkeypatch: Any) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        chunks = [
+            {
+                "model": "gemini-3.5-flash",
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "id": "call_list_dir",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "default_api:list_dir",
+                                        "arguments": '{"DirectoryPath": "/tmp"}',
+                                    },
+                                    "thought_signature": "gemini_encrypted_signature_abc123",
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "model": "gemini-3.5-flash",
+                "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+            },
+        ]
+        body = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=body + b"data: [DONE]\n\n",
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("agentos.provider.openai.httpx.AsyncClient", patched_async_client)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="gemini-3.5-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        provider_kind="gemini",
+    )
+    tool = ToolDefinition(
+        name="default_api:list_dir",
+        description="List dir.",
+        input_schema=ToolInputSchema(
+            properties={"DirectoryPath": {"type": "string"}},
+            required=["DirectoryPath"],
+        ),
+    )
+
+    events = _collect_events(provider, ChatConfig(), tools=[tool])
+
+    tool_end = next(event for event in events if isinstance(event, ToolUseEndEvent))
+    assert tool_end.tool_use_id == "call_list_dir"
+    assert tool_end.tool_name == "default_api:list_dir"
+    assert tool_end.arguments == {"DirectoryPath": "/tmp"}
+    assert tool_end.thought_signature == "gemini_encrypted_signature_abc123"
+
+
+def test_gemini_build_messages_preserves_thought_signature() -> None:
+    from agentos.provider.openai import _build_openai_messages
+
+    msg = Message(
+        role="assistant",
+        content=[
+            ContentBlockToolUse(
+                id="call_list_dir",
+                name="default_api:list_dir",
+                input={"DirectoryPath": "/tmp"},
+                thought_signature="gemini_encrypted_signature_abc123",
+            )
+        ],
+    )
+
+    formatted = _build_openai_messages(msg, provider_kind="gemini")
+    assert len(formatted) == 1
+    assert formatted[0]["role"] == "assistant"
+    tool_calls = formatted[0]["tool_calls"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["id"] == "call_list_dir"
+    assert tool_calls[0]["thought_signature"] == "gemini_encrypted_signature_abc123"
+
+
+def test_gemini_build_messages_synthetic_adds_skip_validator() -> None:
+    from agentos.provider.openai import _build_openai_messages
+
+    msg = Message(
+        role="assistant",
+        content=[
+            ContentBlockToolUse(
+                id="call_list_dir",
+                name="default_api:list_dir",
+                input={"DirectoryPath": "/tmp"},
+                thought_signature=None,
+            )
+        ],
+    )
+
+    formatted = _build_openai_messages(msg, provider_kind="gemini")
+    assert len(formatted) == 1
+    assert formatted[0]["role"] == "assistant"
+    tool_calls = formatted[0]["tool_calls"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["id"] == "call_list_dir"
+    assert tool_calls[0]["thought_signature"] == "skip_thought_signature_validator"
+
+
+def test_gemini_outbound_chat_payload_includes_thought_signature(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+
+    provider = OpenAIProvider(
+        api_key="test",
+        model="gemini-3.5-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        provider_kind="gemini",
+    )
+
+    messages = [
+        Message(role="user", content="List the directory"),
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockToolUse(
+                    id="call_list_dir",
+                    name="default_api:list_dir",
+                    input={"DirectoryPath": "/tmp"},
+                    thought_signature="sig_encrypted_999",
+                )
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call_list_dir",
+                    content='["file1.txt"]',
+                )
+            ],
+        ),
+    ]
+
+    _collect_events(provider, ChatConfig(), messages=messages)
+
+    outbound_messages = captured["payload"]["messages"]
+    assistant_msg = next(m for m in outbound_messages if m["role"] == "assistant")
+    assert assistant_msg["tool_calls"][0]["thought_signature"] == "sig_encrypted_999"
+
+
+def test_stream_consumer_stage_persists_thought_signature_and_history_rebuilds_it() -> None:
+    from agentos.engine.history import reconstruct_messages_from_entry
+    from agentos.engine.turn_runner.stream_consumer_stage import (
+        _StreamState,
+        _ToolResultHandler,
+        _ToolUseStartHandler,
+    )
+    from agentos.engine.types import ToolResultEvent, ToolUseStartEvent
+
+    state = _StreamState()
+    start_handler = _ToolUseStartHandler()
+    result_handler = _ToolResultHandler()
+
+    # 1. ToolUseStart arrives
+    start_handler.handle(
+        ToolUseStartEvent(
+            tool_use_id="call_test_123",
+            tool_name="test_tool",
+        ),
+        state,
+    )
+
+    # 2. ToolResult arrives carrying thought_signature
+    result_handler.handle(
+        ToolResultEvent(
+            tool_use_id="call_test_123",
+            tool_name="test_tool",
+            arguments={"query": "hello"},
+            result="success",
+            thought_signature="gemini_sig_transcript_persist",
+        ),
+        state,
+    )
+
+    # Verify tool_use segment in turn_segments has thought_signature
+    tool_use_seg = next(s for s in state.turn_segments if s.get("type") == "tool_use")
+    assert tool_use_seg["thought_signature"] == "gemini_sig_transcript_persist"
+
+    # Rebuild history from transcript segments
+    messages = reconstruct_messages_from_entry(
+        role="assistant",
+        content="",
+        tool_calls=state.turn_segments,
+    )
+    assert len(messages) >= 1
+    assistant_msg = messages[0]
+    tool_use_block = next(b for b in assistant_msg.content if b.type == "tool_use")
+    assert tool_use_block.thought_signature == "gemini_sig_transcript_persist"

--- a/tests/test_provider_opencap.py
+++ b/tests/test_provider_opencap.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from agentos.gateway.config import (
@@ -20,6 +22,7 @@ from agentos.provider.model_catalog import ModelCatalog
 from agentos.provider.openai import OpenAIProvider
 from agentos.provider.registry import ProviderSpec, get_provider_spec, list_provider_names
 from agentos.provider.selector import ProviderConfig, _build_provider
+from agentos.provider.types import ChatConfig, Message
 
 
 def test_opencap_gateway_is_registered() -> None:
@@ -293,3 +296,116 @@ def test_opencap_deepseek_v4_models_resolve_deepseek_reasoning() -> None:
         caps = catalog.get_capabilities(model, provider_name="opencap")
         assert caps.supports_reasoning is False
         assert caps.reasoning_format == "none"
+
+
+@pytest.mark.asyncio
+async def test_opencap_outbound_stream_request_includes_api_key_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'data: {"choices": [{"delta": {"content": "hello"}}]}\n\ndata: [DONE]\n\n',
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("agentos.provider.openai.httpx.AsyncClient", patched_async_client)
+    provider = OpenAIProvider(
+        api_key="oc_secret_key_123",
+        model="gpt-5.6-luna",
+        base_url="https://gw.capminal.ai/api/inference/v1",
+        provider_kind="opencap",
+    )
+
+    events = []
+    async for event in provider.chat([Message(role="user", content="hi")], config=ChatConfig()):
+        events.append(event)
+
+    headers = captured.get("headers", {})
+    assert headers.get("authorization") == "Bearer oc_secret_key_123"
+    assert headers.get("x-api-key") == "oc_secret_key_123"
+
+
+@pytest.mark.asyncio
+async def test_opencap_list_models_includes_api_key_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "gpt-5.6-luna", "name": "GPT 5.6 Luna"}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("agentos.provider.openai.httpx.AsyncClient", patched_async_client)
+    provider = OpenAIProvider(
+        api_key="oc_secret_key_123",
+        model="gpt-5.6-luna",
+        base_url="https://gw.capminal.ai/api/inference/v1",
+        provider_kind="opencap",
+    )
+
+    models = await provider.list_models()
+    assert len(models) == 1
+    assert models[0].model_id == "gpt-5.6-luna"
+
+    headers = captured.get("headers", {})
+    assert headers.get("authorization") == "Bearer oc_secret_key_123"
+    assert headers.get("x-api-key") == "oc_secret_key_123"
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_outbound_stream_request_omits_x_api_key_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'data: {"choices": [{"delta": {"content": "hello"}}]}\n\ndata: [DONE]\n\n',
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("agentos.provider.openai.httpx.AsyncClient", patched_async_client)
+    provider = OpenAIProvider(
+        api_key="sk-openai-compat-key",
+        model="custom-model",
+        base_url="https://api.example.com/v1",
+        provider_kind="openai_compat",
+    )
+
+    events = []
+    async for event in provider.chat([Message(role="user", content="hi")], config=ChatConfig()):
+        events.append(event)
+
+    headers = captured.get("headers", {})
+    assert headers.get("authorization") == "Bearer sk-openai-compat-key"
+    assert "x-api-key" not in headers


### PR DESCRIPTION
### Summary of Changes

1. **OpenCAP Provider (`HTTP 401: API key required for remote API access`)**:
   - Injected the required `x-api-key` header for outbound chat completions and model listing requests when targeting `opencap` or `bankr` provider kinds.
   - Added unit test coverage in `tests/test_provider_opencap.py`.

2. **Gemini Reasoning Models Tool Calling (`HTTP 400: Function call is missing a thought_signature`)**:
   - Extended `ToolUseEndEvent`, `ContentBlockToolUse`, and `ToolCall` to store `thought_signature`.
   - Extracted `thought_signature` from chunk deltas in `OpenAIProvider._stream` and `_complete_non_stream`.
   - Preserved `thought_signature` across turn loop messages, session sanitization, and history deserialization.
   - Echoed `thought_signature` back in `_build_openai_messages`, defaulting to `"thought_signature": "skip_thought_signature_validator"` when serializing tool calls for Gemini if a signature is absent.
   - Added unit test coverage in `tests/test_provider_openai_compat_payloads.py`.

### Quality Gate Verification
- `uv run ruff check src tests` (Passed)
- `uv run mypy src/agentos/provider src/agentos/engine src/agentos/tool_boundary.py --show-error-codes` (Passed)
- `uv run pytest tests/test_provider_opencap.py tests/test_provider_openai_compat_payloads.py` (69 passed)

Fixes #519

