### PR TITLE
fix(provider): classify insufficient_quota and billing_error as INSUFFICIENT_CREDITS (#777, #775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Classify provider insufficient_quota and billing_error error
+  responses as INSUFFICIENT_CREDITS, enabling automatic tier
+  fallback when a provider returns quota/billing errors.
+  ([#777](https://github.com/use-agent-os/agent-os/issues/777),
+  [#775](https://github.com/use-agent-os/agent-os/issues/775))
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -54,6 +54,10 @@ _OPENAI_COMPAT_PROVIDERS = {
     "vllm",
     "lm_studio",
     "ovms",
+    # Added in #775 — these providers also use the openai_compat backend
+    "bankr",
+    "volcengine_coding_plan",
+    "byteplus_coding_plan",
 }
 
 _GATEWAY_TRANSIENT_STATUS_CODES = {499, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529}
@@ -134,6 +138,32 @@ def _is_empty_response(raw_code: str, message: str) -> bool:
     }
 
 
+def _is_insufficient_credits(text: str) -> bool:
+    return any(
+        marker in text
+        for marker in (
+            # OpenAI / OpenAI-compatible providers
+            "insufficient_quota",
+            "insufficient quota",
+            "insufficient credits",
+            "no credits",
+            "exceeded your current quota",
+            "quota exceeded",
+            "out of credits",
+            "credits exhausted",
+            # Anthropic
+            "billing_error",
+            "credit balance is too low",
+            # Generic gateways
+            "billing hard limit",
+            "exceeded spend limit",
+            "payment required",
+            "insufficient balance",
+            "billing failed",
+        )
+    )
+
+
 def _is_gateway_transient(text: str) -> bool:
     return bool(_GATEWAY_TRANSIENT_RE.search(text))
 
@@ -155,6 +185,14 @@ def classify_provider_error(
         return ProviderFailureKind.POLICY_REFUSAL
     if _is_empty_response(raw_code, message):
         return ProviderFailureKind.EMPTY_RESPONSE
+
+    # Provider-agnostic, BEFORE any provider-specific block: OpenAI-compat
+    # providers report credit exhaustion with HTTP 429 ("insufficient_quota"),
+    # which would otherwise land in the rate-limit branch below and wrongly
+    # trip the circuit breaker. HTTP 402 "Payment Required" is semantically
+    # credit exhaustion for any provider.
+    if status_code == 402 or _is_insufficient_credits(text):
+        return ProviderFailureKind.INSUFFICIENT_CREDITS
 
     if provider in _OPENAI_COMPAT_PROVIDERS:
         if status_code in {401, 403} or "invalid api key" in text or "unauthorized" in text:

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -93,3 +93,260 @@ def test_anthropic_request_size_exceeds_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+
+# ── #775: bankr and coding-plan providers in OpenAI-compat set ────────────
+
+
+def test_bankr_401_is_auth_invalid() -> None:
+    assert (
+        classify_provider_error("bankr", 401, message="Unauthorized")
+        is ProviderFailureKind.AUTH_INVALID
+    )
+
+
+def test_bankr_402_is_insufficient_credits() -> None:
+    assert (
+        classify_provider_error("bankr", 402, message="Insufficient credits")
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_bankr_429_is_rate_limited() -> None:
+    assert (
+        classify_provider_error("bankr", 429, message="Rate limit exceeded")
+        is ProviderFailureKind.RATE_LIMITED
+    )
+
+
+def test_bankr_generic_unknown_falls_through() -> None:
+    """Bankr errors that don't match any known pattern should still fall through to UNKNOWN."""
+    assert (
+        classify_provider_error("bankr", 500, message="Internal server error")
+        is ProviderFailureKind.PROVIDER_OVERLOADED
+    )
+
+
+def test_volcengine_coding_plan_401_is_auth_invalid() -> None:
+    assert (
+        classify_provider_error("volcengine_coding_plan", 401, message="Unauthorized")
+        is ProviderFailureKind.AUTH_INVALID
+    )
+
+
+def test_volcengine_coding_plan_429_is_rate_limited() -> None:
+    assert (
+        classify_provider_error("volcengine_coding_plan", 429, message="Rate limit exceeded")
+        is ProviderFailureKind.RATE_LIMITED
+    )
+
+
+def test_byteplus_coding_plan_401_is_auth_invalid() -> None:
+    assert (
+        classify_provider_error("byteplus_coding_plan", 401, message="Unauthorized")
+        is ProviderFailureKind.AUTH_INVALID
+    )
+
+
+def test_byteplus_coding_plan_429_is_rate_limited() -> None:
+    assert (
+        classify_provider_error("byteplus_coding_plan", 429, message="Rate limit exceeded")
+        is ProviderFailureKind.RATE_LIMITED
+    )
+
+
+# ── #777: credit/quota exhaustion → INSUFFICIENT_CREDITS ─────────────────
+
+
+def test_openai_insufficient_quota_429_is_insufficient_credits() -> None:
+    """insufficient_quota with HTTP 429 must not be swallowed by the rate-limit branch."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            raw_code="insufficient_quota",
+            message="You exceeded your current quota, please check your plan and billing details.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_openai_quota_exceeded_message_is_insufficient_credits() -> None:
+    """Quota message without raw_code should still be caught."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            message="You exceeded your current quota.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_openrouter_insufficient_quota_is_insufficient_credits() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="openrouter",
+            status_code=429,
+            raw_code="insufficient_quota",
+            message="Insufficient quota",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_deepseek_insufficient_quota_is_insufficient_credits() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="deepseek",
+            status_code=429,
+            raw_code="insufficient_quota",
+            message="Insufficient quota",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_anthropic_billing_error_402_is_insufficient_credits() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=402,
+            raw_code="billing_error",
+            message="Your credit balance is too low to access the Anthropic API.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_anthropic_bare_402_is_insufficient_credits() -> None:
+    """A bare HTTP 402 with no marker text must still resolve to INSUFFICIENT_CREDITS."""
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=402,
+            message="Payment Required",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_anthropic_credit_balance_too_low_is_insufficient_credits() -> None:
+    assert (
+        classify_provider_error(
+            provider_name="anthropic",
+            status_code=None,
+            message="Your credit balance is too low to access the Anthropic API.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_genuine_429_rate_limit_still_rate_limited() -> None:
+    """A genuine rate-limit 429 without quota markers must still be RATE_LIMITED."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            message="Rate limit exceeded, please wait and retry.",
+        )
+        is ProviderFailureKind.RATE_LIMITED
+    )
+
+
+def test_policy_refusal_not_misread_as_insufficient_credits() -> None:
+    """Policy refusal markers must win over any accidental credit marker match."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=400,
+            message="Your content violates our safety policy.",
+        )
+        is ProviderFailureKind.POLICY_REFUSAL
+    )
+
+
+def test_context_overflow_still_wins_over_insufficient_credits() -> None:
+    """Context overflow check runs before insufficient-credits; must take priority."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=400,
+            message=(
+                "prompt is too long, context window exceeded, and you have insufficient credits."
+            ),
+        )
+        is ProviderFailureKind.CONTEXT_OVERFLOW
+    )
+
+
+def test_quota_exceeded_without_status_code_is_insufficient_credits() -> None:
+    """quota exceeded marker without any HTTP status code should be caught."""
+    assert (
+        classify_provider_error(
+            provider_name="azure",
+            status_code=None,
+            message="Quota exceeded for this API deployment.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_non_openai_provider_402_is_insufficient_credits() -> None:
+    """Even for non-OpenAI providers, HTTP 402 should be INSUFFICIENT_CREDITS."""
+    assert (
+        classify_provider_error(
+            provider_name="some_random_provider",
+            status_code=402,
+            message="Payment required for this request.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_unknown_provider_402_is_insufficient_credits() -> None:
+    """A completely unknown provider with HTTP 402 must still be INSUFFICIENT_CREDITS."""
+    assert (
+        classify_provider_error(
+            provider_name="unknown_provider",
+            status_code=402,
+            message="402 Payment Required",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_insufficient_balance_marker_is_insufficient_credits() -> None:
+    """Insufficient balance text in message should be caught."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            message="Your account has an insufficient balance. Please add funds.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_billing_failed_marker_is_insufficient_credits() -> None:
+    """Billing failed text should be caught."""
+    assert (
+        classify_provider_error(
+            provider_name="openrouter",
+            status_code=429,
+            message="Billing failed: unable to charge payment method.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )
+
+
+def test_out_of_credits_marker_is_insufficient_credits() -> None:
+    """Out of credits text should be caught."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=429,
+            message="You are out of credits for this API.",
+        )
+        is ProviderFailureKind.INSUFFICIENT_CREDITS
+    )


### PR DESCRIPTION
## Summary

`classify_provider_error` in `src/agentos/provider/failures.py` misclassifies credit/quota exhaustion errors from multiple providers, causing incorrect circuit breaker behavior. Also adds missing OpenAI-compatible providers.

Fixes #777, fixes #775

## Problem

### #777 — misclassified credit/quota errors

| Provider | Error | HTTP | Was | Now |
|---|---|---|---|---|
| OpenAI | `insufficient_quota` | 429 | `RATE_LIMITED` ❌ | `INSUFFICIENT_CREDITS` ✅ |
| OpenRouter | `insufficient_quota` | 429 | `RATE_LIMITED` ❌ | `INSUFFICIENT_CREDITS` ✅ |
| DeepSeek | `insufficient_quota` | 429 | `RATE_LIMITED` ❌ | `INSUFFICIENT_CREDITS` ✅ |
| Anthropic | `billing_error` | 402 | `UNKNOWN` ❌ | `INSUFFICIENT_CREDITS` ✅ |

**Root cause**: OpenAI sends `insufficient_quota` with HTTP 429. The classifier's `status_code == 429` check (rate-limit) fires before any quota/credit marker, so the rate-limit branch wins. Anthropic's branch has no check for HTTP 402 or `billing_error` at all.

**Impact**: `RATE_LIMITED` is a circuit-breaker-tripping kind; `INSUFFICIENT_CREDITS` is intentionally excluded from tripping kinds. The misclassification parks a healthy provider for a billing fault that a cooldown can never heal.

### #775 — missing providers

`bankr`, `volcengine_coding_plan`, and `byteplus_coding_plan` all use the `openai_compat` backend but were missing from `_OPENAI_COMPAT_PROVIDERS`. Their HTTP errors (401, 402, 429, etc.) fell through to `UNKNOWN`.

## Changes

### `src/agentos/provider/failures.py`

1. **Add `_is_insufficient_credits()` helper** — cross-provider pre-classification check (same pattern as `_is_context_overflow` and `_is_policy_refusal`). Matches `insufficient_quota`, `exceeded your current quota`, `billing_error`, `credit balance is too low`, `billing hard limit`, `exceeded spend limit`, etc.
2. **Insert pre-check** — runs after context-overflow/policy-refusal/empty-response and **before** any provider-specific branches, so `insufficient_quota` + HTTP 429 is correctly caught before the rate-limit status-code check.
3. **`_OPENAI_COMPAT_PROVIDERS`** — add `bankr`, `volcengine_coding_plan`, `byteplus_coding_plan`.

### `tests/test_provider_failures.py`

24 regression tests covering:
- #777: OpenAI/OpenRouter/DeepSeek `insufficient_quota` (429 → INSUFFICIENT_CREDITS)
- #777: Anthropic `billing_error` (402 → INSUFFICIENT_CREDITS), bare 402, credit balance text
- #775: `bankr` 401/402/429 classification, plus coding-plan providers
- Edge cases: policy refusal priority, context overflow priority, genuine rate limits still RATE_LIMITED, unknown providers, insufficient balance markers

## Verification

- `ruff check` — all passed
- `mypy` — no issues
- `pytest tests/test_provider_failures.py -q` — 31/31 passed
- `pytest tests/test_onboarding/test_provider_specs.py -q` — 44/44 passed (no regressions)
- All existing tests unchanged and passing.
