### PR TITLE
fix(provider): map display names for all supported OpenAI-compatible providers

### DIFF
--- a/src/agentos/provider/openai.py
+++ b/src/agentos/provider/openai.py
@@ -90,6 +90,19 @@ def _provider_display_name(provider_kind: str) -> str:
         "zhipu": "Zhipu",
         "qianfan": "Qianfan",
         "volcengine": "Volcengine",
+        "azure": "Azure OpenAI",
+        "bailian_coding": "Bailian Coding",
+        "mistral": "Mistral",
+        "groq": "Groq",
+        "siliconflow": "SiliconFlow",
+        "aihubmix": "AIHubMix",
+        "minimax": "MiniMax",
+        "minimax_openai": "MiniMax (OpenAI-compatible)",
+        "byteplus": "BytePlus",
+        "bankr": "Bankr",
+        "vllm": "vLLM",
+        "lm_studio": "LM Studio",
+        "ovms": "OVMS",
     }.get(provider_kind, "Provider")
 
 


### PR DESCRIPTION
## Summary
Adds display name mappings for 12 OpenAI-compatible providers that were missing from `_provider_display_name`, causing error messages to show the generic fallback 'Provider' instead of the actual provider name.

## Changes
Added entries for: azure, bailian_coding, mistral, groq, siliconflow, aihubmix, minimax, minimax_openai, byteplus, bankr, vllm, lm_studio, ovms

Fixes #607

Closes #607