### PR TITLE
fix(provider): clarify operator precedence in Ollama failure classification #582

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -168,7 +168,7 @@ def classify_provider_error(
             return ProviderFailureKind.BAD_REQUEST
 
     if provider == "ollama":
-        if "model not found" in text or "pull" in text and "model" in text:
+        if "model not found" in text or ("pull" in text and "model" in text):
             return ProviderFailureKind.MODEL_NOT_FOUND
         if (
             "connection refused" in text

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -290,3 +290,19 @@ def test_new_transient_status_codes_match_via_text(message: str) -> None:
         classify_provider_error("openrouter", None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
     )
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_kind"),
+    [
+        ("model not found", ProviderFailureKind.MODEL_NOT_FOUND),
+        ("model 'llama3' not found, try pulling it first", ProviderFailureKind.MODEL_NOT_FOUND),
+        ("pull the model before running", ProviderFailureKind.MODEL_NOT_FOUND),
+        ("connection refused", ProviderFailureKind.TRANSPORT_TRANSIENT),
+        ("request error", ProviderFailureKind.TRANSPORT_TRANSIENT),
+        ("timeout", ProviderFailureKind.TRANSPORT_TRANSIENT),
+    ],
+)
+def test_ollama_failure_classification(message: str, expected_kind: ProviderFailureKind) -> None:
+    assert classify_provider_error("ollama", None, message=message) is expected_kind
+


### PR DESCRIPTION
Closes #582

### Summary
Clarifies operator precedence in `classify_provider_error` for the Ollama provider by adding explicit parentheses around `("pull" in text and "model" in text)`.

### Problem
In `src/agentos/provider/failures.py`:
```python
# Before (line 171)
if "model not found" in text or "pull" in text and "model" in text:
While Python evaluates and with higher precedence than or, the unparenthesized expression is misleading and fragile against future refactoring.

Fix
# After
if "model not found" in text or ("pull" in text and "model" in text):
### Verification
Added parameterized regression tests in tests/test_provider_failure_classification.py (test_ollama_failure_classification).
All 94 tests in tests/test_provider_failure_classification.py pass.
ruff check and mypy pass with 0 errors.