### PR TITLE
fix: media image fetch buffers entire body before size check (#506)

### DIFF
--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -299,7 +299,8 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
             current_url = url
             for _redirect_count in range(_MAX_REDIRECTS + 1):
                 _check_image_url(current_url)
-                resp = await client.get(current_url)
+                request = client.build_request("GET", current_url)
+                resp = await client.send(request, stream=True)
                 if resp.status_code not in {301, 302, 303, 307, 308}:
                     break
                 location = resp.headers.get("location")
@@ -309,13 +310,23 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
             else:
                 raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")
             resp.raise_for_status()
-            image_bytes = resp.content
+            # Stream body with a hard ceiling at _IMAGE_SIZE_LIMIT (20 MB)
+            # to prevent OOM on oversized responses.
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                remaining = _IMAGE_SIZE_LIMIT - total
+                if remaining <= 0:
+                    break
+                chunks.append(chunk[:remaining])
+                total += len(chunks[-1])
+            image_bytes = b"".join(chunks)
     except ToolError:
         raise
     except Exception as exc:
         raise ToolError(f"Failed to fetch image from URL: {exc}") from exc
 
-    if len(image_bytes) > _IMAGE_SIZE_LIMIT:
+    if total > _IMAGE_SIZE_LIMIT or len(image_bytes) > _IMAGE_SIZE_LIMIT:
         raise ToolError("Image exceeds 20MB size limit")
 
     # Detect format from content-type or URL extension


### PR DESCRIPTION
_fetch_image_url used resp.content which buffers the entire HTTP response body in memory before the 20 MB size limit check. A single oversized/unbounded image URL could exhaust process memory.

Switch to streaming: build_request() + send(stream=True) and accumulate aiter_bytes() up to the _IMAGE_SIZE_LIMIT (20 MB) hard ceiling. Prevents OOM on oversized image responses.

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
