### PR TITLE
fix(cli): handle UnicodeEncodeError when emitting JSON on non-UTF-8 terminals

### DIFF
--- a/src/agentos/cli/output.py
+++ b/src/agentos/cli/output.py
@@ -3,15 +3,36 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
 
 import typer
 
 
+def _safe_echo(text: str, err: bool = False) -> None:
+    """Echo text, safe for terminals with non-UTF-8 encoding.
+
+    Falls back to writing UTF-8 bytes to the underlying binary stream
+    when the terminal encoding cannot represent the text (e.g. Windows
+    cp1252/cp437 with emoji or non-Latin characters).
+    """
+    try:
+        typer.echo(text, err=err)
+    except UnicodeEncodeError:
+        out = sys.stderr if err else sys.stdout
+        buffer = getattr(out, "buffer", None)
+        if buffer is not None:
+            buffer.write(text.encode("utf-8") + b"\n")
+            buffer.flush()
+        else:
+            out.write(text + "\n")
+            out.flush()
+
+
 def print_json(payload: Any) -> None:
     """Print JSON payload to stdout using the AgentOS CLI contract."""
 
-    typer.echo(json.dumps(payload, ensure_ascii=False, default=str))
+    _safe_echo(json.dumps(payload, ensure_ascii=False, default=str))
 
 
 def error_payload(
@@ -40,7 +61,7 @@ def emit_error(
     """Emit an error to stderr without polluting JSON stdout."""
 
     if json_output:
-        typer.echo(
+        _safe_echo(
             json.dumps(
                 error_payload(message, code=code, details=details),
                 ensure_ascii=False,

--- a/tests/test_cli/test_output_helpers.py
+++ b/tests/test_cli/test_output_helpers.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 
-from agentos.cli.output import emit_error, print_json
+import typer
+
+from agentos.cli.output import _safe_echo, emit_error, print_json
 
 
 def test_print_json_uses_stdout(capsys):
@@ -27,3 +29,23 @@ def test_emit_error_json_uses_stderr(capsys):
             "details": {"field": "x"},
         }
     }
+
+
+def test_safe_echo_falls_back_when_typer_echo_raises_unicode_error(monkeypatch):
+    """When typer.echo raises UnicodeEncodeError, _safe_echo does not crash."""
+
+    def fake_echo(text, err=False):
+        raise UnicodeEncodeError("utf-8", "", 0, 1, "test encoding error")
+
+    monkeypatch.setattr(typer, "echo", fake_echo)
+
+    _safe_echo("✅ done")
+
+    assert True  # no exception
+
+
+def test_safe_echo_normal_case(capsys):
+    _safe_echo("héllo world")
+
+    captured = capsys.readouterr()
+    assert captured.out == "héllo world\n"


### PR DESCRIPTION
## Problem

`print_json()` and `emit_error(json_output=True)` use `typer.echo()` which
writes through `sys.stdout.encoding`. On Windows cp1252/cp437 or legacy
terminals, non-ASCII UTF-8 characters (em-dashes, emoji, non-Latin text)
cause a fatal `UnicodeEncodeError`.

## Fix

Add `_safe_echo()` helper that wraps `typer.echo()` and falls back to
writing UTF-8 encoded bytes to `sys.stdout.buffer` / `sys.stderr.buffer`
when the string cannot be represented in the terminal's encoding.

## Not Changed

- Non-JSON error output (`typer.secho(...)`) is unchanged.
- `ensure_ascii=False` is preserved — characters are not escaped unnecessarily.
- No new dependencies.

## Tests

- `test_safe_echo_normal_case` — normal UTF-8 terminal behaviour preserved
- `test_safe_echo_falls_back_when_typer_echo_raises_unicode_error` — monkeypatches typer.echo to raise UnicodeEncodeError, verifies no crash
- Existing `test_print_json_uses_stdout` and `test_emit_error_json_uses_stderr` still pass

Fixes #764