### PR TITLE
fix(mcp): use newline framing for stdio

### DIFF
--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -121,14 +121,25 @@ class MCPStdioClient(MCPClient):
         await self._process.stdin.drain()
 
     async def _read_response(self) -> dict[str, Any]:
-        """Read and decode one newline-delimited response from stdout."""
+        """Read one response even when it exceeds the stream's buffer limit."""
         assert self._process is not None
         assert self._process.stdout is not None
 
-        line = await self._process.stdout.readline()
-        if not line:
-            raise ValueError("Unexpected EOF while reading response")
-        return self._decode_response(line)
+        reader = self._process.stdout
+        line = bytearray()
+        while True:
+            try:
+                line.extend(await reader.readuntil(b"\n"))
+                break
+            except asyncio.LimitOverrunError as exc:
+                # Consume only bytes before the delimiter, leaving later
+                # responses buffered for the next request.
+                line.extend(await reader.readexactly(exc.consumed))
+            except asyncio.IncompleteReadError as exc:
+                if line or exc.partial:
+                    raise ValueError("Truncated response: missing newline delimiter") from exc
+                raise ValueError("Unexpected EOF while reading response") from exc
+        return self._decode_response(bytes(line))
 
     async def list_tools(self) -> list[MCPToolDef]:
         """List tools from the MCP server."""

--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -13,7 +13,7 @@ from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 
 
 class MCPStdioClient(MCPClient):
-    """MCP client using stdio transport (subprocess + Content-Length framing)."""
+    """MCP client using newline-delimited JSON-RPC over a subprocess."""
 
     _CLOSE_TIMEOUT_SECONDS = 2.0
 
@@ -24,33 +24,19 @@ class MCPStdioClient(MCPClient):
 
     @staticmethod
     def _encode_request(request: dict[str, Any]) -> bytes:
-        """Encode a JSON-RPC request with Content-Length framing."""
-        body = json.dumps(request)
-        header = f"Content-Length: {len(body)}\r\n\r\n"
-        return header.encode() + body.encode()
+        """Encode one compact newline-delimited JSON-RPC message."""
+        return json.dumps(request, separators=(",", ":")).encode() + b"\n"
 
     @staticmethod
     def _decode_response(data: bytes) -> dict[str, Any]:
-        """Decode a Content-Length framed response."""
-        if b"\r\n\r\n" not in data:
-            raise ValueError("Missing header/body separator in response")
+        """Decode one newline-delimited JSON-RPC response."""
+        if not data.endswith(b"\n"):
+            raise ValueError("Truncated response: missing newline delimiter")
 
-        header_part, body = data.split(b"\r\n\r\n", 1)
-        headers = header_part.decode()
-
-        content_length: int | None = None
-        for line in headers.splitlines():
-            if line.lower().startswith("content-length:"):
-                content_length = int(line.split(":", 1)[1].strip())
-                break
-
-        if content_length is None:
-            raise ValueError("Missing Content-Length header")
-
-        if len(body) < content_length:
-            raise ValueError(f"Truncated body: expected {content_length} bytes, got {len(body)}")
-
-        return cast(dict[str, Any], json.loads(body[:content_length].decode()))
+        body = data[:-1]
+        if b"\n" in body:
+            raise ValueError("Response contains an embedded newline")
+        return cast(dict[str, Any], json.loads(body.decode()))
 
     def _next_id(self) -> int:
         self._request_id += 1
@@ -135,40 +121,14 @@ class MCPStdioClient(MCPClient):
         await self._process.stdin.drain()
 
     async def _read_response(self) -> dict[str, Any]:
-        """Read and decode a Content-Length framed response from stdout."""
+        """Read and decode one newline-delimited response from stdout."""
         assert self._process is not None
         assert self._process.stdout is not None
 
