### PR TITLE
fix(mcp): validate MCP server URLs against metadata SSRF endpoints (#662)

### DIFF
--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -11,6 +11,7 @@ from agentos import __version__
 from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.tools.ssrf import validate_mcp_server_url
 
 
 class MCPSSEClient(MCPClient):
@@ -70,6 +71,7 @@ class MCPSSEClient(MCPClient):
 
     async def connect(self) -> None:
         """Create the HTTP client session and perform MCP initialization handshake."""
+        validate_mcp_server_url(self.config.url)
         self._client = httpx.AsyncClient(trust_env=_trust_env())
 
         # Send initialize request (response is acknowledged server-side;

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -20,6 +20,7 @@ from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 from agentos.paths import state_dir as default_state_dir
+from agentos.tools.ssrf import validate_mcp_server_url
 
 
 class MCPDependencyError(RuntimeError):
@@ -145,6 +146,7 @@ class MCPStreamableHTTPClient(MCPClient):
     async def connect(self) -> None:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
+        validate_mcp_server_url(self.config.url)
 
         try:
             from mcp.client.auth import OAuthClientProvider

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -239,6 +239,26 @@ def validate_http_url_for_fetch(
         assert_address_allowed_for_fetch(hostname, addr, trusted_networks)
 
 
+def validate_mcp_server_url(url: str | None) -> None:
+    """Validate an MCP server URL against metadata SSRF endpoints.
+
+    Blocks cloud metadata endpoints (169.254.169.254, metadata.google.internal,
+    etc.) while allowing private/LAN addresses that are legitimate for local
+    MCP servers.
+    """
+    if not url:
+        return  # will fail on connect with its own error
+    try:
+        assert_not_metadata_endpoint(url)
+    except SSRFBlockedError:
+        raise
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise UnsupportedURLSchemeError(
+            f"MCP server URL must use http or https, got {parsed.scheme}"
+        )
+
+
 def _hard_block_reason(addr: IPAddress) -> str | None:
     for network in _HARD_BLOCKED_NETWORKS:
         if addr.version == network.version and addr in network:

--- a/tests/test_mcp/test_mcp_ssrf.py
+++ b/tests/test_mcp/test_mcp_ssrf.py
@@ -1,0 +1,68 @@
+"""Regression tests for MCP server URL SSRF validation.
+
+Ensures MCP transports reject cloud metadata endpoints while allowing
+legitimate local/deployed MCP server URLs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.tools.ssrf import SSRFBlockedError, UnsupportedURLSchemeError, validate_mcp_server_url
+
+
+class TestMCPSSRFValidation:
+    """Cloud metadata endpoints are blocked."""
+
+    def test_metadata_ip_literal(self) -> None:
+        with pytest.raises(SSRFBlockedError):
+            validate_mcp_server_url("http://169.254.169.254/")
+
+    def test_metadata_hostname_google(self) -> None:
+        with pytest.raises(SSRFBlockedError):
+            validate_mcp_server_url("http://metadata.google.internal/")
+
+    def test_metadata_hostname_aws(self) -> None:
+        with pytest.raises(SSRFBlockedError):
+            validate_mcp_server_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_metadata_hostname_azure(self) -> None:
+        with pytest.raises(SSRFBlockedError):
+            validate_mcp_server_url("http://169.254.169.254/metadata/instance")
+
+    """Legitimate MCP server URLs pass through."""
+
+    def test_localhost_allowed(self) -> None:
+        # No exception = pass
+        validate_mcp_server_url("http://127.0.0.1:8000/")
+
+    def test_lan_allowed(self) -> None:
+        validate_mcp_server_url("http://192.168.1.100:8080/")
+
+    def test_localhost_hostname_allowed(self) -> None:
+        validate_mcp_server_url("http://localhost:8931/")
+
+    def test_public_url_allowed(self) -> None:
+        validate_mcp_server_url("https://mcp.example.com/tools")
+
+    def test_https_schema_allowed(self) -> None:
+        validate_mcp_server_url("https://mcp.myorg.internal/")
+
+    """Scheme validation."""
+
+    def test_unsupported_scheme_rejected(self) -> None:
+        with pytest.raises(UnsupportedURLSchemeError):
+            validate_mcp_server_url("ftp://mcp.example.com/")
+
+    def test_no_scheme_raises(self) -> None:
+        with pytest.raises(UnsupportedURLSchemeError):
+            validate_mcp_server_url("mcp.example.com")
+
+    """Edge cases."""
+
+    def test_none_url_passes(self) -> None:
+        # Will fail later on connect with its own error
+        validate_mcp_server_url(None)
+
+    def test_empty_url_passes(self) -> None:
+        validate_mcp_server_url("")


### PR DESCRIPTION
## Summary

MCP SSE and Streamable HTTP transports connect to `MCPServerConfig.url` via httpx with no SSRF validation. Every other URL-fetching path calls `assert_not_metadata_endpoint()` — the MCP transport skipped this entirely.

## Approach

Uses `assert_not_metadata_endpoint` (blocks cloud metadata only) rather than `validate_http_url_for_fetch` (which also blocks private/LAN). MCP servers routinely run on localhost and LAN — blocking those would break legitimate configurations. Added a shared `validate_mcp_server_url()` helper to `tools/ssrf.py` with scheme validation.

## Changes

- `src/agentos/tools/ssrf.py` — added `validate_mcp_server_url()` shared helper
- `src/agentos/mcp/sse.py` — call `validate_mcp_server_url()` in `connect()`
- `src/agentos/mcp/streamable_http.py` — call `validate_mcp_server_url()` in `connect()`
- `tests/test_mcp/test_mcp_ssrf.py` — new file, 13 regression tests

## Tests (13 regression cases)

- **Metadata blocked**: IP literal 169.254.169.254, Google/AWS/Azure metadata hostnames
- **Legitimate allowed**: localhost, 127.0.0.1, LAN (192.168.x), public URLs, both http/https
- **Scheme rejected**: unsupported schemes (ftp), bare hostname without scheme
- **Edge cases**: None url, empty string

## Verification
- `ruff check src tests` ✅ all checks passed
- `pytest tests/test_mcp/test_mcp_ssrf.py -v` → 13/13 passed ✅
- `pytest tests/test_security/test_ssrf_fake_ip.py -v` → 6/6 passed (existing SSRF guards unaffected) ✅
- mypy on touched files: only pre-existing import-not-found errors (httpx/mcp stubs) ✅
- No breaking changes: existing MCP tests need live SDK, already pre-existing

Fixes #662