### PR TITLE
fix(channels): retry every transient timeout and parse Retry-After safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Channel HTTP retries now cover every transient timeout, survive an
+  HTTP-date `Retry-After`, and hand back an exhausted rate limit.
+  `retry_request` caught `(ConnectError, ReadTimeout)`, but `ConnectTimeout`,
+  `WriteTimeout` and `PoolTimeout` descend from `TimeoutException` — a sibling
+  of `ConnectError` under `TransportError` — so a DNS, TLS-handshake, upload or
+  connection-pool timeout on any Slack/Discord/Telegram/webhook call escaped
+  the backoff and crashed the caller on the first stall; the clause is now
+  `(ConnectError, TimeoutException)`. `Retry-After` was parsed with a bare
+  `float()`, so the HTTP-date form RFC 7231 §7.1.3 permits turned a rate limit
+  into a `ValueError` inside the retry loop: the header is now resolved as
+  delay-seconds or HTTP-date, falls back to the computed backoff when it is
+  unparseable, non-finite, negative or already past, and is clamped to 300s so
+  a provider cannot park a send for hours. The 429 branch also gained the
+  `attempt < max_retries` guard the 5xx branch already had, so an exhausted
+  rate limit returns the response — status, headers and provider error body
+  intact — instead of sleeping once more and raising a bare
+  `RuntimeError("retry_request exhausted")` (#642, #599).
 - `SubscriptionManager._message_subs` now removes empty sets on
   unsubscription and connection teardown, preventing a slow memory leak
   on long-running gateways (#609).

--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -9,11 +9,14 @@ describe their admit/deny semantics. Item-5 adapter adoptions wire the
 from __future__ import annotations
 
 import asyncio
+import math
 import random
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Literal
 
 import httpx
@@ -271,6 +274,42 @@ class FloodStrikeBackoff:
         self._fallback = False
 
 
+#: Upper bound on a server-supplied ``Retry-After``. The header is remote input
+#: and a provider can legally ask for hours; a channel send parked that long is
+#: worse for the caller than one that comes back rate-limited.
+MAX_RETRY_AFTER_S = 300.0
+
+
+def _retry_after_delay(header: str | None, fallback: float) -> float:
+    """Resolve a ``Retry-After`` header to a sleep in seconds.
+
+    RFC 7231 §7.1.3 allows either delay-seconds or an HTTP-date, so a bare
+    ``float()`` turns a date-formatted rate-limit into a ``ValueError`` inside
+    the retry loop. Anything that parses as neither — and any value that is
+    negative, non-finite or already in the past — falls back to the caller's
+    computed backoff; a usable value is clamped to ``MAX_RETRY_AFTER_S``.
+    """
+    if header is None:
+        return fallback
+    raw = header.strip()
+    if not raw:
+        return fallback
+    try:
+        delay = float(raw)
+    except ValueError:
+        try:
+            when = parsedate_to_datetime(raw)
+        except (TypeError, ValueError):
+            return fallback
+        # An HTTP-date carries no offset other than GMT (RFC 7231 §7.1.1.1).
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=UTC)
+        delay = (when - datetime.now(UTC)).total_seconds()
+    if not math.isfinite(delay) or delay < 0.0:
+        return fallback
+    return min(delay, MAX_RETRY_AFTER_S)
+
+
 async def retry_request(
     func: Callable[..., Awaitable[httpx.Response]],
     *args: Any,
@@ -283,8 +322,13 @@ async def retry_request(
     for attempt in range(max_retries + 1):
         try:
             resp = await func(*args, **kwargs)
-            if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+            # Guarded like the 5xx branch below: on the final attempt the
+            # rate-limited response is handed back instead of being slept on
+            # and then discarded by the ``exhausted`` raise.
+            if resp.status_code == 429 and attempt < max_retries:
+                retry_after = _retry_after_delay(
+                    resp.headers.get("Retry-After"), base_delay * (2**attempt)
+                )
                 log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
                 await asyncio.sleep(retry_after)
                 continue
@@ -294,7 +338,11 @@ async def retry_request(
                 await asyncio.sleep(delay)
                 continue
             return resp
-        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+        # ``ConnectTimeout``/``WriteTimeout``/``PoolTimeout`` descend from
+        # ``TimeoutException``, a sibling of ``ConnectError`` under
+        # ``TransportError`` — naming ``ReadTimeout`` alone let a DNS, TLS or
+        # pool timeout escape the backoff entirely.
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
             last_exc = exc
             if attempt < max_retries:
                 delay = base_delay * (2**attempt) + random.random()

--- a/tests/test_channels/test_channel_retry_util.py
+++ b/tests/test_channels/test_channel_retry_util.py
@@ -1,0 +1,240 @@
+"""``retry_request`` transient-failure coverage at the utility boundary.
+
+The adapter-level suites (``test_slack_retry``, ``test_telegram_retry``)
+exercise the retry helper through a channel; these tests pin the helper's
+own contract — which exceptions count as transient, how a server-supplied
+``Retry-After`` is resolved, and what an exhausted rate-limit returns.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from agentos.channels._util import MAX_RETRY_AFTER_S, retry_request
+
+_REQUEST = httpx.Request("POST", "https://channel.test/api")
+
+
+def _resp(status_code: int = 200, headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(status_code, json={"ok": True}, headers=headers, request=_REQUEST)
+
+
+def _caller(*results: Any) -> AsyncMock:
+    """An awaitable request callable that yields ``results`` in order."""
+
+    async def _call(*args: Any, **kwargs: Any) -> httpx.Response:
+        outcome = pending.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    pending = list(results)
+    return AsyncMock(side_effect=_call)
+
+
+@pytest.fixture
+def sleeps() -> Any:
+    """Collapse the backoff and record every delay ``retry_request`` slept."""
+    with patch("agentos.channels._util.asyncio.sleep", new=AsyncMock()) as sleep:
+        yield sleep
+
+
+def _slept(sleeps: Any) -> list[float]:
+    return [call.args[0] for call in sleeps.await_args_list]
+
+
+# ---------------------------------------------------------------------------
+# Transient transport errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("refused"),
+        httpx.ConnectTimeout("dns/tls handshake timed out"),
+        httpx.ReadTimeout("slow response"),
+        httpx.WriteTimeout("slow upload"),
+        httpx.PoolTimeout("no free connection"),
+    ],
+    ids=["connect_error", "connect_timeout", "read_timeout", "write_timeout", "pool_timeout"],
+)
+async def test_transient_transport_errors_are_retried(exc: Exception, sleeps: Any) -> None:
+    """Every transport error that can resolve on a second try is retried.
+
+    ``ConnectTimeout``/``WriteTimeout``/``PoolTimeout`` descend from
+    ``TimeoutException``, not from ``ConnectError`` — catching only the
+    latter let a DNS or TLS timeout crash the caller without any backoff.
+    """
+    func = _caller(exc, _resp(200))
+
+    resp = await retry_request(func)
+
+    assert resp.status_code == 200
+    assert func.await_count == 2
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [httpx.ConnectError("refused"), httpx.ConnectTimeout("timed out"), httpx.PoolTimeout("busy")],
+    ids=["connect_error", "connect_timeout", "pool_timeout"],
+)
+async def test_transport_error_is_reraised_once_retries_are_exhausted(
+    exc: Exception, sleeps: Any
+) -> None:
+    func = _caller(*[exc] * 4)
+
+    with pytest.raises(type(exc)):
+        await retry_request(func, max_retries=3)
+
+    assert func.await_count == 4  # initial attempt + 3 retries
+
+
+async def test_non_transient_transport_error_is_not_retried(sleeps: Any) -> None:
+    """A protocol violation is not going to fix itself — surface it at once."""
+    func = _caller(httpx.UnsupportedProtocol("no scheme"))
+
+    with pytest.raises(httpx.UnsupportedProtocol):
+        await retry_request(func)
+
+    assert func.await_count == 1
+    assert _slept(sleeps) == []
+
+
+# ---------------------------------------------------------------------------
+# Retry-After resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_numeric_retry_after_is_honoured(sleeps: Any) -> None:
+    func = _caller(_resp(429, {"Retry-After": "2"}), _resp(200))
+
+    resp = await retry_request(func)
+
+    assert resp.status_code == 200
+    assert _slept(sleeps) == [2.0]
+
+
+async def test_http_date_retry_after_is_resolved_to_a_delay(sleeps: Any) -> None:
+    """RFC 7231 §7.1.3 permits an HTTP-date; it must not crash the loop."""
+    when = datetime.now(UTC) + timedelta(seconds=30)
+    func = _caller(_resp(429, {"Retry-After": format_datetime(when)}), _resp(200))
+
+    resp = await retry_request(func)
+
+    assert resp.status_code == 200
+    assert len(_slept(sleeps)) == 1
+    assert 25.0 <= _slept(sleeps)[0] <= 31.0
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Fri, 99 Xyz 2026 07:28:00 GMT",
+        "2026-10-21T07:28:00Z",
+        "soon",
+        "",
+        "   ",
+        "nan",
+        "inf",
+        "-5",
+    ],
+    ids=["malformed_date", "iso_8601", "word", "empty", "blank", "nan", "inf", "negative"],
+)
+async def test_unusable_retry_after_falls_back_to_backoff(header: str, sleeps: Any) -> None:
+    """An unparseable, non-finite or negative header must not raise."""
+    func = _caller(_resp(429, {"Retry-After": header}), _resp(200))
+
+    resp = await retry_request(func, base_delay=1.0)
+
+    assert resp.status_code == 200
+    assert _slept(sleeps) == [1.0]  # base_delay * 2**0
+
+
+async def test_past_http_date_retry_after_falls_back_to_backoff(sleeps: Any) -> None:
+    func = _caller(
+        _resp(429, {"Retry-After": format_datetime(datetime.now(UTC) - timedelta(hours=1))}),
+        _resp(200),
+    )
+
+    await retry_request(func, base_delay=1.0)
+
+    assert _slept(sleeps) == [1.0]
+
+
+async def test_missing_retry_after_falls_back_to_backoff(sleeps: Any) -> None:
+    func = _caller(_resp(429), _resp(429), _resp(200))
+
+    await retry_request(func, base_delay=1.0)
+
+    assert _slept(sleeps) == [1.0, 2.0]  # base_delay * 2**attempt
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["86400", "Wed, 21 Oct 2093 07:28:00 GMT"],
+    ids=["seconds", "http_date"],
+)
+async def test_oversized_retry_after_is_clamped(header: str, sleeps: Any) -> None:
+    """A provider cannot park a channel send for hours."""
+    func = _caller(_resp(429, {"Retry-After": header}), _resp(200))
+
+    await retry_request(func)
+
+    assert _slept(sleeps) == [MAX_RETRY_AFTER_S]
+
+
+# ---------------------------------------------------------------------------
+# Status handling
+# ---------------------------------------------------------------------------
+
+
+async def test_exhausted_rate_limit_returns_the_response(sleeps: Any) -> None:
+    """The last 429 is handed back — status, headers and body intact.
+
+    Without the ``attempt < max_retries`` guard the loop slept on the final
+    attempt and then fell out into ``RuntimeError("retry_request exhausted")``,
+    discarding the provider's error payload.
+    """
+    func = _caller(*[_resp(429, {"Retry-After": "1"})] * 3)
+
+    resp = await retry_request(func, max_retries=2)
+
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "1"
+    assert func.await_count == 3
+    assert _slept(sleeps) == [1.0, 1.0]  # no pointless sleep on the last attempt
+
+
+async def test_exhausted_server_error_returns_the_response(sleeps: Any) -> None:
+    func = _caller(*[_resp(503)] * 3)
+
+    resp = await retry_request(func, max_retries=2)
+
+    assert resp.status_code == 503
+    assert func.await_count == 3
+
+
+async def test_client_error_is_returned_without_retrying(sleeps: Any) -> None:
+    func = _caller(_resp(401))
+
+    resp = await retry_request(func)
+
+    assert resp.status_code == 401
+    assert func.await_count == 1
+    assert _slept(sleeps) == []
+
+
+async def test_success_passes_through_arguments(sleeps: Any) -> None:
+    func = _caller(_resp(200))
+
+    resp = await retry_request(func, "https://channel.test/api", json={"a": 1})
+
+    assert resp.status_code == 200
+    func.assert_awaited_once_with("https://channel.test/api", json={"a": 1})


### PR DESCRIPTION
Fixes #642
Fixes #599

Per the maintainer note on both issues ("please coordinate so the three land coherently rather than as conflicting edits to one 30-line function"), this covers all three defects in `retry_request` in one change.

## 1. Timeouts that never reached the backoff (#642)

The clause was `except (httpx.ConnectError, httpx.ReadTimeout)`. `ConnectTimeout`, `WriteTimeout` and `PoolTimeout` descend from `TimeoutException` — a sibling of `ConnectError` under `TransportError` — so a DNS lookup, TLS handshake, upload or connection-pool stall on any Slack/Discord/Telegram/webhook call went straight past the retry loop and crashed the caller on the first blip.

`(httpx.ConnectError, httpx.TimeoutException)` covers all four timeout types in one clause. `ReadTimeout` is included by inheritance, so nothing that was retried before stops being retried.

## 2. `Retry-After` crash (#642)

`float(resp.headers.get("Retry-After", ...))` is a bare parse of a caller-controlled header, and RFC 7231 §7.1.3 permits an HTTP-date — a provider sending one turned a rate limit into a `ValueError` inside the retry loop.

`_retry_after_delay` now:

- parses **delay-seconds or HTTP-date** — a date-formatted header is resolved to an actual delay rather than merely not crashing;
- falls back to the caller's computed backoff when the value is unparseable, empty, non-finite (`nan`/`inf` both survive `float()`), negative, or an HTTP-date already in the past;
- clamps a usable value to `MAX_RETRY_AFTER_S = 300.0`, the "sane upper clamp" asked for in the issue thread — a provider can otherwise ask us to sleep for hours, and the header is remote input.

The caller's own backoff is never clamped; only the remote value is.

## 3. Exhausted 429 discarded the response (#599)

The 5xx branch is guarded by `attempt < max_retries` and falls through to `return resp` on the last attempt; the 429 branch had no such guard, so the final rate-limited attempt slept once more and then fell out of the loop into `raise last_exc or RuntimeError("retry_request exhausted")` — with `last_exc is None` there, the caller got a bare `RuntimeError` and the status, `Retry-After` and provider error body were all thrown away.

The 429 branch now carries the same guard, so an exhausted rate limit returns the response exactly like an exhausted 5xx does. Callers that `raise_for_status()` (Slack, Discord) now get an `HTTPStatusError` carrying the provider payload instead of an opaque `RuntimeError`. Nothing in the tree caught that `RuntimeError` (`grep -rn "exhausted" src/agentos/channels src/agentos/scheduler` finds no consumer).

## Tests

27 new tests in `tests/test_channels/test_channel_retry_util.py`, pinning the helper's own contract rather than going through an adapter:

- all five transient transport errors retried (`ConnectError`, `ConnectTimeout`, `ReadTimeout`, `WriteTimeout`, `PoolTimeout`), and re-raised once retries are exhausted;
- a non-transient `UnsupportedProtocol` still surfaces on the first attempt with no sleep;
- `Retry-After` as seconds, as an HTTP-date, missing, empty/blank, malformed, ISO-8601, `nan`, `inf`, negative, in the past, and oversized (clamped);
- exhausted 429 returns the response with headers intact and does **not** sleep on the final attempt; exhausted 5xx unchanged; 4xx returned immediately.

**18 of the 27 fail against `main`** and pass with the patch.

## Verification

```
$ uv run --all-extras pytest tests/test_channels/test_channel_retry_util.py -q
27 passed

$ uv run --all-extras pytest tests/test_channels tests/test_scheduler -q
803 passed

$ uv run --all-extras pytest tests/ -q
3 failed, 8835 passed, 26 skipped     # the 3 are pre-existing env failures
                                      # (mem0 present in the venv, missing
                                      #  weasyprint system lib) — unrelated

$ uv run --all-extras ruff format --check src/agentos/channels/_util.py tests/test_channels/test_channel_retry_util.py
2 files already formatted
$ uv run --all-extras ruff check .        # All checks passed
$ uv run --all-extras mypy src            # only the pre-existing mem0 import-untyped error
```

Note: #643 and #645 also target #642, and #603 targets all three — offered as an alternative for whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5mxRuJ5TQhEaUKz1g8QJq
