### PR TITLE
fix(channels): decode Slack webhook body as latin-1 for signature check

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -989,7 +989,7 @@ class SlackChannel:
         """Verify Slack request signature using HMAC-SHA256."""
         if self.signing_secret is None:
             return False
-        sig_basestring = f"v0:{timestamp}:{body.decode()}"
+        sig_basestring = f"v0:{timestamp}:{body.decode('latin-1')}"
         expected = (
             "v0="
             + hmac.HMAC(

--- a/tests/test_channels/test_slack_signature_latin1.py
+++ b/tests/test_channels/test_slack_signature_latin1.py
@@ -1,0 +1,45 @@
+"""Regression tests for Slack webhook signature verification (issue #680)."""
+
+from __future__ import annotations
+
+from agentos.channels.slack import SlackChannel
+
+
+def test_verify_signature_handles_non_utf8_body() -> None:
+    """A non-UTF-8 body must not raise UnicodeDecodeError in _verify_signature."""
+    channel = SlackChannel(
+        token="xoxb-test",
+        slack_channel_id="C1",
+        signing_secret="test_secret",
+    )
+    body = b"\x80\x81\x82\xff\xfe"  # invalid UTF-8, valid latin-1
+    # Must return a bool (False for a junk signature), not raise
+    result = channel._verify_signature(body, "12345", "v0=junk")  # noqa: SLF001
+    assert result is False
+
+
+def test_verify_signature_still_accepts_valid_utf8() -> None:
+    """UTF-8 bodies keep working with the latin-1 decode."""
+    import hashlib
+    import hmac as hmac_mod
+
+    channel = SlackChannel(
+        token="xoxb-test",
+        slack_channel_id="C1",
+        signing_secret="test_secret",
+    )
+    body = b'{"type": "event_callback"}'
+    timestamp = "1234567890"
+    sig_basestring = f"v0:{timestamp}:{body.decode('latin-1')}"
+    expected = (
+        "v0="
+        + hmac_mod.HMAC(
+            b"test_secret",
+            sig_basestring.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+    )
+    result = channel._verify_signature(  # noqa: SLF001
+        body, timestamp, expected
+    )
+    assert result is True


### PR DESCRIPTION
Fixes #680

## Summary
_verify_signature in channels/slack.py decoded the request body with strict UTF-8, so a non-UTF-8 body raised UnicodeDecodeError and surfaced as an unhandled HTTP 500 instead of a clean 401/403. The fix decodes the body as latin-1, which maps every byte 0x00-0xFF faithfully for the HMAC input and never raises.

## What
- src/agentos/channels/slack.py — body.decode('latin-1') in _verify_signature
- tests/test_channels/test_slack_signature_latin1.py — regression tests: non-UTF-8 body returns False without raising, and valid UTF-8 signature still verifies True

## Verification
- uv run pytest tests/test_channels/test_slack_signature_latin1.py -q — 2 passed
- uv run ruff check src/agentos/channels/slack.py tests/test_channels/test_slack_signature_latin1.py — clean
