### PR TITLE
fix(projects): scope the projects_* agent tools to the calling session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- The `projects_*` agent tools are now scoped to the calling session.
+  `projects_list` used to hand the model every project's knowledge text and
+  `projects_update` accepted any `project_id`, so one prompt-injected
+  instruction in any member session could read all knowledge and overwrite
+  another project's — text that then runs inside the system prompt of every
+  member session of that project, every turn. `projects_move_session` likewise
+  accepted arbitrary session keys, allowing the same hand-off by moving a
+  victim session into a poisoned project. Now `projects_update` edits only the
+  calling session's own project, `projects_list` includes knowledge only for
+  that project, and `projects_move_session` moves only the calling session;
+  cross-project management stays on the Web UI / CLI / RPC surface, which is
+  control-plane only.
+
 ### Fixed
 
 - Router metadata no longer reports a model the provider never ran. An explicit

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -634,7 +634,11 @@ Web UI has a "New chat in project" button), and deleting a project never
 deletes sessions: they just detach and stop receiving the knowledge. Agents can manage projects from prompting through the
 `projects_create` / `projects_list` / `projects_update` /
 `projects_move_session` tools, and `session_search scope=project` searches
-only sibling sessions of the calling session's project.
+only sibling sessions of the calling session's project. The tools are scoped
+to the calling session: `projects_update` edits only the session's own
+project, `projects_list` returns knowledge text only for that project, and
+`projects_move_session` moves only the calling session — everything else
+stays on the CLI/Web UI surface.
 
 Read: [`sessions.md`](sessions.md)
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -151,7 +151,11 @@ with, not a membership boundary.
   history, and simply stop receiving the shared knowledge.
 - The agent can manage projects from prompting via the `projects_create`,
   `projects_list`, `projects_update`, and `projects_move_session` tools, and
-  can search sibling transcripts with `session_search scope=project`.
+  can search sibling transcripts with `session_search scope=project`. These
+  tools are scoped to the calling session — knowledge is readable/writable
+  only for the session's own project, and only the calling session itself can
+  be moved — because knowledge a tool writes lands in every member session's
+  system prompt. Cross-project management stays on the Web UI / CLI surface.
 - Existing databases migrate automatically on gateway start: old sessions
   come up project-less (`project_id` empty) and behave exactly as before.
 

--- a/src/agentos/tools/builtin/projects.py
+++ b/src/agentos/tools/builtin/projects.py
@@ -2,8 +2,13 @@
 
 Projects group chat sessions across agents; each project's ``knowledge``
 text is injected into the system prompt of every member session. These
