### PR TITLE
fix(security): close the DNS-rebinding TOCTOU in the SSRF guard (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   resolve in order: `metadata["to"]`, `metadata["recipient"]`, the thread
   cache, then `reply_to` when it parses as an address; a fresh outbound mail
   with no thread also gets a real subject instead of `Re: (no subject)` (#598).
+- **Security (SSRF, DNS rebinding):** the SSRF guard validated a URL by
+  resolving its hostname once, but httpx resolved that hostname *again* when it
+  opened the connection — so a short-TTL (rebinding) domain could answer with a
+  public address for the guard and with `169.254.169.254` for the socket,
+  handing an agent the cloud metadata endpoint and the instance credentials it
+  serves. `agentos.tools.ssrf_client` adds a validating httpcore network backend
+  that resolves and checks the destination itself at connect time and then
+  connects to a validated IP literal, so the address that was checked is the
+  address that is used; TLS is unchanged (SNI and certificate verification still
+  run against the origin hostname). `web_fetch`, the media image fetch,
+  `http_request` and `x_search` (metadata-endpoint floor only, so localhost and
+  LAN targets keep working) and skill-dependency downloads all fetch through it
+  (#516).
 
 ## [2026.9.1] - 2026-09-01
 

--- a/src/agentos/skills/hub/deps.py
+++ b/src/agentos/skills/hub/deps.py
@@ -121,12 +121,11 @@ async def _fetch_to_file(url: str, dest: Path) -> None:
     one at a time with the same guard applied to each, mirroring
     :mod:`agentos.tools.builtin.web_fetch`.
     """
-    import httpx
-
     from agentos.tools.ssrf import validate_http_url_for_fetch
+    from agentos.tools.ssrf_client import ssrf_guarded_client
 
     current_url = url
-    async with httpx.AsyncClient(timeout=120.0, follow_redirects=False) as client:
+    async with ssrf_guarded_client(timeout=120.0, follow_redirects=False) as client:
         for _hop in range(_MAX_DOWNLOAD_REDIRECTS + 1):
             validate_http_url_for_fetch(current_url)
             request = client.build_request("GET", current_url)

--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -279,6 +279,8 @@ def _sensitive_media_url_block(tool_name: str, url: str) -> dict | None:
 async def _fetch_image_url(url: str) -> tuple[bytes, str]:
     import httpx
 
+    from agentos.tools.ssrf_client import ssrf_guarded_client
+
     def _check_image_url(candidate_url: str) -> None:
         marker = _sensitive_media_url_block("image", candidate_url)
         if marker is not None:
@@ -293,7 +295,7 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
             raise ToolError(str(exc)) from exc
 
     try:
-        async with httpx.AsyncClient(
+        async with ssrf_guarded_client(
             timeout=30.0, follow_redirects=False, trust_env=_trust_env()
         ) as client:
             current_url = url

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -19,6 +19,7 @@ from agentos.search.types import SearchProviderError, SearchResult
 from agentos.tools.path_policy import reject_foreign_host_path
 from agentos.tools.registry import tool
 from agentos.tools.ssrf import assert_not_metadata_endpoint
+from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
 from agentos.tools.types import ToolError, UnsupportedURLSchemeError, current_tool_context
 
 
@@ -245,7 +246,15 @@ async def http_request(
 
     content: bytes | None = body.encode() if body else None
 
-    async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:
+    # Metadata-only policy at connect time: http_request keeps reaching
+    # localhost and LAN services on purpose, but a rebinding domain must not be
+    # able to swap a public answer for the instance-credential endpoint between
+    # the URL check and the socket.
+    async with ssrf_guarded_client(
+        timeout=timeout,
+        trust_env=_trust_env(),
+        validator=validate_metadata_only_address,
+    ) as client:
         response = await client.send(
             client.build_request(
                 method=method_upper,

--- a/src/agentos/tools/builtin/web_fetch.py
+++ b/src/agentos/tools/builtin/web_fetch.py
@@ -20,6 +20,7 @@ from agentos.result_budget import (
 from agentos.sandbox.integration import sandboxed
 from agentos.tools.registry import tool
 from agentos.tools.ssrf import validate_http_url_for_fetch
+from agentos.tools.ssrf_client import ssrf_guarded_client
 from agentos.tools.types import SSRFBlockedError, current_tool_context
 
 log = structlog.get_logger(__name__)
@@ -247,7 +248,10 @@ async def web_fetch(
     async def _do_fetch(user_agent: str) -> tuple[int, str, str, str, bool]:
         headers = dict(_DEFAULT_HEADERS)
         headers["User-Agent"] = user_agent
-        async with httpx.AsyncClient(
+        # The guarded client re-validates at connect time, so the address this
+        # socket dials is the one _check_ssrf approved — a rebinding domain
+        # cannot answer differently for the guard and for the connection.
+        async with ssrf_guarded_client(
             timeout=30.0,
             follow_redirects=False,
             trust_env=_trust_env(),

--- a/src/agentos/tools/builtin/x_search.py
+++ b/src/agentos/tools/builtin/x_search.py
@@ -58,6 +58,7 @@ from agentos.env import trust_env as _trust_env
 from agentos.sandbox.integration import sandboxed
 from agentos.tools.registry import tool
 from agentos.tools.ssrf import assert_not_metadata_endpoint
+from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
 
 log = structlog.get_logger(__name__)
 
@@ -392,7 +393,12 @@ async def _post_with_retries(
     """POST to xAI, retrying transient failures inside the total budget."""
     attempt = 0
     last_exc: Exception | None = None
-    async with httpx.AsyncClient(trust_env=_trust_env()) as client:
+    # Same floor the configured base URL was checked against, re-applied to the
+    # address the socket dials: a bearer token rides on every request here, so a
+    # rebinding host must not be able to redirect it to the metadata endpoint.
+    async with ssrf_guarded_client(
+        trust_env=_trust_env(), validator=validate_metadata_only_address
+    ) as client:
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -107,6 +107,63 @@ def _is_metadata_address(addr: IPAddress) -> bool:
     )
 
 
+def is_metadata_hostname(hostname: str) -> bool:
+    """Return whether *hostname* names a cloud metadata service."""
+    return hostname.strip().lower().rstrip(".") in _METADATA_HOSTNAMES
+
+
+def assert_address_not_metadata(hostname: str, addr: IPAddress) -> None:
+    """Raise :class:`SSRFBlockedError` if *addr* is a cloud metadata endpoint.
+
+    The address-level half of :func:`assert_not_metadata_endpoint`, split out so
+    the connect-time guard in :mod:`agentos.tools.ssrf_client` applies the exact
+    same policy to the address it is about to open a socket to.
+    """
+    if _is_metadata_address(addr):
+        raise SSRFBlockedError(
+            f"Blocked request to {hostname}: it resolves to {addr}, a cloud "
+            "metadata endpoint that serves instance credentials."
+        )
+
+
+def resolve_trusted_fake_ip_networks(
+    trusted_fake_ip_cidrs: Iterable[str] | None = None,
+) -> tuple[IPNetwork, ...]:
+    """Return the fake-IP networks to trust, defaulting to the process-wide set."""
+    if trusted_fake_ip_cidrs is None:
+        return _trusted_fake_ip_cidrs
+    return tuple(
+        ipaddress.ip_network(value)
+        for value in validate_trusted_fake_ip_cidrs(trusted_fake_ip_cidrs)
+    )
+
+
+def assert_address_allowed_for_fetch(
+    hostname: str,
+    addr: IPAddress,
+    trusted_networks: tuple[IPNetwork, ...] = (),
+) -> None:
+    """Raise :class:`SSRFBlockedError` if *addr* is not a valid fetch target.
+
+    The address-level half of :func:`validate_http_url_for_fetch`, split out so
+    the connect-time guard in :mod:`agentos.tools.ssrf_client` applies the exact
+    same policy to the address it is about to open a socket to.
+    """
+    block_reason = _hard_block_reason(addr)
+    if block_reason is not None:
+        raise SSRFBlockedError(_blocked_message(hostname, addr, block_reason))
+    if _is_trusted_fake_ip(addr, trusted_networks):
+        return
+    if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+        reason = (
+            f"reserved/private range; configure [tools].trusted_fake_ip_cidrs "
+            f"with {RFC2544_FAKE_IP_NETWORK} only if this is fake-IP DNS"
+            if addr in RFC2544_FAKE_IP_NETWORK
+            else "private/internal range"
+        )
+        raise SSRFBlockedError(_blocked_message(hostname, addr, reason))
+
+
 def assert_not_metadata_endpoint(url: str) -> None:
     """Raise :class:`SSRFBlockedError` if *url* targets a cloud metadata service.
 
@@ -127,7 +184,7 @@ def assert_not_metadata_endpoint(url: str) -> None:
     hostname = (parsed.hostname or "").strip().lower().rstrip(".")
     if not hostname:
         return
-    if hostname in _METADATA_HOSTNAMES:
+    if is_metadata_hostname(hostname):
         raise SSRFBlockedError(
             f"Blocked request to {hostname}: cloud metadata endpoints serve instance "
             "credentials and are never a valid agent target."
@@ -154,11 +211,7 @@ def assert_not_metadata_endpoint(url: str) -> None:
             addr = ipaddress.ip_address(info[4][0])
         except ValueError:  # pragma: no cover - getaddrinfo returned a non-address
             continue
-        if _is_metadata_address(addr):
-            raise SSRFBlockedError(
-                f"Blocked request to {hostname}: it resolves to {addr}, a cloud "
-                "metadata endpoint that serves instance credentials."
-            )
+        assert_address_not_metadata(hostname, addr)
 
 
 def validate_http_url_for_fetch(
@@ -179,30 +232,11 @@ def validate_http_url_for_fetch(
     except socket.gaierror as exc:
         raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
 
-    trusted_networks = (
-        tuple(
-            ipaddress.ip_network(value)
-            for value in validate_trusted_fake_ip_cidrs(trusted_fake_ip_cidrs)
-        )
-        if trusted_fake_ip_cidrs is not None
-        else _trusted_fake_ip_cidrs
-    )
+    trusted_networks = resolve_trusted_fake_ip_networks(trusted_fake_ip_cidrs)
 
     for info in infos:
         addr = ipaddress.ip_address(info[4][0])
-        block_reason = _hard_block_reason(addr)
-        if block_reason is not None:
-            raise SSRFBlockedError(_blocked_message(hostname, addr, block_reason))
-        if _is_trusted_fake_ip(addr, trusted_networks):
-            continue
-        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
-            reason = (
-                f"reserved/private range; configure [tools].trusted_fake_ip_cidrs "
-                f"with {RFC2544_FAKE_IP_NETWORK} only if this is fake-IP DNS"
-                if addr in RFC2544_FAKE_IP_NETWORK
-                else "private/internal range"
-            )
-            raise SSRFBlockedError(_blocked_message(hostname, addr, reason))
+        assert_address_allowed_for_fetch(hostname, addr, trusted_networks)
 
 
 def _hard_block_reason(addr: IPAddress) -> str | None:

--- a/src/agentos/tools/ssrf_client.py
+++ b/src/agentos/tools/ssrf_client.py
@@ -1,0 +1,230 @@
+"""SSRF-guarded HTTP client: validate the address the socket actually uses.
+
+The URL-level guards in :mod:`agentos.tools.ssrf` resolve a hostname once and
+check what came back. The fetch that follows goes through ``httpx``, which
+resolves the same hostname *again* when it opens the connection — so a
+short-TTL (DNS-rebinding) domain can answer with a public address for the
+guard's lookup and with ``169.254.169.254`` for the socket's. That is a
+time-of-check/time-of-use window, and the cloud metadata endpoint sits on the
+other side of it.
+
+The fix is to remove the second resolution rather than narrow the window: a
+network backend resolves the hostname itself at connect time, applies the same
+policy to every address it got, and then connects to a validated **IP literal**.
+The address that was checked is the address the socket uses, because nothing
+resolves the name a second time.
+
+TLS is unaffected. ``httpcore`` performs the handshake separately from the TCP
+connect and passes ``server_hostname`` from the request origin (or the
+``sni_hostname`` extension), never from the host it connected to — so SNI and
+certificate verification still run against the origin hostname. Only the TCP
+endpoint is pinned.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import anyio
+import httpcore
+import httpx
+
+from agentos.tools.ssrf import (
+    IPAddress,
+    assert_address_allowed_for_fetch,
+    assert_address_not_metadata,
+    is_metadata_hostname,
+    resolve_trusted_fake_ip_networks,
+)
+from agentos.tools.types import SSRFBlockedError
+
+#: The real client class, captured at import. Callers construct through
+#: ``httpx.AsyncClient`` so a test that monkeypatches that attribute still gets
+#: its double; this reference is only used to tell a real client (which must be
+#: guarded, or the call fails closed) from such a double (which never opens a
+#: socket).
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+#: Applied to every address a hostname resolves to, immediately before connect.
+AddressValidator = Callable[[str, IPAddress], None]
+
+__all__ = [
+    "AddressValidator",
+    "ValidatingNetworkBackend",
+    "ssrf_guarded_client",
+    "validate_fetch_address",
+    "validate_metadata_only_address",
+]
+
+
+def validate_fetch_address(hostname: str, addr: IPAddress) -> None:
+    """Full fetch policy: no private, loopback, link-local or reserved targets.
+
+    Used by ``web_fetch``, the media image fetch and skill-dependency downloads
+    — tools that only ever have business on the public internet.
+    """
+    assert_address_allowed_for_fetch(hostname, addr, resolve_trusted_fake_ip_networks())
+
+
+def validate_metadata_only_address(hostname: str, addr: IPAddress) -> None:
+    """Security floor: block cloud metadata endpoints, allow private addresses.
+
+    Used by ``http_request``, which is pointed at ``localhost`` and LAN services
+    on purpose and so cannot take the full fetch policy.
+    """
+    assert_address_not_metadata(hostname, addr)
+
+
+def _as_ip_literal(host: str) -> IPAddress | None:
+    try:
+        return ipaddress.ip_address(host.strip().strip("[]"))
+    except ValueError:
+        return None
+
+
+def _getaddrinfo_addresses(host: str, port: int) -> list[IPAddress]:
+    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    addresses: list[IPAddress] = []
+    for info in infos:
+        try:
+            addr = ipaddress.ip_address(info[4][0])
+        except ValueError:  # pragma: no cover - getaddrinfo returned a non-address
+            continue
+        if addr not in addresses:
+            addresses.append(addr)
+    return addresses
+
+
+class ValidatingNetworkBackend(httpcore.AsyncNetworkBackend):
+    """Network backend that validates the destination address it connects to.
+
+    Wraps another backend, resolving and checking the hostname itself and then
+    delegating the connect to a validated IP literal. Everything else — TLS,
+    HTTP/1.1 and HTTP/2, timeouts, socket options — is the wrapped backend's
+    behaviour, unchanged.
+    """
+
+    def __init__(
+        self,
+        validator: AddressValidator,
+        backend: httpcore.AsyncNetworkBackend | None = None,
+    ) -> None:
+        self._validator = validator
+        self._backend = backend if backend is not None else httpcore.AnyIOBackend()
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[Any] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        addresses = await self._validated_addresses(host, port)
+
+        last_error: Exception | None = None
+        for addr in addresses:
+            try:
+                return await self._backend.connect_tcp(
+                    str(addr),
+                    port,
+                    timeout=timeout,
+                    local_address=local_address,
+                    socket_options=socket_options,
+                )
+            except (httpcore.ConnectError, httpcore.ConnectTimeout, OSError) as exc:
+                # Every candidate here has already passed the guard, so trying
+                # the next one cannot reach a blocked address — it is the same
+                # fallback a resolver-driven connect would do internally.
+                last_error = exc
+        assert last_error is not None  # addresses is never empty past the guard
+        raise last_error
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[Any] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        # No name resolution, no rebinding window: a UDS path is the endpoint.
+        return await self._backend.connect_unix_socket(
+            path, timeout=timeout, socket_options=socket_options
+        )
+
+    async def sleep(self, seconds: float) -> None:
+        await self._backend.sleep(seconds)
+
+    async def _validated_addresses(self, host: str, port: int) -> list[IPAddress]:
+        """Resolve *host* and return the addresses, or raise if any is blocked."""
+        hostname = host.strip().lower().rstrip(".")
+        if is_metadata_hostname(hostname):
+            raise SSRFBlockedError(
+                f"Blocked request to {hostname}: cloud metadata endpoints serve instance "
+                "credentials and are never a valid agent target."
+            )
+
+        literal = _as_ip_literal(host)
+        if literal is not None:
+            addresses = [literal]
+        else:
+            try:
+                addresses = await anyio.to_thread.run_sync(_getaddrinfo_addresses, host, port)
+            except (socket.gaierror, UnicodeError, ValueError) as exc:
+                raise httpcore.ConnectError(f"Cannot resolve hostname: {host}") from exc
+            if not addresses:
+                raise httpcore.ConnectError(f"Cannot resolve hostname: {host}")
+
+        for addr in addresses:
+            self._validator(hostname, addr)
+        return addresses
+
+
+def _install_backend(client: httpx.AsyncClient, validator: AddressValidator) -> None:
+    """Swap the validating backend onto *client*'s default connection pool.
+
+    Only the default transport is touched. Proxy mounts keep their own
+    transports: a forwarding proxy connects to the *proxy*, which is often a
+    private address on purpose, and the destination name is resolved by the
+    proxy rather than by this process — there is no local rebinding window to
+    close there.
+
+    A caller that supplied its own transport (a mock, a recorder) owns its
+    connect path and is left alone. A stock transport whose pool cannot be
+    reached is a different story — that means httpx changed shape underneath
+    us, and returning an unguarded client there would silently reopen the
+    rebinding window, so it raises instead.
+    """
+    transport = client._transport
+    if not isinstance(transport, httpx.AsyncHTTPTransport):
+        return
+    pool = getattr(transport, "_pool", None)
+    backend = getattr(pool, "_network_backend", None)
+    if pool is None or backend is None:  # pragma: no cover - httpx internals changed
+        raise RuntimeError(
+            "Cannot install the SSRF-validating network backend on httpx "
+            f"{httpx.__version__} (transport {type(transport).__name__}); refusing to "
+            "fetch without connect-time SSRF validation."
+        )
+    pool._network_backend = ValidatingNetworkBackend(validator, backend)
+
+
+def ssrf_guarded_client(
+    *,
+    validator: AddressValidator = validate_fetch_address,
+    **kwargs: Any,
+) -> httpx.AsyncClient:
+    """Return an ``httpx.AsyncClient`` that validates addresses at connect time.
+
+    A plain client built from *kwargs* — every httpx default, including
+    environment proxy mounts, is preserved — with the default pool's network
+    backend wrapped so the address it dials is the address the guard approved.
+    """
+    client = httpx.AsyncClient(**kwargs)
+    if isinstance(client, _REAL_ASYNC_CLIENT):
+        # Installation failing raises rather than returning an unguarded
+        # client; no sockets exist yet, so the half-built client is dropped.
+        _install_backend(client, validator)
+    return client

--- a/tests/test_security/test_ssrf_dns_rebinding.py
+++ b/tests/test_security/test_ssrf_dns_rebinding.py
@@ -1,0 +1,297 @@
+"""The connect-time SSRF guard closes the DNS-rebinding TOCTOU (issue #516).
+
+The URL-level guard resolved a hostname and checked the answer; httpx then
+resolved the same name again when it opened the socket. A rebinding domain can
+answer differently for the two lookups, so the address that was validated was
+not necessarily the address that got connected. These tests pin the behaviour
+that removes the window: the backend resolves once, validates what it got, and
+dials a validated IP literal.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import threading
+
+import httpcore
+import httpx
+import pytest
+
+from agentos.tools import ssrf
+from agentos.tools.ssrf_client import (
+    ValidatingNetworkBackend,
+    ssrf_guarded_client,
+    validate_fetch_address,
+    validate_metadata_only_address,
+)
+from agentos.tools.types import SSRFBlockedError
+
+PUBLIC_IP = "93.184.216.34"
+METADATA_IP = "169.254.169.254"
+
+
+class _RecordingBackend(httpcore.AsyncNetworkBackend):
+    """Stand-in for the real backend that records what it was asked to dial."""
+
+    def __init__(self) -> None:
+        self.connections: list[tuple[str, int]] = []
+        self.streams: list[object] = []
+        self.unix_paths: list[str] = []
+        self.slept: list[float] = []
+
+    async def connect_tcp(self, host, port, timeout=None, local_address=None, socket_options=None):
+        self.connections.append((host, port))
+        stream = object()  # the caller never touches the stream in these tests
+        self.streams.append(stream)
+        return stream
+
+    async def connect_unix_socket(self, path, timeout=None, socket_options=None):
+        self.unix_paths.append(path)
+        return object()
+
+    async def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+
+
+def _sequence_resolver(*ips: str):
+    """Resolver that answers with a different address on each call.
+
+    IP literals resolve to themselves, so a validated literal can still be
+    dialled by the underlying backend.
+    """
+    calls: list[str] = []
+
+    def resolver(host, port=None, *args, **kwargs):
+        calls.append(host)
+        try:
+            ipaddress.ip_address(str(host).strip("[]"))
+        except ValueError:
+            index = min(len([c for c in calls if c == host]) - 1, len(ips) - 1)
+            answer = ips[index]
+        else:
+            answer = str(host)
+        family = socket.AF_INET6 if ipaddress.ip_address(answer).version == 6 else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, 6, "", (answer, port or 443))]
+
+    resolver.calls = calls  # type: ignore[attr-defined]
+    return resolver
+
+
+@pytest.fixture(autouse=True)
+def reset_trusted_fake_ip_cidrs():
+    ssrf.configure_trusted_fake_ip_cidrs([])
+    yield
+    ssrf.configure_trusted_fake_ip_cidrs([])
+
+
+async def test_backend_connects_to_the_address_it_validated(monkeypatch) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _sequence_resolver(PUBLIC_IP))
+    inner = _RecordingBackend()
+
+    await ValidatingNetworkBackend(validate_fetch_address, inner).connect_tcp("example.com", 443)
+
+    # An IP literal, not the hostname: nothing downstream re-resolves the name.
+    assert inner.connections == [(PUBLIC_IP, 443)]
+
+
+async def test_backend_hands_back_the_wrapped_stream_untouched(monkeypatch) -> None:
+    """TLS stays the wrapped backend's business.
+
+    The stream is returned as-is, so ``start_tls`` is httpcore's own call with
+    ``server_hostname`` taken from the request origin — SNI and certificate
+    verification still run against the hostname, not the pinned address.
+    """
+    monkeypatch.setattr(socket, "getaddrinfo", _sequence_resolver(PUBLIC_IP))
+    inner = _RecordingBackend()
+
+    stream = await ValidatingNetworkBackend(validate_fetch_address, inner).connect_tcp(
+        "example.com", 443
+    )
+
+    assert stream is inner.streams[-1]
+
+
+async def test_rebinding_to_the_metadata_endpoint_is_blocked_at_connect(monkeypatch) -> None:
+    """The guard's lookup says public, the connect-time lookup says metadata."""
+    resolver = _sequence_resolver(PUBLIC_IP, METADATA_IP)
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    inner = _RecordingBackend()
+    backend = ValidatingNetworkBackend(validate_fetch_address, inner)
+
+    # Resolution #1 — the URL-level guard, which passes.
+    ssrf.validate_http_url_for_fetch("https://rebind.example/x")
+
+    # Resolution #2 — what the socket would have used. It never reaches one.
+    with pytest.raises(SSRFBlockedError) as excinfo:
+        await backend.connect_tcp("rebind.example", 443)
+
+    assert METADATA_IP in str(excinfo.value)
+    assert inner.connections == []
+
+
+async def test_ip_literals_are_validated_without_resolving(monkeypatch) -> None:
+    def explode(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("an IP literal must not be resolved")
+
+    monkeypatch.setattr(socket, "getaddrinfo", explode)
+    inner = _RecordingBackend()
+    backend = ValidatingNetworkBackend(validate_fetch_address, inner)
+
+    with pytest.raises(SSRFBlockedError):
+        await backend.connect_tcp(METADATA_IP, 80)
+    assert inner.connections == []
+
+
+async def test_metadata_hostnames_are_blocked_by_name(monkeypatch) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _sequence_resolver(PUBLIC_IP))
+    inner = _RecordingBackend()
+    backend = ValidatingNetworkBackend(validate_fetch_address, inner)
+
+    with pytest.raises(SSRFBlockedError):
+        await backend.connect_tcp("metadata.google.internal", 80)
+    assert inner.connections == []
+
+
+async def test_metadata_only_validator_allows_private_but_not_metadata(monkeypatch) -> None:
+    """http_request keeps reaching localhost; it never reaches the IMDS."""
+    monkeypatch.setattr(socket, "getaddrinfo", _sequence_resolver("127.0.0.1"))
+    inner = _RecordingBackend()
+    backend = ValidatingNetworkBackend(validate_metadata_only_address, inner)
+
+    await backend.connect_tcp("dev.local", 8000)
+    assert inner.connections == [("127.0.0.1", 8000)]
+
+    with pytest.raises(SSRFBlockedError):
+        await backend.connect_tcp(METADATA_IP, 80)
+
+
+async def test_private_addresses_are_blocked_by_the_fetch_validator(monkeypatch) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _sequence_resolver("10.1.2.3"))
+    inner = _RecordingBackend()
+
+    with pytest.raises(SSRFBlockedError):
+        await ValidatingNetworkBackend(validate_fetch_address, inner).connect_tcp(
+            "intranet.example", 80
+        )
+    assert inner.connections == []
+
+
+async def test_unresolvable_hostname_raises_a_connect_error(monkeypatch) -> None:
+    def fail(*args, **kwargs):
+        raise socket.gaierror("nope")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fail)
+
+    with pytest.raises(httpcore.ConnectError):
+        await ValidatingNetworkBackend(validate_fetch_address, _RecordingBackend()).connect_tcp(
+            "nowhere.example", 80
+        )
+
+
+async def test_unix_sockets_and_sleep_delegate_to_the_wrapped_backend() -> None:
+    inner = _RecordingBackend()
+    backend = ValidatingNetworkBackend(validate_fetch_address, inner)
+
+    await backend.connect_unix_socket("/tmp/sock")
+    await backend.sleep(0.0)
+
+    assert inner.unix_paths == ["/tmp/sock"]
+    assert inner.slept == [0.0]
+
+
+def test_guarded_client_installs_the_backend_and_keeps_httpx_defaults() -> None:
+    client = ssrf_guarded_client(timeout=7.0, follow_redirects=False)
+
+    backend = client._transport._pool._network_backend
+    assert isinstance(backend, ValidatingNetworkBackend)
+    assert client.timeout.connect == 7.0
+    assert client.follow_redirects is False
+
+
+def test_guarded_client_leaves_proxy_mounts_alone(monkeypatch) -> None:
+    """A forwarding proxy resolves the destination itself; only the pool is swapped."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+    client = ssrf_guarded_client(trust_env=True)
+
+    assert isinstance(client._transport._pool._network_backend, ValidatingNetworkBackend)
+    proxy_transports = [t for pattern, t in client._mounts.items() if t is not None]
+    assert proxy_transports, "expected an env proxy mount"
+    for transport in proxy_transports:
+        assert not isinstance(transport._pool._network_backend, ValidatingNetworkBackend)
+
+
+def test_guarded_client_fails_closed_when_the_backend_cannot_be_installed(monkeypatch) -> None:
+    """A stock transport with no reachable pool means httpx changed shape."""
+
+    class _PoollessTransport(httpx.AsyncHTTPTransport):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self._pool = None  # type: ignore[assignment]
+
+    monkeypatch.setattr(httpx._client, "AsyncHTTPTransport", _PoollessTransport)
+
+    with pytest.raises(RuntimeError, match="refusing to fetch"):
+        ssrf_guarded_client()
+
+
+def test_guarded_client_leaves_a_caller_supplied_transport_alone() -> None:
+    """A mock/recorder transport owns its own connect path; nothing to pin."""
+    transport = httpx.MockTransport(lambda request: httpx.Response(200))
+
+    client = ssrf_guarded_client(transport=transport)
+
+    assert client._transport is transport
+
+
+class _LocalServer:
+    """A minimal HTTP/1.1 responder on an ephemeral loopback port."""
+
+    def __init__(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        try:
+            conn, _ = self._sock.accept()
+            with conn:
+                conn.recv(65536)
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n"
+                    b"Content-Length: 2\r\nConnection: close\r\n\r\nok"
+                )
+                conn.shutdown(socket.SHUT_WR)
+        except OSError:  # pragma: no cover - the socket closed under us
+            pass
+
+    def close(self) -> None:
+        self._sock.close()
+
+
+async def test_real_request_uses_the_first_resolution_only(monkeypatch) -> None:
+    """End-to-end: a name that rebinds after the guard still reaches the checked host.
+
+    The resolver answers ``127.0.0.1`` once and the metadata address every time
+    after. On an unguarded client the second answer is what the socket would
+    use; here the request completes against the address that was validated.
+    """
+    server = _LocalServer()
+    resolver = _sequence_resolver("127.0.0.1", METADATA_IP)
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    try:
+        async with ssrf_guarded_client(
+            timeout=5.0, validator=validate_metadata_only_address
+        ) as client:
+            response = await client.get(f"http://rebind.example:{server.port}/x")
+    finally:
+        server.close()
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+    # Exactly one lookup of the rebinding name: the guard's answer is the
+    # socket's answer, so there is no second resolution to poison.
+    assert resolver.calls.count("rebind.example") == 1


### PR DESCRIPTION
## Problem

`validate_http_url_for_fetch` / `assert_not_metadata_endpoint` resolve a hostname once and check the answer. The fetch that follows goes through `httpx`, which resolves the same hostname **again** at connect time. With a short-TTL (rebinding) domain the two lookups can return different addresses, so the guard validates a public IP while the socket connects to `169.254.169.254` — the cloud metadata endpoint, and the instance credentials it serves.

Fixes #516.

## Fix

`agentos.tools.ssrf_client` adds a `ValidatingNetworkBackend` (an httpcore network backend) that:

1. resolves the destination itself at connect time (in a worker thread),
2. applies the guard's policy to **every** address the resolver returned, and
3. delegates the connect to a validated **IP literal**.

The second resolution is gone rather than narrowed — the address that was checked is the address the socket uses. IP literals are validated without resolving at all; metadata hostnames (`metadata.google.internal`, …) are blocked by name.

`ssrf_guarded_client(**kwargs)` builds a plain `httpx.AsyncClient` (all httpx defaults and env proxy mounts intact) and swaps the backend onto the **default pool only**.

### Points the review asked about

- **TLS is unaffected.** httpcore does the handshake separately from the TCP connect and takes `server_hostname` from the request origin (or the `sni_hostname` extension), never from the host it dialled — so SNI and certificate verification still run against the origin hostname; only the TCP endpoint is pinned. The backend returns the wrapped backend's stream object untouched (asserted by a test), so `start_tls` is entirely httpcore's own call.
- **httpx defaults and env-proxy mounts survive.** Only `pool._network_backend` on the default transport is replaced. Proxy mounts keep their own transports on purpose: a forwarding proxy is dialled at a deliberately private address and resolves the destination itself, so there is no local rebinding window to close there. Both are covered by tests.
- **Every affected caller is covered:**
  | site | policy |
  |---|---|
  | `web_fetch` | full fetch policy |
  | media image fetch (`_fetch_image_url`) | full fetch policy |
  | `skills/hub/deps.py` (`_fetch_to_file`) | full fetch policy |
  | `http_request` | metadata-endpoint floor only — localhost/LAN targets keep working |
  | `x_search` (`_post_with_retries`) | metadata-endpoint floor only — same floor its configured base URL is already checked against, and a bearer token rides on every request there |

The address-level halves of the two URL guards (`assert_address_allowed_for_fetch`, `assert_address_not_metadata`, `is_metadata_hostname`, `resolve_trusted_fake_ip_networks`) are split out of `agentos.tools.ssrf` so the URL layer and the connect layer apply the exact same rules, including the `trusted_fake_ip_cidrs` configuration.

### Failure modes

- A blocked address raises `SSRFBlockedError` before any socket is opened.
- An unresolvable name raises `httpcore.ConnectError` (the request fails on its own, as it would have).
- If the backend cannot be installed on a **stock** transport (i.e. httpx changed shape underneath us), `ssrf_guarded_client` raises rather than returning an unguarded client — it fails closed. A caller-supplied transport (mock/recorder) owns its own connect path and is left alone.

## Tests

`tests/test_security/test_ssrf_dns_rebinding.py` (13 tests), including:

- the rebinding scenario end to end: the guard's lookup answers public, the connect-time lookup answers `169.254.169.254`, and the connect is blocked with no socket opened;
- a real request against a local server through a resolver that rebinds after the first answer — the request lands on the validated address and the rebinding name is resolved **exactly once**;
- the stream is passed through untouched (TLS unchanged);
- IP literals validated without resolution; metadata hostnames blocked by name; private addresses blocked by the fetch validator but allowed by the metadata-only validator; UDS/`sleep` delegation; proxy mounts left unguarded; fail-closed on a poolless stock transport.

## Verification

```
uv run ruff check src tests          # clean
uv run mypy src/agentos              # Success: no issues found in 619 source files
uv run pytest -q -m "not llm"        # 8673 passed, 23 skipped
```

(No frontend changes, so the React gate was not exercised. No CLI/config surface change, so `docs/cli.md` and the bundled `SKILL.md` are unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqvLaSytAAS2dSFZiPuqy5