### PR TITLE
feat(provider): add Anthropic-specific context overflow markers

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -83,10 +83,14 @@ def _is_context_overflow(text: str) -> bool:
             "context window",
             "maximum context",
             "prompt is too long",
+            "prompt_too_long",
             "input is too long",
             "input exceeds",
             "provider_request_budget_exhausted",
             "too many tokens",
+            "exceed context limit",
+            "request_too_large",
+            "request size exceeds",
         )
     )
 

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -290,3 +290,67 @@ def test_new_transient_status_codes_match_via_text(message: str) -> None:
         classify_provider_error("openrouter", None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
     )
+
+
+# -- Anthropic-specific context overflow markers ----------------------------
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message", "desc"),
+    [
+        (
+            "anthropic",
+            400,
+            "invalid_request_error",
+            "input length and max_tokens exceed context limit: 188240 + 21333 > 200000",
+            "canonical Anthropic 400 message",
+        ),
+        (
+            "anthropic",
+            413,
+            "request_too_large",
+            "Request exceeds the maximum allowed number of bytes",
+            "Anthropic 413 error type",
+        ),
+        (
+            "anthropic",
+            413,
+            "",
+            "Request size exceeds model context window",
+            "Anthropic 413 message variant",
+        ),
+        (
+            "anthropic",
+            400,
+            "prompt_too_long",
+            "prompt is too long",
+            "prompt_too_long raw code",
+        ),
+    ],
+    ids=lambda v: v if isinstance(v, str) and len(v) < 40 else None,
+)
+def test_anthropic_context_overflow_markers(
+    provider: str,
+    status_code: int,
+    raw_code: str,
+    message: str,
+    desc: str,
+) -> None:
+    """Anthropic context overflow messages must classify as CONTEXT_OVERFLOW."""
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    ), f"Failed for: {desc}"
+
+
+def test_anthropic_invalid_request_without_overflow_stays_bad_request() -> None:
+    """Anthropic invalid_request_error without overflow markers → BAD_REQUEST."""
+    assert (
+        classify_provider_error(
+            "anthropic",
+            400,
+            raw_code="invalid_request_error",
+            message="messages: roles must alternate between user and assistant",
+        )
+        is ProviderFailureKind.BAD_REQUEST
+    )


### PR DESCRIPTION
## Summary

Anthropic's API returns context overflow errors using distinct phrasing and error types compared to OpenAI-compatible providers. Without matching markers in `_is_context_overflow()`, Anthropic overflow errors fell through to `ProviderFailureKind.BAD_REQUEST` (via `invalid_request_error`), bypassing the `COMPACT_AND_RETRY` recovery action and immediately failing out to the user.

This PR adds dedicated markers to `_is_context_overflow()` to properly classify Anthropic context overflows:
- `"prompt_too_long"` — matches raw error code / proxy responses
- `"exceed context limit"` — matches Anthropic's canonical 400 error message (`"input length and max_tokens exceed context limit: ..."`)
- `"request_too_large"` — matches Anthropic's 413 error type
- `"request size exceeds"` — matches the 413 payload message variant

*(Note: `"max_tokens"` was intentionally omitted as a standalone marker to avoid false positives on valid requests mentioning parameter names).*

## Changes

- **`src/agentos/provider/failures.py`**: Added Anthropic-specific markers to `_is_context_overflow()`.
- **`tests/test_provider_failure_classification.py`**: Added unit tests covering canonical Anthropic 400 messages, 413 error types, and negative cases ensuring non-overflow `invalid_request_error` stays `BAD_REQUEST`.

## Verification

- `uv run ruff check src/agentos/provider/failures.py tests/test_provider_failure_classification.py` (Passed)
- `uv run mypy src/agentos/provider/failures.py --show-error-codes` (Passed)
- `uv run pytest tests/test_provider_failure_classification.py -q` (93/93 tests passed)
closes #613 
