### PR TITLE
fix(engine): auto-fallback across router tiers on model timeout in Auto Pilot

### DIFF
--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -86,7 +86,11 @@ from agentos.provider import (
 from agentos.provider import (
     ToolUseStartEvent as ProviderToolUseStart,
 )
-from agentos.provider.failures import ProviderFailureKind, classify_provider_error
+from agentos.provider.failures import (
+    ProviderFailureKind,
+    classify_provider_error,
+    is_transport_timeout,
+)
 from agentos.provider.types import ContentBlockImage
 from agentos.result_budget import (
     ToolResultBudgetClass,
@@ -2982,10 +2986,25 @@ class Agent:
                             )
                             _call_attempt += 1
                             continue
-                        if not _fallback.should_retry(kind, _retry_attempt):
+                        _is_timeout = is_transport_timeout(
+                            raw_code=provider_error.code,
+                            message=provider_error.message,
+                        )
+                        if not _fallback.should_retry_timeout(
+                            kind, _retry_attempt, is_timeout=_is_timeout
+                        ):
                             yield self._transition(AgentState.ERROR)
+                            _err_msg = provider_error.message
+                            if _is_timeout:
+                                _err_msg = (
+                                    f"{provider_error.message}. "
+                                    "The upstream model endpoint did not respond "
+                                    "within the timeout window. Try switching "
+                                    "to a different model tier with /c0, /c2, "
+                                    "or /auto to restore automatic routing."
+                                )
                             terminal_error = ErrorEvent(
-                                message=provider_error.message,
+                                message=_err_msg,
                                 code=provider_error.code,
                             )
                             yield terminal_error
@@ -3001,7 +3020,15 @@ class Agent:
                             attempt=_retry_attempt + 1,
                             kind=kind.value,
                             delay_s=round(delay, 2),
+                            is_timeout=_is_timeout,
                         )
+                        if _is_timeout:
+                            yield WarningEvent(
+                                code="provider_timeout_retry",
+                                message=(
+                                    "The upstream model timed out; retrying once before giving up."
+                                ),
+                            )
                         await asyncio.sleep(delay)
                         _retry_attempt += 1
                         _call_attempt += 1

--- a/src/agentos/engine/fallback.py
+++ b/src/agentos/engine/fallback.py
@@ -34,6 +34,9 @@ class FallbackPolicy:
     """Policy for retrying failed provider calls and falling back to alternate models."""
 
     max_retries: int = 3
+    # Timeout-specific cap: each timeout retry burns the full read-timeout
+    # window (~120s), so 1 retry means at most ~4 min total (request + retry).
+    max_timeout_retries: int = 1
     fallback_models: list[str] = field(default_factory=list)
     base_backoff_ms: int = 1000
     max_backoff_ms: int = 30_000
@@ -70,6 +73,23 @@ class FallbackPolicy:
         if kind in retryable:
             return True
         return False  # Unknown errors: don't retry by default
