### PR TITLE
fix(application): stop flag escalation replay in intent approval cache

### DIFF
--- a/src/agentos/application/approval_rpc.py
+++ b/src/agentos/application/approval_rpc.py
@@ -91,7 +91,7 @@ def approval_snapshot_rpc_payload(queue: ApprovalQueue, intent_cache: Any) -> di
         "intent_cache_size": len(intent_cache._entries),  # noqa: SLF001 - diagnostic
         "intent_cache_entries": [
             {"kind": kind, "target": target, "scope": scope}
-            for (kind, target), (_expires, scope) in intent_cache._entries.items()  # noqa: SLF001
+            for (kind, target), (_expires, scope, _flags) in intent_cache._entries.items()  # noqa: SLF001
         ],
     }
 

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -45,12 +45,27 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
 
 # Regex-based single-capture extractors for Python-flavoured deletes. Each
 # regex uses ``finditer`` so ``shutil.rmtree("a"); os.remove("b")`` yields
-# both paths.
-_PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bos\.(?:remove|unlink|rmdir|removedirs)\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(
-        r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.(?:unlink|rmdir)\s*\("
+# both paths. Each pattern carries the escalation flags its operation
+# implies (e.g. ``shutil.rmtree`` is inherently recursive) so the approval
+# cache can tell ``os.remove`` apart from a recursive delete.
+_PY_DELETE_PATTERNS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
+    (
+        re.compile(r"\bos\.(?:remove|unlink|rmdir)\s*\(\s*[\"']([^\"']+)[\"']"),
+        frozenset(),
+    ),
+    (
+        re.compile(r"\bos\.removedirs\s*\(\s*[\"']([^\"']+)[\"']"),
+        frozenset({"recursive"}),
+    ),
+    (
+        re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
+        frozenset({"recursive"}),
+    ),
+    (
+        re.compile(
+            r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.(?:unlink|rmdir)\s*\("
+        ),
+        frozenset(),
     ),
 )
 
@@ -58,11 +73,40 @@ _PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
 _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
-def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of every ``rm`` invocation.
+def _rm_escalation_flags(tokens: list[str]) -> frozenset[str]:
+    """Map an ``rm`` invocation's flags to escalation-relevant capabilities.
+
+    Only flags that make the delete *more* destructive are tracked so an
+    approval for ``rm /a`` can never be replayed as ``rm -rf /a`` while a
+    ``rm -rf /a`` approval still covers the milder ``rm /a`` (monotonic:
+    approval only ever grows stronger, never weaker). ``-i``/``-v`` and
+    other benign flags are ignored.
+    """
+    flags: set[str] = set()
+    for token in tokens:
+        if not token.startswith("-"):
+            continue
+        if token.startswith("--"):
+            if token == "--recursive":
+                flags.add("recursive")
+            elif token == "--force":
+                flags.add("force")
+            elif token == "--no-preserve-root":
+                flags.add("no-preserve-root")
+            continue
+        for char in token[1:]:
+            if char in "rR":
+                flags.add("recursive")
+            elif char == "f":
+                flags.add("force")
+    return frozenset(flags)
+
+
+def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
+    """Pull every (target, escalation-flags) pair out of every ``rm`` invocation.
 
     Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
+    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields pairs
     from both invocations independently. Does not try to be a full shell
     parser — falls back to whitespace split on shlex errors (unbalanced quotes).
     """
@@ -74,8 +118,8 @@ def _extract_rm_targets(command: str) -> list[str]:
     if not matches:
         return []
 
-    targets: list[str] = []
-    seen: set[str] = set()
+    targets: list[tuple[str, frozenset[str]]] = []
+    seen: set[tuple[str, frozenset[str]]] = set()
 
     for match in matches:
         tail = match.group(1).strip()
@@ -94,11 +138,12 @@ def _extract_rm_targets(command: str) -> list[str]:
                 token_sets.append(tail.split())
 
         for tokens in token_sets:
+            flags = _rm_escalation_flags(tokens)
             for token in tokens:
-                if not token or token.startswith("-") or token in seen:
+                if not token or token.startswith("-") or (token, flags) in seen:
                     continue
-                seen.add(token)
-                targets.append(token)
+                seen.add((token, flags))
+                targets.append((token, flags))
 
     return targets
 
@@ -107,31 +152,36 @@ def _extract_intents(
     command: str,
     *,
     base_dir: str | Path | None = None,
-) -> list[tuple[str, str]]:
+) -> list[tuple[str, str, frozenset[str]]]:
     """Return every recognized destructive intent, deduped and normalized.
 
     ``rm /a /b /c`` -> three tuples; ``shutil.rmtree('a'); os.remove('b')`` ->
-    two tuples; a plain echo returns an empty list.
+    two tuples; a plain echo returns an empty list. Each tuple is
+    ``(kind, target, escalation_flags)`` so the cache can distinguish
+    ``rm /a`` from ``rm -rf /a`` on the same path.
     """
     if not command:
         return []
-    paths: list[str] = []
-    paths.extend(_extract_rm_targets(command))
-    for pattern in _PY_DELETE_PATTERNS:
-        paths.extend(m.group(1) for m in pattern.finditer(command))
 
-    result: list[tuple[str, str]] = []
-    seen: set[tuple[str, str]] = set()
-    for raw in paths:
-        intent = ("delete", _norm_path(raw, base_dir=base_dir))
+    result: list[tuple[str, str, frozenset[str]]] = []
+    seen: set[tuple[str, str, frozenset[str]]] = set()
+    for raw, flags in _extract_rm_targets(command):
+        intent = ("delete", _norm_path(raw, base_dir=base_dir), flags)
         if intent in seen:
             continue
         seen.add(intent)
         result.append(intent)
+    for pattern, flags in _PY_DELETE_PATTERNS:
+        for match in pattern.finditer(command):
+            intent = ("delete", _norm_path(match.group(1), base_dir=base_dir), flags)
+            if intent in seen:
+                continue
+            seen.add(intent)
+            result.append(intent)
     return result
 
 
-def _extract_intent(command: str) -> tuple[str, str] | None:
+def _extract_intent(command: str) -> tuple[str, str, frozenset[str]] | None:
     """First extracted intent, or None. Convenience for single-target callers."""
     intents = _extract_intents(command)
     return intents[0] if intents else None
@@ -152,13 +202,13 @@ class IntentApprovalCache:
 
     def __init__(self, default_ttl: float = _DEFAULT_TTL_SECONDS) -> None:
         self._default_ttl = default_ttl
-        # intent -> (expires_monotonic, scope)
-        self._entries: dict[tuple[str, str], tuple[float, str]] = {}
+        # intent -> (expires_monotonic, scope, approved_flags)
+        self._entries: dict[tuple[str, str], tuple[float, str, frozenset[str]]] = {}
         self._lock = threading.Lock()
 
     def record(
         self, command: str, ttl: float | None = None, *, scope: str = "once"
-    ) -> list[tuple[str, str]]:
+    ) -> list[tuple[str, str, frozenset[str]]]:
         """Mark every intent extracted from *command* as approved.
 
         Handles multi-target commands like ``rm a b c`` — each path becomes its
@@ -170,11 +220,20 @@ class IntentApprovalCache:
             return []
         expires = time.monotonic() + (ttl if ttl is not None else self._default_ttl)
         with self._lock:
-            for intent in intents:
-                self._entries[intent] = (expires, scope)
+            for kind, target, flags in intents:
+                key = (kind, target)
+                existing = self._entries.get(key)
+                if existing is not None:
+                    # Keep the later expiry; union flags so approved
+                    # capability only grows, never shrinks.
+                    new_expiry = max(existing[0], expires)
+                    new_scope = existing[1] if existing[0] >= expires else scope
+                    self._entries[key] = (new_expiry, new_scope, existing[2] | flags)
+                else:
+                    self._entries[key] = (expires, scope, flags)
         return intents
 
-    def record_always(self, command: str) -> list[tuple[str, str]]:
+    def record_always(self, command: str) -> list[tuple[str, str, frozenset[str]]]:
         """Remember every intent in *command* for the session lifetime."""
         return self.record(command, ttl=_ALWAYS_TTL_SECONDS, scope="always")
 
@@ -182,20 +241,25 @@ class IntentApprovalCache:
         """Return True only when **every** extracted intent is still approved.
 
         Multi-target commands must have approval for *all* targets — one
