### PR TITLE
feat(cli): add `agentos cost savings` with a PDF export

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,7 @@ agentos <command> --help
 | `agentos sandbox` | Inspect or change default sandbox posture. |
 | `agentos cron` | Manage scheduled AgentOS runs. |
 | `agentos cost` | Inspect usage and estimated cost. |
+| `agentos cost savings` | Report what the Pilot Router saved against the priciest configured tier. |
 | `agentos context` | Show the fixed per-request context cost and what each tool profile would cost. |
 | `agentos diagnostics` | Enable or disable runtime diagnostics logging. |
 | `agentos replay` | Replay a recorded turn from the decision log. |
@@ -810,6 +811,7 @@ Read:
 agentos context
 agentos context --json
 agentos cost
+agentos cost savings
 agentos diagnostics status
 agentos diagnostics on
 agentos diagnostics off
@@ -845,6 +847,44 @@ agentos cost --export /path/to/export.csv
 | `--tool-name` | Filter by tool name. |
 | `--skill` | Filter by skill name. |
 | `--export` | Path to export results (JSON/CSV). |
+
+### `agentos cost savings`
+
+`agentos cost` answers "what did I spend"; `agentos cost savings` answers "what
+did the [Pilot Router](features/agentos-router.md) save me". It reads the local
+decision log (`~/.agentos/logs/decisions-*.jsonl`) rather than the gateway, so
+it works with the gateway stopped:
+
+```sh
+agentos cost savings                                  # summary + per-route table
+agentos cost savings --json
+agentos cost savings --csv
+agentos cost savings --start-date 2026-08-01 --end-date 2026-08-31
+agentos cost savings --pdf ~/pilot-router-savings.pdf
+```
+
+| Option | Purpose |
+| --- | --- |
+| `--pdf` | Write a branded, shareable PDF report to this path. |
+| `--json` | Emit machine-readable JSON. |
+| `--csv` | Emit machine-readable CSV, one row per route pair. |
+| `--start-date` | Filter by start date (YYYY-MM-DD, UTC, inclusive). |
+| `--end-date` | Filter by end date (YYYY-MM-DD, UTC, inclusive). |
+| `--log-dir` | Read a decision-log directory other than `~/.agentos/logs`. |
+
+**Read the number correctly.** The baseline is *the most expensive model
+configured in `[router.tiers]`* — what every routed turn would have cost had it
+gone to your top tier — and not the model the request arrived with. Only input
+tokens are priced, at list rates, so the figure is a floor rather than a
+full-turn saving. The report covers routing alone: tool-result projection,
+short-reply enforcement, prompt-cache hits and thinking mode are excluded, even
+though the decision log carries them too. The `Requested` column names the
+model the turn asked for, which is *not* the price comparison — a turn can be
+routed back onto the requested model and still show a saving, because the top
+tier is dearer than both.
+
+Turns are logged only when the decision log is being written, so the window
+starts at your oldest retained `decisions-*.jsonl` file.
 
 Use diagnostics and replay when you need to understand why a turn behaved a
 certain way. For Prometheus metrics (`/metrics`), OTLP trace export, and log retention

--- a/docs/features/agentos-router.md
+++ b/docs/features/agentos-router.md
@@ -159,6 +159,12 @@ have been removed from the tree entirely (Phase C); a config that still pins it
 is auto-migrated to `pilot-v1` on the next load (see **Upgrading from
 v4_phase3**).
 
