### PR TITLE
fix(mcp): validate server URLs against SSRF before connecting (#662)

### DIFF
--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -11,6 +11,7 @@ from agentos import __version__
 from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.tools.ssrf import validate_http_url_for_fetch
 
 
 class MCPSSEClient(MCPClient):
@@ -70,6 +71,7 @@ class MCPSSEClient(MCPClient):
 
     async def connect(self) -> None:
         """Create the HTTP client session and perform MCP initialization handshake."""
+        validate_http_url_for_fetch(self.config.url)
         self._client = httpx.AsyncClient(trust_env=_trust_env())
 
         # Send initialize request (response is acknowledged server-side;

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -71,7 +71,9 @@ class MCPSSEClient(MCPClient):
 
     async def connect(self) -> None:
         """Create the HTTP client session and perform MCP initialization handshake."""
-        validate_http_url_for_fetch(self.config.url)
+        url = self.config.url
+        if url:
+            validate_http_url_for_fetch(url)
         self._client = httpx.AsyncClient(trust_env=_trust_env())
 
         # Send initialize request (response is acknowledged server-side;

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -20,6 +20,7 @@ from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 from agentos.paths import state_dir as default_state_dir
+from agentos.tools.ssrf import validate_http_url_for_fetch
 
 
 class MCPDependencyError(RuntimeError):
@@ -145,6 +146,7 @@ class MCPStreamableHTTPClient(MCPClient):
     async def connect(self) -> None:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
+        validate_http_url_for_fetch(self.config.url)
 
         try:
             from mcp.client.auth import OAuthClientProvider

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -146,7 +146,7 @@ class MCPStreamableHTTPClient(MCPClient):
     async def connect(self) -> None:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
-        validate_http_url_for_fetch(self.config.url)
+        validate_http_url_for_fetch(self.config.url)  # type: ignore[arg-type]  # validated above
 
         try:
             from mcp.client.auth import OAuthClientProvider

--- a/tests/test_mcp/test_streamable_http_client.py
+++ b/tests/test_mcp/test_streamable_http_client.py
@@ -9,8 +9,10 @@ from typing import Any
 import pytest
 
 from agentos.mcp.discovery import create_client
+from agentos.mcp.sse import MCPSSEClient
 from agentos.mcp.streamable_http import FileOAuthStorage, MCPStreamableHTTPClient
 from agentos.mcp.types import MCPServerConfig
+from agentos.tools.types import SSRFBlockedError
 
 
 def test_factory_builds_streamable_http_client() -> None:
@@ -95,6 +97,9 @@ async def test_cancelled_connect_closes_all_partial_transport_contexts(
         async def initialize(self) -> None:
             raise asyncio.CancelledError
 
+    monkeypatch.setattr(
+        "agentos.mcp.streamable_http.validate_http_url_for_fetch", lambda _url: None
+    )
     monkeypatch.setattr("agentos.mcp.streamable_http.httpx.AsyncClient", fake_http_client)
     monkeypatch.setattr(transport_module, "streamable_http_client", fake_transport)
     monkeypatch.setattr(session_module, "ClientSession", lambda *_args, **_kwargs: FakeSession())
@@ -110,3 +115,31 @@ async def test_cancelled_connect_closes_all_partial_transport_contexts(
         await client.connect()
 
     assert closed == ["session", "transport", "http"]
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_connect_rejects_cloud_metadata_ip() -> None:
+    """Regression: MCP Streamable HTTP must reject cloud metadata IPs."""
+    client = MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="test",
+            transport="streamable_http",
+            url="http://169.254.169.254/latest/meta-data/",
+        )
+    )
+    with pytest.raises(SSRFBlockedError):
+        await client.connect()
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_rejects_cloud_metadata_ip() -> None:
+    """Regression: MCP SSE must reject cloud metadata IPs."""
+    client = MCPSSEClient(
+        MCPServerConfig(
+            name="test",
+            transport="sse",
+            url="http://169.254.169.254/latest/meta-data/",
+        )
+    )
+    with pytest.raises(SSRFBlockedError):
+        await client.connect()


### PR DESCRIPTION
## Summary

MCP SSE and Streamable HTTP transports connect to `MCPServerConfig.url` via httpx with no SSRF validation. Every other URL-fetching path (`web_fetch`, `http_request`, skill-hub) calls `validate_http_url_for_fetch()` before connecting — the MCP transport skipped this entirely.

## Impact

Cloud metadata endpoints (169.254.169.254), private ranges, and unsupported schemes are reachable through MCP server config. An attacker who controls or injects the MCP server URL can exfiltrate instance credentials or redirect agent traffic to internal hosts.

## Changes

- `src/agentos/mcp/sse.py`: Added `validate_http_url_for_fetch(self.config.url)` in `MCPSSEClient.connect()`
- `src/agentos/mcp/streamable_http.py`: Added `validate_http_url_for_fetch(self.config.url)` in `MCPStreamableHTTPClient.connect()`
- `tests/test_mcp/test_streamable_http_client.py`: Monkeypatch SSRF validation in the transport-cleanup test that uses `example.test` (which does not resolve)

## Tests

```
$ python -m pytest tests/test_mcp/ -q --no-header
13 passed in 1.29s

$ python -m pytest tests/test_security/test_ssrf_fake_ip.py -q --no-header
6 passed in 0.94s
```

- [x] This pull request fully resolves the linked issue.
- [x] Security fix: no breaking changes to existing behavior
- [x] Minimal 2-line change in production code, 1 test monkeypatch

Fixes #662