### PR TITLE
fix(router): stop reporting a route the explicit model overrode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Router metadata no longer reports a model the provider never ran. An explicit
+  model — a durable `config.agents[].model`, a session pin, or a per-call
+  override — beats the Pilot Router's pick when `PromptAssemblerStage` resolves
+  the final model, but the metadata kept advertising the route as applied, so
+  the Web UI router HUD, the `DoneEvent`, per-turn usage and the savings figures
+  all named the routed model and credited savings for a route the turn never
+  took. The decision is now demoted the same way the `observe` rollout phase
+  already does it (`routing_applied=false`, tier and model kept on the record as
+  advice), and per-turn savings are priced from the model that actually ran —
+  which also corrects the cost basis reported during `observe` (#586).
+
 ## [2026.8.29] - 2026-08-29
 
 ### Added

--- a/src/agentos/engine/router_decision.py
+++ b/src/agentos/engine/router_decision.py
@@ -2,11 +2,53 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import Any, cast
 
 from agentos.engine.pipeline import TurnContext
 from agentos.engine.types import RouterDecisionEvent
 from agentos.router_tiers import normalize_text_tier, tier_index
+
+ROUTING_OVERRIDE_EXPLICIT_MODEL = "explicit_model"
+
+
+def reconcile_routing_metadata(
+    metadata: MutableMapping[str, Any],
+    resolved_model: str,
+) -> bool:
+    """Demote a routing decision the turn did not actually honor.
+
+    The Pilot Router writes its pick into ``turn.model``, but the model sent to
+    the provider is resolved as ``explicit > pipeline-routed > selector`` (see
+    :class:`~agentos.engine.turn_runner.prompt_assembler_stage.PromptAssemblerStage`).
+    An explicit per-call model — a durable ``config.agents[].model``, a session
+    pin, or an API override — therefore beats the route, while the router
+    metadata still advertised the route as applied. Everything reading that
+    metadata (``RouterDecisionEvent``, the ``DoneEvent``, per-turn usage and the
+    savings figures) then reported a model that never ran, and credited savings
+    against a price nobody was billed.
+
+    This reuses the ``routing_applied=False`` contract the ``observe`` rollout
+    phase already established: the tier and model stay on the record as the
+    router's advice, ``applied_model``/``baseline_model`` name the model that
+    really ran, and the unrealized savings are zeroed.
+
+    Returns ``True`` when the metadata was demoted.
+    """
+    if not metadata.get("routed_tier") or not resolved_model:
+        return False
+    applied_model = str(metadata.get("applied_model") or "")
+    if not applied_model or applied_model == resolved_model:
+        return False
+
+    metadata["routing_applied"] = False
+    metadata["routing_override_source"] = ROUTING_OVERRIDE_EXPLICIT_MODEL
+    metadata["applied_model"] = resolved_model
+    metadata["baseline_model"] = resolved_model
+    metadata["savings_pct"] = 0.0
+    metadata["savings_max_price_per_m"] = 0.0
+    metadata["savings_routed_price_per_m"] = 0.0
+    return True
 
 
 def _coerce_probs(value: object) -> list[float]:

--- a/src/agentos/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/agentos/engine/turn_runner/prompt_assembler_stage.py
@@ -441,6 +441,14 @@ class PromptAssemblerStage:
             except Exception:  # noqa: BLE001 - defensive
                 selector_model = ""
         resolved_model = inp.model or turn.model or selector_model
+        # An explicit model beats the routed one above. Tell the router
+        # metadata so nothing downstream reports (or prices) a route the
+        # provider call never used. Local import for the same reason as
+        # ``_SelectorFallbackProvider`` above: the stage keeps engine
+        # imports off its module top level.
+        from agentos.engine.router_decision import reconcile_routing_metadata
+
+        reconcile_routing_metadata(turn.metadata, resolved_model)
         provider_name = (
             getattr(provider, "provider_name", "") or type(provider).__name__
         )

--- a/src/agentos/engine/turn_runner/stream_consumer_stage.py
+++ b/src/agentos/engine/turn_runner/stream_consumer_stage.py
@@ -509,12 +509,18 @@ class _DoneHandler:
             "estimated_output_savings_pct",
             0.03,
         )
