### PR TITLE
fix(channels): ensure named artifact delivery path falls back to vali…

### DIFF
--- a/src/agentos/artifacts.py
+++ b/src/agentos/artifacts.py
@@ -347,6 +347,8 @@ class ArtifactStore:
 def _safe_filename(name: str) -> str:
     cleaned = Path(name).name.strip() or "artifact"
     cleaned = _UNSAFE_FILENAME_RE.sub("_", cleaned).strip()
+    if cleaned in (".", "..") or not cleaned.strip("."):
+        return "artifact"
     return cleaned[:160] or "artifact"
 
 

--- a/src/agentos/channels/artifact_delivery.py
+++ b/src/agentos/channels/artifact_delivery.py
@@ -140,10 +140,26 @@ def can_deliver_channel_files(channel: Any) -> bool:
     return True
 
 
+def _safe_delivery_leaf(filename: str, source: Path) -> str:
+    """Return a safe single-path-component filename leaf for delivery.
+
+    Falls back to source.name when filename is empty or dots-only, and to
+    'artifact' if source.name is also dots-only or empty.
+    """
+    leaf = Path(filename).name.strip() if filename else ""
+    if leaf and leaf not in (".", "..") and leaf.strip("."):
+        return leaf
+    source_leaf = source.name.strip() if source.name else ""
+    if source_leaf and source_leaf not in (".", "..") and source_leaf.strip("."):
+        return source_leaf
+    return "artifact"
+
+
 @contextlib.contextmanager
 def _named_artifact_delivery_path(source: Path, filename: str) -> Iterator[Path]:
+    safe_name = _safe_delivery_leaf(filename, source)
     with tempfile.TemporaryDirectory(prefix="agentos-artifact-") as tmp_dir:
-        target = Path(tmp_dir) / Path(filename).name
+        target = Path(tmp_dir) / safe_name
         try:
             target.hardlink_to(source)
         except OSError:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -652,3 +652,17 @@ async def test_publish_artifact_tool_rejects_missing_workspace_and_escape(tmp_pa
             await publish_artifact(path="../outside.txt")
     finally:
         current_tool_context.reset(token)
+
+
+@pytest.mark.parametrize("unsafe_name", ["..", "...", "../..", "   ..   ", ".", "", "////", "./."])
+def test_artifact_store_sanitizes_dot_and_empty_filenames(tmp_path: Path, unsafe_name: str) -> None:
+    store = ArtifactStore(tmp_path)
+    ref = store.publish_bytes(
+        b"payload",
+        session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        name=unsafe_name,
+        mime="text/plain",
+        source="publish_artifact",
+    )
+    assert ref.name == "artifact"

--- a/tests/test_channels/test_channel_capabilities.py
+++ b/tests/test_channels/test_channel_capabilities.py
@@ -8,6 +8,8 @@ import pytest
 
 from agentos.artifacts import ArtifactStore
 from agentos.channels.artifact_delivery import (
+    _named_artifact_delivery_path,
+    _safe_delivery_leaf,
     can_deliver_channel_files,
     deliver_artifacts_as_channel_files,
     strip_delivered_artifact_image_references,
@@ -479,6 +481,92 @@ async def test_artifact_delivery_preserves_fallback_on_structured_failure(
     )
 
     assert undelivered == [ref.to_dict()]
+
+
+@pytest.mark.parametrize("invalid_name", ["", "   ", "/", ".", "..", "///"])
+def test_named_artifact_delivery_path_empty_or_dot_leaf(tmp_path: Path, invalid_name: str) -> None:
+    source = tmp_path / "source_data.bin"
+    source.write_bytes(b"sample artifact content")
+
+    with _named_artifact_delivery_path(source, invalid_name) as delivery_path:
+        assert delivery_path.is_file()
+        assert not delivery_path.is_dir()
+        assert delivery_path.read_bytes() == b"sample artifact content"
+        assert delivery_path.name == "source_data.bin"
+
+
+@pytest.mark.parametrize(
+    ("filename", "source_name", "expected"),
+    [
+        ("report.pdf", "source.bin", "report.pdf"),
+        ("path/to/report.pdf", "source.bin", "report.pdf"),
+        ("", "source.bin", "source.bin"),
+        ("   ", "source.bin", "source.bin"),
+        ("/", "source.bin", "source.bin"),
+        (".", "source.bin", "source.bin"),
+        ("..", "source.bin", "source.bin"),
+        ("...", "source.bin", "source.bin"),
+        ("///", "source.bin", "source.bin"),
+        ("", "..", "artifact"),
+        ("..", "", "artifact"),
+        (".", ".", "artifact"),
+    ],
+)
+def test_safe_delivery_leaf_exact_mapping(filename: str, source_name: str, expected: str) -> None:
+    source = Path(source_name)
+    assert _safe_delivery_leaf(filename, source) == expected
+
+
+@pytest.mark.asyncio
+async def test_artifact_delivery_succeeds_with_dot_dot_filename(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path)
+    ref = store.publish_bytes(
+        b"content",
+        session_id="session-1",
+        session_key="agent:main:channel:session-1",
+        name="..",
+        mime="text/plain",
+        source="test",
+    )
+    assert ref.name == "artifact"
+
+    delivered_files: list[str] = []
+
+    class SuccessFileChannel:
+        capability_profile = ChannelCapabilityProfile(
+            channel_type="files",
+            native_file_upload=True,
+            media=True,
+        )
+
+        async def send_file(self, channel_id: str, file_path: str) -> ChannelSendResult:
+            p = Path(file_path)
+            assert p.is_file()
+            assert p.name == "artifact"
+            delivered_files.append(file_path)
+            return ChannelSendResult.sent(
+                capability=ChannelCapabilities.NATIVE_FILE_UPLOAD,
+                target_id=channel_id,
+            )
+
+    msg = IncomingMessage(
+        sender_id="u1",
+        channel_id="c1",
+        content="",
+        metadata={"is_group": False},
+    )
+    config = SimpleNamespace(attachments=SimpleNamespace(media_root=str(tmp_path)))
+
+    undelivered = await deliver_artifacts_as_channel_files(
+        SuccessFileChannel(),
+        msg,
+        [ref.to_dict()],
+        config,
+    )
+
+    assert undelivered == []
+    assert len(delivered_files) == 1
+    assert Path(delivered_files[0]).name == "artifact"
 
 
 def test_discord_profile_and_inbound_group_metadata() -> None:


### PR DESCRIPTION
## Summary closes #742 
In `src/agentos/channels/artifact_delivery.py`:
`_named_artifact_delivery_path` previously computed `target = Path(tmp_dir) / Path(filename).name`. When delivering artifacts whose metadata has an empty leaf, whitespace, root, or dot-relative target (`""`, `"   "`, `"/"`, `"."`, `".."`), `Path(filename).name` evaluates to `""`, making `target` point to the temporary directory itself.
This caused `target.hardlink_to(source)` to fail with `FileExistsError` / `OSError`, and the fallback `shutil.copy2` copied the source file into the directory using its internal storage hash name while yielding the directory path to `send_file`.

## Changes
- In `_named_artifact_delivery_path`, sanitized `leaf` and added fallback to `source.name` or `"artifact"` whenever the leaf is empty or dot-relative.
- Added parameterized unit tests and an artifact delivery integration test in `tests/test_channels/test_channel_capabilities.py`.
