### PR TITLE
fix(skills): verify Robinhood RWA addresses on chain, not by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`robinhood-rwa-addresses` now verifies every address against Robinhood
+  Chain instead of trusting the token index.** The skill decided what counted
+  as a genuine Stock Token from a name suffix in CoinGecko's list, which was
+  wrong in both directions. CoinGecko caps `name` at 60 characters, so long
+  listings lost the "• Robinhood Token" marker mid-word and were dropped
+  entirely — `--query IBM` returned no matches at all, as did VTI, XLK, CTSH
+  and CRDO. In the other direction, 47 of the 238 entries the skill reported as
+  verified Stock Tokens (JPM, MCD, DIS, UBER, ABNB, PYPL and others) have **no
+  contract deployed at the advertised address**; the skill handed them out as
+  usable addresses, and funds sent to one would be unrecoverable.
+
+  Discovery still ranks candidates from the token list, but the answer is now
+  settled on chain: every genuine Stock Token is a proxy pointing at Robinhood's
+  shared EIP-1967 beacon `0xe10b6f6b275de231345c20d14ab812db62151b00`, which a
+  permissionless impersonator cannot forge. One batched JSON-RPC round-trip
+  (`https://rpc.mainnet.chain.robinhood.com`, no key, ~0.5s) classifies each
+  match as `verified`, `not-deployed`, `not-a-stock-token`, or `unverified`,
+  and a top-level `warning` carries the caveat. Undeployed listings are still
+  returned — silently dropping them reads as "the skill is broken" — but are
+  flagged and never presented as usable addresses.
+
+  Following `robinhood-chain-stocks`, an unreachable node yields `unverified`
+  rather than a negative verdict: a network fault is never reported as evidence
+  that a token is fake. `--no-verify` skips the check explicitly and says so in
+  its own wording, and `--rpc-url` points at an alternate node. The name-suffix
+  match is retained only as the offline fallback, now tolerant of truncation.
+
 - The sensitive-path hard block now refuses destructive intents that target
   the filesystem root. `rm -rf /` carries no sensitive *prefix*, so the
   denylist never matched it and a whole-host wipe fell through to the ordinary

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -35,10 +35,37 @@ entrypoint:
 Resolve a real-world stock or ETF to its **Robinhood tokenized-asset (RWA)**
 on-chain token: ticker/symbol, contract address, chain id, and decimals.
 
-Data source (public, no key): `https://tokens.coingecko.com/robinhood/all.json`
-— the official CoinGecko token list for Robinhood Chain (chainId `4663`). Stock
-Token names in that list carry a "• Robinhood Token" suffix; this skill strips
-it for display so plain company names match, and uses it to filter.
+The lookup runs in two stages, and the second one is what makes the answer
+trustworthy.
+
+**1. Discovery** — rank candidates against the public CoinGecko token list for
+Robinhood Chain (`https://tokens.coingecko.com/robinhood/all.json`, chainId
+`4663`, no key). This is a third-party index, so it is a starting point, not
+proof: it advertises assets Robinhood has announced but never deployed, and it
+caps `name` at 60 characters, which chops the "• Robinhood Token" marker off
+long listings like IBM and XLK.
+
+**2. Verification** — confirm each candidate against Robinhood Chain itself over
+JSON-RPC (`https://rpc.mainnet.chain.robinhood.com`, no key). Every genuine
+Stock Token is a proxy pointing at Robinhood's shared EIP-1967 beacon
+`0xe10b6f6b275de231345c20d14ab812db62151b00`. A permissionless impersonator
+cannot forge that, and an undeployed listing has no contract at all. One
+batched round-trip covers every candidate.
+
+## Read `status` before you answer
+
+Every match carries a `status`. **Never report an address without it.**
+
+| `status` | Meaning | How to answer |
+|---|---|---|
+| `verified` | Beacon matches: a genuine, deployed Stock Token | Safe to give as the answer |
+| `not-deployed` | Listed by the index, **no contract at that address** | Say the token is not live yet; warn against sending funds |
+| `not-a-stock-token` | A contract exists but is not Robinhood's | Treat as an impersonator |
+| `unverified` | The chain could not be reached, or `--no-verify` was passed | Say it is **unverified, not disproven** |
+
+`unverified` never means "fake". If the RPC call failed, say the check could not
+run — do not downgrade the token's legitimacy on the strength of a network
+fault. A top-level `warning` field spells out whichever caveat applies.
 
 ## Community tokens are excluded on purpose
 
@@ -46,15 +73,12 @@ Robinhood Chain is permissionless, so the same list also carries community
 tokens — and **some reuse a listed company's name and symbol verbatim**. Two
 entries are called "GameStop" with symbol `GME`:
 
-- `0x1b0e319c6a659f002271b69db8a7df2f911c153e` — the real Stock Token
-- `0x7e86381a763f0ecca2bdf27c54eac403ddd48123` — a community impersonator
+- `0x1b0e319c6a659f002271b69db8a7df2f911c153e` — the real Stock Token (`verified`)
+- `0x7e86381a763f0ecca2bdf27c54eac403ddd48123` — an impersonator (`not-a-stock-token`)
 
