### PR TITLE
fix: git tools return output with no credential redaction (#496)

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -88,8 +88,11 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
         )
         output = _redact_git_output(result.stdout + result.stderr)
         if result.returncode != 0:
-            raise RuntimeError(f"git {' '.join(args)} failed (exit {result.returncode}):\n{output}")
-        return output
+            raise RuntimeError(
+                f"git {' '.join(args)} failed (exit {result.returncode}):\n"
+                f"{redact_sensitive_text(output, force=True, code_file=False)}"
+            )
+        return redact_sensitive_text(output, force=True, code_file=False)
     proc = await asyncio.create_subprocess_exec(
         "git",
         *args,
@@ -100,8 +103,11 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
     stdout, _ = await proc.communicate()
     output = _redact_git_output(stdout.decode("utf-8", errors="replace"))
     if proc.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed (exit {proc.returncode}):\n{output}")
-    return output
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (exit {proc.returncode}):\n"
+            f"{redact_sensitive_text(output, force=True, code_file=False)}"
+        )
+    return redact_sensitive_text(output, force=True, code_file=False)
 
 
 def build_request_for_git(args: tuple[str, ...], cwd: Path, action_kind: str, policy):

--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -86,13 +86,14 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
             build_request_for_git(args, workspace, action_kind, policy),
             runtime=runtime,
         )
-        output = _redact_git_output(result.stdout + result.stderr)
+        output = result.stdout + result.stderr
+        redacted = redact_sensitive_text(output, force=True, code_file=False)
         if result.returncode != 0:
             raise RuntimeError(
                 f"git {' '.join(args)} failed (exit {result.returncode}):\n"
-                f"{redact_sensitive_text(output, force=True, code_file=False)}"
+                f"{redacted}"
             )
-        return redact_sensitive_text(output, force=True, code_file=False)
+        return redacted if redacted is not None else output
     proc = await asyncio.create_subprocess_exec(
         "git",
         *args,
@@ -101,13 +102,14 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
         cwd=cwd,
     )
     stdout, _ = await proc.communicate()
-    output = _redact_git_output(stdout.decode("utf-8", errors="replace"))
+    output = stdout.decode("utf-8", errors="replace")
+    redacted = redact_sensitive_text(output, force=True, code_file=False)
     if proc.returncode != 0:
         raise RuntimeError(
             f"git {' '.join(args)} failed (exit {proc.returncode}):\n"
-            f"{redact_sensitive_text(output, force=True, code_file=False)}"
+            f"{redacted if redacted is not None else output}"
         )
-    return redact_sensitive_text(output, force=True, code_file=False)
+    return redacted if redacted is not None else output
 
 
 def build_request_for_git(args: tuple[str, ...], cwd: Path, action_kind: str, policy):


### PR DESCRIPTION
Route _run_git output through redact_sensitive_text(force=True, code_file=False) so committed and working-tree credentials are masked before reaching the model.

Also fix the unified-diff marker gap in _ASSIGNMENT_RE: add an optional (?:[+\-])? prefix so named credentials on diff +/- lines (e.g. +MY_SECRET=value) are captured. Vendor-prefixed keys were already caught by the separate shape pass, but non-vendor named secrets (DB passwords, custom tokens) leaked through the +/- marker.

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
