### PR TITLE
fix(cli): handle non-UTF-8 stream encoding in JSON output helpers

### DIFF
--- a/src/agentos/cli/output.py
+++ b/src/agentos/cli/output.py
@@ -3,15 +3,38 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
 
 import typer
 
 
+def _write_encoded_json(text: str, *, err: bool = False) -> None:
+    stream = sys.stderr if err else sys.stdout
+    line = text + "\n"
+    buffer = getattr(stream, "buffer", None)
+    if buffer is not None:
+        try:
+            buffer.write(line.encode("utf-8"))
+            buffer.flush()
+            return
+        except (AttributeError, OSError, TypeError):
+            pass
+    try:
+        stream.write(line)
+        stream.flush()
+    except UnicodeEncodeError:
+        encoding = getattr(stream, "encoding", None) or "utf-8"
+        encoded = line.encode(encoding, errors="replace").decode(encoding)
+        stream.write(encoded)
+        stream.flush()
+
+
 def print_json(payload: Any) -> None:
     """Print JSON payload to stdout using the AgentOS CLI contract."""
 
-    typer.echo(json.dumps(payload, ensure_ascii=False, default=str))
+    text = json.dumps(payload, ensure_ascii=False, default=str)
+    _write_encoded_json(text, err=False)
 
 
 def error_payload(
@@ -40,13 +63,11 @@ def emit_error(
     """Emit an error to stderr without polluting JSON stdout."""
 
     if json_output:
-        typer.echo(
-            json.dumps(
-                error_payload(message, code=code, details=details),
-                ensure_ascii=False,
-                default=str,
-            ),
-            err=True,
+        text = json.dumps(
+            error_payload(message, code=code, details=details),
+            ensure_ascii=False,
+            default=str,
         )
+        _write_encoded_json(text, err=True)
     else:
         typer.secho(f"Error: {message}", fg=typer.colors.RED, err=True)

--- a/tests/test_cli/test_output_helpers.py
+++ b/tests/test_cli/test_output_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 
 from agentos.cli.output import emit_error, print_json
 
@@ -14,16 +15,46 @@ def test_print_json_uses_stdout(capsys):
     assert captured.err == ""
 
 
+def test_print_json_handles_unicode_and_em_dash(capsys):
+    print_json({"desc": "Analyze wallet — holdings 🚀"})
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["desc"] == "Analyze wallet — holdings 🚀"
+
+
 def test_emit_error_json_uses_stderr(capsys):
-    emit_error("bad input", json_output=True, code="INVALID_REQUEST", details={"field": "x"})
+    emit_error("bad input — test", json_output=True, code="INVALID_REQUEST", details={"field": "x"})
 
     captured = capsys.readouterr()
     assert captured.out == ""
     payload = json.loads(captured.err)
     assert payload == {
         "error": {
-            "message": "bad input",
+            "message": "bad input — test",
             "code": "INVALID_REQUEST",
             "details": {"field": "x"},
         }
     }
+
+
+def test_write_encoded_json_fallback(monkeypatch, capsys):
+    class DummyStream:
+        def __init__(self):
+            self.encoding = "ascii"
+            self.written = ""
+
+        def write(self, text: str) -> None:
+            # First attempt raises UnicodeEncodeError for non-ascii
+            if any(ord(c) > 127 for c in text):
+                raise UnicodeEncodeError("ascii", text, 0, len(text), "ordinal not in range(128)")
+            self.written += text
+
+        def flush(self) -> None:
+            pass
+
+    dummy = DummyStream()
+    monkeypatch.setattr(sys, "stdout", dummy)
+
+    print_json({"text": "test — unicode"})
+    assert "test" in dummy.written


### PR DESCRIPTION
Fixes #764

## Summary of Changes
- Update print_json and emit_error in src/agentos/cli/output.py to write UTF-8 encoded bytes directly to sys.stdout.buffer and sys.stderr.buffer when available.
- Add fallback replacement for streams with restricted encodings where buffer is unavailable.
- Add comprehensive unit tests in tests/test_cli/test_output_helpers.py covering unicode text, em-dashes, emojis, and stream encoding fallbacks.

## Quality Gate Verification
- [x] uv run ruff check src tests (0 errors)
- [x] uv run mypy src/agentos --show-error-codes (0 errors)
- [x] uv run pytest -q (726 passed)