-The suffix is the only thing separating them, so this lookup returns **Stock
-Tokens only** by default and tags every match with `isStockToken`. Pass
-`--include-community` to widen the search; genuine Stock Tokens still rank
-above impersonators. To confirm an address on-chain, use the
-`robinhood-chain-stocks` skill — a real Stock Token answers `uiMultiplier()`
-and an impersonator's call reverts.
+The lookup returns **Stock Tokens only** by default. Pass `--include-community`
+to widen the search; genuine Stock Tokens still rank above impersonators, and
+the beacon check labels each one.
 
 ## When the user asks
 
@@ -82,6 +106,12 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "Tesla" --limit 1
 
 # Include non-stock community tokens (off by default)
 python3 {baseDir}/scripts/rwa_lookup.py --query "GME" --include-community
+
+# Skip the on-chain check (offline; every match comes back "unverified")
+python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" --no-verify
+
+# Point at a different Robinhood Chain node
+python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" --rpc-url https://…
 ```
 
 ### Output (JSON)
@@ -90,8 +120,10 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "GME" --include-community
 {
   "query": "Apple",
   "source": "https://tokens.coingecko.com/robinhood/all.json",
-  "total_tokens": 658,
-  "stock_tokens": 221,
+  "rpc": "https://rpc.mainnet.chain.robinhood.com",
+  "beacon": "0xe10b6f6b275de231345c20d14ab812db62151b00",
+  "total_tokens": 683,
+  "stock_tokens": 243,
   "matches": [
     {
       "name": "Apple",
@@ -100,15 +132,28 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "GME" --include-community
       "chainId": 4663,
       "decimals": 18,
       "isStockToken": true,
-      "logoURI": "https://assets.coingecko.com/..."
+      "logoURI": "https://assets.coingecko.com/...",
+      "status": "verified",
+      "beacon": "0xe10b6f6b275de231345c20d14ab812db62151b00"
     }
   ]
 }
 ```
 
-`total_tokens` counts the whole list; `stock_tokens` counts the tokenized
-stocks and ETFs within it. Both move as Robinhood lists new assets and the
-community deploys more tokens — read them from the payload, never assume.
+An undeployed listing looks like this — the address is reported, but flagged:
+
+```json
+{
+  "matches": [{ "symbol": "JPM", "status": "not-deployed", "beacon": null }],
+  "warning": "listed by the token index but not deployed on Robinhood Chain: …"
+}
+```
+
+`total_tokens` counts the whole list; `stock_tokens` counts the entries whose
+*name* looks like a tokenized stock or ETF. Both move as Robinhood lists new
+assets and the community deploys more tokens — read them from the payload,
+never assume. Note that `stock_tokens` is a name-based hint over the whole
+list; only a match's own `status` reflects the chain.
 
 ## Matching rules
 
@@ -123,7 +168,9 @@ failure the script still returns JSON with an `error` field (never crashes).
 
 ## Notes
 
-- No API key required; the token list is public and cached by CoinGecko.
+- No API key required; both the token list and the RPC node are public.
 - Addresses are on **Robinhood Chain** (chainId `4663`) — not Ethereum mainnet.
-- This skill resolves addresses only. For live price, holdings, supply, or an
-  on-chain authenticity check, use **`robinhood-chain-stocks`**.
+- Verification adds one batched RPC round-trip (~0.5s). Use `--no-verify` only
+  when the chain is unreachable, and say so in the answer.
+- This skill resolves and verifies addresses. For live price, holdings, supply,
+  or the ERC-8056 corporate-action multiplier, use **`robinhood-chain-stocks`**.

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python3
 """Look up Robinhood tokenized-stock (RWA) contract addresses by name or ticker.
 
-Reads the public CoinGecko Robinhood token list and resolves a free-text query
-(a company name like "Apple", or a ticker like "AAPL") to the matching on-chain
-token(s): symbol, contract address, chain id, and decimals.
+Resolves a free-text query (a company name like "Apple", or a ticker like
+"AAPL") to the matching on-chain token: symbol, contract address, chain id, and
+decimals.
+
+Two stages, deliberately separated:
+
+1. **Discovery** -- rank candidates against the public CoinGecko Robinhood token
+   list. Cheap, offline-friendly, but the list is a third-party index: it names
+   assets Robinhood has announced but not yet deployed, and it truncates long
+   names (so the "Robinhood Token" suffix that used to be the only stock filter
+   goes missing on entries like IBM and XLK).
+2. **Verification** -- confirm each candidate against Robinhood Chain itself.
+   Every genuine Stock Token is a beacon proxy pointing at Robinhood's shared
+   EIP-1967 beacon; an impersonator cannot forge that, and an undeployed listing
+   has no contract at all. This is the authoritative signal.
 
 Emits a compact JSON object on stdout so a meta-skill can run it as a bounded
-tool without spawning an LLM sub-agent.
+tool without spawning an LLM sub-agent. Network failures degrade to
+``status: "unverified"`` rather than raising -- an unreachable node must never
+be reported as evidence that a token is fake.
 """
 
 from __future__ import annotations
