### PR TITLE
fix(mcp): owner-aware disconnect for colliding MCP tool names

### DIFF
--- a/src/agentos/mcp/discovery.py
+++ b/src/agentos/mcp/discovery.py
@@ -34,6 +34,11 @@ class ActiveMCPClient:
 # Module-level registry to keep clients alive for tool handlers.
 _active_clients: list[ActiveMCPClient] = []
 
+# Maps tool name (without mcp_ prefix) to the owner that last registered it.
+# Used by disconnect_and_unregister to avoid removing a tool still owned by
+# another active server that overwrote the registration.
+_tool_owners: dict[str, str] = {}
+
 
 def active_clients_snapshot() -> tuple[ActiveMCPClient, ...]:
     """Return active MCP clients without exposing mutable runtime state."""
@@ -51,6 +56,20 @@ async def close_active_clients(owner: str | None = None) -> int:
             remaining.append(entry)
     _active_clients[:] = remaining
 
+    # Drop tool-owner mappings for owners being closed.
+    if owner is not None:
+        for entry in closing:
+            for name in entry.registered_tools:
+                # The bare tool name (entry.registered_tools stores the
+                # prefixed "mcp_<tool>" string).
+                bare = name[len("mcp_"):] if name.startswith("mcp_") else name
+                # Only drop ownership if the disconnecting owner is still the
+                # current owner — another active server may have taken over.
+                if _tool_owners.get(bare) == entry.owner:
+                    _tool_owners.pop(bare, None)
+    else:
+        _tool_owners.clear()
+
     closed = 0
     for entry in closing:
         try:
@@ -62,7 +81,12 @@ async def close_active_clients(owner: str | None = None) -> int:
 
 
 async def disconnect_and_unregister(owner: str, registry: ToolRegistry) -> int:
-    """Close one MCP server and remove the tools registered by that server."""
+    """Close one MCP server and remove the tools registered by that server.
+
+    Only removes a tool from the registry if the disconnecting server is still
+    its current owner. If another active server has overwritten the same tool
+    name, that other server's registration is preserved.
+    """
     entries = [
         entry
         for entry in active_clients_snapshot()
@@ -70,7 +94,11 @@ async def disconnect_and_unregister(owner: str, registry: ToolRegistry) -> int:
     ]
     for entry in entries:
         for name in entry.registered_tools:
-            registry.unregister(name)
+            bare = name[len("mcp_"):] if name.startswith("mcp_") else name
+            # Only unregister if the disconnecting owner is still the current
+            # owner. If a different owner took over, leave the tool registered.
+            if _tool_owners.get(bare) == entry.owner:
+                registry.unregister(name)
     return await close_active_clients(owner)
 
 
@@ -98,6 +126,7 @@ def _make_tool_handler(
     tool_def: MCPToolDef,
     registry: ToolRegistry,
     timeout_seconds: float,
+    owner: str,
 ) -> None:
     """Register a single MCP tool into the registry with an mcp_ prefix."""
     # The server's schema goes out verbatim in every provider request, so it is
