### PR TITLE
fix(onboarding): validate LLM provider base_url before it reaches httpx (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `upsert_llm_provider` now validates an operator-supplied provider `base_url`
+  before it is persisted or handed to the httpx client. The RPC
+  (`onboarding.provider.configure`) and `agentos providers configure` accepted
+  any string, so a caller could point every completion request — carrying the
+  provider `Authorization` header — at a cloud metadata service, an internal
+  host, or an attacker's server, or hand a `file://` URL to httpx. The value
+  must now be an absolute http(s) URL and may not be a cloud metadata endpoint
+  or a private / link-local / reserved IP — including the `inet_aton` spellings
+  (`http://2852039166/`) that reach the metadata service without looking like
+  an address. Loopback stays allowed for local model servers, and a `base_url`
+  that is already persisted (a saved profile, a provider default, or the value
+  the onboarding import path replays) is not re-validated (#551).
+
 ### Changed
 
 - The Ollama "model not found" branch of `classify_provider_error` now spells

--- a/src/agentos/onboarding/mutations.py
+++ b/src/agentos/onboarding/mutations.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import functools
+import ipaddress
 import os
+import socket
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
@@ -417,6 +419,114 @@ def _validate_judge_base_url(base_url: str) -> None:
         )
 
 
+#: Hostnames that answer for a cloud metadata service. Kept in step with
+#: ``agentos.tools.ssrf``, duplicated rather than imported because the
+#: architecture contract keeps ``onboarding`` independent of ``tools``.
+_METADATA_HOSTNAMES: frozenset[str] = frozenset(
+    {
+        "metadata.google.internal",
+        "metadata.goog",
+        "instance-data",
+    }
+)
+
+#: Addresses that serve instance credentials. The link-local ones are already
+#: covered by the link-local check below; Alibaba Cloud's endpoint sits in a
+#: public range and would otherwise pass.
+_METADATA_ADDRESSES: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS / GCP / Azure / DO / Oracle
+        "169.254.169.253",  # Azure IMDS wire server
+        "169.254.170.2",  # AWS ECS task role credentials
+        "100.100.100.200",  # Alibaba Cloud
+        "fd00:ec2::254",  # AWS metadata over IPv6
+    }
+)
+
+
+def _parse_ip_literal(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Return the IP address *hostname* denotes, or ``None`` if it is a name.
+
+    ``ipaddress`` only accepts dotted-quad IPv4, but the C resolver httpx ends
+    up on also accepts the ``inet_aton`` forms — ``2852039166``, ``0251.0376.
+    0251.0376``, ``0xA9.0xFE.0xA9.0xFE`` all reach 169.254.169.254. Reading
+    those as ordinary hostnames would hand the metadata endpoint a free pass,
+    so fall back to ``inet_aton``, which rejects a real hostname.
+    """
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    try:
+        packed = socket.inet_aton(hostname)
+    except OSError:
+        return None
+    return ipaddress.IPv4Address(packed)
+
+
+def _validate_provider_base_url(base_url: str) -> None:
+    """Validate an operator-supplied LLM provider ``base_url``.
+
+    Every completion request goes to this URL carrying the provider
+    ``Authorization`` header, so an unvalidated value handed to the RPC
+    (``onboarding.provider.configure``) or the CLI redirects credentials to a
+    host of the caller's choosing. Require an absolute http(s) URL — this also
+    keeps non-network schemes such as ``file://`` away from the httpx client —
+    and reject the destinations that are never a legitimate provider endpoint:
+    cloud metadata services and private / link-local / reserved IP literals.
+
+    Loopback stays allowed: a local model server (Ollama, vLLM, LM Studio) is
+    the common reason to set a base_url at all. Hostnames are not resolved
+    here; the resolved address is a connect-time concern tracked separately.
+    """
+    from urllib.parse import urlparse
+
+    malformed = ValueError(
+        "base_url must be an absolute http(s) URL (e.g. https://openrouter.ai/api/v1)"
+    )
+    try:
+        # ``urlparse`` raises "Invalid IPv6 URL" on an unterminated literal
+        # such as ``http://[::1``.
+        parsed = urlparse(base_url)
+        raw_hostname = parsed.hostname
+    except ValueError as exc:
+        raise malformed from exc
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise malformed
+    hostname = (raw_hostname or "").strip().lower().rstrip(".")
+    if not hostname:
+        raise ValueError("base_url must include a hostname")
+    if hostname in _METADATA_HOSTNAMES:
+        raise ValueError(
+            f"base_url host {hostname!r} is a cloud metadata endpoint, "
+            "which is never a valid LLM provider"
+        )
+
+    addr = _parse_ip_literal(hostname)
+    if addr is None:
+        return
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        # ``::ffff:169.254.169.254`` is the same endpoint wearing another hat.
+        addr = addr.ipv4_mapped
+    if str(addr) in _METADATA_ADDRESSES:
+        raise ValueError(
+            f"base_url host {hostname!r} is a cloud metadata endpoint, "
+            "which is never a valid LLM provider"
+        )
+    if addr.is_loopback:
+        return
+    if addr.is_link_local:
+        raise ValueError(
+            f"base_url host {hostname!r} is a link-local address (cloud metadata "
+            "range), which is never a valid LLM provider"
+        )
+    if addr.is_private or addr.is_reserved or addr.is_multicast:
+        raise ValueError(
+            f"base_url host {hostname!r} is a private/reserved address; an LLM "
+            "provider must be a public host or loopback"
+        )
+
+
 def _verify_local_judge_endpoint(base_url: str, model: str, api_key: str) -> None:
     """Probe a local judge endpoint with one test classification (spec D2).
 
@@ -533,6 +643,14 @@ def upsert_llm_provider(
         if saved_profile is not None
         else (config.llm.base_url if active_provider == provider_id else "")
     )
+    # Validate only a *new* destination. A base_url restored from a saved
+    # profile or from the provider spec's default is trusted config, and the
+    # onboarding import path (``flow.py``) replays the already-persisted value
+    # as an explicit argument — re-checking either would turn an unrelated edit
+    # into a hard failure on a config the operator never typed.
+    base_url = str(base_url or "").strip()
+    if base_url and base_url != str(saved_base_url or "").strip():
+        _validate_provider_base_url(base_url)
     effective_base_url = base_url or saved_base_url or spec.default_base_url
     if spec.requires_base_url and not effective_base_url:
         raise ValueError(f"provider {provider_id!r} requires a base_url")

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -156,6 +156,112 @@ def test_unverified_base_url_provider_rejected_before_configuration():
         upsert_llm_provider(cfg, provider_id="azure", model="x", api_key="k")
 
 
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/v1",
+        "openrouter.ai/api/v1",  # no scheme
+        "https://",  # no host
+        "http://[::1",  # unterminated IPv6 literal
+    ],
+)
+def test_upsert_provider_rejects_non_http_base_url(base_url):
+    cfg = GatewayConfig()
+    with pytest.raises(ValueError, match="base_url must"):
+        upsert_llm_provider(
+            cfg,
+            provider_id="openrouter",
+            model="x",
+            api_key="sk-test",
+            base_url=base_url,
+        )
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://10.0.0.1:8080/internal",
+        "http://192.168.1.10:11434/v1",
+        "http://172.16.4.2/v1",
+        # inet_aton forms of 169.254.169.254 / 10.0.0.1 — ``ipaddress`` rejects
+        # them, the resolver httpx uses does not.
+        "http://2852039166/latest/meta-data/",
+        "http://0251.0376.0251.0376/",
+        "http://167772161:8080/internal",
+        # Alibaba Cloud's metadata endpoint sits in a public range.
+        "http://100.100.100.200/latest/meta-data/",
+        "http://[fd00:ec2::254]/latest/meta-data/",
+    ],
+)
+def test_upsert_provider_rejects_internal_base_url(base_url):
+    # An RPC/CLI caller must not be able to point provider traffic — which
+    # carries the Authorization header — at cloud metadata or the LAN.
+    cfg = GatewayConfig()
+    with pytest.raises(ValueError, match="never a valid LLM provider|private/reserved"):
+        upsert_llm_provider(
+            cfg,
+            provider_id="openrouter",
+            model="x",
+            api_key="sk-test",
+            base_url=base_url,
+        )
+    assert cfg.llm.base_url != base_url
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:11434/v1",
+        "http://[::1]:11434/v1",
+    ],
+)
+def test_upsert_provider_allows_loopback_base_url(base_url):
+    cfg = GatewayConfig()
+    res = upsert_llm_provider(cfg, provider_id="ollama", model="llama3.1", base_url=base_url)
+    assert res.config.llm.base_url == base_url
+
+
+def test_upsert_provider_accepts_replayed_stored_base_url():
+    # The onboarding import path (flow.py) re-supplies the persisted base_url as
+    # an explicit argument. That is the same destination, not a new one, so a
+    # config that predates this check must not dead-end the wizard.
+    cfg = GatewayConfig()
+    cfg.llm.provider = "ollama"
+    cfg.llm.model = "llama3.1"
+    cfg.llm.base_url = "http://192.168.1.10:11434/v1"
+    res = upsert_llm_provider(
+        cfg,
+        provider_id="ollama",
+        model="llama3.2",
+        base_url="http://192.168.1.10:11434/v1",
+    )
+    assert res.config.llm.base_url == "http://192.168.1.10:11434/v1"
+
+
+def test_upsert_provider_treats_none_base_url_as_omitted():
+    # An RPC caller can send an explicit JSON null; params.get returns it as-is.
+    cfg = GatewayConfig()
+    res = upsert_llm_provider(cfg, provider_id="ollama", model="llama3.1", base_url=None)
+    assert res.config.llm.provider == "ollama"
+
+
+def test_upsert_provider_does_not_revalidate_saved_base_url():
+    # Only the caller-supplied argument is validated: an operator editing an
+    # unrelated field on a provider whose stored base_url predates this check
+    # (or is intentionally on-host) must not be locked out.
+    cfg = GatewayConfig()
+    cfg.llm.provider = "ollama"
+    cfg.llm.model = "llama3.1"
+    cfg.llm.base_url = "http://192.168.1.10:11434/v1"
+    res = upsert_llm_provider(cfg, provider_id="ollama", model="llama3.2")
+    assert res.config.llm.base_url == "http://192.168.1.10:11434/v1"
+
+
 def test_ollama_does_not_require_api_key():
     cfg = GatewayConfig()
     res = upsert_llm_provider(cfg, provider_id="ollama", model="llama3.1")


