### PR TITLE
fix(channels): reject unsigned Slack webhooks instead of ingesting them

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -231,7 +231,10 @@ Request URL. It requires the bot token (`xoxb-...`) plus an app-level token
 (`xapp-...`) saved as `app_token`.
 
 Slack webhook mode uses the Events API Request URL. It requires the bot token
-plus `signing_secret`, and the gateway must be reachable by Slack.
+plus `signing_secret`, and the gateway must be reachable by Slack. The secret
+is mandatory, not advisory: without it the endpoint answers Slack's
+`url_verification` handshake and rejects everything else with `401`, because an
+unsigned POST cannot be attributed to Slack.
 
 Leave `slack_channel_id` empty when the adapter should reply to the incoming
 conversation. Set it only when you want a default fallback channel. Enable

--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -66,6 +66,24 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
 )
 
 
+def _unsigned_url_verification_challenge(body: bytes, headers: Mapping[str, str]) -> str | None:
+    """Return the challenge of an unsigned ``url_verification`` request.
+
+    ``None`` means the request is anything else and must be rejected when no
+    signing secret is configured.
+    """
+    if headers.get("content-type", "").startswith("application/x-www-form-urlencoded"):
+        return None
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("type") != "url_verification":
+        return None
+    challenge = data.get("challenge", "")
+    return challenge if isinstance(challenge, str) else ""
+
+
 class SlackAuthError(Exception):
     """Raised when Slack token validation fails."""
 
@@ -727,8 +745,10 @@ class SlackChannel:
         """Handle an incoming Slack Events API request."""
         body = await request.body()
 
-        # Signature verification
-        if self.signing_secret is not None:
+        # Signature verification. A blank secret is treated as no secret: an
+        # empty HMAC key is one anybody can compute with, so it would verify
+        # forged requests rather than reject them.
+        if self.signing_secret:
             timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
             signature = request.headers.get("X-Slack-Signature", "")
 
@@ -742,22 +762,21 @@ class SlackChannel:
             if not self._verify_signature(body, timestamp, signature):
                 return Response(status_code=401)
         else:
-            content_type = request.headers.get("content-type", "")
-            if content_type.startswith("application/x-www-form-urlencoded"):
-                import urllib.parse
-
-                try:
-                    decoded_body = body.decode("utf-8")
-                except UnicodeDecodeError:
-                    decoded_body = ""
-                parsed = urllib.parse.parse_qs(decoded_body)
-                if "payload" in parsed:
-                    log.warning("slack.webhook_blocked_unsigned_form")
-                    return Response(
-                        "Slack signing secret required for interactive payloads",
-                        status_code=401,
-                    )
+            # Fail closed. Without a signing secret nothing about this request
+            # can be attributed to Slack, so an unauthenticated caller could
+            # forge events, slash commands, or interactive payloads. The one
+            # exception is the ``url_verification`` handshake: it only echoes a
+            # challenge back and has no side effects, so an operator can still
+            # pass Slack's endpoint check while wiring the secret up.
+            challenge = _unsigned_url_verification_challenge(body, request.headers)
+            if challenge is None:
+                log.warning("slack.webhook_unsigned_rejected")
+                return Response(
+                    "Slack signing secret required",
+                    status_code=401,
+                )
             log.warning("slack.webhook_no_signing_secret")
+            return JSONResponse({"challenge": challenge})
 
         content_type = request.headers.get("content-type", "")
         if content_type.startswith("application/x-www-form-urlencoded"):
@@ -987,7 +1006,7 @@ class SlackChannel:
 
     def _verify_signature(self, body: bytes, timestamp: str, signature: str) -> bool:
         """Verify Slack request signature using HMAC-SHA256."""
