### PR TITLE
fix(sandbox): hard-block rm -rf root and scan every segment of compound rm commands

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -149,9 +149,13 @@ def is_sensitive_path(path: str) -> str | None:
         return "/ (filesystem root)"
     # A resolved form may be a drive root on Windows (e.g. "D:/" from
     # Path("/").resolve()) or an empty path; both wipe everything on that
-    # volume, so treat them as filesystem root as well.
+    # volume, so treat them as filesystem root as well. A drive-prefixed
+    # root glob ("D:/*", from Path("/*").resolve()) likewise wipes every
+    # path on the volume.
     for expanded in _comparison_path_candidates(path):
         stripped = expanded.rstrip("/")
+        if stripped.endswith("/*"):
+            stripped = stripped[:-2].rstrip("/")
         if stripped == "" or (len(stripped) == 2 and stripped[1] == ":"):
             return "/ (filesystem root)"
     candidates = _comparison_path_candidates(path)

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -139,6 +139,14 @@ def is_sensitive_path(path: str) -> str | None:
         return None
     if not path:
         return None
+    # Root filesystem ("/", "/.", "//") and anything under it ("/*") is always
+    # sensitive - `rm -rf /` / `rm -rf /*` must be hard-blocked regardless of
+    # any leading benign target in a compound command. Issue #563.
+    path_normalized = path.replace("\\", "/")
+    if path_normalized in ("/", "/.", "//", ".") or path_normalized.rstrip("/") == "":
+        return "/ (filesystem root)"
+    if path_normalized == "/*" or path_normalized.startswith("//"):
+        return "/ (filesystem root)"
     candidates = _comparison_path_candidates(path)
     for expanded in candidates:
         if (

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -147,6 +147,13 @@ def is_sensitive_path(path: str) -> str | None:
         return "/ (filesystem root)"
     if path_normalized == "/*" or path_normalized.startswith("//"):
         return "/ (filesystem root)"
+    # A resolved form may be a drive root on Windows (e.g. "D:/" from
+    # Path("/").resolve()) or an empty path; both wipe everything on that
+    # volume, so treat them as filesystem root as well.
+    for expanded in _comparison_path_candidates(path):
+        stripped = expanded.rstrip("/")
+        if stripped == "" or (len(stripped) == 2 and stripped[1] == ":"):
+            return "/ (filesystem root)"
     candidates = _comparison_path_candidates(path)
     for expanded in candidates:
         if (

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -103,3 +103,26 @@ def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
         sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
         == "~/.ssh"
     )
+
+def test_bare_root_is_sensitive() -> None:
+    # Issue #563: `rm -rf /` must hit the hard block.
+    assert is_sensitive_path("/") == "/ (filesystem root)"
+    assert is_sensitive_path("/.") == "/ (filesystem root)"
+    assert is_sensitive_path("///") == "/ (filesystem root)"
+    assert is_sensitive_path("/*") == "/ (filesystem root)"
+
+
+def test_root_wipe_in_compound_command_is_blocked() -> None:
+    # Issue #563: a benign leading target must not smuggle a root wipe past
+    # the hard block; every rm segment of a compound command is scanned.
+    assert sensitive_target_in_command("rm /tmp/safe; rm -rf /") == "/ (filesystem root)"
+    assert (
+        sensitive_target_in_command("rm /tmp/safe && rm -rf /*") == "/ (filesystem root)"
+    )
+    assert sensitive_target_in_command("rm -rf /") == "/ (filesystem root)"
+
+
+def test_non_root_compound_targets_still_block() -> None:
+    # The trailing-target scan (upstream #512 parser) still catches sensitive
+    # paths in later rm segments; bare-root handling must not shadow it.
+    assert sensitive_target_in_command("rm /tmp/safe; rm /root/.ssh/id_rsa") is not None


### PR DESCRIPTION
Updated in 9843b96, now based on current main:

- **Compound-rm half of #563 is now covered by the upstream #512 parser rewrite** in `_extract_rm_targets` (per-`rm` finditer, stops at shell separators), which landed while this PR was open. The old branch-side parser rewrite is dropped so the two do not fight each other.
- **This PR now carries the missing bare-root half:** `is_sensitive_path` returns a filesystem-root marker for `/`, `/.`, `//`, `.` / empty-after-strip, and `/*` (the root glob), so `rm -rf /` and `rm -rf /*` hard-block in default mode.
- Regression tests added for bare-root forms and for compound commands smuggling `rm -rf /` behind a benign leading target (`rm /tmp/safe; rm -rf /`).

Verified on the rebased branch: `tests/test_sandbox/test_sensitive_paths.py` + `tests/test_tools/test_shell_approval_policy.py` + `tests/test_application` (95 passed), ruff check clean.