### PR TITLE
fix(gateway): dedicate per-IP bucket for GET /api/approvals rate limit (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   AgentOS is refused (#550).
 
 ### Fixed
+- `GET /api/approvals` no longer bypasses rate-limiting entirely. It now
+  gets a dedicated per-IP bucket (default 300 req/60 s) so the Web UI poll
+  (~40 req/min/tab) fits comfortably without sharing the generic API bucket
+  and without leaving the endpoint unbounded (#569).
+
 
 - `upsert_llm_provider` now validates an operator-supplied provider `base_url`
   before it is persisted or handed to the httpx client. The RPC

--- a/frontend/src/services/approval-monitor.ts
+++ b/frontend/src/services/approval-monitor.ts
@@ -365,11 +365,12 @@ export class ApprovalMonitor {
 /**
  * approval_monitor.js:67 — the poll endpoint. Legacy fetched the ROOT-absolute
  * '/api/approvals'; these routes are registered at the gateway root (app.py:
- * 535-537), NOT under control_ui.base_path, and the rate-limit exemption keys
- * off the bare '/api/approvals' (middleware.py:240). So — unlike /api/bootstrap
- * which lives under base_path — the approvals REST surface is root-absolute and
- * must NOT be rewritten through the BASE_URL-derived base. We keep the legacy
- * root-absolute path verbatim.
+ * 535-537), NOT under control_ui.base_path, and the rate-limit now uses a
+ * dedicated approval bucket (middleware.py) with a generous ceiling so the UI
+ * poll (~40 req/min/tab) fits comfortably without removing rate-limiting
+ * entirely. So — unlike /api/bootstrap which lives under base_path — the
+ * approvals REST surface is root-absolute and must NOT be rewritten through
+ * the BASE_URL-derived base. We keep the legacy root-absolute path verbatim.
  */
 export function approvalsUrl(): string {
   return '/api/approvals'

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -277,8 +277,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return request.headers.get("x-agentos-token")
 
 
+#: Default max requests per window for the dedicated approval bucket.
+#: Higher than the shared API bucket so the UI poll (~40 req/min/tab) fits
+#: comfortably without removing the rate-limit entirely.
+_APPROVAL_BUCKET_MAX_REQUESTS: int = 300
+#: Default window for the approval bucket (same unit as rate_limit.window_seconds).
+_APPROVAL_BUCKET_WINDOW_SECONDS: float = 60.0
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Simple sliding-window rate limiter per client IP."""
+    """Simple sliding-window rate limiter per client IP.
+
+    ``GET /api/approvals`` gets its own bucket (``_approval_windows``) so the
+    UI poll does not collide with normal REST traffic, while still preventing
+    an attacker from saturating the approval endpoint.
+    """
 
     def __init__(
         self,
@@ -295,6 +308,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
         # {ip: [timestamp, ...]} with LRU eviction ordering
         self._windows: OrderedDict[str, list[float]] = OrderedDict()
+        # Separate bucket for GET /api/approvals — UI poll never starves
+        # legitimate API requests and vice versa.
+        self._approval_windows: OrderedDict[str, list[float]] = OrderedDict()
         self._max_tracked_clients = max_tracked_clients
         self._last_sweep: float = 0.0
 
@@ -340,6 +356,43 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         while len(self._windows) > self._max_tracked_clients:
             self._windows.popitem(last=False)
 
+    async def _check_approval_bucket(
+        self,
+        request: Request,
+        call_next: Callable,
+    ) -> Response:
+        """Rate-limit ``GET /api/approvals`` in a dedicated bucket."""
+        client_ip = self._get_client_ip(request)
+        now = time.time()
+        window = float(
+            self._config.rate_limit.window_seconds
+            if hasattr(self._config.rate_limit, "window_seconds")
+            and self._config.rate_limit.window_seconds
+            else _APPROVAL_BUCKET_WINDOW_SECONDS
+        )
+        max_req = _APPROVAL_BUCKET_MAX_REQUESTS
+
+        timestamps = [
+            t for t in self._approval_windows.get(client_ip, []) if now - t < window
+        ]
+
+        if len(timestamps) >= max_req:
+            self._approval_windows[client_ip] = timestamps
+            self._approval_windows.move_to_end(client_ip)
+            return JSONResponse(
+                {"error": "Too Many Requests", "code": "RATE_LIMITED"}, status_code=429
+            )
+
+        timestamps.append(now)
+        self._approval_windows[client_ip] = timestamps
+        self._approval_windows.move_to_end(client_ip)
+
+        # Keep approval window cache under the same ceiling
+        while len(self._approval_windows) > self._max_tracked_clients:
+            self._approval_windows.popitem(last=False)
+
+        return await call_next(request)  # type: ignore[no-any-return]
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if not self._config.rate_limit.enabled:
             return await call_next(request)  # type: ignore[no-any-return]
@@ -350,10 +403,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         # blows past the API bucket and the operator sees a hard 429 on the
         # bare HTML. Mutating endpoints under /api/* are still limited.
         path = request.url.path
+        is_approval_get = request.method == "GET" and path == "/api/approvals"
         if self._is_ui_path(path):
             return await call_next(request)  # type: ignore[no-any-return]
-        if request.method == "GET" and path == "/api/approvals":
-            return await call_next(request)  # type: ignore[no-any-return]
+
+        if is_approval_get:
+            # Dedicated approval bucket — the UI polls every 1.5 s per tab;
+            # sharing the API bucket would hit 429 on 2-3 tabs.
+            return await self._check_approval_bucket(request, call_next)
 
         client_ip = self._get_client_ip(request)
         now = time.time()


### PR DESCRIPTION
Fixes #569

Replace the blanket rate-limit exemption for GET /api/approvals with a
dedicated per-IP bucket (default 300 req/60 s). The UI polls every 1.5 s
(~40 req/min/tab), so sharing the generic API bucket would hit 429 on 2-3
tabs — which is what blocked competitor PRs #572 and #704.

Changes:
- Separate _approval_windows OrderedDict in RateLimitMiddleware
- _check_approval_bucket method with its own ceiling
- Update stale comment in frontend/src/services/approval-monitor.ts
- Existing test (test_approval_polling_does_not_consume_generic_api_rate_limit) passes