### PR TITLE
fix(frontend): configure endOfLine auto in prettier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,7 @@ src/agentos/memory/models/embeddings/**/*.txt text eol=lf
 # guarded by required-files hydration assertions in the release workflows.
 src/agentos/agentos_router/models/pilot_v1/*.onnx filter=lfs diff=lfs merge=lfs -text
 src/agentos/agentos_router/models/pilot_v1/*.json text eol=lf
+
+# React control console source and assets. Normalised to LF so Prettier
+# line-ending checks pass consistently across platforms.
+frontend/** text=auto eol=lf

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,1 +1,1 @@
-{ "semi": false, "singleQuote": true, "printWidth": 100 }
+{ "semi": false, "singleQuote": true, "printWidth": 100, "endOfLine": "auto" }


### PR DESCRIPTION
## Summary
Adds `"endOfLine": "auto"` to `frontend/.prettierrc.json` to prevent line-ending mismatch failures when running `npm run check` (`prettier --check src`) on Windows checkouts.

## Quality Gate Verification
- [x] Prettier check passed on `frontend/src`.
- [x] `uv run ruff check src tests` passed.
closes #825 