### PR TITLE
fix(security): SSRF DNS-rebinding TOCTOU (#516)

### DIFF
--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -236,7 +236,7 @@ def resolve_and_validate(
     port: int,
     *,
     trusted_fake_ip_cidrs: Iterable[str] | None = None,
-) -> list[tuple[str, int, str, int]]:
+) -> list[tuple[str, int]]:
     """Resolve *hostname* and validate every resolved address.
 
     Returns a list of ``(family, type, proto, sockaddr)`` tuples compatible
@@ -257,15 +257,17 @@ def resolve_and_validate(
         else _trusted_fake_ip_cidrs
     )
 
-    validated: list[tuple[int, int, int, str, int]] = []
+    validated: list[tuple[str, int]] = []
     for info in infos:
         family, socktype, proto, _canonname, sockaddr = info
-        addr = ipaddress.ip_address(sockaddr[0])
+        sockaddr_host: str = sockaddr[0]  # type: ignore[assignment]
+        sockaddr_port: int = sockaddr[1]  # type: ignore[assignment]
+        addr = ipaddress.ip_address(sockaddr_host)
         block_reason = _hard_block_reason(addr)
         if block_reason is not None:
             raise SSRFBlockedError(_blocked_message(hostname, addr, block_reason))
         if _is_trusted_fake_ip(addr, trusted_networks):
-            validated.append((family, socktype, proto, sockaddr[0], sockaddr[1]))
+            validated.append((sockaddr_host, sockaddr_port))
             continue
         if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
             reason = (
@@ -275,32 +277,39 @@ def resolve_and_validate(
                 else "private/internal range"
             )
             raise SSRFBlockedError(_blocked_message(hostname, addr, reason))
-        validated.append((family, socktype, proto, sockaddr[0], sockaddr[1]))
+        validated.append((sockaddr_host, sockaddr_port))
 
-    return [
-        (family, socktype, proto, (str_addr, port))
-        for family, socktype, proto, str_addr, _port in validated
-    ]
+    return validated
 
 
 class ValidatingNetworkBackend:
     """httpcore network backend that resolves and validates at connect time.
 
-    Wraps the default backend but intercepts connection setup to resolve the
-    hostname and validate every resolved address against SSRF rules *before*
-    connecting. This eliminates the DNS-rebinding TOCTOU: the address the
-    guard validates IS the address the socket connects to.
+    Implements :class:`httpcore.AsyncNetworkBackend` — the low-level
+    interface that ``httpcore`` calls when it needs to open a TCP
+    connection. Intercepts ``connect_tcp`` to resolve the hostname and
+    validate every resolved address against SSRF rules *before* connecting.
+    This eliminates the DNS-rebinding TOCTOU: the address the guard
+    validates IS the address the socket connects to.
 
     TLS is unaffected: httpcore still performs the handshake against the
     origin hostname (SNI + certificate verification); only the TCP endpoint
     is pinned to the validated address.
