### PR TITLE
fix: GitHub skill-hub blob download has no size cap (#510)

### DIFF
--- a/src/agentos/skills/hub/github.py
+++ b/src/agentos/skills/hub/github.py
@@ -15,6 +15,10 @@ log = structlog.get_logger(__name__)
 
 _GITHUB_HOSTS = {"github.com", "www.github.com"}
 _RAW_GITHUB_HOST = "raw.githubusercontent.com"
+#: Per-blob download ceiling — 8 MiB covers every reasonable skill file.
+_MAX_BLOB_BYTES = 8 * 1024 * 1024
+#: Cumulative total budget for all blobs in a single skill fetch.
+_MAX_TOTAL_BYTES = 32 * 1024 * 1024
 _REPO_RE = re.compile(
     r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)"
     r"(?:@(?P<ref>[^:]+))?(?::(?P<path>.+))?$"
@@ -276,9 +280,44 @@ class GitHubSource(SkillSource):
                         f"https://raw.githubusercontent.com/{ref.repo_full}/"
                         f"{quote(ref.ref, safe='')}/{quote(path, safe='/')}"
                     )
-                    raw_resp = await client.get(raw_url, headers=self._headers())
-                    raw_resp.raise_for_status()
-                    files[rel_path] = _decode_file(rel_path, raw_resp.content)
+                    blob_request = client.build_request("GET", raw_url)
+                    raw_resp = await client.send(blob_request, stream=True)
+                    try:
+                        raw_resp.raise_for_status()
+                        chunks: list[bytes] = []
+                        total = 0
+                        async for chunk in raw_resp.aiter_bytes():
+                            remaining = _MAX_BLOB_BYTES - total
+                            if remaining <= 0:
+                                break
+                            chunks.append(chunk[:remaining])
+                            total += len(chunks[-1])
+                        raw_content = b"".join(chunks)
+                        if total >= _MAX_BLOB_BYTES:
+                            log.warning(
+                                "github.blob_exceeded_per_blob_cap",
+                                path=path,
+                                bytes=total,
+                                cap=_MAX_BLOB_BYTES,
+                            )
+                            continue
+                    finally:
+                        await raw_resp.aclose()
+
+                    # Check cumulative total budget
+                    cumulative = sum(
+                        len(v) if isinstance(v, bytes) else len(v.encode("utf-8"))
+                        for v in files.values()
+                    )
+                    if cumulative + len(raw_content) > _MAX_TOTAL_BYTES:
+                        log.warning(
+                            "github.total_exceeded_cumulative_budget",
+                            bytes=cumulative + len(raw_content),
+                            cap=_MAX_TOTAL_BYTES,
+                        )
+                        continue
+
+                    files[rel_path] = _decode_file(rel_path, raw_content)
         except Exception as exc:
             log.warning("github.fetch_failed", identifier=identifier, error=str(exc))
             return None

--- a/tests/test_skills_hub_github.py
+++ b/tests/test_skills_hub_github.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
@@ -27,6 +28,13 @@ class _Response:
         if self.status_code >= 400:
             raise RuntimeError(f"HTTP {self.status_code}")
 
+    async def aiter_bytes(self) -> AsyncGenerator[bytes, None]:
+        if self.content:
+            yield self.content
+
+    async def aclose(self) -> None:
+        pass
+
 
 class _AsyncClient:
     tree_entries = [
@@ -50,6 +58,12 @@ class _AsyncClient:
 
     async def __aexit__(self, *args: Any) -> None:
         return None
+
+    def build_request(self, method: str, url: str, **kwargs: Any) -> str:
+        return url
+
+    async def send(self, request: str, **kwargs: Any) -> _Response:
+        return await self.get(request)
 
     async def get(self, url: str, **kwargs: Any) -> _Response:
         self.requests.append((url, kwargs))


### PR DESCRIPTION
GitHubSource.fetch() downloaded every blob with a non-streaming client.get() + raw_resp.content, so httpx buffered the entire blob before any size check. A hostile repo could ship an oversized blob and OOM the installer.

Add per-blob ceiling (_MAX_BLOB_BYTES = 8 MiB) and cumulative total budget (_MAX_TOTAL_BYTES = 32 MiB). Stream each blob with build_request() + send(stream=True), accumulate aiter_bytes() up to the cap, and skip oversized blobs with a warning.

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
