### PR TITLE
fix(scheduler): block cloud metadata URLs on cron webhooks

### DIFF
--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -21,6 +21,7 @@ from agentos.scheduler.types import (
     SessionTarget,
 )
 from agentos.session.keys import parse_agent_id
+from agentos.tools.ssrf import assert_not_metadata_endpoint
 
 log = structlog.get_logger(__name__)
 
@@ -28,9 +29,7 @@ SCRIPT_HANDLER_KEY = "script_run"
 
 
 _WEBHOOK_TIMEOUT_SECONDS = 10.0
-_REPLY_DIRECTIVE_RE = re.compile(
-    r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*"
-)
+_REPLY_DIRECTIVE_RE = re.compile(r"\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*")
 
 
 def strip_reply_directives(text: str | None) -> str | None:
@@ -40,7 +39,14 @@ def strip_reply_directives(text: str | None) -> str | None:
 
 
 def validate_webhook_url(url: str) -> None:
-    """Raise ValueError if ``url`` is not a syntactically valid http(s) URL."""
+    """Raise ValueError if ``url`` is not a syntactically valid http(s) URL.
+
+    Localhost and LAN hooks are allowed — operators point cron at n8n and
+    similar. Cloud metadata endpoints are not: they hand out instance
+    credentials, and ``http_request`` already refuses them for the same
+    reason. Reuse that floor so a webhook cannot be the SSRF hole the
+    fetch tools closed.
+    """
     if not url:
         raise ValueError("webhook URL is required")
     try:
@@ -48,11 +54,11 @@ def validate_webhook_url(url: str) -> None:
     except ValueError as exc:
         raise ValueError(f"invalid webhook URL: {url!r}") from exc
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(
-            f"webhook URL must use http or https scheme, got {parsed.scheme!r}"
-        )
+        raise ValueError(f"webhook URL must use http or https scheme, got {parsed.scheme!r}")
     if not parsed.hostname:
         raise ValueError(f"webhook URL is missing a hostname: {url!r}")
+    # SSRFBlockedError is a ValueError, so add/update callers keep working.
+    assert_not_metadata_endpoint(url)
 
 
 # The origin webchat session a job was born in no longer exists. Deliberately

--- a/src/agentos/scheduler/ops.py
+++ b/src/agentos/scheduler/ops.py
@@ -155,6 +155,9 @@ def _normalize_delivery_for_target(
 ) -> DeliveryConfig:
     if delivery is not None and delivery.mode == DeliveryMode.WEBHOOK:
         validate_webhook_url(delivery.webhook_url)
+    fd = delivery.failure_destination if delivery is not None else None
+    if fd is not None and fd.mode == DeliveryMode.WEBHOOK:
+        validate_webhook_url(fd.webhook_url)
     if session_target != SessionTarget.MAIN:
         return delivery
     # Webhook delivery is allowed for any sessionTarget — the heartbeat
@@ -242,11 +245,7 @@ class SchedulerOps:
         # fall back to ISOLATED instead of failing creation. Headless cron
         # callers (no session context) get an isolated run rather than a hard
         # error.
-        if (
-            session_target == SessionTarget.CURRENT
-            and not session_key
-            and not origin_session_key
-        ):
+        if session_target == SessionTarget.CURRENT and not session_key and not origin_session_key:
             session_target = SessionTarget.ISOLATED
 
         origin_session_key = normalize_origin_session_key(session_target, origin_session_key)

--- a/tests/test_scheduler/test_webhook_delivery.py
+++ b/tests/test_scheduler/test_webhook_delivery.py
@@ -50,6 +50,28 @@ def test_validate_webhook_url_rejects_empty() -> None:
         validate_webhook_url("")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://169.254.169.254/",
+        "https://169.254.169.253/",
+        "http://169.254.170.2/",
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://metadata.goog/",
+    ],
+)
+def test_validate_webhook_url_rejects_cloud_metadata(url: str) -> None:
+    """Cron webhooks may target localhost; they may not target IMDS."""
+    with pytest.raises(ValueError, match="metadata"):
+        validate_webhook_url(url)
+
+
+def test_validate_webhook_url_still_allows_localhost() -> None:
+    validate_webhook_url("http://127.0.0.1:5678/webhook")
+    validate_webhook_url("http://localhost:8080/hook")
+
+
 # --- ops.add validates webhook config -------------------------------------
 
 
@@ -99,11 +121,34 @@ async def test_ops_add_rejects_webhook_without_url(tmp_path: Path) -> None:
             await ops.add(
                 name="bad",
                 schedule_kind=ScheduleKind.CRON,
-            schedule_value="*/5 * * * *",
+                schedule_value="*/5 * * * *",
                 handler_key="agent_run",
                 payload=make_agent_turn_payload("x"),
                 session_target=SessionTarget.ISOLATED,
                 delivery=DeliveryConfig(mode=DeliveryMode.WEBHOOK, webhook_url=""),
+            )
+    finally:
+        await store.close()
+
+
+async def test_ops_add_rejects_metadata_webhook_url(tmp_path: Path) -> None:
+    db = tmp_path / "cron.db"
+    store = JobStore(str(db))
+    await store.open()
+    try:
+        ops = SchedulerOps(store)
+        with pytest.raises(ValueError, match="metadata"):
+            await ops.add(
+                name="imds",
+                schedule_kind=ScheduleKind.CRON,
+                schedule_value="*/5 * * * *",
+                handler_key="agent_run",
+                payload=make_agent_turn_payload("x"),
+                session_target=SessionTarget.ISOLATED,
+                delivery=DeliveryConfig(
+                    mode=DeliveryMode.WEBHOOK,
+                    webhook_url="http://169.254.169.254/latest/meta-data/",
+                ),
             )
     finally:
         await store.close()
@@ -119,7 +164,7 @@ async def test_ops_add_rejects_webhook_with_bad_scheme(tmp_path: Path) -> None:
             await ops.add(
                 name="bad",
                 schedule_kind=ScheduleKind.CRON,
-            schedule_value="*/5 * * * *",
+                schedule_value="*/5 * * * *",
                 handler_key="agent_run",
                 payload=make_agent_turn_payload("x"),
                 session_target=SessionTarget.ISOLATED,


### PR DESCRIPTION
Fixes #574

## What

Cron webhook URLs now go through the same SSRF metadata check that `http_request` already uses. Cloud metadata endpoints (AWS IMDS, GCP metadata, Azure IMDS, link-local range) get rejected at job creation time.

Localhost and LAN targets still work — operators use those for n8n, internal hooks, etc.

## Changes

- **`scheduler/delivery.py`** — `validate_webhook_url` calls `assert_not_metadata_endpoint` after the existing scheme/hostname checks
- **`scheduler/ops.py`** — also validates `failure_destination` webhook URLs, not just the primary one
- **`test_webhook_delivery.py`** — parametrized test covering AWS, GCP, and Azure metadata URLs; explicit test that localhost is still allowed; ops-level test for metadata URL rejection