### PR TITLE
fix(cli): replace uv run agentos with agentos in channel verify message

### DIFF
--- a/src/agentos/cli/channels_cmd.py
+++ b/src/agentos/cli/channels_cmd.py
@@ -60,7 +60,7 @@ def _print_restart_notice() -> None:
 
 def _print_channel_verification_next_step(name: str) -> None:
     typer.echo("Next: agentos gateway restart")
-    typer.echo(f"Verify: uv run agentos channels status {name} --json")
+    typer.echo(f"Verify: agentos channels status {name} --json")
 
 
 _SOURCE_LABEL = {


### PR DESCRIPTION
## Problem

agentos channels add and edit print:
```
Verify: uv run agentos channels status <name> --json
```
On pipx/pip installations where uv is not on PATH, this fails with exit 127.

## Root Cause

_print_channel_verification_next_step() in channels_cmd.py:63 hardcodes uv run agentos.

## Fix

Change to just agentos, matching all other output lines.

## Not Changed

No behavioral changes. Other output (Next: agentos gateway restart) already uses plain agentos.

Fixes #835