### PR TITLE
fix(channels): catch ConnectTimeout/WriteTimeout and handle non-numeric Retry-After (#642)

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -284,7 +284,12 @@ async def retry_request(
         try:
             resp = await func(*args, **kwargs)
             if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+                raw_retry_after = resp.headers.get("Retry-After", "")
+                try:
+                    retry_after = float(raw_retry_after)
+                except (ValueError, TypeError):
+                    # Retry-After could be an HTTP-date; fall back to default backoff
+                    retry_after = base_delay * (2**attempt)
                 log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
                 await asyncio.sleep(retry_after)
                 continue
@@ -294,7 +299,7 @@ async def retry_request(
                 await asyncio.sleep(delay)
                 continue
             return resp
-        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+        except (httpx.ConnectError, httpx.ReadTimeout, httpx.TimeoutException) as exc:
             last_exc = exc
             if attempt < max_retries:
                 delay = base_delay * (2**attempt) + random.random()

--- a/tests/test_channels/test_channel_retry_util.py
+++ b/tests/test_channels/test_channel_retry_util.py
@@ -14,7 +14,6 @@ import pytest
 
 from agentos.channels._util import retry_request
 
-
 _REQUEST = httpx.Request("POST", "https://test.example/api")
 
 

--- a/tests/test_channels/test_channel_retry_util.py
+++ b/tests/test_channels/test_channel_retry_util.py
@@ -1,0 +1,107 @@
+"""Direct regression tests for ``retry_request`` (``agentos.channels._util``).
+
+Pins the two fixes in this PR:
+1. Non-numeric Retry-After (HTTP-date) falls back to exponential backoff
+2. httpx.TimeoutException subclasses are caught and retried
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from agentos.channels._util import retry_request
+
+
+_REQUEST = httpx.Request("POST", "https://test.example/api")
+
+
+def _resp(
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    return httpx.Response(status_code, headers=headers or {}, request=_REQUEST)
+
+
+@pytest.fixture(autouse=True)
+def no_sleep():
+    with patch("agentos.channels._util.asyncio.sleep", new=AsyncMock()) as sleep:
+        yield sleep
+
+
+async def test_retry_429_with_numeric_retry_after() -> None:
+    """A 429 with a numeric Retry-After header uses that value for backoff."""
+    func = AsyncMock(side_effect=[_resp(429, headers={"Retry-After": "2.5"}), _resp(200)])
+
+    result = await retry_request(func, max_retries=3, base_delay=1.0)
+
+    assert result.status_code == 200
+    assert func.await_count == 2
+
+
+async def test_retry_429_with_http_date_retry_after_falls_back() -> None:
+    """A 429 with an HTTP-date Retry-After (RFC 7231) falls back to default backoff."""
+    func = AsyncMock(
+        side_effect=[
+            _resp(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}),
+            _resp(200),
+        ]
+    )
+
+    result = await retry_request(func, max_retries=3, base_delay=1.0)
+
+    assert result.status_code == 200
+    assert func.await_count == 2
+
+
+async def test_retry_429_with_empty_retry_after_falls_back() -> None:
+    """A 429 with an empty Retry-After header falls back to default backoff."""
+    func = AsyncMock(side_effect=[_resp(429, headers={"Retry-After": ""}), _resp(200)])
+
+    result = await retry_request(func, max_retries=3, base_delay=1.0)
+
+    assert result.status_code == 200
+    assert func.await_count == 2
+
+
+async def test_retry_connect_timeout() -> None:
+    """httpx.ConnectTimeout is retried like ConnectError."""
+    func = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout("dns timeout", request=_REQUEST),
+            _resp(200),
+        ]
+    )
+
+    result = await retry_request(func, max_retries=3, base_delay=1.0)
+
+    assert result.status_code == 200
+    assert func.await_count == 2
+
+
+async def test_retry_generic_timeout_exception() -> None:
+    """Any httpx.TimeoutException subclass is retried."""
+    func = AsyncMock(
+        side_effect=[
+            httpx.ReadTimeout("read timed out", request=_REQUEST),
+            _resp(200),
+        ]
+    )
+
+    result = await retry_request(func, max_retries=3, base_delay=1.0)
+
+    assert result.status_code == 200
+    assert func.await_count == 2
+
+
+async def test_retry_exhausted_raises_last_exception() -> None:
+    """After exhausting retries, the last exception is re-raised."""
+    exc = httpx.ConnectTimeout("always fails", request=_REQUEST)
+    func = AsyncMock(side_effect=exc)
+
+    with pytest.raises(httpx.ConnectTimeout):
+        await retry_request(func, max_retries=2, base_delay=0.1)
+
+    assert func.await_count == 3  # initial + 2 retries


### PR DESCRIPTION
## Summary

Fixes two bugs in `retry_request` that cause unnecessary crashes in production:

1. **Missing timeout exception types** — `httpx.ConnectTimeout` and `WriteTimeout` inherit from `TimeoutException`, not `ConnectError`. Added `httpx.TimeoutException` to the catch clause so all transient timeouts (DNS, TLS, write, pool) are retried instead of crashing.

2. **Non-numeric Retry-After crash** — Per RFC 7231 §7.1.3, `Retry-After` can be an HTTP-date string (e.g. `Wed, 21 Oct 2026 07:28:00 GMT`). A bare `float()` call on such values causes a `ValueError` crash. Added try/except fallback to the standard exponential backoff delay.

## Changes

- `src/agentos/channels/_util.py`: Added `httpx.TimeoutException` to retry catch clause
- `src/agentos/channels/_util.py`: Wrapped `float(Retry-After)` in try/except with fallback to `base_delay * (2**attempt)`

## Tests
6 new regression tests in `tests/test_channels/test_channel_retry_util.py`:

```
$ uv run pytest tests/test_channels/test_channel_retry_util.py -v --tb=short
...
tests/test_channels/test_channel_retry_util.py::test_retry_429_with_numeric_retry_after PASSED
tests/test_channels/test_channel_retry_util.py::test_retry_429_with_http_date_retry_after_falls_back PASSED
tests/test_channels/test_channel_retry_util.py::test_retry_429_with_empty_retry_after_falls_back PASSED
tests/test_channels/test_channel_retry_util.py::test_retry_connect_timeout PASSED
tests/test_channels/test_channel_retry_util.py::test_retry_generic_timeout_exception PASSED
tests/test_channels/test_channel_retry_util.py::test_retry_exhausted_raises_last_exception PASSED
============================== 6 passed in 0.90s ===============================
```

All channel tests still pass:
```
$ uv run pytest tests/test_channels/ -q
48 passed
```

- [x] This pull request fully resolves the linked issue.
- [x] Bug fix: no breaking changes to existing behavior
- [x] Both fixes are minimal, targeted changes in a single file

Fixes #642