### PR TITLE
perf(skills): reuse SQLite FTS5 connection in LexicalIndex with lazy build and lock

### DIFF
--- a/src/agentos/skills/retrieval/__init__.py
+++ b/src/agentos/skills/retrieval/__init__.py
@@ -88,7 +88,9 @@ class HybridRetriever:
         with self._lock:
             self._lexical_fp = None
             self._semantic_fp = None
-            self._lexical = None
+            if self._lexical is not None:
+                self._lexical.close()
+                self._lexical = None
             if self._semantic is not None:
                 self._semantic.invalidate()
 
@@ -107,6 +109,8 @@ class HybridRetriever:
             # population for ~44 skills is sub-millisecond, and even
             # strategy="semantic" needs it for fallback (spec §5.1).
             if self._lexical_fp != fp:
+                if self._lexical is not None:
+                    self._lexical.close()
                 self._lexical = LexicalIndex(skills)
                 self._lexical_fp = fp
 

--- a/src/agentos/skills/retrieval/lexical.py
+++ b/src/agentos/skills/retrieval/lexical.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+import threading
 from dataclasses import dataclass
 
 import structlog
@@ -60,6 +61,9 @@ class LexicalIndex:
 
     def __init__(self, skills: list[SkillSpec]) -> None:
         self._skills = list(skills)
+        self._conn: sqlite3.Connection | None = None
+        self._built: bool = False
+        self._lock = threading.Lock()
 
     def rank(self, query: str, top_n: int = 20) -> list[Hit]:
         if not self._skills or not query or not query.strip():
@@ -75,34 +79,62 @@ class LexicalIndex:
             for i, (s, score) in enumerate(scored[:top_n])
         ]
 
-    def _fts_search(self, query: str) -> list[tuple[SkillSpec, float]]:
-        try:
-            conn = sqlite3.connect(":memory:")
-            conn.execute("CREATE VIRTUAL TABLE skills_fts USING fts5(name, description, triggers)")
-            for i, skill in enumerate(self._skills):
-                triggers_text = _stringify(skill.triggers)
+    def _ensure_built(self) -> sqlite3.Connection | None:
+        """Lazy thread-safe initialization of in-memory FTS5 table."""
+        if self._built:
+            return self._conn
+
+        with self._lock:
+            if self._built:
+                return self._conn
+            if not self._skills:
+                self._built = True
+                return None
+            try:
+                conn = sqlite3.connect(":memory:", check_same_thread=False)
                 conn.execute(
-                    "INSERT INTO skills_fts(rowid, name, description, triggers)"
-                    " VALUES (?, ?, ?, ?)",
+                    "CREATE VIRTUAL TABLE skills_fts USING fts5(name, description, triggers)"
+                )
+                rows = [
                     (
                         i,
                         _stringify(skill.name),
                         _stringify(skill.description),
-                        triggers_text,
-                    ),
-                )
+                        _stringify(skill.triggers),
+                    )
+                    for i, skill in enumerate(self._skills)
+                ]
+                with conn:
+                    conn.executemany(
+                        "INSERT INTO skills_fts(rowid, name, description, triggers)"
+                        " VALUES (?, ?, ?, ?)",
+                        rows,
+                    )
+                self._conn = conn
+            except Exception as exc:
+                log.debug("skills.retrieval.lexical_init_failed", error=str(exc))
+                self._conn = None
+            self._built = True
+            return self._conn
 
-            tokens = re.findall(r"\w+", query.lower())
-            if not tokens:
-                conn.close()
-                return []
-            fts_query = " OR ".join(tokens)
+    def _fts_search(self, query: str) -> list[tuple[SkillSpec, float]]:
+        conn = self._ensure_built()
+        if conn is None:
+            return []
 
