### PR TITLE
fix(gateway): use constant-time comparison for gateway token

### DIFF
--- a/src/agentos/gateway/audio_transcription.py
+++ b/src/agentos/gateway/audio_transcription.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from agentos.gateway.auth import token_matches
 from agentos.gateway.config import GatewayConfig
 from agentos.gateway.uploads import (
     _MULTIPART_FRAMING_ALLOWANCE,
@@ -94,7 +95,9 @@ def register_audio_transcription_routes(
 
     async def transcribe_handler(request: Request) -> JSONResponse:
         if config.auth.mode == "token":
-            if config.auth.token and _extract_authorization_token(request) != config.auth.token:
+            if config.auth.token and not token_matches(
+                _extract_authorization_token(request), config.auth.token
+            ):
                 return JSONResponse(
                     {
                         "error": (

--- a/src/agentos/gateway/auth.py
+++ b/src/agentos/gateway/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,20 @@ def denied_access(surface: ConnectionSurface = ConnectionSurface.CONTROL) -> Acc
     """Build a fail-closed context for a rejected connection."""
 
     return AccessContext(surface=surface, admitted=False, credential_verified=False)
+
+
+def token_matches(provided: object, configured: str | None) -> bool:
+    """Constant-time check of a caller-supplied token against the secret.
+
+    Fails closed on a missing/empty configured token and on any non-string or
+    missing provided value. Comparison runs on UTF-8 bytes via
+    ``hmac.compare_digest`` so response time does not reveal the secret's
+    matching prefix (#498).
+    """
+
+    if not configured or not isinstance(provided, str) or not provided:
+        return False
+    return hmac.compare_digest(provided.encode("utf-8"), configured.encode("utf-8"))
 
 
 def _surface(value: str | ConnectionSurface | None) -> ConnectionSurface:
@@ -67,8 +82,7 @@ def resolve_auth(
 
     if config.auth.mode == "token":
         provided = (auth_params or {}).get("token")
-        configured = config.auth.token
-        if not configured or provided != configured:
+        if not token_matches(provided, config.auth.token):
             log.warning("auth.failed", mode=config.auth.mode, error="invalid token")
             return None
         return AccessContext(
@@ -96,4 +110,4 @@ def resolve_auth(
     return None
 
 
-__all__ = ["AccessContext", "denied_access", "resolve_auth"]
+__all__ = ["AccessContext", "denied_access", "resolve_auth", "token_matches"]

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -15,6 +15,7 @@ from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.types import ASGIApp
 
 from agentos.gateway.access import is_loopback_address
+from agentos.gateway.auth import token_matches
 from agentos.gateway.config import GatewayConfig
 
 log = structlog.get_logger(__name__)
@@ -243,8 +244,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         if auth_mode == "token":
             token = self._extract_token(request)
-            configured_token = self._config.auth.token
-            if not configured_token or token != configured_token:
+            if not token_matches(token, self._config.auth.token):
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )

--- a/src/agentos/gateway/uploads.py
+++ b/src/agentos/gateway/uploads.py
@@ -39,6 +39,7 @@ from agentos.contracts.attachments import (
     attachment_size_limit_for_mime,
     normalize_attachment_mime,
 )
+from agentos.gateway.auth import token_matches
 from agentos.gateway.config import GatewayConfig
 
 log = logging.getLogger(__name__)
@@ -366,7 +367,9 @@ def register_upload_routes(
 
     async def upload_handler(request: Request) -> JSONResponse:
         if config.auth.mode == "token":
-            if config.auth.token and _extract_authorization_token(request) != config.auth.token:
+            if config.auth.token and not token_matches(
+                _extract_authorization_token(request), config.auth.token
+            ):
                 return JSONResponse(
                     {
                         "error": (

--- a/tests/test_gateway/test_auth_control_access.py
+++ b/tests/test_gateway/test_auth_control_access.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from agentos.gateway.access import ConnectionSurface
-from agentos.gateway.auth import resolve_auth
+from agentos.gateway.auth import resolve_auth, token_matches
 from agentos.gateway.config import AuthConfig, GatewayConfig
 
 
@@ -51,3 +51,31 @@ def test_token_auth_without_configured_token_fails_closed() -> None:
     config = GatewayConfig(auth=AuthConfig(mode="token", token=None))
 
     assert resolve_auth(config, {}, "control", peer_ip="127.0.0.1") is None
+
+
+class TestTokenMatches:
+    """Constant-time token comparison helper (#498)."""
+
+    def test_matching_tokens_pass(self) -> None:
+        assert token_matches("secret", "secret") is True
+
+    def test_mismatched_tokens_fail(self) -> None:
+        assert token_matches("secret", "secreX") is False
+        assert token_matches("secre", "secret") is False
+
+    def test_missing_configured_token_fails_closed(self) -> None:
+        assert token_matches("secret", None) is False
+        assert token_matches("secret", "") is False
+
+    def test_missing_or_empty_provided_token_fails(self) -> None:
+        assert token_matches(None, "secret") is False
+        assert token_matches("", "secret") is False
+
+    def test_non_string_provided_token_fails(self) -> None:
+        assert token_matches(123, "secret") is False
+        assert token_matches(b"secret", "secret") is False
+        assert token_matches(["secret"], "secret") is False
+
+    def test_utf8_tokens_compare_by_bytes(self) -> None:
+        assert token_matches("tökën", "tökën") is True
+        assert token_matches("tökën", "töken") is False


### PR DESCRIPTION
## Summary

Gateway token auth compared the caller-supplied token to the configured secret with `==` / `!=`, which short-circuits on the first differing byte and leaks the matching prefix through response timing. All four gateway token-check sites now go through one shared `token_matches` helper built on `hmac.compare_digest` over UTF-8 bytes, matching the pattern the Slack adapter already uses.

## Changes

- `src/agentos/gateway/auth.py` — new `token_matches(provided, configured)` helper: fails closed on missing/empty configured token and on missing/empty/non-string provided values; compares UTF-8 bytes via `hmac.compare_digest`. `resolve_auth` token mode now uses it.
- `src/agentos/gateway/middleware.py` — `AuthMiddleware.dispatch` token branch uses `token_matches` (fail-closed behavior for unset configured token preserved).
- `src/agentos/gateway/uploads.py` — upload route token check uses `token_matches` (guard semantics unchanged: only checked when a token is configured).
- `src/agentos/gateway/audio_transcription.py` — transcribe route token check uses `token_matches` (same preserved semantics).
- `tests/test_gateway/test_auth_control_access.py` — new `TestTokenMatches` unit tests: match / mismatch / missing / empty / non-string input / UTF-8 byte comparison.

No behavior change to the auth contract; no new dependencies (`hmac` is stdlib).

## Testing

- `pytest tests/test_gateway/test_auth_control_access.py test_auth_mode_enforcement.py test_auth_no_query_token.py test_uploads_endpoint.py test_audio_transcription_route.py test_middleware_ui_exemptions.py` — 79 passed.
- Full `tests/test_gateway/` — 1259 passed; the only 5 failures (`test_router_boot.py`, `test_rpc_doctor.py`) reproduce on pristine `upstream/main` and are pre-existing/unrelated.

Fixes use-agent-os/agent-os#498