### PR TITLE
fix(packaging): cap skill-hub blob download size to prevent OOM

### DIFF
--- a/src/agentos/skills/hub/github.py
+++ b/src/agentos/skills/hub/github.py
@@ -15,6 +15,14 @@ log = structlog.get_logger(__name__)
 
 _GITHUB_HOSTS = {"github.com", "www.github.com"}
 _RAW_GITHUB_HOST = "raw.githubusercontent.com"
+
+# Download caps for blob bodies. A skill bundle is a handful of text files plus
+# the odd asset, so these ceilings sit far above any real skill and far below
+# what it takes to OOM the installer. Without them a hostile repo pointed at
+# ``fetch()`` buffers every blob of the skill directory into RAM unchecked.
+_MAX_BLOB_BYTES = 8 * 1024 * 1024  # per file
+_MAX_TOTAL_BYTES = 32 * 1024 * 1024  # whole skill directory
+_BLOB_READ_CHUNK = 64 * 1024
 _REPO_RE = re.compile(
     r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)"
     r"(?:@(?P<ref>[^:]+))?(?::(?P<path>.+))?$"
@@ -108,6 +116,23 @@ def _parse_identifier(identifier: str) -> _GitHubSkillRef | None:
         match.group("ref") or "HEAD",
         _normalize_skill_path(match.group("path") or ""),
     )
+
+
+async def _read_capped(resp, limit: int) -> bytes | None:
+    """Accumulate a streamed blob body, returning ``None`` past ``limit`` bytes.
+
+    The tree API's ``size`` field is attacker-influenced metadata, so the
+    declared-size check by the caller is only a first filter; this running
+    total is what actually stops a blob that lies about how big it is.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in resp.aiter_bytes(_BLOB_READ_CHUNK):
+        total += len(chunk)
+        if total > limit:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _relative_to_skill_dir(path: str, skill_dir: str) -> str | None:
@@ -265,6 +290,7 @@ class GitHubSource(SkillSource):
                     return None
 
                 files: dict[str, str | bytes] = {}
+                budget = _MAX_TOTAL_BYTES
                 for item in tree_data.get("tree", []):
                     path = str(item.get("path") or "")
                     if item.get("type") != "blob":
@@ -272,13 +298,42 @@ class GitHubSource(SkillSource):
                     rel_path = _relative_to_skill_dir(path, ref.skill_dir)
                     if not rel_path:
                         continue
+                    # First filter on the declared size — attacker-influenced,
+                    # but cheap; the streamed running total below decides.
+                    declared = item.get("size")
+                    if isinstance(declared, int) and declared > _MAX_BLOB_BYTES:
+                        log.warning(
+                            "github.fetch_blob_declared_too_large",
+                            identifier=identifier,
+                            path=rel_path,
+                            size=declared,
+                            limit=_MAX_BLOB_BYTES,
+                        )
+                        return None
                     raw_url = (
                         f"https://raw.githubusercontent.com/{ref.repo_full}/"
                         f"{quote(ref.ref, safe='')}/{quote(path, safe='/')}"
                     )
-                    raw_resp = await client.get(raw_url, headers=self._headers())
-                    raw_resp.raise_for_status()
-                    files[rel_path] = _decode_file(rel_path, raw_resp.content)
+                    # Streamed, not buffered: a plain ``client.get`` reads the
+                    # whole body into ``response.content`` before any cap could
+                    # apply, which is exactly the OOM this guards against.
+                    async with client.stream(
+                        "GET", raw_url, headers=self._headers()
+                    ) as raw_resp:
+                        raw_resp.raise_for_status()
+                        content = await _read_capped(
+                            raw_resp, min(_MAX_BLOB_BYTES, budget)
+                        )
+                    if content is None:
+                        log.warning(
+                            "github.fetch_blob_too_large",
+                            identifier=identifier,
+                            path=rel_path,
+                            limit=_MAX_BLOB_BYTES,
+                        )
+                        return None
+                    budget -= len(content)
+                    files[rel_path] = _decode_file(rel_path, content)
         except Exception as exc:
             log.warning("github.fetch_failed", identifier=identifier, error=str(exc))
             return None

--- a/tests/test_skills_hub_github.py
+++ b/tests/test_skills_hub_github.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
 
+from agentos.skills.hub import github
 from agentos.skills.hub.github import GitHubSource
 
 
@@ -28,6 +30,30 @@ class _Response:
             raise RuntimeError(f"HTTP {self.status_code}")
 
 
+class _StreamResponse:
+    """Stands in for an httpx streaming response, counting chunks handed over."""
+
+    def __init__(self, content: bytes, chunk_size: int = 4096) -> None:
+        self._content = content
+        self._chunk_size = chunk_size
+        self.chunks_yielded = 0
+
+    async def __aenter__(self) -> _StreamResponse:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_bytes(self, chunk_size: int | None = None) -> AsyncIterator[bytes]:
+        step = chunk_size or self._chunk_size
+        for start in range(0, max(len(self._content), 1), step):
+            self.chunks_yielded += 1
+            yield self._content[start : start + step]
+
+
 class _AsyncClient:
     tree_entries = [
         {"path": "skills/demo/SKILL.md", "type": "blob"},
@@ -41,6 +67,7 @@ class _AsyncClient:
         "skills/demo/assets/logo.bin": b"\x00\xff",
     }
     requests: list[tuple[str, dict[str, Any]]] = []
+    streamed: list[_StreamResponse] = []
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
@@ -55,10 +82,16 @@ class _AsyncClient:
         self.requests.append((url, kwargs))
         if "/git/trees/" in url:
             return _Response(json_data={"tree": self.tree_entries, "truncated": False})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    def stream(self, method: str, url: str, **kwargs: Any) -> _StreamResponse:
+        self.requests.append((url, kwargs))
         marker = "raw.githubusercontent.com/acme/skillpack/main/"
         if marker in url:
             rel_path = url.split(marker, 1)[1]
-            return _Response(content=self.raw_payloads[rel_path])
+            resp = _StreamResponse(self.raw_payloads[rel_path])
+            self.streamed.append(resp)
+            return resp
         raise AssertionError(f"unexpected URL: {url}")
 
 
@@ -191,3 +224,128 @@ def test_frontmatter_handles_crlf_line_endings() -> None:
 
     skill_md = "---\r\ndescription: On-chain data\r\n---\r\n# Body\r\n"
     assert _frontmatter_field(skill_md, "description") == "On-chain data"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_a_blob_whose_declared_size_exceeds_the_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tree API's ``size`` field is a cheap first filter before any bytes move."""
