### PR TITLE
fix(mcp): validate server URL against SSRF on connect

### DIFF
--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -11,6 +11,7 @@ from agentos import __version__
 from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.tools.ssrf import validate_http_url_for_fetch
 
 
 class MCPSSEClient(MCPClient):
@@ -70,6 +71,7 @@ class MCPSSEClient(MCPClient):
 
     async def connect(self) -> None:
         """Create the HTTP client session and perform MCP initialization handshake."""
+        validate_http_url_for_fetch(self.config.url or "")
         self._client = httpx.AsyncClient(trust_env=_trust_env())
 
         # Send initialize request (response is acknowledged server-side;

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -20,6 +20,7 @@ from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 from agentos.paths import state_dir as default_state_dir
+from agentos.tools.ssrf import validate_http_url_for_fetch
 
 
 class MCPDependencyError(RuntimeError):
@@ -145,6 +146,7 @@ class MCPStreamableHTTPClient(MCPClient):
     async def connect(self) -> None:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
+        validate_http_url_for_fetch(self.config.url)
 
         try:
             from mcp.client.auth import OAuthClientProvider

--- a/tests/test_mcp/test_streamable_http_client.py
+++ b/tests/test_mcp/test_streamable_http_client.py
@@ -69,6 +69,8 @@ async def test_cancelled_connect_closes_all_partial_transport_contexts(
     from mcp.client import session as session_module
     from mcp.client import streamable_http as transport_module
 
+    monkeypatch.setattr("agentos.mcp.streamable_http.validate_http_url_for_fetch", lambda _u: None)
+
     closed: list[str] = []
 
     @asynccontextmanager
@@ -110,3 +112,69 @@ async def test_cancelled_connect_closes_all_partial_transport_contexts(
         await client.connect()
 
     assert closed == ["session", "transport", "http"]
+
+
+@pytest.mark.asyncio
+async def test_connect_rejects_metadata_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """connect() must validate the server URL against SSRF guards."""
+    from agentos.tools.ssrf import SSRFBlockedError
+
+    def _boom(_url: str) -> None:
+        raise SSRFBlockedError("Blocked")
+
+    monkeypatch.setattr("agentos.mcp.streamable_http.validate_http_url_for_fetch", _boom)
+    client = MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="evil",
+            transport="streamable_http",
+            url="http://169.254.169.254/latest/meta-data/",
+        )
+    )
+    with pytest.raises(SSRFBlockedError):
+        await client.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_passes_valid_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """connect() calls validate_http_url_for_fetch and does not raise for valid URLs."""
+    called_with: list[str] = []
+
+    def _check(url: str) -> None:
+        called_with.append(url)
+
+    monkeypatch.setattr("agentos.mcp.streamable_http.validate_http_url_for_fetch", _check)
+    # Mock the downstream imports so connect() does not actually connect
+    from mcp.client import session as session_module
+    from mcp.client import streamable_http as transport_module
+
+    @asynccontextmanager
+    async def fake_http_client(**_kwargs: Any):
+        yield object()
+
+    @asynccontextmanager
+    async def fake_transport(_url: str, **_kwargs: Any):
+        yield object(), object(), None
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            pass
+
+        async def initialize(self) -> None:
+            pass
+
+    monkeypatch.setattr("agentos.mcp.streamable_http.httpx.AsyncClient", fake_http_client)
+    monkeypatch.setattr(transport_module, "streamable_http_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_a, **_kw: FakeSession())
+
+    client = MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="valid",
+            transport="streamable_http",
+            url="https://example.test/mcp",
+        )
+    )
+    await client.connect()
+    assert called_with == ["https://example.test/mcp"]


### PR DESCRIPTION
Fixes #662

## Summary
MCP SSE and Streamable HTTP transports connect to MCPServerConfig.url with no SSRF validation. Other URL-fetching paths (web_fetch, http_request, skill-hub) call validate_http_url_for_fetch() before connecting; the MCP transport skipped this entirely.

## What
- `src/agentos/mcp/sse.py` — MCPSSEClient.connect() now calls validate_http_url_for_fetch(self.config.url) before creating the httpx client.
- `src/agentos/mcp/streamable_http.py` — StreamableHttpTransport.connect() does the same.
- `tests/test_mcp/test_streamable_http_client.py` — two regression tests:
  - rejects cloud-metadata endpoints (169.254.169.254)
  - accepts a valid URL and forwards it to the validator
- Existing test that mocks the downstream MCP SDK transport also monkeypatches the validator to keep passing under the new guard.

## Verification
- `uv run pytest tests/test_mcp -q` — 15 passed
- `uv run ruff check src/agentos/mcp tests/test_mcp` — clean
- `uv run ruff format --check src/agentos/mcp tests/test_mcp` — clean
- `uv run mypy src/agentos/mcp --show-error-codes` — no issues
