### PR TITLE
fix(scheduler): cancel startup catch-up tasks on shutdown

### DIFF
--- a/src/agentos/scheduler/timer.py
+++ b/src/agentos/scheduler/timer.py
@@ -40,6 +40,7 @@ class SchedulerTimer:
         self._max_catchup = max_catchup
         self._reaper = reaper
         self._running: dict[str, asyncio.Task] = {}
+        self._catchup_tasks: set[asyncio.Task[None]] = set()
         self._loop_task: asyncio.Task | None = None
         self._started = False
         self._nudge_event = asyncio.Event()
@@ -117,7 +118,9 @@ class SchedulerTimer:
 
             for reservation in reservations:
                 delay = delays.get(reservation.job.id, 0.0)
-                asyncio.create_task(self._staggered_run(reservation, delay))
+                task = asyncio.create_task(self._staggered_run(reservation, delay))
+                self._catchup_tasks.add(task)
+                task.add_done_callback(self._catchup_tasks.discard)
 
         # Step 4: fast-forward remaining (except AT one-shots). Delegates to
         # the shared next-run helper so EVERY+anchor jobs use the interval-grid
@@ -297,7 +300,7 @@ class SchedulerTimer:
         logger.info("scheduler_timer_started")
 
     async def stop(self) -> None:
-        """Stop the timer loop and cancel all running tasks."""
+        """Stop the timer loop and await cancellation of all owned job tasks."""
         self._started = False
         if self._loop_task is not None and not self._loop_task.done():
             self._loop_task.cancel()
@@ -305,9 +308,12 @@ class SchedulerTimer:
                 await self._loop_task
             except asyncio.CancelledError:
                 pass
-        # Cancel all running job tasks
-        for task in self._running.values():
+        job_tasks = {*self._running.values(), *self._catchup_tasks}
+        for task in job_tasks:
             if not task.done():
                 task.cancel()
+        if job_tasks:
+            await asyncio.gather(*job_tasks, return_exceptions=True)
         self._running.clear()
+        self._catchup_tasks.clear()
         logger.info("scheduler_timer_stopped")

--- a/tests/test_scheduler/test_startup_catchup_shutdown.py
+++ b/tests/test_scheduler/test_startup_catchup_shutdown.py
@@ -1,0 +1,86 @@
+"""Scheduler shutdown owns the full lifecycle of startup catch-up tasks."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentos.scheduler import timer as timer_module
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.timer import SchedulerTimer
+from agentos.scheduler.types import CronJob, JobStatus, ScheduleKind, SessionTarget
+
+
+def _overdue_at_job(job_id: str) -> CronJob:
+    scheduled_at = datetime.now(UTC) - timedelta(minutes=1)
+    return CronJob(
+        id=job_id,
+        name=job_id,
+        cron_expr=scheduled_at.isoformat(),
+        schedule_raw=scheduled_at.isoformat(),
+        handler_key="agent_run",
+        payload={"kind": "agent_turn", "task": "noop", "agent_id": "main"},
+        session_target=SessionTarget.ISOLATED,
+        schedule_kind=ScheduleKind.AT,
+        next_run_at=scheduled_at,
+        status=JobStatus.PENDING,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_delayed_startup_catchup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+
+    async def handler(_job: CronJob) -> str:
+        started.set()
+        return "done"
+
+    monkeypatch.setattr(
+        timer_module,
+        "spread_jobs",
+        lambda job_ids, *, window_seconds: dict.fromkeys(job_ids, 60.0),
+    )
+
+    async with JobStore(":memory:") as store:
+        await store.save(_overdue_at_job("late"))
+        timer = SchedulerTimer(store, handlers={"agent_run": handler})
+
+        await timer.startup_catchup()
+
+        assert len(timer._catchup_tasks) == 1
+        await timer.stop()
+        await asyncio.sleep(0)
+
+        assert started.is_set() is False
+        assert timer._catchup_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_completed_startup_catchup_is_removed_from_tracking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def handler(_job: CronJob) -> str:
+        return "done"
+
+    monkeypatch.setattr(
+        timer_module,
+        "spread_jobs",
+        lambda job_ids, *, window_seconds: dict.fromkeys(job_ids, 0.0),
+    )
+
+    async with JobStore(":memory:") as store:
+        await store.save(_overdue_at_job("ready"))
+        timer = SchedulerTimer(store, handlers={"agent_run": handler})
+
+        await timer.startup_catchup()
+        tasks = tuple(timer._catchup_tasks)
+
+        assert len(tasks) == 1
+        await asyncio.gather(*tasks)
+        await asyncio.sleep(0)
+
+        assert timer._catchup_tasks == set()


### PR DESCRIPTION
Fixes #655

## Summary

- retain startup catch-up tasks until they complete
- cancel and await catch-up tasks together with regular timer tasks during shutdown
- add deterministic regression coverage for delayed cancellation and completed-task cleanup

## Testing

- uv run pytest tests/test_scheduler/test_startup_catchup_shutdown.py -q (2 passed)
- uv run pytest tests/test_scheduler -q (457 passed)
- uv run python scripts/build_control_ui.py build (passed)
- npm --prefix frontend run check (98 files, 2004 tests passed)
- uv run ruff check src tests (passed)
- uv run mypy src/agentos --show-error-codes (615 files passed)
- uv build --wheel (passed)
- uv run pytest -q (8576 passed, 32 skipped; 6 failures and 3 errors reproduced unchanged on clean origin/main: local ONNX assets are not hydrated and the installed uv does not support build --clear)

No public API or schema changes. Third-party origin: none.