### PR TITLE
chore(video-merger): enable strict shell mode in install.sh

### DIFF
--- a/src/agentos/skills/bundled/video-merger/install.sh
+++ b/src/agentos/skills/bundled/video-merger/install.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 echo "安装 video-merger 技能依赖..."
 
 # 检查并安装ffmpeg


### PR DESCRIPTION
Every other shell script in this tree (`install.sh`, `scripts/install_source.sh`, `start.sh`, `.github/scripts/*.sh`, `src/.../pptx/scripts/*.sh`, `src/.../tmux/scripts/*.sh`) opens with `set -euo pipefail` so any single failing command exits the run instead of being silently ignored.

`src/agentos/skills/bundled/video-merger/install.sh` was the lone outlier, still relying on a bare `#!/bin/bash` shebang with no shell options.

- Switch shebang from `#!/bin/bash` to `#!/usr/bin/env bash` to match the rest of the repo.
- Add `set -euo pipefail` immediately after the shebang.

The script is user-invoked (`bash install.sh`) and either succeeds or `exit 1`s on the two existing failure paths (missing ffmpeg, missing python3). The explicit `exit 1`s are preserved; `pipefail` only adds protection for any future pipeline that might be added to the script.

Pure hygiene — no behavioral change for the happy path.

Diff: 1 file, +3/-1.