### PR TITLE
fix(mcp): preserve colliding tools across disconnects

### DIFF
--- a/src/agentos/mcp/discovery.py
+++ b/src/agentos/mcp/discovery.py
@@ -12,9 +12,21 @@ from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef
 from agentos.tools.registry import ToolRegistry
 from agentos.tools.schema_sanitize import sanitize_input_schema
-from agentos.tools.types import ToolSpec
+from agentos.tools.types import ToolHandler, ToolSpec
 
 log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class MCPToolRegistration:
+    """One registry entry owned by an MCP client."""
+
+    spec: ToolSpec
+    handler: ToolHandler
+
+    @property
+    def name(self) -> str:
+        return self.spec.name
 
 
 @dataclass(frozen=True)
@@ -26,6 +38,7 @@ class ActiveMCPClient:
     transport: str
     client: MCPClient
     registered_tools: tuple[str, ...] = ()
+    tool_registrations: tuple[MCPToolRegistration, ...] = ()
 
     async def close(self) -> None:
         await self.client.close()
@@ -68,9 +81,34 @@ async def disconnect_and_unregister(owner: str, registry: ToolRegistry) -> int:
         for entry in active_clients_snapshot()
         if entry.owner == owner or entry.server_name == owner
     ]
-    for entry in entries:
-        for name in entry.registered_tools:
-            registry.unregister(name)
+    closing_ids = {id(entry) for entry in entries}
+    remaining = [entry for entry in _active_clients if id(entry) not in closing_ids]
+    affected_names = {
+        registration.name for entry in entries for registration in entry.tool_registrations
+    }
+    for name in affected_names:
+        current = registry.get(name)
+        if current is None:
+            continue
+        current_is_closing = any(
+            registration.name == name and registration.handler is current.handler
+            for entry in entries
+            for registration in entry.tool_registrations
+        )
+        if not current_is_closing:
+            continue
+        replacement = next(
+            (
+                registration
+                for entry in reversed(remaining)
+                for registration in reversed(entry.tool_registrations)
+                if registration.name == name
+            ),
+            None,
+        )
+        registry.unregister(name)
+        if replacement is not None:
+            registry.register(replacement.spec, replacement.handler)
     return await close_active_clients(owner)
 
 
@@ -98,7 +136,7 @@ def _make_tool_handler(
     tool_def: MCPToolDef,
     registry: ToolRegistry,
     timeout_seconds: float,
-) -> None:
+) -> MCPToolRegistration:
     """Register a single MCP tool into the registry with an mcp_ prefix."""
     # The server's schema goes out verbatim in every provider request, so it is
     # normalized once here rather than per turn. A shape one backend tolerates
