### PR TITLE
fix(cli): handle bare .dev segments and fix PEP 440 dev-on-pre ordering (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+-  now parses bare  segments and fixes PEP 440
+  dev-on-pre-release ordering so  (#740).
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -63,10 +63,10 @@ class Version:
         if self.dev is not None and self.pre is None and self.post is None:
             phase: tuple[int, ...] = (0, self.dev)
         elif self.pre is not None:
-            dev_tie = -1 if self.dev is None else self.dev
+            dev_tie = self.dev if self.dev is not None else 999999
             phase = (1, self.pre[0], self.pre[1], dev_tie)
         elif self.post is not None:
-            dev_tie = -1 if self.dev is None else self.dev
+            dev_tie = self.dev if self.dev is not None else 999999
             phase = (3, self.post, dev_tie)
         else:
             phase = (2,)
@@ -101,6 +101,8 @@ def parse_version(value: str | None) -> Version:
     if post is None and re.search(r"[._-]?post", raw):
         post = 0
     dev = int(match.group("dev")) if match.group("dev") is not None else None
+    if dev is None and re.search(r"[._-]?dev", raw):
+        dev = 0
     return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
 
 

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -30,6 +30,13 @@ from agentos.compat.version_utils import compare_versions, is_newer, parse_versi
         # dev sorts below everything of the same release
         ("2026.7.18.dev1", "2026.7.18rc1", -1),
         ("2026.7.18.dev1", "2026.7.18", -1),
+        # bare .dev (no number) sorts below final and pre-release
+        ("2026.7.18.dev", "2026.7.18", -1),
+        ("2026.7.18.dev", "2026.7.18rc1", -1),
+        ("2026.7.18", "2026.7.18.dev", 1),
+        # .devX on pre-release sorts below the pre-release without dev
+        ("2026.7.18rc1.dev1", "2026.7.18rc1", -1),
+        ("2026.7.18rc1", "2026.7.18rc1.dev1", 1),
         # leading v is tolerated
         ("v2026.7.18", "2026.7.18", 0),
     ],
@@ -54,6 +61,9 @@ def test_is_newer() -> None:
     assert is_newer("2026.7.18", "2026.7.18") is False
     assert is_newer("2026.7.18", "2026.7.19") is False
     assert is_newer("2026.7.18.post1", "2026.7.18") is True
+    # A semver final release is newer than a dev snapshot of the same version
+    assert is_newer("2026.7.18", "2026.7.18.dev") is True
+    assert is_newer("2026.7.18", "2026.7.18.dev1") is True
 
 
 def test_parse_version_fields() -> None:


### PR DESCRIPTION
## Summary

Two PEP 440 ordering bugs in `version_utils.py`:

1. **Bare `.dev` (no number):** `parse_version("2026.7.18.dev")` returned `dev=None`, making it compare equal to the final release `2026.7.18`. The upgrade notice (`is_newer`) never triggered for dev build users.
2. **Pre-release dev ordering inverted:** `rc1.dev1` sorted *after* `rc1` because `dev_tie` used `-1` (no dev) vs positive N. Per PEP 440, a dev snapshot of a pre-release should sort *before* the pre-release itself.

## Changes

- `parse_version()`: detect bare `.dev` (no number) and set `dev=0`
- `sort_key()`: use `999999` sentinel for `None dev` in dev-tie logic so any explicit `.devN` (even `dev=0`) sorts before the non-dev release

## Testing

Added parametrized cases:
- `"2026.7.18.dev" < "2026.7.18"`
- `"2026.7.18.dev" < "2026.7.18rc1"`
- `"2026.7.18rc1.dev1" < "2026.7.18rc1"`
- `"2026.7.18rc1" > "2026.7.18rc1.dev1"`
- `is_newer("2026.7.18", "2026.7.18.dev") is True`

Closes #740