### PR TITLE
refactor(chat): share elevation-mode allowlist with permissions module

### DIFF
--- a/src/agentos/chat/source.py
+++ b/src/agentos/chat/source.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from agentos.permissions import ELEVATED_PERMISSION_MODES
+
 
 def chat_source_metadata(
     *,
@@ -23,6 +25,6 @@ def chat_source_metadata(
         "source_kind": source_kind,
         "source_name": source_name,
     }
-    if elevated in ("on", "bypass", "full"):
+    if elevated in ELEVATED_PERMISSION_MODES:
         source["elevated"] = elevated
     return source

--- a/tests/unit/chat/test_conversation.py
+++ b/tests/unit/chat/test_conversation.py
@@ -36,6 +36,26 @@ def test_web_chat_source_metadata_preserves_allowed_elevation_hint() -> None:
     assert source["elevated"] == "bypass"
 
 
+def test_chat_source_metadata_drops_non_elevated_hint() -> None:
+    """Non-elevated modes (``off``/``restricted``/arbitrary strings) must be stripped.
+
+    The elevation filter anchors on ``agentos.permissions.ELEVATED_PERMISSION_MODES``,
+    so the allowlist stays in lockstep with the rest of the permission posture.
+    """
+    for hint in ("off", "restricted", "turbo", ""):
+        source = chat_source_metadata(
+            caller_kind="web",
+            channel_kind="webchat",
+            channel_id="webchat:webchat:main",
+            sender_id="operator",
+            source_kind="webui",
+            source_name="WebChat",
+            elevated=hint,
+        )
+
+        assert "elevated" not in source
+
+
 def test_chat_send_request_preserves_message_attachments_and_intent() -> None:
     request = ChatSendRequest(
         session_key="webchat:main",


### PR DESCRIPTION
## Scope

`chat_source_metadata` in `src/agentos/chat/source.py` hand-rolled an `("on", "bypass", "full")` tuple to gate which elevation hints are surfaced. That literal duplicates `ELEVATED_PERMISSION_MODES` in `src/agentos/permissions.py`, the canonical source-of-truth frozenset already consumed by `configured_default_elevated` and `normalize_permission_mode`.

Reuse the existing constant so the allowlist stays in lockstep with the rest of the permission posture the next time a mode is added.

## Files changed

- `src/agentos/chat/source.py` (1 import + 1 in-place edit)
- `tests/unit/chat/test_conversation.py` (adds the negative-case coverage that pins the equivalence)

```
 src/agentos/chat/source.py           |  4 +++-
 tests/unit/chat/test_conversation.py | 20 ++++++++++++++++++++
 2 files changed, 23 insertions(+), 1 deletion(-)
```

## Behavior

Unchanged for the current set `{on, bypass, full}`. A new test (`test_chat_source_metadata_drops_non_elevated_hint`) asserts that `off`, `restricted`, an empty string, and an arbitrary unknown mode are all stripped from the emitted source dict — locking in the equivalence between the old literal and the new constant.

## Quality gates (on touched paths only)

- `git diff --check` → clean
- `uv run ruff check src/agentos/chat/source.py tests/unit/chat/test_conversation.py` → All checks passed
- `uv run mypy src/agentos/chat/source.py` → Success: no issues found in 1 source file
- `uv run pytest -q tests/unit/chat/test_conversation.py` → 4 passed

No full-suite runs.