-        # Read header lines until blank line
-        header_lines: list[str] = []
-        while True:
-            line = await self._process.stdout.readline()
-            decoded = line.decode().rstrip("\r\n")
-            if decoded == "":
-                break
-            header_lines.append(decoded)
-
-        content_length: int | None = None
-        for h in header_lines:
-            if h.lower().startswith("content-length:"):
-                content_length = int(h.split(":", 1)[1].strip())
-                break
-
-        if content_length is None:
-            raise ValueError("Missing Content-Length header in response")
-
-        # ``StreamReader.read(n)`` returns *up to* n bytes and yields as soon as
-        # any data is buffered, so a body split across pipe writes (large tool
-        # results, chunked flushes) would be truncated and fail ``json.loads``.
-        # ``readexactly`` enforces the Content-Length framing contract, matching
-        # the guard in the sibling ``_decode_response`` helper.
-        try:
-            body = await self._process.stdout.readexactly(content_length)
-        except asyncio.IncompleteReadError as exc:
-            raise ValueError(
-                f"Truncated body: expected {content_length} bytes, got {len(exc.partial)}"
-            ) from exc
-        return cast(dict[str, Any], json.loads(body.decode()))
+        line = await self._process.stdout.readline()
+        if not line:
+            raise ValueError("Unexpected EOF while reading response")
+        return self._decode_response(line)
 
     async def list_tools(self) -> list[MCPToolDef]:
         """List tools from the MCP server."""

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -119,16 +119,58 @@ async def test_read_response_handles_line_split_across_reads() -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_response_raises_when_eof_precedes_newline() -> None:
+@pytest.mark.parametrize("chunk_size", [8192, 262144])
+async def test_read_large_response_preserves_following_message(chunk_size: int) -> None:
+    response = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": "é" * 100_000}]},
+    }
+    following = {"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}
+    data = _line(json.dumps(response, ensure_ascii=False).encode()) + _line(
+        json.dumps(following).encode()
+    )
+    reader = asyncio.StreamReader(limit=65536)
+    client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
+    client._process = _StdoutOnlyProcess(reader)  # type: ignore[assignment]
+
+    async def feed() -> None:
+        for start in range(0, len(data), chunk_size):
+            reader.feed_data(data[start : start + chunk_size])
+            await asyncio.sleep(0)
+        reader.feed_eof()
+
+    feeder = asyncio.create_task(feed())
+    try:
+        assert await client._read_response() == response
+        assert await client._read_response() == following
+    finally:
+        await feeder
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text_size", [0, 200_000])
+async def test_read_response_raises_when_eof_precedes_newline(text_size: int) -> None:
     """EOF before the newline delimiter must surface as a clear error."""
-    payload = b'{"jsonrpc":"2.0","id":1,"result":{}}'
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"text": "x" * text_size}})
 
     reader = asyncio.StreamReader()
-    reader.feed_data(payload)
+    reader.feed_data(payload.encode())
     reader.feed_eof()
     process = _StdoutOnlyProcess(reader)
     client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
     client._process = process  # type: ignore[assignment]
 
     with pytest.raises(ValueError, match="missing newline delimiter"):
+        await client._read_response()
+
+
+@pytest.mark.asyncio
+async def test_read_response_raises_on_empty_eof() -> None:
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
+    client._process = _StdoutOnlyProcess(reader)  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="Unexpected EOF while reading response"):
         await client._read_response()

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -73,25 +73,31 @@ class _StdoutOnlyProcess:
         self.stdin = None
 
 
-def _framed(payload: bytes) -> bytes:
-    return f"Content-Length: {len(payload)}\r\n\r\n".encode() + payload
+def _line(payload: bytes) -> bytes:
+    return payload + b"\n"
+
+
+def test_encode_request_uses_newline_delimited_json() -> None:
+    encoded = MCPStdioClient._encode_request({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+    assert encoded.endswith(b"\n")
+    assert encoded.count(b"\n") == 1
+    assert b"Content-Length" not in encoded
+    assert json.loads(encoded) == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+    }
 
 
 @pytest.mark.asyncio
-async def test_read_response_handles_body_split_across_reads() -> None:
-    """A body delivered in multiple pipe writes must not be truncated.
-
-    ``StreamReader.read(n)`` returns as soon as *any* data is buffered, so the
-    pre-fix code truncated bodies that did not arrive in a single read and then
-    failed ``json.loads``. The fix uses ``readexactly`` to honor the
-    Content-Length frame.
-    """
+async def test_read_response_handles_line_split_across_reads() -> None:
+    """A newline-delimited response may arrive in multiple pipe writes."""
     payload = json.dumps(
         {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "x"} for _ in range(50)]}}
     ).encode()