-tools let the agent manage projects from prompting — the same operations
-the ``projects.*`` RPC surface exposes to the Web UI and CLI.
+tools let the agent manage projects from prompting, but — unlike the
+``projects.*`` RPC surface the Web UI and CLI use — they are scoped to the
+calling session: knowledge is readable and writable only for the project
+the calling session belongs to, and only the calling session itself can be
+moved. Knowledge a tool call writes lands in the system prompt of every
+member session, so an unscoped surface would hand any prompt-injected
+instruction a persistent, cross-project write primitive.
 """
 
 from __future__ import annotations
@@ -51,6 +56,15 @@ def _resolve_agent_id(agent_id: str | None) -> str:
 def _current_session_key() -> str | None:
     ctx = current_tool_context.get()
     return getattr(ctx, "session_key", None) if ctx else None
+
+
+async def _calling_session_project_id(mgr: object) -> str | None:
+    """Project of the calling session, or None (no session / not in a project)."""
+    session_key = _current_session_key()
+    if not session_key:
+        return None
+    node = await mgr.get_session(session_key)  # type: ignore[attr-defined]
+    return getattr(node, "project_id", None) if node is not None else None
 
 
 # ---------------------------------------------------------------------------
@@ -109,11 +123,14 @@ async def projects_create(
 
 @tool(
     name="projects_list",
-    description="List projects (with per-project session counts).",
+    description=(
+        "List projects (with per-project session counts). Knowledge text is "
+        "included only for the calling session's own project."
+    ),
     params={
         "agent_id": {
             "type": "string",
-            "description": "Filter by owning agent ID (defaults to all agents).",
+            "description": "Filter by default agent ID (defaults to all agents).",
         },
     },
     required=[],
@@ -122,6 +139,12 @@ async def projects_list(agent_id: str | None = None) -> str:
     try:
         mgr = _get_session_manager()
         projects = await mgr.list_projects(agent_id=agent_id or None)
+        # Knowledge feeds member sessions' system prompts; exposing every
+        # project's text would let one injected session read them all.
+        own_project = await _calling_session_project_id(mgr)
+        for row in projects:
+            if row.get("project_id") != own_project:
+                row.pop("knowledge", None)
         return json.dumps(projects, ensure_ascii=False)
     except ToolError:
         raise
@@ -137,13 +160,16 @@ async def projects_list(agent_id: str | None = None) -> str:
 @tool(
     name="projects_update",
     description=(
-        "Rename a project and/or replace its shared knowledge text. Member "
-        "sessions pick up the new knowledge on their next turn."
+        "Rename the calling session's project and/or replace its shared "
+        "knowledge text. Member sessions pick up the new knowledge on their "
+        "next turn. Only the project this session belongs to can be updated; "
+        "other projects are managed from the Web UI or the `agentos projects` "
+        "CLI."
     ),
     params={
         "project_id": {
             "type": "string",
-            "description": "Project ID to update.",
+            "description": "Project ID to update (must be the calling session's project).",
         },
         "name": {
             "type": "string",
@@ -167,6 +193,15 @@ async def projects_update(
         raise ToolError("Provide name and/or knowledge to update")
     try:
         mgr = _get_session_manager()
+        # Checked before existence so foreign project ids are neither
+        # writable nor probeable from a prompt.
+        own_project = await _calling_session_project_id(mgr)
+        if own_project is None or project_id.strip() != own_project:
+            raise ToolError(
+                "projects_update can only edit the project the calling session "
+                "belongs to; manage other projects from the Web UI or the "
+                "`agentos projects` CLI"
+            )
         project = await mgr.update_project(project_id.strip(), name=name, knowledge=knowledge)
         return json.dumps(project, ensure_ascii=False)
     except (ToolError, ValueError):
@@ -185,8 +220,9 @@ async def projects_update(
 @tool(
     name="projects_move_session",
     description=(
-        "Move a session into a project, or detach it by omitting project_id. "
-        "Defaults to the calling session when session_key is omitted."
+        "Move the calling session into a project, or detach it by omitting "
+        "project_id. Only the calling session can be moved; move other "
+        "sessions from the Web UI or the `agentos projects` CLI."
     ),
     params={
         "project_id": {
@@ -195,7 +231,7 @@ async def projects_update(
         },
         "session_key": {
             "type": "string",
-            "description": "Session to move (defaults to the calling session).",
+            "description": "Optional; must match the calling session when provided.",
         },
     },
     required=[],
@@ -204,9 +240,18 @@ async def projects_move_session(
     project_id: str | None = None,
     session_key: str | None = None,
 ) -> str:
-    resolved_key = (session_key or "").strip() or _current_session_key()
-    if not resolved_key:
-        raise ToolError("session_key is required (no calling session available)")
+    calling_key = _current_session_key()
+    if not calling_key:
+        raise ToolError("projects_move_session requires a calling session")
+    requested_key = (session_key or "").strip()
+    if requested_key and requested_key != calling_key:
+        # Moving a foreign session would pull this project's knowledge into
+        # that session's system prompt — an injection hand-off, so refuse.
+        raise ToolError(
+            "projects_move_session can only move the calling session; move "
+            "other sessions from the Web UI or the `agentos projects` CLI"
+        )
+    resolved_key = calling_key
     try:
         mgr = _get_session_manager()
         node = await mgr.move_session_to_project(

--- a/tests/test_tools/test_projects_tools.py
+++ b/tests/test_tools/test_projects_tools.py
@@ -39,9 +39,7 @@ async def manager(storage):
 
 
 def _set_ctx(session_key: str | None, agent_id: str = "main"):
-    return current_tool_context.set(
-        ToolContext(session_key=session_key, agent_id=agent_id)
-    )
+    return current_tool_context.set(ToolContext(session_key=session_key, agent_id=agent_id))
 
 
 @pytest.mark.asyncio
@@ -57,9 +55,7 @@ async def test_projects_create_defaults_agent_from_context(manager):
 
 @pytest.mark.asyncio
 async def test_projects_list_returns_counts(manager):
-    project = json.loads(
-        await projects_tool.projects_create(name="Research", agent_id="main")
-    )
+    project = json.loads(await projects_tool.projects_create(name="Research", agent_id="main"))
     await manager.create(SESSION_KEY, agent_id="main", project_id=project["project_id"])
 
     rows = json.loads(await projects_tool.projects_list())
@@ -67,29 +63,59 @@ async def test_projects_list_returns_counts(manager):
 
 
 @pytest.mark.asyncio
-async def test_projects_update_replaces_knowledge(manager):
+async def test_projects_update_replaces_knowledge_of_own_project(manager):
     project = json.loads(
         await projects_tool.projects_create(name="Research", agent_id="main", knowledge="v1")
     )
-    data = json.loads(
-        await projects_tool.projects_update(
-            project_id=project["project_id"], knowledge="v2"
+    await manager.create(SESSION_KEY, agent_id="main", project_id=project["project_id"])
+
+    token = _set_ctx(SESSION_KEY)
+    try:
+        data = json.loads(
+            await projects_tool.projects_update(project_id=project["project_id"], knowledge="v2")
         )
-    )
+    finally:
+        current_tool_context.reset(token)
     assert data["knowledge"] == "v2"
 
 
 @pytest.mark.asyncio
-async def test_projects_update_unknown_project_is_tool_error(manager):
-    with pytest.raises(ToolError, match="not found"):
+async def test_projects_update_foreign_project_is_denied(manager):
+    """A session in project A must not be able to write project B's knowledge."""
+    own = json.loads(await projects_tool.projects_create(name="Own", agent_id="main"))
+    other = json.loads(await projects_tool.projects_create(name="Other", agent_id="main"))
+    await manager.create(SESSION_KEY, agent_id="main", project_id=own["project_id"])
+
+    token = _set_ctx(SESSION_KEY)
+    try:
+        with pytest.raises(ToolError, match="calling session"):
+            await projects_tool.projects_update(
+                project_id=other["project_id"], knowledge="injected"
+            )
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_projects_update_outside_any_project_is_denied(manager):
+    """Sessions without a project (or without context) get the scoping error,
+    not an existence oracle for foreign project ids."""
+    await manager.create(SESSION_KEY, agent_id="main")
+
+    token = _set_ctx(SESSION_KEY)
+    try:
+        with pytest.raises(ToolError, match="calling session"):
+            await projects_tool.projects_update(project_id="missing", knowledge="v2")
+    finally:
+        current_tool_context.reset(token)
+
+    with pytest.raises(ToolError, match="calling session"):
         await projects_tool.projects_update(project_id="missing", knowledge="v2")
 
 
 @pytest.mark.asyncio
 async def test_projects_move_session_defaults_to_calling_session(manager):
