### PR TITLE
fix(provider): route empty and malformed responses to RETRY in decide_recovery_action

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -196,6 +196,11 @@ def decide_recovery_action(kind: ProviderFailureKind) -> ProviderRecoveryAction:
     if kind is ProviderFailureKind.CONTEXT_OVERFLOW:
         return ProviderRecoveryAction.COMPACT_AND_RETRY
     if kind in {
+        ProviderFailureKind.EMPTY_RESPONSE,
+        ProviderFailureKind.MALFORMED_RESPONSE,
+    }:
+        return ProviderRecoveryAction.RETRY
+    if kind in {
         ProviderFailureKind.PROVIDER_OVERLOADED,
         ProviderFailureKind.TRANSPORT_TRANSIENT,
     }:

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from agentos.provider.failures import ProviderFailureKind, classify_provider_error
+import pytest
+
+from agentos.provider.failures import (
+    ProviderFailureKind,
+    ProviderRecoveryAction,
+    classify_provider_error,
+    decide_recovery_action,
+)
 
 
 def test_provider_request_budget_exhausted_is_context_overflow() -> None:
@@ -13,3 +20,34 @@ def test_provider_request_budget_exhausted_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_action"),
+    [
+        (ProviderFailureKind.CONTEXT_OVERFLOW, ProviderRecoveryAction.COMPACT_AND_RETRY),
+        (ProviderFailureKind.EMPTY_RESPONSE, ProviderRecoveryAction.RETRY),
+        (ProviderFailureKind.MALFORMED_RESPONSE, ProviderRecoveryAction.RETRY),
+        (ProviderFailureKind.PROVIDER_OVERLOADED, ProviderRecoveryAction.RETRY_THEN_FALLBACK),
+        (ProviderFailureKind.TRANSPORT_TRANSIENT, ProviderRecoveryAction.RETRY_THEN_FALLBACK),
+        (ProviderFailureKind.RATE_LIMITED, ProviderRecoveryAction.FALLBACK_PROVIDER),
+        (ProviderFailureKind.INSUFFICIENT_CREDITS, ProviderRecoveryAction.FALLBACK_PROVIDER),
+        (ProviderFailureKind.MODEL_NOT_FOUND, ProviderRecoveryAction.FALLBACK_PROVIDER),
+        (ProviderFailureKind.UNSUPPORTED_FEATURE, ProviderRecoveryAction.FALLBACK_PROVIDER),
+        (ProviderFailureKind.AUTH_INVALID, ProviderRecoveryAction.FAIL_CONFIG),
+        (ProviderFailureKind.POLICY_REFUSAL, ProviderRecoveryAction.SURFACE),
+        (ProviderFailureKind.BAD_REQUEST, ProviderRecoveryAction.SURFACE),
+        (ProviderFailureKind.UNKNOWN, ProviderRecoveryAction.SURFACE),
+    ],
+)
+def test_decide_recovery_action(
+    kind: ProviderFailureKind, expected_action: ProviderRecoveryAction
+) -> None:
+    assert decide_recovery_action(kind) is expected_action
+
+
+def test_all_provider_recovery_actions_are_reachable() -> None:
+    reachable_actions = {decide_recovery_action(kind) for kind in ProviderFailureKind}
+    for action in ProviderRecoveryAction:
+        assert action in reachable_actions, f"ProviderRecoveryAction.{action.name} is unreachable"
+


### PR DESCRIPTION
## Summary
- Updates `decide_recovery_action()` in `src/agentos/provider/failures.py` to map `EMPTY_RESPONSE` and `MALFORMED_RESPONSE` to `ProviderRecoveryAction.RETRY`.
- Ensures single-turn response glitches (corrupt JSON chunks, transient empty stream bodies) are retried with the current provider before considering model failover, and makes all `ProviderRecoveryAction` enum variants reachable.

## Tests Added
- Added parametrized test `test_decide_recovery_action` and reachability assertion `test_all_provider_recovery_actions_are_reachable` in `tests/test_provider_failures.py`.
closes #611 