### PR TITLE
fix(web-ui): normalize Windows backslashes in env shortPath

### DIFF
--- a/frontend/src/views/env/logic.test.ts
+++ b/frontend/src/views/env/logic.test.ts
@@ -184,10 +184,13 @@ describe('splitGroupRows', () => {
 describe('shortPath', () => {
   it('keeps the identifying tail and marks the elision', () => {
     expect(shortPath('/very/long/path/to/state/.env')).toBe('…/state/.env')
+    expect(shortPath('C:\\Users\\alice\\AppData\\Roaming\\.agentos\\.env')).toBe('…/.agentos/.env')
   })
 
   it('leaves an already-short path alone', () => {
     expect(shortPath('/tmp/.env')).toBe('/tmp/.env')
+    expect(shortPath('.env')).toBe('.env')
+    expect(shortPath('C:\\.env')).toBe('C:\\.env')
   })
 
   it('handles an absent path', () => {

--- a/frontend/src/views/env/logic.ts
+++ b/frontend/src/views/env/logic.ts
@@ -203,7 +203,8 @@ export function validateNewName(name: string, known: EnvVarRow[]): string | null
  */
 export function shortPath(path: string | undefined): string {
   if (!path) return ''
-  const segments = path.split('/').filter(Boolean)
+  const normalized = path.replace(/\\/g, '/')
+  const segments = normalized.split('/').filter(Boolean)
   if (segments.length <= 2) return path
   return t('env.shortPath', { tail: segments.slice(-2).join('/') })
 }


### PR DESCRIPTION
## Summary
Resolves #590 by normalizing Windows backslashes (`\`) to `/` in `shortPath` (`src/views/env/logic.ts`) before segmenting.

## Changes
- Normalized backslashes with `.replace(/\\/g, '/')` in `shortPath` before splitting.
- Added test coverage in `src/views/env/logic.test.ts` asserting that Windows-style paths (e.g. `C:\Users\...\.agentos\.env` and `C:\.env`) are correctly handled and trimmed.

Closes #590