### PR TITLE
fix(cli): drop uv run from channels add/edit verify step

### DIFF
--- a/src/agentos/cli/channels_cmd.py
+++ b/src/agentos/cli/channels_cmd.py
@@ -60,7 +60,7 @@ def _print_restart_notice() -> None:
 
 def _print_channel_verification_next_step(name: str) -> None:
     typer.echo("Next: agentos gateway restart")
-    typer.echo(f"Verify: uv run agentos channels status {name} --json")
+    typer.echo(f"Verify: agentos channels status {name} --json")
 
 
 _SOURCE_LABEL = {

--- a/tests/test_cli/test_channels_cmd.py
+++ b/tests/test_cli/test_channels_cmd.py
@@ -423,6 +423,7 @@ def test_channels_add_prints_status_verification_next_step(tmp_path, monkeypatch
     out = result.stdout.lower()
     assert "agentos gateway restart" in out
     assert "agentos channels status w --json" in out
+    assert "uv run agentos" not in out
 
 
 def test_channels_add_echoes_resolved_path_and_source(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #835

## Summary
- `channels add` / `edit` printed `Verify: uv run agentos channels status …`. That command exits 127 on pipx/pip installs, which are documented install methods.
- Print `agentos channels status …` instead, matching the adjacent `Next:` line and `docs/troubleshooting.md` / `docs/configuration.md`.
- Tighten the existing CLI test so a `uv run` prefix cannot regress.

## Test plan
- [x] `test_channels_add_prints_status_verification_next_step` now asserts `uv run agentos` is absent
- [ ] `uv run pytest tests/test_cli/test_channels_cmd.py -q`

Default tests stay offline and credential-free. No channel runtime change.