### PR TITLE
fix(media): raise ToolError on redirect response missing Location header

### DIFF
--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -308,9 +308,13 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
                 if resp.status_code not in {301, 302, 303, 307, 308}:
                     break
                 location = resp.headers.get("location")
-                await resp.aclose()
                 if not location:
-                    break
+                    await resp.aclose()
+                    raise ToolError(
+                        f"Redirect response ({resp.status_code}) from {current_url} "
+                        "missing Location header"
+                    )
+                await resp.aclose()
                 current_url = urljoin(str(resp.url), location)
             else:
                 raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")

--- a/tests/test_tools/test_media_image_download_cap.py
+++ b/tests/test_tools/test_media_image_download_cap.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from agentos.tools.builtin.media import _fetch_image_url
+from agentos.tools.types import ToolError
 
 
 def _png_header() -> bytes:
@@ -66,3 +67,51 @@ async def test_fetch_image_small_body_ok(monkeypatch: pytest.MonkeyPatch) -> Non
     data, mime = await _fetch_image_url("https://example.com/small.png")
     assert mime == "image/png"
     assert data == _png_header()
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_redirect_missing_location_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A redirect response without a Location header raises ToolError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="missing Location header"):
+        await _fetch_image_url("https://example.com/redirect.png")
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_redirect_follows_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 302 redirect with Location header follows and returns the image."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/redirect.png":
+            return httpx.Response(302, headers={"location": "/final.png"})
+        return httpx.Response(200, headers={"content-type": "image/png"}, content=_png_header())
+
+    _patch_network(monkeypatch, handler)
+
+    data, mime = await _fetch_image_url("https://example.com/redirect.png")
+    assert mime == "image/png"
+    assert data == _png_header()
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_too_many_redirects_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceeding MAX_REDIRECTS raises ToolError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "/loop.png"})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="Too many redirects"):
+        await _fetch_image_url("https://example.com/redirect-loop.png")


### PR DESCRIPTION

### Description
closes #616 
``### Summary
Fixes `_fetch_image_url` crashing with `httpx.StreamClosed` when a redirect response omits the `Location` header, and adds test coverage for redirect handling.

### Problem
When receiving a redirect status code (301, 302, 303, 307, 308) missing a `Location` header, `_fetch_image_url` closed the response (`await resp.aclose()`) and `break`ed out of the redirect loop. Downstream, `resp.raise_for_status()` does not raise on 3xx, leading into `async for chunk in resp.aiter_bytes()` on the closed stream. This failed with an internal `StreamClosed` error rather than a clear explanation.

### Solution
- When `location` is missing on a redirect response, immediately raise an explicit `ToolError` naming the status code, the current URL, and the missing header.
- Added comprehensive unit tests in `tests/test_tools/test_media_image_download_cap.py`:
  - Missing `Location` header raises clear `ToolError`.
  - Valid `Location` header is followed and the image downloaded.
  - Exceeding `_MAX_REDIRECTS` raises `ToolError("Too many redirects (>5)")`.

Fixes #616

```