+    import httpx
+
+    _AsyncClient.requests = []
+    _AsyncClient.streamed = []
+    _AsyncClient.tree_entries = [
+        {"path": "skills/demo/SKILL.md", "type": "blob", "size": 100},
+        {"path": "skills/demo/big.bin", "type": "blob", "size": github._MAX_BLOB_BYTES + 1},
+    ]
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    try:
+        bundle = await GitHubSource().fetch(
+            "https://github.com/acme/skillpack/tree/main/skills/demo"
+        )
+    finally:
+        _AsyncClient.tree_entries = [
+            {"path": "skills/demo/SKILL.md", "type": "blob"},
+            {"path": "skills/demo/scripts/run.py", "type": "blob"},
+            {"path": "skills/demo/assets/logo.bin", "type": "blob"},
+            {"path": "skills/other/SKILL.md", "type": "blob"},
+        ]
+
+    assert bundle is None
+    # The oversized blob must never be downloaded — only SKILL.md streamed.
+    assert len(_AsyncClient.streamed) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_stops_reading_an_oversized_blob_mid_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blob that lies about its size is stopped by the streamed running total."""
+    import httpx
+
+    monkeypatch.setattr(github, "_MAX_BLOB_BYTES", 4096)
+    _AsyncClient.requests = []
+    _AsyncClient.streamed = []
+    _AsyncClient.tree_entries = [
+        {"path": "skills/demo/SKILL.md", "type": "blob", "size": 60},
+        # Declared small, served huge — only the streaming cap can catch it.
+        {"path": "skills/demo/big.bin", "type": "blob", "size": 10},
+    ]
+    _AsyncClient.raw_payloads["skills/demo/big.bin"] = b"\0" * (64 * 4096)
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    try:
+        bundle = await GitHubSource().fetch(
+            "https://github.com/acme/skillpack/tree/main/skills/demo"
+        )
+    finally:
+        del _AsyncClient.raw_payloads["skills/demo/big.bin"]
+        _AsyncClient.tree_entries = [
+            {"path": "skills/demo/SKILL.md", "type": "blob"},
+            {"path": "skills/demo/scripts/run.py", "type": "blob"},
+            {"path": "skills/demo/assets/logo.bin", "type": "blob"},
+            {"path": "skills/other/SKILL.md", "type": "blob"},
+        ]
+
+    assert bundle is None
+    # The reader stops as soon as the running total crosses the cap — the
+    # first 64 KiB read chunk already dwarfs the 4096-byte limit.
+    assert _AsyncClient.streamed[-1].chunks_yielded == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_enforces_the_total_budget_across_blobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Many individually-legal blobs must not sum past the total budget."""
+    import httpx
+
+    monkeypatch.setattr(github, "_MAX_TOTAL_BYTES", 8 * 1024)
+    _AsyncClient.requests = []
+    _AsyncClient.streamed = []
+    _AsyncClient.tree_entries = [
+        {"path": "skills/demo/SKILL.md", "type": "blob", "size": 60},
+        {"path": "skills/demo/a.bin", "type": "blob", "size": 6 * 1024},
+        {"path": "skills/demo/b.bin", "type": "blob", "size": 6 * 1024},
+    ]
+    _AsyncClient.raw_payloads["skills/demo/a.bin"] = b"a" * (6 * 1024)
+    _AsyncClient.raw_payloads["skills/demo/b.bin"] = b"b" * (6 * 1024)
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    try:
+        bundle = await GitHubSource().fetch(
+            "https://github.com/acme/skillpack/tree/main/skills/demo"
+        )
+    finally:
+        del _AsyncClient.raw_payloads["skills/demo/a.bin"]
+        del _AsyncClient.raw_payloads["skills/demo/b.bin"]
+        _AsyncClient.tree_entries = [
+            {"path": "skills/demo/SKILL.md", "type": "blob"},
+            {"path": "skills/demo/scripts/run.py", "type": "blob"},
+            {"path": "skills/demo/assets/logo.bin", "type": "blob"},
+            {"path": "skills/other/SKILL.md", "type": "blob"},
+        ]
+
+    assert bundle is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_still_downloads_normal_blobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A well-formed skill directory under the caps installs exactly as before."""
+    import httpx
+
+    _AsyncClient.requests = []
+    _AsyncClient.streamed = []
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    bundle = await GitHubSource().fetch(
+        "https://github.com/acme/skillpack/tree/main/skills/demo"
+    )
+
+    assert bundle is not None
+    assert bundle.name == "demo"
+    assert set(bundle.files) == {"SKILL.md", "scripts/run.py", "assets/logo.bin"}
+    assert bundle.files["scripts/run.py"] == "print('demo')\n"
+    assert bundle.files["assets/logo.bin"] == b"\x00\xff"


### PR DESCRIPTION
## Summary

`GitHubSource.fetch()` downloaded every blob of a skill directory with a non-streaming `client.get(...)`, buffering each body fully into RAM with no per-blob cap and no total budget — a hostile repo (reachable via community skill search results / shared links) could OOM the installer. This adds the same class of hardening the ClawHub source already has: named caps, streamed reads, and fail-closed behavior.

## Changes

- New named constants in `src/agentos/skills/hub/github.py`: `_MAX_BLOB_BYTES` (8 MiB per file), `_MAX_TOTAL_BYTES` (32 MiB per skill directory), `_BLOB_READ_CHUNK` (64 KiB read step) — mirroring the ClawHub ceilings.
- First-pass filter on the tree API's declared blob `size` before any bytes move (attacker-influenced, so only a cheap pre-filter).
- Blob downloads now stream via `client.stream(...)` and accumulate through a `_read_capped` helper that stops reading the moment the running total crosses `min(_MAX_BLOB_BYTES, remaining_budget)`; the response is closed by the context manager and `fetch()` fails closed (returns `None` with a warning log) instead of buffering an unbounded body.
- Cumulative total budget decremented per blob so many individually-legal blobs cannot sum past `_MAX_TOTAL_BYTES`.

## Testing

- `tests/test_skills_hub_github.py`: existing fetch tests updated for the streaming path (mock `client.stream`); new tests cover: declared-size rejection before any download, mid-stream cutoff of a blob that lies about its size, the cross-blob total budget, and that a normal skill directory still installs unchanged.
- Full skill-hub suite: 114 passed (`test_skills_hub_github`, `test_skills_hub_clawhub_zip_security`, `test_skills_hub_installer_security`, `test_skills_hub_download_security`, `test_skills_hub_installer_update`, `test_skills_hub_aeon`, `test_skills_hub_bankr`, `test_skills_hub_capminal`).

Fixes use-agent-os/agent-os#510