### PR TITLE
fix(skills): validate rpc-url scheme in robinhood chain stocks reader

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -56,13 +56,21 @@ class RpcError(RuntimeError):
     """A JSON-RPC call returned an error or an unusable result."""
 
 
+def _validate_http_url(url: str) -> str:
+    cleaned = (url or "").strip()
+    if not (cleaned.startswith("http://") or cleaned.startswith("https://")):
+        raise ValueError(f"invalid url {url!r}: must start with http:// or https://")
+    return cleaned
+
+
 def _http_json(url: str, timeout: float, payload: dict[str, Any] | None = None) -> Any:
+    url = _validate_http_url(url)
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     headers = {"User-Agent": "AgentOS-robinhood-chain-stocks/0.1"}
     if data is not None:
         headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(url, data=data, headers=headers)  # noqa: S310 - fixed endpoints
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+    req = urllib.request.Request(url, data=data, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - validated http(s) URL
         return json.loads(resp.read().decode("utf-8", errors="replace"))
 
 
@@ -79,7 +87,11 @@ def _eth_call(rpc_url: str, to: str, data: str, timeout: float) -> str:
         },
     )
     if isinstance(body, dict) and "error" in body:
-        message = str(body["error"].get("message", body["error"]))
+        error_val = body["error"]
+        if isinstance(error_val, dict):
+            message = str(error_val.get("message", error_val))
+        else:
+            message = str(error_val)
         raise RpcError(message)
     result = body.get("result") if isinstance(body, dict) else None
     if not isinstance(result, str) or not result.startswith("0x"):
@@ -384,7 +396,7 @@ def _resolve_target(
     return str(match.get("address", "")), match, feeds
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Robinhood Chain on-chain stock reader")
     parser.add_argument("--query", help="Company name or ticker (e.g. Apple, AAPL)")
     parser.add_argument("--address", help="Token contract address; skips name resolution")
@@ -406,7 +418,8 @@ def main() -> int:
         action="store_true",
         help="Do not write the card artifact (JSON on stdout only).",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
 
     if not args.query and not args.address:
         print(json.dumps({"error": "provide --query or --address"}))
@@ -414,6 +427,18 @@ def main() -> int:
     if args.holder and not _ADDRESS_RE.match(args.holder):
         print(json.dumps({"error": f"not a valid holder address: {args.holder}"}))
         return 0
+    if args.rpc_url:
+        rpc_url = args.rpc_url.strip()
+        if not (rpc_url.startswith("http://") or rpc_url.startswith("https://")):
+            print(
+                json.dumps(
+                    {
+                        "error": f"invalid rpc-url {args.rpc_url!r}: must start with http:// or https://"
+                    }
+                )
+            )
+            return 0
+        args.rpc_url = rpc_url
 
     try:
         address, listed, feeds = _resolve_target(args, args.timeout)

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -368,3 +368,74 @@ def test_skill_documents_the_read_only_boundary() -> None:
     assert "read-only" in body.lower()
     assert "uiMultiplier()" in body
     assert "4663" in body
+
+
+def test_validate_http_url_rejects_non_http_schemes() -> None:
+    for invalid in [
+        "file:///etc/passwd",
+        "file:///c:/windows/system32/drivers/etc/hosts",
+        "ftp://rpc.example.com",
+        "gopher://example.com",
+        "javascript:alert(1)",
+        "/etc/passwd",
+        "relative/path.json",
+        "c:\\windows\\system32",
+        "",
+        "   ",
+    ]:
+        with pytest.raises(ValueError, match="must start with http:// or https://"):
+            chain_stocks._validate_http_url(invalid)
+
+    assert chain_stocks._validate_http_url("http://127.0.0.1:8545") == "http://127.0.0.1:8545"
+    assert (
+        chain_stocks._validate_http_url("https://rpc.mainnet.chain.robinhood.com")
+        == "https://rpc.mainnet.chain.robinhood.com"
+    )
+
+
+def test_http_json_rejects_file_scheme() -> None:
+    with pytest.raises(ValueError, match="must start with http:// or https://"):
+        chain_stocks._http_json("file:///etc/passwd", timeout=5.0)
+
+
+def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    code = chain_stocks.main(["--address", AAPL, "--rpc-url", "file:///etc/passwd"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "invalid rpc-url" in payload.get("error", "")
+    assert "must start with http:// or https://" in payload.get("error", "")
+
+
+def test_eth_call_handles_string_error_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        chain_stocks, "_http_json", lambda *a, **kw: {"error": "rate limit exceeded"}
+    )
+    with pytest.raises(chain_stocks.RpcError, match="rate limit exceeded"):
+        chain_stocks._eth_call("http://127.0.0.1:8545", AAPL, "0x", 5.0)
+
+
+def test_inspect_token_handles_string_rpc_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        chain_stocks, "_http_json", lambda *a, **kw: {"error": "rate limit exceeded"}
+    )
+    result = chain_stocks.inspect_token("http://127.0.0.1:8545", AAPL, timeout=5.0)
+    assert "readErrors" in result
+    assert result["readErrors"].get("symbol") == "rate limit exceeded"
+
+
+def test_main_handles_string_rpc_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import json
+
+    monkeypatch.setattr(
+        chain_stocks, "_http_json", lambda *a, **kw: {"error": "rate limit exceeded"}
+    )
+    code = chain_stocks.main(["--address", AAPL, "--rpc-url", "http://127.0.0.1:8545"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert payload["token"]["readErrors"]["symbol"] == "rate limit exceeded"


### PR DESCRIPTION
### Summary closes #815 
`chain_stocks.py` now enforces that `rpc-url` and all target URLs use `http://` or `https://`, preventing unintended access to local files via `file://` or other custom URL schemes.
### Changes
- `src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py`:
  - Added `_validate_http_url(url: str)` to enforce `http://` or `https://` schemes.
  - Added schema validation to `_http_json()`.
  - Added `--rpc-url` validation in `main()` returning clean JSON error.
  - Added `argv: list[str] | None = None` parameter to `main()`.
- `tests/test_skill_robinhood_chain_stocks.py`:
  - Added unit tests for URL scheme validation, `_http_json()` rejection of `file://`, and CLI `--rpc-url` validation.
### Third-Party Origins
None