### PR TITLE
fix(gateway): rate-limit GET /api/approvals in a dedicated per-IP bucket (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- `GET /api/approvals` is no longer exempt from per-IP rate limiting. The
+  endpoint serializes every pending exec/plugin approval — command, argv and
+  params — and takes a SQLite read on each call, so the carve-out let any
+  caller that clears the auth gate poll it at unlimited rate: continuous
+  observation of pending tool-call arguments, and enough SQLite read pressure
+  to stall the approval/chat pipeline. On the default `auth.mode="none"`
+  (loopback-confined) that is any local process; under token auth it is any
+  token holder. `HEAD` is covered too — Starlette serves it from the same
+  route, so it runs the same handler.
+
+  It is now counted in a dedicated per-IP bucket rather than the shared
+  `/api/*` one, because the Web UI polls it every 1.5s (~40 req/min per open
+  tab) and the shared default of 100/min would have 429'd operators out of
+  their own approval queue. The cap is `AGENTOS_RATE_APPROVALS_MAX_REQUESTS`,
+  default 300 per window. Being per-IP, it bounds a single source; it is not a
+  defence against a distributed one (#569).
+
 ### Changed
 
 - OpenCAP's router tier defaults track OpenCAP's own catalog again. `c2` moves

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -82,6 +82,13 @@ These require no auth and are safe for load balancers and container probes.
 | `POST` | `/api/approvals/resolve` | Approve or deny a pending item. |
 | `POST` | `/api/elevated-mode` | Set per-session elevated mode (admitted Control connection only). |
 
+`GET /api/approvals` serializes every pending command and its arguments, so it
+is rate limited per client IP like the rest of `/api/*` — just in its own
+bucket, because the Web UI polls it every 1.5s. The cap is
+`AGENTOS_RATE_APPROVALS_MAX_REQUESTS` (default 300 per
+`AGENTOS_RATE_WINDOW_SECONDS`, i.e. 300/min), which clears several open tabs.
+Raise it only if you run more consoles than that against one gateway.
+
 ## Files and Media
 
 | Method | Path | Purpose |

--- a/frontend/src/services/approval-monitor.ts
+++ b/frontend/src/services/approval-monitor.ts
@@ -365,11 +365,16 @@ export class ApprovalMonitor {
 /**
  * approval_monitor.js:67 — the poll endpoint. Legacy fetched the ROOT-absolute
  * '/api/approvals'; these routes are registered at the gateway root (app.py:
- * 535-537), NOT under control_ui.base_path, and the rate-limit exemption keys
- * off the bare '/api/approvals' (middleware.py:240). So — unlike /api/bootstrap
- * which lives under base_path — the approvals REST surface is root-absolute and
- * must NOT be rewritten through the BASE_URL-derived base. We keep the legacy
+ * 535-537), NOT under control_ui.base_path, and the gateway's dedicated
+ * approvals rate-limit bucket keys off the bare '/api/approvals'
+ * (middleware.py, _APPROVALS_PATH). So — unlike /api/bootstrap which lives
+ * under base_path — the approvals REST surface is root-absolute and must NOT
+ * be rewritten through the BASE_URL-derived base. We keep the legacy
  * root-absolute path verbatim.
+ *
+ * That bucket is generous (rate_limit.approvals_max_requests, default 300/min)
+ * but it is a bound, not an exemption: POLL_MS below is what keeps this poll
+ * comfortably under it.
  */
 export function approvalsUrl(): string {
   return '/api/approvals'

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -133,6 +133,15 @@ class RateLimitConfig(BaseSettings):
     enabled: bool = True
     max_requests: int = 100
     window_seconds: int = 60
+    # Dedicated cap for ``GET /api/approvals``, counted in its own per-IP
+    # window (same ``window_seconds``). The Control UI polls that endpoint
+    # every 1.5s (~40 req/min per open tab, ApprovalMonitor.POLL_MS), so
+    # charging it to the shared ``max_requests`` bucket would 429 the operator
+    # out of the approval queue with two or three tabs open. It is bounded
+    # rather than exempt: the handler serializes every pending command/argv
+    # and takes a SQLite read on each poll, so an unlimited endpoint is an
+    # enumeration + lock-contention lever for anyone who reaches the gateway.
+    approvals_max_requests: int = Field(default=300, ge=1)
 
 
 class ControlUiConfig(BaseSettings):

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -35,6 +35,11 @@ _API_PREFIX = "/api"
 # like the root ``/api/*`` routes.
 _UI_BOOTSTRAP_SUFFIX = f"{_API_PREFIX}/bootstrap"
 
+# The approval queue the Control UI polls. Rate-limited in its own per-IP
+# bucket (see ``RateLimitMiddleware._bucket_for``) rather than shared with the
+# rest of ``/api/*``.
+_APPROVALS_PATH = f"{_API_PREFIX}/approvals"
+
 
 def _is_under(prefix: str, path: str) -> bool:
     """True for the prefix itself or anything below it — never a bare-prefix match.
@@ -293,7 +298,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Simple sliding-window rate limiter per client IP."""
+    """Simple sliding-window rate limiter per client IP.
+
+    Requests are counted in named buckets. Everything shares the ``"api"``
+    bucket except ``GET /api/approvals``, which gets its own ``"approvals"``
+    bucket with a higher cap (``rate_limit.approvals_max_requests``) so the
+    Control UI's 1.5s poll cannot exhaust the budget the rest of the API
+    depends on — and so that poll cannot be used to enumerate pending tool
+    calls without limit either.
+    """
 
     def __init__(
         self,
@@ -308,8 +321,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             config.control_ui.base_path if control_ui_base_path is None else control_ui_base_path
         )
         self._ui_prefix = _safe_ui_exempt_prefix(base_path)
-        # {ip: [timestamp, ...]} with LRU eviction ordering
-        self._windows: OrderedDict[str, list[float]] = OrderedDict()
+        # {(bucket, ip): [timestamp, ...]} with LRU eviction ordering. An IP
+        # that both polls approvals and calls the rest of the API therefore
+        # holds two entries; ``max_tracked_clients`` bounds entries, not IPs.
+        self._windows: OrderedDict[tuple[str, str], list[float]] = OrderedDict()
         self._max_tracked_clients = max_tracked_clients
         self._last_sweep: float = 0.0
 
@@ -336,17 +351,32 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     def _sweep_expired(self, now: float, window: float) -> None:
         self._last_sweep = now
         expired = [
-            ip
-            for ip, timestamps in self._windows.items()
+            key
+            for key, timestamps in self._windows.items()
             if not timestamps or (now - timestamps[-1] >= window)
         ]
-        for ip in expired:
-            self._windows.pop(ip, None)
+        for key in expired:
+            self._windows.pop(key, None)
 
     def _evict_excess(self, now: float, window: float) -> None:
         self._sweep_expired(now, window)
         while len(self._windows) > self._max_tracked_clients:
             self._windows.popitem(last=False)
+
+    def _bucket_for(self, request: Request, path: str) -> tuple[str, int]:
+        """Return the ``(bucket name, max requests)`` this request counts against.
+
+        Only the polled approvals read gets the dedicated bucket. ``HEAD`` is
+        included because Starlette serves it from the same ``methods=["GET"]``
+        route, so a HEAD runs the handler — and therefore the SQLite read — in
+        full; charging it elsewhere would leave the handler reachable
+        ``max_requests`` extra times per window on top of the advertised cap.
+        The mutating approval routes (``/api/approvals/resolve``,
+        ``/api/approvals/settings``) are not polled and stay on the shared cap.
+        """
+        if request.method in ("GET", "HEAD") and path == _APPROVALS_PATH:
+            return "approvals", self._config.rate_limit.approvals_max_requests
+        return "api", self._config.rate_limit.max_requests
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if not self._config.rate_limit.enabled:
@@ -360,13 +390,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         if self._is_ui_path(path):
             return await call_next(request)  # type: ignore[no-any-return]
-        if request.method == "GET" and path == "/api/approvals":
-            return await call_next(request)  # type: ignore[no-any-return]
 
+        bucket, max_req = self._bucket_for(request, path)
         client_ip = self._get_client_ip(request)
+        key = (bucket, client_ip)
         now = time.time()
         window = float(self._config.rate_limit.window_seconds)
-        max_req = self._config.rate_limit.max_requests
         sweep_interval = min(window, 60.0)
 
         # Periodic sweep of expired windows
@@ -374,18 +403,18 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             self._sweep_expired(now, window)
 
         # Prune old timestamps
-        timestamps = [t for t in self._windows.get(client_ip, []) if now - t < window]
+        timestamps = [t for t in self._windows.get(key, []) if now - t < window]
 
         if len(timestamps) >= max_req:
-            self._windows[client_ip] = timestamps
-            self._windows.move_to_end(client_ip)
+            self._windows[key] = timestamps
+            self._windows.move_to_end(key)
             return JSONResponse(
                 {"error": "Too Many Requests", "code": "RATE_LIMITED"}, status_code=429
             )
 
         timestamps.append(now)
-        self._windows[client_ip] = timestamps
-        self._windows.move_to_end(client_ip)
+        self._windows[key] = timestamps
+        self._windows.move_to_end(key)
 
         if len(self._windows) > self._max_tracked_clients:
             self._evict_excess(now, window)

--- a/tests/test_gateway/test_rate_limit_approvals.py
+++ b/tests/test_gateway/test_rate_limit_approvals.py
@@ -1,32 +1,198 @@
+"""GET /api/approvals is bounded, but in its own per-IP bucket (#569).
+
+The endpoint used to be exempt from rate limiting altogether, so anyone who
+could reach the gateway could loop it to enumerate every pending exec/plugin
+approval (command, argv, params) and to hold the SQLite read lock against the
+approval/chat pipeline. It is now counted — in a dedicated bucket, because the
+Control UI polls it every 1.5s and charging that to the shared ``/api/*`` cap
+would 429 the operator out of their own approval queue.
+"""
+
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
-from agentos.gateway.config import GatewayConfig
-from agentos.gateway.middleware import RateLimitMiddleware
+from agentos.gateway.config import GatewayConfig, RateLimitConfig
+from agentos.gateway.middleware import _APPROVALS_PATH, RateLimitMiddleware
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_APPROVAL_MONITOR_TS = _REPO_ROOT / "frontend" / "src" / "services" / "approval-monitor.ts"
 
 
-def test_approval_polling_does_not_consume_generic_api_rate_limit() -> None:
+def _frontend_poll_ms() -> int:
+    """ApprovalMonitor's base poll delay, read from the TS source.
+
+    Read rather than duplicated so that lowering ``POLL_MS`` in the frontend
+    actually moves the drift guard below instead of leaving it asserting
+    against a stale copy of the number.
+    """
+    match = re.search(r"^const POLL_MS = (\d+)$", _APPROVAL_MONITOR_TS.read_text(), re.MULTILINE)
+    assert match is not None, f"POLL_MS declaration not found in {_APPROVAL_MONITOR_TS}"
+    return int(match.group(1))
+
+
+def _build_app(
+    *,
+    max_requests: int = 100,
+    approvals_max_requests: int = 300,
+    window_seconds: int = 60,
+) -> Starlette:
     app = Starlette()
 
-    async def approvals(_request):
+    async def approvals(_request: Request) -> JSONResponse:
         return JSONResponse({"approvals": []})
 
-    async def sessions(_request):
+    async def sessions(_request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    async def resolve(_request: Request) -> JSONResponse:
         return JSONResponse({"ok": True})
 
     app.add_route("/api/approvals", approvals, methods=["GET"])
     app.add_route("/api/sessions", sessions, methods=["GET"])
-    config = GatewayConfig()
-    config.rate_limit.enabled = True
-    config.rate_limit.max_requests = 1
-    config.rate_limit.window_seconds = 60
+    app.add_route("/api/approvals/resolve", resolve, methods=["POST"])
+
+    config = GatewayConfig(
+        rate_limit=RateLimitConfig(
+            enabled=True,
+            max_requests=max_requests,
+            approvals_max_requests=approvals_max_requests,
+            window_seconds=window_seconds,
+        )
+    )
     app.add_middleware(RateLimitMiddleware, config=config)
+    return app
+
+
+def test_approval_polling_is_bounded() -> None:
+    """The enumeration lever from #569: the endpoint can no longer be sprayed."""
+    app = _build_app(approvals_max_requests=2)
 
     with TestClient(app) as client:
         assert client.get("/api/approvals").status_code == 200
         assert client.get("/api/approvals").status_code == 200
+        resp = client.get("/api/approvals")
+        assert resp.status_code == 429
+        assert resp.json() == {"error": "Too Many Requests", "code": "RATE_LIMITED"}
+
+
+def test_approval_polling_does_not_consume_generic_api_rate_limit() -> None:
+    """The UI poll must not spend the budget the rest of /api/* runs on."""
+    app = _build_app(max_requests=1, approvals_max_requests=10)
+
+    with TestClient(app) as client:
+        for _ in range(5):
+            assert client.get("/api/approvals").status_code == 200
+        # The shared bucket is untouched: /api/sessions still has its one slot.
         assert client.get("/api/sessions").status_code == 200
         assert client.get("/api/sessions").status_code == 429
+
+
+def test_generic_api_traffic_does_not_exhaust_the_approvals_bucket() -> None:
+    """The reverse: busy REST traffic must not lock the operator out of approvals."""
+    app = _build_app(max_requests=1, approvals_max_requests=2)
+
+    with TestClient(app) as client:
+        assert client.get("/api/sessions").status_code == 200
+        assert client.get("/api/sessions").status_code == 429
+        assert client.get("/api/approvals").status_code == 200
+        assert client.get("/api/approvals").status_code == 200
+        assert client.get("/api/approvals").status_code == 429
+
+
+def test_mutating_approval_routes_use_the_shared_bucket() -> None:
+    """Only the polled GET gets the roomy bucket; resolve/settings do not."""
+    app = _build_app(max_requests=1, approvals_max_requests=100)
+
+    with TestClient(app) as client:
+        assert client.post("/api/approvals/resolve", json={}).status_code == 200
+        assert client.post("/api/approvals/resolve", json={}).status_code == 429
+        # ...and it drew from the same bucket as the rest of the API.
+        assert client.get("/api/sessions").status_code == 429
+
+
+def test_approvals_bucket_is_per_ip() -> None:
+    """Two clients get independent approval budgets."""
+    app = _build_app(approvals_max_requests=1)
+
+    with TestClient(app, client=("198.51.100.7", 40000)) as client:
+        assert client.get("/api/approvals").status_code == 200
+        assert client.get("/api/approvals").status_code == 429
+
+    with TestClient(app, client=("198.51.100.8", 40000)) as client:
+        assert client.get("/api/approvals").status_code == 200
+
+
+def test_disabled_rate_limit_still_bypasses_everything() -> None:
+    app = Starlette()
+
+    async def approvals(_request: Request) -> JSONResponse:
+        return JSONResponse({"approvals": []})
+
+    app.add_route("/api/approvals", approvals, methods=["GET"])
+    config = GatewayConfig(
+        rate_limit=RateLimitConfig(enabled=False, max_requests=1, window_seconds=60)
+    )
+    app.add_middleware(RateLimitMiddleware, config=config)
+
+    with TestClient(app) as client:
+        for _ in range(5):
+            assert client.get("/api/approvals").status_code == 200
+
+
+def test_default_approvals_bucket_leaves_room_for_several_open_tabs() -> None:
+    """Drift guard: the default must not 429 a normally-polling operator.
+
+    ApprovalMonitor polls every ``POLL_MS``; the default bucket has to clear
+    that rate for a handful of open Control UI tabs with slack left over. The
+    real per-tab rate runs a little above the steady-state figure — the monitor
+    re-polls on focus/visibility change and after each resolve — so the margin
+    here is deliberately more than the tab count implies.
+    """
+    defaults = RateLimitConfig()
+    per_tab_per_window = (defaults.window_seconds * 1000) // _frontend_poll_ms()
+    assert defaults.approvals_max_requests >= per_tab_per_window * 4
+    # And it must still be a bound, not an exemption.
+    assert defaults.approvals_max_requests > defaults.max_requests
+
+
+def test_bucket_path_matches_the_registered_approvals_route() -> None:
+    """The dedicated bucket hangs on an exact path match — pin it to the route.
+
+    ``_bucket_for`` compares against ``_APPROVALS_PATH`` literally. If the
+    route in ``gateway/app.py`` is ever renamed or re-prefixed, the match
+    silently stops firing and the UI poll drops back into the shared bucket,
+    429-ing the operator out of the approval queue at ~2.5 open tabs — with
+    every other test in this file still green.
+    """
+    from agentos.gateway import app as gateway_app
+
+    source = Path(gateway_app.__file__).read_text()
+    assert f'Route("{_APPROVALS_PATH}", api_approvals, methods=["GET"])' in source, (
+        f"the approvals route no longer matches _APPROVALS_PATH ({_APPROVALS_PATH}); "
+        "update middleware._APPROVALS_PATH to match gateway/app.py"
+    )
+
+
+def test_head_on_approvals_uses_the_approvals_bucket() -> None:
+    """HEAD runs the same handler as GET, so it must draw on the same bucket.
+
+    Starlette serves HEAD from a ``methods=["GET"]`` route, so a HEAD does the
+    full pending-approval serialization and SQLite read. Charging it to the
+    shared bucket would leave the handler reachable ``max_requests`` extra
+    times per window on top of the approvals cap.
+    """
+    app = _build_app(max_requests=5, approvals_max_requests=1)
+
+    with TestClient(app) as client:
+        assert client.head("/api/approvals").status_code == 200
+        assert client.head("/api/approvals").status_code == 429
+        # It spent the approvals budget, not the shared one.
+        assert client.get("/api/approvals").status_code == 429
+        assert client.get("/api/sessions").status_code == 200

--- a/tests/test_gateway/test_rate_limit_trusted_proxy.py
+++ b/tests/test_gateway/test_rate_limit_trusted_proxy.py
@@ -11,6 +11,15 @@ from agentos.gateway.config import AuthConfig, GatewayConfig, RateLimitConfig
 from agentos.gateway.middleware import RateLimitMiddleware
 
 
+def _tracked_ips(mw: RateLimitMiddleware) -> list[str]:
+    """IPs tracked in the shared ``"api"`` bucket, in LRU order.
+
+    ``_windows`` is keyed by ``(bucket, ip)`` since GET /api/approvals moved to
+    its own bucket (#569); these tests only exercise the shared bucket.
+    """
+    return [ip for bucket, ip in mw._windows if bucket == "api"]
+
+
 def _create_app(
     *,
     max_requests: int = 2,
@@ -70,10 +79,12 @@ def test_untrusted_client_cannot_bypass_rate_limit_via_x_forwarded_for() -> None
 
     # Memory check: only the peer IP was tracked, not the spoofed IPs
     mw = mw_holder[0]
-    assert "198.51.100.1" in mw._windows
-    assert "1.1.1.1" not in mw._windows
-    assert "2.2.2.2" not in mw._windows
-    assert "3.3.3.3" not in mw._windows
+    assert "198.51.100.1" in _tracked_ips(mw)
+    assert "1.1.1.1" not in _tracked_ips(mw)
+    assert "2.2.2.2" not in _tracked_ips(mw)
+    assert "3.3.3.3" not in _tracked_ips(mw)
+    assert _tracked_ips(mw) == ["198.51.100.1"]
+    # Whole-table check: the spoofed IPs created no entry in *any* bucket.
     assert len(mw._windows) == 1
 
 
@@ -104,9 +115,9 @@ def test_trusted_proxy_honors_x_forwarded_for() -> None:
         )
 
     mw = mw_holder[0]
-    assert "203.0.113.50" in mw._windows
-    assert "203.0.113.51" in mw._windows
-    assert "10.0.0.1" not in mw._windows
+    assert "203.0.113.50" in _tracked_ips(mw)
+    assert "203.0.113.51" in _tracked_ips(mw)
+    assert "10.0.0.1" not in _tracked_ips(mw)
 
 
 def test_trusted_proxy_x_forwarded_for_multiple_ips() -> None:
@@ -125,7 +136,7 @@ def test_trusted_proxy_x_forwarded_for_multiple_ips() -> None:
         assert resp.status_code == 200
 
     mw = mw_holder[0]
-    assert "203.0.113.99" in mw._windows
+    assert "203.0.113.99" in _tracked_ips(mw)
     assert len(mw._windows) == 1
 
 
@@ -142,7 +153,7 @@ def test_trusted_proxy_missing_or_blank_forwarded_for_falls_back_to_peer() -> No
         assert client.get("/api/test").status_code == 429
 
     mw = mw_holder[0]
-    assert "10.0.0.1" in mw._windows
+    assert "10.0.0.1" in _tracked_ips(mw)
 
 
 def test_max_tracked_clients_evicts_lru() -> None:
@@ -161,17 +172,17 @@ def test_max_tracked_clients_evicts_lru() -> None:
 
         mw = mw_holder[0]
         assert len(mw._windows) == 3
-        assert list(mw._windows.keys()) == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+        assert _tracked_ips(mw) == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
 
         # Accessing 1.1.1.1 again makes 2.2.2.2 the least recently used
         client.get("/api/test", headers={"x-forwarded-for": "1.1.1.1"})
-        assert list(mw._windows.keys()) == ["2.2.2.2", "3.3.3.3", "1.1.1.1"]
+        assert _tracked_ips(mw) == ["2.2.2.2", "3.3.3.3", "1.1.1.1"]
 
         # Adding 4.4.4.4 exceeds capacity (3), so 2.2.2.2 should be evicted
         client.get("/api/test", headers={"x-forwarded-for": "4.4.4.4"})
         assert len(mw._windows) == 3
-        assert list(mw._windows.keys()) == ["3.3.3.3", "1.1.1.1", "4.4.4.4"]
-        assert "2.2.2.2" not in mw._windows
+        assert _tracked_ips(mw) == ["3.3.3.3", "1.1.1.1", "4.4.4.4"]
+        assert "2.2.2.2" not in _tracked_ips(mw)
 
 
 def test_sweep_expired_entries() -> None:
@@ -197,6 +208,6 @@ def test_sweep_expired_entries() -> None:
         client.get("/api/test", headers={"x-forwarded-for": "3.3.3.3"})
 
         # Expired entries 1.1.1.1 and 2.2.2.2 should have been swept
-        assert "1.1.1.1" not in mw._windows
-        assert "2.2.2.2" not in mw._windows
-        assert "3.3.3.3" in mw._windows
+        assert "1.1.1.1" not in _tracked_ips(mw)
+        assert "2.2.2.2" not in _tracked_ips(mw)
+        assert "3.3.3.3" in _tracked_ips(mw)


### PR DESCRIPTION
## What

`RateLimitMiddleware.dispatch` carved `GET /api/approvals` out of the per-IP
bucket entirely:

```python
if request.method == "GET" and path == "/api/approvals":
    return await call_next(request)
```

The handler serializes every pending exec/plugin approval — command, argv,
params — and takes a SQLite read per call, so any caller that clears the auth
gate could poll it at unlimited rate: continuous observation of pending
tool-call arguments, plus enough read pressure to stall the approval/chat
pipeline. On the default `auth.mode="none"` (which `enforce_public_bind_auth_guard`
confines to loopback) that is any local process; under token auth it is any
token holder. `RateLimitMiddleware` also sits **above** `AuthMiddleware`
(`app.py:598` vs `:604`), so the bucket is spent before any SQLite work
happens — which is the property that makes limiting here worth anything.

Being per-IP, the bucket bounds a single source; it is not a defence against a
distributed one. And rate limiting doesn't stop enumeration outright — one
request returns the whole pending set — it bounds *continuous* observation and
lock contention, which is what #569 actually describes.

## The fix

The exemption is gone. `GET /api/approvals` is now counted per client IP — in
its **own** bucket rather than the shared `/api/*` one.

Why a separate bucket instead of just deleting the carve-out: `ApprovalMonitor`
polls every `POLL_MS = 1500`, i.e. ~40 req/min **per open tab**. Against the
shared default of `max_requests=100 / 60s`, two Control UI tabs plus ordinary
REST traffic would 429 the operator out of their own approval queue — the exact
screen you need working to unblock a pending tool call. The new cap is
`rate_limit.approvals_max_requests` (`AGENTOS_RATE_APPROVALS_MAX_REQUESTS`,
default **300 per window**): roomy enough for several tabs, still a hard bound
on enumeration.

Implementation: `_windows` is now keyed by `(bucket, ip)` instead of `ip`, and
`_bucket_for()` picks the bucket. That keeps **one** store, so the existing
sweep / LRU-eviction / `max_tracked_clients` paths cover the new bucket for
free — a second `OrderedDict` would have needed its own eviction or it becomes
a fresh unbounded-memory vector.

`HEAD` is bucketed with `GET`. Starlette serves HEAD from the same
`methods=["GET"]` route, so `HEAD /api/approvals` runs the handler and takes
the SQLite read in full; matching on `GET` alone left the handler reachable
`max_requests` extra times per window on top of the advertised cap, and spent
the shared API budget doing it. Reproduced before fixing (one GET + two HEADs
against `approvals_max_requests=1, max_requests=2` → **3** handler
invocations), and `test_head_on_approvals_uses_the_approvals_bucket` fails
without it.

Scope is otherwise narrow: `POST /api/approvals/resolve` and `/settings` are
not polled and stay on the shared cap.

## Tests

`tests/test_gateway/test_rate_limit_approvals.py` — the old test asserted the
exempt behaviour and is replaced. New coverage:

- the endpoint is bounded (the #569 lever)
- `HEAD` draws on the approvals bucket, not the shared one
- polling does not consume the generic `/api/*` budget
- busy REST traffic does not exhaust the approvals budget (reverse isolation)
- mutating approval routes stay on the shared bucket
- the approvals bucket is per-IP
- `rate_limit.enabled = false` still bypasses everything
- `_APPROVALS_PATH` is pinned to the route registered in `app.py` — the whole
  mechanism is an exact string match, and a rename would silently drop the UI
  poll back into the shared bucket with every other test still green
- drift guard: the default cap clears the frontend's `POLL_MS` for 4+ tabs and
  is still strictly greater than `max_requests` (a bound, not an exemption).
  `POLL_MS` is *read out of* `approval-monitor.ts` rather than copied, so
  lowering it there moves the guard.

Verified the four security-relevant tests fail on the unpatched middleware and
pass with it. `tests/test_gateway/test_rate_limit_trusted_proxy.py` asserts on
`_windows` keys, so it gains a `_tracked_ips()` helper for the tuple key; its
existing assertions are otherwise unchanged (the one whole-table
`len(mw._windows)` check is kept alongside the bucket-filtered one).

Gate: `ruff check src tests` clean, `ruff format --check` clean on touched
files, `mypy src/agentos` unchanged (one pre-existing `mem0` stub error),
`pytest tests/test_gateway` 1338 passed, full suite 8803 passed with only the
three failures that are already red on `main` (two `mem0` stub tests and
`test_render_html_to_pdf`, a missing system dependency).

One thing I did **not** change: `max_requests` and `window_seconds` still
accept `0`/negative while the new `approvals_max_requests` carries `ge=1`. The
asymmetry is conspicuous but tightening the existing fields is a behaviour
change outside this issue — happy to add it if you want it here.

## Note on overlapping PRs

#572, #704 and #738 also target #569, and a maintainer has already pointed at
#572 — so treat this as an alternative, not a claim of priority; happy to close
it if #572 lands.

The one substantive difference worth flagging: #704 removes the carve-out
without giving the endpoint its own bucket, which is what the issue text
suggests but does hand the operator the multi-tab 429 described above (40
req/min per tab against a 100 req/min shared cap). #572 and #738 both reach the
dedicated-bucket conclusion; this PR differs mainly in keeping a single
`(bucket, ip)` store instead of a second dict or a general `path_buckets` map,
and in the isolation/drift tests. Fold in whatever is useful.

Closes #569
