### PR TITLE
fix(session): serialize writes on shared SQLite connection

### DIFF
--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import Any
+from functools import wraps
+from typing import Any, Concatenate
 
 from agentos.compat import aiosqlite
 from agentos.session.keys import canonicalize_session_key, normalize_agent_id
@@ -21,6 +24,26 @@ from agentos.session.models import (
 )
 
 log = logging.getLogger(__name__)
+
+
+def _serialized_write[**P, R](
+    method: Callable[Concatenate[SessionStorage, P], Awaitable[R]],
+) -> Callable[Concatenate[SessionStorage, P], Awaitable[R]]:
+    """Hold transaction ownership for a complete mutating storage call."""
+
+    @wraps(method)
+    async def wrapped(
+        self: SessionStorage, /, *args: P.args, **kwargs: P.kwargs
+    ) -> R:
+        async with self._write_lock:
+            try:
+                return await method(self, *args, **kwargs)
+            except BaseException:
+                if self.conn.in_transaction:
+                    await self.conn.rollback()
+                raise
+
+    return wrapped
 
 
 class StaleEpochError(Exception):
@@ -416,6 +439,7 @@ class SessionStorage:
     ) -> None:
         self._db_path = db_path
         self._conn: Any | None = None
+        self._write_lock = asyncio.Lock()
 
     async def connect(self) -> None:
         self._conn = await aiosqlite.connect(self._db_path)
@@ -634,6 +658,7 @@ class SessionStorage:
 
     # ── Session CRUD ────────────────────────────────────────────────────────
 
+    @_serialized_write
     async def upsert_session(self, node: SessionNode) -> None:
         node.session_key = canonicalize_session_key(node.session_key)
         node.agent_id = normalize_agent_id(node.agent_id)
@@ -698,6 +723,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [SessionNode(**_deserialize_row(dict(r))) for r in rows]
 
+    @_serialized_write
     async def delete_session(self, session_key: str) -> None:
         session_key = canonicalize_session_key(session_key)
         session = await self.get_session(session_key)
@@ -756,6 +782,7 @@ class SessionStorage:
             row = await cur.fetchone()
         return row[0] if row else 0
 
+    @_serialized_write
     async def increment_epoch(self, session_key: str) -> int:
         """Atomically increment the epoch counter for a session.
 
@@ -786,6 +813,7 @@ class SessionStorage:
 
     # ── Project CRUD ────────────────────────────────────────────────────────
 
+    @_serialized_write
     async def upsert_project(self, project: ProjectNode) -> None:
         project.agent_id = normalize_agent_id(project.agent_id)
         data = project.model_dump()
@@ -800,6 +828,7 @@ class SessionStorage:
         await self.conn.execute(sql, values)
         await self.conn.commit()
 
+    @_serialized_write
     async def update_project_fields(
         self,
         project_id: str,
@@ -857,6 +886,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [ProjectNode(**dict(r)) for r in rows]
 
+    @_serialized_write
     async def delete_project(self, project_id: str) -> int:
         """Delete a project, detaching its sessions (they survive project-less).
 
@@ -902,6 +932,7 @@ class SessionStorage:
 
     # ── AgentTask ledger CRUD ───────────────────────────────────────────────
 
+    @_serialized_write
     async def create_agent_task(self, task: AgentTaskRecord) -> AgentTaskRecord:
         task.session_key = canonicalize_session_key(task.session_key)
         task.agent_id = normalize_agent_id(task.agent_id)
@@ -924,6 +955,7 @@ class SessionStorage:
             return None
         return AgentTaskRecord(**_deserialize_row(dict(row)))
 
+    @_serialized_write
     async def update_agent_task(self, task_id: str, **fields: Any) -> AgentTaskRecord:
         if not fields:
             existing = await self.get_agent_task(task_id)
@@ -974,6 +1006,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [AgentTaskRecord(**_deserialize_row(dict(row))) for row in rows]
 