+
+    def should_retry_timeout(
+        self,
+        kind: ProviderErrorKind,
+        attempt: int,
+        *,
+        is_timeout: bool = False,
+    ) -> bool:
+        """Timeout-aware retry decision.
+
+        When ``is_timeout`` is True the per-retry cost is the full read-timeout
+        window (typically 120 s), so we cap at ``max_timeout_retries`` instead
+        of the generic ``max_retries``.
+        """
+        if is_timeout and attempt >= self.max_timeout_retries:
+            return False
+        return self.should_retry(kind, attempt)
 
     def get_fallback_model(self, current_model: str) -> str | None:
         """Return the next fallback model after current_model, or None if exhausted."""

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -144,6 +144,7 @@ from agentos.provider import (
 )
 from agentos.provider import (
     ProviderFailureKind,
+    ProviderHeartbeatEvent,
     ProviderRecoveryAction,
     classify_provider_error,
     decide_recovery_action,
@@ -1096,6 +1097,24 @@ def _drop_unpaired_tool_use_segments(segments: list[dict[str, Any]]) -> list[dic
     ]
 
 
+def _selector_model_name(provider: Any, selector: Any) -> str:
+    m = getattr(provider, "_model", None) or getattr(provider, "model", None)
+    if not m:
+        cfg = getattr(selector, "current_config", None)
+        m = getattr(cfg, "model", "") if cfg is not None else ""
+    return str(m or "")
+
+
+def _selector_has_fallback(selector: Any) -> bool:
+    fn = getattr(selector, "has_fallback", None)
+    if callable(fn):
+        try:
+            return bool(fn())
+        except Exception:
+            return False
+    return False
+
+
 class _SelectorFallbackProvider:
     """Provider wrapper that switches to selector fallback on pre-content errors.
 
@@ -1179,6 +1198,7 @@ class _SelectorFallbackProvider:
                     recorded_failure = trips_breaker(kind)
                     self._record_failure(kind, event.message)
                 if _kind_uses_selector_fallback(kind):
+                    failed_model = _selector_model_name(self._provider, self._selector)
                     try:
                         self._provider = self._selector.next_fallback_after_failure(
                             RuntimeError(event.message)
@@ -1188,6 +1208,14 @@ class _SelectorFallbackProvider:
                             yield buffered_event
                         yield event
                         return
+                    fallback_model = _selector_model_name(self._provider, self._selector)
+                    yield ProviderHeartbeatEvent(
+                        phase="llm_fallback",
+                        message=(
+                            f"Model {failed_model or 'primary'} failed; "
+                            f"automatically switching to fallback model {fallback_model}."
+                        ),
+                    )
                     async for fallback_event in self._fallback_chat(messages, tools, config):
                         yield fallback_event
                     return
@@ -1239,6 +1267,25 @@ class _SelectorFallbackProvider:
                     kind = _classify_provider_event(self.provider_name, event)
                     recorded_failure = trips_breaker(kind)
                     self._record_failure(kind, event.message)
+                if _kind_uses_selector_fallback(kind) and _selector_has_fallback(self._selector):
+                    failed_model = _selector_model_name(self._provider, self._selector)
+                    try:
+                        self._provider = self._selector.next_fallback_after_failure(
+                            RuntimeError(event.message)
+                        )
+                        fallback_model = _selector_model_name(self._provider, self._selector)
+                        yield ProviderHeartbeatEvent(
+                            phase="llm_fallback",
+                            message=(
+                                f"Model {failed_model or 'fallback'} failed; "
+                                f"automatically switching to fallback model {fallback_model}."
+                            ),
+                        )
+                        async for next_ev in self._fallback_chat(messages, tools, config):
+                            yield next_ev
+                        return
+                    except Exception:
+                        pass
             elif not recorded_success and (
                 _is_non_empty_provider_text_delta(event)
                 or (getattr(event, "kind", "") == "done" and not saw_provider_error)
@@ -1505,6 +1552,80 @@ def _claims_image_without_tool_use(
         return False
     lowered = final_text.lower()
     return any(p.lower() in lowered for p in _IMAGE_CLAIM_PATTERNS)
+
+
+def _derive_router_tier_fallbacks(
+    turn: TurnContext,
+    cloned_selector: Any,
+) -> list[Any] | None:
+    """Derive fallback provider configs from the router's active tiers.
+
+    When Auto Pilot selects a model for a turn, other configured text tiers in the
+    active profile serve as automatic failovers if the routed model fails (e.g.
+    times out or encounters upstream errors).
+    """
+    if not turn.metadata.get("routing_applied"):
+        return None
+    routed_tier = turn.metadata.get("routed_tier")
+    if not routed_tier:
+        return None
+    router_cfg = getattr(turn.config, "agentos_router", None)
+    if router_cfg is None or not getattr(router_cfg, "enabled", False):
+        return None
+    tiers = getattr(router_cfg, "tiers", None)
+    if not isinstance(tiers, dict) or not tiers:
+        return None
+
+    tier_preferences = {
+        "c0": ["c1", "c2", "c3"],
+        "c1": ["c2", "c0", "c3"],
+        "c2": ["c1", "c3", "c0"],
+        "c3": ["c2", "c1", "c0"],
+    }
+    preferred_order = tier_preferences.get(str(routed_tier).lower(), ["c1", "c2", "c0", "c3"])
+    candidate_tiers = [t for t in preferred_order if t in tiers and t != routed_tier]
+    for t in tiers:
+        if t not in candidate_tiers and t != routed_tier:
+            candidate_tiers.append(t)
+
+    primary_cfg = getattr(cloned_selector, "current_config", None)
+    if primary_cfg is None and hasattr(cloned_selector, "_chain") and cloned_selector._chain:
+        primary_cfg = cloned_selector._chain[0]
+    if primary_cfg is None:
+        return None
+
+    from agentos.provider.selector import ProviderConfig
+
+    fallbacks: list[ProviderConfig] = []
+    seen_models: set[str] = {turn.model or primary_cfg.model}
+
+    for tier_name in candidate_tiers:
+        tier_data = tiers.get(tier_name)
+        if not isinstance(tier_data, dict):
+            continue
+        if tier_data.get("image_only"):
+            continue
+        candidate_model = tier_data.get("model")
+        if not candidate_model or candidate_model in seen_models:
+            continue
+        seen_models.add(candidate_model)
+
+        candidate_provider = str(
+            tier_data.get("provider") or getattr(primary_cfg, "provider", "") or ""
+        )
+        fallbacks.append(
+            ProviderConfig(
+                provider=candidate_provider,
+                model=candidate_model,
+                api_key=getattr(primary_cfg, "api_key", ""),
+                base_url=getattr(primary_cfg, "base_url", ""),
+                org_id=getattr(primary_cfg, "org_id", ""),
+                proxy=getattr(primary_cfg, "proxy", ""),
+                provider_routing=getattr(primary_cfg, "provider_routing", {}),
+            )
+        )
+
+    return fallbacks if fallbacks else None
 
 
 class TurnRunner:
@@ -4633,7 +4754,11 @@ class TurnRunner:
 
         # Apply routed model back to cloned selector (local, not shared)
         if turn.model and cloned_selector is not None:
-            cloned_selector.override_model(turn.model)
+            tier_fallbacks = _derive_router_tier_fallbacks(turn, cloned_selector)
+            try:
+                cloned_selector.override_model(turn.model, fallbacks=tier_fallbacks)
+            except TypeError:
+                cloned_selector.override_model(turn.model)
             provider = cloned_selector.resolve()
 
         return turn, provider

--- a/src/agentos/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/agentos/engine/turn_runner/prompt_assembler_stage.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 # ``None`` and the pipeline branches on truthiness internally.
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class RunPipelineRequest:
     """Typed input for ``PipelineExecutionPort.run_pipeline``.
@@ -68,12 +69,14 @@ class RunPipelineRequest:
     tool_context: ToolContext | None = None
     normalization_metadata: dict[str, Any] | None = None
 
+
 # ---------------------------------------------------------------------------
 # Ports — narrow Protocols so the stage is unit-testable without the full
 # TurnRunner. The runtime adapters in ``harness.py`` bind these to the
 # concrete TurnRunner methods (or to the module-level helper for prompt
 # report).
 # ---------------------------------------------------------------------------
+
 
 @runtime_checkable
 class PromptAssemblerPort(Protocol):
@@ -97,6 +100,7 @@ class PromptAssemblerPort(Protocol):
         fresh_user_session: bool = False,
     ) -> str | tuple[str, str]: ...
 
