### PR TITLE
  Fixes #657

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -87,9 +87,14 @@ def _is_context_overflow(text: str) -> bool:
             "input exceeds",
             "provider_request_budget_exhausted",
             "too many tokens",
+            # Gemini's canonical input-token-limit error, e.g. "The input token
+            # count (5911388) exceeds the maximum number of tokens allowed
+            # (1048576)." — does not contain "input exceeds" or "maximum
+            # context" since the token counts sit between the fixed phrases.
+            "input token count",
+            "exceeds the maximum number of tokens allowed",
         )
     )
-
 
 def _is_policy_refusal(text: str) -> bool:
     return any(

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -13,3 +13,43 @@ def test_provider_request_budget_exhausted_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+def test_gemini_input_token_count_message_is_context_overflow() -> None:
+    # Gemini's real, canonical context-overflow error. Numbers vary per
+    # request but the surrounding phrasing is fixed. Before the fix this
+    # matched none of the context-overflow markers and fell through to
+    # BAD_REQUEST, so the runtime never triggered COMPACT_AND_RETRY.
+    message = (
+        "The input token count (5911388) exceeds the maximum number of "
+        "tokens allowed (1048576)."
+    )
+
+    assert (
+        classify_provider_error(
+            provider_name="gemini",
+            status_code=400,
+            raw_code="400",
+            message=message,
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
+def test_gemini_input_token_count_message_is_context_overflow_regardless_of_token_counts() -> (
+    None
+):
+    # Same shape, different digit counts — guards against a marker that
+    # accidentally depends on a specific number of digits.
+    message = (
+        "The input token count (132478) exceeds the maximum number of "
+        "tokens allowed (131072)."
+    )
+
+    assert (
+        classify_provider_error(
+            provider_name="gemini",
+            status_code=400,
+            message=message,
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )


### PR DESCRIPTION
## Linked issue

Fixes # (none — issue creation is restricted for external contributors on
this repo, so there's no issue number to link. The full bug report,
impact, and fix are documented below.)

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

Gemini is a fully-supported provider in AgentOS (`gemini` is listed in
`_OPENAI_COMPAT_PROVIDERS`). Its real, canonical context-overflow error
message is:

> "The input token count (X) exceeds the maximum number of tokens allowed (Y)."

None of the markers in `_is_context_overflow()` (`"context length"`,
`"context window"`, `"maximum context"`, `"input is too long"`,
`"input exceeds"`, `"too many tokens"`) match this phrasing — "input" and
"exceeds" aren't adjacent in the real message, and it says "maximum number
of tokens" rather than "maximum context" or "too many tokens".

As a result, the error was misclassified as `BAD_REQUEST` instead of
`CONTEXT_OVERFLOW`. Per `decide_recovery_action()`, that means
`COMPACT_AND_RETRY` never fired for Gemini users who hit their context
limit — they got a raw surfaced error instead of AgentOS automatically
compacting the conversation and retrying, which defeats a documented
recovery path for one of AgentOS's headline-supported providers.

This PR adds two markers to `_is_context_overflow()` covering Gemini's
fixed surrounding phrasing (not the variable token-count numbers, which
differ per request).

## Tests

Added two regression tests to `tests/test_provider_failures.py`:

- `test_gemini_input_token_count_message_is_context_overflow` — asserts
  the exact real-world Gemini message classifies as `CONTEXT_OVERFLOW`.
- `test_gemini_input_token_count_message_is_context_overflow_regardless_of_token_counts`
  — same shape with different digit counts, guarding against a marker
  that accidentally depends on a specific number of digits.

Commands run locally: