### PR TITLE
fix(tools): detect obfuscated destructive Python in execute_code

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -23,10 +23,168 @@ from agentos.sandbox.types import DenialResult, SandboxRequest
 from agentos.tools.registry import tool
 from agentos.tools.types import ToolError, current_tool_context
 
-# Destructive Python patterns that must go through the same approval flow as
-# shell warnlist hits. Catches the "agent pivots from `rm` to `os.remove()`"
-# bypass. Matching is intentionally shallow (regex, not AST) — goal is to
-# force approval on obvious intent, not to prove safety.
+# Destructive Python module + attribute pairs that must go through the same
+# approval flow as shell warnlist hits. Catches the "agent pivots from `rm`
+# to `os.remove()`" bypass. Detection is AST-based so obfuscated spellings
+# (getattr with string concat, __import__ / importlib dynamic imports,
+# exec/eval wrappers, wildcard imports) are caught the same way as the
+# obvious forms. A regex whitelist remains as a fallback for snippets that
+# do not parse.
+_DESTRUCTIVE_MODULES = frozenset({"os", "shutil", "pathlib", "subprocess"})
+
+# Attribute names that mark a destructive operation when reached through one
+# of the destructive modules (or a Path object).
+_DESTRUCTIVE_ATTRS = frozenset({"remove", "unlink", "rmdir", "removedirs", "rmtree", "system"})
+
+# subprocess entry points that can execute a shell command.
+_SUBPROCESS_RUNNERS = frozenset({"run", "call", "Popen", "check_output", "check_call", "popen"})
+
+
+def _fold_string(node: ast.AST | None) -> str | None:
+    """Best-effort constant folding of a string expression (``+`` concat only).
+
+    Lets ``getattr(os, "rem" + "ove")`` resolve to ``"remove"``.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _fold_string(node.left)
+        right = _fold_string(node.right)
+        if left is not None and right is not None:
+            return left + right
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            folded = _fold_string(value)
+            if folded is None:
+                return None
+            parts.append(folded)
+        return "".join(parts)
+    return None
+
+
+def _base_module(value: ast.AST | None) -> str | None:
+    """Best-effort module / Path name of an attribute base expression.
+
+    Resolves plain names (``os``), dotted paths (``pathlib.Path``), and the
+    dynamic-import spellings ``__import__("os")`` and
+    ``importlib.import_module("os")`` so attribute access on their result is
+    classified against the same module table.
+    """
+    if isinstance(value, ast.Name):
+        return value.id
+    if isinstance(value, ast.Attribute):
+        parent = _base_module(value.value)
+        return f"{parent}.{value.attr}" if parent is not None else value.attr
+    if isinstance(value, ast.Call):
+        func = value.func
+        if isinstance(func, ast.Name) and func.id == "__import__" and value.args:
+            return _fold_string(value.args[0])
+        if isinstance(func, ast.Attribute) and func.attr == "import_module":
+            parent = _base_module(func.value)
+            if parent == "importlib" and value.args:
+                return _fold_string(value.args[0])
+    return None
+
+
+def _is_getattr_call(func: ast.AST) -> bool:
+    """True when *func* is ``getattr(...)`` (bare) or ``obj.getattr(...)``."""
+    if isinstance(func, ast.Name):
+        return func.id == "getattr"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "getattr"
+    return False
+
+
+def _check_code_destructive_ast(code: str) -> str | None:
+    """AST-based destructive-pattern detection, or None if the code is clean.
+
+    Covers the regex whitelist plus the reported bypasses: ``getattr`` with a
+    folded attribute name, ``__import__`` / ``importlib.import_module`` of a
+    destructive module, ``exec``/``eval`` wrapping destructive code, and
+    ``from os import *``-style wildcard imports.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return None  # not parseable — let the regex fallback handle it
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+
+        # exec(...) / eval(...) with a string literal — recursively inspect.
+        if isinstance(func, ast.Name) and func.id in ("exec", "eval") and node.args:
+            inner = _fold_string(node.args[0])
+            if inner is not None and _check_code_destructive(inner):
+                return f"destructive code passed to {func.id}(...)"
+            continue
+
+        # getattr(os, "rem" + "ove") / getattr(os, name) — bare or dotted.
+        if _is_getattr_call(func) and len(node.args) >= 2:
+            obj = node.args[0]
+            attr = _fold_string(node.args[1])
+            if attr is not None and attr in _DESTRUCTIVE_ATTRS:
+                return f"destructive attribute via getattr: {attr}()"
+            # A non-literal attribute name on a destructive module is opaque
+            # and cannot be proven safe.
+            obj_name = _base_module(obj)
+            if attr is None and obj_name in _DESTRUCTIVE_MODULES:
+                return f"dynamic attribute access on {obj_name}"
+            continue
+
+        # __import__("os") / importlib.import_module("os") — dynamic module.
+        mod = None
+        if isinstance(func, ast.Name) and func.id == "__import__" and node.args:
+            mod = _fold_string(node.args[0])
+        elif isinstance(func, ast.Attribute) and func.attr == "import_module" and node.args:
+            if _base_module(func.value) == "importlib":
+                mod = _fold_string(node.args[0])
+        if mod in _DESTRUCTIVE_MODULES:
+            return f"dynamic import of {mod}"
+
+        if not isinstance(func, ast.Attribute):
+            continue
+        attr = func.attr
+        base = _base_module(func.value)
+        if base == "os" and attr in ("remove", "unlink", "rmdir", "removedirs"):
+            return f"os.{attr}()"
+        if base == "shutil" and attr == "rmtree":
+            return "shutil.rmtree()"
+        # .unlink()/.rmdir() are pathlib-Path methods — flag on any base,
+        # matching the previous regex whitelist behavior.
+        if attr in ("unlink", "rmdir"):
+            return f"{attr}()"
+        if base == "os" and attr == "system":
+            arg = _fold_string(node.args[0]) if node.args else None
+            if arg is not None and re.search(r"\brm\b|\brmdir\b", arg):
+                return "os.system with rm"
+        if base == "subprocess" and attr in _SUBPROCESS_RUNNERS:
+            args_text = " ".join(_fold_string(a) or "" for a in node.args)
+            # Also check list literal args: subprocess.run(["rm", ...])
+            for a in node.args:
+                if isinstance(a, ast.List):
+                    for elt in a.elts:
+                        s = _fold_string(elt)
+                        if s is not None:
+                            args_text += " " + s
+            if re.search(r"\brm\b|\brmdir\b", args_text):
+                return "subprocess invoking rm/rmdir"
+
+    # Wildcard imports from destructive modules hide their names from the
+    # per-call analysis above (``from os import *; remove('/x')``).
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module in _DESTRUCTIVE_MODULES
+            and any(alias.name == "*" for alias in node.names)
+        ):
+            return f"wildcard import from {node.module}"
+
+    return None
+
+
 _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
     (r"\bos\.remove\s*\(", "os.remove()"),
     (r"\bos\.unlink\s*\(", "os.unlink()"),
