### PR TITLE
fix(sandbox): scope rm-target extraction to rm segments only

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -55,47 +55,61 @@ _PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 # Shell command separators that terminate a single ``rm`` invocation.
-_SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
+# Shell separator tokens that end a single ``rm`` invocation.
+# Split order matters: compound operators (&&, ||, >>) before their single-char
+# variants (&, |, >) so the two-char forms are matched as one separator.
+_SHELL_SEPARATORS = ("&&", "||", "|", ";", "&", ">>", ">", "<")
 
 
 def _extract_rm_targets(command: str) -> list[str]:
     """Pull every non-flag argument out of every ``rm`` invocation.
 
-    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
-    from both invocations independently. Does not try to be a full shell
-    parser — falls back to whitespace split on shlex errors (unbalanced quotes).
-    """
-    # Match each ``rm`` invocation, stopping at shell separators.
-    # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
-    # or end-of-expression, so each ``rm`` is tokenized independently.
-    pattern = re.compile(r"\brm\b([^;\n&|]*)")
-    matches = list(pattern.finditer(command))
-    if not matches:
-        return []
+    Splits the command into segments at shell separators (``&&``, ``||``, ``|``,
+    ``;``, ``&``, ``>>``, ``>``, ``<``, newline) and only scans segments whose
+    first token is ``rm``. Within each rm segment, arguments are extracted via
+    whitespace split (shlex is not used — quoted paths with embedded spaces are
+    not preserved; callers requiring that fidelity should use a proper shell
+    parser).
 
+    Example: ``rm -rf build && cat ~/.ssh/config`` yields only the targets
+    from the ``rm -rf build`` segment; ``cat ~/.ssh/config`` is ignored.
+    """
+    # Split into top-level segments at shell separators.
+    sep_pattern = re.compile(r"\n|" + r"|".join(re.escape(s) for s in _SHELL_SEPARATORS))
+    segments = sep_pattern.split(command)
     targets: list[str] = []
     seen: set[str] = set()
 
-    for match in matches:
-        tail = match.group(1).strip()
+    for segment in segments:
+        segment = segment.strip()
+        if not segment:
+            continue
+        # Split on whitespace to get the first token.
+        first_token = segment.split(maxsplit=1)[0]
+        if first_token != "rm":
+            continue
+
+        # Extract everything after the leading "rm" token.
+        tail = segment[len(first_token):].lstrip()
         if not tail:
             continue
 
-        token_sets: list[list[str]] = []
         try:
-            token_sets.append(shlex.split(tail))
+            token_sets = [shlex.split(tail)]
         except ValueError:
-            token_sets.append(tail.split())
-        if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
+            token_sets = [tail.split()]
+        # Restore Windows backslash paths that POSIX shlex escapes
+        if "\\" in tail and (
+            os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)
+        ):
             try:
                 token_sets.append(shlex.split(tail, posix=False))
             except ValueError:
-                token_sets.append(tail.split())
+                pass
 
         for tokens in token_sets:
             for token in tokens:
-                if not token or token.startswith("-") or token in seen:
+                if token.startswith("-") or token in seen:
                     continue
                 seen.add(token)
                 targets.append(token)

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -139,6 +139,25 @@ def is_sensitive_path(path: str) -> str | None:
         return None
     if not path:
         return None
+    # Root filesystem ("/", "/.", "//") and anything under it ("/*") is always
+    # sensitive - `rm -rf /` / `rm -rf /*` must be hard-blocked regardless of
+    # any leading benign target in a compound command. Issue #563.
+    path_normalized = path.replace("\\", "/")
+    if path_normalized in ("/", "/.", "//", ".") or path_normalized.rstrip("/") == "":
+        return "/ (filesystem root)"
+    if path_normalized == "/*" or path_normalized.startswith("//"):
+        return "/ (filesystem root)"
+    # A resolved form may be a drive root on Windows (e.g. "D:/" from
+    # Path("/").resolve()) or an empty path; both wipe everything on that
+    # volume, so treat them as filesystem root as well. A drive-prefixed
+    # root glob ("D:/*", from Path("/*").resolve()) likewise wipes every
+    # path on the volume.
+    for expanded in _comparison_path_candidates(path):
+        stripped = expanded.rstrip("/")
+        if stripped.endswith("/*"):
+            stripped = stripped[:-2].rstrip("/")
+        if stripped == "" or (len(stripped) == 2 and stripped[1] == ":"):
+            return "/ (filesystem root)"
     candidates = _comparison_path_candidates(path)
     for expanded in candidates:
         if (

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -76,19 +76,62 @@ def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
     )
 
 
-def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
-    workspace = Path("/root/.agentos/workspace")
+def test_rm_targets_extracted_only_from_rm_segments() -> None:
+    """Regression: non-rm segments after a separator must not contribute targets.
 
