### PR TITLE
fix(skills): validate rpc-url scheme in robinhood chain stocks reader

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -23,6 +23,7 @@ import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -55,12 +56,36 @@ class RpcError(RuntimeError):
     """A JSON-RPC call returned an error or an unusable result."""
 
 
+def _validate_http_url(url: str) -> str:
+    """Validate and return a URL that must be http:// or https://.
+
+    Rejects ``file://``, ``ftp://``, and any custom scheme that could leak
+    local data or be abused as an SSRF oracle.  Uses ``urlsplit`` for robust
+    scheme detection (not a fragile ``startswith`` prefix check — see #818).
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty URL: {url!r}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid URL {url!r}: {exc}") from exc
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"invalid URL scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"URL missing host {url!r}: must be http:// or https://")
+    return cleaned
+
+
 def _http_json(url: str, timeout: float, payload: dict[str, Any] | None = None) -> Any:
+    url = _validate_http_url(url)
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     headers = {"User-Agent": "AgentOS-robinhood-chain-stocks/0.1"}
     if data is not None:
         headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(url, data=data, headers=headers)  # noqa: S310 - fixed endpoints
+    req = urllib.request.Request(url, data=data, headers=headers)  # noqa: S310 — validated http/https above
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         return json.loads(resp.read().decode("utf-8", errors="replace"))
 
@@ -383,7 +408,7 @@ def _resolve_target(
     return str(match.get("address", "")), match, feeds
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Robinhood Chain on-chain stock reader")
     parser.add_argument("--query", help="Company name or ticker (e.g. Apple, AAPL)")
     parser.add_argument("--address", help="Token contract address; skips name resolution")
@@ -391,13 +416,18 @@ def main() -> int:
     parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help="Robinhood Chain JSON-RPC URL")
     parser.add_argument("--no-price", action="store_true", help="Skip the Chainlink price read")
     parser.add_argument("--timeout", type=float, default=15.0, help="HTTP timeout seconds")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.query and not args.address:
         print(json.dumps({"error": "provide --query or --address"}))
         return 0
     if args.holder and not _ADDRESS_RE.match(args.holder):
         print(json.dumps({"error": f"not a valid holder address: {args.holder}"}))
+        return 0
+    try:
+        args.rpc_url = _validate_http_url(args.rpc_url)
+    except ValueError as exc:
+        print(json.dumps({"error": f"invalid rpc-url: {exc}"}, ensure_ascii=False))
         return 0
 
     try:

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -368,3 +368,51 @@ def test_skill_documents_the_read_only_boundary() -> None:
     assert "read-only" in body.lower()
     assert "uiMultiplier()" in body
     assert "4663" in body
+
+
+# ── #815: --rpc-url must be http(s), not file:// or a custom scheme ─────────
+
+
+def test_validate_http_url_rejects_non_http_schemes() -> None:
+    for invalid in [
+        "file:///etc/passwd",
+        "file:///c:/windows/system32/drivers/etc/hosts",
+        "ftp://rpc.example.com",
+        "gopher://example.com",
+        "javascript:alert(1)",
+    ]:
+        with pytest.raises(ValueError, match="must be http:// or https://"):
+            chain_stocks._validate_http_url(invalid)
+
+    # Empty / whitespace-only URLs are rejected too (with a clear message).
+    for empty in ["", "   "]:
+        with pytest.raises(ValueError, match="empty URL"):
+            chain_stocks._validate_http_url(empty)
+
+    assert chain_stocks._validate_http_url("http://127.0.0.1:8545") == "http://127.0.0.1:8545"
+    assert (
+        chain_stocks._validate_http_url("https://rpc.mainnet.chain.robinhood.com")
+        == "https://rpc.mainnet.chain.robinhood.com"
+    )
+
+
+def test_validate_http_url_rejects_missing_host() -> None:
+    """A bare scheme with no host must be rejected even if it starts with http://."""
+    with pytest.raises(ValueError, match="missing host"):
+        chain_stocks._validate_http_url("http://")
+
+
+def test_http_json_rejects_file_scheme() -> None:
+    with pytest.raises(ValueError, match="must be http:// or https://"):
+        chain_stocks._http_json("file:///etc/passwd", timeout=5.0)
+
+
+def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    code = chain_stocks.main(["--address", AAPL, "--rpc-url", "file:///etc/passwd"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "invalid rpc-url" in payload.get("error", "")
+    assert "must be http:// or https://" in payload.get("error", "")


### PR DESCRIPTION
## Summary

Fixes #815 — `chain_stocks.py` accepted `--rpc-url` with a `file://` scheme and passed it straight into `urllib.request.urlopen`, leaking arbitrary local file contents through the JSON output.

New `_validate_http_url(url)` validator:
- **Robust scheme detection via `urlsplit`** — not a fragile `startswith("http://")` prefix check. Rejects `file://`, `ftp://`, `gopher://`, `javascript:`, **and** a bare scheme with no host (`http://` with empty netloc).
- **Applied at the `_http_json` level**, so *every* URL entry point is covered — `--rpc-url`, the feed list, and the token list — not just the CLI flag.
- **Clean JSON error** from `main()` when `--rpc-url` is invalid (no traceback).

## Why this supersedes PR #818

PR #818 uses `url.startswith("http://") or url.startswith("https://")` — the issue's own body cites `http_fetch.py:61-66` (a proper scheme check) as the reference pattern. `startswith` accepts malformed inputs like `http://` with no host and is a string-prefix heuristic rather than a scheme parse. This PR parses the scheme with `urlsplit` and also requires a non-empty host, and validates at the HTTP layer (all URLs) instead of only the CLI flag.

## Tests (4 new, all offline)

- `test_validate_http_url_rejects_non_http_schemes` — file://, ftp://, gopher://, javascript:, empty
- `test_validate_http_url_rejects_missing_host` — `http://` bare scheme
- `test_http_json_rejects_file_scheme` — validation enforced at the HTTP layer
- `test_main_rejects_invalid_rpc_url` — clean JSON error, exit 0

Quality gate: ruff check ✅, ruff format ✅, mypy ✅, test file 29 passed ✅