+        # Price the turn from the model that actually ran. When routing was
+        # not applied — observe rollout, or an explicit model that beat the
+        # route in PromptAssemblerStage — ``routed_model`` is the router's
+        # advice, not what the provider billed, and pricing against it invents
+        # a cost (and a saving) for a model nobody called.
+        priced_model = routed_model if routing_applied else (event.model or routed_model)
         comprehensive = _compute_comprehensive_turn_savings(
             event,
             metadata,
             agentos_router_tiers,
-            routed_model,
-            routed_tier=str(routed_tier or ""),
+            priced_model,
+            routed_tier=str(routed_tier or "") if routing_applied else "",
             estimated_output_savings_pct=estimated_output_savings_pct,
         )
         provider_cache_hit = (event.cached_tokens or 0) > 0

--- a/tests/test_engine/test_router_metadata_reconcile.py
+++ b/tests/test_engine/test_router_metadata_reconcile.py
@@ -1,0 +1,108 @@
+"""Regression tests for ``reconcile_routing_metadata``.
+
+An explicit model (a durable ``config.agents[].model``, a session pin, an API
+override) beats the Pilot Router's pick when ``PromptAssemblerStage`` resolves
+the final model. Before the reconcile step the router metadata kept claiming
+the route had been applied, so the HUD event, the DoneEvent, per-turn usage and
+the savings figures all named a model the provider was never asked for.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.router_decision import (
+    ROUTING_OVERRIDE_EXPLICIT_MODEL,
+    build_router_decision_event,
+    reconcile_routing_metadata,
+)
+
+
+def _ctx(metadata: dict[str, Any], model: str = "") -> TurnContext:
+    return TurnContext(
+        message="hi",
+        session_key="agent:main:webchat:abc",
+        config=SimpleNamespace(),
+        provider=None,
+        model=model,
+        tool_defs=[],
+        system_prompt="",
+        metadata=metadata,
+    )
+
+
+def _routed_metadata() -> dict[str, Any]:
+    return {
+        "routed_tier": "c0",
+        "routed_model": "minimax-m3",
+        "applied_model": "minimax-m3",
+        "baseline_model": "claude-opus-4.8",
+        "routing_applied": True,
+        "routing_source": "router",
+        "routing_confidence": 0.82,
+        "savings_pct": 87.5,
+        "savings_max_price_per_m": 2.0,
+        "savings_routed_price_per_m": 0.08,
+    }
+
+
+def test_noop_when_router_did_not_fire() -> None:
+    metadata: dict[str, Any] = {"applied_model": "minimax-m3"}
+    assert reconcile_routing_metadata(metadata, "claude-opus-4.8") is False
+    assert metadata == {"applied_model": "minimax-m3"}
+
+
+def test_noop_when_resolved_model_is_empty() -> None:
+    metadata = _routed_metadata()
+    assert reconcile_routing_metadata(metadata, "") is False
+    assert metadata == _routed_metadata()
+
+
+def test_noop_when_the_route_is_what_actually_ran() -> None:
+    metadata = _routed_metadata()
+    assert reconcile_routing_metadata(metadata, "minimax-m3") is False
+    assert metadata == _routed_metadata()
+
+
+def test_noop_when_router_left_no_applied_model() -> None:
+    metadata = _routed_metadata()
+    del metadata["applied_model"]
+    before = dict(metadata)
+    assert reconcile_routing_metadata(metadata, "claude-opus-4.8") is False
+    assert metadata == before
+
+
+def test_demotes_route_the_explicit_model_overrode() -> None:
+    metadata = _routed_metadata()
+    assert reconcile_routing_metadata(metadata, "claude-opus-4.8") is True
+
+    assert metadata["routing_applied"] is False
+    assert metadata["routing_override_source"] == ROUTING_OVERRIDE_EXPLICIT_MODEL
+    # The model that actually ran, on both fields that name it.
+    assert metadata["applied_model"] == "claude-opus-4.8"
+    assert metadata["baseline_model"] == "claude-opus-4.8"
+    # Savings against a price nobody was billed are not savings.
+    assert metadata["savings_pct"] == 0.0
+    assert metadata["savings_max_price_per_m"] == 0.0
+    assert metadata["savings_routed_price_per_m"] == 0.0
+    # The router's advice stays on the record, exactly as in observe phase.
+    assert metadata["routed_tier"] == "c0"
+    assert metadata["routed_model"] == "minimax-m3"
+    assert metadata["routing_source"] == "router"
+    assert metadata["routing_confidence"] == 0.82
+
+
+def test_reconciled_metadata_reaches_the_router_decision_event() -> None:
+    metadata = _routed_metadata()
+    reconcile_routing_metadata(metadata, "claude-opus-4.8")
+
+    event = build_router_decision_event(_ctx(metadata, model="minimax-m3"))
+    assert event is not None
+    assert event.routing_applied is False
+    assert event.savings_pct == 0.0
+    assert event.baseline_model == "claude-opus-4.8"
+    # Advisory, and flagged as such by routing_applied.
+    assert event.tier == "c0"
+    assert event.model == "minimax-m3"

--- a/tests/test_engine/turn_runner/test_prompt_assembler_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_prompt_assembler_stage_unit.py
@@ -429,6 +429,68 @@ async def test_case09_model_override_at_call_site() -> None:
 
 
 @pytest.mark.asyncio
+async def test_explicit_model_demotes_the_route_it_overrode() -> None:
+    """An explicit model beats the route, so the route must stop claiming it ran.
+
+    Regression: the metadata kept ``routing_applied=True`` and the routed
+    model, so the HUD event, the DoneEvent and per-turn usage all reported a
+    model the provider was never asked for — and credited savings for it.
+    """
+    turn = _make_turn(
+        metadata={
+            "routed_tier": "c0",
+            "routed_model": "minimax-m3",
+            "applied_model": "minimax-m3",
+            "baseline_model": "claude-opus-4.8",
+            "routing_applied": True,
+            "savings_pct": 87.5,
+            "savings_max_price_per_m": 2.0,
+            "savings_routed_price_per_m": 0.08,
+        },
+        model="minimax-m3",
+    )
+    executor = _RecordingPipelineExecutor(turn=turn, provider=_StubProvider("pp"))
+    stage = _make_stage(executor=executor)
+
+    out = await stage.run(_make_input(model="claude-opus-4.8"))
+
+    assert out.output.resolved_model == "claude-opus-4.8"
+    metadata = out.output.turn.metadata
+    assert metadata["routing_applied"] is False
+    assert metadata["routing_override_source"] == "explicit_model"
+    assert metadata["applied_model"] == "claude-opus-4.8"
+    assert metadata["baseline_model"] == "claude-opus-4.8"
+    assert metadata["savings_pct"] == 0.0
+    # The router's advice survives — flagged as advice by routing_applied.
+    assert metadata["routed_tier"] == "c0"
+    assert metadata["routed_model"] == "minimax-m3"
+
+
+@pytest.mark.asyncio
+async def test_route_that_ran_keeps_its_metadata_intact() -> None:
+    turn = _make_turn(
+        metadata={
+            "routed_tier": "c0",
+            "routed_model": "minimax-m3",
+            "applied_model": "minimax-m3",
+            "routing_applied": True,
+            "savings_pct": 87.5,
+        },
+        model="minimax-m3",
+    )
+    executor = _RecordingPipelineExecutor(turn=turn, provider=_StubProvider("pp"))
+    stage = _make_stage(executor=executor)
+
+    out = await stage.run(_make_input(model=None))
+
+    assert out.output.resolved_model == "minimax-m3"
+    metadata = out.output.turn.metadata
+    assert metadata["routing_applied"] is True
+    assert "routing_override_source" not in metadata
+    assert metadata["savings_pct"] == 87.5
+
+
+@pytest.mark.asyncio
 async def test_case10_no_session_manager() -> None:
     session_id = _RecordingSessionIdResolver(session_id=None)
     stage = _make_stage(session_id=session_id)

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -619,6 +619,58 @@ def test_done_handler_uses_provider_from_exact_routed_tier(
     assert extra == []
 
 
+def test_done_handler_prices_the_model_that_actually_ran(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Routing not applied → price the turn from the model the provider billed.
+
+    Regression: the routed model was priced even when it never ran (observe
+    rollout, or an explicit model that beat the route), inventing a cost and a
+    saving for a model nobody called.
+    """
+    lookups: list[tuple[str, str]] = []
+
+    def lookup_price(model_id: str, provider_id: str = "") -> PriceEntry:
+        lookups.append((model_id, provider_id))
+        prices = {
+            ("minimax-m3", "bankr"): PriceEntry(0.08, 0.32),
+            ("claude-opus-4.8", "opencap"): PriceEntry(2.0, 8.0),
+        }
+        return prices.get((model_id, provider_id), PriceEntry(0.0, 0.0))
+
+    monkeypatch.setattr(runtime_module, "lookup_price", lookup_price)
+    tiers = {
+        "c0": {"provider": "bankr", "model": "minimax-m3"},
+        "c3": {"provider": "opencap", "model": "claude-opus-4.8"},
+    }
+    state = _make_state()
+    inp = _make_input(
+        state=state,
+        turn=_make_turn(
+            metadata={
+                "routed_tier": "c0",
+                "routed_model": "minimax-m3",
+                "routing_applied": False,
+                "routing_override_source": "explicit_model",
+            }
+        ),
+        router_cfg=SimpleNamespace(tiers=tiers, estimated_output_savings_pct=0.03),
+    )
+
+    transformed, extra = _DoneHandler().handle(
+        DoneEvent(text="result", input_tokens=1_000_000, model="claude-opus-4.8"),
+        inp,
+        state,
+    )
+
+    # Priced as opus (what ran), not as the c0 tier the router only advised:
+    # same model as the savings baseline, so there is nothing to claim.
+    assert transformed.total_savings_usd == pytest.approx(0.0)
+    assert transformed.total_savings_pct == pytest.approx(0.0)
+    assert lookups[-1] == ("claude-opus-4.8", "opencap")
+    assert extra == []
+
+
 @pytest.mark.asyncio
 async def test_compaction_handler_runs_persist_snapshot_prompt_in_order() -> None:
     persist = _RecordingCompactionPersist()


