### PR TITLE
test(sandbox): pin sensitive-path checks across compound shell commands

### DIFF
--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -103,3 +103,38 @@ def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
         sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
         == "~/.ssh"
     )
+
+
+def test_every_rm_in_a_compound_command_is_checked() -> None:
+    """Issue #676: a benign leading ``rm`` must not shadow a later one.
+
+    Each shell separator ends one ``rm`` invocation, so ``rm /tmp/ok; rm -rf
+    /root`` yields both targets and the sensitive one wins.
+    """
+    workspace = Path("/workspace")
+
+    for separator in (";", "&&", "||", "|", "&", "\n"):
+        command = f"rm /tmp/ok {separator} rm -rf /root"
+        assert sensitive_target_in_command(command, workspace=workspace) == "/root", command
+
+    assert (
+        sensitive_target_in_command(
+            "rm /tmp/ok; shutil.rmtree('/etc/ssl')",
+            workspace=workspace,
+        )
+        == "/etc"
+    )
+
+
+def test_sensitive_reads_in_a_later_segment_are_blocked_at_the_tool_boundary() -> None:
+    """Issue #676: the delete-intent scan only sees ``rm`` targets, so a
+    non-destructive second segment (``cat /root/.bash_history``) is caught by
+    the text scan ``exec_command`` runs alongside it, not by this one."""
+    workspace = Path("/workspace")
+
+    assert sensitive_target_in_command("rm /tmp/ok; ls /root", workspace=workspace) is None
+    assert sensitive_path_in_text("rm /tmp/ok; ls /root", workspace=workspace) == "/root"
+    assert (
+        sensitive_path_in_text("rm /tmp/ok; cat /root/.bash_history", workspace=workspace)
+        == "/root"
+    )

--- a/tests/test_tools/test_shell_sensitive.py
+++ b/tests/test_tools/test_shell_sensitive.py
@@ -141,3 +141,27 @@ def test_effective_workdir_rejects_foreign_posix_absolute_path_on_windows(
             shell._effective_workdir("/Users/a1/Desktop")
     finally:
         current_tool_context.reset(token)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm /tmp/ok; cat /root/.bash_history",
+        "rm /tmp/ok; ls /root",
+        "rm /tmp/ok && rm -rf /root",
+        "rm /tmp/ok | cat ~/.ssh/id_rsa",
+    ],
+)
+def test_a_benign_first_segment_does_not_smuggle_a_sensitive_second_one(
+    command: str,
+) -> None:
+    """Issue #676: chaining past the block.
+
+    The delete-intent scan only reads ``rm`` targets, so the later segment is
+    caught by the whole-command text scan instead — either way ``exec_command``
+    refuses the command rather than running half of it.
+    """
+    payload = shell._sensitive_shell_block("exec_command", command)
+
+    assert payload is not None, command
+    assert json.loads(payload)["reason"] == "sensitive_path"


### PR DESCRIPTION
Refs #676

## This is coverage, not a fix — #676 does not reproduce on main

I could not reproduce the reported bypass. Two separate reasons:

**1. The title's claim is stale.** #676 says `_extract_rm_targets` uses `re.search(r'\brm\b([^\n]*)')` and finds only the first `rm`. Current `main` already uses `finditer` with a separator-bounded pattern (`\brm\b([^;\n&|]*)`), so each `rm` is tokenized independently:

```
'rm /tmp/ok; rm -rf /root'    -> sensitive_target_in_command == '/root'
'rm /tmp/ok && rm /etc/passwd' -> '/etc'
'rm /tmp/ok | rm /root/x'      -> '/root'
```

**2. The repro commands are reads, and a different layer blocks those.** `cat /root/.bash_history` and `ls /root` are not delete intents, so `sensitive_target_in_command` — which by design only inspects destructive targets — returns `None` for them. That is not the whole story: `exec_command` runs `_sensitive_shell_block` alongside it, which scans the *entire* command text via `sensitive_path_in_text`. Every repro from the issue is refused at the tool boundary:

```
rm /tmp/ok; cat /root/.bash_history  -> blocked (sensitive_path)
rm /tmp/ok; ls /root                 -> blocked (sensitive_path)
rm /tmp/ok; mv ~/.ssh/id_rsa /tmp/   -> blocked (sensitive_path)
rm /tmp/ok; : > /etc/hosts           -> blocked (sensitive_path)
```

So rather than change behavior, this PR pins the split so it stays deliberate. Maintainers may prefer to close #676 on the strength of it.

## Tests

- `tests/test_sandbox/test_sensitive_paths.py` — every shell separator (`;`, `&&`, `||`, `|`, `&`, newline) ends one `rm` invocation and the sensitive target still wins; and an explicit assertion that the delete-intent scan returns `None` for a read while the text scan catches it, so the division of labour is recorded rather than assumed.
- `tests/test_tools/test_shell_sensitive.py` — the issue's four repro commands, asserted blocked at the `exec_command` boundary.

Full suite green: 8689 passed. The 2 failures are pre-existing local env breakage, not this change — `test_enabled_but_module_missing_boots_with_none` (mem0 *is* installed via `--all-extras`) and `test_render_html_to_pdf` (weasyprint missing a system library); both fail identically on a clean `upstream/main` checkout in the same venv.

## Separate gap found while probing this

`rm -rf $HOME/.ssh` passes **both** layers — `_norm_path` deliberately skips `$`-prefixed tokens (so globs and variables are not mis-expanded), and the text scan never sees an expanded path. That is a distinct issue from #676 and is left alone here; happy to file it separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)