### PR TITLE
fix(channels): quote the IMAP folder name per RFC 3501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   rate limit returns the response — status, headers and provider error body
   intact — instead of sleeping once more and raising a bare
   `RuntimeError("retry_request exhausted")` (#642, #599).
+- The email channel can poll an IMAP folder whose name contains spaces.
+  `imap_folder` was handed to `imaplib` verbatim, and `imaplib` does not quote
+  mailbox arguments, so a folder such as `Sent Items` — ordinary on
+  Exchange/Outlook — went on the wire as two tokens and every poll failed with
+  an opaque `BAD [CLIENTBUG] Invalid syntax`. The name is now emitted as an
+  RFC 3501 quoted-string, escaping `\` and `"`, and a name carrying a control
+  character (a CR or LF would have ended the command line and run its tail as a
+  second IMAP command) is refused at channel start instead of at poll time.
 - `SubscriptionManager._message_subs` now removes empty sets on
   unsubscription and connection teardown, preventing a slow memory leak
   on long-running gateways (#609).

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -108,6 +108,11 @@ Providers with two-factor authentication normally require an app password
 rather than the account password. Set `smtp_ssl=true` (and `smtp_port=465`)
 for implicit TLS; the default is STARTTLS on port 587.
 
+`imap_folder` picks the mailbox to poll and defaults to `INBOX`. Names with
+spaces (`Sent Items`, `Archive 2026`) are quoted per RFC 3501 before they go on
+the wire, so they need no quoting of your own; a name carrying a control
+character is rejected at channel start rather than at poll time.
+
 ### Access Control
 
 `allowed_senders` is a fail-closed From-address allowlist and is **required** —

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -208,6 +208,27 @@ def sender_allowed(sender: str, allowlist: list[str] | tuple[str, ...]) -> bool:
     return False
 
 
+def _quote_imap_mailbox(folder: str) -> str:
+    """Return ``folder`` as an RFC 3501 quoted-string for ``SELECT``.
+
+    ``imaplib`` splices command arguments onto the wire verbatim, so a name
+    with a space in it — ``Sent Items`` and friends are ordinary on
+    Exchange/Outlook — arrives as two tokens and the server answers ``BAD``.
+    RFC 3501 4.3 escapes only ``\\`` and ``"`` inside a quoted-string;
+    control characters cannot appear at all, and a bare CR/LF would end the
+    command line and let the tail of the name run as a second IMAP command, so
+    those are refused rather than escaped.
+    """
+
+    name = folder or ""
+    if not name.strip():
+        raise ValueError("email channel imap_folder must not be empty")
+    if any(char < " " or char == "\x7f" for char in name):
+        raise ValueError(f"email channel imap_folder must not contain control characters: {name!r}")
+    escaped = name.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def decode_header_value(value: str | None) -> str:
     """Decode an RFC 2047 header into text, degrading to the raw value."""
 
@@ -389,6 +410,9 @@ class EmailChannel:
                 "email channel requires a non-empty allowed_senders allowlist; "
                 "an open inbox would let any stranger drive the agent"
             )
+        # Surface an unusable folder name here instead of as an opaque server
+        # ``BAD`` once every poll interval.
+        _quote_imap_mailbox(self.config.imap_folder)
         if not self.config.imap_ssl:
             log.warning("email.imap_plaintext", name=self.config.name)
         if not (self.config.smtp_ssl or self.config.smtp_starttls):
@@ -465,7 +489,7 @@ class EmailChannel:
 
         client = self._imap_connect()
         try:
-            client.select(self.config.imap_folder)
+            client.select(_quote_imap_mailbox(self.config.imap_folder))
             status, data = client.search(None, "UNSEEN")
             if status != "OK":
                 raise RuntimeError(f"IMAP search failed: {status}")

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -17,6 +17,7 @@ from agentos.channels.email import (
     _DEFAULT_OUTBOUND_SUBJECT,
     EmailChannel,
     EmailChannelConfig,
+    _quote_imap_mailbox,
     html_to_text,
     is_automated,
     is_email_address,
@@ -504,9 +505,11 @@ class _FakeIMAP:
         self._raw = raw
         self._size = len(raw) if size is None else size
         self.stored: list[tuple[str, str, str]] = []
+        self.selected: list[str] = []
         self.closed = False
 
     def select(self, folder: str) -> tuple[str, list[bytes]]:
+        self.selected.append(folder)
         return "OK", [b"1"]
 
     def search(self, charset: Any, criteria: str) -> tuple[str, list[bytes]]:
@@ -573,6 +576,63 @@ def test_one_unreadable_message_does_not_sink_the_poll(
 
     assert calls == ["7", "8"]
     assert len(messages) == 1
+
+
+@pytest.mark.parametrize(
+    ("folder", "expected"),
+    [
+        ("INBOX", '"INBOX"'),
+        ("Sent Items", '"Sent Items"'),
+        ("INBOX/Archive 2026", '"INBOX/Archive 2026"'),
+        # RFC 3501 4.3: only backslash and double-quote are escaped in a
+        # quoted-string, and the escape is a backslash.
+        ('say "hi"', '"say \\"hi\\""'),
+        ("back\\slash", '"back\\\\slash"'),
+        ('mix "a\\b"', '"mix \\"a\\\\b\\""'),
+    ],
+)
+def test_quote_imap_mailbox_wraps_and_escapes(folder: str, expected: str) -> None:
+    assert _quote_imap_mailbox(folder) == expected
+
+
+@pytest.mark.parametrize("folder", ["", "   ", "In\rbox", "In\nbox", "In\x00box"])
+def test_quote_imap_mailbox_refuses_names_it_cannot_encode(folder: str) -> None:
+    # A bare CR/LF would end the command line and let the rest of the name run
+    # as a second IMAP command, so this has to raise rather than be escaped.
+    with pytest.raises(ValueError, match="imap_folder"):
+        _quote_imap_mailbox(folder)
+
+
+def test_poll_selects_a_folder_with_spaces_as_one_quoted_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config(imap_folder="Sent Items"))
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    channel._fetch_unseen()
+
+    assert fake.selected == ['"Sent Items"']
+
+
+def test_poll_selects_the_default_folder_quoted(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = EmailChannel(config=_config())
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    channel._fetch_unseen()
+
+    assert fake.selected == ['"INBOX"']
+
+
+@pytest.mark.parametrize("folder", ["", "Sent\r\nLOGOUT"])
+async def test_start_refuses_an_unusable_imap_folder(folder: str) -> None:
+    # Fail at start() with the offending value rather than as an opaque BAD
+    # once every poll interval.
+    channel = EmailChannel(config=_config(imap_folder=folder))
+
+    with pytest.raises(ValueError, match="imap_folder"):
+        await channel.start()
 
 
 def test_mark_seen_disabled_leaves_the_flag_alone(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #618.

## Problem

`EmailChannel._fetch_unseen()` passes `imap_folder` to `client.select()` verbatim, and `imaplib` does not quote mailbox arguments for the caller — `IMAP4._command()` splices each argument onto the wire as-is:

```python
for arg in args:
    if arg is None: continue
    if isinstance(arg, str):
        arg = bytes(arg, self._encoding)
    data = data + b' ' + arg
```

So a folder whose name contains a space — `Sent Items`, `Archive 2026`, `[Gmail]/All Mail`, all ordinary on Exchange/Outlook — goes out as two tokens:

```
A1 SELECT Sent Items\r\n
```

and the server answers `BAD [CLIENTBUG] Invalid syntax: unexpected argument`, so every poll fails. `imap_folder` defaults to `INBOX`, which is why this has not been hit before.

## Change

`_quote_imap_mailbox()` emits the name as an RFC 3501 §4.3 quoted-string:

```
A1 SELECT "Sent Items"\r\n
```

Addressing the two points raised in the issue thread:

- **Not a bare `f'"{folder}"'`.** `\` and `"` are escaped, so a folder literally named `say "hi"` or `back\slash` produces a well-formed quoted-string instead of a truncated or mis-parsed one. The escaping is byte-for-byte what `imaplib.IMAP4._quote` applies to the commands it does quote — verified against the stdlib for every case in the test table.
- **`select()` is the only `imaplib` call the configured folder reaches.** The other two references to `imap_folder` are an `access_snapshot()` field and a log field, neither of which touches the wire.

A control character cannot appear in a quoted-string at all, and a bare CR/LF would end the command line and let the tail of the name run as a **second IMAP command**, so a name carrying one is refused rather than escaped. `_validate_config()` runs the same check at `start()`, next to the existing `allowed_senders` refusal, so an unusable folder (empty, or with a control character) surfaces as a per-channel entry in `ChannelManager.start_errors()` instead of an opaque `BAD` once every poll interval. `start_all()` already isolates per-channel start failures, so this cannot take the gateway down.

## Tests

`tests/test_channels/test_email_channel.py`, all new:

- Parametrized quoting table: plain, spaces, hierarchy delimiter, embedded `"`, embedded `\`, and both together.
- Parametrized rejection: empty, whitespace-only, CR, LF, NUL.
- Two poll-path regressions asserting `_FakeIMAP` receives exactly `'"Sent Items"'` / `'"INBOX"'` (the fake now records what it was handed).
- `start()` refuses an empty folder and a `Sent\r\nLOGOUT` injection attempt.

Verified red→green: with the helper present but the two call sites reverted, the four behavioral tests fail and the rest pass; the failing run logs `email.started folder='Sent\r\nLOGOUT'`, showing the injection was reachable before this change.

## Verification

- `uv run pytest tests/test_channels -q` → 319 passed
- `uv run pytest -q` → **8815 passed**, 26 skipped, 3 failed — all three pre-existing on `main` and unrelated (`test_mem0_provider`/`test_provider_config`: `mem0` installed in this env; `test_render_html_to_pdf`: missing weasyprint system library)
- `uv run ruff check src tests` → clean; `ruff format --check` on both touched files → already formatted
- `uv run mypy src/agentos --show-error-codes` → 1 error, pre-existing and unrelated (`mem0_provider.py` missing library stubs)

Docs: added the `imap_folder` behaviour to the email section of `docs/channels.md` (the key was previously undocumented), plus a CHANGELOG entry under Unreleased → Fixed.

## Out of scope

A **non-ASCII** folder name (`Gelöschte Elemente` on a German Exchange) is quoted correctly here but still fails one level down: `imaplib` encodes command arguments with `self._encoding`, which is `ascii` until the server enables `UTF8=ACCEPT`, so it raises `UnicodeEncodeError`. Making that work needs modified-UTF-7 (RFC 2152/3501 §5.1.3) encoding, which is a separate change with its own compatibility questions — happy to open a follow-up issue if you want it tracked.

## Relationship to #626 and #621

Both target this issue. #626 takes the same always-quote-and-escape approach; #621 preserves already-quoted input and silently defaults an empty name to `INBOX`, which misreads a folder whose name genuinely contains a quote. This PR adds, on top of the quoting itself, the control-character refusal (the CR/LF command-injection path), the start-time validation so the failure is not deferred to poll time, the audit of every other `imaplib` call the value reaches, and the missing docs. Close whichever you prefer — no attachment to this one being the one that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kcta1pR32c4Z2jrXBNLD3Q