### PR TITLE
fix(mcp): close DNS-rebinding gap in SSRF validation (extends #794/#797, fixes #662)

### DIFF
--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -11,7 +11,7 @@ from agentos import __version__
 from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
-
+from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
 
 class MCPSSEClient(MCPClient):
     """MCP client using SSE transport (HTTP POST for calls, SSE for responses)."""
@@ -70,7 +70,12 @@ class MCPSSEClient(MCPClient):
 
     async def connect(self) -> None:
         """Create the HTTP client session and perform MCP initialization handshake."""
-        self._client = httpx.AsyncClient(trust_env=_trust_env())
+        assert self.config.url is not None
+        if not self.config.url.startswith(("http://", "https://")):
+            raise ValueError("MCP server URL must use http or https scheme")
+        self._client = ssrf_guarded_client(
+            trust_env=_trust_env(), validator=validate_metadata_only_address
+        )
 
         # Send initialize request (response is acknowledged server-side;
         # we don't inspect it — the MCP spec only requires us to send the

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -20,6 +20,7 @@ from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 from agentos.paths import state_dir as default_state_dir
+from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
 
 
 class MCPDependencyError(RuntimeError):
@@ -145,6 +146,8 @@ class MCPStreamableHTTPClient(MCPClient):
     async def connect(self) -> None:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
+        if not self.config.url.startswith(("http://", "https://")):
+            raise ValueError("MCP server URL must use http or https scheme")
 
         try:
             from mcp.client.auth import OAuthClientProvider
@@ -178,11 +181,12 @@ class MCPStreamableHTTPClient(MCPClient):
         stack = AsyncExitStack()
         try:
             http_client = await stack.enter_async_context(
-                httpx.AsyncClient(
+                ssrf_guarded_client(
                     auth=auth,
                     headers=self.config.headers,
                     timeout=httpx.Timeout(self.config.tool_timeout_seconds),
                     trust_env=_trust_env(),
+                    validator=validate_metadata_only_address
                 )
             )
             read_stream, write_stream, _ = await stack.enter_async_context(

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -34,6 +34,8 @@ _METADATA_HOSTNAMES: frozenset[str] = frozenset(
         "metadata.google.internal",
         "metadata.goog",
         "instance-data",
+        "metadata.azure.com",
+        "metadata.azure.net",
     }
 )
 
@@ -46,6 +48,7 @@ _METADATA_ADDRESSES: frozenset[IPAddress] = frozenset(
         ipaddress.ip_address("169.254.169.253"),  # Azure IMDS wire server
         ipaddress.ip_address("169.254.170.2"),  # AWS ECS task role credentials
         ipaddress.ip_address("100.100.100.200"),  # Alibaba Cloud
+        ipaddress.ip_address("192.0.0.192"),  # Azure IMDS (legacy wire server)
         ipaddress.ip_address("fd00:ec2::254"),  # AWS metadata over IPv6
     }
 )

--- a/tests/test_mcp/test_mcp_ssrf.py
+++ b/tests/test_mcp/test_mcp_ssrf.py
@@ -1,0 +1,110 @@
+"""Regression tests for MCP server URL validation.
+
+The MCP HTTP/SSE/streamable-HTTP transports connect to operator-configured
+``config.url`` values. Both transports must reject cloud-metadata endpoints
+and any URL whose scheme is not http(s) — and, critically, must validate the
+address the socket actually dials rather than just the URL text once
+upfront, or a short-TTL DNS-rebinding domain bypasses the check entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.mcp.sse import MCPSSEClient
+from agentos.mcp.streamable_http import MCPStreamableHTTPClient
+from agentos.mcp.types import MCPServerConfig
+from agentos.tools.ssrf_client import ValidatingNetworkBackend
+
+
+def _contains(exc: BaseException, cls: type[BaseException]) -> bool:
+    """True if *exc* is *cls*, or an ExceptionGroup containing one.
+
+    The streamable-HTTP transport runs inside an anyio task group (part of
+    the upstream MCP SDK), so an error raised deep in a background task
+    surfaces wrapped in an ExceptionGroup rather than directly — the block
+    still happened, it just isn't the top-level exception type.
+    """
+    if isinstance(exc, cls):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_contains(sub, cls) for sub in exc.exceptions)
+    return False
+
+
+def _sse(url: str) -> MCPSSEClient:
+    return MCPSSEClient(MCPServerConfig(name="mcp", transport="sse", url=url))
+
+
+def _http(url: str) -> MCPStreamableHTTPClient:
+    return MCPStreamableHTTPClient(
+        MCPServerConfig(name="mcp", transport="streamable_http", url=url)
+    )
+
+
+CLOUD_METADATA_URLS = [
+    "http://169.254.169.254/metadata/instance",
+    "http://169.254.169.254/computeMetadata/v1/",
+    "http://[fd00:ec2::254]/latest/meta-data/",
+    "http://metadata.google.internal/computeMetadata/v1/",
+    "http://metadata.azure.com/metadata/instance",
+    "http://100.100.100.200/latest/meta-data/",
+    "http://192.0.0.192/latest/meta-data/",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", CLOUD_METADATA_URLS)
+@pytest.mark.parametrize("factory", [_sse, _http])
+async def test_mcp_transports_reject_metadata_endpoints(url: str, factory) -> None:
+    client = factory(url)
+    with pytest.raises((ValueError, BaseExceptionGroup)) as exc_info:
+        await client.connect()
+    assert _contains(exc_info.value, ValueError), (
+        f"connect() raised {type(exc_info.value).__name__} but it wasn't (or "
+        "didn't contain) a ValueError/SSRFBlockedError"
+    )
+
+
+BAD_SCHEMES = [
+    "file:///etc/passwd",
+    "gopher://169.254.169.254/metadata",
+    "ftp://example.com/secret",
+    "javascript:alert(1)",
+    "data:text/plain,hello",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", BAD_SCHEMES)
+@pytest.mark.parametrize("factory", [_sse, _http])
+async def test_mcp_transports_reject_non_http_schemes(url: str, factory) -> None:
+    client = factory(url)
+    with pytest.raises((ValueError, BaseExceptionGroup)) as exc_info:
+        await client.connect()
+    assert _contains(exc_info.value, ValueError)
+
+
+@pytest.mark.asyncio
+async def test_mcp_sse_uses_connect_time_ssrf_guard() -> None:
+    """The client must validate the address it actually dials, not just the
+    URL text once upfront — otherwise a DNS-rebinding domain (safe answer for
+    the pre-check, metadata IP for the real connect) bypasses the guard.
+
+    This is a structural check: it proves ssrf_guarded_client's
+    ValidatingNetworkBackend is actually installed on the transport, rather
+    than trying to simulate live DNS rebinding.
+    """
+    client = _sse("http://127.0.0.1:1")  # loopback: allowed by policy, port closed
+    try:
+        await client.connect()
+    except Exception:
+        pass  # connecting to a closed local port is expected to fail
+    assert client._client is not None, "connect() must set self._client before the handshake"
+    backend = client._client._transport._pool._network_backend
+    assert isinstance(backend, ValidatingNetworkBackend), (
+        "MCPSSEClient is not using ssrf_guarded_client — it will re-resolve the "
+        "hostname a second time at connect, outside any SSRF check, which a "
+        "DNS-rebinding domain can exploit."
+    )
+    await client.close()


### PR DESCRIPTION
Fixes #662.

## Problem

MCP SSE and Streamable HTTP transports connect to `MCPServerConfig.url`
via httpx with no SSRF validation, so cloud-metadata endpoints
(169.254.169.254, `metadata.google.internal`, Azure IMDS, etc.) and
disallowed schemes were reachable through MCP server config — an
attacker who controls or injects the MCP server URL can exfiltrate
instance credentials.

Two other PRs are open against this issue (#794, #797). Both correctly
identify that MCP needs a *metadata-only* block (not the stricter
private/LAN-blocking policy `validate_http_url_for_fetch` uses, since
MCP servers routinely run on localhost/LAN) — but both have the same
underlying gap, described below.

## Root cause the other PRs don't close

Both #794 and #797 validate the URL text once with a one-shot check
(`assert_not_metadata_endpoint` / `validate_mcp_server_url`, which
wraps the same function), then construct a **bare `httpx.AsyncClient()`**:

​```python
assert_not_metadata_endpoint(self.config.url)   # resolves hostname once
self._client = httpx.AsyncClient(trust_env=_trust_env())  # resolves again at connect
​```

httpx independently re-resolves the hostname when it actually opens the
TCP connection. A domain with a short-TTL DNS record can answer with a
safe public IP for the pre-check and swap to `169.254.169.254` before
the real connect a moment later — a standard TOCTOU/DNS-rebinding
bypass. Neither PR's test suite catches this: both only test literal
metadata IPs and known metadata hostnames, which the one-shot check
does handle correctly.

## Fix

This codebase already has the connect-time-safe version of this policy:
`agentos.tools.ssrf_client.ssrf_guarded_client()`. It wraps httpx's
network backend so the address that gets *validated* is the address
that gets *dialed* — no second resolution, no window. It's already used
by `http_request`, `web_fetch`, `media`, and `x_search` with the
identical metadata-only policy (`validate_metadata_only_address`). The
MCP transports just never adopted it.

​```python
self._client = ssrf_guarded_client(
    trust_env=_trust_env(), validator=validate_metadata_only_address
)
​```

## What changed

- `src/agentos/mcp/sse.py` — `MCPSSEClient.connect()`: scheme check +
  `ssrf_guarded_client(validator=validate_metadata_only_address)`
  instead of a bare `httpx.AsyncClient()`
- `src/agentos/mcp/streamable_http.py` — `MCPStreamableHTTPClient.connect()`:
  same swap for the `http_client` passed into `streamable_http_client()`
- `src/agentos/tools/ssrf.py` — added Azure IMDS hostname/IP coverage
  (`metadata.azure.com`, `metadata.azure.net`, `192.0.0.192`), carried
  over from #794's second commit since it's a genuine improvement
  independent of the connect-time issue
- `tests/test_mcp/test_mcp_ssrf.py` — new file:
  - 14 cases confirming metadata endpoints are still rejected (same
    coverage as #794/#797)
  - 10 cases confirming bad schemes are rejected
  - **1 structural regression test** that specifically targets the gap:
    asserts the transport's httpx client has `ValidatingNetworkBackend`
    installed. This is the test that distinguishes this fix from the
    other two PRs — it fails against their exact approach (verified
    locally by reverting to their pattern and rerunning: their 14
    metadata-URL tests still pass, but this one fails) and passes here.

## Verification

- `pytest tests/test_mcp/test_mcp_ssrf.py -v` → 25/25 passed
- Confirmed the new structural test actually catches the class of bug
  it's meant to catch (not just passing trivially): reverted `sse.py`
  to the `assert_not_metadata_endpoint` + bare-`httpx.AsyncClient`
  pattern used by #794/#797, reran — the 14 metadata-URL tests still
  passed (14/14) but `test_mcp_sse_uses_connect_time_ssrf_guard` failed,
  exactly as expected. Restored the real fix, full suite passes again.

## Relationship to #794 / #797

Not proposing to just pile on a third competing PR — happy for a
maintainer to cherry-pick pieces (e.g. #794's Azure IMDS additions are
already folded in here) or close this in favor of either PR being
updated in place with the `ssrf_guarded_client` swap, whichever is less
churn. Left the same explanation as a comment on #662 so both PR
authors see it regardless of which PR ends up merging.