### PR TITLE
fix(gateway): enforce rate limit on Control UI API subtree (#748)

### DIFF
--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -301,7 +301,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     def _is_ui_path(self, path: str) -> bool:
         if self._ui_prefix is None:
             return False
-        return _is_under(self._ui_prefix, path)
+        if not _is_under(self._ui_prefix, path):
+            return False
+        if path == self._ui_prefix + _UI_BOOTSTRAP_SUFFIX:
+            return True
+        return not _is_under(self._ui_prefix + _API_PREFIX, path)
 
     def _is_trusted_proxy(self, peer_ip: str | None) -> bool:
         if not peer_ip:

--- a/tests/test_gateway/test_middleware_ui_exemptions.py
+++ b/tests/test_gateway/test_middleware_ui_exemptions.py
@@ -102,3 +102,21 @@ def test_http_token_auth_rejects_wrong_token(tmp_path) -> None:
 
     assert response.status_code == 401
     assert response.json()["code"] == "UNAUTHORIZED"
+
+
+def test_control_ui_api_subtree_is_rate_limited_while_shell_is_exempt(tmp_path) -> None:
+    config = _config(tmp_path, base_path="/control", max_requests=2)
+    headers = {"authorization": "Bearer test-token"}
+    with TestClient(create_gateway_app(config), base_url="http://localhost") as client:
+        # API calls under /control/api/ are rate-limited
+        r1 = client.get("/control/api/config", headers=headers)
+        r2 = client.get("/control/api/config", headers=headers)
+        r3 = client.get("/control/api/config", headers=headers)
+        assert r1.status_code != 429
+        assert r2.status_code != 429
+        assert r3.status_code == 429
+
+        # Static UI shell under /control is exempt from rate limiting
+        for _ in range(5):
+            shell_resp = client.get("/control/")
+            assert shell_resp.status_code != 429


### PR DESCRIPTION
## Summary

Fixes #748.

`RateLimitMiddleware._is_ui_path()` exempts the **entire** Control UI prefix from per-IP rate limiting, including all API endpoints mounted under `{base_path}/api/*`. This allows unlimited unauthenticated requests to `/control/api/sessions`, `/control/api/chat`, `/control/api/config`, etc.

## Root Cause

`AuthMiddleware._is_ui_path()` already handles this correctly — it carves out the `/api/*` subtree so only static shell assets are exempt. This guard was not replicated in `RateLimitMiddleware._is_ui_path()`.

## Changes

### `src/agentos/gateway/middleware.py`

Align `RateLimitMiddleware._is_ui_path()` with `AuthMiddleware._is_ui_path()`:

```python
def _is_ui_path(self, path: str) -> bool:
    if self._ui_prefix is None:
        return False
    if not _is_under(self._ui_prefix, path):
        return False
    if path == self._ui_prefix + _UI_BOOTSTRAP_SUFFIX:
        return True
    return not _is_under(self._ui_prefix + _API_PREFIX, path)
```

- Static UI shell and assets (`/control/`, `/control/assets/app.js`): **exempt** (unchanged)
- Bootstrap endpoint (`/control/api/bootstrap`): **exempt** (carve-out, matches auth layer)
- All other API routes (`/control/api/*`): **now rate-limited**

### `tests/test_gateway/test_middleware_ui_exemptions.py`

Added `test_control_ui_api_subtree_is_rate_limited_while_shell_is_exempt`: verifies 3 requests to `/control/api/config` triggers 429 at threshold, while 5 requests to `/control/` never 429.

## Test Results

```
tests/test_gateway/test_middleware_ui_exemptions.py ... 9 passed
tests/test_gateway/test_control_ui_api_guards.py ... 14 passed
tests/test_gateway/test_rate_limit_approvals.py ... 1 passed
```

All existing tests pass — zero regressions.