### PR TITLE
feat(tools): add scoped path filtering to git_log

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
+from typing import Any
 
 from agentos.redact import redact_sensitive_text
 from agentos.sandbox.integration import get_runtime, run_under_backend, sandboxed
@@ -207,25 +208,44 @@ async def git_commit(
     return await _run_git("commit", "-m", message, cwd=cwd)
 
 
+def _git_log_argv(a: dict[str, Any]) -> tuple[str, ...]:
+    argv = ["git", "log", f"--max-count={int(a.get('count', 10))}"]
+    path = a.get("path")
+    if path:
+        argv += ["--", str(path)]
+    return tuple(argv)
+
+
 @tool(
     name="git_log",
-    description="Show recent git commit log.",
+    description="Show recent git commit log, optionally scoped to a file or directory path.",
     params={
         "count": {"type": "integer", "description": "Number of commits to show (default 10)."},
+        "path": {
+            "type": "string",
+            "description": "Limit commit log to this file or directory path.",
+        },
         "workdir": {"type": "string", "description": "Git repository directory (default: cwd)."},
     },
     required=[],
 )
 @sandboxed(
     kind="git.read",
-    argv_factory=lambda a: ("git", "log", str(a.get("count", 10))),
+    argv_factory=_git_log_argv,
     record_payload=False,
 )
-async def git_log(count: int = 10, workdir: str | None = None) -> str:
-    return await _run_git(
+async def git_log(
+    count: int = 10,
+    path: str | None = None,
+    workdir: str | None = None,
+) -> str:
+    args = [
         "log",
         f"--max-count={count}",
         "--oneline",
         "--decorate",
-        cwd=_effective_workdir(workdir),
-    )
+    ]
+    if path:
+        _reject_foreign_git_path(path)
+        args += ["--", path]
+    return await _run_git(*args, cwd=_effective_workdir(workdir))

--- a/tests/test_security/test_git_output_redaction.py
+++ b/tests/test_security/test_git_output_redaction.py
@@ -235,3 +235,21 @@ def test_assignment_pass_survives_the_diff_marker(marker: str) -> None:
 )
 def test_diff_marker_does_not_create_false_positives(line: str) -> None:
     assert redact_sensitive_text(line, force=True, code_file=False) == line
+
+
+async def test_git_log_scoped_to_path(repo: Path) -> None:
+    (repo / "other.txt").write_text("hello", encoding="utf-8")
+    _git(repo, "add", "other.txt")
+    _git(repo, "commit", "-qm", "add other")
+
+    fn = getattr(git.git_log, "__wrapped__", git.git_log)
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+
+    log_other = await fn(count=10, path="other.txt", workdir=str(repo))
+    assert "add other" in log_other
+    assert "add env" not in log_other
+
+    log_env = await fn(count=10, path=".env", workdir=str(repo))
+    assert "add env" in log_env
+    assert "add other" not in log_env

--- a/tests/test_tools/test_git_workdir_policy.py
+++ b/tests/test_tools/test_git_workdir_policy.py
@@ -50,3 +50,31 @@ def test_git_rejects_foreign_commit_file_on_windows(
 
     with pytest.raises(ToolError, match="foreign_host_path"):
         git._reject_foreign_git_path("/Users/a1/Desktop/repo/file.py")
+
+
+def test_git_log_argv_without_path() -> None:
+    assert git._git_log_argv({}) == ("git", "log", "--max-count=10")
+    assert git._git_log_argv({"count": 5, "path": None}) == ("git", "log", "--max-count=5")
+
+
+def test_git_log_argv_with_path() -> None:
+    assert git._git_log_argv({"count": 5, "path": "src/main.py"}) == (
+        "git",
+        "log",
+        "--max-count=5",
+        "--",
+        "src/main.py",
+    )
+
+
+async def test_git_log_rejects_foreign_path_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(git, "os", SimpleNamespace(name="nt"), raising=False)
+
+    fn = getattr(git.git_log, "__wrapped__", git.git_log)
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+
+    with pytest.raises(ToolError, match="foreign_host_path"):
+        await fn(path="/Users/a1/Desktop/repo/file.py")


### PR DESCRIPTION

### Description
closes #623 
```markdown
### Summary
Adds optional path filtering to the built-in `git_log` tool in `src/agentos/tools/builtin/git.py`.

### Problem
Previously, `git_log` only supported `count` and `workdir`. When an agent investigated changes to a specific file or directory, it had to retrieve the top `N` commits across the entire repository. This consumed unnecessary context tokens and missed older commits that touched the target file.

### Changes
- Added optional `path: str | None = None` parameter to `git_log()`.
- Validated `path` using `_reject_foreign_git_path(path)` to prevent directory traversal and foreign Windows path injections.
- Added `_git_log_argv` helper to derive clean sandboxed arguments (`git log --max-count=N -- path`).
- Added unit tests in `tests/test_tools/test_git_workdir_policy.py` and path-scoping integration tests in `tests/test_security/test_git_output_redaction.py`.

### Verification
- `uv run pytest tests/test_tools/test_git_workdir_policy.py` (7 passed)
- `uv run pytest tests/test_security/test_git_output_redaction.py` (23 passed)
- `ruff check`, `ruff format`, and `mypy` all passed with 0 errors.
```