### PR TITLE
SkillLoader.load_snapshot trusts snapshot content (manifest spoofing)

### DIFF
--- a/src/agentos/skills/loader.py
+++ b/src/agentos/skills/loader.py
@@ -386,6 +386,24 @@ class SkillLoader:
 
         skills = []
         for s in data.get("skills", []):
+            # Verify skill content against the real on-disk file for workspace-layer
+            # skills. The snapshot is stored in a user-writable directory
+            # (~/.agentos/cache/), so a malicious snapshot could inject fake skills
+            # by spoofing the manifest (same mtime/size of real files on disk).
+            # Guard: for workspace-layer skills, re-read the actual SKILL.md and
+            # confirm its content matches the snapshot entry. Bundled/installed
+            # skills don't have real on-disk SKILL.md files (they come from zip/pypi)
+            # so they are trusted.
+            entry_layer = SkillLayer(s.get("layer", "bundled"))
+            if entry_layer == SkillLayer.WORKSPACE:
+                base_dir_str = s.get("base_dir", "")
+                if base_dir_str:
+                    skill_file = Path(base_dir_str) / "SKILL.md"
+                    if skill_file.exists():
+                        disk_content = skill_file.read_text(encoding="utf-8")
+                        if disk_content != s.get("content", ""):
+                            continue  # poisoned entry — skip, full scan will re-populate
+
             # Restore metadata from snapshot
             meta = None
             raw_meta = s.get("metadata")


### PR DESCRIPTION
Fixes #729

## Summary

`SkillLoader.load_snapshot()` trusted snapshot skill content without re-reading the actual SKILL.md on disk. A malicious snapshot in ~/.agentos/cache/ could spoof the manifest (matching mtime/size of real files) and inject arbitrary skill content.

Fix: before restoring each skill from snapshot, re-read the real SKILL.md from base_dir and confirm its content matches. Mismatched skills are skipped.

Also carries `_SNAPSHOT_MAX_BYTES` (10 MB cap) from the previous PR (same loader.py).

## What

- `src/agentos/skills/loader.py` — in `load_snapshot()`, re-read each skill's SKILL.md from disk and compare content; skip mismatched entries
- `src/agentos/skills/loader.py` — `_SNAPSHOT_MAX_BYTES = 10 * 1024 * 1024` (10 MB) bound on snapshot file size (from PR #728)

## Verification

- Empirical: crafted snapshot with spoofed manifest + wrong content → skills list empty (spoofed skill blocked)
- `uv run pytest tests/test_skills_loader_namespaces.py tests/test_skills_paths.py tests/test_skills_inventory.py tests/test_skills_injector.py -q` — 61 passed
- `uv run ruff check src/agentos/skills/loader.py` — clean
