### PR TITLE
fix(provider): classify Anthropic context overflow errors

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -79,6 +79,7 @@ def _is_context_overflow(text: str) -> bool:
     return any(
         marker in text
         for marker in (
+            # OpenAI-compatible providers
             "context length",
             "context window",
             "maximum context",
@@ -87,6 +88,11 @@ def _is_context_overflow(text: str) -> bool:
             "input exceeds",
             "provider_request_budget_exhausted",
             "too many tokens",
+            # Anthropic-specific markers
+            "prompt_too_long",
+            "exceed context limit",
+            "request_too_large",
+            "request size exceeds",
         )
     )
 

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -13,3 +13,52 @@ def test_provider_request_budget_exhausted_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+
+def test_anthropic_prompt_too_long_is_context_overflow() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=400,
+            raw_code="prompt_too_long",
+            message="prompt_too_long: prompt is longer than the maximum allowed length",
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
+def test_anthropic_exceed_context_limit_is_context_overflow() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=400,
+            raw_code="invalid_request_error",
+            message="input length and max_tokens exceed context limit: 200000 > 199999",
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
+def test_anthropic_request_too_large_is_context_overflow() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=413,
+            raw_code="request_too_large",
+            message="request_too_large: request body is too large",
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
+def test_anthropic_request_size_exceeds_is_context_overflow() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=413,
+            raw_code="invalid_request_error",
+            message="request size exceeds the 131072 byte limit",
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+


### PR DESCRIPTION
Fixes #613

## Problem
`_is_context_overflow()` in `src/agentos/provider/failures.py` only contains OpenAI-centric markers, so Anthropic context overflow errors are misclassified as `BAD_REQUEST` instead of `CONTEXT_OVERFLOW`. This prevents the `COMPACT_AND_RETRY` recovery path from activating.

## Change
Added Anthropic-specific markers to `_is_context_overflow()`:
- `prompt_too_long` — error code
- `exceed context limit` — canonical 400 message ("input length and max_tokens exceed context limit")
- `request_too_large` — 413 error type
- `request size exceeds` — 413 message variant

Now Anthropic context overflows classify as `CONTEXT_OVERFLOW` → `COMPACT_AND_RETRY`, consistent with OpenAI-compatible providers.

## Tests
4 new regression tests covering each marker. `tests/test_provider_failure_classification.py`, `tests/test_gateway/test_context_overflow.py`, `tests/test_provider_failures.py`: 120 passed. Ruff + mypy clean.