### PR TITLE
fix(gateway): decrement agentos_queue_depth gauge when tasks leave pe…

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -1120,8 +1120,17 @@ class TaskRuntime:
     async def _mark_running(self, task: _RuntimeTask) -> None:
         async with self._state_lock:
             task.status = AgentTaskStatus.RUNNING
-            self._remove_pending(task)
+            removed = self._remove_pending(task)
             self._running_by_session[task.envelope.session_key] = task
+            _total_queue_depth = (
+                sum(len(v) for v in self._pending_by_session.values()) if removed else None
+            )
+        if _total_queue_depth is not None:
+            _emit_metric(
+                "agentos_queue_depth",
+                value=_total_queue_depth,
+                session_key=task.envelope.session_key,
+            )
         await self._storage.update_agent_task(
             task.task_id,
             status=AgentTaskStatus.RUNNING,
@@ -1156,7 +1165,10 @@ class TaskRuntime:
                 return
             task.terminal_emitted = True
             task.status = status
-            self._remove_pending(task)
+            removed = self._remove_pending(task)
+            _total_queue_depth = (
+                sum(len(v) for v in self._pending_by_session.values()) if removed else None
+            )
             if self._running_by_session.get(task.envelope.session_key) is task:
                 self._running_by_session.pop(task.envelope.session_key, None)
             self._tasks.pop(task.task_id, None)
@@ -1185,6 +1197,12 @@ class TaskRuntime:
                     if not active:
                         self._agent_active_sessions.pop(agent_id, None)
                         self._agent_session_rr.pop(agent_id, None)
+        if _total_queue_depth is not None:
+            _emit_metric(
+                "agentos_queue_depth",
+                value=_total_queue_depth,
+                session_key=task.envelope.session_key,
+            )
         terminal_payload = {
             "status": status,
             "terminal_reason": terminal_reason,
@@ -1260,16 +1278,17 @@ class TaskRuntime:
                 terminal_reason="shutdown_timeout",
             )
 
-    def _remove_pending(self, task: _RuntimeTask) -> None:
+    def _remove_pending(self, task: _RuntimeTask) -> bool:
         pending = self._pending_by_session.get(task.envelope.session_key)
         if not pending:
-            return
+            return False
         try:
             pending.remove(task)
         except ValueError:
-            return
+            return False
         if not pending:
             self._pending_by_session.pop(task.envelope.session_key, None)
+        return True
 
     async def _emit(self, session_key: str, event_name: str, payload: dict[str, Any]) -> None:
         if self._event_emitter is None:

--- a/tests/test_gateway/test_metrics_counters.py
+++ b/tests/test_gateway/test_metrics_counters.py
@@ -255,10 +255,64 @@ async def test_agentos_queue_depth_multi_session_total() -> None:
         await rt.wait(h3.task_id, timeout=2.0)
 
     qd_events = [e for e in captured if e.get("metric") == "agentos_queue_depth"]
-    assert len(qd_events) == 3
-    # First enqueue: 1 pending on sess-a (total=1)
-    assert qd_events[0]["value"] == 1
-    # Second enqueue: task-1 running, task-2 pending on sess-a (total=1)
-    assert qd_events[1]["value"] == 1
-    # Third enqueue: task-2 pending on sess-a, task-3 pending on sess-b (total=2)
-    assert qd_events[2]["value"] == 2
+    values = [e["value"] for e in qd_events]
+    assert values == [
+        1,  # First enqueue: 1 pending on sess-a (total=1)
+        0,  # h1 starts running: 0 pending across all sessions (total=0)
+        1,  # Second enqueue: task-1 running, task-2 pending on sess-a (total=1)
+        2,  # Third enqueue: task-2 pending on sess-a, task-3 pending on sess-b (total=2)
+        1,  # task-2 starts running: task-3 pending on sess-b (total=1)
+        0,  # task-3 starts running: 0 pending across all sessions (total=0)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_agentos_queue_depth_drains_to_zero_after_completion() -> None:
+    """Prometheus gauge drains to 0 when tasks complete."""
+    from agentos.observability.metrics import get_metrics_registry
+
+    reg = get_metrics_registry()
+    gauge = reg._gauges.get("agentos_queue_depth")
+    assert gauge is not None
+    gauge.reset()
+
+    rt = _make_runtime()
+    env = _make_envelope("agent-1::sess-drain")
+    h1 = await rt.enqueue(env, "drain-1")
+    h2 = await rt.enqueue(env, "drain-2")
+    await rt.wait(h1.task_id, timeout=2.0)
+    await rt.wait(h2.task_id, timeout=2.0)
+
+    assert gauge.get() == 0.0
+    text = reg.format_prometheus()
+    assert "agentos_queue_depth 0" in text
+
+
+@pytest.mark.asyncio
+async def test_agentos_queue_depth_decrements_on_cancel_while_pending() -> None:
+    """Cancelling a task while pending decrements agentos_queue_depth."""
+    gate = asyncio.Event()
+
+    async def _blocking_handler(_run: Any) -> None:
+        await gate.wait()
+
+    rt = _make_runtime(turn_handler=_blocking_handler, max_concurrency=1)
+    env_a = _make_envelope("agent-1::sess-cancel-a")
+    env_b = _make_envelope("agent-1::sess-cancel-b")
+
+    with _capture_metric_logs() as captured:
+        h1 = await rt.enqueue(env_a, "running-task")
+        await asyncio.sleep(0.05)
+        h2 = await rt.enqueue(env_b, "pending-task")
+        await asyncio.sleep(0.05)
+        # Cancel the pending task directly
+        cancelled_count = await rt.cancel(task_id=h2.task_id)
+        assert cancelled_count == 1
+        await asyncio.sleep(0.05)
+        gate.set()
+        await rt.wait(h1.task_id, timeout=2.0)
+
+    qd_events = [e for e in captured if e.get("metric") == "agentos_queue_depth"]
+    values = [e["value"] for e in qd_events]
+    # h1 enqueued (1) -> h1 running (0) -> h2 enqueued (1) -> h2 cancelled while pending (0)
+    assert values == [1, 0, 1, 0]


### PR DESCRIPTION
closes #668 
```markdown
## Summary
`agentos_queue_depth` is one of the four locked core metrics specified in `AGENTS.md` and CI as `agentos_queue_depth (gauge) — pending queue depth across all sessions`.

Previously, `_emit_metric("agentos_queue_depth", ...)` was only called upon enqueue in `TaskRuntime.enqueue()`. When a task left the pending queue (entering running state in `_mark_running`, or being cancelled / terminated in `_mark_terminal`), `_remove_pending` was called but `agentos_queue_depth` was never re-emitted.

Because `agentos_queue_depth` is an in-memory `Gauge`, the value remained permanently stuck at peak enqueue depth even when the pending queue drained back down to 0, causing downstream Prometheus monitoring and autoscalers to report false backlog indefinitely.

## Changes
1. Updated `_remove_pending(self, task: _RuntimeTask) -> bool` in `src/agentos/gateway/task_runtime.py` to return `True` when a task was present in `self._pending_by_session` and successfully removed.
2. Updated `_mark_running` and `_mark_terminal` to re-emit `agentos_queue_depth` with the updated pending queue depth whenever a pending task is dequeued.
3. Updated `test_agentos_queue_depth_multi_session_total` in `tests/test_gateway/test_metrics_counters.py` to verify full lifecycle transitions (`[1, 0, 1, 2, 1, 0]`).
4. Added `test_agentos_queue_depth_drains_to_zero_after_completion` and `test_agentos_queue_depth_decrements_on_cancel_while_pending` covering queue drain to 0 and pre-start cancellation.
```