### PR TITLE
fix(provider): group the Ollama model-not-found predicate explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The Ollama "model not found" branch of `classify_provider_error` now spells
+  out its grouping as `"model not found" in text or ("pull" in text and "model"
+  in text)`. The behaviour is unchanged — `and` already bound tighter than `or`
+  — but the intent no longer rests on implicit precedence, and the branch is
+  now covered by tests (#582).
+
 ## [2026.9.1] - 2026-09-01
 
 ### Added

--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -168,7 +168,7 @@ def classify_provider_error(
             return ProviderFailureKind.BAD_REQUEST
 
     if provider == "ollama":
-        if "model not found" in text or "pull" in text and "model" in text:
+        if "model not found" in text or ("pull" in text and "model" in text):
             return ProviderFailureKind.MODEL_NOT_FOUND
         if (
             "connection refused" in text

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -290,3 +290,50 @@ def test_new_transient_status_codes_match_via_text(message: str) -> None:
         classify_provider_error("openrouter", None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
     )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "model not found",
+        "model 'llama3' not found, try pulling it first",
+        "pull the model first",
+    ],
+)
+def test_ollama_missing_model_messages_classify_as_model_not_found(message: str) -> None:
+    assert (
+        classify_provider_error("ollama", None, message=message)
+        is ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "pull failed",
+        "model registry unavailable",
+    ],
+)
+def test_ollama_partial_pull_model_matches_do_not_classify_as_model_not_found(
+    message: str,
+) -> None:
+    assert (
+        classify_provider_error("ollama", None, message=message)
+        is not ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "connection refused",
+        "connection error",
+        "request error",
+        "timeout",
+    ],
+)
+def test_ollama_transport_messages_classify_as_transport_transient(message: str) -> None:
+    assert (
+        classify_provider_error("ollama", None, message=message)
+        is ProviderFailureKind.TRANSPORT_TRANSIENT
+    )


### PR DESCRIPTION
Closes #582

## What

`classify_provider_error` classified an Ollama missing-model failure with

```python
if "model not found" in text or "pull" in text and "model" in text:
```

The intent — `"model not found"`, **or** (`"pull"` **and** `"model"`) — was correct only because `and` binds tighter than `or`. This writes the grouping out:

```python
if "model not found" in text or ("pull" in text and "model" in text):
```

**No behaviour change.** The parentheses match Python's existing precedence exactly; this is a readability/robustness fix so a future edit to the branch can't silently re-associate it.

## Tests

The Ollama branch of the classifier had no coverage at all, so the change ships with tests that pin it:

- missing-model messages (`model not found`, `model 'llama3' not found, try pulling it first`, `pull the model first`) → `MODEL_NOT_FOUND`
- partial matches that must **not** trip the branch (`pull failed`, `model registry unavailable`) → not `MODEL_NOT_FOUND`
- transport messages (`connection refused`, `connection error`, `request error`, `timeout`) → `TRANSPORT_TRANSIENT`

These pass on both the old and the new expression, which is the point — they lock in the semantics the parentheses now state explicitly.

## Quality gate

Run against `upstream/main` (5b740f3):

- `uv run ruff check src tests` → All checks passed
- `uv run mypy src/agentos --show-error-codes` → no issues in 618 source files
- `uv run pytest -q` → 8651 passed, 27 skipped
- `uv build --wheel` → ok

Formatting note: `ruff format` would restyle ~412 pre-existing files repo-wide, so per AGENTS.md ("don't restyle untouched code") only the added block is format-clean; no untouched lines were reflowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116p1usKiKP8bjkRQeqTio5