### PR TITLE
fix(channels): mark email seen after conversion

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -478,6 +478,8 @@ class EmailChannel:
                     if parsed is None:
                         continue
                     message = self._to_incoming(parsed)
+                    # Acknowledge only after parsing and conversion return normally.
+                    self._mark_seen(client, uid)
                 except Exception as exc:  # noqa: BLE001 — one bad mail, not the batch
                     log.warning("email.message_read_failed", name=self.config.name, error=str(exc))
                     continue
@@ -522,7 +524,6 @@ class EmailChannel:
             self._mark_seen(client, uid)
             return None
 
-        self._mark_seen(client, uid)
         parsed = BytesParser(policy=email_policy).parsebytes(raw)
         return parsed if isinstance(parsed, EmailMessage) else None
 

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -541,6 +541,44 @@ def test_poll_parses_and_marks_seen(monkeypatch: pytest.MonkeyPatch) -> None:
     assert fake.closed is True
 
 
+def test_poll_retries_message_after_transient_conversion_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+    real_to_incoming = channel._to_incoming
+    attempts = 0
+
+    def _flaky(parsed: EmailMessage) -> IncomingMessage | None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ValueError("transient conversion failure")
+        return real_to_incoming(parsed)
+
+    monkeypatch.setattr(channel, "_to_incoming", _flaky)
+
+    assert channel._fetch_unseen() == []
+    assert fake.stored == []
+
+    messages = channel._fetch_unseen()
+
+    assert [message.sender_id for message in messages] == ["owner@example.com"]
+    assert fake.stored == [("7", "+FLAGS", "\\Seen")]
+
+
+def test_poll_marks_deliberately_filtered_message_seen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    fake = _FakeIMAP(_raw(sender="stranger@example.net").as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    assert channel._fetch_unseen() == []
+    assert fake.stored == [("7", "+FLAGS", "\\Seen")]
+
+
 def test_poll_skips_a_message_larger_than_the_cap(monkeypatch: pytest.MonkeyPatch) -> None:
     channel = EmailChannel(config=_config(max_message_bytes=32))
     fake = _FakeIMAP(_raw().as_bytes(), size=10_000)
@@ -573,6 +611,7 @@ def test_one_unreadable_message_does_not_sink_the_poll(
 
     assert calls == ["7", "8"]
     assert len(messages) == 1
+    assert fake.stored == [("8", "+FLAGS", "\\Seen")]
 
 
 def test_mark_seen_disabled_leaves_the_flag_alone(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #719

## Summary

- move the normal IMAP Seen acknowledgement until after MIME parsing and IncomingMessage conversion return normally
- leave transient parse/conversion failures unread so a later poll can retry, while preserving Seen behavior for deliberate filters and oversized mail
- add deterministic regression coverage for retry, filtered mail, and mixed successful/failed batches

## Testing

- uv run pytest tests/test_channels/test_email_channel.py -q (51 passed)
- uv run pytest tests/test_channels -q (303 passed)
- uv run python scripts/build_control_ui.py build (passed)
- npm --prefix frontend run check (98 files, 2007 tests passed)
- uv run ruff check src tests (passed)
- uv run mypy src/agentos --show-error-codes (619 files passed)
- uv build --wheel (passed)
- uv run pytest -q (8721 passed, 32 skipped; 6 failures and 3 errors reproduced unchanged on clean origin/main: local ONNX assets are not hydrated and the installed uv does not support build --clear)

No public API or schema changes. Third-party origin: none.