-        missing path means the whole command needs fresh approval.
+        missing path means the whole command needs fresh approval.  The
+        approved escalation flags must be a superset of the requested flags
+        so ``rm -rf /a`` can never replay on a ``rm /a`` approval.
         """
         intents = _extract_intents(command)
         if not intents:
             return False
         now = time.monotonic()
         with self._lock:
-            for intent in intents:
-                entry = self._entries.get(intent)
+            for kind, target, flags in intents:
+                key = (kind, target)
+                entry = self._entries.get(key)
                 if entry is None:
                     return False
-                expires, _scope = entry
+                expires, _scope, approved_flags = entry
                 if expires < now:
-                    self._entries.pop(intent, None)
+                    self._entries.pop(key, None)
+                    return False
+                if not flags <= approved_flags:
                     return False
         return True
 
@@ -204,8 +268,8 @@ class IntentApprovalCache:
         if not intents:
             return
         with self._lock:
-            for intent in intents:
-                self._entries.pop(intent, None)
+            for kind, target, _flags in intents:
+                self._entries.pop((kind, target), None)
 
     def clear(self) -> None:
         with self._lock:
@@ -215,9 +279,7 @@ class IntentApprovalCache:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
             self._entries = {
-                intent: data
-                for intent, data in self._entries.items()
-                if data[1] != scope
+                intent: data for intent, data in self._entries.items() if data[1] != scope
             }
 
 

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -745,7 +745,7 @@ async def _handle_approvals_command(cmd: str, client: object | None = None) -> N
             return
         entries = [
             f"  [dim]{scope}[/dim] {k}:{t}"
-            for (k, t), (_exp, scope) in cache._entries.items()  # noqa: SLF001
+            for (k, t), (_exp, scope, _flags) in cache._entries.items()  # noqa: SLF001
         ]
         console.print(f"[{ACCENT}]mode:[/] {queue.get_settings().mode}")
         console.print(f"[{ACCENT}]cached intents ({len(entries)}):[/]")

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -21,9 +21,12 @@ from pathlib import Path, PurePosixPath
 # the entire sensitive-path block layer. ONLY for trusted single-operator
 # environments / E2E testing where sandbox=false + sensitive_path checks
 # block valid agent commands like ``ls /etc/...``. Default off.
-_DISABLED = os.environ.get(
-    "AGENTOS_SENSITIVE_PATHS_DISABLED", ""
-).lower() in ("1", "true", "yes", "on")
+_DISABLED = os.environ.get("AGENTOS_SENSITIVE_PATHS_DISABLED", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
 
 
 # Directory prefixes whose contents must not be read/written/deleted by the agent
@@ -122,9 +125,7 @@ def _path_contains(path: str, root: str) -> bool:
         return False
     normalized_path = path.rstrip("/")
     normalized_root = root.rstrip("/")
-    return normalized_path == normalized_root or normalized_path.startswith(
-        normalized_root + "/"
-    )
+    return normalized_path == normalized_root or normalized_path.startswith(normalized_root + "/")
 
 
 def is_sensitive_path(path: str) -> str | None:
@@ -178,9 +179,7 @@ def _workspace_contains(path: str, workspace: str | Path | None) -> bool:
     candidate_paths = _comparison_path_candidates(str(path))
     workspace_paths = _comparison_path_candidates(str(workspace))
     return any(
-        _path_contains(candidate, root)
-        for candidate in candidate_paths
-        for root in workspace_paths
+        _path_contains(candidate, root) for candidate in candidate_paths for root in workspace_paths
     )
 
 
@@ -198,9 +197,7 @@ def _workspace_nested_under_marker(workspace: str | Path | None, marker: str) ->
         pass
     for workspace_text in _comparison_path_candidates(str(workspace)):
         for marker_text in _comparison_path_candidates(marker):
-            if workspace_text != marker_text and _path_contains(
-                workspace_text, marker_text
-            ):
+            if workspace_text != marker_text and _path_contains(workspace_text, marker_text):
                 return True
     return False
 
@@ -245,9 +242,7 @@ def sensitive_path_marker(
     marker = is_sensitive_path(path)
     if marker is None:
         return None
-    if _workspace_contains(path, workspace) and _workspace_nested_under_marker(
-        workspace, marker
-    ):
+    if _workspace_contains(path, workspace) and _workspace_nested_under_marker(workspace, marker):
         leaf_marker = _sensitive_leaf_marker(path)
         return leaf_marker
     return marker
@@ -282,8 +277,7 @@ def sensitive_path_in_text(
         (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(text)
     )
     with_context.extend(
-        (match.group("path"), match.start("path"))
-        for match in _DOTENV_LITERAL_RE.finditer(text)
+        (match.group("path"), match.start("path")) for match in _DOTENV_LITERAL_RE.finditer(text)
     )
 
     for raw in candidates:
@@ -330,7 +324,7 @@ def sensitive_target_in_command(
     if effective_workspace is None:
         effective_workspace = cwd if cwd is not None else Path.cwd()
 
-    for _kind, target in _extract_intents(command, base_dir=effective_workspace):
+    for _kind, target, _flags in _extract_intents(command, base_dir=effective_workspace):
         marker = sensitive_path_marker(target, workspace=effective_workspace)
         if marker is not None:
             return marker

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -96,3 +96,82 @@ class TestRecordAndCheck:
         cache.clear()
         assert cache.check("rm /a") is False
         assert cache.check("rm /b") is False
+
+
+class TestFlagEscalationBypass:
+    """Approving a plain delete must not unlock flag-escalated variants.
+
+    Issue #849: ``cache.record('rm /tmp/a')`` then ``cache.check('rm -rf
+    /tmp/a')`` returned True because only the target path was part of the
+    cache key. Escalation flags (-r/-R/--recursive, -f/--force,
+    --no-preserve-root, and Python recursion like shutil.rmtree) must be
+    part of the approved capability, monotonic in one direction only:
+    approving a *stronger* delete still covers the *milder* form, but a
+    milder approval never covers a stronger one.
+    """
+
+    def test_plain_approval_does_not_cover_recursive_force(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is False
+        assert cache.check("rm -r /tmp/a") is False
+        assert cache.check("rm -f /tmp/a") is False
+
+    def test_plain_approval_still_covers_exact_and_milder(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm /tmp/a") is True
+        # A path with a trailing slash normalizes to the same target and
+        # carries no escalation flags, so it stays approved.
+        assert cache.check("rm /tmp/a/") is True
+
+    def test_strong_approval_covers_milder_but_not_stronger(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        # Recursive+force approval still covers the plain and single-flag
+        # variants of the same target (monotonic — capability only grows).
+        assert cache.check("rm /tmp/a") is True
+        assert cache.check("rm -r /tmp/a") is True
+        assert cache.check("rm -f /tmp/a") is True
+        assert cache.check("rm -rf /tmp/a") is True
+        # But never a different, stronger target.
+        assert cache.check("rm -rf /tmp/b") is False
+
+    def test_long_flag_escalation(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm --recursive /tmp/a") is False
+        assert cache.check("rm --force /tmp/a") is False
+
+    def test_force_alone_does_not_cover_recursive(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -f /tmp/a")
+        assert cache.check("rm -f /tmp/a") is True
+        assert cache.check("rm -rf /tmp/a") is False
+
+    def test_python_rmtree_is_recursive_escalation(self) -> None:
+        cache = IntentApprovalCache()
+        # os.remove approval must not cover the recursive shutil.rmtree on
+        # the same path (rmtree implies the "recursive" capability).
+        cache.record("os.remove('/tmp/a')")
+        assert cache.check("os.remove('/tmp/a')") is True
+        assert cache.check("shutil.rmtree('/tmp/a')") is False
+        assert cache.check("os.removedirs('/tmp/a')") is False
+
+    def test_python_rmtree_approval_covers_single_delete(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("shutil.rmtree('/tmp/a')")
+        assert cache.check("shutil.rmtree('/tmp/a')") is True
+        assert cache.check("os.remove('/tmp/a')") is True
+        assert cache.check("Path('/tmp/a').unlink()") is True
+
+    def test_record_merges_flags_monotonically(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        # A later, stronger approval upgrades the same (kind, target) entry.
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is True
+        assert cache.check("rm /tmp/a") is True
+        # And a later milder record does not downgrade the entry.
+        cache.record("rm /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is True


### PR DESCRIPTION
## Summary

The approval cache keyed approvals only on ``(kind, target)``, so approving ``rm /tmp/a`` (via `cache.record`) and then re-issuing ``rm -rf /tmp/a`` (via `cache.check`) hit the cache and skipped a fresh approval. A single low-privilege approval escalated into a recursive force delete.

## Fix

Track **escalation flags** as part of the approved capability:

| Flag | Source | Canonical name |
|------|--------|----------------|
| `-r`/`-R`/`--recursive` | shell rm | `recursive` |
| `-f`/`--force` | shell rm | `force` |
| `--no-preserve-root` | shell rm | `no-preserve-root` |
| `shutil.rmtree` / `os.removedirs` | Python | `recursive` |

Other Python deletes (`os.remove`, `os.unlink`, `os.rmdir`, `Path.unlink`, `Path.rmdir`) carry no escalation flags. The cache records flags **monotonically**: a later approval for the same (kind, target) **unions** flags, so approved capability only grows, never shrinks. `check()` requires `requested_flags ⊆ approved_flags`.

**Examples:**
- `record('rm /a')` → `check('rm -rf /a')` = **False** (the reported bypass)
- `record('rm -rf /a')` → `check('rm /a')` = **True** (monotonic: stronger approval covers milder)
- `record('os.remove(\"/a\")')` → `check('shutil.rmtree(\"/a\")')` = **False** (bonus: single-file delete doesn't unlock recursive tree delete)

## Tests

9 new tests covering: plain→flag escalation, strong→milder monotonicity, long flags, Python rmtree escalation, and merge monotonicity.

Fixes #849