### PR TITLE
fix(provider): raise clear error when failover chain is exhausted

### DIFF
--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -242,13 +242,20 @@ class ModelSelector:
         """
         chain = resolve_failover_chain(primary_failure, self._config, self._plugin)
         if not chain:
-            raise IndexError("No fallback chain available")
+            raise IndexError("No more provider fallbacks available")
         self._chain = [self._chain[0], *chain]
         # Same strict-advance rule as ``next_fallback``: when ``resolve()``
         # already skipped an open primary the active link is 1+, so restarting
         # the search at 1 would re-pick the link this call is failing over from.
+        start = max(1, self._index + 1)
+        if start >= len(self._chain):
+            # The chain is exhausted: the active provider is the last link and
+            # it just failed again. Raise the same clear error as
+            # ``next_fallback`` instead of leaking a bare ``IndexError`` from
+            # indexing past the end of the chain below.
+            raise IndexError("No more provider fallbacks available")
         self._admitted_index = None
-        self._index = self._first_admitted_index(max(1, self._index + 1))
+        self._index = self._first_admitted_index(start)
         return _build_provider(self._chain[self._index])
 
     def override_model(self, model: str) -> None:

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -476,3 +476,52 @@ def test_failover_from_the_primary_still_starts_at_the_first_fallback() -> None:
 
     selector.next_fallback_after_failure(RuntimeError("503"))
     assert selector.active_provider_id == "deepseek"
+
+
+# ── exhausted failover chain ─────────────────────────────────────────
+
+
+def test_next_fallback_after_failure_on_a_single_provider_chain_raises_clear_error() -> None:
+    """A primary-only chain has nothing to fail over to: clear IndexError."""
+    clock = FakeClock()
+    breaker = _breaker(clock)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig("openrouter", "openai/gpt-5.6-luna", api_key="k"),
+        ),
+        breaker=breaker,
+    )
+
+    selector.resolve()
+
+    with pytest.raises(IndexError, match="No more provider fallbacks available"):
+        selector.next_fallback_after_failure(RuntimeError("503"))
+
+
+def test_next_fallback_after_failure_at_the_last_link_raises_clear_error() -> None:
+    """Last link failing again must not leak a bare list-index IndexError."""
+    clock = FakeClock()
+    breaker = _breaker(clock)
+    selector = _three_link_selector(breaker)
+
+    selector.resolve()
+    selector.next_fallback_after_failure(RuntimeError("503"))
+    assert selector.active_provider_id == "deepseek"
+    selector.next_fallback_after_failure(RuntimeError("503"))
+    assert selector.active_provider_id == "anthropic"
+
+    with pytest.raises(IndexError, match="No more provider fallbacks available"):
+        selector.next_fallback_after_failure(RuntimeError("503"))
+
+
+def test_next_fallback_after_failure_from_an_early_link_still_advances() -> None:
+    """The exhaustion guard must not block a legitimate advance."""
+    clock = FakeClock()
+    breaker = _breaker(clock)
+    selector = _three_link_selector(breaker)
+
+    selector.resolve()
+    assert selector.active_provider_id == "openrouter"
+
+    selector.next_fallback_after_failure(RuntimeError("503"))
+    assert selector.active_provider_id == "deepseek"


### PR DESCRIPTION
## Summary

`ModelSelector.next_fallback_after_failure()` advanced the chain index with `self._index + 1` and no upper bound. When the fallback chain was already consumed (the active provider is the last link and it fails again), the call fell through to `_first_admitted_index(start)` with `start >= len(chain)`, which retreated to `start`, and `_build_provider(self._chain[start])` then raised a bare `IndexError: list index out of range` — indistinguishable from the clear `"No more provider fallbacks available"` raised by the sibling `next_fallback()`, and unreadable to callers driving failover from `engine/runtime.py`.

## Changes

- `src/agentos/provider/selector.py`: clamp the advance in `next_fallback_after_failure()` — when `start >= len(self._chain)` the chain is exhausted, so raise `IndexError("No more provider fallbacks available")` to match `next_fallback()`.
- Normalize the empty-plugin-chain message from `"No fallback chain available"` to the same `"No more provider fallbacks available"`, so every exhaustion path surfaces one consistent, catchable error.
- `tests/test_provider_circuit_breaker.py`: new tests covering (1) a single-provider chain raising the clear error, (2) a chain whose index is already at the last link raising the clear error instead of the bare list-index `IndexError`, and (3) a legitimate advance from an early link still working past the new guard.

## Testing

- `tests/test_provider_circuit_breaker.py`: 35 passed (includes the 3 new tests).
- `tests/test_engine/test_selector_fallback_circuit_breaker.py`, `tests/test_engine/test_agent_invalid_provider_response.py`: pass on a clean tree with this change applied.

Fixes use-agent-os/agent-os#488