### PR TITLE
fix(memory): handle non-finite and out-of-bounds vector distances safely

### DIFF
--- a/src/agentos/memory/store.py
+++ b/src/agentos/memory/store.py
@@ -133,7 +133,9 @@ def _l2_normalize_vector(vector: list[float]) -> list[float]:
 
 
 def _vector_distance_to_score(distance: float) -> float:
-    return max(0.0, 1.0 - distance / 2.0)
+    if not math.isfinite(distance):
+        return 0.0
+    return min(1.0, max(0.0, 1.0 - distance / 2.0))
 
 
 def _chunk_id(

--- a/tests/test_memory_vector_normalization.py
+++ b/tests/test_memory_vector_normalization.py
@@ -11,6 +11,8 @@ from agentos.memory.store import (
     VECTOR_NORMALIZATION_META_KEY,
     VECTOR_NORMALIZATION_META_VALUE,
     LongTermMemoryStore,
+    _l2_normalize_vector,
+    _vector_distance_to_score,
 )
 from agentos.memory.types import MemorySource
 
@@ -191,3 +193,28 @@ async def test_normalization_meta_still_rebuilds_missing_vec_table(tmp_path: Pat
         assert row[0] == 1
     finally:
         await store.close()
+
+
+def test_l2_normalize_vector_edge_cases() -> None:
+    # Empty vector
+    assert _l2_normalize_vector([]) == []
+
+    # Zero vector (norm == 0.0) returns unchanged vector without ZeroDivisionError
+    assert _l2_normalize_vector([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+    # Non-finite values (inf / nan) return unchanged vector
+    inf_vec = [float("inf"), 1.0]
+    assert _l2_normalize_vector(inf_vec) == inf_vec
+
+    nan_vec = [float("nan"), 2.0]
+    assert _l2_normalize_vector(nan_vec) == nan_vec
+
+
+def test_vector_distance_to_score_clamping() -> None:
+    assert _vector_distance_to_score(0.0) == 1.0
+    assert _vector_distance_to_score(1.0) == 0.5
+    assert _vector_distance_to_score(2.0) == 0.0
+    # Clamping ensures negative scores are prevented
+    assert _vector_distance_to_score(3.0) == 0.0
+    assert _vector_distance_to_score(100.0) == 0.0
+

--- a/tests/test_memory_vector_normalization.py
+++ b/tests/test_memory_vector_normalization.py
@@ -214,7 +214,12 @@ def test_vector_distance_to_score_clamping() -> None:
     assert _vector_distance_to_score(0.0) == 1.0
     assert _vector_distance_to_score(1.0) == 0.5
     assert _vector_distance_to_score(2.0) == 0.0
-    # Clamping ensures negative scores are prevented
+    # Clamping ensures upper and lower bounds [0.0, 1.0] are strictly preserved
+    assert _vector_distance_to_score(-0.1) == 1.0
     assert _vector_distance_to_score(3.0) == 0.0
     assert _vector_distance_to_score(100.0) == 0.0
+    # Non-finite distances return 0.0 score safely
+    assert _vector_distance_to_score(float("nan")) == 0.0
+    assert _vector_distance_to_score(float("inf")) == 0.0
+    assert _vector_distance_to_score(float("-inf")) == 0.0
 


### PR DESCRIPTION
Fixes #755

### Summary of Changes
- **`src/agentos/memory/store.py`**: Added `math.isfinite()` guard and range clamping `[0.0, 1.0]` to `_vector_distance_to_score(distance)` to prevent invalid similarity score calculations during memory retrieval.
- **`tests/test_memory_vector_normalization.py`**: Added regression unit tests covering `NaN`, `Inf`, `-Inf`, zero vectors, and negative distances.

### Verification
- `uv run pytest tests/test_memory_vector_normalization.py -q` (7 passed)
- `uv run ruff check src tests` (All checks passed!)
- `uv run mypy src/agentos --show-error-codes` (Success: no issues found in 619 source files)
