### PR TITLE
fix(observability): skip malformed and partial lines in load_entries

### DIFF
--- a/src/agentos/observability/decision_log.py
+++ b/src/agentos/observability/decision_log.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 from dataclasses import asdict, dataclass, field, fields
@@ -23,6 +24,8 @@ from typing import Literal
 
 from agentos.bootstrap_types import BootstrapFileReport
 from agentos.paths import default_agentos_home
+
+log = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 14
 _INTENT_SUMMARY_MAX_CHARS = 500
@@ -265,40 +268,83 @@ def load_entries(path: Path) -> list[DecisionEntry]:
     """Read a decisions JSONL file and return hydrated DecisionEntry records.
 
     Unknown fields are ignored so readers tolerate a future schema bump that
-    adds attributes (additive-only policy; see SCHEMA_VERSION).
+    adds attributes (additive-only policy; see SCHEMA_VERSION). Malformed or
+    partial lines are skipped so ungracefully interrupted writes do not crash
+    readers.
     """
 
     if not path.is_file():
         return []
 
     entries: list[DecisionEntry] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
+    skipped_count = 0
+    for line_no, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
         if not line:
             continue
-        payload = json.loads(line)
-        payload = _coerce_decision_payload(payload)
-        steps_payload = payload.pop("pipeline_steps", [])
-        steps = [
-            PipelineStepRecord(**_filter_payload(PipelineStepRecord, s))
-            for s in steps_payload
-            if isinstance(s, dict)
-        ]
-        bootstrap_payload = payload.pop("bootstrap_files", [])
-        bootstrap_files = [
-            BootstrapFileReport(**_filter_payload(BootstrapFileReport, item))
-            for item in bootstrap_payload
-            if isinstance(item, dict)
-        ]
-        savings_payload = payload.pop("savings", {})
-        savings = SavingsTelemetry(**_filter_payload(SavingsTelemetry, savings_payload))
-        entries.append(
-            DecisionEntry(
-                pipeline_steps=steps,
-                bootstrap_files=bootstrap_files,
-                savings=savings,
-                **_filter_payload(DecisionEntry, payload),
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            skipped_count += 1
+            log.warning(
+                "Skipping malformed decision log line %d in %s (JSONDecodeError: %s)",
+                line_no,
+                path,
+                exc,
             )
+            continue
+        if not isinstance(payload, dict):
+            skipped_count += 1
+            log.warning(
+                "Skipping non-dict decision log line %d in %s (type=%s)",
+                line_no,
+                path,
+                type(payload).__name__,
+            )
+            continue
+        try:
+            payload = _coerce_decision_payload(payload)
+            steps_payload = payload.pop("pipeline_steps", [])
+            steps = [
+                PipelineStepRecord(**_filter_payload(PipelineStepRecord, s))
+                for s in steps_payload
+                if isinstance(s, dict)
+            ]
+            bootstrap_payload = payload.pop("bootstrap_files", [])
+            bootstrap_files = [
+                BootstrapFileReport(**_filter_payload(BootstrapFileReport, item))
+                for item in bootstrap_payload
+                if isinstance(item, dict)
+            ]
+            savings_payload = payload.pop("savings", {})
+            savings = (
+                SavingsTelemetry(**_filter_payload(SavingsTelemetry, savings_payload))
+                if isinstance(savings_payload, dict)
+                else SavingsTelemetry()
+            )
+            entries.append(
+                DecisionEntry(
+                    pipeline_steps=steps,
+                    bootstrap_files=bootstrap_files,
+                    savings=savings,
+                    **_filter_payload(DecisionEntry, payload),
+                )
+            )
+        except (TypeError, ValueError) as exc:
+            skipped_count += 1
+            log.warning(
+                "Skipping unhydratable decision log line %d in %s (%s: %s)",
+                line_no,
+                path,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+    if skipped_count:
+        log.warning(
+            "Skipped %d corrupted line(s) while reading decision log %s",
+            skipped_count,
+            path,
         )
     return entries
 

--- a/src/agentos/observability/savings_report.py
+++ b/src/agentos/observability/savings_report.py
@@ -141,7 +141,7 @@ def collect_entries(
             if end_date and day > end_date:
                 continue
             entries.append(entry)
-    entries.sort(key=lambda e: e.ts)
+    entries.sort(key=lambda e: e.ts or "")
     return entries
 
 

--- a/tests/test_observability/test_decision_log_contract.py
+++ b/tests/test_observability/test_decision_log_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from agentos.observability.decision_log import (
     DecisionEntry,
     build_intent_summary,
@@ -128,3 +130,65 @@ def test_decision_log_round_trips_daily_notes_policy(tmp_path) -> None:
     assert loaded[0].daily_notes_omitted is True
     assert loaded[0].daily_notes_count_before_omit == 3
     assert loaded[0].daily_notes_policy_reason == "auto_injection_disabled"
+
+
+def test_load_entries_skips_malformed_and_partial_lines(
+    tmp_path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    entry1 = DecisionEntry(
+        turn_id="turn-valid-1",
+        session_key="agent:main:test",
+        prompt_hash="a" * 16,
+        system_prompt_hash="b" * 16,
+        tool_list_hash="c" * 16,
+        tool_choice="auto",
+        tokens_input=10,
+        tokens_output=5,
+        model="fake-model",
+        provider="fake",
+        latency_ms=10,
+        ts="2026-05-03T20:00:00Z",
+    )
+    entry2 = DecisionEntry(
+        turn_id="turn-valid-2",
+        session_key="agent:main:test",
+        prompt_hash="d" * 16,
+        system_prompt_hash="e" * 16,
+        tool_list_hash="f" * 16,
+        tool_choice="auto",
+        tokens_input=20,
+        tokens_output=15,
+        model="fake-model-2",
+        provider="fake",
+        latency_ms=25,
+        ts="2026-05-03T20:01:00Z",
+    )
+
+    from dataclasses import asdict
+
+    log_file = tmp_path / "decisions-20260503.jsonl"
+    content = (
+        json.dumps(asdict(entry1))
+        + "\n"
+        + '{"turn_id": "truncated-line-no-close\n'
+        + "42\n"
+        + "null\n"
+        + '{"turn_id": "missing-required-fields"}\n'
+        + '{"turn_id": 12345, "invalid": "types"}\n'
+        + "{not valid json\n"
+        + "\n"
+        + json.dumps(asdict(entry2))
+        + "\n"
+        + '{"turn_id": "sigkill-mid-write-truncated-final-line'
+    )
+    log_file.write_text(content, encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        loaded = load_entries(log_file)
+    assert len(loaded) == 2
+    assert loaded[0].turn_id == "turn-valid-1"
+    assert loaded[1].turn_id == "turn-valid-2"
+    assert "Skipping malformed decision log line" in caplog.text
+    assert "Skipped" in caplog.text and "corrupted line(s)" in caplog.text

--- a/tests/test_observability/test_savings_report.py
+++ b/tests/test_observability/test_savings_report.py
@@ -178,3 +178,28 @@ def test_empty_log_dir_yields_a_zeroed_report(tmp_path: Path) -> None:
     assert report.by_route == []
     assert report.by_day == []
     assert report.start_date is None
+
+
+def test_build_savings_report_survives_corrupted_log_lines(tmp_path: Path) -> None:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    log_file = tmp_path / "decisions-20260901.jsonl"
+    turn1 = _turn("2026-09-01", savings_usd=0.04, cost_usd=0.06)
+    turn2 = _turn("2026-09-01", savings_usd=0.02, cost_usd=0.03)
+    content = (
+        json.dumps(turn1)
+        + "\n"
+        + '{"turn_id": "aborted-write\n'
+        + "{bad json}\n"
+        + "12345\n"
+        + '{"invalid": "schema"}\n'
+        + json.dumps(turn2)
+        + "\n"
+    )
+    log_file.write_text(content, encoding="utf-8")
+
+    report = build_savings_report(tmp_path)
+    assert report.turns_total == 2
+    assert report.turns_routed == 2
+    assert report.routing_savings_usd == 0.06
+    assert report.actual_cost_usd == 0.09
+    assert report.top_tier_cost_usd == 0.15


### PR DESCRIPTION
### Summary
`load_entries()` in `decision_log.py` now catches `json.JSONDecodeError` and `(TypeError, ValueError)` during JSONL record hydration, safely skipping partial lines (e.g. from SIGKILL or ungraceful shutdown) and non-dict records instead of raising an unhandled exception.
### Changes
- `src/agentos/observability/decision_log.py`: Skip lines that fail `json.loads()` or `DecisionEntry` instantiation; safely default `savings_payload`.
- `src/agentos/observability/savings_report.py`: Ensure `entries.sort(key=lambda e: e.ts or "")` tolerates empty timestamps.
- `tests/test_observability/test_decision_log_contract.py`: Added `test_load_entries_skips_malformed_and_partial_lines`.
- `tests/test_observability/test_savings_report.py`: Added `test_build_savings_report_survives_corrupted_log_lines`.
### Third-Party Origins
None

closes #812 