### PR TITLE
fix(cli): sanitize session_id in export filename to prevent path traversal (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- `sessions export` now sanitizes the session_id before using it as a
+  filename, preventing path traversal. Slashes, backslashes, and other
+  non-alphanumeric characters are stripped.
+
 ## [2026.9.2] - 2026-09-02
 
 ### Added

--- a/src/agentos/cli/sessions_cmd.py
+++ b/src/agentos/cli/sessions_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -377,7 +378,8 @@ def sessions_export(
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
         return
-    target = output or Path(f"{session_id.replace(':', '-')}.{format}")
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "-", session_id).strip("-") or "session"
+    target = output or Path(f"{safe_name}.{format}")
     if format == "json":
         target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     else:

--- a/tests/test_cli/test_sessions_export_cmd.py
+++ b/tests/test_cli/test_sessions_export_cmd.py
@@ -1,0 +1,79 @@
+"""Regression tests for sessions export filename sanitization.
+
+Ensures session_id values containing path separators or shell metacharacters
+are sanitized before use as a filename, preventing directory traversal.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# Same sanitization used in sessions_cmd.py::sessions_export
+def _safe_export_name(session_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", session_id).strip("-") or "session"
+
+
+class TestSessionExportSanitization:
+    """Safe names pass through unchanged."""
+
+    def test_normal_session_id_passes(self) -> None:
+        assert _safe_export_name("session_abc123") == "session_abc123"
+
+    def test_colon_replaced(self) -> None:
+        assert _safe_export_name("abc:123:xyz") == "abc-123-xyz"
+
+    def test_hyphen_preserved(self) -> None:
+        assert _safe_export_name("my-session-id") == "my-session-id"
+
+    def test_dot_preserved(self) -> None:
+        assert _safe_export_name("session.v1") == "session.v1"
+
+    def test_underscore_preserved(self) -> None:
+        assert _safe_export_name("my_session") == "my_session"
+
+    """Path traversal payloads — slashes are removed, preventing traversal."""
+
+    def test_path_traversal_slashes_removed(self) -> None:
+        name = _safe_export_name("../../etc/pwned")
+        assert "/" not in name
+
+    def test_path_traversal_backslashes_removed(self) -> None:
+        name = _safe_export_name("..\\..\\etc\\pwned")
+        assert "\\" not in name
+
+    def test_absolute_path_removed(self) -> None:
+        name = _safe_export_name("/etc/passwd")
+        assert "/" not in name
+
+    def test_mixed_traversal(self) -> None:
+        name = _safe_export_name("../../etc/passwd.json")
+        assert "/" not in name
+
+    def test_encoded_slash_removed(self) -> None:
+        assert _safe_export_name("safe%2Ftraversal") == "safe-2Ftraversal"
+
+    """Edge cases produce a safe fallback."""
+
+    def test_all_invalid_chars_falls_back(self) -> None:
+        assert _safe_export_name("!!!@@@###") == "session"
+
+    def test_empty_string_falls_back(self) -> None:
+        assert _safe_export_name("") == "session"
+
+    def test_only_slashes_falls_back(self) -> None:
+        assert _safe_export_name("///") == "session"
+
+    def test_leading_trailing_dashes_stripped(self) -> None:
+        assert _safe_export_name("---hello---") == "hello"
+
+    def test_tab_newline_removed(self) -> None:
+        assert _safe_export_name("abc\tdef\nghi") == "abc-def-ghi"
+
+    def test_unicode_letters_preserved(self) -> None:
+        name = _safe_export_name("sesión-123")
+        # ñ is stripped by the regex [^A-Za-z0-9_.-]
+        assert "-" in name
+
+    def test_spaces_replaced(self) -> None:
+        assert _safe_export_name("my session id") == "my-session-id"


### PR DESCRIPTION
## Summary

In `cli/sessions_cmd.py` line 385, the export command constructs the output filename using the raw `session_id` with only colons replaced. Slashes and backslashes pass through, allowing path traversal (e.g. `../../etc/pwned` writes to an arbitrary location).

## Fix

Applied the same sanitization used in `session/manager.py` `_safe_archive_part` — strip everything except alphanumerics, underscore, dot, and hyphen — before constructing the filename.

## Verification
- `ruff check src tests` ✅ all checks passed
- CLI session tests pass ✅
- No breaking changes to the export API

Fixes #678