### PR TITLE
fix(channels): return 429 response on exhaustion and parse HTTP-date Retry-After

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -14,6 +14,8 @@ import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Literal
 
 import httpx
@@ -271,6 +273,46 @@ class FloodStrikeBackoff:
         self._fallback = False
 
 
+_MAX_RETRY_AFTER_SECONDS: float = 300.0
+"""Upper bound for a single Retry-After backoff (5 minutes).
+
+A server that sends a far-future HTTP-date or an unreasonably large
+integer in its ``Retry-After`` header cannot make the async task sleep
+indefinitely — the delay is capped at this value.  The limit is generous
+enough to cover every legitimate rate-limit window seen in practice
+(most are 1–120 seconds) while bounding worst-case resource exhaustion.
+"""
+
+
+def _parse_retry_after(
+    header_val: str | None,
+    default_delay: float,
+    max_delay: float = _MAX_RETRY_AFTER_SECONDS,
+) -> float:
+    """Parse a ``Retry-After`` header value into seconds.
+
+    Supports RFC 7231 / RFC 9110 formats: an integer/float number of
+    seconds, or an HTTP-date (e.g. ``Wed, 21 Oct 2026 07:28:00 GMT``).
+    Falls back to ``default_delay`` when the header is missing, empty,
+    or unparseable.  The result is clamped to ``[0.0, max_delay]`` to
+    bound worst-case sleep duration.
+    """
+    if not header_val:
+        return default_delay
+
+    stripped = header_val.strip()
+    try:
+        delay = float(stripped)
+    except ValueError:
+        try:
+            dt = parsedate_to_datetime(stripped)
+            delay = (dt - datetime.now(UTC)).total_seconds()
+        except Exception:  # noqa: BLE001 — best-effort, fall back to default
+            return default_delay
+
+    return min(max(0.0, delay), max_delay)
+
+
 async def retry_request(
     func: Callable[..., Awaitable[httpx.Response]],
     *args: Any,
@@ -278,16 +320,26 @@ async def retry_request(
     base_delay: float = 1.0,
     **kwargs: Any,
 ) -> httpx.Response:
-    """Retry an httpx request with exponential backoff on transient errors."""
+    """Retry an httpx request with exponential backoff on transient errors.
+
+    On the final attempt the response is returned unconditionally (even
+    for HTTP 429), so the caller can inspect the status, headers, and
+    body instead of catching a bare ``RuntimeError``.
+    """
     last_exc: Exception | None = None
     for attempt in range(max_retries + 1):
         try:
             resp = await func(*args, **kwargs)
             if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
-                log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
-                await asyncio.sleep(retry_after)
-                continue
+                if attempt < max_retries:
+                    retry_after = _parse_retry_after(
+                        resp.headers.get("Retry-After"),
+                        base_delay * (2**attempt),
+                    )
+                    log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
+                    await asyncio.sleep(retry_after)
+                    continue
+                return resp
             if resp.status_code in {500, 502, 503, 504} and attempt < max_retries:
                 delay = base_delay * (2**attempt) + random.random()
                 log.warning("transient_error", status=resp.status_code, delay=delay)

--- a/tests/test_channels/test_slack_retry.py
+++ b/tests/test_channels/test_slack_retry.py
@@ -7,6 +7,7 @@ timeouts are retried, and a fatal 4xx is returned on the first attempt.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -14,6 +15,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from agentos.channels._util import _parse_retry_after, retry_request
 from agentos.channels.slack import SlackChannel
 from agentos.channels.types import OutgoingMessage
 
@@ -189,3 +191,91 @@ async def test_send_does_not_retry_slack_level_error(no_sleep) -> None:
         await channel.send(OutgoingMessage(content="hi", reply_to="C123"))
 
     assert post.await_count == 1
+
+
+# ── retry_request: exhausted 429 + Retry-After parsing (#718) ───────────────
+
+
+def test_parse_retry_after_formats() -> None:
+    """Numeric seconds and RFC 7231 HTTP-dates both parse; garbage falls back."""
+    # Integer / float seconds.
+    assert _parse_retry_after("10", 1.0) == 10.0
+    assert _parse_retry_after("2.5", 1.0) == 2.5
+
+    # Missing / empty / unparseable → default_delay.
+    assert _parse_retry_after(None, 5.0) == 5.0
+    assert _parse_retry_after("", 5.0) == 5.0
+    assert _parse_retry_after("   ", 5.0) == 5.0
+    assert _parse_retry_after("not-a-number", 5.0) == 5.0
+
+    # Past HTTP-date clamps to 0.0.
+    from datetime import timedelta
+
+    past = (datetime.now(UTC) - timedelta(seconds=30)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    assert _parse_retry_after(past, 1.0) == 0.0
+
+    # A far-future HTTP-date is capped at max_delay (5 minutes).
+    far_future = (datetime.now(UTC) + timedelta(days=1)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    assert _parse_retry_after(far_future, 1.0) == 300.0
+
+    # A huge numeric Retry-After is also capped.
+    assert _parse_retry_after("86400", 1.0) == 300.0
+
+
+async def test_retry_request_returns_429_response_on_final_attempt(no_sleep) -> None:
+    """An exhausted 429 returns the Response, not a bare RuntimeError.
+
+    Mirrors the 5xx branch: on the final attempt ``retry_request`` must not
+    sleep again or fall through to ``RuntimeError("retry_request exhausted")``
+    — it returns the 429 so the caller sees the true status, ``Retry-After``
+    header, and response body (e.g. Slack's ``{"ok": false}`` payload).
+    """
+
+    async def always_429() -> httpx.Response:
+        return _resp(429, {"ok": False, "error": "rate_limited"}, headers={"Retry-After": "2"})
+
+    resp = await retry_request(always_429, max_retries=1, base_delay=0.1)
+
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "2"
+    assert resp.json() == {"ok": False, "error": "rate_limited"}
+    # Slept exactly once (attempt 0 → 1), not after the final attempt.
+    assert no_sleep.await_count == 1
+
+
+async def test_retry_request_parses_http_date_retry_after(no_sleep) -> None:
+    """An RFC 7231 HTTP-date Retry-After drives the backoff instead of crashing."""
+
+    def _http_date_soon() -> str:
+        from datetime import timedelta
+
+        return (datetime.now(UTC) + timedelta(seconds=15)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    responses = [
+        _resp(429, headers={"Retry-After": _http_date_soon()}),
+        _resp(200),
+    ]
+
+    async def _endpoint() -> httpx.Response:
+        return responses.pop(0)
+
+    resp = await retry_request(_endpoint, max_retries=1, base_delay=0.1)
+
+    assert resp.status_code == 200
+    slept_time = no_sleep.call_args[0][0]
+    # ~15s into the future, generous 5s tolerance for test execution.
+    assert 10.0 <= slept_time <= 20.0
+
+
+async def test_retry_request_429_on_final_attempt_does_not_sleep_again(no_sleep) -> None:
+    """Once retries are exhausted, a 429 must be returned without another sleep."""
+    responses = [_resp(429, headers={"Retry-After": "5"})] * 2
+
+    async def _endpoint() -> httpx.Response:
+        return responses.pop(0)
+
+    resp = await retry_request(_endpoint, max_retries=1, base_delay=0.1)
+
+    assert resp.status_code == 429
+    # One sleep for the retry, none after the final attempt.
+    assert no_sleep.await_count == 1


### PR DESCRIPTION
## Summary

Fixes #718 — two defects in `retry_request` (`src/agentos/channels/_util.py`) when handling HTTP 429 rate limits:

1. **429 response dropped on retry exhaustion.** The 429 branch slept and `continue`d unconditionally, so on the final attempt the loop fell through to `raise RuntimeError("retry_request exhausted")` with `last_exc=None`, discarding the actual 429 response, headers, and provider error body. The 5xx branch already guards with `attempt < max_retries`; the 429 branch now does the same and **returns the Response** on the final attempt so callers (Slack, Discord, webhook delivery) can inspect the true status/body.

2. **Crash on RFC 7231 HTTP-date `Retry-After`.** `float(resp.headers.get("Retry-After", ...))` assumed a numeric string. Servers emitting standard HTTP-dates (e.g. `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`) crashed with `ValueError: could not convert string to float`.

New `_parse_retry_after(header_val, default_delay, max_delay=300.0)` helper:
- parses integer/float seconds **and** HTTP-date (via `email.utils.parsedate_to_datetime`)
- clamps to `[0.0, 300.0]` — a malicious/far-future `Retry-After` cannot trigger an **unbounded sleep** (resource exhaustion)
- falls back to exponential backoff on missing/empty/unparseable values

## Tests

- `test_parse_retry_after_formats` — numeric, HTTP-date, missing/empty/garbage fallback, past-date clamp to 0, far-future cap to 300
- `test_retry_request_returns_429_response_on_final_attempt` — exhausted 429 returns the Response, sleeps exactly once (not after final attempt)
- `test_retry_request_parses_http_date_retry_after` — HTTP-date drives the backoff without crashing
- `test_retry_request_429_on_final_attempt_does_not_sleep_again`

Quality gate: ruff check ✅, ruff format ✅, mypy ✅, full pytest (8743 passed; only pre-existing failures) ✅

Refs #599