@@ -20,19 +34,49 @@ import urllib.request
 from typing import Any
 
 TOKEN_LIST_URL = "https://tokens.coingecko.com/robinhood/all.json"
-# The Robinhood-token names are suffixed with this marker in the list. Robinhood
-# Chain is permissionless, so the same list also carries community tokens -- and
-# some of those reuse a listed company's name and symbol verbatim (two entries
-# are called "GameStop" with symbol GME). The suffix is the only thing in the
-# list that separates a real Stock Token from an impersonator, so it is a filter
-# here, not just cosmetic: stripping it for display must not lose it for ranking.
+DEFAULT_RPC_URL = "https://rpc.mainnet.chain.robinhood.com"
+
+# EIP-1967 beacon slot: bytes32(uint256(keccak256("eip1967.proxy.beacon")) - 1).
+BEACON_SLOT = "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50"
+# Robinhood's shared implementation beacon. Every Stock Token on chain 4663 is a
+# proxy pointing here; nothing else on the permissionless chain can point at it.
+ROBINHOOD_BEACON = "0xe10b6f6b275de231345c20d14ab812db62151b00"
+
+# Robinhood-token names carry this marker in the CoinGecko list. It is a *hint*
+# only: CoinGecko caps `name` at 60 characters, so long listings arrive with the
+# suffix chopped ("... - Robinhood Toke"). Used for display cleanup and as the
+# offline fallback filter, never as proof on its own.
 _RH_SUFFIX_RE = re.compile(r"\s*[•·|-]?\s*robinhood token\s*$", re.IGNORECASE)
+# The truncation-tolerant form: a bullet followed by any prefix of the marker.
+_RH_SUFFIX_LOOSE_RE = re.compile(
+    r"\s*[•·|-]\s*r(?:o(?:b(?:i(?:n(?:h(?:o(?:o(?:d)?)?)?)?)?)?)?)?"
+    r"(?:\s+t(?:o(?:k(?:e(?:n)?)?)?)?)?\s*$",
+    re.IGNORECASE,
+)
+_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+# Verification outcomes, most trustworthy first.
+STATUS_VERIFIED = "verified"  # beacon matches: a genuine, deployed Stock Token
+STATUS_NOT_DEPLOYED = "not-deployed"  # listed by the index, no contract on chain
+STATUS_NOT_STOCK = "not-a-stock-token"  # a contract exists, but not Robinhood's
+STATUS_UNVERIFIED = "unverified"  # the chain could not be reached
+
+_STATUS_RANK = {
+    STATUS_VERIFIED: 0,
+    STATUS_UNVERIFIED: 1,
+    STATUS_NOT_DEPLOYED: 2,
+    STATUS_NOT_STOCK: 3,
+}
+
+
+class RpcError(RuntimeError):
+    """A JSON-RPC call returned an error or an unusable result."""
 
 
 def _fetch_tokens(timeout: float) -> list[dict[str, Any]]:
     req = urllib.request.Request(  # noqa: S310 - fixed trusted CoinGecko endpoint
         TOKEN_LIST_URL,
-        headers={"User-Agent": "AgentOS-robinhood-rwa-skill/0.1"},
+        headers={"User-Agent": "AgentOS-robinhood-rwa-skill/0.2"},
     )
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         data = json.loads(resp.read().decode("utf-8", errors="replace"))
@@ -41,13 +85,26 @@ def _fetch_tokens(timeout: float) -> list[dict[str, Any]]:
 
 
 def _clean_name(name: str) -> str:
-    """Strip the '• Robinhood Token' suffix so 'Apple' matches cleanly."""
-    return _RH_SUFFIX_RE.sub("", name or "").strip()
+    """Strip the '• Robinhood Token' suffix so 'Apple' matches cleanly.
+
+    Handles the truncated tail too: CoinGecko cuts `name` at 60 characters, so
+    'International Business Machines Corporation • Robinhood Toke' must still
+    display as the company name.
+    """
+    stripped = _RH_SUFFIX_RE.sub("", name or "").strip()
+    if stripped == (name or "").strip():
+        stripped = _RH_SUFFIX_LOOSE_RE.sub("", stripped).strip()
+    return stripped
 
 
 def is_stock_token(token: dict[str, Any]) -> bool:
-    """True when the entry is a Robinhood Stock Token rather than a community token."""
-    return bool(_RH_SUFFIX_RE.search(token.get("name", "") or ""))
+    """True when the list entry *looks* like a Robinhood Stock Token.
+
+    Name-based and therefore only a hint -- ``verify_tokens`` is what actually
+    decides. Kept as the offline fallback for when the chain is unreachable.
+    """
+    name = token.get("name", "") or ""
+    return bool(_RH_SUFFIX_RE.search(name) or _RH_SUFFIX_LOOSE_RE.search(name))
 
 
 def _norm(text: str) -> str:
