### PR TITLE
fix(gateway): cap debounce buffer per session_key

### DIFF
--- a/src/agentos/gateway/_debounce.py
+++ b/src/agentos/gateway/_debounce.py
@@ -13,6 +13,14 @@ from agentos.channels.types import IncomingMessage
 
 log = structlog.get_logger(__name__)
 
+# Maximum messages buffered per session_key before the debounce batch is
+# delivered early. Without a cap, a sender who posts faster than the window
+# expires grows state.buffer unboundedly — O(messages) memory and attachment
+# references until the timer fires (#796). A 50-message cap bounds the batch
+# regardless of post rate; the excess flushes immediately instead of being
+# dropped.
+MAX_COALESCED_MESSAGES = 50
+
 
 class DebounceCoordinator(Protocol):
     async def schedule(self, session_key: str, message: IncomingMessage, *, window_s: float, on_fire: Any) -> None: ...
@@ -27,6 +35,19 @@ class _DefaultDebounceCoordinator:
         async with self._lock:
             if state := self._pending.get(session_key):
                 state.buffer.append(message)
+                if len(state.buffer) >= MAX_COALESCED_MESSAGES:
+                    # Cap hit — deliver the whole batch immediately so the buffer
+                    # stays bounded. Pop first, then cancel the sleeping timer:
+                    # cancel keeps the orphan from waking later and stealing the
+                    # *next* window's state (#796).
+                    self._pending.pop(session_key, None)
+                    state.task.cancel()
+                    log.warning(
+                        "channel.debounce_buffer_cap_reached",
+                        session_key=session_key,
+                        coalesced_count=len(state.buffer),
+                    )
+                    asyncio.create_task(self._deliver(session_key, state.buffer, state.on_fire))
                 return
             task = asyncio.create_task(self._fire(session_key, window_s), name=f"channel-debounce:{session_key}")
             self._pending[session_key] = SimpleNamespace(buffer=[message], on_fire=on_fire, task=task)
@@ -51,13 +72,19 @@ class _DefaultDebounceCoordinator:
                 state = self._pending.pop(session_key, None)
             if state is None:
                 return
-            first = state.buffer[0]
-            content = "\n".join(m.content for m in state.buffer)
-            attachments = [a for m in state.buffer for a in (m.attachments or [])]
+        except asyncio.CancelledError:
+            raise
+        await self._deliver(session_key, state.buffer, state.on_fire)
+
+    async def _deliver(self, session_key: str, buffer: list[IncomingMessage], on_fire: Any) -> None:
+        try:
+            first = buffer[0]
+            content = "\n".join(m.content for m in buffer)
+            attachments = [a for m in buffer for a in (m.attachments or [])]
             msg = IncomingMessage(sender_id=first.sender_id, channel_id=first.channel_id, content=content, attachments=attachments, metadata=dict(first.metadata or {}))
-            combined = SimpleNamespace(content=content, attachments=attachments, message=msg, coalesced_count=len(state.buffer))
+            combined = SimpleNamespace(content=content, attachments=attachments, message=msg, coalesced_count=len(buffer))
             log.info("channel.debounce_coalesced", session_key=session_key, coalesced_count=combined.coalesced_count)
-            await state.on_fire(combined)
+            await on_fire(combined)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/src/agentos/gateway/_debounce.py
+++ b/src/agentos/gateway/_debounce.py
@@ -30,6 +30,12 @@ class _DefaultDebounceCoordinator:
     def __init__(self) -> None:
         self._pending: dict[str, Any] = {}
         self._lock = asyncio.Lock()
+        # Strong references to in-flight cap-triggered deliveries. The event
+        # loop holds only weak references to tasks, so a fire-and-forget
+        # create_task can be GC'd mid-execution and the batch is silently
+        # lost; retaining the task until completion prevents that and lets
+        # cancel_all() drain in-flight flushes at shutdown.
+        self._deliveries: set[asyncio.Task[None]] = set()
 
     async def schedule(self, session_key: str, message: IncomingMessage, *, window_s: float, on_fire: Any) -> None:
         async with self._lock:
@@ -47,7 +53,12 @@ class _DefaultDebounceCoordinator:
                         session_key=session_key,
                         coalesced_count=len(state.buffer),
                     )
-                    asyncio.create_task(self._deliver(session_key, state.buffer, state.on_fire))
+                    # Retain the delivery task: the loop only holds weak
+                    # references, so an unreferenced task can be GC'd before
+                    # it runs and the whole batch is silently lost.
+                    delivery = asyncio.create_task(self._deliver(session_key, state.buffer, state.on_fire))
+                    self._deliveries.add(delivery)
+                    delivery.add_done_callback(self._deliveries.discard)
                 return
             task = asyncio.create_task(self._fire(session_key, window_s), name=f"channel-debounce:{session_key}")
             self._pending[session_key] = SimpleNamespace(buffer=[message], on_fire=on_fire, task=task)
@@ -64,6 +75,10 @@ class _DefaultDebounceCoordinator:
 
     async def cancel_all(self) -> None:
         await asyncio.gather(*(self.cancel(k) for k in list(self._pending)), return_exceptions=True)