+
+    Usage::
+
+        backend = ValidatingNetworkBackend()
+        pool = httpcore.AsyncConnectionPool(network_backend=backend)
+        transport = httpx.AsyncHTTPTransport()
+        transport._pool = pool
+        client = httpx.AsyncClient(transport=transport)
     """
 
     def __init__(
         self,
         trusted_fake_ip_cidrs: Iterable[str] | None = None,
     ) -> None:
-        self._backend = httpcore.AsyncConnectionPool()
+        self._inner = httpcore.AnyIOBackend()
         self._trusted_fake_ip_cidrs = list(trusted_fake_ip_cidrs) if trusted_fake_ip_cidrs else None
 
     async def connect_tcp(
@@ -309,8 +318,8 @@ class ValidatingNetworkBackend:
         port: int,
         timeout: float | None = None,
         local_address: str | None = None,
-        socket_options: int | None = None,
-    ) -> httpcore.AsyncConnectionInterface:
+        socket_options: Any = None,
+    ) -> httpcore.AsyncNetworkStream:
         # Resolve and validate the hostname at connect time, pinning the
         # validated address. This is the same logic as the guard but happens
         # inside the connection setup — no second resolution.
@@ -322,14 +331,12 @@ class ValidatingNetworkBackend:
         if not validated:
             raise SSRFBlockedError(f"No valid addresses for {host}")
 
-        # Take the first validated address family.
-        family, socktype, proto, address = validated[0]
-        resolved_host, resolved_port = address
+        # Take the first validated address.
+        resolved_host, resolved_port = validated[0]
 
-        # Delegate to the default backend with the IP literal, not the
-        # hostname. httpcore handles TLS SNI from the original hostname
-        # separately.
-        return await self._backend.connect_tcp(
+        # Delegate to AnyIOBackend with the IP literal, not the hostname.
+        # httpcore handles TLS SNI from the original hostname separately.
+        return await self._inner.connect_tcp(
             host=resolved_host,
             port=resolved_port,
             timeout=timeout,
@@ -341,22 +348,16 @@ class ValidatingNetworkBackend:
         self,
         path: str,
         timeout: float | None = None,
-        socket_options: int | None = None,
-    ) -> httpcore.AsyncConnectionInterface:
-        return await self._backend.connect_unix_socket(
+        socket_options: Any = None,
+    ) -> httpcore.AsyncNetworkStream:
+        return await self._inner.connect_unix_socket(
             path=path,
             timeout=timeout,
             socket_options=socket_options,
         )
 
-    async def close(self) -> None:
-        await self._backend.close()
-
-    async def __aenter__(self) -> ValidatingNetworkBackend:
-        return self
-
-    async def __aexit__(self, *args: object) -> None:
-        await self.close()
+    async def sleep(self, seconds: float) -> None:
+        return await self._inner.sleep(seconds)
 
 
 async def ssrf_guarded_client(
@@ -369,19 +370,20 @@ async def ssrf_guarded_client(
     """Build an :class:`httpx.AsyncClient` whose connections are
     SSRF-guarded at connect time, eliminating the DNS-rebinding TOCTOU.
 
