### PR TITLE
fix(tools): derive valid git diff argv in sandboxed decorator

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
+from typing import Any
 
 from agentos.redact import redact_sensitive_text
 from agentos.sandbox.integration import get_runtime, run_under_backend, sandboxed
@@ -133,6 +134,16 @@ async def git_status(workdir: str | None = None) -> str:
     return await _run_git("status", "--short", "--branch", cwd=_effective_workdir(workdir))
 
 
+def _git_diff_argv(a: dict[str, Any]) -> tuple[str, ...]:
+    argv = ["git", "diff"]
+    if a.get("staged"):
+        argv.append("--cached")
+    path = a.get("path")
+    if path:
+        argv += ["--", str(path)]
+    return tuple(argv)
+
+
 @tool(
     name="git_diff",
     description="Show git diff (staged + unstaged changes).",
@@ -145,12 +156,7 @@ async def git_status(workdir: str | None = None) -> str:
 )
 @sandboxed(
     kind="git.read",
-    argv_factory=lambda a: (
-        "git",
-        "diff",
-        "--cached" if a.get("staged") else "--unstaged",
-        str(a.get("path", "")),
-    ),
+    argv_factory=_git_diff_argv,
     record_payload=False,
 )
 async def git_diff(

--- a/tests/test_tools/test_git_workdir_policy.py
+++ b/tests/test_tools/test_git_workdir_policy.py
@@ -50,3 +50,32 @@ def test_git_rejects_foreign_commit_file_on_windows(
 
     with pytest.raises(ToolError, match="foreign_host_path"):
         git._reject_foreign_git_path("/Users/a1/Desktop/repo/file.py")
+
+
+def test_git_diff_argv_unstaged_without_path() -> None:
+    assert git._git_diff_argv({}) == ("git", "diff")
+    assert git._git_diff_argv({"staged": False, "path": None}) == ("git", "diff")
+
+
+def test_git_diff_argv_staged_without_path() -> None:
+    assert git._git_diff_argv({"staged": True}) == ("git", "diff", "--cached")
+    assert git._git_diff_argv({"staged": True, "path": None}) == ("git", "diff", "--cached")
+
+
+def test_git_diff_argv_unstaged_with_path() -> None:
+    assert git._git_diff_argv({"path": "src/main.py"}) == (
+        "git",
+        "diff",
+        "--",
+        "src/main.py",
+    )
+
+
+def test_git_diff_argv_staged_with_path() -> None:
+    assert git._git_diff_argv({"staged": True, "path": "src/main.py"}) == (
+        "git",
+        "diff",
+        "--cached",
+        "--",
+        "src/main.py",
+    )


### PR DESCRIPTION

### Description
Closes #614 

### Summary
Fixes the `@sandboxed` `argv_factory` derivation for the built-in `git_diff` tool.

### Problem
`git_diff`'s `@sandboxed` decorator defined its `argv_factory` as:
```python
argv_factory=lambda a: (
    "git",
    "diff",
    "--cached" if a.get("staged") else "--unstaged",
    str(a.get("path", "")),
)
```
This produced invalid arguments:
1. `--unstaged` is not a valid git flag.
2. When `path` is omitted (`None`), `str(a.get("path", ""))` stringifies `None` to `"None"`.

While this tuple is not directly executed by the runner, it feeds sandbox action fingerprinting (`sandbox/integration.py`) and operator approval surfaces:
- **Approval Safety & Auditability**: Operators and audit logs are presented with `git diff --unstaged None`, misrepresenting the command that will execute.
- **Fingerprint Equivalence**: Fingerprints derived from invalid tuples misrepresent action equivalence across calls.

### Solution
Replaced the inline lambda with `_git_diff_argv(a)` that mirrors the actual command construction in `git_diff`:
- Returns `("git", "diff")`
- Appends `"--cached"` only when `staged` is truthy
- Appends `["--", str(path)]` only when `path` is provided and non-empty

### Tests
Added regression tests in `tests/test_tools/test_git_workdir_policy.py` verifying:
- Unstaged diff without path: `("git", "diff")`
- Staged diff without path: `("git", "diff", "--cached")`
- Unstaged diff with path: `("git", "diff", "--", "src/main.py")`
- Staged diff with path: `("git", "diff", "--cached", "--", "src/main.py")`

Fixes #614 