### PR TITLE
fix(mcp): upper-clamp events_wait and transcript limits in bridge

### DIFF
--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -131,8 +131,8 @@ class AgentOSMCPBridge:
             current_stream_seq = int(
                 subscription.get("current_stream_seq") or since_stream_seq or 0
             )
-            deadline = time.monotonic() + max(0, timeout_ms) / 1000
-            max_events = max(1, max_events)
+            deadline = time.monotonic() + min(max(0, timeout_ms), 300_000) / 1000
+            max_events = max(1, min(max_events, 10_000))
 
             while len(events) < max_events:
                 remaining = deadline - time.monotonic()
@@ -168,7 +168,7 @@ class AgentOSMCPBridge:
             await client.close()
 
     async def transcript_jsonl(self, key: str, limit: int = 1000) -> str:
-        history = await self.messages_read(key, limit=limit)
+        history = await self.messages_read(key, limit=min(max(1, limit), 5_000))
         messages = history.get("messages", []) if isinstance(history, dict) else []
         rows = [_message_to_event(row) for row in messages if isinstance(row, dict)]
         flattened: list[dict[str, Any]] = []


### PR DESCRIPTION
Fixes #685

## Summary
The MCP bridge accepted unbounded max_events, timeout_ms and history limit values from clients (only lower-clamped). The fix upper-clamps them: max_events to 10,000, timeout_ms to 300s, transcript/message limits to 5,000.

## What
- src/agentos/mcp_server/bridge.py — clamp events_wait timeout_ms/max_events and transcript_jsonl limit

## Verification
- uv run pytest tests/test_mcp_server tests/test_mcp -q — 30 passed
- uv run ruff check src/agentos/mcp_server/bridge.py — clean