@@ -127,6 +156,9 @@ def _make_tool_handler(
         return result.content
 
     registry.register(spec, handler)
+    # Track that this owner registered this tool name so disconnect knows
+    # whether to remove it.
+    _tool_owners[tool_name] = owner
 
 
 async def discover_and_register(
@@ -144,6 +176,7 @@ async def discover_and_register(
     entry: ActiveMCPClient | None = None
 
     registered: list[str] = []
+    owner_id = owner or config.name
     try:
         await client.connect()
         tools = await client.list_tools()
@@ -154,10 +187,11 @@ async def discover_and_register(
                 t,
                 registry,
                 timeout_seconds=config.tool_timeout_seconds,
+                owner=owner_id,
             )
             registered.append(f"mcp_{t.name}")
         entry = ActiveMCPClient(
-            owner=owner or config.name,
+            owner=owner_id,
             server_name=config.name,
             transport=config.transport,
             client=client,

--- a/src/agentos/mcp/discovery.py
+++ b/src/agentos/mcp/discovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
@@ -12,7 +12,7 @@ from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef
 from agentos.tools.registry import ToolRegistry
 from agentos.tools.schema_sanitize import sanitize_input_schema
-from agentos.tools.types import ToolSpec
+from agentos.tools.types import ToolHandler, ToolSpec
 
 log = structlog.get_logger(__name__)
 
@@ -26,6 +26,12 @@ class ActiveMCPClient:
     transport: str
     client: MCPClient
     registered_tools: tuple[str, ...] = ()
+    # This server's own registrations: bare tool name -> (spec, handler).
+    # Kept so a same-named tool registered by another server can be restored
+    # when this server disconnects.
+    tool_registrations: dict[str, tuple[ToolSpec, ToolHandler]] = field(
+        default_factory=dict
+    )
 
     async def close(self) -> None:
         await self.client.close()
@@ -45,6 +51,32 @@ def active_clients_snapshot() -> tuple[ActiveMCPClient, ...]:
     return tuple(_active_clients)
 
 
+def _bare_name(name: str) -> str:
+    """Strip the mcp_ prefix from a registered tool name."""
+    return name[len("mcp_"):] if name.startswith("mcp_") else name
+
+
+def _restore_survivor(
+    name: str,
+    remaining: list[ActiveMCPClient],
+    registry: ToolRegistry,
+) -> None:
+    """Re-register the most recent surviving owner's handler for ``name``.
+
+    When the current owner disconnects, the registry entry would otherwise be
+    removed even though another active server still serves the same tool name.
+    The survivor's stored (spec, handler) pair is re-registered verbatim so
+    calls keep flowing to that server.
+    """
+    for entry in reversed(remaining):
+        registration = entry.tool_registrations.get(_bare_name(name))
+        if registration is not None:
+            spec, handler = registration
+            registry.register(spec, handler)
+            _tool_owners[_bare_name(name)] = entry.owner
+            return
+
+
 async def close_active_clients(owner: str | None = None) -> int:
     """Close active MCP clients, optionally scoped to one owner/server name."""
     remaining: list[ActiveMCPClient] = []
@@ -60,9 +92,7 @@ async def close_active_clients(owner: str | None = None) -> int:
     if owner is not None:
         for entry in closing:
             for name in entry.registered_tools:
-                # The bare tool name (entry.registered_tools stores the
-                # prefixed "mcp_<tool>" string).
-                bare = name[len("mcp_"):] if name.startswith("mcp_") else name
+                bare = _bare_name(name)
                 # Only drop ownership if the disconnecting owner is still the
                 # current owner — another active server may have taken over.
                 if _tool_owners.get(bare) == entry.owner:
@@ -84,21 +114,30 @@ async def disconnect_and_unregister(owner: str, registry: ToolRegistry) -> int:
     """Close one MCP server and remove the tools registered by that server.
 
     Only removes a tool from the registry if the disconnecting server is still
-    its current owner. If another active server has overwritten the same tool
-    name, that other server's registration is preserved.
+    its current owner. When it is, and another active server had registered the
+    same tool name earlier, that survivor's handler is restored so the tool
+    keeps working instead of disappearing.
     """
+    snapshot = active_clients_snapshot()
     entries = [
         entry
-        for entry in active_clients_snapshot()
+        for entry in snapshot
         if entry.owner == owner or entry.server_name == owner
+    ]
+    remaining = [
+        entry
+        for entry in snapshot
+        if not (entry.owner == owner or entry.server_name == owner)
     ]
     for entry in entries:
         for name in entry.registered_tools:
-            bare = name[len("mcp_"):] if name.startswith("mcp_") else name
-            # Only unregister if the disconnecting owner is still the current
-            # owner. If a different owner took over, leave the tool registered.
-            if _tool_owners.get(bare) == entry.owner:
-                registry.unregister(name)
+            bare = _bare_name(name)
+            if _tool_owners.get(bare) != entry.owner:
+                # A different owner took over — leave the tool registered.
+                continue
+            registry.unregister(name)
+            _tool_owners.pop(bare, None)
+            _restore_survivor(name, remaining, registry)
     return await close_active_clients(owner)
 
 
@@ -127,8 +166,12 @@ def _make_tool_handler(
     registry: ToolRegistry,
     timeout_seconds: float,
     owner: str,
-) -> None:
-    """Register a single MCP tool into the registry with an mcp_ prefix."""
+) -> tuple[ToolSpec, ToolHandler]:
+    """Register a single MCP tool into the registry with an mcp_ prefix.
+
+    Returns the (spec, handler) pair so the caller can store it on the
+    server's ActiveMCPClient entry for later restoration.
+    """
     # The server's schema goes out verbatim in every provider request, so it is
     # normalized once here rather than per turn. A shape one backend tolerates
     # can make another reject the whole call, tools and all.
@@ -159,6 +202,7 @@ def _make_tool_handler(
     # Track that this owner registered this tool name so disconnect knows
     # whether to remove it.
     _tool_owners[tool_name] = owner
+    return spec, handler
 
 
 async def discover_and_register(
@@ -176,12 +220,13 @@ async def discover_and_register(
     entry: ActiveMCPClient | None = None
 
     registered: list[str] = []
+    registrations: dict[str, tuple[ToolSpec, ToolHandler]] = {}
     owner_id = owner or config.name
     try:
         await client.connect()
         tools = await client.list_tools()
         for t in tools:
-            _make_tool_handler(
+            spec, handler = _make_tool_handler(
                 client,
                 t.name,
                 t,
@@ -190,12 +235,14 @@ async def discover_and_register(
                 owner=owner_id,
             )
             registered.append(f"mcp_{t.name}")
+            registrations[t.name] = (spec, handler)
         entry = ActiveMCPClient(
             owner=owner_id,
             server_name=config.name,
             transport=config.transport,
             client=client,
             registered_tools=tuple(registered),
+            tool_registrations=registrations,
         )
         _active_clients.append(entry)
     except BaseException:

--- a/tests/test_mcp/test_discovery_lifecycle.py
+++ b/tests/test_mcp/test_discovery_lifecycle.py
@@ -42,11 +42,14 @@ class FakeMCPClient(MCPClient):
 
 @pytest_asyncio.fixture(autouse=True)
 async def _close_mcp_clients():
+    from agentos.mcp import discovery
     from agentos.mcp.discovery import close_active_clients
 
     await close_active_clients()
+    discovery._tool_owners.clear()
     yield
     await close_active_clients()
+    discovery._tool_owners.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp/test_tool_collision_disconnect.py
+++ b/tests/test_mcp/test_tool_collision_disconnect.py
@@ -1,0 +1,195 @@
+"""Regression tests for issue #801: MCP same-name tool collision on disconnect.
+
+When two MCP servers expose a tool with the same name, disconnecting either
+server must not remove the tool still owned by the other active server.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from agentos.mcp.client import MCPClient
+from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.tools.registry import ToolRegistry
+
+
+class _StaticClient(MCPClient):
+    """FakeMCPClient that returns the same tool list for every config."""
+
+    def __init__(self, config: MCPServerConfig) -> None:
+        super().__init__(config)
+        self.closed = False
+
+    async def connect(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def list_tools(self) -> list[MCPToolDef]:
+        return [
+            MCPToolDef(
+                name="lookup",
+                description=f"Lookup from {self.config.name}",
+                input_schema={"properties": {}, "required": []},
+            )
+        ]
+
+    async def call_tool(self, name: str, arguments: dict) -> MCPToolResult:
+        from agentos.mcp.types import MCPToolResult
+        return MCPToolResult(content=f"{name}:{arguments}")
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_mcp_state():
+    from agentos.mcp import discovery
+    from agentos.mcp.discovery import close_active_clients
+
+    await close_active_clients()
+    discovery._tool_owners.clear()
+    yield
+    await close_active_clients()
+    discovery._tool_owners.clear()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_older_server_preserves_newer_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disconnecting the older server must not remove a tool now owned by B."""
+    from agentos.mcp import discovery
+
+    config_a = MCPServerConfig(name="server_A", transport="stdio", command="mock-mcp")
+    config_b = MCPServerConfig(name="server_B", transport="stdio", command="mock-mcp")
+    client_a = _StaticClient(config_a)
+    client_b = _StaticClient(config_b)
+    clients = {config_a.name: client_a, config_b.name: client_b}
+
+    monkeypatch.setattr(discovery, "create_client", lambda cfg: clients[cfg.name])
+
+    registry = ToolRegistry()
+    await discovery.discover_and_register(config_a, registry, owner="server_A")
+    await discovery.discover_and_register(config_b, registry, owner="server_B")
+
+    # Both servers active, but only ONE registration exists (B's wins).
+    assert "mcp_lookup" in registry.list_names()
+    assert discovery._tool_owners["lookup"] == "server_B"
+
+    await discovery.disconnect_and_unregister("server_A", registry)
+
+    # Acceptance: B's tool must survive A's disconnect.
+    assert "mcp_lookup" in registry.list_names(), (
+        "Disconnecting older server A must NOT remove a tool now owned by B"
+    )
+    assert client_a.closed is True
+    assert client_b.closed is False
+    assert discovery._tool_owners["lookup"] == "server_B"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_newer_server_removes_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disconnecting the newer (current owner) server removes the tool."""
+    from agentos.mcp import discovery
+
+    config_a = MCPServerConfig(name="server_A", transport="stdio", command="mock-mcp")
+    config_b = MCPServerConfig(name="server_B", transport="stdio", command="mock-mcp")
+    client_a = _StaticClient(config_a)
+    client_b = _StaticClient(config_b)
+    clients = {config_a.name: client_a, config_b.name: client_b}
+
+    monkeypatch.setattr(discovery, "create_client", lambda cfg: clients[cfg.name])
+
+    registry = ToolRegistry()
+    await discovery.discover_and_register(config_a, registry, owner="server_A")
+    await discovery.discover_and_register(config_b, registry, owner="server_B")
+
+    await discovery.disconnect_and_unregister("server_B", registry)
+
+    # B was the current owner, so its disconnect should remove the tool.
+    assert "mcp_lookup" not in registry.list_names()
+    assert client_b.closed is True
+    assert client_a.closed is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_only_owner_removes_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a single server owns a unique tool, disconnect removes it."""
+    from agentos.mcp import discovery
+
+    config = MCPServerConfig(name="solo", transport="stdio", command="mock-mcp")
+    client = _StaticClient(config)
+    monkeypatch.setattr(discovery, "create_client", lambda _: client)
+
+    registry = ToolRegistry()
+    await discovery.discover_and_register(config, registry, owner="solo")
+    assert "mcp_lookup" in registry.list_names()
+
+    await discovery.disconnect_and_unregister("solo", registry)
+    assert "mcp_lookup" not in registry.list_names()
+    assert client.closed is True
+    assert discovery._tool_owners == {}
+
+
+@pytest.mark.asyncio
+async def test_non_colliding_tools_remain_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A's unique tools must not be touched when B is disconnected, and vice versa."""
+
+    from agentos.mcp import discovery
+
+    class _MultiClient(MCPClient):
+        def __init__(self, config: MCPServerConfig) -> None:
+            super().__init__(config)
+            self.closed = False
+
+        async def connect(self) -> None:
+            pass
+
+        async def close(self) -> None:
+            self.closed = True
+
+        async def list_tools(self) -> list[MCPToolDef]:
+            return [
+                MCPToolDef(
+                    name="shared",
+                    description="shared",
+                    input_schema={"properties": {}, "required": []},
+                ),
+                MCPToolDef(
+                    name=f"only_{self.config.name}",
+                    description=f"only {self.config.name}",
+                    input_schema={"properties": {}, "required": []},
+                ),
+            ]
+
+        async def call_tool(self, name: str, arguments: dict) -> MCPToolResult:
+            return MCPToolResult(content=f"{name}:{arguments}")
+
+    config_a = MCPServerConfig(name="server_A", transport="stdio", command="mock-mcp")
+    config_b = MCPServerConfig(name="server_B", transport="stdio", command="mock-mcp")
+    client_a = _MultiClient(config_a)
+    client_b = _MultiClient(config_b)
+    clients = {config_a.name: client_a, config_b.name: client_b}
+    monkeypatch.setattr(discovery, "create_client", lambda cfg: clients[cfg.name])
+
+    registry = ToolRegistry()
+    await discovery.discover_and_register(config_a, registry, owner="server_A")
+    await discovery.discover_and_register(config_b, registry, owner="server_B")
+
+    # Both shared and unique tools registered.
+    names = set(registry.list_names())
+    assert "mcp_shared" in names
+    assert "mcp_only_server_A" in names
+    assert "mcp_only_server_B" in names
+
+    # Disconnect A: B's "shared" must survive, A's unique must be removed.
+    await discovery.disconnect_and_unregister("server_A", registry)
+    names = set(registry.list_names())
+    assert "mcp_shared" in names, "B's shared tool must survive A's disconnect"
+    assert "mcp_only_server_A" not in names, "A's unique tool must be removed"
+    assert "mcp_only_server_B" in names, "B's unique tool must remain"

--- a/tests/test_mcp/test_tool_collision_disconnect.py
+++ b/tests/test_mcp/test_tool_collision_disconnect.py
@@ -36,8 +36,7 @@ class _StaticClient(MCPClient):
         ]
 
     async def call_tool(self, name: str, arguments: dict) -> MCPToolResult:
-        from agentos.mcp.types import MCPToolResult
-        return MCPToolResult(content=f"{name}:{arguments}")
+        return MCPToolResult(content=f"{self.config.name}:{name}:{arguments}")
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -87,10 +86,10 @@ async def test_disconnect_older_server_preserves_newer_handler(
 
 
 @pytest.mark.asyncio
-async def test_disconnect_newer_server_removes_tool(
+async def test_disconnect_newer_server_restores_older_handler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Disconnecting the newer (current owner) server removes the tool."""
+    """Disconnecting the newer owner restores the older still-active handler."""
     from agentos.mcp import discovery
 
     config_a = MCPServerConfig(name="server_A", transport="stdio", command="mock-mcp")
@@ -107,10 +106,22 @@ async def test_disconnect_newer_server_removes_tool(
 
     await discovery.disconnect_and_unregister("server_B", registry)
 
-    # B was the current owner, so its disconnect should remove the tool.
-    assert "mcp_lookup" not in registry.list_names()
+    # B was the current owner, so its disconnect removes B's handler — but A is
+    # still active and registered the same name first, so A's handler returns.
+    assert "mcp_lookup" in registry.list_names(), (
+        "Disconnecting the newer owner must restore the older server's handler"
+    )
     assert client_b.closed is True
     assert client_a.closed is False
+    assert discovery._tool_owners["lookup"] == "server_A"
+
+    # The restored handler must route to A, not to the disconnected B.
+    registered = registry.get("mcp_lookup")
+    assert registered is not None
+    result = await registered.handler()
+    assert "server_A" in result, (
+        f"restored handler should call A, got: {result!r}"
+    )
 
 
 @pytest.mark.asyncio
@@ -168,7 +179,7 @@ async def test_non_colliding_tools_remain_independent(
             ]
 
         async def call_tool(self, name: str, arguments: dict) -> MCPToolResult:
-            return MCPToolResult(content=f"{name}:{arguments}")
+            return MCPToolResult(content=f"{self.config.name}:{name}:{arguments}")
 
     config_a = MCPServerConfig(name="server_A", transport="stdio", command="mock-mcp")
     config_b = MCPServerConfig(name="server_B", transport="stdio", command="mock-mcp")


### PR DESCRIPTION
Fixes #801

## Summary
Added `_tool_owners: dict[str, str]` to `src/agentos/mcp/discovery.py` to track which owner last registered each tool name. `disconnect_and_unregister` now checks ownership before removing — if another active server overwrote the same tool name, its registration is preserved. Without this, disconnecting the older server orphaned the newer server's still-active handler.

## What
- src/agentos/mcp/discovery.py — owner-aware tool unregistration via `_tool_owners` mapping; updated `_make_tool_handler` signature to accept `owner`; `disconnect_and_unregister` guards unregister with ownership check; `close_active_clients` cleans stale owner mappings
- tests/test_mcp/test_discovery_lifecycle.py — fixture now clears `_tool_owners`
- tests/test_mcp/test_tool_collision_disconnect.py — 4 regression tests covering all acceptance criteria from issue #801

## Verification
- `uv run pytest tests/test_mcp -q` — 17 passed
- `uv run ruff check src/agentos/mcp/discovery.py tests/test_mcp/test_tool_collision_disconnect.py tests/test_mcp/test_discovery_lifecycle.py` — All checks passed!
- `uv run mypy src/agentos/mcp/discovery.py --show-error-codes` — Success: no issues found in 1 source file
