### PR TITLE
fix(cli): terminate entire subprocess tree on Windows upgrade timeout

### DIFF
--- a/src/agentos/cli/upgrade_cmd.py
+++ b/src/agentos/cli/upgrade_cmd.py
@@ -84,16 +84,26 @@ def _run_upgrade_subprocess(
     leave a background zombie.
     """
 
-    start_new_session = os.name != "nt"
     try:
-        proc = subprocess.Popen(  # noqa: S603 - argv built internally
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=env,
-            start_new_session=start_new_session,
-        )
+        if os.name == "nt":
+            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200)
+            proc = subprocess.Popen(  # noqa: S603 - argv built internally
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                creationflags=creationflags,
+            )
+        else:
+            proc = subprocess.Popen(  # noqa: S603 - argv built internally
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                start_new_session=True,
+            )
     except OSError as exc:
         return UpgradeRunResult(
             ok=False, timed_out=False, returncode=None, stdout="", stderr=str(exc)
@@ -103,7 +113,20 @@ def _run_upgrade_subprocess(
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
         _kill_process_group(proc)
-        stdout, stderr = proc.communicate()
+        try:
+            stdout, stderr = proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired as exc:
+            stdout_data = exc.stdout or ""
+            stderr_data = exc.stderr or ""
+            if isinstance(stdout_data, bytes):
+                stdout = stdout_data.decode("utf-8", errors="replace")
+            else:
+                stdout = stdout_data
+            if isinstance(stderr_data, bytes):
+                stderr = stderr_data.decode("utf-8", errors="replace")
+            else:
+                stderr = stderr_data
+            proc.poll()
         return UpgradeRunResult(
             ok=False,
             timed_out=True,
@@ -123,7 +146,16 @@ def _run_upgrade_subprocess(
 
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     if os.name == "nt":
-        proc.kill()
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+                timeout=5.0,
+            )
+        except Exception:
+            proc.kill()
         return
     try:
         pgid = os.getpgid(proc.pid)  # type: ignore[attr-defined]
@@ -364,8 +396,7 @@ def upgrade_command(
     new_version = _installed_version_via(sys.executable, env=env) or "unknown"
     console.print(f"Upgraded: {__version__} → {new_version}")
     console.print(
-        "[dim]Config migrations (with an automatic timestamped backup) run at "
-        "gateway start.[/dim]"
+        "[dim]Config migrations (with an automatic timestamped backup) run at gateway start.[/dim]"
     )
 
     if no_restart:

--- a/tests/test_cli/test_upgrade_cmd.py
+++ b/tests/test_cli/test_upgrade_cmd.py
@@ -306,3 +306,144 @@ def test_upgrade_failure_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(_app(), ["upgrade"])
     assert result.exit_code == 1
     assert "Upgrade failed" in result.stdout
+
+
+# --- _kill_process_group ---------------------------------------------------
+
+
+def test_kill_process_group_windows_uses_taskkill(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeProc:
+        pid = 12345
+
+        def kill(self) -> None:
+            raise AssertionError("kill() should not be called if taskkill succeeds")
+
+    executed_cmd: list[str] = []
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        executed_cmd.extend(cmd)
+        return None
+
+    monkeypatch.setattr("os.name", "nt")
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    fake_proc = _FakeProc()
+    upgrade_cmd._kill_process_group(fake_proc)  # type: ignore[arg-type]
+    assert executed_cmd == ["taskkill", "/PID", "12345", "/T", "/F"]
+
+
+def test_kill_process_group_windows_fallback_to_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    killed = {"called": False}
+
+    class _FakeProc:
+        pid = 12345
+
+        def kill(self) -> None:
+            killed["called"] = True
+
+    def _failing_run(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("taskkill not found")
+
+    monkeypatch.setattr("os.name", "nt")
+    monkeypatch.setattr("subprocess.run", _failing_run)
+
+    fake_proc = _FakeProc()
+    upgrade_cmd._kill_process_group(fake_proc)  # type: ignore[arg-type]
+    assert killed["called"] is True
+
+
+def test_run_upgrade_subprocess_windows_timeout_success_on_second_communicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess
+
+    class MockPopen:
+        last_kwargs: dict[str, Any] = {}
+
+        def __init__(self, command: list[str], **kwargs: Any) -> None:
+            MockPopen.last_kwargs = kwargs
+            self.pid = 9999
+            self.returncode = None
+            self.args = command
+            self.communicate_calls: list[float | None] = []
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            self.communicate_calls.append(timeout)
+            if len(self.communicate_calls) == 1:
+                raise subprocess.TimeoutExpired(self.args, timeout)
+            else:
+                self.returncode = -15
+                return "stdout after kill", "stderr after kill"
+
+    monkeypatch.setattr("os.name", "nt")
+    monkeypatch.setattr(subprocess, "Popen", MockPopen)
+
+    taskkill_called = []
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        taskkill_called.append(cmd)
+        return None
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = upgrade_cmd._run_upgrade_subprocess(["dummy_cmd"], env={}, timeout=10.0)
+
+    expected_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200)
+    assert MockPopen.last_kwargs.get("creationflags") == expected_flags
+    assert taskkill_called == [["taskkill", "/PID", "9999", "/T", "/F"]]
+    assert result.ok is False
+    assert result.timed_out is True
+    assert result.returncode == -15
+    assert result.stdout == "stdout after kill"
+    assert result.stderr == "stderr after kill"
+
+
+def test_run_upgrade_subprocess_windows_timeout_secondary_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess
+
+    class MockPopen:
+        last_kwargs: dict[str, Any] = {}
+
+        def __init__(self, command: list[str], **kwargs: Any) -> None:
+            MockPopen.last_kwargs = kwargs
+            self.pid = 9999
+            self.returncode = None
+            self.args = command
+            self.communicate_calls: list[float | None] = []
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            self.communicate_calls.append(timeout)
+            if len(self.communicate_calls) == 1:
+                raise subprocess.TimeoutExpired(self.args, timeout)
+            else:
+                raise subprocess.TimeoutExpired(
+                    self.args, timeout, output="secondary stdout", stderr="secondary stderr"
+                )
+
+        def poll(self) -> int | None:
+            self.returncode = -9
+            return self.returncode
+
+    monkeypatch.setattr("os.name", "nt")
+    monkeypatch.setattr(subprocess, "Popen", MockPopen)
+
+    taskkill_called = []
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        taskkill_called.append(cmd)
+        return None
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = upgrade_cmd._run_upgrade_subprocess(["dummy_cmd"], env={}, timeout=10.0)
+
+    expected_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200)
+    assert MockPopen.last_kwargs.get("creationflags") == expected_flags
+    assert taskkill_called == [["taskkill", "/PID", "9999", "/T", "/F"]]
+    assert result.ok is False
+    assert result.timed_out is True
+    assert result.returncode == -9
+    assert result.stdout == "secondary stdout"
+    assert result.stderr == "secondary stderr"


### PR DESCRIPTION


Fixes #536

- [x] This pull request fully resolves the linked issue.

## Summary

This PR addresses the issue where the upgrade subprocess timeout on Windows leaks orphaned child processes, resulting in file locks and CLI hangs. 

- **Process Group Creation**: Passes `creationflags=subprocess.CREATE_NEW_PROCESS_GROUP` at `Popen` time on Windows (`os.name == "nt"`) so child processes are tracked in a targetable group.
- **Tree Kill**: Terminates the entire process tree on Windows using `taskkill /PID <pid> /T /F` on timeout. This gracefully degrades to `proc.kill()` on any error or missing utility.
- **POSIX Safety**: Keeps the POSIX `killpg` code path byte-for-byte unchanged.
- **Bounded Communication**: Guards the post-kill `.communicate()` call with a `timeout=5.0` to prevent CLI hangs in case surviving orphans keep the stdout/stderr pipe handles open.

## Tests

- Added unit tests to cover the Windows `Popen` parameters, taskkill order, and secondary communicate timeout scenarios on non-Windows/Linux CI.
- Ran validation tests:
  ```bash
  uv run pytest tests/test_cli/test_upgrade_cmd.py -q
  ```
  **Result:** All 19 tests passed successfully.
```