### PR TITLE
fix(cli): write UTF-8 bytes to stream buffer for JSON output

### DIFF
--- a/src/agentos/cli/agents_cmd.py
+++ b/src/agentos/cli/agents_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
@@ -14,14 +13,11 @@ from rich.console import Console
 from rich.table import Table
 
 from agentos.agents.registry import AgentRegistry
+from agentos.cli.output import print_json
 from agentos.onboarding.config_store import default_config_path, load_config, persist_config
 from agentos.session.keys import normalize_agent_id
 
 agents_app = typer.Typer(help="Manage durable agents.")
-
-
-def _print_json(payload: Any) -> None:
-    typer.echo(json.dumps(payload, ensure_ascii=False, default=str))
 
 
 def _print_restart_notice() -> None:
@@ -59,7 +55,7 @@ def agents_list(
     agents = asyncio.run(registry.list_agents(include_builtin=True))
 
     if json_output:
-        _print_json(agents)
+        print_json(agents)
         return
 
     console = Console(width=200, force_terminal=False)
@@ -109,7 +105,7 @@ def agents_add(
 
     persist = _persist_agents_config(cfg, target, quiet=json_output)
     if json_output:
-        _print_json(agent)
+        print_json(agent)
         return
 
     typer.echo(f"Agent saved: {agent['id']}")
@@ -144,7 +140,7 @@ def agents_delete(
         "stateDeleted": False,
     }
     if json_output:
-        _print_json(payload)
+        print_json(payload)
         return
 
     typer.echo(f"Agent deleted: {agent_id}")

--- a/src/agentos/cli/output.py
+++ b/src/agentos/cli/output.py
@@ -3,15 +3,47 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
 
 import typer
 
 
+def _safe_echo_utf8(text: str, *, err: bool = False) -> None:
+    """Write *text* as a complete UTF-8 line, surviving non-UTF-8 streams.
+
+    Primary path: encode to UTF-8 and write raw bytes to the underlying
+    ``sys.stdout.buffer`` (or ``sys.stderr.buffer``).  This bypasses the
+    stream's own encoding so non-ASCII characters are never mangled by a
+    narrow code-page (cp1252 / cp437 on Windows).
+
+    Fallback: when ``.buffer`` is absent — which happens under pytest's
+    ``capsys``, Click's ``CliRunner``, or any other wrapper that replaces
+    the standard streams with pure-Python ``StringIO`` objects — we write
+    through the text stream with ``errors="replace"`` so the JSON contract
+    (one payload, one line, on stdout) survives even if individual
+    characters are substituted with U+FFFD.
+    """
+    stream = sys.stderr if err else sys.stdout
+    buf = getattr(stream, "buffer", None)
+    if buf is not None:
+        buf.write(text.encode("utf-8"))
+        buf.write(b"\n")
+        buf.flush()
+    else:
+        # capsys / CliRunner — no raw buffer available.
+        # Re-encode through the text stream; replace un-encodable chars
+        # rather than crashing.
+        encoded = text.encode(stream.encoding or "utf-8", errors="replace")
+        stream.write(encoded.decode(stream.encoding or "utf-8", errors="replace"))
+        stream.write("\n")
+        stream.flush()
+
+
 def print_json(payload: Any) -> None:
     """Print JSON payload to stdout using the AgentOS CLI contract."""
 
-    typer.echo(json.dumps(payload, ensure_ascii=False, default=str))
+    _safe_echo_utf8(json.dumps(payload, ensure_ascii=False, default=str))
 
 
 def error_payload(
@@ -40,7 +72,7 @@ def emit_error(
     """Emit an error to stderr without polluting JSON stdout."""
 
     if json_output:
-        typer.echo(
+        _safe_echo_utf8(
             json.dumps(
                 error_payload(message, code=code, details=details),
                 ensure_ascii=False,

--- a/tests/test_cli/test_output_helpers.py
+++ b/tests/test_cli/test_output_helpers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import io
 import json
+import sys
 
 from agentos.cli.output import emit_error, print_json
 
@@ -27,3 +29,64 @@ def test_emit_error_json_uses_stderr(capsys):
             "details": {"field": "x"},
         }
     }
+
+
+def test_print_json_survives_latin1_buffer_stream(monkeypatch):
+    """Simulate Windows cp1252/latin-1 terminal with a raw underlying buffer.
+
+    Ensures UTF-8 bytes containing non-ASCII characters (em-dash, emoji, non-Latin)
+    are written directly to the buffer rather than raising UnicodeEncodeError.
+    """
+    raw_buffer = io.BytesIO()
+    # A TextIOWrapper with latin-1 encoding will fail if text is written through it,
+    # but print_json should write raw UTF-8 bytes to raw_buffer.
+    text_stream = io.TextIOWrapper(raw_buffer, encoding="latin-1")
+    monkeypatch.setattr(sys, "stdout", text_stream)
+
+    test_payload = {
+        "title": "Fix — em-dash & 日本語 & 🚀",
+        "description": "Unicode test string",
+    }
+    print_json(test_payload)
+
+    raw_buffer.seek(0)
+    data = raw_buffer.read().decode("utf-8")
+    assert json.loads(data) == test_payload
+
+
+def test_emit_error_json_survives_latin1_buffer_stream(monkeypatch):
+    """Simulate Windows cp1252/latin-1 stderr with a raw underlying buffer."""
+    raw_buffer = io.BytesIO()
+    text_stream = io.TextIOWrapper(raw_buffer, encoding="latin-1")
+    monkeypatch.setattr(sys, "stderr", text_stream)
+
+    emit_error("Crash — 💥 non-ASCII error", json_output=True, code="TEST_CODE")
+
+    raw_buffer.seek(0)
+    data = raw_buffer.read().decode("utf-8")
+    payload = json.loads(data)
+    assert payload["error"]["message"] == "Crash — 💥 non-ASCII error"
+    assert payload["error"]["code"] == "TEST_CODE"
+
+
+def test_print_json_fallback_without_buffer_replaces_unencodable(monkeypatch):
+    """Simulate a buffer-less stream with restricted encoding (e.g. ascii StringIO).
+
+    When .buffer is absent and encoding cannot represent characters,
+    errors='replace' ensures a valid line is still produced without raising.
+    """
+
+    class RestrictedStringIO(io.StringIO):
+        @property
+        def encoding(self) -> str:
+            return "ascii"
+
+    restricted_stream = RestrictedStringIO()
+    monkeypatch.setattr(sys, "stdout", restricted_stream)
+
+    print_json({"title": "Fix — em-dash"})
+    output = restricted_stream.getvalue()
+    # Line ends with newline and is valid JSON despite character replacement
+    assert output.endswith("\n")
+    payload = json.loads(output)
+    assert "Fix" in payload["title"]


### PR DESCRIPTION
Fixes #764

### Summary
When CLI commands emit JSON output with \--json\ (e.g. \skills list\, \cron list\, \channels\, \gents\), non-ASCII characters (such as em-dashes \—\, emojis, or non-Latin text in descriptions/titles) trigger \UnicodeEncodeError\ on terminals with non-UTF-8 default encodings (e.g. Windows cp1252 / cp437).

### Solution
- Added \_safe_echo_utf8\ in [output.py](file:///c:/laragon/www/agent-os/src/agentos/cli/output.py) which writes raw UTF-8 bytes to \sys.stdout.buffer\ / \sys.stderr.buffer\ when available.
- Added a fallback with \rrors='replace'\ when \.buffer\ is absent (e.g., under pytest \capsys\ or Click's \CliRunner\) so that the JSON contract (one payload, one newline) remains intact without crashing.
- Updated \print_json\ and \mit_error\ to use \_safe_echo_utf8\.
- Consolidated the duplicate \_print_json\ helper in [agents_cmd.py](file:///c:/laragon/www/agent-os/src/agentos/cli/agents_cmd.py) to use the shared \print_json\.
- Added unit tests in [test_output_helpers.py](file:///c:/laragon/www/agent-os/tests/test_cli/test_output_helpers.py) verifying latin-1 stream buffers and fallback behavior.