### PR TITLE
fix(gateway): clean up empty sets in SubscriptionManager._message_subs (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `SubscriptionManager._message_subs` now removes empty sets on
+  unsubscription and connection teardown, preventing a slow memory leak
+  on long-running gateways (#609).
+
 ## [2026.9.2] - 2026-09-02
 
 ### Added

--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -570,6 +570,8 @@ class SubscriptionManager:
     def unsubscribe_messages(self, conn_id: str, session_key: str) -> None:
         if session_key in self._message_subs:
             self._message_subs[session_key].discard(conn_id)
+            if not self._message_subs[session_key]:
+                del self._message_subs[session_key]
 
     def get_message_subscribers(self, session_key: str) -> set[str]:
         return set(self._message_subs.get(session_key, set()))
@@ -591,8 +593,13 @@ class SubscriptionManager:
     def remove_connection(self, conn_id: str) -> None:
         """Clean up all subscriptions for a disconnected connection."""
         self._session_subs.discard(conn_id)
-        for subs in self._message_subs.values():
+        empty_keys: list[str] = []
+        for key, subs in self._message_subs.items():
             subs.discard(conn_id)
+            if not subs:
+                empty_keys.append(key)
+        for key in empty_keys:
+            del self._message_subs[key]
         empty_topics = []
         for topic, subs in self._topic_subs.items():
             subs.discard(conn_id)

--- a/tests/test_gateway/test_subscription_manager.py
+++ b/tests/test_gateway/test_subscription_manager.py
@@ -1,0 +1,82 @@
+"""SubscriptionManager tests — primarily leak detection on unsubscription."""
+
+from __future__ import annotations
+
+from agentos.gateway.websocket import SubscriptionManager
+
+
+def test_subscribe_messages_populates_dict() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "session-A")
+    mgr.subscribe_messages("conn-2", "session-A")
+    mgr.subscribe_messages("conn-1", "session-B")
+
+    assert mgr.get_message_subscribers("session-A") == {"conn-1", "conn-2"}
+    assert mgr.get_message_subscribers("session-B") == {"conn-1"}
+    # Keys exist in internal dict
+    assert "session-A" in mgr._message_subs
+    assert "session-B" in mgr._message_subs
+
+
+def test_unsubscribe_messages_removes_conn_and_empties_key() -> None:
+    """Issue #609: after discarding the last subscriber, the session key
+    must be deleted from _message_subs to prevent leaking empty sets."""
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "session-A")
+    mgr.subscribe_messages("conn-2", "session-A")
+
+    mgr.unsubscribe_messages("conn-1", "session-A")
+    assert mgr.get_message_subscribers("session-A") == {"conn-2"}
+    assert "session-A" in mgr._message_subs  # still has conn-2
+
+    mgr.unsubscribe_messages("conn-2", "session-A")
+    assert mgr.get_message_subscribers("session-A") == set()
+    # Session key must be cleaned up (issue #609)
+    assert "session-A" not in mgr._message_subs
+
+
+def test_unsubscribe_messages_on_single_subscriber_removes_key() -> None:
+    """Single subscriber unsubscribing must clean up the empty set."""
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "session-A")
+    mgr.unsubscribe_messages("conn-1", "session-A")
+    assert "session-A" not in mgr._message_subs
+
+
+def test_remove_connection_cleans_up_empty_keys() -> None:
+    """Issue #609: after remove_connection discards the last subscriber for
+    a session, the empty set must be deleted from _message_subs."""
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "session-A")
+    mgr.subscribe_messages("conn-1", "session-B")
+    mgr.subscribe_messages("conn-2", "session-A")
+
+    mgr.remove_connection("conn-2")
+    assert "session-A" in mgr._message_subs  # conn-1 still subbed
+
+    mgr.remove_connection("conn-1")
+    assert "session-A" not in mgr._message_subs
+    assert "session-B" not in mgr._message_subs
+
+
+def test_remove_connection_does_not_affect_other_connections() -> None:
+    mgr = SubscriptionManager()
+    mgr.subscribe_messages("conn-1", "session-A")
+    mgr.subscribe_messages("conn-2", "session-A")
+
+    mgr.remove_connection("conn-1")
+    assert "session-A" in mgr._message_subs
+    assert mgr.get_message_subscribers("session-A") == {"conn-2"}
+
+
+def test_topic_subscription_cleanup_existing() -> None:
+    """topic subs already had the correct cleanup pattern — verify it works."""
+    mgr = SubscriptionManager()
+    mgr.subscribe_topic("conn-1", "topic-A")
+    mgr.subscribe_topic("conn-2", "topic-A")
+
+    mgr.unsubscribe_topic("conn-2", "topic-A")
+    assert "topic-A" in mgr._topic_subs
+
+    mgr.unsubscribe_topic("conn-1", "topic-A")
+    assert "topic-A" not in mgr._topic_subs


### PR DESCRIPTION
## Summary

Fixes #609 — P3 memory leak

`unsubscribe_messages` and `remove_connection` both discarded `conn_id` from the per-session set, but **never removed the session_key entry** when the set became empty. Every created-and-deleted session left a lingering empty `set()` in `_message_subs`.

## Changes

- `unsubscribe_messages`: delete the key from `_message_subs` after discarding if the set is empty
- `remove_connection`: collect empty keys during iteration, then delete them (avoids dict mutation during iteration)
- `subscribe_topic` → `unsubscribe_topic` already had this cleanup pattern correctly ✅ — used as reference

## New tests (6 total, all passing)

| Test | What it verifies |
|---|---|
| `test_subscribe_messages_populates_dict` | basic setup |
| `test_unsubscribe_messages_removes_conn_and_empties_key` | key deleted after last subscriber leaves |
| `test_unsubscribe_messages_on_single_subscriber_removes_key` | single subscriber cleanup |
| `test_remove_connection_cleans_up_empty_keys` | disconnect cleanup for all sessions |
| `test_remove_connection_does_not_affect_other_connections` | unrelated sessions unaffected |
| `test_topic_subscription_cleanup_existing` | topic cleanup already works (regression guard) |