### PR TITLE
fix(sandbox): block bare root targets (/) in sensitive-path hard block

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -34,11 +34,15 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
     """
     if not raw or raw.startswith(("$", "`")) or raw in {"*", "-"}:
         return raw
-    # Paths starting with ``/`` (like ``/*``, ``/``, ``/.``) are root
-    # references on POSIX.  On Windows they are ambiguous (no drive letter)
-    # and Path.resolve() will incorrectly join them with the CWD, making
-    # the root-sensitive-path hard block unreachable.  Return them as-is.
-    if raw.lstrip().startswith("/"):
+    # Paths that are bare root references (``/*``, ``/``, ``/.``) are
+    # ambiguous on Windows (no drive letter) and Path.resolve() would
+    # incorrectly join them with the CWD, making the root-sensitive-path
+    # hard block unreachable.  Return them as-is.
+    stripped = raw.strip().replace("\\", "/")
+    if stripped in ("/", "/.", "/*"):
+        return raw
+    _drive, tail = os.path.splitdrive(stripped)
+    if tail.strip("/\\") == "":
         return raw
     try:
         path = Path(raw).expanduser()

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -36,7 +36,11 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
         return raw
     try:
         path = Path(raw).expanduser()
-        if base_dir is not None and not path.is_absolute():
+        # On Windows, ``/*`` is not absolute (no drive letter), but it is a
+        # valid root reference that should not be joined with the CWD — that
+        # would turn ``rm -rf /*`` into a resolved Windows path that bypasses
+        # the root-sensitive-path hard block.
+        if base_dir is not None and not path.is_absolute() and not raw.startswith("/"):
             path = Path(base_dir).expanduser() / path
         return str(path.resolve(strict=False))
     except (OSError, ValueError):

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -34,13 +34,15 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
     """
     if not raw or raw.startswith(("$", "`")) or raw in {"*", "-"}:
         return raw
+    # Paths starting with ``/`` (like ``/*``, ``/``, ``/.``) are root
+    # references on POSIX.  On Windows they are ambiguous (no drive letter)
+    # and Path.resolve() will incorrectly join them with the CWD, making
+    # the root-sensitive-path hard block unreachable.  Return them as-is.
+    if raw.lstrip().startswith("/"):
+        return raw
     try:
         path = Path(raw).expanduser()
-        # On Windows, ``/*`` is not absolute (no drive letter), but it is a
-        # valid root reference that should not be joined with the CWD — that
-        # would turn ``rm -rf /*`` into a resolved Windows path that bypasses
-        # the root-sensitive-path hard block.
-        if base_dir is not None and not path.is_absolute() and not raw.startswith("/"):
+        if base_dir is not None and not path.is_absolute():
             path = Path(base_dir).expanduser() / path
         return str(path.resolve(strict=False))
     except (OSError, ValueError):

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -141,10 +141,17 @@ def is_sensitive_path(path: str) -> str | None:
         return None
 
     # Block bare root targets: ``/``, ``/.``, ``/*``, and empty-after-strip variants.
+    # On Windows, drive-letter roots like ``C:\`` are also covered.
     # ``rm -rf /`` is the most destructive command — never allow it without
     # the explicit /elevated full escape hatch.
