### PR TITLE
fix(observability): serialize OtlpTraceSink.flush with flush lock

### DIFF
--- a/src/agentos/observability/otlp.py
+++ b/src/agentos/observability/otlp.py
@@ -231,34 +231,35 @@ class OtlpTraceSink(TraceSink):
         """Flush all buffered events to the OTLP HTTP collector."""
         import httpx
 
-        with self._queue_lock:
-            if not self._queue:
-                return True
-            events_to_send = self._queue[:]
-            self._queue.clear()
-
-        if not events_to_send:
-            return True
-
-        payload = self.build_export_payload(events_to_send)
-        req_headers = {
-            "Content-Type": "application/json",
-            **self.headers,
-        }
-
-        try:
-            async with httpx.AsyncClient(timeout=10.0, trust_env=_trust_env()) as client:
-                resp = await client.post(self.endpoint, json=payload, headers=req_headers)
-                resp.raise_for_status()
-                return True
-        except Exception as exc:
-            log.warning("otlp.export_failed", endpoint=self.endpoint, error=str(exc))
-            # Put unsent events back on failure up to max_queue_size
+        async with self._flush_lock:
             with self._queue_lock:
-                remaining_space = max(0, self.max_queue_size - len(self._queue))
-                if remaining_space > 0:
-                    self._queue = events_to_send[-remaining_space:] + self._queue
-            return False
+                if not self._queue:
+                    return True
+                events_to_send = self._queue[:]
+                self._queue.clear()
+
+            if not events_to_send:
+                return True
+
+            payload = self.build_export_payload(events_to_send)
+            req_headers = {
+                "Content-Type": "application/json",
+                **self.headers,
+            }
+
+            try:
+                async with httpx.AsyncClient(timeout=10.0, trust_env=_trust_env()) as client:
+                    resp = await client.post(self.endpoint, json=payload, headers=req_headers)
+                    resp.raise_for_status()
+                    return True
+            except Exception as exc:
+                log.warning("otlp.export_failed", endpoint=self.endpoint, error=str(exc))
+                # Put unsent events back on failure up to max_queue_size
+                with self._queue_lock:
+                    remaining_space = max(0, self.max_queue_size - len(self._queue))
+                    if remaining_space > 0:
+                        self._queue = events_to_send[-remaining_space:] + self._queue
+                return False
 
     async def close(self) -> None:
         """Close sink, cancel background flush task, and perform final flush."""

--- a/tests/test_observability_otlp.py
+++ b/tests/test_observability_otlp.py
@@ -258,3 +258,62 @@ def test_otlp_multithreaded_writes() -> None:
         t.join()
 
     assert len(sink._queue) == 100
+
+
+@pytest.mark.asyncio
+async def test_otlp_flush_is_serialized_with_flush_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    import httpx
+
+    in_flight = 0
+    max_in_flight = 0
+    request_batches: list[list[Any]] = []
+
+    class _MockClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: Any = None, headers: Any = None) -> Any:
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            request_batches.append(json)
+            await asyncio.sleep(0.05)
+            in_flight -= 1
+
+            class _MockResp:
+                status_code = 200
+
+                def raise_for_status(self) -> None:
+                    pass
+
+            return _MockResp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+
+    sink = OtlpTraceSink(endpoint="http://collector.internal:4318", max_queue_size=100)
+    ctx = TraceContext.new(trace_id="test-flush-lock")
+
+    # Populate some events
+    for i in range(5):
+        sink.write(TraceEvent(kind=f"event-{i}", context=ctx))
+
+    # Trigger multiple concurrent flushes simultaneously
+    results = await asyncio.gather(
+        sink.flush(),
+        sink.flush(),
+        sink.flush(),
+    )
+
+    assert all(results)
+    # The lock guarantees no two HTTP posts execute concurrently
+    assert max_in_flight == 1
+    # Only one export actually sent the batch because subsequent flushes saw an empty queue
+    assert len(request_batches) == 1


### PR DESCRIPTION
## Summary closes #672 
`OtlpTraceSink` initialized `self._flush_lock = asyncio.Lock()` at line 97 of `src/agentos/observability/otlp.py`, but never acquired it during `flush()`.

When trace events were generated under concurrency, background tasks spawned by `write()` upon hitting `batch_size` ran simultaneously with `_periodic_flush()`. This led to:
1. Multiple overlapping HTTP POST requests to the OTLP collector, resulting in out-of-order span reception due to network latency jitter.
2. Race conditions during network failure where unsent events prepended back onto `self._queue` out of order.

## Changes
- Wrapped `flush()` in `async with self._flush_lock:` in `src/agentos/observability/otlp.py`.
- Added `test_otlp_flush_is_serialized_with_flush_lock` in `tests/test_observability_otlp.py` ensuring concurrent calls are serialized and subsequent flushes exit cleanly when the queue is drained.
