### PR TITLE
fix(engine): complete _FAILURE_KIND_MAP in fallback policy

### DIFF
--- a/src/agentos/engine/fallback.py
+++ b/src/agentos/engine/fallback.py
@@ -26,6 +26,13 @@ _FAILURE_KIND_MAP: dict[ProviderFailureKind, ProviderErrorKind] = {
     ProviderFailureKind.AUTH_INVALID: ProviderErrorKind.AUTH_FAILURE,
     ProviderFailureKind.CONTEXT_OVERFLOW: ProviderErrorKind.CONTEXT_OVERFLOW,
     ProviderFailureKind.EMPTY_RESPONSE: ProviderErrorKind.EMPTY_RESPONSE,
+    ProviderFailureKind.MALFORMED_RESPONSE: ProviderErrorKind.TRANSPORT_TRANSIENT,
+    ProviderFailureKind.INSUFFICIENT_CREDITS: ProviderErrorKind.AUTH_FAILURE,
+    ProviderFailureKind.MODEL_NOT_FOUND: ProviderErrorKind.UNKNOWN,
+    ProviderFailureKind.UNSUPPORTED_FEATURE: ProviderErrorKind.UNKNOWN,
+    ProviderFailureKind.POLICY_REFUSAL: ProviderErrorKind.UNKNOWN,
+    ProviderFailureKind.BAD_REQUEST: ProviderErrorKind.UNKNOWN,
+    ProviderFailureKind.UNKNOWN: ProviderErrorKind.UNKNOWN,
 }
 
 

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -290,3 +290,36 @@ def test_new_transient_status_codes_match_via_text(message: str) -> None:
         classify_provider_error("openrouter", None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
     )
+
+
+def test_failure_kind_map_covers_all_provider_failure_kinds() -> None:
+    from agentos.engine.fallback import _FAILURE_KIND_MAP
+
+    for kind in ProviderFailureKind:
+        msg = f"ProviderFailureKind.{kind.name} missing from _FAILURE_KIND_MAP"
+        assert kind in _FAILURE_KIND_MAP, msg
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_error_kind", "expected_retryable"),
+    [
+        (ProviderFailureKind.MALFORMED_RESPONSE, ProviderErrorKind.TRANSPORT_TRANSIENT, True),
+        (ProviderFailureKind.INSUFFICIENT_CREDITS, ProviderErrorKind.AUTH_FAILURE, False),
+        (ProviderFailureKind.MODEL_NOT_FOUND, ProviderErrorKind.UNKNOWN, False),
+        (ProviderFailureKind.UNSUPPORTED_FEATURE, ProviderErrorKind.UNKNOWN, False),
+        (ProviderFailureKind.POLICY_REFUSAL, ProviderErrorKind.UNKNOWN, False),
+        (ProviderFailureKind.BAD_REQUEST, ProviderErrorKind.UNKNOWN, False),
+    ],
+)
+def test_fallback_policy_classification_and_retryability(
+    kind: ProviderFailureKind,
+    expected_error_kind: ProviderErrorKind,
+    expected_retryable: bool,
+) -> None:
+    from agentos.engine.fallback import _FAILURE_KIND_MAP
+
+    policy = FallbackPolicy(max_retries=2)
+    error_kind = _FAILURE_KIND_MAP[kind]
+    assert error_kind is expected_error_kind
+    assert policy.should_retry(error_kind, attempt=0) is expected_retryable
+


### PR DESCRIPTION
## Summary

Explicitly maps all 13 `ProviderFailureKind` enum variants in `_FAILURE_KIND_MAP` (`src/agentos/engine/fallback.py`):

- **`MALFORMED_RESPONSE`** $\rightarrow$ `ProviderErrorKind.TRANSPORT_TRANSIENT`: Allows transient corrupted response bodies from upstream providers to be retried by `FallbackPolicy`.
- **`INSUFFICIENT_CREDITS`** $\rightarrow$ `ProviderErrorKind.AUTH_FAILURE`: Fails fast without retrying when credits/quota are exhausted.
- **`MODEL_NOT_FOUND`**, **`UNSUPPORTED_FEATURE`**, **`POLICY_REFUSAL`**, **`BAD_REQUEST`**, **`UNKNOWN`** $\rightarrow$ `ProviderErrorKind.UNKNOWN`: Explicitly mapped for exhaustive enum coverage so unhandled kinds cannot silently fall through.

## Tests Added

- Added `test_failure_kind_map_covers_all_provider_failure_kinds` in `tests/test_provider_failure_classification.py` to enforce that every member of `ProviderFailureKind` is registered in `_FAILURE_KIND_MAP`.
- Added parametrized test cases verifying classification and retryability decisions for newly mapped failure kinds.

Closes #604
