### PR TITLE
fix(code_exec): prevent static pattern bypass via AST destructive call detection (#848)

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -25,8 +25,8 @@ from agentos.tools.types import ToolError, current_tool_context
 
 # Destructive Python patterns that must go through the same approval flow as
 # shell warnlist hits. Catches the "agent pivots from `rm` to `os.remove()`"
-# bypass. Matching is intentionally shallow (regex, not AST) — goal is to
-# force approval on obvious intent, not to prove safety.
+# bypass. We scan using shallow regex (fast-path) plus AST analysis to catch
+# dynamic evasion (getattr, __import__, importlib, exec/eval, and wildcard imports).
 _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
     (r"\bos\.remove\s*\(", "os.remove()"),
     (r"\bos\.unlink\s*\(", "os.unlink()"),
@@ -46,13 +46,209 @@ _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
     ),
 ]
 
+_OS_DESTRUCTIVE_ATTRS: frozenset[str] = frozenset({"remove", "unlink", "rmdir", "removedirs"})
+_SHUTIL_DESTRUCTIVE_ATTRS: frozenset[str] = frozenset({"rmtree", "rmdir"})
+_PATH_DESTRUCTIVE_ATTRS: frozenset[str] = frozenset({"unlink", "rmdir"})
+_ALL_DESTRUCTIVE_NAMES: frozenset[str] = frozenset(
+    {"remove", "unlink", "rmdir", "removedirs", "rmtree"}
+)
+_SUBPROCESS_CALL_NAMES: frozenset[str] = frozenset(
+    {"run", "call", "Popen", "check_output", "check_call"}
+)
+
+
+def _eval_const_str(node: ast.AST) -> str | None:
+    """Evaluate a statically resolvable string expression (literals, concat, f-strings)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.FormattedValue):
+        return _eval_const_str(node.value)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _eval_const_str(node.left)
+        right = _eval_const_str(node.right)
+        if left is not None and right is not None:
+            return left + right
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for val in node.values:
+            part = _eval_const_str(val)
+            if part is None:
+                return None
+            parts.append(part)
+        return "".join(parts)
+    return None
+
+
+def _resolve_module_from_node(node: ast.AST, aliases: dict[str, str]) -> str | None:
+    """Return the canonical module name ('os', 'shutil', etc.) if node resolves to one."""
+    if isinstance(node, ast.Name):
+        return aliases.get(node.id, node.id)
+    if isinstance(node, ast.Call):
+        # __import__("os")
+        if isinstance(node.func, ast.Name) and node.func.id == "__import__" and node.args:
+            mod = _eval_const_str(node.args[0])
+            if mod:
+                return aliases.get(mod, mod)
+        # importlib.import_module("os")
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "import_module":
+            mod_val = _resolve_module_from_node(node.func.value, aliases)
+            if mod_val == "importlib" and node.args:
+                mod = _eval_const_str(node.args[0])
+                if mod:
+                    return aliases.get(mod, mod)
+    return None
+
+
+class _DestructiveCodeVisitor(ast.NodeVisitor):
+    """AST visitor detecting obfuscated and dynamic destructive operations."""
+
+    def __init__(self) -> None:
+        self.warning: str | None = None
+        self.module_aliases: dict[str, str] = {
+            "os": "os",
+            "shutil": "shutil",
+            "pathlib": "pathlib",
+            "subprocess": "subprocess",
+            "importlib": "importlib",
+        }
+        self.destructive_funcs: dict[str, str] = {}
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            target = alias.asname or alias.name
+            if alias.name in ("os", "shutil", "pathlib", "subprocess", "importlib"):
+                self.module_aliases[target] = alias.name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        mod = node.module or ""
+        canonical = self.module_aliases.get(mod, mod)
+        if canonical == "os":
+            for alias in node.names:
+                name = alias.name
+                target = alias.asname or name
+                if name == "*":
+                    for fn in _OS_DESTRUCTIVE_ATTRS:
+                        self.destructive_funcs[fn] = f"os.{fn}()"
+                elif name in _OS_DESTRUCTIVE_ATTRS:
+                    self.destructive_funcs[target] = f"os.{name}()"
+        elif canonical == "shutil":
+            for alias in node.names:
+                name = alias.name
+                target = alias.asname or name
+                if name == "*":
+                    for fn in _SHUTIL_DESTRUCTIVE_ATTRS:
+                        self.destructive_funcs[fn] = f"shutil.{fn}()"
+                elif name in _SHUTIL_DESTRUCTIVE_ATTRS:
+                    self.destructive_funcs[target] = f"shutil.{name}()"
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self.warning is not None:
+            return
+
+        # 1. Direct function call: remove(), r(), etc.
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+            if func_name in self.destructive_funcs:
+                self.warning = (
+                    f"destructive Python operation detected: {self.destructive_funcs[func_name]}"
+                )
+                return
+
+            # 2. Dynamic getattr: getattr(os, "rem"+"ove"), getattr(Path, "unlink"), etc.
+            if func_name == "getattr" and len(node.args) >= 2:
+                attr_name = _eval_const_str(node.args[1])
+                if attr_name in _ALL_DESTRUCTIVE_NAMES:
+                    mod = _resolve_module_from_node(node.args[0], self.module_aliases)
+                    if mod == "os" and attr_name in _OS_DESTRUCTIVE_ATTRS:
+                        self.warning = (
+                            f"destructive Python operation detected: os.{attr_name}() via getattr"
+                        )
+                        return
+                    if mod == "shutil" and attr_name in _SHUTIL_DESTRUCTIVE_ATTRS:
+                        self.warning = (
+                            f"destructive Python operation detected: "
+                            f"shutil.{attr_name}() via getattr"
+                        )
+                        return
+                    if attr_name in _PATH_DESTRUCTIVE_ATTRS:
+                        self.warning = (
+                            f"destructive Python operation detected: Path.{attr_name}() via getattr"
+                        )
+                        return
+                    self.warning = (
+                        f"destructive Python operation detected: {attr_name}() via getattr"
+                    )
+                    return
+
+            # 3. eval() or exec() with embedded destructive code
+            if func_name in ("eval", "exec") and node.args:
+                inner_code = _eval_const_str(node.args[0])
+                if inner_code:
+                    inner_warning = _check_code_destructive(inner_code)
+                    if inner_warning:
+                        self.warning = (
+                            f"destructive Python operation detected: "
+                            f"{func_name}() with {inner_warning}"
+                        )
+                        return
+
+        # 4. Method call on an attribute: obj.method()
+        if isinstance(node.func, ast.Attribute):
+            attr_name = node.func.attr
+            mod = _resolve_module_from_node(node.func.value, self.module_aliases)
+
+            if mod == "os" and attr_name in _OS_DESTRUCTIVE_ATTRS:
+                self.warning = f"destructive Python operation detected: os.{attr_name}()"
+                return
+            if mod == "shutil" and attr_name in _SHUTIL_DESTRUCTIVE_ATTRS:
+                self.warning = f"destructive Python operation detected: shutil.{attr_name}()"
+                return
+            if attr_name in _PATH_DESTRUCTIVE_ATTRS:
+                self.warning = f"destructive Python operation detected: Path.{attr_name}()"
+                return
+
+            if mod == "os" and attr_name in ("system", "popen") and node.args:
+                cmd_str = _eval_const_str(node.args[0])
+                if cmd_str and re.search(r"\b(rm|rmdir)\b", cmd_str):
+                    self.warning = f"destructive Python operation detected: os.{attr_name} with rm"
+                    return
+
+            if mod == "subprocess" and attr_name in _SUBPROCESS_CALL_NAMES and node.args:
+                first_arg = node.args[0]
+                if isinstance(first_arg, ast.List):
+                    parts = [_eval_const_str(elt) for elt in first_arg.elts]
+                    if any(p in ("rm", "rmdir") for p in parts if p is not None):
+                        self.warning = (
+                            "destructive Python operation detected: subprocess invoking rm"
+                        )
+                        return
+                else:
+                    cmd_str = _eval_const_str(first_arg)
+                    if cmd_str and re.search(r"\b(rm|rmdir)\b", cmd_str):
+                        self.warning = (
+                            "destructive Python operation detected: subprocess invoking rm"
+                        )
+                        return
+
+        self.generic_visit(node)
+
 
 def _check_code_destructive(code: str) -> str | None:
     """Return a human-readable warning if *code* triggers a destructive pattern, else None."""
     for pattern, label in _DESTRUCTIVE_PY_PATTERNS:
         if re.search(pattern, code):
             return f"destructive Python operation detected: {label}"
-    return None
+
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return None
+
+    visitor = _DestructiveCodeVisitor()
+    visitor.visit(tree)
+    return visitor.warning
 
 
 _CODE_SENSITIVE_READ_TOKENS = (

--- a/tests/test_tools/test_code_exec_destructive_ast.py
+++ b/tests/test_tools/test_code_exec_destructive_ast.py
@@ -1,0 +1,92 @@
+"""Tests for AST-based detection of destructive operations in code_exec (Issue #848).
+
+Verifies that static regex evasion techniques (getattr, string concatenation,
+__import__, importlib, exec/eval, wildcard imports, and import aliasing)
+are accurately caught without false positives on benign code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.tools.builtin.code_exec import _check_code_destructive
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_keyword"),
+    [
+        # Concatenated strings in getattr
+        ('import os; getattr(os, "rem" + "ove")("/tmp/x")', "remove"),
+        ('import os; getattr(os, "un" + "link")("/tmp/x")', "unlink"),
+        ('import os; getattr(os, "rm" + "dir")("/tmp/x")', "rmdir"),
+        ('import shutil; getattr(shutil, "rm" + "tree")("/tmp/x")', "rmtree"),
+        # f-strings in getattr
+        ('import os; getattr(os, f"{\'rem\'}ove")("/tmp/x")', "remove"),
+        # Dynamic __import__
+        ('__import__("os").remove("/tmp/x")', "remove"),
+        ('__import__("os").unlink("/tmp/x")', "unlink"),
+        ('__import__("shutil").rmtree("/tmp/x")', "rmtree"),
+        # Dynamic importlib.import_module
+        ('import importlib; importlib.import_module("os").remove("/tmp/x")', "remove"),
+        ('import importlib; importlib.import_module("shutil").rmtree("/tmp/x")', "rmtree"),
+        # exec / eval with nested destructive code
+        ("exec(\"os.remove('/tmp/x')\")", "remove"),
+        ("eval(\"os.remove('/tmp/x')\")", "remove"),
+        ('exec(\'getattr(os, "rem" + "ove")("/tmp/x")\')', "remove"),
+        # Wildcard imports
+        ("from os import *; remove('/tmp/x')", "remove"),
+        ("from os import *; unlink('/tmp/x')", "unlink"),
+        ("from shutil import *; rmtree('/tmp/x')", "rmtree"),
+        # Aliased imports
+        ("from os import remove as delete_file; delete_file('/tmp/x')", "remove"),
+        ("from shutil import rmtree as nukedir; nukedir('/tmp/x')", "rmtree"),
+        ("import os as my_os; my_os.remove('/tmp/x')", "remove"),
+        ("import shutil as s; s.rmtree('/tmp/x')", "rmtree"),
+        # Path methods via getattr
+        ('from pathlib import Path; getattr(Path("/tmp/x"), "unlink")()', "unlink"),
+        ('from pathlib import Path; getattr(Path("/tmp/x"), "rmdir")()', "rmdir"),
+        # Subprocess list invocation of rm
+        ('import subprocess; subprocess.run(["rm", "-rf", "/tmp/x"])', "subprocess invoking rm"),
+        ('import subprocess as sp; sp.call(["rmdir", "/tmp/x"])', "subprocess invoking rm"),
+    ],
+)
+def test_destructive_ast_evasions_detected(code: str, expected_keyword: str) -> None:
+    warning = _check_code_destructive(code)
+    assert warning is not None, f"Expected warning for: {code}"
+    assert "destructive Python operation detected:" in warning
+    assert expected_keyword.lower() in warning.lower()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # Standard list.remove should NOT trigger
+        "items = [1, 2, 3]\nitems.remove(2)",
+        # Set.remove should NOT trigger
+        "s = {1, 2, 3}\ns.remove(2)",
+        # Benign math/sys/os calls
+        "import math\nx = math.sqrt(16)",
+        "import os\ncwd = os.getcwd()",
+        "import os\nfiles = os.listdir('.')",
+        "import shutil\nshutil.copy('a.txt', 'b.txt')",
+        "from pathlib import Path\np = Path('a.txt').read_text()",
+        # Benign getattr
+        "import os\npath_fn = getattr(os, 'getcwd')",
+        "getattr(dict, 'get')",
+    ],
+)
+def test_benign_code_does_not_trigger_warning(code: str) -> None:
+    warning = _check_code_destructive(code)
+    assert warning is None, f"Unexpected warning for safe code: {warning}"
+
+
+def test_syntax_error_code_falls_back_to_regex() -> None:
+    # Syntax error with os.remove() still caught by regex fallback
+    bad_syntax_destructive = "os.remove( unclosed string"
+    warning = _check_code_destructive(bad_syntax_destructive)
+    assert warning is not None
+    assert "os.remove()" in warning
+
+    # Benign syntax error returns None
+    bad_syntax_benign = "def foo( unclosed"
+    assert _check_code_destructive(bad_syntax_benign) is None


