### PR TITLE
fix: http_request unbounded buffer OOM (#508)

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -212,23 +212,40 @@ async def http_request(
     content: bytes | None = body.encode() if body else None
 
     async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:
-        response = await client.request(
+        request = client.build_request(
             method=method_upper,
             url=url,
             headers=headers or {},
             content=content,
         )
+        response = await client.send(request, stream=True)
 
     content_type = response.headers.get("content-type", "")
     is_text = _is_text_response_content_type(content_type)
-    raw_body = response.content
+
+    # Stream body with a hard byte ceiling to prevent OOM on oversized
+    # responses. The byte ceiling is the display cap (1 MB) — we don't need
+    # more than that in memory regardless of the output path.
+    _HARD_BYTE_CEILING = _BINARY_BODY_LIMIT
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        remaining = _HARD_BYTE_CEILING - total
+        if remaining <= 0:
+            break
+        chunks.append(chunk[:remaining])
+        total += len(chunks[-1])
+    raw_body = b"".join(chunks)
+    download_capped = total >= _HARD_BYTE_CEILING
+
     should_save = output_path is not None
     from agentos.safety.injection_guard import wrap_untrusted_boundary
 
     if should_save:
         saved_path, digest = _save_http_response_body(raw_body, output_path)
+        text_decoded = raw_body.decode("utf-8", errors="replace")
         preview = (
-            wrap_untrusted_boundary(response.text[:_TEXT_BODY_LIMIT], str(response.url))
+            wrap_untrusted_boundary(text_decoded[:_TEXT_BODY_LIMIT], str(response.url))
             if is_text
             else None
         )
@@ -245,18 +262,19 @@ async def http_request(
             "body_omitted_reason": "saved_to_file",
             "body_preview": preview,
             "path": str(saved_path),
-            "size": len(raw_body),
+            "size": total,
             "sha256": digest,
+            "download_capped": download_capped,
         }
         return json.dumps(result, ensure_ascii=False, indent=2)
 
     capped = raw_body[:_BINARY_BODY_LIMIT]
     body_base64 = base64.b64encode(capped).decode("ascii")
-    body_base64_truncated = len(raw_body) > _BINARY_BODY_LIMIT
+    body_base64_truncated = download_capped or len(raw_body) > _BINARY_BODY_LIMIT
     if is_text:
-        text_body = response.text
-        body = wrap_untrusted_boundary(text_body[:_TEXT_BODY_LIMIT], str(response.url))
-        body_truncated = len(text_body) > _TEXT_BODY_LIMIT
+        text_decoded = raw_body.decode("utf-8", errors="replace")
+        body = wrap_untrusted_boundary(text_decoded[:_TEXT_BODY_LIMIT], str(response.url))
+        body_truncated = len(text_decoded) > _TEXT_BODY_LIMIT or download_capped
     else:
         body = None
         body_truncated = False
@@ -272,8 +290,9 @@ async def http_request(
         "body_base64_truncated": body_base64_truncated,
         "body_saved": False,
         "path": None,
-        "size": len(raw_body),
+        "size": total,
         "sha256": hashlib.sha256(raw_body).hexdigest(),
+        "download_capped": download_capped,
     }
     return json.dumps(result, ensure_ascii=False, indent=2)
 

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -226,17 +226,17 @@ async def http_request(
     # Stream body with a hard byte ceiling to prevent OOM on oversized
     # responses. The byte ceiling is the display cap (1 MB) — we don't need
     # more than that in memory regardless of the output path.
-    _HARD_BYTE_CEILING = _BINARY_BODY_LIMIT
+    hard_byte_ceiling = _BINARY_BODY_LIMIT
     chunks: list[bytes] = []
     total = 0
     async for chunk in response.aiter_bytes():
-        remaining = _HARD_BYTE_CEILING - total
+        remaining = hard_byte_ceiling - total
         if remaining <= 0:
             break
         chunks.append(chunk[:remaining])
         total += len(chunks[-1])
     raw_body = b"".join(chunks)
-    download_capped = total >= _HARD_BYTE_CEILING
+    download_capped = total >= hard_byte_ceiling
 
     should_save = output_path is not None
     from agentos.safety.injection_guard import wrap_untrusted_boundary

--- a/tests/test_tools/test_credential_egress_guard.py
+++ b/tests/test_tools/test_credential_egress_guard.py
@@ -51,6 +51,12 @@ def ok_response(monkeypatch: pytest.MonkeyPatch) -> None:
         async def __aexit__(self, *args: object) -> None:
             return None
 
+        def build_request(self, method: str, url: str, **kwargs: object) -> str:
+            return url
+
+        async def send(self, request: str, **kwargs: object) -> httpx.Response:
+            return response
+
         async def request(self, **kwargs: object) -> httpx.Response:
             return response
 

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -31,6 +31,14 @@ def _patch_response(monkeypatch: pytest.MonkeyPatch, response: httpx.Response) -
         async def __aexit__(self, *args: object) -> None:
             return None
 
+        def build_request(self, method: str, url: str, **kwargs: object) -> httpx.Request:
+            return httpx.Request(method, url)
+
+        async def send(
+            self, request: httpx.Request, *, stream: bool = True, **kwargs: object
+        ) -> httpx.Response:
+            return response
+
         async def request(self, **kwargs: object) -> httpx.Response:
             return response
 
@@ -147,16 +155,14 @@ async def test_http_request_does_not_implicitly_save_large_binary_response(
 
     payload = json.loads(await _original_http_request()(url="https://example.test/large"))
 
-    digest = hashlib.sha256(raw).hexdigest()
-    saved_path = tmp_path / ".fetch" / f"{digest}.bin"
-    assert payload["size"] == len(raw)
-    assert payload["sha256"] == digest
+    # With streaming, size is capped at _HARD_BYTE_CEILING (1 MB)
+    assert payload["size"] <= 1_000_000
     assert payload["body_saved"] is False
     assert payload["body"] is None
     assert payload["body_base64"] is not None
     assert payload["body_base64_truncated"] is True
+    assert payload["download_capped"] is True
     assert payload["path"] is None
-    assert not saved_path.exists()
 
 
 @pytest.mark.asyncio
@@ -178,10 +184,7 @@ async def test_http_request_does_not_implicitly_save_large_text_response(
 
     payload = json.loads(await _original_http_request()(url="https://example.test/feed"))
 
-    digest = hashlib.sha256(raw).hexdigest()
-    saved_path = tmp_path / ".fetch" / f"{digest}.bin"
-    assert payload["size"] == len(raw)
-    assert payload["sha256"] == digest
+    assert payload["size"] <= 1_000_000
     assert payload["body_saved"] is False
     envelope_open = "<untrusted source='https://example.test/feed'>"
     assert payload["body"].startswith(envelope_open + "<feed>")
@@ -191,8 +194,8 @@ async def test_http_request_does_not_implicitly_save_large_text_response(
     assert payload["body_base64"] is not None
     assert payload["body_truncated"] is True
     assert payload["body_base64_truncated"] is False
+    assert payload["download_capped"] is False
     assert payload["path"] is None
-    assert not saved_path.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_web_http_request.py
+++ b/tests/test_tools/test_web_http_request.py
@@ -31,12 +31,10 @@ def _patch_response(monkeypatch: pytest.MonkeyPatch, response: httpx.Response) -
         async def __aexit__(self, *args: object) -> None:
             return None
 
-        def build_request(self, method: str, url: str, **kwargs: object) -> httpx.Request:
-            return httpx.Request(method, url)
+        def build_request(self, method: str, url: str, **kwargs: object) -> str:
+            return url
 
-        async def send(
-            self, request: httpx.Request, *, stream: bool = True, **kwargs: object
-        ) -> httpx.Response:
+        async def send(self, request: str, **kwargs: object) -> httpx.Response:
             return response
 
         async def request(self, **kwargs: object) -> httpx.Response:
@@ -155,14 +153,19 @@ async def test_http_request_does_not_implicitly_save_large_binary_response(
 
     payload = json.loads(await _original_http_request()(url="https://example.test/large"))
 
-    # With streaming, size is capped at _HARD_BYTE_CEILING (1 MB)
-    assert payload["size"] <= 1_000_000
+    # With streaming, the body is capped at _BINARY_BODY_LIMIT (1 MB).
+    capped = raw[:1_000_000]
+    digest = hashlib.sha256(capped).hexdigest()
+    saved_path = tmp_path / ".fetch" / f"{digest}.bin"
+    assert payload["size"] == 1_000_000
+    assert payload["sha256"] == digest
     assert payload["body_saved"] is False
     assert payload["body"] is None
     assert payload["body_base64"] is not None
     assert payload["body_base64_truncated"] is True
     assert payload["download_capped"] is True
     assert payload["path"] is None
+    assert not saved_path.exists()
 
 
 @pytest.mark.asyncio
@@ -184,7 +187,10 @@ async def test_http_request_does_not_implicitly_save_large_text_response(
 
     payload = json.loads(await _original_http_request()(url="https://example.test/feed"))
 
-    assert payload["size"] <= 1_000_000
+    digest = hashlib.sha256(raw).hexdigest()
+    saved_path = tmp_path / ".fetch" / f"{digest}.bin"
+    assert payload["size"] == len(raw)
+    assert payload["sha256"] == digest
     assert payload["body_saved"] is False
     envelope_open = "<untrusted source='https://example.test/feed'>"
     assert payload["body"].startswith(envelope_open + "<feed>")
@@ -194,8 +200,8 @@ async def test_http_request_does_not_implicitly_save_large_text_response(
     assert payload["body_base64"] is not None
     assert payload["body_truncated"] is True
     assert payload["body_base64_truncated"] is False
-    assert payload["download_capped"] is False
     assert payload["path"] is None
+    assert not saved_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Switch to streaming: use build_request() + send(stream=True) instead of the single-shot request() call. Accumulate aiter_bytes() up to _BINARY_BODY_LIMIT (1 MB) hard ceiling.

Expose download_capped flag so callers know the body was truncated. Prevents OOM on oversized or maliciously large HTTP responses.

Also updates FakeAsyncClient mock in tests to support the new build_request() + send() API, and adjusts size/truncation assertions.

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
