### PR TITLE
fix(provider): degrade non-numeric BreakerSettings values instead of raising

### DIFF
--- a/src/agentos/provider/circuit_breaker.py
+++ b/src/agentos/provider/circuit_breaker.py
@@ -74,9 +74,18 @@ class BreakerSettings:
     max_cooldown_seconds: float = DEFAULT_MAX_COOLDOWN_SECONDS
 
     def __post_init__(self) -> None:
-        threshold = max(1, int(self.failure_threshold))
-        cooldown = max(1.0, float(self.cooldown_seconds))
-        max_cooldown = max(cooldown, float(self.max_cooldown_seconds))
+        try:
+            threshold = max(1, int(self.failure_threshold))
+        except (ValueError, TypeError):
+            threshold = DEFAULT_FAILURE_THRESHOLD
+        try:
+            cooldown = max(1.0, float(self.cooldown_seconds))
+        except (ValueError, TypeError):
+            cooldown = DEFAULT_COOLDOWN_SECONDS
+        try:
+            max_cooldown = max(cooldown, float(self.max_cooldown_seconds))
+        except (ValueError, TypeError):
+            max_cooldown = DEFAULT_MAX_COOLDOWN_SECONDS
         object.__setattr__(self, "failure_threshold", threshold)
         object.__setattr__(self, "cooldown_seconds", cooldown)
         object.__setattr__(self, "max_cooldown_seconds", max_cooldown)
@@ -90,17 +99,29 @@ class BreakerSettings:
         """
         if config is None:
             return cls()
+        try:
+            failure_threshold = int(
+                getattr(config, "failure_threshold", DEFAULT_FAILURE_THRESHOLD)
+            )
+        except (ValueError, TypeError):
+            failure_threshold = DEFAULT_FAILURE_THRESHOLD
+        try:
+            cooldown_seconds = float(
+                getattr(config, "cooldown_seconds", DEFAULT_COOLDOWN_SECONDS)
+            )
+        except (ValueError, TypeError):
+            cooldown_seconds = DEFAULT_COOLDOWN_SECONDS
+        try:
+            max_cooldown_seconds = float(
+                getattr(config, "max_cooldown_seconds", DEFAULT_MAX_COOLDOWN_SECONDS)
+            )
+        except (ValueError, TypeError):
+            max_cooldown_seconds = DEFAULT_MAX_COOLDOWN_SECONDS
         return cls(
             enabled=bool(getattr(config, "enabled", True)),
-            failure_threshold=int(
-                getattr(config, "failure_threshold", DEFAULT_FAILURE_THRESHOLD)
-            ),
-            cooldown_seconds=float(
-                getattr(config, "cooldown_seconds", DEFAULT_COOLDOWN_SECONDS)
-            ),
-            max_cooldown_seconds=float(
-                getattr(config, "max_cooldown_seconds", DEFAULT_MAX_COOLDOWN_SECONDS)
-            ),
+            failure_threshold=failure_threshold,
+            cooldown_seconds=cooldown_seconds,
+            max_cooldown_seconds=max_cooldown_seconds,
         )
 
 

--- a/tests/test_provider/test_circuit_breaker_settings.py
+++ b/tests/test_provider/test_circuit_breaker_settings.py
@@ -1,0 +1,80 @@
+"""Regression: BreakerSettings degrades non-numeric config values instead of raising."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentos.provider.circuit_breaker import (
+    DEFAULT_COOLDOWN_SECONDS,
+    DEFAULT_FAILURE_THRESHOLD,
+    DEFAULT_MAX_COOLDOWN_SECONDS,
+    BreakerSettings,
+)
+
+
+class _FakeConfig:
+    """Config object whose fields hold non-numeric string values."""
+
+    def __init__(
+        self,
+        failure_threshold: Any = None,
+        cooldown_seconds: Any = None,
+        max_cooldown_seconds: Any = None,
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.cooldown_seconds = cooldown_seconds
+        self.max_cooldown_seconds = max_cooldown_seconds
+
+
+# ── __init__ path ───────────────────────────────────────────────────────────
+
+
+def test_non_numeric_failure_threshold_degrades_to_default() -> None:
+    s = BreakerSettings(failure_threshold="three")
+    assert s.failure_threshold == DEFAULT_FAILURE_THRESHOLD
+
+
+def test_non_numeric_cooldown_seconds_degrades_to_default() -> None:
+    s = BreakerSettings(cooldown_seconds="invalid")
+    assert s.cooldown_seconds == DEFAULT_COOLDOWN_SECONDS
+
+
+def test_non_numeric_max_cooldown_degrades_to_default() -> None:
+    s = BreakerSettings(max_cooldown_seconds="bad")
+    assert s.max_cooldown_seconds == DEFAULT_MAX_COOLDOWN_SECONDS
+
+
+def test_none_field_values_degrade_to_defaults() -> None:
+    s = BreakerSettings(failure_threshold=None, cooldown_seconds=None, max_cooldown_seconds=None)
+    assert s.failure_threshold == DEFAULT_FAILURE_THRESHOLD
+    assert s.cooldown_seconds == DEFAULT_COOLDOWN_SECONDS
+    assert s.max_cooldown_seconds == DEFAULT_MAX_COOLDOWN_SECONDS
+
+
+def test_numeric_values_unchanged() -> None:
+    s = BreakerSettings(failure_threshold=7, cooldown_seconds=90.0, max_cooldown_seconds=300.0)
+    assert s.failure_threshold == 7
+    assert s.cooldown_seconds == 90.0
+    assert s.max_cooldown_seconds == 300.0
+
+
+# ── from_config path ─────────────────────────────────────────────────────────
+
+
+def test_from_config_non_numeric_degrades_to_defaults() -> None:
+    cfg = _FakeConfig(
+        failure_threshold="ten",
+        cooldown_seconds="ninety",
+        max_cooldown_seconds="five hundred",
+    )
+    s = BreakerSettings.from_config(cfg)
+    assert s.failure_threshold == DEFAULT_FAILURE_THRESHOLD
+    assert s.cooldown_seconds == DEFAULT_COOLDOWN_SECONDS
+    assert s.max_cooldown_seconds == DEFAULT_MAX_COOLDOWN_SECONDS
+
+
+def test_from_config_none_returns_defaults() -> None:
+    s = BreakerSettings.from_config(None)
+    assert s.failure_threshold == DEFAULT_FAILURE_THRESHOLD
+    assert s.cooldown_seconds == DEFAULT_COOLDOWN_SECONDS
+    assert s.max_cooldown_seconds == DEFAULT_MAX_COOLDOWN_SECONDS


### PR DESCRIPTION
Fixes #702

## Summary
BreakerSettings.__post_init__ and from_config call int()/float() directly on failure_threshold, cooldown_seconds, and max_cooldown_seconds without a try/except. A hand-edited config with a non-numeric value (e.g. failure_threshold = "three") raises ValueError at boot, contradicting the class docstring which promises graceful degradation to defaults instead of crashing the runtime.

## What
- src/agentos/provider/circuit_breaker.py — wrap int()/float() in __post_init__ and from_config with try/except; non-numeric or None values fall back to DEFAULT_* constants
- tests/test_provider/test_circuit_breaker_settings.py — regression tests covering non-numeric degrade, None degrade, numeric unchanged, and from_config paths (7 tests)

## Verification
- uv run pytest tests/test_provider/test_circuit_breaker_settings.py -q — 7 passed
- uv run ruff check src/agentos/provider/circuit_breaker.py tests/test_provider/test_circuit_breaker_settings.py — clean