-            rows = conn.execute(
-                "SELECT rowid, rank FROM skills_fts WHERE skills_fts MATCH ? ORDER BY rank",
-                (fts_query,),
-            ).fetchall()
-            conn.close()
+        tokens = re.findall(r"\w+", query.lower())
+        if not tokens:
+            return []
+        fts_query = " OR ".join(tokens)
+
+        try:
+            with self._lock:
+                if self._conn is None:
+                    return []
+                rows = self._conn.execute(
+                    "SELECT rowid, rank FROM skills_fts WHERE skills_fts MATCH ? ORDER BY rank",
+                    (fts_query,),
+                ).fetchall()
 
             # bm25 rank from FTS5 is a negative number (lower = better).
             # Negate and normalise to [0,1] across the result set for debug.
@@ -116,6 +148,17 @@ class LexicalIndex:
         except Exception as exc:
             log.debug("skills.retrieval.lexical_failed", error=str(exc))
             return []
+
+    def close(self) -> None:
+        """Idempotent teardown of the in-memory SQLite connection."""
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                except Exception:
+                    pass
+                self._conn = None
+            self._built = False
 
     def _substring_search(self, query: str) -> list[tuple[SkillSpec, float]]:
         tokens = list(set(query.lower().split()))

--- a/tests/test_skills_retrieval_lexical.py
+++ b/tests/test_skills_retrieval_lexical.py
@@ -1,0 +1,189 @@
+"""Tests for LexicalIndex and its lifecycle/concurrency optimizations."""
+
+from __future__ import annotations
+
+import concurrent.futures
+
+from agentos.skills.retrieval import HybridRetriever
+from agentos.skills.retrieval.lexical import Hit, LexicalIndex
+from agentos.skills.types import SkillLayer, SkillSpec
+
+
+def _make_sample_skills() -> list[SkillSpec]:
+    return [
+        SkillSpec(
+            name="weather_reporter",
+            description="Fetches weather forecast and temperature for cities",
+            layer=SkillLayer.BUNDLED,
+            always=False,
+            triggers=["weather", "forecast", "rain", "temperature"],
+            content="Weather skill content",
+        ),
+        SkillSpec(
+            name="stock_analyzer",
+            description="Analyzes market stock prices and equities",
+            layer=SkillLayer.BUNDLED,
+            always=False,
+            triggers=["stocks", "finance", "shares"],
+            content="Stock analyzer content",
+        ),
+        SkillSpec(
+            name="crypto_tracker",
+            description="Tracks Bitcoin and Solana cryptocurrency prices",
+            layer=SkillLayer.BUNDLED,
+            always=False,
+            triggers=["crypto", "btc", "solana"],
+            content="Crypto tracker content",
+        ),
+    ]
+
+
+def test_lexical_index_basic_ranking() -> None:
+    skills = _make_sample_skills()
+    index = LexicalIndex(skills)
+
+    hits = index.rank("forecast in tokyo")
+    assert len(hits) > 0
+    assert hits[0].skill_id == "weather_reporter"
+    assert isinstance(hits[0], Hit)
+    assert hits[0].rank == 1
+
+    hits_crypto = index.rank("solana price")
+    assert len(hits_crypto) > 0
+    assert hits_crypto[0].skill_id == "crypto_tracker"
+    index.close()
+
+
+def test_lexical_index_lazy_build_and_connection_reuse() -> None:
+    skills = _make_sample_skills()
+    index = LexicalIndex(skills)
+
+    # Before rank(), no connection should be created
+    assert index._built is False
+    assert index._conn is None
+
+    # First rank() builds the connection
+    hits1 = index.rank("weather")
+    assert hits1[0].skill_id == "weather_reporter"
+    assert index._built is True
+    assert index._conn is not None
+    conn_ref = index._conn
+
+    # Subsequent rank() reuses the exact same SQLite connection
+    hits2 = index.rank("stocks")
+    assert index._conn is conn_ref
+    assert hits2[0].skill_id == "stock_analyzer"
+
+    # Close tears down the connection
+    index.close()
+    assert index._conn is None
+    assert index._built is False
+
+    # Close is idempotent
+    index.close()
+
+
+def test_lexical_index_concurrency_thread_safety() -> None:
+    skills = _make_sample_skills()
+    index = LexicalIndex(skills)
+
+    queries = [
+        "weather report",
+        "stock forecast",
+        "bitcoin crypto",
+        "temperature rain",
+        "finance shares",
+    ]
+
+    def _query_task(q: str) -> list[Hit]:
+        return index.rank(q)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(_query_task, q) for q in queries * 5]
+        results = [f.result() for f in futures]
+
+    assert len(results) == 25
+    for r in results:
+        assert len(r) > 0
+
+    index.close()
+
+
+def test_lexical_index_handles_special_fts_characters() -> None:
+    skills = _make_sample_skills()
+    index = LexicalIndex(skills)
+
+    # Queries containing FTS5 reserved characters / syntax
+    problematic_queries = [
+        '* " " *',
+        "weather AND OR NOT NEAR",
+        "weather*",
+        "'''weather'''",
+        "---",
+        "()()()",
+    ]
+
+    for q in problematic_queries:
+        # Must not raise sqlite3.OperationalError or crash
+        hits = index.rank(q)
+        assert isinstance(hits, list)
+
+    index.close()
+
+
+def test_hybrid_retriever_invalidate_closes_lexical_index() -> None:
+    skills = _make_sample_skills()
+    retriever = HybridRetriever(strategy="lexical")
+
+    retriever.retrieve(skills, "weather")
+    assert retriever._lexical is not None
+    assert retriever._lexical._conn is not None
+
+    lex_ref = retriever._lexical
+    retriever.invalidate()
+
+    assert retriever._lexical is None
+    assert lex_ref._conn is None
+
+
+def test_hybrid_retriever_reuses_lexical_index_across_turns() -> None:
+    skills = _make_sample_skills()
+    retriever = HybridRetriever(strategy="lexical")
+
+    retriever.retrieve(skills, "weather")
+    lex_instance_1 = retriever._lexical
+    assert lex_instance_1 is not None
+    conn_1 = lex_instance_1._conn
+
+    retriever.retrieve(skills, "stocks")  # same skill set, next turn
+    lex_instance_2 = retriever._lexical
+    assert lex_instance_2 is not None
+    conn_2 = lex_instance_2._conn
+
+    assert lex_instance_1 is lex_instance_2
+    assert conn_1 is conn_2
+
+
+def test_hybrid_retriever_closes_old_index_on_skill_set_change() -> None:
+    skills_v1 = _make_sample_skills()
+    skills_v2 = skills_v1 + [
+        SkillSpec(
+            name="new_skill",
+            description="A newly installed skill",
+            layer=SkillLayer.BUNDLED,
+            always=False,
+            triggers=["new"],
+            content="New skill content",
+        ),
+    ]
+    retriever = HybridRetriever(strategy="lexical")
+
+    retriever.retrieve(skills_v1, "weather")
+    old_lex = retriever._lexical
+    assert old_lex is not None
+    assert old_lex._conn is not None
+
+    retriever.retrieve(skills_v2, "new")  # skill set changed
+
+    assert retriever._lexical is not old_lex
+    assert old_lex._conn is None


### PR DESCRIPTION
## Summary
Resolves #592 by reusing the in-memory SQLite FTS5 table across ranking queries in `LexicalIndex`, eliminating redundant table creation and loop inserts on every message turn.

## Changes
- **Lazy build & single-transaction batch insert**: `LexicalIndex` builds the in-memory SQLite FTS5 table only on the first `rank()` call using `executemany` wrapped in a single transaction `with conn:`.
- **Connection reuse with thread-safety**: Reuses `self._conn` for subsequent queries with `check_same_thread=False` and `threading.Lock()` to prevent race conditions across concurrent turn requests.
- **Clean teardown**: Added an idempotent `close()` method wired into `HybridRetriever.invalidate()` and fingerprint mismatch refresh in `_ensure_indexes()`.
- **Testing**: Added `tests/test_skills_retrieval_lexical.py` with comprehensive coverage asserting:
  - Basic lexical ranking across name, description, and triggers
  - Direct connection reuse and lazy build lifecycle
  - Multi-turn index & SQLite connection reuse at the `HybridRetriever` level
  - Old index teardown on skill set fingerprint change
  - Concurrent multi-threaded query execution
  - Resilience against FTS5 special/syntax characters

Closes #592