@@ -57,9 +114,9 @@ def _norm(text: str) -> str:
 def _score(query: str, token: dict[str, Any]) -> int:
     """Rank a token against the query. Higher is better; 0 = no match.
 
-    The query may be a bare name/ticker ("Apple", "AAPL") or a full sentence —
+    The query may be a bare name/ticker ("Apple", "AAPL") or a full sentence --
     the skill entrypoint defaults ``--query`` to the raw user message (e.g.
-    "what is Apple's ticker?", "mã cổ phiếu Apple là gì") — so matching must
+    "what is Apple's ticker?", "mã cổ phiếu Apple là gì") -- so matching must
     also find the company name or ticker *inside* the query.
     """
     q = _norm(query)
@@ -109,11 +166,12 @@ def lookup(
     *,
     include_community: bool = False,
 ) -> list[dict[str, Any]]:
-    """Rank tokens against the query, Stock Tokens first.
+    """Rank tokens against the query, likely Stock Tokens first.
 
-    Community tokens are dropped unless explicitly requested: several of them
-    impersonate a listed company, so answering "GameStop's address" with one of
-    those would hand the user a token that is not the equity they asked for.
+    Discovery only -- no network. Community tokens are dropped unless explicitly
+    requested: several of them impersonate a listed company, so answering
+    "GameStop's address" with one of those would hand the user a token that is
+    not the equity they asked for.
     """
     pool = tokens if include_community else [t for t in tokens if is_stock_token(t)]
     scored = [(s, t) for t in pool if (s := _score(query, t)) > 0]
@@ -123,6 +181,136 @@ def lookup(
         key=lambda pair: (-pair[0], not is_stock_token(pair[1]), _norm(pair[1].get("symbol", "")))
     )
     return [_shape(t) for _s, t in scored[:limit]]
+
+
+def _rpc_batch(rpc_url: str, calls: list[dict[str, Any]], timeout: float) -> dict[str, str]:
+    """Send one batched JSON-RPC request; return ``{id: result}`` for successes.
+
+    Batching keeps verification to a single HTTP round-trip no matter how many
+    candidates are being checked.
+    """
+    payload = json.dumps(calls).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310 - operator-supplied RPC endpoint
+        rpc_url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "AgentOS-robinhood-rwa-skill/0.2",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    if not isinstance(body, list):
+        raise RpcError("expected a batched JSON-RPC response")
+    out: dict[str, str] = {}
+    for item in body:
+        if isinstance(item, dict) and isinstance(item.get("result"), str):
+            out[str(item.get("id"))] = item["result"]
+    return out
+
+
+def classify(beacon_word: str | None, code: str | None) -> str:
+    """Turn a raw beacon-slot word and ``eth_getCode`` result into a status."""
+    if beacon_word is None or code is None:
+        return STATUS_UNVERIFIED
+    if len(code) <= 2:  # "0x" -- nothing deployed at this address
+        return STATUS_NOT_DEPLOYED
+    if beacon_word[-40:].lower() == ROBINHOOD_BEACON.removeprefix("0x").lower():
+        return STATUS_VERIFIED
+    return STATUS_NOT_STOCK
+
+
+def verify_tokens(
+    matches: list[dict[str, Any]],
+    rpc_url: str,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    """Annotate each match with its on-chain ``status`` (and beacon when genuine).
+
+    On any RPC failure every match is marked ``unverified`` -- an unreachable
+    node means the check did not run, never that the token is fake.
+    """
+    checkable = [m for m in matches if _ADDRESS_RE.match(str(m.get("address", "")))]
+    if not checkable:
+        for match in matches:
+            match["status"] = STATUS_UNVERIFIED
+            match["beacon"] = None
+        return matches
+
+    calls: list[dict[str, Any]] = []
+    for index, match in enumerate(checkable):
+        address = match["address"]
+        calls.append(
+            {
+                "jsonrpc": "2.0",
+                "id": f"s{index}",
+                "method": "eth_getStorageAt",
+                "params": [address, BEACON_SLOT, "latest"],
+            }
+        )
+        calls.append(
+            {
+                "jsonrpc": "2.0",
+                "id": f"c{index}",
+                "method": "eth_getCode",
+                "params": [address, "latest"],
+            }
+        )
+
+    try:
+        results = _rpc_batch(rpc_url, calls, timeout)
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError, RpcError):
+        results = {}
+
+    for match in matches:
+        match["status"] = STATUS_UNVERIFIED
+        match["beacon"] = None
+    for index, match in enumerate(checkable):
+        status = classify(results.get(f"s{index}"), results.get(f"c{index}"))
+        match["status"] = status
+        if status == STATUS_VERIFIED:
+            match["beacon"] = ROBINHOOD_BEACON
+    return matches
+
+
+def sort_by_status(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Stable re-sort so verified tokens outrank unverified/undeployed ones."""
+    return sorted(matches, key=lambda m: _STATUS_RANK.get(str(m.get("status")), 9))
+
+
+def _warning_for(
+    matches: list[dict[str, Any]], *, verification_skipped: bool = False
+) -> str | None:
+    """A single caller-facing caveat, chosen by the worst status that surfaced.
+
+    ``verification_skipped`` distinguishes "the operator turned the check off"
+    from "the node was unreachable" -- both leave matches unverified, but only
+    the second one is a fault worth retrying.
+    """
+    statuses = {str(m.get("status")) for m in matches}
+    if verification_skipped and statuses:
+        return (
+            "on-chain verification was skipped (--no-verify), so these addresses are "
+            "UNVERIFIED: the token index alone cannot prove a contract is deployed or genuine."
+        )
+    if STATUS_VERIFIED in statuses:
+        return None
+    if STATUS_NOT_DEPLOYED in statuses:
+        return (
+            "listed by the token index but not deployed on Robinhood Chain: there is no "
+            "contract at this address. Do not send funds to it."
+        )
+    if STATUS_NOT_STOCK in statuses:
+        return (
+            "a contract exists at this address but it is not a Robinhood Stock Token "
+            "(it does not use Robinhood's beacon). Treat it as an impersonator."
+        )
+    if STATUS_UNVERIFIED in statuses:
+        return (
+            "Robinhood Chain could not be reached, so these addresses are UNVERIFIED "
+            "(not disproven). Re-run before relying on them."
+        )
+    return None
 
 
 def main() -> int:
