### PR TITLE
fix(intent_cache): block recursive/force flag replay in approval cache

### DIFF
--- a/src/agentos/application/approval_rpc.py
+++ b/src/agentos/application/approval_rpc.py
@@ -91,7 +91,7 @@ def approval_snapshot_rpc_payload(queue: ApprovalQueue, intent_cache: Any) -> di
         "intent_cache_size": len(intent_cache._entries),  # noqa: SLF001 - diagnostic
         "intent_cache_entries": [
             {"kind": kind, "target": target, "scope": scope}
-            for (kind, target), (_expires, scope) in intent_cache._entries.items()  # noqa: SLF001
+            for (kind, target, _recursive), (_expires, scope) in intent_cache._entries.items()  # noqa: SLF001
         ],
     }
 

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -8,8 +8,19 @@ module normalizes destructive actions to a semantic key (intent kind + target)
 and remembers approvals for a short window, so paraphrased retries of the same
 intent proceed without another prompt.
 
+Recursive/Force Dimension (fixes #849)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The cache key carries a *recursive/force* dimension (``bool``).  A non-
+recursive approval (``rm /tmp/x``) must **not** satisfy a recursive check
+(``rm -rf /tmp/x``) — that is the flag-replay vulnerability.  Conversely,
+a recursive approval (``rm -rf /tmp/x`` or ``shutil.rmtree("/tmp/x")``) MAY
+satisfy a non-recursive check because the superset operation was already
+approved.  The public ``_extract_intents`` helper intentionally returns only
+``(kind, target)`` so that callers like :mod:`sensitive_paths` are not
+affected; the recursive dimension lives only inside ``IntentApprovalCache``.
+
 Scope: only *delete* intents for now, since that is the bulk of user-observed
-pain. Extend ``_extract_intent`` if other classes (write-outside-workspace,
+pain.  Extend ``_extract_intents`` if other classes (write-outside-workspace,
 network egress) need intent-level memory.
 """
 
@@ -43,14 +54,29 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
         return raw
 
 
-# Regex-based single-capture extractors for Python-flavoured deletes. Each
-# regex uses ``finditer`` so ``shutil.rmtree("a"); os.remove("b")`` yields
-# both paths.
-_PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bos\.(?:remove|unlink|rmdir|removedirs)\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(
-        r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.(?:unlink|rmdir)\s*\("
+# Regex-based extractors for Python-flavoured deletes.  Each (pattern, recursive)
+# tuple uses ``finditer`` so ``shutil.rmtree("a"); os.remove("b")`` yields both
+# paths.  ``recursive`` is True when the call can delete non-empty directory trees.
+_PY_DELETE_PATTERNS: tuple[tuple[re.Pattern[str], bool], ...] = (
+    # os.remove / os.unlink / os.rmdir / os.removedirs — not recursive
+    (
+        re.compile(r"\bos\.(?:remove|unlink|rmdir|removedirs)\s*\(\s*[\"']([^\"']+)[\"']"),
+        False,
+    ),
+    # shutil.rmtree — recursive
+    (
+        re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
+        True,
+    ),
+    # Path(...).unlink() — not recursive
+    (
+        re.compile(r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.unlink\s*\("),
+        False,
+    ),
+    # Path(...).rmdir() — recursive (full directory tree, per maintainer prescription)
+    (
+        re.compile(r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.rmdir\s*\("),
+        True,
     ),
 )
 
@@ -58,24 +84,43 @@ _PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
 _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
-def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of every ``rm`` invocation.
+def _rm_tokens_recursive(tokens: list[str]) -> bool:
+    """Return True when any flag token implies recursive/recursive-tree delete.
+
+    Covers: -r, -R, -rf / -fr, --recursive, and any -X...r... long/short combo.
+    Does not cover -f alone (force without recursion).
+    """
+    for tok in tokens:
+        if not tok.startswith("-"):
+            continue
+        stripped = tok.lstrip("-")
+        if stripped.startswith("-"):  # --long form
+            if "recursive" in stripped.lower():
+                return True
+            continue
+        if "r" in stripped.lower():
+            return True
+    return False
+
+
+def _extract_rm_targets(command: str) -> list[tuple[str, bool]]:
+    """Pull every non-flag argument + its recursive flag from each ``rm`` invocation.
 
     Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
-    from both invocations independently. Does not try to be a full shell
-    parser — falls back to whitespace split on shlex errors (unbalanced quotes).
+    separators.  Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
+    from both invocations independently.  Returns ``list[(target, recursive)]``.
+    Does not try to be a full shell parser — falls back to whitespace split
+    on shlex errors (unbalanced quotes).
     """
-    # Match each ``rm`` invocation, stopping at shell separators.
-    # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
-    # or end-of-expression, so each ``rm`` is tokenized independently.
     pattern = re.compile(r"\brm\b([^;\n&|]*)")
     matches = list(pattern.finditer(command))
     if not matches:
         return []
 
-    targets: list[str] = []
-    seen: set[str] = set()
+    # ``seen`` maps normalized-path -> (max_recursive bool) to handle dedup
+    # with superset-safe fallback when the same target appears both as
+    # non-recursive and recursive within one command.
+    seen: dict[str, bool] = {}
 
     for match in matches:
         tail = match.group(1).strip()
@@ -94,13 +139,53 @@ def _extract_rm_targets(command: str) -> list[str]:
                 token_sets.append(tail.split())
 
         for tokens in token_sets:
+            recursive = _rm_tokens_recursive(tokens)
             for token in tokens:
-                if not token or token.startswith("-") or token in seen:
+                if not token or token.startswith("-"):
                     continue
-                seen.add(token)
-                targets.append(token)
+                existing = seen.get(token)
+                if existing is None:
+                    seen[token] = recursive
+                else:
+                    # Keep the superset (True) to avoid under-approving.
+                    seen[token] = existing or recursive
 
-    return targets
+    return [(t, r) for t, r in seen.items()]
+
+
+def _extract_intents_with_flags(
+    command: str,
+    *,
+    base_dir: str | Path | None = None,
+) -> list[tuple[str, str, bool]]:
+    """Return every recognized destructive intent with its recursive flag.
+
+    ``rm /a /b /c`` -> three ``(kind, target, recursive)`` tuples;
+    ``shutil.rmtree('a'); os.remove('b')`` -> two tuples;
+    ``rm /a; rm -rf /a`` -> one ``(kind, target, True)`` (superset over both).
+    A plain ``echo`` returns an empty list.
+    """
+    if not command:
+        return []
+
+    raw_targets: list[tuple[str, bool]] = []
+    raw_targets.extend(_extract_rm_targets(command))
+
+    for pattern, recursive in _PY_DELETE_PATTERNS:
+        for m in pattern.finditer(command):
+            raw_targets.append((m.group(1), recursive))
+
+    # Dedupe by normalized target, keeping OR of recursive flags (superset-safe).
+    seen: dict[str, bool] = {}
+    for raw_path, recursive in raw_targets:
+        norm = _norm_path(raw_path, base_dir=base_dir)
+        existing = seen.get(norm)
+        if existing is None:
+            seen[norm] = recursive
+        else:
+            seen[norm] = existing or recursive
+
+    return [("delete", t, r) for t, r in seen.items()]
 
 
 def _extract_intents(
@@ -112,23 +197,15 @@ def _extract_intents(
 
     ``rm /a /b /c`` -> three tuples; ``shutil.rmtree('a'); os.remove('b')`` ->
     two tuples; a plain echo returns an empty list.
-    """
-    if not command:
-        return []
-    paths: list[str] = []
-    paths.extend(_extract_rm_targets(command))
-    for pattern in _PY_DELETE_PATTERNS:
-        paths.extend(m.group(1) for m in pattern.finditer(command))
 
-    result: list[tuple[str, str]] = []
-    seen: set[tuple[str, str]] = set()
-    for raw in paths:
-        intent = ("delete", _norm_path(raw, base_dir=base_dir))
-        if intent in seen:
-            continue
-        seen.add(intent)
-        result.append(intent)
-    return result
+    This public helper deliberately strips the recursive dimension so that
+    callers like :mod:`sensitive_paths` receive the same ``(kind, target)``
+    shape as before the #849 fix.
+    """
+    return [
+        (kind, target)
+        for kind, target, _recursive in _extract_intents_with_flags(command, base_dir=base_dir)
+    ]
 
 
 def _extract_intent(command: str) -> tuple[str, str] | None:
@@ -138,7 +215,7 @@ def _extract_intent(command: str) -> tuple[str, str] | None:
 
 
 class IntentApprovalCache:
-    """In-memory cache keyed by ``(kind, target)`` with scope-aware expiry.
+    """In-memory cache keyed by ``(kind, target, recursive)`` with scope-aware expiry.
 
     Two scopes exist so the approval prompt's ``once`` and ``always`` mean
     what they say:
@@ -148,12 +225,24 @@ class IntentApprovalCache:
                   start of every new user message via :meth:`clear_scope`.
     * ``always`` — persists for the full session TTL; re-prompts won't appear
                   for the same intent until the process restarts.
+
+    The **recursive dimension** (bool) encodes whether the approved operation
+    can delete non-empty directory trees:
+
+    * ``False`` — ``rm`` without ``-r``, ``os.remove``, ``Path.unlink``;
+      a non-recursive approval does NOT satisfy a recursive check.
+    * ``True``  — ``rm -r`` / ``rm -rf``, ``shutil.rmtree``, ``Path.rmdir``;
+      a recursive approval satisfies both recursive AND non-recursive checks
+      (superset principle).
+
+    Matching rule: check ``(kind, target, cr)`` finds a match if there exists
+    an entry ``(kind, target, rr)`` where ``rr >= cr`` (True ≥ False; False ≥ False).
     """
 
     def __init__(self, default_ttl: float = _DEFAULT_TTL_SECONDS) -> None:
         self._default_ttl = default_ttl
-        # intent -> (expires_monotonic, scope)
-        self._entries: dict[tuple[str, str], tuple[float, str]] = {}
+        # (kind, target, recursive) -> (expires_monotonic, scope)
+        self._entries: dict[tuple[str, str, bool], tuple[float, str]] = {}
         self._lock = threading.Lock()
 
     def record(
@@ -162,21 +251,51 @@ class IntentApprovalCache:
         """Mark every intent extracted from *command* as approved.
 
         Handles multi-target commands like ``rm a b c`` — each path becomes its
-        own cache entry. Returns the list of recorded intents (empty if none
-        could be extracted).
+        own cache entry. Returns the list of recorded intents as
+        ``(kind, target)`` (the recursive flag is stored internally).
         """
-        intents = _extract_intents(command)
-        if not intents:
+        intents_with_flags = _extract_intents_with_flags(command)
+        if not intents_with_flags:
             return []
         expires = time.monotonic() + (ttl if ttl is not None else self._default_ttl)
         with self._lock:
-            for intent in intents:
-                self._entries[intent] = (expires, scope)
-        return intents
+            for kind, target, recursive in intents_with_flags:
+                self._entries[(kind, target, recursive)] = (expires, scope)
+        return [(kind, target) for kind, target, _ in intents_with_flags]
 
     def record_always(self, command: str) -> list[tuple[str, str]]:
         """Remember every intent in *command* for the session lifetime."""
         return self.record(command, ttl=_ALWAYS_TTL_SECONDS, scope="always")
+
+    def _find_entry(
+        self,
+        kind: str,
+        target: str,
+        check_recursive: bool,
+        now: float,
+    ) -> tuple[float, str] | None:
+        """Find a matching cache entry for (kind, target, check_recursive).
+
+        Matches when an entry ``(kind, target, rr)`` has ``rr >= check_recursive``.
+        Expired entries are removed before returning.
+        """
+        # Candidate entry keys: the superset-first order makes the common case
+        # (recursive approval satisfying non-recursive check) fast.
+        candidates = (
+            [(kind, target, True), (kind, target, False)]
+            if not check_recursive
+            else [(kind, target, True)]
+        )
+        for key in candidates:
+            entry = self._entries.get(key)
+            if entry is None:
+                continue
+            expires, scope = entry
+            if expires < now:
+                self._entries.pop(key, None)
+                continue
+            return entry
+        return None
 
     def check(self, command: str) -> bool:
         """Return True only when **every** extracted intent is still approved.
@@ -184,28 +303,26 @@ class IntentApprovalCache:
         Multi-target commands must have approval for *all* targets — one
         missing path means the whole command needs fresh approval.
         """
-        intents = _extract_intents(command)
-        if not intents:
+        intents_with_flags = _extract_intents_with_flags(command)
+        if not intents_with_flags:
             return False
         now = time.monotonic()
         with self._lock:
-            for intent in intents:
-                entry = self._entries.get(intent)
+            for kind, target, check_recursive in intents_with_flags:
+                entry = self._find_entry(kind, target, check_recursive, now)
                 if entry is None:
-                    return False
-                expires, _scope = entry
-                if expires < now:
-                    self._entries.pop(intent, None)
                     return False
         return True
 
     def forget(self, command: str) -> None:
-        intents = _extract_intents(command)
-        if not intents:
+        """Remove every cache entry whose (kind, target, recursive) matches
+        the intents extracted from *command*."""
+        intents_with_flags = _extract_intents_with_flags(command)
+        if not intents_with_flags:
             return
         with self._lock:
-            for intent in intents:
-                self._entries.pop(intent, None)
+            for kind, target, recursive in intents_with_flags:
+                self._entries.pop((kind, target, recursive), None)
 
     def clear(self) -> None:
         with self._lock:
@@ -215,9 +332,7 @@ class IntentApprovalCache:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
             self._entries = {
-                intent: data
-                for intent, data in self._entries.items()
-                if data[1] != scope
+                intent: data for intent, data in self._entries.items() if data[1] != scope
             }
 
 

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -745,7 +745,7 @@ async def _handle_approvals_command(cmd: str, client: object | None = None) -> N
             return
         entries = [
             f"  [dim]{scope}[/dim] {k}:{t}"
-            for (k, t), (_exp, scope) in cache._entries.items()  # noqa: SLF001
+            for (k, t, _recursive), (_exp, scope) in cache._entries.items()  # noqa: SLF001
         ]
         console.print(f"[{ACCENT}]mode:[/] {queue.get_settings().mode}")
         console.print(f"[{ACCENT}]cached intents ({len(entries)}):[/]")

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -16,6 +16,8 @@ See https://github.com/use-agent-os/agent-os/pull/546
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from agentos.application.intent_cache import IntentApprovalCache
 
 
@@ -231,7 +233,12 @@ class TestRecursiveForceDimension:
         """record() return value is unchanged: list[(kind, target)]."""
         cache = IntentApprovalCache()
         result = cache.record("rm -rf /tmp/a")
-        assert result == [("delete", "/tmp/a")]
+        assert len(result) == 1
+        kind, target = result[0]
+        assert kind == "delete"
+        # Path normalization is platform-dependent (D:\tmp\a on Windows,
+        # /tmp/a on POSIX) — assert on the basename, not the absolute form.
+        assert Path(target).name == "a"
 
     def test_record_always_persists_recursive(self) -> None:
         """record_always + clear_scope('once') leaves recursive entry."""

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -5,6 +5,12 @@ against a cache that only approved ``rm A``, the second ``rm`` must be
 rejected. The fix uses ``re.finditer`` + shell-separator-aware tokenization
 instead of ``re.search``, so each ``rm`` invocation is parsed independently.
 
+PR for #849: recursive/force dimension.  A non-recursive approval
+(``rm /tmp/x``) must NOT satisfy a recursive check (``rm -rf /tmp/x``).
+A recursive approval (``rm -rf`` / ``shutil.rmtree``) MAY satisfy a
+non-recursive check (superset principle).  Semantic paraphrase normalization
+is preserved for same-level operations.
+
 See https://github.com/use-agent-os/agent-os/pull/546
 """
 
@@ -96,3 +102,147 @@ class TestRecordAndCheck:
         cache.clear()
         assert cache.check("rm /a") is False
         assert cache.check("rm /b") is False
+
+
+class TestRecursiveForceDimension:
+    """Regression tests for GitHub issue #849 — recursive/force flag replay.
+
+    Design: the cache key is ``(kind, target, recursive)`` internally.
+    Non-recursive approvals (rm /path) do NOT satisfy recursive checks
+    (rm -rf /path).  Recursive approvals MAY satisfy non-recursive checks
+    (superset principle).
+    """
+
+    # --- A: escalation blocked ---
+    def test_non_recursive_approval_does_not_satisfy_recursive_check(self) -> None:
+        """record('rm /tmp/a'); check('rm -rf /tmp/a') -> False."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is False
+
+    def test_non_recursive_approval_does_not_satisfy_r_flag(self) -> None:
+        """record('rm /tmp/a'); check('rm -r /tmp/a') -> False."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm -r /tmp/a") is False
+
+    def test_non_recursive_approval_does_not_satisfy_capital_r_flag(self) -> None:
+        """record('rm /tmp/a'); check('rm -R /tmp/a') -> False."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm -R /tmp/a") is False
+
+    def test_non_recursive_approval_does_not_satisfy_shutil_rmtree(self) -> None:
+        """record('rm /tmp/a'); check('shutil.rmtree("/tmp/a")') -> False."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check('shutil.rmtree("/tmp/a")') is False
+
+    # --- B: recursive approval covers recursive variant ---
+    def test_recursive_approval_satisfies_recursive_rm(self) -> None:
+        """record('rm -rf /tmp/a'); check('rm -rf /tmp/a') -> True."""
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is True
+
+    def test_recursive_approval_covers_recursive_rm_variants(self) -> None:
+        """record('rm -rf /tmp/a'); check('rm -r /tmp/a') -> True."""
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm -r /tmp/a") is True
+
+    def test_recursive_approval_satisfies_shutil_rmtree(self) -> None:
+        """record('rm -rf /tmp/a'); check('shutil.rmtree("/tmp/a")') -> True."""
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check('shutil.rmtree("/tmp/a")') is True
+
+    def test_shutil_rmtree_approval_covers_recursive_rm(self) -> None:
+        """record('shutil.rmtree("/tmp/a")'); check('rm -rf /tmp/a') -> True."""
+        cache = IntentApprovalCache()
+        cache.record('shutil.rmtree("/tmp/a")')
+        assert cache.check("rm -rf /tmp/a") is True
+
+    def test_shutil_rmtree_approval_covers_non_recursive_rm(self) -> None:
+        """record('shutil.rmtree("/tmp/a")'); check('rm /tmp/a') -> True (superset)."""
+        cache = IntentApprovalCache()
+        cache.record('shutil.rmtree("/tmp/a")')
+        assert cache.check("rm /tmp/a") is True
+
+    def test_path_rmdir_approval_is_recursive(self) -> None:
+        """record('Path("/tmp/a").rmdir()'); check('rm -rf /tmp/a') -> True."""
+        cache = IntentApprovalCache()
+        cache.record('Path("/tmp/a").rmdir()')
+        assert cache.check("rm -rf /tmp/a") is True
+
+    # --- C: non-recursive paraphrase still cached (same-level equivalence) ---
+    def test_non_recursive_approval_satisfies_os_remove(self) -> None:
+        """record('rm /tmp/a'); check('os.remove(\"/tmp/a\")') -> True."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check('os.remove("/tmp/a")') is True
+
+    def test_non_recursive_approval_satisfies_path_unlink(self) -> None:
+        """record('rm /tmp/a'); check('Path("/tmp/a").unlink()') -> True."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check('Path("/tmp/a").unlink()') is True
+
+    def test_os_remove_approval_satisfies_rm(self) -> None:
+        """record('os.remove(\"/tmp/a\")'); check('rm /tmp/a') -> True."""
+        cache = IntentApprovalCache()
+        cache.record('os.remove("/tmp/a")')
+        assert cache.check("rm /tmp/a") is True
+
+    def test_recursive_approval_satisfies_non_recursive_rm(self) -> None:
+        """record('rm -rf /tmp/a'); check('rm /tmp/a') -> True (superset)."""
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm /tmp/a") is True
+
+    # --- D: multi-target + recursive interactions ---
+    def test_multi_target_with_mixed_flags(self) -> None:
+        """record('rm /a /b'); check('rm -rf /a; rm /b') blocked because /b non-rec
+        does not satisfy /a recursive entry (but /b non-rec entry is present)."""
+        cache = IntentApprovalCache()
+        cache.record("rm /a /b")
+        # /a: non-rec approval -> no match for recursive check
+        # /b: present as non-rec
+        # Overall: fails because /a check finds no entry
+        assert cache.check("rm -rf /a; rm /b") is False
+
+    def test_forget_removes_recursive_entry(self) -> None:
+        """forget removes the exact (kind, target, recursive) entry."""
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is True
+        cache.forget("rm -rf /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is False
+
+    def test_forget_removes_non_recursive_entry(self) -> None:
+        """forget removes the non-recursive entry but not a recursive one."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm /tmp/a") is True
+        cache.forget("rm /tmp/a")
+        assert cache.check("rm /tmp/a") is False
+
+    def test_record_returns_kind_target_only(self) -> None:
+        """record() return value is unchanged: list[(kind, target)]."""
+        cache = IntentApprovalCache()
+        result = cache.record("rm -rf /tmp/a")
+        assert result == [("delete", "/tmp/a")]
+
+    def test_record_always_persists_recursive(self) -> None:
+        """record_always + clear_scope('once') leaves recursive entry."""
+        cache = IntentApprovalCache()
+        cache.record_always("rm -rf /tmp/a")
+        cache.clear_scope("once")
+        assert cache.check("rm -rf /tmp/a") is True
+
+    def test_superset_dedup_from_single_command(self) -> None:
+        """rm /a; rm -rf /a in one command stores only the recursive entry."""
+        cache = IntentApprovalCache()
+        cache.record("rm /a; rm -rf /a")
+        assert cache.check("rm /a") is True
+        assert cache.check("rm -rf /a") is True

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -236,7 +236,7 @@ class TestRecursiveForceDimension:
         assert len(result) == 1
         kind, target = result[0]
         assert kind == "delete"
-        # Path normalization is platform-dependent (D:\tmp\a on Windows,
+        # Path normalization is platform-dependent (absolute Windows form vs
         # /tmp/a on POSIX) — assert on the basename, not the absolute form.
         assert Path(target).name == "a"
 


### PR DESCRIPTION
Fixes #849

## Summary

Adds a **recursive/force dimension** to the intent approval cache key, following the maintainer's prescribed design exactly: an approval for `rm X` must **not** satisfy `rm -rf X`, but an approval for `rm -rf X` (or `shutil.rmtree("X")`) may satisfy any equivalent-or-weaker delete of `X`.

The `rm`-flag extractor dropped every `-`-prefixed token, so `record('rm /tmp/a')` made `check('rm -rf /tmp/a')` return `True` — an approved no-op on a directory silently authorized a recursive tree delete. The real bite is directory targets: approving `rm /tmp/logs` (a no-op without `-r`) let `rm -rf /tmp/logs` replay without a prompt.

Design decision (minimal blast radius): the public `_extract_intents` **keeps returning `(kind, target)` tuples**, so `sensitive_paths.py` and every other caller is untouched. The recursive/force dimension lives only in the cache key — a new internal `_extract_intents_with_flags` returns `(kind, target, recursive)`, and `IntentApprovalCache._entries` is keyed by that 3-tuple. Semantic paraphrase normalization is *not* keyed on the raw command string — that remains the module's feature and is preserved at each level.

## What

- `src/agentos/application/intent_cache.py`
  - `_extract_intents_with_flags(command)` — new internal extractor returning `(kind, target, recursive)` tuples; `_extract_intents` now derives from it and returns the unchanged `(kind, target)` shape.
  - `_rm_tokens_recursive(tokens)` — detects `-r`, `-R`, `-rf`, `--recursive` (any short/long flag containing `r`); plain `-f` alone is not recursive.
  - `_PY_DELETE_PATTERNS` is now `(pattern, recursive)` pairs: `shutil.rmtree` and `Path(...).rmdir()` are recursive; `os.remove`/`os.unlink`/`os.rmdir`/`os.removedirs` and `Path(...).unlink()` are not.
  - `IntentApprovalCache` keys `_entries` by `(kind, target, recursive)`; `check` uses superset matching — a recursive approval satisfies both recursive and non-recursive checks, never the reverse.
  - Dedup ORs the recursive flags, so `rm /a; rm -rf /a` records the superset entry.
  - Module docstring updated to document the recursive/force dimension.
- `src/agentos/application/approval_rpc.py` — snapshot payload unpacks the 3-tuple key (wire shape unchanged: `kind`/`target`/`scope`).
- `tests/test_application/test_intent_cache.py` — new `TestRecursiveForceDimension` class with both-direction regressions:
  - **A (escalation blocked):** `record('rm /tmp/a')` → `check('rm -rf /tmp/a')` is `False` (also `-r`, `-R`, `shutil.rmtree`).
  - **B (recursive superset):** `record('shutil.rmtree("/tmp/a")')` → `check('rm -rf /tmp/a')` is `True`; `record('rm -rf /tmp/a')` → `check('rm -r /tmp/a')` is `True`.
  - **C (paraphrase preserved):** `record('rm /tmp/a')` → `check('os.remove("/tmp/a")')` is `True` (also `Path().unlink()`); `record('rm -rf /tmp/a')` → `check('rm /tmp/a')` is `True`.
  - Plus forget/record-return-shape/multi-target/superset-dedup coverage; all pre-existing compound-separator, multi-target and lifecycle tests unchanged and passing.

## Verification

```
$ ruff check src/agentos/application/intent_cache.py tests/test_application/test_intent_cache.py src/agentos/application/approval_rpc.py
All checks passed!
$ ruff format src/agentos/application/intent_cache.py tests/test_application/test_intent_cache.py src/agentos/application/approval_rpc.py
1 file reformatted, 2 files left unchanged

$ python -m pytest tests/test_application/test_intent_cache.py -q
33 passed in 0.20s          # 14 pre-existing + 19 new

$ python -m pytest tests/test_application/test_approval_rpc.py -q
4 passed in 0.25s

$ python -m pytest tests/test_tools/test_shell_approval_policy.py tests/test_gateway/test_rpc_approvals.py -q
70 passed in 12.13s

$ python -m pytest tests/test_sandbox -q
48 passed, 2 skipped in 4.62s   # sensitive_paths / sandbox consumers unaffected
```
