### PR TITLE
fix(channels): quote IMAP mailbox names per RFC 3501

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -120,6 +120,17 @@ _HTML_DROP_RE = re.compile(r"(?is)<\s*(script|style)\b.*?<\s*/\s*\1\s*>")
 _HTML_TAG_RE = re.compile(r"(?s)<[^>]+>")
 
 
+def _quote_imap_mailbox(mailbox: str) -> str:
+    """Quote an IMAP mailbox name per RFC 3501 §4.3 quoted-string syntax.
+
+    ``imaplib`` passes mailbox arguments to the wire command verbatim, so a
+    folder whose name contains whitespace (e.g. ``"Sent Items"``) is sent as
+    multiple unquoted tokens and rejected by the server with an IMAP protocol
+    error.
+    """
+    return '"' + mailbox.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 class EmailChannelConfig(BaseModel):
     """Adapter-level config for the IMAP/SMTP email channel.
 
@@ -451,7 +462,7 @@ class EmailChannel:
 
         client = self._imap_connect()
         try:
-            client.select(self.config.imap_folder)
+            client.select(_quote_imap_mailbox(self.config.imap_folder))
             status, data = client.search(None, "UNSEEN")
             if status != "OK":
                 raise RuntimeError(f"IMAP search failed: {status}")

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -16,6 +16,7 @@ from agentos.channels.contract import ChannelSendStatus, run_channel_contract
 from agentos.channels.email import (
     EmailChannel,
     EmailChannelConfig,
+    _quote_imap_mailbox,
     html_to_text,
     is_automated,
     normalize_address,
@@ -382,9 +383,11 @@ class _FakeIMAP:
         self._raw = raw
         self._size = len(raw) if size is None else size
         self.stored: list[tuple[str, str, str]] = []
+        self.selected: list[str] = []
         self.closed = False
 
     def select(self, folder: str) -> tuple[str, list[bytes]]:
+        self.selected.append(folder)
         return "OK", [b"1"]
 
     def search(self, charset: Any, criteria: str) -> tuple[str, list[bytes]]:
@@ -461,6 +464,33 @@ def test_mark_seen_disabled_leaves_the_flag_alone(monkeypatch: pytest.MonkeyPatc
     channel._fetch_unseen()
 
     assert fake.stored == []
+
+
+@pytest.mark.parametrize(
+    ("folder", "expected"),
+    [
+        ("INBOX", '"INBOX"'),
+        ("Sent Items", '"Sent Items"'),
+        ("Archive/2026", '"Archive/2026"'),
+        ('Weird"Name', '"Weird\\"Name"'),
+        (r"Back\slash", r'"Back\\slash"'),
+        ("", '""'),
+    ],
+)
+def test_imap_mailbox_is_quoted_per_rfc3501(folder: str, expected: str) -> None:
+    assert _quote_imap_mailbox(folder) == expected
+
+
+def test_poll_selects_a_quoted_folder_with_spaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config(imap_folder="Sent Items"))
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    channel._fetch_unseen()
+
+    assert fake.selected == ['"Sent Items"']
 
 
 async def test_poll_loop_survives_a_failing_poll(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #618

## Problem
`EmailChannel._fetch_unseen()` calls `client.select(self.config.imap_folder)` directly. `imaplib` passes the mailbox argument to the wire command verbatim, so a folder whose name contains whitespace (e.g. `"Sent Items"`, common in Outlook/Exchange) is sent as multiple unquoted tokens:

```
TAG SELECT Sent Items\r\n
```

The server rejects it:
```
RuntimeError: IMAP search failed: BAD [CLIENTBUG] Invalid syntax: unexpected argument
```

## Change
Added `_quote_imap_mailbox()` which quotes the mailbox as an RFC 3501 4.3 quoted-string (escaping backslash and double-quote), and `_fetch_unseen()` now uses it:

```
TAG SELECT "Sent Items"\r\n
```

## Tests
- Parametrized unit tests for `_quote_imap_mailbox` (spaces, slashes, quotes, backslashes, empty)
- Regression test asserting `_fetch_unseen` selects the quoted folder
- Full `tests/test_channels/` suite: 299 passed; ruff + mypy clean