### PR TITLE
fix(gateway): expose provider-routed memory tools

### DIFF
--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -1738,23 +1738,14 @@ async def build_services(
                 provider_managers=memory_provider_managers or None,
             )
             log.info("build_services.memory_tools_registered", agents=list(memory_stores))
-            # TODO(B4/B5): expose provider-routed tools. Every configured
-            # provider manager already computes its exposable schemas
-            # (``get_tool_schemas()`` / ``handle_tool_call``) with reserved
-            # builtin names skipped. Registering them into ``tool_registry``
-            # needs a per-agent routing handler (the registry is global; the
-            # active agent is resolved from ``current_tool_context``, as the
-            # builtin memory tools do). Deferred as an additive step — no
-            # in-tree provider ships tools yet (mem0 arrives in B5). Left
-            # unexposed with this marker rather than forcing invasive
-            # per-agent tool plumbing now.
-            for _agent_id, _pm in (memory_provider_managers or {}).items():
-                if _pm.get_tool_schemas():
-                    log.info(
-                        "build_services.memory_provider_tools_unexposed",
-                        agent_id=_agent_id,
-                        tool_count=len(_pm.get_tool_schemas()),
-                    )
+            if memory_provider_managers and tool_registry:
+                for _agent_id, _pm in memory_provider_managers.items():
+                    if _pm.get_tool_schemas():
+                        log.info(
+                            "build_services.memory_provider_tools_exposed",
+                            agent_id=_agent_id,
+                            tool_count=len(_pm.get_tool_schemas()),
+                        )
     except Exception as e:
         log.warning("build_services.memory_tools_failed", error=str(e))
 

--- a/src/agentos/tools/builtin/memory_tools.py
+++ b/src/agentos/tools/builtin/memory_tools.py
@@ -41,7 +41,7 @@ from agentos.memory.types import (
     normalize_memory_source_filter,
 )
 from agentos.tools.registry import tool
-from agentos.tools.types import ToolError, current_tool_context
+from agentos.tools.types import ToolError, ToolSpec, current_tool_context
 
 if TYPE_CHECKING:
     from agentos.memory.retrieval import MemoryRetriever
@@ -1235,3 +1235,67 @@ def create_memory_tools(
             "memory_delete",
         ],
     )
+
+    if provider_managers and registry:
+        register_provider_memory_tools(provider_managers, registry)
+
+
+def register_provider_memory_tools(
+    provider_managers: dict[str, Any] | None,
+    registry: ToolRegistry | None = None,
+) -> list[str]:
+    """Register provider-routed memory tools into the global ToolRegistry.
+
+    Routes tool calls at call time based on the active agent_id from ToolContext.
+    Returns the list of tool names registered.
+    """
+    if not provider_managers or not registry:
+        return []
+
+    reserved = set(registry.list_names())
+    tool_schemas: dict[str, dict[str, Any]] = {}
+    for _aid, pm in provider_managers.items():
+        if pm is None:
+            continue
+        for schema in pm.get_tool_schemas():
+            name = schema.get("name")
+            if name and name not in reserved and name not in tool_schemas:
+                tool_schemas[name] = schema
+
+    registered_names: list[str] = []
+    for name, schema in tool_schemas.items():
+        spec = ToolSpec(
+            name=name,
+            description=schema.get("description", ""),
+            parameters=schema.get("parameters", {}),
+            required=schema.get("required", []),
+            exposed_by_default=True,
+        )
+
+        def _make_handler(tool_name: str) -> Any:
+            async def _handler(**kwargs: Any) -> str:
+                ctx = current_tool_context.get()
+                from agentos.session.keys import normalize_agent_id
+
+                agent_id = normalize_agent_id((ctx.agent_id if ctx else None) or "main")
+                pm = provider_managers.get(agent_id) or provider_managers.get("main")
+                if pm is None or not pm.has_tool(tool_name):
+                    return (
+                        f'{{"error": "No memory provider handles tool \'{tool_name}\' '
+                        f"for agent '{agent_id}'\"}}"
+                    )
+                res = await pm.handle_tool_call(tool_name, kwargs)
+                return str(res)
+
+            return _handler
+
+        registry.register(spec, _make_handler(name))
+        registered_names.append(name)
+
+    if registered_names:
+        logger.info(
+            "memory_provider_tools_registered",
+            tools=registered_names,
+            agents=list(provider_managers.keys()),
+        )
+    return registered_names

