### PR TITLE
fix(cli): create parent directories when exporting cost data

### DIFF
--- a/src/agentos/cli/cost_cmd.py
+++ b/src/agentos/cli/cost_cmd.py
@@ -66,6 +66,7 @@ def cost(
 
     if export_path:
         path = Path(export_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
         is_csv = csv_output or path.suffix.lower() == ".csv"
         if is_csv:
             import io

--- a/tests/test_cli/test_cost_savings_cmd.py
+++ b/tests/test_cli/test_cost_savings_cmd.py
@@ -153,3 +153,40 @@ def test_bare_cost_still_queries_the_gateway(monkeypatch: pytest.MonkeyPatch) ->
 
     assert result.exit_code == 0, result.output
     assert calls == [True]
+
+
+def test_cost_export_creates_parent_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "breakdown": [
+                {
+                    "session": "s1",
+                    "model": "gpt-5.6-luna",
+                    "provider": "openrouter",
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cost_usd": 0.01,
+                    "created_at": 1700000000,
+                }
+            ],
+            "totalCostUsd": 0.01,
+        }
+
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _fake_run)
+
+    json_export = tmp_path / "nested" / "reports" / "cost.json"
+    result_json = runner.invoke(app, ["cost", "--export", str(json_export)])
+    assert result_json.exit_code == 0, result_json.output
+    assert json_export.exists()
+    payload = json.loads(json_export.read_text(encoding="utf-8"))
+    assert payload["totalCostUsd"] == 0.01
+
+    csv_export = tmp_path / "deep" / "nested" / "cost.csv"
+    result_csv = runner.invoke(app, ["cost", "--export", str(csv_export)])
+    assert result_csv.exit_code == 0, result_csv.output
+    assert csv_export.exists()
+    assert "gpt-5.6-luna" in csv_export.read_text(encoding="utf-8")
+


### PR DESCRIPTION
## Summary

Fixes #846

In `src/agentos/cli/cost_cmd.py`, `agentos cost --export <path>` called `path.write_text(...)` without ensuring that the target file's parent directories exist. When exporting to a non-existent or nested directory (e.g. `--export reports/usage.json`), the command crashed with an unhandled `FileNotFoundError`.

This PR adds `path.parent.mkdir(parents=True, exist_ok=True)` before writing the exported JSON/CSV, matching the convention used across AgentOS CLI export commands.

## Changes

- **`src/agentos/cli/cost_cmd.py`**: Ensure parent directory exists before writing exported cost files.
- **`tests/test_cli/test_cost_savings_cmd.py`**: Added test `test_cost_export_creates_parent_directories` verifying both JSON and CSV export into nested directories.

## Quality Gate Checklist

- [x] `uv run ruff check src tests` passes
- [x] `uv run mypy src/agentos --show-error-codes` passes
- [x] `uv run pytest tests/test_cli -q` (735 passed)
- [x] `uv build --wheel` succeeds