### PR TITLE
fix(web-ui): shorten Windows paths in the env header strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Environment view's path strip shortens Windows paths again. `shortPath`
+  split on `/` only, so a gateway-reported `C:\Users\<name>\.agentos\.env` counted
+  as a single segment and was rendered untrimmed, overflowing the header strip
+  it was written to keep short. Backslashes are normalised before splitting, so
+  Windows and mixed-separator paths trim to their last two segments like POSIX
+  ones do.
+
 ## [2026.9.2] - 2026-09-02
 
 ### Added

--- a/frontend/src/views/env/logic.test.ts
+++ b/frontend/src/views/env/logic.test.ts
@@ -193,4 +193,16 @@ describe('shortPath', () => {
   it('handles an absent path', () => {
     expect(shortPath(undefined)).toBe('')
   })
+
+  it('shortens a Windows path', () => {
+    expect(shortPath('C:\\Users\\username\\.agentos\\.env')).toBe('…/.agentos/.env')
+  })
+
+  it('leaves an already-short Windows path alone', () => {
+    expect(shortPath('C:\\.env')).toBe('C:\\.env')
+  })
+
+  it('shortens a mixed-separator path', () => {
+    expect(shortPath('C:\\Users\\me/projects/app/.env')).toBe('…/app/.env')
+  })
 })

--- a/frontend/src/views/env/logic.ts
+++ b/frontend/src/views/env/logic.ts
@@ -200,10 +200,16 @@ export function validateNewName(name: string, known: EnvVarRow[]): string | null
  * and the `direction: rtl` trick used to keep the tail visibly relocates the
  * leading slash. Trimming to the last two segments keeps the identifying part
  * intact and leaves the full path for the title attribute.
+ *
+ * The gateway sends whatever `pathlib.Path` stringifies to, so on Windows the
+ * value arrives backslash-separated (`C:\Users\<name>\.agentos\.env`).
+ * Backslashes are normalised to `/` before splitting; without that every
+ * Windows path counts as a single segment and is returned untrimmed, which is
+ * exactly the overflow this function exists to prevent.
  */
 export function shortPath(path: string | undefined): string {
   if (!path) return ''
-  const segments = path.split('/').filter(Boolean)
+  const segments = path.replace(/\\/g, '/').split('/').filter(Boolean)
   if (segments.length <= 2) return path
   return t('env.shortPath', { tail: segments.slice(-2).join('/') })
 }


### PR DESCRIPTION
## Problem

`shortPath` (`frontend/src/views/env/logic.ts`) splits the `.env` path on `/` only. The gateway sends `str(env_store.env_file_path())` (`gateway/rpc_env.py`), a `pathlib.Path`, so on Windows the value arrives as `C:\Users\me\.agentos\.env`. Under a `/`-only split that is a single segment, which hits the `segments.length <= 2` early return and renders the full path untrimmed — the exact header-strip overflow the function exists to prevent.

## Fix

Normalise backslashes to `/` before splitting:

```ts
const segments = path.replace(/\\/g, '/').split('/').filter(Boolean)
```

- POSIX paths are byte-identical to before.
- Windows and mixed-separator paths now trim to their last two segments.
- Genuinely short paths (`C:\.env`) still return the original string, separators intact — no display mangling.

## Tests

Three cases added to `shortPath`'s block in `frontend/src/views/env/logic.test.ts`: a full Windows path, a short Windows path, and a mixed-separator path. The full-Windows-path case fails on `main` and passes with the fix.

Verified with `npm run check` in `frontend/` (tsc + eslint + prettier + vitest): 98 files, 2010 tests pass.

## Note

Issue author opened #591 for the same bug; maintainers should take whichever they prefer. This one adds the CHANGELOG entry and the short/mixed-separator edge cases alongside the normalisation.

Fixes #590