### PR TITLE
feat(provider): add provider-specific policy refusal markers

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -101,6 +101,12 @@ def _is_policy_refusal(text: str) -> bool:
             "moderation",
             "refusal",
             "blocked by policy",
+            "content_filter",
+            "content filter",
+            "responsible_ai_policy",
+            "content management policy",
+            "flagged by content filter",
+            "blocked by safety",
         )
     )
 

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -290,3 +290,65 @@ def test_new_transient_status_codes_match_via_text(message: str) -> None:
         classify_provider_error("openrouter", None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
     )
+
+
+# -- Policy refusal markers -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message", "desc"),
+    [
+        (
+            "azure",
+            400,
+            "content_filter",
+            (
+                "The response was filtered due to the prompt triggering "
+                "Azure OpenAI's content management policy."
+            ),
+            "Azure OpenAI content filter error",
+        ),
+        (
+            "openai",
+            400,
+            "",
+            "The prompt was flagged by content filter and violates safety policy",
+            "OpenAI content filter violation",
+        ),
+        (
+            "azure",
+            400,
+            "responsible_ai_policy",
+            "Request blocked due to responsible_ai_policy violation",
+            "Responsible AI policy violation",
+        ),
+        (
+            "gemini",
+            400,
+            "BLOCKED_BY_SAFETY",
+            "Candidate was blocked by safety filters",
+            "Gemini blocked by safety",
+        ),
+        (
+            "anthropic",
+            400,
+            "policy_violation",
+            "Output generation was blocked by policy refusal",
+            "Anthropic policy refusal",
+        ),
+    ],
+    ids=lambda v: v if isinstance(v, str) and len(v) < 40 else None,
+)
+def test_provider_failure_classifies_policy_refusal_markers(
+    provider: str,
+    status_code: int,
+    raw_code: str,
+    message: str,
+    desc: str,
+) -> None:
+    """Policy refusal error messages must classify as POLICY_REFUSAL."""
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is ProviderFailureKind.POLICY_REFUSAL
+    ), f"Failed for: {desc}"
+


### PR DESCRIPTION
## Summary

When upstream LLM providers (such as Azure OpenAI, OpenAI, Gemini, or Anthropic) filter or reject a prompt or response due to content safety or moderation policies, they return specific error codes or message phrases (e.g. `content_filter`, `responsible_ai_policy`, `content management policy`, `flagged by content filter`, `blocked by safety`).

Previously, `_is_policy_refusal()` only matched a small set of generic phrases, causing these upstream safety blocks to fall through and be misclassified as `BAD_REQUEST` or `UNKNOWN`.

This PR adds common provider safety and moderation markers to `_is_policy_refusal()` to ensure all such errors consistently classify as `ProviderFailureKind.POLICY_REFUSAL`.

## Changes

- **`src/agentos/provider/failures.py`**: Added the following markers to `_is_policy_refusal()`:
  - `"content_filter"` (Azure OpenAI / OpenAI error code & finish reason)
  - `"content filter"` (e.g. `"The prompt was flagged by content filter"`)
  - `"responsible_ai_policy"` (Azure / cloud policy violation code)
  - `"content management policy"` (Azure OpenAI canonical error phrasing)
  - `"flagged by content filter"`
  - `"blocked by safety"` (Google Gemini block reason)
- **`tests/test_provider_failure_classification.py`**: Added unit tests covering policy refusal error shapes across Azure OpenAI, OpenAI, Gemini, and Anthropic.

## Verification

- `uv run ruff check src/agentos/provider/failures.py tests/test_provider_failure_classification.py` (Passed)
- `uv run mypy src/agentos/provider/failures.py --show-error-codes` (Passed)
- `uv run pytest tests/test_provider_failure_classification.py -q` (93/93 tests passed)

closes #629 