### PR TITLE
fix(channels): cap send_file at 25MB in email, discord and telegram adapters

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -1024,7 +1024,12 @@ class DiscordChannel:
     ) -> ChannelSendResult:
         max_send_file_bytes = 25 * 1024 * 1024  # 25 MB
         path = Path(file_path)
-        st = path.stat()
+        try:
+            st = path.stat()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"send_file: file not found: {file_path}"
+            ) from exc
         if st.st_size > max_send_file_bytes:
             raise ValueError(
                 f"File exceeds {max_send_file_bytes} byte limit for send_file"

--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -1022,6 +1022,13 @@ class DiscordChannel:
         file_path: str,
         content: str = "",
     ) -> ChannelSendResult:
+        max_send_file_bytes = 25 * 1024 * 1024  # 25 MB
+        path = Path(file_path)
+        st = path.stat()
+        if st.st_size > max_send_file_bytes:
+            raise ValueError(
+                f"File exceeds {max_send_file_bytes} byte limit for send_file"
+            )
         await self._rate_limiter.acquire()
         client = self._get_client()
         with open(file_path, "rb") as f:

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -757,6 +757,13 @@ class EmailChannel:
             )
             _attach(outbound, path.name, None, payload)
             await asyncio.to_thread(self._smtp_send, outbound)
+        except FileNotFoundError:
+            return ChannelSendResult.failed(
+                capability=ChannelCapabilities.NATIVE_FILE_UPLOAD,
+                target_id=thread_id,
+                reason=f"send_file: file not found: {file_path}",
+                retryable=False,
+            )
         except (OSError, ValueError, smtplib.SMTPException) as exc:
             return ChannelSendResult.failed(
                 capability=ChannelCapabilities.NATIVE_FILE_UPLOAD,

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -735,9 +735,15 @@ class EmailChannel:
         content: str = "",
     ) -> ChannelSendResult:
         """Mail one file back into ``thread_id`` as an attachment."""
+        max_send_file_bytes = 25 * 1024 * 1024  # 25 MB
 
         path = Path(file_path)
         try:
+            st = path.stat()
+            if st.st_size > max_send_file_bytes:
+                raise ValueError(
+                    f"File exceeds {max_send_file_bytes} byte limit for send_file"
+                )
             payload = path.read_bytes()
             to_address, subject, in_reply_to, references = self._resolve_target(
                 OutgoingMessage(content="", reply_to=thread_id)

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -1412,6 +1412,9 @@ class TelegramChannel:
         if not self.config.token:
             raise ValueError("telegram.send_file requires token")
         path = Path(file_path)
+        st = path.stat()
+        if st.st_size > 25 * 1024 * 1024:
+            raise ValueError("File exceeds 25MB limit for telegram send_file")
         payload = {"chat_id": str(chat_id)}
         if content:
             payload["caption"] = render_telegram_html(content)

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -1412,7 +1412,12 @@ class TelegramChannel:
         if not self.config.token:
             raise ValueError("telegram.send_file requires token")
         path = Path(file_path)
-        st = path.stat()
+        try:
+            st = path.stat()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"send_file: file not found: {file_path}"
+            ) from exc
         if st.st_size > 25 * 1024 * 1024:
             raise ValueError("File exceeds 25MB limit for telegram send_file")
         payload = {"chat_id": str(chat_id)}


### PR DESCRIPTION
Fixes #683

## Summary
send_file in the email, discord and telegram adapters read/stream files with no size ceiling. The fix adds a stat().st_size pre-check with a 25 MB ceiling in all three adapters, raising ValueError before any read/upload happens.

## What
- src/agentos/channels/email.py — size check before read_bytes()
- src/agentos/channels/discord.py — size check before multipart upload
- src/agentos/channels/telegram.py — size check before sendDocument upload

## Verification
- uv run pytest tests/test_channels -q — 292 passed
- uv run ruff check src/agentos/channels/email.py src/agentos/channels/discord.py src/agentos/channels/telegram.py — clean