+
 @runtime_checkable
 class PipelineExecutionPort(Protocol):
     """Wraps ``TurnRunner._run_pipeline``.
@@ -112,6 +116,7 @@ class PipelineExecutionPort(Protocol):
         self,
         request: RunPipelineRequest,
     ) -> tuple[Any, Any]: ...
+
 
 @runtime_checkable
 class RouterContextPort(Protocol):
@@ -131,6 +136,7 @@ class RouterContextPort(Protocol):
         exclude_last_user: bool,
     ) -> dict[str, Any]: ...
 
+
 @runtime_checkable
 class PromptConfigResolverPort(Protocol):
     """Wraps ``TurnRunner._resolve_prompt_config``.
@@ -143,6 +149,7 @@ class PromptConfigResolverPort(Protocol):
         self,
         turn: Any,
     ) -> tuple[str, list[Any] | None, str | None]: ...
+
 
 @runtime_checkable
 class PromptReportBuilderPort(Protocol):
@@ -167,6 +174,7 @@ class PromptReportBuilderPort(Protocol):
         tool_profile: str | None,
     ) -> PromptReport: ...
 
+
 @runtime_checkable
 class SessionIdResolverPort(Protocol):
     """Wraps ``TurnRunner._resolve_session_id_for_log``.
@@ -181,6 +189,7 @@ class SessionIdResolverPort(Protocol):
         session_key: str,
     ) -> str | None: ...
 
+
 @runtime_checkable
 class MemoryFingerprintPort(Protocol):
     """Wraps ``TurnRunner._config.memory_mode_fingerprint`` if present.