-    The returned client uses :class:`ValidatingNetworkBackend` so every
+    The returned client uses :class:`ValidatingNetworkBackend` as the
+    network backend inside the ``httpcore`` connection pool, so every
     hostname is resolved and validated inside the connection setup, not
     in a separate guard call that httpx then re-resolves.
 
     All other httpx defaults (env-proxy mounts, etc.) are preserved.
     """
     backend = ValidatingNetworkBackend(trusted_fake_ip_cidrs=trusted_fake_ip_cidrs)
-    mounts = {
-        "all://": httpx.AsyncHTTPTransport(backend=backend),
-    }
+    pool = httpcore.AsyncConnectionPool(network_backend=backend)  # type: ignore[arg-type]
+    transport = httpx.AsyncHTTPTransport()
+    transport._pool = pool  # type: ignore[attr-defined]
     return httpx.AsyncClient(
+        transport=transport,
         timeout=timeout,
         follow_redirects=follow_redirects,
-        mounts=mounts,
         **kwargs,
     )

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 from collections.abc import Iterable
+from typing import Any
 from urllib.parse import urlparse
 
 from agentos.tools.types import SSRFBlockedError, UnsupportedURLSchemeError
@@ -218,3 +219,170 @@ def _is_trusted_fake_ip(addr: IPAddress, trusted_networks: tuple[IPNetwork, ...]
 
 def _blocked_message(hostname: str, addr: IPAddress, reason: str) -> str:
     return f"Blocked: {hostname} resolves to {addr} ({reason})"
+
+
+# ---------------------------------------------------------------------------
+# Validating network backend — resolves hostnames at connect time and
+# validates the resolved addresses against SSRF rules, eliminating the
+# DNS-rebinding TOCTOU window between the guard and the actual connection.
+# ---------------------------------------------------------------------------
+
+
+def resolve_and_validate(
+    hostname: str,
+    port: int,
+    *,
+    trusted_fake_ip_cidrs: Iterable[str] | None = None,
+) -> list[tuple[str, int, str, int]]:
+    """Resolve *hostname* and validate every resolved address.
+
+    Returns a list of ``(family, type, proto, sockaddr)`` tuples compatible
+    with ``httpcore`` backends. Raises :class:`SSRFBlockedError` if any
+    resolved address is blocked.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, port)
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
+
+    trusted_networks = (
+        tuple(
+            ipaddress.ip_network(value)
+            for value in validate_trusted_fake_ip_cidrs(trusted_fake_ip_cidrs)
+        )
+        if trusted_fake_ip_cidrs is not None
+        else _trusted_fake_ip_cidrs
+    )
+
+    validated: list[tuple[int, int, int, str, int]] = []
+    for info in infos:
+        family, socktype, proto, _canonname, sockaddr = info
+        addr = ipaddress.ip_address(sockaddr[0])
+        block_reason = _hard_block_reason(addr)
+        if block_reason is not None:
+            raise SSRFBlockedError(_blocked_message(hostname, addr, block_reason))
+        if _is_trusted_fake_ip(addr, trusted_networks):
+            validated.append((family, socktype, proto, sockaddr[0], sockaddr[1]))
+            continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            reason = (
+                f"reserved/private range; configure [tools].trusted_fake_ip_cidrs "
+                f"with {RFC2544_FAKE_IP_NETWORK} only if this is fake-IP DNS"
+                if addr in RFC2544_FAKE_IP_NETWORK
+                else "private/internal range"
+            )
+            raise SSRFBlockedError(_blocked_message(hostname, addr, reason))
+        validated.append((family, socktype, proto, sockaddr[0], sockaddr[1]))
+
+    return [
+        (family, socktype, proto, (str_addr, port))
+        for family, socktype, proto, str_addr, _port in validated
+    ]
+
+
+class ValidatingNetworkBackend:
+    """httpcore network backend that resolves and validates at connect time.
+
+    Wraps the default backend but intercepts connection setup to resolve the
+    hostname and validate every resolved address against SSRF rules *before*
+    connecting. This eliminates the DNS-rebinding TOCTOU: the address the
+    guard validates IS the address the socket connects to.
+
+    TLS is unaffected: httpcore still performs the handshake against the
+    origin hostname (SNI + certificate verification); only the TCP endpoint
+    is pinned to the validated address.
+    """
+
+    def __init__(
+        self,
+        trusted_fake_ip_cidrs: Iterable[str] | None = None,
+    ) -> None:
+        import httpcore
+
+        self._backend = httpcore.AsyncConnectionPool()
+        self._trusted_fake_ip_cidrs = list(trusted_fake_ip_cidrs) if trusted_fake_ip_cidrs else None
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: int | None = None,
+    ) -> httpcore.AsyncConnectionInterface:
+        # Resolve and validate the hostname at connect time, pinning the
+        # validated address. This is the same logic as the guard but happens
+        # inside the connection setup — no second resolution.
+        validated = resolve_and_validate(
+            host,
+            port,
+            trusted_fake_ip_cidrs=self._trusted_fake_ip_cidrs,
+        )
+        if not validated:
+            raise SSRFBlockedError(f"No valid addresses for {host}")
+
+        # Take the first validated address family.
+        family, socktype, proto, address = validated[0]
+        resolved_host, resolved_port = address
+
+        # Delegate to the default backend with the IP literal, not the
+        # hostname. httpcore handles TLS SNI from the original hostname
+        # separately.
+        return await self._backend.connect_tcp(
+            host=resolved_host,
+            port=resolved_port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: int | None = None,
+    ) -> httpcore.AsyncConnectionInterface:
+        return await self._backend.connect_unix_socket(
+            path=path,
+            timeout=timeout,
+            socket_options=socket_options,
+        )
+
+    async def close(self) -> None:
+        await self._backend.close()
+
+    async def __aenter__(self) -> ValidatingNetworkBackend:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+
+async def ssrf_guarded_client(
+    *,
+    timeout: float = 30.0,
+    follow_redirects: bool = False,
+    trusted_fake_ip_cidrs: Iterable[str] | None = None,
+    **kwargs: Any,
+) -> httpx.AsyncClient:
+    """Build an :class:`httpx.AsyncClient` whose connections are
+    SSRF-guarded at connect time, eliminating the DNS-rebinding TOCTOU.
+
+    The returned client uses :class:`ValidatingNetworkBackend` so every
+    hostname is resolved and validated inside the connection setup, not
+    in a separate guard call that httpx then re-resolves.
+
+    All other httpx defaults (env-proxy mounts, etc.) are preserved.
+    """
+    import httpx
+
+    backend = ValidatingNetworkBackend(trusted_fake_ip_cidrs=trusted_fake_ip_cidrs)
+    mounts = {
+        "all://": httpx.AsyncHTTPTransport(backend=backend),
+    }
+    return httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        mounts=mounts,
+        **kwargs,
+    )

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -8,6 +8,9 @@ from collections.abc import Iterable
 from typing import Any
 from urllib.parse import urlparse
 
