### PR TITLE
fix: set_env_var can set AGENTOS_LLM_PROXY to MITM all LLM traffic (#550

### DIFF
--- a/src/agentos/env_policy.py
+++ b/src/agentos/env_policy.py
@@ -114,6 +114,18 @@ _SHELL_NAMES = (
 #
 # Bind posture (host/port/listen) is CLI-only by design — ``rpc_config.py``
 # already refuses to persist it — so it is listed here for the same reason.
+_PROXY_NAMES = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+    "AGENTOS_LLM_PROXY",
+)
+
 _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_SENSITIVE_PATHS_DISABLED",
     "AGENTOS_SENSITIVE_PAYLOAD_DISABLED",
@@ -140,12 +152,13 @@ _AGENTOS_POSTURE_NAMES = (
 
 #: Names that may never be written through an AgentOS surface.
 WRITE_DENYLIST: frozenset[str] = frozenset(
-    _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _AGENTOS_POSTURE_NAMES
+    _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _PROXY_NAMES + _AGENTOS_POSTURE_NAMES
 )
 
 _DENY_MESSAGE = (
     "Environment variable {key!r} cannot be written through AgentOS. Names that "
-    "steer subprocess execution (PATH, LD_PRELOAD, PYTHONPATH, EDITOR, ...) or "
+    "steer subprocess execution (PATH, LD_PRELOAD, PYTHONPATH, EDITOR, ...), "
+    "egress-steering (HTTP_PROXY, AGENTOS_LLM_PROXY, ...), or "
     "AgentOS runtime posture (AGENTOS_AGENT_PERMISSIONS, AGENTOS_GATEWAY_TOKEN, "
     "...) are refused so this surface cannot escalate its own privileges. Edit "
     "~/.agentos/.env directly if you genuinely need to set it."


### PR DESCRIPTION
**Fixes #550**

## Problem

`set_env_var` (and the underlying `env_policy.py`) allows writing `AGENTOS_LLM_PROXY` to the environment, which an attacker can set to a malicious proxy server to MITM all LLM traffic. The same applies to `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, `https_proxy`, `ALL_PROXY`, `all_proxy`, `NO_PROXY`, and `no_proxy`.

## Fix

Added `_PROXY_NAMES` tuple containing all 9 proxy-related environment variable names to `WRITE_DENYLIST` in `src/agentos/env_policy.py`. These variable names are now blocked from being set via `set_env_var`.

## Testing

All 9 proxy names verified blocked via `assert name in WRITE_DENYLIST`. 2 non-proxy `AGENTOS_LLM_*` variants confirmed still writable. 65 existing env_policy tests pass.