### PR DESCRIPTION
Closes #551.

## The bug

`upsert_llm_provider` (`src/agentos/onboarding/mutations.py`) took `base_url: str` and never looked at it. Both entry points pass a caller-supplied value — `onboarding.provider.configure` over RPC (`rpc_onboarding.py:174`) and `agentos providers configure` (`cli/providers_cmd.py:128`) — and the value is persisted and handed to the httpx client that carries the provider `Authorization` header. The same module already validated the *judge* endpoint (`_validate_judge_base_url`); the provider base_url had nothing.

So a client could set it to `http://169.254.169.254/latest/meta-data/…` (instance credentials), `http://10.0.0.1:8080/internal` (internal reach), `http://attacker.example` (every request plus the API key), or `file:///etc/passwd` (non-network scheme into httpx).

## The fix

`_validate_provider_base_url` — require an absolute http(s) URL, then reject destinations that are never a legitimate provider:

- cloud metadata **hostnames** (`metadata.google.internal`, `metadata.goog`, `instance-data`) and **addresses**, mirroring `agentos.tools.ssrf` — including Alibaba's `100.100.100.200`, which is in a public range and would otherwise pass, and `fd00:ec2::254`;
- private / link-local / reserved / multicast IP literals, with `::ffff:` IPv4-mapped forms unwrapped first;
- host literals normalized through `inet_aton` before the address checks, so `http://2852039166/`, `http://0251.0376.0251.0376/` and `http://0xA9.0xFE.0xA9.0xFE/` — all of which reach 169.254.169.254 through the resolver but are rejected by `ipaddress` — do not walk past as "just a hostname".

