### PR TITLE
fix(gateway): clean up empty session message subscriptions in SubscriptionManager

### DIFF
--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -570,6 +570,8 @@ class SubscriptionManager:
     def unsubscribe_messages(self, conn_id: str, session_key: str) -> None:
         if session_key in self._message_subs:
             self._message_subs[session_key].discard(conn_id)
+            if not self._message_subs[session_key]:
+                del self._message_subs[session_key]
 
     def get_message_subscribers(self, session_key: str) -> set[str]:
         return set(self._message_subs.get(session_key, set()))
@@ -591,8 +593,13 @@ class SubscriptionManager:
     def remove_connection(self, conn_id: str) -> None:
         """Clean up all subscriptions for a disconnected connection."""
         self._session_subs.discard(conn_id)
-        for subs in self._message_subs.values():
+        empty_sessions = []
+        for session_key, subs in self._message_subs.items():
             subs.discard(conn_id)
+            if not subs:
+                empty_sessions.append(session_key)
+        for session_key in empty_sessions:
+            del self._message_subs[session_key]
         empty_topics = []
         for topic, subs in self._topic_subs.items():
             subs.discard(conn_id)


### PR DESCRIPTION
## Summary
Fixes two memory leaks in `SubscriptionManager`:

1. **`unsubscribe_messages()`** removed conn_ids from `_message_subs` sets but left empty set entries behind, leaking memory over time.

2. **`remove_connection()`** iterated over `_message_subs.values()` and discarded conn_ids, but never cleaned up the empty sets. `_message_subs` was not cleaned up at all — only `_session_subs` and `_topic_subs` were.

Fixes #609