-        if self.signing_secret is None:
+        if not self.signing_secret:
             return False
         sig_basestring = f"v0:{timestamp}:{body.decode()}"
         expected = (

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -242,6 +242,93 @@ async def test_slack_interactive_payload_unsigned_rejected() -> None:
     assert resp.status_code == 401
 
 
+def _unsigned_json_request(payload: dict[str, Any]) -> Request:
+    body = json.dumps(payload).encode()
+    request = Request({"type": "http", "method": "POST", "headers": []})
+
+    async def _body() -> bytes:
+        return body
+
+    request.body = _body  # type: ignore[method-assign]
+    return request
+
+
+@pytest.mark.asyncio
+async def test_slack_event_callback_unsigned_rejected() -> None:
+    """No signing secret means no way to attribute the POST to Slack, so the
+    event must not be ingested (GH #674)."""
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345", signing_secret=None)
+
+    resp = await channel._handle_webhook(  # noqa: SLF001
+        _unsigned_json_request(
+            {
+                "type": "event_callback",
+                "event": {
+                    "type": "message",
+                    "user": "U1",
+                    "channel": "C12345",
+                    "text": "pwned",
+                    "ts": "1710000000.000100",
+                    "channel_type": "im",
+                },
+            }
+        )
+    )
+
+    assert resp.status_code == 401
+    assert channel._queue.empty()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_slack_slash_command_unsigned_rejected() -> None:
+    """Slash commands ride the same unauthenticated path as event callbacks."""
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345", signing_secret=None)
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/x-www-form-urlencoded")],
+    }
+    request = Request(scope)
+
+    async def _body() -> bytes:
+        return b"command=%2Fstatus&user_id=U1&channel_id=C12345"
+
+    request.body = _body  # type: ignore[method-assign]
+
+    resp = await channel._handle_webhook(request)  # noqa: SLF001
+
+    assert resp.status_code == 401
+    assert channel._queue.empty()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_slack_event_callback_rejected_when_signing_secret_is_blank() -> None:
+    """An empty HMAC key verifies anything an attacker signs with it, so a
+    blank secret counts as no secret."""
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345", signing_secret="")
+
+    resp = await channel._handle_webhook(  # noqa: SLF001
+        _unsigned_json_request({"type": "event_callback", "event": {"type": "message"}})
+    )
+
+    assert resp.status_code == 401
+    assert channel._queue.empty()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_slack_url_verification_still_answered_unsigned() -> None:
+    """The handshake has no side effects, so it stays open — an operator can
+    pass Slack's endpoint check before the signing secret is wired up."""
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C12345", signing_secret=None)
+
+    resp = await channel._handle_webhook(  # noqa: SLF001
+        _unsigned_json_request({"type": "url_verification", "challenge": "abc123"})
+    )
+
+    assert resp.status_code == 200
+    assert json.loads(bytes(resp.body)) == {"challenge": "abc123"}
+
+
 @pytest.mark.asyncio
 async def test_discord_component_interaction_handling() -> None:
     queue = get_approval_queue()

--- a/tests/test_channels/test_channel_dedupe.py
+++ b/tests/test_channels/test_channel_dedupe.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
+import time
 
 import pytest
 
@@ -9,11 +12,22 @@ from agentos.channels.msteams import MSTeamsChannel, MSTeamsChannelConfig
 from agentos.channels.slack import SlackChannel
 from agentos.channels.types import IncomingMessage
 
+_SIGNING_SECRET = "s3cr3t"
+
 
 class _BodyRequest:
-    def __init__(self, payload: dict) -> None:
+    def __init__(self, payload: dict, *, signing_secret: str = _SIGNING_SECRET) -> None:
         self._body = json.dumps(payload).encode()
-        self.headers: dict[str, str] = {}
+        timestamp = str(int(time.time()))
+        digest = hmac.HMAC(
+            signing_secret.encode(),
+            f"v0:{timestamp}:{self._body.decode()}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        self.headers: dict[str, str] = {
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": f"v0={digest}",
+        }
 
     async def body(self) -> bytes:
         return self._body