-    frame = _framed(payload)
-    # Split mid-body so the first read cannot see the whole payload.
-    split = len(frame) - (len(payload) // 2)
+    line = _line(payload)
+    split = len(line) - (len(payload) // 2)
 
     reader = asyncio.StreamReader()
     process = _StdoutOnlyProcess(reader)
@@ -99,9 +105,9 @@ async def test_read_response_handles_body_split_across_reads() -> None:
     client._process = process  # type: ignore[assignment]
 
     async def feed() -> None:
-        reader.feed_data(frame[:split])
+        reader.feed_data(line[:split])
         await asyncio.sleep(0)  # force a scheduler yield between chunks
-        reader.feed_data(frame[split:])
+        reader.feed_data(line[split:])
         reader.feed_eof()
 
     feeder = asyncio.create_task(feed())
@@ -113,17 +119,16 @@ async def test_read_response_handles_body_split_across_reads() -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_response_raises_on_truncated_body() -> None:
-    """Premature EOF must surface as a clear ValueError, not a JSON error."""
+async def test_read_response_raises_when_eof_precedes_newline() -> None:
+    """EOF before the newline delimiter must surface as a clear error."""
     payload = b'{"jsonrpc":"2.0","id":1,"result":{}}'
-    frame = _framed(payload)[:-5]  # drop the tail so EOF arrives early
 
     reader = asyncio.StreamReader()
-    reader.feed_data(frame)
+    reader.feed_data(payload)
     reader.feed_eof()
     process = _StdoutOnlyProcess(reader)
     client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
     client._process = process  # type: ignore[assignment]
 
-    with pytest.raises(ValueError, match="Truncated body"):
+    with pytest.raises(ValueError, match="missing newline delimiter"):
         await client._read_response()


### PR DESCRIPTION
## Summary

- replace HTTP-style `Content-Length` framing with the newline-delimited JSON-RPC framing required by MCP stdio
- encode each request/notification as compact JSON followed by one newline
- reject EOF before the response delimiter with an actionable error
- update regression tests to cover encoded requests, split pipe writes, and truncated responses

The MCP stdio transport requires UTF-8 JSON-RPC messages delimited by newlines and disallows embedded newlines: https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#stdio

Fixes #894

## Transport choice

This PR deliberately retains the existing hand-written stdio transport and changes only the wire framing. That keeps the current asyncio subprocess ownership, command/environment handling, and terminate-then-kill shutdown contract intact. The newline reader waits for the complete line across split pipe writes and explicitly rejects EOF before the delimiter; the regression tests cover those boundaries and the existing shutdown tests remain in place.

Using `mcp.client.stdio.stdio_client` together with `ClientSession` is a valid follow-up direction, consistent with the HTTP transports. It would also change subprocess/session ownership and request dispatch, so this PR does not combine that migration with the focused framing correction. This is a scope/lifecycle choice, not a claim that the SDK cannot support stdio.

## Test plan

- `uv run pytest tests/test_mcp/test_stdio_client.py -q` — 9 passed.
- `uv run pytest tests/test_mcp -q` — 18 passed.
- Three large-response regression cases fail on the previous PR head and pass with the reader fix. Coverage includes incremental/buffered >64 KiB UTF-8 responses, the following message remaining readable, truncated large messages, and empty EOF.
- `uv run ruff check src tests` — passed.
- `uv run mypy src/agentos --show-error-codes` — passed (621 source files).
- Control UI production build — passed.
- `npm --prefix frontend run check -- --maxWorkers=1 --no-file-parallelism` — 2,009 passed, one timing-sensitive ChannelsPage dialog assertion failed; the complete affected file passed on immediate rerun (28/28). No frontend files changed.
- `uv run pytest -q --tb=short` — 8,933 passed, 32 skipped, 6 failed, 3 setup errors; 21 snapshots passed. The same six failures and three setup errors were reproduced on clean upstream commit `2e4d6ac`: unhydrated ONNX/LFS assets and uv 0.8.15 rejecting the wheelhouse tests' `--clear` option. No unrelated workaround is included.
- `uv build --wheel` — passed.
- [GitHub CI for `56c29fb`](https://github.com/use-agent-os/agent-os/actions/runs/33842811738).

The reader accumulates `readuntil(b"\n")` fragments after `LimitOverrunError`, consuming only the reported prefix. This preserves the subprocess's existing buffer limit without imposing a 64 KiB message ceiling or consuming a subsequent response.