+import httpcore
+import httpx
+
 from agentos.tools.types import SSRFBlockedError, UnsupportedURLSchemeError
 
 IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
@@ -297,8 +300,6 @@ class ValidatingNetworkBackend:
         self,
         trusted_fake_ip_cidrs: Iterable[str] | None = None,
     ) -> None:
-        import httpcore
-
         self._backend = httpcore.AsyncConnectionPool()
         self._trusted_fake_ip_cidrs = list(trusted_fake_ip_cidrs) if trusted_fake_ip_cidrs else None
 
@@ -374,8 +375,6 @@ async def ssrf_guarded_client(
 
     All other httpx defaults (env-proxy mounts, etc.) are preserved.
     """
-    import httpx
-
     backend = ValidatingNetworkBackend(trusted_fake_ip_cidrs=trusted_fake_ip_cidrs)
     mounts = {
         "all://": httpx.AsyncHTTPTransport(backend=backend),

--- a/tests/test_security/test_ssrf_network_backend.py
+++ b/tests/test_security/test_ssrf_network_backend.py
@@ -1,0 +1,127 @@
+"""Regression tests for ValidatingNetworkBackend / resolve_and_validate (#516 / PR #597).
+
+Tests that the DNS-rebinding TOCTOU fix resolves hostnames at connect time
+and validates every resolved address against SSRF rules.
+
+See https://github.com/use-agent-os/agent-os/pull/597
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from agentos.tools import ssrf
+from agentos.tools.types import SSRFBlockedError
+
+
+def _fake_getaddrinfo(ip: str):
+    def resolver(hostname: str, port: int | None, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port or 443))]
+
+    return resolver
+
+
+class TestResolveAndValidate:
+    """resolve_and_validate resolves and validates in one atomic call."""
+
+    def test_public_ip_resolves_successfully(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("1.2.3.4")):
+            result = ssrf.resolve_and_validate("example.com", 443)
+            assert len(result) == 1
+            assert result[0] == ("1.2.3.4", 443)
+
+    def test_private_ip_raises_ssrf_blocked(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.1")):
+            with pytest.raises(SSRFBlockedError, match="10.0.0.1"):
+                ssrf.resolve_and_validate("malicious.internal", 443)
+
+    def test_link_local_raises_ssrf_blocked(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")):
+            with pytest.raises(SSRFBlockedError, match="169.254.169.254"):
+                ssrf.resolve_and_validate("metadata.internal", 443)
+
+    def test_loopback_raises_ssrf_blocked(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("127.0.0.1")):
+            with pytest.raises(SSRFBlockedError, match="127.0.0.1"):
+                ssrf.resolve_and_validate("localhost", 443)
+
+    def test_rfc1918_private_192_168_raises(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("192.168.1.1")):
+            with pytest.raises(SSRFBlockedError, match="192.168.1.1"):
+                ssrf.resolve_and_validate("internal.router", 443)
+
+    def test_rfc1918_private_172_raises(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("172.16.0.5")):
+            with pytest.raises(SSRFBlockedError, match="172.16.0.5"):
+                ssrf.resolve_and_validate("internal.server", 443)
+
+    def test_unspecified_raises(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("0.0.0.0")):
+            with pytest.raises(SSRFBlockedError, match="0.0.0.0"):
+                ssrf.resolve_and_validate("anyhost", 80)
+
+    def test_rfc2544_fake_ip_blocked_by_default(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("198.18.0.2")):
+            with pytest.raises(SSRFBlockedError, match="198.18.0.2"):
+                ssrf.resolve_and_validate("fake-dns.example", 443)
+
+    def test_rfc2544_fake_ip_allowed_with_trusted_cidr(self):
+        with patch.object(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("198.18.0.2")):
+            result = ssrf.resolve_and_validate(
+                "fake-dns.example", 443,
+                trusted_fake_ip_cidrs=["198.18.0.0/15"],
+            )
+            assert result[0] == ("198.18.0.2", 443)
+
+    def test_multiple_resolved_addresses_all_validated(self):
+        def multi_resolver(hostname, port, *args, **kwargs):
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", port or 443)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", port or 443)),
+            ]
+
+        with patch.object(ssrf.socket, "getaddrinfo", multi_resolver):
+            with pytest.raises(SSRFBlockedError, match="10.0.0.1"):
+                ssrf.resolve_and_validate("mixed.example", 443)
+
+    def test_no_valid_addresses_error(self):
+        def empty_resolver(hostname, port, *args, **kwargs):
+            return []
+
+        with patch.object(ssrf.socket, "getaddrinfo", empty_resolver):
+            with pytest.raises(ValueError, match="Cannot resolve"):
+                ssrf.resolve_and_validate("nowhere.example", 443)
+
+
+class TestValidatingNetworkBackend:
+    """ValidatingNetworkBackend wraps resolve_and_validate at connect time."""
+
+    def test_backend_imports(self):
+        """ValidatingNetworkBackend is importable and has the right shape."""
+        backend = ssrf.ValidatingNetworkBackend()
+        assert hasattr(backend, "connect_tcp")
+        assert hasattr(backend, "connect_unix_socket")
+        assert hasattr(backend, "sleep")
+
+    def test_ssrf_guarded_client_imports(self):
+        """ssrf_guarded_client is importable and returns an httpx client."""
+        import httpx
+
+        client = ssrf.ssrf_guarded_client(timeout=10)
+        assert isinstance(client, httpx.AsyncClient)
+
+
+class TestRegressions:
+    """Existing SSRF behaviour must not regress."""
+
+    def test_public_url_still_passes_validate_http_url(self, monkeypatch):
+        monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("140.82.121.3"))
+        ssrf.validate_http_url_for_fetch("https://github.com/use-agent-os/agent-os")
+
+    def test_private_url_still_blocked_in_validate_http_url(self, monkeypatch):
+        monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.1"))
+        with pytest.raises(SSRFBlockedError):
+            ssrf.validate_http_url_for_fetch("https://internal.example.com")


### PR DESCRIPTION
Fixes #516

Adds `resolve_and_validate()` — resolves hostname and validates all
resolved addresses in one atomic call, eliminating the race window
between DNS resolution and connection.

Adds `ValidatingNetworkBackend` (httpcore network backend) that resolves
and validates at connect time, so the validated address IS the address
that gets connected to. TLS SNI still uses the origin hostname.

Adds `ssrf_guarded_client()` helper that builds an httpx.AsyncClient
with the validating backend.

Rebased on latest main.