### PR TITLE
fix(channels): resolve outbound email recipients from metadata and reply_to

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -168,6 +168,20 @@ def normalize_address(value: str) -> str:
     return address.strip().lower()
 
 
+def _is_email_address(value: str | None) -> bool:
+    """Return True when ``value`` looks like a plain email address.
+
+    Used to decide whether an outbound ``reply_to`` is a recipient address
+    (scheduler/heartbeat delivery) rather than a thread key.
+    """
+
+    if not value:
+        return False
+    _, address = email.utils.parseaddr(value or "")
+    return bool(address) and "@" in address
+
+
+
 def sender_allowed(sender: str, allowlist: list[str] | tuple[str, ...]) -> bool:
     """Return True when ``sender`` matches the fail-closed allowlist.
 
@@ -636,7 +650,12 @@ class EmailChannel:
 
         thread = self._threads.get((message.reply_to or "").strip())
         metadata = message.metadata or {}
-        to_address = str(metadata.get("to") or (thread.to_address if thread else ""))
+        to_address = str(
+            metadata.get("to")
+            or metadata.get("recipient")
+            or (thread.to_address if thread else "")
+            or (message.reply_to if _is_email_address(message.reply_to) else "")
+        )
         if not to_address:
             raise ValueError("email.send has no recipient for reply_to")
         subject = str(metadata.get("subject") or "").strip()

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -328,6 +328,40 @@ async def test_send_resolves_the_recipient_from_the_thread_cache(
     assert sent[0]["Subject"] == "Re: Status?"
 
 
+async def test_send_resolves_recipient_from_metadata_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outbound message-tool sends resolve the address from metadata["recipient"]."""
+
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    msg = OutgoingMessage(
+        content="Daily status update",
+        reply_to="colleague@example.com",
+        metadata={"recipient": "colleague@example.com"},
+    )
+    await channel.send(msg)
+
+    assert sent[0]["To"] == "colleague@example.com"
+    assert sent[0]["Subject"] == "Re: (no subject)"
+
+
+async def test_send_resolves_recipient_from_reply_to_email_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduler/heartbeat delivery resolve the address from an email-shaped reply_to."""
+
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(OutgoingMessage(content="alert", reply_to="alerts@example.com"))
+
+    assert sent[0]["To"] == "alerts@example.com"
+
+
 async def test_send_without_a_known_thread_is_refused() -> None:
     channel = EmailChannel(config=_config())
 


### PR DESCRIPTION
## Summary

Fixes outbound email sends failing with `ValueError: email.send has no recipient for reply_to`.

`EmailChannel._resolve_target()` only consulted `metadata["to"]` and the inbound thread cache, so every outbound send initiated by the agent failed:

- **Message tool sends** (`agentos.tools.builtin.messaging`) set `metadata["recipient"]` — never checked.
- **Scheduler/heartbeat delivery** pass the recipient as `reply_to` (e.g. `alerts@example.com`) — never checked.

## Change

Resolve the recipient in priority order:
1. `metadata["to"]` (existing reply flow)
2. `metadata["recipient"]` (message tool)
3. thread cache lookup (existing — kept before the email-shaped `reply_to` so thread keys that look like addresses still resolve to the thread)
4. `reply_to` when it parses as an email address (scheduler/heartbeat)

## Tests

- `test_send_resolves_recipient_from_metadata_recipient` — message tool path
- `test_send_resolves_recipient_from_reply_to_email_address` — scheduler/heartbeat path
- Existing thread-cache and refusal tests still pass (42 tests total in `test_email_channel.py`)

Fixes #598