### PR TITLE
fix(memory): retry files whose index_file() call failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   "next runs" preview (`frontend/src/views/cron/logic.ts`) has always applied
   the OR rule — so the times it showed disagreed with when the job actually
   fired. ([#660](https://github.com/use-agent-os/agent-os/issues/660))
+- `MemorySyncManager` retries a file whose indexing failed instead of losing it
+  until the next edit. `_do_file_sync()` replaced `_mtimes` with the fresh scan
+  *before* the index loop ran, so by the time `store.index_file()` raised, the
+  failing path was already recorded as seen — the next watcher tick compared
+  equal, the path never entered `changes`, and the retry its docstring promised
+  never happened. A transient store error (SQLite lock, provider timeout) on
+  `MEMORY.md` therefore left searches running against a stale or missing index
+  for that file until it was modified again or the process restarted. Index
+  failures now come back from `_do_file_sync()` alongside the existing delete
+  failures and are re-enqueued into `_pending_changes`, keeping the manager
+  dirty until a retry succeeds. The initial `start()` pass re-enqueues too,
+  where `_mtimes` is empty and the watcher diff could never have recovered the
+  path (#638).
 
 ## [2026.9.2] - 2026-09-02
 

--- a/src/agentos/memory/sync_manager.py
+++ b/src/agentos/memory/sync_manager.py
@@ -43,6 +43,21 @@ class SessionDeltaTracker:
         self._pending_messages = 0
 
 
+@dataclass(frozen=True)
+class FileSyncFailures:
+    """Paths a single ``_do_file_sync()`` pass could not apply to the store.
+
+    Both sets are re-enqueued by the caller so a transient store error
+    (SQLite lock, provider timeout) does not drop the path forever.
+    """
+
+    failed_changes: frozenset[str] = frozenset()
+    failed_deletes: frozenset[str] = frozenset()
+
+    def __bool__(self) -> bool:
+        return bool(self.failed_changes or self.failed_deletes)
+
+
 class MemorySyncManager:
     """Manages all memory sync triggers through a unified sync() entry point.
 
@@ -116,8 +131,12 @@ class MemorySyncManager:
         #    embedding content we are about to throw away.
         if self._ttl_enabled():
             await self._do_ttl_sweep(initial=True)
-        # 2. THEN initial sync — surviving files get indexed.
-        await self._do_file_sync()
+        # 2. THEN initial sync — surviving files get indexed. _mtimes is
+        #    empty here, so a file whose index fails now would never be
+        #    rediscovered by the watcher diff; re-enqueue it explicitly.
+        initial_failures = await self._do_file_sync()
+        if initial_failures:
+            self._requeue(initial_failures, reason="initial")
         await self._do_session_sync(reason="initial")
         # 3. Now start background loops.
         self._poll_task = asyncio.create_task(self._poll_loop())
@@ -145,11 +164,12 @@ class MemorySyncManager:
     async def sync(self, reason: str, *, force: bool = False) -> None:
         """Unified sync entry point.
 
-        Re-enqueues ``store.remove_file`` failures into
-        ``_pending_deletes`` so a transient SQLite lock does not lose
-        the path forever. Without this the first watcher tick would clear
-        the queue regardless of outcome and orphan SQLite chunks for any
-        path whose retry also failed.
+        Re-enqueues ``store.index_file`` failures into ``_pending_changes``
+        and ``store.remove_file`` failures into ``_pending_deletes`` so a
+        transient store error does not lose the path forever. Without this
+        the first watcher tick would clear the queue regardless of outcome:
+        an unindexed file would keep its recorded mtime and never be
+        rediscovered, and a failed delete would orphan SQLite chunks.
         """
         is_search_reason = reason == "search" or reason.startswith("search:")
         session_delta_pending = self._delta.has_pending()
@@ -167,20 +187,14 @@ class MemorySyncManager:
             deletes = set(self._pending_deletes)
             self._pending_changes.clear()
             self._pending_deletes.clear()
-            failed_deletes = await self._do_file_sync(changes=changes, deletes=deletes)
+            failures = await self._do_file_sync(changes=changes, deletes=deletes)
         else:
-            failed_deletes = await self._do_file_sync(force=force)
+            failures = await self._do_file_sync(force=force)
 
         session_sync_failed = await self._do_session_sync(reason=reason, force=force)
 
-        if failed_deletes:
-            self._pending_deletes.update(failed_deletes)
-            self._dirty = True
-            logger.warning(
-                "sync_manager.deletes_requeued",
-                reason=reason,
-                paths=sorted(failed_deletes),
-            )
+        if failures:
+            self._requeue(failures, reason=reason)
         else:
             # Don't clobber _dirty=True set by a concurrent _do_ttl_sweep
             # (separate background task). If anything is still queued,
@@ -214,6 +228,28 @@ class MemorySyncManager:
         self._delta.record(byte_count=byte_count)
 
     # --- Internal ---
+
+    def _requeue(self, failures: FileSyncFailures, *, reason: str) -> None:
+        """Put paths the store rejected back on the pending queues.
+
+        Keeps the manager dirty so the next watcher tick retries them even
+        though nothing on disk changed.
+        """
+        if failures.failed_changes:
+            self._pending_changes.update(failures.failed_changes)
+            logger.warning(
+                "sync_manager.changes_requeued",
+                reason=reason,
+                paths=sorted(failures.failed_changes),
+            )
+        if failures.failed_deletes:
+            self._pending_deletes.update(failures.failed_deletes)
+            logger.warning(
+                "sync_manager.deletes_requeued",
+                reason=reason,
+                paths=sorted(failures.failed_deletes),
+            )
+        self._dirty = True
 
     def _scan_files(self) -> dict[str, float]:
         """Scan watched paths and return {relative_path: mtime}."""
@@ -259,14 +295,18 @@ class MemorySyncManager:
         changes: set[str] | None = None,
         deletes: set[str] | None = None,
         force: bool = False,
-    ) -> set[str]:
+    ) -> FileSyncFailures:
         """Re-index changed and deleted files from disk.
 
-        Returns the set of delete paths whose ``store.remove_file`` raised
-        (anything other than success). Caller is expected to re-enqueue
-        them so a transient SQLite lock does not orphan chunks. Index
-        failures stay log-only because the file is still on disk and the
-        next watcher tick will rediscover it via mtime.
+        Returns the paths the store rejected: those whose
+        ``store.index_file`` raised and those whose ``store.remove_file``
+        raised. Caller is expected to re-enqueue both so a transient store
+        error does not orphan chunks or leave a file unindexed.
+
+        Index failures cannot be left to the watcher: ``self._mtimes`` is
+        replaced with the fresh scan *before* the index loop runs, so a
+        failing path already counts as seen and the next diff would find
+        it unchanged.
         """
         if changes is None or deletes is None:
             current = self._scan_files()
@@ -293,6 +333,7 @@ class MemorySyncManager:
                 failed_deletes.add(rel_path)
                 logger.warning("sync_manager.remove_failed", path=rel_path)
 
+        failed_changes: set[str] = set()
         for rel_path in changes:
             abs_path = self._workspace_dir / rel_path
             if not abs_path.is_file():
@@ -324,9 +365,13 @@ class MemorySyncManager:
                         source=source.value,
                     )
             except Exception:
+                failed_changes.add(rel_path)
                 logger.warning("sync_manager.index_failed", path=rel_path)
 
-        return failed_deletes
+        return FileSyncFailures(
+            failed_changes=frozenset(failed_changes),
+            failed_deletes=frozenset(failed_deletes),
+        )
 
     async def _do_session_sync(self, *, reason: str, force: bool = False) -> bool:
         """Sync the derived sessions source when the current trigger can affect it.
@@ -391,10 +436,10 @@ class MemorySyncManager:
                     now - self._last_change_time >= self._debounce_seconds
                 ):
                     # sync(reason="watch") atomically snapshots, clears,
-                    # and re-enqueues failed store removals. Do NOT clear
-                    # _pending_* here — that would wipe the re-enqueued
-                    # failures and orphan SQLite chunks on transient
-                    # errors.
+                    # and re-enqueues failed store indexes and removals.
+                    # Do NOT clear _pending_* here — that would wipe the
+                    # re-enqueued failures, orphaning SQLite chunks and
+                    # dropping retries on transient errors.
                     await self.sync(reason="watch")
 
             except asyncio.CancelledError:

--- a/tests/test_memory_sync_manager_architecture.py
+++ b/tests/test_memory_sync_manager_architecture.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from agentos.memory.sync_manager import MemorySyncManager
+from agentos.memory.sync_manager import FileSyncFailures, MemorySyncManager
 
 
 class NoopStore:
@@ -107,9 +107,9 @@ async def test_sync_force_overrides_search_clean_fast_path(tmp_path):
     first_count = len(store.indexed)
     sync_calls: list[dict[str, object]] = []
 
-    async def fake_do_file_sync(**kwargs: object) -> set[str]:
+    async def fake_do_file_sync(**kwargs: object) -> FileSyncFailures:
         sync_calls.append(kwargs)
-        return set()
+        return FileSyncFailures()
 
     manager._do_file_sync = fake_do_file_sync  # type: ignore[method-assign]
     await manager.sync(reason="search")

--- a/tests/test_memory_sync_manager_index_retry.py
+++ b/tests/test_memory_sync_manager_index_retry.py
@@ -1,0 +1,216 @@
+"""Regression tests for issue #638.
+
+``_do_file_sync`` replaces ``_mtimes`` with the fresh scan *before* it
+indexes anything, so a path whose ``index_file`` raises is already
+recorded as seen. Dropping it there means the watcher diff never
+rediscovers it and the file stays unindexed until it is edited again or
+the process restarts.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agentos.memory.sync_manager import MemorySyncManager
+
+
+class FlakyStore:
+    """Store whose ``index_file`` fails for the first N calls on a path."""
+
+    def __init__(self, *, failures: dict[str, int] | None = None) -> None:
+        self.indexed: list[str] = []
+        self.removed: list[str] = []
+        self._failures = dict(failures or {})
+        self.remove_failures: dict[str, int] = {}
+
+    async def index_file(
+        self,
+        *,
+        path: str,
+        content: str,
+        source: object,
+        mtime: float | None = None,
+    ) -> int:
+        self.indexed.append(path)
+        remaining = self._failures.get(path, 0)
+        if remaining > 0:
+            self._failures[path] = remaining - 1
+            raise RuntimeError(f"transient index failure for {path}")
+        return 1
+
+    def fail_next_index(self, path: str, times: int = 1) -> None:
+        self._failures[path] = times
+
+    async def remove_file(self, path: str) -> None:
+        self.removed.append(path)
+        remaining = self.remove_failures.get(path, 0)
+        if remaining > 0:
+            self.remove_failures[path] = remaining - 1
+            raise RuntimeError(f"transient remove failure for {path}")
+
+
+def _make_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    (workspace / "MEMORY.md").write_text("root\n", encoding="utf-8")
+    return workspace, memory
+
+
+def _touch_newer(path) -> None:
+    """Bump mtime past the recorded scan without relying on clock ticks."""
+    stat = path.stat()
+    os.utime(path, (stat.st_atime + 10, stat.st_mtime + 10))
+
+
+def _manager(store, workspace, memory) -> MemorySyncManager:
+    return MemorySyncManager(store=store, workspace_dir=workspace, memory_dir=memory)
+
+
+@pytest.mark.asyncio
+async def test_transient_index_failure_is_retried_on_next_watch_sync(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    store = FlakyStore(failures={"MEMORY.md": 1})
+    manager = _manager(store, workspace, memory)
+
+    await manager.sync(reason="manual")
+
+    assert store.indexed == ["MEMORY.md"]
+    assert manager._pending_changes == {"MEMORY.md"}
+    assert manager._dirty is True
+
+    # The file is untouched on disk, so the mtime diff alone would find
+    # nothing — the retry has to come from the pending queue.
+    await manager.sync(reason="watch")
+
+    assert store.indexed == ["MEMORY.md", "MEMORY.md"]
+    assert manager._pending_changes == set()
+    assert manager._dirty is False
+
+
+@pytest.mark.asyncio
+async def test_persistent_index_failure_stays_pending_and_dirty(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    store = FlakyStore(failures={"MEMORY.md": 5})
+    manager = _manager(store, workspace, memory)
+
+    await manager.sync(reason="manual")
+    await manager.sync(reason="watch")
+    await manager.sync(reason="watch")
+
+    assert store.indexed == ["MEMORY.md"] * 3
+    assert manager._pending_changes == {"MEMORY.md"}
+    assert manager._dirty is True
+
+
+@pytest.mark.asyncio
+async def test_clean_sync_does_not_requeue_or_reindex(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    store = FlakyStore()
+    manager = _manager(store, workspace, memory)
+
+    await manager.sync(reason="manual")
+    await manager.sync(reason="watch")
+    await manager.sync(reason="manual")
+
+    assert store.indexed == ["MEMORY.md"]
+    assert manager._pending_changes == set()
+    assert manager._dirty is False
+
+
+@pytest.mark.asyncio
+async def test_only_the_failing_path_is_requeued(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    (memory / "note.md").write_text("note\n", encoding="utf-8")
+    store = FlakyStore(failures={"memory/note.md": 1})
+    manager = _manager(store, workspace, memory)
+
+    await manager.sync(reason="manual")
+
+    assert sorted(store.indexed) == ["MEMORY.md", "memory/note.md"]
+    assert manager._pending_changes == {"memory/note.md"}
+
+    await manager.sync(reason="watch")
+
+    assert store.indexed.count("MEMORY.md") == 1
+    assert store.indexed.count("memory/note.md") == 2
+    assert manager._pending_changes == set()
+    assert manager._dirty is False
+
+
+@pytest.mark.asyncio
+async def test_index_failure_during_initial_sync_is_requeued(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    store = FlakyStore(failures={"MEMORY.md": 1})
+    manager = _manager(store, workspace, memory)
+
+    # start() runs _do_file_sync directly with empty _mtimes, so a failure
+    # there is exactly the case the watcher diff can never recover from.
+    failures = await manager._do_file_sync()
+    manager._requeue(failures, reason="initial")
+
+    assert failures.failed_changes == frozenset({"MEMORY.md"})
+    assert manager._pending_changes == {"MEMORY.md"}
+    assert manager._dirty is True
+
+    await manager.sync(reason="watch")
+
+    assert store.indexed == ["MEMORY.md", "MEMORY.md"]
+    assert manager._pending_changes == set()
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_retry_still_works(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    doomed = memory / "doomed.md"
+    doomed.write_text("bye\n", encoding="utf-8")
+    store = FlakyStore()
+    manager = _manager(store, workspace, memory)
+
+    await manager.sync(reason="manual")
+    assert manager._pending_deletes == set()
+
+    doomed.unlink()
+    store.remove_failures["memory/doomed.md"] = 1
+    await manager.sync(reason="manual")
+
+    assert store.removed == ["memory/doomed.md"]
+    assert manager._pending_deletes == {"memory/doomed.md"}
+    assert manager._dirty is True
+
+    await manager.sync(reason="watch")
+
+    assert store.removed == ["memory/doomed.md"] * 2
+    assert manager._pending_deletes == set()
+    assert manager._dirty is False
+
+
+@pytest.mark.asyncio
+async def test_index_and_delete_failures_requeue_together(tmp_path):
+    workspace, memory = _make_workspace(tmp_path)
+    doomed = memory / "doomed.md"
+    doomed.write_text("bye\n", encoding="utf-8")
+    store = FlakyStore()
+    manager = _manager(store, workspace, memory)
+
+    await manager.sync(reason="manual")
+
+    doomed.unlink()
+    store.remove_failures["memory/doomed.md"] = 1
+    (workspace / "MEMORY.md").write_text("root updated\n", encoding="utf-8")
+    _touch_newer(workspace / "MEMORY.md")
+    store.fail_next_index("MEMORY.md")
+
+    await manager.sync(reason="manual")
+
+    assert manager._pending_changes == {"MEMORY.md"}
+    assert manager._pending_deletes == {"memory/doomed.md"}
+    assert manager._dirty is True
+
+    await manager.sync(reason="watch")
+
+    assert manager._pending_changes == set()
+    assert manager._pending_deletes == set()
+    assert manager._dirty is False


### PR DESCRIPTION
Fixes #638.

## The bug

`_do_file_sync()` records the fresh scan into `self._mtimes` **before** it runs the
index loop:

```python
self._mtimes = current          # every scanned path now counts as "seen"
...
except Exception:
    logger.warning("sync_manager.index_failed", path=rel_path)   # dropped
```

So when `store.index_file()` raises, the failing path has already been marked as
seen. The next watcher scan compares equal, the path never enters `changes`, and
the retry never happens — the file stays unindexed until it is edited again or the
process restarts, while searches keep running against a stale or missing index.

The `_do_file_sync` docstring asserted the opposite ("the next watcher tick will
rediscover it via mtime"), which is what made the drop look deliberate.

## The fix

The delete path immediately above already does the right thing: it returns the
failed paths for the caller to re-enqueue. The index path now follows that same
pattern rather than introducing a second mechanism.

- `_do_file_sync()` returns a `FileSyncFailures` record carrying both
  `failed_changes` and `failed_deletes` (previously a bare `set` of delete
  failures).
- `sync()` re-enqueues both through one `_requeue()` helper: index failures into
  `_pending_changes`, delete failures into `_pending_deletes`, and the manager
  stays dirty while anything is pending.
- The watch branch already snapshots-and-clears the pending sets *before* the
  sync, so a re-enqueued path lands in a clean set and survives into the next
  tick. Retry therefore does not need an mtime change.
- `start()` re-enqueues too. Its `_do_file_sync()` pass runs with an empty
  `_mtimes`, so a failure there is the one case the watcher diff could never have
  recovered from at all.
- The `_do_file_sync` docstring is corrected, along with the `sync()` and
  `_poll_loop` comments that repeated the same claim.

Delete-failure behaviour is unchanged.

## Tests

`tests/test_memory_sync_manager_index_retry.py` — offline, no provider, network
or credentials; a fake store whose `index_file` fails a configurable number of
times per path.

- transient failure is retried on the next watcher sync with the file untouched
  on disk, and the pending state clears after the retry succeeds
- persistent failure stays queued and keeps the manager dirty
- a clean sync neither requeues nor re-indexes (no duplicate work)
- only the failing path is requeued; its healthy sibling is not re-indexed
- an index failure during the initial `start()` pass is requeued
- delete-failure retry still works (preserved behaviour)
- index and delete failures requeue together and both clear on retry

5 of the 7 fail on `main`; the other 2 guard the behaviour this change must not
break.

## Note for review

A path that fails *permanently* now stays in `_pending_changes`, so the poll loop
retries it every tick. That is exactly the existing behaviour for permanently
failing deletes, so this keeps the two paths symmetric — but indexing is the more
expensive of the two. If you'd rather bound it, a retry cap or backoff is easy to
add on top; I left it out because it would be new machinery rather than the
established pattern.

## Quality gate

- `uv run ruff check src tests` — clean
- `uv run ruff format` — clean
- `uv run mypy src/agentos --show-error-codes` — only the pre-existing
  `mem0_provider.py` `import-untyped` error, untouched by this change
- `uv run pytest -q` — full suite
