### PR TITLE
fix(channels): enforce size limit on msteams conversation cache (#733)

### DIFF
--- a/src/agentos/channels/msteams.py
+++ b/src/agentos/channels/msteams.py
@@ -69,6 +69,7 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
 )
 
 _CONVERSATION_CACHE_SCHEMA_VERSION = 1
+_MAX_CONVERSATION_CACHE_BYTES = 1_000_000  # 1 MB DoS limit for conversations.json
 
 
 def _default_workspace_dir() -> Path:
@@ -220,16 +221,22 @@ class MSTeamsChannel:
         return workspace / "state" / "msteams" / "conversations.json"
 
     def _load_conversation_cache(self) -> None:
-        from botbuilder.schema import (  # type: ignore[import-untyped]  # noqa: PLC0415
-            ConversationReference,
-        )
-
         path = self._cache_path()
         if not path.is_file():
             self._references = {}
             return
 
         try:
+            size = path.stat().st_size
+            if size > _MAX_CONVERSATION_CACHE_BYTES:
+                log.warning(
+                    "msteams.cache_file_too_large",
+                    path=str(path),
+                    size=size,
+                    limit=_MAX_CONVERSATION_CACHE_BYTES,
+                )
+                self._references = {}
+                return
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             log.warning("msteams.cache_load_failed", error=str(exc))
@@ -245,6 +252,10 @@ class MSTeamsChannel:
             )
             self._references = {}
             return
+
+        from botbuilder.schema import (  # type: ignore[import-untyped]  # noqa: PLC0415
+            ConversationReference,
+        )
 
         loaded: dict[str, Any] = {}
         for key, ref_dict in data.get("conversations", {}).items():

--- a/tests/test_channels/test_msteams_cache.py
+++ b/tests/test_channels/test_msteams_cache.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from agentos.channels.msteams import (
+    _MAX_CONVERSATION_CACHE_BYTES,
+    MSTeamsChannel,
+    MSTeamsChannelConfig,
+)
+
+
+def test_msteams_load_cache_nonexistent_file(tmp_path: Path) -> None:
+    config = MSTeamsChannelConfig(workspace_dir=str(tmp_path))
+    channel = MSTeamsChannel(config)
+
+    channel._load_conversation_cache()
+
+    assert channel._references == {}
+
+
+def test_msteams_load_cache_rejects_oversized_file(tmp_path: Path) -> None:
+    config = MSTeamsChannelConfig(workspace_dir=str(tmp_path))
+    channel = MSTeamsChannel(config)
+
+    cache_file = tmp_path / "state" / "msteams" / "conversations.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write a file that exceeds the 1 MB limit
+    oversized_data = b" " * (_MAX_CONVERSATION_CACHE_BYTES + 10)
+    cache_file.write_bytes(oversized_data)
+
+    channel._load_conversation_cache()
+
+    assert channel._references == {}
+
+
+def test_msteams_load_cache_corrupted_json(tmp_path: Path) -> None:
+    config = MSTeamsChannelConfig(workspace_dir=str(tmp_path))
+    channel = MSTeamsChannel(config)
+
+    cache_file = tmp_path / "state" / "msteams" / "conversations.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("{not valid json", encoding="utf-8")
+
+    channel._load_conversation_cache()
+
+    assert channel._references == {}
+
+
+def test_msteams_load_cache_schema_mismatch(tmp_path: Path) -> None:
+    config = MSTeamsChannelConfig(workspace_dir=str(tmp_path))
+    channel = MSTeamsChannel(config)
+
+    cache_file = tmp_path / "state" / "msteams" / "conversations.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps({"schema_version": 999}), encoding="utf-8")
+
+    channel._load_conversation_cache()
+
+    assert channel._references == {}
+
+
+def test_msteams_load_cache_valid_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = MSTeamsChannelConfig(workspace_dir=str(tmp_path))
+    channel = MSTeamsChannel(config)
+
+    cache_file = tmp_path / "state" / "msteams" / "conversations.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "conversations": {
+                    "conv-1": {"activity_id": "act-123"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _MockRef:
+        def deserialize(self, d: dict) -> dict:
+            return d
+
+    mock_schema = types.ModuleType("botbuilder.schema")
+    mock_schema.ConversationReference = _MockRef  # type: ignore[attr-defined]
+    mock_botbuilder = types.ModuleType("botbuilder")
+    mock_botbuilder.schema = mock_schema  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(__import__("sys").modules, "botbuilder", mock_botbuilder)
+    monkeypatch.setitem(__import__("sys").modules, "botbuilder.schema", mock_schema)
+
+    channel._load_conversation_cache()
+
+    assert channel._references == {"conv-1": {"activity_id": "act-123"}}


### PR DESCRIPTION
## Summary
Fixes #733 

`MSTeamsChannel._load_conversation_cache()` at `src/agentos/channels/msteams.py:222-255` previously read `conversations.json` into memory via `path.read_text()` without checking the file size. A bloated or maliciously planted cache file could lead to memory exhaustion (DoS).

## Changes
- Defined `_MAX_CONVERSATION_CACHE_BYTES = 1_000_000` (1 MB).
- Checked `path.stat().st_size` in `_load_conversation_cache()` before reading into memory; logged `msteams.cache_file_too_large` and reset `_references` if the threshold is exceeded.
- Added comprehensive unit tests in `tests/test_channels/test_msteams_cache.py`.

