### PR TITLE
fix(tools): record UpdateFile writes for auto-publish and support standard hunk headers (#753)

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -123,18 +123,22 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
 
 
 def _parse_hunk_header(header: str) -> Hunk:
-    """Parse '@@@ -old_start,old_count +new_start,new_count @@@'."""
-    # Format: @@@ -10,3 +10,4 @@@
+    """Parse '@@@ -old_start[,old_count] +new_start[,new_count] @@@'."""
+    # Format: @@@ -10,3 +10,4 @@@ or @@@ -10 +10,4 @@@
     import re
 
-    m = re.match(r"@@@\s+-(\d+),(\d+)\s+\+(\d+),(\d+)\s+@@@", header.strip())
+    m = re.match(r"@@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@@", header.strip())
     if not m:
         raise ValueError(f"Invalid hunk header: {header!r}")
+    old_start = int(m.group(1))
+    old_count = int(m.group(2)) if m.group(2) is not None else (0 if old_start == 0 else 1)
+    new_start = int(m.group(3))
+    new_count = int(m.group(4)) if m.group(4) is not None else (0 if new_start == 0 else 1)
     return Hunk(
-        old_start=int(m.group(1)),
-        old_count=int(m.group(2)),
-        new_start=int(m.group(3)),
-        new_count=int(m.group(4)),
+        old_start=old_start,
+        old_count=old_count,
+        new_start=new_start,
+        new_count=new_count,
     )
 
 
@@ -217,7 +221,7 @@ def _notify_bootstrap_source_writes(ops: list[PatchOp], root: Path) -> None:
 
 def _record_workspace_file_writes(ops: list[PatchOp], root: Path) -> None:
     for op in ops:
-        if isinstance(op, AddFile):
+        if isinstance(op, (AddFile, UpdateFile)):
             record_workspace_file_write(_validate_path(op.path, root))
 
 

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -495,3 +495,82 @@ async def test_apply_patch_add_file_refuses_existing_file(tmp_path: Path) -> Non
     finally:
         current_tool_context.reset(token)
     assert target.read_text(encoding="utf-8") == "old\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_records_workspace_file_writes_for_add_and_update(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "existing.csv"
+    existing.write_text("a,b\n1,2\n", encoding="utf-8")
+    ctx = ToolContext(workspace_dir=str(tmp_path))
+    token = current_tool_context.set(ctx)
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Add File: created.json
++{"hello": "world"}
+*** Update File: existing.csv
+@@@ -1,2 +1,3 @@@
+ a,b
+ 1,2
++3,4
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) added, 1 file(s) modified" in result
+    written_relative_paths = [w["relative_path"] for w in ctx.workspace_file_writes]
+    assert "created.json" in written_relative_paths
+    assert "existing.csv" in written_relative_paths
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_supports_hunk_header_without_explicit_counts(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "hello.txt"
+    existing.write_text("line1\n", encoding="utf-8")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: hello.txt
+@@@ -1 +1,2 @@@
+ line1
++line2
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert existing.read_text(encoding="utf-8") == "line1\nline2\n"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "@@@",
+        "@@@ @@@",
+        "@@@ -abc +def @@@",
+        "@@@ - +1 @@@",
+        "@@@ -1 + @@@",
+        "@@@ -1,2 @@@",
+        "@@@ +1,2 @@@",
+        "@@@ -1 +1",
+        "-1 +1 @@@",
+        "@@@ -1, +1,2 @@@",
+        "@@@ -1,2 +1, @@@",
+        "",
+        "not a header at all",
+    ],
+)
+def test_parse_hunk_header_rejects_malformed_input(header: str) -> None:
+    from agentos.tools.builtin.patch import _parse_hunk_header
+
+    with pytest.raises(ValueError, match="Invalid hunk header"):
+        _parse_hunk_header(header)


### PR DESCRIPTION
## Summary

Fixes #753.

Two bugs in `apply_patch` tool:

1. **`_record_workspace_file_writes`** only checks `isinstance(op, AddFile)`, so `UpdateFile` operations are never recorded in `ctx.workspace_file_writes`. `UpdateFile` is a peer of `AddFile` in the `PatchOp` union and is handled everywhere else in the module, so its absence here is plainly an oversight. The engine's `auto_publish_omitted_workspace_artifacts` never sees modified deliverable files.

2. **`_parse_hunk_header`** requires explicit count specifiers (`@@@ -10,3 +10,4 @@@`). This tool parses AgentOS's own `*** Begin Patch` envelope with `@@@` markers, not unified diff — `git diff` and GNU `diff` never emit this format. The real failure path is that the tool description only tells the model `*** Update File: path` with `@@@` hunks and never specifies the header grammar, so a model that writes `@@@ -1 +1,2 @@@` by analogy with unified diff gets a hard `ValueError`. Making the count optional and defaulting it to 1 is the right robustness call for a model-facing parser. The parser still rejects genuinely malformed headers.

## Changes

### `src/agentos/tools/builtin/patch.py`

**`_record_workspace_file_writes()`** (line ~221):
```diff
-if isinstance(op, AddFile):
+if isinstance(op, (AddFile, UpdateFile)):
```

**`_parse_hunk_header()`** (line ~125):
```diff
-m = re.match(r"@@@\s+-(\d+),(\d+)\s+\+(\d+),(\d+)\s+@@@", header.strip())
+m = re.match(r"@@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@@", header.strip())
```
Count groups are now optional (`(?:,(\d+))?`). When omitted, defaults to 1 (or 0 when start is 0, per the spec for empty files). Genuinely malformed headers (missing `@@@` delimiters, non-numeric values, etc.) are still rejected.

### `tests/test_tools/test_apply_patch_gates.py`

- **`test_apply_patch_records_workspace_file_writes_for_add_and_update`**: Patch with 1 AddFile + 1 UpdateFile → both appear in `ctx.workspace_file_writes`.
- **`test_apply_patch_supports_hunk_header_without_explicit_counts`**: Hunk header `@@@ -1 +1,2 @@@` (no old count) → parses and applies correctly.

## Test Results

```
tests/test_tools/test_apply_patch_gates.py ... 19 passed
```

All existing tests pass — zero regressions.