**Loopback stays allowed**: a local model server (Ollama, vLLM, LM Studio) is the usual reason to set a base_url, and `localhost` / `127.0.0.1` / `[::1]` are unaffected.

**Only a new destination is validated.** A base_url coming from a saved profile or the provider spec default is trusted config. `flow.py`'s "keep imported provider" paths also replay the *already-persisted* value as an explicit argument, so the check is skipped when the argument equals what is already stored — otherwise an operator migrating a config whose provider points at a LAN box would hit an uncaught `ValueError` mid-wizard on a value they never typed.

The metadata hostname/address lists are duplicated from `agentos.tools.ssrf` rather than imported: `tests/test_ci/test_architecture_import_contracts.py` keeps `onboarding` independent of `tools`, and adding that edge for two constants isn't the right trade in a security fix.

## Scope

Per the issue: DNS rebinding at connect time is out of scope (#516). Two adjacent gaps found while reviewing and deliberately left for their own issues, since neither is what #551 describes:

- `proxy` on the same mutation is unvalidated and also reaches httpx — but a proxy is by definition "route my traffic through this host", and private addresses are legitimate there, so it needs a different policy rather than this one.
- `config.set {"path": "llm.base_url"}` writes the field with no validation at all (`llm.base_url` is not in `_READONLY_PATHS`). Closing that means moving the rule onto `LLMConfig` or the `config.set` path — a broader change than this fix.

## Tests

`tests/test_onboarding/test_mutations.py`: non-http(s) and malformed URLs rejected (including `file://`, a scheme-less value, and an unterminated IPv6 literal); metadata / LAN / numeric-spelling destinations rejected; loopback in three spellings accepted; a replayed stored private base_url accepted; an omitted and a JSON-`null` base_url treated as absent.

Gate: `ruff check src tests`, `mypy src/agentos`, `pytest -q` → 8691 passed, 27 skipped.