--- a/tests/test_memory_provider_tools_exposure.py
+++ b/tests/test_memory_provider_tools_exposure.py
@@ -1,0 +1,111 @@
+"""Tests for exposing provider-routed memory tools (TODO B4/B5)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.tools.builtin.memory_tools import (
+    create_memory_tools,
+    register_provider_memory_tools,
+)
+from agentos.tools.registry import ToolRegistry
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+class DummyMemoryProviderManager:
+    def __init__(self, schemas: list[dict[str, Any]], responses: dict[str, str] | None = None):
+        self._schemas = schemas
+        self._responses = responses or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return self._schemas
+
+    def has_tool(self, name: str) -> bool:
+        return any(s.get("name") == name for s in self._schemas)
+
+    async def handle_tool_call(self, name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        self.calls.append((name, args))
+        return self._responses.get(name, '{"status": "ok"}')
+
+
+@pytest.mark.asyncio
+async def test_register_provider_memory_tools_exposes_schemas():
+    registry = ToolRegistry()
+    pm = DummyMemoryProviderManager(
+        schemas=[
+            {
+                "name": "ext_memory_search",
+                "description": "External memory search tool",
+                "parameters": {"query": {"type": "string"}},
+                "required": ["query"],
+            }
+        ]
+    )
+
+    names = register_provider_memory_tools({"main": pm}, registry=registry)
+    assert names == ["ext_memory_search"]
+
+    registered = registry.get("ext_memory_search")
+    assert registered is not None
+    assert registered.spec.description == "External memory search tool"
+
+
+@pytest.mark.asyncio
+async def test_provider_memory_tools_skips_reserved_names():
+    registry = ToolRegistry()
+    create_memory_tools(
+        stores={},
+        retrievers={},
+        memory_dir="/tmp",
+        registry=registry,
+    )
+    assert "memory_search" in registry.list_names()
+
+    pm = DummyMemoryProviderManager(
+        schemas=[
+            {"name": "memory_search", "description": "Colliding name"},
+            {"name": "ext_memory_custom", "description": "Custom name"},
+        ]
+    )
+
+    names = register_provider_memory_tools({"main": pm}, registry=registry)
+    assert names == ["ext_memory_custom"]
+    assert "memory_search" not in names
+
+
+@pytest.mark.asyncio
+async def test_provider_memory_tool_invocation_routes_by_agent_id():
+    registry = ToolRegistry()
+    pm_main = DummyMemoryProviderManager(
+        schemas=[{"name": "custom_mem_tool", "description": "Main tool"}],
+        responses={"custom_mem_tool": "main_response"},
+    )
+    pm_agent_b = DummyMemoryProviderManager(
+        schemas=[{"name": "custom_mem_tool", "description": "Agent B tool"}],
+        responses={"custom_mem_tool": "agent_b_response"},
+    )
+
+    provider_managers = {"main": pm_main, "agent_b": pm_agent_b}
+    register_provider_memory_tools(provider_managers, registry=registry)
+
+    rt = registry.get("custom_mem_tool")
+    assert rt is not None
+
+    token = current_tool_context.set(ToolContext(agent_id="main"))
+    try:
+        res = await rt.handler(key="value")
+        assert res == "main_response"
+        assert pm_main.calls == [("custom_mem_tool", {"key": "value"})]
+    finally:
+        current_tool_context.reset(token)
+
+    token = current_tool_context.set(ToolContext(agent_id="agent_b"))
+    try:
+        res = await rt.handler(key="value2")
+        assert res == "agent_b_response"
+        assert pm_agent_b.calls == [("custom_mem_tool", {"key": "value2"})]
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
Fixes #758

### Summary
Exposes provider-routed memory tools (e.g. `mem0` memory provider schemas) into the global `ToolRegistry` with per-agent context routing, resolving `TODO(B4/B5)` in `src/agentos/gateway/boot.py`.

### Key Changes
1. **`src/agentos/tools/builtin/memory_tools.py`**:
   - Added `register_provider_memory_tools(provider_managers, registry)` to convert provider tool schemas into registered `ToolSpec` and `ToolHandler` entries.
   - Handlers dynamically resolve `agent_id` from `current_tool_context` to route calls to the correct `MemoryProviderManager`.
   - Guaranteed built-in tool names take precedence over provider tools.
   - Integrated provider tool registration into `create_memory_tools`.

2. **`src/agentos/gateway/boot.py`**:
   - Replaced unexposed TODO log with `build_services.memory_provider_tools_exposed` log statements when provider memory tools are registered.

3. **`tests/test_memory_provider_tools_exposure.py`**:
   - Added unit test suite validating schema exposure, built-in collision prevention, and per-agent context routing.

### Verification
- `uv run pytest tests/test_memory_provider_tools_exposure.py tests/test_memory_curated_tool.py -q` (18 passed)
- `uv run ruff check src/agentos/gateway/boot.py src/agentos/tools/builtin/memory_tools.py tests/test_memory_provider_tools_exposure.py` (Clean)
- `uv run mypy src/agentos/tools/builtin/memory_tools.py src/agentos/gateway/boot.py --show-error-codes` (Success, no issues)