-    project = json.loads(
-        await projects_tool.projects_create(name="Research", agent_id="main")
-    )
+    project = json.loads(await projects_tool.projects_create(name="Research", agent_id="main"))
     await manager.create(SESSION_KEY, agent_id="main")
 
     token = _set_ctx(SESSION_KEY)
@@ -111,9 +137,54 @@ async def test_projects_move_session_defaults_to_calling_session(manager):
 
 
 @pytest.mark.asyncio
-async def test_projects_move_session_without_context_requires_key(manager):
-    with pytest.raises(ToolError, match="session_key is required"):
+async def test_projects_move_session_without_context_is_denied(manager):
+    with pytest.raises(ToolError, match="requires a calling session"):
         await projects_tool.projects_move_session(project_id="whatever")
+
+
+@pytest.mark.asyncio
+async def test_projects_move_session_foreign_session_is_denied(manager):
+    """Only the calling session may be moved — a foreign key would hand the
+    project's knowledge to another session's system prompt."""
+    project = json.loads(await projects_tool.projects_create(name="Research", agent_id="main"))
+    await manager.create(SESSION_KEY, agent_id="main")
+    victim = await manager.create("agent:main:webchat:cafe0009", agent_id="main")
+
+    token = _set_ctx(SESSION_KEY)
+    try:
+        with pytest.raises(ToolError, match="only move the calling session"):
+            await projects_tool.projects_move_session(
+                project_id=project["project_id"], session_key=victim.session_key
+            )
+    finally:
+        current_tool_context.reset(token)
+    moved = await manager.get_session(victim.session_key)
+    assert moved.project_id is None
+
+
+@pytest.mark.asyncio
+async def test_projects_list_hides_foreign_knowledge(manager):
+    """Knowledge text is returned only for the calling session's own project."""
+    own = json.loads(
+        await projects_tool.projects_create(name="Own", agent_id="main", knowledge="mine")
+    )
+    json.loads(
+        await projects_tool.projects_create(name="Other", agent_id="main", knowledge="theirs")
+    )
+    await manager.create(SESSION_KEY, agent_id="main", project_id=own["project_id"])
+
+    token = _set_ctx(SESSION_KEY)
+    try:
+        rows = json.loads(await projects_tool.projects_list())
+    finally:
+        current_tool_context.reset(token)
+    by_name = {row["name"]: row for row in rows}
+    assert by_name["Own"]["knowledge"] == "mine"
+    assert "knowledge" not in by_name["Other"]
+
+    # Without any calling session, no knowledge is exposed at all.
+    rows = json.loads(await projects_tool.projects_list())
+    assert all("knowledge" not in row for row in rows)
 
 
 @pytest.mark.asyncio
