### PR TITLE
fix(provider): classify credit/quota exhaustion errors as INSUFFICIENT_CREDITS (#777)

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -122,6 +122,24 @@ def _is_empty_response(raw_code: str, message: str) -> bool:
     }
 
 
+def _is_insufficient_credits(text: str) -> bool:
+    return any(
+        marker in text
+        for marker in (
+            # OpenAI / OpenAI-compatible providers
+            "insufficient_quota",
+            "insufficient quota",
+            "exceeded your current quota",
+            # Anthropic
+            "billing_error",
+            "credit balance is too low",
+            # Common across gateways
+            "billing hard limit",
+            "exceeded spend limit",
+        )
+    )
+
+
 def _is_gateway_transient(text: str) -> bool:
     return bool(_GATEWAY_TRANSIENT_RE.search(text))
 
@@ -143,6 +161,8 @@ def classify_provider_error(
         return ProviderFailureKind.POLICY_REFUSAL
     if _is_empty_response(raw_code, message):
         return ProviderFailureKind.EMPTY_RESPONSE
+    if _is_insufficient_credits(text):
+        return ProviderFailureKind.INSUFFICIENT_CREDITS
 
     if provider in _OPENAI_COMPAT_PROVIDERS:
         if status_code in {401, 403} or "invalid api key" in text or "unauthorized" in text:
@@ -167,6 +187,8 @@ def classify_provider_error(
     if provider in {"anthropic", "minimax", "minimax_cn", "minimax_global"}:
         if status_code in {401, 403} or "authentication_error" in text:
             return ProviderFailureKind.AUTH_INVALID
+        if status_code == 402 or "billing_error" in text:
+            return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate_limit_error" in text:
             return ProviderFailureKind.RATE_LIMITED
         if status_code in _GATEWAY_TRANSIENT_STATUS_CODES or "overloaded_error" in text:

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -93,3 +93,93 @@ def test_anthropic_request_size_exceeds_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+
+# ── INSUFFICIENT_CREDITS regressions ─────────────────────────────────
+
+
+def test_openai_insufficient_quota_429_is_credits() -> None:
+    """OpenAI returns insufficient_quota with HTTP 429.
+
+    Before this fix the 429 status code was caught by the rate-limit check
+    first, misclassifying the error as RATE_LIMITED.  RATE_LIMITED is a
+    circuit-breaker-tripping kind; INSUFFICIENT_CREDITS is not, so the
+    misclassification could park a healthy provider for a billing fault
+    that a cooldown can never heal.
+    """
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            raw_code="insufficient_quota",
+            message=(
+                "You exceeded your current quota, please check your plan "
+                "and billing details."
+            ),
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_openai_exceeded_quota_message_is_credits() -> None:
+    """Quota message without the raw code should still be caught."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            message="You exceeded your current quota.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_anthropic_billing_error_402_is_credits() -> None:
+    """Anthropic billing_error with HTTP 402 was previously UNKNOWN."""
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=402,
+            raw_code="billing_error",
+            message="Your credit balance is too low to access the Anthropic API.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_anthropic_credit_balance_too_low_is_credits() -> None:
+    """Anthropic credit balance message without status code should match."""
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=None,
+            message="Your credit balance is too low to access the Anthropic API.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_openrouter_insufficient_quota_is_credits() -> None:
+    """Same insufficient_quota pattern routed through OpenRouter."""
+    assert (
+        classify_provider_error(
+            provider_name="openrouter",
+            status_code=429,
+            raw_code="insufficient_quota",
+            message="You exceeded your current quota.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_deepseek_insufficient_quota_is_credits() -> None:
+    """DeepSeek quota exhaustion should not be classified as RATE_LIMITED."""
+    assert (
+        classify_provider_error(
+            provider_name="deepseek",
+            status_code=429,
+            raw_code="insufficient_quota",
+            message="Insufficient quota to complete the request.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+


### PR DESCRIPTION
## Summary

`classify_provider_error` misclassifies credit/quota exhaustion errors from OpenAI and Anthropic, causing incorrect circuit breaker behavior and wrong operator-facing failure kinds.

Fixes #777

## Problem

| Provider | Error | HTTP | Was | Now |
|---|---|---|---|---|
| OpenAI | `insufficient_quota` | 429 | `RATE_LIMITED` ❌ | `INSUFFICIENT_CREDITS` ✅ |
| OpenRouter | `insufficient_quota` | 429 | `RATE_LIMITED` ❌ | `INSUFFICIENT_CREDITS` ✅ |
| DeepSeek | `insufficient_quota` | 429 | `RATE_LIMITED` ❌ | `INSUFFICIENT_CREDITS` ✅ |
| Anthropic | `billing_error` | 402 | `UNKNOWN` ❌ | `INSUFFICIENT_CREDITS` ✅ |

**Root cause**: OpenAI sends `insufficient_quota` with HTTP 429. The classifier's `status_code == 429` check (rate-limit) fires before any quota/credit marker, so the rate-limit branch wins. Anthropic's branch has no check for HTTP 402 or `billing_error` at all.

**Impact**: `RATE_LIMITED` is a circuit-breaker-tripping kind; `INSUFFICIENT_CREDITS` is intentionally excluded from tripping kinds (see `circuit_breaker.py` L44). The misclassification parks a healthy provider for a billing fault that a cooldown can never heal.

## Changes

### `src/agentos/provider/failures.py`

- **Add `_is_insufficient_credits()` helper**: Cross-provider pre-classification check (same pattern as `_is_context_overflow` and `_is_policy_refusal`). Matches `insufficient_quota`, `exceeded your current quota`, `billing_error`, `credit balance is too low`, `billing hard limit`, `exceeded spend limit`.
- **Insert pre-check**: Runs after context-overflow/policy-refusal/empty-response and **before** provider-specific branches, so `insufficient_quota` + HTTP 429 is correctly caught before the rate-limit status-code check.
- **Anthropic branch**: Add `status_code == 402 or "billing_error" in text` → `INSUFFICIENT_CREDITS`.

### `tests/test_provider_failures.py`

6 regression tests covering each misclassification scenario:
- `test_openai_insufficient_quota_429_is_credits`
- `test_openai_exceeded_quota_message_is_credits`
- `test_anthropic_billing_error_402_is_credits`
- `test_anthropic_credit_balance_too_low_is_credits`
- `test_openrouter_insufficient_quota_is_credits`
- `test_deepseek_insufficient_quota_is_credits`

## Verification

```
uv run pytest tests/test_provider_failures.py -q   # 13 passed
uv run pytest tests/test_engine -q                  # 1015 passed
uv run ruff check src/agentos/provider/failures.py  # All checks passed
uv run mypy src/agentos/provider/failures.py        # Success: no issues
```

Backward-compatible: existing classifications are not changed; only previously-wrong ones are corrected.
