### PR TITLE
fix(provider): name every OpenAI-compatible provider in HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The offline vision fallback recognizes `gpt-5.6-*`, `glm-5.3-flash` and
   `muse-spark-*` as image-capable. Previously, if the catalog fetch failed, the
   `c1` default was reported as text-only and image turns had nowhere to route.
+- HTTP errors from an OpenAI-compatible provider name the provider again.
+  `_provider_display_name` mapped 10 provider kinds while the registry ships 21
+  that reach `OpenAIProvider`, so Azure, Mistral, Groq, SiliconFlow, AIHubMix,
+  MiniMax, BytePlus, Bailian Coding, Bankr, LM Studio and OVMS all reported
+  `Provider chat request failed (HTTP 401)` — on an install with several
+  providers configured that does not say which key to rotate. The table is now
+  complete, and a registry-derived test fails if a new `openai_compat` provider
+  is added without a display name.
 
 ### Added
 

--- a/src/agentos/provider/openai.py
+++ b/src/agentos/provider/openai.py
@@ -78,19 +78,39 @@ def _openai_tool_result_content(block: Any) -> str:
     )
 
 
+# Keyed on `ProviderSpec.provider_kind` — the value `provider/selector.py`
+# hands `OpenAIProvider` — not on the provider id. Several ids share one kind
+# (`vllm` and the coding-plan providers all run as `openai`, every MiniMax
+# variant as `minimax`). Covers every runtime-supported `openai_compat` kind in
+# the registry; `tests/test_provider_display_names.py` fails if the two drift.
+# Display strings follow each vendor's own casing.
+_PROVIDER_DISPLAY_NAMES: dict[str, str] = {
+    "aihubmix": "AIHubMix",
+    "azure": "Azure OpenAI",
+    "bailian_coding": "Bailian Coding",
+    "bankr": "Bankr",
+    "byteplus": "BytePlus",
+    "dashscope": "DashScope",
+    "deepseek": "DeepSeek",
+    "gemini": "Gemini",
+    "groq": "Groq",
+    "lm_studio": "LM Studio",
+    "minimax": "MiniMax",
+    "mistral": "Mistral",
+    "moonshot": "Moonshot",
+    "openai": "OpenAI",
+    "opencap": "OpenCAP",
+    "openrouter": "OpenRouter",
+    "ovms": "OVMS",
+    "qianfan": "Qianfan",
+    "siliconflow": "SiliconFlow",
+    "volcengine": "Volcengine",
+    "zhipu": "Zhipu",
+}
+
+
 def _provider_display_name(provider_kind: str) -> str:
-    return {
-        "openai": "OpenAI",
-        "openrouter": "OpenRouter",
-        "opencap": "OpenCAP",
-        "deepseek": "DeepSeek",
-        "moonshot": "Moonshot",
-        "dashscope": "DashScope",
-        "gemini": "Gemini",
-        "zhipu": "Zhipu",
-        "qianfan": "Qianfan",
-        "volcengine": "Volcengine",
-    }.get(provider_kind, "Provider")
+    return _PROVIDER_DISPLAY_NAMES.get(provider_kind, "Provider")
 
 
 def _http_error_body_text(body: bytes | str) -> str:

