### PR TITLE
fix(channels): resolve email recipients for agent-initiated and scheduled sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   — but the intent no longer rests on implicit precedence, and the branch is
   now covered by tests (#582).
 
+### Fixed
+
+- Email channel outbound sends no longer fail for every agent-initiated
+  message. `EmailChannel._resolve_target` read only `metadata["to"]` and the
+  in-memory inbound-thread table, so the built-in `message` tool (which writes
+  the target as `metadata["recipient"]`) and scheduler / heartbeat delivery
+  (which pass the bare address as `reply_to`) both raised
+  `ValueError: email.send has no recipient for reply_to`. Recipients now
+  resolve in order: `metadata["to"]`, `metadata["recipient"]`, the thread
+  cache, then `reply_to` when it parses as an address; a fresh outbound mail
+  with no thread also gets a real subject instead of `Re: (no subject)` (#598).
+
 ## [2026.9.1] - 2026-09-01
 
 ### Added

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -118,6 +118,7 @@ _QUOTE_MARKERS: tuple[re.Pattern[str], ...] = (
 _HTML_BREAK_RE = re.compile(r"(?i)<\s*(?:br\s*/?|/p|/div|/tr|/li)\s*>")
 _HTML_DROP_RE = re.compile(r"(?is)<\s*(script|style)\b.*?<\s*/\s*\1\s*>")
 _HTML_TAG_RE = re.compile(r"(?s)<[^>]+>")
+_DEFAULT_OUTBOUND_SUBJECT = "Message from AgentOS"
 
 
 class EmailChannelConfig(BaseModel):
@@ -166,6 +167,19 @@ def normalize_address(value: str) -> str:
 
     _, address = email.utils.parseaddr(value or "")
     return address.strip().lower()
+
+
+def is_email_address(value: str) -> bool:
+    """Return True when ``value`` carries a usable mailbox address.
+
+    Outbound callers hand us ``reply_to`` values that are sometimes an address
+    and sometimes an opaque routing token (``cron``, a thread key), so the
+    address fallback has to be able to tell the two apart.
+    """
+
+    address = normalize_address(value)
+    local, at, domain = address.partition("@")
+    return bool(local and at and domain)
 
 
 def sender_allowed(sender: str, allowlist: list[str] | tuple[str, ...]) -> bool:
@@ -634,14 +648,22 @@ class EmailChannel:
     def _resolve_target(self, message: OutgoingMessage) -> tuple[str, str, str, str]:
         """Return ``(to, subject, in_reply_to, references)`` for an outbound send."""
 
-        thread = self._threads.get((message.reply_to or "").strip())
+        reply_to = (message.reply_to or "").strip()
+        thread = self._threads.get(reply_to)
         metadata = message.metadata or {}
-        to_address = str(metadata.get("to") or (thread.to_address if thread else ""))
+        # The message tool writes "recipient", channel replies write "to", and
+        # scheduler/heartbeat delivery sends the bare address as reply_to, so
+        # every producer has to be able to name the mailbox.
+        to_address = str(
+            metadata.get("to") or metadata.get("recipient") or (thread.to_address if thread else "")
+        ).strip()
+        if not to_address and is_email_address(reply_to):
+            to_address = normalize_address(reply_to)
         if not to_address:
             raise ValueError("email.send has no recipient for reply_to")
         subject = str(metadata.get("subject") or "").strip()
         if not subject:
-            subject = reply_subject(thread.subject if thread else "")
+            subject = reply_subject(thread.subject) if thread else _DEFAULT_OUTBOUND_SUBJECT
         in_reply_to = str(metadata.get("in_reply_to") or (thread.last_message_id if thread else ""))
         references = str(metadata.get("references") or (thread.references if thread else ""))
         return to_address, subject, in_reply_to, references

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -14,10 +14,12 @@ import pytest
 from agentos.channels import email as email_module
 from agentos.channels.contract import ChannelSendStatus, run_channel_contract
 from agentos.channels.email import (
+    _DEFAULT_OUTBOUND_SUBJECT,
     EmailChannel,
     EmailChannelConfig,
     html_to_text,
     is_automated,
+    is_email_address,
     normalize_address,
     reply_subject,
     sender_allowed,
@@ -326,6 +328,91 @@ async def test_send_resolves_the_recipient_from_the_thread_cache(
 
     assert sent[0]["To"] == "owner@example.com"
     assert sent[0]["Subject"] == "Re: Status?"
+
+
+async def test_send_resolves_the_recipient_from_metadata_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The built-in message tool writes the target as ``metadata["recipient"]``."""
+
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(
+        OutgoingMessage(
+            content="Daily status update",
+            reply_to="colleague@example.com",
+            metadata={"recipient": "colleague@example.com"},
+        )
+    )
+
+    assert sent[0]["To"] == "colleague@example.com"
+    assert sent[0]["Subject"] == _DEFAULT_OUTBOUND_SUBJECT
+    assert sent[0].get("In-Reply-To") is None
+
+
+async def test_send_resolves_the_recipient_from_reply_to_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduler and heartbeat delivery pass the address as ``reply_to`` alone."""
+
+    channel = EmailChannel(config=_config())
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(OutgoingMessage(content="alert", reply_to="alerts@example.com"))
+
+    assert sent[0]["To"] == "alerts@example.com"
+    assert sent[0].get_content().strip() == "alert"
+
+
+async def test_send_recipient_resolution_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``to`` beats ``recipient`` beats the thread cache beats ``reply_to``."""
+
+    channel = EmailChannel(config=_config())
+    assert channel._to_incoming(_raw()) is not None
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(
+        OutgoingMessage(
+            content="x",
+            reply_to="m1@example.com",
+            metadata={"to": "first@example.com", "recipient": "second@example.com"},
+        )
+    )
+    await channel.send(
+        OutgoingMessage(
+            content="x",
+            reply_to="m1@example.com",
+            metadata={"recipient": "second@example.com"},
+        )
+    )
+    await channel.send(OutgoingMessage(content="x", reply_to="m1@example.com"))
+    await channel.send(OutgoingMessage(content="x", reply_to="fourth@example.com"))
+
+    assert [m["To"] for m in sent] == [
+        "first@example.com",
+        "second@example.com",
+        "owner@example.com",
+        "fourth@example.com",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("owner@example.com", True),
+        ("Owner Name <owner@example.com>", True),
+        ("unknown", False),
+        ("cron", False),
+        ("", False),
+        ("m1@example.com", True),
+    ],
+)
+def test_is_email_address_accepts_only_addressable_values(value: str, expected: bool) -> None:
+    assert is_email_address(value) is expected
 
 
 async def test_send_without_a_known_thread_is_refused() -> None:


### PR DESCRIPTION
Closes #598.

## Problem

`EmailChannel._resolve_target` (`src/agentos/channels/email.py`) read only `metadata["to"]` and the in-memory `self._threads` table, which is populated exclusively from inbound mail. Two producers can therefore never resolve a recipient:

- `agentos.tools.builtin.messaging._outgoing_metadata` writes the target as `metadata["recipient"]` for every non-telegram/slack channel.
- `agentos.scheduler.delivery` (and `heartbeat_service`) builds `OutgoingMessage(content=text, reply_to=channel_id or None)` with no metadata at all.

Both landed on `raise ValueError("email.send has no recipient for reply_to")`, so agent-initiated and cron-initiated email was broken 100% of the time — only replies into a thread the channel had itself received could send.

## Fix

Recipient resolution follows the precedence agreed on the issue:

1. `metadata["to"]`
2. `metadata["recipient"]`
3. the thread cache (`thread.to_address`)
4. `message.reply_to` when it parses as an address (new module-level `is_email_address` helper, so opaque routing tokens like `cron` or `unknown` still refuse)
5. otherwise the existing `ValueError`

One adjacent correctness fix in the same function: with no thread to reply into, the subject fell through to `reply_subject("")` → `Re: (no subject)`. A brand-new outbound mail now gets `_DEFAULT_OUTBOUND_SUBJECT` instead. Threaded replies keep their existing `Re: <subject>` behaviour.

## Tests

`tests/test_channels/test_email_channel.py`:

- `test_send_resolves_the_recipient_from_metadata_recipient` — the `message` tool path.
- `test_send_resolves_the_recipient_from_reply_to_address` — the scheduler / heartbeat path.
- `test_send_recipient_resolution_precedence` — all four tiers in one channel, asserting the resolution order.
- `test_is_email_address_accepts_only_addressable_values` — parametrized helper coverage.

`test_send_without_a_known_thread_is_refused` still passes unchanged: `reply_to="unknown"` is not an address, so refusal behaviour is preserved.

## Verification

- `uv run ruff check src tests` / `ruff format --check` on the changed files — clean.
- `uv run mypy src/agentos --show-error-codes` — only the pre-existing `mem0` missing-stubs error.
- `uv run pytest -q -m "not llm"` — 8648 passed. Three failures are pre-existing in this environment and reproduce on an unmodified checkout (`mem0` happens to be installed, and `weasyprint`'s native libs are missing).

## Note for reviewers

#575 is landing an allowlist check on the outbound recipient. This PR does not touch outbound policy — it only widens where the address is read from — so the two should compose: the allowlist check applies to whatever address this function returns. Worth noting that tier 4 means a `reply_to` that looks like an address but is really an evicted thread key (thread keys are Message-ID shaped) would now be mailed instead of raising; the outbound allowlist from #575 is the right place to catch that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wjtDpZCmdPh6DghsPv1Mm