@@ -192,9 +201,11 @@ class MemoryFingerprintPort(Protocol):
 
     def memory_mode_fingerprint(self) -> dict[str, str] | None: ...
 
+
 # ---------------------------------------------------------------------------
 # Stage I/O dataclasses (frozen)
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class PromptAssemblerStageInput:
@@ -230,6 +241,7 @@ class PromptAssemblerStageInput:
     fresh_user_session: bool = False
     ingress_pipeline_steps: list[PipelineStepRecord] | None = None
     normalization_metadata: dict[str, Any] | None = None
+
 
 @dataclass(frozen=True)
 class PromptAssemblerStageOutput:
@@ -280,9 +292,11 @@ class PromptAssemblerStageOutput:
     selector_model: str
     agentos_router_tier: Any = None
 
+
 # ---------------------------------------------------------------------------
 # Stage
 # ---------------------------------------------------------------------------
+
 
 class PromptAssemblerStage:
     """Assemble identity prompt + run pre-turn pipeline + finalize prompt.
@@ -358,9 +372,7 @@ class PromptAssemblerStage:
         # 2. Fetch router context (transcript-driven)
         router_context = await self._router_context.fetch_router_context(
             inp.session_key,
-            exclude_last_user=(
-                inp.history_has_persisted_user or inp.persist_input
-            ),
+            exclude_last_user=(inp.history_has_persisted_user or inp.persist_input),
         )
 
         # 3. Run pre-turn pipeline (model routing, skills, prompt cache, etc.)
@@ -392,9 +404,7 @@ class PromptAssemblerStage:
         if fingerprint is not None:
             prompt_fingerprint = turn.metadata.get("memory_mode_fingerprint")
             if isinstance(prompt_fingerprint, dict):
-                fingerprint.update(
-                    {str(k): str(v) for k, v in prompt_fingerprint.items()}
-                )
+                fingerprint.update({str(k): str(v) for k, v in prompt_fingerprint.items()})
             turn.metadata["memory_mode_fingerprint"] = fingerprint
 
         # 6. Effective runtime message + selector override / fallback wrap
@@ -402,6 +412,23 @@ class PromptAssemblerStage:
         if inp.model and inp.cloned_selector is not None:
             inp.cloned_selector.override_model(inp.model)
             provider = inp.cloned_selector.resolve()
+        elif (
+            turn.model
+            and inp.cloned_selector is not None
+            and not (
+                callable(getattr(inp.cloned_selector, "has_fallback", None))
+                and inp.cloned_selector.has_fallback()
+            )
+        ):
+            from agentos.engine.runtime import _derive_router_tier_fallbacks
+
+            fallbacks = _derive_router_tier_fallbacks(turn, inp.cloned_selector)
+            if fallbacks:
+                try:
+                    inp.cloned_selector.override_model(turn.model, fallbacks=fallbacks)
+                except TypeError:
+                    inp.cloned_selector.override_model(turn.model)
+                provider = inp.cloned_selector.resolve()
         if inp.cloned_selector is not None:
             # Local import to avoid pulling _SelectorFallbackProvider name
             # into the stage's module-top namespace.
@@ -435,9 +462,7 @@ class PromptAssemblerStage:
         selector_model = ""
         if inp.cloned_selector is not None:
             try:
-                selector_model = (
-                    getattr(inp.cloned_selector.current_config, "model", "") or ""
-                )
+                selector_model = getattr(inp.cloned_selector.current_config, "model", "") or ""
             except Exception:  # noqa: BLE001 - defensive
                 selector_model = ""
         resolved_model = inp.model or turn.model or selector_model
@@ -449,9 +474,7 @@ class PromptAssemblerStage:
         from agentos.engine.router_decision import reconcile_routing_metadata
 
         reconcile_routing_metadata(turn.metadata, resolved_model)
-        provider_name = (
-            getattr(provider, "provider_name", "") or type(provider).__name__
-        )
+        provider_name = getattr(provider, "provider_name", "") or type(provider).__name__
 
         return StageOutcome.success(
             PromptAssemblerStageOutput(

--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -218,3 +218,19 @@ def decide_recovery_action(kind: ProviderFailureKind) -> ProviderRecoveryAction:
     if kind is ProviderFailureKind.AUTH_INVALID:
         return ProviderRecoveryAction.FAIL_CONFIG
     return ProviderRecoveryAction.SURFACE
+
+
+def is_transport_timeout(raw_code: str = "", message: str = "") -> bool:
+    """Return True when the error is specifically a request timeout.
+
+    Transport-transient covers both brief blips (connection reset, DNS hiccup)
+    and hard timeouts (upstream hangs for the full read-timeout window).
+    Timeouts are far less likely to resolve on a simple same-model retry —
+    the upstream is usually genuinely unreachable — so callers can use this
+    to cap retries more aggressively.
+    """
+    code = (raw_code or "").strip().lower()
+    msg = (message or "").strip().lower()
+    if code == "timeout":
+        return True
+    return "timed out" in msg or "request timed out" in msg

--- a/src/agentos/provider/selector.py
+++ b/src/agentos/provider/selector.py
@@ -44,10 +44,7 @@ class ProviderBuildError(Exception):
 
 
 def _unsupported_runtime_message(provider: str) -> str:
-    return (
-        f"Provider '{provider}' is registered but runtime support "
-        "is not enabled in this wave"
-    )
+    return f"Provider '{provider}' is registered but runtime support is not enabled in this wave"
 
 
 def _missing_base_url_message(provider: str) -> str:
@@ -262,8 +259,16 @@ class ModelSelector:
         self._index = self._first_admitted_index(start)
         return _build_provider(self._chain[self._index])
 
-    def override_model(self, model: str) -> None:
-        """Update the model on the primary provider config (for runtime switching)."""
+    def override_model(
+        self,
+        model: str,
+        fallbacks: list[ProviderConfig] | None = None,
+    ) -> None:
+        """Update the model on the primary provider config (for runtime switching).
+
+        When ``fallbacks`` is provided, the selector's fallback chain is also updated
+        (e.g. candidate router tier models that can be tried if the primary fails).
+        """
         if model and model != self._chain[0].model:
             self._chain[0] = ProviderConfig(
                 provider=self._chain[0].provider,
@@ -274,6 +279,9 @@ class ModelSelector:
                 proxy=self._chain[0].proxy,
                 provider_routing=self._chain[0].provider_routing,
             )
+        if fallbacks is not None:
+            self._config.fallbacks = list(fallbacks)
+            self._chain = [self._chain[0], *fallbacks]
 
     def sync_primary(self, cfg: ProviderConfig) -> None:
         """Replace the primary provider config for future resolves and clones."""

--- a/tests/test_engine/test_auto_pilot_tier_fallback.py
+++ b/tests/test_engine/test_auto_pilot_tier_fallback.py
@@ -1,0 +1,205 @@
+"""Tests for automatic router tier model fallback in Auto Pilot.
+
+When Auto Pilot routes to a model (e.g. c1 -> gpt-5.6-luna) and that model
+fails (e.g. upstream timeout, 503, or connection drop), the system automatically
+falls back to alternative models in the router profile (e.g. c2 -> glm-5.3)
+without requiring manual cancellation or waiting through multiple long retry loops.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from agentos.engine.pipeline import TurnContext
+from agentos.engine.runtime import (
+    _derive_router_tier_fallbacks,
+    _SelectorFallbackProvider,
+)
+from agentos.gateway.config import AgentOSRouterConfig, GatewayConfig
+from agentos.provider import DoneEvent as ProviderDone
+from agentos.provider import ErrorEvent as ProviderError
+from agentos.provider import ProviderHeartbeatEvent
+from agentos.provider import TextDeltaEvent as ProviderText
+from agentos.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+pytestmark = pytest.mark.anyio
+
+
+class _StubProvider:
+    def __init__(self, name: str, model: str, streams: list[list[Any]]) -> None:
+        self.provider_name = name
+        self._model = model
+        self._streams = streams
+        self.calls = 0
+
+    def chat(self, messages: list[Any], tools: Any = None, config: Any = None) -> AsyncIterator:
+        index = min(self.calls, len(self._streams) - 1)
+        self.calls += 1
+        return self._stream(self._streams[index])
+
+    async def _stream(self, events: list[Any]) -> AsyncIterator[Any]:
+        for event in events:
+            yield event
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+async def _drain(wrapper: _SelectorFallbackProvider) -> list[Any]:
+    return [event async for event in wrapper.chat([], tools=None, config=None)]
+
+
+def test_derive_router_tier_fallbacks_for_c1() -> None:
+    """Auto Pilot on c1 generates c2, c0, c3 fallback ProviderConfigs."""
+    router_cfg = AgentOSRouterConfig(
+        enabled=True,
+        tiers={
+            "c0": {"provider": "opencap", "model": "deepseek-v4-flash"},
+            "c1": {"provider": "opencap", "model": "gpt-5.6-luna"},
+            "c2": {"provider": "opencap", "model": "glm-5.3"},
+            "c3": {"provider": "opencap", "model": "claude-opus-5"},
+            "image_model": {"provider": "opencap", "model": "nano-banana", "image_only": True},
+        },
+    )
+    gw_config = GatewayConfig(llm={"provider": "opencap", "model": "gpt-5.6-luna", "api_key": "k"})
+    gw_config.agentos_router = router_cfg
+
+    turn = TurnContext(
+        message="bisa trading gk kamu?",
+        session_key="test-key",
+        config=gw_config,
+        provider=None,
+        model="gpt-5.6-luna",
+        tool_defs=[],
+        system_prompt="sys",
+        metadata={"routing_applied": True, "routed_tier": "c1"},
+    )
+
+    primary_cfg = ProviderConfig(
+        provider="opencap",
+        model="gpt-5.6-luna",
+        api_key="k",
+        base_url="https://api.opencap.ai",
+    )
+    selector = ModelSelector(SelectorConfig(primary=primary_cfg))
+
+    fallbacks = _derive_router_tier_fallbacks(turn, selector)
+    assert fallbacks is not None
+    # c1 preferred order: c2 first, then c0, then c3; image_only skipped; gpt-5.6-luna skipped
+    assert [f.model for f in fallbacks] == ["glm-5.3", "deepseek-v4-flash", "claude-opus-5"]
+    assert all(f.provider == "opencap" for f in fallbacks)
+    assert all(f.api_key == "k" for f in fallbacks)
+
+
+def test_derive_router_tier_fallbacks_ignored_when_routing_not_applied() -> None:
+    """When user manually pins a model (no auto routing), no auto tier fallbacks are generated."""
+    gw_config = GatewayConfig(llm={"provider": "opencap", "model": "gpt-5.6-luna", "api_key": "k"})
+    turn = TurnContext(
+        message="hi",
+        session_key="test-key",
+        config=gw_config,
+        provider=None,
+        model="gpt-5.6-luna",
+        tool_defs=[],
+        system_prompt="sys",
+        metadata={"routing_applied": False},
+    )
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig("opencap", "gpt-5.6-luna", api_key="k"))
+    )
+    assert _derive_router_tier_fallbacks(turn, selector) is None
+
+
+async def test_auto_fallback_switches_model_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When primary model (gpt-5.6-luna) times out, _SelectorFallbackProvider automatically
+    switches to the next fallback model (glm-5.3) and yields its tokens."""
+    from agentos.provider import selector as selector_module
+
+    providers_created: list[tuple[str, str]] = []
+
+    def _stub_build(cfg: ProviderConfig) -> _StubProvider:
+        providers_created.append((cfg.provider, cfg.model))
+        if cfg.model == "gpt-5.6-luna":
+            # Primary hangs/times out
+            return _StubProvider(
+                cfg.provider,
+                cfg.model,
+                [[ProviderError(code="timeout", message="Request timed out: ReadTimeout")]],
+            )
+        # Fallback model succeeds
+        return _StubProvider(
+            cfg.provider,
+            cfg.model,
+            [[ProviderText(text="Hello from GLM 5.3!"), ProviderDone(stop_reason="stop")]],
+        )
+
+    monkeypatch.setattr(selector_module, "_build_provider", _stub_build)
+
+    primary_cfg = ProviderConfig("opencap", "gpt-5.6-luna", api_key="k")
+    fallback_cfg = ProviderConfig("opencap", "glm-5.3", api_key="k")
+    selector = ModelSelector(SelectorConfig(primary=primary_cfg, fallbacks=[fallback_cfg]))
+
+    initial_provider = selector.resolve()
+    fallback_wrapper = _SelectorFallbackProvider(initial_provider, selector)
+
+    events = await _drain(fallback_wrapper)
+
+    # 1. Heartbeat event was emitted to notify user of the automatic switch
+    heartbeats = [e for e in events if isinstance(e, ProviderHeartbeatEvent)]
+    assert len(heartbeats) == 1
+    assert heartbeats[0].phase == "llm_fallback"
+    assert "gpt-5.6-luna" in heartbeats[0].message
+    assert "glm-5.3" in heartbeats[0].message
+
+    # 2. Text from fallback model was emitted
+    text_events = [e for e in events if isinstance(e, ProviderText)]
+    assert len(text_events) == 1
+    assert text_events[0].text == "Hello from GLM 5.3!"
+
+    # 3. Both providers were built
+    assert ("opencap", "gpt-5.6-luna") in providers_created
+    assert ("opencap", "glm-5.3") in providers_created
+
+
+async def test_auto_fallback_cascades_if_first_fallback_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If primary fails AND first fallback fails, it cascades to the second fallback."""
+    from agentos.provider import selector as selector_module
+
+    def _stub_build(cfg: ProviderConfig) -> _StubProvider:
+        if cfg.model in {"gpt-5.6-luna", "glm-5.3"}:
+            return _StubProvider(
+                cfg.provider,
+                cfg.model,
+                [[ProviderError(code="503", message="temporary overload")]],
+            )
+        return _StubProvider(
+            cfg.provider,
+            cfg.model,
+            [[ProviderText(text="Hello from DeepSeek!"), ProviderDone(stop_reason="stop")]],
+        )
+
+    monkeypatch.setattr(selector_module, "_build_provider", _stub_build)
+
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig("opencap", "gpt-5.6-luna", api_key="k"),
+            fallbacks=[
+                ProviderConfig("opencap", "glm-5.3", api_key="k"),
+                ProviderConfig("opencap", "deepseek-v4-flash", api_key="k"),
+            ],
+        )
+    )
+
+    initial_provider = selector.resolve()
+    fallback_wrapper = _SelectorFallbackProvider(initial_provider, selector)
+
+    events = await _drain(fallback_wrapper)
+
+    text_events = [e for e in events if isinstance(e, ProviderText)]
+    assert len(text_events) == 1
+    assert text_events[0].text == "Hello from DeepSeek!"

