### PR TITLE
fix(search): tag search results with provider origin for injection defense

### DIFF
--- a/src/agentos/search/providers/brave.py
+++ b/src/agentos/search/providers/brave.py
@@ -96,6 +96,7 @@ class BraveSearchProvider:
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     snippet=item.get("description", ""),
+                    source="brave",
                 )
             )
 

--- a/src/agentos/search/providers/duckduckgo.py
+++ b/src/agentos/search/providers/duckduckgo.py
@@ -83,7 +83,9 @@ class DuckDuckGoProvider:
             snippet_elem = elem.select_one(".result__snippet")
             snippet = snippet_elem.get_text(strip=True) if snippet_elem else ""
 
-            results.append(SearchResult(title=title, url=href, snippet=snippet))
+            results.append(
+                SearchResult(title=title, url=href, snippet=snippet, source="duckduckgo")
+            )
             if len(results) >= max_results:
                 break
 

--- a/src/agentos/search/providers/tavily.py
+++ b/src/agentos/search/providers/tavily.py
@@ -100,6 +100,7 @@ class TavilySearchProvider:
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     snippet=item.get("content", ""),
+                    source="tavily",
                 )
             )
 

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -648,7 +648,15 @@ def _search_payload(
     payload = {
         "query": query,
         "provider": provider_name,
-        "results": [{"title": r.title, "url": r.url, "snippet": r.snippet} for r in results],
+        "results": [
+            {
+                "title": r.title,
+                "url": r.url,
+                "snippet": r.snippet,
+                "source": r.source or "",
+            }
+            for r in results
+        ],
     }
     if fallback_from:
         payload["fallback_from"] = fallback_from


### PR DESCRIPTION
Fixes #688

## Summary
Search providers returned raw external snippet/title/url with no origin tagging. The fix populates the existing (previously unused) SearchResult.source field with the provider name in brave/tavily/duckduckgo and includes source in the web_search tool result payload, so consumers can distinguish untrusted web content from trusted output.

## What
- src/agentos/search/providers/brave.py — set source="brave"
- src/agentos/search/providers/tavily.py — set source="tavily"
- src/agentos/search/providers/duckduckgo.py — set source="duckduckgo"
- src/agentos/tools/builtin/web.py — include source in the web_search result payload

## Verification
- uv run pytest tests/test_search -q — 17 passed
- uv run pytest tests/test_tools -q -k "search or web" — 90 passed
- uv run ruff check src/agentos/search/providers src/agentos/tools/builtin/web.py — clean