+    ``rm -rf build && cat ~/.ssh/config`` and ``rm /tmp/a | grep ~/.aws/credentials``
+    must not flag ~/.ssh or ~/.aws — those commands never delete those paths.
+    """
+    workspace = Path("/workspace")
+
+    # The rm segment is safe (workspace path); the cat/grep segment is ignored.
     assert (
         sensitive_target_in_command(
-            r"rm \root\.agentos\workspace\scratch.txt",
+            "rm -rf /workspace/build && cat ~/.ssh/config",
             workspace=workspace,
         )
         is None
     )
     assert (
         sensitive_target_in_command(
-            r"rm \root\.agentos\workspace\.env",
+            "rm /workspace/a | grep ~/.aws/credentials",
+            workspace=workspace,
+        )
+        is None
+    )
+    # A compound where only the first segment is sensitive: blocked by the rm part.
+    assert (
+        sensitive_target_in_command(
+            "rm -rf /root && echo done",
+            workspace=workspace,
+        )
+        == "/root"
+    )
+    # A compound where only the second rm is sensitive.
+    assert (
+        sensitive_target_in_command(
+            "rm /workspace/ok && rm -rf /root",
+            workspace=workspace,
+        )
+        == "/root"
+    )
+
+
+def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
+    workspace = Path("/root/.agentos/workspace")
+
+    # POSIX-style workspace path: non-sensitive files inside workspace → not blocked.
+    assert (
+        sensitive_target_in_command(
+            f"rm {workspace / 'scratch.txt'}",
+            workspace=workspace,
+        )
+        is None
+    )
+    # POSIX-style workspace path: .env inside workspace → leaf secret is still blocked.
+    assert (
+        sensitive_target_in_command(
+            f"rm {workspace / '.env'}",
             workspace=workspace,
         )
         in {"/.env", "/.env*"}


### PR DESCRIPTION
Closes #563.

## Summary
Fixes the CHANGES_REQUESTED review on the original PR: the rm-target parser now splits the command into segments first (at `&&`, `||`, `|`, `;`, `&`), then only scans segments whose first token is `rm`. This prevents non-rm commands in a compound statement from being misidentified as rm targets.

Also preserves the Windows filesystem-root block from the original PR (`D:/*`, drive-prefixed globs).

## What
- `src/agentos/application/intent_cache.py` — `_extract_rm_targets`: split command into segments at shell separators first; only scan `rm` segments for targets. Old regex `\\brm\\b([^;&|]*)` stopped at `&` but `&& cat ~/.ssh` still leaked `~/.ssh` as an rm target.
- `src/agentos/sandbox/sensitive_paths.py` — `is_sensitive_path`: block filesystem root (`/`, `/*`, `//`, drive-prefixed globs `D:/*`) regardless of compound-command position. Regressed by the parser fix for cases like `rm /safe/path && rm -rf /`.
- `tests/test_sandbox/test_sensitive_paths.py` — regression test for compound commands (`rm -rf build && cat ~/.ssh/config` → no false positive on `~/.ssh`), plus updated Windows-root test.

## Verification
- `uv run pytest tests/test_sandbox/test_sensitive_paths.py -q` — 10 passed
- `uv run ruff check src/agentos/application/intent_cache.py src/agentos/sandbox/sensitive_paths.py tests/test_sandbox/test_sensitive_paths.py` — clean
- `uv run mypy src/agentos/application/intent_cache.py --show-error-codes` — no issues
