### PR TITLE
fix(cli): fix .dev version ordering per PEP 440

### DIFF
--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -63,10 +63,10 @@ class Version:
         if self.dev is not None and self.pre is None and self.post is None:
             phase: tuple[int, ...] = (0, self.dev)
         elif self.pre is not None:
-            dev_tie = -1 if self.dev is None else self.dev
+            dev_tie: int | float = self.dev if self.dev is not None else float("inf")
             phase = (1, self.pre[0], self.pre[1], dev_tie)
         elif self.post is not None:
-            dev_tie = -1 if self.dev is None else self.dev
+            dev_tie: int | float = self.dev if self.dev is not None else float("inf")
             phase = (3, self.post, dev_tie)
         else:
             phase = (2,)
@@ -101,6 +101,8 @@ def parse_version(value: str | None) -> Version:
     if post is None and re.search(r"[._-]?post", raw):
         post = 0
     dev = int(match.group("dev")) if match.group("dev") is not None else None
+    if dev is None and re.search(r"[._-]?dev", raw):
+        dev = 0
     return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
 
 

--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -61,12 +61,12 @@ class Version:
             # but a given raw string stays equal to itself.
             return ((-1,) * width, (-1,), self.raw)
         if self.dev is not None and self.pre is None and self.post is None:
-            phase: tuple[int, ...] = (0, self.dev)
+            phase: tuple[int | float, ...] = (0, self.dev)
         elif self.pre is not None:
             dev_tie: int | float = self.dev if self.dev is not None else float("inf")
             phase = (1, self.pre[0], self.pre[1], dev_tie)
         elif self.post is not None:
-            dev_tie: int | float = self.dev if self.dev is not None else float("inf")
+            dev_tie = self.dev if self.dev is not None else float("inf")
             phase = (3, self.post, dev_tie)
         else:
             phase = (2,)

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -76,3 +76,21 @@ def test_ordering_is_total_and_sortable() -> None:
         "2026.7.18.post1",
         "2026.7.19",
     ]
+
+
+def test_bare_dev_sorts_before_final_release() -> None:
+    assert compare_versions("2026.7.18.dev", "2026.7.18") == -1
+
+
+def test_dev_pre_sorts_before_release_candidate() -> None:
+    assert compare_versions("2026.7.18rc1.dev1", "2026.7.18rc1") == -1
+
+
+def test_is_newer_detects_final_newer_than_dev() -> None:
+    assert is_newer("2026.7.18", "2026.7.18.dev") is True
+
+
+def test_parse_version_fills_dev_fallback() -> None:
+    v = parse_version("2026.7.18.dev")
+    assert v.dev == 0
+    assert v.release == (2026, 7, 18)


### PR DESCRIPTION
## Problem

`version_utils.py` has two ordering bugs with `.dev` versions:

| Comparison | Expected | Actual | Bug |
|---|---|---|---|
| `2026.7.18.dev` vs `2026.7.18` | -1 (dev < final) | 0 (equal) | dev=None → final phase |
| `2026.7.18rc1.dev1` vs `2026.7.18rc1` | -1 (dev < rc) | 1 (dev > rc) | dev_tie=-1 for None |
| `is_newer("2026.7.18", "2026.7.18.dev")` | True | False | dev == final |

## Root Cause

1. **`parse_version`**: `.dev` without a number (e.g. `2026.7.18.dev`) sets `dev=None`. The `sort_key` method then falls through to `phase = (2,)` (final release), making `.dev` equal to the final release. Compare: `.post` already has the same kind of fallback (`post=0`).

2. **`sort_key`**: In pre-release and post-release branches, `dev_tie = -1 if self.dev is None else self.dev`. Since `-1 < 1`, `rc1` (dev=None) sorts before `rc1.dev1` (dev=1), inverting PEP 440 ordering which requires `rc1.dev1 < rc1`.

## Fix

1. **parse_version**: Add `dev=0` fallback when the regex matches a `.dev` segment without a number — same pattern as the existing `post=0` fallback.
2. **sort_key**: Use `float('inf')` for `dev_tie` when `dev is None`, so `dev1.devN < dev1` and `rc1.devN < rc1`.

## Not Changed

- No changes to release segment parsing, pre-release ordering, post-release ordering, or local label handling.
- Existing sort order for `dev1` (with explicit number), `rc1`, `a1`, `b1`, post releases, and `0.0.0+unknown` is preserved.

## Tests

- `test_bare_dev_sorts_before_final_release` — 2026.7.18.dev < 2026.7.18
- `test_dev_pre_sorts_before_release_candidate` — 2026.7.18rc1.dev1 < 2026.7.18rc1
- `test_is_newer_detects_final_newer_than_dev` — is_newer(2026.7.18, 2026.7.18.dev) is True
- `test_parse_version_fills_dev_fallback` — 2026.7.18.dev has dev=0

Fixes #740