### PR TITLE
fix(channels): keep the thread root when an inbound email has no References

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `SubscriptionManager._message_subs` now removes empty sets on
   unsubscription and connection teardown, preventing a slow memory leak
   on long-running gateways (#609).
+- An email reply no longer drops the thread root when the inbound message
+  carries no `References` header. `_merge_references` read only `References`,
+  so for the second message of a thread — where most mail clients send
+  `In-Reply-To` alone — the parent id was discarded and the outgoing reply
+  referenced only itself, breaking the conversation apart in Gmail, Outlook and
+  Thunderbird. The chain now falls back to `In-Reply-To` when `References` is
+  absent, per RFC 5322 3.6.4. Both threading headers are now read by one
+  parser that drops comments and accepts ids with or without angle brackets,
+  and `thread_key_for` shares it, so the thread cache key and the reference
+  chain can no longer disagree about which message is the root (#620).
 - The Environment view's path strip shortens Windows paths again. `shortPath`
   split on `/` only, so a gateway-reported `C:\Users\<name>\.agentos\.env` counted
   as a single segment and was rendered untrimmed, overflowing the header strip

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -118,6 +118,7 @@ _QUOTE_MARKERS: tuple[re.Pattern[str], ...] = (
 _HTML_BREAK_RE = re.compile(r"(?i)<\s*(?:br\s*/?|/p|/div|/tr|/li)\s*>")
 _HTML_DROP_RE = re.compile(r"(?is)<\s*(script|style)\b.*?<\s*/\s*\1\s*>")
 _HTML_TAG_RE = re.compile(r"(?s)<[^>]+>")
+_HEADER_COMMENT_RE = re.compile(r"\([^()]*\)")
 _DEFAULT_OUTBOUND_SUBJECT = "Message from AgentOS"
 
 
@@ -270,12 +271,12 @@ def strip_quoted_reply(body: str) -> str:
 def thread_key_for(parsed: EmailMessage) -> str:
     """Return the stable thread id for an inbound message."""
 
-    references = (parsed.get("References") or "").split()
+    references = _message_ids(parsed.get("References"))
     if references:
-        return references[0].strip().strip("<>")
-    in_reply_to = (parsed.get("In-Reply-To") or "").strip()
+        return references[0]
+    in_reply_to = _message_ids(parsed.get("In-Reply-To"))
     if in_reply_to:
-        return in_reply_to.strip("<>")
+        return in_reply_to[0]
     return (parsed.get("Message-ID") or "").strip().strip("<>")
 
 
@@ -857,10 +858,30 @@ def _body_text(parsed: EmailMessage) -> str:
 
 
 def _merge_references(parsed: EmailMessage, message_id: str) -> str:
-    existing = (parsed.get("References") or "").split()
-    if message_id:
-        existing.append(f"<{message_id}>")
-    return " ".join(dict.fromkeys(existing))
+    """Build the ``References`` chain a reply to ``parsed`` must carry.
+
+    RFC 5322 3.6.4: the reply repeats the parent's ``References`` and appends the
+    parent's ``Message-ID``. A parent that carries no ``References`` -- the second
+    message of a thread in most mail clients -- keeps the thread root in
+    ``In-Reply-To``, so fall back to it or the root is lost for good.
+    """
+
+    chain = _message_ids(parsed.get("References")) or _message_ids(parsed.get("In-Reply-To"))
+    own = message_id.strip().strip("<>")
+    if own:
+        chain.append(own)
+    return " ".join(f"<{ref}>" for ref in dict.fromkeys(chain))
+
+
+def _message_ids(raw: Any) -> list[str]:
+    """Return the bare message ids in a threading header value, in order.
+
+    Clients decorate these headers with comments and drop the angle brackets, so
+    a plain ``split()`` yields tokens that are not ids at all.
+    """
+
+    text = _HEADER_COMMENT_RE.sub(" ", str(raw or ""))
+    return [token for token in (raw_id.strip().strip("<>") for raw_id in text.split()) if token]
 
 
 def _first_literal(data: Any) -> bytes | None:

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -17,6 +17,7 @@ from agentos.channels.email import (
     _DEFAULT_OUTBOUND_SUBJECT,
     EmailChannel,
     EmailChannelConfig,
+    _merge_references,
     _quote_imap_mailbox,
     html_to_text,
     is_automated,
@@ -348,6 +349,151 @@ async def test_send_composes_threading_headers(monkeypatch: pytest.MonkeyPatch) 
     assert outbound["References"] == "<m1@example.com>"
     assert normalize_address(outbound["From"]) == "agent@example.com"
     assert outbound.get_content().strip() == "the answer"
+
+
+def test_merge_references_falls_back_to_in_reply_to() -> None:
+    """RFC 5322 3.6.4: a parent without ``References`` still names the thread root."""
+
+    parsed = _raw(
+        message_id="reply-102@example.com",
+        extra_headers={"In-Reply-To": "<root-001@example.com>"},
+    )
+
+    merged = _merge_references(parsed, "reply-102@example.com")
+
+    assert merged == "<root-001@example.com> <reply-102@example.com>"
+
+
+def test_merge_references_prefers_the_existing_chain() -> None:
+    parsed = _raw(
+        message_id="reply-103@example.com",
+        extra_headers={
+            "References": "<root-001@example.com> <reply-102@example.com>",
+            "In-Reply-To": "<reply-102@example.com>",
+        },
+    )
+
+    merged = _merge_references(parsed, "reply-103@example.com")
+
+    assert merged == ("<root-001@example.com> <reply-102@example.com> <reply-103@example.com>")
+
+
+def test_merge_references_keeps_a_root_message_alone() -> None:
+    parsed = _raw(message_id="root-001@example.com")
+
+    assert _merge_references(parsed, "root-001@example.com") == "<root-001@example.com>"
+
+
+def test_merge_references_drops_header_comments() -> None:
+    """Some clients decorate the header with comments; only ids belong in the chain."""
+
+    parsed = _raw(
+        message_id="reply-102@example.com",
+        extra_headers={"In-Reply-To": "<root-001@example.com> (from Outlook)"},
+    )
+
+    merged = _merge_references(parsed, "reply-102@example.com")
+
+    assert merged == "<root-001@example.com> <reply-102@example.com>"
+
+
+def test_merge_references_drops_comments_around_bare_ids() -> None:
+    parsed = _raw(
+        message_id="reply-102@example.com",
+        extra_headers={"In-Reply-To": "root-001@example.com (from Outlook)"},
+    )
+
+    merged = _merge_references(parsed, "reply-102@example.com")
+
+    assert merged == "<root-001@example.com> <reply-102@example.com>"
+
+
+def test_merge_references_keeps_ids_a_mixed_header_brackets_unevenly() -> None:
+    """A chain that brackets only some ids must still keep the root."""
+
+    parsed = _raw(
+        message_id="reply-103@example.com",
+        extra_headers={"References": "root-001@example.com <reply-102@example.com>"},
+    )
+
+    merged = _merge_references(parsed, "reply-103@example.com")
+
+    assert merged == ("<root-001@example.com> <reply-102@example.com> <reply-103@example.com>")
+
+
+def test_merge_references_brackets_bare_ids() -> None:
+    parsed = _raw(
+        message_id="reply-102@example.com",
+        extra_headers={"In-Reply-To": "root-001@example.com"},
+    )
+
+    merged = _merge_references(parsed, "reply-102@example.com")
+
+    assert merged == "<root-001@example.com> <reply-102@example.com>"
+
+
+def test_merge_references_deduplicates_repeated_ids() -> None:
+    parsed = _raw(
+        message_id="reply-102@example.com",
+        extra_headers={"References": "<root-001@example.com> <root-001@example.com>"},
+    )
+
+    merged = _merge_references(parsed, "reply-102@example.com")
+
+    assert merged == "<root-001@example.com> <reply-102@example.com>"
+
+
+def test_thread_key_ignores_header_comments() -> None:
+    """The thread cache key and the reference chain must name the same root."""
+
+    parsed = _raw(
+        message_id="m2@example.com",
+        extra_headers={"References": "(from Outlook) <root-001@example.com> <m1@example.com>"},
+    )
+
+    assert thread_key_for(parsed) == "root-001@example.com"
+    assert _merge_references(parsed, "m2@example.com").startswith("<root-001@example.com>")
+
+
+def test_thread_key_reads_the_first_id_of_a_multi_id_in_reply_to() -> None:
+    parsed = _raw(
+        message_id="m2@example.com",
+        extra_headers={"In-Reply-To": "<root-001@example.com> <m1@example.com>"},
+    )
+
+    assert thread_key_for(parsed) == "root-001@example.com"
+
+
+def test_merge_references_without_a_message_id() -> None:
+    parsed = _raw(
+        message_id="reply-102@example.com",
+        extra_headers={"In-Reply-To": "<root-001@example.com>"},
+    )
+
+    assert _merge_references(parsed, "") == "<root-001@example.com>"
+
+
+async def test_send_keeps_the_thread_root_when_inbound_has_no_references(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reply must stay in the thread mail clients built from ``In-Reply-To``."""
+
+    channel = EmailChannel(config=_config())
+    inbound = channel._to_incoming(
+        _raw(
+            message_id="m2@example.com",
+            extra_headers={"In-Reply-To": "<m1@example.com>"},
+        )
+    )
+    assert inbound is not None
+    sent: list[EmailMessage] = []
+    monkeypatch.setattr(channel, "_smtp_send", sent.append)
+
+    await channel.send(channel.build_reply_message("the answer", inbound))
+
+    outbound = sent[0]
+    assert outbound["In-Reply-To"] == "<m2@example.com>"
+    assert outbound["References"] == "<m1@example.com> <m2@example.com>"
 
 
 async def test_send_resolves_the_recipient_from_the_thread_cache(


### PR DESCRIPTION
Closes #620.

### Problem

`_merge_references` read only the `References` header. The second message of a thread carries no `References` in most mail clients — the parent lives in `In-Reply-To` alone — so the parent id was dropped and the outgoing reply referenced only itself. Gmail, Outlook and Thunderbird then show the answer as a new conversation.

```python
msg["Message-ID"] = "<reply-102@example.com>"
msg["In-Reply-To"] = "<root-001@example.com>"
_merge_references(msg, "reply-102@example.com")  # '<reply-102@example.com>' — root lost
```

### Fix

- Fall back to `In-Reply-To` when `References` is absent, as RFC 5322 §3.6.4 requires.
- Read both threading headers through one `_message_ids` parser that strips header comments and accepts ids with or without angle brackets. The old bare `.split()` turned `In-Reply-To: <root@x> (from Outlook)` into two "references", one of them `<(from>`.
- `thread_key_for` shares that parser. It previously took `References.split()[0]` verbatim, so a leading comment became the thread id while `_merge_references` named the real root — the thread cache key and the reference chain disagreeing about the same conversation.

Ordering, dedup and the empty-`message_id` path are unchanged.

### Tests

11 cases in `tests/test_channels/test_email_channel.py`: the issue's repro, an existing chain, a root-only message, comments around bracketed and bare ids, a header that brackets only some ids, dedup, an empty message id, `thread_key_for` consistency, and an end-to-end `send()` asserting `References: <m1@example.com> <m2@example.com>` on the outbound reply. 9 of them fail without the source change.

### Verification

- `uv run pytest tests/test_channels -q` → 316 passed
- `uv run pytest -q -m "not llm"` → 8819 passed, 3 failed — all three (`test_mem0_provider`, `test_provider_config`, `test_skill_html_to_pdf`) fail on `main` in this environment and are unrelated
- `uv run ruff check src tests` → clean; `ruff format` clean on both touched files
- `uv run mypy src/agentos` → 1 error, the pre-existing `mem0` missing-stubs one

### Note

#622 fixes the same issue with the `In-Reply-To` fallback. This PR adds the comment/bracket-tolerant parsing and the `thread_key_for` consistency fix on top; happy for maintainers to take whichever they prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014T9kLcHQnL65C1rDZ8vJzn