### PR TITLE
fix(scheduler): apply the POSIX day-of-month/day-of-week OR rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   it was written to keep short. Backslashes are normalised before splitting, so
   Windows and mixed-separator paths trim to their last two segments like POSIX
   ones do.
+- Cron schedules that restrict both day-of-month and day-of-week now follow the
+  POSIX OR rule instead of ANDing the two fields. `0 0 1,15 * 5` means "the 1st,
+  the 15th, or any Friday" — as it does in cron, croniter, and every scheduler
+  users compare against — where AgentOS previously required a date to be both a
+  1st/15th *and* a Friday, silently killing such schedules for virtually the
+  whole month. `CronField` now records whether the field was written as a bare
+  `*`, since expanding `*` to the full value set made it indistinguishable from
+  an explicit `1-31`/`0-6` at match time and the rule applies only when neither
+  day field is a wildcard. Schedules with a wildcard in either day field are
+  unchanged. This also restores parity with the cron panel in the web UI, whose
+  "next runs" preview (`frontend/src/views/cron/logic.ts`) has always applied
+  the OR rule — so the times it showed disagreed with when the job actually
+  fired. ([#660](https://github.com/use-agent-os/agent-os/issues/660))
 
 ## [2026.9.2] - 2026-09-02
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -61,6 +61,12 @@ agentos cron add \
 
 Use `--exact` when you do not want the default stagger.
 
+Day-of-month and day-of-week follow the POSIX rule: when **both** fields are
+restricted (neither is a bare `*`), the job fires when *either* matches. So
+`0 0 1,15 * 5` runs on the 1st, the 15th, **or** any Friday. When one of the two
+is `*`, the fields are ANDed as usual — `0 0 1 * *` is the 1st only, and
+`0 0 * * 5` is Fridays only.
+
 ## Add a One-Time Job
 
 ```sh

--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -68,6 +68,11 @@ _PRESETS: dict[str, str] = {
 @dataclass(frozen=True)
 class CronField:
     values: frozenset[int]
+    #: Whether the field was written as a bare ``*``. Expanding ``*`` to the
+    #: full value set makes it indistinguishable from an explicit ``0-6`` /
+    #: ``1-31`` at match time, and the POSIX day-of-month/day-of-week OR rule
+    #: turns on exactly that distinction — so the parser has to carry it.
+    is_wildcard: bool = False
 
     def matches(self, value: int) -> bool:
         return value in self.values
@@ -83,13 +88,25 @@ class CronExpression:
     raw: str
 
     def matches(self, dt: datetime) -> bool:
-        return (
+        if not (
             self.minute.matches(dt.minute)
             and self.hour.matches(dt.hour)
-            and self.day_of_month.matches(dt.day)
             and self.month.matches(dt.month)
-            and self.day_of_week.matches((dt.weekday() + 1) % 7)  # Python Mon=0 → cron Sun=0
-        )
+        ):
+            return False
+
+        day_of_month_ok = self.day_of_month.matches(dt.day)
+        day_of_week_ok = self.day_of_week.matches((dt.weekday() + 1) % 7)  # Mon=0 → Sun=0
+
+        # POSIX day-of-month / day-of-week rule: when both fields are
+        # restricted (neither is a bare ``*``) the job fires when *either*
+        # matches, which is what cron, croniter and every scheduler users will
+        # compare against do. ``0 0 1,15 * 5`` means "the 1st, the 15th, or any
+        # Friday" — ANDing the two would restrict it to a 1st or 15th that also
+        # happens to be a Friday, which is almost never true.
+        if self.day_of_month.is_wildcard or self.day_of_week.is_wildcard:
+            return day_of_month_ok and day_of_week_ok
+        return day_of_month_ok or day_of_week_ok
 
 
 def _parse_field(token: str, field_name: str, names: dict[str, int] | None = None) -> CronField:
@@ -157,7 +174,9 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
         values.remove(7)
         values.add(0)
 
-    return CronField(frozenset(values))
+    # Only an exact ``*`` is a wildcard: ``*/2`` and ``0-6`` both name a
+    # specific set of days and count as restricted, matching croniter.
+    return CronField(frozenset(values), is_wildcard=token.strip() == "*")
 
 
 def _to_int(s: str, field_name: str, lo: int, hi: int) -> int:

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -97,6 +97,75 @@ def test_parse_cron_rejects_reversed_range_with_step() -> None:
         parse_cron("0 0 * dec-feb/2 *")
 
 
+# --- POSIX day-of-month / day-of-week OR rule ----------------------------
+
+
+def test_dom_and_dow_both_restricted_fire_on_either() -> None:
+    # "0 0 1,15 * 5" means the 1st, the 15th, OR any Friday. ANDing the two
+    # fields restricted it to a 1st/15th that also happened to be a Friday,
+    # which silently killed the schedule for virtually the whole month.
+    expr = parse_cron("0 0 1,15 * 5")
+    assert expr.matches(datetime(2026, 8, 7, 0, 0))  # Friday, neither 1st nor 15th
+    assert expr.matches(datetime(2026, 8, 1, 0, 0))  # 1st, a Saturday
+    assert expr.matches(datetime(2026, 8, 15, 0, 0))  # 15th, a Saturday
+    assert expr.matches(datetime(2026, 8, 14, 0, 0))  # Friday
+    assert not expr.matches(datetime(2026, 8, 6, 0, 0))  # Thursday, neither day
+
+
+def test_dom_and_dow_or_rule_still_honours_minute_hour_month() -> None:
+    # OR applies to the two day fields only — the other three still AND.
+    expr = parse_cron("30 9 1,15 8 5")
+    assert expr.matches(datetime(2026, 8, 7, 9, 30))
+    assert not expr.matches(datetime(2026, 8, 7, 9, 31))  # wrong minute
+    assert not expr.matches(datetime(2026, 8, 7, 10, 30))  # wrong hour
+    assert not expr.matches(datetime(2026, 9, 4, 9, 30))  # Friday, wrong month
+
+
+def test_dow_wildcard_keeps_and_semantics() -> None:
+    # Only one field restricted: no OR, or "0 0 1 * *" would fire every day.
+    expr = parse_cron("0 0 1 * *")
+    assert expr.matches(datetime(2026, 8, 1, 0, 0))
+    assert not expr.matches(datetime(2026, 8, 7, 0, 0))
+
+
+def test_dom_wildcard_keeps_and_semantics() -> None:
+    expr = parse_cron("0 0 * * 5")
+    assert expr.matches(datetime(2026, 8, 7, 0, 0))  # Friday
+    assert not expr.matches(datetime(2026, 8, 6, 0, 0))  # Thursday
+
+
+def test_both_wildcards_match_every_day() -> None:
+    expr = parse_cron("0 0 * * *")
+    assert expr.matches(datetime(2026, 8, 6, 0, 0))
+    assert expr.matches(datetime(2026, 8, 7, 0, 0))
+
+
+def test_step_over_star_counts_as_restricted() -> None:
+    # Only a bare "*" is a wildcard: "*/2" names a specific set of days, so the
+    # OR rule applies — same call croniter makes.
+    expr = parse_cron("0 0 */2 * 5")  # day-of-month 1,3,5,...,31
+    assert expr.matches(datetime(2026, 8, 5, 0, 0))  # Wednesday the 5th, via day-of-month
+    assert expr.matches(datetime(2026, 8, 14, 0, 0))  # Friday the 14th, via day-of-week
+    assert not expr.matches(datetime(2026, 8, 6, 0, 0))  # Thursday the 6th, neither
+
+
+def test_wildcard_flag_is_recorded_per_field() -> None:
+    expr = parse_cron("0 0 1,15 * 5")
+    assert not expr.day_of_month.is_wildcard
+    assert expr.month.is_wildcard
+    assert not expr.day_of_week.is_wildcard
+    assert parse_cron("0 0 * * *").day_of_month.is_wildcard
+    assert not parse_cron("0 0 1-31 * *").day_of_month.is_wildcard
+
+
+def test_weekly_preset_is_unaffected_by_the_or_rule() -> None:
+    # "@weekly" expands to "0 0 * * 0" — day-of-month is a wildcard, so it
+    # stays a Sunday-only schedule rather than firing daily.
+    expr = parse_cron("@weekly")
+    assert expr.matches(datetime(2026, 8, 30, 0, 0))  # Sunday
+    assert not expr.matches(datetime(2026, 8, 31, 0, 0))  # Monday
+
+
 # --- parse_iso_at --------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #660.

## The bug

`CronExpression.matches()` ANDs all five fields unconditionally:

```python
return (
    self.minute.matches(dt.minute)
    and self.hour.matches(dt.hour)
    and self.day_of_month.matches(dt.day)
    and self.month.matches(dt.month)
    and self.day_of_week.matches((dt.weekday() + 1) % 7)
)
```

POSIX requires the opposite for the two day fields: when day-of-month and
day-of-week are **both** restricted (neither is a bare `*`), the job fires when
*either* matches. `0 0 1,15 * 5` means "the 1st, the 15th, or any Friday";
AgentOS required a date to be a 1st/15th **and** a Friday, which silently kills
such a schedule for virtually the entire month.

**The web UI already disagreed with the scheduler.** The cron panel's "next 3
runs" preview (`frontend/src/views/cron/logic.ts:531-545`) has always applied
the OR rule, so it showed users fire times the scheduler never honored. This
change makes the backend agree with the preview users were already reading.

## The fix

As the maintainer noted on the issue, `CronField` did not record whether the
field was a literal `*` — expanding `*` to the full value set makes it
indistinguishable from an explicit `1-31` / `0-6` at match time, and the OR rule
must not apply when either field is a wildcard. So the parser now carries an
`is_wildcard` flag (defaulted, so existing positional construction is
unaffected), and `matches()` branches on it:

```python
if self.day_of_month.is_wildcard or self.day_of_week.is_wildcard:
    return day_of_month_ok and day_of_week_ok
return day_of_month_ok or day_of_week_ok
```

Only an exact `*` counts as a wildcard — `*/2` and `0-6` name a specific set of
days and are restricted. That matches croniter and the frontend's own `all`
flag, which is likewise set only for a literal `*`.

Minute, hour and month keep ANDing. Every schedule with a wildcard in either day
field — which is the overwhelming majority, including all the `@presets` —
behaves exactly as before.

Both `_next_run` implementations (`scheduler/engine.py:38-43`,
`scheduler/jobs.py:215-225`) are plain minute-by-minute scans over `matches()`,
so this is the only place the rule lives.

## Tests

`tests/test_scheduler/test_parser.py` gains 8 cases covering the issue's exact
expression, the OR rule not leaking into minute/hour/month, both single-wildcard
directions staying ANDed, `*/2` counting as restricted, `@weekly` staying
Sunday-only, and the flag itself. Four fail on `main`.

Also documents the rule in `docs/scheduling.md`, since silently-never-firing is
the kind of thing worth writing down.

Full `tests/test_scheduler` (480) and `tests/test_tools` pass; ruff and mypy
clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvHsK3pwyiKfiAHyKLAEcP
