### PR TITLE
feat(provider): add Anthropic-specific markers to _is_context_overflow

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -87,6 +87,18 @@ def _is_context_overflow(text: str) -> bool:
             "input exceeds",
             "provider_request_budget_exhausted",
             "too many tokens",
+            # Anthropic-specific
+            "prompt_too_long",
+            "exceed context limit",
+            "request_too_large",
+            "request size exceeds",
+            # Anthropic API error format
+            "input length and max_tokens exceed context limit",
+            # OpenAI
+            "maximum context length exceeded",
+            # Gemini
+            "token count exceeds",
+            "max_input_tokens",
         )
     )
 

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -290,3 +290,75 @@ def test_new_transient_status_codes_match_via_text(message: str) -> None:
         classify_provider_error("openrouter", None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
     )
+
+
+# -- Anthropic-specific context overflow markers ----------------------------
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message", "desc"),
+    [
+        (
+            "anthropic",
+            400,
+            "invalid_request_error",
+            "input length and max_tokens exceed context limit: 188240 + 21333 > 200000",
+            "canonical Anthropic 400 message",
+        ),
+        (
+            "anthropic",
+            413,
+            "request_too_large",
+            "Request exceeds the maximum allowed number of bytes",
+            "Anthropic 413 error type",
+        ),
+        (
+            "anthropic",
+            413,
+            "",
+            "Request size exceeds model context window",
+            "Anthropic 413 message variant",
+        ),
+        (
+            "anthropic",
+            400,
+            "prompt_too_long",
+            "prompt is too long",
+            "prompt_too_long raw code",
+        ),
+        (
+            "openai",
+            400,
+            "",
+            "This model's maximum context length is 128000 tokens",
+            "OpenAI context length exceeded",
+        ),
+        (
+            "gemini",
+            400,
+            "max_input_tokens",
+            "Token count exceeds max_input_tokens limit",
+            "Gemini max_input_tokens",
+        ),
+        (
+            "gemini",
+            400,
+            "",
+            "Token count exceeds the maximum allowed",
+            "Gemini generic token count exceeded",
+        ),
+    ],
+    ids=lambda v: v if isinstance(v, str) and len(v) < 40 else None,
+)
+def test_anthropic_context_overflow_markers(
+    provider: str,
+    status_code: int,
+    raw_code: str,
+    message: str,
+    desc: str,
+) -> None:
+    """Provider-specific context overflow messages must classify as CONTEXT_OVERFLOW."""
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    ), f"Failed for: {desc}"


### PR DESCRIPTION
## Summary
Adds provider-specific context overflow markers to `_is_context_overflow`:

**Anthropic**: `prompt_too_long`, `request_too_large`, `exceed context limit`, `request size exceeds`, `input length and max_tokens exceed context limit`
**OpenAI**: `maximum context length exceeded`
**Gemini**: `max_input_tokens`, `token count exceeds`

Adds 7 parametrized test cases covering all providers.

Fixes #613
Closes #613