### PR TITLE
fix(tools): fix sandbox git_diff argv_factory emitting invalid --unstaged flag

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -145,11 +145,16 @@ async def git_status(workdir: str | None = None) -> str:
 )
 @sandboxed(
     kind="git.read",
-    argv_factory=lambda a: (
-        "git",
-        "diff",
-        "--cached" if a.get("staged") else "--unstaged",
-        str(a.get("path", "")),
+    argv_factory=lambda a: tuple(
+        x
+        for x in (
+            "git",
+            "diff",
+            "--cached" if a.get("staged") else None,
+            "--" if a.get("path") else None,
+            a.get("path"),
+        )
+        if x is not None
     ),
     record_payload=False,
 )


### PR DESCRIPTION
## Summary
Fixes the `@sandboxed` decorator's `argv_factory` for `git_diff` which was producing invalid git invocations:

1. Used `--unstaged` flag which doesn't exist in git — `git diff` only supports `--cached` for staged diffs, unstaged is the default with no flag
2. Appended empty string path when `path=None`, causing `fatal: empty string is not a valid pathspec`

## Changes
- `argv_factory` now filters out `None` values from the argv tuple
- When `staged=False` and `path=None`: produces `("git", "diff")`
- When `staged=True` and `path=None`: produces `("git", "diff", "--cached")`
- When `path` is set: adds `"--"` separator before the path for safety

Fixes #614