### PR TITLE
fix(scheduler): use POSIX OR semantics when day-of-month and day-of-week are both restricted (#660)

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -68,6 +68,7 @@ _PRESETS: dict[str, str] = {
 @dataclass(frozen=True)
 class CronField:
     values: frozenset[int]
+    is_wildcard: bool = False
 
     def matches(self, value: int) -> bool:
         return value in self.values
@@ -83,16 +84,31 @@ class CronExpression:
     raw: str
 
     def matches(self, dt: datetime) -> bool:
-        return (
+        # Standard AND for all fields except the POSIX day-of-month/day-of-week
+        # special case: when both are restricted (neither is a literal `*`),
+        # the job fires when EITHER field matches (POSIX OR).
+        base = (
             self.minute.matches(dt.minute)
             and self.hour.matches(dt.hour)
-            and self.day_of_month.matches(dt.day)
             and self.month.matches(dt.month)
-            and self.day_of_week.matches((dt.weekday() + 1) % 7)  # Python Mon=0 → cron Sun=0
         )
+        if not base:
+            return False
+
+        dom_ok = self.day_of_month.matches(dt.day)
+        dow_ok = self.day_of_week.matches((dt.weekday() + 1) % 7)  # Python Mon=0 → cron Sun=0
+
+        if not self.day_of_month.is_wildcard and not self.day_of_week.is_wildcard:
+            # POSIX: when both day-of-month and day-of-week are restricted,
+            # fire when either matches (OR).
+            return dom_ok or dow_ok
+
+        # Standard AND fallback.
+        return dom_ok and dow_ok
 
 
 def _parse_field(token: str, field_name: str, names: dict[str, int] | None = None) -> CronField:
+    is_wildcard = token.strip() == "*"
     lo, hi = _FIELD_RANGES[field_name]
     values: set[int] = set()
 
@@ -157,7 +173,7 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
         values.remove(7)
         values.add(0)
 
-    return CronField(frozenset(values))
+    return CronField(frozenset(values), is_wildcard=is_wildcard)
 
 
 def _to_int(s: str, field_name: str, lo: int, hi: int) -> int:

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -130,3 +130,176 @@ def test_parse_iso_at_rejects_empty() -> None:
 def test_parse_iso_at_rejects_non_string() -> None:
     with pytest.raises(CronParseError, match="Expected ISO-8601 string"):
         parse_iso_at(12345)  # type: ignore[arg-type]
+
+
+# --- POSIX day-of-month / day-of-week OR semantics (#660) ---------------
+#
+# Per POSIX: when both day-of-month and day-of-week are restricted (neither
+# is a literal `*`), the job fires when EITHER field matches, not both.
+# When only one is restricted, standard AND applies.
+
+
+class TestCronDomDowOrSemantics:
+    """Regression tests for POSIX OR semantics (issue #660)."""
+
+    # --- OR case: "0 0 1,15 * 5" (1st, 15th, or any Friday) ---
+
+    def test_dom_dow_or_matches_dom_only(self) -> None:
+        """Dec 1 (Tuesday, not Friday) — fires on 1st."""
+        expr = parse_cron("0 0 1,15 * 5")
+        dt = datetime(2026, 12, 1, 0, 0)  # Tuesday
+        assert expr.matches(dt)
+
+    def test_dom_dow_or_matches_dow_only(self) -> None:
+        """Dec 4 (Friday, not 1st or 15th) — fires on Friday."""
+        expr = parse_cron("0 0 1,15 * 5")
+        dt = datetime(2026, 12, 4, 0, 0)  # Friday
+        assert expr.matches(dt)
+
+    def test_dom_dow_or_matches_both(self) -> None:
+        """May 15 (Friday) — fires on both 15th and Friday."""
+        expr = parse_cron("0 0 1,15 * 5")
+        dt = datetime(2026, 5, 15, 0, 0)  # Friday the 15th
+        assert expr.matches(dt)
+
+    def test_dom_dow_or_no_match(self) -> None:
+        """Dec 2 (Wednesday, not 1st/15th/Friday) — should not fire."""
+        expr = parse_cron("0 0 1,15 * 5")
+        dt = datetime(2026, 12, 2, 0, 0)  # Wednesday
+        assert not expr.matches(dt)
+
+    def test_dom_dow_or_cross_month_boundary(self) -> None:
+        """Mar 1 (Sunday) — fires on 1st regardless of month."""
+        expr = parse_cron("0 0 1,15 * 5")
+        dt = datetime(2026, 3, 1, 0, 0)  # Sunday
+        assert expr.matches(dt)
+
+    # --- Single-value restriction OR ---
+
+    def test_single_value_dom_with_dow_or_matches_dom(self) -> None:
+        """"0 0 15 * 5" — Dec 15 (Tuesday) fires on 15th."""
+        expr = parse_cron("0 0 15 * 5")
+        dt = datetime(2026, 12, 15, 0, 0)  # Tuesday
+        assert expr.matches(dt)
+
+    def test_single_value_dom_with_dow_or_matches_dow(self) -> None:
+        """"0 0 15 * 5" — Dec 11 (Friday, not 15th) fires on Friday."""
+        expr = parse_cron("0 0 15 * 5")
+        dt = datetime(2026, 12, 11, 0, 0)  # Friday
+        assert expr.matches(dt)
+
+    def test_single_value_dom_with_dow_or_no_match(self) -> None:
+        """"0 0 15 * 5" — Dec 10 (Thursday) neither 15th nor Friday."""
+        expr = parse_cron("0 0 15 * 5")
+        dt = datetime(2026, 12, 10, 0, 0)  # Thursday
+        assert not expr.matches(dt)
+
+    # --- AND fallback when DOM is wildcard ---
+
+    def test_dom_wildcard_and_fallback_matches(self) -> None:
+        """"0 0 * * 5" — only Fridays, DOW restricted, DOM wildcard → AND."""
+        expr = parse_cron("0 0 * * 5")
+        dt = datetime(2026, 12, 4, 0, 0)  # Friday
+        assert expr.matches(dt)
+
+    def test_dom_wildcard_and_fallback_no_match(self) -> None:
+        """"0 0 * * 5" — Monday should not match."""
+        expr = parse_cron("0 0 * * 5")
+        dt = datetime(2026, 12, 7, 0, 0)  # Monday
+        assert not expr.matches(dt)
+
+    # --- AND fallback when DOW is wildcard ---
+
+    def test_dow_wildcard_and_fallback_matches(self) -> None:
+        """"0 0 15 * *" — only 15th, DOM restricted, DOW wildcard → AND."""
+        expr = parse_cron("0 0 15 * *")
+        dt = datetime(2026, 12, 15, 0, 0)
+        assert expr.matches(dt)
+
+    def test_dow_wildcard_and_fallback_no_match(self) -> None:
+        """"0 0 15 * *" — 16th should not match."""
+        expr = parse_cron("0 0 15 * *")
+        dt = datetime(2026, 12, 16, 0, 0)
+        assert not expr.matches(dt)
+
+    # --- AND fallback when both are wildcard ---
+
+    def test_both_wildcard_matches_all(self) -> None:
+        """"0 0 * * *" — every day."""
+        expr = parse_cron("0 0 * * *")
+        assert expr.matches(datetime(2026, 12, 1, 0, 0))
+        assert expr.matches(datetime(2026, 12, 31, 0, 0))
+        assert expr.matches(datetime(2026, 1, 1, 0, 0))
+
+    # --- POSIX: `*` vs explicit full-range (e.g. `1-31`) ---
+    # POSIX ties the OR-vs-AND rule to a literal `*` in the expression,
+    # not to whether the resolved set spans every possible value.
+    # `0 0 * * 5` uses AND (only Fridays), but `0 0 1-31 * 5` fires OR
+    # because `1-31` is "restricted" even though it covers every day.
+
+    def test_explicit_full_range_is_restricted(self) -> None:
+        """"0 0 1-31 * 5" — DOM `1-31` is restricted, so OR fires every day."""
+        expr = parse_cron("0 0 1-31 * 5")
+        # Every day of month matches 1-31, so ANY day fires.
+        tue = datetime(2026, 12, 1, 0, 0)  # Tuesday
+        thu = datetime(2026, 12, 3, 0, 0)  # Thursday
+        sat = datetime(2026, 12, 5, 0, 0)  # Saturday
+        assert expr.matches(tue)
+        assert expr.matches(thu)
+        assert expr.matches(sat)
+
+    def test_both_full_range_is_restricted(self) -> None:
+        """"0 0 1-31 * 0-6" — both are explicit full range, still restricted → OR."""
+        expr = parse_cron("0 0 1-31 * 0-6")
+        assert expr.matches(datetime(2026, 12, 1, 0, 0))
+        assert expr.matches(datetime(2026, 12, 31, 0, 0))
+
+    def test_wildcard_star_triggers_and(self) -> None:
+        """"0 0 * * 0-6" — DOM `*` wildcard, DOW `0-6` restricted → AND.
+        DOW `0-6` covers every day, so this still matches any day — the
+        important thing is the AND code path is taken, not the OR path."""
+        expr = parse_cron("0 0 * * 0-6")
+        # All days match since DOW covers 0-6 (Sunday through Saturday)
+        assert expr.matches(datetime(2026, 12, 6, 0, 0))  # Sunday
+        assert expr.matches(datetime(2026, 12, 7, 0, 0))  # Monday
+        assert expr.matches(datetime(2026, 12, 5, 0, 0))  # Saturday
+
+    # --- Presets that should not regress ---
+
+    def test_monthly_preset_still_and(self) -> None:
+        """"@monthly" = "0 0 1 * *" — DOM restricted, DOW wildcard → AND."""
+        expr = parse_cron("@monthly")
+        assert expr.matches(datetime(2026, 12, 1, 0, 0))
+        assert not expr.matches(datetime(2026, 12, 2, 0, 0))
+
+    def test_weekly_preset_still_and(self) -> None:
+        """"@weekly" = "0 0 * * 0" — DOW restricted, DOM wildcard → AND."""
+        expr = parse_cron("@weekly")
+        assert expr.matches(datetime(2026, 11, 29, 0, 0))  # Sunday
+        assert not expr.matches(datetime(2026, 11, 30, 0, 0))  # Monday
+
+    # --- Name-based restrictions ---
+
+    def test_name_or_matches_dom_only(self) -> None:
+        """"0 0 1-15 * Mon-Fri" — Saturday within 1-15 → fires on DOM."""
+        expr = parse_cron("0 0 1-15 * Mon-Fri")
+        # Dec 5 2026 = Saturday (cron_dow=6) — outside Mon-Fri, inside 1-15
+        assert expr.matches(datetime(2026, 12, 5, 0, 0))
+
+    def test_name_or_matches_dow_only(self) -> None:
+        """"0 0 1-15 * Mon-Fri" — Monday after 15th → fires on DOW."""
+        expr = parse_cron("0 0 1-15 * Mon-Fri")
+        # Dec 21 2026 = Monday (cron_dow=1) — inside Mon-Fri, outside 1-15
+        assert expr.matches(datetime(2026, 12, 21, 0, 0))
+
+    def test_name_or_matches_both(self) -> None:
+        """"0 0 1-15 * Mon-Fri" — Monday within 1-15 → fires on both."""
+        expr = parse_cron("0 0 1-15 * Mon-Fri")
+        # Dec 7 2026 = Monday (cron_dow=1) — inside 1-15 AND Mon-Fri
+        assert expr.matches(datetime(2026, 12, 7, 0, 0))
+
+    def test_name_or_no_match(self) -> None:
+        """"0 0 1-15 * Mon-Fri" — Sunday outside 1-15 → no match."""
+        expr = parse_cron("0 0 1-15 * Mon-Fri")
+        # Dec 20 2026 = Sunday (cron_dow=0) — outside both
+        assert not expr.matches(datetime(2026, 12, 20, 0, 0))


### PR DESCRIPTION

Fixes #660

## Summary

Per POSIX, when both day-of-month and day-of-week are restricted (neither is a literal `*`), the job fires when **either** field matches (OR), not when both match (AND). The old matcher ANDed all five fields unconditionally, so an expression like `0 0 1,15 * 5` (1st, 15th, or any Friday) almost never fired — it required the date to be both the 1st/15th **and** a Friday simultaneously.

## Changes

- **CronField**: added `is_wildcard` flag, set from the raw token before any name/range substitutions — POSIX ties the OR-vs-AND rule to a literal `*` in the source expression, not to whether the resolved set spans the full range.
- **CronExpression.matches()**: split DOM/DOW out of the unconditional AND chain. When both fields are not wildcards, apply POSIX OR; otherwise fall back to standard AND.

## Tests (22 regression cases)

**OR when both restricted:**
- `0 0 1,15 * 5` — matches on 1st-only, Friday-only, both, and rejects non-matching days
- Cross-month boundary (March 1 = Sunday)
- Single-value DOM `0 0 15 * 5` — matches 15th, Friday, rejects non-matching

**AND fallback when one is wildcard:**
- `0 0 * * 5` — DOM wildcard: only Fridays
- `0 0 15 * *` — DOW wildcard: only 15th
- `0 0 * * *` — both wildcard: every day

**POSIX `*` vs explicit full-range distinction:**
- `0 0 1-31 * 5` — `1-31` is restricted even though it spans all days → OR fires every day
- `0 0 1-31 * 0-6` — both explicit full-range → OR
- `0 0 * * 0-6` — DOW restricted but DOM `*` wildcard → AND

**Preset regression guards:**
- `@monthly` still fires only on the 1st
- `@weekly` still fires only on Sundays

**Name-based restrictions:**
- `0 0 1-15 * Mon-Fri` — OR: matches DOM-only, DOW-only, both, and rejects non-match

## Verification


ruff check → All checks passed
mypy → Success: no issues found
pytest tests/test_scheduler/ -q → 494 passed (472 baseline + 22 new)


- [x] This pull request fully resolves the linked issue.
- [x] Includes regression tests for both positive and negative cases.