### PR TITLE
fix(projects): concurrency-safe updates, one knowledge cap, live UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Project knowledge is now capped at 24,000 characters on write — the same
+  ceiling the per-turn injection applies — instead of 32,000. Text between the
+  two caps used to save fine, echo back intact from the API, and then be
+  silently truncated out of every turn with only the model able to see the
+  marker. Rows already above the new cap keep working (validated on the next
+  write, truncated at injection until then), and the Web UI knowledge editor
+  now shows a character counter for the real limit.
+
 ### Fixed
+
+- Two clients editing the same project no longer overwrite each other.
+  `projects.update` used to read the whole row, apply the change, and write
+  every column back, so a rename holding a stale row silently reverted a
+  concurrent knowledge save. Updates now write only the fields passed, and the
+  Web UI sends the `updatedAt` it last read so a lost race returns a
+  `project.conflict` error (draft kept, latest version loaded) instead of
+  clobbering. Same-millisecond writes get distinct `updated_at` values, and a
+  unique index on project names (V012) backstops the duplicate-name check
+  under concurrent creates.
+- The Projects page now listens to the gateway's `projects.changed` /
+  `sessions.changed` broadcasts, so another client's create, rename, delete,
+  or session move shows up without pressing Refresh. Moving a session between
+  projects via `sessions.patch` also broadcasts `projects.changed`, keeping
+  other clients' session counts fresh, and the move can no longer be reverted
+  by a simultaneous field patch on storage-only session managers.
+- The Projects page no longer renders its loading and error states as the
+  "No projects yet" empty state (with a create button) — loads show a spinner
+  and failures show the error with a Retry action. Browser back/forward can no
+  longer leak one project's unsaved draft into another project's editor, and
+  a saved knowledge edit no longer flashes the stale pre-save text.
 
 - Router metadata no longer reports a model the provider never ran. An explicit
   model — a durable `config.agents[].model`, a session pin, or a per-call

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -624,7 +624,9 @@ agentos projects delete <project-id>               # sessions survive, detached
 ```
 
 A project groups chat sessions across agents and carries a free-form
-**knowledge** text (capped at 32,000 characters). Every session in the project
+**knowledge** text (capped at 24,000 characters — the same ceiling the
+per-turn injection applies, so everything that saves reaches the prompt in
+full). Every session in the project
 gets that knowledge injected into its system prompt as a `Project Knowledge`
 block — edit it and the next turn of every member session picks it up.
 Sessions of any agent can join the same project (the `--agent` on `create`

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -107,6 +107,10 @@ Projects (session groups with shared knowledge) are WebSocket-only:
 `projects.create` / `projects.list` / `projects.get` / `projects.update` /
 `projects.delete` (params use `projectId`, `agentId`, `name`, `knowledge`;
 delete responds with `sessionsCleared` — sessions are detached, not deleted).
+`projects.update` writes only the fields you pass and accepts an optional
+`expectedUpdatedAt` (the `updatedAt` you last read): when the row changed in
+between, the call fails with code `project.conflict` instead of silently
+overwriting the other writer's edit.
 `sessions.create` accepts an optional `projectId`, `sessions.patch` moves a
 session with `projectId` (explicit `null` detaches), and `sessions.list`
 accepts a `projectId` filter and emits `project_id`/`projectId` on every row.

--- a/frontend/src/i18n/en/projects.ts
+++ b/frontend/src/i18n/en/projects.ts
@@ -10,6 +10,11 @@ export const projects = defineNamespace('projects', {
   refreshBusy: 'Refreshing…',
   newProject: 'New project',
 
+  // Loading / error states.
+  loadingLabel: 'Loading projects…',
+  errorTitle: 'Projects failed to load',
+  errorRetry: 'Retry',
+
   // Empty states.
   emptyTitle: 'No projects yet',
   emptyBody:
@@ -46,6 +51,8 @@ export const projects = defineNamespace('projects', {
   saveName: 'Save name',
   knowledgeSave: 'Save knowledge',
   knowledgeSaved: 'Knowledge saved',
+  knowledgeCounter: '{count} / {max} characters',
+  unsavedChanges: 'Unsaved changes',
   deleteProject: 'Delete project',
 
   // Delete confirm.
@@ -60,6 +67,8 @@ export const projects = defineNamespace('projects', {
   toastCreateFailed: 'Failed to create project: {message}',
   toastUpdated: 'Project updated',
   toastUpdateFailed: 'Failed to update project: {message}',
+  toastUpdateConflict:
+    'This project changed elsewhere — latest version loaded, your draft is kept. Review and save again.',
   toastDeleted: 'Project deleted',
   toastDeleteFailed: 'Failed to delete project: {message}',
   toastSessionCreated: 'Session created in project',

--- a/frontend/src/views/projects/ProjectsPage.test.tsx
+++ b/frontend/src/views/projects/ProjectsPage.test.tsx
@@ -63,7 +63,7 @@ function wireRpc(
   opts: {
     projects?: unknown[]
     createReject?: boolean
-    updateReject?: boolean
+    updateReject?: boolean | 'conflict'
   } = {},
 ) {
   mockRpc.call.mockImplementation((method: string) => {
@@ -79,6 +79,11 @@ function wireRpc(
           ? Promise.reject(new Error('create failed'))
           : Promise.resolve({ project: { project_id: 'proj-new', name: 'New one' } })
       case 'projects.update':
+        if (opts.updateReject === 'conflict') {
+          const err = new Error('changed since it was read') as Error & { code?: string }
+          err.code = 'project.conflict'
+          return Promise.reject(err)
+        }
         return opts.updateReject
           ? Promise.reject(new Error('update failed'))
           : Promise.resolve({ project: {} })
@@ -168,8 +173,44 @@ describe('ProjectsPage', () => {
       expect(mockRpc.call).toHaveBeenCalledWith('projects.update', {
         projectId: 'proj-1',
         knowledge: 'Updated knowledge',
+        expectedUpdatedAt: 300,
       }),
     )
+  })
+
+  it('subscribes to projects.changed and sessions.changed for live updates', async () => {
+    wireRpc()
+    renderPage()
+    await screen.findByText('Token research')
+    const events = (mockRpc.on.mock.calls as unknown[][]).map((c) => c[0])
+    expect(events).toContain('projects.changed')
+    expect(events).toContain('sessions.changed')
+  })
+
+  it('shows a conflict toast and keeps the draft when the save loses the CAS', async () => {
+    wireRpc({ updateReject: 'conflict' })
+    renderPage('/projects?project=proj-1')
+    const textarea = await screen.findByDisplayValue('Solana pools context.')
+    fireEvent.change(textarea, { target: { value: 'Mine' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save knowledge' }))
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('changed elsewhere'),
+        expect.anything(),
+      ),
+    )
+    // The user's draft survives the conflict for re-apply.
+    expect(screen.getByDisplayValue('Mine')).toBeTruthy()
+  })
+
+  it('shows the load error state instead of the empty state', async () => {
+    mockRpc.call.mockImplementation((method: string) =>
+      method === 'projects.list' ? Promise.reject(new Error('gateway down')) : Promise.resolve({}),
+    )
+    renderPage()
+    await screen.findByText('Projects failed to load')
+    expect(screen.queryByText('No projects yet')).toBeNull()
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeTruthy()
   })
 
   it('starts a new chat in the project and navigates to it', async () => {

--- a/frontend/src/views/projects/ProjectsPage.tsx
+++ b/frontend/src/views/projects/ProjectsPage.tsx
@@ -41,9 +41,10 @@ interface AgentsList {
 
 // Mirrors PROJECT_NAME_MAX_CHARS / PROJECT_KNOWLEDGE_MAX_CHARS in
 // src/agentos/session/manager.py — the gateway rejects past these, so stop
-// the inputs there instead of failing on save.
+// the inputs there instead of failing on save. The knowledge cap equals the
+// per-turn injection ceiling: everything that saves reaches the prompt.
 const PROJECT_NAME_MAX = 200
-const PROJECT_KNOWLEDGE_MAX = 32_000
+const PROJECT_KNOWLEDGE_MAX = 24_000
 
 // ── Create-project dialog ────────────────────────────────────────────────────
 function CreateProjectDialog({
@@ -203,6 +204,23 @@ export function ProjectsPage() {
     document.title = t('projects.documentTitle')
   }, [])
 
+  // Live updates: the gateway broadcasts projects.changed on every project
+  // CRUD (and on session moves) and sessions.changed on membership edits.
+  // Without these, a second client's rename/delete stays invisible until a
+  // manual Refresh. Unsubscribed on unmount (StrictMode-safe).
+  useEffect(() => {
+    const unsubProjects = rpc.on('projects.changed', () => {
+      void queryClient.invalidateQueries({ queryKey: ['projects'] })
+    })
+    const unsubSessions = rpc.on('sessions.changed', () => {
+      void queryClient.invalidateQueries({ queryKey: ['sessions'] })
+    })
+    return () => {
+      unsubProjects()
+      unsubSessions()
+    }
+  }, [rpc, queryClient])
+
   const projectsQuery = useQuery<RawProject[]>({
     queryKey: ['projects'],
     queryFn: async () => {
@@ -252,13 +270,22 @@ export function ProjectsPage() {
   const selected = projects.find((p) => projectIdOf(p) === selectedId) ?? null
   const selectedSessions = selected ? sessionsInProject(allSessions, selectedId) : []
 
-  // Drafts reset whenever the selected project (or its stored values) change.
   const selectedName = selected ? projectName(selected) : ''
   const selectedKnowledge = selected ? String(selected.knowledge ?? '') : ''
 
-  function selectProject(id: string) {
+  // Drafts reset whenever the selected project changes — keyed on the URL
+  // param, not on selectProject(), so browser back/forward (which changes
+  // ?project= without going through the click handler) cannot leak project
+  // A's draft into project B's editor. Adjusted during render (React's
+  // documented pattern) rather than in an effect.
+  const [draftProjectId, setDraftProjectId] = useState(selectedId)
+  if (draftProjectId !== selectedId) {
+    setDraftProjectId(selectedId)
     setNameDraft(null)
     setKnowledgeDraft(null)
+  }
+
+  function selectProject(id: string) {
     setSearchParams(id ? { project: id } : {}, { replace: false })
   }
 
@@ -285,21 +312,42 @@ export function ProjectsPage() {
 
   const updateMutation = useMutation({
     mutationFn: (vars: { id: string; name?: string; knowledge?: string }) =>
-      rpc.call('projects.update', {
+      rpc.call<{ project?: RawProject }>('projects.update', {
         projectId: vars.id,
         ...(vars.name !== undefined ? { name: vars.name } : {}),
         ...(vars.knowledge !== undefined ? { knowledge: vars.knowledge } : {}),
+        // Compare-and-swap: the gateway refuses the write (project.conflict)
+        // if the row changed since this client last read it, instead of
+        // silently clobbering another editor's save.
+        ...(selected
+          ? { expectedUpdatedAt: Number(selected.updated_at ?? selected.updatedAt) }
+          : {}),
       }),
-    onSuccess: (_data, vars) => {
+    onSuccess: (data, vars) => {
       toast.success(
         vars.knowledge !== undefined ? t('projects.knowledgeSaved') : t('projects.toastUpdated'),
         { id: 'projects-update' },
       )
+      // Patch the cached row from the response before clearing drafts, so
+      // the editor doesn't flash the stale pre-save value until the
+      // invalidated refetch lands.
+      const fresh = data?.project
+      if (fresh) {
+        queryClient.setQueryData<RawProject[]>(['projects'], (rows) =>
+          rows?.map((p) => (projectIdOf(p) === vars.id ? { ...p, ...fresh } : p)),
+        )
+      }
       setNameDraft(null)
       setKnowledgeDraft(null)
       invalidate()
     },
     onError: (err) => {
+      const code = (err as { code?: string }).code
+      if (code === 'project.conflict') {
+        toast.error(t('projects.toastUpdateConflict'), { id: 'projects-update-err' })
+        invalidate()
+        return
+      }
       const message = err instanceof Error ? err.message : String(err)
       toast.error(t('projects.toastUpdateFailed', { message }), { id: 'projects-update-err' })
     },
@@ -343,6 +391,8 @@ export function ProjectsPage() {
   })
 
   const hasProjects = projects.length > 0
+  const isLoading = projectsQuery.isLoading
+  const isError = projectsQuery.isError && !hasProjects
 
   return (
     <div className="proj-stage">
@@ -375,7 +425,28 @@ export function ProjectsPage() {
         </div>
       </header>
 
-      {!hasProjects ? (
+      {isLoading ? (
+        // Distinct from the empty state: a load in flight (or a failed load
+        // below) must not read as "no projects yet" with a create CTA.
+        <div className="proj-empty" aria-busy="true">
+          <RefreshCwIcon className="proj-empty__icon proj-refresh-spin" aria-hidden="true" />
+          <div className="proj-empty__title">{t('projects.loadingLabel')}</div>
+        </div>
+      ) : isError ? (
+        <div className="proj-empty" role="alert">
+          <FolderKanbanIcon className="proj-empty__icon" aria-hidden="true" />
+          <div className="proj-empty__title">{t('projects.errorTitle')}</div>
+          <p className="proj-empty__msg">
+            {projectsQuery.error instanceof Error
+              ? projectsQuery.error.message
+              : String(projectsQuery.error)}
+          </p>
+          <Button onClick={invalidate}>
+            <RefreshCwIcon />
+            <span>{t('projects.errorRetry')}</span>
+          </Button>
+        </div>
+      ) : !hasProjects ? (
         <div className="proj-empty">
           <FolderKanbanIcon className="proj-empty__icon" aria-hidden="true" />
           <div className="proj-empty__title">{t('projects.emptyTitle')}</div>
@@ -448,11 +519,13 @@ export function ProjectsPage() {
                       </Button>
                     </div>
                   </label>
-                  <span className="proj-detail__meta proj-dim t-data">
-                    {t('projects.updatedAt', {
-                      time: relTimeLabel(Number(selected.updated_at ?? selected.updatedAt ?? 0)),
-                    })}
-                  </span>
+                  {selected.updated_at != null || selected.updatedAt != null ? (
+                    <span className="proj-detail__meta proj-dim t-data">
+                      {t('projects.updatedAt', {
+                        time: relTimeLabel(Number(selected.updated_at ?? selected.updatedAt)),
+                      })}
+                    </span>
+                  ) : null}
                 </div>
 
                 <label className="proj-field">
@@ -465,9 +538,20 @@ export function ProjectsPage() {
                     placeholder={t('projects.knowledgePlaceholder')}
                     onChange={(e) => setKnowledgeDraft(e.target.value)}
                   />
-                  <small className="proj-field__hint">{t('projects.knowledgeHint')}</small>
+                  <small className="proj-field__hint">
+                    {t('projects.knowledgeHint')}{' '}
+                    <span className="t-data">
+                      {t('projects.knowledgeCounter', {
+                        count: (knowledgeDraft ?? selectedKnowledge).length,
+                        max: PROJECT_KNOWLEDGE_MAX,
+                      })}
+                    </span>
+                  </small>
                 </label>
                 <div className="proj-knowledge-actions">
+                  {knowledgeDraft !== null && knowledgeDraft !== selectedKnowledge ? (
+                    <span className="proj-dim t-data">{t('projects.unsavedChanges')}</span>
+                  ) : null}
                   <Button
                     size="sm"
                     disabled={

--- a/migrations/V012__projects_name_unique.py
+++ b/migrations/V012__projects_name_unique.py
@@ -1,0 +1,41 @@
+"""V012 - unique index on project names.
+
+Project-name uniqueness was enforced only by an advisory Python-side check,
+so two concurrent creates could both pass it and both commit. The index is
+the database-level backstop. ``COLLATE NOCASE`` folds ASCII case only,
+narrower than the Python ``casefold`` check that stays the primary guard —
+the index exists to close the race, not to redefine uniqueness.
+
+Legacy databases that already carry case-insensitive duplicate names keep
+working: index creation is then skipped and uniqueness stays advisory for
+that database.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from yoyo import step
+
+__depends__: set[str] = {"V011__projects"}
+
+CREATE_UNIQUE_NAME_INDEX = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_name_nocase ON projects(name COLLATE NOCASE)"
+)
+
+
+def apply_step(conn) -> None:
+    cur = conn.cursor()
+    try:
+        cur.execute(CREATE_UNIQUE_NAME_INDEX)
+    except sqlite3.IntegrityError:
+        # Pre-existing duplicate names: leave uniqueness advisory here.
+        pass
+
+
+def rollback_step(conn) -> None:
+    cur = conn.cursor()
+    cur.execute("DROP INDEX IF EXISTS idx_projects_name_nocase")
+
+
+steps = [step(apply_step, rollback_step)]

--- a/src/agentos/cli/projects_cmd.py
+++ b/src/agentos/cli/projects_cmd.py
@@ -40,7 +40,11 @@ def _excerpt(text: str, max_chars: int = 60) -> str:
 
 @app.command("list")
 def projects_list(
-    agent: str | None = typer.Option(None, "--agent", help="Filter by agent id"),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        help="Filter by the project's default agent (not a membership filter)",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """List projects with session counts."""

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -1886,9 +1886,11 @@ class TurnRunner:
         merged["Memory Context"] = block
         return merged
 
-    # Injection ceiling for project knowledge. Writes are already capped at
-    # SessionManager.PROJECT_KNOWLEDGE_MAX_CHARS; this second cap only guards
-    # rows written before that limit existed (or edited out-of-band).
+    # Injection ceiling for project knowledge. Kept equal to
+    # SessionManager.PROJECT_KNOWLEDGE_MAX_CHARS (a release-consistency test
+    # asserts this) so nothing that saves is silently cut here; the guard
+    # still truncates rows written under the old, larger write cap or edited
+    # out-of-band.
     PROJECT_KNOWLEDGE_INJECT_MAX_CHARS = 24_000
 
     async def _augment_extra_context_with_project_knowledge(

--- a/src/agentos/gateway/rpc_projects.py
+++ b/src/agentos/gateway/rpc_projects.py
@@ -17,6 +17,7 @@ import structlog
 
 from agentos.gateway.rpc import RpcContext, RpcHandlerError, RpcUnavailableError, get_dispatcher
 from agentos.session.keys import normalize_agent_id
+from agentos.session.manager import ProjectUpdateConflictError
 
 log = structlog.get_logger(__name__)
 
@@ -119,19 +120,33 @@ async def _handle_projects_update(params: dict | None, ctx: RpcContext) -> dict:
     project_id = _require_project_id(params)
     name = params.get("name")
     knowledge = params.get("knowledge")
+    expected = params.get("expectedUpdatedAt", params.get("expected_updated_at"))
     if name is None and knowledge is None:
         raise ValueError("params.name or params.knowledge is required")
     if name is not None and not isinstance(name, str):
         raise ValueError("params.name must be a string")
     if knowledge is not None and not isinstance(knowledge, str):
         raise ValueError("params.knowledge must be a string")
+    if expected is not None and not isinstance(expected, int):
+        raise ValueError("params.expectedUpdatedAt must be an integer timestamp")
 
     try:
-        project = await manager.update_project(project_id, name=name, knowledge=knowledge)
+        project = await manager.update_project(
+            project_id,
+            name=name,
+            knowledge=knowledge,
+            expected_updated_at=expected,
+        )
     except KeyError as exc:
         raise RpcHandlerError(
             "project.not_found",
             f"Project '{project_id}' does not exist",
+            details={"projectId": project_id},
+        ) from exc
+    except ProjectUpdateConflictError as exc:
+        raise RpcHandlerError(
+            "project.conflict",
+            f"Project '{project_id}' changed since it was read; reload and retry",
             details={"projectId": project_id},
         ) from exc
     await _broadcast_projects_changed("updated", project_id)

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1517,9 +1517,22 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
             update_values[attr] = value
             updated_fields.append(field)
 
-    # Project moves route through the manager's validation choke point
-    # (project must exist and belong to the session's agent). An explicit
-    # null detaches; an absent field is untouched.
+    if update_values:
+        update = getattr(ctx.session_manager, "update", None)
+        if update is not None:
+            await update(key, **update_values)
+        else:
+            for attr, value in update_values.items():
+                setattr(session, attr, value)
+            upsert = getattr(storage, "upsert_session", None)
+            if upsert is not None:
+                await upsert(session)
+
+    # Project moves route through the manager's validation choke point (the
+    # project must exist; membership is cross-agent). An explicit null
+    # detaches; an absent field is untouched. Runs after the generic field
+    # update: that path may upsert the ``session`` snapshot read before this
+    # handler ran, which would silently revert a project move applied first.
     if "projectId" in params or "project_id" in params:
         raw_project = params.get("projectId", params.get("project_id"))
         if raw_project is not None and not isinstance(raw_project, str):
@@ -1545,17 +1558,11 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
             "sessions.changed",
             build_sessions_changed_payload(key, "project_moved", project_id=raw_project),
         )
+        # Project lists show per-project session counts; a move changes them
+        # even though no projects.* CRUD ran.
+        from agentos.gateway.rpc_projects import _broadcast_projects_changed
 
-    if update_values:
-        update = getattr(ctx.session_manager, "update", None)
-        if update is not None:
-            await update(key, **update_values)
-        else:
-            for attr, value in update_values.items():
-                setattr(session, attr, value)
-            upsert = getattr(storage, "upsert_session", None)
-            if upsert is not None:
-                await upsert(session)
+        await _broadcast_projects_changed("session_moved", raw_project)
 
     return {"key": key, "updated": updated_fields}
 

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from agentos.compat import aiosqlite
 from agentos.engine.steps.inject_time_prefix import stamp as _stamp_time_prefix
 from agentos.paths import default_agentos_home
 from agentos.session.compaction import (
@@ -84,6 +85,10 @@ def _resolve_local_tz_name() -> str:
         pass
 
     return "UTC"
+
+
+class ProjectUpdateConflictError(Exception):
+    """A project write lost a compare-and-swap: the row changed since read."""
 
 
 def _now_ms() -> int:
@@ -624,18 +629,19 @@ class SessionManager:
     # ── Projects ─────────────────────────────────────────────────────────────
 
     PROJECT_NAME_MAX_CHARS = 200
-    PROJECT_KNOWLEDGE_MAX_CHARS = 32_000
+    # Must equal TurnRunner.PROJECT_KNOWLEDGE_INJECT_MAX_CHARS: anything
+    # accepted here is injected in full, so a larger write cap would mean
+    # text that saves fine but is silently truncated out of every turn.
+    # Rows written under the old 32k cap are grandfathered — validated only
+    # on the next write, truncated at injection until then.
+    PROJECT_KNOWLEDGE_MAX_CHARS = 24_000
 
-    def _validate_project_fields(
-        self, name: str | None, knowledge: str | None
-    ) -> None:
+    def _validate_project_fields(self, name: str | None, knowledge: str | None) -> None:
         if name is not None:
             if not name.strip():
                 raise ValueError("Project name cannot be empty")
             if len(name) > self.PROJECT_NAME_MAX_CHARS:
-                raise ValueError(
-                    f"Project name exceeds {self.PROJECT_NAME_MAX_CHARS} characters"
-                )
+                raise ValueError(f"Project name exceeds {self.PROJECT_NAME_MAX_CHARS} characters")
         if knowledge is not None and len(knowledge) > self.PROJECT_KNOWLEDGE_MAX_CHARS:
             raise ValueError(
                 f"Project knowledge exceeds {self.PROJECT_KNOWLEDGE_MAX_CHARS} characters"
@@ -670,7 +676,11 @@ class SessionManager:
         if any(p.name.casefold() == name.casefold() for p in existing):
             raise ValueError(f"Project name already exists: {name}")
         project = ProjectNode(agent_id=agent_id, name=name, knowledge=knowledge)
-        await self._storage.upsert_project(project)
+        try:
+            await self._storage.upsert_project(project)
+        except aiosqlite.IntegrityError as exc:
+            # Unique-index backstop: a concurrent create won the name race.
+            raise ValueError(f"Project name already exists: {name}") from exc
         return project.model_dump(mode="json")
 
     async def get_project(self, project_id: str) -> dict[str, Any] | None:
@@ -697,26 +707,46 @@ class SessionManager:
         project_id: str,
         name: str | None = None,
         knowledge: str | None = None,
+        expected_updated_at: int | None = None,
     ) -> dict[str, Any]:
-        """Update name and/or knowledge of an existing project."""
+        """Update name and/or knowledge of an existing project.
+
+        Only the provided fields are written (a rename can no longer clobber
+        a concurrent knowledge edit), and when ``expected_updated_at`` is
+        given the write is a compare-and-swap: ``ProjectUpdateConflictError`` is
+        raised if the row changed since the caller read it.
+        """
         project = await self._storage.get_project(project_id)
         if project is None:
             raise KeyError(f"Project not found: {project_id}")
         self._validate_project_fields(name, knowledge)
+        stripped_name: str | None = None
         if name is not None:
-            stripped = name.strip()
+            stripped_name = name.strip()
             siblings = await self._storage.list_projects()
             if any(
-                p.project_id != project_id and p.name.casefold() == stripped.casefold()
+                p.project_id != project_id and p.name.casefold() == stripped_name.casefold()
                 for p in siblings
             ):
-                raise ValueError(f"Project name already exists: {stripped}")
-            project.name = stripped
-        if knowledge is not None:
-            project.knowledge = knowledge
-        project.updated_at = _now_ms()
-        await self._storage.upsert_project(project)
-        row = project.model_dump(mode="json")
+                raise ValueError(f"Project name already exists: {stripped_name}")
+        try:
+            updated = await self._storage.update_project_fields(
+                project_id,
+                updated_at=_now_ms(),
+                name=stripped_name,
+                knowledge=knowledge,
+                expected_updated_at=expected_updated_at,
+            )
+        except aiosqlite.IntegrityError as exc:
+            raise ValueError(f"Project name already exists: {stripped_name}") from exc
+        if not updated:
+            if await self._storage.get_project(project_id) is None:
+                raise KeyError(f"Project not found: {project_id}")
+            raise ProjectUpdateConflictError(f"Project changed since it was read: {project_id}")
+        refreshed = await self._storage.get_project(project_id)
+        if refreshed is None:
+            raise KeyError(f"Project not found: {project_id}")
+        row = refreshed.model_dump(mode="json")
         row["session_count"] = await self._storage.count_sessions_in_project(project_id)
         return row
 

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -113,6 +113,13 @@ _CREATE_IDX_PROJECTS_AGENT = (
     "CREATE INDEX IF NOT EXISTS idx_projects_agent ON projects(agent_id)"
 )
 
+# Backstop for the advisory Python-side name check (closes the concurrent
+# create race). NOCASE folds ASCII only; the casefold check stays primary.
+_CREATE_UNIQUE_IDX_PROJECTS_NAME = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_name_nocase "
+    "ON projects(name COLLATE NOCASE)"
+)
+
 _CREATE_IDX_SESSIONS_PROJECT = (
     "CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id)"
 )
@@ -467,6 +474,7 @@ class SessionStorage:
         await self._conn.execute(_CREATE_IDX_SESSIONS_PROJECT)
         await self._conn.execute(_CREATE_IDX_MEMORY_DURABLE_RECEIPTS_COVERAGE)
         await self._conn.commit()
+        await self._ensure_projects_name_index()
         await self.mark_abandoned_agent_tasks()
 
     async def _migrate_epoch_column(self) -> None:
@@ -602,6 +610,21 @@ class SessionStorage:
         if "project_id" not in columns:
             await self._conn.execute("ALTER TABLE sessions ADD COLUMN project_id TEXT")
             await self._conn.commit()
+
+    async def _ensure_projects_name_index(self) -> None:
+        """Create the unique project-name index; legacy duplicates skip it.
+
+        Mirrors migration V012: a database that already carries
+        case-insensitive duplicate names keeps working with uniqueness
+        enforced only by the Python-side check.
+        """
+        assert self._conn is not None
+        try:
+            await self._conn.execute(_CREATE_UNIQUE_IDX_PROJECTS_NAME)
+            await self._conn.commit()
+        except aiosqlite.IntegrityError:
+            await self._conn.rollback()
+            log.warning("projects name index skipped: duplicate names already exist")
 
     @property
     def conn(self) -> Any:
@@ -776,6 +799,43 @@ class SessionStorage:
         )
         await self.conn.execute(sql, values)
         await self.conn.commit()
+
+    async def update_project_fields(
+        self,
+        project_id: str,
+        *,
+        updated_at: int,
+        name: str | None = None,
+        knowledge: str | None = None,
+        expected_updated_at: int | None = None,
+    ) -> bool:
+        """Partial, optionally compare-and-swap project update.
+
+        Only the provided columns are written, so a concurrent rename can
+        never clobber another writer's knowledge (and vice versa). With
+        ``expected_updated_at`` the UPDATE matches only if the row still
+        carries that timestamp — the caller distinguishes "row gone" from
+        "row changed" on a ``False`` return.
+        """
+        # MAX(..) keeps the timestamp strictly increasing even when two
+        # writes land in the same millisecond — same-ms writes would
+        # otherwise share updated_at and blind the compare-and-swap.
+        sets = ["updated_at = MAX(?, updated_at + 1)"]
+        values: list[Any] = [updated_at]
+        if name is not None:
+            sets.append("name = ?")
+            values.append(name)
+        if knowledge is not None:
+            sets.append("knowledge = ?")
+            values.append(knowledge)
+        sql = f"UPDATE projects SET {', '.join(sets)} WHERE project_id = ?"
+        values.append(project_id)
+        if expected_updated_at is not None:
+            sql += " AND updated_at = ?"
+            values.append(expected_updated_at)
+        cur = await self.conn.execute(sql, values)
+        await self.conn.commit()
+        return int(cur.rowcount or 0) > 0
 
     async def get_project(self, project_id: str) -> ProjectNode | None:
         async with self.conn.execute(

--- a/tests/test_engine/test_project_knowledge_injection.py
+++ b/tests/test_engine/test_project_knowledge_injection.py
@@ -82,8 +82,20 @@ async def test_knowledge_edit_is_picked_up_next_turn(runner, manager):
 
 @pytest.mark.asyncio
 async def test_oversized_knowledge_is_truncated_with_marker(runner, manager):
+    """Rows written under the old 32k cap (or edited out-of-band) still get
+    truncated at injection; writes above the cap are rejected up front now,
+    so the legacy row is planted directly in storage."""
+    from agentos.session.models import ProjectNode
+
     cap = TurnRunner.PROJECT_KNOWLEDGE_INJECT_MAX_CHARS
-    project = await manager.create_project("main", "Research", knowledge="x" * 30_000)
+    project = await manager.create_project("main", "Research", knowledge="v1")
+    legacy = ProjectNode(
+        project_id=project["project_id"],
+        agent_id="main",
+        name="Research",
+        knowledge="x" * 30_000,
+    )
+    await manager._storage.upsert_project(legacy)
     await manager.create(SESSION_KEY, agent_id="main", project_id=project["project_id"])
 
     merged = await runner._augment_extra_context_with_project_knowledge(

--- a/tests/test_gateway/test_rpc_projects.py
+++ b/tests/test_gateway/test_rpc_projects.py
@@ -59,16 +59,12 @@ class TestProjectsCreate:
 
     @pytest.mark.asyncio
     async def test_create_requires_name(self, dispatcher, ctx):
-        res = await dispatcher.dispatch(
-            "r1", "projects.create", {"agentId": "main"}, ctx
-        )
+        res = await dispatcher.dispatch("r1", "projects.create", {"agentId": "main"}, ctx)
         assert res.ok is False
 
     @pytest.mark.asyncio
     async def test_create_requires_manager(self, dispatcher, ctx_no_manager):
-        res = await dispatcher.dispatch(
-            "r1", "projects.create", {"name": "X"}, ctx_no_manager
-        )
+        res = await dispatcher.dispatch("r1", "projects.create", {"name": "X"}, ctx_no_manager)
         assert res.ok is False
         assert res.error.code == "UNAVAILABLE"
 
@@ -102,6 +98,47 @@ class TestProjectsListGetUpdateDelete:
         )
         assert res.ok is True
         assert res.payload["project"]["knowledge"] == "v2"
+
+    @pytest.mark.asyncio
+    async def test_update_with_stale_expected_updated_at_conflicts(self, dispatcher, ctx):
+        project = await _create_project(dispatcher, ctx)
+        first = await dispatcher.dispatch(
+            "r1",
+            "projects.update",
+            {"projectId": project["project_id"], "knowledge": "v2"},
+            ctx,
+        )
+        assert first.ok is True
+        res = await dispatcher.dispatch(
+            "r2",
+            "projects.update",
+            {
+                "projectId": project["project_id"],
+                "knowledge": "v3",
+                "expectedUpdatedAt": project["updated_at"],
+            },
+            ctx,
+        )
+        assert res.ok is False
+        assert res.error.code == "project.conflict"
+        # The losing write must not have landed.
+        fresh = await dispatcher.dispatch(
+            "r3", "projects.get", {"projectId": project["project_id"]}, ctx
+        )
+        assert fresh.payload["project"]["knowledge"] == "v2"
+
+        winner = await dispatcher.dispatch(
+            "r4",
+            "projects.update",
+            {
+                "projectId": project["project_id"],
+                "knowledge": "v3",
+                "expectedUpdatedAt": first.payload["project"]["updated_at"],
+            },
+            ctx,
+        )
+        assert winner.ok is True
+        assert winner.payload["project"]["knowledge"] == "v3"
 
     @pytest.mark.asyncio
     async def test_delete_reports_detached_sessions(self, dispatcher, ctx, manager):
@@ -202,6 +239,4 @@ class TestSessionsProjectIntegration:
             "r2", "sessions.list", {"projectId": project["project_id"]}, ctx
         )
         assert res.ok is True
-        assert [row["key"] for row in res.payload["sessions"]] == [
-            "agent:main:webchat:11110005"
-        ]
+        assert [row["key"] for row in res.payload["sessions"]] == ["agent:main:webchat:11110005"]

--- a/tests/test_session/test_projects.py
+++ b/tests/test_session/test_projects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 
-from agentos.session.manager import SessionManager
+from agentos.session.manager import ProjectUpdateConflictError, SessionManager
 from agentos.session.storage import SessionStorage
 
 
@@ -59,9 +59,7 @@ async def test_create_project_rejects_empty_name_and_oversized_knowledge(manager
 @pytest.mark.asyncio
 async def test_session_create_with_unknown_project_raises(manager):
     with pytest.raises(KeyError, match="Project not found"):
-        await manager.create(
-            "agent:main:webchat:aaaa0002", agent_id="main", project_id="missing"
-        )
+        await manager.create("agent:main:webchat:aaaa0002", agent_id="main", project_id="missing")
 
 
 @pytest.mark.asyncio
@@ -94,9 +92,7 @@ async def test_move_session_across_agents_is_allowed(manager):
 @pytest.mark.asyncio
 async def test_update_project_name_and_knowledge(manager):
     project = await manager.create_project("main", "Research", knowledge="v1")
-    updated = await manager.update_project(
-        project["project_id"], name="Research 2", knowledge="v2"
-    )
+    updated = await manager.update_project(project["project_id"], name="Research 2", knowledge="v2")
     assert updated["name"] == "Research 2"
     assert updated["knowledge"] == "v2"
     assert updated["updated_at"] >= project["updated_at"]
@@ -155,14 +151,10 @@ async def test_get_project_knowledge_for_session(manager):
         await manager.get_project_knowledge_for_session("agent:main:webchat:aaaa0008")
         == "Shared facts."
     )
-    assert (
-        await manager.get_project_knowledge_for_session("agent:main:webchat:aaaa0009") is None
-    )
+    assert await manager.get_project_knowledge_for_session("agent:main:webchat:aaaa0009") is None
     # Blank knowledge injects nothing.
     await manager.update_project(project["project_id"], knowledge="   ")
-    assert (
-        await manager.get_project_knowledge_for_session("agent:main:webchat:aaaa0008") is None
-    )
+    assert await manager.get_project_knowledge_for_session("agent:main:webchat:aaaa0008") is None
 
 
 @pytest.mark.asyncio
@@ -178,7 +170,62 @@ async def test_search_transcript_scoped_to_project(manager, storage):
     all_hits = await storage.search_transcript("quantum widget")
     assert len(all_hits) == 2
 
-    scoped = await storage.search_transcript(
-        "quantum widget", project_id=project["project_id"]
-    )
+    scoped = await storage.search_transcript("quantum widget", project_id=project["project_id"])
     assert [hit["session_key"] for hit in scoped] == [inside.session_key]
+
+
+@pytest.mark.asyncio
+async def test_update_project_rename_does_not_clobber_concurrent_knowledge(manager):
+    """A rename holding a stale row must not revert another writer's knowledge."""
+    project = await manager.create_project("main", "Research", knowledge="v1")
+    pid = project["project_id"]
+
+    # Writer B saves new knowledge after writer A read the row; A then
+    # renames without a precondition. Partial UPDATE keeps B's knowledge.
+    await manager.update_project(pid, knowledge="v2")
+    renamed = await manager.update_project(pid, name="Renamed")
+    assert renamed["name"] == "Renamed"
+    assert renamed["knowledge"] == "v2"
+
+
+@pytest.mark.asyncio
+async def test_update_project_cas_conflict_on_stale_read(manager):
+    project = await manager.create_project("main", "Research", knowledge="v1")
+    pid = project["project_id"]
+    stale = project["updated_at"]
+
+    fresh = await manager.update_project(pid, knowledge="v2")
+    assert fresh["updated_at"] != stale
+    with pytest.raises(ProjectUpdateConflictError):
+        await manager.update_project(pid, knowledge="v3", expected_updated_at=stale)
+    # Nothing was written by the losing update.
+    row = await manager.get_project(pid)
+    assert row["knowledge"] == "v2"
+
+    # A matching precondition succeeds.
+    winner = await manager.update_project(
+        pid, knowledge="v3", expected_updated_at=fresh["updated_at"]
+    )
+    assert winner["knowledge"] == "v3"
+
+
+@pytest.mark.asyncio
+async def test_storage_unique_name_index_backstops_python_check(manager, storage):
+    """Writing a duplicate name straight to storage (bypassing the advisory
+    Python check, as a concurrent create would) hits the unique index."""
+    from agentos.compat import aiosqlite
+    from agentos.session.models import ProjectNode
+
+    await manager.create_project("main", "Research")
+    with pytest.raises(aiosqlite.IntegrityError):
+        await storage.upsert_project(ProjectNode(agent_id="main", name="research"))
+
+
+def test_write_cap_matches_injection_cap():
+    """Anything that saves must inject in full — the caps may never diverge
+    again (a larger write cap silently truncated every turn)."""
+    from agentos.engine.runtime import TurnRunner
+
+    assert (
+        SessionManager.PROJECT_KNOWLEDGE_MAX_CHARS == TurnRunner.PROJECT_KNOWLEDGE_INJECT_MAX_CHARS
+    )


### PR DESCRIPTION
Follow-up to the projects feature (#494) and companion to #653, fixing the three non-security defects found in the same review.

## 1. Lost updates between concurrent editors

`projects.update` was a full-row read-modify-write: a rename holding a stale row silently reverted a concurrent knowledge save.

- New `SessionStorage.update_project_fields`: a partial `UPDATE` that writes only the provided columns, with an optional compare-and-swap on `updated_at`. The timestamp is kept strictly increasing (`MAX(?, updated_at + 1)`) so two writes in the same millisecond can't blind the CAS — a test caught exactly that.
- `projects.update` accepts `expectedUpdatedAt` and maps a lost race to a new `project.conflict` error code. The Web UI sends it, and on conflict keeps your draft, loads the latest row, and asks you to review and save again — no more silent clobber in either direction.
- Migration **V012** (mirrored in the in-process schema layer) adds a unique `NOCASE` index on project names as a backstop for the advisory duplicate-name check under concurrent creates. Legacy databases with pre-existing duplicate names skip the index and keep today's behavior.

## 2. One knowledge cap instead of two

Knowledge saved at up to 32k characters but injected at most 24k — text between the caps saved fine, came back intact from the API, and was silently truncated out of every turn (only the model saw the marker). The write cap now equals the injection ceiling (24k, with a test asserting the two constants stay equal). Rows above the new cap are grandfathered: validated on the next write, truncated at injection until then. The editor shows a character counter for the real limit.

## 3. Live UI + state fixes

The gateway already broadcast `projects.changed` on every CRUD; no frontend code subscribed to it.

- ProjectsPage now listens to `projects.changed` / `sessions.changed`; a second client's create/rename/delete/move shows up without Refresh.
- `sessions.patch` project moves also broadcast `projects.changed` (session counts on other clients were stale), and the move block runs after the generic field patch so a storage-only fallback upsert can't revert it. Stale "belong to the session's agent" comment corrected.
- Loading and error no longer render as the "No projects yet" empty state with a create CTA — loading gets a spinner, errors get the message plus Retry.
- Browser back/forward no longer leaks one project's unsaved draft into another project's editor (drafts are keyed to the `?project=` param, not the click handler).
- A saved knowledge edit no longer flashes the stale pre-save value: the mutation patches the cached row from the response before the refetch lands. An "Unsaved changes" hint appears while the draft differs.
- CLI `projects list --agent` help now says what it filters (the default agent — projects are cross-agent), instead of implying membership.

## Verification

- Backend: `uv run pytest` over session, gateway RPC (projects + sessions), tools, engine injection, CLI, and migration suites — 330 passed. New tests: rename-vs-knowledge non-clobber, CAS conflict (manager + RPC, including the winning retry), unique-index backstop, caps-equal assertion, legacy >24k row truncation.
- Frontend: `npm run check` (tsc, eslint, prettier, vitest — 2007 tests). New tests: live-update subscriptions, conflict toast + draft retention, error state vs empty state.
- `ruff check` and `mypy` clean.