--- a/tests/test_engine/test_transport_timeout_reduced_retries.py
+++ b/tests/test_engine/test_transport_timeout_reduced_retries.py
@@ -1,0 +1,84 @@
+"""Transport-timeout retry cap: timeouts allow fewer retries than other transient errors."""
+
+from __future__ import annotations
+
+from agentos.engine.fallback import FallbackPolicy, ProviderErrorKind
+from agentos.provider.failures import is_transport_timeout
+
+# ---------------------------------------------------------------------------
+# is_transport_timeout unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransportTimeout:
+    def test_timeout_code(self) -> None:
+        assert is_transport_timeout(raw_code="timeout") is True
+
+    def test_timeout_code_case_insensitive(self) -> None:
+        assert is_transport_timeout(raw_code="Timeout") is True
+
+    def test_timed_out_in_message(self) -> None:
+        assert is_transport_timeout(message="Request timed out: ReadTimeout") is True
+
+    def test_request_error_is_not_timeout(self) -> None:
+        assert is_transport_timeout(raw_code="request_error", message="Connection reset") is False
+
+    def test_503_is_not_timeout(self) -> None:
+        assert is_transport_timeout(raw_code="503", message="upstream 503") is False
+
+    def test_empty_inputs(self) -> None:
+        assert is_transport_timeout() is False
+
+
+# ---------------------------------------------------------------------------
+# FallbackPolicy.should_retry_timeout
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRetryTimeout:
+    def test_non_timeout_transport_uses_max_retries(self) -> None:
+        """Non-timeout transport errors (connection reset) still get full retries."""
+        policy = FallbackPolicy(max_retries=3, max_timeout_retries=1)
+        kind = ProviderErrorKind.TRANSPORT_TRANSIENT
+
+        assert policy.should_retry_timeout(kind, 0, is_timeout=False) is True
+        assert policy.should_retry_timeout(kind, 1, is_timeout=False) is True
+        assert policy.should_retry_timeout(kind, 2, is_timeout=False) is True
+        assert policy.should_retry_timeout(kind, 3, is_timeout=False) is False
+
+    def test_timeout_capped_at_max_timeout_retries(self) -> None:
+        """Timeout errors are capped at max_timeout_retries (default 1)."""
+        policy = FallbackPolicy(max_retries=3, max_timeout_retries=1)
+        kind = ProviderErrorKind.TRANSPORT_TRANSIENT
+
+        assert policy.should_retry_timeout(kind, 0, is_timeout=True) is True
+        assert policy.should_retry_timeout(kind, 1, is_timeout=True) is False
+
+    def test_timeout_with_zero_retries(self) -> None:
+        """When max_timeout_retries=0, timeout errors never retry."""
+        policy = FallbackPolicy(max_retries=3, max_timeout_retries=0)
+        kind = ProviderErrorKind.TRANSPORT_TRANSIENT
+
+        assert policy.should_retry_timeout(kind, 0, is_timeout=True) is False
+
+    def test_auth_failure_never_retries_even_with_timeout(self) -> None:
+        """Auth failures should never retry regardless of timeout flag."""
+        policy = FallbackPolicy(max_retries=3, max_timeout_retries=1)
+        kind = ProviderErrorKind.AUTH_FAILURE
+
+        assert policy.should_retry_timeout(kind, 0, is_timeout=True) is False
+        assert policy.should_retry_timeout(kind, 0, is_timeout=False) is False
+
+    def test_default_max_timeout_retries_is_one(self) -> None:
+        """Default policy allows 1 timeout retry."""
+        policy = FallbackPolicy()
+        assert policy.max_timeout_retries == 1
+
+    def test_backwards_compatible_should_retry(self) -> None:
+        """The original should_retry method is unchanged."""
+        policy = FallbackPolicy(max_retries=3)
+        kind = ProviderErrorKind.TRANSPORT_TRANSIENT
+
+        assert policy.should_retry(kind, 0) is True
+        assert policy.should_retry(kind, 2) is True
+        assert policy.should_retry(kind, 3) is False


