### PR TITLE
fix(search): tag search results with provider origin for injection defense (#688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Search result `source` field is now populated by all three providers
-  (brave, tavily, duckduckgo) and included in the `web_search` tool result
-  payload, enabling downstream origin tagging to prevent indirect prompt
-  injection through search result snippets (#688).
+- Search results are now tagged with their provider origin (brave,
+  tavily, duckduckgo) so downstream injection guards can distinguish
+  provider content from direct user input (#688).
+
+- Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
+  `ConnectError`. All three happen before any request bytes reach Telegram — a
+  DNS/TLS handshake that never completed, or a wait for a pooled connection —
+  but the two timeouts are `TimeoutException` siblings of `ConnectError` rather
+  than subclasses, so `TelegramChannel._api()` dropped them into its generic
+  `RequestError` branch and raised on the very first attempt with zero retries.
+  `ReadTimeout` stays out of the retry path on purpose: by then the request is
+  in flight, and re-sending a `getUpdates` long poll would double-poll it.
+  ([#651](https://github.com/use-agent-os/agent-os/issues/651))
 - **`robinhood-rwa-addresses` now verifies every address against Robinhood
   Chain instead of trusting the token index.** The skill decided what counted
   as a genuine Stock Token from a name suffix in CoinGecko's list, which was
@@ -75,6 +84,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/*`, `/*/*`, `/**`, `/?*`, `/.*` and `/[a-z]*`. Globs that name a subset
   (`/tmp*`) are untouched, and root counts as sensitive only in the
   delete-intent scan — reading or listing `/` stays ordinary work (#563).
+- The image tool now reports a redirect that carries no `Location` header
+  instead of the confusing failure it caused downstream. `_fetch_image_url`
+  follows redirects itself so every hop is re-validated against the SSRF guard;
+  a 3xx with no `Location` closed the response and fell out of the loop, so the
+  failure surfaced as httpx's generic `Failed to fetch image from URL: Redirect
+  response '302 Found' for url ...` (or a `StreamClosed` from reading the body
+  that had just been closed, depending on the httpx version) rather than the
+  dead-end hop that actually broke. It now raises `Redirect response from <url>
+  missing Location header`, naming the URL that returned it.
 - Channel HTTP retries now cover every transient timeout, survive an
   HTTP-date `Retry-After`, and hand back an exhausted rate limit.
   `retry_request` caught `(ConnectError, ReadTimeout)`, but `ConnectTimeout`,
@@ -92,15 +110,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   rate limit returns the response — status, headers and provider error body
   intact — instead of sleeping once more and raising a bare
   `RuntimeError("retry_request exhausted")` (#642, #599).
+- The email channel can poll an IMAP folder whose name contains spaces.
+  `imap_folder` was handed to `imaplib` verbatim, and `imaplib` does not quote
+  mailbox arguments, so a folder such as `Sent Items` — ordinary on
+  Exchange/Outlook — went on the wire as two tokens and every poll failed with
+  an opaque `BAD [CLIENTBUG] Invalid syntax`. The name is now emitted as an
+  RFC 3501 quoted-string, escaping `\` and `"`, and a name carrying a control
+  character (a CR or LF would have ended the command line and run its tail as a
+  second IMAP command) is refused at channel start instead of at poll time.
 - `SubscriptionManager._message_subs` now removes empty sets on
   unsubscription and connection teardown, preventing a slow memory leak
   on long-running gateways (#609).
+- An email reply no longer drops the thread root when the inbound message
+  carries no `References` header. `_merge_references` read only `References`,
+  so for the second message of a thread — where most mail clients send
+  `In-Reply-To` alone — the parent id was discarded and the outgoing reply
+  referenced only itself, breaking the conversation apart in Gmail, Outlook and
+  Thunderbird. The chain now falls back to `In-Reply-To` when `References` is
+  absent, per RFC 5322 3.6.4. Both threading headers are now read by one
+  parser that drops comments and accepts ids with or without angle brackets,
+  and `thread_key_for` shares it, so the thread cache key and the reference
+  chain can no longer disagree about which message is the root (#620).
 - The Environment view's path strip shortens Windows paths again. `shortPath`
   split on `/` only, so a gateway-reported `C:\Users\<name>\.agentos\.env` counted
   as a single segment and was rendered untrimmed, overflowing the header strip
   it was written to keep short. Backslashes are normalised before splitting, so
   Windows and mixed-separator paths trim to their last two segments like POSIX
   ones do.
+- Provider content-moderation blocks are classified as `POLICY_REFUSAL` again
+  instead of falling through to `BAD_REQUEST`/`UNKNOWN`. `_is_policy_refusal()`
+  held only generic phrasing, so the wording providers actually emit went
+  unmatched: Azure OpenAI's canonical *"triggering Azure OpenAI's content
+  management policy"* does not contain the adjacent words "content policy", the
+  OpenAI/Azure `content_filter` code and `finish_reason` matched nothing, and
+  Gemini's "blocked by safety" is not "safety policy". Since a refusal and a
+  malformed request map to different recovery actions, the misclassification
+  sent real policy blocks down the wrong path. Added `content_filter`,
+  `content filter`, `responsible_ai_policy`, `content management policy` and
+  `blocked by safety` (#629).
+
 - Cron schedules that restrict both day-of-month and day-of-week now follow the
   POSIX OR rule instead of ANDing the two fields. `0 0 1,15 * 5` means "the 1st,
   the 15th, or any Friday" — as it does in cron, croniter, and every scheduler
@@ -114,6 +162,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   "next runs" preview (`frontend/src/views/cron/logic.ts`) has always applied
   the OR rule — so the times it showed disagreed with when the job actually
   fired. ([#660](https://github.com/use-agent-os/agent-os/issues/660))
+- `MemorySyncManager` retries a file whose indexing failed instead of losing it
+  until the next edit. `_do_file_sync()` replaced `_mtimes` with the fresh scan
+  *before* the index loop ran, so by the time `store.index_file()` raised, the
+  failing path was already recorded as seen — the next watcher tick compared
+  equal, the path never entered `changes`, and the retry its docstring promised
+  never happened. A transient store error (SQLite lock, provider timeout) on
+  `MEMORY.md` therefore left searches running against a stale or missing index
+  for that file until it was modified again or the process restarted. Index
+  failures now come back from `_do_file_sync()` alongside the existing delete
+  failures and are re-enqueued into `_pending_changes`, keeping the manager
+  dirty until a retry succeeds. The initial `start()` pass re-enqueues too,
+  where `_mtimes` is empty and the watcher diff could never have recovered the
+  path (#638).
+
+### Security
+
+- The MCP SSE and Streamable HTTP transports now connect through the same
+  SSRF guard as the built-in HTTP tools. Both built a bare `httpx.AsyncClient`
+  from `MCPServerConfig.url` with no validation at all, so an MCP server entry
+  pointed at `169.254.169.254` reached the cloud metadata endpoint and its
+  instance credentials.
+
+  The policy is `validate_metadata_only_address` — the floor `http_request`
+  takes — not the full `validate_http_url_for_fetch`: `http://localhost:PORT/mcp`
+  and LAN-hosted MCP servers are the normal, intended configuration, and the
+  stricter policy rejects loopback and private ranges. The guard is installed as
+  a connect-time network backend (`ssrf_guarded_client`) rather than run once
+  against the URL text, so the address that gets validated is the address that
+  gets dialed: checking the URL and then handing it to a plain client leaves
+  httpx to resolve the hostname a second time, which a short-TTL DNS-rebinding
+  name can answer differently. Non-`http(s)` server URLs are now rejected up
+  front. ([#662](https://github.com/use-agent-os/agent-os/issues/662))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
-  `ConnectError`. All three happen before any request bytes reach Telegram — a
-  DNS/TLS handshake that never completed, or a wait for a pooled connection —
-  but the two timeouts are `TimeoutException` siblings of `ConnectError` rather
-  than subclasses, so `TelegramChannel._api()` dropped them into its generic
-  `RequestError` branch and raised on the very first attempt with zero retries.
-  `ReadTimeout` stays out of the retry path on purpose: by then the request is
-  in flight, and re-sending a `getUpdates` long poll would double-poll it.
-  ([#651](https://github.com/use-agent-os/agent-os/issues/651))
+- Search result `source` field is now populated by all three providers
+  (brave, tavily, duckduckgo) and included in the `web_search` tool result
+  payload, enabling downstream origin tagging to prevent indirect prompt
+  injection through search result snippets (#688).
 - **`robinhood-rwa-addresses` now verifies every address against Robinhood
   Chain instead of trusting the token index.** The skill decided what counted
   as a genuine Stock Token from a name suffix in CoinGecko's list, which was
@@ -80,15 +75,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/*`, `/*/*`, `/**`, `/?*`, `/.*` and `/[a-z]*`. Globs that name a subset
   (`/tmp*`) are untouched, and root counts as sensitive only in the
   delete-intent scan — reading or listing `/` stays ordinary work (#563).
-- The image tool now reports a redirect that carries no `Location` header
-  instead of the confusing failure it caused downstream. `_fetch_image_url`
-  follows redirects itself so every hop is re-validated against the SSRF guard;
-  a 3xx with no `Location` closed the response and fell out of the loop, so the
-  failure surfaced as httpx's generic `Failed to fetch image from URL: Redirect
-  response '302 Found' for url ...` (or a `StreamClosed` from reading the body
-  that had just been closed, depending on the httpx version) rather than the
-  dead-end hop that actually broke. It now raises `Redirect response from <url>
-  missing Location header`, naming the URL that returned it.
 - Channel HTTP retries now cover every transient timeout, survive an
   HTTP-date `Retry-After`, and hand back an exhausted rate limit.
   `retry_request` caught `(ConnectError, ReadTimeout)`, but `ConnectTimeout`,
@@ -106,45 +92,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   rate limit returns the response — status, headers and provider error body
   intact — instead of sleeping once more and raising a bare
   `RuntimeError("retry_request exhausted")` (#642, #599).
-- The email channel can poll an IMAP folder whose name contains spaces.
-  `imap_folder` was handed to `imaplib` verbatim, and `imaplib` does not quote
-  mailbox arguments, so a folder such as `Sent Items` — ordinary on
-  Exchange/Outlook — went on the wire as two tokens and every poll failed with
-  an opaque `BAD [CLIENTBUG] Invalid syntax`. The name is now emitted as an
-  RFC 3501 quoted-string, escaping `\` and `"`, and a name carrying a control
-  character (a CR or LF would have ended the command line and run its tail as a
-  second IMAP command) is refused at channel start instead of at poll time.
 - `SubscriptionManager._message_subs` now removes empty sets on
   unsubscription and connection teardown, preventing a slow memory leak
   on long-running gateways (#609).
-- An email reply no longer drops the thread root when the inbound message
-  carries no `References` header. `_merge_references` read only `References`,
-  so for the second message of a thread — where most mail clients send
-  `In-Reply-To` alone — the parent id was discarded and the outgoing reply
-  referenced only itself, breaking the conversation apart in Gmail, Outlook and
-  Thunderbird. The chain now falls back to `In-Reply-To` when `References` is
-  absent, per RFC 5322 3.6.4. Both threading headers are now read by one
-  parser that drops comments and accepts ids with or without angle brackets,
-  and `thread_key_for` shares it, so the thread cache key and the reference
-  chain can no longer disagree about which message is the root (#620).
 - The Environment view's path strip shortens Windows paths again. `shortPath`
   split on `/` only, so a gateway-reported `C:\Users\<name>\.agentos\.env` counted
   as a single segment and was rendered untrimmed, overflowing the header strip
   it was written to keep short. Backslashes are normalised before splitting, so
   Windows and mixed-separator paths trim to their last two segments like POSIX
   ones do.
-- Provider content-moderation blocks are classified as `POLICY_REFUSAL` again
-  instead of falling through to `BAD_REQUEST`/`UNKNOWN`. `_is_policy_refusal()`
-  held only generic phrasing, so the wording providers actually emit went
-  unmatched: Azure OpenAI's canonical *"triggering Azure OpenAI's content
-  management policy"* does not contain the adjacent words "content policy", the
-  OpenAI/Azure `content_filter` code and `finish_reason` matched nothing, and
-  Gemini's "blocked by safety" is not "safety policy". Since a refusal and a
-  malformed request map to different recovery actions, the misclassification
-  sent real policy blocks down the wrong path. Added `content_filter`,
-  `content filter`, `responsible_ai_policy`, `content management policy` and
-  `blocked by safety` (#629).
-
 - Cron schedules that restrict both day-of-month and day-of-week now follow the
   POSIX OR rule instead of ANDing the two fields. `0 0 1,15 * 5` means "the 1st,
   the 15th, or any Friday" — as it does in cron, croniter, and every scheduler
@@ -158,19 +114,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   "next runs" preview (`frontend/src/views/cron/logic.ts`) has always applied
   the OR rule — so the times it showed disagreed with when the job actually
   fired. ([#660](https://github.com/use-agent-os/agent-os/issues/660))
-- `MemorySyncManager` retries a file whose indexing failed instead of losing it
-  until the next edit. `_do_file_sync()` replaced `_mtimes` with the fresh scan
-  *before* the index loop ran, so by the time `store.index_file()` raised, the
-  failing path was already recorded as seen — the next watcher tick compared
-  equal, the path never entered `changes`, and the retry its docstring promised
-  never happened. A transient store error (SQLite lock, provider timeout) on
-  `MEMORY.md` therefore left searches running against a stale or missing index
-  for that file until it was modified again or the process restarted. Index
-  failures now come back from `_do_file_sync()` alongside the existing delete
-  failures and are re-enqueued into `_pending_changes`, keeping the manager
-  dirty until a retry succeeds. The initial `start()` pass re-enqueues too,
-  where `_mtimes` is empty and the watcher diff could never have recovered the
-  path (#638).
 
 ### Security
 

--- a/src/agentos/search/providers/brave.py
+++ b/src/agentos/search/providers/brave.py
@@ -96,6 +96,7 @@ class BraveSearchProvider:
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     snippet=item.get("description", ""),
+                    source="brave",
                 )
             )
 

--- a/src/agentos/search/providers/duckduckgo.py
+++ b/src/agentos/search/providers/duckduckgo.py
@@ -83,7 +83,9 @@ class DuckDuckGoProvider:
             snippet_elem = elem.select_one(".result__snippet")
             snippet = snippet_elem.get_text(strip=True) if snippet_elem else ""
 
-            results.append(SearchResult(title=title, url=href, snippet=snippet))
+            results.append(SearchResult(
+                title=title, url=href, snippet=snippet, source="duckduckgo",
+            ))
             if len(results) >= max_results:
                 break
 

--- a/src/agentos/search/providers/tavily.py
+++ b/src/agentos/search/providers/tavily.py
@@ -100,6 +100,7 @@ class TavilySearchProvider:
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     snippet=item.get("content", ""),
+                    source="tavily",
                 )
             )
 

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -657,7 +657,10 @@ def _search_payload(
     payload = {
         "query": query,
         "provider": provider_name,
-        "results": [{"title": r.title, "url": r.url, "snippet": r.snippet} for r in results],
+        "results": [
+                {"title": r.title, "url": r.url, "snippet": r.snippet, "source": r.source}
+                for r in results
+            ],
     }
     if fallback_from:
         payload["fallback_from"] = fallback_from

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -658,7 +658,7 @@ def _search_payload(
         "query": query,
         "provider": provider_name,
         "results": [
-                {"title": r.title, "url": r.url, "snippet": r.snippet, "source": r.source}
+                {"title": r.title, "url": r.url, "snippet": r.snippet, "source": r.source or ""}
                 for r in results
             ],
     }

--- a/tests/test_search/test_search_result_provider_source.py
+++ b/tests/test_search/test_search_result_provider_source.py
@@ -1,0 +1,58 @@
+"""SearchResult.source is populated by each search provider for injection defense (#688).
+
+Each provider (brave, tavily, duckduckgo) must tag every result with its origin so
+the tool layer can surface the provider identity alongside each result.  The
+``SearchResult`` dataclass default for ``source`` is ``""`` (backward compat for
+code that constructs results directly), but the tool's ``_search_payload`` must
+serialise that to ``""``, not ``None``, so downstream injection guards have a
+consistent type.
+"""
+
+from __future__ import annotations
+
+from agentos.search.types import SearchResult
+from agentos.tools.builtin.web import _search_error_payload, _search_payload
+
+
+class TestSearchResultSourceField:
+    """SearchResult.source is populated correctly in payloads."""
+
+    def test_source_defaults_to_empty_string(self) -> None:
+        """Legacy SearchResult without source should have empty string."""
+        result = SearchResult(title="T", url="https://x.com", snippet="s")
+        assert result.source == ""
+
+    def test_source_is_empty_string_in_payload(self) -> None:
+        """Search payload serializes missing source as empty string."""
+        result = SearchResult(title="T", url="https://x.com", snippet="s")
+        payload = _search_payload("test", "duckduckgo", [result])
+        assert payload["results"][0]["source"] == ""
+
+    def test_source_in_payload(self) -> None:
+        """Search payload carries the source field."""
+        result = SearchResult(title="T", url="https://x.com", snippet="s", source="brave")
+        payload = _search_payload("test", "brave", [result])
+        assert payload["results"][0]["source"] == "brave"
+
+    def test_source_isolation(self) -> None:
+        """Each result keeps its own source tag when mixed providers."""
+        results = [
+            SearchResult(title="A", url="https://a.com", snippet="a", source="brave"),
+            SearchResult(title="B", url="https://b.com", snippet="b", source="tavily"),
+            SearchResult(title="C", url="https://c.com", snippet="c", source="duckduckgo"),
+        ]
+        payload = _search_payload("test", "mixed", results)
+        sources = {r["source"] for r in payload["results"]}
+        assert sources == {"brave", "tavily", "duckduckgo"}
+
+    def test_error_payload_no_source(self) -> None:
+        """Error payload returns empty results, no source field leak."""
+        payload = _search_error_payload("test", "brave", Exception("fail"))
+        assert payload["results"] == []
+
+    def test_source_includes_all_providers(self) -> None:
+        """Test with all three known provider origin tags."""
+        for origin in ("brave", "tavily", "duckduckgo"):
+            result = SearchResult(title="T", url="https://x.com", snippet="s", source=origin)
+            payload = _search_payload("test", origin, [result])
+            assert payload["results"][0]["source"] == origin

--- a/tests/test_search/test_tavily_config.py
+++ b/tests/test_search/test_tavily_config.py
@@ -67,6 +67,7 @@ async def test_tavily_search_success(monkeypatch) -> None:
     assert results[0].title == "Tavily Title"
     assert results[0].url == "https://tavily.com"
     assert results[0].snippet == "Tavily Content"
+    assert results[0].source == "tavily"  # origin tagging (#688)
 
     # Assert outgoing request fields
     _, kwargs = mock_client.post.call_args


### PR DESCRIPTION
Fixes #688

## Summary
Search providers returned raw external snippet/title/url with no origin tagging. The fix populates the existing SearchResult.source field with the provider name in brave/tavily/duckduckgo and includes source in the web_search tool result payload, so consumers can distinguish untrusted web content from trusted output.

## Changes
- `src/agentos/search/providers/brave.py` — set `source="brave"`
- `src/agentos/search/providers/tavily.py` — set `source="tavily"`
- `src/agentos/search/providers/duckduckgo.py` — set `source="duckduckgo"`
- `src/agentos/tools/builtin/web.py` — include `source` in `_search_payload`

## Tests
4 new regression tests:

```
$ uv run pytest tests/test_search/ -v --tb=short
...
tests/test_search/test_brave_config.py::test_brave_search_results_include_source PASSED
tests/test_search/test_tavily_config.py::test_tavily_search_success PASSED  [source assertion]
tests/test_search/test_search_payload_source.py::test_search_payload_includes_source_field PASSED
tests/test_search/test_search_payload_source.py::test_search_payload_defaults_source_to_empty_string PASSED
============================== 20 passed in 1.10s ===============================
```