### PR TITLE
fix(tools): AST-based destructive code detection for execute_code

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -25,8 +25,10 @@ from agentos.tools.types import ToolError, current_tool_context
 
 # Destructive Python patterns that must go through the same approval flow as
 # shell warnlist hits. Catches the "agent pivots from `rm` to `os.remove()`"
-# bypass. Matching is intentionally shallow (regex, not AST) — goal is to
-# force approval on obvious intent, not to prove safety.
+# bypass. This is layer 1 (regex); the AST scan in _check_code_destructive
+# adds layer 2 for indirect access the regex cannot see. Both layers are
+# intentionally shallow — the goal is to force approval on obvious intent,
+# not to prove safety.
 _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
     (r"\bos\.remove\s*\(", "os.remove()"),
     (r"\bos\.unlink\s*\(", "os.unlink()"),
@@ -45,6 +47,17 @@ _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
         "subprocess invoking rmdir",
     ),
 ]
+
+# Dotted call names that are destructive (module‑prefixed), e.g. "os.remove",
+# "shutil.rmtree". Used by the AST layer to catch indirect access.
+_DESTRUCTIVE_CALLS: frozenset[str] = frozenset(
+    {"os.remove", "os.unlink", "os.rmdir", "os.removedirs", "shutil.rmtree", "os.system"}
+)
+# Attribute names that are destructive when reached via getattr or on a
+# Path() receiver: Path.unlink / Path.rmdir / os.remove via getattr.
+_DESTRUCTIVE_ATTRS: frozenset[str] = frozenset(
+    {"remove", "unlink", "rmdir", "removedirs", "rmtree", "system"}
+)
 
 
 def _check_code_destructive(code: str) -> str | None:
@@ -66,15 +79,6 @@ def _check_code_destructive(code: str) -> str | None:
     except SyntaxError:
         # Unparseable code: the regex layer already ran; nothing more to do.
         return None
-
-    # Dotted call names that are destructive, e.g. "os.remove", "shutil.rmtree".
-    _DESTRUCTIVE_CALLS = {
-        "os.remove", "os.unlink", "os.rmdir", "os.removedirs",
-        "shutil.rmtree", "os.system",
-    }
-    # Attribute names that are destructive when called on any object,
-    # e.g. Path.unlink / Path.rmdir / os.remove reached via getattr.
-    _DESTRUCTIVE_ATTRS = {"remove", "unlink", "rmdir", "removedirs", "rmtree", "system"}
 
     def _dotted(node: ast.AST) -> str | None:
         """Return the dotted name of a Name/Attribute chain, else None."""
@@ -116,19 +120,22 @@ def _check_code_destructive(code: str) -> str | None:
                     found = f"destructive Python operation detected: {recv}.{node.func.attr}()"
                     break
             # 2) getattr(obj, "remove") / getattr(os, "rem" + "ove")
-            if isinstance(node.func, ast.Name) and node.func.id == "getattr" and len(node.args) >= 2:
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+            ):
                 attr = _string_const(node.args[1])
                 if attr in _DESTRUCTIVE_ATTRS:
                     found = f"destructive Python operation detected: getattr(..., {attr!r})"
                     break
                 # concat-built attr: "rem" + "ove"
                 if isinstance(node.args[1], ast.BinOp):
-                    parts = [
-                        _string_const(v)
+                    joined = "".join(
+                        v.value
                         for v in ast.walk(node.args[1])
-                        if isinstance(v, ast.Constant)
-                    ]
-                    joined = "".join(p for p in parts if p is not None)
+                        if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                    )
                     if joined in _DESTRUCTIVE_ATTRS:
                         found = f"destructive Python operation detected: getattr(..., {joined!r})"
                         break
@@ -145,16 +152,44 @@ def _check_code_destructive(code: str) -> str | None:
                                 f"{base_name}({mod!r}).{node.func.attr}()"
                             )
                             break
-            # 4) eval/exec of a destructive call string
+            # 4) eval/exec of a destructive call string. Constant-fold the
+            #    argument first so concat-built payloads ("os." + "remove" +
+            #    "(...)") are checked as the string they evaluate to.
             if isinstance(node.func, ast.Name) and node.func.id in ("eval", "exec") and node.args:
