### PR TITLE
fix(web-ui): support camelCase updatedAt in project session sorting

### DIFF
--- a/frontend/src/views/projects/logic.test.ts
+++ b/frontend/src/views/projects/logic.test.ts
@@ -59,13 +59,13 @@ describe('filterProjects', () => {
 
 describe('sessionsInProject / filterSessionsByProject', () => {
   const sessions = [
-    { key: 'k1', project_id: 'p1', updated_at: 100 },
-    { key: 'k2', project_id: 'p1', updated_at: 300 },
+    { key: 'k1', project_id: 'p1', updatedAt: 100 },
+    { key: 'k2', project_id: 'p1', updatedAt: 300 },
     { key: 'k3', projectId: 'p2', updated_at: 200 },
-    { key: 'k4', updated_at: 400 },
+    { key: 'k4', updatedAt: 400 },
   ]
 
-  it('lists a project sessions newest first', () => {
+  it('lists a project sessions newest first across both timestamp casings', () => {
     expect(sessionsInProject(sessions, 'p1').map((s) => s.key)).toEqual(['k2', 'k1'])
   })
 
@@ -77,11 +77,11 @@ describe('sessionsInProject / filterSessionsByProject', () => {
 })
 
 describe('groupProjectSessionsByAgent', () => {
-  it('buckets by agent alphabetically, each bucket newest first', () => {
+  it('buckets by agent alphabetically, each bucket newest first across both timestamp casings', () => {
     const sessions = [
-      { key: 'k1', agent_id: 'zeta', updated_at: 100 },
-      { key: 'k2', agentId: 'alpha', updated_at: 100 },
-      { key: 'k3', agent_id: 'alpha', updated_at: 300 },
+      { key: 'k1', agent_id: 'zeta', updatedAt: 100 },
+      { key: 'k2', agentId: 'alpha', updatedAt: 100 },
+      { key: 'k3', agent_id: 'alpha', updatedAt: 300 },
       { key: 'k4', updated_at: 50 },
     ]
     const groups = groupProjectSessionsByAgent(sessions)

--- a/frontend/src/views/projects/logic.ts
+++ b/frontend/src/views/projects/logic.ts
@@ -76,7 +76,11 @@ export function filterProjects(projects: RawProject[], query: string): RawProjec
 export function sessionsInProject(sessions: RawSession[], id: string): RawSession[] {
   return sessions
     .filter((s) => sessionProjectId(s) === id)
-    .sort((a, b) => (Number(b.updated_at ?? 0) || 0) - (Number(a.updated_at ?? 0) || 0))
+    .sort(
+      (a, b) =>
+        (Number(b.updated_at ?? b.updatedAt ?? 0) || 0) -
+        (Number(a.updated_at ?? a.updatedAt ?? 0) || 0),
+    )
 }
 
 /** Group a project's sessions by their agent id (alphabetical), each bucket
@@ -96,7 +100,9 @@ export function groupProjectSessionsByAgent(
     .map(([agentId, items]) => ({
       agentId,
       items: [...items].sort(
-        (a, b) => (Number(b.updated_at ?? 0) || 0) - (Number(a.updated_at ?? 0) || 0),
+        (a, b) =>
+          (Number(b.updated_at ?? b.updatedAt ?? 0) || 0) -
+          (Number(a.updated_at ?? a.updatedAt ?? 0) || 0),
       ),
     }))
     .sort((a, b) => a.agentId.localeCompare(b.agentId))


### PR DESCRIPTION
## Summary
Resolves #588 by checking both `updated_at` and `updatedAt` in `sessionsInProject` and `groupProjectSessionsByAgent` in `src/views/projects/logic.ts`.

## Changes
- Updated `sessionsInProject` to sort using `(Number(b.updated_at ?? b.updatedAt ?? 0) || 0) - (Number(a.updated_at ?? a.updatedAt ?? 0) || 0)`.
- Updated `groupProjectSessionsByAgent` to use the same timestamp fallback when ordering sessions within agent buckets.
- Added test coverage in `src/views/projects/logic.test.ts` asserting newest-first ordering across both `updated_at` and `updatedAt` casings.

Closes #588