### PR TITLE
fix(channels): catch ConnectTimeout/PoolTimeout in Telegram retry loop (#651)

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -514,7 +514,7 @@ class TelegramChannel:
                     request_kwargs["timeout"] = request_timeout
                 response = await client.post(f"/bot{self.config.token}/{method}", **request_kwargs)
                 break
-            except httpx.ConnectError:
+            except httpx.TransportError:
                 if retry_delay is None:
                     raise TelegramApiError(f"Telegram {method} connection failed") from None
                 log.warning(

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -514,7 +514,7 @@ class TelegramChannel:
                     request_kwargs["timeout"] = request_timeout
                 response = await client.post(f"/bot{self.config.token}/{method}", **request_kwargs)
                 break
-            except httpx.TransportError:
+            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout):
                 if retry_delay is None:
                     raise TelegramApiError(f"Telegram {method} connection failed") from None
                 log.warning(

--- a/tests/test_channels/test_telegram_retry.py
+++ b/tests/test_channels/test_telegram_retry.py
@@ -36,6 +36,56 @@ async def test_telegram_api_retries_connect_error_before_sending() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectTimeout("dns timed out"),
+        httpx.PoolTimeout("no pooled connection"),
+    ],
+)
+async def test_telegram_api_retries_connect_timeout_and_pool_timeout(exc: httpx.RequestError) -> None:
+    """ConnectTimeout and PoolTimeout are retried, just like ConnectError."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=[exc, _Response()])
+    channel._client = client
+    channel._owns_client = False
+
+    with patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()) as sleep:
+        result = await channel._api("sendMessage", {"chat_id": "1", "text": "hello"})
+
+    assert result == {"id": 1}
+    assert client.post.await_count == 2
+    sleep.assert_awaited_once_with(0.25)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.WriteTimeout("write timed out"),
+        httpx.ReadTimeout("read timed out"),
+    ],
+)
+async def test_telegram_api_does_not_retry_write_or_read_timeout(exc: httpx.RequestError) -> None:
+    """WriteTimeout/ReadTimeout raise immediately — retrying risks double-send."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=[exc, _Response()])
+    channel._client = client
+    channel._owns_client = False
+
+    with (
+        patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(TelegramApiError),
+    ):
+        await channel._api("sendMessage", {"chat_id": "1", "text": "hello"})
+
+    # Only 1 attempt — no retry
+    assert client.post.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_telegram_long_poll_timeout_has_network_headroom() -> None:
     channel = TelegramChannel(TelegramChannelConfig(token="token", poll_timeout_s=30))
     client = AsyncMock()

--- a/tests/test_channels/test_telegram_retry.py
+++ b/tests/test_channels/test_telegram_retry.py
@@ -43,7 +43,9 @@ async def test_telegram_api_retries_connect_error_before_sending() -> None:
         httpx.PoolTimeout("no pooled connection"),
     ],
 )
-async def test_telegram_api_retries_connect_timeout_and_pool_timeout(exc: httpx.RequestError) -> None:
+async def test_telegram_api_retries_connect_timeout_and_pool_timeout(
+    exc: httpx.RequestError,
+) -> None:
     """ConnectTimeout and PoolTimeout are retried, just like ConnectError."""
     channel = TelegramChannel(TelegramChannelConfig(token="token"))
     client = AsyncMock()


### PR DESCRIPTION
## Summary

`TelegramChannel._api()` has its own retry loop (separate from the shared `retry_request()` helper in `_util.py`). Its retry-with-backoff branch only caught `httpx.ConnectError`, but `ConnectTimeout` and `PoolTimeout` inherit from `TimeoutException`, not `ConnectError` — both fell through to the generic `except httpx.RequestError` branch and raised `TelegramApiError` on the first attempt, with zero retries.

## Fix

Changed from `except httpx.TransportError` to `except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)`. `TransportError` is too broad — it would also retry `WriteTimeout`/`ReadTimeout`, which can occur *after* Telegram has received the request, risking double-send.

## Changes

- `src/agentos/channels/telegram.py`: 1 line changed
- `tests/test_channels/test_telegram_retry.py`: 2 new regression tests

## Tests

```
$ python -m pytest tests/test_channels/ -q --no-header
296 passed (no regressions)
```

Regression tests added:
- `test_telegram_api_retries_connect_timeout_and_pool_timeout` — confirms ConnectTimeout and PoolTimeout now retry and succeed
- `test_telegram_api_does_not_retry_write_or_read_timeout` — confirms WriteTimeout/ReadTimeout still raise immediately

- [x] This pull request fully resolves the linked issue.
- [x] Bug fix: no breaking changes to existing behavior
- [x] Includes regression tests for both positive and negative cases

Fixes #651