### PR TITLE
fix(skills): withhold price/holding for a confirmed Robinhood Chain i…

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -318,7 +318,24 @@ def inspect_token(
         if isinstance(onchain_symbol, str) and onchain_symbol:
             feed = find_feed(onchain_symbol, feeds)
 
-    if feed is not None:
+        # Prefer the ticker the contract reports over any caller-supplied hint, so
+    # an address-only run resolves its own feed.
+    if feed is None and feeds:
+        onchain_symbol = out.get("onchainSymbol")
+        if isinstance(onchain_symbol, str) and onchain_symbol:
+            feed = find_feed(onchain_symbol, feeds)
+
+    # `isStockToken: False` is documented (and tested) as "the caller should
+    # refuse this address" -- but attaching a real company's live Chainlink
+    # price to a contract already proven fake does the opposite: an
+    # impersonator can self-report a real ticker via symbol() (this lookup
+    # trusts that string, not the contract identity) and walk away wearing a
+    # genuine, accurate quote. Unverified (None) still gets a price -- only a
+    # *confirmed* impersonator is refused, per the same "unverified is not
+    # disproven" rule already applied to isStockToken itself above.
+    is_confirmed_fake = out["isStockToken"] is False
+
+    if feed is not None and not is_confirmed_fake:
         price = _try(
             lambda: _read_price(rpc_url, str(feed["proxyAddress"]), timeout, now), errors, "price"
         )
@@ -332,8 +349,10 @@ def inspect_token(
             beyond = isinstance(age, int) and isinstance(heartbeat, int) and age > heartbeat
             price["stale"] = bool(beyond or out.get("oraclePaused"))
             out["price"] = price
+    elif feed is not None and is_confirmed_fake:
+        errors["price"] = "withheld: uiMultiplier() proved this is not a Stock Token"
 
-    if holder:
+    if holder and not is_confirmed_fake:
         balance = _try(
             lambda: _word(
                 _eth_call(rpc_url, address, _encode_address_arg(SEL_BALANCE_OF, holder), timeout), 0
@@ -352,7 +371,6 @@ def inspect_token(
             if usd is not None:
                 holding["valueUsd"] = tokens_held * usd
             out["holding"] = holding
-
     if errors:
         out["readErrors"] = errors
     return out

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -265,11 +265,50 @@ def test_feed_lookup_is_skipped_when_the_symbol_is_unreadable(
     assert "price" not in state
 
 
+def test_confirmed_impersonator_does_not_get_a_real_tickers_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proven-fake contract must not be decorated with a genuine quote.
+
+    `isStockToken: False` is documented (see the test above) as "the caller
+    should refuse the address". Nothing stopped an impersonator from
+    self-reporting a real ticker via `symbol()` and having that string
+    resolve a legitimate Chainlink feed anyway -- the price is fetched by
+    ticker, not by cross-checking the contract's identity, so a proven fake
+    could still walk away wearing an accurate, credible-looking quote.
+    """
+    proxy = str(_FEEDS[0]["proxyAddress"]).lower()
+    chain = _FakeChain(
+        {
+            # The impersonator self-reports AAPL's real ticker...
+            (FAKE_GME, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32)
+            + _word_hex(4)
+            + b"AAPL".hex().ljust(64, "0"),
+            # ...but uiMultiplier() reverts: it is not a genuine Stock Token.
+            (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
+            + "".join(_word_hex(v) for v in (1, 31747461437, 0, 1788206389, 1)),
+            (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),
+        }
+    )
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+
+    state = chain_stocks.inspect_token("rpc", FAKE_GME, 5.0, feeds=_FEEDS, now=1788206389 + 60)
+
+    assert state["isStockToken"] is False
+    assert "price" not in state
+    assert "withheld" in state["readErrors"]["price"]
+
+
 def _price_chain(answer: int, updated_at: int, paused: int = 0) -> _FakeChain:
     proxy = str(_FEEDS[0]["proxyAddress"]).lower()
     return _FakeChain(
         {
             (AAPL, chain_stocks.SEL_ORACLE_PAUSED): "0x" + _word_hex(paused),
+            # A genuine Stock Token answers uiMultiplier(); these tests are
+            # exercising price-parsing math, not impersonator detection, so
+            # AAPL must resolve as real or price gets correctly withheld.
+            (AAPL, chain_stocks.SEL_UI_MULTIPLIER): "0x" + _word_hex(chain_stocks.WAD),
             (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
             + "".join(_word_hex(v) for v in (1, answer, 0, updated_at, 1)),
             (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),


### PR DESCRIPTION
## Linked issue

Fixes #866

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

`robinhood-chain-stocks` (merged in #747) reads on-chain state for
Robinhood Chain tokenized stocks, including `uiMultiplier()` — the
authoritative on-chain proof of whether a contract is a genuine Stock
Token or an impersonator. The PR's own stated purpose is to "stop RWA
lookup returning impersonators."

`inspect_token()` resolves the Chainlink price feed via
`find_feed(onchain_symbol, feeds)`, where `onchain_symbol` comes from the
target contract's own `symbol()` call — trusting that self-reported
string with no cross-check against the contract's verified identity.

This means a contract that **fails** `uiMultiplier()` (proven not a
genuine Stock Token — `isStockToken: false`) but implements `symbol()`
returning a real, listed ticker (e.g. `"GME"`) still gets that real
company's genuine, accurate, live Chainlink price attached to its
output. `SKILL.md`'s own documented contract states plainly:

> `false` | The node answered and the call **reverted** | Not a Stock
> Token — say so plainly, and **do not hand over the address**

but the script never enforced that for `price`/`holding` — a proven
impersonator walks away wearing a real company's live quote, with the
only disclaimer sitting in a low-visibility `notes`/`readErrors` field
alongside a prominently-populated, entirely accurate `price` object.

I confirmed this end-to-end with an offline repro: a fake contract
reverting on `uiMultiplier()` but self-reporting `symbol() == "GME"`
against a simulated genuine GameStop Chainlink feed still produces
`{"isStockToken": false, "price": {"usd": 25.0, ...}}` in the final
JSON output an agent would summarize for a user.

## Fix

`price` and `holding`/`valueUsd` are now withheld once `uiMultiplier()`
has proven the token is not genuine (`isStockToken is False`). A merely
*unverified* status (`None` — a network fault, not proof of anything)
still gets a price, preserving the file's own existing "unverified is
not disproven" principle already applied to `isStockToken` itself.

Per `SKILL.md`'s explicit reporting rule — *"Report `readErrors` and
`notes` rather than silently omitting a field"* — withholding the price
also adds `readErrors["price"] = "withheld: uiMultiplier() proved this
is not a Stock Token"`, so the omission is explained, not silent.

Deliberately **not** touched: `address`, `onchainSymbol`, `totalSupply`,
and `isStockToken` itself all stay in the output. `SKILL.md` documents
`--address 0x...` explicitly as a way to check a *suspect* address —
stripping the address itself would break that documented verification
workflow. Only the data *borrowed* from a real, unrelated contract's
oracle (`price`, and the `valueUsd` derived from it) is withheld.

## Tests

- `test_confirmed_impersonator_does_not_get_a_real_tickers_price` (new)
  — the exact repro: an impersonator self-reporting a real ticker no
  longer gets that ticker's price attached, and `readErrors` explains
  why.
- `_price_chain` (existing fixture, used by several price-parsing tests)
  now also mocks `uiMultiplier()` for `AAPL`, since those tests exercise
  price-parsing math against what's meant to represent a *genuine*
  token — before this fix, `isStockToken` didn't gate price attachment,
  so the fixture's missing mock was silently inconsequential; after this
  fix it would have made every price-parsing test look like it was
  hitting a confirmed impersonator. Making the fixture accurately
  simulate a real Stock Token is the correct fix, not a workaround.

Commands run locally:
uv sync --extra dev
uv run ruff format src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py tests/test_skill_robinhood_chain_stocks.py
uv run ruff check src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py tests/test_skill_robinhood_chain_stocks.py
uv run mypy src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py --show-error-codes
uv run pytest tests/test_skill_robinhood_chain_stocks.py -v


Results: `ruff format`/`ruff check` — clean. `mypy` — no issues found.
`pytest` — 26 passed (25 pre-existing + 1 new), no regressions.

Third-party origin: none.