### PR TITLE
fix(tools): cap background process output

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -61,6 +61,7 @@ _DEFAULT_BACKGROUND_TIMEOUT = 1800.0
 _MAX_BACKGROUND_TIMEOUT = 3600.0
 _BACKGROUND_TERMINATE_TIMEOUT = 1.0
 _BACKGROUND_KILL_TIMEOUT = 1.0
+_MAX_BACKGROUND_OUTPUT_CHARS = 1_000_000
 _EXEC_TERMINATE_TIMEOUT = 0.25
 _EXEC_KILL_TIMEOUT = 0.25
 _COMMAND_AUDIT_MAX_CHARS = 4096
@@ -100,6 +101,8 @@ class _BgSession:
     agent_id: str | None = None
     local_urls: list[str] = field(default_factory=list)
     output_lines: list[str] = field(default_factory=list)
+    output_chars: int = 0
+    output_truncated: bool = False
     done: bool = False
     timed_out: bool = False
     killed: bool = False
@@ -475,6 +478,8 @@ def _bg_session_payload(session: _BgSession) -> dict[str, object]:
         "ended_at": session.ended_at,
         "killed": session.killed,
         "timed_out": session.timed_out,
+        "output_chars": session.output_chars,
+        "output_truncated": session.output_truncated,
     }
     if session.local_urls:
         payload["local_urls"] = list(session.local_urls)
@@ -562,7 +567,23 @@ async def _read_bg_output(session: _BgSession) -> None:
     if stdout is None:
         return
     while chunk := await stdout.read(4096):
-        session.output_lines.append(chunk.decode("utf-8", errors="replace"))
+        _append_bg_output(session, chunk.decode("utf-8", errors="replace"))
+
+
+def _append_bg_output(session: _BgSession, output: str) -> None:
+    """Retain bounded output while allowing the collector to keep draining stdout."""
+    remaining = max(0, _MAX_BACKGROUND_OUTPUT_CHARS - session.output_chars)
+    retained = output[:remaining]
+    if retained:
+        session.output_lines.append(retained)
+        session.output_chars += len(retained)
+    if len(retained) < len(output) and not session.output_truncated:
+        session.output_truncated = True
+        log.warning(
+            "shell.bg_output_truncated",
+            session_id=session.session_id,
+            max_chars=_MAX_BACKGROUND_OUTPUT_CHARS,
+        )
 
 
 def _finalize_bg_session(session: _BgSession) -> None:
