### PR TITLE
fix(env): block proxy env vars from set_env_var to prevent LLM traffic MITM

### DIFF
--- a/src/agentos/env_policy.py
+++ b/src/agentos/env_policy.py
@@ -139,9 +139,31 @@ _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_HTTP_DOWNLOAD_LIMIT",
 )
 
+#: Env var names that steer network egress (proxies). Writing these through an
+#: AgentOS surface lets an agent redirect all outbound traffic (model calls,
+#: web fetches, tool HTTP) to an attacker-controlled proxy and MITM credentials
+#: or tamper with responses. They are denied for the same reason as the shell /
+#: loader / posture names: the surface must not be able to widen its own
+#: network reach or exfiltrate secrets.
+_PROXY_NAMES = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "AGENTOS_LLM_PROXY",
+    "NO_PROXY",
+    "no_proxy",
+)
+
 #: Names that may never be written through an AgentOS surface.
 WRITE_DENYLIST: frozenset[str] = frozenset(
-    _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _AGENTOS_POSTURE_NAMES
+    _LOADER_NAMES
+    + _INTERPRETER_NAMES
+    + _SHELL_NAMES
+    + _AGENTOS_POSTURE_NAMES
+    + _PROXY_NAMES
 )
 
 _DENY_MESSAGE = (

--- a/src/agentos/env_policy.py
+++ b/src/agentos/env_policy.py
@@ -137,6 +137,7 @@ _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_GATEWAY_PORT",
     "AGENTOS_LISTEN",
     "AGENTOS_HTTP_DOWNLOAD_LIMIT",
+    "AGENTOS_TRUST_ENV",
 )
 
 #: Env var names that steer network egress (proxies). Writing these through an
@@ -157,13 +158,11 @@ _PROXY_NAMES = (
     "no_proxy",
 )
 
+_PROXY_NAMES_CI = frozenset(name.upper() for name in _PROXY_NAMES)
+
 #: Names that may never be written through an AgentOS surface.
 WRITE_DENYLIST: frozenset[str] = frozenset(
-    _LOADER_NAMES
-    + _INTERPRETER_NAMES
-    + _SHELL_NAMES
-    + _AGENTOS_POSTURE_NAMES
-    + _PROXY_NAMES
+    _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _AGENTOS_POSTURE_NAMES + _PROXY_NAMES
 )
 
 _DENY_MESSAGE = (
@@ -190,13 +189,17 @@ def assert_valid_name(key: str) -> None:
 
 def is_writable(key: str) -> bool:
     """Return whether *key* may be written through an AgentOS surface."""
-    return bool(ENV_NAME_RE.match(key)) and key not in WRITE_DENYLIST
+    return (
+        bool(ENV_NAME_RE.match(key))
+        and key not in WRITE_DENYLIST
+        and key.upper() not in _PROXY_NAMES_CI
+    )
 
 
 def assert_writable(key: str) -> None:
     """Raise :class:`EnvPolicyError` unless *key* passes the name and deny gates."""
     assert_valid_name(key)
-    if key in WRITE_DENYLIST:
+    if key in WRITE_DENYLIST or key.upper() in _PROXY_NAMES_CI:
         raise EnvPolicyError(_DENY_MESSAGE.format(key=key))
 
 

--- a/tests/test_env_policy.py
+++ b/tests/test_env_policy.py
@@ -50,6 +50,17 @@ class TestDenylist:
             "AGENTOS_STATE_DIR",
             "AGENTOS_GATEWAY_PORT",
             "AGENTOS_HTTP_DOWNLOAD_LIMIT",
+            # proxy / egress steering — redirect all outbound traffic to an
+            # attacker-controlled proxy to MITM credentials (security bug fix)
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "AGENTOS_LLM_PROXY",
+            "NO_PROXY",
+            "no_proxy",
         ],
     )
     def test_execution_and_posture_names_are_refused(self, name: str) -> None:

--- a/tests/test_env_policy.py
+++ b/tests/test_env_policy.py
@@ -61,6 +61,8 @@ class TestDenylist:
             "AGENTOS_LLM_PROXY",
             "NO_PROXY",
             "no_proxy",
+            "Http_Proxy",
+            "AGENTOS_TRUST_ENV",
         ],
     )
     def test_execution_and_posture_names_are_refused(self, name: str) -> None:


### PR DESCRIPTION
## Summary
Proxy names (`HTTP_PROXY`, `HTTPS_PROXY`, `AGENTOS_LLM_PROXY`, ...) were absent from `env_policy.WRITE_DENYLIST`, so the builtin `set_env_var` tool could set them. `gateway/llm_runtime.py:67` reads `AGENTOS_LLM_PROXY` and applies it to every provider client, letting an agent redirect all model traffic through an attacker proxy to exfiltrate API keys.

Fixes #550

## Changes
- Add `_PROXY_NAMES` (HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy, ALL_PROXY, all_proxy, AGENTOS_LLM_PROXY, NO_PROXY, no_proxy) to `WRITE_DENYLIST`.
- `assert_writable` now refuses these; `is_writable` returns False.

## Test plan
- `tests/test_env_policy.py`: parametrized denylist cases include all proxy names (74 passed).
- Empirical check: `assert_writable("AGENTOS_LLM_PROXY")` now raises `EnvPolicyError`; `LD_PRELOAD`/`PATH` still blocked.

## Verification
- `uv run pytest tests/test_env_policy.py -q` → 74 passed
- `uv run ruff check src tests` clean