### PR TITLE
fix(cli): ensure parent directories exist for agentos cost --export

### DIFF
--- a/src/agentos/cli/cost_cmd.py
+++ b/src/agentos/cli/cost_cmd.py
@@ -106,8 +106,10 @@ def cost(
                         int(row.get("created_at") or row.get("createdAt") or 0),
                     ]
                 )
+            path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(f.getvalue(), encoding="utf-8")
         else:
+            path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         console.print(f"Exported usage data to {export_path}")
         return


### PR DESCRIPTION
## Problem

`agentos cost --export reports/usage.json` crashes with:
```
FileNotFoundError: [Errno 2] No such file or directory: 'reports/usage.json'
```

because `path.write_text()` at cost_cmd.py:109 and :111 does not ensure the parent directory exists first.

## Root Cause

`cost_cmd.py`:109 and `cost_cmd.py`:111 call `path.write_text(...)` directly without creating parent directories.

## Fix

Add `path.parent.mkdir(parents=True, exist_ok=True)` before each `write_text` call, matching the existing pattern in `render_savings_pdf` in `savings_pdf.py`.

## Not Changed

- CSV/JSON export logic is unchanged.
- Only 2 lines added, no new dependencies.

## Tests

Existing tests continue to pass (no test existed for this specific export-path scenario).

Fixes #846