### PR TITLE
fix(gateway): populate _turn_runner_ref in build_turn_runner_from_ser…

### DIFF
--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -2042,7 +2042,7 @@ def build_turn_runner_from_services(
     def _standalone_lock_provider(session_key: str) -> _asyncio.Lock:
         return _standalone_locks.setdefault(session_key, _asyncio.Lock())
 
-    return TurnRunner(
+    turn_runner = TurnRunner(
         provider_selector=svc.provider_selector,
         tool_registry=svc.tool_registry,
         session_manager=svc.session_manager,
@@ -2062,6 +2062,15 @@ def build_turn_runner_from_services(
         compaction_hooks=getattr(svc, "compaction_hooks", None),
         tool_hooks=getattr(svc, "tool_hooks", None),
     )
+    # Populate the deferred callback ref so memory write callbacks can
+    # refresh memory snapshots on the active TurnRunner. Covers all three
+    # callers at once (gateway, CLI agent, standalone TUI) — see #761.
+    # Create the list if it does not exist yet (CLI/standalone paths that
+    # call build_turn_runner_from_services directly without build_services).
+    if not hasattr(svc, "_turn_runner_ref"):
+        svc._turn_runner_ref = []  # type: ignore[attr-defined]
+    svc._turn_runner_ref.append(turn_runner)
+    return turn_runner
 
 
 async def start_gateway_server(
@@ -2180,9 +2189,8 @@ async def start_gateway_server(
         config=config,
         diagnostics_state=diagnostics_state,
     )
-    # Patch deferred callback so memory writes refresh TurnRunner snapshots
-    if hasattr(svc, "_turn_runner_ref"):
-        svc._turn_runner_ref.append(turn_runner)  # type: ignore[attr-defined]
+    # _turn_runner_ref is now populated inside build_turn_runner_from_services,
+    # which covers all three callers (gateway, CLI agent, standalone TUI).
 
     # Lazy ref for channel_manager — cron handler captures it via closure,
     # populated after channel_manager is constructed below.

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -1244,3 +1244,45 @@ async def test_start_gateway_server_wires_hooks(tmp_path) -> None:
     finally:
         await server.close()
 
+
+def test_build_turn_runner_from_services_populates_turn_runner_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """build_turn_runner_from_services must populate svc._turn_runner_ref
+    so _on_memory_write can call refresh_memory_snapshot on the active
+    TurnRunner. Covers the CLI and standalone TUI paths (#761)."""
+    from types import SimpleNamespace
+
+    from agentos.gateway import boot
+
+    refresh_called: list[str] = []
+
+    class MockTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def refresh_memory_snapshot(self, agent_id: str) -> None:
+            refresh_called.append(agent_id)
+
+    monkeypatch.setattr("agentos.engine.runtime.TurnRunner", MockTurnRunner)
+
+    services = SimpleNamespace(
+        provider_selector=object(),
+        tool_registry=object(),
+        session_manager=object(),
+        skill_loader=object(),
+        usage_tracker=object(),
+        config=GatewayConfig(),
+    )
+
+    # Call build_turn_runner_from_services like CLI/standalone paths do
+    runner = boot.build_turn_runner_from_services(services)
+
+    # The TurnRunner must be in _turn_runner_ref
+    assert hasattr(services, "_turn_runner_ref")
+    assert services._turn_runner_ref == [runner]
+
+    # Simulate _on_memory_write — must call refresh_memory_snapshot
+    services._turn_runner_ref[0].refresh_memory_snapshot("main")
+    assert refresh_called == ["main"]
+


### PR DESCRIPTION
## Summary

`_on_memory_write` callback refreshes the memory snapshot on the active TurnRunner via `_turn_runner_ref[0]`. This ref was only populated by `start_gateway_server` — CLI and standalone TUI paths (`agent_cmd.py`, `standalone_runtime.py`) silently skipped `refresh_memory_snapshot` on every memory write.

## Fix

1. **`build_turn_runner_from_services`**: populate `_turn_runner_ref` after constructing TurnRunner — covers all three callers at once
2. **`start_gateway_server`**: removed the now-redundant append
3. **Attribute guard**: create `_turn_runner_ref` if nonexistent for CLI/standalone paths

## Changes

- `src/agentos/gateway/boot.py`: 12 lines added/modified
- `tests/test_gateway/test_router_boot.py`: regression test

## Verification

- ✅ `ruff check` — clean
- ✅ `pytest tests/test_gateway/test_router_boot.py -k "build_turn_runner or populates_turn_runner"` — **3/3 passed**

Fixes #761