### PR TITLE
fix(channels): quote IMAP mailbox folder names containing spaces

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -451,7 +451,7 @@ class EmailChannel:
 
         client = self._imap_connect()
         try:
-            client.select(self.config.imap_folder)
+            client.select(_quote_imap_mailbox(self.config.imap_folder))
             status, data = client.search(None, "UNSEEN")
             if status != "OK":
                 raise RuntimeError(f"IMAP search failed: {status}")
@@ -814,6 +814,19 @@ def _parse_rfc822_size(data: Any) -> int | None:
         if match:
             return int(match.group(1))
     return None
+
+
+def _quote_imap_mailbox(name: str) -> str:
+    """Quote an IMAP mailbox name per RFC 3501 if it contains whitespace or special chars."""
+    raw = (name or "").strip()
+    if not raw:
+        return "INBOX"
+    if (raw.startswith('"') and raw.endswith('"')) or (raw.startswith("'") and raw.endswith("'")):
+        return raw
+    if any(ch in raw for ch in ' \t()[]{"%*\\'):
+        escaped = raw.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return raw
 
 
 __all__ = [

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -382,9 +382,11 @@ class _FakeIMAP:
         self._raw = raw
         self._size = len(raw) if size is None else size
         self.stored: list[tuple[str, str, str]] = []
+        self.selected_folder: str | None = None
         self.closed = False
 
     def select(self, folder: str) -> tuple[str, list[bytes]]:
+        self.selected_folder = folder
         return "OK", [b"1"]
 
     def search(self, charset: Any, criteria: str) -> tuple[str, list[bytes]]:
@@ -417,6 +419,28 @@ def test_poll_parses_and_marks_seen(monkeypatch: pytest.MonkeyPatch) -> None:
     assert [m.sender_id for m in messages] == ["owner@example.com"]
     assert fake.stored == [("7", "+FLAGS", "\\Seen")]
     assert fake.closed is True
+
+
+def test_quote_imap_mailbox() -> None:
+    from agentos.channels.email import _quote_imap_mailbox
+
+    assert _quote_imap_mailbox("INBOX") == "INBOX"
+    assert _quote_imap_mailbox("") == "INBOX"
+    assert _quote_imap_mailbox("Sent Items") == '"Sent Items"'
+    assert _quote_imap_mailbox('"Already Quoted"') == '"Already Quoted"'
+    assert _quote_imap_mailbox("'Single Quoted'") == "'Single Quoted'"
+    assert _quote_imap_mailbox("Archive/2026 Projects") == '"Archive/2026 Projects"'
+
+
+def test_poll_quotes_mailbox_with_spaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config(imap_folder="Sent Items"))
+    raw = _raw().as_bytes()
+    fake = _FakeIMAP(raw)
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    channel._fetch_unseen()
+
+    assert fake.selected_folder == '"Sent Items"'
 
 
 def test_poll_skips_a_message_larger_than_the_cap(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION

### Description
closes #618 
```markdown
### Summary
Quotes IMAP mailbox folder names in `EmailChannel` (`src/agentos/channels/email.py`) in compliance with RFC 3501.

### Problem
When `imap_folder` contained spaces (e.g. `"Sent Items"`, `"All Mail"`, or `"Archive 2026"`), `client.select(self.config.imap_folder)` sent unquoted tokens across the wire (`TAG SELECT Sent Items\r\n`). Standard IMAP servers reject unquoted multi-word mailbox arguments with `BAD [CLIENTBUG] Invalid syntax: unexpected argument`, preventing the adapter from polling the configured folder.

### Solution
- Added helper `_quote_imap_mailbox()` to quote and escape mailbox names that contain spaces or IMAP special characters, while preserving already-quoted strings and defaulting empty strings to `"INBOX"`.
- Called `_quote_imap_mailbox()` in `_fetch_unseen()` before passing the folder to `client.select()`.
- Added unit tests for `_quote_imap_mailbox()` and polling with folders containing spaces in `tests/test_channels/test_email_channel.py`.

### Verification
- `uv run pytest tests/test_channels/test_email_channel.py` (42 passed)
- `ruff check`, `ruff format`, and `mypy` all passed with 0 errors.
```