### PR TITLE
fix(intent_cache): _extract_rm_targets only parses first rm in compound command

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -49,9 +49,7 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
 _PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bos\.(?:remove|unlink|rmdir|removedirs)\s*\(\s*[\"']([^\"']+)[\"']"),
     re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(
-        r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.(?:unlink|rmdir)\s*\("
-    ),
+    re.compile(r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.(?:unlink|rmdir)\s*\("),
 )
 
 # Shell command separators that terminate a single ``rm`` invocation.
@@ -59,46 +57,56 @@ _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
 def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of an ``rm`` invocation.
+    """Pull every non-flag argument out of every ``rm`` invocation.
 
-    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Does not try to be a full shell parser — falls back to
-    whitespace split on shlex errors (unbalanced quotes).
+    Handles compound commands like ``rm a; rm b``, ``rm x && rm y`` by
+    splitting on shell separators and processing each segment independently.
+    Per-segment also handles ``rm a b c``, ``rm -rf /a /b``, quoted paths,
+    and stops at shell separators. Does not try to be a full shell parser
+    — falls back to whitespace split on shlex errors (unbalanced quotes).
     """
-    match = re.search(r"\brm\b([^\n]*)", command)
-    if not match:
-        return []
-    tail = match.group(1)
-
-    # Cut at the first shell separator so ``rm foo; ls bar`` doesn't pick ``ls``/``bar``.
-    cut = len(tail)
-    for sep in _SHELL_SEPARATORS:
-        idx = tail.find(sep)
-        if idx != -1 and idx < cut:
-            cut = idx
-    tail = tail[:cut].strip()
-    if not tail:
-        return []
-
-    token_sets: list[list[str]] = []
-    try:
-        token_sets.append(shlex.split(tail))
-    except ValueError:
-        token_sets.append(tail.split())
-    if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
-        try:
-            token_sets.append(shlex.split(tail, posix=False))
-        except ValueError:
-            token_sets.append(tail.split())
+    # Split compound command at shell separators so each segment is a
+    # single command. ``rm /tmp/ok; rm /root`` -> two segments, each
+    # with its own ``rm`` extracted.
+    _sep_pattern = "|".join(re.escape(s) for s in _SHELL_SEPARATORS)
 
     targets: list[str] = []
     seen: set[str] = set()
-    for tokens in token_sets:
-        for token in tokens:
-            if not token or token.startswith("-") or token in seen:
-                continue
-            seen.add(token)
-            targets.append(token)
+    for segment in re.split(_sep_pattern, command):
+        match = re.search(r"\brm\b([^\n]*)", segment)
+        if not match:
+            continue
+        tail = match.group(1)
+
+        # Cut at the first shell separator so ``rm foo; ls bar`` doesn't
+        # pick ``ls``/``bar``.  (Redundant after the outer split, but
+        # kept as a defensive double-check for space-separated segments.)
+        cut = len(tail)
+        for sep in _SHELL_SEPARATORS:
+            idx = tail.find(sep)
+            if idx != -1 and idx < cut:
+                cut = idx
+        tail = tail[:cut].strip()
+        if not tail:
+            continue
+
+        token_sets: list[list[str]] = []
+        try:
+            token_sets.append(shlex.split(tail))
+        except ValueError:
+            token_sets.append(tail.split())
+        if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
+            try:
+                token_sets.append(shlex.split(tail, posix=False))
+            except ValueError:
+                token_sets.append(tail.split())
+
+        for tokens in token_sets:
+            for token in tokens:
+                if not token or token.startswith("-") or token in seen:
+                    continue
+                seen.add(token)
+                targets.append(token)
     return targets
 
 
@@ -214,9 +222,7 @@ class IntentApprovalCache:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
             self._entries = {
-                intent: data
-                for intent, data in self._entries.items()
-                if data[1] != scope
+                intent: data for intent, data in self._entries.items() if data[1] != scope
             }
 
 

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -1,0 +1,97 @@
+"""Tests for intent_cache — compound command handling in _extract_rm_targets."""
+
+from __future__ import annotations
+
+from agentos.application.intent_cache import _extract_rm_targets
+
+
+def test_single_rm_simple() -> None:
+    """Single rm still works."""
+    assert _extract_rm_targets("rm /tmp/ok") == ["/tmp/ok"]
+
+
+def test_single_rm_multi_target() -> None:
+    """rm with multiple args extracts all."""
+    targets = _extract_rm_targets("rm -rf /tmp/a /tmp/b /tmp/c")
+    assert "/tmp/a" in targets
+    assert "/tmp/b" in targets
+    assert "/tmp/c" in targets
+
+
+def test_compound_rm_semicolon() -> None:
+    """Compound command: rm A; rm B — both extracted."""
+    targets = _extract_rm_targets("rm /tmp/ok; rm /root/.bash_history")
+    assert "/tmp/ok" in targets
+    assert "/root/.bash_history" in targets
+
+
+def test_compound_rm_and() -> None:
+    """Compound command: rm A && rm B — both extracted."""
+    targets = _extract_rm_targets("rm /tmp/ok && rm -rf /etc")
+    assert "/tmp/ok" in targets
+    assert "/etc" in targets
+
+
+def test_compound_rm_or() -> None:
+    """Compound command: rm A || rm B — both extracted."""
+    targets = _extract_rm_targets("rm -f /tmp/ok || rm /root")
+    assert "/tmp/ok" in targets
+    assert "/root" in targets
+
+
+def test_compound_rm_pipe() -> None:
+    """Compound command: rm A | rm B — both extracted."""
+    targets = _extract_rm_targets("rm /tmp/ok | rm /root/.ssh/id_rsa")
+    assert "/tmp/ok" in targets
+    assert "/root/.ssh/id_rsa" in targets
+
+
+def test_compound_rm_triple_multiplex() -> None:
+    """Three-segment compound: rm A; rm B; rm C — all three extracted."""
+    targets = _extract_rm_targets("rm /tmp/ok; rm /root; rm -rf /etc/passwd")
+    assert "/tmp/ok" in targets
+    assert "/root" in targets
+    assert "/etc/passwd" in targets
+
+
+def test_compound_rm_with_non_destructive_segment() -> None:
+    """Non-destructive segment in compound is ignored by rm extraction."""
+    targets = _extract_rm_targets("rm /tmp/trash; cat /root/.bash_history")
+    assert "/tmp/trash" in targets
+    # cat is not an rm command — not extracted
+    assert len(targets) == 1
+
+
+def test_compound_rm_with_leading_echo() -> None:
+    """Leading non-rm segment before rm is fine."""
+    targets = _extract_rm_targets("echo starting; rm /root/.bash_history")
+    assert "/root/.bash_history" in targets
+
+
+def test_only_non_rm_segments() -> None:
+    """No rm at all — empty result."""
+    assert _extract_rm_targets("cat /root/.bash_history") == []
+    assert _extract_rm_targets("ls /root") == []
+
+
+def test_empty_command() -> None:
+    """Empty string — empty result."""
+    assert _extract_rm_targets("") == []
+    assert _extract_rm_targets("   ") == []
+
+
+def test_compound_rm_sensitive_target_in_command() -> None:
+    """Integration: compound rm with sensitive path gets blocked."""
+    from agentos.sandbox.sensitive_paths import sensitive_target_in_command
+
+    # compound rm with second rm targeting sensitive path
+    assert (
+        sensitive_target_in_command("rm /tmp/ok; rm /root/.bash_history", cwd="/workspace")
+        is not None
+    )
+
+    # single rm targeting sensitive path still works
+    assert sensitive_target_in_command("rm /root/.bash_history", cwd="/workspace") is not None
+
+    # no sensitive path — not blocked
+    assert sensitive_target_in_command("rm /tmp/ok", cwd="/workspace") is None


### PR DESCRIPTION
## What
`_extract_rm_targets()` used `re.search(r"\brm\b([^\n]*)")`, which only captures the **first** `rm` in a compound command. For `rm /tmp/ok; rm /root/.bash_history`, only `/tmp/ok` was extracted and checked for sensitivity — the second segment silently bypassed `sensitive_target_in_command()`.

## Fix
Split the command by shell separators (`;`, `&&`, `||`, `|`, `&`) before running the existing rm-target extraction on each segment, so every `rm` invocation in a compound command yields its targets. `_PY_DELETE_PATTERNS` already used `finditer` (not `search`), so Python-style deletes were handled — rm extraction was the only gap.

## Tests
Added `tests/test_application/test_intent_cache.py` (12 tests) covering: single rm, multi-target rm, compound rm via `;` / `&&` / `||` / `|`, triple compound, non-destructive segment ignored, leading echo, no-rm commands, empty command, and an integration test asserting `sensitive_target_in_command()` now blocks compound rm targeting sensitive paths.

Quality gate: `ruff check` + `ruff format --check` clean, `mypy` clean, `pytest tests/test_application tests/test_sandbox` → 62 passed, 2 skipped.

Fixes #676