### PR TITLE
feat(channels): email (IMAP/SMTP) channel adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Email channel (`type = "email"`). A mailbox is now a first-class channel:
+  inbound over IMAP polling, outbound over SMTP with `In-Reply-To`/`References`
+  so replies stay in the originating thread. No platform app registration —
+  just IMAP/SMTP credentials. One mail thread is one session, quoted history is
+  stripped before the text reaches the model, HTML-only mail is flattened to
+  text, and inbound attachments plus generated artifacts ride the shared
+  attachment pipeline under the usual size limits. Access is a required
+  fail-closed `allowed_senders` From-address allowlist (exact addresses or
+  `*@domain` patterns); mail from the agent's own address and anything marked
+  auto-generated (`Auto-Submitted`, `X-Autoreply`, `List-Id`,
+  `Precedence: bulk`) is dropped so an autoresponder cannot start a mail loop
+  (#369).
+
+### Changed
+
+- Channel session keys: a DM-shaped channel whose surface is itself threaded
+  can opt into one session per thread with `metadata['dm_thread_scoped']`.
+  Adapters that do not set it keep one session per peer, so Slack, Discord and
+  Telegram DM keys are unchanged.
+
 ### Fixed
 
 - Security: the git tools (`git_status`, `git_diff`, `git_log`, `git_commit`)

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -602,6 +602,28 @@ cron_default_mode = "bypass"            # off | bypass | full
 # transcribe_voice = false
 # max_voice_duration_s = 120
 
+# [[channels.channels]]
+# name = "inbox"
+# type = "email"
+# imap_host = "imap.example.com"
+# imap_port = 993
+# imap_username = "agent@example.com"
+# imap_password = "app-password"
+# imap_folder = "INBOX"
+# smtp_host = "smtp.example.com"
+# smtp_port = 587
+# smtp_starttls = true          # set smtp_ssl = true with port 465 for implicit TLS
+# smtp_username = "agent@example.com"
+# smtp_password = "app-password"
+# from_address = "agent@example.com"
+# from_name = "Agent"
+# Required fail-closed From-address allowlist: exact addresses or *@domain
+# patterns. Mail from anyone else is dropped before it reaches the agent.
+# allowed_senders = ["you@example.com", "*@yourteam.example"]
+# poll_interval_s = 30.0
+# max_messages_per_poll = 10
+# mark_seen = true
+
 # MCP (Model Context Protocol) external servers.
 # [[mcp.servers]]
 # name = "fetch"

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -2,7 +2,7 @@
 
 Channels let AgentOS run from messaging platforms while sharing the same
 agent runtime as the CLI and Web UI. Use channels when you want the same agent
-to answer from Slack, Telegram, or Discord.
+to answer from Slack, Telegram, Discord, or plain email.
 
 ## Supported Channel Types
 
@@ -19,6 +19,7 @@ This build exposes the following channel families:
 | Type | Label | Transport | Public URL needed |
 | --- | --- | --- | :---: |
 | `discord` | Discord | websocket | no |
+| `email` | Email (IMAP/SMTP) | polling | no |
 | `slack` | Slack | mixed | depends on mode |
 | `telegram` | Telegram | mixed | depends on mode |
 
@@ -85,6 +86,74 @@ agentos channels remove <name>
 
 Use `gateway restart` after config changes. Use `channels restart <name>` only
 for an already-loaded live adapter.
+
+## Email (IMAP/SMTP)
+
+The email channel needs no platform app registration — only IMAP and SMTP
+credentials for a mailbox the agent owns. Inbound is IMAP polling; outbound is
+SMTP, with `In-Reply-To`/`References` set so replies land in the originating
+thread.
+
+```sh
+agentos channels add email --name inbox \
+  --field imap_host=imap.example.com \
+  --field imap_username=agent@example.com \
+  --field imap_password=<app-password> \
+  --field smtp_host=smtp.example.com \
+  --field from_address=agent@example.com \
+  --field allowed_senders=you@example.com,*@yourteam.example
+```
+
+Providers with two-factor authentication normally require an app password
+rather than the account password. Set `smtp_ssl=true` (and `smtp_port=465`)
+for implicit TLS; the default is STARTTLS on port 587.
+
+### Access Control
+
+`allowed_senders` is a fail-closed From-address allowlist and is **required** —
+a channel with an empty list is rejected at config load, because an open inbox
+would let anyone who can send mail drive the agent. Entries are exact addresses
+(`you@example.com`) or domain patterns (`*@example.com`, equivalently
+`@example.com`). Mail from any other sender is logged and dropped without ever
+being queued.
+
+The adapter also refuses to answer itself and drops machine-generated mail —
+anything carrying `Auto-Submitted`, `X-Autoreply`, `List-Id`,
+`List-Unsubscribe`, or `Precedence: bulk`. Without that guard an autoresponder
+on the far end and the agent would reply to each other indefinitely.
+
+### Threads and Sessions
+
+One mail thread is one session. The thread identity is the first id in
+`References`, falling back to `In-Reply-To` and then the message's own
+`Message-ID`, so a long back-and-forth keeps its context while a fresh email
+from the same person starts a fresh session.
+
+The thread routing table (which address and subject a reply goes back to) is
+rebuilt from each inbound message and kept in memory only, so a gateway
+restart does not affect replying to live conversations.
+
+Quoted history below a reply is stripped before the text reaches the model, and
+HTML-only mail is flattened to text. Replies are sent as plain text: mail
+clients do not render Markdown, so the agent is told to answer without it.
+
+### Attachments
+
+Inbound attachments are decoded and passed through the shared attachment
+pipeline under the same per-type size limits as every other channel; anything
+over the limit is dropped with a warning rather than truncated. Generated
+artifacts are mailed back into the same thread as attachments. Whole messages
+larger than `max_message_bytes` (25 MB by default) are skipped without being
+downloaded.
+
+### Polling
+
+`poll_interval_s` (default 30) sets how often the mailbox is checked, and
+`max_messages_per_poll` (default 10) bounds one cycle. Handled mail is flagged
+`\Seen`; set `mark_seen=false` to leave the mailbox untouched, at the cost of
+re-reading the same messages on the next poll. There is no IMAP IDLE support —
+a failed poll is logged, surfaces in `agentos channels status`, and the loop
+retries on the next interval.
 
 ## Telegram Account Pairing
 
@@ -222,7 +291,7 @@ underlying agent turn.
 ## Webhook Channels
 
 Slack webhook mode requires a public, provider-reachable URL. Telegram may
-require one depending on mode.
+require one depending on mode. Discord and email need none.
 
 For public channels:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -391,7 +391,7 @@ reachable. See [`x-search.md`](x-search.md).
 
 Channels:
 
-Built-in channel types are `discord`, `slack`, and `telegram`; `agentos
+Built-in channel types are `discord`, `email`, `slack`, and `telegram`; `agentos
 channels types` is the authoritative catalog. On upgrade, config entries for
 retired built-in channel types are removed only after AgentOS creates the
 normal secure config backup.
@@ -402,6 +402,10 @@ agentos channels describe telegram
 agentos channels native-commands telegram
 agentos channels native-commands slack --request-url https://agent.example/slack/events
 agentos channels add telegram --name personal
+agentos channels add email --name inbox \
+  --field imap_host=imap.example.com --field imap_username=agent@example.com \
+  --field imap_password=<app-password> --field smtp_host=smtp.example.com \
+  --field from_address=agent@example.com --field allowed_senders=you@example.com
 agentos channels list
 agentos channels status
 agentos channels pairing list personal

--- a/src/agentos/channels/__init__.py
+++ b/src/agentos/channels/__init__.py
@@ -1,9 +1,10 @@
 """agentos.channels — Channel adapter layer.
 
-Adapters: Terminal, WebSocket, Slack, Discord, Telegram.
+Adapters: Terminal, WebSocket, Slack, Discord, Telegram, Email.
 """
 
 from agentos.channels.discord import DiscordChannel
+from agentos.channels.email import EmailChannel, EmailChannelConfig
 from agentos.channels.manager import ChannelManager
 from agentos.channels.slack import SlackChannel
 from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
@@ -37,4 +38,6 @@ __all__ = [
     "DiscordChannel",
     "TelegramChannel",
     "TelegramChannelConfig",
+    "EmailChannel",
+    "EmailChannelConfig",
 ]

--- a/src/agentos/channels/contract.py
+++ b/src/agentos/channels/contract.py
@@ -22,10 +22,13 @@ from typing import Any
 # Allowed values
 # ---------------------------------------------------------------------------
 
+#: Adapters this build ships and advertises. ``email`` is an open protocol
+#: rather than a vendor SaaS, but it carries the same shared contract.
 PUBLIC_VENDOR_ADAPTERS: tuple[str, ...] = (
     "slack",
     "discord",
     "telegram",
+    "email",
 )
 
 #: Capability tier values declared by adapters via ``CAPABILITY_TIER``.

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -1,0 +1,834 @@
+"""Email (IMAP/SMTP) channel adapter.
+
+Inbound is IMAP polling: every ``poll_interval_s`` the adapter opens a
+short-lived IMAP connection, searches ``UNSEEN`` in ``imap_folder``,
+skips anything oversized or auto-generated, and enqueues the rest.
+Outbound is SMTP — replies carry ``In-Reply-To``/``References`` so mail
+clients keep them in the originating thread.
+
+Threading contract
+------------------
+One email thread is one session. The thread key is the first id in
+``References`` (falling back to ``In-Reply-To``, then the message's own
+``Message-ID``), published as ``metadata['native_thread_id']`` so
+``ChannelManager._build_session_key`` scopes the DM key per thread.
+
+Access control
+--------------
+``allowed_senders`` is a fail-closed From-address allowlist. Entries are
+exact addresses (``me@example.com``) or domain patterns (``*@example.com``
+/ ``@example.com``). It is enforced twice: at poll time, so a stranger's
+mail is never queued, and again through ``evaluate_access`` so gateway
+dispatch reaches the same verdict.
+
+Loop safety
+-----------
+Mail from ``from_address`` itself, and anything carrying
+``Auto-Submitted``/``X-Autoreply``/``Precedence: bulk``/``List-Id``, is
+dropped. Without that an autoresponder on the far end and this adapter
+would answer each other forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import email.utils
+import html
+import imaplib
+import re
+import smtplib
+import ssl
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.header import decode_header, make_header
+from email.message import EmailMessage
+from email.parser import BytesParser
+from email.policy import default as email_policy
+from pathlib import Path
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, Field
+
+from agentos.channels._attachment_io import (
+    attachment_limit_for_mime,
+    ensure_bytes_within_limit,
+)
+from agentos.channels._util import (
+    AccessDecision,
+    ChannelAccessPolicy,
+    EventDedupeCache,
+)
+from agentos.channels.contract import (
+    ChannelCapabilities,
+    ChannelCapabilityProfile,
+    ChannelSendResult,
+)
+from agentos.channels.types import (
+    Attachment,
+    ChannelHealth,
+    IncomingMessage,
+    OutgoingMessage,
+    UnsupportedChannelOperation,
+)
+
+log = structlog.get_logger(__name__)
+
+# Channel-contract constants pinned by the adapter audit.
+CAPABILITY_TIER = "GREEN-shipping"
+
+DM_SAFETY_TIERS: tuple[str, ...] = ("safe", "confirm")
+
+RETRYABLE_ERROR_CLASSES: tuple[str, ...] = (
+    "transport_transient",
+    "rate_limited",
+    "channel_degraded",
+)
+FATAL_ERROR_CLASSES: tuple[str, ...] = (
+    "auth_invalid",
+    "payload_rejected",
+    "target_missing",
+    "contract_violation",
+)
+
+#: Bound on the in-memory thread routing table.
+_MAX_TRACKED_THREADS = 1000
+
+#: Headers that mark a message as machine-generated. Answering one risks a
+#: mail loop, so the adapter drops them before they reach the queue.
+_AUTOMATED_HEADERS: tuple[str, ...] = (
+    "auto-submitted",
+    "x-autoreply",
+    "x-autorespond",
+    "list-id",
+    "list-unsubscribe",
+)
+
+# Deliberately narrow: a marker that can appear in ordinary prose (a bare
+# ``From:`` line) would silently truncate the user's own text. Outlook's
+# quote block is caught by the underscore rule that precedes its header.
+_QUOTE_MARKERS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*-{2,}\s*Original Message\s*-{2,}\s*$", re.I),
+    re.compile(r"^\s*_{5,}\s*$"),
+    re.compile(r"^\s*On .+ wrote:\s*$", re.I),
+)
+
+_HTML_BREAK_RE = re.compile(r"(?i)<\s*(?:br\s*/?|/p|/div|/tr|/li)\s*>")
+_HTML_DROP_RE = re.compile(r"(?is)<\s*(script|style)\b.*?<\s*/\s*\1\s*>")
+_HTML_TAG_RE = re.compile(r"(?s)<[^>]+>")
+
+
+class EmailChannelConfig(BaseModel):
+    """Adapter-level config for the IMAP/SMTP email channel.
+
+    Every field defaults so ``EmailChannel(config=EmailChannelConfig())``
+    stays valid for contract construction; ``start()`` is what refuses an
+    under-configured entry.
+    """
+
+    name: str = "email"
+    imap_host: str = ""
+    imap_port: int = 993
+    imap_ssl: bool = True
+    imap_username: str = ""
+    imap_password: str = ""
+    imap_folder: str = "INBOX"
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_ssl: bool = False
+    smtp_starttls: bool = True
+    smtp_username: str = ""
+    smtp_password: str = ""
+    from_address: str = ""
+    from_name: str = ""
+    allowed_senders: list[str] = Field(default_factory=list)
+    poll_interval_s: float = 30.0
+    max_messages_per_poll: int = 10
+    max_message_bytes: int = 25 * 1024 * 1024
+    mark_seen: bool = True
+    connect_timeout_s: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class _EmailThread:
+    """Outbound routing state for one inbound mail thread."""
+
+    to_address: str
+    subject: str
+    last_message_id: str
+    references: str
+
+
+def normalize_address(value: str) -> str:
+    """Return the bare, lowercased address out of a From/To header value."""
+
+    _, address = email.utils.parseaddr(value or "")
+    return address.strip().lower()
+
+
+def sender_allowed(sender: str, allowlist: list[str] | tuple[str, ...]) -> bool:
+    """Return True when ``sender`` matches the fail-closed allowlist.
+
+    Entries are exact addresses or domain patterns (``*@example.com`` and
+    ``@example.com`` are equivalent). An empty allowlist admits nobody.
+    """
+
+    address = normalize_address(sender) or (sender or "").strip().lower()
+    if not address:
+        return False
+    domain = address.rpartition("@")[2]
+    for raw in allowlist:
+        pattern = (raw or "").strip().lower()
+        if not pattern:
+            continue
+        if pattern.startswith("*@"):
+            pattern = pattern[1:]
+        if pattern.startswith("@"):
+            if domain and domain == pattern[1:]:
+                return True
+            continue
+        if address == pattern:
+            return True
+    return False
+
+
+def decode_header_value(value: str | None) -> str:
+    """Decode an RFC 2047 header into text, degrading to the raw value."""
+
+    if not value:
+        return ""
+    try:
+        return str(make_header(decode_header(value)))
+    except (UnicodeDecodeError, ValueError, LookupError):
+        return str(value)
+
+
+def html_to_text(payload: str) -> str:
+    """Flatten an HTML mail part into readable plain text."""
+
+    without_blocks = _HTML_DROP_RE.sub(" ", payload)
+    with_breaks = _HTML_BREAK_RE.sub("\n", without_blocks)
+    stripped = _HTML_TAG_RE.sub("", with_breaks)
+    text = html.unescape(stripped)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+
+def strip_quoted_reply(body: str) -> str:
+    """Drop the quoted history below a reply so only the new text remains."""
+
+    lines = body.replace("\r\n", "\n").split("\n")
+    kept: list[str] = []
+    for line in lines:
+        if any(marker.match(line) for marker in _QUOTE_MARKERS):
+            break
+        kept.append(line)
+    while kept and kept[-1].startswith(">"):
+        kept.pop()
+    text = "\n".join(kept).strip()
+    # A reply that is nothing but quoted history keeps its original body:
+    # an empty prompt is worse than a noisy one.
+    return text or body.strip()
+
+
+def thread_key_for(parsed: EmailMessage) -> str:
+    """Return the stable thread id for an inbound message."""
+
+    references = (parsed.get("References") or "").split()
+    if references:
+        return references[0].strip().strip("<>")
+    in_reply_to = (parsed.get("In-Reply-To") or "").strip()
+    if in_reply_to:
+        return in_reply_to.strip("<>")
+    return (parsed.get("Message-ID") or "").strip().strip("<>")
+
+
+def is_automated(parsed: EmailMessage) -> bool:
+    """Return True for machine-generated mail that must not be answered."""
+
+    for header in _AUTOMATED_HEADERS:
+        raw = parsed.get(header)
+        if not raw:
+            continue
+        if header == "auto-submitted" and str(raw).strip().lower() == "no":
+            continue
+        return True
+    precedence = str(parsed.get("Precedence") or "").strip().lower()
+    return precedence in {"bulk", "list", "junk", "auto_reply"}
+
+
+def reply_subject(subject: str) -> str:
+    """Return ``subject`` prefixed with ``Re:`` unless it already is one."""
+
+    text = (subject or "").strip() or "(no subject)"
+    return text if text.lower().startswith("re:") else f"Re: {text}"
+
+
+@dataclass
+class EmailChannel:
+    """IMAP/SMTP adapter implementing ``ManagedChannel``.
+
+    Inbound polls IMAP on a background task; outbound sends over SMTP. Both
+    transports are blocking stdlib clients, so every network call is handed
+    to ``asyncio.to_thread`` — the event loop never blocks on mail I/O.
+    """
+
+    config: EmailChannelConfig
+
+    _queue: asyncio.Queue[IncomingMessage] = field(
+        default_factory=asyncio.Queue, init=False, repr=False
+    )
+    _task: asyncio.Task | None = field(default=None, init=False, repr=False)
+    _threads: OrderedDict[str, _EmailThread] = field(
+        default_factory=OrderedDict, init=False, repr=False
+    )
+    _dedupe: EventDedupeCache = field(
+        default_factory=lambda: EventDedupeCache(max_size=10_000),
+        init=False,
+        repr=False,
+    )
+    _connected: bool = field(default=False, init=False, repr=False)
+    _last_message_at: datetime | None = field(default=None, init=False, repr=False)
+    _last_error: str = field(default="", init=False, repr=False)
+
+    # ------------------------------------------------------------------
+    # Capability declaration
+    # ------------------------------------------------------------------
+
+    @property
+    def policy(self) -> ChannelAccessPolicy:
+        """Fail-closed DM-only policy backed by the From-address allowlist."""
+
+        return ChannelAccessPolicy(
+            dm_allowed=True,
+            group_allowed=False,
+            mention_required_in_group=False,
+            allowlist=frozenset(
+                address
+                for address in (a.strip().lower() for a in self.config.allowed_senders)
+                if address
+            ),
+            allowlist_enabled=True,
+        )
+
+    @property
+    def capability_profile(self) -> ChannelCapabilityProfile:
+        return ChannelCapabilityProfile(
+            channel_type="email",
+            threads=True,
+            thread_messages=True,
+            reply=True,
+            thread_reply=True,
+            native_file_upload=True,
+            media=True,
+            artifact_delivery=True,
+            transports=("polling",),
+            notes=(
+                "IMAP polling inbound, SMTP outbound. Mail has no edit, delete, "
+                "reactions, or typing indicator, so those stay unsupported.",
+                "Replies are plain text; Markdown markers would render literally.",
+            ),
+        )
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        return self.capability_profile.capability_tags()
+
+    def evaluate_access(
+        self,
+        message: IncomingMessage,
+        *,
+        is_group: bool,
+        mentioned: bool,
+    ) -> AccessDecision:
+        """Apply the From-address allowlist, including domain patterns."""
+
+        if is_group:
+            return AccessDecision(admit=False, reason="group_denied")
+        if sender_allowed(message.sender_id, self.config.allowed_senders):
+            return AccessDecision(admit=True, reason="dm_admitted")
+        return AccessDecision(admit=False, reason="not_in_allowlist")
+
+    def access_snapshot(self) -> dict[str, Any]:
+        return {
+            "allowed_senders": list(self.config.allowed_senders),
+            "from_address": self.config.from_address,
+            "imap_folder": self.config.imap_folder,
+            "poll_interval_s": self.config.poll_interval_s,
+        }
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _validate_config(self) -> None:
+        missing = [
+            name
+            for name in ("imap_host", "imap_username", "smtp_host", "from_address")
+            if not str(getattr(self.config, name, "") or "").strip()
+        ]
+        if missing:
+            raise ValueError(f"email channel requires {', '.join(missing)}")
+        if not self.config.allowed_senders:
+            raise ValueError(
+                "email channel requires a non-empty allowed_senders allowlist; "
+                "an open inbox would let any stranger drive the agent"
+            )
+        if not self.config.imap_ssl:
+            log.warning("email.imap_plaintext", name=self.config.name)
+        if not (self.config.smtp_ssl or self.config.smtp_starttls):
+            log.warning("email.smtp_plaintext", name=self.config.name)
+
+    async def start(self) -> None:
+        self._validate_config()
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(
+                self._poll_loop(), name=f"email-poll:{self.config.name}"
+            )
+        log.info(
+            "email.started",
+            name=self.config.name,
+            imap_host=self.config.imap_host,
+            folder=self.config.imap_folder,
+            allowed_senders=len(self.config.allowed_senders),
+        )
+
+    async def stop(self) -> None:
+        task, self._task = self._task, None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        self._connected = False
+        log.info("email.stopped", name=self.config.name)
+
+    async def health_check(self) -> ChannelHealth:
+        return ChannelHealth(
+            connected=self._connected,
+            bot_user_id=self.config.from_address or None,
+            last_message_at=self._last_message_at,
+            extra={"last_error": self._last_error} if self._last_error else {},
+        )
+
+    # ------------------------------------------------------------------
+    # Inbound
+    # ------------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        while True:
+            try:
+                messages = await asyncio.to_thread(self._fetch_unseen)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — a bad poll must not kill the loop
+                self._connected = False
+                self._last_error = str(exc)
+                log.warning("email.poll_failed", name=self.config.name, error=str(exc))
+            else:
+                self._connected = True
+                self._last_error = ""
+                for message in messages:
+                    self.enqueue(message)
+            await asyncio.sleep(max(1.0, self.config.poll_interval_s))
+
+    def _imap_connect(self) -> imaplib.IMAP4:
+        timeout = self.config.connect_timeout_s
+        if self.config.imap_ssl:
+            client: imaplib.IMAP4 = imaplib.IMAP4_SSL(
+                self.config.imap_host,
+                self.config.imap_port,
+                ssl_context=ssl.create_default_context(),
+                timeout=timeout,
+            )
+        else:
+            client = imaplib.IMAP4(self.config.imap_host, self.config.imap_port, timeout=timeout)
+        client.login(self.config.imap_username, self.config.imap_password)
+        return client
+
+    def _fetch_unseen(self) -> list[IncomingMessage]:
+        """Blocking IMAP poll — always called through ``asyncio.to_thread``."""
+
+        client = self._imap_connect()
+        try:
+            client.select(self.config.imap_folder)
+            status, data = client.search(None, "UNSEEN")
+            if status != "OK":
+                raise RuntimeError(f"IMAP search failed: {status}")
+            raw_uids = (data[0] or b"").split()[: max(1, self.config.max_messages_per_poll)]
+            uids = [uid.decode("ascii", "ignore") for uid in raw_uids]
+            messages: list[IncomingMessage] = []
+            for uid in uids:
+                try:
+                    parsed = self._fetch_one(client, uid)
+                    if parsed is None:
+                        continue
+                    message = self._to_incoming(parsed)
+                except Exception as exc:  # noqa: BLE001 — one bad mail, not the batch
+                    log.warning("email.message_read_failed", name=self.config.name, error=str(exc))
+                    continue
+                if message is not None:
+                    messages.append(message)
+            return messages
+        finally:
+            with contextlib.suppress(Exception):
+                client.close()
+            with contextlib.suppress(Exception):
+                client.logout()
+
+    def _fetch_one(self, client: imaplib.IMAP4, uid: str) -> EmailMessage | None:
+        """Fetch one message, refusing oversized bodies before downloading them."""
+
+        status, size_data = client.fetch(uid, "(RFC822.SIZE)")
+        if status == "OK" and size_data:
+            declared = _parse_rfc822_size(size_data)
+            if declared is not None and declared > self.config.max_message_bytes:
+                log.warning(
+                    "email.message_too_large",
+                    name=self.config.name,
+                    size=declared,
+                    limit=self.config.max_message_bytes,
+                )
+                self._mark_seen(client, uid)
+                return None
+
+        status, body_data = client.fetch(uid, "(BODY.PEEK[])")
+        if status != "OK":
+            return None
+        raw = _first_literal(body_data)
+        if raw is None:
+            return None
+        if len(raw) > self.config.max_message_bytes:
+            log.warning(
+                "email.message_too_large",
+                name=self.config.name,
+                size=len(raw),
+                limit=self.config.max_message_bytes,
+            )
+            self._mark_seen(client, uid)
+            return None
+
+        self._mark_seen(client, uid)
+        parsed = BytesParser(policy=email_policy).parsebytes(raw)
+        return parsed if isinstance(parsed, EmailMessage) else None
+
+    def _mark_seen(self, client: imaplib.IMAP4, uid: str) -> None:
+        if not self.config.mark_seen:
+            return
+        with contextlib.suppress(Exception):
+            client.store(uid, "+FLAGS", "\\Seen")
+
+    def _to_incoming(self, parsed: EmailMessage) -> IncomingMessage | None:
+        sender = normalize_address(parsed.get("From", ""))
+        if not sender:
+            return None
+        if sender == normalize_address(self.config.from_address):
+            log.debug("email.skipped_self", name=self.config.name)
+            return None
+        if is_automated(parsed):
+            log.info("email.skipped_automated", name=self.config.name, sender=sender)
+            return None
+        if not sender_allowed(sender, self.config.allowed_senders):
+            log.warning("email.sender_not_allowed", name=self.config.name, sender=sender)
+            return None
+
+        thread_id = thread_key_for(parsed)
+        if not thread_id:
+            return None
+        message_id = (parsed.get("Message-ID") or "").strip().strip("<>")
+        subject = decode_header_value(parsed.get("Subject"))
+        body = strip_quoted_reply(_body_text(parsed))
+        reply_to = normalize_address(parsed.get("Reply-To", "")) or sender
+
+        self._remember_thread(
+            thread_id,
+            _EmailThread(
+                to_address=reply_to,
+                subject=subject,
+                last_message_id=message_id,
+                references=_merge_references(parsed, message_id),
+            ),
+        )
+
+        return IncomingMessage(
+            sender_id=sender,
+            channel_id=thread_id,
+            content=body,
+            attachments=self._extract_attachments(parsed),
+            metadata={
+                "is_group": False,
+                "dm_thread_scoped": True,
+                "conversation_kind": "thread",
+                "native_message_id": message_id,
+                "native_chat_id": thread_id,
+                "native_thread_id": thread_id,
+                "reply_target_id": message_id,
+                "subject": subject,
+                "email_from": sender,
+                "email_reply_to": reply_to,
+                "email_to": decode_header_value(parsed.get("To")),
+                "email_date": decode_header_value(parsed.get("Date")),
+            },
+        )
+
+    def _extract_attachments(self, parsed: EmailMessage) -> list[Attachment]:
+        attachments: list[Attachment] = []
+        for part in parsed.iter_attachments():
+            if not isinstance(part, EmailMessage):
+                continue
+            name = part.get_filename() or "attachment"
+            mime = part.get_content_type()
+            payload = part.get_payload(decode=True)
+            if not isinstance(payload, bytes):
+                continue
+            try:
+                data = ensure_bytes_within_limit(
+                    payload,
+                    name=name,
+                    limit=attachment_limit_for_mime(mime),
+                )
+            except ValueError as exc:
+                log.warning(
+                    "email.attachment_rejected",
+                    name=self.config.name,
+                    attachment=name,
+                    error=str(exc),
+                )
+                continue
+            attachments.append(Attachment(name=name, mime_type=mime, data=data, size=len(data)))
+        return attachments
+
+    def _remember_thread(self, thread_id: str, state: _EmailThread) -> None:
+        self._threads[thread_id] = state
+        self._threads.move_to_end(thread_id)
+        while len(self._threads) > _MAX_TRACKED_THREADS:
+            self._threads.popitem(last=False)
+
+    def enqueue(self, message: IncomingMessage) -> None:
+        message_id = str(message.metadata.get("native_message_id") or "")
+        if message_id and not self._dedupe.check_and_add(message_id):
+            return
+        self._queue.put_nowait(message)
+
+    async def receive(self) -> IncomingMessage:
+        message = await self._queue.get()
+        self._last_message_at = datetime.now(UTC)
+        return message
+
+    def is_group_mentioned(self, msg: IncomingMessage) -> bool:
+        # Email has no group surface; every admitted message is addressed to us.
+        return True
+
+    # ------------------------------------------------------------------
+    # Outbound
+    # ------------------------------------------------------------------
+
+    def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
+        metadata: dict[str, Any] = {
+            "to": inbound.metadata.get("email_reply_to") or inbound.sender_id,
+            "subject": reply_subject(str(inbound.metadata.get("subject") or "")),
+            "in_reply_to": inbound.metadata.get("native_message_id") or "",
+        }
+        return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)
+
+    def _resolve_target(self, message: OutgoingMessage) -> tuple[str, str, str, str]:
+        """Return ``(to, subject, in_reply_to, references)`` for an outbound send."""
+
+        thread = self._threads.get((message.reply_to or "").strip())
+        metadata = message.metadata or {}
+        to_address = str(metadata.get("to") or (thread.to_address if thread else ""))
+        if not to_address:
+            raise ValueError("email.send has no recipient for reply_to")
+        subject = str(metadata.get("subject") or "").strip()
+        if not subject:
+            subject = reply_subject(thread.subject if thread else "")
+        in_reply_to = str(metadata.get("in_reply_to") or (thread.last_message_id if thread else ""))
+        references = str(metadata.get("references") or (thread.references if thread else ""))
+        return to_address, subject, in_reply_to, references
+
+    def _compose(
+        self,
+        *,
+        to_address: str,
+        subject: str,
+        body: str,
+        in_reply_to: str,
+        references: str,
+    ) -> EmailMessage:
+        message = EmailMessage()
+        message["From"] = email.utils.formataddr(
+            (self.config.from_name or "", self.config.from_address)
+        )
+        message["To"] = to_address
+        message["Subject"] = subject
+        message["Date"] = email.utils.formatdate(localtime=True)
+        message["Message-ID"] = email.utils.make_msgid()
+        if in_reply_to:
+            message["In-Reply-To"] = f"<{in_reply_to.strip('<>')}>"
+        if references:
+            message["References"] = references
+        message.set_content(body or "")
+        return message
+
+    def _smtp_send(self, message: EmailMessage) -> None:
+        """Blocking SMTP send — always called through ``asyncio.to_thread``."""
+
+        context = ssl.create_default_context()
+        timeout = self.config.connect_timeout_s
+        if self.config.smtp_ssl:
+            server: smtplib.SMTP = smtplib.SMTP_SSL(
+                self.config.smtp_host,
+                self.config.smtp_port,
+                context=context,
+                timeout=timeout,
+            )
+        else:
+            server = smtplib.SMTP(self.config.smtp_host, self.config.smtp_port, timeout=timeout)
+        with server:
+            if not self.config.smtp_ssl and self.config.smtp_starttls:
+                server.starttls(context=context)
+            if self.config.smtp_username:
+                server.login(self.config.smtp_username, self.config.smtp_password)
+            server.send_message(message)
+
+    async def send(self, message: OutgoingMessage) -> None:
+        to_address, subject, in_reply_to, references = self._resolve_target(message)
+        outbound = self._compose(
+            to_address=to_address,
+            subject=subject,
+            body=message.content,
+            in_reply_to=in_reply_to,
+            references=references,
+        )
+        for attachment in message.attachments:
+            if attachment.data:
+                _attach(outbound, attachment.name, attachment.mime_type, attachment.data)
+        await asyncio.to_thread(self._smtp_send, outbound)
+        log.info("email.outbound_sent", name=self.config.name, thread_id=message.reply_to)
+
+    async def send_file(
+        self,
+        thread_id: str,
+        file_path: str,
+        content: str = "",
+    ) -> ChannelSendResult:
+        """Mail one file back into ``thread_id`` as an attachment."""
+
+        path = Path(file_path)
+        try:
+            payload = path.read_bytes()
+            to_address, subject, in_reply_to, references = self._resolve_target(
+                OutgoingMessage(content="", reply_to=thread_id)
+            )
+            outbound = self._compose(
+                to_address=to_address,
+                subject=subject,
+                body=content or f"Attached: {path.name}",
+                in_reply_to=in_reply_to,
+                references=references,
+            )
+            _attach(outbound, path.name, None, payload)
+            await asyncio.to_thread(self._smtp_send, outbound)
+        except (OSError, ValueError, smtplib.SMTPException) as exc:
+            return ChannelSendResult.failed(
+                capability=ChannelCapabilities.NATIVE_FILE_UPLOAD,
+                target_id=thread_id,
+                reason=str(exc),
+                retryable=isinstance(exc, smtplib.SMTPException),
+            )
+        return ChannelSendResult.sent(
+            capability=ChannelCapabilities.NATIVE_FILE_UPLOAD,
+            target_id=thread_id,
+        )
+
+    async def edit(self, message_id: str, content: str) -> None:
+        raise UnsupportedChannelOperation(
+            channel="email",
+            operation="edit",
+            reason="a delivered email cannot be edited",
+        )
+
+    async def delete(self, message_id: str) -> None:
+        raise UnsupportedChannelOperation(
+            channel="email",
+            operation="delete",
+            reason="a delivered email cannot be recalled",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def _attach(message: EmailMessage, name: str, mime_type: str | None, payload: bytes) -> None:
+    maintype, _, subtype = (mime_type or "application/octet-stream").partition("/")
+    message.add_attachment(
+        payload,
+        maintype=maintype or "application",
+        subtype=subtype or "octet-stream",
+        filename=name,
+    )
+
+
+def _body_text(parsed: EmailMessage) -> str:
+    body = parsed.get_body(preferencelist=("plain", "html"))
+    if body is None:
+        return ""
+    try:
+        content = body.get_content()
+    except (LookupError, UnicodeDecodeError):
+        raw = body.get_payload(decode=True)
+        content = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else ""
+    if not isinstance(content, str):
+        return ""
+    if body.get_content_type() == "text/html":
+        return html_to_text(content)
+    return content.strip()
+
+
+def _merge_references(parsed: EmailMessage, message_id: str) -> str:
+    existing = (parsed.get("References") or "").split()
+    if message_id:
+        existing.append(f"<{message_id}>")
+    return " ".join(dict.fromkeys(existing))
+
+
+def _first_literal(data: Any) -> bytes | None:
+    """Pull the raw RFC822 payload out of an ``imaplib`` FETCH response."""
+
+    for item in data or []:
+        if isinstance(item, tuple) and len(item) >= 2 and isinstance(item[1], (bytes, bytearray)):
+            return bytes(item[1])
+    return None
+
+
+def _parse_rfc822_size(data: Any) -> int | None:
+    for item in data or []:
+        raw = item[0] if isinstance(item, tuple) and item else item
+        if isinstance(raw, (bytes, bytearray)):
+            raw = bytes(raw).decode("ascii", "replace")
+        if not isinstance(raw, str):
+            continue
+        match = re.search(r"RFC822\.SIZE\s+(\d+)", raw)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+__all__ = [
+    "CAPABILITY_TIER",
+    "DM_SAFETY_TIERS",
+    "FATAL_ERROR_CLASSES",
+    "RETRYABLE_ERROR_CLASSES",
+    "EmailChannel",
+    "EmailChannelConfig",
+    "decode_header_value",
+    "html_to_text",
+    "is_automated",
+    "normalize_address",
+    "reply_subject",
+    "sender_allowed",
+    "strip_quoted_reply",
+    "thread_key_for",
+]

--- a/src/agentos/channels/manager.py
+++ b/src/agentos/channels/manager.py
@@ -486,7 +486,9 @@ class ChannelManager:
         - Slack: ``metadata.channel_type in ("channel", "group")``
 
         Group keys use ``msg.channel_id`` as peer_id (per-room session).
-        DM keys use ``msg.sender_id`` as peer_id (per-user session).
+        DM keys use ``msg.sender_id`` as peer_id (per-user session), plus a
+        ``:thread:`` suffix when the adapter opts in with
+        ``metadata['dm_thread_scoped']``.
         """
         meta = getattr(msg, "metadata", {}) or {}
         flag = meta.get("is_group")
@@ -513,9 +515,17 @@ class ChannelManager:
                 return build_thread_key(base_key, thread_id, channel_hint=channel_name)
             return base_key
 
-        return build_direct_key(
+        direct_key = build_direct_key(
             agent_id=agent_id,
             channel=channel_name,
             peer_id=msg.sender_id,
             dm_scope=DmScope.PER_CHANNEL_PEER,
         )
+        # A DM surface can still be threaded — one email peer holds many
+        # independent threads. Opt-in only: an adapter asks for per-thread DM
+        # sessions with ``metadata['dm_thread_scoped']``, so chat adapters that
+        # happen to carry a thread id on a DM keep their per-peer session.
+        dm_thread_id = meta.get("native_thread_id")
+        if meta.get("dm_thread_scoped") and isinstance(dm_thread_id, str) and dm_thread_id:
+            return build_thread_key(direct_key, dm_thread_id, channel_hint=channel_name)
+        return direct_key

--- a/src/agentos/channels/registry.py
+++ b/src/agentos/channels/registry.py
@@ -32,6 +32,7 @@ _PLAIN_TEXT_MARKDOWN_HINT = (
     "the user explicitly asks for raw Markdown."
 )
 _MARKDOWN_RENDER_HINTS = {
+    "email": _PLAIN_TEXT_MARKDOWN_HINT,
     "whatsapp": _PLAIN_TEXT_MARKDOWN_HINT,
     "signal": _PLAIN_TEXT_MARKDOWN_HINT,
     "sms": _PLAIN_TEXT_MARKDOWN_HINT,

--- a/src/agentos/channels/types.py
+++ b/src/agentos/channels/types.py
@@ -50,6 +50,11 @@ class IncomingMessage(BaseModel):
     - ``interaction_type``: explicit native interaction kind, such as
       ``slash_command``.
     - ``is_group``: bool consumed by ``ChannelManager`` for session keys.
+    - ``dm_thread_scoped``: bool opt-in for adapters whose DM surface is
+      itself threaded (email). When true, ``ChannelManager`` appends
+      ``native_thread_id`` to the DM session key so each thread is its own
+      session. Adapters that merely carry a thread id on a DM leave it unset
+      and keep one session per peer.
     """
 
     sender_id: str

--- a/src/agentos/dist/workspace_state.py
+++ b/src/agentos/dist/workspace_state.py
@@ -47,6 +47,7 @@ SCHEMA_VERSION = 1
 # are intentionally excluded — they are infra, not channels.
 BUNDLED_CHANNELS: tuple[str, ...] = (
     "discord",
+    "email",
     "slack",
     "telegram",
     "terminal",

--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -499,7 +499,15 @@ _MUTATING_TOOL_NAMES = frozenset({"write_file", "edit_file", "apply_patch"})
 _COMMAND_TOOL_NAMES = frozenset({"exec_command", "execute_code", "background_process"})
 # Sessions whose surface is a person in a chat rather than a checkout. There is
 # usually no test command to run there, so the verification nudge is withheld.
-_MESSAGING_SESSION_MARKERS = ("telegram", "slack", "discord", "msteams", "whatsapp", "signal")
+_MESSAGING_SESSION_MARKERS = (
+    "telegram",
+    "slack",
+    "discord",
+    "msteams",
+    "email",
+    "whatsapp",
+    "signal",
+)
 
 
 def _mutated_paths(arguments: dict[str, Any]) -> list[str]:

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -1667,6 +1667,49 @@ class MSTeamsChannelEntry(ConfiguredChannelEntry):
     webhook_path: str = "/msteams/messages"
 
 
+class EmailChannelEntry(ConfiguredChannelEntry):
+    """Gateway config entry for an IMAP/SMTP email channel."""
+
+    type: Literal["email"] = "email"
+    imap_host: str
+    imap_port: int = Field(default=993, ge=1, le=65535)
+    imap_ssl: bool = True
+    imap_username: str
+    imap_password: str = ""
+    imap_folder: str = "INBOX"
+    smtp_host: str
+    smtp_port: int = Field(default=587, ge=1, le=65535)
+    smtp_ssl: bool = False
+    smtp_starttls: bool = True
+    smtp_username: str = ""
+    smtp_password: str = ""
+    from_address: str
+    from_name: str = ""
+    allowed_senders: list[str] = Field(default_factory=list)
+    poll_interval_s: float = Field(default=30.0, ge=1.0, le=3600.0)
+    max_messages_per_poll: int = Field(default=10, ge=1, le=200)
+    max_message_bytes: int = Field(default=25 * 1024 * 1024, ge=1024)
+    mark_seen: bool = True
+    connect_timeout_s: float = Field(default=30.0, ge=1.0, le=300.0)
+
+    @field_validator("allowed_senders", mode="before")
+    @classmethod
+    def _normalize_allowed_senders(cls, value: Any) -> list[str]:
+        values = value.split(",") if isinstance(value, str) else (value or [])
+        normalized = (str(item).strip().lower() for item in values)
+        return list(dict.fromkeys(item for item in normalized if item))
+
+    @model_validator(mode="after")
+    def _validate_email_entry(self) -> EmailChannelEntry:
+        # Fail closed: an inbox with no allowlist would let any stranger who
+        # can send mail drive the agent.
+        if not self.allowed_senders:
+            raise ValueError("email channels require at least one allowed_senders entry")
+        if "@" not in self.from_address:
+            raise ValueError("email from_address must be a full address")
+        return self
+
+
 class TelegramChannelEntry(ConfiguredChannelEntry):
     """Gateway config entry for a Telegram Bot API channel."""
 

--- a/src/agentos/onboarding/channel_specs.py
+++ b/src/agentos/onboarding/channel_specs.py
@@ -158,6 +158,75 @@ def _msteams_spec() -> ChannelSetupSpec:
     )
 
 
+def _email_spec() -> ChannelSetupSpec:
+    return ChannelSetupSpec(
+        type="email",
+        label="Email",
+        description="Email via IMAP polling (inbound) and SMTP (outbound).",
+        transport="polling",
+        requires_public_url=False,
+        dependency_extra=None,
+        restart_required=True,
+        docs_hint="https://support.google.com/mail/answer/7126229",
+        help=(
+            "Needs no platform app registration - only IMAP and SMTP credentials. "
+            "allowed_senders is a fail-closed From-address allowlist: exact "
+            "addresses or domain patterns (*@example.com). One mail thread is one "
+            "session. Providers with 2FA usually require an app password."
+        ),
+        fields=(
+            *_common_fields(),
+            ChannelSetupField("imap_host", "IMAP host", "text", required=True,
+                              group="inbound", placeholder="imap.gmail.com"),
+            ChannelSetupField("imap_port", "IMAP port", "int", required=False,
+                              default=993, group="inbound"),
+            ChannelSetupField("imap_ssl", "IMAP SSL", "bool", required=False,
+                              default=True, group="inbound"),
+            ChannelSetupField("imap_username", "IMAP username", "text",
+                              required=True, group="inbound"),
+            ChannelSetupField("imap_password", "IMAP password", "password",
+                              required=True, secret=True, group="credentials"),
+            ChannelSetupField("imap_folder", "IMAP folder", "text", required=False,
+                              default="INBOX", group="inbound"),
+            ChannelSetupField("smtp_host", "SMTP host", "text", required=True,
+                              group="outbound", placeholder="smtp.gmail.com"),
+            ChannelSetupField("smtp_port", "SMTP port", "int", required=False,
+                              default=587, group="outbound"),
+            ChannelSetupField("smtp_ssl", "SMTP implicit TLS", "bool", required=False,
+                              default=False, group="outbound",
+                              description="Use SMTPS (usually port 465) instead of STARTTLS."),
+            ChannelSetupField("smtp_starttls", "SMTP STARTTLS", "bool", required=False,
+                              default=True, group="outbound"),
+            ChannelSetupField("smtp_username", "SMTP username", "text", required=False,
+                              default="", group="outbound",
+                              description="Defaults to unauthenticated relay when empty."),
+            ChannelSetupField("smtp_password", "SMTP password", "password",
+                              required=False, secret=True, default="",
+                              group="credentials"),
+            ChannelSetupField("from_address", "From address", "text", required=True,
+                              placeholder="agent@example.com"),
+            ChannelSetupField("from_name", "From display name", "text",
+                              required=False, default=""),
+            ChannelSetupField("allowed_senders", "Allowed senders", "text",
+                              required=True,
+                              description="Comma-separated From addresses or domain "
+                              "patterns (*@example.com). Mail from anyone else is "
+                              "dropped."),
+            ChannelSetupField("poll_interval_s", "Poll interval (s)", "float",
+                              required=False, default=30.0, group="polling"),
+            ChannelSetupField("max_messages_per_poll", "Max messages per poll", "int",
+                              required=False, default=10, group="polling"),
+            ChannelSetupField("max_message_bytes", "Max message bytes", "int",
+                              required=False, default=25 * 1024 * 1024,
+                              advanced=True, group="polling"),
+            ChannelSetupField("mark_seen", "Mark handled mail as seen", "bool",
+                              required=False, default=True, group="polling"),
+            ChannelSetupField("connect_timeout_s", "Connect timeout (s)", "float",
+                              required=False, default=30.0, advanced=True),
+        ),
+    )
+
+
 def _telegram_spec() -> ChannelSetupSpec:
     return ChannelSetupSpec(
         type="telegram",
@@ -219,6 +288,7 @@ def _telegram_spec() -> ChannelSetupSpec:
 
 _BUILDERS = {
     "discord": _discord_spec,
+    "email": _email_spec,
     # msteams is intentionally absent: the adapter is text-only and hidden
     # from runtime catalog surfaces until first-class support lands. The
     # _msteams_spec helper is retained for future restoration.

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -145,8 +145,8 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `mcp-server` | `run` (MCP bridge) |
 | `replay`, `dist`, `onboard` | replay recorded turns / workspace inventory / setup status |
 
-Built-in channel types are `discord`, `slack`, and `telegram`; use `agentos
-channels types` as the authoritative catalog. Config migration backs up the
+Built-in channel types are `discord`, `email`, `slack`, and `telegram`; use
+`agentos channels types` as the authoritative catalog. Config migration backs up the
 file before removing entries for retired built-in channel types.
 
 Telegram direct messages always require pairing. Use `agentos channels pairing
@@ -154,6 +154,11 @@ list <name>`, `approve <name> <code>`, `deny <name> <sender-id>`, or `revoke
 <name> <sender-id>`. Pairing is binary and has no admin/owner tier. Telegram
 groups are disabled by default; enable them only with explicit
 `group_chat_ids`, paired senders, and the desired mention requirement.
+
+The `email` channel is IMAP polling in, SMTP out, and needs no platform app
+registration. `allowed_senders` is a required fail-closed From-address
+allowlist (exact addresses or `*@domain` patterns); one mail thread is one
+session.
 
 Platform-native interactive tool approvals (Slack block actions, Telegram inline keyboard callbacks, and Discord message components) allow operators to approve or deny gated tool executions directly using interactive buttons. For security, these approvals are restricted to channel DMs (never group chats), access-gated by evaluating the clicker's sender ID against the channel's access policy, and strictly session-bound to their originating chat context.
 

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -1,0 +1,536 @@
+"""Contract and behavior tests for the IMAP/SMTP email channel adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from email.message import EmailMessage
+from email.parser import BytesParser
+from email.policy import default as email_policy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.channels import email as email_module
+from agentos.channels.contract import ChannelSendStatus, run_channel_contract
+from agentos.channels.email import (
+    EmailChannel,
+    EmailChannelConfig,
+    html_to_text,
+    is_automated,
+    normalize_address,
+    reply_subject,
+    sender_allowed,
+    strip_quoted_reply,
+    thread_key_for,
+)
+from agentos.channels.manager import ChannelManager
+from agentos.channels.registry import discover_all, markdown_render_hint_for, parse_channel_entry
+from agentos.channels.types import IncomingMessage, OutgoingMessage, UnsupportedChannelOperation
+
+
+def _config(**overrides: Any) -> EmailChannelConfig:
+    base: dict[str, Any] = {
+        "name": "inbox",
+        "imap_host": "imap.example.com",
+        "imap_username": "agent@example.com",
+        "imap_password": "secret",
+        "smtp_host": "smtp.example.com",
+        "smtp_username": "agent@example.com",
+        "smtp_password": "secret",
+        "from_address": "agent@example.com",
+        "from_name": "Agent",
+        "allowed_senders": ["owner@example.com", "*@team.example"],
+    }
+    base.update(overrides)
+    return EmailChannelConfig(**base)
+
+
+def _raw(
+    *,
+    sender: str = "owner@example.com",
+    subject: str = "Status?",
+    body: str = "hello there",
+    message_id: str = "m1@example.com",
+    extra_headers: dict[str, str] | None = None,
+    subtype: str = "plain",
+) -> EmailMessage:
+    message = EmailMessage()
+    message["From"] = sender
+    message["To"] = "agent@example.com"
+    message["Subject"] = subject
+    message["Message-ID"] = f"<{message_id}>"
+    for key, value in (extra_headers or {}).items():
+        message[key] = value
+    message.set_content(body, subtype=subtype)
+    parsed = BytesParser(policy=email_policy).parsebytes(message.as_bytes())
+    assert isinstance(parsed, EmailMessage)
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Shared channel contract
+# ---------------------------------------------------------------------------
+
+
+def test_email_adapter_keeps_shared_channel_contract() -> None:
+    run_channel_contract(email_module)
+
+
+def test_email_is_discoverable_and_flagged_as_plain_text() -> None:
+    assert "email" in discover_all()
+    assert markdown_render_hint_for("email")
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("sender", "expected"),
+    [
+        ("owner@example.com", True),
+        ("Owner@Example.com", True),
+        ("Owner <owner@example.com>", True),
+        ("anyone@team.example", True),
+        ("stranger@elsewhere.com", False),
+        ("owner@example.com.evil.com", False),
+        ("", False),
+    ],
+)
+def test_sender_allowlist_matches_addresses_and_domain_patterns(
+    sender: str, expected: bool
+) -> None:
+    assert sender_allowed(sender, ["owner@example.com", "*@team.example"]) is expected
+
+
+def test_empty_allowlist_admits_nobody() -> None:
+    assert sender_allowed("owner@example.com", []) is False
+
+
+def test_evaluate_access_denies_unknown_sender_and_any_group() -> None:
+    channel = EmailChannel(config=_config())
+    inbound = IncomingMessage(sender_id="stranger@elsewhere.com", channel_id="t1", content="hi")
+
+    denied = channel.evaluate_access(inbound, is_group=False, mentioned=True)
+    assert denied.admit is False
+    assert denied.reason == "not_in_allowlist"
+
+    admitted = channel.evaluate_access(
+        IncomingMessage(sender_id="owner@example.com", channel_id="t1", content="hi"),
+        is_group=False,
+        mentioned=True,
+    )
+    assert admitted.admit is True
+
+    grouped = channel.evaluate_access(inbound, is_group=True, mentioned=True)
+    assert grouped.admit is False
+    assert grouped.reason == "group_denied"
+
+
+async def test_start_refuses_an_inbox_with_no_allowlist() -> None:
+    channel = EmailChannel(config=_config(allowed_senders=[]))
+
+    with pytest.raises(ValueError, match="allowed_senders"):
+        await channel.start()
+
+
+def test_config_entry_requires_allowlist_and_full_from_address() -> None:
+    payload: dict[str, Any] = {
+        "type": "email",
+        "name": "inbox",
+        "imap_host": "imap.example.com",
+        "imap_username": "agent@example.com",
+        "smtp_host": "smtp.example.com",
+        "from_address": "agent@example.com",
+    }
+
+    with pytest.raises(ValueError, match="allowed_senders"):
+        parse_channel_entry(payload)
+
+    with pytest.raises(ValueError, match="from_address"):
+        parse_channel_entry(
+            {**payload, "allowed_senders": "owner@example.com", "from_address": "agent"}
+        )
+
+    entry = parse_channel_entry(
+        {**payload, "allowed_senders": "Owner@Example.com, owner@example.com"}
+    )
+    assert entry.allowed_senders == ["owner@example.com"]
+
+
+# ---------------------------------------------------------------------------
+# Inbound parsing
+# ---------------------------------------------------------------------------
+
+
+def test_inbound_message_maps_thread_sender_and_body() -> None:
+    channel = EmailChannel(config=_config())
+
+    message = channel._to_incoming(_raw())
+
+    assert message is not None
+    assert message.sender_id == "owner@example.com"
+    assert message.channel_id == "m1@example.com"
+    assert message.content == "hello there"
+    assert message.metadata["is_group"] is False
+    assert message.metadata["native_thread_id"] == "m1@example.com"
+    assert message.metadata["subject"] == "Status?"
+
+
+def test_thread_key_follows_the_references_root() -> None:
+    parsed = _raw(
+        message_id="m3@example.com",
+        extra_headers={
+            "References": "<root@example.com> <m2@example.com>",
+            "In-Reply-To": "<m2@example.com>",
+        },
+    )
+
+    assert thread_key_for(parsed) == "root@example.com"
+
+
+def test_reply_without_references_falls_back_to_in_reply_to() -> None:
+    parsed = _raw(message_id="m2@example.com", extra_headers={"In-Reply-To": "<root@example.com>"})
+
+    assert thread_key_for(parsed) == "root@example.com"
+
+
+def test_messages_from_strangers_self_and_autoresponders_are_dropped() -> None:
+    channel = EmailChannel(config=_config())
+
+    assert channel._to_incoming(_raw(sender="stranger@elsewhere.com")) is None
+    assert channel._to_incoming(_raw(sender="agent@example.com")) is None
+    assert channel._to_incoming(_raw(extra_headers={"Auto-Submitted": "auto-replied"})) is None
+    assert channel._to_incoming(_raw(extra_headers={"List-Id": "<news.example.com>"})) is None
+    assert channel._to_incoming(_raw(extra_headers={"Precedence": "bulk"})) is None
+
+
+def test_auto_submitted_no_is_not_treated_as_automated() -> None:
+    assert is_automated(_raw(extra_headers={"Auto-Submitted": "no"})) is False
+
+
+def test_html_bodies_are_flattened_to_text() -> None:
+    channel = EmailChannel(config=_config())
+
+    message = channel._to_incoming(
+        _raw(body="<div>Hi <b>there</b></div><script>bad()</script>", subtype="html")
+    )
+
+    assert message is not None
+    assert message.content == "Hi there"
+
+
+def test_html_to_text_drops_styles_and_unescapes_entities() -> None:
+    assert html_to_text("<style>a{}</style><p>a &amp; b</p><p>c</p>") == "a & b\nc"
+
+
+def test_quoted_history_is_stripped_from_replies() -> None:
+    body = "My answer\n\nOn Mon, someone wrote:\n> earlier question"
+
+    assert strip_quoted_reply(body) == "My answer"
+
+
+def test_a_body_that_is_only_quoted_history_is_kept() -> None:
+    body = "On Mon, someone wrote:\n> earlier question"
+
+    assert strip_quoted_reply(body) == body
+
+
+def test_attachments_are_carried_through_and_oversized_ones_dropped() -> None:
+    channel = EmailChannel(config=_config())
+    message = EmailMessage()
+    message["From"] = "owner@example.com"
+    message["Subject"] = "files"
+    message["Message-ID"] = "<m9@example.com>"
+    message.set_content("see attached")
+    message.add_attachment(b"small", maintype="text", subtype="plain", filename="ok.txt")
+    message.add_attachment(
+        b"x" * (60 * 1024 * 1024), maintype="application", subtype="pdf", filename="huge.pdf"
+    )
+    parsed = BytesParser(policy=email_policy).parsebytes(message.as_bytes())
+
+    inbound = channel._to_incoming(parsed)
+
+    assert inbound is not None
+    assert [a.name for a in inbound.attachments] == ["ok.txt"]
+    assert inbound.attachments[0].data == b"small"
+
+
+def test_enqueue_dedupes_on_message_id() -> None:
+    channel = EmailChannel(config=_config())
+    first = channel._to_incoming(_raw())
+    duplicate = channel._to_incoming(_raw())
+    assert first is not None and duplicate is not None
+
+    channel.enqueue(first)
+    channel.enqueue(duplicate)
+
+    assert channel._queue.qsize() == 1
+
+
+# ---------------------------------------------------------------------------
+# Outbound
+# ---------------------------------------------------------------------------
+
+
+def test_reply_targets_the_thread_and_quotes_the_subject() -> None:
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(_raw())
+    assert inbound is not None
+
+    reply = channel.build_reply_message("done", inbound)
+
+    assert reply.reply_to == "m1@example.com"
+    assert reply.metadata["to"] == "owner@example.com"
+    assert reply.metadata["subject"] == "Re: Status?"
+    assert reply.metadata["in_reply_to"] == "m1@example.com"
+
+
+def test_reply_subject_is_not_double_prefixed() -> None:
+    assert reply_subject("Re: Status?") == "Re: Status?"
+    assert reply_subject("") == "Re: (no subject)"
+
+
+async def test_send_composes_threading_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(_raw())
+    assert inbound is not None
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(channel.build_reply_message("the answer", inbound))
+
+    assert len(sent) == 1
+    outbound = sent[0]
+    assert outbound["To"] == "owner@example.com"
+    assert outbound["Subject"] == "Re: Status?"
+    assert outbound["In-Reply-To"] == "<m1@example.com>"
+    assert outbound["References"] == "<m1@example.com>"
+    assert normalize_address(outbound["From"]) == "agent@example.com"
+    assert outbound.get_content().strip() == "the answer"
+
+
+async def test_send_resolves_the_recipient_from_the_thread_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The message tool and artifact delivery send without reply metadata."""
+
+    channel = EmailChannel(config=_config())
+    assert channel._to_incoming(_raw()) is not None
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(OutgoingMessage(content="ping", reply_to="m1@example.com"))
+
+    assert sent[0]["To"] == "owner@example.com"
+    assert sent[0]["Subject"] == "Re: Status?"
+
+
+async def test_send_without_a_known_thread_is_refused() -> None:
+    channel = EmailChannel(config=_config())
+
+    with pytest.raises(ValueError, match="recipient"):
+        await channel.send(OutgoingMessage(content="ping", reply_to="unknown"))
+
+
+async def test_send_file_attaches_into_the_thread(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    channel = EmailChannel(config=_config())
+    assert channel._to_incoming(_raw()) is not None
+    artifact = tmp_path / "report.csv"
+    artifact.write_bytes(b"a,b\n1,2\n")
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    result = await channel.send_file("m1@example.com", str(artifact), content="here you go")
+
+    assert result.status == ChannelSendStatus.SENT
+    names = [part.get_filename() for part in sent[0].iter_attachments()]
+    assert names == ["report.csv"]
+
+
+async def test_send_file_reports_failure_instead_of_raising() -> None:
+    channel = EmailChannel(config=_config())
+
+    result = await channel.send_file("missing-thread", "/nope/nothing.txt")
+
+    assert result.status == ChannelSendStatus.FAILED
+    assert result.retryable is False
+
+
+async def test_edit_and_delete_are_unsupported() -> None:
+    channel = EmailChannel(config=_config())
+
+    with pytest.raises(UnsupportedChannelOperation):
+        await channel.edit("m1", "text")
+    with pytest.raises(UnsupportedChannelOperation):
+        await channel.delete("m1")
+
+
+# ---------------------------------------------------------------------------
+# Polling lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _FakeIMAP:
+    """Minimal imaplib stand-in covering the calls the adapter makes."""
+
+    def __init__(self, raw: bytes, *, size: int | None = None) -> None:
+        self._raw = raw
+        self._size = len(raw) if size is None else size
+        self.stored: list[tuple[str, str, str]] = []
+        self.closed = False
+
+    def select(self, folder: str) -> tuple[str, list[bytes]]:
+        return "OK", [b"1"]
+
+    def search(self, charset: Any, criteria: str) -> tuple[str, list[bytes]]:
+        return "OK", [b"7"]
+
+    def fetch(self, uid: str, spec: str) -> tuple[str, list[Any]]:
+        if "RFC822.SIZE" in spec:
+            return "OK", [f"7 (RFC822.SIZE {self._size})".encode()]
+        return "OK", [(b"7 (BODY[] {%d}" % len(self._raw), self._raw), b")"]
+
+    def store(self, uid: str, command: str, flags: str) -> tuple[str, list[bytes]]:
+        self.stored.append((uid, command, flags))
+        return "OK", [b""]
+
+    def close(self) -> None:
+        self.closed = True
+
+    def logout(self) -> None:
+        return None
+
+
+def test_poll_parses_and_marks_seen(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config())
+    raw = _raw().as_bytes()
+    fake = _FakeIMAP(raw)
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    messages = channel._fetch_unseen()
+
+    assert [m.sender_id for m in messages] == ["owner@example.com"]
+    assert fake.stored == [("7", "+FLAGS", "\\Seen")]
+    assert fake.closed is True
+
+
+def test_poll_skips_a_message_larger_than_the_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config(max_message_bytes=32))
+    fake = _FakeIMAP(_raw().as_bytes(), size=10_000)
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    assert channel._fetch_unseen() == []
+    # Still flagged so the same oversized mail is not re-read every poll.
+    assert fake.stored == [("7", "+FLAGS", "\\Seen")]
+
+
+def test_one_unreadable_message_does_not_sink_the_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+    real_fetch_one = channel._fetch_one
+    calls: list[str] = []
+
+    def _flaky(client: Any, uid: str) -> Any:
+        calls.append(uid)
+        if len(calls) == 1:
+            raise ValueError("malformed mime")
+        return real_fetch_one(client, uid)
+
+    monkeypatch.setattr(fake, "search", lambda charset, criteria: ("OK", [b"7 8"]))
+    monkeypatch.setattr(channel, "_fetch_one", _flaky)
+
+    messages = channel._fetch_unseen()
+
+    assert calls == ["7", "8"]
+    assert len(messages) == 1
+
+
+def test_mark_seen_disabled_leaves_the_flag_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config(mark_seen=False))
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    channel._fetch_unseen()
+
+    assert fake.stored == []
+
+
+async def test_poll_loop_survives_a_failing_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config(poll_interval_s=1.0))
+    calls: list[int] = []
+
+    def _boom() -> list[IncomingMessage]:
+        calls.append(1)
+        raise OSError("imap down")
+
+    monkeypatch.setattr(channel, "_fetch_unseen", _boom)
+
+    await channel.start()
+    await asyncio.sleep(0.05)
+    health = await channel.health_check()
+    await channel.stop()
+
+    assert calls
+    assert health.connected is False
+    assert "imap down" in health.extra["last_error"]
+    assert channel._task is None
+
+
+async def test_receive_yields_polled_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config(poll_interval_s=1.0))
+    inbound = channel._to_incoming(_raw())
+    assert inbound is not None
+    monkeypatch.setattr(channel, "_fetch_unseen", lambda: [inbound])
+
+    await channel.start()
+    received = await asyncio.wait_for(channel.receive(), timeout=2.0)
+    await channel.stop()
+
+    assert received.sender_id == "owner@example.com"
+    assert (await channel.health_check()).last_message_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Session keying
+# ---------------------------------------------------------------------------
+
+
+def test_each_mail_thread_gets_its_own_session_key() -> None:
+    first = SimpleNamespace(
+        sender_id="owner@example.com",
+        channel_id="root-a",
+        metadata={"is_group": False, "dm_thread_scoped": True, "native_thread_id": "root-a"},
+    )
+    second = SimpleNamespace(
+        sender_id="owner@example.com",
+        channel_id="root-b",
+        metadata={"is_group": False, "dm_thread_scoped": True, "native_thread_id": "root-b"},
+    )
+
+    key_a = ChannelManager._build_session_key("email", first, agent_id="main")
+    key_b = ChannelManager._build_session_key("email", second, agent_id="main")
+
+    assert key_a == "agent:main:email:direct:owner@example.com:thread:root-a"
+    assert key_a != key_b
+
+
+def test_a_dm_thread_id_without_the_opt_in_still_maps_to_one_session() -> None:
+    """Per-thread DM sessions are opt-in; other adapters must not move."""
+
+    message = SimpleNamespace(
+        sender_id="user-1",
+        channel_id="D-1",
+        metadata={"is_group": False, "native_thread_id": "t-1", "thread_ts": "171234.000"},
+    )
+
+    assert ChannelManager._build_session_key("slack", message, agent_id="ops") == (
+        "agent:ops:slack:direct:user-1"
+    )

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -57,7 +57,7 @@ async def test_onboarding_catalog_returns_providers_and_channels(tmp_path, monke
     assert "audioProviders" in payload
     assert "memoryEmbeddingProviders" in payload
     types = {c["type"] for c in payload["channels"]}
-    assert types == {"slack", "telegram", "discord"}
+    assert types == {"slack", "telegram", "discord", "email"}
     search_provider_ids = {p["providerId"] for p in payload["searchProviders"]}
     assert {"brave", "duckduckgo"} <= search_provider_ids
     image_provider_ids = {p["providerId"] for p in payload["imageGenerationProviders"]}

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -6,6 +6,7 @@ import pytest
 
 from agentos.gateway.config import (
     DiscordChannelEntry,
+    EmailChannelEntry,
     SlackChannelEntry,
     TelegramChannelEntry,
 )
@@ -18,10 +19,11 @@ from agentos.onboarding.channel_specs import (
 
 # msteams is intentionally absent: the adapter is text-only and hidden
 # from runtime catalog surfaces until first-class support lands.
-ALL_TYPES = {"discord", "slack", "telegram"}
+ALL_TYPES = {"discord", "email", "slack", "telegram"}
 
 ENTRY_MODELS = {
     "slack": SlackChannelEntry,
+    "email": EmailChannelEntry,
     "discord": DiscordChannelEntry,
     "telegram": TelegramChannelEntry,
 }
@@ -71,6 +73,21 @@ def test_slack_secrets_are_marked_secret():
     spec = get_channel_setup_spec("slack")
     secrets = {f.name for f in spec.fields if f.secret}
     assert {"token", "app_token", "manifest_token", "signing_secret"} <= secrets
+
+
+def test_email_secrets_are_marked_secret():
+    spec = get_channel_setup_spec("email")
+    secrets = {f.name for f in spec.fields if f.secret}
+    assert {"imap_password", "smtp_password"} <= secrets
+
+
+def test_email_requires_an_explicit_sender_allowlist():
+    spec = get_channel_setup_spec("email")
+    fields = {f.name: f for f in spec.fields}
+
+    assert fields["allowed_senders"].required is True
+    assert spec.transport == "polling"
+    assert spec.requires_public_url is False
 
 
 def test_telegram_secrets_are_marked_secret():


### PR DESCRIPTION
Closes #369.

## What

An IMAP/SMTP email channel, so a mailbox is a first-class AgentOS channel alongside Slack, Discord and Telegram. Inbound is IMAP polling; outbound is SMTP with `In-Reply-To`/`References` so replies land back in the originating thread. No platform app registration and no public URL — just IMAP/SMTP credentials, which is what makes email the async "forward this to my agent" surface the issue is about.

```sh
agentos channels add email --name inbox \
  --field imap_host=imap.example.com \
  --field imap_username=agent@example.com \
  --field imap_password=<app-password> \
  --field smtp_host=smtp.example.com \
  --field from_address=agent@example.com \
  --field allowed_senders=you@example.com,*@yourteam.example
```

## Threading — and the one shared change

One mail thread is one session. The thread id is the first entry in `References`, falling back to `In-Reply-To` and then the message's own `Message-ID`.

That needed a small change outside the adapter: `ChannelManager._build_session_key` keys a DM per *peer*, so all mail from one person would have collapsed into one session. Rather than change that rule for everyone, per-thread DM sessions are **opt-in** — an adapter sets `metadata['dm_thread_scoped']` and only then is `native_thread_id` appended to the DM key. Adapters that merely carry a thread id on a DM are untouched, so Slack, Discord and Telegram DM keys do not move (there is an existing test asserting exactly that, and it still passes; a new test covers the opt-out path explicitly).

## Access control

`allowed_senders` is a **required** fail-closed From-address allowlist — exact addresses or domain patterns (`*@example.com`). A config with an empty list is rejected at load, because an open inbox lets anyone who can send mail drive the agent. It is enforced twice: at poll time, so a stranger's mail is never queued, and again through `evaluate_access` so gateway dispatch reaches the same verdict.

Loop safety: mail from the agent's own address, and anything carrying `Auto-Submitted`, `X-Autoreply`, `List-Id`, `List-Unsubscribe` or `Precedence: bulk`, is dropped. Without that an autoresponder on the far end and the agent would answer each other indefinitely.

## Body, attachments, resilience

- Quoted history is stripped before the text reaches the model; HTML-only mail is flattened to text. The quote markers are deliberately narrow — a bare `From:` line was dropped from the set because it also appears in ordinary prose.
- Inbound attachments go through the shared `_attachment_io` limits; oversized ones are dropped with a warning rather than truncated. Generated artifacts are mailed back into the thread via `send_file`.
- Whole messages over `max_message_bytes` (25 MB default) are skipped using `RFC822.SIZE`, before the body is downloaded.
- Both stdlib clients block, so every IMAP/SMTP call runs through `asyncio.to_thread`. A failed poll is logged, surfaces in `health_check` / `agentos channels status`, and the loop retries next interval. One unreadable message does not sink the batch.
- `edit`/`delete` raise `UnsupportedChannelOperation` — mail has neither. No `send_streaming`/`send_typing`, so the shared stream policy resolves to `final_only` on its own.

Also fills in the registry's plain-text Markdown hint for `email` (one of the three dead hints the issue points at), since mail clients render Markdown markers literally.

## Surface updated

`docs/channels.md` (new Email section + type table), `docs/cli.md`, `SKILL.md`, `agentos.toml.example`, `CHANGELOG.md`, the onboarding channel spec (so `agentos channels types/describe email` and the Web UI setup form work), and the bundled-channel inventory.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos` — success, 615 files
- `uv run pytest -q` — **8505 passed, 27 skipped**

40 new tests in `tests/test_channels/test_email_channel.py` cover the shared channel contract, the allowlist (exact / wildcard / denial / empty), config validation, thread-key derivation, self- and auto-reply drops, HTML and quoted-reply handling, attachment limits, dedupe, reply header composition, SMTP send and `send_file`, the IMAP poll path against a fake client (mark-seen, oversize skip, per-message failure isolation), poll-loop resilience, and session keying in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fjAj8R9GwdZXh4ihPYXCz