### PR TITLE
fix(media): raise ToolError on redirect missing Location header

### DIFF
--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -308,9 +308,13 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
                 if resp.status_code not in {301, 302, 303, 307, 308}:
                     break
                 location = resp.headers.get("location")
-                await resp.aclose()
                 if not location:
-                    break
+                    await resp.aclose()
+                    raise ToolError(
+                        f"Redirect response ({resp.status_code}) from {current_url} "
+                        "missing Location header"
+                    )
+                await resp.aclose()
                 current_url = urljoin(str(resp.url), location)
             else:
                 raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")

--- a/tests/test_tools/test_media_image_download_cap.py
+++ b/tests/test_tools/test_media_image_download_cap.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from agentos.tools.builtin.media import _fetch_image_url
+from agentos.tools.types import ToolError
 
 
 def _png_header() -> bytes:
@@ -66,3 +67,51 @@ async def test_fetch_image_small_body_ok(monkeypatch: pytest.MonkeyPatch) -> Non
     data, mime = await _fetch_image_url("https://example.com/small.png")
     assert mime == "image/png"
     assert data == _png_header()
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_redirect_missing_location_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A redirect response without a Location header raises ToolError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="missing Location header"):
+        await _fetch_image_url("https://example.com/redirect.png")
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_redirect_follows_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 302 redirect with Location header follows and returns the image."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/redirect.png":
+            return httpx.Response(302, headers={"location": "/final.png"})
+        return httpx.Response(200, headers={"content-type": "image/png"}, content=_png_header())
+
+    _patch_network(monkeypatch, handler)
+
+    data, mime = await _fetch_image_url("https://example.com/redirect.png")
+    assert mime == "image/png"
+    assert data == _png_header()
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_too_many_redirects_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceeding MAX_REDIRECTS raises ToolError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "/loop.png"})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="Too many redirects"):
+        await _fetch_image_url("https://example.com/redirect-loop.png")


### PR DESCRIPTION
## Summary closes #721 
In `src/agentos/tools/builtin/media.py`, `_fetch_image_url` closed the HTTP streaming response before checking if a `Location` header was present on 3xx redirect responses. When an image endpoint returned a 3xx redirect without a `Location` header, breaking out of the loop caused `resp.aiter_bytes()` to attempt reading from a closed response stream, failing with `httpx.StreamClosed: Attempted to read or stream content, but the stream has been closed.`

## Changes
- Reordered the `location` header check in `_fetch_image_url` to inspect the header before closing the stream.
- Raised a clear, actionable `ToolError(f"Redirect response ({resp.status_code}) from {current_url} missing Location header")` if the header is absent, ensuring the stream is cleanly closed first.
- Added tests in `tests/test_tools/test_media_image_download_cap.py` covering redirects without Location headers, valid redirect-following, and redirect loop exhaustion.
