### PR TITLE
fix(gateway): drop empty session subscriber sets in SubscriptionManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The gateway's WebSocket `SubscriptionManager` no longer leaks an empty
+  subscriber set for every session key it has ever served. Unsubscribing from
+  session messages, or dropping a connection, discarded the connection id but
+  left the now-empty `session_key -> set()` entry in place, so a long-running
+  gateway accumulated one dead dict entry per distinct session key. Both paths
+  now delete the key once its last subscriber goes away, matching the pruning
+  the topic subscriptions already did.
 - The email channel no longer honours an off-allowlist `Reply-To`. The From
   address was checked against the fail-closed `allowed_senders` list, but the
   `Reply-To` header — equally attacker-controlled on an admitted message — was

--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -568,8 +568,11 @@ class SubscriptionManager:
         self._message_subs.setdefault(session_key, set()).add(conn_id)
 
     def unsubscribe_messages(self, conn_id: str, session_key: str) -> None:
-        if session_key in self._message_subs:
-            self._message_subs[session_key].discard(conn_id)
+        subs = self._message_subs.get(session_key)
+        if subs is not None:
+            subs.discard(conn_id)
+            if not subs:
+                del self._message_subs[session_key]
 
     def get_message_subscribers(self, session_key: str) -> set[str]:
         return set(self._message_subs.get(session_key, set()))
@@ -591,8 +594,13 @@ class SubscriptionManager:
     def remove_connection(self, conn_id: str) -> None:
         """Clean up all subscriptions for a disconnected connection."""
         self._session_subs.discard(conn_id)
-        for subs in self._message_subs.values():
+        empty_sessions = []
+        for session_key, subs in self._message_subs.items():
             subs.discard(conn_id)
+            if not subs:
+                empty_sessions.append(session_key)
+        for session_key in empty_sessions:
+            del self._message_subs[session_key]
         empty_topics = []
         for topic, subs in self._topic_subs.items():
             subs.discard(conn_id)

--- a/tests/test_gateway/test_subscription_manager_cleanup.py
+++ b/tests/test_gateway/test_subscription_manager_cleanup.py
@@ -1,0 +1,150 @@
+"""SubscriptionManager must not leave empty subscriber sets behind.
+
+Regression tests for #609: `_message_subs` kept a `session_key -> set()` entry
+alive after the last subscriber went away, so a long-running gateway grew one
+dead dict entry per session key it ever served. The topic path already pruned
+itself; the message path now matches it.
+"""
+
+from __future__ import annotations
+
+from agentos.gateway.websocket import SubscriptionManager
+
+
+def test_unsubscribe_messages_drops_the_key_once_the_last_subscriber_leaves() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+
+    assert mgr._message_subs == {}
+    assert mgr.get_message_subscribers("sess-a") == set()
+
+
+def test_unsubscribe_messages_keeps_the_key_while_others_remain() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+    mgr.subscribe_messages("conn-2", "sess-a")
+
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+
+    assert mgr.get_message_subscribers("sess-a") == {"conn-2"}
+    assert set(mgr._message_subs) == {"sess-a"}
+
+
+def test_unsubscribe_messages_only_touches_the_named_session() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+    mgr.subscribe_messages("conn-1", "sess-b")
+
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+
+    assert set(mgr._message_subs) == {"sess-b"}
+    assert mgr.get_message_subscribers("sess-b") == {"conn-1"}
+
+
+def test_unsubscribe_messages_for_an_unknown_key_creates_nothing() -> None:
+    mgr = SubscriptionManager()
+
+    mgr.unsubscribe_messages("conn-1", "never-subscribed")
+
+    assert mgr._message_subs == {}
+
+
+def test_unsubscribe_messages_by_a_non_subscriber_leaves_the_set_intact() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+
+    mgr.unsubscribe_messages("conn-2", "sess-a")
+
+    assert mgr.get_message_subscribers("sess-a") == {"conn-1"}
+
+
+def test_repeated_unsubscribe_is_idempotent() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+
+    assert mgr._message_subs == {}
+
+
+def test_resubscribe_after_cleanup_works() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+
+    mgr.subscribe_messages("conn-1", "sess-a")
+
+    assert mgr.get_message_subscribers("sess-a") == {"conn-1"}
+
+
+def test_remove_connection_prunes_emptied_message_subscriptions() -> None:
+    mgr = SubscriptionManager()
+    for key in ("sess-a", "sess-b", "sess-c"):
+        mgr.subscribe_messages("conn-1", key)
+
+    mgr.remove_connection("conn-1")
+
+    assert mgr._message_subs == {}
+
+
+def test_remove_connection_keeps_sessions_with_other_subscribers() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "shared")
+    mgr.subscribe_messages("conn-2", "shared")
+    mgr.subscribe_messages("conn-1", "solo")
+
+    mgr.remove_connection("conn-1")
+
+    assert set(mgr._message_subs) == {"shared"}
+    assert mgr.get_message_subscribers("shared") == {"conn-2"}
+
+
+def test_remove_connection_still_clears_session_and_topic_subscriptions() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_sessions("conn-1")
+    mgr.subscribe_messages("conn-1", "sess-a")
+    mgr.subscribe_topic("conn-1", "cron")
+
+    mgr.remove_connection("conn-1")
+
+    assert mgr.get_session_subscribers() == set()
+    assert mgr._message_subs == {}
+    assert mgr._topic_subs == {}
+
+
+def test_churning_many_sessions_leaves_no_residue() -> None:
+    """The leak in #609 showed up as unbounded growth across a connection churn."""
+    mgr = SubscriptionManager()
+
+    for i in range(200):
+        conn_id = f"conn-{i}"
+        mgr.subscribe_messages(conn_id, f"sess-{i}")
+        mgr.subscribe_topic(conn_id, f"topic-{i}")
+        if i % 2:
+            mgr.unsubscribe_messages(conn_id, f"sess-{i}")
+            mgr.unsubscribe_topic(conn_id, f"topic-{i}")
+        else:
+            mgr.remove_connection(conn_id)
+
+    assert mgr._message_subs == {}
+    assert mgr._topic_subs == {}
+
+
+def test_message_and_topic_paths_prune_alike() -> None:
+    """Drift guard: the two dict-backed paths must stay symmetric (#609)."""
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "sess-a")
+    mgr.subscribe_topic("conn-1", "sess-a")
+
+    mgr.unsubscribe_messages("conn-1", "sess-a")
+    mgr.unsubscribe_topic("conn-1", "sess-a")
+    assert list(mgr._message_subs) == list(mgr._topic_subs) == []
+
+    mgr.subscribe_messages("conn-1", "sess-a")
+    mgr.subscribe_topic("conn-1", "sess-a")
+
+    mgr.remove_connection("conn-1")
+    assert list(mgr._message_subs) == list(mgr._topic_subs) == []


