### PR TITLE
fix(memory): requeue files that fail indexing for retry

### DIFF
--- a/src/agentos/memory/sync_manager.py
+++ b/src/agentos/memory/sync_manager.py
@@ -167,9 +167,11 @@ class MemorySyncManager:
             deletes = set(self._pending_deletes)
             self._pending_changes.clear()
             self._pending_deletes.clear()
-            failed_deletes = await self._do_file_sync(changes=changes, deletes=deletes)
+            failed_deletes, failed_indexes = await self._do_file_sync(
+                changes=changes, deletes=deletes
+            )
         else:
-            failed_deletes = await self._do_file_sync(force=force)
+            failed_deletes, failed_indexes = await self._do_file_sync(force=force)
 
         session_sync_failed = await self._do_session_sync(reason=reason, force=force)
 
@@ -181,7 +183,17 @@ class MemorySyncManager:
                 reason=reason,
                 paths=sorted(failed_deletes),
             )
-        else:
+
+        if failed_indexes:
+            self._pending_changes.update(failed_indexes)
+            self._dirty = True
+            logger.warning(
+                "sync_manager.indexes_requeued",
+                reason=reason,
+                paths=sorted(failed_indexes),
+            )
+
+        if not failed_deletes and not failed_indexes:
             # Don't clobber _dirty=True set by a concurrent _do_ttl_sweep
             # (separate background task). If anything is still queued,
             # leave _dirty truthy so the next search-time sync retries
@@ -259,14 +271,16 @@ class MemorySyncManager:
         changes: set[str] | None = None,
         deletes: set[str] | None = None,
         force: bool = False,
-    ) -> set[str]:
+    ) -> tuple[set[str], set[str]]:
         """Re-index changed and deleted files from disk.
 
-        Returns the set of delete paths whose ``store.remove_file`` raised
-        (anything other than success). Caller is expected to re-enqueue
-        them so a transient SQLite lock does not orphan chunks. Index
-        failures stay log-only because the file is still on disk and the
-        next watcher tick will rediscover it via mtime.
+        Returns a ``(failed_deletes, failed_indexes)`` pair.  Failed
+        deletes are paths whose ``store.remove_file`` raised; failed indexes
+        are paths whose ``store.index_file`` raised.  The caller is expected
+        to re-enqueue both so a transient error does not permanently lose
+        the path — deletes into ``_pending_deletes`` and indexes into
+        ``_pending_changes`` so the next watcher tick retries them without
+        an mtime change.
         """
         if changes is None or deletes is None:
             current = self._scan_files()
@@ -285,6 +299,7 @@ class MemorySyncManager:
             self._mtimes = current
 
         failed_deletes: set[str] = set()
+        failed_indexes: set[str] = set()
         for rel_path in deletes:
             try:
                 await self._store.remove_file(rel_path)
@@ -323,9 +338,10 @@ class MemorySyncManager:
                         source=source.value,
                     )
             except Exception:
+                failed_indexes.add(rel_path)
                 logger.warning("sync_manager.index_failed", path=rel_path)
 
