### PR TITLE
fix(tools): handle broken symlinks in list_dir without crash

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -923,7 +923,10 @@ async def list_dir(path: str) -> str:
             if entry.is_dir():
                 dirs.append(f"[dir]  {entry.name}/")
             else:
-                size = entry.stat().st_size
+                try:
+                    size = entry.stat().st_size
+                except (OSError, FileNotFoundError):
+                    size = entry.lstat().st_size
                 files.append(f"[file] {entry.name} ({size} bytes)")
         return dirs + files + blocked_entries
 


### PR DESCRIPTION
## Problem

`list_dir()` crashes with `FileNotFoundError` when a directory contains a broken or dangling symlink.

**Root cause** — `entry.stat()` follows symlinks by default. On a broken symlink (target does not exist), `os.stat()` raises `FileNotFoundError`. The entire tool call fails instead of listing the remaining entries.

## Fix

Wrap `entry.stat()` in try/except (OSError, FileNotFoundError) and fall back to `entry.lstat()`, which reads the symlink metadata without following the link.

## Not Changed

- Workspace strict symlink detection is unchanged.
- No new dependencies.
- Existing symlink-escape tests still pass unchanged.

Fixes #844