### PR DESCRIPTION
## Linked issue

Fixes #609

- [x] This pull request fully resolves the linked issue.

> **Note on overlap:** #610 is already open for this issue and its
> `remove_connection()` hunk is identical to mine — if a maintainer prefers it,
> close this one. The delta here is a broader regression suite (12 cases vs 2,
> including no-op safety, idempotence, re-subscribe-after-cleanup, a churn test,
> and a message/topic parity guard) plus a CHANGELOG entry.

## Summary

`SubscriptionManager._message_subs` maps a session key to the set of connection
ids watching it. Both removal paths discarded the connection id but left the
now-empty set behind:

- `unsubscribe_messages()` only called `discard()`.
- `remove_connection()` iterated `_message_subs.values()`, so it had no key to
  delete even when a set emptied.

A long-running gateway therefore accumulated one dead `session_key -> set()`
entry per distinct session key it had ever served. Growth is bounded by session
keys rather than connections, which is why this is p3 — but it never shrinks.

Both paths now delete the key once its last subscriber goes away, which is
exactly what the topic path (`unsubscribe_topic()` and the `empty_topics` sweep
in `remove_connection()`) already did. `remove_connection()` collects the
emptied keys and deletes them after the loop, matching the existing topic sweep
rather than mutating the dict mid-iteration.

**No observable behavior change for callers.** Every consumer
(`event_bridge.py`, `boot.py`, `rpc_sessions.py`) reads through
`get_message_subscribers()`, which already returns an empty set for a missing
key, so a pruned key and an empty-set key are indistinguishable from outside.

## Tests

New `tests/test_gateway/test_subscription_manager_cleanup.py` (12 cases):

- key is deleted when the last subscriber unsubscribes; kept while others remain
- unsubscribe touches only the named session key
- unsubscribe for an unknown key creates nothing (no phantom entry)
- unsubscribe by a non-subscriber leaves the set intact
- repeated unsubscribe is idempotent (no `KeyError`)
- re-subscribing after cleanup works
- `remove_connection()` prunes emptied keys, keeps shared ones, and still clears
  session- and topic-level subscriptions
- a 200-connection churn over subscribe/unsubscribe/disconnect leaves both
  `_message_subs` and `_topic_subs` empty
- drift guard: the message and topic paths prune alike

Verified the tests catch the bug — 8 of the 12 fail against unpatched
`websocket.py`, all 12 pass with the fix.

```
uv run ruff check src tests            # All checks passed!
uv run mypy src/agentos                # 1 error, pre-existing (mem0 missing stubs)
uv run pytest tests/test_gateway -q    # 1342 passed
uv run pytest -q                       # 8812 passed, 3 failed
```

The 3 full-suite failures are pre-existing environment gaps on this machine,
unrelated to this change: two mem0 tests that assert the module is *not*
installed (it is, under `--all-extras`) and `test_render_html_to_pdf`, which
needs weasyprint's system libraries.