### PR TITLE
fix(onboarding): validate LLM provider base_url to block SSRF to internal/metadata hosts

### DIFF
--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -417,6 +417,54 @@ def _validate_judge_base_url(base_url: str) -> None:
         )
 
 
+def _validate_provider_base_url(base_url: str) -> None:
+    """Validate an LLM provider ``base_url`` before it reaches an httpx client.
+
+    Rejects malformed URLs, non-http(s) schemes (notably ``file://``), and any
+    host that resolves to a loopback / private / link-local address. Without
+    this, ``onboarding.provider.configure`` (and the CLI) let an RPC client point
+    all provider traffic at an attacker host to exfiltrate API keys, or at the
+    cloud metadata endpoint (``169.254.169.254``) to steal instance credentials.
+    """
+    from urllib.parse import urlparse
+    import ipaddress
+
+    if not base_url:
+        return  # optional field
+    try:
+        parsed = urlparse(base_url)
+    except ValueError as exc:
+        raise ValueError(f"provider base_url is not a valid URL: {exc}") from exc
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"provider base_url must be http(s), got {parsed.scheme!r} "
+            f"(refusing non-network scheme such as file://)"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"provider base_url must have a host: {base_url!r}")
+    host = parsed.hostname
+    if not host:
+        raise ValueError(f"provider base_url has no resolvable host: {base_url!r}")
+    # Reject loopback-excepted? No — loopback IS a local provider (Ollama),
+    # keep it allowed. Reject private / link-local / reserved (internal nets
+    # and the cloud metadata endpoint) which an attacker would aim at.
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        pass  # hostname (DNS) — connectivity is operator's responsibility
+    else:
+        if addr.is_private or addr.is_link_local or addr.is_reserved:
+            # loopback (127.0.0.1) is intentionally allowed for local models
+            if not addr.is_loopback:
+                raise ValueError(
+                    f"provider base_url host must be a public or loopback address, got {addr}"
+                )
+    # Hostname string checks for the metadata endpoint and common internal names.
+    lowered = host.lower()
+    if lowered in ("169.254.169.254", "metadata.google.internal", "metadata"):
+        raise ValueError(f"provider base_url host is not allowed: {host!r}")
+
+
 def _verify_local_judge_endpoint(base_url: str, model: str, api_key: str) -> None:
     """Probe a local judge endpoint with one test classification (spec D2).
 
@@ -534,6 +582,11 @@ def upsert_llm_provider(
         else (config.llm.base_url if active_provider == provider_id else "")
     )
     effective_base_url = base_url or saved_base_url or spec.default_base_url
+    if base_url:
+        # Validate the operator/RPC-supplied base_url before it reaches the
+        # httpx client. saved_base_url / spec.default_base_url come from
+        # trusted config, so only the caller-controlled argument is checked.
+        _validate_provider_base_url(base_url)
     if spec.requires_base_url and not effective_base_url:
         raise ValueError(f"provider {provider_id!r} requires a base_url")
     saved_proxy = (

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -426,8 +426,8 @@ def _validate_provider_base_url(base_url: str) -> None:
     all provider traffic at an attacker host to exfiltrate API keys, or at the
     cloud metadata endpoint (``169.254.169.254``) to steal instance credentials.
     """
-    from urllib.parse import urlparse
     import ipaddress
+    from urllib.parse import urlparse
 
     if not base_url:
         return  # optional field

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -11,6 +11,7 @@ from agentos.gateway.config import GatewayConfig, _router_tier_profile_defaults
 from agentos.gateway.llm_runtime import resolve_llm_runtime_config
 from agentos.onboarding.mutations import (
     MutationResult,
+    _validate_provider_base_url,
     list_channel_entries,
     remove_channel,
     set_channel_enabled,
@@ -1705,3 +1706,48 @@ def test_upsert_channel_replaces_secret_when_provided():
     raw = [e.model_dump(mode="python") for e in second.config.channels.channels]
     entry = next(e for e in raw if e["name"] == "w")
     assert entry["token"] == "xoxb-new"
+
+
+class TestProviderBaseUrlValidation:
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "file:///etc/passwd",                      # non-network scheme
+            "ftp://example.com",                       # non-http(s) scheme
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata endpoint
+            "http://10.0.0.1:8080/internal",            # RFC1918 private
+            "http://192.168.0.1/admin",                 # RFC1918 private
+            "http://[fd00::1]/",                        # IPv6 ULA private
+            "not-a-url",                                # malformed
+        ],
+    )
+    def test_validate_provider_base_url_rejects_untrusted(self, bad_url: str) -> None:
+        with pytest.raises(ValueError):
+            _validate_provider_base_url(bad_url)
+
+    @pytest.mark.parametrize(
+        "good_url",
+        [
+            "https://openrouter.ai/api/v1",
+            "https://api.openai.com/v1",
+            "https://api.anthropic.com",
+        ],
+    )
+    def test_validate_provider_base_url_accepts_public_https(self, good_url: str) -> None:
+        _validate_provider_base_url(good_url)  # must not raise
+
+    def test_upsert_llm_provider_rejects_malicious_base_url(self) -> None:
+        cfg = GatewayConfig()
+        with pytest.raises(ValueError):
+            upsert_llm_provider(
+                cfg,
+                provider_id="openrouter",
+                model="deepseek/deepseek-v4-flash",
+                api_key="sk-test",
+                base_url="http://169.254.169.254/latest/meta-data/",
+            )
+
+
+def test_provider_base_url_validator_importable() -> None:
+    # guard: the validator must exist and be wired into upsert_llm_provider
+    assert callable(_validate_provider_base_url)


### PR DESCRIPTION
## Summary
`upsert_llm_provider` accepted `base_url` with no validation. The RPC surface (`onboarding.provider.configure`) and CLI forward a caller-supplied `base_url` straight into the httpx client, so an attacker could point all provider traffic at `169.254.169.254` (cloud metadata / IAM creds), a private RFC1918 host, or a public attacker endpoint to MITM API keys.

Fixes #551

## Changes
- Add `_validate_provider_base_url`: require http(s) scheme, reject non-network schemes (`file://`), reject literal private / link-local / reserved IPs and the cloud metadata hostname. `localhost` stays allowed for local models (Ollama).
- Call it inside `upsert_llm_provider` for the caller-supplied argument (saved/default base_urls from trusted config are not re-validated).
- DNS-rebinding at connect time (pin resolved IP) is a separate concern, out of scope for this validation.

## Test plan
- `tests/test_onboarding/test_mutations.py::TestProviderBaseUrlValidation`: parametrized good/bad URLs + `test_upsert_llm_provider_rejects_malicious_base_url`.
- Full `tests/test_onboarding/test_mutations.py` → 114 passed.

## Verification
- `uv run pytest tests/test_onboarding/test_mutations.py -q` → 114 passed
- `uv run ruff check src tests` clean