### PR TITLE
fix(env-policy): deny proxy names on the write surface (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- Proxy names are no longer writable through any AgentOS surface. `set_env_var`
+  (and the Web UI, `agentos env set`, and the gateway RPC) could previously
+  write `AGENTOS_LLM_PROXY`, which `gateway/llm_runtime.py`, `provider/openai.py`
+  and `provider/auxiliary.py` apply to every provider client — letting an agent,
+  or a prompt injection reaching one, route all model traffic through a proxy of
+  its choosing and read the `Authorization` header off it. `AGENTOS_LLM_PROXY`,
+  `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` and `NO_PROXY` now join
+  `env_policy.WRITE_DENYLIST`, matched in **any casing** — the proxy readers
+  (`urllib.request.getproxies_environment()`, which httpx goes through)
+  lower-case every name they find, so denying only the two conventional
+  spellings would leave `Http_Proxy` as an equivalent way in. `AGENTOS_TRUST_ENV`,
+  which decides whether the ambient `*_PROXY` names are honoured at all, is
+  denied with the other posture names. Values exported in the shell or
+  hand-written into `~/.agentos/.env` keep working; only writing through
+  AgentOS is refused (#550).
+
 ### Fixed
 
 - `upsert_llm_provider` now validates an operator-supplied provider `base_url`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -499,9 +499,11 @@ command tells you when that is the case.
 
 Names that steer subprocess execution (`PATH`, `LD_PRELOAD`, `PYTHONPATH`,
 `EDITOR`, …) or AgentOS runtime posture (`AGENTOS_AGENT_PERMISSIONS`,
-`AGENTOS_GATEWAY_TOKEN`, `AGENTOS_STATE_DIR`, …) are refused, so this surface
-cannot be used to widen what the agent is allowed to do. Edit
-`~/.agentos/.env` by hand if you genuinely need one of them. Variables already
+`AGENTOS_GATEWAY_TOKEN`, `AGENTOS_STATE_DIR`, …) or outbound routing
+(`HTTP_PROXY`, `AGENTOS_LLM_PROXY`, `AGENTOS_TRUST_ENV`, … — proxy names in
+any casing) are refused, so this surface cannot be
+used to widen what the agent is allowed to do. Edit `~/.agentos/.env` by hand
+if you genuinely need one of them. Variables already
 set that way keep working; only writing through AgentOS is gated.
 
 If `agentos env list` reports a variable as coming from `process env`, the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,9 +67,18 @@ every AgentOS surface — the Web UI, the CLI, the RPC, and the agent tool:
 - AgentOS posture and state location: `AGENTOS_SENSITIVE_PATHS_DISABLED`,
   `AGENTOS_SENSITIVE_PAYLOAD_DISABLED`, `AGENTOS_REDACT_SECRETS`,
   `AGENTOS_STRIP_PROVIDER_ENV`, `AGENTOS_SHELL_DENYLIST`, `AGENTOS_SAFE_BIN_*`,
-  `AGENTOS_AGENT_PERMISSIONS`, `AGENTOS_HOOKS`, `AGENTOS_GATEWAY_TOKEN`,
-  `AGENTOS_GATEWAY_CONFIG_PATH`, `AGENTOS_STATE_DIR`, `AGENTOS_ROOT`, and the
+  `AGENTOS_AGENT_PERMISSIONS`, `AGENTOS_TRUST_ENV`, `AGENTOS_HOOKS`,
+  `AGENTOS_GATEWAY_TOKEN`, `AGENTOS_GATEWAY_CONFIG_PATH`, `AGENTOS_STATE_DIR`, `AGENTOS_ROOT`, and the
   bind settings
+- Outbound routing: `AGENTOS_LLM_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`,
+  `ALL_PROXY`, `NO_PROXY` — **in any casing**, because the libraries that read
+  these names lower-case them first, so `Http_Proxy` routes traffic exactly as
+  `HTTP_PROXY` does. `AGENTOS_LLM_PROXY` is applied to every provider client,
+  so a writable proxy name would let a surface hand each request — API key
+  header included — to a machine of its choosing. `AGENTOS_TRUST_ENV`, which
+  decides whether the ambient `*_PROXY` names are honoured at all, is refused
+  for the same reason. Configure a proxy through `llm.proxy` in the config
+  file, or export it in the shell that starts the gateway.
 
 Tools AgentOS spawns inherit most of `os.environ`, and several AgentOS guards
 are themselves read from it, so a surface that could write these names could

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -407,8 +407,9 @@ screen says so when that is the case.
 Two things the screen deliberately makes visible:
 
 - **Locked variables.** Names that steer subprocess execution or AgentOS
-  runtime posture (`PATH`, `LD_PRELOAD`, `AGENTOS_AGENT_PERMISSIONS`, …) show a
-  lock instead of an edit control. See
+  runtime posture, or outbound routing (`PATH`, `LD_PRELOAD`,
+  `AGENTOS_AGENT_PERMISSIONS`, `HTTP_PROXY`, …) show a lock instead of an edit
+  control. See
   [configuration.md](configuration.md#what-cannot-be-written-through-agentos).
 - **Shadowed variables.** If the shell that started the gateway exported a
   variable, that value wins over the file and editing here has no effect until

--- a/src/agentos/env_policy.py
+++ b/src/agentos/env_policy.py
@@ -107,6 +107,7 @@ _SHELL_NAMES = (
 #   AGENTOS_SHELL_DENYLIST            tools/builtin/shell_policy.py
 #   AGENTOS_SAFE_BIN_ALLOW/DENY/WARN  tools/builtin/shell_policy.py
 #   AGENTOS_AGENT_PERMISSIONS         cli/agent_cmd.py
+#   AGENTOS_TRUST_ENV                 env.py (honour ambient *_PROXY at all)
 #   AGENTOS_HOOKS                     engine/runtime.py
 #   AGENTOS_GATEWAY_TOKEN             cli/gateway_rpc.py
 #   AGENTOS_GATEWAY_CONFIG_PATH       gateway config resolution
@@ -124,6 +125,7 @@ _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_SAFE_BIN_DENY",
     "AGENTOS_SAFE_BIN_WARN",
     "AGENTOS_AGENT_PERMISSIONS",
+    "AGENTOS_TRUST_ENV",
     "AGENTOS_HOOKS",
     "AGENTOS_GATEWAY_TOKEN",
     "AGENTOS_GATEWAY_CONFIG_PATH",
@@ -139,16 +141,50 @@ _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_HTTP_DOWNLOAD_LIMIT",
 )
 
+# Group 5 — egress steering. A proxy name is a posture name: whoever sets it
+# chooses the machine every outbound request is handed to, credentials and all.
+# ``AGENTOS_LLM_PROXY`` is read at ``gateway/llm_runtime.py``,
+# ``provider/openai.py`` and ``provider/auxiliary.py`` and applied to every
+# provider client, so a writable value puts an attacker in front of each
+# ``Authorization: Bearer ...`` header. The standard ``*_PROXY`` names reach the
+# same place through ``trust_env`` on any subprocess or library that honours
+# them, and ``NO_PROXY`` belongs here too — carving a host out of the proxy is
+# as much a routing decision as adding one.
+#
+# Case is not a boundary here. ``agentos.env`` pushes ``.env`` keys into
+# ``os.environ`` verbatim, and the readers downstream lower-case whatever they
+# find — ``urllib.request.getproxies_environment()``, which httpx goes through,
+# treats ``Http_Proxy`` as ``http://`` just as readily as ``HTTP_PROXY``. So
+# these names are matched case-insensitively (``_EGRESS_UPPER`` below) rather
+# than by exact spelling; the two conventional spellings stay in
+# ``WRITE_DENYLIST`` so a plain membership test still sees them.
+_EGRESS_NAMES = (
+    "AGENTOS_LLM_PROXY",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+)
+
+#: Egress names upper-cased, for the case-insensitive comparison. Any spelling
+#: of these — ``Http_Proxy``, ``hTTp_PrOXy`` — is refused.
+_EGRESS_UPPER: frozenset[str] = frozenset(name.upper() for name in _EGRESS_NAMES)
+
 #: Names that may never be written through an AgentOS surface.
 WRITE_DENYLIST: frozenset[str] = frozenset(
-    _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _AGENTOS_POSTURE_NAMES
+    _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _AGENTOS_POSTURE_NAMES + _EGRESS_NAMES
 )
 
 _DENY_MESSAGE = (
     "Environment variable {key!r} cannot be written through AgentOS. Names that "
     "steer subprocess execution (PATH, LD_PRELOAD, PYTHONPATH, EDITOR, ...) or "
     "AgentOS runtime posture (AGENTOS_AGENT_PERMISSIONS, AGENTOS_GATEWAY_TOKEN, "
-    "...) are refused so this surface cannot escalate its own privileges. Edit "
+    "...) or outbound routing (HTTP_PROXY, AGENTOS_LLM_PROXY, ...) are refused "
+    "so this surface cannot escalate its own privileges. Edit "
     "~/.agentos/.env directly if you genuinely need to set it."
 )
 
@@ -166,15 +202,20 @@ def assert_valid_name(key: str) -> None:
         )
 
 
+def _is_denied(key: str) -> bool:
+    """Return whether *key* is on the denylist under either matching rule."""
+    return key in WRITE_DENYLIST or key.upper() in _EGRESS_UPPER
+
+
 def is_writable(key: str) -> bool:
     """Return whether *key* may be written through an AgentOS surface."""
-    return bool(ENV_NAME_RE.match(key)) and key not in WRITE_DENYLIST
+    return bool(ENV_NAME_RE.match(key)) and not _is_denied(key)
 
 
 def assert_writable(key: str) -> None:
     """Raise :class:`EnvPolicyError` unless *key* passes the name and deny gates."""
     assert_valid_name(key)
-    if key in WRITE_DENYLIST:
+    if _is_denied(key):
         raise EnvPolicyError(_DENY_MESSAGE.format(key=key))
 
 

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -181,8 +181,10 @@ binaries read. `agentos env list` shows every variable AgentOS knows about,
 whether it is set, and which skill or provider needs it — values are masked
 unless you ask for `agentos env get <NAME> --reveal`. Names that steer
 subprocess execution (`PATH`, `LD_PRELOAD`, `EDITOR`, …) or runtime posture
-(`AGENTOS_AGENT_PERMISSIONS`, `AGENTOS_GATEWAY_TOKEN`, …) cannot be written
-through AgentOS; edit the file by hand if one is genuinely needed. When
+(`AGENTOS_AGENT_PERMISSIONS`, `AGENTOS_GATEWAY_TOKEN`, …) or outbound routing
+(`HTTP_PROXY`, `AGENTOS_LLM_PROXY`, `AGENTOS_TRUST_ENV`, … — proxy names in any
+casing) cannot be written through AgentOS; edit
+the file by hand if one is genuinely needed. When
 `agentos env list` reports a variable's source as `process env`, the shell
 that started the gateway exported it and that value wins over the file.
 

--- a/tests/test_env_policy.py
+++ b/tests/test_env_policy.py
@@ -45,11 +45,22 @@ class TestDenylist:
             "AGENTOS_SENSITIVE_PATHS_DISABLED",
             "AGENTOS_SAFE_BIN_ALLOW",
             "AGENTOS_AGENT_PERMISSIONS",
+            "AGENTOS_TRUST_ENV",
             "AGENTOS_HOOKS",
             "AGENTOS_GATEWAY_TOKEN",
             "AGENTOS_STATE_DIR",
             "AGENTOS_GATEWAY_PORT",
             "AGENTOS_HTTP_DOWNLOAD_LIMIT",
+            # egress steering
+            "AGENTOS_LLM_PROXY",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+            "no_proxy",
         ],
     )
     def test_execution_and_posture_names_are_refused(self, name: str) -> None:
