### PR TITLE
fix(gateway): restrict RateLimitMiddleware UI exemption to static shell only (#748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `RateLimitMiddleware._is_ui_path` now excludes the ``{base_path}/api/``
+  subtree, so the Control UI JSON/RPC surface is still subject to per-IP
+  rate limiting (previously entirely exempt — #748).
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/gateway/middleware.py
+++ b/src/agentos/gateway/middleware.py
@@ -329,9 +329,17 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._last_sweep: float = 0.0
 
     def _is_ui_path(self, path: str) -> bool:
+        """Exempt the static UI shell from rate limiting.
+
+        The UI prefix exemption stops at ``{base_path}/api/`` so that the
+        JSON/RPC surface under the Control UI prefix is still subject to
+        per-IP rate limiting (see #748).
+        """
         if self._ui_prefix is None:
             return False
-        return _is_under(self._ui_prefix, path)
+        if not _is_under(self._ui_prefix, path):
+            return False
+        return not _is_under(self._ui_prefix + _API_PREFIX, path)
 
     def _is_trusted_proxy(self, peer_ip: str | None) -> bool:
         return peer_is_trusted_proxy(self._config.auth.trusted_proxy, peer_ip)


### PR DESCRIPTION
## Summary

Fixes #748 — P2 Security

`RateLimitMiddleware._is_ui_path` was exempting the **entire** Control UI prefix tree (`/control/*`) from per-IP rate limiting, including the JSON/RPC API surface at `/control/api/*`. This allowed unlimited requests to `sessions`, `config`, `chat`, and other API endpoints without triggering any throttle.

## Root Cause

`AuthMiddleware._is_ui_path` and `CorsMiddleware._is_ui_path` already include the guard `return not _is_under(self._ui_prefix + _API_PREFIX, path)` — but this guard was **not carried over** to `RateLimitMiddleware._is_ui_path`.

## Change

Mirrored the same `/api/` exclusion in `RateLimitMiddleware._is_ui_path`: exempt only the static UI shell and its assets, while keeping JSON/RPC endpoints under rate limiting.

## Files

- `src/agentos/gateway/middleware.py` — 4 lines changed (added the `/api/` guard + docstring)
- `CHANGELOG.md`