### PR DESCRIPTION
## Linked issue

Fixes #860

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

When Auto Pilot routes to a model (e.g. `gpt-5.6-luna` on `c1`) and the upstream endpoint times out or returns a pre-content error, the runtime now automatically falls back to alternative tier models configured in the router profile instead of retrying the same failing model 3 times (~6 min freeze).

### Changes

| File | What changed |
|---|---|
| `provider/failures.py` | Add `is_transport_timeout()` classifier to distinguish hard timeouts from transient blips |
| `engine/fallback.py` | Add `max_timeout_retries=1` and `should_retry_timeout()` to cap timeout retries at 1 |
| `engine/agent.py` | Use `should_retry_timeout`, emit `WarningEvent(code="provider_timeout_retry")`, enrich terminal `ErrorEvent` with actionable guidance (`/c0`, `/c2`, `/auto`) |
| `engine/runtime.py` | Add `_derive_router_tier_fallbacks()` to build prioritised fallback chain from active router tiers; update `_SelectorFallbackProvider` to emit `ProviderHeartbeatEvent(phase="llm_fallback")` and cascade through fallbacks in `_fallback_chat` |
| `provider/selector.py` | Extend `ModelSelector.override_model()` with optional `fallbacks` parameter |
| `turn_runner/prompt_assembler_stage.py` | Derive tier fallbacks in prompt assembler path when selector has no existing fallbacks |

### Behavior

1. Auto Pilot selects `c1` → `gpt-5.6-luna` which hangs/times out
2. `_SelectorFallbackProvider` catches the pre-content error, advances to `c2` → `glm-5.3`
3. UI sees heartbeat: *"Model gpt-5.6-luna failed; automatically switching to fallback model glm-5.3."*
4. If `glm-5.3` also fails, cascades to `c0` → `deepseek-v4-flash`, etc.
5. Only if all tier fallbacks are exhausted does the agent retry loop fire (capped at 1 retry for timeouts)

## Tests

```sh
# New regression tests (16 tests)
uv run pytest tests/test_engine/test_auto_pilot_tier_fallback.py tests/test_engine/test_transport_timeout_reduced_retries.py -q
# 16 passed

# Existing fallback/breaker tests
uv run pytest tests/test_engine/test_selector_fallback_circuit_breaker.py tests/test_provider_failures.py -q
# 18 passed

# Full engine suite
uv run pytest tests/test_engine -q
# 1025 passed

# Quality gate
uv run ruff check src tests          # All checks passed
uv run mypy src/agentos --show-error-codes  # Success: 0 errors in 621 files
```