@@ -75,6 +86,61 @@ class TestDenylist:
 
     def test_invalid_name_is_not_writable_even_when_absent_from_denylist(self) -> None:
         assert env_policy.is_writable("1BAD") is False
+
+    def test_proxy_names_are_denied_in_both_conventional_cases(self) -> None:
+        """Libraries honour ``http_proxy`` as readily as ``HTTP_PROXY``.
+
+        Denying only the upper-case spelling would leave the exfiltration path
+        of issue #550 open through the lower-case one.
+        """
+        for upper in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+            assert upper in env_policy.WRITE_DENYLIST
+            assert upper.lower() in env_policy.WRITE_DENYLIST
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Http_Proxy",
+            "hTTps_PrOxY",
+            "All_Proxy",
+            "No_Proxy",
+            "Agentos_Llm_Proxy",
+        ],
+    )
+    def test_proxy_names_are_denied_in_any_casing(self, name: str) -> None:
+        """Exact-case matching would leave a mixed-case bypass.
+
+        ``agentos.env`` pushes ``.env`` keys into ``os.environ`` verbatim, and
+        ``urllib.request.getproxies_environment()`` — what httpx reads proxies
+        through — lower-cases every name it finds, so ``Http_Proxy`` routes
+        traffic exactly as ``HTTP_PROXY`` does.
+        """
+        assert env_policy.is_writable(name) is False
+        with pytest.raises(EnvPolicyError, match="cannot be written through AgentOS"):
+            env_policy.assert_writable(name)
+
+    def test_case_insensitivity_does_not_leak_to_the_rest_of_the_denylist(self) -> None:
+        """Only the proxy family is matched case-insensitively.
+
+        ``path`` and ``Ld_Preload`` are not names any loader or shell reads, and
+        widening the whole denylist would start refusing ordinary lower-case
+        application variables.
+        """
+        assert env_policy.is_writable("path") is True
+        assert env_policy.is_writable("Ld_Preload") is True
+
+    def test_trust_env_cannot_be_written(self) -> None:
+        """``AGENTOS_TRUST_ENV`` gates whether the ambient ``*_PROXY`` names are
+        honoured at all, so a writable value re-opens the same route."""
+        with pytest.raises(EnvPolicyError, match="cannot be written through AgentOS"):
+            env_policy.assert_writable("AGENTOS_TRUST_ENV")
+
+    def test_llm_proxy_cannot_be_written_while_llm_settings_still_can(self) -> None:
+        """The denial is name-by-name, not a block on the LLM config family."""
+        with pytest.raises(EnvPolicyError, match="cannot be written through AgentOS"):
+            env_policy.assert_writable("AGENTOS_LLM_PROXY")
+        env_policy.assert_writable("AGENTOS_LLM_BASE_URL")
+        env_policy.assert_writable("AGENTOS_LLM_MODEL")
 
 
 class TestSanitizeValue:


