### PR TITLE
fix(media): call raise_for_status before aclose when Location header is absent

### DIFF
--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -308,9 +308,14 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
                 if resp.status_code not in {301, 302, 303, 307, 308}:
                     break
                 location = resp.headers.get("location")
-                await resp.aclose()
                 if not location:
+                    # Call raise_for_status BEFORE closing so a 3xx error
+                    # raises a clear HTTPStatusError instead of a wrapped
+                    # StreamClosed when the body is non-empty.
+                    resp.raise_for_status()
+                    await resp.aclose()
                     break
+                await resp.aclose()
                 current_url = urljoin(str(resp.url), location)
             else:
                 raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")

--- a/tests/test_tools/test_media_image_download_cap.py
+++ b/tests/test_tools/test_media_image_download_cap.py
@@ -15,7 +15,18 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from agentos.tools import ssrf_client as sc_mod
 from agentos.tools.builtin.media import _fetch_image_url
+
+
+class _StreamingBody(httpx.AsyncByteStream):
+    """A genuinely streaming body — reading after close actually raises."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def __aiter__(self):
+        yield self._body
 
 
 def _png_header() -> bytes:
@@ -59,10 +70,113 @@ async def test_fetch_image_small_body_ok(monkeypatch: pytest.MonkeyPatch) -> Non
     """A normal-sized image is fetched and returned."""
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, headers={"content-type": "image/png"}, content=_png_header())
+        return httpx.Response(
+            200, headers={"content-type": "image/png"}, content=_png_header()
+        )
 
     _patch_network(monkeypatch, handler)
 
     data, mime = await _fetch_image_url("https://example.com/small.png")
+    assert mime == "image/png"
+    assert data == _png_header()
+
+
+def _install_streaming_transport(
+    monkeypatch: pytest.MonkeyPatch, transport: httpx.AsyncBaseTransport
+) -> None:
+    """Patch ssrf_guarded_client to yield a client with a streaming transport."""
+
+    from contextlib import asynccontextmanager
+
+    class _StreamingClient(httpx.AsyncClient):
+        def __init__(self, *a: object, **kw: object) -> None:
+            kw.pop("transport", None)
+            super().__init__(*a, transport=transport, **kw)
+
+    @asynccontextmanager
+    async def _streaming_guard(*a: object, **kw: object):
+        client = _StreamingClient(*a, **kw)
+        try:
+            yield client
+        finally:
+            await client.aclose()
+
+    monkeypatch.setattr(sc_mod, "ssrf_guarded_client", _streaming_guard)
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_no_location_3xx_raises_http_error_not_stream_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 302 with no Location header must raise a clear HTTPStatusError, not a
+    wrapped StreamClosed from calling raise_for_status on an already-closed stream.
+
+    Before the fix, the code called aclose() then raise_for_status() on the
+    closed response; when the body was non-empty and the stream had been
+    partially consumed, httpx.StreamClosed was raised instead of HTTPStatusError.
+    """
+
+    async def streaming_handler(request: httpx.Request) -> httpx.Response:
+        # Return a 302 with a non-empty body and NO Location header.
+        # Reading from this stream after close raises StreamError.
+        body = _StreamingBody(b"redirect body that must not be read after close")
+        return httpx.Response(
+            302, headers={"content-type": "text/plain"}, stream=body
+        )
+
+    _handler = staticmethod(streaming_handler)
+
+    class _T(httpx.AsyncBaseTransport):
+        handle_async_request = _handler
+
+    transport = _T()
+    _install_streaming_transport(monkeypatch, transport)
+
+    with pytest.raises(Exception) as exc_info:
+        await _fetch_image_url("https://example.com/no-location.png")
+
+    # Must be HTTPStatusError (redirect status), NOT StreamClosed
+    exc_type = type(exc_info.value).__name__
+    assert "StreamClosed" not in exc_type, (
+        f"Expected HTTPStatusError, got {exc_type}: {exc_info.value}"
+    )
+    assert "302" in str(exc_info.value), (
+        f"Expected 302 in error message, got: {exc_info.value}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_302_follows_valid_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 302 with a valid Location header must be followed to the final URL."""
+
+    async def redirecting_handler(request: httpx.Request) -> httpx.Response:
+        if "final" in str(request.url):
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/png"},
+                content=_png_header(),
+            )
+        # First hop: 302 with Location pointing to /final.png
+        body = _StreamingBody(b"")
+        return httpx.Response(
+            302,
+            headers={
+                "location": "https://example.com/final.png",
+                "content-type": "text/plain",
+            },
+            stream=body,
+        )
+
+    _handler = staticmethod(redirecting_handler)
+
+    class _T(httpx.AsyncBaseTransport):
+        handle_async_request = _handler
+
+    transport = _T()
+    _install_streaming_transport(monkeypatch, transport)
+
+    data, mime = await _fetch_image_url("https://example.com/redirect.png")
     assert mime == "image/png"
     assert data == _png_header()


### PR DESCRIPTION
Fixes #616

## Summary

`agentos/tools/builtin/media.py` — the redirect loop in `_fetch_image_url` calls `await resp.aclose()` and then `raise_for_status()` on a closed response. When the 3xx body is non-empty and the stream has been read, this raises `httpx.StreamClosed` (or a `StreamError` chain) instead of the clear `HTTPStatusError` callers expect. The fix calls `raise_for_status()` BEFORE `aclose()` so the failure path is always a proper `HTTPStatusError("302 Found")` wrapped in `ToolError`.

Before: `ToolError("Failed to fetch image from URL: <wrapped StreamClosed>")` — confusing.
After: `ToolError("Failed to fetch image from URL: 302 Found ...")` — actionable.

## What

- src/agentos/tools/builtin/media.py — call `raise_for_status()` on the 3xx response before `aclose()` when the `Location` header is missing
- tests/test_tools/test_media_image_download_cap.py — adds `_StreamingBody`, `_install_streaming_transport`, and two regression tests:
  - `test_fetch_image_no_location_3xx_raises_http_error_not_stream_closed` — proves the bug
  - `test_fetch_image_302_follows_valid_location` — proves the happy path (valid Location still followed) is not broken

## Verification

- `uv run pytest tests/test_tools/test_media_image_download_cap.py -v` — 4 passed
- `uv run ruff check src/agentos/tools/builtin/media.py tests/test_tools/test_media_image_download_cap.py` — clean
