### PR TITLE
fix(discord): do not cancel self when heartbeat loop initiates reconnect (#882)

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -308,7 +308,7 @@ class DiscordChannel:
 
     async def _do_reconnect(self) -> None:
         log.info("discord.reconnecting", session_id=self._state.session_id)
-        if self._heartbeat_task is not None:
+        if self._heartbeat_task is not None and self._heartbeat_task is not asyncio.current_task():
             self._heartbeat_task.cancel()
             self._heartbeat_task = None
         await self._close_ws()


### PR DESCRIPTION
## What this PR fixes

**Issue #882** — Discord heartbeat timeout initiates reconnect, but `_do_reconnect` cancels `self._heartbeat_task` unconditionally. When the heartbeat loop calls `_reconnect()`, the cancellation target is `asyncio.current_task()` itself — so the reconnect is interrupted before a new socket is established.

### Root Cause

`_do_reconnect` unconditionally cancels `self._heartbeat_task`. When `_heartbeat_loop` detects a missed ack, it calls `_reconnect()` -> `_do_reconnect()` from the same task. The task cancels itself and stops before `_close_ws`/`_connect_ws` completes.

### The Fix

```python
# Before: cancels unconditionally (self-cancels when heartbeat called reconnect)
if self._heartbeat_task is not None:
    self._heartbeat_task.cancel()

# After: only cancel when it's a different task
if self._heartbeat_task is not None and self._heartbeat_task is not asyncio.current_task():
    self._heartbeat_task.cancel()
```

When `_heartbeat_task is asyncio.current_task()`, the task is already executing the reconnect path. No need to cancel — the old loop's `while self._connected` condition exits when `_close_ws` runs.

## Files changed

`src/agentos/channels/discord.py` — 1 guard condition, +1 equals check

## Testing

- Heartbeat timeout -> reconnect: skip cancel -> reconnect completes
- Dispatch error -> reconnect: different task -> cancel heartbeat -> reconnect replaces it
- Shutdown: unchanged (task cancelled by shutdown path)
