### PR TITLE
fix(cli): persist documented skills.config.* via config set

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,7 +204,7 @@ there is nothing to hide and a visible, diffable setting is easier to share and
 review:
 
 ```sh
-agentos config set skills.config.wiki.path /srv/wiki
+agentos config set skills.config.wiki.path /srv/wiki --config ~/.agentos/config.toml
 ```
 
 When the agent opens the skill, the values currently in effect are appended to

--- a/src/agentos/cli/config_cmd.py
+++ b/src/agentos/cli/config_cmd.py
@@ -83,6 +83,15 @@ def config_set(
         console.print("[yellow]Restart the gateway to apply this setting.[/yellow]")
         return
 
+    from agentos.gateway.config import GatewayConfig
+
+    data = GatewayConfig().to_toml_dict()
+    parts = key.split(".")
+    skill_config_map = len(parts) >= 3 and parts[0] == "skills" and parts[1] == "config"
+    if skill_config_map or _get_key(data, key) is _MISSING:
+        console.print(f"[red]Key not found: {escape(key)}[/red]")
+        raise typer.Exit(1)
+
     env_key = "AGENTOS_GATEWAY_" + key.upper().replace(".", "__")
     console.print("[dim]To persist this setting, export:[/dim]")
     console.print(f"  [bold]export {env_key}={value}[/bold]")

--- a/src/agentos/cli/config_cmd.py
+++ b/src/agentos/cli/config_cmd.py
@@ -96,13 +96,26 @@ def _parse_config_value(value: str) -> Any:
 
 
 def _set_key(data: dict[str, Any], key: str, value: Any) -> bool:
+    """Set a dotted key on a TOML dict.
+
+    Unknown keys are rejected so typos do not persist. ``skills.config.*`` is
+    the documented free-form skill-settings map; ``to_toml_dict`` omits it when
+    empty, so this path must create missing intermediate dicts.
+    """
     cursor: Any = data
     parts = key.split(".")
+    create = len(parts) >= 3 and parts[0] == "skills" and parts[1] == "config"
     for part in parts[:-1]:
-        if not isinstance(cursor, dict) or part not in cursor:
+        if not isinstance(cursor, dict):
             return False
+        if part not in cursor:
+            if not create:
+                return False
+            cursor[part] = {}
         cursor = cursor[part]
-    if not isinstance(cursor, dict) or parts[-1] not in cursor:
+    if not isinstance(cursor, dict):
+        return False
+    if parts[-1] not in cursor and not create:
         return False
     cursor[parts[-1]] = value
     return True

--- a/tests/test_cli/test_config_cmd.py
+++ b/tests/test_cli/test_config_cmd.py
@@ -78,3 +78,24 @@ def test_config_set_unknown_key_still_fails(tmp_path: Path, monkeypatch) -> None
     assert result.exit_code == 1
     assert "Key not found" in result.output
     assert not cfg_path.exists()
+
+
+def test_config_set_env_hint_rejects_unknown_key() -> None:
+    result = runner.invoke(app, ["config", "set", "gateway.port", "18791"])
+    assert result.exit_code == 1
+    assert "Key not found" in result.output
+    assert "export " not in result.output.lower()
+
+
+def test_config_set_env_hint_rejects_skills_config_map() -> None:
+    result = runner.invoke(app, ["config", "set", "skills.config.wiki.path", "/srv/wiki"])
+    assert result.exit_code == 1
+    assert "Key not found" in result.output
+    assert "export " not in result.output.lower()
+
+
+def test_config_set_env_hint_still_prints_for_existing_field() -> None:
+    result = runner.invoke(app, ["config", "set", "skills.max_skills_prompt_chars", "32000"])
+    assert result.exit_code == 0, result.output
+    assert "export AGENTOS_GATEWAY_SKILLS__MAX_SKILLS_PROMPT_CHARS=32000" in result.output
+

--- a/tests/test_cli/test_config_cmd.py
+++ b/tests/test_cli/test_config_cmd.py
@@ -1,0 +1,80 @@
+"""CLI tests for ``agentos config set``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentos.cli.config_cmd import _set_key
+from agentos.cli.main import app
+from agentos.gateway.config import GatewayConfig
+from agentos.onboarding.config_store import load_config
+from agentos.skills.config_vars import _value_at
+
+runner = CliRunner()
+
+
+def test_set_key_creates_nested_skills_config() -> None:
+    data = GatewayConfig().to_toml_dict()
+    assert "config" not in data.get("skills", {})
+    assert _set_key(data, "skills.config.wiki.path", "/srv/wiki") is True
+    assert data["skills"]["config"]["wiki"]["path"] == "/srv/wiki"
+    cfg = GatewayConfig.model_validate(data)
+    assert _value_at(cfg, "wiki.path") == "/srv/wiki"
+
+
+def test_set_key_rejects_unknown_keys_outside_skills_config() -> None:
+    data = GatewayConfig().to_toml_dict()
+    assert _set_key(data, "skills.no_such_key", "x") is False
+    assert _set_key(data, "skills.max_skills_prompt_chars", 32000) is True
+
+
+def test_config_set_persists_documented_wiki_path(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "state"))
+    cfg_path = tmp_path / "config.toml"
+    result = runner.invoke(
+        app,
+        [
+            "config",
+            "set",
+            "skills.config.wiki.path",
+            "/srv/wiki",
+            "--config",
+            str(cfg_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    loaded = load_config(cfg_path)
+    assert _value_at(loaded, "wiki.path") == "/srv/wiki"
+
+
+def test_config_set_existing_model_field_still_works(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "state"))
+    cfg_path = tmp_path / "config.toml"
+    result = runner.invoke(
+        app,
+        [
+            "config",
+            "set",
+            "skills.max_skills_prompt_chars",
+            "32000",
+            "--config",
+            str(cfg_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    loaded = load_config(cfg_path)
+    assert loaded.skills.max_skills_prompt_chars == 32000
+
+
+def test_config_set_unknown_key_still_fails(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "state"))
+    cfg_path = tmp_path / "config.toml"
+    result = runner.invoke(
+        app,
+        ["config", "set", "skills.no_such_key", "x", "--config", str(cfg_path)],
+    )
+    assert result.exit_code == 1
+    assert "Key not found" in result.output
+    assert not cfg_path.exists()


### PR DESCRIPTION
Fixes #834

## Summary
- `docs/configuration.md` documents `agentos config set skills.config.wiki.path /srv/wiki`. That command failed with `Key not found` because `_set_key` only overwrites keys already present in `to_toml_dict()`.
- `to_toml_dict()` omits empty `skills.config` (rollback-compat), so the documented free-form skill-settings map could never be created through this CLI.
- `_set_key` now creates missing intermediate dicts **only** under `skills.config.*`. Unknown keys outside that map still fail (typo guard). Existing model fields like `skills.max_skills_prompt_chars` still work.
- The docs example now includes `--config`, matching the persist table. The no-`--config` env-export path is not the persist mechanism for this map.

## Test plan
- [x] `_set_key` creates `skills.config.wiki.path` and `config_vars._value_at(cfg, "wiki.path")` returns `/srv/wiki`
- [x] `_set_key` still rejects `skills.no_such_key`
- [x] CLI `--config` persist + existing field + unknown key tests in `tests/test_cli/test_config_cmd.py`
- [ ] `uv run pytest tests/test_cli/test_config_cmd.py -q`

Default tests stay offline and credential-free.