### PR TITLE
fix(observability): acquire _flush_lock in OtlpTraceSink.flush() to prevent concurrent flush races (#672)

### DIFF
--- a/src/agentos/observability/otlp.py
+++ b/src/agentos/observability/otlp.py
@@ -228,37 +228,45 @@ class OtlpTraceSink(TraceSink):
         }
 
     async def flush(self) -> bool:
-        """Flush all buffered events to the OTLP HTTP collector."""
-        import httpx
+        """Flush all buffered events to the OTLP HTTP collector.
 
-        with self._queue_lock:
-            if not self._queue:
-                return True
-            events_to_send = self._queue[:]
-            self._queue.clear()
-
-        if not events_to_send:
-            return True
-
-        payload = self.build_export_payload(events_to_send)
-        req_headers = {
-            "Content-Type": "application/json",
-            **self.headers,
-        }
-
-        try:
-            async with httpx.AsyncClient(timeout=10.0, trust_env=_trust_env()) as client:
-                resp = await client.post(self.endpoint, json=payload, headers=req_headers)
-                resp.raise_for_status()
-                return True
-        except Exception as exc:
-            log.warning("otlp.export_failed", endpoint=self.endpoint, error=str(exc))
-            # Put unsent events back on failure up to max_queue_size
-            with self._queue_lock:
-                remaining_space = max(0, self.max_queue_size - len(self._queue))
-                if remaining_space > 0:
-                    self._queue = events_to_send[-remaining_space:] + self._queue
+        Acquires ``_flush_lock`` so concurrent calls from batch-triggered
+        flush and ``_periodic_flush`` do not race.
+        """
+        if self._flush_lock.locked():
+            log.debug("otlp.flush_skipped_lock_held")
             return False
+        async with self._flush_lock:
+            import httpx
+
+            with self._queue_lock:
+                if not self._queue:
+                    return True
+                events_to_send = self._queue[:]
+                self._queue.clear()
+
+            if not events_to_send:
+                return True
+
+            payload = self.build_export_payload(events_to_send)
+            req_headers = {
+                "Content-Type": "application/json",
+                **self.headers,
+            }
+
+            try:
+                async with httpx.AsyncClient(timeout=10.0, trust_env=_trust_env()) as client:
+                    resp = await client.post(self.endpoint, json=payload, headers=req_headers)
+                    resp.raise_for_status()
+                    return True
+            except Exception as exc:
+                log.warning("otlp.export_failed", endpoint=self.endpoint, error=str(exc))
+                # Put unsent events back on failure up to max_queue_size
+                with self._queue_lock:
+                    remaining_space = max(0, self.max_queue_size - len(self._queue))
+                    if remaining_space > 0:
+                        self._queue = events_to_send[-remaining_space:] + self._queue
+                return False
 
     async def close(self) -> None:
         """Close sink, cancel background flush task, and perform final flush."""


### PR DESCRIPTION
## What this PR fixes

**Issue #672** — `OtlpTraceSink.flush()` never acquires `self._flush_lock`, allowing concurrent `flush()` calls to race on `self._queue` and make simultaneous HTTP requests.

### Root Cause

`src/agentos/observability/otlp.py:97` declares `self._flush_lock = asyncio.Lock()`, but `flush()` never uses it. Both the batch-size threshold in `record_event()` and `_periodic_flush()` can call `flush()` concurrently.

### Impact

- Concurrent `httpx` POSTs to the OTLP collector
- Race on `self._queue` between the main flush body and failure re-queue logic
- Duplicate or lost trace events

### The Fix

1. Early return if `_flush_lock.locked()` (serialized by another caller)
2. Wrap entire flush body in `async with self._flush_lock:`

### Files changed

`src/agentos/observability/otlp.py` — `flush()` method: +3 lines (lock check + context manager)

### Testing

- Batch-triggered flush while `_periodic_flush` is in flight: `_flush_lock.locked()=True` → skip + `return False`
- Single concurrent flush: lock acquired → serial execution
- No flush in flight: lock not held → normal behavior

## CI

Depends on GitHub Actions runner availability.