### PR TITLE
fix(scheduler): bound timeout_seconds on cron create/update

### DIFF
--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -33,6 +33,11 @@ from .types import (
     SessionTarget,
 )
 
+# Hard cap on job timeout_seconds. A single cron create/update with a huge
+# value would hold a model turn open indefinitely (scheduler DoS); negative
+# values make asyncio.wait_for run the handler with no wait at all.
+_MAX_JOB_TIMEOUT_SECONDS = 24 * 60 * 60  # 24h
+
 
 def _resolve_script_placeholder(job: CronJob) -> None:
     """Replace ``{job_id}`` in the job's script path with the job's own id.
@@ -268,6 +273,20 @@ class SchedulerOps:
             explicit_delivery=delivery is not None,
         )
 
+        # Bound timeout_seconds: a negative or absurdly large value would make
+        # asyncio.wait_for run the handler with no wait at all (<=0) or hold a
+        # model turn open for years (huge), a reliable scheduler DoS via a
+        # single cron create/update call.
+        if timeout_seconds is None or timeout_seconds < 1:
+            raise ValueError(
+                f"timeout_seconds must be >= 1, got {timeout_seconds!r}"
+            )
+        if timeout_seconds > _MAX_JOB_TIMEOUT_SECONDS:
+            raise ValueError(
+                f"timeout_seconds must be <= {_MAX_JOB_TIMEOUT_SECONDS}, "
+                f"got {timeout_seconds!r}"
+            )
+
         job = CronJob(
             name=name,
             schedule_raw=schedule_raw,
@@ -376,6 +395,13 @@ class SchedulerOps:
 
         for field in ("name", "timeout_seconds", "enabled", "origin_session_key"):
             if field in patch:
+                if field == "timeout_seconds":
+                    value = patch[field]
+                    if value is None or value < 1 or value > _MAX_JOB_TIMEOUT_SECONDS:
+                        raise ValueError(
+                            f"timeout_seconds must be 1..{_MAX_JOB_TIMEOUT_SECONDS}, "
+                            f"got {value!r}"
+                        )
                 setattr(job, field, patch.pop(field))
         # Validated after normalize_contract below: a patch that converts the
         # job's kind also moves its handler_key, and the elevation rule is

--- a/tests/test_scheduler/test_timeout_seconds_bound.py
+++ b/tests/test_scheduler/test_timeout_seconds_bound.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.scheduler.ops import SchedulerOps
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import ScheduleKind, SessionTarget
+
+
+def _kw(name: str, **over) -> dict:
+    kw = dict(
+        name=name,
+        handler_key="agent_turn",
+        payload={"text": "ping"},
+        session_target=SessionTarget.ISOLATED,
+        schedule_kind=ScheduleKind.EVERY,
+        schedule_value="60",
+    )
+    kw.update(over)
+    return kw
+
+
+@pytest.mark.parametrize("bad", [-1.0, 0.0, 0.999])
+@pytest.mark.asyncio
+async def test_create_rejects_low_timeout_seconds(bad, tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    try:
+        ops = SchedulerOps(store)
+        with pytest.raises(ValueError, match="timeout_seconds must be >="):
+            await ops.add(**_kw(f"low-{bad}", timeout_seconds=bad))
+    finally:
+        await store.close()
+
+
+@pytest.mark.parametrize("bad", [86401, 86401.0, 1e12])
+@pytest.mark.asyncio
+async def test_create_rejects_high_timeout_seconds(bad, tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    try:
+        ops = SchedulerOps(store)
+        with pytest.raises(ValueError, match="timeout_seconds must be <="):
+            await ops.add(**_kw(f"high-{bad}", timeout_seconds=bad))
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_out_of_range_timeout_seconds(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "cron.db"))
+    await store.open()
+    try:
+        ops = SchedulerOps(store)
+        job = await ops.add(**_kw("ok"))
+        with pytest.raises(ValueError, match="timeout_seconds must be"):
+            await ops.update(job.id, timeout_seconds=-1)
+        with pytest.raises(ValueError, match="timeout_seconds must be"):
+            await ops.update(job.id, timeout_seconds=1e12)
+    finally:
+        await store.close()


### PR DESCRIPTION
Fixes #570

## Summary
timeout_seconds was accepted unbounded. <= 0 makes asyncio.wait_for run the handler with no wait at all; a huge value holds a model turn open for years - a reliable scheduler DoS via a single cron create/update call.

## Changes
- SchedulerOps.add: reject timeout_seconds < 1 or > 24h.
- SchedulerOps.update: same bounds on the patch path.

## Tests
- New test_timeout_seconds_bound.py (7 cases: low/high on create + update)
- 458/458 in tests/test_scheduler/

Co-authored-by: Hermes Agent <hermes@nousresearch.com>