--- a/tests/test_provider_display_names.py
+++ b/tests/test_provider_display_names.py
@@ -1,0 +1,89 @@
+"""`_provider_display_name` must name every OpenAI-compatible provider.
+
+`_format_chat_http_error` is the only consumer of the display table, and its
+whole job is telling an operator *which* provider rejected the request. A
+missing entry degrades that to a generic "Provider chat request failed", which
+is useless on an install with several providers configured.
+
+The table is keyed on `ProviderSpec.provider_kind` (that is what
+`provider/selector.py` hands `OpenAIProvider`), not on the provider id, so the
+drift guard below derives its expectations from the registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.provider.failures import _OPENAI_COMPAT_PROVIDERS
+from agentos.provider.openai import _format_chat_http_error, _provider_display_name
+from agentos.provider.registry import list_provider_specs
+
+
+def _openai_compat_kinds() -> set[str]:
+    """Provider kinds that can reach `OpenAIProvider` at runtime."""
+
+    return {
+        spec.provider_kind
+        for spec in list_provider_specs()
+        if spec.backend == "openai_compat" and spec.runtime_supported
+    }
+
+
+@pytest.mark.parametrize("provider_kind", sorted(_openai_compat_kinds()))
+def test_every_openai_compat_kind_has_a_display_name(provider_kind: str) -> None:
+    assert _provider_display_name(provider_kind) != "Provider", (
+        f"provider_kind {provider_kind!r} falls back to the generic label; "
+        "add it to _provider_display_name"
+    )
+
+
+def test_every_openai_compat_failure_provider_resolves_to_a_named_kind() -> None:
+    """Entries in `_OPENAI_COMPAT_PROVIDERS` must map to a named display name.
+
+    Some entries there are provider *ids* (`vllm`, `minimax_openai`) rather
+    than kinds; resolve those through the registry before checking.
+    """
+
+    id_to_kind = {spec.provider_id: spec.provider_kind for spec in list_provider_specs()}
+    unnamed = sorted(
+        name
+        for name in _OPENAI_COMPAT_PROVIDERS
+        if _provider_display_name(id_to_kind.get(name, name)) == "Provider"
+    )
+
+    assert unnamed == []
+
+
+def test_newly_named_providers_use_each_vendors_own_casing() -> None:
+    """Pins the spelling of the kinds this fix added.
+
+    The parametrized guard above only demands *a* name; these vendors spell
+    themselves in ways an autocomplete will happily get wrong.
+    """
+
+    expected = {
+        "aihubmix": "AIHubMix",
+        "azure": "Azure OpenAI",
+        "bailian_coding": "Bailian Coding",
+        "bankr": "Bankr",
+        "byteplus": "BytePlus",
+        "groq": "Groq",
+        "lm_studio": "LM Studio",
+        "minimax": "MiniMax",
+        "mistral": "Mistral",
+        "ovms": "OVMS",
+        "siliconflow": "SiliconFlow",
+    }
+
+    assert {kind: _provider_display_name(kind) for kind in expected} == expected
+
+
+def test_an_unknown_kind_still_falls_back_to_the_generic_label() -> None:
+    assert _provider_display_name("definitely-not-a-provider") == "Provider"
+
+
+def test_the_formatted_http_error_names_the_provider() -> None:
+    message = _format_chat_http_error("mistral", 401, b'{"error": {"message": "bad key"}}')
+
+    assert message.startswith("Mistral chat request failed (HTTP 401)")
+    assert "bad key" in message

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -8,6 +8,7 @@ import httpx
 
 from agentos.engine.types import ThinkingLevel
 from agentos.provider.openai import OpenAIProvider
+from agentos.provider.selector import ProviderConfig, _build_provider
 from agentos.provider.types import (
     ChatConfig,
     ContentBlockToolResult,
@@ -1847,3 +1848,31 @@ def test_stream_consumer_stage_persists_thought_signature_and_history_rebuilds_i
     assistant_msg = messages[0]
     tool_use_block = next(b for b in assistant_msg.content if b.type == "tool_use")
     assert tool_use_block.thought_signature == "gemini_sig_transcript_persist"
+
+
+def test_mistral_http_error_names_provider_end_to_end(monkeypatch: Any) -> None:
+    """A provider built the way the runtime builds it names itself on failure.
+
+    Goes through `_build_provider` so the registry's `provider_kind` — not a
+    hand-passed one — is what reaches the display table.
+    """
+
+    captured: dict[str, Any] = {}
+    _patch_transport_response(
+        monkeypatch,
+        captured,
+        httpx.Response(
+            401,
+            json={"error": {"message": "Unauthorized"}},
+            request=httpx.Request("POST", "https://api.mistral.ai/v1/chat/completions"),
+        ),
+    )
+    provider = _build_provider(
+        ProviderConfig(provider="mistral", model="mistral-large-latest", api_key="test")
+    )
+
+    events = _collect_events(provider, ChatConfig())
+
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "401"
+    assert error.message == "Mistral chat request failed (HTTP 401): Unauthorized"


### PR DESCRIPTION
Fixes #607

## The bug

`_provider_display_name()` (`src/agentos/provider/openai.py`) mapped 10 provider kinds. The registry ships **21** that reach `OpenAIProvider`. The table's only consumer is `_format_chat_http_error()`, whose entire job is naming the provider that rejected the request — so for half its inputs it emitted:

```
Provider chat request failed (HTTP 401): Unauthorized
```

On an install with several providers configured, that does not tell the operator which key to rotate.

## The fix

11 entries added, spelled the way each vendor spells itself:

| kind | display |
|---|---|
| `aihubmix` | AIHubMix |
| `azure` | Azure OpenAI |
| `bailian_coding` | Bailian Coding |
| `bankr` | Bankr |
| `byteplus` | BytePlus |
| `groq` | Groq |
| `lm_studio` | LM Studio |
| `minimax` | MiniMax |
| `mistral` | Mistral |
| `ovms` | OVMS |
| `siliconflow` | SiliconFlow |

The dict moved to a module-level `_PROVIDER_DISPLAY_NAMES` constant so it is not rebuilt per call and the "keyed on what, exactly" note has somewhere to live.

## One correction to the issue's list

The table is keyed on **`ProviderSpec.provider_kind`** — the value `selector._build_provider()` passes to `OpenAIProvider` — not on the provider **id**. `_OPENAI_COMPAT_PROVIDERS` in `provider/failures.py` mixes the two, which is why the issue's missing-list is slightly off:

- **`minimax_openai`** is a provider id; its kind is `minimax`, so the `minimax` entry covers it. A literal `minimax_openai` key would be dead code.
- **`vllm`** is a provider id whose kind is `openai` (`_spec("vllm", "openai_compat", "openai")`), so a vLLM failure reads *"OpenAI chat request failed"*. A `vllm` key would never be looked up. Naming it properly means changing the registry spec's `provider_kind`, which also feeds cost/usage attribution (`agent.py:3718`, `provider_id=done_provider.provider_kind`) and the onboarding API's `providerKind` field — a behavior change well past a cosmetic label fix, so I left it alone. Happy to do it as a follow-up if you want it.
- **`bankr`** was missing from the issue's list *and* from `_OPENAI_COMPAT_PROVIDERS`, but it is a runtime-supported `openai_compat` spec, so it hit the generic label too. Named here.

## Drift guard

Per the review note on the issue, `tests/test_provider_display_names.py`:

- derives the expected key set from `list_provider_specs()` (every runtime-supported `openai_compat` kind) and parametrizes over it, so a newly registered provider cannot land without a display name;
- resolves every `_OPENAI_COMPAT_PROVIDERS` entry through the registry id→kind map before asserting, so the id-shaped entries there are checked against the kind they actually run as;
- pins the casing of the 11 added names;
- keeps the generic `"Provider"` fallback for an unknown kind.

Plus an end-to-end case in `tests/test_provider_openai_compat_payloads.py` that builds a Mistral provider through `_build_provider()` (registry kind, not a hand-passed one) against a mocked 401 and asserts the streamed `ErrorEvent` reads `Mistral chat request failed (HTTP 401): Unauthorized`. Verified it fails on the pre-fix table.

## Verification

```
uv run ruff check src tests                     # All checks passed
uv run ruff format --check <touched files>      # 3 files already formatted
uv run mypy src/agentos --show-error-codes      # 1 error, pre-existing (mem0 stubs)
uv run pytest -q                                # 8810 passed, 3 failed
```

The 3 failures are pre-existing environment issues, confirmed by re-running them against a clean `upstream/main` tree in the same venv: two mem0 tests that assume mem0 is *not* installed (it is, under `--all-extras`) and `test_skill_html_to_pdf` failing on a missing native library.

No CLI surface change, so `docs/cli.md` and `agentos/SKILL.md` are unaffected. `CHANGELOG.md` gets an `Unreleased → Fixed` entry.

Note: #608 is open against this issue as well — this one differs in keying the table on `provider_kind` rather than the failures-set names, which is what fixes `bankr` and avoids the two dead keys.