### PR TITLE
fix(cli): strip path separators from the sessions export filename

### DIFF
--- a/src/agentos/cli/sessions_cmd.py
+++ b/src/agentos/cli/sessions_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,20 @@ _ACTION_FAILED = object()
 
 # Rows pulled before a client-side --search filter runs.
 _SEARCH_FETCH_LIMIT = 500
+
+
+_UNSAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _safe_export_stem(session_id: str) -> str:
+    """Filename stem for a session export, with path separators removed.
+
+    ``session_id`` is user-supplied and used to build the default output path,
+    so everything outside ``[A-Za-z0-9_.-]`` collapses to ``-`` — the same rule
+    ``session/manager.py`` applies to archive filenames. Without it an id like
+    ``../../etc/pwned`` writes outside the working directory.
+    """
+    return _UNSAFE_FILENAME_RE.sub("-", session_id).strip("-.") or "session"
 
 
 def _resolved_key(payload: dict[str, Any], fallback: str) -> str:
@@ -377,7 +392,7 @@ def sessions_export(
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
         return
-    target = output or Path(f"{session_id.replace(':', '-')}.{format}")
+    target = output or Path(f"{_safe_export_stem(session_id)}.{format}")
     if format == "json":
         target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     else:

--- a/tests/test_cli/test_sessions_export_cmd.py
+++ b/tests/test_cli/test_sessions_export_cmd.py
@@ -1,0 +1,85 @@
+"""Issue #678: ``agentos sessions export`` must not write outside the CWD.
+
+The gateway round-trip is stubbed at ``run_gateway_sync`` — these cover the
+default-filename derivation, which is where the user-supplied ``session_id``
+reaches the filesystem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli import sessions_cmd
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    async def resolve_session(self, session_id: str) -> dict[str, Any]:
+        return {"session_key": session_id, "status": "done", "model": "gpt-x"}
+
+    async def preview_sessions(self, keys: list[str]) -> dict[str, Any]:
+        return {"previews": [{"lastMessage": "hello"}]}
+
+    async def session_history(self, key: str, limit: int = 1000) -> dict[str, Any]:
+        return {"messages": []}
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    fake = _FakeClient()
+
+    async def _with_client(action):
+        return await action(fake)
+
+    monkeypatch.setattr(sessions_cmd, "_with_client", _with_client)
+    return fake
+
+
+@pytest.mark.parametrize(
+    ("session_id", "expected"),
+    [
+        ("agent:main:cli:aaa", "agent-main-cli-aaa"),
+        ("../../etc/pwned", "etc-pwned"),
+        ("..\\..\\Windows\\pwned", "Windows-pwned"),
+        ("/absolute/path", "absolute-path"),
+        ("..", "session"),
+        ("", "session"),
+    ],
+)
+def test_safe_export_stem_strips_path_separators(session_id: str, expected: str) -> None:
+    assert sessions_cmd._safe_export_stem(session_id) == expected
+
+
+def test_export_writes_inside_the_working_directory(
+    client: _FakeClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A traversal id lands in the CWD under a flattened name, not at /etc."""
+    monkeypatch.chdir(tmp_path)
+    escaped = tmp_path.parent / "pwned.json"
+
+    result = runner.invoke(sessions_cmd.app, ["export", "../pwned", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert not escaped.exists()
+    assert (tmp_path / "pwned.json").exists()
+
+
+def test_export_honours_an_explicit_output_path(
+    client: _FakeClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--output is the caller's own choice and is left untouched."""
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "nested" / "chosen.md"
+    target.parent.mkdir()
+
+    result = runner.invoke(
+        sessions_cmd.app, ["export", "agent:main:cli:aaa", "--output", str(target)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert target.exists()


### PR DESCRIPTION
Fixes #678

## Problem

`sessions export` built its default output path from the raw `session_id`:

```python
target = output or Path(f"{session_id.replace(':', '-')}.{format}")
```

Only colons were replaced. Slashes and backslashes survived, so `agentos sessions export ../../etc/pwned` wrote the export to `/etc/pwned.json` — anywhere the agentos process can write.

## Change

`_safe_export_stem` collapses everything outside `[A-Za-z0-9_.-]` to `-`, the same rule `session/manager.py::_safe_archive_part` already applies to archive filenames, and falls back to `session` when nothing usable is left (`..` → `session`). An explicit `--output` is the caller's own choice and stays untouched.

No CLI surface change — same command, same flags, same config keys — so `docs/cli.md` and the bundled skill need no update.

## Tests

New `tests/test_cli/test_sessions_export_cmd.py`: the stem derivation across POSIX traversal, Windows traversal, absolute paths and degenerate ids; an end-to-end export with a traversal id landing in the CWD rather than above it; and `--output` still honoured verbatim.

I confirmed the traversal test fails on the old expression and passes on the new one, so it is not vacuous.

Full suite green: 8691 passed. The 2 failures are pre-existing local env breakage, not this change — `test_enabled_but_module_missing_boots_with_none` (mem0 *is* installed via `--all-extras`) and `test_render_html_to_pdf` (weasyprint missing a system library); both fail identically on a clean `upstream/main` checkout in the same venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)