### PR TITLE
fix(sandbox): block root filesystem paths in sensitive_path hard block (#563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `is_sensitive_path` now returns ``"/"`` for root filesystem references
+  (``/``, ``/*``, ``/.``), fixing ``rm -rf /`` and variants slipping past
+  the hard block (P0, #563).
+
 ## [2026.9.2] - 2026-09-02
 
 ### Added

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -139,7 +139,21 @@ def is_sensitive_path(path: str) -> str | None:
         return None
     if not path:
         return None
+
+    # Root filesystem /, /*, and /.  are critical and must never slip.
+    # Check BEFORE any path resolution because on Windows Path('/').resolve()
+    # returns 'C:\' (drive root), not '/' (#563).
+    raw = str(path).strip()
+    root_markers = ("/", "/*", "/.", "//", "///")
+    if raw in root_markers or raw.replace("\\", "/") in root_markers:
+        return "/"
+
     candidates = _comparison_path_candidates(path)
+
+    # Also check after normalization (catches '' from empty-after-strip)
+    for expanded in candidates:
+        if expanded == "":
+            return "/"
     for expanded in candidates:
         if (
             expanded == "/root/.ssh"

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -138,3 +138,28 @@ def test_sensitive_reads_in_a_later_segment_are_blocked_at_the_tool_boundary() -
         sensitive_path_in_text("rm /tmp/ok; cat /root/.bash_history", workspace=workspace)
         == "/root"
     )
+
+
+def test_sensitive_path_blocks_root_filesystem() -> None:
+    """Issue #563: ``rm -rf /``, ``rm -rf /*``, and ``rm -rf /.`` must
+    be blocked by the hard block (sensitive_target_in_command) because
+    ``/`` is not covered by _SENSITIVE_PREFIXES like ``/etc`` or ``/root``."""
+    workspace = Path("/workspace")
+
+    for cmd in [
+        "rm -rf /",
+        "rm -rf /*",
+        "rm -rf /.",
+        "rm -rf / .",
+    ]:
+        result = sensitive_target_in_command(cmd, workspace=workspace)
+        assert result == "/", f"Expected '/' marker for {cmd!r}, got {result!r}"
+
+
+def test_sensitive_path_is_path_root() -> None:
+    """Issue #563: ``is_sensitive_path`` must return ``'/'`` for root
+    filesystem references."""
+    for path in ("/", "/*", "/."):
+        assert (
+            is_sensitive_path(path) == "/"
+        ), f"Expected '/' for {path!r}, got {is_sensitive_path(path)!r}"


### PR DESCRIPTION
## Summary

Fixes #563 — **P0 Security** (host filesystem wipe)

`is_sensitive_path` returned `None` for bare root filesystem references (`/`, `/*`, `/.`), so `rm -rf /` (and variants) completely bypassed the pre-approval hard block and could wipe the host without any user prompt.

## Root Cause

`_SENSITIVE_PREFIXES` includes specific directories (`/etc`, `/root`, `/dev`, etc.) but not `/` itself. `is_sensitive_path("/")` fell through every prefix and suffix match and returned `None`.

## Changes

- **`is_sensitive_path`** checks root markers (`/`, `/*`, `/.`) before the prefix loop, returning `"/"` marker
- **2 new tests** confirming `sensitive_target_in_command("rm -rf /")` returns `"/"` marker
- Verified `test_active_workspace_under_root_is_not_blocked_by_root_prefix` still passes (no false positive for legitimate workspace paths under `/`)

## Files

- `src/agentos/sandbox/sensitive_paths.py` — root check added (6 lines)
- `tests/test_sandbox/test_sensitive_paths.py` — 2 new tests (26 lines, 11 total)
- `CHANGELOG.md`