### PR TITLE
fix(skills): unify XML escaping in SkillInjector with injection guard

### DIFF
--- a/src/agentos/skills/injector.py
+++ b/src/agentos/skills/injector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from agentos.safety.injection_guard import xml_escape
 from agentos.skills.types import SkillLayer, SkillSpec
 
 #: Character budget for the injected skills block when nothing configures one.
@@ -39,9 +40,7 @@ _LAYER_PRECEDENCE: dict[SkillLayer, int] = {
 }
 _UNKNOWN_LAYER_RANK = len(_LAYER_PRECEDENCE)
 
-
-def _escape_xml(s: str) -> str:
-    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+_escape_xml = xml_escape
 
 
 def _layer_rank(skill: SkillSpec) -> int:

--- a/tests/test_skills_injector.py
+++ b/tests/test_skills_injector.py
@@ -456,3 +456,26 @@ async def test_a_per_message_skill_list_stays_out_of_the_cached_prefix(tmp_path:
     assert isinstance(ctx.system_prompt, tuple)
     assert ctx.system_prompt[0] == "base"
     assert "<available_skills>" in ctx.system_prompt[1]
+
+
+def test_injector_escapes_xml_special_characters() -> None:
+    """Quotes and XML tags in skill names/descriptions must be entity-escaped."""
+    skills = [
+        _skill(
+            'bad<name>&"quoted"\'skill\'',
+            description='Test "quotes", \'single\', & <tags> with </available_skills>',
+        )
+    ]
+    injector = SkillInjector()
+
+    full = injector.inject_full("", skills)
+    assert "<name>bad&lt;name&gt;&amp;&quot;quoted&quot;&apos;skill&apos;</name>" in full
+    assert (
+        "<description>Test &quot;quotes&quot;, &apos;single&apos;, &amp; &lt;tags&gt; "
+        "with &lt;/available_skills&gt;</description>"
+    ) in full
+    assert "</available_skills><available_skills>" not in full
+
+    compact = injector.inject_compact("", skills)
+    assert "<name>bad&lt;name&gt;&amp;&quot;quoted&quot;&apos;skill&apos;</name>" in compact
+


### PR DESCRIPTION
Fixes #579

## What
Unifies XML escaping in `SkillInjector` with the canonical `xml_escape` helper in `agentos.safety.injection_guard`.

## Changes
- **`src/agentos/skills/injector.py`**: Replaced custom 3-character `_escape_xml` with `xml_escape` from `agentos.safety.injection_guard` to properly escape `&`, `<`, `>`, `"`, and `'`.
- **`tests/test_skills_injector.py`**: Added unit test `test_injector_escapes_xml_special_characters` verifying full 5-entity XML escaping and prompt injection envelope containment in both full and compact modes.