@@ -21,7 +35,7 @@ class _BodyRequest:
 
 @pytest.mark.asyncio
 async def test_slack_webhook_dedupes_retried_event_callback() -> None:
-    channel = SlackChannel(token="xoxb-test", slack_channel_id="C1")
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C1", signing_secret=_SIGNING_SECRET)
     payload = {
         "type": "event_callback",
         "event_id": "Ev123",

--- a/tests/test_channels/test_native_commands.py
+++ b/tests/test_channels/test_native_commands.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import json
+import time
 from typing import Any
 
 import httpx
@@ -333,11 +336,25 @@ async def test_slack_start_survives_manifest_sync_failure() -> None:
     await channel.stop()
 
 
-class _SlashRequest:
-    headers = {"content-type": "application/x-www-form-urlencoded"}
+_SLASH_SIGNING_SECRET = "s3cr3t"
 
-    def __init__(self, channel_id: str = "C1") -> None:
+
+class _SlashRequest:
+    def __init__(
+        self, channel_id: str = "C1", *, signing_secret: str = _SLASH_SIGNING_SECRET
+    ) -> None:
         self.channel_id = channel_id
+        timestamp = str(int(time.time()))
+        digest = hmac.HMAC(
+            signing_secret.encode(),
+            f"v0:{timestamp}:command=%2Fstatus".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        self.headers = {
+            "content-type": "application/x-www-form-urlencoded",
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": f"v0={digest}",
+        }
 
     async def body(self) -> bytes:
         return b"command=%2Fstatus"
@@ -366,7 +383,9 @@ async def test_slack_slash_command_form_uses_channel_id_conversation_type(
     channel_type: str,
     is_group: bool,
 ) -> None:
-    channel = SlackChannel(token="token", slack_channel_id="C1")
+    channel = SlackChannel(
+        token="token", slack_channel_id="C1", signing_secret=_SLASH_SIGNING_SECRET
+    )
 
     response = await channel._handle_webhook(_SlashRequest(channel_id))  # noqa: SLF001
 


### PR DESCRIPTION
Fixes #674

## Problem

When no signing secret was configured, `SlackChannel._handle_webhook` logged a warning and carried on. `event_callback` payloads were ingested and slash commands were enqueued, so any unauthenticated POST to the Events API endpoint could inject messages and commands into a session. Only interactive form payloads were turned away.

Two related holes went with it:

- **Slash commands rode the same path.** The existing unsigned-form check rejected only payloads carrying a `payload` key; a `command=/status` form fell straight through to `_ingest_slash_command`. Fixing `event_callback` alone would have left the identical hole open one branch over, so both are closed here.
- **A blank secret was worse than a missing one.** The branch tested `signing_secret is not None`, so `signing_secret = ""` took the *verification* path — and an empty HMAC key is one an attacker can sign with themselves, so forged requests would have verified rather than been rejected.

## Change

Fail closed. Without a usable signing secret the handler answers the `url_verification` handshake — it only echoes a challenge back and has no side effects, so an operator can still pass Slack's endpoint check while wiring the secret up — and returns 401 for everything else. A blank secret now counts as no secret in both `_handle_webhook` and `_verify_signature`.

`docs/channels.md` records that the secret is mandatory rather than advisory.

## Tests

New, in `tests/test_channels/test_channel_approvals.py`: unsigned `event_callback` rejected and not enqueued, unsigned slash command rejected and not enqueued, blank-secret `event_callback` rejected, and `url_verification` still answered unsigned.

Two existing tests posted unsigned webhooks and relied on them being ingested (`test_channel_dedupe.py`, `test_native_commands.py`); they now sign their requests, which is what a real Slack delivery does.

Full suite green: 8687 passed. Three tests were deselected as broken by the local env, not this change — two mem0 tests that assert the module is *absent* while `--all-extras` installs it, and `test_render_html_to_pdf` (weasyprint missing a system library). All three fail identically on a clean `upstream/main` checkout in the same venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)