### PR TITLE
fix: kill entire process tree on Windows upgrade timeout (#536)

### DIFF
--- a/src/agentos/cli/upgrade_cmd.py
+++ b/src/agentos/cli/upgrade_cmd.py
@@ -103,7 +103,14 @@ def _run_upgrade_subprocess(
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
         _kill_process_group(proc)
-        stdout, stderr = proc.communicate()
+        try:
+            stdout, stderr = proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            # The tree is dead, but orphaned grandchildren can keep the
+            # inherited stdout/stderr pipe handles open, so communicate() would
+            # block past the timeout it was supposed to enforce. Don't let a
+            # stuck handle hang the CLI — give up on the streams.
+            stdout, stderr = "", ""
         return UpgradeRunResult(
             ok=False,
             timed_out=True,
@@ -123,7 +130,14 @@ def _run_upgrade_subprocess(
 
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     if os.name == "nt":
-        proc.kill()
+        try:
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                capture_output=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            proc.kill()
         return
     try:
         pgid = os.getpgid(proc.pid)  # type: ignore[attr-defined]

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+import signal
+import subprocess
+import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -306,3 +310,119 @@ def test_upgrade_failure_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(_app(), ["upgrade"])
     assert result.exit_code == 1
     assert "Upgrade failed" in result.stdout
+
+
+# --- _kill_process_group ---------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in: records kills, never exits."""
+
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def poll(self) -> None:
+        return None
+
+
+def test_kill_process_group_windows_kills_whole_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows the timeout kill must terminate the ENTIRE process tree.
+
+    Regression for #536: ``proc.kill()`` (``TerminateProcess``) only kills the
+    direct child, orphaning grandchildren (compilers, downloads) that hold
+    file locks on the virtualenv. ``taskkill /T /F`` terminates the tree.
+    """
+
+    monkeypatch.setattr(upgrade_cmd.os, "name", "nt")
+    calls: list[tuple[Any, Any]] = []
+
+    def fake_run(*args: Any, **kwargs: Any) -> types.SimpleNamespace:
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(upgrade_cmd.subprocess, "run", fake_run)
+    proc = _FakeProc(4242)
+    upgrade_cmd._kill_process_group(proc)
+
+    assert calls, "taskkill must be invoked on Windows"
+    argv = calls[0][0][0]
+    assert argv[:2] == ["taskkill", "/T"], "must kill the whole tree with /T"
+    assert "/F" in argv
+    assert argv[argv.index("/PID") + 1] == "4242"
+    assert calls[0][1]["timeout"] == 5
+    assert proc.killed is False, "fallback kill() must not fire when taskkill succeeds"
+
+
+def test_kill_process_group_windows_falls_back_when_taskkill_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If taskkill itself errors (timeout/OSError), degrade to proc.kill()."""
+
+    monkeypatch.setattr(upgrade_cmd.os, "name", "nt")
+
+    def fake_run(*args: Any, **kwargs: Any) -> types.SimpleNamespace:
+        raise subprocess.TimeoutExpired(cmd="taskkill", timeout=5)
+
+    monkeypatch.setattr(upgrade_cmd.subprocess, "run", fake_run)
+    proc = _FakeProc(4242)
+    upgrade_cmd._kill_process_group(proc)
+    assert proc.killed is True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only code path (os.getpgid/killpg)")
+def test_kill_process_group_unix_still_uses_killpg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POSIX behavior is unchanged: SIGTERM then SIGKILL to the process group."""
+
+    monkeypatch.setattr(upgrade_cmd.os, "name", "posix")
+    monkeypatch.setattr(upgrade_cmd.os, "getpgid", lambda pid: 9999)
+    sent: list[tuple[int, Any]] = []
+    monkeypatch.setattr(upgrade_cmd.os, "killpg", lambda pgid, sig: sent.append((pgid, sig)))
+    proc = _FakeProc(4242)
+    # First SIGTERM lands; fake proc dies instantly so the loop exits before SIGKILL.
+    proc.poll = lambda: 0
+    upgrade_cmd._kill_process_group(proc)
+    assert sent == [(9999, signal.SIGTERM)]
+
+
+# --- _run_upgrade_subprocess timeout path ----------------------------------
+
+
+class _StuckPopen:
+    """Popen stand-in whose communicate() always times out.
+
+    Simulates the #536 regression: after the tree kill, orphaned grandchildren
+    keep the inherited stdout/stderr pipe handles open, so communicate() never
+    returns. The CLI must still give up instead of hanging.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.pid = 4242
+        self.returncode: int | None = None
+
+    def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+        raise subprocess.TimeoutExpired(cmd="uv", timeout=timeout or 0)
+
+
+def test_upgrade_subprocess_windows_guards_stuck_communicate_after_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stuck pipe handle after the kill must not hang the CLI (Windows path)."""
+
+    monkeypatch.setattr(upgrade_cmd.os, "name", "nt")
+    monkeypatch.setattr(upgrade_cmd.subprocess, "Popen", _StuckPopen)
+    killed: list[Any] = []
+    monkeypatch.setattr(upgrade_cmd, "_kill_process_group", lambda p: killed.append(p))
+
+    result = upgrade_cmd._run_upgrade_subprocess(
+        ["uv", "tool", "install", "use-agent-os"], env={}, timeout=1.0
+    )
+
+    assert killed, "_kill_process_group must run on timeout"
+    assert result.timed_out is True
+    assert result.ok is False
+    assert result.stdout == ""
+    assert result.stderr == ""


### PR DESCRIPTION
Fixes #536

**Problem** — On Windows, `_kill_process_group()` in `src/agentos/cli/upgrade_cmd.py` called `proc.kill()` (which wraps `TerminateProcess`). That only terminates the **direct child** process. Any grandchildren spawned by that child (compilers, downloads, python sub-invocations) become orphaned zombie processes that keep running and hold file locks on the virtualenv.

**Fix** — Replace the Windows branch with `taskkill /T /F /PID`, which terminates the **entire process tree**. Falls back to `proc.kill()` only if `taskkill` itself times out or raises `OSError`.

POSIX behavior is unchanged (still `os.killpg` SIGTERM→SIGKILL).

**Verification** — Reproduced and verified on real Windows Python (`C:\Python314\python.exe`, `os.name == nt`) via WSL interop with a controlled process-tree test:
- Before: child killed, grandchild **survived** (zombie leak confirmed)
- After: child **and** grandchild both terminated (fix confirmed)
- Also confirmed `taskkill` on an already-dead PID is a safe no-op (rc=128, no exception)

**Tests** — Added 3 unit tests:
- Windows path invokes `taskkill /T /F /PID` (not bare `proc.kill()`)
- Windows fallback to `proc.kill()` when `taskkill` errors
- POSIX path still uses `os.killpg` (regression guard)