### PR TITLE
fix(channels): preserve In-Reply-To in email References chain per RFC…

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -788,9 +788,18 @@ def _body_text(parsed: EmailMessage) -> str:
 
 
 def _merge_references(parsed: EmailMessage, message_id: str) -> str:
-    existing = (parsed.get("References") or "").split()
-    if message_id:
-        existing.append(f"<{message_id}>")
+    raw_refs = (parsed.get("References") or "").split()
+    if not raw_refs:
+        raw_refs = (parsed.get("In-Reply-To") or "").split()
+
+    existing: list[str] = []
+    for ref in raw_refs:
+        clean = ref.strip().strip("<>")
+        if clean:
+            existing.append(f"<{clean}>")
+    clean_id = (message_id or "").strip().strip("<>")
+    if clean_id:
+        existing.append(f"<{clean_id}>")
     return " ".join(dict.fromkeys(existing))
 
 

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -16,6 +16,7 @@ from agentos.channels.contract import ChannelSendStatus, run_channel_contract
 from agentos.channels.email import (
     EmailChannel,
     EmailChannelConfig,
+    _merge_references,
     html_to_text,
     is_automated,
     normalize_address,
@@ -310,6 +311,55 @@ async def test_send_composes_threading_headers(monkeypatch: pytest.MonkeyPatch) 
     assert outbound["References"] == "<m1@example.com>"
     assert normalize_address(outbound["From"]) == "agent@example.com"
     assert outbound.get_content().strip() == "the answer"
+
+
+def test_merge_references_falls_back_to_in_reply_to() -> None:
+    msg = EmailMessage()
+    msg["Message-ID"] = "<reply-102@example.com>"
+    msg["In-Reply-To"] = "<root-001@example.com>"
+
+    merged = _merge_references(msg, "reply-102@example.com")
+    assert merged == "<root-001@example.com> <reply-102@example.com>"
+
+
+def test_merge_references_with_existing_references() -> None:
+    msg = EmailMessage()
+    msg["Message-ID"] = "<reply-103@example.com>"
+    msg["In-Reply-To"] = "<reply-102@example.com>"
+    msg["References"] = "<root-001@example.com> <reply-102@example.com>"
+
+    merged = _merge_references(msg, "reply-103@example.com")
+    assert merged == "<root-001@example.com> <reply-102@example.com> <reply-103@example.com>"
+
+
+def test_merge_references_root_message_without_references_or_in_reply_to() -> None:
+    msg = EmailMessage()
+    msg["Message-ID"] = "<root-001@example.com>"
+
+    merged = _merge_references(msg, "root-001@example.com")
+    assert merged == "<root-001@example.com>"
+
+
+async def test_send_composes_threading_headers_when_inbound_lacks_references(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(
+        _raw(
+            message_id="m2@example.com",
+            extra_headers={"In-Reply-To": "<m1@example.com>"},
+        )
+    )
+    assert inbound is not None
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(channel.build_reply_message("reply body", inbound))
+
+    assert len(sent) == 1
+    outbound = sent[0]
+    assert outbound["In-Reply-To"] == "<m2@example.com>"
+    assert outbound["References"] == "<m1@example.com> <m2@example.com>"
 
 
 async def test_send_resolves_the_recipient_from_the_thread_cache(


### PR DESCRIPTION

### Description
closes #620 
```markdown
### Summary
Fixes email conversation threading in `EmailChannel._merge_references()` (`src/agentos/channels/email.py`) when replying to messages that lack a `References` header.

### Problem
Per RFC 5322 §3.6.4, when a parent email lacks a `References` field, the child's `References` header must contain the parent's `In-Reply-To` followed by the parent's `Message-ID`. Previously, `_merge_references()` only inspected `parsed.get("References")`. When absent (standard for the second message in many email client threads), the parent message was omitted entirely and only the child's ID was kept, breaking conversation threading in clients like Gmail, Outlook, and Thunderbird.

### Solution
- When `parsed.get("References")` is empty, fall back to `parsed.get("In-Reply-To")` so the parent reference is preserved.
- Standardized reference format to `<message-id>` and deduplicated entries while preserving order.
- Added regression tests in `tests/test_channels/test_email_channel.py`.

### Verification
- `uv run pytest tests/test_channels/test_email_channel.py` (44 passed)
- `ruff check`, `ruff format`, and `mypy` all passed with 0 errors.
```