### PR TITLE
fix(provider): include bankr in OpenAI-compatible failure classification (#775)

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -32,6 +32,7 @@ class ProviderRecoveryAction(StrEnum):
 
 
 _OPENAI_COMPAT_PROVIDERS = {
+    "bankr",
     "opencap",
     "openrouter",
     "openai",
@@ -53,6 +54,8 @@ _OPENAI_COMPAT_PROVIDERS = {
     "vllm",
     "lm_studio",
     "ovms",
+    "volcengine_coding_plan",
+    "byteplus_coding_plan",
 }
 
 _GATEWAY_TRANSIENT_STATUS_CODES = {499, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529}

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -93,3 +93,32 @@ def test_anthropic_request_size_exceeds_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+
+def test_bankr_provider_error_classification() -> None:
+    """Verify bankr errors use OpenAI-compatible classification."""
+    assert (
+        classify_provider_error(
+            provider_name="bankr",
+            status_code=401,
+            message="Unauthorized",
+        )
+        is ProviderFailureKind.AUTH_INVALID
+    )
+    assert (
+        classify_provider_error(
+            provider_name="bankr",
+            status_code=402,
+            message="Insufficient credits",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+    assert (
+        classify_provider_error(
+            provider_name="bankr",
+            status_code=429,
+            message="Rate limit exceeded",
+        )
+        is ProviderFailureKind.RATE_LIMITED
+    )
+


### PR DESCRIPTION
classify_provider_error in src/agentos/provider/failures.py determines OpenAI-compatible failure classification by checking if provider_name is present in _OPENAI_COMPAT_PROVIDERS.

bankr uses the openai_compat backend spec in registry.py, but was omitted from _OPENAI_COMPAT_PROVIDERS. As a result, HTTP status code failures from Bankr (such as 401 Unauthorized or 402 Insufficient Credits) fell through to ProviderFailureKind.UNKNOWN rather than AUTH_INVALID / INSUFFICIENT_CREDITS, preventing decide_recovery_action from triggering FAIL_CONFIG or FALLBACK_PROVIDER.

This PR adds bankr (along with volcengine_coding_plan and byteplus_coding_plan) to _OPENAI_COMPAT_PROVIDERS and adds public regression unit tests in tests/test_provider_failures.py.

Fixes #775