### PR TITLE
fix(mcp): route both HTTP transports through the connect-time SSRF guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Windows and mixed-separator paths trim to their last two segments like POSIX
   ones do.
 
+### Security
+
+- The MCP SSE and Streamable HTTP transports now connect through the same
+  SSRF guard as the built-in HTTP tools. Both built a bare `httpx.AsyncClient`
+  from `MCPServerConfig.url` with no validation at all, so an MCP server entry
+  pointed at `169.254.169.254` reached the cloud metadata endpoint and its
+  instance credentials.
+
+  The policy is `validate_metadata_only_address` — the floor `http_request`
+  takes — not the full `validate_http_url_for_fetch`: `http://localhost:PORT/mcp`
+  and LAN-hosted MCP servers are the normal, intended configuration, and the
+  stricter policy rejects loopback and private ranges. The guard is installed as
+  a connect-time network backend (`ssrf_guarded_client`) rather than run once
+  against the URL text, so the address that gets validated is the address that
+  gets dialed: checking the URL and then handing it to a plain client leaves
+  httpx to resolve the hostname a second time, which a short-TTL DNS-rebinding
+  name can answer differently. Non-`http(s)` server URLs are now rejected up
+  front. ([#662](https://github.com/use-agent-os/agent-os/issues/662))
+
 ## [2026.9.2] - 2026-09-02
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -770,6 +770,14 @@ Supported transports are `stdio`, `sse`, and `streamable_http`. The MCP SDK is
 included in the standard AgentOS installation, so Streamable HTTP and OAuth work
 without installing an additional package extra.
 
+The HTTP transports accept `http://` and `https://` URLs only, and both connect
+through the same SSRF guard the built-in HTTP tools use. `http://localhost:PORT`
+and LAN-hosted servers keep working — the guard blocks cloud metadata endpoints
+(`169.254.169.254` and friends), which serve instance credentials and are never
+a valid MCP target. The check runs against the address the socket actually
+dials, so a short-TTL DNS name cannot answer safely for the check and with the
+metadata address for the connection.
+
 OAuth access and refresh tokens are not written to `config.toml`. AgentOS keeps
 them in a server-scoped JSON file under the configured state directory with
 file mode `0600` inside a `0700` directory on POSIX systems. On Windows, the

--- a/src/agentos/mcp/http.py
+++ b/src/agentos/mcp/http.py
@@ -1,0 +1,65 @@
+"""SSRF-guarded HTTP client construction for the MCP HTTP transports.
+
+Every other outbound-URL path in the tree runs through ``agentos.tools.ssrf``
+before it opens a socket; the SSE and Streamable HTTP transports used to build a
+bare ``httpx.AsyncClient`` from ``MCPServerConfig.url`` with no check at all, so
+an MCP server entry pointed at ``169.254.169.254`` reached the instance
+credential endpoint.
+
+Two things are deliberate about the guard used here:
+
+* **The policy is metadata-only, not the full fetch policy.**
+  ``validate_http_url_for_fetch`` rejects loopback, private, link-local and
+  reserved ranges — but ``http://localhost:PORT/mcp`` and LAN-hosted servers are
+  the normal, intended MCP configuration, so that policy would break the
+  majority of real setups. ``validate_metadata_only_address`` is the same floor
+  ``http_request`` takes, for the same reason: no configuration makes the
+  instance-credential endpoint a legitimate destination.
+
+* **The check happens at connect time, not once against the URL text.**
+  Validating the URL and then handing it to a plain client leaves httpx to
+  resolve the hostname a second time when it dials, which is a DNS-rebinding
+  window: a short-TTL name can answer with a public address for the check and
+  with the metadata address for the socket. ``ssrf_guarded_client`` pins the
+  address that was validated as the address that gets dialed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from agentos.env import trust_env as _trust_env
+from agentos.tools.ssrf_client import ssrf_guarded_client, validate_metadata_only_address
+from agentos.tools.types import UnsupportedURLSchemeError
+
+__all__ = ["assert_supported_mcp_url", "mcp_http_client"]
+
+
+def assert_supported_mcp_url(url: str) -> None:
+    """Raise unless *url* is an ``http``/``https`` URL with a hostname.
+
+    A ``file://`` or ``gopher://`` entry is not something either HTTP transport
+    can serve, and letting one through would push the decision down into httpx
+    (or the MCP SDK) where the failure is far less legible.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise UnsupportedURLSchemeError(f"Invalid MCP server URL: {url!r}") from exc
+    if parsed.scheme not in ("http", "https"):
+        raise UnsupportedURLSchemeError(
+            "MCP HTTP transports only support http:// and https:// URLs; got "
+            f"{parsed.scheme or 'no'} scheme"
+        )
+    if not parsed.hostname:
+        raise UnsupportedURLSchemeError(f"Invalid MCP server URL: {url!r} has no hostname")
+
+
+def mcp_http_client(url: str, **kwargs: Any) -> httpx.AsyncClient:
+    """Return an ``httpx.AsyncClient`` for *url* with the metadata guard installed."""
+    assert_supported_mcp_url(url)
+    kwargs.setdefault("trust_env", _trust_env())
+    return ssrf_guarded_client(validator=validate_metadata_only_address, **kwargs)

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -8,8 +8,8 @@ from typing import Any, cast
 import httpx
 
 from agentos import __version__
-from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
+from agentos.mcp.http import mcp_http_client
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 
 
@@ -70,7 +70,9 @@ class MCPSSEClient(MCPClient):
 
     async def connect(self) -> None:
         """Create the HTTP client session and perform MCP initialization handshake."""
-        self._client = httpx.AsyncClient(trust_env=_trust_env())
+        if not self.config.url:
+            raise ValueError("SSE MCP server requires a URL")
+        self._client = mcp_http_client(self.config.url)
 
         # Send initialize request (response is acknowledged server-side;
         # we don't inspect it — the MCP spec only requires us to send the

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -16,8 +16,8 @@ from typing import Any
 import httpx
 
 from agentos import __version__
-from agentos.env import trust_env as _trust_env
 from agentos.mcp.client import MCPClient
+from agentos.mcp.http import assert_supported_mcp_url, mcp_http_client
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 from agentos.paths import state_dir as default_state_dir
 
@@ -145,6 +145,9 @@ class MCPStreamableHTTPClient(MCPClient):
     async def connect(self) -> None:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
+        # Checked here as well as inside ``mcp_http_client`` so an unusable URL
+        # fails before the OAuth provider is built from it.
+        assert_supported_mcp_url(self.config.url)
 
         try:
             from mcp.client.auth import OAuthClientProvider
@@ -178,11 +181,11 @@ class MCPStreamableHTTPClient(MCPClient):
         stack = AsyncExitStack()
         try:
             http_client = await stack.enter_async_context(
-                httpx.AsyncClient(
+                mcp_http_client(
+                    self.config.url,
                     auth=auth,
                     headers=self.config.headers,
                     timeout=httpx.Timeout(self.config.tool_timeout_seconds),
-                    trust_env=_trust_env(),
                 )
             )
             read_stream, write_stream, _ = await stack.enter_async_context(

--- a/tests/test_mcp/test_mcp_ssrf.py
+++ b/tests/test_mcp/test_mcp_ssrf.py
@@ -1,0 +1,257 @@
+"""Both MCP HTTP transports dial through the connect-time SSRF guard (issue #662).
+
+The transports used to build a bare ``httpx.AsyncClient`` from
+``MCPServerConfig.url`` with no validation, so a server entry pointed at the
+cloud metadata endpoint reached instance credentials.
+
+The tests that matter here check the *transport's own client*, not a helper:
+validating the URL text once and then handing it to an unguarded client passes
+every literal-address test while leaving the DNS-rebinding window wide open, so
+``test_*_installs_the_connect_time_guard`` is the assertion that separates the
+two approaches.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import threading
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+from agentos.mcp.http import assert_supported_mcp_url, mcp_http_client
+from agentos.mcp.sse import MCPSSEClient
+from agentos.mcp.streamable_http import MCPStreamableHTTPClient
+from agentos.mcp.types import MCPServerConfig
+from agentos.tools.ssrf_client import (
+    ValidatingNetworkBackend,
+    validate_metadata_only_address,
+)
+from agentos.tools.types import SSRFBlockedError, UnsupportedURLSchemeError
+
+METADATA_IP = "169.254.169.254"
+
+
+def _sse_config(url: str | None) -> MCPServerConfig:
+    return MCPServerConfig(name="sse-server", transport="sse", url=url)
+
+
+def _streamable_config(url: str) -> MCPServerConfig:
+    return MCPServerConfig(name="remote", transport="streamable_http", url=url)
+
+
+def _installed_backend(client: Any) -> Any:
+    return client._transport._pool._network_backend
+
+
+def _resolver(mapping: dict[str, str]):
+    """getaddrinfo stand-in: names answer from *mapping*, literals themselves."""
+    calls: list[str] = []
+
+    def resolve(host, port=None, *args, **kwargs):
+        calls.append(host)
+        try:
+            ipaddress.ip_address(str(host).strip("[]"))
+            answer = str(host)
+        except ValueError:
+            answer = mapping[str(host)]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (answer, port or 80))]
+
+    resolve.calls = calls  # type: ignore[attr-defined]
+    return resolve
+
+
+# --- the guard is installed on the transport's own client ----------------
+
+
+@pytest.mark.asyncio
+async def test_sse_client_installs_the_connect_time_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _noop(self: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(MCPSSEClient, "_send_and_receive", _noop)
+    monkeypatch.setattr(MCPSSEClient, "_send_notification", _noop)
+
+    client = MCPSSEClient(_sse_config("http://localhost:9999/sse"))
+    await client.connect()
+    try:
+        backend = _installed_backend(client._client)
+        assert isinstance(backend, ValidatingNetworkBackend)
+        assert backend._validator is validate_metadata_only_address
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_client_installs_the_connect_time_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp.client import session as session_module
+    from mcp.client import streamable_http as transport_module
+
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def fake_transport(url: str, *, http_client: Any = None, **_kwargs: Any):
+        captured["url"] = url
+        captured["http_client"] = http_client
+        yield object(), object(), None
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def initialize(self) -> None:
+            return None
+
+    monkeypatch.setattr(transport_module, "streamable_http_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_a, **_k: FakeSession())
+
+    client = MCPStreamableHTTPClient(_streamable_config("https://example.test/mcp"))
+    await client.connect()
+    try:
+        assert captured["url"] == "https://example.test/mcp"
+        backend = _installed_backend(captured["http_client"])
+        assert isinstance(backend, ValidatingNetworkBackend)
+        assert backend._validator is validate_metadata_only_address
+    finally:
+        await client.close()
+
+
+# --- what the guard actually blocks --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_is_blocked_from_the_metadata_address() -> None:
+    client = MCPSSEClient(_sse_config(f"http://{METADATA_IP}/sse"))
+    try:
+        with pytest.raises(SSRFBlockedError) as excinfo:
+            await client.connect()
+    finally:
+        await client.close()
+
+    assert METADATA_IP in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_is_blocked_when_the_hostname_resolves_to_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The URL text is unremarkable; the address it dials is the credential endpoint."""
+    monkeypatch.setattr(socket, "getaddrinfo", _resolver({"mcp.example": METADATA_IP}))
+
+    client = MCPSSEClient(_sse_config("http://mcp.example/sse"))
+    try:
+        with pytest.raises(SSRFBlockedError) as excinfo:
+            await client.connect()
+    finally:
+        await client.close()
+
+    assert METADATA_IP in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_metadata_hostnames_are_blocked_by_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _resolver({"metadata.google.internal": "1.2.3.4"}))
+
+    client = MCPSSEClient(_sse_config("http://metadata.google.internal/sse"))
+    try:
+        with pytest.raises(SSRFBlockedError):
+            await client.connect()
+    finally:
+        await client.close()
+
+
+# --- what the guard must keep allowing -----------------------------------
+
+
+class _LocalServer:
+    """A minimal HTTP/1.1 responder on an ephemeral loopback port."""
+
+    def __init__(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        threading.Thread(target=self._serve, daemon=True).start()
+
+    def _serve(self) -> None:
+        try:
+            conn, _ = self._sock.accept()
+            with conn:
+                conn.recv(65536)
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n"
+                    b"Content-Length: 2\r\nConnection: close\r\n\r\nok"
+                )
+                conn.shutdown(socket.SHUT_WR)
+        except OSError:  # pragma: no cover - the socket closed under us
+            pass
+
+    def close(self) -> None:
+        self._sock.close()
+
+
+@pytest.mark.asyncio
+async def test_localhost_mcp_servers_are_still_reachable() -> None:
+    """The metadata-only policy is deliberate: localhost/LAN MCP is the normal setup.
+
+    The full ``validate_http_url_for_fetch`` policy rejects loopback and private
+    ranges, which would break the majority of real MCP configurations.
+    """
+    server = _LocalServer()
+    try:
+        async with mcp_http_client(f"http://127.0.0.1:{server.port}/mcp") as client:
+            response = await client.get(f"http://127.0.0.1:{server.port}/mcp")
+    finally:
+        server.close()
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+# --- scheme and URL validation -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["file:///etc/passwd", "gopher://example.test/", "ftp://example.test/mcp", "/mcp", ""],
+)
+def test_non_http_urls_are_rejected(url: str) -> None:
+    with pytest.raises(UnsupportedURLSchemeError):
+        assert_supported_mcp_url(url)
+
+
+def test_http_and_https_urls_are_accepted() -> None:
+    assert_supported_mcp_url("http://localhost:3000/mcp")
+    assert_supported_mcp_url("https://example.test/mcp")
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_rejects_a_non_http_url() -> None:
+    client = MCPSSEClient(_sse_config("file:///etc/passwd"))
+    with pytest.raises(UnsupportedURLSchemeError):
+        await client.connect()
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_connect_rejects_a_non_http_url() -> None:
+    client = MCPStreamableHTTPClient(_streamable_config("file:///etc/passwd"))
+    with pytest.raises(UnsupportedURLSchemeError):
+        await client.connect()
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_requires_a_url() -> None:
+    client = MCPSSEClient(_sse_config(None))
+    with pytest.raises(ValueError, match="requires a URL"):
+        await client.connect()


### PR DESCRIPTION
Closes #662.

## The bug

`MCPSSEClient.connect()` and `MCPStreamableHTTPClient.connect()` built a bare
`httpx.AsyncClient` from `MCPServerConfig.url` with no validation at all. Every
other outbound-URL path in the tree (`web_fetch`, `http_request`, `media`,
`x_search`, skill-hub) goes through `agentos.tools.ssrf` first. MCP was the one
gap, so an MCP server entry pointed at `169.254.169.254` reached the cloud
metadata endpoint and its instance credentials.

## Two deliberate choices

**Policy: metadata-only, not the full fetch policy.** Following the maintainer's
correction on the issue, this does *not* use `validate_http_url_for_fetch` — it
rejects loopback, private, link-local and reserved ranges, and
`http://localhost:PORT/mcp` and LAN-hosted servers are the normal, intended MCP
configuration. `validate_metadata_only_address` is the same floor `http_request`
takes, for the same reason.

**Placement: at connect, not once against the URL text.** This is the gap
@andrew1234-arch identified in #794 and #797. Validating the URL string and then
handing it to a plain `httpx.AsyncClient` leaves httpx to resolve the hostname a
second time when it opens the socket — a DNS-rebinding TOCTOU window where a
short-TTL name answers with a public address for the check and with
`169.254.169.254` for the connection. `ssrf_guarded_client()` (already used by
`http_request`, `web_fetch`, `media`, `x_search`) wraps httpcore's network
backend so the address that was validated is the address that gets dialed.

I did not add Azure IMDS entries: `169.254.169.253` (wire server) and the whole
`169.254.0.0/16` network are already covered by `_METADATA_ADDRESSES` /
`_METADATA_NETWORKS` on `main`.

## The change

New `src/agentos/mcp/http.py` with one choke point both transports call:

```python
def mcp_http_client(url: str, **kwargs: Any) -> httpx.AsyncClient:
    assert_supported_mcp_url(url)
    kwargs.setdefault("trust_env", _trust_env())
    return ssrf_guarded_client(validator=validate_metadata_only_address, **kwargs)
```

`assert_supported_mcp_url()` rejects anything that is not `http`/`https` with a
hostname — a `file://` entry is not something either transport can serve, and
letting it through pushes the failure down into httpx or the MCP SDK where it
reads far worse. Streamable HTTP calls it early as well, so an unusable URL
fails before the OAuth provider is built from it. SSE now also raises on a
missing URL instead of tripping a bare `assert` in `_base_url`.

Timeouts, headers, `auth`, and `trust_env` behaviour are otherwise unchanged.

## Tests

New `tests/test_mcp/test_mcp_ssrf.py`, 12 cases; **8 fail without the wiring.**
The two that matter most assert against the transport's *own* client:

```python
backend = client._client._transport._pool._network_backend
assert isinstance(backend, ValidatingNetworkBackend)
assert backend._validator is validate_metadata_only_address
```

That pair is what a URL-text-only fix cannot pass, while its literal-IP tests
pass either way. The rest cover: the metadata address blocked via SSE connect;
a hostname whose *resolution* is the metadata address blocked (a URL-literal
check would miss it); metadata hostnames blocked by name; non-`http(s)` URLs
rejected by both transports; and — proving the policy choice is real — an
end-to-end request to a loopback HTTP server through `mcp_http_client`
succeeding, so localhost MCP setups keep working.

The pre-existing `tests/test_mcp` suite passes unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvHsK3pwyiKfiAHyKLAEcP