### PR DESCRIPTION
Closes #550.

## The hole

`env_policy.WRITE_DENYLIST` was built from four groups — loader, interpreter, shell, AgentOS posture — and none of them contained a proxy name. So `env_policy.assert_writable("AGENTOS_LLM_PROXY")` returned cleanly, and every write surface (the `set_env_var` builtin, `agentos env set`, the gateway RPC, the Web UI) would store it.

That name is read at `gateway/llm_runtime.py:67`, `provider/openai.py:226` and `provider/auxiliary.py:222` and applied to every provider client. A chat-privileged agent — or a prompt injection reaching one — could set it to a host it controls and take the `Authorization: Bearer ...` header off every subsequent model request, plus a position to tamper with responses on the way back.

`HTTP_PROXY` and friends reach the same position through `trust_env` on any subprocess or library that honours them.

## The fix

A fifth group, `_EGRESS_NAMES` — `AGENTOS_LLM_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` — folded into `WRITE_DENYLIST`, **matched case-insensitively**.

Case is not a boundary for this family. `agentos.env` pushes `.env` keys into `os.environ` verbatim (`env.py:124`), and `urllib.request.getproxies_environment()` — what httpx reads proxies through — lower-cases every name it finds, so `Http_Proxy` routes traffic exactly as `HTTP_PROXY` does. Listing the two conventional spellings is not enough; `is_writable` / `assert_writable` now compare `key.upper()` against `_EGRESS_UPPER`. The rest of the denylist keeps exact-case matching — `path` and `Ld_Preload` are not names any loader or shell reads, and widening the whole list would start refusing ordinary lower-case application variables. Both conventional spellings stay in `WRITE_DENYLIST` so a plain membership test still sees them.