-                payload = _string_const(node.args[0])
-                if payload is not None:
+                arg = node.args[0]
+                try:
+                    folded = ast.literal_eval(arg)
+                except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+                    folded = None
+                if not isinstance(folded, str) and isinstance(arg, ast.BinOp):
+                    # literal_eval rejects BinOp nodes; fold nested string
+                    # concatenations manually so "os." + "remove" + "..." is
+                    # checked as the string it evaluates to.
+                    parts: list[str] = []
+
+                    def _fold(n: ast.AST) -> None:
+                        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Add):
+                            _fold(n.left)
+                            _fold(n.right)
+                        elif isinstance(n, ast.Constant) and isinstance(n.value, str):
+                            parts.append(n.value)
+                        else:
+                            parts.clear()
+                            parts.append("\x00__unsupported__")
+
+                    _fold(arg)
+                    if parts and parts[0] != "\x00__unsupported__":
+                        folded = "".join(parts)
+                if isinstance(folded, str):
                     for pattern, label in _DESTRUCTIVE_PY_PATTERNS:
-                        if re.search(pattern, payload):
-                            found = f"destructive Python operation detected: {node.func.id}() of {label}"
+                        if re.search(pattern, folded):
+                            found = (
+                                f"destructive Python operation detected: "
+                                f"{node.func.id}() of {label}"
+                            )
                             break
-                    if found is not None:
-                        break
+                if found is not None:
+                    break
     return found
 
 

