### PR TITLE
fix(media): raise ToolError on redirect response missing Location header (#616)

### DIFF
--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -310,7 +310,10 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
                 location = resp.headers.get("location")
                 await resp.aclose()
                 if not location:
-                    break
+                    raise ToolError(
+                        "Redirect response missing Location header — "
+                        "cannot follow redirect without a target URL"
+                    )
                 current_url = urljoin(str(resp.url), location)
             else:
                 raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")

--- a/tests/test_tools/test_media_image_download_cap.py
+++ b/tests/test_tools/test_media_image_download_cap.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from agentos.tools.builtin.media import _fetch_image_url
+from agentos.tools.types import ToolError
 
 
 def _png_header() -> bytes:

--- a/tests/test_tools/test_media_image_download_cap.py
+++ b/tests/test_tools/test_media_image_download_cap.py
@@ -66,3 +66,55 @@ async def test_fetch_image_small_body_ok(monkeypatch: pytest.MonkeyPatch) -> Non
     data, mime = await _fetch_image_url("https://example.com/small.png")
     assert mime == "image/png"
     assert data == _png_header()
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_redirect_missing_location_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 302 redirect without Location header raises ToolError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="missing Location header"):
+        await _fetch_image_url("https://example.com/redirect-no-location.png")
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_redirect_follows_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 302 redirect with Location header follows and returns the image."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/redirect.png":
+            return httpx.Response(302, headers={"location": "/final.png"})
+        return httpx.Response(200, headers={"content-type": "image/png"}, content=_png_header())
+
+    _patch_network(monkeypatch, handler)
+
+    data, mime = await _fetch_image_url("https://example.com/redirect.png")
+    assert mime == "image/png"
+    assert data == _png_header()
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_too_many_redirects_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """More than MAX_REDIRECTS redirects raises ToolError."""
+
+    redirect_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal redirect_count
+        redirect_count += 1
+        return httpx.Response(302, headers={"location": "/loop"})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="Too many redirects"):
+        await _fetch_image_url("https://example.com/redirect-loop.png")


### PR DESCRIPTION
## Summary

When `_fetch_image_url` encounters a redirect response (301, 302, 303, 307, 308) but the response has no `Location` header, the code previously `break` out of the redirect loop and continued to process the response as a non-redirect. This caused `httpx.StreamClosed` errors when trying to read the body of an already-closed response.

## Fix
- Raise a `ToolError` immediately when a redirect response is missing the `Location` header
- Provides a clear, actionable error message instead of a cryptic `StreamClosed` crash

## Changes
- `src/agentos/tools/builtin/media.py`: 3 lines changed

## Tests
3 new regression tests in `tests/test_tools/test_media_image_download_cap.py`:

```
$ uv run pytest tests/test_tools/test_media_image_download_cap.py -v --tb=short
...
tests/test_tools/test_media_image_download_cap.py::test_fetch_image_redirect_missing_location_raises_tool_error PASSED
tests/test_tools/test_media_image_download_cap.py::test_fetch_image_redirect_follows_location PASSED
tests/test_tools/test_media_image_download_cap.py::test_fetch_image_too_many_redirects_raises_tool_error PASSED
============================== 5 passed in 1.07s ===============================
```

- [x] This pull request fully resolves the linked issue.
- [x] Bug fix: no breaking changes to existing behavior
- [x] Includes regression tests for redirect edge cases

Fixes #616