+Those reports measure routing *quality* and feature-extraction *latency*. For
+what the router has saved you in dollars on your own traffic, see
+[`agentos cost savings`](../cli.md#agentos-cost-savings) — it rolls the
+per-turn savings telemetry in `~/.agentos/logs/decisions-*.jsonl` up into a
+summary, JSON/CSV, or a shareable PDF.
+
 The default needs no config, but the Pilot safety-net floor is tunable:
 
 ```toml

--- a/docs/usage-and-cost.md
+++ b/docs/usage-and-cost.md
@@ -46,6 +46,26 @@ agentos cost --by-model --json
 JSON output is useful for local dashboards, regression checks, and automated
 reports.
 
+## Report What Routing Saved
+
+```sh
+agentos cost savings
+agentos cost savings --start-date 2026-08-01 --end-date 2026-08-31
+agentos cost savings --pdf ~/pilot-router-savings.pdf
+```
+
+`agentos cost` shows what you spent; `agentos cost savings` shows what the
+[Pilot Router](features/agentos-router.md) avoided spending. It reads the local
+decision log instead of the gateway, so it works with the gateway stopped, and
+`--pdf` writes a branded one-page report you can send on.
+
+The baseline is the most expensive model configured in `[router.tiers]` — what
+every routed turn would have cost on your top tier — priced on input tokens
+only at list rates. That makes the figure a floor, not a full-turn saving, and
+it covers routing alone: tool-result projection, short-reply enforcement,
+prompt-cache hits and thinking mode are excluded. See
+[`cli.md`](cli.md#agentos-cost-savings) for the full option list.
+
 ## What to Check First
 
 | Signal | What it can mean |

--- a/src/agentos/cli/cost_cmd.py
+++ b/src/agentos/cli/cost_cmd.py
@@ -14,12 +14,16 @@ from rich.table import Table
 from agentos.cli.gateway_rpc import run_gateway_sync
 from agentos.cli.output import print_json
 from agentos.cli.ui import ACCENT_HEADER, console
+from agentos.observability.decision_log import _default_log_dir
+from agentos.observability.savings_pdf import render_savings_pdf
+from agentos.observability.savings_report import SavingsReport, build_savings_report
 
 app = typer.Typer(help="Inspect usage and estimated cost.")
 
 
 @app.callback(invoke_without_command=True)
 def cost(
+    ctx: typer.Context,
     by_model: bool = typer.Option(False, "--by-model", help="Group aggregate rows by model"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
     csv_output: bool = typer.Option(False, "--csv", help="Emit machine-readable CSV"),
@@ -32,6 +36,12 @@ def cost(
     export_path: str = typer.Option(None, "--export", help="Path to export results (JSON/CSV)"),
 ) -> None:
     """Show aggregate usage/cost from the running gateway."""
+
+    # The group is invoke_without_command, so this callback also runs ahead of
+    # every subcommand. Subcommands own their own output (and `savings` reads
+    # the local decision log, with no gateway to talk to).
+    if ctx.invoked_subcommand is not None:
+        return
 
     params = {}
     if start_date:
@@ -211,3 +221,150 @@ def cost(
         )
     console.print(table)
     console.print(f"[dim]total: ${float(payload.get('totalCostUsd') or 0.0):.6f}[/dim]")
+
+
+@app.command("savings")
+def savings(
+    pdf: str = typer.Option(None, "--pdf", help="Write a branded PDF report to this path"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    csv_output: bool = typer.Option(False, "--csv", help="Emit machine-readable CSV"),
+    start_date: str = typer.Option(None, "--start-date", help="Filter by start date (YYYY-MM-DD)"),
+    end_date: str = typer.Option(None, "--end-date", help="Filter by end date (YYYY-MM-DD)"),
+    log_dir: str = typer.Option(None, "--log-dir", help="Decision-log directory to read"),
+) -> None:
+    """Report what the Pilot Router saved against the baseline model.
+
+    Reads the local decision log (``~/.agentos/logs/decisions-*.jsonl``), so it
+    works with the gateway stopped. Routing only — the other savings mechanisms
+    are excluded so the number is attributable to the router.
+    """
+
+    directory = Path(log_dir) if log_dir else _default_log_dir()
+    report = build_savings_report(directory, start_date=start_date, end_date=end_date)
+
+    if pdf:
+        path = render_savings_pdf(report, Path(pdf))
+        if json_output:
+            print_json({**_savings_payload(report), "pdfPath": str(path)})
+        else:
+            # soft_wrap keeps the path on one line so it stays copy-pasteable.
+            console.print(f"Wrote Pilot Router savings report to {path}", soft_wrap=True)
+        return
+
+    if json_output:
+        print_json(_savings_payload(report))
+        return
+
+    if csv_output:
+        import io
+
+        f = io.StringIO()
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "RequestedModel",
+                "RoutedModel",
+                "Turns",
+                "AvgSavingsPct",
+                "AvgConfidence",
+                "SavedUsd",
+            ]
+        )
+        for row in report.by_route:
+            writer.writerow(
+                [
+                    row.requested_model,
+                    row.routed_model,
+                    row.turns,
+                    "" if row.avg_savings_pct is None else f"{row.avg_savings_pct:.2f}",
+                    "" if row.avg_confidence is None else f"{row.avg_confidence:.4f}",
+                    f"{row.savings_usd:.6f}",
+                ]
+            )
+        console.print(f.getvalue().strip())
+        return
+
+    _render_savings_table(report)
+
+
+def _savings_payload(report: SavingsReport) -> dict[str, Any]:
+    """Camel-case the report for the CLI JSON contract."""
+
+    return {
+        "startDate": report.start_date,
+        "endDate": report.end_date,
+        "turnsTotal": report.turns_total,
+        "turnsRouted": report.turns_routed,
+        "turnsRerouted": report.turns_rerouted,
+        "turnsKept": report.turns_kept,
+        "turnsAtTopTier": report.turns_at_top_tier,
+        "actualCostUsd": report.actual_cost_usd,
+        "routingSavingsUsd": report.routing_savings_usd,
+        "topTierCostUsd": report.top_tier_cost_usd,
+        "savingsPct": report.savings_pct,
+        "avgConfidence": report.avg_confidence,
+        "tokensInput": report.tokens_input,
+        "tokensOutput": report.tokens_output,
+        "byRoute": [
+            {
+                "requestedModel": row.requested_model,
+                "routedModel": row.routed_model,
+                "turns": row.turns,
+                "avgSavingsPct": row.avg_savings_pct,
+                "avgConfidence": row.avg_confidence,
+                "savingsUsd": row.savings_usd,
+            }
+            for row in report.by_route
+        ],
+        "byDay": [
+            {
+                "date": row.date,
+                "turns": row.turns,
+                "savingsUsd": row.savings_usd,
+                "actualCostUsd": row.actual_cost_usd,
+            }
+            for row in report.by_day
+        ],
+    }
+
+
+def _render_savings_table(report: SavingsReport) -> None:
+    """Print the savings summary and the per-route breakdown."""
+
+    window = (
+        f"{report.start_date} to {report.end_date}"
+        if report.start_date and report.end_date
+        else "no routed turns in window"
+    )
+    console.print(
+        f"[bold]Pilot Router savings[/bold] [dim]({window})[/dim]\n"
+        f"  saved       [bold]${report.routing_savings_usd:,.2f}[/bold] "
+        f"({report.savings_pct:.1f}% of the top-tier bill)\n"
+        f"  actual      ${report.actual_cost_usd:,.2f}\n"
+        f"  top tier    ${report.top_tier_cost_usd:,.2f}\n"
+        f"  turns       {report.turns_routed:,} routed of {report.turns_total:,} logged "
+        f"({report.turns_rerouted:,} moved off the request, {report.turns_kept:,} kept, "
+        f"{report.turns_at_top_tier:,} on the top tier)\n"
+        f"[dim]  Baseline is the priciest model in \\[router.tiers]; input tokens only.[/dim]"
+    )
+
+    if not report.by_route:
+        return
+
+    table = Table(title="Savings by Route", show_header=True, header_style=ACCENT_HEADER)
+    table.add_column("Requested")
+    table.add_column("Routed To")
+    table.add_column("Turns", justify="right")
+    table.add_column("Avg %", justify="right")
+    table.add_column("Avg Conf", justify="right")
+    table.add_column("Saved", justify="right")
+    for row in report.by_route:
+        table.add_row(
+            row.requested_model,
+            row.routed_model,
+            f"{row.turns:,}",
+            "-" if row.avg_savings_pct is None else f"{row.avg_savings_pct:.1f}%",
+            "-" if row.avg_confidence is None else f"{row.avg_confidence:.2f}",
+            f"${row.savings_usd:,.2f}",
+        )
+    console.print(table)

--- a/src/agentos/observability/savings_pdf.py
+++ b/src/agentos/observability/savings_pdf.py
@@ -1,0 +1,416 @@
+"""Render a :class:`~agentos.observability.savings_report.SavingsReport` as a
+branded, shareable PDF.
+
+Drawn straight onto a ReportLab canvas rather than assembled with Platypus:
+the page is a fixed one-off layout, not a flowing document, and the AgentOS
+mark is vector geometry (four discs and three spokes) that has to sit exactly
+in the header corner. ``reportlab`` is a base dependency, so no extra install
+is needed.
+
+Palette follows the product brand — near-black ink, lime ``#ccff00`` accent —
+on a white ground so the report stays printable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from math import cos, pi, sin
+from pathlib import Path
+from typing import Any
+
+from agentos.observability.savings_report import SavingsReport
+
+# Brand palette. LIME is the same accent the Web UI uses (`--color-accent`).
+_LIME = (0.8, 1.0, 0.0)
+_INK = (0.063, 0.078, 0.094)
+_MUTED = (0.42, 0.45, 0.49)
+_HAIRLINE = (0.85, 0.87, 0.89)
+_TINT = (0.965, 0.984, 0.898)
+_WHITE = (1.0, 1.0, 1.0)
+
+_PAGE_MARGIN = 44.0
+_HEADER_HEIGHT = 92.0
+_FOOTER_HEIGHT = 38.0
+
+#: Route-table rows that fit below the chart on page 1, and on a full page.
+_ROUTE_ROWS_FIRST_PAGE = 14
+_ROUTE_ROWS_PER_PAGE = 30
+_ROW_HEIGHT = 17.0
+
+#: Header title, split so the two halves can carry different weights. Laid out
+#: by measuring the lead rather than by a hand-tuned offset.
+_TITLE_LEAD = "Pilot Router"
+_TITLE_TAIL = "Cost Savings Report"
+_TITLE_SIZE = 19.0
+
+#: Stat-grid type sizes. Labels must fit their share of the text column - see
+#: ``test_stat_labels_fit_inside_their_column``.
+_STAT_VALUE_SIZE = 15.0
+_STAT_LABEL_SIZE = 7.5
+
+
+def render_savings_pdf(
+    report: SavingsReport,
+    path: Path,
+    *,
+    generated_at: datetime | None = None,
+) -> Path:
+    """Write ``report`` to ``path`` as a PDF and return the path."""
+
+    from reportlab.lib.pagesizes import A4  # type: ignore[import-untyped]
+    from reportlab.pdfgen import canvas as pdfcanvas  # type: ignore[import-untyped]
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    width, height = A4
+    stamp = (generated_at or datetime.now(UTC)).strftime("%Y-%m-%d %H:%M UTC")
+
+    c = pdfcanvas.Canvas(str(path), pagesize=A4)
+    c.setTitle("AgentOS Pilot Router - Cost Savings Report")
+    c.setAuthor("AgentOS")
+    c.setSubject("Estimated model-routing cost savings vs the most expensive configured tier")
+
+    _draw_header(c, width, height, subtitle=_window_label(report))
+    y = height - _HEADER_HEIGHT - 28.0
+    y = _draw_hero(c, width, y, report)
+    y = _draw_stat_grid(c, width, y, report)
+    y = _draw_daily_chart(c, width, y, report)
+    remaining = _draw_route_table(c, width, y, report.by_route, limit=_ROUTE_ROWS_FIRST_PAGE)
+    _draw_footer(c, width, stamp)
+
+    while remaining:
+        c.showPage()
+        _draw_header(c, width, height, subtitle=_window_label(report))
+        y = height - _HEADER_HEIGHT - 28.0
+        remaining = _draw_route_table(c, width, y, remaining, limit=_ROUTE_ROWS_PER_PAGE)
+        _draw_footer(c, width, stamp)
+
+    c.save()
+    return path
+
+
+def _window_label(report: SavingsReport) -> str:
+    if report.start_date and report.end_date:
+        return f"{report.start_date} to {report.end_date}"
+    return "no data in window"
+
+
+# --------------------------------------------------------------------------
+# Chrome
+# --------------------------------------------------------------------------
+
+
+def _draw_header(c: Any, width: float, height: float, *, subtitle: str) -> None:
+    """Black band with the title on the left and the AgentOS mark on the right."""
+
+    c.setFillColorRGB(*_INK)
+    c.rect(0, height - _HEADER_HEIGHT, width, _HEADER_HEIGHT, stroke=0, fill=1)
+
+    c.setFillColorRGB(*_LIME)
+    c.rect(0, height - _HEADER_HEIGHT, width, 3, stroke=0, fill=1)
+
+    from reportlab.pdfbase.pdfmetrics import stringWidth  # type: ignore[import-untyped]
+
+    c.setFillColorRGB(*_WHITE)
+    c.setFont("Helvetica-Bold", _TITLE_SIZE)
+    c.drawString(_PAGE_MARGIN, height - 46, _TITLE_LEAD)
+    lead_width = stringWidth(_TITLE_LEAD + " ", "Helvetica-Bold", _TITLE_SIZE)
+    c.setFont("Helvetica", _TITLE_SIZE)
+    c.drawString(_PAGE_MARGIN + lead_width, height - 46, _TITLE_TAIL)
+
+    c.setFillColorRGB(*_LIME)
+    c.setFont("Helvetica", 9.5)
+    c.drawString(_PAGE_MARGIN, height - 64, subtitle)
+
+    _draw_logo(c, width - _PAGE_MARGIN - 27, height - _HEADER_HEIGHT / 2 + 6, 27)
+
+
+def _draw_logo(c: Any, cx: float, cy: float, radius: float) -> None:
+    """Draw the AgentOS mark centred on ``(cx, cy)`` with the wordmark below.
+
+    The mark is a hub disc with three spokes to satellite discs at 90 deg,
+    210 deg and 330 deg — the same geometry as ``assets/agentos-stacked-logo.png``.
+    """
+
+    hub = radius * 0.42
+    satellite = radius * 0.20
+
+    c.setStrokeColorRGB(*_LIME)
+    c.setFillColorRGB(*_LIME)
+    c.setLineWidth(max(1.1, radius * 0.06))
+
+    for degrees in (90.0, 210.0, 330.0):
+        angle = degrees * pi / 180.0
+        sx = cx + radius * cos(angle)
+        sy = cy + radius * sin(angle)
+        c.line(cx, cy, sx, sy)
+        c.circle(sx, sy, satellite, stroke=0, fill=1)
+
+    c.circle(cx, cy, hub, stroke=0, fill=1)
+
+    c.setFont("Courier-Bold", 8)
+    c.drawCentredString(cx, cy - radius - 12, "agentOS_")
+
+
+#: What the headline number is and is not, printed on every page.
+_METHOD_NOTE = (
+    "Method: the baseline is the most expensive model configured in [router.tiers] - what every "
+    "routed turn would have cost had it gone to your top tier. Only input tokens are priced, at "
+    "list rates, so the figure is a floor rather than a full-turn saving. Routing only: "
+    "tool-result projection, short-reply enforcement, prompt-cache hits and thinking mode are "
+    'excluded. "Requested" names the model the turn asked for, which is not the price '
+    "comparison."
+)
+
+
+def _draw_footer(c: Any, width: float, stamp: str) -> None:
+    inner = width - 2 * _PAGE_MARGIN
+    lines = _wrap(_METHOD_NOTE, "Helvetica", 7.0, inner)
+
+    rule_y = _FOOTER_HEIGHT + 9 * len(lines)
+    c.setStrokeColorRGB(*_HAIRLINE)
+    c.setLineWidth(0.6)
+    c.line(_PAGE_MARGIN, rule_y, width - _PAGE_MARGIN, rule_y)
+
+    c.setFillColorRGB(*_MUTED)
+    c.setFont("Helvetica", 7.0)
+    text_y = rule_y - 11
+    for line in lines:
+        c.drawString(_PAGE_MARGIN, text_y, line)
+        text_y -= 9
+
+    c.setFont("Helvetica", 7.0)
+    c.drawRightString(width - _PAGE_MARGIN, rule_y + 5, f"agentOS - generated {stamp}")
+
+
+def _wrap(text: str, font: str, size: float, max_width: float) -> list[str]:
+    """Greedy word wrap against the real glyph widths of ``font`` at ``size``."""
+
+    from reportlab.pdfbase.pdfmetrics import stringWidth  # type: ignore[import-untyped]
+
+    lines: list[str] = []
+    current = ""
+    for word in text.split():
+        candidate = f"{current} {word}".strip()
+        if current and stringWidth(candidate, font, size) > max_width:
+            lines.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Body
+# --------------------------------------------------------------------------
+
+
+def _draw_hero(c: Any, width: float, y: float, report: SavingsReport) -> float:
+    """The headline dollar figure, on a lime-tinted card."""
+
+    card_height = 96.0
+    top = y
+    c.setFillColorRGB(*_TINT)
+    c.rect(_PAGE_MARGIN, top - card_height, width - 2 * _PAGE_MARGIN, card_height, stroke=0, fill=1)
+    c.setFillColorRGB(*_LIME)
+    c.rect(_PAGE_MARGIN, top - card_height, 4, card_height, stroke=0, fill=1)
+
+    c.setFillColorRGB(*_MUTED)
+    c.setFont("Helvetica-Bold", 8.5)
+    c.drawString(_PAGE_MARGIN + 20, top - 24, "ESTIMATED SAVED BY ROUTING")
+
+    c.setFillColorRGB(*_INK)
+    c.setFont("Helvetica-Bold", 40)
+    c.drawString(_PAGE_MARGIN + 20, top - 66, f"${report.routing_savings_usd:,.2f}")
+
+    c.setFont("Helvetica", 10)
+    c.setFillColorRGB(*_MUTED)
+    if report.turns_routed:
+        c.drawString(
+            _PAGE_MARGIN + 20,
+            top - 84,
+            f"{report.savings_pct:.1f}% of a ${report.top_tier_cost_usd:,.2f} top-tier bill "
+            f"over {report.turns_routed:,} routed turns",
+        )
+    else:
+        c.drawString(_PAGE_MARGIN + 20, top - 84, "No routed turns in this window")
+
+    # Right-hand pair: what was actually paid vs the top-tier counterfactual.
+    right = width - _PAGE_MARGIN - 20
+    c.setFillColorRGB(*_MUTED)
+    c.setFont("Helvetica-Bold", 8.5)
+    c.drawRightString(right, top - 24, "ACTUAL / TOP TIER")
+    c.setFillColorRGB(*_INK)
+    c.setFont("Helvetica-Bold", 17)
+    c.drawRightString(
+        right,
+        top - 48,
+        f"${report.actual_cost_usd:,.2f} / ${report.top_tier_cost_usd:,.2f}",
+    )
+    c.setFillColorRGB(*_MUTED)
+    c.setFont("Helvetica", 9)
+    c.drawRightString(right, top - 64, f"{report.savings_pct:.1f}% avoided")
+
+    return top - card_height - 26.0
+
+
+def _stat_cells(report: SavingsReport) -> list[tuple[str, str]]:
+    """The stat-grid labels and values, in display order.
+
+    Labels are kept short on purpose: six cells share the text column, so a
+    long one runs into its neighbour.
+    """
+
+    confidence = f"{report.avg_confidence:.2f}" if report.avg_confidence is not None else "n/a"
+    return [
+        ("TURNS LOGGED", f"{report.turns_total:,}"),
+        ("ROUTED", f"{report.turns_routed:,}"),
+        ("REROUTED", f"{report.turns_rerouted:,}"),
+        ("KEPT", f"{report.turns_kept:,}"),
+        ("TOP TIER", f"{report.turns_at_top_tier:,}"),
+        ("AVG CONF", confidence),
+    ]
+
+
+def _draw_stat_grid(c: Any, width: float, y: float, report: SavingsReport) -> float:
+    """Six small stat cells across the page."""
+
+    cells = _stat_cells(report)
+
+    inner = width - 2 * _PAGE_MARGIN
+    cell_width = inner / len(cells)
+    for index, (label, value) in enumerate(cells):
+        x = _PAGE_MARGIN + index * cell_width
+        c.setFillColorRGB(*_INK)
+        c.setFont("Helvetica-Bold", _STAT_VALUE_SIZE)
+        c.drawString(x, y - 16, value)
+        c.setFillColorRGB(*_MUTED)
+        c.setFont("Helvetica", _STAT_LABEL_SIZE)
+        c.drawString(x, y - 28, label)
+
+    c.setStrokeColorRGB(*_HAIRLINE)
+    c.setLineWidth(0.6)
+    c.line(_PAGE_MARGIN, y - 42, width - _PAGE_MARGIN, y - 42)
+
+    return y - 62.0
+
+
+def _draw_daily_chart(c: Any, width: float, y: float, report: SavingsReport) -> float:
+    """Bar chart of savings per day."""
+
+    chart_height = 108.0
+    c.setFillColorRGB(*_INK)
+    c.setFont("Helvetica-Bold", 10.5)
+    c.drawString(_PAGE_MARGIN, y, "Saved per day")
+
+    top = y - 14.0
+    baseline_y = top - chart_height
+    inner = width - 2 * _PAGE_MARGIN
+
+    if not report.by_day:
+        c.setFillColorRGB(*_MUTED)
+        c.setFont("Helvetica", 9)
+        c.drawString(_PAGE_MARGIN, top - 20, "No routed turns to chart.")
+        return top - 40.0
+
+    peak = max(row.savings_usd for row in report.by_day)
+    peak = peak if peak > 0 else 1.0
+    slot = inner / len(report.by_day)
+    bar_width = min(26.0, slot * 0.62)
+
+    c.setStrokeColorRGB(*_HAIRLINE)
+    c.setLineWidth(0.6)
+    c.line(_PAGE_MARGIN, baseline_y, width - _PAGE_MARGIN, baseline_y)
+
+    # Label every Nth day so a long window keeps a readable axis.
+    step = max(1, len(report.by_day) // 10)
+    for index, row in enumerate(report.by_day):
+        centre = _PAGE_MARGIN + index * slot + slot / 2
+        bar = max(1.0, (max(row.savings_usd, 0.0) / peak) * (chart_height - 16))
+        c.setFillColorRGB(*_LIME)
+        c.rect(centre - bar_width / 2, baseline_y, bar_width, bar, stroke=0, fill=1)
+        if index % step == 0 or index == len(report.by_day) - 1:
+            c.setFillColorRGB(*_MUTED)
+            c.setFont("Helvetica", 6.5)
+            c.drawCentredString(centre, baseline_y - 10, row.date[5:])
+
+    c.setFillColorRGB(*_MUTED)
+    c.setFont("Helvetica", 7.5)
+    c.drawRightString(width - _PAGE_MARGIN, top, f"peak ${peak:,.2f}")
+
+    return baseline_y - 34.0
+
+
+def _draw_route_table(c: Any, width: float, y: float, rows: list[Any], *, limit: int) -> list[Any]:
+    """Draw up to ``limit`` route rows; return the rows that did not fit."""
+
+    c.setFillColorRGB(*_INK)
+    c.setFont("Helvetica-Bold", 10.5)
+    c.drawString(_PAGE_MARGIN, y, "Where the savings came from")
+
+    header_y = y - 18.0
+    columns = _route_columns(width)
+
+    c.setFillColorRGB(*_MUTED)
+    c.setFont("Helvetica-Bold", 7.5)
+    c.drawString(columns["requested"], header_y, "REQUESTED")
+    c.drawString(columns["routed"], header_y, "ROUTED TO")
+    c.drawRightString(columns["turns"], header_y, "TURNS")
+    c.drawRightString(columns["pct"], header_y, "AVG %")
+    c.drawRightString(columns["confidence"], header_y, "AVG CONF")
+    c.drawRightString(columns["saved"], header_y, "SAVED")
+
+    c.setStrokeColorRGB(*_HAIRLINE)
+    c.setLineWidth(0.6)
+    c.line(_PAGE_MARGIN, header_y - 6, width - _PAGE_MARGIN, header_y - 6)
+
+    if not rows:
+        c.setFillColorRGB(*_MUTED)
+        c.setFont("Helvetica", 9)
+        c.drawString(_PAGE_MARGIN, header_y - 22, "No routed turns in this window.")
+        return []
+
+    row_y = header_y - 20.0
+    for row in rows[:limit]:
+        c.setFillColorRGB(*_INK)
+        c.setFont("Helvetica", 8.5)
+        c.drawString(columns["requested"], row_y, _clip(row.requested_model, 26))
+        c.setFont("Helvetica-Bold", 8.5)
+        c.drawString(columns["routed"], row_y, _clip(row.routed_model, 26))
+        c.setFont("Helvetica", 8.5)
+        c.drawRightString(columns["turns"], row_y, f"{row.turns:,}")
+        c.drawRightString(
+            columns["pct"],
+            row_y,
+            f"{row.avg_savings_pct:.1f}%" if row.avg_savings_pct is not None else "-",
+        )
+        c.drawRightString(
+            columns["confidence"],
+            row_y,
+            f"{row.avg_confidence:.2f}" if row.avg_confidence is not None else "-",
+        )
+        c.setFillColorRGB(*_INK)
+        c.setFont("Helvetica-Bold", 8.5)
+        c.drawRightString(columns["saved"], row_y, f"${row.savings_usd:,.2f}")
+        row_y -= _ROW_HEIGHT
+
+    return list(rows[limit:])
+
+
+def _route_columns(width: float) -> dict[str, float]:
+    right = width - _PAGE_MARGIN
+    return {
+        "requested": _PAGE_MARGIN,
+        "routed": _PAGE_MARGIN + 150,
+        "turns": right - 210,
+        "pct": right - 150,
+        "confidence": right - 80,
+        "saved": right,
+    }
+
+
+def _clip(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"

--- a/src/agentos/observability/savings_report.py
+++ b/src/agentos/observability/savings_report.py
@@ -1,0 +1,268 @@
+"""Aggregate Pilot Router cost savings out of the decision log.
+
+Every completed turn writes a :class:`~agentos.observability.decision_log.
+SavingsTelemetry` block to ``~/.agentos/logs/decisions-YYYYMMDD.jsonl``. This
+module rolls the routing part of those blocks up into a :class:`SavingsReport`
+— the shape rendered by ``agentos cost savings`` as a table, as JSON/CSV, and
+as the branded PDF.
+
+What the dollar figure actually means
+-------------------------------------
+The engine computes per-turn routing savings in ``runtime.
+_compute_route_input_savings_usd`` as::
+
+    (top_tier_input_price_per_m - routed_input_price_per_m) * input_tokens / 1e6
+
+So the comparison is against **the most expensive model configured in
+``[router.tiers]``** — the bill you would have run up sending every turn to
+your top tier — and not against the model named by the telemetry's
+``baseline_model`` field, which records the model the *request* arrived with.
+This module therefore reports that field as ``requested_model`` and never
+implies it is the price comparison.
+
+Two consequences worth carrying into any presentation of these numbers:
+
+* Only **input** tokens are priced. Output tokens, which are dearer per token
+  on every tier, are not counted — the figure is a conservative floor.
+* The per-turn value is clamped at zero, so a turn routed onto the top tier
+  contributes nothing rather than a negative.
+
+**Scope:** routing only. The other savings mechanisms in the telemetry block
+(tool-result projection, short-reply enforcement, cache hits, thinking mode)
+are deliberately excluded so the headline number is attributable to the router
+and nothing else.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from agentos.observability.decision_log import DecisionEntry, load_entries
+
+#: Monetary aggregates are rounded to this many decimals. Per-turn savings run
+#: to fractions of a cent, so summing raw floats leaves visible drift.
+_USD_PRECISION = 6
+_PCT_PRECISION = 2
+_CONFIDENCE_PRECISION = 4
+
+
+@dataclass
+class RouteRow:
+    """One ``requested_model -> routed_model`` pair, summed over the window."""
+
+    requested_model: str
+    routed_model: str
+    turns: int
+    savings_usd: float
+    avg_savings_pct: float | None
+    avg_confidence: float | None
+
+
+@dataclass
+class DayRow:
+    """One calendar day (UTC), summed over the turns the router decided."""
+
+    date: str
+    turns: int
+    savings_usd: float
+    actual_cost_usd: float
+
+
+@dataclass
+class SavingsReport:
+    """Pilot Router savings over a window of decision-log turns.
+
+    ``actual_cost_usd`` and ``top_tier_cost_usd`` cover only the turns the
+    router actually decided (``turns_routed``), so the two are comparable:
+    ``savings_pct`` is the share of the top-tier bill that routing avoided.
+
+    ``top_tier_cost_usd`` is ``actual_cost_usd`` plus the input-side savings.
+    Because the engine prices only input tokens, this understates what the top
+    tier would really have charged — its output tokens are dearer too.
+    """
+
+    start_date: str | None
+    end_date: str | None
+    turns_total: int
+    turns_routed: int
+    #: Turns the router moved off the model the request arrived with.
+    turns_rerouted: int
+    #: Turns the router landed back on the requested model.
+    turns_kept: int
+    #: Turns that saved nothing because they ran on the most expensive tier.
+    turns_at_top_tier: int
+    actual_cost_usd: float
+    routing_savings_usd: float
+    top_tier_cost_usd: float
+    savings_pct: float
+    avg_confidence: float | None
+    tokens_input: int
+    tokens_output: int
+    by_route: list[RouteRow] = field(default_factory=list)
+    by_day: list[DayRow] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the report as plain JSON-serialisable data."""
+
+        return asdict(self)
+
+
+def _entry_date(entry: DecisionEntry) -> str:
+    """Return the ``YYYY-MM-DD`` day of a turn, from its ISO timestamp."""
+
+    return entry.ts[:10]
+
+
+def collect_entries(
+    log_dir: Path,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> list[DecisionEntry]:
+    """Load every decision-log turn in ``log_dir`` inside the date window.
+
+    Dates are inclusive ``YYYY-MM-DD`` strings compared against the turn's own
+    UTC timestamp, not the log filename — a turn just after midnight UTC lands
+    in the day it was actually served.
+    """
+
+    if not log_dir.is_dir():
+        return []
+
+    entries: list[DecisionEntry] = []
+    for path in sorted(log_dir.glob("decisions-*.jsonl")):
+        for entry in load_entries(path):
+            day = _entry_date(entry)
+            if start_date and day < start_date:
+                continue
+            if end_date and day > end_date:
+                continue
+            entries.append(entry)
+    entries.sort(key=lambda e: e.ts)
+    return entries
+
+
+def build_savings_report(
+    log_dir: Path,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> SavingsReport:
+    """Aggregate Pilot Router savings from the decision logs in ``log_dir``."""
+
+    entries = collect_entries(log_dir, start_date=start_date, end_date=end_date)
+
+    routed = 0
+    rerouted = 0
+    kept = 0
+    at_top_tier = 0
+    savings_usd = 0.0
+    actual_cost = 0.0
+    tokens_input = 0
+    tokens_output = 0
+    confidences: list[float] = []
+
+    route_turns: dict[tuple[str, str], int] = defaultdict(int)
+    route_savings: dict[tuple[str, str], float] = defaultdict(float)
+    route_pcts: dict[tuple[str, str], list[float]] = defaultdict(list)
+    route_confidences: dict[tuple[str, str], list[float]] = defaultdict(list)
+
+    day_turns: dict[str, int] = defaultdict(int)
+    day_savings: dict[str, float] = defaultdict(float)
+    day_cost: dict[str, float] = defaultdict(float)
+
+    for entry in entries:
+        telemetry = entry.savings
+        delta = telemetry.routing_savings_usd_estimated_vs_baseline
+        requested = telemetry.baseline_model
+        if delta is None or not telemetry.routed_model or not requested:
+            continue
+
+        routed += 1
+        savings_usd += delta
+        actual_cost += telemetry.cost_usd or telemetry.billed_cost_usd or 0.0
+        tokens_input += entry.tokens_input
+        tokens_output += entry.tokens_output
+
+        if telemetry.routed_model == requested:
+            kept += 1
+        else:
+            rerouted += 1
+        if delta == 0:
+            at_top_tier += 1
+
+        if telemetry.routing_confidence is not None:
+            confidences.append(telemetry.routing_confidence)
+
+        pair = (requested, telemetry.routed_model)
+        route_turns[pair] += 1
+        route_savings[pair] += delta
+        if telemetry.routing_savings_pct is not None:
+            route_pcts[pair].append(telemetry.routing_savings_pct)
+        if telemetry.routing_confidence is not None:
+            route_confidences[pair].append(telemetry.routing_confidence)
+
+        day = _entry_date(entry)
+        day_turns[day] += 1
+        day_savings[day] += delta
+        day_cost[day] += telemetry.cost_usd or telemetry.billed_cost_usd or 0.0
+
+    by_route = sorted(
+        (
+            RouteRow(
+                requested_model=requested_model,
+                routed_model=model,
+                turns=route_turns[(requested_model, model)],
+                savings_usd=round(route_savings[(requested_model, model)], _USD_PRECISION),
+                avg_savings_pct=_mean(route_pcts[(requested_model, model)], _PCT_PRECISION),
+                avg_confidence=_mean(
+                    route_confidences[(requested_model, model)], _CONFIDENCE_PRECISION
+                ),
+            )
+            for requested_model, model in route_turns
+        ),
+        key=lambda row: (-row.savings_usd, row.routed_model),
+    )
+
+    by_day = [
+        DayRow(
+            date=day,
+            turns=day_turns[day],
+            savings_usd=round(day_savings[day], _USD_PRECISION),
+            actual_cost_usd=round(day_cost[day], _USD_PRECISION),
+        )
+        for day in sorted(day_turns)
+    ]
+
+    top_tier_cost = actual_cost + savings_usd
+    savings_pct = (savings_usd / top_tier_cost * 100.0) if top_tier_cost > 0 else 0.0
+
+    return SavingsReport(
+        start_date=by_day[0].date if by_day else None,
+        end_date=by_day[-1].date if by_day else None,
+        turns_total=len(entries),
+        turns_routed=routed,
+        turns_rerouted=rerouted,
+        turns_kept=kept,
+        turns_at_top_tier=at_top_tier,
+        actual_cost_usd=round(actual_cost, _USD_PRECISION),
+        routing_savings_usd=round(savings_usd, _USD_PRECISION),
+        top_tier_cost_usd=round(top_tier_cost, _USD_PRECISION),
+        savings_pct=round(savings_pct, _PCT_PRECISION),
+        avg_confidence=_mean(confidences, _CONFIDENCE_PRECISION),
+        tokens_input=tokens_input,
+        tokens_output=tokens_output,
+        by_route=by_route,
+        by_day=by_day,
+    )
+
+
+def _mean(values: list[float], precision: int) -> float | None:
+    """Return the rounded mean of ``values``, or ``None`` when empty."""
+
+    if not values:
+        return None
+    return round(sum(values) / len(values), precision)

--- a/src/agentos/skills/bundled/agentos/SKILL.md
+++ b/src/agentos/skills/bundled/agentos/SKILL.md
@@ -138,7 +138,7 @@ Top-level: `init`, `onboard`, `configure`, `doctor`, `upgrade`, `chat`,
 | `search` | `list`, `status`, `query`, `configure` |
 | `auth` | `login xai` (`--no-wait`/`--resume`/`--json` for non-blocking use), `status`, `logout xai` — xAI OAuth (SuperGrok / X Premium+) for `x_search`; tokens in `~/.agentos/auth.json`, never printed |
 | `configure x-search` | xAI X (Twitter) search: `--api-key-env`, `--x-search-model`, `--x-search-reasoning-effort`, `--no-x-search-enabled`; catalog via `onboard catalog x-search` |
-| `cost` | usage and estimated cost report |
+| `cost` | usage and estimated cost report; `savings` for the Pilot Router savings report (`--pdf`) |
 | `diagnostics` | `status`, `on`, `off` |
 | `migrate` | `openclaw`, `hermes` (`--source`, `--profile`, `--apply`, `--migrate-secrets`; dry-run without `--apply`) |
 | `agents` | `list`, `add`, `delete` (durable agents) |
@@ -521,6 +521,11 @@ agentos cost                   # usage + estimated spend
 # agentos cost --agent-id <agent-id> --channel-type <channel-type>
 # agentos cost --tool-name <tool-name> --skill <skill-name>
 # agentos cost --export /path/to/export.csv
+agentos cost savings           # what the Pilot Router saved, from the local decision log
+# agentos cost savings [--json] [--csv] [--start-date …] [--end-date …] [--log-dir …]
+# agentos cost savings --pdf /path/to/report.pdf   # branded, shareable PDF
+# Baseline = the priciest model in [router.tiers], input tokens only, routing
+# mechanism only. Reads ~/.agentos/logs/decisions-*.jsonl; no gateway needed.
 agentos diagnostics on         # runtime diagnostics logging
 agentos migrate hermes --source <dir> [--apply]   # dry-run first, then --apply
 ```

--- a/tests/test_cli/test_cost_savings_cmd.py
+++ b/tests/test_cli/test_cost_savings_cmd.py
@@ -1,0 +1,155 @@
+"""`agentos cost savings` — Pilot Router savings report from the decision log."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_log(log_dir: Path) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "turn_id": "t1",
+            "session_key": "s1",
+            "prompt_hash": "a" * 16,
+            "system_prompt_hash": "b" * 16,
+            "tool_list_hash": "c" * 16,
+            "tool_choice": "auto",
+            "tokens_input": 1000,
+            "tokens_output": 100,
+            "model": "glm-5.2",
+            "provider": "openrouter",
+            "latency_ms": 900,
+            "ts": "2026-09-01T10:00:00Z",
+            "savings": {
+                "routed_model": "glm-5.2",
+                "baseline_model": "gpt-5.6-luna",
+                "routing_confidence": 0.6,
+                "routing_savings_pct": 20.0,
+                "routing_savings_usd_estimated_vs_baseline": 0.25,
+                "cost_usd": 0.75,
+            },
+        },
+    ]
+    (log_dir / "decisions-20260901.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "logs"
+    _write_log(path)
+    return path
+
+
+def _explode(*args: Any, **kwargs: Any) -> Any:
+    raise AssertionError("cost savings must not talk to the gateway")
+
+
+def test_savings_reads_the_decision_log_without_the_gateway(
+    log_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _explode)
+
+    result = runner.invoke(app, ["cost", "savings", "--log-dir", str(log_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "0.25" in result.output
+
+
+def test_savings_json_carries_the_aggregate_and_route_rows(
+    log_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _explode)
+
+    result = runner.invoke(app, ["cost", "savings", "--log-dir", str(log_dir), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["routingSavingsUsd"] == 0.25
+    assert payload["topTierCostUsd"] == 1.0
+    assert payload["savingsPct"] == 25.0
+    assert payload["byRoute"][0]["routedModel"] == "glm-5.2"
+    assert payload["byRoute"][0]["requestedModel"] == "gpt-5.6-luna"
+
+
+def test_savings_csv_emits_one_row_per_route_pair(
+    log_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _explode)
+
+    result = runner.invoke(app, ["cost", "savings", "--log-dir", str(log_dir), "--csv"])
+
+    assert result.exit_code == 0, result.output
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert lines[0].startswith("RequestedModel,RoutedModel,Turns")
+    assert "gpt-5.6-luna,glm-5.2,1" in lines[1]
+
+
+def test_savings_pdf_writes_a_branded_report(
+    log_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _explode)
+    out = tmp_path / "report.pdf"
+
+    result = runner.invoke(app, ["cost", "savings", "--log-dir", str(log_dir), "--pdf", str(out)])
+
+    assert result.exit_code == 0, result.output
+    assert out.read_bytes().startswith(b"%PDF-")
+    assert str(out) in result.output
+
+
+def test_savings_date_window_is_applied(
+    log_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _explode)
+
+    result = runner.invoke(
+        app,
+        [
+            "cost",
+            "savings",
+            "--log-dir",
+            str(log_dir),
+            "--start-date",
+            "2026-09-02",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["turnsRouted"] == 0
+    assert payload["routingSavingsUsd"] == 0.0
+
+
+def test_bare_cost_still_queries_the_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[bool] = []
+
+    def _fake_run(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(True)
+        return {"breakdown": [], "totalCostUsd": 0.0}
+
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _fake_run)
+
+    result = runner.invoke(app, ["cost"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [True]

--- a/tests/test_observability/test_savings_pdf.py
+++ b/tests/test_observability/test_savings_pdf.py
@@ -1,0 +1,189 @@
+"""Branded PDF rendering of the Pilot Router savings report."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pypdf import PdfReader
+
+from agentos.observability.savings_pdf import render_savings_pdf
+from agentos.observability.savings_report import DayRow, RouteRow, SavingsReport
+
+
+def _report(**overrides: object) -> SavingsReport:
+    base = SavingsReport(
+        start_date="2026-08-18",
+        end_date="2026-09-01",
+        turns_total=274,
+        turns_routed=260,
+        turns_rerouted=157,
+        turns_kept=103,
+        turns_at_top_tier=98,
+        actual_cost_usd=17.401,
+        routing_savings_usd=34.7016,
+        top_tier_cost_usd=52.1026,
+        savings_pct=66.6,
+        avg_confidence=0.5177,
+        tokens_input=1_234_567,
+        tokens_output=45_678,
+        by_route=[
+            RouteRow("gpt-5.6-luna", "glm-5.2", 103, 20.5, 21.0, 0.52),
+            RouteRow("gpt-5.6-luna", "deepseek-v4-flash", 39, 12.2, 64.0, 0.61),
+        ],
+        by_day=[
+            DayRow("2026-08-18", 30, 4.5, 2.1),
+            DayRow("2026-09-01", 8, 1.2, 0.6),
+        ],
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def _text(path: Path) -> str:
+    return "\n".join(page.extract_text() or "" for page in PdfReader(str(path)).pages)
+
+
+def _flat(path: Path) -> str:
+    """Page text with all whitespace collapsed, so line wrapping cannot hide a phrase."""
+
+    return " ".join(_text(path).split())
+
+
+def test_pdf_is_written_and_readable(tmp_path: Path) -> None:
+    out = tmp_path / "savings.pdf"
+
+    render_savings_pdf(_report(), out)
+
+    assert out.read_bytes().startswith(b"%PDF-")
+    assert len(PdfReader(str(out)).pages) >= 1
+
+
+def test_pdf_carries_the_agentos_wordmark(tmp_path: Path) -> None:
+    out = tmp_path / "savings.pdf"
+
+    render_savings_pdf(_report(), out)
+
+    assert "agentOS_" in _text(out)
+
+
+def test_pdf_states_the_headline_savings_and_window(tmp_path: Path) -> None:
+    out = tmp_path / "savings.pdf"
+
+    render_savings_pdf(_report(), out)
+    text = _text(out)
+
+    assert "$34.70" in text
+    assert "66.6%" in text
+    assert "2026-08-18" in text
+    assert "2026-09-01" in text
+
+
+def test_pdf_states_that_the_comparison_is_the_top_tier_on_input_tokens(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "savings.pdf"
+
+    render_savings_pdf(_report(), out)
+    text = _flat(out)
+
+    # The figure is not "vs the requested model" and not a full-turn price;
+    # a reader must be able to see both limits on the page itself.
+    assert "most expensive model configured in [router.tiers]" in text
+    assert "Only input tokens are priced" in text
+
+
+def test_pdf_lists_each_route_pair(tmp_path: Path) -> None:
+    out = tmp_path / "savings.pdf"
+
+    render_savings_pdf(_report(), out)
+    text = _text(out)
+
+    assert "glm-5.2" in text
+    assert "deepseek-v4-flash" in text
+    assert "gpt-5.6-luna" in text
+
+
+def test_pdf_renders_an_empty_report_without_crashing(tmp_path: Path) -> None:
+    empty = SavingsReport(
+        start_date=None,
+        end_date=None,
+        turns_total=0,
+        turns_routed=0,
+        turns_rerouted=0,
+        turns_kept=0,
+        turns_at_top_tier=0,
+        actual_cost_usd=0.0,
+        routing_savings_usd=0.0,
+        top_tier_cost_usd=0.0,
+        savings_pct=0.0,
+        avg_confidence=None,
+        tokens_input=0,
+        tokens_output=0,
+    )
+    out = tmp_path / "empty.pdf"
+
+    render_savings_pdf(empty, out)
+
+    assert out.read_bytes().startswith(b"%PDF-")
+    assert "No routed turns" in _text(out)
+
+
+def test_pdf_paginates_a_long_route_table(tmp_path: Path) -> None:
+    many = [RouteRow("gpt-5.6-luna", f"model-{i:03d}", 3, 1.0, 20.0, 0.5) for i in range(60)]
+    out = tmp_path / "long.pdf"
+
+    render_savings_pdf(_report(by_route=many), out)
+
+    assert len(PdfReader(str(out)).pages) >= 2
+    assert "model-059" in _text(out)
+
+
+def _fits(text: str, font: str, size: float, width: float) -> bool:
+    from reportlab.pdfbase.pdfmetrics import stringWidth
+
+    return bool(stringWidth(text, font, size) <= width)
+
+
+def test_stat_labels_fit_inside_their_column(tmp_path: Path) -> None:
+    """Six stats share the text column; a long label must not run into the next."""
+
+    from reportlab.lib.pagesizes import A4
+
+    from agentos.observability.savings_pdf import (
+        _PAGE_MARGIN,
+        _STAT_LABEL_SIZE,
+        _stat_cells,
+    )
+
+    cells = _stat_cells(_report())
+    column = (A4[0] - 2 * _PAGE_MARGIN) / len(cells)
+
+    for label, _value in cells:
+        assert _fits(label, "Helvetica", _STAT_LABEL_SIZE, column - 6), label
+
+
+def test_header_title_halves_do_not_overlap(tmp_path: Path) -> None:
+    """The two-weight title is laid out by measurement, not a fixed offset."""
+
+    from reportlab.pdfbase.pdfmetrics import stringWidth
+
+    from agentos.observability.savings_pdf import _TITLE_LEAD, _TITLE_SIZE, _TITLE_TAIL
+
+    lead = stringWidth(_TITLE_LEAD, "Helvetica-Bold", _TITLE_SIZE)
+    out = tmp_path / "savings.pdf"
+    render_savings_pdf(_report(), out)
+
+    # The tail starts after the lead plus a real space, so the strings are
+    # separated in the extracted text rather than run together.
+    assert f"{_TITLE_LEAD} {_TITLE_TAIL}" in " ".join(_text(out).split())
+    assert lead > 0
+
+
+def test_a_dozen_route_rows_still_fit_on_one_page(tmp_path: Path) -> None:
+    rows = [RouteRow("gpt-5.6-luna", f"model-{i:02d}", 3, 1.0, 20.0, 0.5) for i in range(12)]
+    out = tmp_path / "one-page.pdf"
+
+    render_savings_pdf(_report(by_route=rows), out)
+
+    assert len(PdfReader(str(out)).pages) == 1

--- a/tests/test_observability/test_savings_report.py
+++ b/tests/test_observability/test_savings_report.py
@@ -1,0 +1,180 @@
+"""Pilot Router savings aggregation over the decision log."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agentos.observability.savings_report import build_savings_report
+
+
+def _turn(
+    date: str,
+    *,
+    routed: str | None = "glm-5.2",
+    requested: str | None = "gpt-5.6-luna",
+    savings_usd: float | None = 0.02,
+    savings_pct: float | None = 20.5,
+    cost_usd: float | None = 0.08,
+    confidence: float | None = 0.5,
+    tokens_input: int = 1000,
+    tokens_output: int = 100,
+) -> dict[str, Any]:
+    return {
+        "turn_id": f"t-{date}-{routed}-{savings_usd}",
+        "session_key": "s1",
+        "prompt_hash": "a" * 16,
+        "system_prompt_hash": "b" * 16,
+        "tool_list_hash": "c" * 16,
+        "tool_choice": "auto",
+        "tokens_input": tokens_input,
+        "tokens_output": tokens_output,
+        "model": routed or "gpt-5.6-luna",
+        "provider": "openrouter",
+        "latency_ms": 1200,
+        "ts": f"{date}T10:00:00Z",
+        "savings": {
+            "routed_model": routed,
+            "baseline_model": requested,
+            "routing_confidence": confidence,
+            "routing_savings_pct": savings_pct,
+            "routing_savings_usd_estimated_vs_baseline": savings_usd,
+            "cost_usd": cost_usd,
+        },
+    }
+
+
+def _write_log(log_dir: Path, date: str, rows: list[dict[str, Any]]) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    compact = date.replace("-", "")
+    path = log_dir / f"decisions-{compact}.jsonl"
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_totals_ignore_turns_without_routing_savings(tmp_path: Path) -> None:
+    _write_log(
+        tmp_path,
+        "2026-09-01",
+        [
+            _turn("2026-09-01", savings_usd=0.02, cost_usd=0.08),
+            _turn("2026-09-01", savings_usd=0.03, cost_usd=0.07),
+            # No routing telemetry at all — counted in turns_total, not in savings.
+            _turn("2026-09-01", routed=None, requested=None, savings_usd=None, cost_usd=0.10),
+        ],
+    )
+
+    report = build_savings_report(tmp_path)
+
+    assert report.turns_total == 3
+    assert report.turns_routed == 2
+    assert report.routing_savings_usd == 0.05
+    assert report.actual_cost_usd == 0.15
+    assert report.top_tier_cost_usd == 0.20
+    assert report.savings_pct == 25.0
+
+
+def test_route_pairs_are_grouped_and_sorted_by_savings(tmp_path: Path) -> None:
+    _write_log(
+        tmp_path,
+        "2026-09-01",
+        [
+            _turn("2026-09-01", routed="glm-5.2", savings_usd=0.01),
+            _turn("2026-09-01", routed="glm-5.2", savings_usd=0.02),
+            _turn("2026-09-01", routed="deepseek-v4-flash", savings_usd=0.09),
+        ],
+    )
+
+    report = build_savings_report(tmp_path)
+
+    assert [(r.routed_model, r.turns) for r in report.by_route] == [
+        ("deepseek-v4-flash", 1),
+        ("glm-5.2", 2),
+    ]
+    assert report.by_route[0].savings_usd == 0.09
+    assert report.by_route[1].savings_usd == 0.03
+    assert report.by_route[0].requested_model == "gpt-5.6-luna"
+
+
+def test_days_are_grouped_in_calendar_order(tmp_path: Path) -> None:
+    _write_log(tmp_path, "2026-08-31", [_turn("2026-08-31", savings_usd=0.04)])
+    _write_log(
+        tmp_path,
+        "2026-09-01",
+        [
+            _turn("2026-09-01", savings_usd=0.01),
+            _turn("2026-09-01", savings_usd=0.02),
+        ],
+    )
+
+    report = build_savings_report(tmp_path)
+
+    assert [(d.date, d.turns, d.savings_usd) for d in report.by_day] == [
+        ("2026-08-31", 1, 0.04),
+        ("2026-09-01", 2, 0.03),
+    ]
+    assert report.start_date == "2026-08-31"
+    assert report.end_date == "2026-09-01"
+
+
+def test_date_filter_excludes_turns_outside_the_window(tmp_path: Path) -> None:
+    _write_log(tmp_path, "2026-08-30", [_turn("2026-08-30", savings_usd=0.50)])
+    _write_log(tmp_path, "2026-08-31", [_turn("2026-08-31", savings_usd=0.04)])
+    _write_log(tmp_path, "2026-09-01", [_turn("2026-09-01", savings_usd=0.01)])
+
+    report = build_savings_report(tmp_path, start_date="2026-08-31", end_date="2026-08-31")
+
+    assert report.turns_total == 1
+    assert report.routing_savings_usd == 0.04
+
+
+def test_turns_split_by_whether_the_router_moved_off_the_requested_model(
+    tmp_path: Path,
+) -> None:
+    _write_log(
+        tmp_path,
+        "2026-09-01",
+        [
+            _turn("2026-09-01", routed="glm-5.2", savings_usd=0.02),
+            _turn("2026-09-01", routed="deepseek-v4-flash", savings_usd=0.05),
+            # Routed off the request, but onto the priciest tier: nothing saved.
+            _turn("2026-09-01", routed="gpt-5.6-terra-pro", savings_usd=0.0),
+            _turn("2026-09-01", routed="gpt-5.6-luna", savings_usd=0.0),
+        ],
+    )
+
+    report = build_savings_report(tmp_path)
+
+    assert report.turns_rerouted == 3
+    assert report.turns_kept == 1
+    assert report.turns_at_top_tier == 2
+
+
+def test_average_confidence_covers_only_scored_turns(tmp_path: Path) -> None:
+    _write_log(
+        tmp_path,
+        "2026-09-01",
+        [
+            _turn("2026-09-01", confidence=0.4),
+            _turn("2026-09-01", confidence=0.6),
+            _turn("2026-09-01", confidence=None),
+        ],
+    )
+
+    report = build_savings_report(tmp_path)
+
+    assert report.avg_confidence == 0.5
+
+
+def test_empty_log_dir_yields_a_zeroed_report(tmp_path: Path) -> None:
+    report = build_savings_report(tmp_path)
+
+    assert report.turns_total == 0
+    assert report.routing_savings_usd == 0.0
+    assert report.savings_pct == 0.0
+    assert report.by_route == []
+    assert report.by_day == []
+    assert report.start_date is None


### PR DESCRIPTION
## Linked issue

Fixes #788

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

Adds `agentos cost savings` — a report of what the Pilot Router avoided spending, with a PDF export.

The router's existing reports cover routing **quality** (`scripts/pilot_router/eval_report.md`) and feature-extraction **latency** (`benchmark_features.py`). Neither says what it saved in money, even though every completed turn already writes a `SavingsTelemetry` block to `~/.agentos/logs/decisions-*.jsonl` that nothing reads back. `agentos cost` reports spend, from the gateway, and has no notion of what was avoided.

```sh
agentos cost savings                              # summary + per-route breakdown
agentos cost savings --json
agentos cost savings --csv                        # one row per route pair
agentos cost savings --start-date … --end-date …  # UTC, inclusive
agentos cost savings --log-dir …
agentos cost savings --pdf /path/to/report.pdf
```

It reads the decision log directly rather than the gateway, so it works with the gateway stopped, and covers **routing only** — tool-result projection, short-reply enforcement, prompt-cache hits and thinking mode are excluded so the headline number stays attributable to the router.

### Reporting the number honestly

This is the part worth reviewing closely.

Despite its name, `routing_savings_usd_estimated_vs_baseline` is **not** measured against the sibling `baseline_model` field. `runtime._compute_route_input_savings_usd` computes:

```
(top_tier_input_price_per_m - routed_input_price_per_m) * input_tokens / 1e6
```

where the top tier is the most expensive model configured in `[router.tiers]` (`steps/agentos_router._compute_savings`). `baseline_model` separately records `ctx.model`, the model the *request* arrived with. Only **input** tokens are priced, and the per-turn value is clamped at `max(0.0, …)`.

The first draft of this report took the field name at its word and was wrong. The symptom on real logs: rows where `routed_model == baseline_model` showed the single largest savings figure — correct under the top-tier definition, nonsense under the requested-model reading.

So the shipped version labels that column `Requested`, names the comparison as the top tier everywhere, and prints on the face of the PDF that only input tokens are priced and the figure is a floor rather than a full-turn saving. `test_pdf_states_that_the_comparison_is_the_top_tier_on_input_tokens` pins both statements to the rendered page so a future layout change cannot quietly drop them.

### Files

| File | What |
| --- | --- |
| `observability/savings_report.py` | Aggregation over `decisions-*.jsonl`: totals, per-day rows, per-route-pair rows |
| `observability/savings_pdf.py` | ReportLab canvas renderer — brand header with the AgentOS mark, hero figure, stat grid, daily bar chart, paginated route table, method note |
| `cli/cost_cmd.py` | The `savings` subcommand, plus a `ctx.invoked_subcommand` guard |

`reportlab` is already a base dependency, so the PDF path needs no new install.

### Incidental fix

The `cost` group is `invoke_without_command=True`, so its callback runs ahead of *every* subcommand — `agentos cost savings` would have made a gateway RPC call and printed the spend table before producing its own output. Guarded with `ctx.invoked_subcommand`, and `test_bare_cost_still_queries_the_gateway` holds the existing no-subcommand behavior in place.

## Tests

23 new tests across three files, written test-first.

```
$ uv run pytest tests/test_observability/test_savings_report.py \
                tests/test_observability/test_savings_pdf.py \
                tests/test_cli/test_cost_savings_cmd.py -q
23 passed
```

Full gate:

```
$ uv run ruff check src tests
All checks passed!

$ uv run mypy src/agentos --show-error-codes
Found 1 error in 1 file (checked 621 source files)

$ uv run pytest -q -m "not llm"
2 failed, 8822 passed, 22 skipped, 6 deselected in 199.17s
```

The one mypy error (`memory/providers/mem0_provider.py:121`, missing `mem0` stubs) and both test failures (`test_provider_config.py::test_enabled_but_module_missing_boots_with_none`, `test_skill_html_to_pdf.py::test_render_html_to_pdf`) reproduce identically on a clean tree — verified by stashing this branch and re-running them. They are environmental: `mem0` is installed in this venv, and WeasyPrint's system libraries are not. This change adds no new failures.

Also exercised end to end against 276 real logged turns over 15 days, which is where the top-tier/requested misreading surfaced.
