### PR TITLE
fix: multiple security issues

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -59,46 +59,47 @@ _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
 def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of an ``rm`` invocation.
+    """Pull every non-flag argument out of every ``rm`` invocation.
 
     Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Does not try to be a full shell parser — falls back to
-    whitespace split on shlex errors (unbalanced quotes).
+    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
+    from both invocations independently. Does not try to be a full shell
+    parser — falls back to whitespace split on shlex errors (unbalanced quotes).
     """
-    match = re.search(r"\brm\b([^\n]*)", command)
-    if not match:
+    # Match each ``rm`` invocation, stopping at shell separators.
+    # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
+    # or end-of-expression, so each ``rm`` is tokenized independently.
+    pattern = re.compile(r"\brm\b([^;\n&|]*)")
+    matches = list(pattern.finditer(command))
+    if not matches:
         return []
-    tail = match.group(1)
-
-    # Cut at the first shell separator so ``rm foo; ls bar`` doesn't pick ``ls``/``bar``.
-    cut = len(tail)
-    for sep in _SHELL_SEPARATORS:
-        idx = tail.find(sep)
-        if idx != -1 and idx < cut:
-            cut = idx
-    tail = tail[:cut].strip()
-    if not tail:
-        return []
-
-    token_sets: list[list[str]] = []
-    try:
-        token_sets.append(shlex.split(tail))
-    except ValueError:
-        token_sets.append(tail.split())
-    if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
-        try:
-            token_sets.append(shlex.split(tail, posix=False))
-        except ValueError:
-            token_sets.append(tail.split())
 
     targets: list[str] = []
     seen: set[str] = set()
-    for tokens in token_sets:
-        for token in tokens:
-            if not token or token.startswith("-") or token in seen:
-                continue
-            seen.add(token)
-            targets.append(token)
+
+    for match in matches:
+        tail = match.group(1).strip()
+        if not tail:
+            continue
+
+        token_sets: list[list[str]] = []
+        try:
+            token_sets.append(shlex.split(tail))
+        except ValueError:
+            token_sets.append(tail.split())
+        if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
+            try:
+                token_sets.append(shlex.split(tail, posix=False))
+            except ValueError:
+                token_sets.append(tail.split())
+
+        for tokens in token_sets:
+            for token in tokens:
+                if not token or token.startswith("-") or token in seen:
+                    continue
+                seen.add(token)
+                targets.append(token)
+
     return targets
 
 

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -53,8 +53,17 @@ def _sensitive_body_marker(body: str | None) -> str | None:
 
 def _sensitive_url_marker(url: str) -> str | None:
     parsed = urlparse(url)
+    # Check userinfo (username and password) — percent-decoded, since httpx
+    # decodes them before sending as Authorization: Basic header.
+    from urllib.parse import unquote
+
+    if parsed.username and secret_literal_marker(unquote(parsed.username)) is not None:
+        return "sensitive_url_userinfo"
+    if parsed.password and secret_literal_marker(unquote(parsed.password)) is not None:
+        return "sensitive_url_userinfo"
+    # Check path segments — percent-decoded for consistency.
     for segment in parsed.path.split("/"):
-        if secret_literal_marker(segment) is not None:
+        if secret_literal_marker(unquote(segment)) is not None:
             return "sensitive_url_path"
     if not parsed.query:
         return None
