### PR TITLE
fix(channels): retry ConnectTimeout/PoolTimeout in Telegram API calls…

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -514,7 +514,13 @@ class TelegramChannel:
                     request_kwargs["timeout"] = request_timeout
                 response = await client.post(f"/bot{self.config.token}/{method}", **request_kwargs)
                 break
-            except httpx.ConnectError:
+            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout):
+                # These three all fail before any request bytes reach Telegram
+                # (DNS/TLS handshake, or waiting for a pooled connection), so
+                # retrying is safe. WriteTimeout/ReadTimeout are deliberately
+                # excluded below: the request may already have been sent, and
+                # blindly retrying it risks Telegram acting on it twice (e.g.
+                # sending the same message twice).
                 if retry_delay is None:
                     raise TelegramApiError(f"Telegram {method} connection failed") from None
                 log.warning(

--- a/tests/test_channels/test_telegram_retry.py
+++ b/tests/test_channels/test_telegram_retry.py
@@ -36,6 +36,66 @@ async def test_telegram_api_retries_connect_error_before_sending() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        httpx.ConnectTimeout("tls handshake timed out"),
+        httpx.PoolTimeout("no pooled connection became available"),
+    ],
+)
+async def test_telegram_api_retries_pre_send_timeouts_like_connect_error(
+    transient_error: httpx.TimeoutException,
+) -> None:
+    """ConnectTimeout/PoolTimeout also fail before a request is sent, so they
+    should get the same retry-with-backoff treatment as ConnectError.
+
+    ConnectTimeout is not a subclass of ConnectError (they're siblings under
+    TransportError/TimeoutException respectively), so catching only
+    ConnectError silently skips retrying these and raises immediately.
+    """
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=[transient_error, _Response()])
+    channel._client = client
+    channel._owns_client = False
+
+    with patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()) as sleep:
+        result = await channel._api("sendMessage", {"chat_id": "1", "text": "hello"})
+
+    assert result == {"id": 1}
+    assert client.post.await_count == 2
+    sleep.assert_awaited_once_with(0.25)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "post_send_error",
+    [
+        httpx.WriteTimeout("timed out sending request body"),
+        httpx.ReadTimeout("timed out waiting for response"),
+    ],
+)
+async def test_telegram_api_does_not_retry_post_send_timeouts(
+    post_send_error: httpx.TimeoutException,
+) -> None:
+    """WriteTimeout/ReadTimeout can occur after Telegram already received the
+    request, so retrying risks duplicate sends (e.g. sendMessage firing
+    twice). These must raise immediately rather than retry.
+    """
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=[post_send_error])
+    channel._client = client
+    channel._owns_client = False
+
+    with pytest.raises(TelegramApiError) as exc_info:
+        await channel._api("sendMessage", {"chat_id": "1", "text": "hello"})
+
+    assert str(exc_info.value) == "Telegram sendMessage request failed"
+    assert client.post.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_telegram_long_poll_timeout_has_network_headroom() -> None:
     channel = TelegramChannel(TelegramChannelConfig(token="token", poll_timeout_s=30))
     client = AsyncMock()


### PR DESCRIPTION
## Linked issue

Fixes #651

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

`TelegramChannel._api()` has its own independent retry loop (separate from
the shared `retry_request()` helper in `_util.py` that #642/#643/#645
patch — Telegram never calls that function). Its retry-with-backoff branch
only catches `httpx.ConnectError`, but `httpx.ConnectTimeout` (DNS/TLS
handshake timeout) and `httpx.PoolTimeout` (no pooled connection
available) are siblings of `ConnectError` under `TransportError`, not
subclasses of it. Both fall through to the generic `except
httpx.RequestError:` branch and raise `TelegramApiError` on the very
first attempt, with zero retries.

This fix extends the retry branch to `(httpx.ConnectError,
httpx.ConnectTimeout, httpx.PoolTimeout)`. `WriteTimeout`/`ReadTimeout`
are deliberately left out of the retry set: those can occur *after*
Telegram has already received the request, so blindly retrying risks
Telegram acting on it twice (e.g. sending the same message twice).

## Tests

Added two parametrized regression tests to `tests/test_channels/test_telegram_retry.py`:

- `test_telegram_api_retries_pre_send_timeouts_like_connect_error` —
  confirms `ConnectTimeout` and `PoolTimeout` now retry and succeed,
  mirroring the existing `ConnectError` test.
- `test_telegram_api_does_not_retry_post_send_timeouts` — confirms
  `WriteTimeout`/`ReadTimeout` still raise immediately, guarding against
  a future "just catch everything" regression.

Commands run locally:
uv sync --extra dev
uv run ruff check src/agentos/channels/telegram.py tests/test_channels/test_telegram_retry.py
uv run mypy src/agentos/channels/telegram.py --show-error-codes
uv run pytest tests/test_channels/ -q


Results: `ruff` — all checks passed. `mypy` — no issues found. `pytest` —
296 passed, no regressions.

Third-party origin: none.