### PR TITLE
feat(skills): add robinhood-chain-stocks and stop RWA lookup returning impersonators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- New bundled skill `robinhood-chain-stocks`: reads tokenized-stock state
+  directly from Robinhood Chain (chainId 4663) over JSON-RPC — Chainlink USD
+  price, the ERC-8056 `uiMultiplier()` corporate-action ratio, `oraclePaused()`,
+  total supply, and wallet balances with their USD value. Read-only by
+  construction: it issues only `eth_call` and never signs, sends, or holds a
+  key. Feed addresses are resolved from Chainlink's reference-data directory
+  rather than hardcoded, resolved from the ticker the contract reports so an
+  address-only lookup still finds its price. Prices carry `ageSeconds` and a
+  `stale` flag (past the feed's heartbeat, or oracle paused) so a market-closed
+  quote is not read as the current price, and a non-positive feed answer is
+  reported as unusable instead of `$0`. Authenticity is reported three ways —
+  verified, disproven by a revert, or unverified because the node was
+  unreachable — so a network fault is never presented as proof that a genuine
+  listing is fake.
+
 ### Security
 
 - Proxy names are no longer writable through any AgentOS surface. `set_env_var`
@@ -38,6 +55,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   an address. Loopback stays allowed for local model servers, and a `base_url`
   that is already persisted (a saved profile, a provider default, or the value
   the onboarding import path replays) is not re-validated (#551).
+
+- `robinhood-rwa-addresses` no longer answers a company question with a
+  community token that impersonates it. Robinhood Chain is permissionless and
+  the public token list carries both kinds: two entries are named "GameStop"
+  with symbol `GME`, and the lookup stripped the `• Robinhood Token` suffix —
+  the only thing telling them apart — before ranking, so which address came
+  back was down to list order. Asking for `NET` returned the "NetNet" community
+  token above Cloudflare. The lookup now matches Stock Tokens only (opt back in
+  with `--include-community`, where real listings still rank first), tags every
+  match with `isStockToken`, and reports a `stock_tokens` count. The skill doc's
+  hardcoded "~228 tokens" claim, stale against the 658-entry list, is gone
+  (#745).
 
 ### Changed
 
@@ -136,6 +165,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   1 second or above 24 hours are now rejected (#570).
 
 ### Fixed
+
+- `robinhood-rwa-addresses` no longer answers a company question with a
+  community token that impersonates it. Robinhood Chain is permissionless and
+  the public token list carries both kinds: two entries are named "GameStop"
+  with symbol `GME`, and the lookup stripped the `• Robinhood Token` suffix —
+  the only thing telling them apart — before ranking, so which address came
+  back was down to list order. Asking for `NET` returned the "NetNet" community
+  token above Cloudflare. The lookup now matches Stock Tokens only (opt back in
+  with `--include-community`, where real listings still rank first), tags every
+  match with `isStockToken`, and reports a `stock_tokens` count. The skill doc's
+  hardcoded "~228 tokens" claim, stale against the 658-entry list, is gone.
 
 - Two clients editing the same project no longer overwrite each other.
   `projects.update` used to read the whole row, apply the change, and write

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -222,6 +222,7 @@ are released under AgentOS's repository license (Apache-2.0; see `LICENSE`):
 - `poolsdotfun-token-launcher`
 - `pptx`
 - `robinhood-agentic-trading`
+- `robinhood-chain-stocks`
 - `robinhood-rwa-addresses`
 - `senior-unilp-manager`
 - `stack-trace-generic-probe`

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: robinhood-chain-stocks
+description: "Read live on-chain state for Robinhood Chain tokenized stocks (Stock Tokens). Use when: the user asks for the on-chain price of a tokenized stock or ETF, a wallet's holding/value of one, total supply, whether a token is a genuine Robinhood Stock Token, the corporate-action multiplier, or whether the price oracle is paused (e.g. 'AAPL price on Robinhood Chain', 'giá TSLA on-chain', 'is 0x… a real Robinhood stock token', 'how much NVDA does 0x… hold'). Read-only: never signs or sends a transaction. NOT for: placing trades (use robinhood-agentic-trading) or plain address lookup (use robinhood-rwa-addresses). No API key needed."
+homepage: https://docs.robinhood.com/chain/
+provenance:
+  origin: agentos-original
+  license: MIT
+  maintained_by: AgentOS
+publisher:
+  id: robinhood
+metadata:
+  {
+    "agentos":
+      {
+        "emoji": "📈",
+        "homepage": "https://docs.robinhood.com/chain/",
+        "requires": { "anyBins": ["python3", "python"] },
+      },
+  }
+entrypoint:
+  command: python3 {baseDir}/scripts/chain_stocks.py
+  args:
+    - --query
+    - "{{ with.query | default(inputs.user_message) }}"
+    - --timeout
+    - "{{ with.timeout | default(15) }}"
+  parse: json
+  timeout: 40
+---
+
+# Robinhood Chain Stock Tokens (on-chain)
+
+Read tokenized-stock state **directly from Robinhood Chain** (chainId `4663`)
+over plain JSON-RPC: Chainlink USD price, `uiMultiplier()`, oracle pause state,
+total supply, and wallet balances.
+
+This skill is **read-only**. It issues only `eth_call`, never signs, sends, or
+holds a private key. Trade execution belongs to `robinhood-agentic-trading`.
+
+## What a Stock Token is
+
+Each Stock Token is a standard **ERC-20 with 18 decimals**, one per underlying
+equity or ETF, deployed behind an OpenZeppelin beacon proxy (all tokens share
+one upgradeable implementation). Two non-ERC-20 functions matter:
+
+| Function | Selector | Meaning |
+|---|---|---|
+| `uiMultiplier()` | `0xa60bf13d` | ERC-8056 scaled-UI ratio. Dividends and splits move this multiplier instead of rebasing balances, so a raw balance stays constant until redemption. |
+| `oraclePaused()` | `0x7706ba52` | `true` while a corporate action is processing — the Chainlink feed stops publishing fresh prices. **Treat any price as stale when this is true.** |
+
+Prices come from a per-asset **Chainlink `AggregatorV3Interface`** feed (8
+decimals) and already incorporate the multiplier, so the feed answer is the
+price *per token* — do not multiply it by `uiMultiplier()` again.
+
+## Verifying a token is genuine — do this before quoting an address
+
+Robinhood Chain is permissionless, and community tokens on it **reuse listed
+companies' names and symbols**. The CoinGecko token list carries both: only
+Stock Tokens have the `• Robinhood Token` name suffix. For example two entries
+share the symbol `GME` and the name "GameStop":
+
+- `0x1b0e319c6a659f002271b69db8a7df2f911c153e` — real, answers `uiMultiplier()`
+- `0x7e86381a763f0ecca2bdf27c54eac403ddd48123` — impersonator, call reverts
+
+`uiMultiplier()` answering is the authoritative on-chain check, and this script
+applies it. `isStockToken` has **three** states, and the difference matters:
+
+| Value | Meaning | What to say |
+|---|---|---|
+| `true` | The call returned a multiplier | Genuine Stock Token |
+| `false` | The node answered and the call **reverted** | Not a Stock Token — say so plainly, and do not hand over the address |
+| `null` | The node was **unreachable** | Unverified, *not* disproven. Say the check could not run; never call the token fake on this basis |
+
+A network fault is not evidence about a contract. Report `null` as uncertainty.
+
+## Run it
+
+```bash
+# Price + on-chain state by name or ticker
+python3 {baseDir}/scripts/chain_stocks.py --query "Apple"
+python3 {baseDir}/scripts/chain_stocks.py --query TSLA
+
+# A wallet's holding and its USD value
+python3 {baseDir}/scripts/chain_stocks.py --query NVDA --holder 0xYourWallet
+
+# Verify an arbitrary address without resolving a name
+python3 {baseDir}/scripts/chain_stocks.py --address 0x7e86381a763f0ecca2bdf27c54eac403ddd48123
+
+# Skip the price read (fewer calls, no feed fetch)
+python3 {baseDir}/scripts/chain_stocks.py --query MSFT --no-price
+
+# Point at a dedicated provider instead of the rate-limited public RPC
+python3 {baseDir}/scripts/chain_stocks.py --query SPY --rpc-url https://your-provider/rpc
+```
+
+### Output (JSON, trimmed)
+
+```json
+{
+  "query": "Apple",
+  "chainId": 4663,
+  "explorer": "https://robinhoodchain.blockscout.com/token/0xaf3d...93f9",
+  "token": {
+    "address": "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9",
+    "symbol": "AAPL",
+    "onchainSymbol": "AAPL",
+    "isStockToken": true,
+    "uiMultiplierFormatted": 1.0005660800610925,
+    "oraclePaused": false,
+    "totalSupplyFormatted": 10301.40749861,
+    "price": {
+      "feedAddress": "0x6B22A786bAa607d76728168703a39Ea9C99f2cD0",
+      "usd": 317.47461437,
+      "decimals": 8,
+      "updatedAt": 1788206389,
+      "ageSeconds": 41231,
+      "stale": false,
+      "heartbeatSeconds": 86400,
+      "deviationThresholdPercent": 0.5
+    }
+  }
+}
+```
+
+## Reporting rules
+
+- **Check `price.stale` before quoting.** It is `true` when the answer is older
+  than the feed's heartbeat or the oracle is paused. When it is `true`, give the
+  age and call the number a last-known quote, never "the current price".
+- Use `price.ageSeconds` rather than doing date maths on `updatedAt` yourself.
+  Stock feeds update **24/5**, following equity market hours, and carry an
+  86400s heartbeat — a day-old answer is normal, not an error.
+- `price.unusableAnswer: true` means the feed returned a non-positive value.
+  There is no price; do not report `$0`.
+- Say `oraclePaused: true` out loud when it happens, and do not present a price.
+- Report `readErrors` and `notes` rather than silently omitting a field. A note
+  that says something was *unverified* never becomes a claim that it is false.
+- These are **tokenized debt securities, not shares**. They are unavailable to
+  US persons and restricted in several other jurisdictions. Never frame output
+  as investment advice or as ownership of the underlying equity.
+
+## Network reference
+
+| | |
+|---|---|
+| Mainnet chain ID | `4663` |
+| Public RPC | `https://rpc.mainnet.chain.robinhood.com` (rate-limited, no archive) |
+| Explorer | `https://robinhoodchain.blockscout.com` |
+| Testnet chain ID | `46630` (`https://rpc.testnet.chain.robinhood.com`) |
+| Gas token | ETH |
+
+Data sources, both public and key-free: the CoinGecko Robinhood token list for
+name→address resolution, and Chainlink's reference-data directory for feed
+addresses. Feed addresses are read from that directory rather than hardcoded —
+Chainlink's list is the source of truth.
+
+## Notes
+
+- Only a subset of tokens have an official Chainlink feed; when none exists the
+  payload carries a note and omits `price` instead of guessing.
+- The public RPC has no archive data. Historical reads and `eth_getLogs` sweeps
+  need a dedicated provider — pass `--rpc-url`.
+- Every failure path still prints JSON with an `error` or `readErrors` field;
+  the script does not crash on a network fault.

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Read Robinhood Chain tokenized-stock state directly from the chain.
+
+Resolves a company name or ticker to its Stock Token on Robinhood Chain
+(chainId 4663), then reads live on-chain state over plain JSON-RPC: the
+Chainlink USD price, the ERC-8056 ``uiMultiplier()`` corporate-action ratio,
+whether the price oracle is paused, total supply, and optionally a holder
+balance and its USD value.
+
+Read-only by construction: it issues only ``eth_call`` / ``eth_chainId`` and
+never signs, sends, or holds a key.
+
+Emits a compact JSON object on stdout so a meta-skill can run it as a bounded
+tool without spawning an LLM sub-agent. Network and contract failures are
+reported in the payload rather than raised, so the caller always gets JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+CHAIN_ID = 4663
+DEFAULT_RPC_URL = "https://rpc.mainnet.chain.robinhood.com"
+EXPLORER_URL = "https://robinhoodchain.blockscout.com"
+TOKEN_LIST_URL = "https://tokens.coingecko.com/robinhood/all.json"
+FEEDS_URL = "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json"
+
+# Only Stock Tokens carry this suffix in the CoinGecko list. Community tokens on
+# the same chain do not -- several of them reuse a real company's name, so the
+# suffix is the offline signal that separates the two. `uiMultiplier()` is the
+# on-chain confirmation.
+_RH_SUFFIX_RE = re.compile(r"\s*[•·|-]?\s*robinhood token\s*$", re.IGNORECASE)
+_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+# Function selectors (first 4 bytes of keccak256 of the signature).
+SEL_SYMBOL = "0x95d89b41"  # symbol()
+SEL_DECIMALS = "0x313ce567"  # decimals()
+SEL_TOTAL_SUPPLY = "0x18160ddd"  # totalSupply()
+SEL_BALANCE_OF = "0x70a08231"  # balanceOf(address)
+SEL_UI_MULTIPLIER = "0xa60bf13d"  # uiMultiplier()      -- ERC-8056
+SEL_ORACLE_PAUSED = "0x7706ba52"  # oraclePaused()
+SEL_LATEST_ROUND_DATA = "0xfeaf968c"  # latestRoundData() -- AggregatorV3Interface
+
+WAD = 10**18
+
+
+class RpcError(RuntimeError):
+    """A JSON-RPC call returned an error or an unusable result."""
+
+
+def _http_json(url: str, timeout: float, payload: dict[str, Any] | None = None) -> Any:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"User-Agent": "AgentOS-robinhood-chain-stocks/0.1"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers)  # noqa: S310 - fixed endpoints
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _eth_call(rpc_url: str, to: str, data: str, timeout: float) -> str:
+    """Return the raw hex result of an ``eth_call``, or raise ``RpcError``."""
+    body = _http_json(
+        rpc_url,
+        timeout,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_call",
+            "params": [{"to": to, "data": data}, "latest"],
+        },
+    )
+    if isinstance(body, dict) and "error" in body:
+        message = str(body["error"].get("message", body["error"]))
+        raise RpcError(message)
+    result = body.get("result") if isinstance(body, dict) else None
+    if not isinstance(result, str) or not result.startswith("0x"):
+        raise RpcError("malformed RPC result")
+    return result
+
+
+def _word(raw: str, index: int) -> int:
+    """Decode the ``index``-th 32-byte word of an ABI return blob as uint256."""
+    body = raw[2:]
+    start = index * 64
+    chunk = body[start : start + 64]
+    if len(chunk) < 64:
+        raise RpcError("result too short")
+    return int(chunk, 16)
+
+
+def _word_signed(raw: str, index: int) -> int:
+    """Same as ``_word`` but interpreted as int256 (Chainlink answers are signed)."""
+    value = _word(raw, index)
+    return value - (1 << 256) if value >= (1 << 255) else value
+
+
+def _decode_string(raw: str) -> str:
+    """Decode an ABI-encoded dynamic ``string`` return value."""
+    offset = _word(raw, 0)
+    body = raw[2:]
+    head = offset * 2
+    length = int(body[head : head + 64], 16)
+    payload = body[head + 64 : head + 64 + length * 2]
+    return bytes.fromhex(payload).decode("utf-8", errors="replace")
+
+
+def _encode_address_arg(selector: str, address: str) -> str:
+    return selector + address.lower().removeprefix("0x").rjust(64, "0")
+
+
+def _clean_name(name: str) -> str:
+    """Strip the '- Robinhood Token' suffix so 'Apple' matches cleanly."""
+    return _RH_SUFFIX_RE.sub("", name or "").strip()
+
+
+def is_stock_token(token: dict[str, Any]) -> bool:
+    """True when the list entry is a Robinhood Stock Token, not a community token."""
+    return bool(_RH_SUFFIX_RE.search(token.get("name", "") or ""))
+
+
+def _norm(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).strip()
+
+
+def _score(query: str, token: dict[str, Any]) -> int:
+    """Rank a token against a free-text query. Higher is better; 0 = no match."""
+    q = _norm(query)
+    if not q:
+        return 0
+    symbol = _norm(token.get("symbol", ""))
+    name = _norm(_clean_name(token.get("name", "")))
+
+    if q == symbol:
+        return 100
+    if q == name:
+        return 90
+    if name and re.search(rf"\b{re.escape(name)}\b", q):
+        return 80
+    if len(symbol) >= 2 and re.search(rf"\b{re.escape(symbol)}\b", q):
+        return 75
+    if re.search(rf"\b{re.escape(q)}\b", name):
+        return 70
+    if q in name:
+        return 50
+    if q in symbol:
+        return 40
+    return 0
+
+
+def resolve_token(query: str, tokens: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Resolve a name/ticker query to the best-matching Stock Token.
+
+    Community tokens are excluded outright: several impersonate a listed
+    company's name and symbol, and handing back an impersonator's address in
+    answer to "what is GameStop's contract" is the failure this guards.
+    """
+    stocks = [t for t in tokens if is_stock_token(t)]
+    scored = [(s, t) for t in stocks if (s := _score(query, t)) > 0]
+    if not scored:
+        return None
+    scored.sort(key=lambda pair: (-pair[0], _norm(pair[1].get("symbol", ""))))
+    return scored[0][1]
+
+
+def feed_ticker(feed: dict[str, Any]) -> str:
+    """Extract the equity ticker a Robinhood Chainlink feed prices.
+
+    Feed names are not uniform -- 'Robinhood AAPL / USD', 'Robinhood DELL-USD',
+    'Robinhood SGOV-USD' all appear -- so prefer the structured ``docs.baseAsset``
+    and fall back to parsing the display name.
+    """
+    docs = feed.get("docs")
+    if isinstance(docs, dict):
+        base = docs.get("baseAsset")
+        if isinstance(base, str) and base.strip():
+            return base.strip().upper()
+    name = str(feed.get("name", ""))
+    if not name.lower().startswith("robinhood"):
+        return ""
+    rest = name[len("robinhood") :].strip()
+    return re.split(r"\s*[/-]\s*", rest, maxsplit=1)[0].strip().upper()
+
+
+def find_feed(symbol: str, feeds: list[dict[str, Any]]) -> dict[str, Any] | None:
+    target = symbol.strip().upper()
+    for feed in feeds:
+        if feed_ticker(feed) == target and feed.get("proxyAddress"):
+            return feed
+    return None
+
+
+def _read_price(rpc_url: str, proxy: str, timeout: float, now: float) -> dict[str, Any]:
+    """Read one Chainlink feed, reporting age alongside the answer.
+
+    Age is computed here rather than left to the caller: stock feeds update 24/5
+    and carry a 24h heartbeat, so a bare ``updatedAt`` invites reading a
+    market-closed quote as the current price.
+    """
+    raw = _eth_call(rpc_url, proxy, SEL_LATEST_ROUND_DATA, timeout)
+    answer = _word_signed(raw, 1)
+    updated_at = _word(raw, 3)
+    decimals = _word(_eth_call(rpc_url, proxy, SEL_DECIMALS, timeout), 0)
+
+    out: dict[str, Any] = {
+        "feedAddress": proxy,
+        "answer": answer,
+        "decimals": decimals,
+        "updatedAt": updated_at,
+    }
+    # A non-positive answer is not a price; AggregatorV3 uses it to signal an
+    # unusable round. Emitting it as "$0.00" would read as a real quote.
+    if answer <= 0:
+        out["usd"] = None
+        out["unusableAnswer"] = True
+    else:
+        out["usd"] = answer / (10**decimals) if decimals <= 36 else None
+    if updated_at > 0:
+        out["ageSeconds"] = max(0, int(now - updated_at))
+    return out
+
+
+def _try(fn: Any, errors: dict[str, str], key: str) -> Any:
+    """Run a read, recording the failure instead of aborting the whole payload."""
+    try:
+        return fn()
+    except (RpcError, urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+        errors[key] = str(exc)
+        return None
+
+
+def _try_call(fn: Any, errors: dict[str, str], key: str) -> tuple[Any, bool]:
+    """Like ``_try`` but reports whether the contract answered at all.
+
+    The second element is True only when the node was reached and the contract
+    rejected the call. An unreachable node is not evidence about the contract,
+    and conflating the two would let a network fault masquerade as proof that a
+    genuine Stock Token is an impersonator.
+    """
+    try:
+        return fn(), True
+    except RpcError as exc:
+        errors[key] = str(exc)
+        return None, True
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+        errors[key] = str(exc)
+        return None, False
+
+
+def inspect_token(
+    rpc_url: str,
+    address: str,
+    timeout: float,
+    holder: str | None = None,
+    feed: dict[str, Any] | None = None,
+    feeds: list[dict[str, Any]] | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Read live on-chain state for one token address.
+
+    ``feeds`` lets the price feed be resolved from the ticker the contract
+    reports itself, which is what makes ``--address`` (no name resolution)
+    still find a price. Without it, "we never looked up a feed" would surface
+    as "this token has no feed" -- a claim the run never actually tested.
+    """
+    errors: dict[str, str] = {}
+    out: dict[str, Any] = {"address": address, "chainId": CHAIN_ID}
+    now = time.time() if now is None else now
+
+    out["onchainSymbol"] = _try(
+        lambda: _decode_string(_eth_call(rpc_url, address, SEL_SYMBOL, timeout)), errors, "symbol"
+    )
+    out["decimals"] = _try(
+        lambda: _word(_eth_call(rpc_url, address, SEL_DECIMALS, timeout), 0), errors, "decimals"
+    )
+    total_supply = _try(
+        lambda: _word(_eth_call(rpc_url, address, SEL_TOTAL_SUPPLY, timeout), 0),
+        errors,
+        "totalSupply",
+    )
+    if total_supply is not None:
+        out["totalSupply"] = str(total_supply)
+        out["totalSupplyFormatted"] = total_supply / WAD
+
+    # `uiMultiplier()` is the ERC-8056 marker. A genuine Stock Token answers it;
+    # a community token reverts, which is what makes this the authoritative check.
+    # A node we could not reach proves neither, so that case stays `None` --
+    # callers must not present "unverified" as "fake".
+    multiplier, answered = _try_call(
+        lambda: _word(_eth_call(rpc_url, address, SEL_UI_MULTIPLIER, timeout), 0),
+        errors,
+        "uiMultiplier",
+    )
+    out["isStockToken"] = True if multiplier is not None else (False if answered else None)
+    if multiplier is not None:
+        out["uiMultiplier"] = str(multiplier)
+        out["uiMultiplierFormatted"] = multiplier / WAD
+
+    paused = _try(
+        lambda: _word(_eth_call(rpc_url, address, SEL_ORACLE_PAUSED, timeout), 0),
+        errors,
+        "oraclePaused",
+    )
+    if paused is not None:
+        out["oraclePaused"] = bool(paused)
+
+    # Prefer the ticker the contract reports over any caller-supplied hint, so
+    # an address-only run resolves its own feed.
+    if feed is None and feeds:
+        onchain_symbol = out.get("onchainSymbol")
+        if isinstance(onchain_symbol, str) and onchain_symbol:
+            feed = find_feed(onchain_symbol, feeds)
+
+    if feed is not None:
+        price = _try(
+            lambda: _read_price(rpc_url, str(feed["proxyAddress"]), timeout, now), errors, "price"
+        )
+        if price is not None:
+            heartbeat = feed.get("heartbeat")
+            price["heartbeatSeconds"] = heartbeat
+            price["deviationThresholdPercent"] = feed.get("threshold")
+            # Mark staleness in the payload instead of leaving the reader to
+            # compare a unix timestamp against the heartbeat by eye.
+            age = price.get("ageSeconds")
+            beyond = isinstance(age, int) and isinstance(heartbeat, int) and age > heartbeat
+            price["stale"] = bool(beyond or out.get("oraclePaused"))
+            out["price"] = price
+
+    if holder:
+        balance = _try(
+            lambda: _word(
+                _eth_call(rpc_url, address, _encode_address_arg(SEL_BALANCE_OF, holder), timeout), 0
+            ),
+            errors,
+            "balanceOf",
+        )
+        if balance is not None:
+            tokens_held = balance / WAD
+            holding: dict[str, Any] = {
+                "holder": holder,
+                "balance": str(balance),
+                "balanceFormatted": tokens_held,
+            }
+            usd = (out.get("price") or {}).get("usd")
+            if usd is not None:
+                holding["valueUsd"] = tokens_held * usd
+            out["holding"] = holding
+
+    if errors:
+        out["readErrors"] = errors
+    return out
+
+
+def _resolve_target(
+    args: argparse.Namespace, timeout: float
+) -> tuple[str, dict[str, Any] | None, list[dict[str, Any]]]:
+    """Return (address, list-entry-or-None, feeds) for the requested target."""
+    feeds: list[dict[str, Any]] = []
+    if not args.no_price:
+        fetched = _http_json(FEEDS_URL, timeout)
+        if isinstance(fetched, list):
+            feeds = fetched
+
+    if args.address:
+        if not _ADDRESS_RE.match(args.address):
+            raise ValueError(f"not a valid 0x address: {args.address}")
+        return args.address, None, feeds
+
+    listed = _http_json(TOKEN_LIST_URL, timeout)
+    tokens = listed.get("tokens") if isinstance(listed, dict) else None
+    if not isinstance(tokens, list):
+        raise ValueError("token list unavailable")
+    match = resolve_token(args.query or "", tokens)
+    if match is None:
+        raise ValueError(f"no Robinhood Stock Token matched {args.query!r}")
+    return str(match.get("address", "")), match, feeds
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Robinhood Chain on-chain stock reader")
+    parser.add_argument("--query", help="Company name or ticker (e.g. Apple, AAPL)")
+    parser.add_argument("--address", help="Token contract address; skips name resolution")
+    parser.add_argument("--holder", help="Wallet address to read a balance for")
+    parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help="Robinhood Chain JSON-RPC URL")
+    parser.add_argument("--no-price", action="store_true", help="Skip the Chainlink price read")
+    parser.add_argument("--timeout", type=float, default=15.0, help="HTTP timeout seconds")
+    args = parser.parse_args()
+
+    if not args.query and not args.address:
+        print(json.dumps({"error": "provide --query or --address"}))
+        return 0
+    if args.holder and not _ADDRESS_RE.match(args.holder):
+        print(json.dumps({"error": f"not a valid holder address: {args.holder}"}))
+        return 0
+
+    try:
+        address, listed, feeds = _resolve_target(args, args.timeout)
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+        print(json.dumps({"query": args.query, "error": str(exc)}, ensure_ascii=False))
+        return 0
+
+    symbol = str((listed or {}).get("symbol", "")) or ""
+    feed = find_feed(symbol, feeds) if symbol and feeds else None
+
+    state = inspect_token(
+        args.rpc_url, address, args.timeout, holder=args.holder, feed=feed, feeds=feeds
+    )
+    if not args.no_price and "price" not in state:
+        # Say which of the two happened. "We could not fetch the feed list" is
+        # not the same claim as "this token has no feed", and reporting the
+        # first as the second asserts something the run never checked.
+        state.setdefault("notes", []).append(
+            "could not fetch the Chainlink feed directory; price unavailable, not disproven"
+            if not feeds
+            else "no Chainlink feed published for this token; price omitted"
+        )
+    if listed is not None:
+        state["name"] = _clean_name(str(listed.get("name", "")))
+        state["symbol"] = symbol
+    if state.get("isStockToken") is False:
+        state.setdefault("notes", []).append(
+            "uiMultiplier() reverted: this address is not a Robinhood Stock Token"
+        )
+    elif state.get("isStockToken") is None:
+        state.setdefault("notes", []).append(
+            "could not reach the RPC node: Stock Token status unverified, not disproven"
+        )
+
+    result = {
+        "query": args.query,
+        "chainId": CHAIN_ID,
+        "rpcUrl": args.rpc_url,
+        "explorer": f"{EXPLORER_URL}/token/{address}",
+        "sources": {"tokenList": TOKEN_LIST_URL, "priceFeeds": FEEDS_URL},
+        "token": state,
+    }
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -36,9 +36,25 @@ Resolve a real-world stock or ETF to its **Robinhood tokenized-asset (RWA)**
 on-chain token: ticker/symbol, contract address, chain id, and decimals.
 
 Data source (public, no key): `https://tokens.coingecko.com/robinhood/all.json`
-— the official CoinGecko token list for Robinhood Chain (chainId `4663`). Names
-in that list carry a "• Robinhood Token" suffix; this skill strips it so plain
-company names match.
+— the official CoinGecko token list for Robinhood Chain (chainId `4663`). Stock
+Token names in that list carry a "• Robinhood Token" suffix; this skill strips
+it for display so plain company names match, and uses it to filter.
+
+## Community tokens are excluded on purpose
+
+Robinhood Chain is permissionless, so the same list also carries community
+tokens — and **some reuse a listed company's name and symbol verbatim**. Two
+entries are called "GameStop" with symbol `GME`:
+
+- `0x1b0e319c6a659f002271b69db8a7df2f911c153e` — the real Stock Token
+- `0x7e86381a763f0ecca2bdf27c54eac403ddd48123` — a community impersonator
+
+The suffix is the only thing separating them, so this lookup returns **Stock
+Tokens only** by default and tags every match with `isStockToken`. Pass
+`--include-community` to widen the search; genuine Stock Tokens still rank
+above impersonators. To confirm an address on-chain, use the
+`robinhood-chain-stocks` skill — a real Stock Token answers `uiMultiplier()`
+and an impersonator's call reverts.
 
 ## When the user asks
 
@@ -63,6 +79,9 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "AAPL"
 
 # Limit matches
 python3 {baseDir}/scripts/rwa_lookup.py --query "Tesla" --limit 1
+
+# Include non-stock community tokens (off by default)
+python3 {baseDir}/scripts/rwa_lookup.py --query "GME" --include-community
 ```
 
 ### Output (JSON)
@@ -71,7 +90,8 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "Tesla" --limit 1
 {
   "query": "Apple",
   "source": "https://tokens.coingecko.com/robinhood/all.json",
-  "total_tokens": 228,
+  "total_tokens": 658,
+  "stock_tokens": 221,
   "matches": [
     {
       "name": "Apple",
@@ -79,11 +99,16 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "Tesla" --limit 1
       "address": "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9",
       "chainId": 4663,
       "decimals": 18,
+      "isStockToken": true,
       "logoURI": "https://assets.coingecko.com/..."
     }
   ]
 }
 ```
+
+`total_tokens` counts the whole list; `stock_tokens` counts the tokenized
+stocks and ETFs within it. Both move as Robinhood lists new assets and the
+community deploys more tokens — read them from the payload, never assume.
 
 ## Matching rules
 
@@ -100,4 +125,5 @@ failure the script still returns JSON with an `error` field (never crashes).
 
 - No API key required; the token list is public and cached by CoinGecko.
 - Addresses are on **Robinhood Chain** (chainId `4663`) — not Ethereum mainnet.
-- The list covers ~228 tokenized stocks/ETFs and a few Robinhood-native tokens.
+- This skill resolves addresses only. For live price, holdings, supply, or an
+  on-chain authenticity check, use **`robinhood-chain-stocks`**.

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
@@ -20,7 +20,12 @@ import urllib.request
 from typing import Any
 
 TOKEN_LIST_URL = "https://tokens.coingecko.com/robinhood/all.json"
-# The Robinhood-token names are suffixed with this marker in the list.
+# The Robinhood-token names are suffixed with this marker in the list. Robinhood
+# Chain is permissionless, so the same list also carries community tokens -- and
+# some of those reuse a listed company's name and symbol verbatim (two entries
+# are called "GameStop" with symbol GME). The suffix is the only thing in the
+# list that separates a real Stock Token from an impersonator, so it is a filter
+# here, not just cosmetic: stripping it for display must not lose it for ranking.
 _RH_SUFFIX_RE = re.compile(r"\s*[•·|-]?\s*robinhood token\s*$", re.IGNORECASE)
 
 
@@ -38,6 +43,11 @@ def _fetch_tokens(timeout: float) -> list[dict[str, Any]]:
 def _clean_name(name: str) -> str:
     """Strip the '• Robinhood Token' suffix so 'Apple' matches cleanly."""
     return _RH_SUFFIX_RE.sub("", name or "").strip()
+
+
+def is_stock_token(token: dict[str, Any]) -> bool:
+    """True when the entry is a Robinhood Stock Token rather than a community token."""
+    return bool(_RH_SUFFIX_RE.search(token.get("name", "") or ""))
 
 
 def _norm(text: str) -> str:
@@ -87,13 +97,31 @@ def _shape(token: dict[str, Any]) -> dict[str, Any]:
         "address": token.get("address", ""),
         "chainId": token.get("chainId"),
         "decimals": token.get("decimals"),
+        "isStockToken": is_stock_token(token),
         "logoURI": token.get("logoURI", ""),
     }
 
 
-def lookup(query: str, tokens: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
-    scored = [(s, t) for t in tokens if (s := _score(query, t)) > 0]
-    scored.sort(key=lambda pair: (-pair[0], _norm(pair[1].get("symbol", ""))))
+def lookup(
+    query: str,
+    tokens: list[dict[str, Any]],
+    limit: int,
+    *,
+    include_community: bool = False,
+) -> list[dict[str, Any]]:
+    """Rank tokens against the query, Stock Tokens first.
+
+    Community tokens are dropped unless explicitly requested: several of them
+    impersonate a listed company, so answering "GameStop's address" with one of
+    those would hand the user a token that is not the equity they asked for.
+    """
+    pool = tokens if include_community else [t for t in tokens if is_stock_token(t)]
+    scored = [(s, t) for t in pool if (s := _score(query, t)) > 0]
+    # Stock Tokens outrank community tokens at equal relevance, so an impersonator
+    # can never displace the real listing even when both are requested.
+    scored.sort(
+        key=lambda pair: (-pair[0], not is_stock_token(pair[1]), _norm(pair[1].get("symbol", "")))
+    )
     return [_shape(t) for _s, t in scored[:limit]]
 
 
@@ -102,23 +130,27 @@ def main() -> int:
     parser.add_argument("--query", required=True, help="Company name or ticker (e.g. Apple, AAPL)")
     parser.add_argument("--limit", type=int, default=5, help="Max matches to return")
     parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout seconds")
+    parser.add_argument(
+        "--include-community",
+        action="store_true",
+        help="Also match non-stock community tokens (off by default; some impersonate listings)",
+    )
     args = parser.parse_args()
 
     try:
         tokens = _fetch_tokens(args.timeout)
     except (urllib.error.URLError, TimeoutError, ValueError) as exc:
-        print(
-            json.dumps(
-                {"query": args.query, "matches": [], "error": f"fetch failed: {exc}"}
-            )
-        )
+        print(json.dumps({"query": args.query, "matches": [], "error": f"fetch failed: {exc}"}))
         return 0
 
-    matches = lookup(args.query, tokens, max(1, args.limit))
+    matches = lookup(
+        args.query, tokens, max(1, args.limit), include_community=args.include_community
+    )
     result = {
         "query": args.query,
         "source": TOKEN_LIST_URL,
         "total_tokens": len(tokens),
+        "stock_tokens": sum(1 for t in tokens if is_stock_token(t)),
         "matches": matches,
     }
     if not matches:

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -1,0 +1,370 @@
+"""Offline regression tests for the robinhood-chain-stocks on-chain reader.
+
+No network: every RPC read is stubbed. The cases below pin the two behaviours
+that make the skill safe to answer with -- ABI decoding of real return blobs,
+and refusing to resolve a company name to a community token that impersonates
+it (Robinhood Chain is permissionless, and two entries in the public token list
+are both called "GameStop" with symbol GME).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentos.skills.loader import SkillLoader
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "src" / "agentos" / "skills" / "bundled"
+SKILL_DIR = BUNDLED / "robinhood-chain-stocks"
+_SCRIPT = SKILL_DIR / "scripts" / "chain_stocks.py"
+
+_spec = importlib.util.spec_from_file_location("chain_stocks", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+chain_stocks = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(chain_stocks)
+
+REAL_GME = "0x1b0e319c6a659f002271b69db8a7df2f911c153e"
+FAKE_GME = "0x7e86381a763f0ecca2bdf27c54eac403ddd48123"
+AAPL = "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9"
+
+_TOKENS: list[dict[str, Any]] = [
+    {
+        "chainId": 4663,
+        "address": AAPL,
+        "name": "Apple • Robinhood Token",
+        "symbol": "AAPL",
+        "decimals": 18,
+    },
+    {
+        "chainId": 4663,
+        "address": REAL_GME,
+        "name": "GameStop • Robinhood Token",
+        "symbol": "GME",
+        "decimals": 18,
+    },
+    # Community token impersonating the listing: same name, same symbol, no suffix.
+    {"chainId": 4663, "address": FAKE_GME, "name": "GameStop", "symbol": "GME", "decimals": 18},
+    {"chainId": 4663, "address": "0xca9c", "name": "NetNet", "symbol": "NET", "decimals": 18},
+    {
+        "chainId": 4663,
+        "address": "0x116f",
+        "name": "Cloudflare, Inc. • Robinhood Token",
+        "symbol": "NET",
+        "decimals": 18,
+    },
+]
+
+_FEEDS: list[dict[str, Any]] = [
+    {
+        "name": "Robinhood AAPL / USD",
+        "proxyAddress": "0x6B22A786bAa607d76728168703a39Ea9C99f2cD0",
+        "heartbeat": 86400,
+        "threshold": 0.5,
+        "docs": {"baseAsset": "AAPL"},
+    },
+    # Real feed names are not uniform; these two shapes both occur upstream.
+    {"name": "Robinhood DELL-USD", "proxyAddress": "0xdeLL", "docs": {}},
+    {"name": "ETH / USD", "proxyAddress": "0xeth", "docs": {"baseAsset": "ETH"}},
+]
+
+
+def _word_hex(value: int) -> str:
+    return f"{value & ((1 << 256) - 1):064x}"
+
+
+class _FakeChain:
+    """Minimal eth_call stand-in keyed by (address, selector)."""
+
+    def __init__(self, responses: dict[tuple[str, str], str]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, _rpc: str, to: str, data: str, _timeout: float) -> str:
+        key = (to.lower(), data[:10])
+        self.calls.append(key)
+        try:
+            return self.responses[key]
+        except KeyError:
+            raise chain_stocks.RpcError("execution reverted") from None
+
+
+# --- ABI decoding -----------------------------------------------------------
+
+
+def test_decode_string_reads_dynamic_return() -> None:
+    blob = "0x" + _word_hex(32) + _word_hex(4) + b"AAPL".hex().ljust(64, "0")
+    assert chain_stocks._decode_string(blob) == "AAPL"
+
+
+def test_word_signed_handles_negative_answers() -> None:
+    assert chain_stocks._word_signed("0x" + _word_hex(-1), 0) == -1
+    assert chain_stocks._word_signed("0x" + _word_hex(31747461437), 0) == 31747461437
+
+
+def test_word_rejects_short_result() -> None:
+    with pytest.raises(chain_stocks.RpcError):
+        chain_stocks._word("0x1234", 0)
+
+
+def test_encode_address_arg_pads_to_a_full_word() -> None:
+    encoded = chain_stocks._encode_address_arg(chain_stocks.SEL_BALANCE_OF, AAPL)
+    assert encoded.startswith(chain_stocks.SEL_BALANCE_OF)
+    assert len(encoded) == 10 + 64
+    assert encoded.endswith(AAPL[2:])
+
+
+# --- impersonation guard ----------------------------------------------------
+
+
+def test_is_stock_token_keys_off_the_suffix() -> None:
+    assert chain_stocks.is_stock_token(_TOKENS[1]) is True
+    assert chain_stocks.is_stock_token(_TOKENS[2]) is False
+
+
+def test_resolve_token_never_returns_an_impersonator() -> None:
+    for query in ("GME", "GameStop", "mã cổ phiếu GME là gì"):
+        match = chain_stocks.resolve_token(query, _TOKENS)
+        assert match is not None, query
+        assert match["address"] == REAL_GME, query
+
+
+def test_resolve_token_prefers_the_listing_over_a_lookalike_symbol() -> None:
+    match = chain_stocks.resolve_token("NET", _TOKENS)
+    assert match is not None
+    assert match["name"].startswith("Cloudflare")
+
+
+def test_resolve_token_returns_none_when_nothing_matches() -> None:
+    assert chain_stocks.resolve_token("zzz-not-a-company", _TOKENS) is None
+
+
+# --- Chainlink feed mapping -------------------------------------------------
+
+
+def test_feed_ticker_prefers_base_asset_then_parses_the_name() -> None:
+    assert chain_stocks.feed_ticker(_FEEDS[0]) == "AAPL"
+    assert chain_stocks.feed_ticker(_FEEDS[1]) == "DELL"
+    assert chain_stocks.feed_ticker({"name": "Robinhood SPY / USD", "docs": {}}) == "SPY"
+
+
+def test_feed_ticker_ignores_non_robinhood_feeds_without_base_asset() -> None:
+    assert chain_stocks.feed_ticker({"name": "USDC / USD", "docs": {}}) == ""
+
+
+def test_find_feed_matches_by_ticker_only() -> None:
+    assert chain_stocks.find_feed("AAPL", _FEEDS) is _FEEDS[0]
+    assert chain_stocks.find_feed("TSLA", _FEEDS) is None
+
+
+# --- on-chain inspection ----------------------------------------------------
+
+
+def test_inspect_token_reads_price_multiplier_and_balance(monkeypatch: pytest.MonkeyPatch) -> None:
+    feed = _FEEDS[0]
+    proxy = str(feed["proxyAddress"]).lower()
+    round_data = "0x" + "".join(_word_hex(v) for v in (1, 31747461437, 1788206000, 1788206389, 1))
+    chain = _FakeChain(
+        {
+            (AAPL, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32)
+            + _word_hex(4)
+            + b"AAPL".hex().ljust(64, "0"),
+            (AAPL, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(18),
+            (AAPL, chain_stocks.SEL_TOTAL_SUPPLY): "0x" + _word_hex(10301407498610000000000),
+            (AAPL, chain_stocks.SEL_UI_MULTIPLIER): "0x" + _word_hex(1000566080061092436),
+            (AAPL, chain_stocks.SEL_ORACLE_PAUSED): "0x" + _word_hex(0),
+            (AAPL, chain_stocks.SEL_BALANCE_OF): "0x" + _word_hex(2 * 10**18),
+            (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): round_data,
+            (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),
+        }
+    )
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+
+    # `now` is pinned so age/staleness never depend on the wall clock.
+    state = chain_stocks.inspect_token(
+        "rpc", AAPL, 5.0, holder=AAPL, feed=feed, now=1788206389 + 600
+    )
+
+    assert state["isStockToken"] is True
+    assert state["onchainSymbol"] == "AAPL"
+    assert state["oraclePaused"] is False
+    assert state["uiMultiplierFormatted"] == pytest.approx(1.000566080061092)
+    assert state["price"]["usd"] == pytest.approx(317.47461437)
+    assert state["price"]["updatedAt"] == 1788206389
+    assert state["price"]["ageSeconds"] == 600
+    assert state["price"]["stale"] is False
+    assert state["price"]["heartbeatSeconds"] == 86400
+    assert state["holding"]["balanceFormatted"] == pytest.approx(2.0)
+    assert state["holding"]["valueUsd"] == pytest.approx(634.94922874)
+    assert "readErrors" not in state
+
+
+def test_inspect_token_flags_a_token_that_cannot_answer_ui_multiplier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Everything except the ERC-8056 marker resolves -- exactly how an
+    # impersonating ERC-20 presents itself.
+    chain = _FakeChain(
+        {
+            (FAKE_GME, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32)
+            + _word_hex(3)
+            + b"GME".hex().ljust(64, "0"),
+            (FAKE_GME, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(18),
+            (FAKE_GME, chain_stocks.SEL_TOTAL_SUPPLY): "0x" + _word_hex(10**24),
+        }
+    )
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+
+    state = chain_stocks.inspect_token("rpc", FAKE_GME, 5.0)
+
+    assert state["isStockToken"] is False
+    assert "uiMultiplier" not in state
+    assert "uiMultiplier" in state["readErrors"]
+
+
+def test_address_only_run_resolves_its_feed_from_the_onchain_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--address` skips name resolution, so the feed must come from `symbol()`.
+
+    Otherwise a run that never looked up a feed reports "no feed published for
+    this token" -- asserting a fact it never checked.
+    """
+    proxy = str(_FEEDS[0]["proxyAddress"]).lower()
+    chain = _FakeChain(
+        {
+            (AAPL, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32)
+            + _word_hex(4)
+            + b"AAPL".hex().ljust(64, "0"),
+            (AAPL, chain_stocks.SEL_UI_MULTIPLIER): "0x" + _word_hex(10**18),
+            (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
+            + "".join(_word_hex(v) for v in (1, 31747461437, 0, 1788206389, 1)),
+            (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),
+        }
+    )
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+
+    # No `feed=` passed, exactly as an --address run does.
+    state = chain_stocks.inspect_token("rpc", AAPL, 5.0, feeds=_FEEDS, now=1788206389 + 60)
+
+    assert state["price"]["usd"] == pytest.approx(317.47461437)
+    assert state["price"]["feedAddress"] == _FEEDS[0]["proxyAddress"]
+
+
+def test_feed_lookup_is_skipped_when_the_symbol_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _FakeChain({}))
+    state = chain_stocks.inspect_token("rpc", AAPL, 5.0, feeds=_FEEDS)
+    assert "price" not in state
+
+
+def _price_chain(answer: int, updated_at: int, paused: int = 0) -> _FakeChain:
+    proxy = str(_FEEDS[0]["proxyAddress"]).lower()
+    return _FakeChain(
+        {
+            (AAPL, chain_stocks.SEL_ORACLE_PAUSED): "0x" + _word_hex(paused),
+            (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
+            + "".join(_word_hex(v) for v in (1, answer, 0, updated_at, 1)),
+            (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),
+        }
+    )
+
+
+def test_price_age_is_computed_and_fresh_answers_are_not_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _price_chain(31747461437, 1_000_000))
+    price = chain_stocks.inspect_token("rpc", AAPL, 5.0, feed=_FEEDS[0], now=1_000_600.0)["price"]
+    assert price["ageSeconds"] == 600
+    assert price["stale"] is False
+
+
+def test_answer_older_than_the_heartbeat_is_flagged_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _price_chain(31747461437, 1_000_000))
+    # heartbeat is 86400; 90000s old is past it.
+    price = chain_stocks.inspect_token("rpc", AAPL, 5.0, feed=_FEEDS[0], now=1_090_000.0)["price"]
+    assert price["ageSeconds"] == 90_000
+    assert price["stale"] is True
+
+
+def test_paused_oracle_marks_the_price_stale_even_when_recent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _price_chain(31747461437, 1_000_000, paused=1))
+    state = chain_stocks.inspect_token("rpc", AAPL, 5.0, feed=_FEEDS[0], now=1_000_060.0)
+    assert state["oraclePaused"] is True
+    assert state["price"]["stale"] is True
+
+
+def test_non_positive_answer_is_not_reported_as_a_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _price_chain(0, 1_000_000))
+    price = chain_stocks.inspect_token("rpc", AAPL, 5.0, feed=_FEEDS[0], now=1_000_060.0)["price"]
+    assert price["usd"] is None
+    assert price["unusableAnswer"] is True
+
+
+def test_inspect_token_reports_a_paused_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
+    chain = _FakeChain({(AAPL, chain_stocks.SEL_ORACLE_PAUSED): "0x" + _word_hex(1)})
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+    assert chain_stocks.inspect_token("rpc", AAPL, 5.0)["oraclePaused"] is True
+
+
+def test_inspect_token_degrades_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _FakeChain({}))
+    state = chain_stocks.inspect_token("rpc", AAPL, 5.0, feed=_FEEDS[0])
+    assert state["isStockToken"] is False
+    assert set(state["readErrors"]) >= {"symbol", "decimals", "totalSupply", "price"}
+
+
+def test_unreachable_node_leaves_stock_status_unknown_not_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead RPC must never be reported as proof that a real token is fake.
+
+    `isStockToken: false` tells the caller to refuse the address, so a network
+    fault resolving to `false` would brand a genuine listing an impersonator.
+    """
+
+    def _dead(_rpc: str, _to: str, _data: str, _timeout: float) -> str:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(chain_stocks, "_eth_call", _dead)
+    state = chain_stocks.inspect_token("rpc", AAPL, 5.0)
+
+    assert state["isStockToken"] is None
+    assert "uiMultiplier" in state["readErrors"]
+
+
+def test_reverting_contract_is_still_reported_as_not_a_stock_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chain_stocks, "_eth_call", _FakeChain({}))
+    assert chain_stocks.inspect_token("rpc", FAKE_GME, 5.0)["isStockToken"] is False
+
+
+# --- skill packaging --------------------------------------------------------
+
+
+def test_chain_stocks_skill_loads() -> None:
+    skill = SkillLoader(bundled_dir=BUNDLED).get_by_name("robinhood-chain-stocks")
+    assert skill is not None
+    assert skill.provenance.origin == "agentos-original"
+    assert skill.provenance.maintained_by == "AgentOS"
+
+
+def test_skill_documents_the_read_only_boundary() -> None:
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    assert "read-only" in body.lower()
+    assert "uiMultiplier()" in body
+    assert "4663" in body

--- a/tests/test_skill_robinhood_rwa.py
+++ b/tests/test_skill_robinhood_rwa.py
@@ -45,7 +45,28 @@ _TOKENS = [
         "decimals": 18,
         "logoURI": "",
     },
+    {
+        "chainId": 4663,
+        "address": "0x1b0e319c6a659f002271b69db8a7df2f911c153e",
+        "name": "GameStop • Robinhood Token",
+        "symbol": "GME",
+        "decimals": 18,
+        "logoURI": "",
+    },
+    # Robinhood Chain is permissionless: this community token reuses GameStop's
+    # name and ticker, and only the missing suffix tells the two apart.
+    {
+        "chainId": 4663,
+        "address": "0x7e86381a763f0ecca2bdf27c54eac403ddd48123",
+        "name": "GameStop",
+        "symbol": "GME",
+        "decimals": 18,
+        "logoURI": "",
+    },
 ]
+
+_REAL_GME = "0x1b0e319c6a659f002271b69db8a7df2f911c153e"
+_FAKE_GME = "0x7e86381a763f0ecca2bdf27c54eac403ddd48123"
 
 
 def _symbols(query: str) -> list[str]:
@@ -77,3 +98,30 @@ def test_robinhood_suffix_stripped_from_names() -> None:
     matches = rwa_lookup.lookup("Apple", _TOKENS, limit=1)
     assert matches[0]["name"] == "Apple"
     assert matches[0]["address"] == "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9"
+
+
+def test_community_token_impersonating_a_listing_is_excluded() -> None:
+    """A lookalike must never be offered as the answer to a company question.
+
+    Both entries clean up to the display name "GameStop" with symbol GME, so
+    without the suffix filter the caller cannot tell which address is the equity.
+    """
+    for query in ("GME", "GameStop", "mã cổ phiếu GME là gì"):
+        matches = rwa_lookup.lookup(query, _TOKENS, limit=5)
+        assert [m["address"] for m in matches] == [_REAL_GME], query
+
+
+def test_include_community_widens_the_search_but_keeps_stock_tokens_first() -> None:
+    matches = rwa_lookup.lookup("GME", _TOKENS, limit=5, include_community=True)
+    assert [m["address"] for m in matches] == [_REAL_GME, _FAKE_GME]
+    assert [m["isStockToken"] for m in matches] == [True, False]
+
+
+def test_matches_are_tagged_with_stock_token_status() -> None:
+    assert rwa_lookup.lookup("Apple", _TOKENS, limit=1)[0]["isStockToken"] is True
+
+
+def test_is_stock_token_keys_off_the_suffix() -> None:
+    assert rwa_lookup.is_stock_token({"name": "Apple • Robinhood Token"}) is True
+    assert rwa_lookup.is_stock_token({"name": "GameStop"}) is False
+    assert rwa_lookup.is_stock_token({}) is False

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -51,6 +51,7 @@ DEFAULTS = (
         "poolsdotfun-token-launcher",
         "pptx",
         "robinhood-agentic-trading",
+        "robinhood-chain-stocks",
         "robinhood-rwa-addresses",
         "seedance-2-prompt",
         "senior-unilp-manager",

--- a/tests/test_skills_publisher_contract.py
+++ b/tests/test_skills_publisher_contract.py
@@ -272,4 +272,8 @@ def test_other_bundled_skills_stay_unbranded(tmp_path: Path) -> None:
 
     branded = {skill.name for skill in loader.load_all() if skill.publisher != SkillPublisher()}
 
-    assert branded == {"robinhood-agentic-trading", "robinhood-rwa-addresses"}
+    assert branded == {
+        "robinhood-agentic-trading",
+        "robinhood-chain-stocks",
+        "robinhood-rwa-addresses",
+    }

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -27,6 +27,7 @@ ORIGINALS = {
     "poolsdotfun-token-launcher",
     "pptx",
     "robinhood-agentic-trading",
+    "robinhood-chain-stocks",
     "robinhood-rwa-addresses",
     "senior-unilp-manager",
     "stack-trace-generic-probe",


### PR DESCRIPTION
Closes #745
Closes #746

## What changed

**New bundled skill `robinhood-chain-stocks`** — reads Robinhood Chain (chainId `4663`) Stock Token state over plain JSON-RPC: the Chainlink USD price, the ERC-8056 `uiMultiplier()` corporate-action ratio, `oraclePaused()`, total supply, and wallet balances with their USD value. It issues only `eth_call` and never signs, sends, or holds a key; trade execution stays with `robinhood-agentic-trading`. Feed addresses come from Chainlink's reference-data directory rather than a hardcoded table, and are resolved from the ticker the contract reports itself, so an address-only lookup still finds its price.

**Fix `robinhood-rwa-addresses`** — it could return a community token impersonating a listed company (#745). The lookup stripped the `• Robinhood Token` name suffix before ranking, and that suffix is the only field separating a real Stock Token from a lookalike. Two entries are named `GameStop` with symbol `GME`; `--query NET` ranked the `NetNet` community token above Cloudflare. The lookup now matches Stock Tokens only, with `--include-community` to widen the search (real listings still rank first), tags every match with `isStockToken`, and reports a `stock_tokens` count. The doc's hardcoded "~228 tokens" claim — stale against a list now holding 658 entries, 221 of them equities — is gone.

## Design note: unverified is not the same as false

The skill's authenticity signal tells an agent whether to hand a contract address to a user, so the failure modes had to be kept apart. Three values, not two:

| `isStockToken` | Meaning |
|---|---|
| `true` | `uiMultiplier()` returned |
| `false` | the node answered and the call **reverted** |
| `null` | the node was **unreachable** — unverified, not disproven |

The same rule is applied to prices: a missing price says whether the feed directory was unreachable or the token genuinely has no published feed, and a non-positive feed answer is reported as `unusableAnswer` rather than rendered as `$0`.

Prices also carry `ageSeconds` and a `stale` flag (past the 86400s heartbeat, or oracle paused). Stock feeds update 24/5, so outside market hours the last answer is legitimately hours old — the payload states that rather than leaving a caller to compare a unix timestamp against the heartbeat by eye.

## Verification

Full gate: `ruff check src tests`, `mypy src/agentos` (615 files), `pytest -q` (8624 passed, 27 skipped), `uv build --wheel` — and the wheel was unpacked to confirm the new skill actually ships in it.

`tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force` fails on this branch. It fails identically on a clean tree (verified by stashing the whole change and re-running); it is an ANSI line-wrapping assertion unrelated to this work.

27 new offline tests — ABI decoding against real return blobs, the impersonation guard, feed-name parsing across the three shapes upstream actually uses, and each degraded-network path. No network in the default test path; `now` is injected so age and staleness never depend on the wall clock.

Exercised against mainnet: chain id, `AAPL`/`TSLA`/`GME`/`NVDA` prices, `uiMultiplier()` and `oraclePaused()` reads, a holder balance, the impersonating `GME` contract reverting, an unreachable RPC, and a stock with no published feed. Also driven end-to-end through real agent turns (CLI and the Web UI console) to confirm the skill is discovered, executed, and reported on correctly — those runs are what surfaced two of the bugs fixed here.

## Notes for review

- Both data sources are public and key-free: the CoinGecko Robinhood token list and Chainlink's reference-data directory.
- The public RPC is rate-limited with no archive data; `--rpc-url` points the script at a dedicated provider.
- Stock Tokens are tokenized debt securities, unavailable to US persons and restricted in other jurisdictions. `SKILL.md` requires that caveat in output and forbids framing results as investment advice.