@@ -124,9 +195,7 @@ async def test_session_search_project_scope(manager, storage):
     assert registered is not None
     search = registered.handler
 
-    project = json.loads(
-        await projects_tool.projects_create(name="Research", agent_id="main")
-    )
+    project = json.loads(await projects_tool.projects_create(name="Research", agent_id="main"))
     inside = await manager.create(SESSION_KEY, agent_id="main", project_id=project["project_id"])
     outside = await manager.create("agent:main:webchat:cafe0002", agent_id="main")
     await manager.append_message(inside.session_key, role="user", content="quantum widget alpha")


### PR DESCRIPTION
## Problem

The agent-facing `projects_*` tools shared the unscoped implementation of the control-plane `projects.*` RPC surface. Since project knowledge is injected into the system prompt of every member session each turn, that handed any prompt-injected instruction a persistent, cross-project write primitive:

- `projects_list` returned **every** project's full knowledge text to the model — bulk read of what amounts to system-prompt content for all projects.
- `projects_update` accepted any `project_id`, so a compromised session could overwrite another project's knowledge — text that then executes in every member session of that project, cross-agent, every turn.
- `projects_move_session` accepted arbitrary `session_key`s, enabling the same hand-off by the back door: create a project with hostile knowledge, then move a victim session into it.

## Change

All three tools are now scoped to the calling session:

- `projects_update` edits only the project the calling session belongs to. The scope check runs **before** the existence check, so foreign project ids are neither writable nor probeable.
- `projects_list` still lists all projects (names, counts, timestamps) but includes `knowledge` only for the calling session's own project.
- `projects_move_session` moves only the calling session; a foreign `session_key` is refused.

`projects_create` is unchanged (a fresh project has no member sessions, so its knowledge reaches nobody until a session joins). Cross-project management stays on the Web UI / CLI / RPC surface, which is control-plane only.

Known residual: a session can still move **itself** into an existing project and then edit that project's knowledge. That path is a visible two-step in the transcript and emits `sessions.changed`; operators who want agent-written knowledge off entirely can unexpose the write tools via tool policy.

## Verification

- New deny-path tests against the real `SessionManager` (foreign update, no-project update, foreign move, knowledge stripping in list) plus updates to the existing happy-path tests.
- `uv run pytest tests/test_tools tests/test_session/test_projects.py tests/test_gateway/test_rpc_projects.py tests/test_cli/test_projects_cmd.py tests/test_engine/test_project_knowledge_injection.py` → 912 passed.
- `ruff check`, `ruff format`, `mypy` clean. Docs (`docs/cli.md`, `docs/sessions.md`), tool descriptions, and CHANGELOG updated.