### PR TITLE
fix(cli): sanitize session_id in export filename to prevent path traversal

### DIFF
--- a/src/agentos/cli/sessions_cmd.py
+++ b/src/agentos/cli/sessions_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,12 @@ _ACTION_FAILED = object()
 
 # Rows pulled before a client-side --search filter runs.
 _SEARCH_FETCH_LIMIT = 500
+
+
+def _safe_export_filename(session_id: str) -> str:
+    """Sanitize session_id for use in a filename — strip all unsafe chars."""
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", session_id).strip("-")
+    return safe or "session"
 
 
 def _resolved_key(payload: dict[str, Any], fallback: str) -> str:
@@ -377,7 +384,7 @@ def sessions_export(
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
         return
-    target = output or Path(f"{session_id.replace(':', '-')}.{format}")
+    target = output or Path(f"{_safe_export_filename(session_id)}.{format}")
     if format == "json":
         target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     else:


### PR DESCRIPTION
Fixes #678

## Summary
The sessions export command in cli/sessions_cmd.py built the output filename from the raw session_id with only colon-to-dash replacement, so session_id values containing / or \ escaped the working directory (path traversal). The fix adds _safe_export_filename which strips everything except alphanumerics, underscore, dot and hyphen (mirroring _safe_archive_part in session/manager.py).

## What
- src/agentos/cli/sessions_cmd.py — added _safe_export_filename() and use it for the default export filename

## Verification
- uv run pytest tests/test_cli -q -k session — 41 passed
- uv run ruff check src/agentos/cli/sessions_cmd.py — clean