@@ -937,7 +958,7 @@ async def background_process(
             except TimeoutError:
                 session.timed_out = True
                 await _terminate_bg_session(session)
-                session.output_lines.append(f"[timeout after {effective_timeout}s]\n")
+                _append_bg_output(session, f"[timeout after {effective_timeout}s]\n")
             finally:
                 await _await_bg_output_task(output_task)
                 _finalize_bg_session(session)
@@ -989,7 +1010,7 @@ async def background_process(
         except TimeoutError:
             session.timed_out = True
             await _terminate_bg_session(session)
-            session.output_lines.append(f"[timeout after {effective_timeout}s]\n")
+            _append_bg_output(session, f"[timeout after {effective_timeout}s]\n")
         finally:
             await _await_bg_output_task(output_task)
             _finalize_bg_session(session)
@@ -1143,7 +1164,7 @@ async def process(
                 "output": sliced,
                 "offset": start,
                 "limit": max_chars,
-                "truncated": start > 0 or end < len(output),
+                "truncated": session.output_truncated or start > 0 or end < len(output),
             }
         )
 

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -571,13 +571,24 @@ async def _read_bg_output(session: _BgSession) -> None:
 
 
 def _append_bg_output(session: _BgSession, output: str) -> None:
-    """Retain bounded output while allowing the collector to keep draining stdout."""
-    remaining = max(0, _MAX_BACKGROUND_OUTPUT_CHARS - session.output_chars)
-    retained = output[:remaining]
-    if retained:
-        session.output_lines.append(retained)
-        session.output_chars += len(retained)
-    if len(retained) < len(output) and not session.output_truncated:
+    """Retain the bounded output tail while continuing to drain stdout."""
+    if not output:
+        return
+
+    session.output_lines.append(output)
+    session.output_chars += len(output)
+    truncated_now = session.output_chars > _MAX_BACKGROUND_OUTPUT_CHARS
+    while session.output_chars > _MAX_BACKGROUND_OUTPUT_CHARS:
+        overflow = session.output_chars - _MAX_BACKGROUND_OUTPUT_CHARS
+        first = session.output_lines[0]
+        if len(first) <= overflow:
+            session.output_lines.pop(0)
+            session.output_chars -= len(first)
+        else:
+            session.output_lines[0] = first[overflow:]
+            session.output_chars -= overflow
+
+    if truncated_now and not session.output_truncated:
         session.output_truncated = True
         log.warning(
             "shell.bg_output_truncated",

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -36,10 +36,21 @@ class _FakeStdin:
         return None
 
 
+class _FakeStdout:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = list(chunks)
+        self.read_calls = 0
+
+    async def read(self, _limit: int) -> bytes:
+        self.read_calls += 1
+        return self.chunks.pop(0)
+
+
 @dataclass
 class _FakeProcess:
     returncode: int | None = None
     stdin: _FakeStdin | None = None
+    stdout: _FakeStdout | None = None
 
     def __post_init__(self) -> None:
         if self.stdin is None:
@@ -104,6 +115,46 @@ def test_background_process_result_surfaces_local_http_server_url() -> None:
     assert "local_urls:" in result
     assert "- http://127.0.0.1:8080/" in result
     assert "include the local URL" in result
+
+
+@pytest.mark.asyncio
+async def test_background_output_is_capped_while_stdout_is_fully_drained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(shell, "_MAX_BACKGROUND_OUTPUT_CHARS", 10)
+    stdout = _FakeStdout([b"abcdef", b"ghijkl", b"mnop", b""])
+    session = shell._BgSession(
+        session_id="noisy",
+        command="noisy command",
+        process=_FakeProcess(returncode=0, stdout=stdout),  # type: ignore[arg-type]
+        session_key="agent:main:one",
+    )
+
+    await shell._read_bg_output(session)
+
+    assert "".join(session.output_lines) == "abcdefghij"
+    assert session.output_chars == 10
+    assert session.output_truncated is True
+    assert stdout.read_calls == 4
+
+
+@pytest.mark.asyncio
+async def test_process_log_reports_background_output_truncation() -> None:
+    session = _session("noisy", "agent:main:one", done=True)
+    session.output_lines = ["abcdefghij"]
+    session.output_chars = 10
+    session.output_truncated = True
+    shell._bg_sessions[session.session_id] = session
+
+    token = current_tool_context.set(_ctx("agent:main:one"))
+    try:
+        payload = json.loads(await shell.process("log", session_id=session.session_id))
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload["output"] == "abcdefghij"
+    assert payload["truncated"] is True
+    assert payload["session"]["output_truncated"] is True
 
 
 @pytest.mark.skipif(os.name != "posix", reason="process group behavior is POSIX-specific")

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -132,7 +132,7 @@ async def test_background_output_is_capped_while_stdout_is_fully_drained(
 
     await shell._read_bg_output(session)
 
-    assert "".join(session.output_lines) == "abcdefghij"
+    assert "".join(session.output_lines) == "ghijklmnop"
     assert session.output_chars == 10
     assert session.output_truncated is True
     assert stdout.read_calls == 4


### PR DESCRIPTION
## Summary

- cap retained stdout for each `background_process` session at 1,000,000 characters
- retain the most recent output tail by evicting older chunks once the cap is exceeded
- keep draining stdout after the cap so noisy subprocesses cannot block on a full pipe
- expose retained character count and truncation state in process session/log payloads
- route timeout markers through the same bounded append path
- add deterministic regression coverage for tail retention, full drain, and truncation reporting

Fixes #803

## Testing

- `uv run pytest tests/test_tools/test_shell_process_isolation.py -q` — 18 passed
- broad Python suite excluding the three environment-blocked ONNX/wheelhouse modules — 8,783 passed, 32 skipped
- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `python scripts/build_control_ui.py build` via `uv run python` — passed
- `npm --prefix frontend run check` — 2,006/2,007 passed; the unrelated timing-sensitive Skills test passed 58/58 on immediate isolated rerun
- `uv build --wheel` — passed

The excluded Python modules require hydrated Git LFS ONNX assets and a newer `uv` supporting `uv build --clear`; both failures reproduce on clean `origin/main` in this checkout.

## Third-party origin

None.