+        # Drain in-flight cap-triggered deliveries so no batch is dropped on
+        # gateway shutdown.
+        if self._deliveries:
+            await asyncio.gather(*self._deliveries, return_exceptions=True)
 
     async def _fire(self, session_key: str, window_s: float) -> None:
         try:

--- a/tests/test_gateway/test_debounce_buffer_cap.py
+++ b/tests/test_gateway/test_debounce_buffer_cap.py
@@ -1,0 +1,117 @@
+"""Regression tests for the debounce buffer cap (issue #796).
+
+Before the fix, ``_DefaultDebounceCoordinator.schedule`` appended every
+message to ``state.buffer`` with no cap: a sender who posts faster than
+``window_s`` expires grows the buffer unboundedly (memory DoS). The fix caps
+the batch at ``MAX_COALESCED_MESSAGES`` and delivers the batch early when the
+cap is hit, so the buffer stays bounded regardless of post rate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agentos.channels.types import IncomingMessage
+from agentos.gateway._debounce import MAX_COALESCED_MESSAGES, _DefaultDebounceCoordinator
+
+
+def _msg(content: str = "x") -> IncomingMessage:
+    return IncomingMessage(
+        sender_id="spammer",
+        channel_id="telegram",
+        content=content,
+        attachments=[],
+        metadata={},
+    )
+
+
+async def test_debounce_buffer_capped_at_max_coalesced_messages():
+    """The buffer never exceeds MAX_COALESCED_MESSAGES, no matter the post rate."""
+    coord = _DefaultDebounceCoordinator()
+    fired: list[object] = []
+
+    async def on_fire(combined: object) -> None:
+        fired.append(combined)
+
+    spam = MAX_COALESCED_MESSAGES * 4
+    for i in range(spam):
+        await coord.schedule("tg:chat1", _msg(f"m{i}"), window_s=3600.0, on_fire=on_fire)
+
+    state = coord._pending.get("tg:chat1")
+    buffered = len(state.buffer) if state is not None else 0
+    assert buffered <= MAX_COALESCED_MESSAGES
+
+    # Let cap-triggered delivery tasks complete.
+    for _ in range(spam):
+        await asyncio.sleep(0)
+
+    delivered = sum(getattr(c, "coalesced_count", 0) for c in fired)
+    state_after = coord._pending.get("tg:chat1")
+    buffered_after = len(state_after.buffer) if state_after is not None else 0
+    # Every scheduled message must be accounted for: currently buffered + delivered
+    # in earlier cap-flushes. The latest buffer (if any) is a fresh window.
+    assert buffered_after + delivered == spam
+
+
+async def test_debounce_cap_hit_delivers_batch_immediately():
+    """Hitting the cap flushes the whole batch through on_fire right away."""
+    coord = _DefaultDebounceCoordinator()
+    fired: list[object] = []
+    delivered_event = asyncio.Event()
+
+    async def on_fire(combined: object) -> None:
+        fired.append(combined)
+        delivered_event.set()
+
+    for i in range(MAX_COALESCED_MESSAGES):
+        await coord.schedule(
+            "tg:chat1", _msg(f"m{i}"), window_s=3600.0, on_fire=on_fire
+        )
+
+    await asyncio.wait_for(delivered_event.wait(), timeout=2.0)
+    assert len(fired) == 1
+    assert getattr(fired[0], "coalesced_count") == MAX_COALESCED_MESSAGES
+    contents = getattr(fired[0], "content")
+    assert contents.count("m") == MAX_COALESCED_MESSAGES
+    # The window slot was cleared so a fresh one can start.
+    assert "tg:chat1" not in coord._pending
+
+
+async def test_debounce_normal_coalesce_below_cap_still_windows():
+    """Below the cap, messages still coalesce across the window as before."""
+    coord = _DefaultDebounceCoordinator()
+    fired: list[object] = []
+
+    async def on_fire(combined: object) -> None:
+        fired.append(combined)
+
+    await coord.schedule("tg:chat1", _msg("a"), window_s=0.05, on_fire=on_fire)
+    await coord.schedule("tg:chat1", _msg("b"), window_s=0.05, on_fire=on_fire)
+    await coord.schedule("tg:chat1", _msg("c"), window_s=0.05, on_fire=on_fire)
+
+    await asyncio.sleep(0.15)
+    assert len(fired) == 1
+    assert getattr(fired[0], "coalesced_count") == 3
+    assert getattr(fired[0], "content") == "a\nb\nc"
+
+
+async def test_debounce_cap_flush_isolates_next_window():
+    """After a cap flush, a new message starts a fresh window — the orphan
+    timer of the flushed batch must not steal the next window's state."""
+    coord = _DefaultDebounceCoordinator()
+    fired: list[object] = []
+
+    async def on_fire(combined: object) -> None:
+        fired.append(combined)
+
+    for i in range(MAX_COALESCED_MESSAGES):
+        await coord.schedule("tg:chat1", _msg(f"old{i}"), window_s=3600.0, on_fire=on_fire)
+    await asyncio.sleep(0)  # cap-triggered delivery runs
+
+    # Fresh window with one message and a short window.
+    await coord.schedule("tg:chat1", _msg("new"), window_s=0.05, on_fire=on_fire)
+    await asyncio.sleep(0.2)
+
+    counts = [getattr(c, "coalesced_count", 0) for c in fired]
+    assert counts.count(MAX_COALESCED_MESSAGES) == 1
+    assert counts.count(1) == 1