-    stripped = path.strip()
-    if stripped in ("/", "/.", "/*", "/ *") or stripped.rstrip("/") == "":
+    stripped = path.strip().replace("\\", "/")
+    if stripped in ("/", "/.", "/*", "/ *"):
+        return "/"
+    # Cross-platform: strip drive letter and check for empty/root tail.
+    # On Windows, Path("/").resolve() may produce a drive-letter root like
+    # ``C:\``, and ``_norm_path`` in the intent layer will pass it through.
+    _drive, tail = os.path.splitdrive(stripped)
+    if tail.strip("/\\") == "":
         return "/"
 
     candidates = _comparison_path_candidates(path)

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -260,6 +260,9 @@ def sensitive_path_marker(
     marker = is_sensitive_path(path)
     if marker is None:
         return None
+    # Root marker ("/") is absolute — never soften it with workspace exceptions.
+    if marker == "/":
+        return marker
     if _workspace_contains(path, workspace) and _workspace_nested_under_marker(
         workspace, marker
     ):

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -112,6 +112,21 @@ def _looks_like_rooted_path_text(path: str) -> bool:
     return normalized.startswith(("/", "~/")) and not normalized.startswith("//")
 
 
+def _is_root_target(text: str) -> bool:
+    """Return True if *text* resolves to a bare root target.
+
+    On Windows, ``Path("/*").is_absolute()`` is ``False`` (no drive
+    letter), so the normal ``is_sensitive_path`` guard in
+    :func:`sensitive_path_marker` is bypassed entirely.  This helper
+    catches the same pattern after path normalization.
+    """
+    stripped = text.strip().replace("\\", "/")
+    if stripped in ("/", "/.", "/*"):
+        return True
+    _drive, tail = os.path.splitdrive(stripped)
+    return tail.strip("/\\") == ""
+
+
 def _path_name(path: str) -> str:
     normalized = str(path).strip().replace("\\", "/").rstrip("/")
     return PurePosixPath(normalized).name.lower()
@@ -256,6 +271,11 @@ def sensitive_path_marker(
         and not _looks_like_rooted_path_text(text)
     ):
         return _sensitive_leaf_marker(text)
+
+    # Re-check root-like targets after path normalization may have stripped
+    # the leading ``/`` on Windows (where ``/*`` is not absolute).
+    if _is_root_target(text):
+        return "/"
 
     marker = is_sensitive_path(path)
     if marker is None:

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -139,6 +139,14 @@ def is_sensitive_path(path: str) -> str | None:
         return None
     if not path:
         return None
+
+    # Block bare root targets: ``/``, ``/.``, ``/*``, and empty-after-strip variants.
+    # ``rm -rf /`` is the most destructive command — never allow it without
+    # the explicit /elevated full escape hatch.
+    stripped = path.strip()
+    if stripped in ("/", "/.", "/*", "/ *") or stripped.rstrip("/") == "":
+        return "/"
+
     candidates = _comparison_path_candidates(path)
     for expanded in candidates:
         if (

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -103,3 +103,27 @@ def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
         sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
         == "~/.ssh"
     )
+
+
+def test_bare_root_is_sensitive() -> None:
+    """rm -rf / must be blocked by the hard block."""
+    assert is_sensitive_path("/") == "/"
+    assert is_sensitive_path("/.") == "/"
+    assert is_sensitive_path("/*") == "/"
+
+
+def test_bare_root_blocks_rm_rf() -> None:
+    """rm -rf / triggers the hard block."""
+    assert sensitive_target_in_command("rm -rf /") == "/"
+    assert sensitive_target_in_command("rm -rf --no-preserve-root /") == "/"
+
+
+def test_bare_root_blocks_rm_rf_with_glob() -> None:
+    assert sensitive_target_in_command("rm -rf /*") == "/"
+
+
+def test_bare_root_leaves_legitimate_commands_alone() -> None:
+    """Files under / (like /tmp) are not affected by the root block."""
+    assert is_sensitive_path("/tmp") is None
+    assert is_sensitive_path("/tmp/foo.txt") is None
+    assert sensitive_target_in_command("rm /tmp/scratch.txt") is None


### PR DESCRIPTION
is_sensitive_path did not check for bare root paths like /, /., or /*, so rm -rf / and rm -rf /* passed the hard block and reached the approval queue — where a single click could wipe the host filesystem.

Add an early guard in is_sensitive_path that returns a "/" marker for bare root targets before any prefix matching. The marker flows through sensitive_target_in_command() to block the destructive command.

The companion under-parse in _extract_rm_targets (compound commands with trailing targets after a shell separator) was already fixed in PR #546 (issue #512). Both fixes are needed to fully close #563.

Test: 11 test_sensitive_paths tests pass (4 new), 0 regressions.

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
