### PR TITLE
fix(provider): map display names for all supported OpenAI-compatible providers

### DIFF
--- a/src/agentos/provider/openai.py
+++ b/src/agentos/provider/openai.py
@@ -90,6 +90,19 @@ def _provider_display_name(provider_kind: str) -> str:
         "zhipu": "Zhipu",
         "qianfan": "Qianfan",
         "volcengine": "Volcengine",
+        "azure": "Azure OpenAI",
+        "bailian_coding": "Bailian Coding",
+        "mistral": "Mistral",
+        "groq": "Groq",
+        "siliconflow": "SiliconFlow",
+        "aihubmix": "AIHubMix",
+        "minimax": "MiniMax",
+        "minimax_openai": "MiniMax",
+        "byteplus": "BytePlus",
+        "bankr": "Bankr",
+        "vllm": "vLLM",
+        "lm_studio": "LM Studio",
+        "ovms": "OVMS",
     }.get(provider_kind, "Provider")
 
 

--- a/tests/test_provider_mainstream_profiles.py
+++ b/tests/test_provider_mainstream_profiles.py
@@ -226,3 +226,39 @@ def test_azure_default_construction_is_outside_a_stage_support() -> None:
         _build_provider(
             ProviderConfig(provider="azure", model="deployment-name", api_key="test-key")
         )
+
+
+@pytest.mark.parametrize(
+    ("provider_kind", "expected_display_name"),
+    [
+        ("openai", "OpenAI"),
+        ("openrouter", "OpenRouter"),
+        ("opencap", "OpenCAP"),
+        ("deepseek", "DeepSeek"),
+        ("moonshot", "Moonshot"),
+        ("dashscope", "DashScope"),
+        ("gemini", "Gemini"),
+        ("zhipu", "Zhipu"),
+        ("qianfan", "Qianfan"),
+        ("volcengine", "Volcengine"),
+        ("azure", "Azure OpenAI"),
+        ("bailian_coding", "Bailian Coding"),
+        ("mistral", "Mistral"),
+        ("groq", "Groq"),
+        ("siliconflow", "SiliconFlow"),
+        ("aihubmix", "AIHubMix"),
+        ("minimax", "MiniMax"),
+        ("minimax_openai", "MiniMax"),
+        ("byteplus", "BytePlus"),
+        ("bankr", "Bankr"),
+        ("vllm", "vLLM"),
+        ("lm_studio", "LM Studio"),
+        ("ovms", "OVMS"),
+        ("unknown_provider", "Provider"),
+    ],
+)
+def test_provider_display_name_mapping(provider_kind: str, expected_display_name: str) -> None:
+    from agentos.provider.openai import _provider_display_name
+
+    assert _provider_display_name(provider_kind) == expected_display_name
+


### PR DESCRIPTION
## Summary
Expands `_provider_display_name` in `src/agentos/provider/openai.py` to map all supported provider kinds (Azure, Bailian, Mistral, Groq, SiliconFlow, AIHubMix, MiniMax, BytePlus, Bankr, vLLM, LM Studio, OVMS) so HTTP chat error messages accurately identify the failing provider instead of falling back to generic `"Provider"`.

## Tests Added
- Added parametrized test `test_provider_display_name_mapping` in `tests/test_provider_mainstream_profiles.py` covering all provider kinds.

closes #607 