### PR TITLE
fix(slack): catch UnicodeDecodeError in _verify_signature (#680)

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -989,7 +989,13 @@ class SlackChannel:
         """Verify Slack request signature using HMAC-SHA256."""
         if self.signing_secret is None:
             return False
-        sig_basestring = f"v0:{timestamp}:{body.decode()}"
+        try:
+            body_str = body.decode("utf-8")
+        except UnicodeDecodeError:
+            # Non-UTF-8 body is never a valid Slack request; reject cleanly
+            # instead of crashing with an HTTP 500 (see issue #680).
+            return False
+        sig_basestring = f"v0:{timestamp}:{body_str}"
         expected = (
             "v0="
             + hmac.HMAC(


### PR DESCRIPTION
Fixes #680. `body.decode()` with strict UTF-8 raises UnicodeDecodeError on non-UTF-8 bodies, crashing with HTTP 500.