### PR TITLE
chore(video-merger): enable strict shell mode in install.sh

### DIFF
--- a/src/agentos/skills/bundled/video-merger/install.sh
+++ b/src/agentos/skills/bundled/video-merger/install.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 echo "安装 video-merger 技能依赖..."
 
 # 检查并安装ffmpeg


### PR DESCRIPTION
## Summary
Every other shell script in this repository uses `set -euo pipefail` for safety. The video-merger `install.sh` was the lone outlier.

## Changes
- Switch shebang from `#!/bin/bash` to `#!/usr/bin/env bash` (matches the rest of the repo)
- Add `set -euo pipefail` immediately after the shebang

Fixes #525