### PR TITLE
fix(tools): name the redirect that has no Location header in image fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/*`, `/*/*`, `/**`, `/?*`, `/.*` and `/[a-z]*`. Globs that name a subset
   (`/tmp*`) are untouched, and root counts as sensitive only in the
   delete-intent scan — reading or listing `/` stays ordinary work (#563).
+- The image tool now reports a redirect that carries no `Location` header
+  instead of the confusing failure it caused downstream. `_fetch_image_url`
+  follows redirects itself so every hop is re-validated against the SSRF guard;
+  a 3xx with no `Location` closed the response and fell out of the loop, so the
+  failure surfaced as httpx's generic `Failed to fetch image from URL: Redirect
+  response '302 Found' for url ...` (or a `StreamClosed` from reading the body
+  that had just been closed, depending on the httpx version) rather than the
+  dead-end hop that actually broke. It now raises `Redirect response from <url>
+  missing Location header`, naming the URL that returned it.
 - Channel HTTP retries now cover every transient timeout, survive an
   HTTP-date `Retry-After`, and hand back an exhausted rate limit.
   `retry_request` caught `(ConnectError, ReadTimeout)`, but `ConnectTimeout`,

--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -310,7 +310,11 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
                 location = resp.headers.get("location")
                 await resp.aclose()
                 if not location:
-                    break
+                    # A redirect with no Location is a dead end: nothing to
+                    # follow, and the body was just closed. Falling through
+                    # leaves the reader on a closed 3xx stream, which reports
+                    # httpx's generic error instead of the hop that broke.
+                    raise ToolError(f"Redirect response from {current_url} missing Location header")
                 current_url = urljoin(str(resp.url), location)
             else:
                 raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")

--- a/tests/test_tools/test_media_image_redirects.py
+++ b/tests/test_tools/test_media_image_redirects.py
@@ -1,0 +1,136 @@
+"""Regression tests for redirect handling in the media image fetcher.
+
+`_fetch_image_url` follows redirects by hand so every hop is re-validated
+against the SSRF guard. A redirect whose `Location` header is missing used to
+close the response and `break` out of the loop, leaving the 3xx to be reported
+by whatever failed first downstream: httpx's generic
+"Redirect response '302 Found' for url ..." from `raise_for_status()`, or a
+`StreamClosed` from reading the body that was just closed. Neither names the
+malformed hop, so a dead-end redirect now gets its own message; the hop budget
+around it has to keep working.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from agentos.tools.builtin.media import _MAX_REDIRECTS, _fetch_image_url
+from agentos.tools.types import ToolError
+
+
+def _png_bytes() -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+def _patch_network(monkeypatch: pytest.MonkeyPatch, handler: object) -> None:
+    real = httpx.AsyncClient
+
+    def factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)  # type: ignore[attr-defined]
+        return real(*args, transport=httpx.MockTransport(handler), **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "socket.getaddrinfo", lambda h, p, **k: [(2, 1, 6, "", ("93.184.216.34", 0))]
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+@pytest.mark.asyncio
+async def test_redirect_without_location_reports_the_malformed_redirect(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """A `Location`-less redirect names the URL and the missing header."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, headers={})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError) as exc_info:
+        await _fetch_image_url("https://example.com/test.png")
+
+    message = str(exc_info.value)
+    assert "https://example.com/test.png" in message
+    assert "Location" in message
+    # Not httpx's generic redirect/stream complaint wrapped by the caller.
+    assert "Failed to fetch image from URL" not in message
+
+
+@pytest.mark.asyncio
+async def test_redirect_without_location_mid_chain_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The malformed hop is named, not the URL the caller passed in."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/start.png":
+            return httpx.Response(302, headers={"location": "/broken.png"})
+        return httpx.Response(302, headers={})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError) as exc_info:
+        await _fetch_image_url("https://example.com/start.png")
+
+    assert "https://example.com/broken.png" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_redirect_with_location_is_followed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A well-formed redirect chain still resolves to the final image."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/start":
+            return httpx.Response(302, headers={"location": "/final.png"})
+        return httpx.Response(200, headers={"content-type": "image/png"}, content=_png_bytes())
+
+    _patch_network(monkeypatch, handler)
+
+    data, mime = await _fetch_image_url("https://example.com/start")
+    assert mime == "image/png"
+    assert data == _png_bytes()
+
+
+@pytest.mark.asyncio
+async def test_redirect_chain_beyond_the_budget_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One hop past `_MAX_REDIRECTS` stops with the hop-budget error."""
+
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        hop = len(seen)
+        return httpx.Response(302, headers={"location": f"/hop{hop}.png"})
+
+    _patch_network(monkeypatch, handler)
+
+    with pytest.raises(ToolError) as exc_info:
+        await _fetch_image_url("https://example.com/start.png")
+
+    assert f"Too many redirects (>{_MAX_REDIRECTS})" in str(exc_info.value)
+    assert len(seen) == _MAX_REDIRECTS + 1
+
+
+@pytest.mark.asyncio
+async def test_last_allowed_redirect_still_delivers_the_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hop budget is off-by-one free: `_MAX_REDIRECTS` hops still succeed."""
+
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if len(seen) <= _MAX_REDIRECTS:
+            return httpx.Response(302, headers={"location": f"/hop{len(seen)}.png"})
+        return httpx.Response(200, headers={"content-type": "image/png"}, content=_png_bytes())
+
+    _patch_network(monkeypatch, handler)
+
+    data, mime = await _fetch_image_url("https://example.com/start.png")
+    assert mime == "image/png"
+    assert data == _png_bytes()


### PR DESCRIPTION
### Problem

`_fetch_image_url` follows redirects by hand (`follow_redirects=False`) so every
hop can be re-validated against the SSRF guard. When a hop answered 3xx with no
`Location` header, the loop closed the response and `break`ed out of it:

```python
location = resp.headers.get("location")
await resp.aclose()
if not location:
    break
```

`break` lands on `resp.raise_for_status()` / `resp.aiter_bytes(...)` holding a
3xx response whose stream is already closed, so the caller is told something
other than what went wrong.

### One correction to the issue report

On the httpx range this project pins (`httpx>=0.27,<0.29`, 0.28.1 in the lock),
`raise_for_status()` **does** raise on a 3xx — it only returns early for
`is_success` — so the body read on the closed stream is never reached and the
actual symptom is:

```
ToolError: Failed to fetch image from URL: Redirect response '302 Found' for url 'https://example.com/test.png'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
```

not the `StreamClosed` in the report (that is what older httpx, whose
`raise_for_status` fired only on 4xx/5xx, produced). The user-visible defect is
the same either way — the message describes httpx's plumbing instead of the
malformed hop — and so is the fix. Flagging it so the tests assert what the code
really does; a test written against the `StreamClosed` string would pass for the
wrong reason.

### Fix

A `Location`-less redirect is a dead end, so it raises instead of falling
through, naming the URL that returned it (the wording the issue asked for):

```
ToolError: Redirect response from https://example.com/test.png missing Location header
```

The raise sits inside the existing `try`, whose `except ToolError: raise` passes
it through unwrapped, and the response is already closed on the line above, so
no stream is leaked.

### The `_MAX_REDIRECTS` exhaustion path

Checked as the triage comment asked — it is correct and stays that way. The loop
runs `range(_MAX_REDIRECTS + 1)`, so `_MAX_REDIRECTS` hops are followed and the
next redirect falls out of the loop into
`ToolError("Too many redirects (>5)")`; every redirect response is closed in the
body before that. Both edges are now pinned by tests rather than left to
inspection.

### Tests

`tests/test_tools/test_media_image_redirects.py` (new, 9 cases):

- a `Location`-less 301/302/303/307/308 raises a `ToolError` naming the URL and
  the missing header, and not httpx's generic wrapper (5 params)
- a malformed hop mid-chain names *that* hop, not the URL the caller passed
- a well-formed redirect is still followed to the image
- one hop past `_MAX_REDIRECTS` raises `Too many redirects (>5)` after exactly
  `_MAX_REDIRECTS + 1` requests
- a chain of exactly `_MAX_REDIRECTS` hops still delivers the image

The first six fail on `main` and pass with the fix; the two budget tests pass
either way and exist to keep the off-by-one honest.

### Verification

```
uv run --all-extras ruff check src tests            # All checks passed!
uv run --all-extras mypy src/agentos                # 1 pre-existing error (mem0 stubs), unchanged
uv run --all-extras pytest tests/test_tools -q      # 904 passed
uv run --all-extras pytest -q                       # 8809 passed, 3 pre-existing failures (mem0 x2, html-to-pdf)
```

### Scope note

The other two hand-rolled redirect loops were checked while in here and need no
change: `skills/hub/deps.py` already raises on a missing `Location`, and
`web_fetch.py` leaves its response **open** on that branch, so it returns the
3xx body with its status instead of crashing.

### Relative to the open PRs

#633 and #619 make the same one-line change. This one adds the correction about
which httpx error actually surfaces (so the tests assert real behaviour), covers
all five redirect statuses and the mid-chain case, and pins the `_MAX_REDIRECTS`
edges the triage comment asked about. Happy for a maintainer to take whichever
is easiest to land.

Fixes #616