@@ -127,6 +165,7 @@ def _make_tool_handler(
         return result.content
 
     registry.register(spec, handler)
+    return MCPToolRegistration(spec=spec, handler=handler)
 
 
 async def discover_and_register(
@@ -144,24 +183,27 @@ async def discover_and_register(
     entry: ActiveMCPClient | None = None
 
     registered: list[str] = []
+    registrations: list[MCPToolRegistration] = []
     try:
         await client.connect()
         tools = await client.list_tools()
         for t in tools:
-            _make_tool_handler(
+            registration = _make_tool_handler(
                 client,
                 t.name,
                 t,
                 registry,
                 timeout_seconds=config.tool_timeout_seconds,
             )
-            registered.append(f"mcp_{t.name}")
+            registered.append(registration.name)
+            registrations.append(registration)
         entry = ActiveMCPClient(
             owner=owner or config.name,
             server_name=config.name,
             transport=config.transport,
             client=client,
             registered_tools=tuple(registered),
+            tool_registrations=tuple(registrations),
         )
         _active_clients.append(entry)
     except BaseException:

--- a/tests/test_mcp/test_discovery_lifecycle.py
+++ b/tests/test_mcp/test_discovery_lifecycle.py
@@ -112,6 +112,76 @@ async def test_disconnect_unregisters_tools_owned_by_server(
 
 
 @pytest.mark.asyncio
+async def test_disconnect_older_server_preserves_newer_same_named_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentos.mcp import discovery
+
+    older_config = MCPServerConfig(name="older", transport="stdio", command="mock-mcp")
+    newer_config = MCPServerConfig(name="newer", transport="stdio", command="mock-mcp")
+    tool = MCPToolDef(
+        name="lookup",
+        description="Lookup",
+        input_schema={"properties": {}, "required": []},
+    )
+    older_client = FakeMCPClient(older_config, tools=[tool])
+    newer_client = FakeMCPClient(newer_config, tools=[tool])
+    clients = iter((older_client, newer_client))
+    monkeypatch.setattr(discovery, "create_client", lambda _config: next(clients))
+    registry = ToolRegistry()
+
+    await discovery.discover_and_register(older_config, registry, owner="older")
+    older_registration = registry.get("mcp_lookup")
+    assert older_registration is not None
+    older_handler = older_registration.handler
+    await discovery.discover_and_register(newer_config, registry, owner="newer")
+    newer_registration = registry.get("mcp_lookup")
+    assert newer_registration is not None
+    newer_handler = newer_registration.handler
+
+    assert newer_handler is not older_handler
+    assert await discovery.disconnect_and_unregister("older", registry) == 1
+    registered = registry.get("mcp_lookup")
+    assert registered is not None
+    assert registered.handler is newer_handler
+    assert older_client.closed is True
+    assert newer_client.closed is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_newer_server_restores_older_same_named_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agentos.mcp import discovery
+
+    older_config = MCPServerConfig(name="older", transport="stdio", command="mock-mcp")
+    newer_config = MCPServerConfig(name="newer", transport="stdio", command="mock-mcp")
+    tool = MCPToolDef(
+        name="lookup",
+        description="Lookup",
+        input_schema={"properties": {}, "required": []},
+    )
+    older_client = FakeMCPClient(older_config, tools=[tool])
+    newer_client = FakeMCPClient(newer_config, tools=[tool])
+    clients = iter((older_client, newer_client))
+    monkeypatch.setattr(discovery, "create_client", lambda _config: next(clients))
+    registry = ToolRegistry()
+
+    await discovery.discover_and_register(older_config, registry, owner="older")
+    older_registration = registry.get("mcp_lookup")
+    assert older_registration is not None
+    older_handler = older_registration.handler
+    await discovery.discover_and_register(newer_config, registry, owner="newer")
+
+    assert await discovery.disconnect_and_unregister("newer", registry) == 1
+    registered = registry.get("mcp_lookup")
+    assert registered is not None
+    assert registered.handler is older_handler
+    assert older_client.closed is False
+    assert newer_client.closed is True
+
+
+@pytest.mark.asyncio
 async def test_failed_mcp_discovery_closes_client_without_leaking(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- track the exact registry spec and handler owned by each active MCP client
- only unregister a colliding tool when the disconnecting client owns the active handler
- restore the most recently registered handler from a still-active MCP client when the current owner disconnects
- cover both disconnect orders with offline regression tests

Fixes #801

## Testing

- `uv run pytest tests/test_mcp/test_discovery_lifecycle.py -q` — 8 passed
- `uv run pytest tests/test_mcp -q` — 15 passed
- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `python scripts/build_control_ui.py build` via `uv run python` — passed
- `npm --prefix frontend run check` — 98 files / 2007 tests passed
- `uv build --wheel` — passed
- `uv run pytest -q` — 8824 passed, 32 skipped; 6 failures and 3 setup errors are unrelated environment/tooling failures: the temporary worktree contains Git LFS pointer text instead of the hydrated ONNX model, and local `uv 0.8.15` rejects the existing wheelhouse helper's `uv build --clear` option

## Third-party origin

None.
