### PR TITLE
fix(provider): classify insufficient_quota/billing_error as INSUFFICIENT_CREDITS

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -148,7 +148,13 @@ def classify_provider_error(
     if provider in _OPENAI_COMPAT_PROVIDERS:
         if status_code in {401, 403} or "invalid api key" in text or "unauthorized" in text:
             return ProviderFailureKind.AUTH_INVALID
-        if status_code == 402 or "insufficient credits" in text or "no credits" in text:
+        if (
+            status_code == 402
+            or "insufficient_quota" in text
+            or "insufficient credits" in text
+            or "no credits" in text
+            or "credit balance" in text
+        ):
             return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate limit" in text or "rate_limit" in text:
             return ProviderFailureKind.RATE_LIMITED
@@ -168,6 +174,13 @@ def classify_provider_error(
     if provider in {"anthropic", "minimax", "minimax_cn", "minimax_global"}:
         if status_code in {401, 403} or "authentication_error" in text:
             return ProviderFailureKind.AUTH_INVALID
+        if (
+            status_code == 402
+            or "billing_error" in text
+            or "credit balance" in text
+            or "insufficient_quota" in text
+        ):
+            return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate_limit_error" in text:
             return ProviderFailureKind.RATE_LIMITED
         if status_code in _GATEWAY_TRANSIENT_STATUS_CODES or "overloaded_error" in text:

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -337,3 +337,55 @@ def test_ollama_transport_messages_classify_as_transport_transient(message: str)
         classify_provider_error("ollama", None, message=message)
         is ProviderFailureKind.TRANSPORT_TRANSIENT
     )
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message"),
+    [
+        ("openai", 429, "insufficient_quota", "You exceeded your current quota"),
+        ("openrouter", 429, "insufficient_quota", "Insufficient quota"),
+        ("deepseek", 429, "insufficient_quota", "quota exceeded"),
+        ("openai", None, "insufficient_quota", ""),
+        ("openai", 402, "billing_error", "Insufficient credits"),
+        ("openai", None, "", "credit balance is too low"),
+    ],
+)
+def test_openai_compat_insufficient_quota_classifies_as_insufficient_credits(
+    provider: str, status_code: int | None, raw_code: str, message: str
+) -> None:
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "status_code", "raw_code", "message"),
+    [
+        ("anthropic", 402, "billing_error", "Your credit balance is too low"),
+        ("minimax", 402, "billing_error", "credit balance exhausted"),
+        ("anthropic", None, "", "credit balance is too low"),
+        ("anthropic", None, "insufficient_quota", ""),
+    ],
+)
+def test_anthropic_billing_error_classifies_as_insufficient_credits(
+    provider: str, status_code: int | None, raw_code: str, message: str
+) -> None:
+    assert (
+        classify_provider_error(provider, status_code, raw_code=raw_code, message=message)
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_openai_real_rate_limit_still_classifies_as_rate_limited() -> None:
+    assert (
+        classify_provider_error("openai", 429, message="rate limit exceeded")
+        is ProviderFailureKind.RATE_LIMITED
+    )
+
+
+def test_anthropic_real_rate_limit_still_classifies_as_rate_limited() -> None:
+    assert (
+        classify_provider_error("anthropic", 429, message="rate limit exceeded")
+        is ProviderFailureKind.RATE_LIMITED
+    )


### PR DESCRIPTION
## Problem

`classify_provider_error` misclassifies credit/quota exhaustion errors:

| Provider | Error | HTTP | Current | Correct |
|---|---|---|---|---|
| OpenAI/DeepSeek/OpenRouter | insufficient_quota | 429 | RATE_LIMITED | INSUFFICIENT_CREDITS |
| Anthropic | billing_error | 402 | UNKNOWN | INSUFFICIENT_CREDITS |

## Root Cause

- **OpenAI-compat:** `status_code == 429` (rate-limit branch) fires before quota markers are checked, so `insufficient_quota` at HTTP 429 hits `RATE_LIMITED`.
- **Anthropic:** No check exists for HTTP 402, `billing_error`, `credit balance`, or `insufficient_quota` — falls through to `UNKNOWN`.

## Impact

RATE_LIMITED is a circuit-breaker tripping kind; INSUFFICIENT_CREDITS is not. A billing fault that only a top-up can fix instead parks a healthy provider behind a breaker that a cooldown will never heal. Operator dashboards also mislabel the failure as rate-limiting.

## Fix

1. **OpenAI-compat:** Add `insufficient_quota` and `credit balance` markers to the existing INSUFFICIENT_CREDITS check (already positioned before the rate-limit branch).
2. **Anthropic:** Add a dedicated INSUFFICIENT_CREDITS check for HTTP 402, `billing_error`, `credit balance`, `insufficient_quota`.

## Not Changed

- No changes to `decide_recovery_action`, `circuit_breaker.py`, or other provider branches.
- Existing parametrized tests for AUTH_INVALID, RATE_LIMITED are preserved and pass.

## Tests

- `test_openai_compat_insufficient_quota_classifies_as_insufficient_credits` (6 parametrized cases)
- `test_anthropic_billing_error_classifies_as_insufficient_credits` (4 parametrized cases)
- `test_openai_real_rate_limit_still_classifies_as_rate_limited` (regression guard)
- `test_anthropic_real_rate_limit_still_classifies_as_rate_limited` (regression guard)

Fixes #777