### PR TITLE
fix(compat): support case-insensitive version comparison and dev pre-release ordering (#756)

### DIFF
--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -29,7 +29,8 @@ _VERSION_RE = re.compile(
     r"(?:[._-]?post[._-]?(?P<post>\d+)?)?"
     r"(?:[._-]?dev[._-]?(?P<dev>\d+)?)?"
     r"(?:\+(?P<local>[a-zA-Z0-9.]+))?"
-    r"\s*$"
+    r"\s*$",
+    re.IGNORECASE,
 )
 
 # Ordering weight for the pre-release phase (lower = earlier).
@@ -63,7 +64,7 @@ class Version:
         if self.dev is not None and self.pre is None and self.post is None:
             phase: tuple[int, ...] = (0, self.dev)
         elif self.pre is not None:
-            dev_tie = -1 if self.dev is None else self.dev
+            dev_tie = 1_000_000_000 if self.dev is None else self.dev
             phase = (1, self.pre[0], self.pre[1], dev_tie)
         elif self.post is not None:
             dev_tie = -1 if self.dev is None else self.dev
@@ -96,11 +97,14 @@ def parse_version(value: str | None) -> Version:
     release = tuple(int(part) for part in match.group("release").split("."))
     pre: tuple[int, int] | None = None
     if match.group("pre_l"):
-        pre = (_PRE_ORDER.get(match.group("pre_l"), 2), int(match.group("pre_n") or 0))
+        pre_tag = match.group("pre_l").lower()
+        pre = (_PRE_ORDER.get(pre_tag, 2), int(match.group("pre_n") or 0))
     post = int(match.group("post")) if match.group("post") is not None else None
-    if post is None and re.search(r"[._-]?post", raw):
+    if post is None and re.search(r"[._-]?post", raw, re.IGNORECASE):
         post = 0
     dev = int(match.group("dev")) if match.group("dev") is not None else None
+    if dev is None and re.search(r"[._-]?dev", raw, re.IGNORECASE):
+        dev = 0
     return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
 
 

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -30,8 +30,19 @@ from agentos.compat.version_utils import compare_versions, is_newer, parse_versi
         # dev sorts below everything of the same release
         ("2026.7.18.dev1", "2026.7.18rc1", -1),
         ("2026.7.18.dev1", "2026.7.18", -1),
-        # leading v is tolerated
+        # leading v is tolerated (case-insensitive)
         ("v2026.7.18", "2026.7.18", 0),
+        ("V2026.7.18", "2026.7.18", 0),
+        # case-insensitive pre-release, post-release, and dev tags
+        ("2026.7.18RC1", "2026.7.18rc1", 0),
+        ("2026.7.18-BETA2", "2026.7.18b2", 0),
+        ("2026.7.18.POST1", "2026.7.18.post1", 0),
+        ("2026.7.18.DEV1", "2026.7.18.dev1", 0),
+        # bare dev sorts before final release
+        ("2026.7.18.dev", "2026.7.18", -1),
+        ("2026.7.18.DEV", "2026.7.18", -1),
+        # dev pre-releases sort before the candidate (PEP 440)
+        ("2026.7.18rc1.dev1", "2026.7.18rc1", -1),
     ],
 )
 def test_compare_versions(a: str, b: str, expected: int) -> None:
@@ -51,9 +62,12 @@ def test_unparsable_sorts_below_real_release() -> None:
 
 def test_is_newer() -> None:
     assert is_newer("2026.7.19", "2026.7.18") is True
+    assert is_newer("V2026.7.19", "2026.7.18") is True
     assert is_newer("2026.7.18", "2026.7.18") is False
     assert is_newer("2026.7.18", "2026.7.19") is False
     assert is_newer("2026.7.18.post1", "2026.7.18") is True
+    assert is_newer("2026.7.18.POST1", "2026.7.18") is True
+    assert is_newer("2026.7.18", "2026.7.18.dev") is True
 
 
 def test_parse_version_fields() -> None:
@@ -62,15 +76,32 @@ def test_parse_version_fields() -> None:
     assert v.post == 1
     assert v.parsed is True
 
+    v_upper = parse_version("V2026.7.18RC2.POST1.DEV0")
+    assert v_upper.release == (2026, 7, 18)
+    assert v_upper.pre == (2, 2)
+    assert v_upper.post == 1
+    assert v_upper.dev == 0
+    assert v_upper.parsed is True
+
     bad = parse_version("nonsense")
     assert bad.parsed is False
 
 
 def test_ordering_is_total_and_sortable() -> None:
-    versions = ["2026.7.18", "2026.7.18.post1", "2026.7.18rc1", "2026.7.19", "0.0.0+unknown"]
+    versions = [
+        "2026.7.18",
+        "2026.7.18.post1",
+        "2026.7.18rc1",
+        "2026.7.19",
+        "0.0.0+unknown",
+        "V2026.7.18.DEV1",
+        "2026.7.18RC1.DEV1",
+    ]
     ordered = sorted(versions, key=parse_version)
     assert ordered == [
         "0.0.0+unknown",
+        "V2026.7.18.DEV1",
+        "2026.7.18RC1.DEV1",
         "2026.7.18rc1",
         "2026.7.18",
         "2026.7.18.post1",


### PR DESCRIPTION
Fixes #756

## Summary

In `src/agentos/compat/version_utils.py`:
1. `_VERSION_RE` was previously case-sensitive, causing version tags with uppercase prefixes (e.g. `V2026.7.18`) or uppercase release tails (`2026.7.18RC1`, `2026.7.18.POST1`, `2026.7.18.DEV1`, `2026.7.18-BETA2`) to fail parsing (`parsed=False`, `release=(-1,)`). This caused `is_newer("V2026.7.19", "2026.7.18")` to return `False`, breaking upgrade checks for operators on uppercase/tagged builds.
2. Added fallback for bare `.dev` versions (e.g. `2026.7.18.dev`) defaulting to `dev = 0`, and corrected `dev_tie` ordering on pre-releases so development snapshots sort before release candidates (`rc1.dev1 < rc1`) per PEP 440.

## What was changed

- **`src/agentos/compat/version_utils.py`**:
  - Added `re.IGNORECASE` to `_VERSION_RE` and fallback regexes for `.post` and `.dev`.
  - Normalized pre-release identifier strings with `.lower()` before lookup in `_PRE_ORDER`.
  - Set `dev_tie = 1_000_000_000 if self.dev is None else self.dev` on pre-releases to maintain `tuple[int, ...]` typing while ensuring final/candidates sort after development builds.
  - Added bare `.dev` fallback (`dev = 0`).
- **`tests/test_compat/test_version_utils.py`**:
  - Added parametrized tests for case-insensitive prefixes (`V`), pre-releases (`RC`, `BETA`), post-releases (`POST`), and dev tags (`DEV`).
  - Added test cases verifying `is_newer()` with uppercase strings and dev comparisons.
  - Added field verification for uppercase tags in `test_parse_version_fields()`.

## Quality Gate Verification

- `uv run ruff check src/agentos tests/test_compat` — clean (0 errors)
- `uv run ruff format --check src/agentos/compat/version_utils.py tests/test_compat/test_version_utils.py` — clean
- `uv run mypy src/agentos/compat/version_utils.py --show-error-codes` — clean (0 errors)
- `uv run pytest tests/test_compat -q` — 36 passed (100% deterministic & offline)
