### PR TITLE
fix(channels): reject off-allowlist Reply-To on email replies

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -17,9 +17,10 @@ Access control
 --------------
 ``allowed_senders`` is a fail-closed From-address allowlist. Entries are
 exact addresses (``me@example.com``) or domain patterns (``*@example.com``
-/ ``@example.com``). It is enforced twice: at poll time, so a stranger's
-mail is never queued, and again through ``evaluate_access`` so gateway
-dispatch reaches the same verdict.
+/ ``@example.com``). It is enforced three times: at poll time, so a
+stranger's mail is never queued; through ``evaluate_access`` so gateway
+dispatch reaches the same verdict; and on outbound ``To``, so an
+allowlisted sender cannot redirect the reply via ``Reply-To``.
 
 Loop safety
 -----------
@@ -539,6 +540,18 @@ class EmailChannel:
         subject = decode_header_value(parsed.get("Subject"))
         body = strip_quoted_reply(_body_text(parsed))
         reply_to = normalize_address(parsed.get("Reply-To", "")) or sender
+        # Outbound To is the blast radius of a reply. Honor Reply-To only when
+        # the address is on the same fail-closed allowlist that admitted the
+        # sender; otherwise an allowlisted From can exfiltrate the agent's
+        # answer (and any tool output in it) to an arbitrary mailbox.
+        if not sender_allowed(reply_to, self.config.allowed_senders):
+            log.warning(
+                "email.reply_to_not_allowed",
+                name=self.config.name,
+                sender=sender,
+                reply_to=reply_to,
+            )
+            reply_to = sender
 
         self._remember_thread(
             thread_id,
@@ -639,6 +652,8 @@ class EmailChannel:
         to_address = str(metadata.get("to") or (thread.to_address if thread else ""))
         if not to_address:
             raise ValueError("email.send has no recipient for reply_to")
+        if not sender_allowed(to_address, self.config.allowed_senders):
+            raise ValueError("email.send recipient is not on the allowed_senders allowlist")
         subject = str(metadata.get("subject") or "").strip()
         if not subject:
             subject = reply_subject(thread.subject if thread else "")

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -312,6 +312,52 @@ async def test_send_composes_threading_headers(monkeypatch: pytest.MonkeyPatch) 
     assert outbound.get_content().strip() == "the answer"
 
 
+def test_off_allowlist_reply_to_does_not_become_the_outbound_recipient() -> None:
+    """An allowlisted From cannot redirect the reply via Reply-To.
+
+    The inbound allowlist is fail-closed on From. Without a matching check on
+    the outbound To, a sender on that list can set Reply-To to an arbitrary
+    mailbox and receive the agent's answer (and any tool output in it).
+    """
+
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(_raw(extra_headers={"Reply-To": "exfil@evil.example"}))
+    assert inbound is not None
+    assert inbound.metadata["email_reply_to"] == "owner@example.com"
+    assert inbound.metadata["email_from"] == "owner@example.com"
+
+    reply = channel.build_reply_message("secret answer", inbound)
+    assert reply.metadata["to"] == "owner@example.com"
+
+
+def test_allowlisted_reply_to_is_honored() -> None:
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(_raw(extra_headers={"Reply-To": "anyone@team.example"}))
+    assert inbound is not None
+    assert inbound.metadata["email_reply_to"] == "anyone@team.example"
+    assert channel.build_reply_message("ok", inbound).metadata["to"] == "anyone@team.example"
+
+
+async def test_send_refuses_an_off_allowlist_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(_raw())
+    assert inbound is not None
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    with pytest.raises(ValueError, match="allowed_senders"):
+        await channel.send(
+            OutgoingMessage(
+                content="leak",
+                reply_to=inbound.channel_id,
+                metadata={"to": "exfil@evil.example", "subject": "Re: Status?"},
+            )
+        )
+    assert sent == []
+
+
 async def test_send_resolves_the_recipient_from_the_thread_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #575

## What

The email channel now checks Reply-To against the same `allowed_senders` allowlist used for From. If the Reply-To address is not on the list, the reply goes back to the original sender instead.

This also adds a guard on the outbound send path — `send()` refuses to deliver to a recipient that is not on the allowlist.

## Changes

- **`channels/email.py`** — `_to_incoming` validates Reply-To against `sender_allowed()` and falls back to the From address; `send()` raises if the resolved `to_address` is off-list
- **`test_email_channel.py`** — tests for off-list Reply-To fallback, on-list Reply-To passthrough, and send rejection for off-list recipients