### PR TITLE
fix(cli): block directory traversal in sessions export command (#678)

### DIFF
--- a/src/agentos/cli/sessions_cmd.py
+++ b/src/agentos/cli/sessions_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -15,7 +16,6 @@ from agentos.cli.chat.session_state import messages_to_markdown
 from agentos.cli.gateway_rpc import default_gateway_token, default_gateway_url, run_gateway_sync
 from agentos.cli.output import print_json
 from agentos.cli.ui import ACCENT, ACCENT_HEADER, console, error_panel, markup_escape
-from agentos.session.manager import _safe_archive_part
 
 app = typer.Typer(help="Manage chat sessions.")
 
@@ -24,6 +24,56 @@ _ACTION_FAILED = object()
 
 # Rows pulled before a client-side --search filter runs.
 _SEARCH_FETCH_LIMIT = 500
+
+
+def _safe_export_filename(session_id: str) -> str:
+    r"""Sanitize *session_id* for use as a filename.
+
+    Strips all characters outside a strict safe set, matching the
+    approach used by :func:`_safe_archive_part` in the session manager.
+    The bare ``session_id.replace(':', '-')`` that preceded this function
+    let path separators (``/``, ``\``) pass through, enabling directory
+    traversal via a crafted session key.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", session_id).strip("-")
+    # Strip leading and trailing dots — a sanitised value that starts or
+    # ends with ``.`` (e.g. ``..-etc-pwned``) could still be misinterpreted
+    # as a hidden file or a parent-directory reference on case-insensitive
+    # filesystems. The inner dot stays so filenames like ``session.v2`` work.
+    safe = safe.strip(".")
+    return safe or "session"
+
+
+def _resolve_export_target(
+    session_id: str,
+    explicit_output: Path | None,
+    ext: str,
+) -> Path:
+    """Resolve the export output path, guarding against directory traversal.
+
+    Two attack surfaces:
+
+    1. **Session ID injection.** The raw *session_id* (which a remote gateway
+       returns) is sanitised via :func:`_safe_export_filename` before use.
+
+    2. **Explicit output path.** The ``--output`` CLI option is a
+       :class:`Path` that Typer resolves eagerly. An authenticated user could
+       pass ``--output ../../etc/pwned.json``. We resolve and verify the path
+       is within the working directory, rejecting any traversal outside it.
+    """
+    if explicit_output is not None:
+        explicit_output = explicit_output.expanduser().resolve()
+        cwd = Path.cwd().resolve()
+        try:
+            explicit_output.relative_to(cwd)
+        except ValueError:
+            raise typer.BadParameter(
+                f"Output path {explicit_output} is outside the working "
+                f"directory ({cwd}). Refusing to write there."
+            )
+        return explicit_output
+
+    return Path(f"{_safe_export_filename(session_id)}.{ext}")
 
 
 def _resolved_key(payload: dict[str, Any], fallback: str) -> str:
@@ -378,7 +428,7 @@ def sessions_export(
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
         return
-    target = output or Path(f"{_safe_archive_part(session_id)}.{format}")
+    target = _resolve_export_target(session_id, output, format)
     if format == "json":
         target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     else:

--- a/tests/test_cli/test_sessions_export_cmd.py
+++ b/tests/test_cli/test_sessions_export_cmd.py
@@ -1,14 +1,13 @@
-"""Issue #678: ``agentos sessions export`` must not write outside the CWD.
+"""Issue #678: sessions export path traversal.
 
-The gateway round-trip is stubbed at ``run_gateway_sync`` — these cover the
-default-filename derivation, which is where the user-supplied ``session_id``
-reaches the filesystem.
+The CLI surface is stubbed at ``run_gateway_sync`` — these test the
+argument sanitisation (session ID injection, output path traversal),
+not the RPC layer.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 from typer.testing import CliRunner
@@ -18,73 +17,111 @@ from agentos.cli import sessions_cmd
 runner = CliRunner()
 
 
-class _FakeClient:
-    async def resolve_session(self, session_id: str) -> dict[str, Any]:
-        return {"session_key": session_id, "status": "done", "model": "gpt-x"}
+class TestSafeExportFilename:
+    def test_replaces_path_separators(self) -> None:
+        """Slashes and backslashes must be stripped, not passed through."""
+        safe = sessions_cmd._safe_export_filename("../../etc/pwned")
+        assert "/" not in safe
+        assert "\\" not in safe
 
-    async def preview_sessions(self, keys: list[str]) -> dict[str, Any]:
-        return {"previews": [{"lastMessage": "hello"}]}
+    def test_replaces_colons(self) -> None:
+        """The original session_id.replace(':', '-') only handled colons."""
+        safe = sessions_cmd._safe_export_filename("agent:main:cli:abc")
+        assert ":" not in safe
+        assert safe == "agent-main-cli-abc"
 
-    async def session_history(self, key: str, limit: int = 1000) -> dict[str, Any]:
-        return {"messages": []}
+    def test_rejects_traversal_with_mixed_separators(self) -> None:
+        safe = sessions_cmd._safe_export_filename("..\\..\\secret\\key")
+        assert "\\" not in safe
+        assert "/" not in safe
 
+    def test_empty_after_sanitize_falls_back(self) -> None:
+        safe = sessions_cmd._safe_export_filename("///")
+        assert safe == "session"
 
-@pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
-    fake = _FakeClient()
+    def test_all_dots_falls_back(self) -> None:
+        safe = sessions_cmd._safe_export_filename("...")
+        assert safe == "session"
 
-    async def _with_client(action):
-        return await action(fake)
+    def test_leading_dot_removed_to_prevent_hidden_file(self) -> None:
+        """Leading dots are stripped so the filename is not hidden on Unix."""
+        safe = sessions_cmd._safe_export_filename(".hidden")
+        assert not safe.startswith(".")
 
-    monkeypatch.setattr(sessions_cmd, "_with_client", _with_client)
-    return fake
+    def test_normal_session_key_passes_through(self) -> None:
+        safe = sessions_cmd._safe_export_filename("agent-main-cli-abc")
+        assert safe == "agent-main-cli-abc"
 
+    def test_inner_dots_are_preserved(self) -> None:
+        """Dots in the middle of a safe name (e.g. version suffixes) stay."""
+        safe = sessions_cmd._safe_export_filename("session.v2")
+        assert safe == "session.v2"
 
-@pytest.mark.parametrize(
-    ("session_id", "expected"),
-    [
-        ("agent:main:cli:aaa", "agent-main-cli-aaa"),
-        ("../../etc/pwned", "etc-pwned"),
-        ("..\\..\\Windows\\pwned", "Windows-pwned"),
-        ("/absolute/path", "absolute-path"),
-        ("..", "session"),
-        ("", "session"),
-    ],
-)
-def test_safe_export_stem_strips_path_separators(
-    session_id: str, expected: str
-) -> None:
-    """_safe_archive_part is reused for export filenames."""
-    from agentos.session.manager import _safe_archive_part
+    def test_trailing_dot_stripped(self) -> None:
+        safe = sessions_cmd._safe_export_filename("name.")
+        assert not safe.endswith(".")
 
-    assert _safe_archive_part(session_id) == expected
-
-
-def test_export_writes_inside_the_working_directory(
-    client: _FakeClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A traversal id lands in the CWD under a flattened name, not at /etc."""
-    monkeypatch.chdir(tmp_path)
-    escaped = tmp_path.parent / "pwned.json"
-
-    result = runner.invoke(sessions_cmd.app, ["export", "../pwned", "--format", "json"])
-
-    assert result.exit_code == 0, result.output
-    assert not escaped.exists()
-    assert (tmp_path / "pwned.json").exists()
+    def test_dot_only_segments_inside_are_harmless(self) -> None:
+        """A ``..`` segment that survives (after slash→hyphen replacement)
+        is just part of the filename, not a directory reference — path
+        separators are already removed."""
+        safe = sessions_cmd._safe_export_filename("../../etc/pwned")
+        # ``/`` becomes ``-`` → ``-..-etc-pwned`` — harmless filename.
+        assert safe.startswith("-")
+        assert ".." in safe  # part of filename, not a traversal
 
 
-def test_export_honours_an_explicit_output_path(
-    client: _FakeClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """--output is the caller's own choice and is left untouched."""
-    monkeypatch.chdir(tmp_path)
-    target = tmp_path / "nested" / "chosen.md"
-    target.parent.mkdir()
+class TestResolveExportTarget:
+    def test_no_output_argument_uses_safe_filename(self) -> None:
+        target = sessions_cmd._resolve_export_target(
+            "agent:main:cli:abc",
+            None,
+            "json",
+        )
+        assert str(target) == "agent-main-cli-abc.json"
+        assert ":" not in str(target)
 
-    result = runner.invoke(
-        sessions_cmd.app, ["export", "agent:main:cli:aaa", "--output", str(target)]
-    )
+    def test_traversal_session_id_gets_path_separators_removed(self) -> None:
+        target = sessions_cmd._resolve_export_target(
+            "../../etc/pwned",
+            None,
+            "md",
+        )
+        assert "/" not in str(target)
+        assert "\\" not in str(target)
+        # The filename can contain ``..`` (harmless once separators are gone),
+        # but it must not be a hidden dotfile.
+        assert not Path(str(target)).name.startswith(".")
 
-    assert result.exit_code == 0
-    assert target.exists()
+    def test_explicit_output_within_cwd_passes(self) -> None:
+        """A file in the current working directory is accepted."""
+        cwd = Path.cwd()
+        target = sessions_cmd._resolve_export_target(
+            "any",
+            cwd / "test-export-tmp.md",
+            "md",
+        )
+        assert str(target) == str(cwd / "test-export-tmp.md")
+
+    def test_explicit_output_outside_cwd_is_rejected(self) -> None:
+        """Path traversal via --output must be blocked."""
+        from click.exceptions import BadParameter
+
+        with pytest.raises(BadParameter, match="outside the working directory"):
+            sessions_cmd._resolve_export_target(
+                "any",
+                Path("/tmp/outside.md"),
+                "md",
+            )
+
+    def test_traversal_path_in_explicit_output_is_rejected(self) -> None:
+        """--output with ../ traversal must be rejected."""
+        from click.exceptions import BadParameter
+
+        traversal = Path("../../etc/pwned.json").resolve()
+        with pytest.raises(BadParameter, match="outside the working directory"):
+            sessions_cmd._resolve_export_target(
+                "any",
+                traversal,
+                "json",
+            )


### PR DESCRIPTION

Fixes #678 — closes the gap PR #679 leaves open.

## Gap in PR #679

PR #679 only sanitizes the session ID's filename and does NOT validate the
`--output` path argument. An authenticated user can pass `--output ../../etc/pwned.json`
to write outside the working directory.

## Fix

Two attack surfaces covered:

1. **Session ID injection** (`_safe_export_filename`). Strips all non-alphanumeric
   characters except `_`, `.`, `-`; removes leading/trailing dots; falls back
   to `"session"` when empty.

2. **Explicit output path** (`_resolve_export_target`). Verifies `--output` path
   stays within `Path.cwd()` using `relative_to` — rejects any traversal
   outside the working directory.

## Changes

- `src/agentos/cli/sessions_cmd.py`:
  - `_safe_export_filename(session_id)` — sanitises session_id
  - `_resolve_export_target()` — validates both session ID injection and
    explicit `--output` path traversal
- `tests/test_cli/test_sessions_export_cmd.py` — 15 regression tests

## Verification


$ uv run pytest tests/test_cli/test_sessions_export_cmd.py -q
15 passed in 0.18s

$ uv run ruff check src tests
All checks passed!