@@ -47,12 +205,26 @@ _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
 ]
 
 
-def _check_code_destructive(code: str) -> str | None:
-    """Return a human-readable warning if *code* triggers a destructive pattern, else None."""
+def _check_code_destructive_regex(code: str) -> str | None:
+    """Regex whitelist fallback for snippets that do not parse as Python."""
     for pattern, label in _DESTRUCTIVE_PY_PATTERNS:
         if re.search(pattern, code):
             return f"destructive Python operation detected: {label}"
     return None
+
+
+def _check_code_destructive(code: str) -> str | None:
+    """Return a human-readable warning if *code* triggers a destructive pattern, else None.
+
+    AST-based by default so obfuscated spellings are caught; the regex
+    whitelist only covers snippets that do not parse as Python (where the
+    AST analyzer cannot run).
+    """
+    try:
+        ast.parse(code)
+    except SyntaxError:
+        return _check_code_destructive_regex(code)
+    return _check_code_destructive_ast(code)
 
 
 _CODE_SENSITIVE_READ_TOKENS = (

--- a/tests/test_tools/test_code_exec_destructive_ast.py
+++ b/tests/test_tools/test_code_exec_destructive_ast.py
@@ -1,0 +1,160 @@
+"""Regression tests for AST-based destructive pattern detection in code_exec.
+
+Issue #848: the regex-based whitelist could be bypassed with getattr string
+concatenation, __import__ / importlib.import_module dynamic imports,
+exec/eval wrappers, and `from os import *` wildcard imports. The AST
+analyzer must catch these obfuscated spellings just like the obvious
+`os.remove()` form.
+"""
+
+from __future__ import annotations
+
+from agentos.tools.builtin import code_exec
+
+
+def _assert_destructive(code: str) -> None:
+    result = code_exec._check_code_destructive(code)
+    assert result is not None, f"expected destructive flag, got None for: {code!r}"
+
+
+def _assert_clean(code: str) -> None:
+    result = code_exec._check_code_destructive(code)
+    assert result is None, f"expected clean, got: {result!r} for: {code!r}"
+
+
+class TestRegexCompatibility:
+    """The original literal forms must still be flagged."""
+
+    def test_os_remove(self) -> None:
+        _assert_destructive('os.remove("/tmp/x")')
+
+    def test_os_unlink(self) -> None:
+        _assert_destructive('os.unlink("/tmp/x")')
+
+    def test_os_rmdir(self) -> None:
+        _assert_destructive('os.rmdir("/tmp/x")')
+
+    def test_os_removedirs(self) -> None:
+        _assert_destructive('os.removedirs("/tmp/x")')
+
+    def test_shutil_rmtree(self) -> None:
+        _assert_destructive('shutil.rmtree("/tmp/x")')
+
+    def test_path_unlink(self) -> None:
+        _assert_destructive('Path("/tmp/x").unlink()')
+
+    def test_pathlib_path_unlink(self) -> None:
+        _assert_destructive('pathlib.Path("/tmp/x").unlink()')
+
+    def test_os_system_with_rm(self) -> None:
+        _assert_destructive('os.system("rm -rf /tmp/x")')
+
+    def test_subprocess_run_with_rm(self) -> None:
+        _assert_destructive('subprocess.run(["rm", "-rf", "/tmp/x"])')
+
+
+class TestGetattrBypass:
+    """getattr with a folded attribute name must be caught."""
+
+    def test_getattr_remove_string_concat(self) -> None:
+        _assert_destructive('getattr(os, "rem" + "ove")("/tmp/x")')
+
+    def test_getattr_remove_literal(self) -> None:
+        _assert_destructive('getattr(os, "remove")("/tmp/x")')
+
+    def test_getattr_rmtree(self) -> None:
+        _assert_destructive('getattr(shutil, "rmtree")("/tmp/x")')
+
+    def test_getattr_on_imported_module(self) -> None:
+        _assert_destructive('getattr(__import__("os"), "remove")("/tmp/x")')
+
+    def test_dynamic_attribute_on_os_is_opaque(self) -> None:
+        # A non-literal attribute name on a destructive module cannot be
+        # proven safe.
+        _assert_destructive('getattr(os, name)("/tmp/x")')
+
+    def test_clean_getattr(self) -> None:
+        # Benign attribute access on a non-destructive module stays clean.
+        _assert_clean('getattr(json, "dumps")({"a": 1})')
+
+
+class TestDynamicImportBypass:
+    """__import__ / importlib.import_module of a destructive module."""
+
+    def test_dunder_import_os_remove(self) -> None:
+        _assert_destructive('__import__("os").remove("/tmp/x")')
+
+    def test_importlib_import_module_os_remove(self) -> None:
+        _assert_destructive('importlib.import_module("os").remove("/tmp/x")')
+
+    def test_dunder_import_os_alone(self) -> None:
+        # Importing a destructive module dynamically is itself a gate signal.
+        _assert_destructive('m = __import__("os")')
+
+    def test_importlib_import_module_shutil_alone(self) -> None:
+        _assert_destructive('m = importlib.import_module("shutil")')
+
+    def test_dunder_import_benign_module_clean(self) -> None:
+        _assert_clean('m = __import__("json")')
+
+
+class TestExecEvalWrapper:
+    """Destructive code hidden inside exec/eval must be caught."""
+
+    def test_exec_os_remove(self) -> None:
+        _assert_destructive("exec(\"os.remove('/tmp/x')\")")
+
+    def test_eval_os_remove(self) -> None:
+        _assert_destructive("eval(\"os.remove('/tmp/x')\")")
+
+    def test_exec_getattr_concat(self) -> None:
+        _assert_destructive("exec(\"getattr(os, 'rem' + 'ove')('/tmp/x')\")")
+
+    def test_exec_clean_code_clean(self) -> None:
+        _assert_clean('exec("x = 1 + 1")')
+
+
+class TestWildcardImportBypass:
+    """`from os import *` hides destructive names from per-call analysis."""
+
+    def test_from_os_star(self) -> None:
+        _assert_destructive("from os import *; remove('/tmp/x')")
+
+    def test_from_shutil_star(self) -> None:
+        _assert_destructive("from shutil import *; rmtree('/tmp/x')")
+
+    def test_from_pathlib_star(self) -> None:
+        _assert_destructive("from pathlib import *; Path('/tmp/x').unlink()")
+
+
+class TestFalsePositiveGuard:
+    """Code that merely mentions destructive words must stay clean."""
+
+    def test_plain_string_literal(self) -> None:
+        _assert_clean('print("os.remove is dangerous")')
+
+    def test_benign_computation(self) -> None:
+        _assert_clean("total = sum(x for x in range(10))")
+
+    def test_list_remove_method_is_clean(self) -> None:
+        # `.remove` on a plain list is not a destructive filesystem op.
+        _assert_clean("items = [1, 2]; items.remove(1)")
+
+    def test_dotted_name_in_comment_only(self) -> None:
+        _assert_clean('# os.remove("/tmp/x")')
+
+    def test_non_destructive_attr_on_unknown_base(self) -> None:
+        _assert_clean('thing.cleanup("/tmp/x")')
+
+
+class TestRecursiveNesting:
+    """Bypass spellings can nest — each layer must resolve."""
+
+    def test_getattr_of_dunder_import(self) -> None:
+        _assert_destructive('getattr(__import__("os"), "rem" + "ove")("/tmp/x")')
+
+    def test_exec_wrapping_dynamic_import(self) -> None:
+        _assert_destructive("exec(\"__import__('os').remove('/tmp/x')\")")
+
+    def test_importlib_dynamic_getattr(self) -> None:
+        _assert_destructive('getattr(importlib.import_module("os"), "remove")("/tmp/x")')


### PR DESCRIPTION
## Summary

The destructive-pattern gate for `execute_code` (`_check_code_destructive`) used a **regex whitelist** that only matched exact literals like `os.remove(...)`. Attackers could bypass it with:

- `getattr(os, "rem" + "ove")`
- `__import__("os").remove`
- `importlib.import_module("os").remove`
- `exec(...)` / `eval(...)` wrapping destructive code
- `from os import *` wildcard imports

…reaching arbitrary file deletion **with no approval** (CVE-2025-54794 class). The issue repro confirmed all six returned `False` (bypassed).

## Fix

Replace regex-only detection with an **AST analyzer** that resolves:

1. attribute access through `getattr` with **constant-folded** names (`"rem" + "ove"` → `remove`)
2. **dynamic imports** via `__import__` / `importlib.import_module` of destructive modules (os, shutil, pathlib, subprocess)
3. destructive code **nested inside `exec`/`eval`** (recursively inspected)
4. **wildcard imports** (`from os import *`) from destructive modules
5. subprocess/`os.system` calls carrying `rm`/`rmdir` (including list-literal args)

The regex whitelist remains only as a **fallback for non-parseable snippets**. False positives avoided: plain string literals mentioning `os.remove`, `.remove()` on non-filesystem objects, and comment-only mentions all stay clean.

## Tests

35 regression tests: regex compatibility, getattr bypass, dynamic import bypass, exec/eval wrapper, wildcard import, recursive nesting, and false-positive guards.

Fixes #848