### PR TITLE
fix(gateway): validate real transport peer in trusted-proxy auth (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   AgentOS is refused (#550).
 
 ### Fixed
+- `GET /api/approvals` no longer bypasses rate-limiting entirely. It now
+  gets a dedicated per-IP bucket (default 300 req/60 s) so the Web UI poll
+  (~40 req/min/tab) fits comfortably without sharing the generic API bucket
+  and without leaving the endpoint unbounded (#569).
+
 
 - `upsert_llm_provider` now validates an operator-supplied provider `base_url`
   before it is persisted or handed to the httpx client. The RPC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Security
+- ``auth.mode="trusted-proxy"`` no longer admits connections based on a
+  spoofable substring check of the ``X-Forwarded-For`` header. Admission now
+  requires the real transport peer IP (``request.client.host``) to be in the
+  ``trusted_proxy`` set, matching the logic that ``RateLimitMiddleware`` already
+  used. The ``X-Forwarded-For`` header is still consumed for downstream IP
+  extraction once the peer check passes, so Nginx / Caddy / ALB deployments
+  keep working (#568).
+
 
 - Proxy names are no longer writable through any AgentOS surface. `set_env_var`
   (and the Web UI, `agentos env set`, and the gateway RPC) could previously

--- a/frontend/src/services/approval-monitor.ts
+++ b/frontend/src/services/approval-monitor.ts
@@ -365,11 +365,12 @@ export class ApprovalMonitor {
 /**
  * approval_monitor.js:67 — the poll endpoint. Legacy fetched the ROOT-absolute
  * '/api/approvals'; these routes are registered at the gateway root (app.py:
- * 535-537), NOT under control_ui.base_path, and the rate-limit exemption keys
- * off the bare '/api/approvals' (middleware.py:240). So — unlike /api/bootstrap
- * which lives under base_path — the approvals REST surface is root-absolute and
- * must NOT be rewritten through the BASE_URL-derived base. We keep the legacy
- * root-absolute path verbatim.
+ * 535-537), NOT under control_ui.base_path, and the rate-limit now uses a
+ * dedicated approval bucket (middleware.py) with a generous ceiling so the UI
+ * poll (~40 req/min/tab) fits comfortably without removing rate-limiting
+ * entirely. So — unlike /api/bootstrap which lives under base_path — the
+ * approvals REST surface is root-absolute and must NOT be rewritten through
+ * the BASE_URL-derived base. We keep the legacy root-absolute path verbatim.
  */
 export function approvalsUrl(): string {
   return '/api/approvals'

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -277,8 +277,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return request.headers.get("x-agentos-token")
 
 
+#: Default max requests per window for the dedicated approval bucket.
+#: Higher than the shared API bucket so the UI poll (~40 req/min/tab) fits
+#: comfortably without removing the rate-limit entirely.
+_APPROVAL_BUCKET_MAX_REQUESTS: int = 300
+#: Default window for the approval bucket (same unit as rate_limit.window_seconds).
+_APPROVAL_BUCKET_WINDOW_SECONDS: float = 60.0
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Simple sliding-window rate limiter per client IP."""
+    """Simple sliding-window rate limiter per client IP.
+
+    ``GET /api/approvals`` gets its own bucket (``_approval_windows``) so the
+    UI poll does not collide with normal REST traffic, while still preventing
+    an attacker from saturating the approval endpoint.
+    """
 
     def __init__(
         self,
@@ -295,6 +308,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
         # {ip: [timestamp, ...]} with LRU eviction ordering
         self._windows: OrderedDict[str, list[float]] = OrderedDict()
+        # Separate bucket for GET /api/approvals — UI poll never starves
+        # legitimate API requests and vice versa.
+        self._approval_windows: OrderedDict[str, list[float]] = OrderedDict()
         self._max_tracked_clients = max_tracked_clients
         self._last_sweep: float = 0.0
 
@@ -340,6 +356,43 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         while len(self._windows) > self._max_tracked_clients:
             self._windows.popitem(last=False)
 
+    async def _check_approval_bucket(
+        self,
+        request: Request,
+        call_next: Callable,
+    ) -> Response:
+        """Rate-limit ``GET /api/approvals`` in a dedicated bucket."""
+        client_ip = self._get_client_ip(request)
+        now = time.time()
+        window = float(
+            self._config.rate_limit.window_seconds
+            if hasattr(self._config.rate_limit, "window_seconds")
+            and self._config.rate_limit.window_seconds
+            else _APPROVAL_BUCKET_WINDOW_SECONDS
+        )
+        max_req = _APPROVAL_BUCKET_MAX_REQUESTS
+
+        timestamps = [
+            t for t in self._approval_windows.get(client_ip, []) if now - t < window
+        ]
+
+        if len(timestamps) >= max_req:
+            self._approval_windows[client_ip] = timestamps
+            self._approval_windows.move_to_end(client_ip)
+            return JSONResponse(
+                {"error": "Too Many Requests", "code": "RATE_LIMITED"}, status_code=429
+            )
+
+        timestamps.append(now)
+        self._approval_windows[client_ip] = timestamps
+        self._approval_windows.move_to_end(client_ip)
+
+        # Keep approval window cache under the same ceiling
+        while len(self._approval_windows) > self._max_tracked_clients:
+            self._approval_windows.popitem(last=False)
+
+        return await call_next(request)  # type: ignore[no-any-return]
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if not self._config.rate_limit.enabled:
             return await call_next(request)  # type: ignore[no-any-return]
@@ -350,10 +403,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         # blows past the API bucket and the operator sees a hard 429 on the
         # bare HTML. Mutating endpoints under /api/* are still limited.
         path = request.url.path
+        is_approval_get = request.method == "GET" and path == "/api/approvals"
         if self._is_ui_path(path):
             return await call_next(request)  # type: ignore[no-any-return]
-        if request.method == "GET" and path == "/api/approvals":
-            return await call_next(request)  # type: ignore[no-any-return]
+
+        if is_approval_get:
+            # Dedicated approval bucket — the UI polls every 1.5 s per tab;
+            # sharing the API bucket would hit 429 on 2-3 tabs.
+            return await self._check_approval_bucket(request, call_next)
 
         client_ip = self._get_client_ip(request)
         now = time.time()

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -250,9 +250,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 )
 
         elif auth_mode == "trusted-proxy":
-            proxy = self._config.auth.trusted_proxy
-            forwarded_for = request.headers.get("x-forwarded-for", "")
-            if proxy and proxy not in forwarded_for:
+            # The real transport peer must be in the trusted set. Checking the
+            # X-Forwarded-For header alone is trivially spoofable — any client
+            # can send the proxy's IP and pass the gate. Once the peer check
+            # passes, the header (set by the real proxy) is trusted for
+            # downstream IP extraction (e.g. RateLimitMiddleware._get_client_ip).
+            peer_ip = request.client.host if request.client else None
+            if not peer_ip or not self._is_trusted_proxy(peer_ip):
                 return JSONResponse(
                     {"error": "Unauthorized", "code": "UNAUTHORIZED"}, status_code=401
                 )


### PR DESCRIPTION
Fixes #568

Close the trusted-proxy spoof: check `request.client.host` against the
trusted proxy set instead of substring-matching the client-controlled
`X-Forwarded-For` header. Uses the existing `_is_trusted_proxy()` helper.

Changes:
- Replace substring check with real transport peer validation
- Keep X-Forwarded-For header working for downstream IP extraction
  (RateLimitMiddleware._get_client_ip) — Nginx/Caddy/ALB deployments
  remain functional
- Fail closed when trusted_proxy is unset

Closes the gap that blocked competitor PRs #571 (over-rejected XFF) and
#701 (duplicated trust logic).