### PR TITLE
fix(gateway): remove /api/approvals rate-limit exemption (#569)

### DIFF
--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -352,9 +352,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         if self._is_ui_path(path):
             return await call_next(request)  # type: ignore[no-any-return]
-        if request.method == "GET" and path == "/api/approvals":
-            return await call_next(request)  # type: ignore[no-any-return]
-
         client_ip = self._get_client_ip(request)
         now = time.time()
         window = float(self._config.rate_limit.window_seconds)

--- a/tests/test_gateway/test_rate_limit_approvals.py
+++ b/tests/test_gateway/test_rate_limit_approvals.py
@@ -1,3 +1,13 @@
+"""Regression tests for GET /api/approvals rate limiting (#569).
+
+The approval-polling endpoint was previously exempt from per-IP rate limiting,
+allowing an attacker to enumerate pending tool calls (info disclosure) and
+stall the pipeline behind SQLite locks (DoS).
+
+Fix: remove the exemption — /api/approvals counts against the same per-IP
+bucket as the rest of /api/*.
+"""
+
 from __future__ import annotations
 
 from starlette.applications import Starlette
@@ -8,7 +18,11 @@ from agentos.gateway.config import GatewayConfig
 from agentos.gateway.middleware import RateLimitMiddleware
 
 
-def test_approval_polling_does_not_consume_generic_api_rate_limit() -> None:
+def test_approval_polling_is_rate_limited() -> None:
+    """GET /api/approvals now counts against the per-IP rate limit.
+
+    With max_requests=1, the second call in the same window is rejected.
+    """
     app = Starlette()
 
     async def approvals(_request):
@@ -26,7 +40,57 @@ def test_approval_polling_does_not_consume_generic_api_rate_limit() -> None:
     app.add_middleware(RateLimitMiddleware, config=config)
 
     with TestClient(app) as client:
+        # First request — passes
         assert client.get("/api/approvals").status_code == 200
-        assert client.get("/api/approvals").status_code == 200
-        assert client.get("/api/sessions").status_code == 200
+        # Second request to /api/approvals — now rate-limited!
+        assert client.get("/api/approvals").status_code == 429
+        # Other API endpoint also rate-limited
         assert client.get("/api/sessions").status_code == 429
+
+
+def test_approval_polling_reasonable_poll_rate_passes() -> None:
+    """Normal UI polling (1 req/s) within a sane bucket passes."""
+    app = Starlette()
+
+    async def approvals(_request):
+        return JSONResponse({"approvals": []})
+
+    app.add_route("/api/approvals", approvals, methods=["GET"])
+    config = GatewayConfig()
+    config.rate_limit.enabled = True
+    config.rate_limit.max_requests = 60
+    config.rate_limit.window_seconds = 60
+    app.add_middleware(RateLimitMiddleware, config=config)
+
+    with TestClient(app) as client:
+        # 3 quick polls — well within the 60 req/min limit
+        for _ in range(3):
+            assert client.get("/api/approvals").status_code == 200
+
+
+def test_approval_polling_abuse_blocked() -> None:
+    """Rapid polling (100 in <1s) hits the rate limit."""
+    app = Starlette()
+
+    async def approvals(_request):
+        return JSONResponse({"approvals": []})
+
+    app.add_route("/api/approvals", approvals, methods=["GET"])
+    config = GatewayConfig()
+    config.rate_limit.enabled = True
+    config.rate_limit.max_requests = 10
+    config.rate_limit.window_seconds = 60
+    app.add_middleware(RateLimitMiddleware, config=config)
+
+    with TestClient(app) as client:
+        ok = 0
+        denied = 0
+        for _ in range(100):
+            resp = client.get("/api/approvals")
+            if resp.status_code == 200:
+                ok += 1
+            elif resp.status_code == 429:
+                denied += 1
+        # At most 10 should pass, the rest are denied
+        assert ok <= 10
+        assert denied >= 90


### PR DESCRIPTION
fix(gateway): remove /api/approvals rate-limit exemption (#569)

## Summary

`RateLimitMiddleware` had a carve-out at `middleware.py:355`:

```python
if request.method == "GET" and path == "/api/approvals":
    return await call_next(request)

This let attackers loop /api/approvals at any rate to:

1. Enumerate every pending tool call's arguments (info disclosure)
2. Stall the approval/chat pipeline behind SQLite locks (DoS)

Fix: Delete the 2-line exemption. /api/approvals now counts against the same per-IP bucket as the rest of /api/*. A sane bucket (60 req/min) is far above any legitimate UI poll frequency.

Tests

• test_rate_limit_approvals.py — 3 tests:
  • test_approval_polling_is_rate_limited: max_requests=1, second call gets 429
  • test_approval_polling_reasonable_poll_rate_passes: 3 polls in <1s with 60 req/min passes
  • test_approval_polling_abuse_blocked: 100 rapid requests, at most 10 pass (90+ denied)

Fixes #569