### PR TITLE
fix(discord): preserve heartbeat reconnect task

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -308,8 +308,9 @@ class DiscordChannel:
 
     async def _do_reconnect(self) -> None:
         log.info("discord.reconnecting", session_id=self._state.session_id)
-        if self._heartbeat_task is not None:
-            self._heartbeat_task.cancel()
+        heartbeat_task = self._heartbeat_task
+        if heartbeat_task is not None and heartbeat_task is not asyncio.current_task():
+            heartbeat_task.cancel()
             self._heartbeat_task = None
         await self._close_ws()
 

--- a/tests/test_channels/test_discord_heartbeat_reconnect.py
+++ b/tests/test_channels/test_discord_heartbeat_reconnect.py
@@ -1,0 +1,74 @@
+"""Regression coverage for Discord heartbeat-initiated reconnects."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+
+
+def _stub_gateway_reconnect(channel: DiscordChannel) -> list[str]:
+    connected_urls: list[str] = []
+
+    async def connect_ws(url: str) -> object:
+        connected_urls.append(url)
+        return object()
+
+    async def recv() -> dict[str, Any]:
+        return {"d": {"heartbeat_interval": 60_000}}
+
+    async def send(_payload: dict[str, Any]) -> None:
+        return None
+
+    channel._connect_ws = connect_ws  # type: ignore[method-assign]
+    channel._ws_recv = recv  # type: ignore[method-assign]
+    channel._ws_send = send  # type: ignore[method-assign]
+    channel._state.resume_url = "wss://resume.example.test"  # noqa: SLF001
+    channel._connected = True  # noqa: SLF001
+    return connected_urls
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_timeout_does_not_cancel_its_own_reconnect() -> None:
+    channel = DiscordChannel(DiscordChannelConfig(token="token"))
+    connected_urls = _stub_gateway_reconnect(channel)
+    channel._state.last_heartbeat_ack = False  # noqa: SLF001
+
+    heartbeat_task = asyncio.create_task(channel._heartbeat_loop())  # noqa: SLF001
+    channel._heartbeat_task = heartbeat_task  # noqa: SLF001
+
+    await heartbeat_task
+
+    assert connected_urls == ["wss://resume.example.test"]
+    assert channel._reconnect_generation == 1  # noqa: SLF001
+    replacement = channel._heartbeat_task  # noqa: SLF001
+    assert replacement is not None
+    assert replacement is not heartbeat_task
+
+    channel._connected = False  # noqa: SLF001
+    replacement.cancel()
+    await asyncio.gather(replacement, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_external_reconnect_still_cancels_obsolete_heartbeat() -> None:
+    channel = DiscordChannel(DiscordChannelConfig(token="token"))
+    _stub_gateway_reconnect(channel)
+
+    obsolete = asyncio.create_task(asyncio.Event().wait())
+    channel._heartbeat_task = obsolete  # noqa: SLF001
+
+    await channel._do_reconnect()  # noqa: SLF001
+    await asyncio.sleep(0)
+
+    assert obsolete.cancelled()
+    replacement = channel._heartbeat_task  # noqa: SLF001
+    assert replacement is not None
+    assert replacement is not obsolete
+
+    channel._connected = False  # noqa: SLF001
+    replacement.cancel()
+    await asyncio.gather(replacement, return_exceptions=True)


### PR DESCRIPTION
## Summary

- avoid cancelling the currently executing Discord heartbeat task when it initiates a reconnect
- preserve cancellation of an obsolete heartbeat task when reconnect starts elsewhere
- add deterministic offline regression coverage for both reconnect paths

Fixes #882

## Testing

- `python scripts/build_control_ui.py build`
- `npm --prefix frontend run check` (98 files, 2,007 tests passed)
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- focused Discord tests (4 passed)
- `uv build --wheel`
- full pytest: 8,856 passed, 32 skipped; 6 failures and 3 setup errors are reproduced on clean `origin/main` in this checkout because the bundled ONNX file is an unhydrated 133-byte Git LFS pointer and local uv 0.8.15 does not support the `uv build --clear` option used by wheelhouse tests

## Third-party origins

None.