### PR TITLE
docs(glossary): add MCP Bridge entry

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -59,6 +59,15 @@ stuffing every old transcript into the active prompt.
 
 Read: [`features/memory.md`](features/memory.md)
 
+## MCP Bridge
+
+A stdio server that exposes AgentOS session workflows over the Model Context
+Protocol so MCP-capable clients (such as other local AI tools) can call into
+AgentOS. It is an integration surface — separate from the Web UI, CLI, channels,
+and gateway control console.
+
+Read: [`mcp-server.md`](mcp-server.md)
+
 ## Permission Profile
 
 The chosen tool-access posture for a run, such as `restricted`, `on`, `bypass`,


### PR DESCRIPTION
## Scope

Add a user-facing **MCP Bridge** entry to `docs/glossary.md`. The term
"MCP" appears in nine docs pages and even has a dedicated reference
page at `docs/mcp-server.md`, but the glossary did not define it.

## Files changed

- `docs/glossary.md` — 1 new term block placed alphabetically between
  `Memory` and `Permission Profile` to match the existing order. Wording
  matches `docs/mcp-server.md` and `CHANGELOG.md` so the glossary,
  reference page, and CHANGELOG describe the same integration surface.

## Diff stats

```
 docs/glossary.md | 9 +++++++++
 1 file changed, 9 insertions(+)
```

## Evidence

MCP appears in 9 other docs pages and was missing from the glossary:

```
$ grep -lc 'MCP' docs/*.md docs/features/*.md | grep -v ":0$" | wc -l
10

$ grep -c '## MCP' docs/glossary.md
0  (before this change)
```

Files that mention MCP and now get a glossary entry pointing at the
canonical reference page:

- `docs/README.md`
- `docs/cli.md`
- `docs/configuration.md`
- `docs/features.md`
- `docs/gateway.md`
- `docs/mcp-server.md`
- `docs/operations.md`
- `docs/web-ui.md`
- `docs/features/agentic-trading.md`

Target reference page verified to exist:

```
$ ls docs/mcp-server.md
docs/mcp-server.md
```

Quality gate:

- `git diff --check` — clean (no whitespace errors)
- Link target `docs/mcp-server.md` — exists
- LoC: 9 / 200 budget
- Files: 1 / 6 budget
- Commit subject: `docs(glossary): add MCP Bridge entry`