--- a/tests/test_gateway/test_debounce_cap_task_retention.py
+++ b/tests/test_gateway/test_debounce_cap_task_retention.py
@@ -1,0 +1,96 @@
+"""Regression tests for cap-flush task retention (review feedback on #800).
+
+The cap-triggered flush is dispatched with ``asyncio.create_task``. The event
+loop keeps only a weak reference to a task, so a delivery with no strong
+reference anywhere can be garbage-collected mid-execution and the whole
+batch is silently lost -- the exact failure the buffer cap is meant to
+prevent. ``cancel_all`` must also drain in-flight flushes so a batch is not
+dropped when the gateway stops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+
+from agentos.channels.types import IncomingMessage
+from agentos.gateway._debounce import MAX_COALESCED_MESSAGES, _DefaultDebounceCoordinator
+
+
+def _msg(content: str = "x") -> IncomingMessage:
+    return IncomingMessage(
+        sender_id="spammer",
+        channel_id="telegram",
+        content=content,
+        attachments=[],
+        metadata={},
+    )
+
+
+async def _fill_to_cap(coord: _DefaultDebounceCoordinator, on_fire, key: str = "tg:chat1") -> None:
+    for i in range(MAX_COALESCED_MESSAGES):
+        await coord.schedule(key, _msg(f"m{i}"), window_s=3600.0, on_fire=on_fire)
+
+
+async def test_cap_flush_task_is_retained_by_coordinator():
+    """The coordinator holds a strong reference while the flush is in flight."""
+    coord = _DefaultDebounceCoordinator()
+    gate = asyncio.Event()
+    fired: list[object] = []
+
+    async def on_fire(combined: object) -> None:
+        await gate.wait()
+        fired.append(combined)
+
+    await _fill_to_cap(coord, on_fire)
+
+    # In flight and referenced: without retention this set would be empty and
+    # the only reference would be the loop's weak one.
+    assert len(coord._deliveries) == 1
+    assert not fired
+
+    gate.set()
+    await asyncio.gather(*coord._deliveries)
+    assert len(fired) == 1
+    # add_done_callback discards the finished task -- no unbounded growth.
+    assert coord._deliveries == set()
+
+
+async def test_cap_flush_completes_with_no_local_reference_after_gc():
+    """A forced collection between dispatch and completion must not lose the batch."""
+    coord = _DefaultDebounceCoordinator()
+    delivered = asyncio.Event()
+    fired: list[object] = []
+
+    async def on_fire(combined: object) -> None:
+        fired.append(combined)
+        delivered.set()
+
+    await _fill_to_cap(coord, on_fire)
+
+    # No local name binds the delivery task here; force a full collection
+    # before the loop ever gets to run it.
+    gc.collect()
+
+    await asyncio.wait_for(delivered.wait(), timeout=5.0)
+    assert len(fired) == 1
+    assert getattr(fired[0], "coalesced_count") == MAX_COALESCED_MESSAGES
+
+
+async def test_cancel_all_drains_inflight_cap_delivery():
+    """Gateway shutdown waits for a cap-triggered flush instead of dropping it."""
+    coord = _DefaultDebounceCoordinator()
+    fired: list[object] = []
+
+    async def on_fire(combined: object) -> None:
+        await asyncio.sleep(0.2)
+        fired.append(combined)
+
+    await _fill_to_cap(coord, on_fire)
+    assert not fired  # still in flight
+
+    await coord.cancel_all()
+
+    assert len(fired) == 1
+    assert getattr(fired[0], "coalesced_count") == MAX_COALESCED_MESSAGES
+    assert coord._deliveries == set()


### PR DESCRIPTION
Fixes #796

## Summary
Capped the debounce buffer in `src/agentos/gateway/_debounce.py:23-29` to prevent unbounded memory growth. When the buffer reaches `MAX_COALESCED_MESSAGES` (50), the coordinator now flushes immediately instead of accumulating indefinitely.

## What
- src/agentos/gateway/_debounce.py — added `MAX_COALESCED_MESSAGES = 50` constant and flush logic when buffer cap is reached
- tests/test_gateway/test_debounce_buffer_cap.py — regression tests for buffer cap behavior

## Verification
- `uv run pytest tests/test_gateway/test_debounce_buffer_cap.py -q` — 4 passed
- `uv run pytest tests/test_gateway -q` — 1342 passed
- `uv run ruff check src/agentos/gateway/_debounce.py tests/test_gateway/test_debounce_buffer_cap.py` — All checks passed!
- `uv run mypy src/agentos/gateway/_debounce.py --show-error-codes` — Success: no issues found in 1 source file
