### PR TITLE
docs: fix config set example to use port instead of gateway.port

### DIFF
--- a/README.product.md
+++ b/README.product.md
@@ -135,7 +135,7 @@ agentos configure router --router recommended
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 agentos configure channels
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -446,7 +446,7 @@ Raw config:
 
 ```sh
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 For Ollama models that do not reliably support native tool calls, set


### PR DESCRIPTION
Fixes #840

## Summary
- `docs/cli.md` and `README.product.md` documented `agentos config set gateway.port 18791`. That key does not exist (`Key not found`). The listen port is top-level `port`.
- Do not invent a `[gateway]` table (`extra = forbid`).
- Examples now use `agentos config set port 18791 --config ~/.agentos/config.toml`, matching the persist table in `docs/configuration.md`.

This is distinct from #834 / #839 (`skills.config.*`).

## Test plan
- [x] `agentos config set port 18791 --config $CFG` exits 0 on 2026.9.1
- [x] `agentos config set gateway.port 18791 --config $CFG` exits 1 (`Key not found`)
- [ ] Docs render the corrected command