@@ -135,26 +323,44 @@ def main() -> int:
         action="store_true",
         help="Also match non-stock community tokens (off by default; some impersonate listings)",
     )
+    parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help="Robinhood Chain JSON-RPC URL")
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Skip the on-chain beacon check (offline; every match is reported unverified)",
+    )
     args = parser.parse_args()
 
     try:
         tokens = _fetch_tokens(args.timeout)
-    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
         print(json.dumps({"query": args.query, "matches": [], "error": f"fetch failed: {exc}"}))
         return 0
 
     matches = lookup(
         args.query, tokens, max(1, args.limit), include_community=args.include_community
     )
-    result = {
+    if args.no_verify:
+        for match in matches:
+            match["status"] = STATUS_UNVERIFIED
+            match["beacon"] = None
+    else:
+        matches = sort_by_status(verify_tokens(matches, args.rpc_url, args.timeout))
+
+    result: dict[str, Any] = {
         "query": args.query,
         "source": TOKEN_LIST_URL,
+        "rpc": None if args.no_verify else args.rpc_url,
+        "beacon": ROBINHOOD_BEACON,
         "total_tokens": len(tokens),
         "stock_tokens": sum(1 for t in tokens if is_stock_token(t)),
         "matches": matches,
     }
     if not matches:
         result["error"] = "no Robinhood token matched the query"
+    warning = _warning_for(matches, verification_skipped=args.no_verify)
+    if warning:
+        result["warning"] = warning
     print(json.dumps(result, ensure_ascii=False))
     return 0
 

--- a/tests/test_skill_robinhood_rwa.py
+++ b/tests/test_skill_robinhood_rwa.py
@@ -1,14 +1,22 @@
 """Offline regression tests for the robinhood-rwa-addresses lookup script.
 
-The skill's entrypoint defaults ``--query`` to the raw user message, so the
-matcher must resolve tokens from full sentences ("what is Apple's ticker?",
-"mã cổ phiếu Apple là gì") as well as bare names/tickers.
+Two behaviours are under test:
+
+* **Discovery** -- the skill's entrypoint defaults ``--query`` to the raw user
+  message, so the matcher must resolve tokens from full sentences ("what is
+  Apple's ticker?", "mã cổ phiếu Apple là gì") as well as bare names/tickers.
+* **Verification** -- the CoinGecko index is not authoritative. It truncates
+  long names (dropping the "Robinhood Token" marker) and lists assets Robinhood
+  has announced but never deployed, so the on-chain beacon check is what decides
+  whether an address is real. Everything here is offline: RPC results are fed in
+  as fixtures.
 """
 
 from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from typing import Any
 
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
@@ -54,7 +62,7 @@ _TOKENS = [
         "logoURI": "",
     },
     # Robinhood Chain is permissionless: this community token reuses GameStop's
-    # name and ticker, and only the missing suffix tells the two apart.
+    # name and ticker. Only the on-chain beacon reliably tells the two apart.
     {
         "chainId": 4663,
         "address": "0x7e86381a763f0ecca2bdf27c54eac403ddd48123",
@@ -63,14 +71,52 @@ _TOKENS = [
         "decimals": 18,
         "logoURI": "",
     },
+    # CoinGecko caps `name` at 60 characters, so long listings lose the
+    # "• Robinhood Token" marker mid-word. These are real Stock Tokens.
+    {
+        "chainId": 4663,
+        "address": "0x980dcf6766fa79f5cf0c4aadb3ab477ff15a9619",
+        "name": "International Business Machines Corporation • Robinhood Toke",
+        "symbol": "IBM",
+        "decimals": 18,
+        "logoURI": "",
+    },
+    {
+        "chainId": 4663,
+        "address": "0x15cd20759ce7f3285c29a319de2d1a2e098c6f43",
+        "name": "State Street Technology Select Sector SPDR ETF • Robinhood T",
+        "symbol": "XLK",
+        "decimals": 18,
+        "logoURI": "",
+    },
+    # Announced by Robinhood and carried by the index, but no contract on chain.
+    {
+        "chainId": 4663,
+        "address": "0x07c44da0848960bff894f17584db8b2f60b2409e",
+        "name": "JPMorgan Chase & Co. • Robinhood Token",
+        "symbol": "JPM",
+        "decimals": 18,
+        "logoURI": "",
+    },
 ]
 
 _REAL_GME = "0x1b0e319c6a659f002271b69db8a7df2f911c153e"
 _FAKE_GME = "0x7e86381a763f0ecca2bdf27c54eac403ddd48123"
+_IBM = "0x980dcf6766fa79f5cf0c4aadb3ab477ff15a9619"
+_JPM = "0x07c44da0848960bff894f17584db8b2f60b2409e"
+
+_BEACON_WORD = "0x000000000000000000000000e10b6f6b275de231345c20d14ab812db62151b00"
+_ZERO_WORD = "0x" + "0" * 64
+_SOME_CODE = "0x6080604052"
 
 
 def _symbols(query: str) -> list[str]:
     return [m["symbol"] for m in rwa_lookup.lookup(query, _TOKENS, limit=3)]
+
+
+# --------------------------------------------------------------------------
+# Discovery
+# --------------------------------------------------------------------------
 
 
 def test_bare_name_and_ticker_resolve() -> None:
@@ -101,11 +147,7 @@ def test_robinhood_suffix_stripped_from_names() -> None:
 
 
 def test_community_token_impersonating_a_listing_is_excluded() -> None:
-    """A lookalike must never be offered as the answer to a company question.
-
-    Both entries clean up to the display name "GameStop" with symbol GME, so
-    without the suffix filter the caller cannot tell which address is the equity.
-    """
+    """A lookalike must never be offered as the answer to a company question."""
     for query in ("GME", "GameStop", "mã cổ phiếu GME là gì"):
         matches = rwa_lookup.lookup(query, _TOKENS, limit=5)
         assert [m["address"] for m in matches] == [_REAL_GME], query
@@ -121,7 +163,157 @@ def test_matches_are_tagged_with_stock_token_status() -> None:
     assert rwa_lookup.lookup("Apple", _TOKENS, limit=1)[0]["isStockToken"] is True
 
 
-def test_is_stock_token_keys_off_the_suffix() -> None:
-    assert rwa_lookup.is_stock_token({"name": "Apple • Robinhood Token"}) is True
-    assert rwa_lookup.is_stock_token({"name": "GameStop"}) is False
+# --------------------------------------------------------------------------
+# Truncated names (CoinGecko caps `name` at 60 chars)
+# --------------------------------------------------------------------------
+
+
+def test_stock_tokens_with_truncated_suffix_are_still_recognised() -> None:
+    """The 60-character cap chops "• Robinhood Token" mid-word on long names."""
+    assert rwa_lookup.is_stock_token({"name": _TOKENS[5]["name"]}) is True  # "… Robinhood Toke"
+    assert rwa_lookup.is_stock_token({"name": _TOKENS[6]["name"]}) is True  # "… Robinhood T"
+
+
+def test_truncated_listings_are_findable_by_ticker_and_name() -> None:
+    """Regression: IBM and XLK used to return zero matches."""
+    assert _symbols("IBM") == ["IBM"]
+    assert _symbols("XLK") == ["XLK"]
+    assert _symbols("International Business Machines")[:1] == ["IBM"]
+
+
+def test_truncated_name_is_cleaned_for_display() -> None:
+    match = rwa_lookup.lookup("IBM", _TOKENS, limit=1)[0]
+    assert match["name"] == "International Business Machines Corporation"
+
+
+def test_suffix_hint_does_not_fire_on_community_tokens_naming_robinhood() -> None:
+    """The loose marker must not turn a memecoin into a "Stock Token"."""
+    for name in (
+        "GameStop",
+        "Robinhood Wrapped ETH (Robinhood Chain)",
+        "Turbo on Robinhood",
+        "CAPTAIN ROBINHOOD",
+        "Robinhood Payments Protocol",
+        "RobinhoodCat",
+    ):
+        assert rwa_lookup.is_stock_token({"name": name}) is False, name
     assert rwa_lookup.is_stock_token({}) is False
+
+
+# --------------------------------------------------------------------------
+# On-chain verification
+# --------------------------------------------------------------------------
+
+
+def test_classify_reads_the_three_on_chain_outcomes() -> None:
+    assert rwa_lookup.classify(_BEACON_WORD, _SOME_CODE) == rwa_lookup.STATUS_VERIFIED
+    # A contract exists but points at some other beacon (or none): impersonator.
+    assert rwa_lookup.classify(_ZERO_WORD, _SOME_CODE) == rwa_lookup.STATUS_NOT_STOCK
+    # Nothing deployed at the address the index advertises.
+    assert rwa_lookup.classify(_ZERO_WORD, "0x") == rwa_lookup.STATUS_NOT_DEPLOYED
+
+
+def test_classify_reports_unreachable_rpc_as_unverified_not_fake() -> None:
+    """A network fault must never be reported as proof that a token is fake."""
+    assert rwa_lookup.classify(None, None) == rwa_lookup.STATUS_UNVERIFIED
+    assert rwa_lookup.classify(_BEACON_WORD, None) == rwa_lookup.STATUS_UNVERIFIED
+    assert rwa_lookup.classify(None, _SOME_CODE) == rwa_lookup.STATUS_UNVERIFIED
+
+
+def _verify(matches: list[dict[str, Any]], results: dict[str, str], monkeypatch: Any) -> None:
+    monkeypatch.setattr(rwa_lookup, "_rpc_batch", lambda *a, **k: results)
+    rwa_lookup.verify_tokens(matches, "http://rpc.invalid", 5.0)
+
+
+def test_verify_tokens_marks_a_genuine_stock_token(monkeypatch: Any) -> None:
+    matches = rwa_lookup.lookup("Apple", _TOKENS, limit=1)
+    _verify(matches, {"s0": _BEACON_WORD, "c0": _SOME_CODE}, monkeypatch)
+    assert matches[0]["status"] == rwa_lookup.STATUS_VERIFIED
+    assert matches[0]["beacon"] == rwa_lookup.ROBINHOOD_BEACON
+
+
+def test_verify_tokens_flags_an_undeployed_listing(monkeypatch: Any) -> None:
+    """Regression: JPM's advertised address holds no contract at all."""
+    matches = rwa_lookup.lookup("JPM", _TOKENS, limit=1)
+    assert matches[0]["address"] == _JPM
+    _verify(matches, {"s0": _ZERO_WORD, "c0": "0x"}, monkeypatch)
+    assert matches[0]["status"] == rwa_lookup.STATUS_NOT_DEPLOYED
+    assert matches[0]["beacon"] is None
+
+
+def test_verify_tokens_separates_the_real_and_fake_gme(monkeypatch: Any) -> None:
+    matches = rwa_lookup.lookup("GME", _TOKENS, limit=5, include_community=True)
+    _verify(
+        matches,
+        {"s0": _BEACON_WORD, "c0": _SOME_CODE, "s1": _ZERO_WORD, "c1": _SOME_CODE},
+        monkeypatch,
+    )
+    by_address = {m["address"]: m["status"] for m in matches}
+    assert by_address[_REAL_GME] == rwa_lookup.STATUS_VERIFIED
+    assert by_address[_FAKE_GME] == rwa_lookup.STATUS_NOT_STOCK
+
+
+def test_verify_tokens_degrades_to_unverified_when_the_rpc_fails(monkeypatch: Any) -> None:
+    def _boom(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(rwa_lookup, "_rpc_batch", _boom)
+    matches = rwa_lookup.lookup("Apple", _TOKENS, limit=1)
+    rwa_lookup.verify_tokens(matches, "http://rpc.invalid", 5.0)
+    assert matches[0]["status"] == rwa_lookup.STATUS_UNVERIFIED
+    assert matches[0]["beacon"] is None
+
+
+def test_verified_matches_outrank_unverified_ones() -> None:
+    ordered = rwa_lookup.sort_by_status(
+        [
+            {"symbol": "A", "status": rwa_lookup.STATUS_NOT_STOCK},
+            {"symbol": "B", "status": rwa_lookup.STATUS_NOT_DEPLOYED},
+            {"symbol": "C", "status": rwa_lookup.STATUS_VERIFIED},
+            {"symbol": "D", "status": rwa_lookup.STATUS_UNVERIFIED},
+        ]
+    )
+    assert [m["symbol"] for m in ordered] == ["C", "D", "B", "A"]
+
+
+# --------------------------------------------------------------------------
+# Caller-facing warnings
+# --------------------------------------------------------------------------
+
+
+def test_no_warning_when_a_verified_token_is_present() -> None:
+    assert _warning([rwa_lookup.STATUS_VERIFIED, rwa_lookup.STATUS_NOT_STOCK]) is None
+
+
+def test_undeployed_warning_tells_the_user_not_to_send_funds() -> None:
+    warning = _warning([rwa_lookup.STATUS_NOT_DEPLOYED])
+    assert warning is not None
+    assert "not deployed" in warning
+    assert "Do not send funds" in warning
+
+
+def test_impersonator_warning_names_the_risk() -> None:
+    warning = _warning([rwa_lookup.STATUS_NOT_STOCK])
+    assert warning is not None
+    assert "impersonator" in warning
+
+
+def test_unreachable_warning_says_unverified_not_disproven() -> None:
+    warning = _warning([rwa_lookup.STATUS_UNVERIFIED])
+    assert warning is not None
+    assert "UNVERIFIED" in warning
+    assert "not disproven" in warning
+
+
+def test_skipped_verification_is_not_reported_as_a_network_fault() -> None:
+    """--no-verify is an operator choice, not an outage; the wording must differ."""
+    warning = rwa_lookup._warning_for(
+        [{"status": rwa_lookup.STATUS_UNVERIFIED}], verification_skipped=True
+    )
+    assert warning is not None
+    assert "--no-verify" in warning
+    assert "could not be reached" not in warning
+
+
+def _warning(statuses: list[str]) -> str | None:
+    return rwa_lookup._warning_for([{"status": s} for s in statuses])


### PR DESCRIPTION
## The problem

`robinhood-rwa-addresses` decided what counted as a genuine Stock Token from a name suffix in CoinGecko's token list. That is wrong in both directions.

**It dropped real tokens.** CoinGecko caps `name` at exactly 60 characters, so long listings arrive with the `• Robinhood Token` marker chopped mid-word:

```
'International Business Machines Corporation • Robinhood Toke'
'State Street Technology Select Sector SPDR ETF • Robinhood T'
```

The suffix regex is anchored at end-of-string, so these failed the filter and were silently excluded. `--query IBM` returned `matches: []`. Same for VTI, XLK, CTSH and CRDO.

**It handed out addresses that hold no contract.** Of the 238 entries the skill reported as verified Stock Tokens, **47 have nothing deployed at the advertised address** — JPM, MCD, DIS, UBER, ABNB, PYPL and others. All 47 confirmed with `eth_getCode`:

```
JPM   codeLen=0  symbol()='0x'
MCD   codeLen=0  symbol()='0x'
AAPL  codeLen=283  symbol()='AAPL'   ← control
```

These are assets Robinhood has announced and the index carries, but which are not live on chain. The skill presented them as usable addresses. Funds sent to one would be unrecoverable.

## The fix

Discovery still ranks candidates from the token list, but the answer is now settled on chain.

Every genuine Stock Token is a proxy pointing at Robinhood's shared EIP-1967 beacon `0xe10b6f6b275de231345c20d14ab812db62151b00`. A permissionless impersonator cannot forge that, and an undeployed listing has no contract at all:

| | beacon slot | code |
|---|---|---|
| AAPL, TSLA, GME, IBM, XLK | `0xe10b6f…1b00` | present |
| GME impersonator `0x7e86…8123` | empty | present |
| JPM `0x07c4…409e` | empty | **absent** |

One batched JSON-RPC round-trip against `rpc.mainnet.chain.robinhood.com` (public, no key, ~0.5s) covers every candidate and classifies each match:

| `status` | Meaning |
|---|---|
| `verified` | Beacon matches — genuine, deployed Stock Token |
| `not-deployed` | Listed by the index, no contract at that address |
| `not-a-stock-token` | A contract exists but is not Robinhood's |
| `unverified` | Chain unreachable, or `--no-verify` passed |

A top-level `warning` carries the caveat. Undeployed listings are still returned rather than dropped — an empty result reads as a broken skill — but are flagged and never presented as usable.

Following the precedent set by `robinhood-chain-stocks`, an unreachable node yields `unverified` rather than a negative verdict: **a network fault is never reported as evidence that a token is fake.** `--no-verify` skips the check with its own distinct wording, so an operator's choice is not reported as an outage. `--rpc-url` points at an alternate node. The name-suffix match is retained only as the offline fallback, now tolerant of truncation.

## Verification

Live against Robinhood Chain:

```
Apple      AAPL   verified           0xaf3d76f1834a1d425780943c99ea8a608f8a93f9
IBM        IBM    verified           0x980dcf6766fa79f5cf0c4aadb3ab477ff15a9619
XLK        XLK    verified           0x15cd20759ce7f3285c29a319de2d1a2e098c6f43
CTSH       CTSH   verified           0x63d5a3b6939a33f1e75d8bcd85759858239600db
JPM        JPM    not-deployed       0x07c44da0848960bff894f17584db8b2f60b2409e
Vinamilk   (no match)
```

`--include-community` separates the two GME entries correctly (`verified` vs `not-a-stock-token`), and an unreachable `--rpc-url` degrades every match to `unverified` with the "not disproven" warning.

The test suite grows from 13 to 24 cases and stays **fully offline** — RPC results are fed in as fixtures, so no network dependency enters the default `pytest` path. New coverage: truncated-name recognition, the loose marker not misfiring on memecoins named after Robinhood, all four `classify` outcomes, undeployed-listing detection, real-vs-fake GME separation, RPC-failure degradation, status ordering, and each warning variant.

Quality gate: `ruff` clean, `mypy` clean (621 files), `uv build --wheel` succeeds, `pytest` 8956 passed. The single failure (`test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`) is an ANSI-width assertion that reproduces on a clean tree.