### PR TITLE
fix(tools): handle broken symlinks gracefully in list_dir

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -923,7 +923,13 @@ async def list_dir(path: str) -> str:
             if entry.is_dir():
                 dirs.append(f"[dir]  {entry.name}/")
             else:
-                size = entry.stat().st_size
+                try:
+                    size = entry.stat().st_size
+                except OSError:
+                    try:
+                        size = entry.lstat().st_size
+                    except OSError:
+                        size = 0
                 files.append(f"[file] {entry.name} ({size} bytes)")
         return dirs + files + blocked_entries
 

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -393,3 +393,20 @@ async def test_sensitive_path_priority_over_workspace_strict(
     assert dir_result["reason"] == "sensitive_path"
     assert "workspace_strict" not in file_result.get("message", "")
     assert "workspace_strict" not in dir_result.get("message", "")
+
+
+@pytest.mark.asyncio
+async def test_list_dir_broken_symlink_does_not_crash(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "valid.txt").write_text("hello", encoding="utf-8")
+    missing_target = workspace / "nonexistent.txt"
+    broken_link = workspace / "broken_link.txt"
+    _make_symlink(broken_link, missing_target)
+
+    with tool_context(workspace, strict=False):
+        output = await fs.list_dir(str(workspace))
+
+    assert "[file] valid.txt" in output
+    assert "broken_link.txt" in output
+


### PR DESCRIPTION
## Summary

Fixes #844

In `src/agentos/tools/builtin/filesystem.py`, `list_dir` called `entry.stat().st_size` on non-directory entries. When an entry was a broken or dangling symlink pointing to a non-existent target, `entry.is_dir()` evaluated to `False`, and `entry.stat()` (which defaults to `follow_symlinks=True`) raised an unhandled `FileNotFoundError`, crashing the entire `list_dir` tool invocation.

This PR wraps `entry.stat()` in a `try...except OSError` block with a fallback to `entry.lstat().st_size` (or `0`), allowing `list_dir` to return the complete directory listing cleanly even in the presence of broken or dangling symlinks.

## Changes

- **`src/agentos/tools/builtin/filesystem.py`**: Gracefully handle `OSError` when querying file size during `list_dir`, falling back to `entry.lstat().st_size`.
- **`tests/test_tools/test_filesystem_read_workspace.py`**: Added regression test `test_list_dir_broken_symlink_does_not_crash`.

## Quality Gate Checklist

- [x] `uv run ruff check src tests` passes
- [x] `uv run mypy src/agentos --show-error-codes` passes
- [x] `uv run pytest tests/test_tools -q` (893 passed)
- [x] `uv build --wheel` succeeds