### PR DESCRIPTION
Fixes #848

### Problem

In `src/agentos/tools/builtin/code_exec.py`, `_check_code_destructive(code)` relied exclusively on shallow regex patterns (`_DESTRUCTIVE_PY_PATTERNS`). This allowed arbitrary destructive commands to bypass approval gates and execute host file deletions through reflection and dynamic import constructs:
- `getattr(os, "rem" + "ove")("/path")`
- `__import__("os").remove("/path")`
- `importlib.import_module("os").remove("/path")`
- `exec("os.remove('...')")` or `eval(...)`
- `from os import *; remove("/path")`
- `from os import remove as r; r("/path")`
- `import os as o; o.remove("/path")`

### Fix

1. **AST-Based Destructive Operation Visitor (`_DestructiveCodeVisitor`)**:
   - Analyzes the parsed AST tree whenever regex fast-path does not match.
   - Evaluates statically resolvable string expressions (`_eval_const_str`) including string constants, binary additions (`"rem" + "ove"`), and formatted values in f-strings (`f"{'rem'}ove"`).
   - Tracks imports and aliases for `os`, `shutil`, `pathlib`, `subprocess`, and `importlib`.
   - Detects wildcard imports (`from os import *`, `from shutil import *`) and tracks imported functions as destructive in the local scope.
   - Detects dynamic `getattr` calls where the target resolves to a destructive attribute (`remove`, `unlink`, `rmdir`, `rmtree`, `removedirs`).
   - Detects dynamic `__import__` and `importlib.import_module` call chains.
   - Detects nested execution in `exec(...)` and `eval(...)` by recursively analyzing string literals.
   - Detects subprocess calls with list arguments (e.g. `subprocess.run(["rm", "-rf", ...])`).
2. **Safe Fallback**:
   - If code contains syntax errors (unparseable by `ast.parse`), falls back cleanly to the regex matcher so malformed code never fails open.
3. **No False Positives**:
   - Benign usages such as standard `list.remove()` or `set.remove()` are unaffected.
4. **Comprehensive Test Suite**:
   - Added `tests/test_tools/test_code_exec_destructive_ast.py` with 34 tests covering all identified bypass vectors, benign calls, and syntax error fallback.

### Verification

- `uv run ruff check src tests` (all checks passed)
- `uv run mypy src/agentos --show-error-codes` (no issues found in 621 source files)
- `uv run pytest tests/test_tools/test_code_exec_destructive_ast.py -v` (34 passed in 2.70s)
- `uv run pytest tests/test_tools/test_shell_approval_policy.py -v` (73 passed in 8.69s)