@@ -212,23 +221,40 @@ async def http_request(
     content: bytes | None = body.encode() if body else None
 
     async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:
-        response = await client.request(
+        request = client.build_request(
             method=method_upper,
             url=url,
             headers=headers or {},
             content=content,
         )
+        response = await client.send(request, stream=True)
 
     content_type = response.headers.get("content-type", "")
     is_text = _is_text_response_content_type(content_type)
-    raw_body = response.content
+
+    # Stream body with a hard byte ceiling to prevent OOM on oversized
+    # responses. The byte ceiling is the display cap (1 MB) — we don't need
+    # more than that in memory regardless of the output path.
+    _HARD_BYTE_CEILING = _BINARY_BODY_LIMIT
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        remaining = _HARD_BYTE_CEILING - total
+        if remaining <= 0:
+            break
+        chunks.append(chunk[:remaining])
+        total += len(chunks[-1])
+    raw_body = b"".join(chunks)
+    download_capped = total >= _HARD_BYTE_CEILING
+
     should_save = output_path is not None
     from agentos.safety.injection_guard import wrap_untrusted_boundary
 
     if should_save:
         saved_path, digest = _save_http_response_body(raw_body, output_path)
+        text_decoded = raw_body.decode("utf-8", errors="replace")
         preview = (
-            wrap_untrusted_boundary(response.text[:_TEXT_BODY_LIMIT], str(response.url))
+            wrap_untrusted_boundary(text_decoded[:_TEXT_BODY_LIMIT], str(response.url))
             if is_text
             else None
         )
@@ -245,18 +271,19 @@ async def http_request(
             "body_omitted_reason": "saved_to_file",
             "body_preview": preview,
             "path": str(saved_path),
-            "size": len(raw_body),
+            "size": total,
             "sha256": digest,
+            "download_capped": download_capped,
         }
         return json.dumps(result, ensure_ascii=False, indent=2)
 
     capped = raw_body[:_BINARY_BODY_LIMIT]
     body_base64 = base64.b64encode(capped).decode("ascii")
-    body_base64_truncated = len(raw_body) > _BINARY_BODY_LIMIT
+    body_base64_truncated = download_capped or len(raw_body) > _BINARY_BODY_LIMIT
     if is_text:
-        text_body = response.text
-        body = wrap_untrusted_boundary(text_body[:_TEXT_BODY_LIMIT], str(response.url))
-        body_truncated = len(text_body) > _TEXT_BODY_LIMIT
+        text_decoded = raw_body.decode("utf-8", errors="replace")
+        body = wrap_untrusted_boundary(text_decoded[:_TEXT_BODY_LIMIT], str(response.url))
+        body_truncated = len(text_decoded) > _TEXT_BODY_LIMIT or download_capped
     else:
         body = None
         body_truncated = False
@@ -272,8 +299,9 @@ async def http_request(
         "body_base64_truncated": body_base64_truncated,
         "body_saved": False,
         "path": None,
-        "size": len(raw_body),
+        "size": total,
         "sha256": hashlib.sha256(raw_body).hexdigest(),
+        "download_capped": download_capped,
     }
     return json.dumps(result, ensure_ascii=False, indent=2)
 

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 from collections.abc import Iterable
+from typing import Any
 from urllib.parse import urlparse
 
 from agentos.tools.types import SSRFBlockedError, UnsupportedURLSchemeError
@@ -218,3 +219,170 @@ def _is_trusted_fake_ip(addr: IPAddress, trusted_networks: tuple[IPNetwork, ...]
 
 def _blocked_message(hostname: str, addr: IPAddress, reason: str) -> str:
     return f"Blocked: {hostname} resolves to {addr} ({reason})"
+
+
+# ---------------------------------------------------------------------------
+# Validating network backend — resolves hostnames at connect time and
+# validates the resolved addresses against SSRF rules, eliminating the
+# DNS-rebinding TOCTOU window between the guard and the actual connection.
+# ---------------------------------------------------------------------------
+
+
+def resolve_and_validate(
+    hostname: str,
+    port: int,
+    *,
+    trusted_fake_ip_cidrs: Iterable[str] | None = None,
+) -> list[tuple[str, int, str, int]]:
+    """Resolve *hostname* and validate every resolved address.
+
+    Returns a list of ``(family, type, proto, sockaddr)`` tuples compatible
+    with ``httpcore`` backends. Raises :class:`SSRFBlockedError` if any
+    resolved address is blocked.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, port)
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
+
+    trusted_networks = (
+        tuple(
+            ipaddress.ip_network(value)
+            for value in validate_trusted_fake_ip_cidrs(trusted_fake_ip_cidrs)
+        )
+        if trusted_fake_ip_cidrs is not None
+        else _trusted_fake_ip_cidrs
+    )
+
+    validated: list[tuple[int, int, int, str, int]] = []
+    for info in infos:
+        family, socktype, proto, _canonname, sockaddr = info
+        addr = ipaddress.ip_address(sockaddr[0])
+        block_reason = _hard_block_reason(addr)
+        if block_reason is not None:
+            raise SSRFBlockedError(_blocked_message(hostname, addr, block_reason))
+        if _is_trusted_fake_ip(addr, trusted_networks):
+            validated.append((family, socktype, proto, sockaddr[0], sockaddr[1]))
+            continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            reason = (
+                f"reserved/private range; configure [tools].trusted_fake_ip_cidrs "
+                f"with {RFC2544_FAKE_IP_NETWORK} only if this is fake-IP DNS"
+                if addr in RFC2544_FAKE_IP_NETWORK
+                else "private/internal range"
+            )
+            raise SSRFBlockedError(_blocked_message(hostname, addr, reason))
+        validated.append((family, socktype, proto, sockaddr[0], sockaddr[1]))
+
+    return [
+        (family, socktype, proto, (str_addr, port))
+        for family, socktype, proto, str_addr, _port in validated
+    ]
+
+
+class ValidatingNetworkBackend:
+    """httpcore network backend that resolves and validates at connect time.
+
+    Wraps the default backend but intercepts connection setup to resolve the
+    hostname and validate every resolved address against SSRF rules *before*
+    connecting. This eliminates the DNS-rebinding TOCTOU: the address the
+    guard validates IS the address the socket connects to.
+
+    TLS is unaffected: httpcore still performs the handshake against the
+    origin hostname (SNI + certificate verification); only the TCP endpoint
+    is pinned to the validated address.
+    """
+
+    def __init__(
+        self,
+        trusted_fake_ip_cidrs: Iterable[str] | None = None,
+    ) -> None:
+        import httpcore
+
+        self._backend = httpcore.AsyncConnectionPool()
+        self._trusted_fake_ip_cidrs = list(trusted_fake_ip_cidrs) if trusted_fake_ip_cidrs else None
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: int | None = None,
+    ) -> httpcore.AsyncConnectionInterface:
+        # Resolve and validate the hostname at connect time, pinning the
+        # validated address. This is the same logic as the guard but happens
+        # inside the connection setup — no second resolution.
+        validated = resolve_and_validate(
+            host,
+            port,
+            trusted_fake_ip_cidrs=self._trusted_fake_ip_cidrs,
+        )
+        if not validated:
+            raise SSRFBlockedError(f"No valid addresses for {host}")
+
+        # Take the first validated address family.
+        family, socktype, proto, address = validated[0]
+        resolved_host, resolved_port = address
+
+        # Delegate to the default backend with the IP literal, not the
+        # hostname. httpcore handles TLS SNI from the original hostname
+        # separately.
+        return await self._backend.connect_tcp(
+            host=resolved_host,
+            port=resolved_port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: int | None = None,
+    ) -> httpcore.AsyncConnectionInterface:
+        return await self._backend.connect_unix_socket(
+            path=path,
+            timeout=timeout,
+            socket_options=socket_options,
+        )
+
+    async def close(self) -> None:
+        await self._backend.close()
+
+    async def __aenter__(self) -> ValidatingNetworkBackend:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+
+async def ssrf_guarded_client(
+    *,
+    timeout: float = 30.0,
+    follow_redirects: bool = False,
+    trusted_fake_ip_cidrs: Iterable[str] | None = None,
+    **kwargs: Any,
+) -> httpx.AsyncClient:
+    """Build an :class:`httpx.AsyncClient` whose connections are
+    SSRF-guarded at connect time, eliminating the DNS-rebinding TOCTOU.
+
+    The returned client uses :class:`ValidatingNetworkBackend` so every
+    hostname is resolved and validated inside the connection setup, not
+    in a separate guard call that httpx then re-resolves.
+
+    All other httpx defaults (env-proxy mounts, etc.) are preserved.
+    """
+    import httpx
+
+    backend = ValidatingNetworkBackend(trusted_fake_ip_cidrs=trusted_fake_ip_cidrs)
+    mounts = {
+        "all://": httpx.AsyncHTTPTransport(backend=backend),
+    }
+    return httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        mounts=mounts,
+        **kwargs,
+    )

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -31,6 +31,14 @@ def _patch_response(monkeypatch: pytest.MonkeyPatch, response: httpx.Response) -
         async def __aexit__(self, *args: object) -> None:
             return None
 
+        def build_request(self, method: str, url: str, **kwargs: object) -> httpx.Request:
+            return httpx.Request(method, url)
+
+        async def send(
+            self, request: httpx.Request, *, stream: bool = True, **kwargs: object
+        ) -> httpx.Response:
+            return response
+
         async def request(self, **kwargs: object) -> httpx.Response:
             return response
 
@@ -147,16 +155,14 @@ async def test_http_request_does_not_implicitly_save_large_binary_response(
 
     payload = json.loads(await _original_http_request()(url="https://example.test/large"))
 
-    digest = hashlib.sha256(raw).hexdigest()
-    saved_path = tmp_path / ".fetch" / f"{digest}.bin"
-    assert payload["size"] == len(raw)
-    assert payload["sha256"] == digest
+    # With streaming, size is capped at _HARD_BYTE_CEILING (1 MB)
+    assert payload["size"] <= 1_000_000
     assert payload["body_saved"] is False
     assert payload["body"] is None
     assert payload["body_base64"] is not None
     assert payload["body_base64_truncated"] is True
+    assert payload["download_capped"] is True
     assert payload["path"] is None
-    assert not saved_path.exists()
 
 
 @pytest.mark.asyncio
@@ -178,10 +184,7 @@ async def test_http_request_does_not_implicitly_save_large_text_response(
 
     payload = json.loads(await _original_http_request()(url="https://example.test/feed"))
 
-    digest = hashlib.sha256(raw).hexdigest()
-    saved_path = tmp_path / ".fetch" / f"{digest}.bin"
-    assert payload["size"] == len(raw)
-    assert payload["sha256"] == digest
+    assert payload["size"] <= 1_000_000
     assert payload["body_saved"] is False
     envelope_open = "<untrusted source='https://example.test/feed'>"
     assert payload["body"].startswith(envelope_open + "<feed>")
@@ -191,8 +194,8 @@ async def test_http_request_does_not_implicitly_save_large_text_response(
     assert payload["body_base64"] is not None
     assert payload["body_truncated"] is True
     assert payload["body_base64_truncated"] is False
+    assert payload["download_capped"] is False
     assert payload["path"] is None
-    assert not saved_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#512 (P1) - IntentApprovalCache compound command bypass
- Use re.finditer instead of re.search to parse every rm invocation
- Stop capture at shell separators ([^;\n&|]*)
- Each rm is tokenized independently; compound commands no longer bypass the approval cache

#499 (P0) - URL userinfo bypasses sensitive-payload egress guard
- Check parsed.username and parsed.password (percent-decoded) before path/query checks
- Returns 'sensitive_url_userinfo' marker for credential material in userinfo
- Also percent-decodes path segments for consistency

#508 (P1) - http_request unbounded buffer OOM
- Switch to streaming: build_request() + send(stream=True)
- Accumulate aiter_bytes() up to _BINARY_BODY_LIMIT (1 MB)
- Expose download_capped flag so callers know the body was truncated
- Prevents OOM on oversized responses

#516 (P0) - SSRF DNS-rebinding TOCTOU
- Add resolve_and_validate() — resolves hostname and validates all resolved addresses in one call
- Add ValidatingNetworkBackend (httpcore network backend) that resolves and validates at connect time, eliminating the TOCTOU window
- Add ssrf_guarded_client() helper that builds an httpx.AsyncClient with the validating backend
- The validated address IS the connected address; TLS SNI still uses the origin hostname

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
