### PR TITLE
fix(channels): return Response on retry_request 429 exhaustion withou…

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -283,8 +283,11 @@ async def retry_request(
     for attempt in range(max_retries + 1):
         try:
             resp = await func(*args, **kwargs)
-            if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+            if resp.status_code == 429 and attempt < max_retries:
+                try:
+                    retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+                except (TypeError, ValueError):
+                    retry_after = base_delay * (2**attempt)
                 log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
                 await asyncio.sleep(retry_after)
                 continue
@@ -294,7 +297,7 @@ async def retry_request(
                 await asyncio.sleep(delay)
                 continue
             return resp
-        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
             last_exc = exc
             if attempt < max_retries:
                 delay = base_delay * (2**attempt) + random.random()

--- a/tests/test_channels/test_slack_retry.py
+++ b/tests/test_channels/test_slack_retry.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from agentos.channels._util import retry_request
 from agentos.channels.slack import SlackChannel
 from agentos.channels.types import OutgoingMessage
 
@@ -189,3 +190,63 @@ async def test_send_does_not_retry_slack_level_error(no_sleep) -> None:
         await channel.send(OutgoingMessage(content="hi", reply_to="C123"))
 
     assert post.await_count == 1
+
+
+async def test_send_returns_response_when_429_retries_exhausted(no_sleep) -> None:
+    """When 429 retries are exhausted, the response is returned without a wasted sleep."""
+    channel = _channel()
+    post = _attach(channel, *[_resp(429, headers={"Retry-After": "1"})] * 4)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await channel.send(OutgoingMessage(content="hi", reply_to="C123"))
+
+    assert exc_info.value.response.status_code == 429
+    assert post.await_count == 4  # attempt 0 + 3 retries
+    # Slept only on attempts 0, 1, 2 — not on attempt 3 when retries were exhausted
+    assert no_sleep.await_count == 3
+
+
+async def test_retry_request_exhausted_429_returns_response(no_sleep) -> None:
+    """Direct retry_request call returns the 429 response when retries are exhausted."""
+    endpoint = AsyncMock(return_value=_resp(429, headers={"Retry-After": "1"}))
+
+    resp = await retry_request(endpoint, max_retries=2, base_delay=0.1)
+
+    assert resp.status_code == 429
+    assert endpoint.await_count == 3  # attempt 0 + 2 retries
+    assert no_sleep.await_count == 2
+
+
+async def test_retry_request_handles_non_numeric_retry_after(no_sleep) -> None:
+    """Non-numeric or HTTP-date Retry-After does not raise ValueError."""
+    endpoint = AsyncMock(
+        side_effect=[
+            _resp(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}),
+            _resp(200),
+        ]
+    )
+
+    resp = await retry_request(endpoint, max_retries=1, base_delay=0.1)
+
+    assert resp.status_code == 200
+    assert endpoint.await_count == 2
+    # Fell back to base_delay * (2 ** 0) = 0.1
+    no_sleep.assert_awaited_once_with(0.1)
+
+
+async def test_retry_request_retries_all_timeout_exceptions(no_sleep) -> None:
+    """ConnectTimeout, WriteTimeout, and other TimeoutException subclasses are retried."""
+    req = httpx.Request("POST", "https://slack.test/api/chat.postMessage")
+    endpoint = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout("connection timed out", request=req),
+            httpx.WriteTimeout("write timed out", request=req),
+            _resp(200),
+        ]
+    )
+
+    resp = await retry_request(endpoint, max_retries=2, base_delay=0.1)
+
+    assert resp.status_code == 200
+    assert endpoint.await_count == 3
+    assert no_sleep.await_count == 2


### PR DESCRIPTION
Here is a short, concise description for your Pull Request:

---closes #599 

### PR Title
```text
fix(channels): return Response on retry_request 429 exhaustion without sleeping on final attempt
```

### Description
```markdown
### Summary
Fixes 429 rate limit exhaustion in `retry_request()` (`src/agentos/channels/_util.py`).

### Changes
- **No wasted sleep**: Added `and attempt < max_retries` check to the `429` status branch so the final attempt doesn't perform an unnecessary `asyncio.sleep()`.
- **Preserve HTTP response**: On 429 exhaustion, `retry_request()` now returns the `httpx.Response` object (status 429) directly instead of raising a generic `RuntimeError("retry_request exhausted")`, allowing callers like `SlackChannel` and `DeliveryChain` to inspect the response or raise `HTTPStatusError`.
- **Safe `Retry-After` parsing**: Handled `ValueError`/`TypeError` when servers return non-numeric or HTTP-date `Retry-After` headers.
- **Regression tests**: Added tests covering 429 exhaustion, sleep call counts, and non-numeric `Retry-After` in `tests/test_channels/test_slack_retry.py`.

### Verification
- `uv run pytest tests/test_channels/test_slack_retry.py` (13 passed)
- `uv run pytest tests/test_scheduler/test_webhook_delivery.py` (15 passed)
- `ruff check`, `ruff format`, and `mypy` all passed with 0 errors.
```