### PR TITLE
fix: gateway token comparison is not constant-time (#498)

### DIFF
--- a/src/agentos/gateway/audio_transcription.py
+++ b/src/agentos/gateway/audio_transcription.py
@@ -94,7 +94,9 @@ def register_audio_transcription_routes(
 
     async def transcribe_handler(request: Request) -> JSONResponse:
         if config.auth.mode == "token":
-            if config.auth.token and _extract_authorization_token(request) != config.auth.token:
+            from agentos.gateway.auth import token_equals
+
+            if not token_equals(_extract_authorization_token(request), config.auth.token):
                 return JSONResponse(
                     {
                         "error": (

--- a/src/agentos/gateway/auth.py
+++ b/src/agentos/gateway/auth.py
@@ -42,6 +42,22 @@ def _surface(value: str | ConnectionSurface | None) -> ConnectionSurface:
         raise ValueError(f"Invalid client kind: {value!r}") from exc
 
 
+def token_equals(provided: str | None, configured: str | None) -> bool:
+    """Constant-time comparison of gateway tokens.
+
+    Uses :func:`hmac.compare_digest` on UTF-8-encoded bytes so that
+    response-time side channels cannot leak the secret. Fails closed:
+    returns ``False`` when either value is missing, empty, or not a string.
+    """
+    import hmac
+
+    if not provided or not configured:
+        return False
+    if not isinstance(provided, str) or not isinstance(configured, str):
+        return False
+    return hmac.compare_digest(provided.encode("utf-8"), configured.encode("utf-8"))
+
+
 def resolve_auth(
     config: GatewayConfig,
     auth_params: dict,
@@ -68,7 +84,7 @@ def resolve_auth(
     if config.auth.mode == "token":
         provided = (auth_params or {}).get("token")
         configured = config.auth.token
-        if not configured or provided != configured:
+        if not configured or not token_equals(provided, configured):
             log.warning("auth.failed", mode=config.auth.mode, error="invalid token")
             return None
         return AccessContext(

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -242,9 +242,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)  # type: ignore[no-any-return]
 
         if auth_mode == "token":
+            from agentos.gateway.auth import token_equals
+
             token = self._extract_token(request)
             configured_token = self._config.auth.token
-            if not configured_token or token != configured_token:
+            if not token_equals(token, configured_token):
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )

--- a/src/agentos/gateway/uploads.py
+++ b/src/agentos/gateway/uploads.py
@@ -366,7 +366,9 @@ def register_upload_routes(
 
     async def upload_handler(request: Request) -> JSONResponse:
         if config.auth.mode == "token":
-            if config.auth.token and _extract_authorization_token(request) != config.auth.token:
+            from agentos.gateway.auth import token_equals
+
+            if not token_equals(_extract_authorization_token(request), config.auth.token):
                 return JSONResponse(
                     {
                         "error": (


### PR DESCRIPTION
Add token_equals() helper using hmac.compare_digest on UTF-8 bytes for constant-time comparison. Fails closed on missing/empty/non-string input.

Replace all four direct equality checks:
- gateway/auth.py: resolve_auth token mode
- gateway/middleware.py: AuthMiddleware.dispatch
- gateway/uploads.py: upload route token check
- gateway/audio_transcription.py: transcribe route token check

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
