### PR TITLE
fix(gateway): clean up empty session message subscriptions in SubscriptionManager

### DIFF
--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -570,6 +570,8 @@ class SubscriptionManager:
     def unsubscribe_messages(self, conn_id: str, session_key: str) -> None:
         if session_key in self._message_subs:
             self._message_subs[session_key].discard(conn_id)
+            if not self._message_subs[session_key]:
+                del self._message_subs[session_key]
 
     def get_message_subscribers(self, session_key: str) -> set[str]:
         return set(self._message_subs.get(session_key, set()))
@@ -591,8 +593,13 @@ class SubscriptionManager:
     def remove_connection(self, conn_id: str) -> None:
         """Clean up all subscriptions for a disconnected connection."""
         self._session_subs.discard(conn_id)
-        for subs in self._message_subs.values():
+        empty_sessions = []
+        for session_key, subs in self._message_subs.items():
             subs.discard(conn_id)
+            if not subs:
+                empty_sessions.append(session_key)
+        for session_key in empty_sessions:
+            del self._message_subs[session_key]
         empty_topics = []
         for topic, subs in self._topic_subs.items():
             subs.discard(conn_id)

--- a/tests/test_gateway/test_subscription_manager_cleanup.py
+++ b/tests/test_gateway/test_subscription_manager_cleanup.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from agentos.gateway.websocket import SubscriptionManager
+
+
+def test_subscription_manager_cleans_up_empty_message_subs_on_unsubscribe() -> None:
+    sm = SubscriptionManager()
+
+    sm.subscribe_messages("conn1", "session_a")
+    sm.subscribe_messages("conn2", "session_a")
+    sm.subscribe_messages("conn1", "session_b")
+
+    assert sm.get_message_subscribers("session_a") == {"conn1", "conn2"}
+    assert sm.get_message_subscribers("session_b") == {"conn1"}
+    assert "session_a" in sm._message_subs
+    assert "session_b" in sm._message_subs
+
+    # Unsubscribe conn1 from session_b -> session_b should be deleted from dict
+    sm.unsubscribe_messages("conn1", "session_b")
+    assert "session_b" not in sm._message_subs
+    assert sm.get_message_subscribers("session_b") == set()
+
+    # Unsubscribe conn1 from session_a -> conn2 still subscribed, key remains
+    sm.unsubscribe_messages("conn1", "session_a")
+    assert "session_a" in sm._message_subs
+    assert sm.get_message_subscribers("session_a") == {"conn2"}
+
+    # Unsubscribe conn2 from session_a -> session_a should be deleted from dict
+    sm.unsubscribe_messages("conn2", "session_a")
+    assert "session_a" not in sm._message_subs
+    assert sm._message_subs == {}
+
+
+def test_subscription_manager_cleans_up_empty_message_subs_on_remove_connection() -> None:
+    sm = SubscriptionManager()
+
+    sm.subscribe_sessions("conn1")
+    sm.subscribe_messages("conn1", "session_1")
+    sm.subscribe_messages("conn1", "session_2")
+    sm.subscribe_messages("conn2", "session_2")
+    sm.subscribe_topic("conn1", "cron_topic")
+
+    assert "session_1" in sm._message_subs
+    assert "session_2" in sm._message_subs
+    assert "cron_topic" in sm._topic_subs
+
+    # Disconnect conn1
+    sm.remove_connection("conn1")
+
+    # session_1 had only conn1, so it should be fully cleaned up
+    assert "session_1" not in sm._message_subs
+    # session_2 still has conn2, so it remains
+    assert "session_2" in sm._message_subs
+    assert sm.get_message_subscribers("session_2") == {"conn2"}
+    # cron_topic had only conn1, so it should be deleted
+    assert "cron_topic" not in sm._topic_subs
+    # sessions subscription should be removed
+    assert "conn1" not in sm.get_session_subscribers()
+
+    # Disconnect conn2
+    sm.remove_connection("conn2")
+    assert sm._message_subs == {}
+    assert sm._topic_subs == {}
+    assert sm._session_subs == set()


### PR DESCRIPTION
## Summary
Fixes an empty set memory leak in `SubscriptionManager` (`src/agentos/gateway/websocket.py`):

- `unsubscribe_messages()` now deletes the session key from `_message_subs` when its subscriber set becomes empty.
- `remove_connection()` now prunes empty session entries from `_message_subs` when connections disconnect (mirroring `_topic_subs`).

## Tests Added
- Added `tests/test_gateway/test_subscription_manager_cleanup.py` with comprehensive unit tests for unsubscribe and disconnect cleanup.
closes #609 