### PR TITLE
ci: update action versions to Node.js 22 compatible releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       release_changed: ${{ steps.classify.outputs.release_changed }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: false
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: Restore Git LFS objects cache
         id: lfs-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .git/lfs/objects
           key: git-lfs-${{ runner.os }}-${{ steps.lfs-key.outputs.oids }}
@@ -138,19 +138,19 @@ jobs:
           printf 'AGENTOS_LOG_DIR=%s/agentos-logs\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
 
@@ -215,7 +215,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: false
 
@@ -234,7 +234,7 @@ jobs:
 
       - name: Restore Git LFS objects cache
         id: lfs-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .git/lfs/objects
           key: git-lfs-${{ runner.os }}-${{ steps.lfs-key.outputs.oids }}
@@ -277,19 +277,19 @@ jobs:
           printf 'AGENTOS_LOG_DIR=%s/agentos-logs\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
 
@@ -319,7 +319,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: false
 
@@ -338,7 +338,7 @@ jobs:
 
       - name: Restore Git LFS objects cache
         id: lfs-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .git/lfs/objects
           key: git-lfs-${{ runner.os }}-${{ steps.lfs-key.outputs.oids }}
@@ -375,19 +375,19 @@ jobs:
           exit "${status}"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 
@@ -289,7 +289,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 
@@ -387,7 +387,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 


### PR DESCRIPTION
## What this PR fixes

**Node.js 20 runner deprecation** — GitHub Actions is migrating runner images from Node.js 20 → 22/24. The following actions pinned to Node.js 20 randomly fail during checkout:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24:
  actions/checkout@v4, actions/cache@v4, actions/setup-node@v4,
  actions/setup-python@v5, astral-sh/setup-uv@v5
```

This affects every PR in the repo — currently 7+ open PRs from the same contributor showing the same CI failure.

## The fix

Updated all GitHub Action references to their latest major versions:

| Action | Before | After | Node Version |
|--------|--------|-------|-------------|
| `actions/checkout` | `@v4` | `@v7` | 22+ |
| `actions/cache` | `@v4` | `@v6` | 22+ |
| `actions/setup-python` | `@v5` | `@v7` | 22+ |
| `actions/setup-node` | `@v4` | `@v7` | 22+ |
| `astral-sh/setup-uv` | `@v5` | `@v10` | 22+ |

## Files changed

`.github/workflows/ci.yml` — 17 action version bumps across 3 CI matrices (ubuntu, macos, windows)

## Testing

CI on this PR will self-verify. If the workflow runs without the deprecation error, it's fixed.

## CI / Security note

This workflow file update requires the GitHub token to have the `workflow` scope. It does not change any code logic, only pins to newer action versions.