### PR TITLE
fix(provider): recognize substring markers in empty response classifi…

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -105,14 +105,24 @@ def _is_policy_refusal(text: str) -> bool:
     )
 
 
+_EMPTY_RESPONSE_MARKERS = (
+    "empty response",
+    "empty_response",
+    "empty completion",
+    "empty_completion",
+    "empty choices",
+    "produced no output",
+    "no content returned",
+    "no response content",
+)
+
+
 def _is_empty_response(raw_code: str, message: str) -> bool:
     normalized_code = (raw_code or "").strip().lower()
     normalized_message = (message or "").strip().lower()
-    return normalized_code == "empty_response" or normalized_message in {
-        "empty_response",
-        "empty response",
-        "provider returned an empty response",
-    }
+    if normalized_code in {"empty_response", "empty_completion"}:
+        return True
+    return any(marker in normalized_message for marker in _EMPTY_RESPONSE_MARKERS)
 
 
 def _is_gateway_transient(text: str) -> bool:
@@ -134,8 +144,9 @@ def classify_provider_error(
         return ProviderFailureKind.CONTEXT_OVERFLOW
     if _is_policy_refusal(text):
         return ProviderFailureKind.POLICY_REFUSAL
-    if _is_empty_response(raw_code, message):
-        return ProviderFailureKind.EMPTY_RESPONSE
+    if status_code not in _GATEWAY_TRANSIENT_STATUS_CODES and not _is_gateway_transient(text):
+        if _is_empty_response(raw_code, message):
+            return ProviderFailureKind.EMPTY_RESPONSE
 
     if provider in _OPENAI_COMPAT_PROVIDERS:
         if status_code in {401, 403} or "invalid api key" in text or "unauthorized" in text:

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -161,9 +161,7 @@ def test_agent_fallback_does_not_retry_unscoped_gateway_numbers(message: str) ->
         "HTTP 523",
     ],
 )
-def test_provider_failure_classifies_gateway_transient_errors(
-    provider: str, message: str
-) -> None:
+def test_provider_failure_classifies_gateway_transient_errors(provider: str, message: str) -> None:
     assert (
         classify_provider_error(provider, None, message=message)
         is ProviderFailureKind.PROVIDER_OVERLOADED
@@ -187,8 +185,7 @@ def test_provider_failure_classifies_gateway_transient_errors(
 )
 def test_provider_failure_does_not_classify_unscoped_gateway_numbers(message: str) -> None:
     assert (
-        classify_provider_error("openrouter", None, message=message)
-        is ProviderFailureKind.UNKNOWN
+        classify_provider_error("openrouter", None, message=message) is ProviderFailureKind.UNKNOWN
     )
 
 
@@ -205,13 +202,18 @@ def test_agent_fallback_still_does_not_retry_auth_failures() -> None:
     ("raw_code", "message"),
     [
         ("empty_response", ""),
+        ("empty_completion", ""),
         ("", "Provider returned an empty response"),
         ("", "empty_response"),
+        ("", "Empty response from model"),
+        ("", "Model returned empty response: gpt-5"),
+        ("", "Model produced no output"),
+        ("", "Empty completion received from upstream"),
+        ("", "No content returned in message"),
+        ("", "Provider returned empty choices"),
     ],
 )
-def test_provider_failure_classifies_empty_responses(
-    raw_code: str, message: str
-) -> None:
+def test_provider_failure_classifies_empty_responses(raw_code: str, message: str) -> None:
     assert (
         classify_provider_error("openrouter", None, raw_code=raw_code, message=message)
         is ProviderFailureKind.EMPTY_RESPONSE


### PR DESCRIPTION
## Summary closes #731 
In `src/agentos/provider/failures.py`, `_is_empty_response` previously enforced an exact match against a rigid 3-string set (`"empty_response"`, `"empty response"`, `"provider returned an empty response"`). Real-world upstream provider error messages such as `"Empty response from model"`, `"Model produced no output"`, `"Empty completion received"`, or `"No content returned in message"` failed this exact match and fell through to `ProviderFailureKind.UNKNOWN`.

## Changes
- Updated `_is_empty_response` to inspect common substring markers (`"empty response"`, `"empty completion"`, `"empty choices"`, `"produced no output"`, `"no content returned"`, `"no response content"`) and raw codes.
- Guarded `_is_empty_response` in `classify_provider_error` so HTTP gateway errors (500, 502, 503, 524) with empty body text continue to classify as `PROVIDER_OVERLOADED`.
- Expanded test coverage in `tests/test_provider_failure_classification.py`.
