### PR TITLE
fix(channels): require signing_secret for Slack event_callback webhooks

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -793,6 +793,12 @@ class SlackChannel:
             return JSONResponse({"challenge": challenge})
 
         if event_type == "event_callback":
+            if self.signing_secret is None:
+                log.warning("slack.webhook_event_callback_requires_signing_secret")
+                return Response(
+                    "Slack signing secret must be configured for event_callback",
+                    status_code=403,
+                )
             self._ingest_event_callback(data)
 
         return Response(status_code=200)

--- a/tests/test_channels/test_channel_dedupe.py
+++ b/tests/test_channels/test_channel_dedupe.py
@@ -21,7 +21,11 @@ class _BodyRequest:
 
 @pytest.mark.asyncio
 async def test_slack_webhook_dedupes_retried_event_callback() -> None:
-    channel = SlackChannel(token="xoxb-test", slack_channel_id="C1")
+    channel = SlackChannel(
+        token="xoxb-test",
+        slack_channel_id="C1",
+        signing_secret="test_secret",
+    )
     payload = {
         "type": "event_callback",
         "event_id": "Ev123",
@@ -35,11 +39,37 @@ async def test_slack_webhook_dedupes_retried_event_callback() -> None:
         },
     }
 
-    await channel._handle_webhook(_BodyRequest(payload))  # noqa: SLF001
-    await channel._handle_webhook(_BodyRequest(payload))  # noqa: SLF001
+    import time
+
+    # Bypass signature verification in test (auth tested separately)
+    channel._verify_signature = lambda *a, **k: True  # type: ignore[method-assign]
+
+    req = _BodyRequest(payload)
+    req.headers["X-Slack-Signature"] = "v0=test"
+    req.headers["X-Slack-Request-Timestamp"] = str(int(time.time()))
+    await channel._handle_webhook(req)  # noqa: SLF001
+    await channel._handle_webhook(req)  # noqa: SLF001
 
     assert channel._queue.qsize() == 1  # noqa: SLF001
     assert (await channel.receive()).content == "draw an image"
+
+
+@pytest.mark.asyncio
+async def test_slack_webhook_rejects_event_callback_when_signing_secret_unset() -> None:
+    """event_callback must be rejected when signing_secret is not configured."""
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C1")
+    # signing_secret defaults to None
+    assert channel.signing_secret is None
+    payload = {
+        "type": "event_callback",
+        "event_id": "Ev999",
+        "event": {"type": "message", "text": "injected"},
+    }
+    req = _BodyRequest(payload)
+    import time
+    req.headers["X-Slack-Request-Timestamp"] = str(int(time.time()))
+    resp = await channel._handle_webhook(req)  # noqa: SLF001
+    assert resp.status_code == 403
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #674

## Summary
When signing_secret is None (not configured), _handle_webhook in channels/slack.py was accepting and processing event_callback payloads without any signature verification (line 795). This allows unauthenticated injection of arbitrary Slack events. The fix adds a fail-closed check: if signing_secret is None and the payload type is event_callback, return 403 instead of ingesting the event.

## What
- src/agentos/channels/slack.py — reject event_callback when signing_secret is unset (fail-closed)
- tests/test_channels/test_channel_dedupe.py — updated existing dedup test to use signing_secret; added regression test for the auth bypass

## Verification
- uv run pytest tests/test_channels/test_channel_dedupe.py -q — 4 passed
- uv run ruff check src/agentos/channels/slack.py tests/test_channels/test_channel_dedupe.py — clean