-        return failed_deletes
+        return failed_deletes, failed_indexes
 
     async def _do_session_sync(self, *, reason: str, force: bool = False) -> bool:
         """Sync the derived sessions source when the current trigger can affect it.

--- a/tests/test_memory_sync_manager_architecture.py
+++ b/tests/test_memory_sync_manager_architecture.py
@@ -80,9 +80,9 @@ async def test_sync_force_overrides_search_clean_fast_path(tmp_path):
     first_count = len(store.indexed)
     sync_calls: list[dict[str, object]] = []
 
-    async def fake_do_file_sync(**kwargs: object) -> set[str]:
+    async def fake_do_file_sync(**kwargs: object) -> tuple[set[str], set[str]]:
         sync_calls.append(kwargs)
-        return set()
+        return set(), set()
 
     manager._do_file_sync = fake_do_file_sync  # type: ignore[method-assign]
     await manager.sync(reason="search")
@@ -94,3 +94,122 @@ async def test_sync_force_overrides_search_clean_fast_path(tmp_path):
     assert first_count == 1
     assert search_count == first_count
     assert sync_calls == [{"force": True}]
+
+
+class FlakyStore(NoopStore):
+    """``index_file`` fails for the configured paths until ``fail_times``."""
+
+    def __init__(self, fail_paths: set[str], fail_times: int = 1) -> None:
+        super().__init__()
+        self._fail_paths = fail_paths
+        self._fail_times = fail_times
+        self._index_calls: dict[str, int] = {}
+
+    async def index_file(self, *, path: str, content: str, source: object) -> int:
+        self._index_calls[path] = self._index_calls.get(path, 0) + 1
+        if path in self._fail_paths and self._index_calls[path] <= self._fail_times:
+            raise OSError("transient index failure")
+        return await super().index_file(path=path, content=content, source=source)
+
+
+@pytest.mark.asyncio
+async def test_transient_index_failure_is_requeued_and_retried(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    (workspace / "MEMORY.md").write_text("root\n", encoding="utf-8")
+    (memory / "a.md").write_text("a\n", encoding="utf-8")
+    store = FlakyStore(fail_paths={"memory/a.md"}, fail_times=1)
+    manager = MemorySyncManager(store=store, workspace_dir=workspace, memory_dir=memory)
+
+    # First sync: a.md fails once, MEMORY.md succeeds.
+    await manager.sync(reason="manual")
+    assert sorted(store.indexed) == ["MEMORY.md"]
+    assert "memory/a.md" in manager._pending_changes
+    assert manager._dirty is True
+
+    # Watcher tick without an mtime change retries the failed path.
+    await manager.sync(reason="watch")
+    assert sorted(store.indexed) == ["MEMORY.md", "memory/a.md"]
+    assert manager._pending_changes == set()
+    assert manager._dirty is False
+
+
+@pytest.mark.asyncio
+async def test_persistent_index_failure_stays_pending_and_dirty(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    (workspace / "MEMORY.md").write_text("root\n", encoding="utf-8")
+    (memory / "a.md").write_text("a\n", encoding="utf-8")
+    store = FlakyStore(fail_paths={"memory/a.md"}, fail_times=100)
+    manager = MemorySyncManager(store=store, workspace_dir=workspace, memory_dir=memory)
+
+    await manager.sync(reason="manual")
+    assert store._index_calls["memory/a.md"] == 1
+
+    # Still failing after several watcher ticks: stays pending + dirty.
+    await manager.sync(reason="watch")
+    await manager.sync(reason="watch")
+    await manager.sync(reason="watch")
+    assert store._index_calls["memory/a.md"] == 4
+    assert "memory/a.md" in manager._pending_changes
+    assert manager._dirty is True
+
+
+@pytest.mark.asyncio
+async def test_clean_sync_after_retry_does_not_duplicate(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    (workspace / "MEMORY.md").write_text("root\n", encoding="utf-8")
+    (memory / "a.md").write_text("a\n", encoding="utf-8")
+    store = FlakyStore(fail_paths={"memory/a.md"}, fail_times=1)
+    manager = MemorySyncManager(store=store, workspace_dir=workspace, memory_dir=memory)
+
+    await manager.sync(reason="manual")  # a.md fails
+    await manager.sync(reason="watch")  # a.md retried and succeeds
+    assert store._index_calls["memory/a.md"] == 2
+
+    # A clean subsequent sync must not re-index anything.
+    await manager.sync(reason="watch")
+    assert store._index_calls["memory/a.md"] == 2
+    assert store.indexed == ["MEMORY.md", "memory/a.md"]
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_retry_is_preserved(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    (workspace / "MEMORY.md").write_text("root\n", encoding="utf-8")
+    (memory / "a.md").write_text("a\n", encoding="utf-8")
+
+    class FlakyDeleteStore(NoopStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.remove_attempts = 0
+
+        async def remove_file(self, path: str) -> None:
+            self.remove_attempts += 1
+            if self.remove_attempts == 1:
+                raise OSError("transient sqlite lock")
+            return await super().remove_file(path)
+
+    store = FlakyDeleteStore()
+    manager = MemorySyncManager(store=store, workspace_dir=workspace, memory_dir=memory)
+
+    # Index everything first, then delete the file.
+    await manager.sync(reason="manual")
+    (memory / "a.md").unlink()
+
+    # First watch: remove_file fails -> requeued into _pending_deletes.
+    await manager.sync(reason="watch")
+    assert "memory/a.md" in manager._pending_deletes
+    assert manager._dirty is True
+
+    # Second watch: retried and succeeds.
+    await manager.sync(reason="watch")
+    assert store.removed == ["memory/a.md"]
+    assert manager._pending_deletes == set()
+    assert manager._dirty is False


### PR DESCRIPTION
Fixes #638

## Problem
`MemorySyncManager._do_file_sync()` records the mtime **before** calling `store.index_file()`. When `index_file()` raises a transient error, the path is logged and dropped — but its mtime was already captured, so later watcher ticks consider the file unchanged and the index is never retried until the file is modified again or the process restarts.

## Change
`_do_file_sync()` now returns a `(failed_deletes, failed_indexes)` pair. Failed indexes are re-enqueued into `_pending_changes` (mirroring how failed deletes already re-enqueue into `_pending_deletes`), and the manager stays dirty while a failed path is pending. The next watcher sync retries the unchanged file and clears the pending state after success.

## Acceptance criteria coverage
- Requeues every path whose `index_file()` fails ✅
- Keeps the manager dirty while a failed path is pending ✅
- Retries on a later watcher sync without requiring an mtime change ✅
- Preserves the existing delete-failure retry behavior ✅

## Tests
4 new offline regression tests (fake store, no network/provider): transient failure then successful retry, persistent failure stays pending+dirty, clean sync after retry does not duplicate, and delete-failure retry preserved. Full memory suite: 389 passed; ruff + mypy clean.