### PR TITLE
fix(scheduler): use POSIX OR semantics when day-of-month and day-of-w…

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -68,6 +68,7 @@ _PRESETS: dict[str, str] = {
 @dataclass(frozen=True)
 class CronField:
     values: frozenset[int]
+    wildcard: bool = False
 
     def matches(self, value: int) -> bool:
         return value in self.values
@@ -83,12 +84,23 @@ class CronExpression:
     raw: str
 
     def matches(self, dt: datetime) -> bool:
+        # POSIX: when both day_of_month and day_of_week are restricted
+        # (neither is a wildcard *), the job fires when EITHER matches.
+        both_restricted = not self.day_of_month.wildcard and not self.day_of_week.wildcard
+
+        dom_ok = self.day_of_month.matches(dt.day)
+        dow_ok = self.day_of_week.matches((dt.weekday() + 1) % 7)
+
+        if both_restricted:
+            day_ok = dom_ok or dow_ok
+        else:
+            day_ok = dom_ok and dow_ok
+
         return (
             self.minute.matches(dt.minute)
             and self.hour.matches(dt.hour)
-            and self.day_of_month.matches(dt.day)
+            and day_ok
             and self.month.matches(dt.month)
-            and self.day_of_week.matches((dt.weekday() + 1) % 7)  # Python Mon=0 → cron Sun=0
         )
 
 
@@ -157,7 +169,7 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
         values.remove(7)
         values.add(0)
 
-    return CronField(frozenset(values))
+    return CronField(frozenset(values), wildcard=token.strip() == "*")
 
 
 def _to_int(s: str, field_name: str, lo: int, hi: int) -> int:

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -93,6 +93,55 @@ def test_parse_cron_rejects_reversed_range_with_step() -> None:
         parse_cron("5-3/2 * * * *")
     with pytest.raises(CronParseError, match="Range start > end"):
         parse_cron("0 0 * * FRI-TUE/2")
+
+
+# ---------------------------------------------------------------------------
+# CronExpression.matches — day-of-month / day-of-week OR semantics (#660)
+# ---------------------------------------------------------------------------
+
+
+def test_matches_ors_dom_and_dow_when_both_restricted() -> None:
+    """POSIX: when both day-of-month and day-of-week are restricted,
+    the job fires when EITHER matches."""
+    expr = parse_cron("0 0 1,15 * 5")
+
+    # Friday (day=7, not 1 or 15) → should match via day-of-week
+    friday = datetime(2026, 8, 7, 0, 0, tzinfo=UTC)
+    assert expr.matches(friday), "Friday should match via day-of-week"
+
+    # 1st (Saturday) → should match via day-of-month
+    first = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    assert expr.matches(first), "1st should match via day-of-month"
+
+    # 15th (Saturday) → should match via day-of-month
+    fifteenth = datetime(2026, 8, 15, 0, 0, tzinfo=UTC)
+    assert expr.matches(fifteenth), "15th should match via day-of-month"
+
+    # Monday 3rd (not 1st/15th, not Friday) → should NOT match
+    monday_3rd = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
+    assert not expr.matches(monday_3rd), "Monday 3rd should NOT match"
+
+
+def test_matches_ands_dom_and_dow_when_one_is_wild() -> None:
+    """When either day-of-month or day-of-week is a wildcard, AND semantics
+    apply as normal."""
+    # DOM restricted, DOW wildcard → only 1st and 15th
+    dom_only = parse_cron("0 0 1,15 * *")
+    friday_7th = datetime(2026, 8, 7, 0, 0, tzinfo=UTC)
+    assert not dom_only.matches(friday_7th), "DOM-only should not match Friday 7th"
+    assert dom_only.matches(datetime(2026, 8, 1, 0, 0, tzinfo=UTC)), "1st should match"
+
+    # DOW restricted, DOM wildcard → only Fridays
+    dow_only = parse_cron("0 0 * * 5")
+    sat_1st = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    assert not dow_only.matches(sat_1st), "DOW-only should not match Saturday 1st"
+    assert dow_only.matches(friday_7th), "DOW-only should match Friday"
+
+
+def test_matches_ands_dom_and_dow_when_both_wild() -> None:
+    """Both wildcards → every day."""
+    every = parse_cron("0 0 * * *")
+    assert every.matches(datetime(2026, 8, 3, 0, 0, tzinfo=UTC))
     with pytest.raises(CronParseError, match="Range start > end"):
         parse_cron("0 0 * dec-feb/2 *")
 


### PR DESCRIPTION
## Summary

Per POSIX, when both day-of-month and day-of-week are restricted (neither is a bare `*`), the cron job fires when EITHER field matches. The existing implementation unconditionally ANDs all five fields, so `0 0 1,15 * 5` (1st, 15th, or every Friday) only fires when a date is simultaneously the 1st/15th AND a Friday — virtually never.

## Fix

1. `CronField.wildcard` flag — tracks whether the field was parsed from a literal `*`
2. `matches()` — when both `day_of_month` and `day_of_week` are restricted, use `dom_ok or dow_ok` instead of `dom_ok and dow_ok`

## Changes

- `src/agentos/scheduler/parser.py`: 18 lines added/modified
- `tests/test_scheduler/test_parser.py`: 3 regression tests

## Verification

- ✅ `ruff check src tests` — clean
- ✅ `pytest tests/test_scheduler/` — **475 passed** (472 existing + 3 new)
- Regression covers:
  - Both restricted (`0 0 1,15 * 5`) → OR: match Friday, 1st, 15th; not Monday 3rd
  - One wildcard → AND: DOM-only or DOW-only still strict
  - Both wildcards → AND: every day

Fixes #660