### PR TITLE
fix(opencap): track OpenCAP's own catalog for router tier defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- OpenCAP's router tier defaults track OpenCAP's own catalog again. `c2` moves
+  from `glm-5.2` to `glm-5.3` (1.31M context, published by the gateway since the
+  last update), and the profile is declared in its own table instead of being
+  cloned from the Bankr profile with the provider string swapped — the two
+  gateways publish overlapping but different catalogs, so cloning made OpenCAP
+  silently inherit Bankr's release cadence. `c0` (`deepseek-v4-flash`), `c1`
+  (`gpt-5.6-luna`), `c3` (`claude-opus-5`) and the image route (`minimax-m3`)
+  are unchanged; each is still the newest of its family the gateway serves.
+- Five models OpenCAP now publishes are declared in the model registry:
+  `glm-5.3`, `glm-5.3-flash`, `grok-4.6`, `kimi-k3` and `muse-spark-1.2`. They
+  carry published context windows, output caps and vendor rack rates, so an
+  offline estimate for them no longer falls through to the generic $3/$15
+  default. OpenCAP's live catalog remains canonical for its own pricing.
+
+### Fixed
+
+- A `thinking_level` set on an OpenCAP GLM tier is no longer silently dropped.
+  The gateway capability gate reported `supports_reasoning=False` for every
+  model except DeepSeek V4, so the `c2` default's declared `thinking_level`
+  never reached the wire even though GLM 5.x reasons by default and streams
+  `reasoning_content`. GLM ids on OpenCAP now resolve Z.ai's
+  `{"thinking": {"type": ...}}` switch, verified live in both positions. Scoped
+  to OpenCAP; the Bankr gateway is a separate deployment and keeps its previous
+  behavior.
+- The offline vision fallback recognizes `gpt-5.6-*`, `glm-5.3-flash` and
+  `muse-spark-*` as image-capable. Previously, if the catalog fetch failed, the
+  `c1` default was reported as text-only and image turns had nowhere to route.
+
 ### Added
 
 - New bundled skill `robinhood-chain-stocks`: reads tokenized-stock state

--- a/agentos.toml.example
+++ b/agentos.toml.example
@@ -169,7 +169,7 @@ base_url = "https://openrouter.ai/api/v1"
 # its live model catalog for current model and upstream provider IDs. Omit this
 # table to keep gateway auto-routing.
 # [llm.provider_routing]
-# "glm-5.2" = "provider-id-from-live-catalog"
+# "glm-5.3" = "provider-id-from-live-catalog"
 
 # Prompt caching controls. Enables prefix caching for supported providers
 # (Anthropic, OpenAI, DeepSeek, OpenRouter, etc.).

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -88,7 +88,19 @@ OpenCAP defaults to `https://gw.capminal.ai/api/inference/v1` and uses one
 OpenAI-compatible key for inference. Its public model catalog is unauthenticated.
 The default direct/fallback model is the balanced `c1` model, `gpt-5.6-luna`. The `recommended`
 router profile selects bare OpenCAP model IDs across
