### PR TITLE
fix(channels): check email Reply-To against the sender allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The email channel no longer honours an off-allowlist `Reply-To`. The From
+  address was checked against the fail-closed `allowed_senders` list, but the
+  `Reply-To` header — equally attacker-controlled on an admitted message — was
+  taken verbatim as the reply target, so an allowlisted sender could redirect
+  the agent's answer, tool output included, to any mailbox. `Reply-To` is now
+  run through the same allowlist and falls back to the From address when it is
+  off-list, rather than the whole message being rejected. The reply target is
+  re-checked when the outbound reply is built, so a stale or tampered thread
+  cache cannot reintroduce an off-list recipient.
 - A `thinking_level` set on an OpenCAP GLM tier is no longer silently dropped.
   The gateway capability gate reported `supports_reasoning=False` for every
   model except DeepSeek V4, so the `c2` default's declared `thinking_level`

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -117,6 +117,13 @@ would let anyone who can send mail drive the agent. Entries are exact addresses
 `@example.com`). Mail from any other sender is logged and dropped without ever
 being queued.
 
+The allowlist also governs where a reply goes. `Reply-To` is set by the same
+sender the allowlist is meant to constrain, so it is honoured only when the
+address it names is itself on the list; otherwise the reply goes back to the
+`From` address and the off-list header is logged and ignored. The message is
+still processed — an off-list `Reply-To` redirects the answer, it does not make
+the mail untrusted.
+
 The adapter also refuses to answer itself and drops machine-generated mail —
 anything carrying `Auto-Submitted`, `X-Autoreply`, `List-Id`,
 `List-Unsubscribe`, or `Precedence: bulk`. Without that guard an autoresponder

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -532,6 +532,28 @@ class EmailChannel:
         with contextlib.suppress(Exception):
             client.store(uid, "+FLAGS", "\\Seen")
 
+    def _reply_target(self, sender: str, reply_to_header: str) -> str:
+        """Return the address replies should go to, honouring the allowlist.
+
+        ``Reply-To`` is attacker-controlled even on an admitted message: an
+        allowlisted sender can point it at any mailbox and redirect the agent's
+        answer — tool output included. Honour it only when it clears the same
+        fail-closed allowlist as ``From``, otherwise reply to the sender.
+        """
+
+        reply_to = normalize_address(reply_to_header)
+        if not reply_to or reply_to == sender:
+            return sender
+        if sender_allowed(reply_to, self.config.allowed_senders):
+            return reply_to
+        log.warning(
+            "email.reply_to_not_allowed",
+            name=self.config.name,
+            sender=sender,
+            reply_to=reply_to,
+        )
+        return sender
+
     def _to_incoming(self, parsed: EmailMessage) -> IncomingMessage | None:
         sender = normalize_address(parsed.get("From", ""))
         if not sender:
@@ -552,7 +574,7 @@ class EmailChannel:
         message_id = (parsed.get("Message-ID") or "").strip().strip("<>")
         subject = decode_header_value(parsed.get("Subject"))
         body = strip_quoted_reply(_body_text(parsed))