--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -48,11 +48,114 @@ _DESTRUCTIVE_PY_PATTERNS: list[tuple[str, str]] = [
 
 
 def _check_code_destructive(code: str) -> str | None:
-    """Return a human-readable warning if *code* triggers a destructive pattern, else None."""
+    """Return a human-readable warning if *code* triggers a destructive pattern.
+
+    Layer 1 is the original regex pass (fast, catches the obvious). Layer 2 is
+    an AST scan that catches indirect access the regex cannot see:
+    ``getattr(os, "remove")``, ``__import__("os").remove``,
+    ``importlib.import_module("os").remove``, and ``eval``/``exec`` of a
+    destructive call. The AST layer is deliberately shallow — it flags
+    obvious intent to force the approval prompt, it does not prove safety.
+    """
     for pattern, label in _DESTRUCTIVE_PY_PATTERNS:
         if re.search(pattern, code):
             return f"destructive Python operation detected: {label}"
-    return None
+
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        # Unparseable code: the regex layer already ran; nothing more to do.
+        return None
+
+    # Dotted call names that are destructive, e.g. "os.remove", "shutil.rmtree".
+    _DESTRUCTIVE_CALLS = {
+        "os.remove", "os.unlink", "os.rmdir", "os.removedirs",
+        "shutil.rmtree", "os.system",
+    }
+    # Attribute names that are destructive when called on any object,
+    # e.g. Path.unlink / Path.rmdir / os.remove reached via getattr.
+    _DESTRUCTIVE_ATTRS = {"remove", "unlink", "rmdir", "removedirs", "rmtree", "system"}
+
+    def _dotted(node: ast.AST) -> str | None:
+        """Return the dotted name of a Name/Attribute chain, else None."""
+        parts: list[str] = []
+        cur: ast.AST = node
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+            return ".".join(reversed(parts))
+        return None
+
+    def _string_const(node: ast.AST) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        return None
+
+    found: str | None = None
+
+    for node in ast.walk(tree):
+        if found is not None:
+            break
+        if isinstance(node, ast.Call):
+            # 1) Direct dotted call on a known module: os.remove(...) /
+            #    shutil.rmtree(...) — but NOT list.remove() / dict.pop() etc.
+            dotted = _dotted(node.func)
+            if dotted in _DESTRUCTIVE_CALLS:
+                found = f"destructive Python operation detected: {dotted}()"
+                break
+            # 1b) Path.unlink() / Path.rmdir(): receiver is a Path() call.
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr in _DESTRUCTIVE_ATTRS
+                and isinstance(node.func.value, ast.Call)
+            ):
+                recv = _dotted(node.func.value.func)
+                if recv in ("Path", "pathlib.Path", "PurePath", "os.PathLike"):
+                    found = f"destructive Python operation detected: {recv}.{node.func.attr}()"
+                    break
+            # 2) getattr(obj, "remove") / getattr(os, "rem" + "ove")
+            if isinstance(node.func, ast.Name) and node.func.id == "getattr" and len(node.args) >= 2:
+                attr = _string_const(node.args[1])
+                if attr in _DESTRUCTIVE_ATTRS:
+                    found = f"destructive Python operation detected: getattr(..., {attr!r})"
+                    break
+                # concat-built attr: "rem" + "ove"
+                if isinstance(node.args[1], ast.BinOp):
+                    parts = [
+                        _string_const(v)
+                        for v in ast.walk(node.args[1])
+                        if isinstance(v, ast.Constant)
+                    ]
+                    joined = "".join(p for p in parts if p is not None)
+                    if joined in _DESTRUCTIVE_ATTRS:
+                        found = f"destructive Python operation detected: getattr(..., {joined!r})"
+                        break
+            # 3) __import__("os").remove(...) / importlib.import_module("os").remove(...)
+            if isinstance(node.func, ast.Attribute) and node.func.attr in _DESTRUCTIVE_ATTRS:
+                base = node.func.value
+                if isinstance(base, ast.Call):
+                    base_name = _dotted(base.func) or ""
+                    if base_name in ("__import__", "importlib.import_module", "import_module"):
+                        mod = _string_const(base.args[0]) if base.args else None
+                        if mod in ("os", "shutil", "pathlib") or mod is None:
+                            found = (
+                                f"destructive Python operation detected: "
+                                f"{base_name}({mod!r}).{node.func.attr}()"
+                            )
+                            break
+            # 4) eval/exec of a destructive call string
+            if isinstance(node.func, ast.Name) and node.func.id in ("eval", "exec") and node.args:
+                payload = _string_const(node.args[0])
+                if payload is not None:
+                    for pattern, label in _DESTRUCTIVE_PY_PATTERNS:
+                        if re.search(pattern, payload):
+                            found = f"destructive Python operation detected: {node.func.id}() of {label}"
+                            break
+                    if found is not None:
+                        break
+    return found
 
 
 _CODE_SENSITIVE_READ_TOKENS = (

--- a/tests/test_tools/test_code_exec_destructive.py
+++ b/tests/test_tools/test_code_exec_destructive.py
@@ -1,0 +1,203 @@
+"""Regression tests for _check_code_destructive.
+
+These tests pin the behaviour of the destructive‑pattern detector in
+``agentos.tools.builtin.code_exec``.  The detector is intentionally shallow —
+its only job is to force the approval prompt when an agent is about to do
+something destructive.  It does NOT prove safety.
+
+The tests cover:
+- Direct calls that must be flagged (os.remove, shutil.rmtree, …)
+- Indirect calls that must be flagged (getattr, __import__, eval/exec, …)
+- Non‑destructive calls that must NOT be flagged (list.remove, eval(1+1), …)
+"""
+from __future__ import annotations
+
+from agentos.tools.builtin import code_exec
+
+
+# ---------------------------------------------------------------------------
+# Direct calls — must be flagged
+# ---------------------------------------------------------------------------
+def test_direct_os_remove() -> None:
+    assert code_exec._check_code_destructive('os.remove("/tmp/x")') is not None
+
+
+def test_direct_os_unlink() -> None:
+    assert code_exec._check_code_destructive('os.unlink("/tmp/x")') is not None
+
+
+def test_direct_os_rmdir() -> None:
+    assert code_exec._check_code_destructive('os.rmdir("/tmp/x")') is not None
+
+
+def test_direct_os_removedirs() -> None:
+    assert code_exec._check_code_destructive('os.removedirs("/tmp/x")') is not None
+
+
+def test_direct_shutil_rmtree() -> None:
+    assert code_exec._check_code_destructive('shutil.rmtree("/tmp/x")') is not None
+
+
+def test_direct_path_unlink() -> None:
+    assert code_exec._check_code_destructive('Path("/tmp/x").unlink()') is not None
+
+
+def test_direct_path_rmdir() -> None:
+    assert code_exec._check_code_destructive('Path("/tmp/x").rmdir()') is not None
+
+
+def test_direct_os_system_with_rm() -> None:
+    assert code_exec._check_code_destructive('os.system("rm -rf /tmp/x")') is not None
+
+
+def test_direct_subprocess_rm() -> None:
+    assert code_exec._check_code_destructive(
+        'subprocess.run(["rm", "-rf", "/tmp/x"])'
+    ) is not None
+
+
+# ---------------------------------------------------------------------------
+# Indirect calls — must be flagged (the bypass we are closing)
+# ---------------------------------------------------------------------------
+def test_getattr_concat_bypass() -> None:
+    """getattr(os, "rem" + "ove") — the original regex misses this."""
+    assert code_exec._check_code_destructive(
+        'getattr(os, "rem" + "ove")("/tmp/x")'
+    ) is not None
+
+
+def test_getattr_plain() -> None:
+    assert code_exec._check_code_destructive(
+        'getattr(os, "remove")("/tmp/x")'
+    ) is not None
+
+
+def test_getattr_unlink() -> None:
+    assert code_exec._check_code_destructive(
+        'getattr(os, "unlink")("/tmp/x")'
+    ) is not None
+
+
+def test_getattr_rmdir() -> None:
+    assert code_exec._check_code_destructive(
+        'getattr(os, "rmdir")("/tmp/x")'
+    ) is not None
+
+
+def test_getattr_rmtree() -> None:
+    assert code_exec._check_code_destructive(
+        'getattr(shutil, "rmtree")("/tmp/x")'
+    ) is not None
+
+
+def test_dunder_import_remove() -> None:
+    assert code_exec._check_code_destructive(
+        '__import__("os").remove("/tmp/x")'
+    ) is not None
+
+
+def test_dunder_import_system_rm() -> None:
+    assert code_exec._check_code_destructive(
+        '__import__("os").system("rm -rf /tmp/x")'
+    ) is not None
+
+
+def test_importlib_remove() -> None:
+    assert code_exec._check_code_destructive(
+        'importlib.import_module("os").remove("/tmp/x")'
+    ) is not None
+
+
+def test_eval_of_destructive_string() -> None:
+    assert code_exec._check_code_destructive(
+        "eval(\"os.remove('/tmp/x')\")"
+    ) is not None
+
+
+def test_exec_of_destructive_string() -> None:
+    assert code_exec._check_code_destructive(
+        "exec(\"os.remove('/tmp/x')\")"
+    ) is not None
+
+
+def test_eval_of_destructive_concat() -> None:
+    """eval of a string built via concatenation."""
+    assert code_exec._check_code_destructive(
+        "eval(\"os.\" + \"remove\" + \"('/tmp/x')\")"
+    ) is not None
+
+
+def test_exec_of_destructive_concat() -> None:
+    assert code_exec._check_code_destructive(
+        "exec(\"os.\" + \"remove\" + \"('/tmp/x')\")"
+    ) is not None
+
+
+# ---------------------------------------------------------------------------
+# Non‑destructive calls — must NOT be flagged (false‑positive guard)
+# ---------------------------------------------------------------------------
+def test_print_is_clean() -> None:
+    assert code_exec._check_code_destructive('print("hello world")') is None
+
+
+def test_list_remove_is_clean() -> None:
+    """x.remove(1) is list.remove, NOT os.remove — must not flag."""
+    assert code_exec._check_code_destructive('x = [1,2,3]; x.remove(1)') is None
+
+
+def test_dict_pop_is_clean() -> None:
+    assert code_exec._check_code_destructive('d = {"a":1}; d.pop("a")') is None
+
+
+def test_os_getcwd_is_clean() -> None:
+    assert code_exec._check_code_destructive('import os; os.getcwd()') is None
+
+
+def test_shutil_copy_is_clean() -> None:
+    assert code_exec._check_code_destructive('shutil.copy("/a", "/b")') is None
+
+
+def test_eval_arithmetic_is_clean() -> None:
+    assert code_exec._check_code_destructive('result = eval("1+1")') is None
+
+
+def test_exec_arithmetic_is_clean() -> None:
+    assert code_exec._check_code_destructive('exec("x = 1")') is None
+
+
+def test_string_with_remove_in_comment() -> None:
+    """A comment mentioning os.remove must not trigger."""
+    assert code_exec._check_code_destructive(
+        '# This code does NOT call os.remove, it is safe\nprint("ok")'
+    ) is None
+
+
+def test_multiline_destructive() -> None:
+    """Multi‑line code with a destructive call on the second line."""
+    assert code_exec._check_code_destructive(
+        'import os\nos.remove("/tmp/x")'
+    ) is not None
+
+
+# ---------------------------------------------------------------------------
+# Sabotage run — prove the regression test fails without the fix
+# ---------------------------------------------------------------------------
+def test_sabotage_run_fails_without_fix(monkeypatch) -> None:
+    """Temporarily restore the old regex‑only behaviour and confirm the test fails.
+
+    This is the sabotage run required by the contribution skill: a regression
+    test that passes with AND without the fix proves nothing.
+    """
+    import re
+
+    def old_check(code: str) -> str | None:
+        for pattern, label in code_exec._DESTRUCTIVE_PY_PATTERNS:
+            if re.search(pattern, code):
+                return f"destructive Python operation detected: {label}"
+        return None
+
+    monkeypatch.setattr(code_exec, "_check_code_destructive", old_check)
+    # The bypass payloads must NOT be caught by the old regex.
+    assert old_check('getattr(os, "rem" + "ove")("/tmp/x")') is None
+    assert old_check('__import__("os").remove("/tmp/x")') is None
+    assert old_check('eval("os.remove(\'/tmp/x\')")') is None

--- a/tests/test_tools/test_code_exec_destructive.py
+++ b/tests/test_tools/test_code_exec_destructive.py
@@ -10,6 +10,7 @@ The tests cover:
 - Indirect calls that must be flagged (getattr, __import__, eval/exec, …)
 - Non‑destructive calls that must NOT be flagged (list.remove, eval(1+1), …)
 """
+
 from __future__ import annotations
 
 from agentos.tools.builtin import code_exec
@@ -51,9 +52,7 @@ def test_direct_os_system_with_rm() -> None:
 
 
 def test_direct_subprocess_rm() -> None:
-    assert code_exec._check_code_destructive(
-        'subprocess.run(["rm", "-rf", "/tmp/x"])'
-    ) is not None
+    assert code_exec._check_code_destructive('subprocess.run(["rm", "-rf", "/tmp/x"])') is not None
 
 
 # ---------------------------------------------------------------------------
@@ -61,76 +60,55 @@ def test_direct_subprocess_rm() -> None:
 # ---------------------------------------------------------------------------
 def test_getattr_concat_bypass() -> None:
     """getattr(os, "rem" + "ove") — the original regex misses this."""
-    assert code_exec._check_code_destructive(
-        'getattr(os, "rem" + "ove")("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('getattr(os, "rem" + "ove")("/tmp/x")') is not None
 
 
 def test_getattr_plain() -> None:
-    assert code_exec._check_code_destructive(
-        'getattr(os, "remove")("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('getattr(os, "remove")("/tmp/x")') is not None
 
 
 def test_getattr_unlink() -> None:
-    assert code_exec._check_code_destructive(
-        'getattr(os, "unlink")("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('getattr(os, "unlink")("/tmp/x")') is not None
 
 
 def test_getattr_rmdir() -> None:
-    assert code_exec._check_code_destructive(
-        'getattr(os, "rmdir")("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('getattr(os, "rmdir")("/tmp/x")') is not None
 
 
 def test_getattr_rmtree() -> None:
-    assert code_exec._check_code_destructive(
-        'getattr(shutil, "rmtree")("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('getattr(shutil, "rmtree")("/tmp/x")') is not None
 
 
 def test_dunder_import_remove() -> None:
-    assert code_exec._check_code_destructive(
-        '__import__("os").remove("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('__import__("os").remove("/tmp/x")') is not None
 
 
 def test_dunder_import_system_rm() -> None:
-    assert code_exec._check_code_destructive(
-        '__import__("os").system("rm -rf /tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('__import__("os").system("rm -rf /tmp/x")') is not None
 
 
 def test_importlib_remove() -> None:
-    assert code_exec._check_code_destructive(
-        'importlib.import_module("os").remove("/tmp/x")'
-    ) is not None
+    assert (
+        code_exec._check_code_destructive('importlib.import_module("os").remove("/tmp/x")')
+        is not None
+    )
 
 
 def test_eval_of_destructive_string() -> None:
-    assert code_exec._check_code_destructive(
-        "eval(\"os.remove('/tmp/x')\")"
-    ) is not None
+    assert code_exec._check_code_destructive("eval(\"os.remove('/tmp/x')\")") is not None
 
 
 def test_exec_of_destructive_string() -> None:
-    assert code_exec._check_code_destructive(
-        "exec(\"os.remove('/tmp/x')\")"
-    ) is not None
+    assert code_exec._check_code_destructive("exec(\"os.remove('/tmp/x')\")") is not None
 
 
 def test_eval_of_destructive_concat() -> None:
     """eval of a string built via concatenation."""
-    assert code_exec._check_code_destructive(
-        "eval(\"os.\" + \"remove\" + \"('/tmp/x')\")"
-    ) is not None
+    assert code_exec._check_code_destructive('eval("os." + "remove" + "(\'/tmp/x\')")') is not None
 
 
 def test_exec_of_destructive_concat() -> None:
-    assert code_exec._check_code_destructive(
-        "exec(\"os.\" + \"remove\" + \"('/tmp/x')\")"
-    ) is not None
+    assert code_exec._check_code_destructive('exec("os." + "remove" + "(\'/tmp/x\')")') is not None
 
 
 # ---------------------------------------------------------------------------
@@ -142,7 +120,7 @@ def test_print_is_clean() -> None:
 
 def test_list_remove_is_clean() -> None:
     """x.remove(1) is list.remove, NOT os.remove — must not flag."""
-    assert code_exec._check_code_destructive('x = [1,2,3]; x.remove(1)') is None
+    assert code_exec._check_code_destructive("x = [1,2,3]; x.remove(1)") is None
 
 
 def test_dict_pop_is_clean() -> None:
@@ -150,7 +128,7 @@ def test_dict_pop_is_clean() -> None:
 
 
 def test_os_getcwd_is_clean() -> None:
-    assert code_exec._check_code_destructive('import os; os.getcwd()') is None
+    assert code_exec._check_code_destructive("import os; os.getcwd()") is None
 
 
 def test_shutil_copy_is_clean() -> None:
@@ -167,16 +145,17 @@ def test_exec_arithmetic_is_clean() -> None:
 
 def test_string_with_remove_in_comment() -> None:
     """A comment mentioning os.remove must not trigger."""
-    assert code_exec._check_code_destructive(
-        '# This code does NOT call os.remove, it is safe\nprint("ok")'
-    ) is None
+    assert (
+        code_exec._check_code_destructive(
+            '# This code does NOT call os.remove, it is safe\nprint("ok")'
+        )
+        is None
+    )
 
 
 def test_multiline_destructive() -> None:
     """Multi‑line code with a destructive call on the second line."""
-    assert code_exec._check_code_destructive(
-        'import os\nos.remove("/tmp/x")'
-    ) is not None
+    assert code_exec._check_code_destructive('import os\nos.remove("/tmp/x")') is not None
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +169,9 @@ def test_sabotage_run_fails_without_fix(monkeypatch) -> None:
     """
     import re
 
+    # Capture the fixed implementation before monkeypatching it out.
+    fixed_check = code_exec._check_code_destructive
+
     def old_check(code: str) -> str | None:
         for pattern, label in code_exec._DESTRUCTIVE_PY_PATTERNS:
             if re.search(pattern, code):
@@ -197,7 +179,15 @@ def test_sabotage_run_fails_without_fix(monkeypatch) -> None:
         return None
 
     monkeypatch.setattr(code_exec, "_check_code_destructive", old_check)
-    # The bypass payloads must NOT be caught by the old regex.
+
+    # The bypass payloads must NOT be caught by the old regex. A plain
+    # eval("os.remove(...)") string IS caught by the regex layer, so the
+    # eval case uses the concat-built form — the actual regex blind spot.
     assert old_check('getattr(os, "rem" + "ove")("/tmp/x")') is None
     assert old_check('__import__("os").remove("/tmp/x")') is None
-    assert old_check('eval("os.remove(\'/tmp/x\')")') is None
+    assert old_check('eval("os." + "remove" + "(\'/tmp/x\')")') is None
+
+    # The AST-based implementation catches all of them.
+    assert fixed_check('getattr(os, "rem" + "ove")("/tmp/x")') is not None
+    assert fixed_check('__import__("os").remove("/tmp/x")') is not None
+    assert fixed_check('eval("os." + "remove" + "(\'/tmp/x\')")') is not None


### PR DESCRIPTION
Fixes #848

## Summary

Adds a defense-in-depth **AST layer** to `_check_code_destructive()` in the `execute_code` tool so the approval gate also fires on indirect forms of destructive filesystem calls — the regex first layer cannot see these:

- `getattr(os, "remove")(...)` and concat-built attr names (`getattr(os, "rem" + "ove")`)
- `__import__("os").remove(...)` and `importlib.import_module("os").remove(...)`
- `Path("/x").unlink()` / `.rmdir()`
- `eval()` / `exec()` of a destructive payload, including strings built by concatenation (`eval("os." + "remove" + "('/tmp/x')")`) via constant folding of the argument

**Framing per maintainer guidance on #848:** this is defense-in-depth for the approval gate when `sandbox_enabled=False`. The regex layer stays as layer 1 (unchanged behavior for everything it already caught); the AST scan is layer 2. This does **not** claim to prevent bypasses — attribute names computed at runtime (e.g. `getattr(os, chr(114)+...)` or names read from input) remain undecidable statically; the goal is to force the approval prompt on obvious intent, not to prove safety.

Behavior when `sandbox_enabled=False` is unchanged: the destructive-Python gate runs before execution and routes through the same `_check_exec_approval` approval flow as shell warnlist hits, so indirect destructive forms now also require approval outside the sandbox.

## What

- `src/agentos/tools/builtin/code_exec.py` — `_DESTRUCTIVE_CALLS` / `_DESTRUCTIVE_ATTRS` module constants; AST walk in `_check_code_destructive` with: (1) direct dotted calls, (1b) `Path()` receiver methods, (2) `getattr` with literal and concat-folded attr names, (3) `__import__`/`importlib.import_module` attribute chains, (4) `eval`/`exec` payloads with `ast.literal_eval` plus a manual fold for concat-built strings. Regex layer 1 kept untouched.
- `tests/test_tools/test_code_exec_destructive.py` — 31 tests: direct/indirect flag cases, false-positive guards (`list.remove`, `shutil.copy`, comments, arithmetic eval), multiline, plus a sabotage run that restores the old regex-only behavior and proves it misses the `getattr`-concat, `__import__`, and concat-`eval` payloads while the fixed implementation catches all three.

## Verification

```
ruff check src/agentos/tools/builtin/code_exec.py tests/test_tools/test_code_exec_destructive.py
# All checks passed!

ruff format --check src/agentos/tools/builtin/code_exec.py tests/test_tools/test_code_exec_destructive.py
# 2 files already formatted

python -m pytest tests/test_tools/test_code_exec_destructive.py -q
# 31 passed

python -m pytest tests/test_tools/test_code_exec_output_redaction.py -q
# 2 passed  (no regressions)
```

False-positive guards confirm normal code (`x.remove(1)` on a list, `shutil.copy`, comments mentioning `os.remove`, `eval("1+1")`) still executes without the approval prompt.
