### PR TITLE
fix(provider): classify provider content-filter blocks as POLICY_REFUSAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   it was written to keep short. Backslashes are normalised before splitting, so
   Windows and mixed-separator paths trim to their last two segments like POSIX
   ones do.
+- Provider content-moderation blocks are classified as `POLICY_REFUSAL` again
+  instead of falling through to `BAD_REQUEST`/`UNKNOWN`. `_is_policy_refusal()`
+  held only generic phrasing, so the wording providers actually emit went
+  unmatched: Azure OpenAI's canonical *"triggering Azure OpenAI's content
+  management policy"* does not contain the adjacent words "content policy", the
+  OpenAI/Azure `content_filter` code and `finish_reason` matched nothing, and
+  Gemini's "blocked by safety" is not "safety policy". Since a refusal and a
+  malformed request map to different recovery actions, the misclassification
+  sent real policy blocks down the wrong path. Added `content_filter`,
+  `content filter`, `responsible_ai_policy`, `content management policy` and
+  `blocked by safety` (#629).
+
 - Cron schedules that restrict both day-of-month and day-of-week now follow the
   POSIX OR rule instead of ANDing the two fields. `0 0 1,15 * 5` means "the 1st,
   the 15th, or any Friday" — as it does in cron, croniter, and every scheduler

--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -109,6 +109,17 @@ def _is_policy_refusal(text: str) -> bool:
             "moderation",
             "refusal",
             "blocked by policy",
+            # Azure OpenAI / OpenAI error code and finish_reason
+            "content_filter",
+            # e.g. "flagged by content filter"
+            "content filter",
+            # Azure responsible AI policy code
+            "responsible_ai_policy",
+            # Azure OpenAI canonical phrasing; "content" and "policy" are not
+            # adjacent here, so "content policy" above does not cover it
+            "content management policy",
+            # Google Gemini block reason
+            "blocked by safety",
         )
     )
 

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -337,3 +337,92 @@ def test_ollama_transport_messages_classify_as_transport_transient(message: str)
         classify_provider_error("ollama", None, message=message)
         is ProviderFailureKind.TRANSPORT_TRANSIENT
     )
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message"),
+    [
+        # Azure OpenAI: canonical content-management-policy wording. Note the words
+        # "content" and "policy" are not adjacent, so the pre-existing
+        # "content policy" marker never fired on this message.
+        (
+            "azure",
+            400,
+            "content_filter",
+            "The response was filtered due to the prompt triggering Azure OpenAI's "
+            "content management policy. Please modify your prompt and retry.",
+        ),
+        # OpenAI/Azure error code and finish_reason.
+        ("openai", 400, "content_filter", "The response was filtered"),
+        # Azure responsible AI policy code.
+        (
+            "azure",
+            400,
+            "responsible_ai_policy",
+            "Your request was rejected by the responsible_ai_policy filter.",
+        ),
+        # "content filter" spelled with a space, e.g. "flagged by content filter".
+        ("openai", 400, "", "This prompt was flagged by content filter."),
+        # Google Gemini block reason.
+        ("gemini", 400, "", "Candidate blocked by safety settings."),
+    ],
+)
+def test_provider_specific_policy_markers_classify_as_policy_refusal(
+    provider: str,
+    status_code: int,
+    raw_code: str,
+    message: str,
+) -> None:
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is ProviderFailureKind.POLICY_REFUSAL
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message", "expected"),
+    [
+        # A plain bad request must not be swept up by the new markers.
+        (
+            "openai",
+            400,
+            "invalid_request_error",
+            "Unsupported parameter: 'max_tokens'.",
+            ProviderFailureKind.UNSUPPORTED_FEATURE,
+        ),
+        (
+            "azure",
+            400,
+            "invalid_request_error",
+            "Missing required parameter: 'messages'.",
+            ProviderFailureKind.BAD_REQUEST,
+        ),
+        # Rate limits stay rate limits.
+        (
+            "openai",
+            429,
+            "rate_limit_exceeded",
+            "Rate limit reached for gpt-4o.",
+            ProviderFailureKind.RATE_LIMITED,
+        ),
+        # Context overflow is checked before policy refusal and stays put.
+        (
+            "openai",
+            400,
+            "context_length_exceeded",
+            "This model's maximum context length is 128000 tokens.",
+            ProviderFailureKind.CONTEXT_OVERFLOW,
+        ),
+    ],
+)
+def test_policy_markers_do_not_capture_unrelated_failures(
+    provider: str,
+    status_code: int,
+    raw_code: str,
+    message: str,
+    expected: ProviderFailureKind,
+) -> None:
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is expected
+    )


### PR DESCRIPTION
Fixes #629.

## Problem

`_is_policy_refusal()` in `src/agentos/provider/failures.py` held only generic phrasing, so the wording providers actually emit for a moderation block went unmatched and fell through to `BAD_REQUEST` or `UNKNOWN`. Since `POLICY_REFUSAL` and `BAD_REQUEST` map to different `ProviderRecoveryAction`s, real policy blocks were sent down the wrong recovery path.

## Change

Adds the five markers agreed in the issue review:

| Marker | Why the existing list missed it |
| --- | --- |
| `content management policy` | Azure's canonical wording is *"…triggering Azure OpenAI's content management policy"*. The words "content" and "policy" are **not adjacent**, so the existing `content policy` marker never fired on it. |
| `content_filter` | The OpenAI/Azure error code and `finish_reason`. Matched nothing. |
| `content filter` | The spaced form, e.g. "flagged by content filter". |
| `responsible_ai_policy` | Azure's policy-violation code. |
| `blocked by safety` | Gemini's block reason; the existing `safety policy` does not cover it. |

`flagged by content filter` from the original proposal is **deliberately omitted**, per the maintainer's review on the issue: it can never fire independently of `content filter`, and a substring list should not carry entries that are dead by construction. (This is the one difference from #630, which still carries it.)

## Tests

- `test_provider_specific_policy_markers_classify_as_policy_refusal` — one case per new marker, using realistic provider payloads (Azure's full filtered-response sentence, Gemini's candidate-blocked message, the bare `content_filter` code).
- `test_policy_markers_do_not_capture_unrelated_failures` — guardrails asserting the wider matching does not swallow neighbouring cases: an unsupported parameter still classifies as `UNSUPPORTED_FEATURE`, a missing parameter as `BAD_REQUEST`, a 429 as `RATE_LIMITED`, and a context-length error as `CONTEXT_OVERFLOW`.

All 5 marker tests fail on `main` and pass with the patch; the 4 guardrail tests pass both before and after, so they hold the blast radius rather than just restating the fix.

## Verification

- `pytest tests/test_provider_failure_classification.py tests/test_provider_failures.py` → 113 passed
- Full suite (`uv run --all-extras pytest tests/`) → **8817 passed**, 26 skipped, 3 failed. The 3 failures (`test_mem0_provider`, `test_provider_config`, `test_render_html_to_pdf`) are pre-existing on `main` and unrelated.
- `ruff check` clean; `mypy src/agentos/provider/failures.py` clean.
- No CLI surface, flags, config keys, ports or paths changed, so `SKILL.md` / `docs/cli.md` need no update.

Note: `ruff format --check` reports pre-existing drift in `tests/test_provider_failure_classification.py` on `main` itself. I let it reformat, then reverted the three unrelated hunks so this diff stays pure additions (+100, −0); the appended block itself is format-clean.

CHANGELOG updated under `[Unreleased]` → `Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D1Huj3pxLsXLCfwwEQNo1