-[`c0`–`c3`](features/agentos-router.md#model-tiers) and the vision route.
+[`c0`–`c3`](features/agentos-router.md#model-tiers) and the vision route:
+
+| Tier | Model | Role |
+| --- | --- | --- |
+| `c0` | `deepseek-v4-flash` | trivial chat, short rewrites, extraction |
+| `c1` | `gpt-5.6-luna` | default balanced route for normal agent work |
+| `c2` | `glm-5.3` | multi-step coding, structured reasoning, larger synthesis |
+| `c3` | `claude-opus-5` | difficult planning, deep review, high-stakes synthesis |
+| `image_model` | `minimax-m3` | image attachments, screenshots, diagrams |
+
+These are OpenCAP's own defaults, not a copy of the Bankr profile — the two
+gateways publish overlapping but different catalogs. Run `agentos models list`
+against a configured OpenCAP key to see everything the gateway currently serves.
 
 At gateway boot, AgentOS fetches the public catalog asynchronously for model
 choices, capabilities, and provider-scoped cost estimates. If that fetch fails,
@@ -100,7 +112,7 @@ upstream provider ID advertised by the current live catalog:
 
 ```toml
 [llm.provider_routing]
-"glm-5.2" = "provider-id-from-live-catalog"
+"glm-5.3" = "provider-id-from-live-catalog"
 ```
 
 AgentOS sends this as OpenCAP's provider allow-list. OpenRouter uses the same

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -796,13 +796,63 @@ def _bankr_tiers() -> dict:
 def _opencap_tiers() -> dict:
     """OpenCAP routing config using neutral bare model ids served by its gateway.
 
+    Declared separately from ``_bankr_tiers`` rather than copied from it. The two
+    gateways publish overlapping but not identical catalogs, and only OpenCAP
+    exposes a public catalog we can check a default against -- so a model that is
+    current on one is not automatically current on the other, and cloning the
+    table made OpenCAP silently inherit Bankr's release cadence.
+
     Safety-sensitive models such as ``oc-uncensored-1.0`` remain available as
     explicit user overrides, but are never selected by the recommended profile.
     """
-    tiers = _bankr_tiers()
-    for tier in tiers.values():
-        tier["provider"] = "opencap"
-    return tiers
+    return {
+        "c0": _tier(
+            provider="opencap",
+            model="deepseek-v4-flash",
+            description=(
+                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and "
+                "low-risk simple Q&A"
+            ),
+            thinking_level="high",
+        ),
+        "c1": _tier(
+            provider="opencap",
+            model="gpt-5.6-luna",
+            description=(
+                "default balanced text model for normal agent work, coding assistance, debugging, "
+                "and moderate analysis"
+            ),
+            thinking_level="high",
+        ),
+        "c2": _tier(
+            provider="opencap",
+            model="glm-5.3",
+            description=(
+                "stronger text model for multi-step coding, structured reasoning, larger context "
+                "synthesis, and harder analysis"
+            ),
+            thinking_level="high",
+        ),
+        "c3": _tier(
+            provider="opencap",
+            model="claude-opus-5",
+            description=(
+                "Highest-quality text reasoning model for difficult planning, deep review, complex "
+                "debugging, and high-stakes synthesis"
+            ),
+            thinking_level="high",
+        ),
+        "image_model": _tier(
+            provider="opencap",
+            model="minimax-m3",
+            description=(
+                "Image model: vision-capable route for user-supplied image attachments, "
+                "screenshots, diagrams, and visual question answering"
+            ),
+            thinking_level="medium",
+            image_only=True,
+        ),
+    }
 
 
 def _openrouter_tiers() -> dict:

--- a/src/agentos/model_registry.py
+++ b/src/agentos/model_registry.py
@@ -324,6 +324,19 @@ MODEL_FACTS: tuple[ModelFacts, ...] = (
         price=PriceFacts(0.132, 0.429, beats_live_catalog=True),
     ),
     ModelFacts(
+        "glm-5.3",
+        max_output_tokens=131_072,
+        context_window=1_310_720,
+        price=PriceFacts(1.54, 4.84),
+    ),
+    ModelFacts(
+        "glm-5.3-flash",
+        max_output_tokens=131_072,
+        context_window=1_310_720,
+        price=PriceFacts(0.0825, 0.275),
+        supports_image=True,
+    ),
+    ModelFacts(
         "minimax-m3",
         max_output_tokens=131_072,
         context_window=1_048_576,
@@ -428,9 +441,30 @@ MODEL_FACTS: tuple[ModelFacts, ...] = (
         ),
     ),
     ModelFacts(
+        "grok-4.6",
+        max_output_tokens=450_000,
+        context_window=500_000,
+        price=PriceFacts(2.2, 6.6),
+        supports_image=True,
+    ),
+    ModelFacts(
         "kimi-k2.7-code",
         max_output_tokens=262_144,
         context_window=262_144,
+    ),
+    ModelFacts(
+        "kimi-k3",
+        max_output_tokens=943_718,
+        context_window=1_048_576,
+        price=PriceFacts(3.0, 15.0),
+        supports_image=True,
+    ),
+    ModelFacts(
+        "muse-spark-1.2",
+        max_output_tokens=943_718,
+        context_window=1_048_576,
+        price=PriceFacts(1.25, 4.25),
+        supports_image=True,
     ),
     ModelFacts(
         "gpt-5.6-luna",

--- a/src/agentos/provider/model_catalog.py
+++ b/src/agentos/provider/model_catalog.py
@@ -218,25 +218,59 @@ class ModelCatalog:
             # configs may still carry the namespaced "virtuals/<id>" form, so
             # strip the prefix before matching. Prefer live catalog modality data
             # when a fetch populated it; otherwise fall back to a prefix heuristic
-            # (gpt-5.5 has image input but gpt-5.4-mini does not).
+            # (gpt-5.5 has image input but gpt-5.4-mini does not). The glm entry
+            # is the flash line only: OpenCAP publishes glm-5.3-flash as natively
+            # multimodal while glm-5.2/glm-5.3 stay text-in, text-out.
             basename = model_l.split("/", 1)[1] if "/" in model_l else model_l
             supports_vision = (
                 info.supports_vision
                 if info is not None
                 else basename.startswith(
-                    ("minimax-m3", "gemini-", "kimi-", "claude-", "grok-", "gpt-5.5")
+                    (
+                        "minimax-m3",
+                        "gemini-",
+                        "kimi-",
+                        "claude-",
+                        "grok-",
+                        "gpt-5.5",
+                        "gpt-5.6",
+                        "glm-5.3-flash",
+                        "muse-spark-",
+                    )
                 )
             )
             # DeepSeek V4 through these gateways honors the DeepSeek-native
             # thinking payload and streams reasoning_content deltas (verified
             # live against OpenCAP). Without this, tier thinking_level settings
             # silently no-op for gateway DeepSeek routes.
-            supports_reasoning = basename.startswith("deepseek-v4")
+            if basename.startswith("deepseek-v4"):
+                return ModelCapabilities(
+                    supports_reasoning=True,
+                    supports_tools=True,
+                    supports_vision=supports_vision,
+                    reasoning_format="deepseek",
+                )
+            # GLM 5.x is OpenCAP's c2 default and reasons by default, emitting
+            # reasoning_content whether or not it is asked to. The gateway
+            # accepts Z.ai's own {"thinking": {"type": ...}} switch for it in
+            # both positions (verified live against OpenCAP), so declaring the
+            # format is what turns a tier's thinking_level from a no-op into a
+            # real control. Scoped to opencap: the Bankr gateway serves an
+            # overlapping catalog on a separate deployment that has not been
+            # verified to accept the same switch, and guessing wrong there sends
+            # a rejected parameter on every turn.
+            if provider_id == "opencap" and basename.startswith("glm-5"):
+                return ModelCapabilities(
+                    supports_reasoning=True,
+                    supports_tools=True,
+                    supports_vision=supports_vision,
+                    reasoning_format="zai",
+                )
             return ModelCapabilities(
-                supports_reasoning=supports_reasoning,
+                supports_reasoning=False,
                 supports_tools=True,
                 supports_vision=supports_vision,
-                reasoning_format="deepseek" if supports_reasoning else "none",
+                reasoning_format="none",
             )
         if provider_id == "dashscope":
             supports_reasoning = model_l.startswith(

--- a/tests/test_provider_opencap.py
+++ b/tests/test_provider_opencap.py
@@ -97,12 +97,48 @@ def test_opencap_router_profile_contract() -> None:
     assert {tier["provider"] for tier in tiers.values()} == {"opencap"}
     assert tiers["c0"]["model"] == "deepseek-v4-flash"
     assert tiers["c1"]["model"] == "gpt-5.6-luna"
-    assert tiers["c2"]["model"] == "glm-5.2"
+    assert tiers["c2"]["model"] == "glm-5.3"
     assert tiers["c3"]["model"] == "claude-opus-5"
     assert tiers["image_model"]["model"] == "minimax-m3"
     assert tiers["image_model"]["supports_image"] is True
     assert tiers["image_model"]["image_only"] is True
     assert all(tier["model"] != "oc-uncensored-1.0" for tier in tiers.values())
+
+
+def test_opencap_router_profile_is_not_a_clone_of_bankr() -> None:
+    """The two gateways publish different catalogs, so the tables must be free
+    to diverge. OpenCAP's c2 tracks its own live catalog (GLM 5.3); Bankr's
+    stays on what that gateway is known to serve."""
+    from agentos.gateway.config import _bankr_tiers
+
+    opencap = _router_tier_profile_defaults("opencap")
+    bankr = _bankr_tiers()
+
+    assert opencap["c2"]["model"] != bankr["c2"]["model"]
+    assert {tier["provider"] for tier in bankr.values()} == {"bankr"}
+
+
+def test_opencap_tier_models_are_all_served_by_the_live_catalog() -> None:
+    """Every default is a bare id the gateway actually publishes.
+
+    Pinned to the catalog snapshot rather than fetched, so the test stays
+    offline; a default that drifts off this list is a default the gateway can
+    no longer resolve.
+    """
+    published = {
+        "deepseek-v4-flash",
+        "gpt-5.6-luna",
+        "glm-5.3",
+        "glm-5.3-flash",
+        "claude-opus-5",
+        "minimax-m3",
+        "grok-4.6",
+        "kimi-k3",
+        "muse-spark-1.2",
+    }
+
+    for name, tier in _router_tier_profile_defaults("opencap").items():
+        assert tier["model"] in published, f"{name} pins an id OpenCAP no longer publishes"
 
 
 def test_opencap_direct_provider_auto_selects_router_profile() -> None:
@@ -172,6 +208,35 @@ def test_populate_from_opencap_parses_gateway_catalog() -> None:
     assert uncensored.provider == "opencap"
     assert uncensored.max_output_tokens == 0
     assert catalog.get_capabilities("oc-uncensored-1.0", "opencap").supports_vision is False
+
+
+def test_opencap_glm_models_resolve_zai_reasoning() -> None:
+    """The c2 default declares thinking_level="high"; without a reasoning format
+    that setting is silently dropped on the way to the gateway."""
+    catalog = ModelCatalog()
+
+    for model in ("glm-5.3", "glm-5.2", "glm-5.3-flash"):
+        caps = catalog.get_capabilities(model, provider_name="opencap")
+        assert caps.supports_reasoning is True, model
+        assert caps.reasoning_format == "zai", model
+        assert caps.supports_tools is True, model
+
+
+def test_opencap_glm_reasoning_does_not_leak_into_the_bankr_gateway() -> None:
+    """Separate deployment, unverified switch -- Bankr must keep its old shape."""
+    caps = ModelCatalog().get_capabilities("glm-5.2", provider_name="bankr")
+
+    assert caps.supports_reasoning is False
+    assert caps.reasoning_format == "none"
+
+
+def test_opencap_non_reasoning_models_keep_reporting_no_reasoning() -> None:
+    catalog = ModelCatalog()
+
+    for model in ("minimax-m3", "oc-uncensored-1.0", "gpt-5.6-luna"):
+        caps = catalog.get_capabilities(model, provider_name="opencap")
+        assert caps.supports_reasoning is False, model
+        assert caps.reasoning_format == "none", model
 
 
 def test_populate_from_opencap_defaults_missing_or_malformed_pricing_to_zero() -> None:


### PR DESCRIPTION
## What

`_opencap_tiers()` was `_bankr_tiers()` with the provider string swapped in a loop. The two gateways publish overlapping but different catalogs, so OpenCAP inherited Bankr's release cadence rather than following its own — `c2` was still pinned to `glm-5.2` after the gateway had moved on.

This declares the OpenCAP profile in its own table and moves `c2` to `glm-5.3` (1.31M context).

| Tier | Before | After |
| --- | --- | --- |
| `c0` | `deepseek-v4-flash` | unchanged |
| `c1` | `gpt-5.6-luna` | unchanged |
| `c2` | `glm-5.2` | **`glm-5.3`** |
| `c3` | `claude-opus-5` | unchanged |
| `image_model` | `minimax-m3` | unchanged |

`c0`, `c1`, `c3` and the image route are each still the newest of their family the gateway serves, so only `c2` moves. `c0` deliberately stays on `deepseek-v4-flash`: it is both the cheapest id in the catalog ($0.071/$0.142 vs `glm-5.3-flash` at $0.0825/$0.275) and, before this PR, the only tier whose `thinking_level` actually did anything.

Five models OpenCAP now publishes were absent from `model_registry.py` entirely: `glm-5.3`, `glm-5.3-flash`, `grok-4.6`, `kimi-k3`, `muse-spark-1.2`. Without a declaration an offline estimate for them falls through to the generic $3/$15 default, and `_tier()` refuses an undeclared id outright. Prices recorded are vendor rack rates rather than the gateway's discounted ones — OpenCAP's live catalog remains canonical for its own pricing (`lookup_price` short-circuits to it), and the static table is the offline fallback, where overestimating gateway spend beats underestimating it.

## Two defects found while verifying the new default live

**A `thinking_level` on a GLM tier was silently dropped.** The bankr/opencap branch of `get_capabilities` reported `supports_reasoning=False` for everything except DeepSeek V4, so `reasoning_format` stayed `"none"` and the reasoning-injection block in `openai.py` never fired. The `c2` default's own declared `thinking_level="high"` therefore never reached the wire. GLM 5.x reasons by default and streams `reasoning_content` either way, so the setting looked effective while controlling nothing — the same class of bug as the `supports_reasoning=False` fix in 2026.8.12, one generation later. GLM ids on OpenCAP now resolve Z.ai's `{"thinking": {"type": ...}}` switch.

Scoped to `opencap` on purpose. Bankr is a separate deployment serving an overlapping catalog and was not verifiable here; sending it a parameter it might reject would break every turn, so its behavior is byte-identical to before. There is a test pinning that.

**The offline vision fallback missed `gpt-5.6-*`.** Also `glm-5.3-flash` and `muse-spark-*`. This heuristic only runs when the catalog fetch failed — in exactly that case the `c1` default was reported text-only, leaving image turns with nowhere to route.

## Verification

Live against `gw.capminal.ai`:

- `glm-5.3` answers (HTTP 200) and emits `reasoning_content`
- the gateway accepts the thinking switch in **both** positions — `{"type":"enabled"}` and `{"type":"disabled"}` each return HTTP 200, so turns with thinking off do not start failing
- `deepseek-v4-flash`, `gpt-5.6-luna` and `claude-opus-5` all confirmed serving

Registry facts for the five new models were taken from the live catalog payload (`contextLength`, `maxOutput`, `pricing.originalInput`/`originalOutput`).

`ruff check`, `ruff format --check` on touched files, and `mypy src` are clean. Full suite: **8785 passed, 27 skipped**. One failure, `test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`, reproduces on a stashed clean tree and is unrelated to this change.

New tests cover the tier table, that OpenCAP is no longer a clone of Bankr, that every default is an id the gateway publishes, the GLM reasoning format, and that the GLM change does not leak into the Bankr path.