### PR TITLE
fix(search): apply untrusted boundary wrapping to search result titles and snippets

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -654,18 +654,21 @@ def _search_payload(
     fallback_from: str = "",
     attempts: list[dict[str, str]] | None = None,
 ) -> dict:
+    from agentos.safety.injection_guard import wrap_untrusted_boundary
+
+    def _build_result(r: SearchResult) -> dict:
+        source_url = r.url or "unknown-source"
+        return {
+            "title": wrap_untrusted_boundary(r.title, source_url),
+            "url": r.url,
+            "snippet": wrap_untrusted_boundary(r.snippet, source_url),
+            "source": r.source or provider_name,
+        }
+
     payload = {
         "query": query,
         "provider": provider_name,
-        "results": [
-            {
-                "title": r.title,
-                "url": r.url,
-                "snippet": r.snippet,
-                "source": r.source or "",
-            }
-            for r in results
-        ],
+        "results": [_build_result(r) for r in results],
     }
     if fallback_from:
         payload["fallback_from"] = fallback_from

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -662,7 +662,7 @@ def _search_payload(
             "title": wrap_untrusted_boundary(r.title, source_url),
             "url": r.url,
             "snippet": wrap_untrusted_boundary(r.snippet, source_url),
-            "source": r.source or provider_name,
+            "source": r.source,
         }
 
     payload = {

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -835,7 +835,9 @@ async def test_search_status_and_query_return_structured_payloads():
     assert status.payload["apiKeyConfigured"] is False
     assert query.error is None, query.error
     assert query.payload["ok"] is True
-    assert query.payload["results"][0]["snippet"] == "hello"
+    assert query.payload["results"][0]["snippet"] == (
+        "<untrusted source='https://example.com'>hello</untrusted>"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
PR #689 only added the `source` field to `SearchResult` construction and `_search_payload`, but did not apply `wrap_untrusted_boundary` to the title and snippet text. This means search results from untrusted external sources are injected into the prompt without the same safety boundary wrapping that `web_fetch` applies to page content.

## Fix
- Import `wrap_untrusted_boundary` from `agentos.safety.injection_guard` in `_search_payload`
- Apply `wrap_untrusted_boundary(r.title, source_url)` and `wrap_untrusted_boundary(r.snippet, source_url)` for each result, where `source_url` is the result's URL
- Keep the `source` field populated from `SearchResult.source` (falling back to `provider_name`)

## What changed
- `src/agentos/tools/builtin/web.py`: `_search_payload` now wraps title/snippet with the untrusted boundary wrapper, same treatment as `web_fetch` applies to page content.

## Verification
- `uv run ruff check --fix` — All checks passed
- `uv run mypy` — Success: no issues found
- `uv run pytest` on relevant test files — 19 passed

Fixes #1132