### PR TITLE
fix(sandbox): hard-block destructive intents that target the filesystem root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The sensitive-path hard block now refuses destructive intents that target
+  the filesystem root. `rm -rf /` carries no sensitive *prefix*, so the
+  denylist never matched it and a whole-host wipe fell through to the ordinary
+  approval flow — which `/elevated bypass` skips outright. Every spelling that
+  resolves to or sweeps the top level is covered: `/`, `//`, `/.`, `/..`,
+  `/*`, `/*/*`, `/**`, `/?*`, `/.*` and `/[a-z]*`. Globs that name a subset
+  (`/tmp*`) are untouched, and root counts as sensitive only in the
+  delete-intent scan — reading or listing `/` stays ordinary work (#563).
 - Channel HTTP retries now cover every transient timeout, survive an
   HTTP-date `Retry-After`, and hand back an exhausted rate limit.
   `retry_request` caught `(ConnectError, ReadTimeout)`, but `ConnectTimeout`,

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -74,6 +74,27 @@ _SENSITIVE_SUFFIXES: tuple[str, ...] = (
 
 _WORKSPACE_PARENT_EXCEPTION_MARKERS: tuple[str, ...] = ("/root",)
 
+# Marker reported when a destructive intent targets the filesystem root. Root
+# is not in ``_SENSITIVE_PREFIXES`` on purpose: reading or listing ``/`` is
+# harmless, so only the delete-intent scan treats it as sensitive.
+_ROOT_TARGET_MARKER = "/"
+
+# Path segments that keep a target at the filesystem root: ``/``, ``/.``,
+# ``/..`` and ``//`` all resolve to root.
+_ROOT_TARGET_SEGMENTS = frozenset({"", ".", "..", "*"})
+
+# A segment made only of glob metacharacters and dots expands across every
+# entry of its parent, so at depth 1 it is a root wipe by another spelling:
+# ``/*``, ``/**``, ``/?*``, ``/.*`` and ``/[a-z]*`` all sweep the top level.
+# Bracket expressions are dropped first so ``/[a-z]*`` counts while a segment
+# carrying literal text (``/tmp*``) does not.
+_BRACKET_EXPRESSION_RE = re.compile(r"\[[^]]*\]")
+_GLOB_ONLY_CHARS = frozenset("*?.")
+
+# Windows runners resolve ``/`` to a drive root (``C:\``), so the drive letter
+# is stripped before the segment check.
+_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
+
 _TOKEN_EDGE_CHARS = " \t\r\n'\"`$(){}[]<>;,|&"
 _ABSOLUTE_OR_TILDE_PATH_RE = re.compile(r"(?:~)?/(?:[^\s'\"`$(){}\[\]<>;,|&]+)")
 _DOTENV_LITERAL_RE = re.compile(
@@ -124,6 +145,37 @@ def _path_contains(path: str, root: str) -> bool:
     normalized_root = root.rstrip("/")
     return normalized_path == normalized_root or normalized_path.startswith(
         normalized_root + "/"
+    )
+
+
+def _segment_sweeps_its_parent(segment: str) -> bool:
+    """Return whether *segment* is a glob matching every entry beside it.
+
+    ``*``, ``**``, ``?*``, ``.*`` and ``[a-z]*`` all do; ``tmp*`` does not,
+    because the literal text narrows it to a named subset.
+    """
+    if "*" not in segment and "?" not in segment:
+        return False
+    literal = _BRACKET_EXPRESSION_RE.sub("", segment)
+    return all(char in _GLOB_ONLY_CHARS for char in literal)
+
+
+def _is_root_target(path: str) -> bool:
+    """Return whether *path* names — or sweeps — the filesystem root.
+
+    ``rm -rf /`` and its spellings carry no sensitive prefix, so the prefix
+    scan never matched them. A target is root when every segment either
+    resolves in place (empty, ``.``, ``..``) or globs across the whole level,
+    covering ``/``, ``//``, ``/.``, ``/..``, ``/*``, ``/**``, ``/.*`` and
+    ``/*/*``.
+    """
+    normalized = str(path).strip().replace("\\", "/")
+    normalized = _DRIVE_PREFIX_RE.sub("", normalized, count=1)
+    if not normalized.startswith("/"):
+        return False
+    return all(
+        segment in _ROOT_TARGET_SEGMENTS or _segment_sweeps_its_parent(segment)
+        for segment in normalized.split("/")
     )
 
 
@@ -319,6 +371,8 @@ def sensitive_target_in_command(
 
     Multi-target commands (``rm /tmp/ok /etc/bad``) are each checked — the
     presence of a single sensitive path is enough to block the whole command.
+    The filesystem root is sensitive here and only here: deleting ``/`` wipes
+    the host, while reading or listing it is ordinary work.
 
     Honors :data:`_DISABLED` (env var ``AGENTOS_SENSITIVE_PATHS_DISABLED``).
     """
@@ -331,6 +385,8 @@ def sensitive_target_in_command(
         effective_workspace = cwd if cwd is not None else Path.cwd()
 
     for _kind, target in _extract_intents(command, base_dir=effective_workspace):
+        if _is_root_target(target):
+            return _ROOT_TARGET_MARKER
         marker = sensitive_path_marker(target, workspace=effective_workspace)
         if marker is not None:
             return marker

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from agentos.sandbox.sensitive_paths import (
+    _is_root_target,
     is_sensitive_path,
     sensitive_path_in_text,
     sensitive_path_marker,
@@ -138,3 +139,103 @@ def test_sensitive_reads_in_a_later_segment_are_blocked_at_the_tool_boundary() -
         sensitive_path_in_text("rm /tmp/ok; cat /root/.bash_history", workspace=workspace)
         == "/root"
     )
+
+
+def test_bare_root_delete_targets_are_hard_blocked() -> None:
+    """Issue #563: ``rm -rf /`` has no sensitive *prefix*, so the prefix list
+    never matched it and the whole-filesystem wipe reached the approval
+    prompt instead of the hard block."""
+    workspace = Path("/workspace")
+
+    for command in (
+        "rm -rf /",
+        "rm -fr /",
+        'rm -rf "/"',
+        "rm -rf / --no-preserve-root",
+        "rm -rf /.",
+        "rm -rf /..",
+        "rm -rf //",
+    ):
+        assert sensitive_target_in_command(command, workspace=workspace) == "/", command
+
+
+def test_root_glob_delete_targets_are_hard_blocked() -> None:
+    """``rm -rf /*`` expands to every top-level entry, so it is a root wipe
+    even though the literal token is not ``/``. ``*`` is not the only spelling:
+    ``/**``, ``/?*``, ``/.*`` and ``/[a-z]*`` sweep the same ground."""
+    workspace = Path("/workspace")
+
+    for command in (
+        "rm -rf /*",
+        "rm -rf /*/*",
+        "rm -rf /./*",
+        "rm -rf /**",
+        "rm -rf /?*",
+        "rm -rf /.*",
+        "rm -rf /[a-z]*",
+    ):
+        assert sensitive_target_in_command(command, workspace=workspace) == "/", command
+
+
+def test_narrowed_top_level_globs_are_not_root_wipes() -> None:
+    """A glob carrying literal text names a subset, not the whole level —
+    ``rm -rf /tmp*`` must not need ``/elevated full``."""
+    workspace = Path("/workspace")
+
+    for command in ("rm -rf /tmp*", "rm -rf /var/log*", "rm -rf /workspace/*", "rm -rf /[abc]"):
+        assert sensitive_target_in_command(command, workspace=workspace) is None, command
+
+
+def test_root_wipe_in_a_later_command_segment_is_hard_blocked() -> None:
+    """A benign approved first target must not smuggle a root wipe past the
+    hard block."""
+    workspace = Path("/workspace")
+
+    for separator in (";", "&&", "||", "|", "&", "\n"):
+        command = f"rm /tmp/ok {separator} rm -rf /"
+        assert sensitive_target_in_command(command, workspace=workspace) == "/", command
+
+
+def test_python_flavoured_root_deletes_are_hard_blocked() -> None:
+    workspace = Path("/workspace")
+
+    assert sensitive_target_in_command("shutil.rmtree('/')", workspace=workspace) == "/"
+    assert sensitive_target_in_command('os.rmdir("/")', workspace=workspace) == "/"
+
+
+def test_ordinary_delete_targets_are_not_read_as_root() -> None:
+    workspace = Path("/workspace")
+
+    for command in ("rm /tmp/ok", "rm -rf ./build", "rm *", "rm -rf /workspace/dist"):
+        assert sensitive_target_in_command(command, workspace=workspace) is None, command
+
+
+def test_root_stays_readable_outside_the_destructive_intent_scan() -> None:
+    """The root block is deliberately scoped to delete intents: listing or
+    reading ``/`` is harmless and must not be hard-blocked."""
+    workspace = Path("/workspace")
+
+    assert is_sensitive_path("/") is None
+    assert sensitive_path_marker("/", workspace=workspace) is None
+    assert sensitive_path_in_text("ls /", workspace=workspace) is None
+    assert sensitive_path_in_text("df -h /", workspace=workspace) is None
+    assert sensitive_target_in_command("ls /", workspace=workspace) is None
+
+
+def test_root_target_detection_covers_windows_drive_roots() -> None:
+    """Windows runners resolve ``/`` to a drive root, so the raw ``/`` never
+    reaches the segment check there."""
+    for target in ("/", "//", "/.", "/..", "/*", "/*/*", "C:\\", "C:/", "c:/*", "D:/./*"):
+        assert _is_root_target(target) is True, target
+
+    for target in (
+        "",
+        "*",
+        "-",
+        "/etc",
+        "/tmp*",
+        "/workspace/dist",
+        "C:/Users",
+        "relative/path",
+    ):
+        assert _is_root_target(target) is False, target

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -857,3 +857,27 @@ async def test_bypass_does_not_override_safe_bin_hard_denies() -> None:
 
     with pytest.raises(ToolError, match="command blocked by policy"):
         await shell.exec_command("Clear-Disk")
+
+
+@pytest.mark.asyncio
+async def test_root_wipe_is_hard_blocked_at_the_exec_approval_boundary() -> None:
+    """Issue #563 at the real entry point: ``rm -rf /`` must never reach the
+    approval prompt, and ``/elevated bypass`` must not lift the floor."""
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.elevated = "bypass"
+
+    for command in ("rm -rf /", "rm -rf /*", "rm /tmp/ok && rm -rf /"):
+        result = await shell._check_exec_approval(
+            "exec_command",
+            command,
+            None,
+            "command requires approval",
+            None,
+            True,
+        )
+
+        assert result is not None, command
+        assert result["status"] == "blocked"
+        assert result["reason"] == "sensitive_path"
+        assert result["sensitive_path"] == "/"


### PR DESCRIPTION
Fixes #563.

## What was actually broken

Reproducing the report against current `main` (`55fc19e`) splits it in two:

| Reported | Status on `main` |
|---|---|
| `rm -rf /` is not blocked | **Real.** `_SENSITIVE_PREFIXES` has no `/` entry, so a bare root target carries no marker. |
| Trailing target after a separator is never scanned | **Already fixed** by 2a517b3 (#512), which landed after the maintainer's repro at `6f9ad5a`. |

```
'rm -rf /'                            -> None          <-- the live hole
'rm -rf /*'                           -> None
'rm /tmp/safe; rm /root/.ssh/id_rsa'  -> '~/.ssh'      <-- already fixed
'rm /tmp/safe && rm /etc/shadow'      -> '/etc'        <-- already fixed
```

Because the hard block runs before the approval queue, the miss is not just "a prompt the user might mis-click": under `/elevated bypass` there is no prompt at all, and the pre-fix log line is `shell_approval_skipped_elevated_bypass command='rm -rf /'`.

## The fix

`_is_root_target`, consulted only by the destructive-intent scan. A target is root when every segment either resolves in place (empty, `.`, `..`) or globs across the whole level:

```
/  //  /.  /..  /*  /*/*  /**  /?*  /.*  /[a-z]*     -> blocked, marker "/"
/tmp*  /var/log*  /workspace/*  /[abc]               -> untouched
```

The glob rule matters as much as the bare `/`: `/**`, `/?*`, `/.*` and `/[a-z]*` sweep exactly the ground `/*` does. A segment carrying literal text names a subset instead of the level, so `rm -rf /tmp*` still needs only ordinary approval. Windows runners resolve `/` to a drive root (`C:\`), so a leading drive letter is stripped before the segment check.

## Why not `is_sensitive_path`

The issue suggests putting a root marker in `is_sensitive_path`. That would be wrong here. The two sensitive-path layers have deliberately different scopes:

- `sensitive_path_in_text` (behind `_sensitive_shell_block`) scans the **whole command text**, so anything it marks is refused on mere mention.
- `sensitive_target_in_command` inspects **destructive intents only**.

`'/'.strip(_TOKEN_EDGE_CHARS) == '/'`, so the bare `/` token in `ls /` does reach `sensitive_path_marker` — a shared root marker would hard-block `ls /`, `df -h /`, `find / -name x` and `read_file("/")`. Deleting root is catastrophic; reading it is ordinary work. A test pins that split so the scope is not widened by accident later.

## Tests

11 new cases across two files, including one at the real boundary (`shell._check_exec_approval` under `elevated="bypass"`) rather than only against the extractor. Reverting just the `sensitive_paths.py` hunk fails exactly the new behavioural tests and no others.

## Verification

- `uv run --all-extras pytest -q` — 8905 passed, 3 failed, 26 skipped. The 3 failures are pre-existing and unrelated (`test_mem0_provider`, `test_provider_config`, `test_skill_html_to_pdf`); they fail identically on unmodified `main`.
- `uv run --all-extras ruff check src tests` — clean.
- `uv run --all-extras mypy src/agentos --show-error-codes` — only the pre-existing `mem0` `import-untyped` error.

## Out of scope, noted while reviewing

Two adjacent gaps in the *existing* denylist, neither caused nor fixed here — happy to file them separately if useful:

1. Brace expansion defeats the text scan: `rm -rf /bin /etc /usr` is blocked on `/etc`, but `rm -rf /{bin,etc,usr}` is not, because `_ABSOLUTE_OR_TILDE_PATH_RE` excludes `{}`.
2. `_extract_intents` knows only `rm` plus three Python delete patterns, so `find / -delete` produces no intent and mentions no sensitive prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R93fTgCgPoWycYJaHmGg95