### PR TITLE
fix(observability): skip corrupted JSONL lines in load_entries (#812)

### DIFF
--- a/src/agentos/observability/decision_log.py
+++ b/src/agentos/observability/decision_log.py
@@ -276,7 +276,12 @@ def load_entries(path: Path) -> list[DecisionEntry]:
         line = line.strip()
         if not line:
             continue
-        payload = json.loads(line)
+        try:
+            payload = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            # Skip corrupted / partial JSONL lines (e.g. from a process
+            # killed mid-turn) so historical cost reporting survives.
+            continue
         payload = _coerce_decision_payload(payload)
         steps_payload = payload.pop("pipeline_steps", [])
         steps = [


### PR DESCRIPTION
Fixes #812. JSONL from a killed process mid-turn would crash `agentos cost savings` with JSONDecodeError.