`NO_PROXY` is in for the same reason as the rest: carving a host *out* of a proxy is as much a routing decision as adding one.

`AGENTOS_TRUST_ENV` joins group 4. It gates `env.trust_env()`, which is what makes every AgentOS httpx client honour the `*_PROXY` vars in the first place — it is a posture name by the same definition as the rest of that group, and leaving it writable means an agent can turn on env-proxy trust and then supply the proxy.

The deny message names outbound routing alongside the existing categories.

## What does not change

The gate is write-only, as it has always been. A proxy exported in the shell that starts the gateway, or hand-written into `~/.agentos/.env`, keeps working exactly as before, and `llm.proxy` in the config file remains the supported way to configure one. I checked that nothing legitimately writes these names through an AgentOS surface today — `onboard_cmd.py`'s `--use-env-proxy` only *reads* the ambient value, and there is no proxy entry in the env catalog or the Web UI catalog.

`AGENTOS_` is still not blanket-blocked: `AGENTOS_LLM_BASE_URL`, `AGENTOS_LLM_MODEL` and `AGENTOS_LLM_API_KEY` stay writable, and a test pins that so the denial cannot silently widen into the whole config family.

## Tests

- The new names added to the existing `test_execution_and_posture_names_are_refused` parametrisation, so each is checked through both `is_writable` and `assert_writable`.
- `test_proxy_names_are_denied_in_any_casing` — `Http_Proxy`, `hTTps_PrOxY`, `All_Proxy`, `No_Proxy`, `Agentos_Llm_Proxy`.
- `test_case_insensitivity_does_not_leak_to_the_rest_of_the_denylist` — `path` and `Ld_Preload` stay writable.
- `test_trust_env_cannot_be_written`.
- `test_proxy_names_are_denied_in_both_conventional_cases` — pins the upper/lower pairing in `WRITE_DENYLIST` itself.
- `test_llm_proxy_cannot_be_written_while_llm_settings_still_can` — pins the name-by-name scope.

`85 passed` in `tests/test_env_policy.py`; `3643 passed` across the env / tools / gateway / config selection. The one failure in that sweep, `test_router_task_type_ceiling.py::test_ceiling_tier_is_configurable`, reproduces on `upstream/main` without this change. ruff check, ruff format and mypy are clean on the touched files.

Docs updated in the same change: the authoritative list in `docs/configuration.md` gains an "Outbound routing" bullet (noting the any-casing rule and `AGENTOS_TRUST_ENV`) pointing at `llm.proxy` as the alternative, and the summaries in `docs/cli.md`, `docs/web-ui.md` and the bundled `agentos` SKILL.md mention the new category.

Rebased onto `main` (`0def0e7`); the only conflict was in `CHANGELOG.md`, where the `Unreleased` section had gained entries for #551, #582 and #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017t4vTamMsYvkNvvtkrBXyN
