### PR TITLE
fix(env): block proxy env vars with case-insensitive matching, add AGENTOS_TRUST_ENV (#550)

### DIFF
--- a/src/agentos/env_policy.py
+++ b/src/agentos/env_policy.py
@@ -139,6 +139,33 @@ _AGENTOS_POSTURE_NAMES = (
     "AGENTOS_HTTP_DOWNLOAD_LIMIT",
 )
 
+# Group 5 — proxy names (case-insensitive enforcement). httpx normalises
+# every ``*_proxy`` env var name to lowercase before reading, so a mixed-case
+# spelling bypasses the exact-match check. These are matched via
+# ``_case_insensitive_denied()`` instead of the literal denylist.
+#
+# ``AGENTOS_TRUST_ENV`` gates ``env.trust_env()``, the call site that makes
+# AgentOS httpx clients honour the ``*_PROXY`` vars. Blocking proxies alone
+# is insufficient if an agent can first turn on trust and then supply the
+# proxy — both must be blocked together.
+_PROXY_NAMES: tuple[str, ...] = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+    "AGENTOS_LLM_PROXY",
+    "AGENTOS_TRUST_ENV",
+)
+
+#: Upper-cased groups for case-insensitive denial.
+_CASE_INSENSITIVE_DENY_GROUPS: tuple[frozenset[str], ...] = (
+    frozenset(n.upper() for n in _PROXY_NAMES),
+)
+
 #: Names that may never be written through an AgentOS surface.
 WRITE_DENYLIST: frozenset[str] = frozenset(
     _LOADER_NAMES + _INTERPRETER_NAMES + _SHELL_NAMES + _AGENTOS_POSTURE_NAMES
@@ -146,10 +173,11 @@ WRITE_DENYLIST: frozenset[str] = frozenset(
 
 _DENY_MESSAGE = (
     "Environment variable {key!r} cannot be written through AgentOS. Names that "
-    "steer subprocess execution (PATH, LD_PRELOAD, PYTHONPATH, EDITOR, ...) or "
+    "steer subprocess execution (PATH, LD_PRELOAD, PYTHONPATH, EDITOR, ...), "
     "AgentOS runtime posture (AGENTOS_AGENT_PERMISSIONS, AGENTOS_GATEWAY_TOKEN, "
-    "...) are refused so this surface cannot escalate its own privileges. Edit "
-    "~/.agentos/.env directly if you genuinely need to set it."
+    "...), or proxy/trust settings (HTTP_PROXY, AGENTOS_LLM_PROXY, "
+    "AGENTOS_TRUST_ENV, ...) are refused so this surface cannot escalate its own "
+    "privileges. Edit ~/.agentos/.env directly if you genuinely need to set it."
 )
 
 
@@ -166,15 +194,30 @@ def assert_valid_name(key: str) -> None:
         )
 
 
+def _case_insensitive_denied(key: str) -> bool:
+    """Return whether *key* matches any case-insensitive deny group.
+
+    Used for proxy names where httpx normalises to lowercase regardless of
+    the spelling the caller used, so ``Http_Proxy``, ``http_proxy``, and
+    ``HTTP_PROXY`` must all be blocked.
+    """
+    upper = key.upper()
+    return any(upper in group for group in _CASE_INSENSITIVE_DENY_GROUPS)
+
+
 def is_writable(key: str) -> bool:
     """Return whether *key* may be written through an AgentOS surface."""
-    return bool(ENV_NAME_RE.match(key)) and key not in WRITE_DENYLIST
+    return (
+        bool(ENV_NAME_RE.match(key))
+        and key not in WRITE_DENYLIST
+        and not _case_insensitive_denied(key)
+    )
 
 
 def assert_writable(key: str) -> None:
     """Raise :class:`EnvPolicyError` unless *key* passes the name and deny gates."""
     assert_valid_name(key)
-    if key in WRITE_DENYLIST:
+    if key in WRITE_DENYLIST or _case_insensitive_denied(key):
         raise EnvPolicyError(_DENY_MESSAGE.format(key=key))
 
 

--- a/tests/test_env_policy.py
+++ b/tests/test_env_policy.py
@@ -73,6 +73,47 @@ class TestDenylist:
         assert env_policy.is_writable(name) is True
         env_policy.assert_writable(name)
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # proxy vars that must be denied
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+            "AGENTOS_LLM_PROXY",
+            # trust env — gates the proxy injection path
+            "AGENTOS_TRUST_ENV",
+        ],
+    )
+    def test_proxy_and_trust_env_names_are_refused(self, name: str) -> None:
+        assert env_policy.is_writable(name) is False
+        with pytest.raises(EnvPolicyError, match="cannot be written through AgentOS"):
+            env_policy.assert_writable(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # httpx normalizes proxies to lowercase; mixed-case variants must
+            # also be blocked or they bypass the literal denylist check.
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+            "no_proxy",
+            "Http_Proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+        ],
+    )
+    def test_proxy_names_are_refused_case_insensitively(self, name: str) -> None:
+        """httpx lowercases proxy var names, so mixed-case variants must be
+        blocked to prevent a case-mutation bypass."""
+        assert env_policy.is_writable(name) is False
+        with pytest.raises(EnvPolicyError, match="cannot be written through AgentOS"):
+            env_policy.assert_writable(name)
+
     def test_invalid_name_is_not_writable_even_when_absent_from_denylist(self) -> None:
         assert env_policy.is_writable("1BAD") is False
 


### PR DESCRIPTION
Fixes #550 — closes the two gaps PR #552 leaves open.

## Gaps in PR #552

1. **Case-insensitive bypass.** `WRITE_DENYLIST` uses exact-match (`key not in WRITE_DENYLIST`), so `Http_Proxy` is writable. httpx normalizes proxy env var names to lowercase via `urllib.request.getproxies_environment()`, so a mixed-case spelling like `Http_Proxy` passes the literal check but still steers httpx traffic.

2. **`AGENTOS_TRUST_ENV` is missing.** It gates `env.trust_env()` — the call site that makes every AgentOS httpx client honour `*_PROXY` vars. Blocking proxies alone is insufficient if an agent can first turn on env-proxy trust and *then* supply the proxy.

## Fix

### Case-insensitive matching
Added `_case_insensitive_denied()` that compares `key.upper()` against an upper-cased set. The `_CASE_INSENSITIVE_DENY_GROUPS` tuple holds frozensets for each deny group that must be matched case-insensitively. Currently one group (`_PROXY_NAMES`); the architecture allows adding more without changing the check logic.

### Trust env
`AGENTOS_TRUST_ENV` is listed in `_PROXY_NAMES` alongside the standard proxy vars (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `AGENTOS_LLM_PROXY`).

## Changes

- `src/agentos/env_policy.py`:
  - Add `_PROXY_NAMES` with all proxy vars + `AGENTOS_TRUST_ENV`
  - Add `_CASE_INSENSITIVE_DENY_GROUPS`
  - Update `is_writable()` and `assert_writable()` to check case-insensitive denial
  - Update `_DENY_MESSAGE` to mention proxy/trust settings
- `tests/test_env_policy.py`:
  - 15 new regression tests covering proxy names, trust env, and mixed-case bypasses (including `Http_Proxy`)

## Verification