+    @_serialized_write
     async def upsert_memory_durable_receipt(
         self,
         receipt: MemoryDurableReceipt,
@@ -1057,6 +1090,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [MemoryDurableReceipt(**_deserialize_row(dict(row))) for row in rows]
 
+    @_serialized_write
     async def update_memory_durable_receipt(
         self,
         receipt_id: str,
@@ -1115,6 +1149,7 @@ class SessionStorage:
                     bucket.append(task)
         return grouped
 
+    @_serialized_write
     async def mark_abandoned_agent_tasks(self, now_ms: int | None = None) -> int:
         """Mark non-terminal persisted tasks as abandoned after process restart."""
         ts = now_ms or _now_ms()
@@ -1141,6 +1176,7 @@ class SessionStorage:
 
     # ── Transcript CRUD ──────────────────────────────────────────────────────
 
+    @_serialized_write
     async def append_transcript_entry(
         self, entry: TranscriptEntry, *, expected_epoch: int | None = None
     ) -> None:
@@ -1263,6 +1299,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [TranscriptEntry(**_deserialize_row(dict(r))) for r in rows]
 
+    @_serialized_write
     async def copy_compacted_transcript_entries(
         self,
         *,
@@ -1366,6 +1403,7 @@ class SessionStorage:
             result.setdefault(sid, 0)
         return result
 
+    @_serialized_write
     async def delete_transcript(self, session_id: str) -> None:
         await self.conn.execute(
             "DELETE FROM transcript_entries WHERE session_id = ?", (session_id,)
@@ -1376,6 +1414,7 @@ class SessionStorage:
         )
         await self.conn.commit()
 
+    @_serialized_write
     async def delete_transcript_entry(self, session_id: str, message_id: str) -> bool:
         """Delete a single transcript entry by ``message_id``.
 
@@ -1392,6 +1431,7 @@ class SessionStorage:
         await self.conn.commit()
         return removed > 0
 
+    @_serialized_write
     async def delete_summaries(self, session_id: str) -> None:
         await self.conn.execute("DELETE FROM session_summaries WHERE session_id = ?", (session_id,))
         await self.conn.commit()
@@ -1408,6 +1448,7 @@ class SessionStorage:
 
     # ── SessionSummary CRUD ──────────────────────────────────────────────────
 
+    @_serialized_write
     async def save_summary(self, summary: SessionSummary) -> SessionSummary:
         """Persist a compaction summary. Sets compaction_index automatically."""
         _next_idx_sql = (
@@ -1463,6 +1504,7 @@ class SessionStorage:
                 values,
             )
 
+    @_serialized_write
     async def rewrite_compacted_session(
         self,
         *,
@@ -1638,6 +1680,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [TranscriptEntry(**_deserialize_row(dict(r))) for r in rows]
 
+    @_serialized_write
     async def update_summary_flush_receipt_status(
         self,
         summary_id: int,
@@ -1649,6 +1692,7 @@ class SessionStorage:
         )
         await self.conn.commit()
 
+    @_serialized_write
     async def update_summary_flush_receipt_status_by_compaction(
         self,
         *,
@@ -1669,6 +1713,7 @@ class SessionStorage:
 
     # ── SessionContextState CRUD ─────────────────────────────────────────────
 
+    @_serialized_write
     async def save_context_state(
         self, state: SessionContextState
     ) -> SessionContextState:
@@ -1715,6 +1760,7 @@ class SessionStorage:
             rows = await cur.fetchall()
         return [SessionContextState(**_deserialize_row(dict(row))) for row in rows]
 
+    @_serialized_write
     async def invalidate_context_states(
         self,
         session_key: str,

--- a/tests/test_session/test_storage_transaction_serialization.py
+++ b/tests/test_session/test_storage_transaction_serialization.py
@@ -1,0 +1,149 @@
+"""SessionStorage writes must not overlap on its shared SQLite connection."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+
+from agentos.session.models import SessionNode, TranscriptEntry
+from agentos.session.storage import SessionStorage, StaleEpochError
+
+_T0 = 1_700_000_000_000
+_FIRST_KEY = "agent:main:webchat:direct:first"
+_SECOND_KEY = "agent:main:webchat:direct:second"
+
+
+class _PauseFirstTransaction:
+    """Connection proxy that holds the first transaction open for assertions."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+        self.first_begin_started = asyncio.Event()
+        self.release_first_begin = asyncio.Event()
+        self.begin_calls = 0
+        self.session_write_calls = 0
+
+    def execute(self, sql: str, params: Iterable[Any] = ()) -> Any:
+        normalized = " ".join(sql.split())
+        if normalized == "BEGIN IMMEDIATE":
+            self.begin_calls += 1
+            if self.begin_calls == 1:
+                return self._begin_and_pause(sql, params)
+        if normalized.startswith("INSERT INTO sessions"):
+            self.session_write_calls += 1
+        return self._connection.execute(sql, params)
+
+    async def _begin_and_pause(self, sql: str, params: Iterable[Any]) -> Any:
+        cursor = await self._connection.execute(sql, params)
+        self.first_begin_started.set()
+        await self.release_first_begin.wait()
+        return cursor
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._connection, name)
+
+
+async def _seed_storage() -> tuple[SessionStorage, dict[str, SessionNode]]:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    nodes = {
+        key: SessionNode(
+            session_key=key,
+            session_id=f"session-{index}",
+            created_at=_T0,
+            updated_at=_T0,
+        )
+        for index, key in enumerate((_FIRST_KEY, _SECOND_KEY), start=1)
+    }
+    for node in nodes.values():
+        await storage.upsert_session(node)
+    return storage, nodes
+
+
+def _stub_session_reads(storage: SessionStorage, nodes: dict[str, SessionNode]) -> None:
+    async def get_session(session_key: str) -> SessionNode | None:
+        return nodes.get(session_key)
+
+    storage.get_session = get_session  # type: ignore[method-assign]
+
+
+async def test_concurrent_explicit_transactions_are_serialized() -> None:
+    storage, nodes = await _seed_storage()
+    _stub_session_reads(storage, nodes)
+    proxy = _PauseFirstTransaction(storage.conn)
+    storage._conn = proxy  # noqa: SLF001
+    tasks: list[asyncio.Task[None]] = []
+
+    try:
+        tasks.append(asyncio.create_task(storage.delete_session(_FIRST_KEY)))
+        await proxy.first_begin_started.wait()
+        tasks.append(asyncio.create_task(storage.delete_session(_SECOND_KEY)))
+        await asyncio.sleep(0)
+
+        assert proxy.begin_calls == 1
+
+        proxy.release_first_begin.set()
+        await asyncio.gather(*tasks)
+        assert proxy.begin_calls == 2
+        assert await storage.count_sessions() == 0
+    finally:
+        proxy.release_first_begin.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await storage.close()
+
+
+async def test_committing_writer_waits_for_explicit_transaction() -> None:
+    storage, nodes = await _seed_storage()
+    _stub_session_reads(storage, nodes)
+    proxy = _PauseFirstTransaction(storage.conn)
+    storage._conn = proxy  # noqa: SLF001
+    tasks: list[asyncio.Task[None]] = []
+    new_node = SessionNode(
+        session_key="agent:main:webchat:direct:new",
+        session_id="session-new",
+        created_at=_T0,
+        updated_at=_T0,
+    )
+
+    try:
+        tasks.append(asyncio.create_task(storage.delete_session(_FIRST_KEY)))
+        await proxy.first_begin_started.wait()
+        tasks.append(asyncio.create_task(storage.upsert_session(new_node)))
+        await asyncio.sleep(0)
+
+        assert proxy.session_write_calls == 0
+
+        proxy.release_first_begin.set()
+        await asyncio.gather(*tasks)
+        assert proxy.session_write_calls == 1
+        assert await storage.count_sessions() == 2
+    finally:
+        proxy.release_first_begin.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await storage.close()
+
+
+async def test_failed_write_rolls_back_before_releasing_serialization_lock() -> None:
+    storage, nodes = await _seed_storage()
+    node = nodes[_FIRST_KEY]
+    entry = TranscriptEntry(
+        session_id=node.session_id,
+        session_key=node.session_key,
+        message_id="stale-message",
+        role="user",
+        content="must not be written",
+        created_at=_T0,
+    )
+
+    try:
+        with pytest.raises(StaleEpochError):
+            await storage.append_transcript_entry(entry, expected_epoch=1)
+
+        assert storage.conn.in_transaction is False
+        await storage.delete_session(_FIRST_KEY)
+        assert await storage.count_sessions() == 1
+    finally:
+        await storage.close()


### PR DESCRIPTION
## Summary

- serialize every runtime SessionStorage method that can commit on the shared SQLite connection
- hold write ownership across complete multi-statement transactions so another coroutine cannot start or commit inside them
- roll back an open transaction when a mutating method exits with an exception, including cancellation
- add deterministic regression tests for transaction-vs-transaction, transaction-vs-writer, and failed-write lock handoff

Fixes #891

## Implementation notes

This uses one typed decorator and one per-storage asyncio lock. Existing method bodies and public APIs remain unchanged; schema and persistence formats are unaffected. Migration writes remain outside the decorator because they run sequentially during connect before the storage instance is exposed.

## Coordination

I claimed #891 at 07:29:40 UTC and this implementation was already in its full quality gate when #892 appeared. This is an independently developed alternative with no source formatting churn and explicit rollback coverage for failed ordinary writes.

## Testing

- new regression tests: 3 passed
- `pytest tests/test_session -q`: 199 passed
- `python scripts/build_control_ui.py build`
- `npm --prefix frontend run check`: 98 files, 2,007 tests passed
- `uv run ruff check src tests`
- `uv run mypy src/agentos --show-error-codes`
- broad Python suite excluding three environment-blocked modules: 8,816 passed, 32 skipped
- `uv build --wheel`

The three excluded modules require hydrated Git LFS ONNX assets and a newer uv supporting `uv build --clear`; both failures reproduce on clean origin/main in this checkout.

## Third-party origins

None.