### PR DESCRIPTION
Closes #586

## Problem

The Pilot Router writes its decision into `ctx.model` and stamps the metadata as applied, but the model actually sent to the provider is resolved later with the routed model in second place:

```python
# src/agentos/engine/turn_runner/prompt_assembler_stage.py
# 9. Resolve model_id: explicit param > pipeline-routed > selector current
resolved_model = inp.model or turn.model or selector_model
```

`inp.model` is the explicit per-call model, which on a gateway turn comes from `resolve_agent_model` (`explicit > session pin > config.agents[<id>].model`). So a durable per-agent model quietly beats the route while the metadata keeps claiming the route ran — and the router HUD event, the `DoneEvent`, per-turn usage and the savings figures all name a model the provider was never asked for, crediting savings against a price nobody was billed.

## Fix

The `observe` rollout phase already has the contract for "the router decided, but we ran something else": `routing_applied=False`, tier and model kept on the record as advice. This reuses it rather than inventing a second shape.

- **`engine/router_decision.py`** — new `reconcile_routing_metadata(metadata, resolved_model)`. When the router fired and the final model differs from `applied_model`, it flips `routing_applied` to `False`, records `routing_override_source="explicit_model"`, points `applied_model`/`baseline_model` at the model that really ran, and zeroes the unrealized savings. `routed_tier`/`routed_model`/`routing_source`/`routing_confidence` stay untouched — the router's advice is still worth reporting, it is just flagged as advice.
- **`turn_runner/prompt_assembler_stage.py`** — calls it right after `resolved_model` is known, which is the single point where the explicit model wins. Every downstream consumer reads the corrected metadata: the `RouterDecisionEvent` is built after this, and so are the `DoneEvent` stamping and the usage payload.
- **`turn_runner/stream_consumer_stage.py`** — per-turn savings are now priced from the model that actually ran whenever routing was not applied. `_compute_comprehensive_turn_savings` resolves `actual_model = routed_model or event.model`, so pricing the advisory model invented both a cost and a saving. This also corrects the cost basis during the existing `observe` rollout phase, where the route is deliberately never applied.

No config keys, CLI flags, ports or paths change, so `SKILL.md` and `docs/cli.md` are unaffected. `routing_override_source` is a new metadata key that is only ever added; no consumer had to change to keep working.

## Tests

`tests/test_engine/test_router_metadata_reconcile.py` (new) covers the helper: the four no-op paths (router never fired, empty resolved model, the route is what ran, no `applied_model` recorded), the demotion itself, and that the demoted metadata reaches `build_router_decision_event` intact.

`test_prompt_assembler_stage_unit.py` gains the end-to-end pair — an explicit model demotes the route, and a route that actually ran keeps its metadata and savings untouched. `test_stream_consumer_stage_unit.py` gains a pricing regression: routing not applied, the turn is priced as the model the provider billed, and the fabricated saving is gone.

Each new test was verified to fail against the pre-fix tree.

## Verification

```
uv run ruff check src tests                                  # All checks passed
uv run mypy src/agentos --show-error-codes                   # 1 pre-existing error (mem0 stubs)
uv run pytest -q                                             # green
```

`tests/test_memory_providers/test_mem0_provider.py::test_is_available_false_without_mem0_installed` fails on a clean tree in this environment too — `mem0` is installed locally, so the "not installed" assertion cannot hold. It is unrelated to this change.
