### PR TITLE
fix(channels): return response on exhausted 429 and parse HTTP-date R…

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -14,6 +14,7 @@ import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC
 from typing import Any, Literal
 
 import httpx
@@ -271,6 +272,29 @@ class FloodStrikeBackoff:
         self._fallback = False
 
 
+def _parse_retry_after(header_val: str | None, default_delay: float) -> float:
+    """Parse a Retry-After header value into seconds.
+
+    Supports RFC 7231 / RFC 9110 formats: integer/float seconds or an HTTP-date.
+    Falls back to ``default_delay`` if missing or unparseable.
+    """
+    if not header_val:
+        return default_delay
+    header_str = header_val.strip()
+    try:
+        delay = float(header_str)
+    except ValueError:
+        try:
+            import email.utils
+            from datetime import datetime
+
+            dt = email.utils.parsedate_to_datetime(header_str)
+            delay = (dt - datetime.now(UTC)).total_seconds()
+        except Exception:
+            return default_delay
+    return max(0.0, delay)
+
+
 async def retry_request(
     func: Callable[..., Awaitable[httpx.Response]],
     *args: Any,
@@ -283,8 +307,10 @@ async def retry_request(
     for attempt in range(max_retries + 1):
         try:
             resp = await func(*args, **kwargs)
-            if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+            if resp.status_code == 429 and attempt < max_retries:
+                retry_after = _parse_retry_after(
+                    resp.headers.get("Retry-After"), base_delay * (2**attempt)
+                )
                 log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
                 await asyncio.sleep(retry_after)
                 continue

--- a/tests/test_channels/test_slack_retry.py
+++ b/tests/test_channels/test_slack_retry.py
@@ -7,6 +7,7 @@ timeouts are retried, and a fatal 4xx is returned on the first attempt.
 
 from __future__ import annotations
 
+from datetime import UTC
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -99,6 +100,64 @@ async def test_send_raises_after_retries_are_exhausted(no_sleep) -> None:
         await channel.send(OutgoingMessage(content="hi", reply_to="C123"))
 
     assert post.await_count == 4  # initial attempt + max_retries=3
+
+
+async def test_send_exhausted_rate_limit_raises_http_status_error(no_sleep) -> None:
+    """When 429 retries are exhausted, the 429 response is returned and raises HTTPStatusError."""
+    channel = _channel()
+    post = _attach(channel, *[_resp(429, {"ok": False, "error": "rate_limited"})] * 4)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await channel.send(OutgoingMessage(content="hi", reply_to="C123"))
+
+    assert exc_info.value.response.status_code == 429
+    assert post.await_count == 4  # initial attempt + 3 retries
+    assert no_sleep.await_count == 3  # slept between retries, but not after final exhaustion
+
+
+async def test_send_retries_rate_limit_with_http_date_header(no_sleep) -> None:
+    """Retry-After header formatted as RFC 7231 / RFC 9110 HTTP-date is parsed properly."""
+    from datetime import datetime, timedelta
+
+    future = datetime.now(UTC) + timedelta(seconds=15)
+    http_date = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    channel = _channel()
+    post = _attach(channel, _resp(429, headers={"Retry-After": http_date}), _resp(200))
+
+    await channel.send(OutgoingMessage(content="hi", reply_to="C123"))
+
+    assert post.await_count == 2
+    assert no_sleep.await_count == 1
+    slept_time = no_sleep.call_args[0][0]
+    # Allow 5s delta for test execution tolerance
+    assert 10.0 <= slept_time <= 20.0
+
+
+def test_parse_retry_after_formats() -> None:
+    from datetime import datetime, timedelta
+
+    from agentos.channels._util import _parse_retry_after
+
+    # Seconds integer and float
+    assert _parse_retry_after("10", 1.0) == 10.0
+    assert _parse_retry_after("2.5", 1.0) == 2.5
+
+    # Missing, empty, or unparseable fallback to default_delay
+    assert _parse_retry_after(None, 5.0) == 5.0
+    assert _parse_retry_after("", 5.0) == 5.0
+    assert _parse_retry_after("not-a-number", 5.0) == 5.0
+
+    # RFC 7231 HTTP-date
+    future = datetime.now(UTC) + timedelta(seconds=30)
+    http_date = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    parsed = _parse_retry_after(http_date, 1.0)
+    assert 25.0 <= parsed <= 35.0
+
+    # Past HTTP-date clamps to 0.0
+    past = datetime.now(UTC) - timedelta(seconds=30)
+    past_date = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    assert _parse_retry_after(past_date, 1.0) == 0.0
 
 
 async def test_edit_retries_transient_error(no_sleep) -> None:


### PR DESCRIPTION
closes #718 ## Summary
In `src/agentos/channels/_util.py`, `retry_request` had two defects when handling HTTP 429 rate limits:

1. **429 Response Dropped on Retry Exhaustion**:
   The 5xx retry branch is guarded by `attempt < max_retries`, ensuring that when retries are exhausted the response is returned to the caller. The 429 branch had no such guard: on the final attempt it slept and continued out of the loop into `raise last_exc or RuntimeError("retry_request exhausted")`. Because no network exception occurred (`last_exc` was `None`), it raised a bare `RuntimeError` and discarded the actual 429 response, headers, and provider error details.
2. **Crash on HTTP-date `Retry-After` Headers**:
   `retry_after = float(resp.headers.get("Retry-After", ...))` unconditionally assumed a numeric string. Servers emitting standard RFC 7231 / RFC 9110 HTTP-dates (e.g. `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`) crashed immediately with `ValueError: could not convert string to float`.

## Changes
- Implemented `_parse_retry_after` to parse both delay-seconds and HTTP-date strings using `email.utils.parsedate_to_datetime`, safely falling back to exponential backoff on invalid values.
- Guarded the 429 branch with `attempt < max_retries` so exhausted retries return the `httpx.Response` to the caller, allowing `resp.raise_for_status()` to raise `httpx.HTTPStatusError` with full response details.
- Added comprehensive unit and regression tests in `tests/test_channels/test_slack_retry.py`.