-        reply_to = normalize_address(parsed.get("Reply-To", "")) or sender
+        reply_to = self._reply_target(sender, parsed.get("Reply-To", ""))
 
         self._remember_thread(
             thread_id,
@@ -638,8 +660,9 @@ class EmailChannel:
     # ------------------------------------------------------------------
 
     def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
+        sender = normalize_address(inbound.sender_id) or inbound.sender_id
         metadata: dict[str, Any] = {
-            "to": inbound.metadata.get("email_reply_to") or inbound.sender_id,
+            "to": self._reply_target(sender, str(inbound.metadata.get("email_reply_to") or "")),
             "subject": reply_subject(str(inbound.metadata.get("subject") or "")),
             "in_reply_to": inbound.metadata.get("native_message_id") or "",
         }

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -290,6 +290,41 @@ def test_reply_targets_the_thread_and_quotes_the_subject() -> None:
     assert reply.metadata["in_reply_to"] == "m1@example.com"
 
 
+def test_off_allowlist_reply_to_falls_back_to_the_sender() -> None:
+    """An allowlisted sender must not be able to redirect the reply off-list."""
+
+    channel = EmailChannel(config=_config())
+
+    inbound = channel._to_incoming(_raw(extra_headers={"Reply-To": "attacker@elsewhere.com"}))
+
+    assert inbound is not None
+    assert inbound.metadata["email_reply_to"] == "owner@example.com"
+    assert channel._threads["m1@example.com"].to_address == "owner@example.com"
+    assert channel.build_reply_message("done", inbound).metadata["to"] == "owner@example.com"
+
+
+def test_allowlisted_reply_to_is_still_honoured() -> None:
+    channel = EmailChannel(config=_config())
+
+    inbound = channel._to_incoming(_raw(extra_headers={"Reply-To": "Mate <mate@team.example>"}))
+
+    assert inbound is not None
+    assert inbound.metadata["email_reply_to"] == "mate@team.example"
+    assert channel._threads["m1@example.com"].to_address == "mate@team.example"
+    assert channel.build_reply_message("done", inbound).metadata["to"] == "mate@team.example"
+
+
+def test_build_reply_message_re_checks_a_tampered_reply_target() -> None:
+    """Metadata can outlive the parse, so the reply target is validated again."""
+
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(_raw())
+    assert inbound is not None
+    inbound.metadata["email_reply_to"] = "attacker@elsewhere.com"
+
+    assert channel.build_reply_message("done", inbound).metadata["to"] == "owner@example.com"
+
+
 def test_reply_subject_is_not_double_prefixed() -> None:
     assert reply_subject("Re: Status?") == "Re: Status?"
     assert reply_subject("") == "Re: (no subject)"


### PR DESCRIPTION
Fixes #575

## The bug

`src/agentos/channels/email.py` gates inbound mail on the fail-closed `allowed_senders` list, but applies it only to `From`. The reply target came straight off the wire:

```python
reply_to = normalize_address(parsed.get("Reply-To", "")) or sender
```

`Reply-To` is written by the very party the allowlist exists to constrain, so an allowlisted sender could point it at any mailbox and have the agent's answer — tool output included — delivered there.

Worth noting beyond the original report: that address is also cached as the thread's `to_address`, so the redirect persists for **every** later reply in the thread, not just the first.

## The fix

- **`_reply_target()`** — new helper running `Reply-To` through the same `sender_allowed()` check as `From`. Off-list values are logged (`email.reply_to_not_allowed`) and the reply falls back to the `From` address. The message itself is still processed: a redirected reply target does not make the mail untrusted, and rejecting it outright would let anyone silence a legitimate sender by forging a header on their behalf.
- **`_to_incoming()`** — uses the helper, so both `metadata["email_reply_to"]` and the cached thread `to_address` are allowlisted.
- **`build_reply_message()`** — re-runs the check on the stored `email_reply_to` before it becomes the outbound `to`, so a stale or tampered thread cache can't put an off-list recipient back on the wire.

## Scope note on outbound `send()`

The issue thread floats gating the `send()` recipient too. I deliberately left it ungated: with the two paths above fixed, every attacker-influenced recipient is already allowlisted, whereas `metadata["recipient"]` is the agent's own choice via the message tool. Gating it would break agent-initiated mail (the existing `test_send_resolves_the_recipient_from_metadata_recipient` covers exactly that flow) without closing anything that is still open.

## Tests

Three new cases in `tests/test_channels/test_email_channel.py`:

- off-allowlist `Reply-To` falls back to the sender — asserted on the metadata, the thread cache, **and** the built reply
- an on-allowlist `Reply-To` (including a display-name form, `Mate <mate@team.example>`) is still honoured
- `build_reply_message()` re-checks a tampered `email_reply_to`

Both attack-path tests fail on `main` and pass with the fix (verified by stashing the source change).

## Verification

- `uv run pytest tests/test_channels/test_email_channel.py -q` → 52 passed
- `uv run pytest -q -m "not llm"` → 8786 passed, 3 failed — all three pre-existing on `main` and unrelated (mem0 "not installed" tests under `--all-extras`, and `test_render_html_to_pdf` needing a system weasyprint lib)
- `uv run ruff check src tests` → clean; `ruff format --check` on both touched files → clean
- `uv run mypy src/agentos` → 1 error, pre-existing (`mem0_provider.py` missing stubs)

Docs and CHANGELOG updated.