### PR TITLE
fix(memory): preserve watched file mtimes

### DIFF
--- a/src/agentos/memory/sync_manager.py
+++ b/src/agentos/memory/sync_manager.py
@@ -298,6 +298,7 @@ class MemorySyncManager:
             if not abs_path.is_file():
                 continue
             try:
+                source_mtime = self._mtimes.get(rel_path)
                 is_kb = rel_path.startswith("knowledge_base/") or rel_path.startswith(
                     "knowledge_base\\"
                 )
@@ -309,11 +310,11 @@ class MemorySyncManager:
                 else:
                     content = abs_path.read_text(encoding="utf-8", errors="replace")
                     source = MemorySource.memory
-
                 n = await self._store.index_file(
                     path=rel_path,
                     content=content,
                     source=source,
+                    mtime=source_mtime,
                 )
                 if n > 0:
                     logger.info(

--- a/tests/test_memory_sync_manager_architecture.py
+++ b/tests/test_memory_sync_manager_architecture.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from agentos.memory.sync_manager import MemorySyncManager
@@ -10,13 +12,38 @@ class NoopStore:
         self.indexed: list[str] = []
         self.removed: list[str] = []
 
-    async def index_file(self, *, path: str, content: str, source: object) -> int:
+    async def index_file(
+        self,
+        *,
+        path: str,
+        content: str,
+        source: object,
+        mtime: float | None = None,
+    ) -> int:
         self.indexed.append(path)
         return 1
 
     async def remove_file(self, path: str) -> None:
         self.removed.append(path)
         return None
+
+
+class MtimeStore(NoopStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mtimes: dict[str, float | None] = {}
+
+    async def index_file(
+        self,
+        *,
+        path: str,
+        content: str,
+        source: object,
+        mtime: float | None = None,
+    ) -> int:
+        self.indexed.append(path)
+        self.mtimes[path] = mtime
+        return 1
 
 
 def test_sync_manager_scans_archive_as_curated_memory_subdir(tmp_path):
@@ -94,3 +121,36 @@ async def test_sync_force_overrides_search_clean_fast_path(tmp_path):
     assert first_count == 1
     assert search_count == first_count
     assert sync_calls == [{"force": True}]
+
+
+@pytest.mark.asyncio
+async def test_sync_passes_source_mtime_for_memory_and_knowledge_base_files(tmp_path):
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    knowledge_base = workspace / "knowledge_base"
+    knowledge_base.mkdir()
+    memory_file = workspace / "MEMORY.md"
+    memory_file.write_text("Durable preference.\n", encoding="utf-8")
+    document = knowledge_base / "guide.md"
+    document.write_text("Deployment runbook.\n", encoding="utf-8")
+    expected_mtimes = {
+        "MEMORY.md": 1_700_000_000.0,
+        "knowledge_base/guide.md": 1_600_000_000.0,
+    }
+    os.utime(memory_file, (expected_mtimes["MEMORY.md"], expected_mtimes["MEMORY.md"]))
+    os.utime(
+        document,
+        (
+            expected_mtimes["knowledge_base/guide.md"],
+            expected_mtimes["knowledge_base/guide.md"],
+        ),
+    )
+
+    store = MtimeStore()
+    manager = MemorySyncManager(store=store, workspace_dir=workspace, memory_dir=memory)
+
+    await manager.sync(reason="manual")
+
+    assert sorted(store.indexed) == ["MEMORY.md", "knowledge_base/guide.md"]
+    assert store.mtimes == expected_mtimes


### PR DESCRIPTION
Fixes #649

## Summary

`MemorySyncManager` now passes the filesystem mtime already captured by its watcher to `LongTermMemoryStore.index_file()` for both watched memory files and knowledge-base documents. This matches the direct ingestion path and keeps persisted freshness metadata and retrieval recency signals tied to the source file instead of the sync time. No extra filesystem stat is performed. Public APIs, schema, persistence, and migrations are unchanged.

## Tests

- Added an offline regression test covering both `MEMORY.md` and `knowledge_base/guide.md` with deterministic mtimes.
- Focused memory suite: 17 passed.
- Control UI build, frontend check (98 files / 2,004 tests), ruff, mypy, and `uv build --wheel` pass.
- Local full pytest: 8,559 passed, 32 skipped; 6 unrelated ONNX/packaging failures and 3 ONNX fixture errors because this checkout's model asset is invalid and its `uv` does not support the test helper's `--clear` flag.

Diff is limited to `src/agentos/memory/sync_manager.py` and `tests/test_memory_sync_manager_architecture.py`.