### PR TITLE
fix(provider): recognize Gemini's real context-overflow message (#657)

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -86,6 +86,7 @@ def _is_context_overflow(text: str) -> bool:
             "prompt is too long",
             "input is too long",
             "input exceeds",
+            "exceeds the maximum number of tokens",
             "provider_request_budget_exhausted",
             "too many tokens",
             # Anthropic-specific markers

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -25,6 +25,7 @@ def test_gemini_input_token_count_message_is_context_overflow() -> None:
                 "the input token count (12345) exceeds the maximum "
                 "number of tokens allowed (8192)."
             ),
+
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
@@ -52,6 +53,7 @@ def test_gemini_input_token_count_message_is_context_overflow_different_counts()
                 "the input token count (512) exceeds the maximum "
                 "number of tokens allowed (4096)."
             ),
+
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -15,6 +15,21 @@ def test_provider_request_budget_exhausted_is_context_overflow() -> None:
     )
 
 
+def test_gemini_input_token_count_message_is_context_overflow() -> None:
+    """Gemini's real context-overflow error should be classified as CONTEXT_OVERFLOW."""
+    assert (
+        classify_provider_error(
+            provider_name="gemini",
+            status_code=400,
+            message=(
+                "the input token count (12345) exceeds the maximum "
+                "number of tokens allowed (8192)."
+            ),
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
 def test_anthropic_prompt_too_long_is_context_overflow() -> None:
     assert (
         classify_provider_error(
@@ -22,6 +37,21 @@ def test_anthropic_prompt_too_long_is_context_overflow() -> None:
             status_code=400,
             raw_code="prompt_too_long",
             message="prompt_too_long: prompt is longer than the maximum allowed length",
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
+def test_gemini_input_token_count_message_is_context_overflow_different_counts() -> None:
+    """Same message with different token counts must still match."""
+    assert (
+        classify_provider_error(
+            provider_name="gemini",
+            status_code=400,
+            message=(
+                "the input token count (512) exceeds the maximum "
+                "number of tokens allowed (4096)."
+            ),
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
@@ -61,4 +91,3 @@ def test_anthropic_request_size_exceeds_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
-


### PR DESCRIPTION
## Summary

Gemini returns `"the input token count (X) exceeds the maximum number of tokens allowed (Y)"` as its context-overflow error message. None of the existing markers in `_is_context_overflow()` match this string — "input" and "exceeds" aren't adjacent in the real message, and it says "maximum number of tokens" rather than "maximum context" or "too many tokens".

As a result, the error was misclassified as `BAD_REQUEST` instead of `CONTEXT_OVERFLOW`. Per `decide_recovery_action()`, that means `COMPACT_AND_RETRY` never fired for Gemini users who hit their context limit — they got a raw surfaced error instead of AgentOS automatically compacting the conversation and retrying.

## Fix

Added `"exceeds the maximum number of tokens"` to the context-overflow marker list. The string is specific enough to avoid false positives (unique to token-limit errors) and stable across Gemini API versions.

## Changes

- `src/agentos/provider/failures.py`: 1 line added to the marker tuple
- `tests/test_provider_failures.py`: 2 regression tests

## Tests

```
$ python -m pytest tests/test_provider_failure_classification.py tests/test_provider_failures.py -q --no-header
91 passed in 0.60s
```

Regression tests:
- `test_gemini_input_token_count_message_is_context_overflow` — exact real-world Gemini message
- `test_gemini_input_token_count_message_is_context_overflow_different_counts` — same shape, different token counts

- [x] This pull request fully resolves the linked issue.
- [x] Bug fix: no breaking changes to existing behavior
- [x] Includes regression tests for multiple token-count variations

Fixes #657