### PR TITLE
fix(skills): handle string and dict error payloads in robinhood chain-stocks eth_call

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -78,7 +78,8 @@ def _eth_call(rpc_url: str, to: str, data: str, timeout: float) -> str:
         },
     )
     if isinstance(body, dict) and "error" in body:
-        message = str(body["error"].get("message", body["error"]))
+        err = body["error"]
+        message = str(err.get("message", err)) if isinstance(err, dict) else str(err)
         raise RpcError(message)
     result = body.get("result") if isinstance(body, dict) else None
     if not isinstance(result, str) or not result.startswith("0x"):

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -117,6 +117,37 @@ def test_encode_address_arg_pads_to_a_full_word() -> None:
     assert encoded.endswith(AAPL[2:])
 
 
+def test_eth_call_handles_string_and_dict_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Dict error with message
+    monkeypatch.setattr(
+        chain_stocks,
+        "_http_json",
+        lambda *args, **kwargs: {
+            "jsonrpc": "2.0",
+            "error": {"message": "execution reverted", "code": -32000},
+        },
+    )
+    with pytest.raises(chain_stocks.RpcError, match="execution reverted"):
+        chain_stocks._eth_call("rpc", AAPL, "0x", 5.0)
+
+    # String error
+    monkeypatch.setattr(
+        chain_stocks,
+        "_http_json",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "error": "rate limit exceeded"},
+    )
+    with pytest.raises(chain_stocks.RpcError, match="rate limit exceeded"):
+        chain_stocks._eth_call("rpc", AAPL, "0x", 5.0)
+
+    # Successful call
+    monkeypatch.setattr(
+        chain_stocks,
+        "_http_json",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "result": "0x1234"},
+    )
+    assert chain_stocks._eth_call("rpc", AAPL, "0x", 5.0) == "0x1234"
+
+
 # --- impersonation guard ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
Fixes an unhandled `AttributeError` in `robinhood-chain-stocks`'s `chain_stocks.py` when an EVM JSON-RPC endpoint or proxy returns a string error payload rather than a dictionary.

- Checks `isinstance(body["error"], dict)` before calling `.get("message", ...)` in `_eth_call`.
- Converts plain string/primitive error responses into `RpcError` cleanly.
- Adds public regression unit tests covering dictionary errors, string errors, and successful RPC calls.

## Quality Gate Verification
- [x] `uv run ruff check src tests` passed cleanly.
- [x] `uv run ruff format src tests` passed.
- [x] `uv run mypy src/agentos --show-error-codes` passed (0 issues across 621 source files).
- [x] `uv run pytest tests/test_skill_robinhood_chain_stocks.py -q` passed (26/26 tests).
closes #816 