### PR TITLE
feat(chat): render skill results as inline card grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Inline card grids in Web chat** — a second AgentOS-native artifact mime,
+  `application/vnd.agentos.cards+json`, alongside the existing chart one. A
+  skill publishes a JSON payload and the transcript renders a responsive grid of
+  record cards, each with an optional logo, a colour-coded status badge, and
+  per-field copy buttons — instead of a download chip.
+
+  This is the shape a markdown table handles badly: a 42-character contract
+  address forces the table into a horizontal scroll, while a card gives the
+  address its own line next to a copy button. `badgeTone` accepts
+  `positive`/`warning`/`danger`/`neutral` and falls back to `neutral` for
+  anything else, so a skill can introduce a new status without waiting on a
+  frontend release. At most 24 cards render and the remainder are counted and
+  reported under the grid rather than dropped silently.
+
+  Every payload string reaches the DOM through `textContent`, never
+  `innerHTML`, and `logo` is restricted to `http(s)` URLs — card fields carry
+  on-chain metadata, which is attacker-controlled on a permissionless chain.
+
+  `robinhood-rwa-addresses` is the first consumer: `scripts/rwa_cards.py` reads
+  the lookup's JSON on stdin and emits the artifact, so an address answer in the
+  Web UI arrives as a grid with the verification badge attached to each result.
+  `docs/artifacts-and-media.md` documents the payload.
+
 ### Fixed
 
 - **`robinhood-rwa-addresses` now verifies every address against Robinhood

--- a/docs/artifacts-and-media.md
+++ b/docs/artifacts-and-media.md
@@ -42,17 +42,18 @@ Use artifacts for:
 
 Use chat text for short answers, decisions, and next steps.
 
-## Inline Charts
+## Inline Charts and Cards
 
 Most artifacts render in Web UI chat as a download chip; images and audio render
-inline. One more mime renders inline as an interactive chart:
+inline. Two more mimes render inline:
 
 | Mime | Rendered as |
 |------|-------------|
 | `application/vnd.agentos.chart+json` | Candlestick chart with a volume histogram |
+| `application/vnd.agentos.cards+json` | Responsive grid of record cards |
 
-There is nothing to register: any skill gets a chart by publishing a file with
-that mime. Two steps, and both have a failure mode worth knowing.
+There is nothing to register: any skill gets one by publishing a file with that
+mime. Two steps, and both have a failure mode worth knowing.
 
 **1. Write the JSON inside the workspace.** Scripts run with the workspace as
 their working directory, so a bare filename lands in the right place.
@@ -88,6 +89,47 @@ The body is:
 candle field is required. Rows may arrive in any order and may repeat a
 timestamp — the renderer sorts them and keeps the last entry per timestamp.
 `title` and `subtitle` are display-only text, never markup.
+
+### Card grids
+
+Use cards when the answer is a handful of small records rather than a series —
+a token lookup, a holder list, a search result. They stay readable where a
+markdown table would not: a 42-character contract address puts a table into a
+horizontal scroll, while a card gives it its own line and a copy button.
+
+```json
+{
+  "type": "cards",
+  "title": "Robinhood Chain — Apple",
+  "subtitle": "optional caveat carried under the heading",
+  "cards": [
+    {
+      "title": "AAPL",
+      "subtitle": "Apple",
+      "logo": "https://assets.example/aapl.png",
+      "badge": "verified",
+      "badgeTone": "positive",
+      "fields": [
+        { "label": "Address", "value": "0xaf3d…93f9", "copyable": true },
+        { "label": "Chain", "value": "4663" }
+      ]
+    }
+  ]
+}
+```
+
+Only `cards` and each card's `title` are required. `badgeTone` is one of
+`positive` / `warning` / `danger` / `neutral`, and anything else falls back to
+`neutral`, so a skill can ship a new status without waiting on a frontend
+release. `copyable` renders the value in monospace with a copy button. `logo`
+must be an `http(s)` URL — other schemes are dropped rather than sanitised.
+
+At most 24 cards render; the rest are counted and reported under the grid
+instead of being dropped silently. Every string is display-only text, never
+markup — see `frontend/src/views/chat/transcript/cards.ts`.
+
+`robinhood-rwa-addresses` is the worked example: `scripts/rwa_cards.py` reads
+the lookup's JSON on stdin and writes this payload.
 
 Hovering a candle reveals its open, high, low, close, volume, and the move from
 open to close as a percentage, so there is no need to repeat those numbers in

--- a/docs/artifacts-and-media.md
+++ b/docs/artifacts-and-media.md
@@ -55,6 +55,24 @@ inline. Two more mimes render inline:
 There is nothing to register: any skill gets one by publishing a file with that
 mime. Two steps, and both have a failure mode worth knowing.
 
+**`exec_command` publishes these two mimes for you.** When a command's stdout
+contains a line that is exactly
+
+```
+publish_artifact path=<file> mime=application/vnd.agentos.<something>+json
+```
+
+the artifact is published automatically and the marker is replaced with a note
+telling the model not to publish it again. This is deliberate: leaving the call
+to the model meant the file got written and the UI never drew, because the model
+would answer with a hand-written table instead. Only the
+`application/vnd.agentos.` family auto-publishes — a plain file still needs an
+explicit `publish_artifact` call, so ordinary command output cannot push a
+workspace file at the user. Path containment is enforced by `publish_artifact`
+itself, unchanged.
+
+Write the marker on its own line: prose that merely mentions it is ignored.
+
 **1. Write the JSON inside the workspace.** Scripts run with the workspace as
 their working directory, so a bare filename lands in the right place.
 `publish_artifact` rejects anything outside the workspace, so an absolute path

--- a/frontend/src/i18n/en/chat.ts
+++ b/frontend/src/i18n/en/chat.ts
@@ -200,13 +200,19 @@ export const chat = defineNamespace('chat', {
   agentError: 'Agent error',
   streamGap: 'Stream connection gap detected; reconnecting.',
 
-  // Transcript: artifacts + charts.
+  // Transcript: artifacts + charts + cards.
   artifactDownload: 'Download',
   artifactDownloadTitle: 'Download {name}',
   chartLoading: 'Loading chart…',
   chartUnavailable: 'Chart data is unavailable.',
   chartUnreadable: 'Chart data could not be read.',
   chartFailed: 'Chart failed to load.',
+  cardsLoading: 'Loading results…',
+  cardsUnavailable: 'Result data is unavailable.',
+  cardsUnreadable: 'Result data could not be read.',
+  cardsFailed: 'Results failed to load.',
+  cardsCopy: 'Copy',
+  cardsOverflow: '+{count} more not shown',
 
   // Transcript: history paging.
   historyLoadingEarlier: 'Loading earlier messages...',

--- a/frontend/src/views/chat/chat-unified.css
+++ b/frontend/src/views/chat/chat-unified.css
@@ -229,7 +229,8 @@
 
 .chat-surface .msg-artifact-gallery,
 .chat-surface .msg-artifact-files,
-.chat-surface .msg-artifact-charts {
+.chat-surface .msg-artifact-charts,
+.chat-surface .msg-artifact-cards-group {
   display: grid;
   gap: 0.625rem;
 }
@@ -364,6 +365,195 @@
 }
 
 .chat-surface .msg-artifact-chart__status[hidden] {
+  display: none;
+}
+
+/* Card-grid artifacts (cards.ts). A skill publishes a set of small records —
+   a token lookup, a holder list — and this renders them as a responsive grid
+   instead of a markdown table, which long values (contract addresses) would
+   force into a horizontal scroll. */
+.chat-surface .msg-artifact-cards-group {
+  max-width: 100%;
+}
+
+.chat-surface .msg-artifact-cards {
+  display: grid;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-surface);
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  color: var(--foreground);
+}
+
+.chat-surface .msg-artifact-cards__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.chat-surface .msg-artifact-cards__name {
+  overflow: hidden;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* auto-fill rather than auto-fit: a single card should keep its natural width
+   instead of stretching across the whole transcript column. */
+.chat-surface .msg-artifact-cards__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(15rem, 100%), 1fr));
+  gap: 0.5rem;
+}
+
+.chat-surface .msg-artifact-cards__card {
+  display: grid;
+  gap: 0.4375rem;
+  align-content: start;
+  min-width: 0;
+  padding: 0.625rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--background);
+}
+
+.chat-surface .msg-artifact-cards__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.chat-surface .msg-artifact-cards__logo {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--card);
+  object-fit: contain;
+}
+
+.chat-surface .msg-artifact-cards__heading {
+  display: grid;
+  gap: 0.0625rem;
+  min-width: 0;
+}
+
+.chat-surface .msg-artifact-cards__title,
+.chat-surface .msg-artifact-cards__subtitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-surface .msg-artifact-cards__title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.chat-surface .msg-artifact-cards__subtitle {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.chat-surface .msg-artifact-cards__badge {
+  justify-self: start;
+  padding: 0.0625rem 0.4375rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  line-height: 1.5;
+}
+
+/* Tone drives colour only. cards.ts falls back to `neutral` for any tone it
+   does not know, so a skill can ship a new status without a frontend release. */
+.chat-surface .msg-artifact-cards__badge[data-tone='positive'] {
+  border-color: color-mix(in srgb, var(--success, #2ea043) 45%, transparent);
+  background: color-mix(in srgb, var(--success, #2ea043) 16%, transparent);
+  color: var(--success, #2ea043);
+}
+
+.chat-surface .msg-artifact-cards__badge[data-tone='warning'] {
+  border-color: color-mix(in srgb, var(--warning, #d29922) 45%, transparent);
+  background: color-mix(in srgb, var(--warning, #d29922) 16%, transparent);
+  color: var(--warning, #d29922);
+}
+
+.chat-surface .msg-artifact-cards__badge[data-tone='danger'] {
+  border-color: color-mix(in srgb, var(--destructive, #f85149) 45%, transparent);
+  background: color-mix(in srgb, var(--destructive, #f85149) 16%, transparent);
+  color: var(--destructive, #f85149);
+}
+
+.chat-surface .msg-artifact-cards__badge[data-tone='neutral'] {
+  border-color: var(--border);
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--muted-foreground);
+}
+
+.chat-surface .msg-artifact-cards__fields {
+  display: grid;
+  gap: 0.1875rem;
+  min-width: 0;
+}
+
+.chat-surface .msg-artifact-cards__field {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.chat-surface .msg-artifact-cards__field-label {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.chat-surface .msg-artifact-cards__field-value {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.6875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-surface .msg-artifact-cards__field-value--mono {
+  font-family: var(--font-mono);
+}
+
+.chat-surface .msg-artifact-cards__copy {
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.chat-surface .msg-artifact-cards__copy:hover {
+  color: var(--foreground);
+}
+
+.chat-surface .msg-artifact-cards__overflow,
+.chat-surface .msg-artifact-cards__status {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+}
+
+.chat-surface .msg-artifact-cards__overflow[hidden],
+.chat-surface .msg-artifact-cards__status[hidden] {
   display: none;
 }
 

--- a/frontend/src/views/chat/chat-unified.css
+++ b/frontend/src/views/chat/chat-unified.css
@@ -429,13 +429,27 @@
   min-width: 0;
 }
 
-.chat-surface .msg-artifact-cards__logo {
+.chat-surface .msg-artifact-cards__logo,
+.chat-surface .msg-artifact-cards__mark {
   flex-shrink: 0;
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 50%;
   background: var(--card);
   object-fit: contain;
+}
+
+/* Ticker monogram — the default mark. See cards.ts for why a remote logo is
+   not fetched. */
+.chat-surface .msg-artifact-cards__mark {
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .chat-surface .msg-artifact-cards__heading {

--- a/frontend/src/views/chat/transcript/artifacts.ts
+++ b/frontend/src/views/chat/transcript/artifacts.ts
@@ -30,6 +30,7 @@ import '@/i18n/en/chat'
 
 export { publishArtifactTargetName } from './tools'
 
+import { isCardsArtifact } from './cards'
 import { isChartArtifact } from './chart'
 
 /* ── Artifact shape ─────────────────────────────────────────────────────── */
@@ -103,11 +104,13 @@ export function artifactExtension(name: string): string {
 }
 
 // chat.js:7538-7549 — category: visual | audio | data | document | code | file,
-// plus the AgentOS-native 'chart' category (chart.ts) which has no legacy
-// counterpart: it renders an inline chart rather than a download chip.
+// plus the AgentOS-native 'chart' (chart.ts) and 'cards' (cards.ts) categories,
+// which have no legacy counterpart: they render inline rather than as a
+// download chip.
 // NOTE: image/* maps to 'visual' (NOT 'image' — the brief example was wrong).
 export function artifactCategory(artifact: Artifact | null | undefined): string {
   if (isChartArtifact(artifact)) return 'chart'
+  if (isCardsArtifact(artifact)) return 'cards'
   const mime = artifactMime(artifact)
   if (mime.startsWith('image/')) return 'visual'
   if (mime.startsWith('audio/')) return 'audio'
@@ -125,6 +128,8 @@ export function artifactCategoryLabel(category: string): string {
   switch (category) {
     case 'chart':
       return 'chart'
+    case 'cards':
+      return 'cards'
     case 'data':
       return 'data'
     case 'document':
@@ -282,7 +287,14 @@ export function createArtifactRenderer(deps: ArtifactRendererDeps) {
     }
     artifacts.forEach((artifact) => {
       const category = artifactCategory(artifact)
-      const groupKind = category === 'visual' ? 'visual' : category === 'chart' ? 'chart' : 'file'
+      const groupKind =
+        category === 'visual'
+          ? 'visual'
+          : category === 'chart'
+            ? 'chart'
+            : category === 'cards'
+              ? 'cards'
+              : 'file'
       if (groupKind !== openGroup) {
         closeGroup()
         html +=
@@ -290,7 +302,9 @@ export function createArtifactRenderer(deps: ArtifactRendererDeps) {
             ? '<div class="msg-artifact-gallery">'
             : groupKind === 'chart'
               ? '<div class="msg-artifact-charts">'
-              : '<div class="msg-artifact-files">'
+              : groupKind === 'cards'
+                ? '<div class="msg-artifact-cards-group">'
+                : '<div class="msg-artifact-files">'
         openGroup = groupKind
       }
       const name = artifactName(artifact)
@@ -320,6 +334,20 @@ export function createArtifactRenderer(deps: ArtifactRendererDeps) {
           <div class="msg-artifact-chart__readout"></div>
           <div class="msg-artifact-chart__canvas"></div>
           <p class="msg-artifact-chart__status">${escAttr(t('chat.chartLoading'))}</p>
+        </div>`
+      } else if (category === 'cards') {
+        // A mount placeholder, not a finished grid: the cards mounter fetches
+        // `data-cards-src` and builds the cards into `__grid`. No download
+        // affordance — the payload is an internal render format, not a file the
+        // user asked for, so `data-artifact-download` stays off deliberately.
+        const payloadUrl = artifactPreviewUrl(artifact || {}, { sessionKey, token })
+        html += `<div class="msg-artifact-cards" data-cards-src="${escAttr(payloadUrl)}" data-artifact-category="${escAttr(category)}" data-artifact-id="${escAttr(artifact?.id || '')}" data-artifact-name="${escAttr(name)}">
+          <div class="msg-artifact-cards__header">
+            <span class="msg-artifact-cards__name">${esc(name)}</span>
+          </div>
+          <div class="msg-artifact-cards__grid"></div>
+          <p class="msg-artifact-cards__overflow" hidden></p>
+          <p class="msg-artifact-cards__status">${escAttr(t('chat.cardsLoading'))}</p>
         </div>`
       } else if (isImageArtifact(artifact)) {
         const previewUrl = artifactPreviewUrl(artifact || {}, { sessionKey, token })

--- a/frontend/src/views/chat/transcript/cards.test.ts
+++ b/frontend/src/views/chat/transcript/cards.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_CARDS,
   createCardsMounter,
   isCardsArtifact,
+  monogram,
   normalizeCardsPayload,
   renderCards,
   safeLogoUrl,
@@ -67,6 +68,20 @@ describe('safeLogoUrl', () => {
   })
 })
 
+describe('monogram', () => {
+  it('takes up to two leading alphanumerics, uppercased', () => {
+    expect(monogram('AAPL')).toBe('AA')
+    expect(monogram('gme')).toBe('GM')
+    expect(monogram('X')).toBe('X')
+  })
+
+  it('skips punctuation and copes with an empty title', () => {
+    expect(monogram('e.l.f. Beauty')).toBe('EL')
+    expect(monogram('...')).toBe('')
+    expect(monogram('')).toBe('')
+  })
+})
+
 describe('normalizeCardsPayload', () => {
   it('normalizes a well-formed payload', () => {
     const payload = normalizeCardsPayload({ title: 'Results', cards: [AAPL] })
@@ -123,6 +138,44 @@ describe('renderCards', () => {
     )
     // The payload title wins over the artifact filename.
     expect(node.querySelector('.msg-artifact-cards__name')!.textContent).toBe('Lookup')
+  })
+
+  it('shows a ticker monogram, because the CSP blocks token-list logo CDNs', () => {
+    const node = host()
+    renderCards(node, normalizeCardsPayload({ cards: [AAPL] })!, () => {})
+
+    const mark = node.querySelector<HTMLElement>('.msg-artifact-cards__mark')!
+    expect(mark.textContent).toBe('AA')
+    expect(mark.getAttribute('aria-hidden')).toBe('true')
+    // The img is still attached; it only replaces the monogram once it loads.
+    expect(node.querySelector('.msg-artifact-cards__logo')).not.toBeNull()
+  })
+
+  it('keeps the monogram when the logo fails to load', () => {
+    const node = host()
+    renderCards(node, normalizeCardsPayload({ cards: [AAPL] })!, () => {})
+
+    const img = node.querySelector<HTMLImageElement>('.msg-artifact-cards__logo')!
+    img.dispatchEvent(new Event('error'))
+    expect(node.querySelector('.msg-artifact-cards__logo')).toBeNull()
+    expect(node.querySelector('.msg-artifact-cards__mark')).not.toBeNull()
+  })
+
+  it('drops the monogram once a logo actually loads', () => {
+    const node = host()
+    renderCards(node, normalizeCardsPayload({ cards: [AAPL] })!, () => {})
+
+    node
+      .querySelector<HTMLImageElement>('.msg-artifact-cards__logo')!
+      .dispatchEvent(new Event('load'))
+    expect(node.querySelector('.msg-artifact-cards__mark')).toBeNull()
+  })
+
+  it('a card with no logo still gets a monogram', () => {
+    const node = host()
+    renderCards(node, normalizeCardsPayload({ cards: [{ title: 'GME' }] })!, () => {})
+    expect(node.querySelector('.msg-artifact-cards__mark')!.textContent).toBe('GM')
+    expect(node.querySelector('.msg-artifact-cards__logo')).toBeNull()
   })
 
   it('never lets a payload string reach the DOM as markup', () => {

--- a/frontend/src/views/chat/transcript/cards.test.ts
+++ b/frontend/src/views/chat/transcript/cards.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CARDS_ARTIFACT_MIME,
+  MAX_CARDS,
+  createCardsMounter,
+  isCardsArtifact,
+  normalizeCardsPayload,
+  renderCards,
+  safeLogoUrl,
+} from './cards'
+
+function host(): HTMLElement {
+  const node = document.createElement('div')
+  node.className = 'msg-artifact-cards'
+  node.innerHTML = `
+    <div class="msg-artifact-cards__header"><span class="msg-artifact-cards__name">lookup.json</span></div>
+    <div class="msg-artifact-cards__grid"></div>
+    <p class="msg-artifact-cards__overflow" hidden></p>
+    <p class="msg-artifact-cards__status">Loading results…</p>`
+  document.body.append(node)
+  return node
+}
+
+const AAPL = {
+  title: 'AAPL',
+  subtitle: 'Apple',
+  badge: 'verified',
+  badgeTone: 'positive',
+  logo: 'https://assets.example/aapl.png',
+  fields: [
+    { label: 'Address', value: '0xaf3d76f1834a1d425780943c99ea8a608f8a93f9', copyable: true },
+  ],
+}
+
+beforeEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('isCardsArtifact', () => {
+  it('matches the cards mime, with or without parameters', () => {
+    expect(isCardsArtifact({ mime: CARDS_ARTIFACT_MIME })).toBe(true)
+    expect(isCardsArtifact({ mime: `${CARDS_ARTIFACT_MIME}; charset=utf-8` })).toBe(true)
+    expect(isCardsArtifact({ mime: 'APPLICATION/VND.AGENTOS.CARDS+JSON' })).toBe(true)
+  })
+
+  it('ignores every other artifact', () => {
+    expect(isCardsArtifact({ mime: 'application/json' })).toBe(false)
+    expect(isCardsArtifact({ mime: 'application/vnd.agentos.chart+json' })).toBe(false)
+    expect(isCardsArtifact(null)).toBe(false)
+    expect(isCardsArtifact({})).toBe(false)
+  })
+})
+
+describe('safeLogoUrl', () => {
+  it('keeps http(s) urls', () => {
+    expect(safeLogoUrl('https://a.example/x.png')).toBe('https://a.example/x.png')
+    expect(safeLogoUrl('http://a.example/x.png')).toBe('http://a.example/x.png')
+  })
+
+  it('drops anything that could execute or inline', () => {
+    // A payload field becomes an <img src>, so these must never survive.
+    expect(safeLogoUrl('javascript:alert(1)')).toBe('')
+    expect(safeLogoUrl('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')).toBe('')
+    expect(safeLogoUrl('not a url')).toBe('')
+    expect(safeLogoUrl(null)).toBe('')
+  })
+})
+
+describe('normalizeCardsPayload', () => {
+  it('normalizes a well-formed payload', () => {
+    const payload = normalizeCardsPayload({ title: 'Results', cards: [AAPL] })
+    expect(payload).not.toBeNull()
+    expect(payload!.title).toBe('Results')
+    expect(payload!.cards).toHaveLength(1)
+    expect(payload!.cards[0]!.badgeTone).toBe('positive')
+    expect(payload!.cards[0]!.fields[0]!.copyable).toBe(true)
+    expect(payload!.overflow).toBe(0)
+  })
+
+  it('returns null when there is nothing to draw', () => {
+    expect(normalizeCardsPayload(null)).toBeNull()
+    expect(normalizeCardsPayload({})).toBeNull()
+    expect(normalizeCardsPayload({ cards: 'nope' })).toBeNull()
+    expect(normalizeCardsPayload({ cards: [] })).toBeNull()
+    // A card with no title has nothing to identify it by.
+    expect(normalizeCardsPayload({ cards: [{ subtitle: 'x' }] })).toBeNull()
+  })
+
+  it('drops fields with no value but keeps label-less ones', () => {
+    const payload = normalizeCardsPayload({
+      cards: [{ title: 'X', fields: [{ label: 'A', value: '' }, { value: 'bare' }] }],
+    })
+    expect(payload!.cards[0]!.fields).toEqual([{ label: '', value: 'bare' }])
+  })
+
+  it('falls back to a neutral tone for an unknown badge tone', () => {
+    const payload = normalizeCardsPayload({ cards: [{ title: 'X', badgeTone: 'chartreuse' }] })
+    expect(payload!.cards[0]!.badgeTone).toBe('neutral')
+  })
+
+  it('caps the grid and reports the overflow rather than truncating silently', () => {
+    const cards = Array.from({ length: MAX_CARDS + 7 }, (_v, i) => ({ title: `T${i}` }))
+    const payload = normalizeCardsPayload({ cards })
+    expect(payload!.cards).toHaveLength(MAX_CARDS)
+    expect(payload!.overflow).toBe(7)
+  })
+})
+
+describe('renderCards', () => {
+  it('builds one card per entry with badge, subtitle and fields', () => {
+    const node = host()
+    renderCards(node, normalizeCardsPayload({ title: 'Lookup', cards: [AAPL] })!, () => {})
+
+    expect(node.querySelectorAll('.msg-artifact-cards__card')).toHaveLength(1)
+    expect(node.querySelector('.msg-artifact-cards__title')!.textContent).toBe('AAPL')
+    expect(node.querySelector('.msg-artifact-cards__subtitle')!.textContent).toBe('Apple')
+    const badge = node.querySelector<HTMLElement>('.msg-artifact-cards__badge')!
+    expect(badge.textContent).toBe('verified')
+    expect(badge.dataset.tone).toBe('positive')
+    expect(node.querySelector('.msg-artifact-cards__field-value')!.textContent).toBe(
+      '0xaf3d76f1834a1d425780943c99ea8a608f8a93f9',
+    )
+    // The payload title wins over the artifact filename.
+    expect(node.querySelector('.msg-artifact-cards__name')!.textContent).toBe('Lookup')
+  })
+
+  it('never lets a payload string reach the DOM as markup', () => {
+    const node = host()
+    const evil = '<img src=x onerror="alert(1)">'
+    renderCards(node, normalizeCardsPayload({ cards: [{ title: evil }] })!, () => {})
+
+    const title = node.querySelector('.msg-artifact-cards__title')!
+    expect(title.textContent).toBe(evil)
+    expect(title.querySelector('img')).toBeNull()
+    expect(node.querySelectorAll('img')).toHaveLength(0)
+  })
+
+  it('copies the field value on click', () => {
+    const node = host()
+    const onCopy = vi.fn()
+    renderCards(node, normalizeCardsPayload({ cards: [AAPL] })!, onCopy)
+
+    node.querySelector<HTMLButtonElement>('.msg-artifact-cards__copy')!.click()
+    expect(onCopy).toHaveBeenCalledWith('0xaf3d76f1834a1d425780943c99ea8a608f8a93f9')
+  })
+
+  it('offers no copy button for a plain field', () => {
+    const node = host()
+    renderCards(
+      node,
+      normalizeCardsPayload({ cards: [{ title: 'X', fields: [{ label: 'A', value: 'b' }] }] })!,
+      () => {},
+    )
+    expect(node.querySelector('.msg-artifact-cards__copy')).toBeNull()
+  })
+
+  it('announces dropped cards instead of hiding them', () => {
+    const node = host()
+    const cards = Array.from({ length: MAX_CARDS + 3 }, (_v, i) => ({ title: `T${i}` }))
+    renderCards(node, normalizeCardsPayload({ cards })!, () => {})
+
+    const overflow = node.querySelector<HTMLElement>('.msg-artifact-cards__overflow')!
+    expect(overflow.hidden).toBe(false)
+    expect(overflow.textContent).toContain('3')
+  })
+
+  it('replaces a previous render rather than appending to it', () => {
+    const node = host()
+    renderCards(node, normalizeCardsPayload({ cards: [AAPL] })!, () => {})
+    renderCards(node, normalizeCardsPayload({ cards: [AAPL] })!, () => {})
+    expect(node.querySelectorAll('.msg-artifact-cards__card')).toHaveLength(1)
+  })
+})
+
+describe('createCardsMounter', () => {
+  it('fetches the payload and clears the status on success', async () => {
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    const fetchPayload = vi.fn().mockResolvedValue({ cards: [AAPL] })
+
+    const mounter = createCardsMounter({ fetchPayload })
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => {
+      expect(node.querySelectorAll('.msg-artifact-cards__card')).toHaveLength(1)
+    })
+
+    expect(fetchPayload).toHaveBeenCalledWith('/preview/lookup.json')
+    expect(node.querySelector<HTMLElement>('.msg-artifact-cards__status')!.hidden).toBe(true)
+  })
+
+  it('claims each host once, so repeated mounts do not double-render', async () => {
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    const fetchPayload = vi.fn().mockResolvedValue({ cards: [AAPL] })
+
+    const mounter = createCardsMounter({ fetchPayload })
+    mounter.mountCards(document.body)
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => expect(fetchPayload).toHaveBeenCalledTimes(1))
+  })
+
+  it('reports an unreadable payload without throwing', async () => {
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    const mounter = createCardsMounter({ fetchPayload: vi.fn().mockResolvedValue({ cards: [] }) })
+
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => {
+      expect(node.querySelector('.msg-artifact-cards__status')!.textContent).toContain('could not')
+    })
+  })
+
+  it('reports a failed fetch without throwing', async () => {
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    const mounter = createCardsMounter({
+      fetchPayload: vi.fn().mockRejectedValue(new Error('offline')),
+    })
+
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => {
+      expect(node.querySelector('.msg-artifact-cards__status')!.textContent).toContain('failed')
+    })
+  })
+
+  it('says so when the placeholder carries an empty source', async () => {
+    // artifacts.ts always emits the attribute; it is empty when the artifact
+    // has no preview URL, which is what this covers.
+    const node = host()
+    node.dataset.cardsSrc = ''
+    const fetchPayload = vi.fn()
+    const mounter = createCardsMounter({ fetchPayload })
+
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => {
+      expect(node.querySelector('.msg-artifact-cards__status')!.textContent).toContain(
+        'unavailable',
+      )
+    })
+    expect(fetchPayload).not.toHaveBeenCalled()
+  })
+
+  it('ignores a node that is not a cards placeholder at all', () => {
+    host() // no data-cards-src attribute
+    const fetchPayload = vi.fn()
+    createCardsMounter({ fetchPayload }).mountCards(document.body)
+    expect(fetchPayload).not.toHaveBeenCalled()
+  })
+
+  it('does not render into a host that left the document mid-fetch', async () => {
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    let release: (value: unknown) => void = () => {}
+    const pending = new Promise((resolve) => {
+      release = resolve
+    })
+    const mounter = createCardsMounter({ fetchPayload: () => pending })
+
+    mounter.mountCards(document.body)
+    node.remove()
+    release({ cards: [AAPL] })
+    await pending
+
+    expect(node.querySelectorAll('.msg-artifact-cards__card')).toHaveLength(0)
+  })
+
+  it('mounts the fresh host when a row rebuild replaces the placeholder', async () => {
+    // "Load earlier" and a session switch rebuild rows wholesale, so the old
+    // host is detached and a new element takes its place.
+    const first = host()
+    first.dataset.cardsSrc = '/preview/lookup.json'
+    const fetchPayload = vi.fn().mockResolvedValue({ cards: [AAPL] })
+    const mounter = createCardsMounter({ fetchPayload })
+
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => expect(fetchPayload).toHaveBeenCalledTimes(1))
+
+    first.remove()
+    const second = host()
+    second.dataset.cardsSrc = '/preview/lookup.json'
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => expect(fetchPayload).toHaveBeenCalledTimes(2))
+    expect(second.querySelectorAll('.msg-artifact-cards__card')).toHaveLength(1)
+  })
+
+  it('re-attaching the same host does not re-render it', async () => {
+    // The node still holds its cards, so refetching would be pure waste.
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    const fetchPayload = vi.fn().mockResolvedValue({ cards: [AAPL] })
+    const mounter = createCardsMounter({ fetchPayload })
+
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => expect(fetchPayload).toHaveBeenCalledTimes(1))
+
+    node.remove()
+    document.body.append(node)
+    mounter.mountCards(document.body)
+    expect(fetchPayload).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroyAll releases claimed hosts', async () => {
+    const node = host()
+    node.dataset.cardsSrc = '/preview/lookup.json'
+    const fetchPayload = vi.fn().mockResolvedValue({ cards: [AAPL] })
+    const mounter = createCardsMounter({ fetchPayload })
+
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => expect(fetchPayload).toHaveBeenCalledTimes(1))
+
+    mounter.destroyAll()
+    mounter.mountCards(document.body)
+    await vi.waitFor(() => expect(fetchPayload).toHaveBeenCalledTimes(2))
+  })
+})

--- a/frontend/src/views/chat/transcript/cards.ts
+++ b/frontend/src/views/chat/transcript/cards.ts
@@ -197,17 +197,34 @@ function buildField(field: CardField, onCopy: (value: string) => void): HTMLElem
   return row
 }
 
+/** Up to two leading alphanumerics of the title, for the monogram. */
+export function monogram(title: string): string {
+  const cleaned = title.replace(/[^\p{L}\p{N}]/gu, '')
+  return cleaned.slice(0, 2).toUpperCase()
+}
+
 function buildCard(card: Card, onCopy: (value: string) => void): HTMLElement {
   const host = el('article', 'msg-artifact-cards__card')
 
   const header = el('header', 'msg-artifact-cards__head')
+  // A ticker monogram is the base, not a fallback. The console's CSP allows
+  // images from 'self', data: and raw.githubusercontent.com only, so a logo on
+  // a token-list CDN never loads (skills/hub/bankr.py hit the same wall and made
+  // the same call). Fetching one would also tell that CDN which tickers the user
+  // is researching, from their IP -- a real leak for a finance surface. The img
+  // below still covers a logo the CSP does happen to allow.
+  const mark = el('span', 'msg-artifact-cards__mark', monogram(card.title))
+  mark.setAttribute('aria-hidden', 'true')
+  header.append(mark)
+
   if (card.logo) {
     const img = document.createElement('img')
     img.className = 'msg-artifact-cards__logo'
     img.src = card.logo
     img.alt = ''
     img.loading = 'lazy'
-    // A broken logo must not leave a torn frame in the grid.
+    // Only take over from the monogram once the bytes actually arrived.
+    img.addEventListener('load', () => mark.remove())
     img.addEventListener('error', () => img.remove())
     header.append(img)
   }

--- a/frontend/src/views/chat/transcript/cards.ts
+++ b/frontend/src/views/chat/transcript/cards.ts
@@ -1,0 +1,366 @@
+// Chat transcript — inline card-grid artifacts.
+//
+// A skill publishes a JSON artifact with the `application/vnd.agentos.cards+json`
+// mime; the artifact renderer emits a mount placeholder for it (instead of the
+// usual download chip) and this module fetches the payload and builds a grid of
+// cards into that placeholder.
+//
+// This is the tabular/record counterpart to chart.ts: where a chart draws a time
+// series, this draws a small set of labelled records — a token lookup, a holder
+// list, a search result — with an optional status badge and copy button per card.
+//
+// Two surfaces, mirroring chart.ts / artifacts.ts:
+//   1. Pure helpers (top-level exports) — mime match and payload normalization.
+//      No DOM, no network. This is the unit-test surface (cards.test.ts).
+//   2. `createCardsMounter(deps)` — the imperative mounter the transcript
+//      composes alongside the chart mounter.
+//
+// SECURITY: every payload-derived string reaches the DOM through `textContent`
+// or `createElement`, never `innerHTML`. Card fields carry token names, symbols
+// and on-chain metadata, which are fully attacker-controlled on a permissionless
+// chain — they are display data, never markup. Logo URLs are additionally
+// restricted to http(s) so a payload cannot smuggle `javascript:` into `src`.
+
+import { t } from '@/i18n'
+import '@/i18n/en/chat'
+
+import type { Artifact } from './artifacts'
+
+/** The mime a skill publishes to get an inline card grid instead of a download chip. */
+export const CARDS_ARTIFACT_MIME = 'application/vnd.agentos.cards+json'
+
+/** Cards rendered before the grid stops growing and the rest are summarised. */
+export const MAX_CARDS = 24
+
+/* ── Payload shape ──────────────────────────────────────────────────────── */
+
+/**
+ * A card's status badge. The tone drives the colour; unknown tones fall back to
+ * neutral so a skill can ship a new status without a frontend release.
+ */
+export type CardTone = 'positive' | 'warning' | 'danger' | 'neutral'
+
+const TONES = new Set<CardTone>(['positive', 'warning', 'danger', 'neutral'])
+
+/** One labelled row inside a card's body. */
+export interface CardField {
+  label: string
+  value: string
+  /** Render in a monospace cell with a copy button — addresses, hashes, ids. */
+  copyable?: boolean
+}
+
+/** One card. Only `title` is required. */
+export interface Card {
+  title: string
+  subtitle: string
+  /** Small leading image — a token or company logo. http(s) only. */
+  logo: string
+  /** Short badge text, e.g. "verified". */
+  badge: string
+  badgeTone: CardTone
+  fields: CardField[]
+}
+
+/** The artifact body a skill writes. Only `cards` is required. */
+export interface CardsPayload {
+  type: 'cards'
+  title: string
+  subtitle: string
+  cards: Card[]
+  /** Cards dropped by the MAX_CARDS cap, so the UI can say so rather than lie. */
+  overflow: number
+}
+
+/* ── Pure helpers (unit-tested) ─────────────────────────────────────────── */
+
+/** True when the artifact should render as an inline card grid. */
+export function isCardsArtifact(artifact: Artifact | null | undefined): boolean {
+  if (!artifact || !artifact.mime) return false
+  return String(artifact.mime).toLowerCase().split(';')[0]?.trim() === CARDS_ARTIFACT_MIME
+}
+
+function textField(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
+}
+
+/**
+ * Keep only http(s) logo URLs.
+ *
+ * A payload field becomes an `<img src>`, so `javascript:` and `data:` are
+ * dropped rather than sanitised — a skill has no reason to inline an image, and
+ * refusing is cheaper to reason about than filtering.
+ */
+export function safeLogoUrl(value: unknown): string {
+  const raw = textField(value)
+  if (!raw) return ''
+  try {
+    const url = new URL(raw)
+    return url.protocol === 'https:' || url.protocol === 'http:' ? raw : ''
+  } catch {
+    return ''
+  }
+}
+
+function normalizeTone(value: unknown): CardTone {
+  const raw = textField(value).toLowerCase()
+  return TONES.has(raw as CardTone) ? (raw as CardTone) : 'neutral'
+}
+
+function normalizeField(raw: unknown): CardField | null {
+  if (!raw || typeof raw !== 'object') return null
+  const row = raw as Record<string, unknown>
+  const label = textField(row.label)
+  const value = textField(row.value)
+  // A field with no value is noise in a dense grid; a label-less value is not.
+  if (!value) return null
+  const field: CardField = { label, value }
+  if (row.copyable === true) field.copyable = true
+  return field
+}
+
+function normalizeCard(raw: unknown): Card | null {
+  if (!raw || typeof raw !== 'object') return null
+  const row = raw as Record<string, unknown>
+  const title = textField(row.title)
+  if (!title) return null
+  const fields = Array.isArray(row.fields)
+    ? row.fields.map(normalizeField).filter((f): f is CardField => f !== null)
+    : []
+  return {
+    title,
+    subtitle: textField(row.subtitle),
+    logo: safeLogoUrl(row.logo),
+    badge: textField(row.badge),
+    badgeTone: normalizeTone(row.badgeTone),
+    fields,
+  }
+}
+
+/**
+ * Validate and normalize an artifact body into a renderable payload, or return
+ * null when there is nothing to draw.
+ *
+ * Cards past `MAX_CARDS` are dropped and counted in `overflow` rather than
+ * rendered: an unbounded grid from a wide query would push the rest of the
+ * transcript off-screen, and silently truncating would misreport the result.
+ */
+export function normalizeCardsPayload(raw: unknown): CardsPayload | null {
+  if (!raw || typeof raw !== 'object') return null
+  const body = raw as Record<string, unknown>
+  if (!Array.isArray(body.cards)) return null
+
+  const all = body.cards.map(normalizeCard).filter((c): c is Card => c !== null)
+  if (all.length === 0) return null
+
+  return {
+    type: 'cards',
+    title: textField(body.title),
+    subtitle: textField(body.subtitle),
+    cards: all.slice(0, MAX_CARDS),
+    overflow: Math.max(0, all.length - MAX_CARDS),
+  }
+}
+
+/* ── DOM building ───────────────────────────────────────────────────────── */
+
+function el(tag: string, className: string, text?: string): HTMLElement {
+  const node = document.createElement(tag)
+  node.className = className
+  // textContent, never innerHTML — see the security note at the top.
+  if (text !== undefined) node.textContent = text
+  return node
+}
+
+function buildField(field: CardField, onCopy: (value: string) => void): HTMLElement {
+  const row = el('div', 'msg-artifact-cards__field')
+  if (field.label) row.append(el('span', 'msg-artifact-cards__field-label', field.label))
+
+  const valueClass = field.copyable
+    ? 'msg-artifact-cards__field-value msg-artifact-cards__field-value--mono'
+    : 'msg-artifact-cards__field-value'
+  const value = el('span', valueClass, field.value)
+  value.title = field.value
+  row.append(value)
+
+  if (field.copyable) {
+    const button = el('button', 'msg-artifact-cards__copy')
+    button.setAttribute('type', 'button')
+    button.setAttribute('aria-label', t('chat.cardsCopy'))
+    button.title = t('chat.cardsCopy')
+    button.textContent = '⧉'
+    button.addEventListener('click', () => onCopy(field.value))
+    row.append(button)
+  }
+  return row
+}
+
+function buildCard(card: Card, onCopy: (value: string) => void): HTMLElement {
+  const host = el('article', 'msg-artifact-cards__card')
+
+  const header = el('header', 'msg-artifact-cards__head')
+  if (card.logo) {
+    const img = document.createElement('img')
+    img.className = 'msg-artifact-cards__logo'
+    img.src = card.logo
+    img.alt = ''
+    img.loading = 'lazy'
+    // A broken logo must not leave a torn frame in the grid.
+    img.addEventListener('error', () => img.remove())
+    header.append(img)
+  }
+
+  const heading = el('div', 'msg-artifact-cards__heading')
+  heading.append(el('span', 'msg-artifact-cards__title', card.title))
+  if (card.subtitle) {
+    const subtitle = el('span', 'msg-artifact-cards__subtitle', card.subtitle)
+    subtitle.title = card.subtitle
+    heading.append(subtitle)
+  }
+  header.append(heading)
+  host.append(header)
+
+  if (card.badge) {
+    const badge = el('span', 'msg-artifact-cards__badge', card.badge)
+    badge.dataset.tone = card.badgeTone
+    host.append(badge)
+  }
+
+  if (card.fields.length > 0) {
+    const body = el('div', 'msg-artifact-cards__fields')
+    card.fields.forEach((field) => body.append(buildField(field, onCopy)))
+    host.append(body)
+  }
+  return host
+}
+
+/**
+ * Replace `host`'s grid with the payload's cards.
+ *
+ * Exported for the unit tests, which assert on the built DOM without standing up
+ * a mounter or a fetch.
+ */
+export function renderCards(
+  host: HTMLElement,
+  payload: CardsPayload,
+  onCopy: (value: string) => void,
+): void {
+  const grid = host.querySelector<HTMLElement>('.msg-artifact-cards__grid')
+  if (!grid) return
+
+  if (payload.title) {
+    const label = host.querySelector<HTMLElement>('.msg-artifact-cards__name')
+    if (label) {
+      label.textContent = payload.title
+      if (payload.subtitle) label.title = payload.subtitle
+    }
+  }
+
+  grid.replaceChildren(...payload.cards.map((card) => buildCard(card, onCopy)))
+
+  const overflow = host.querySelector<HTMLElement>('.msg-artifact-cards__overflow')
+  if (overflow) {
+    overflow.textContent =
+      payload.overflow > 0 ? t('chat.cardsOverflow', { count: String(payload.overflow) }) : ''
+    overflow.hidden = payload.overflow === 0
+  }
+}
+
+/* ── Mounter ────────────────────────────────────────────────────────────── */
+
+export interface CardsMounterDeps {
+  /** Fetch a cards artifact body from its (authenticated) URL. */
+  fetchPayload: (url: string) => Promise<unknown>
+  /** Copy a field value to the clipboard. Default: the Clipboard API. */
+  copyText?: (value: string) => void
+  /** chat.js `_chatDiag` — the diagnostics ring. Default: no-op. */
+  diag?: (event: string, detail: Record<string, unknown>) => void
+}
+
+/**
+ * Create the cards mounter bound to the transcript's fetch surface.
+ *
+ * `mountCards(root)` is idempotent: it only picks up placeholders that have not
+ * been mounted yet, so the streaming path may call it after every artifact
+ * append and the history path after a bulk replay, without double-rendering.
+ *
+ * Unlike charts there is nothing to dispose — a card grid is plain DOM with no
+ * canvas, observer or library handle — so the mounter only tracks claimed hosts
+ * and drops the ones that leave the document.
+ */
+export function createCardsMounter(deps: CardsMounterDeps) {
+  const diag = deps.diag ?? ((): void => {})
+  const copyText =
+    deps.copyText ??
+    ((value: string): void => {
+      void navigator.clipboard?.writeText(value)
+    })
+  /** Hosts this mounter has picked up — payload in flight or cards rendered. */
+  const claimed = new Set<HTMLElement>()
+
+  function pruneDetached(): void {
+    for (const host of [...claimed]) {
+      if (!host.isConnected) claimed.delete(host)
+    }
+  }
+
+  function setStatus(host: HTMLElement, message: string): void {
+    const status = host.querySelector<HTMLElement>('.msg-artifact-cards__status')
+    if (!status) return
+    status.textContent = message
+    status.hidden = message === ''
+  }
+
+  async function mountOne(host: HTMLElement): Promise<void> {
+    const url = host.dataset.cardsSrc || ''
+    if (!url) {
+      setStatus(host, t('chat.cardsUnavailable'))
+      return
+    }
+    try {
+      diag('cards.mount.start', { url })
+      const raw = await deps.fetchPayload(url)
+      const payload = normalizeCardsPayload(raw)
+      if (!payload) {
+        setStatus(host, t('chat.cardsUnreadable'))
+        diag('cards.mount.empty', { url })
+        return
+      }
+      // The row can be rebuilt while the payload is in flight — cards rendered
+      // into a detached host have nobody to show them.
+      if (!host.isConnected) {
+        claimed.delete(host)
+        return
+      }
+      renderCards(host, payload, copyText)
+      setStatus(host, '')
+      diag('cards.mount.done', { url, cards: payload.cards.length })
+    } catch (error) {
+      setStatus(host, t('chat.cardsFailed'))
+      diag('cards.mount.error', { url, error: String(error) })
+    }
+  }
+
+  /** Mount every not-yet-mounted card placeholder inside `root`. */
+  function mountCards(root: HTMLElement | null | undefined): void {
+    if (!root) return
+    pruneDetached()
+    const hosts = root.querySelectorAll<HTMLElement>('[data-cards-src]')
+    hosts.forEach((host) => {
+      if (claimed.has(host)) return
+      claimed.add(host)
+      void mountOne(host)
+    })
+  }
+
+  /** Forget every claimed host (route unmount). */
+  function destroyAll(): void {
+    claimed.clear()
+  }
+
+  return { mountCards, destroyAll, pruneDetached }
+}
+
+export type CardsMounter = ReturnType<typeof createCardsMounter>

--- a/frontend/src/views/chat/useTranscript.ts
+++ b/frontend/src/views/chat/useTranscript.ts
@@ -8,6 +8,7 @@ import { useRpc } from '@/app/providers'
 import { useApprovals } from '@/services/approval-monitor'
 import { useTheme } from '@/stores/theme'
 import { chatMarkdown } from './markdown'
+import { createCardsMounter, type CardsMounter } from './transcript/cards'
 import { createChartMounter, type ChartMounter } from './transcript/chart'
 import {
   createStreamController,
@@ -465,9 +466,23 @@ export function useTranscript(opts: {
       getTheme: () => useTheme.getState().mode,
     }),
   )
+  // Card-grid artifacts (cards.ts). Plain DOM, so unlike charts there is no
+  // canvas or library handle to dispose and no theme callback — the mounter only
+  // tracks which placeholders it has already filled.
+  const [cardsMounter] = useState<CardsMounter>(() =>
+    createCardsMounter({ fetchPayload: fetchChartPayload }),
+  )
+
+  // One seam for both inline-artifact renderers. The downstream deps (stream.ts,
+  // history.ts, artifacts.ts) call this whenever new rows land; keeping a single
+  // callback means a new inline artifact type is composed here rather than
+  // threaded through every one of them.
   const mountCharts = useCallback(
-    (container: HTMLElement) => chartMounter.mountCharts(container),
-    [chartMounter],
+    (container: HTMLElement) => {
+      chartMounter.mountCharts(container)
+      cardsMounter.mountCards(container)
+    },
+    [chartMounter, cardsMounter],
   )
 
   useEffect(() => {
@@ -475,8 +490,9 @@ export function useTranscript(opts: {
     return () => {
       unsubscribe()
       chartMounter.destroyAll()
+      cardsMounter.destroyAll()
     }
-  }, [chartMounter])
+  }, [chartMounter, cardsMounter])
 
   // eslint-disable-next-line react-hooks/refs -- factory stores the refs and reads .current only later, inside methods invoked outside render (never at creation)
   const [controller] = useState<StreamController>(() =>

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/SKILL.md
@@ -103,9 +103,14 @@ command, no flag, no `publish_artifact` call. Price, supply, multiplier and a
 So: answer in prose and let the card carry the numbers. Do **not** also
 hand-write a table of the same fields.
 
-stdout stays pure JSON; the publish marker goes to stderr. `--no-cards` turns it
-off, and `--cards FILE` picks the filename. `scripts/chain_cards.py` builds the
-same payload from the JSON on stdin if you need it separately.
+Two things would silently break this, so do neither:
+
+- **Never append `2>/dev/null`** (or any stderr redirect) to the command. The
+  publish marker travels on stderr; discarding it discards the card.
+- **Never pass `--no-cards`.** It exists for humans running the script by hand.
+
+`--cards FILE` picks the filename if you need a specific one.
+`scripts/chain_cards.py` builds the same payload from the JSON on stdin.
 
 The badge is derived from the reading, worst case first — `unverified` (chain
 unreachable) → `not-a-stock-token` → `price stale` → `oracle paused` →

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/SKILL.md
@@ -93,6 +93,28 @@ python3 {baseDir}/scripts/chain_stocks.py --query MSFT --no-price
 python3 {baseDir}/scripts/chain_stocks.py --query SPY --rpc-url https://your-provider/rpc
 ```
 
+## The card renders itself
+
+Every run writes a Web-chat card next to the JSON (`<SYMBOL>.cards.json`) and
+`exec_command` publishes it. **There is nothing for you to do** — no extra
+command, no flag, no `publish_artifact` call. Price, supply, multiplier and a
+42-character address read far better as a card than as a bullet list.
+
+So: answer in prose and let the card carry the numbers. Do **not** also
+hand-write a table of the same fields.
+
+stdout stays pure JSON; the publish marker goes to stderr. `--no-cards` turns it
+off, and `--cards FILE` picks the filename. `scripts/chain_cards.py` builds the
+same payload from the JSON on stdin if you need it separately.
+
+The badge is derived from the reading, worst case first — `unverified` (chain
+unreachable) → `not-a-stock-token` → `price stale` → `oracle paused` →
+`verified`. Still state the caveat in your own words as well; the card
+supplements the answer, it does not replace it.
+
+Answer in prose plus the card. Do not also hand-write a table of the same
+fields.
+
 ### Output (JSON, trimmed)
 
 ```json

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
@@ -99,6 +99,7 @@ def build_cards(result: dict[str, Any]) -> list[dict[str, Any]]:
         {
             "title": title,
             "subtitle": name if symbol else "",
+            "logo": _text(token.get("logoURI")),
             "badge": label,
             "badgeTone": tone,
             "fields": fields,

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Turn ``chain_stocks.py`` output into a chat card artifact.
+
+The Web chat renders an artifact whose mime is
+``application/vnd.agentos.cards+json`` as an inline card instead of a download
+chip, and ``exec_command`` publishes the marker this script prints without the
+model having to ask for it.
+
+Usage (stdin is ``chain_stocks.py``'s JSON):
+
+    python3 {baseDir}/scripts/chain_stocks.py --query Apple \
+      | python3 {baseDir}/scripts/chain_cards.py --output aapl.cards.json
+
+One card per reading, laid out so the two things a caller can act on wrongly --
+a **stale price** and an **unverified token** -- are the badge, not a footnote.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+CARDS_MIME = "application/vnd.agentos.cards+json"
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def badge(token: dict[str, Any]) -> tuple[str, str]:
+    """Return ``(badge, tone)`` for the token's trustworthiness and freshness.
+
+    Ordered by what would mislead a reader most. ``isStockToken`` is three-state
+    (see the skill's own contract): ``None`` means the chain could not be
+    reached, which is *unverified*, never *fake*.
+    """
+    is_stock = token.get("isStockToken")
+    if is_stock is None:
+        return "unverified", "neutral"
+    if is_stock is False:
+        return "not-a-stock-token", "danger"
+    price = token.get("price")
+    if isinstance(price, dict) and price.get("stale") is True:
+        return "price stale", "warning"
+    if token.get("oraclePaused") is True:
+        return "oracle paused", "warning"
+    return "verified", "positive"
+
+
+def _price_field(token: dict[str, Any]) -> dict[str, Any] | None:
+    price = token.get("price")
+    if not isinstance(price, dict):
+        return None
+    usd = price.get("usd")
+    # A non-positive feed answer is not a price; the skill forbids reporting it
+    # as "$0", so it is omitted rather than shown.
+    if not isinstance(usd, int | float) or usd <= 0:
+        return None
+    return {"label": "Price", "value": f"${usd:,.4f}"}
+
+
+def build_cards(result: dict[str, Any]) -> list[dict[str, Any]]:
+    token = result.get("token")
+    if not isinstance(token, dict):
+        return []
+    symbol = _text(token.get("symbol")) or _text(token.get("onchainSymbol"))
+    name = _text(token.get("name"))
+    title = symbol or name
+    if not title:
+        return []
+
+    label, tone = badge(token)
+    fields: list[dict[str, Any]] = []
+
+    price_field = _price_field(token)
+    if price_field:
+        fields.append(price_field)
+
+    supply = token.get("totalSupplyFormatted")
+    if isinstance(supply, int | float):
+        fields.append({"label": "Supply", "value": f"{supply:,.4f}"})
+
+    multiplier = token.get("uiMultiplierFormatted")
+    if isinstance(multiplier, int | float):
+        fields.append({"label": "Multiplier", "value": f"{multiplier:.6f}"})
+
+    address = _text(token.get("address"))
+    if address:
+        fields.append({"label": "Address", "value": address, "copyable": True})
+
+    chain_id = token.get("chainId") or result.get("chainId")
+    if isinstance(chain_id, int):
+        fields.append({"label": "Chain", "value": str(chain_id)})
+
+    return [
+        {
+            "title": title,
+            "subtitle": name if symbol else "",
+            "badge": label,
+            "badgeTone": tone,
+            "fields": fields,
+        }
+    ]
+
+
+def build_payload(result: dict[str, Any]) -> dict[str, Any]:
+    query = _text(result.get("query"))
+    token = result.get("token")
+    subtitle = ""
+    if isinstance(token, dict):
+        price = token.get("price")
+        if isinstance(price, dict) and price.get("stale") is True:
+            subtitle = "price is stale — do not quote it as current"
+        elif token.get("isStockToken") is None:
+            subtitle = "chain unreachable — unverified, not disproven"
+    return {
+        "type": "cards",
+        "title": f"Robinhood Chain — {query}" if query else "Robinhood Chain",
+        "subtitle": subtitle,
+        "cards": build_cards(result),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render chain_stocks output as a chat card")
+    parser.add_argument("--output", required=True, help="Where to write the cards artifact.")
+    args = parser.parse_args()
+
+    raw = sys.stdin.read().strip()
+    if not raw:
+        print("chain_cards: no input received", file=sys.stderr)
+        return 1
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"chain_cards: input is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(result, dict):
+        print("chain_cards: expected a chain_stocks object", file=sys.stderr)
+        return 1
+
+    payload = build_payload(result)
+    if not payload["cards"]:
+        print("chain_cards: no token to render", file=sys.stderr)
+        return 1
+
+    output = Path(args.output)
+    output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    print(f"publish_artifact path={output} mime={CARDS_MIME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -24,6 +24,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import Any
 
 CHAIN_ID = 4663
@@ -391,6 +392,20 @@ def main() -> int:
     parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help="Robinhood Chain JSON-RPC URL")
     parser.add_argument("--no-price", action="store_true", help="Skip the Chainlink price read")
     parser.add_argument("--timeout", type=float, default=15.0, help="HTTP timeout seconds")
+    parser.add_argument(
+        "--cards",
+        metavar="FILE",
+        help=(
+            "Where to write the Web-chat card artifact. Defaults to <symbol>.cards.json "
+            "in the working directory; the publish marker goes to stderr so stdout stays "
+            "pure JSON."
+        ),
+    )
+    parser.add_argument(
+        "--no-cards",
+        action="store_true",
+        help="Do not write the card artifact (JSON on stdout only).",
+    )
     args = parser.parse_args()
 
     if not args.query and not args.address:
@@ -442,8 +457,51 @@ def main() -> int:
         "token": state,
     }
     print(json.dumps(result, ensure_ascii=False))
+    if not args.no_cards:
+        _write_cards(result, args.cards or _default_cards_name(result))
     return 0
 
 
+def _default_cards_name(result: dict[str, Any]) -> str:
+    token = result.get("token")
+    symbol = ""
+    if isinstance(token, dict):
+        symbol = str(token.get("symbol") or token.get("onchainSymbol") or "")
+    slug = re.sub(r"[^A-Za-z0-9._-]", "", symbol) or "token"
+    return f"{slug}.cards.json"
+
+
+def _write_cards(result: dict[str, Any], output: str) -> None:
+    """Write the card artifact and announce it on **stderr**.
+
+    On by default rather than opt-in. Both were tried first and both failed the
+    same way: told to run a second piped command, or to pass a flag the docs put
+    in every example, the model ran the bare command anyway and answered with a
+    hand-written table. The only arrangement that actually renders is the one
+    that needs no decision from it at all.
+
+    stdout stays pure JSON so the reading itself is unchanged; ``exec_command``
+    merges stderr into the captured output, so the publish marker still reaches
+    the auto-publisher.
+
+    Never fatal -- a failed render must not cost the caller the reading it
+    already paid for.
+    """
+    try:
+        import chain_cards  # noqa: PLC0415 - sibling module, resolved at call time
+
+        payload = chain_cards.build_payload(result)
+        if not payload["cards"]:
+            return
+        Path(output).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        print(
+            f"publish_artifact path={output} mime={chain_cards.CARDS_MIME}",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # noqa: BLE001 - reading already printed; never fail on the card
+        print(f"[card not written: {exc}]", file=sys.stderr)
+
+
 if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     sys.exit(main())

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -439,6 +439,12 @@ def main() -> int:
     if listed is not None:
         state["name"] = _clean_name(str(listed.get("name", "")))
         state["symbol"] = symbol
+        # Display-only, and carried purely so the card renderer has a logo. It
+        # comes from the third-party token list, so the renderer restricts it to
+        # http(s) rather than trusting it.
+        logo = str(listed.get("logoURI", "") or "").strip()
+        if logo:
+            state["logoURI"] = logo
     if state.get("isStockToken") is False:
         state.setdefault("notes", []).append(
             "uiMultiplier() reverted: this address is not a Robinhood Stock Token"

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -135,9 +135,14 @@ So: answer in prose and let the grid carry the addresses. Do **not** also
 hand-write a markdown table of the matches — a 42-character address turns one
 into a horizontal scroll.
 
-stdout stays pure JSON; the publish marker goes to stderr. `--no-cards` turns it
-off, and `--cards FILE` picks the filename. `scripts/rwa_cards.py` builds the
-same payload from the JSON on stdin if you need it separately.
+Two things would silently break this, so do neither:
+
+- **Never append `2>/dev/null`** (or any stderr redirect) to the command. The
+  publish marker travels on stderr; discarding it discards the grid.
+- **Never pass `--no-cards`.** It exists for humans running the script by hand.
+
+`--cards FILE` picks the filename if you need a specific one.
+`scripts/rwa_cards.py` builds the same payload from the JSON on stdin.
 
 Keep `--output` a bare filename as shown. Scripts run with the workspace as
 their working directory, and `publish_artifact` only accepts files inside that

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -92,6 +92,12 @@ Questions this skill answers — in any language:
 Answer with the **symbol** and the **contract address**, and mention it lives on
 Robinhood Chain (chainId 4663). Include the address verbatim.
 
+**On the Web chat channel this is a two-command job, not one.** Run the lookup,
+then run `rwa_cards.py` and publish what it prints — see
+[Show the results as cards](#show-the-results-as-cards-in-web-chat). Do **not**
+hand-write a markdown table of the matches: a 42-character address turns one
+into a horizontal scroll. Answer in prose plus the published card grid.
+
 ## Run it
 
 ```bash
@@ -116,9 +122,12 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" --rpc-url https://…
 
 ## Show the results as cards in Web chat
 
-In the Web UI, render the matches as a card grid instead of a markdown table —
-a contract address is 42 characters and would force the table into a horizontal
-scroll. Pipe the lookup through `rwa_cards.py`, then publish what it prints:
+**Required on the Web chat channel whenever the lookup returned any match.**
+Render the matches as a card grid rather than a markdown table — a contract
+address is 42 characters and would force a table into a horizontal scroll.
+
+Pipe the lookup through `rwa_cards.py`, then publish what it prints. Two
+commands, both of them:
 
 ```bash
 python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" \

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -114,6 +114,35 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" --no-verify
 python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" --rpc-url https://…
 ```
 
+## Show the results as cards in Web chat
+
+In the Web UI, render the matches as a card grid instead of a markdown table —
+a contract address is 42 characters and would force the table into a horizontal
+scroll. Pipe the lookup through `rwa_cards.py`, then publish what it prints:
+
+```bash
+python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" \
+  | python3 {baseDir}/scripts/rwa_cards.py --output apple.cards.json
+```
+
+It prints a `publish_artifact path=… mime=application/vnd.agentos.cards+json`
+line; publish that artifact and the chat draws one card per match with the
+token logo, a status badge, and a copy button on the address.
+
+Keep `--output` a bare filename as shown. Scripts run with the workspace as
+their working directory, and `publish_artifact` only accepts files inside that
+workspace — writing to `/tmp` or any other absolute path outside it makes the
+publish fail.
+
+The badge colour comes from `status`: `verified` reads green, `not-deployed`
+amber, `not-a-stock-token` red, `unverified` grey. The lookup's `warning` is
+carried into the grid subtitle, so the caveat travels with the addresses.
+Still say the caveat in your own answer too — the card grid supplements the
+reply, it does not replace it.
+
+Use the cards only when there is something to show; on an empty result the
+script exits non-zero and you should answer in text instead.
+
 ### Output (JSON)
 
 ```json

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/SKILL.md
@@ -92,11 +92,11 @@ Questions this skill answers — in any language:
 Answer with the **symbol** and the **contract address**, and mention it lives on
 Robinhood Chain (chainId 4663). Include the address verbatim.
 
-**On the Web chat channel this is a two-command job, not one.** Run the lookup,
-then run `rwa_cards.py` and publish what it prints — see
-[Show the results as cards](#show-the-results-as-cards-in-web-chat). Do **not**
-hand-write a markdown table of the matches: a 42-character address turns one
-into a horizontal scroll. Answer in prose plus the published card grid.
+**On the Web chat channel, pipe the lookup through `rwa_cards.py`** — one
+command, see [Show the results as cards](#show-the-results-as-cards-in-web-chat).
+The card grid is published for you; you do not call `publish_artifact`. Do
+**not** hand-write a markdown table of the matches: a 42-character address turns
+one into a horizontal scroll. Answer in prose and let the grid carry the data.
 
 ## Run it
 
@@ -126,17 +126,18 @@ python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" --rpc-url https://…
 Render the matches as a card grid rather than a markdown table — a contract
 address is 42 characters and would force a table into a horizontal scroll.
 
-Pipe the lookup through `rwa_cards.py`, then publish what it prints. Two
-commands, both of them:
+Every run writes a card grid next to the JSON (`<SYMBOL>.cards.json`) and
+`exec_command` publishes it. **There is nothing for you to do** — no extra
+command, no flag, no `publish_artifact` call. The chat draws one card per match
+with the token logo, a status badge, and a copy button on the address.
 
-```bash
-python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" \
-  | python3 {baseDir}/scripts/rwa_cards.py --output apple.cards.json
-```
+So: answer in prose and let the grid carry the addresses. Do **not** also
+hand-write a markdown table of the matches — a 42-character address turns one
+into a horizontal scroll.
 
-It prints a `publish_artifact path=… mime=application/vnd.agentos.cards+json`
-line; publish that artifact and the chat draws one card per match with the
-token logo, a status badge, and a copy button on the address.
+stdout stays pure JSON; the publish marker goes to stderr. `--no-cards` turns it
+off, and `--cards FILE` picks the filename. `scripts/rwa_cards.py` builds the
+same payload from the JSON on stdin if you need it separately.
 
 Keep `--output` a bare filename as shown. Scripts run with the workspace as
 their working directory, and `publish_artifact` only accepts files inside that

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Turn ``rwa_lookup.py`` output into a chat card-grid artifact.
+
+The Web chat renders an artifact whose mime is
+``application/vnd.agentos.cards+json`` as an inline grid of cards instead of a
+download chip. A contract address is 42 characters, so a markdown table forces a
+horizontal scroll; a card carries the address on its own line with a copy
+button next to it.
+
+Usage (stdin is ``rwa_lookup.py``'s JSON):
+
+    python3 {baseDir}/scripts/rwa_lookup.py --query "Apple" \
+      | python3 {baseDir}/scripts/rwa_cards.py --output apple.cards.json
+
+It then prints the written path, which is what ``publish_artifact`` takes.
+
+The badge tone is derived from the lookup's ``status`` so an undeployed listing
+or an impersonator reads as a warning at a glance rather than looking like every
+other result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+CARDS_MIME = "application/vnd.agentos.cards+json"
+
+# status -> badge tone understood by the frontend (cards.ts). Anything missing
+# falls back to "neutral" there, so a new status degrades rather than breaks.
+_TONES = {
+    "verified": "positive",
+    "not-deployed": "warning",
+    "not-a-stock-token": "danger",
+    "unverified": "neutral",
+}
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def build_cards(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map lookup matches onto card payloads, best match first."""
+    cards: list[dict[str, Any]] = []
+    for match in result.get("matches") or []:
+        if not isinstance(match, dict):
+            continue
+        symbol = _text(match.get("symbol"))
+        name = _text(match.get("name"))
+        title = symbol or name
+        if not title:
+            continue
+
+        status = _text(match.get("status"))
+        fields: list[dict[str, Any]] = []
+        address = _text(match.get("address"))
+        if address:
+            fields.append({"label": "Address", "value": address, "copyable": True})
+        chain_id = match.get("chainId")
+        if isinstance(chain_id, int):
+            fields.append({"label": "Chain", "value": str(chain_id)})
+
+        cards.append(
+            {
+                "title": title,
+                "subtitle": name if symbol else "",
+                "logo": _text(match.get("logoURI")),
+                "badge": status,
+                "badgeTone": _TONES.get(status, "neutral"),
+                "fields": fields,
+            }
+        )
+    return cards
+
+
+def build_payload(result: dict[str, Any]) -> dict[str, Any]:
+    query = _text(result.get("query"))
+    return {
+        "type": "cards",
+        "title": f"Robinhood Chain — {query}" if query else "Robinhood Chain",
+        # The lookup's caveat rides along as the subtitle so the grid never shows
+        # an unverified or undeployed address without its warning.
+        "subtitle": _text(result.get("warning")),
+        "cards": build_cards(result),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render rwa_lookup output as chat cards")
+    parser.add_argument("--output", required=True, help="Where to write the cards artifact.")
+    args = parser.parse_args()
+
+    raw = sys.stdin.read().strip()
+    if not raw:
+        print("rwa_cards: no input received", file=sys.stderr)
+        return 1
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"rwa_cards: input is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(result, dict):
+        print("rwa_cards: expected a lookup object", file=sys.stderr)
+        return 1
+
+    payload = build_payload(result)
+    if not payload["cards"]:
+        print("rwa_cards: no matches to render", file=sys.stderr)
+        return 1
+
+    output = Path(args.output)
+    output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    print(f"publish_artifact path={output} mime={CARDS_MIME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
@@ -329,6 +329,20 @@ def main() -> int:
         action="store_true",
         help="Skip the on-chain beacon check (offline; every match is reported unverified)",
     )
+    parser.add_argument(
+        "--cards",
+        metavar="FILE",
+        help=(
+            "Where to write the Web-chat card artifact. Defaults to <query>.cards.json "
+            "in the working directory; the publish marker goes to stderr so stdout stays "
+            "pure JSON."
+        ),
+    )
+    parser.add_argument(
+        "--no-cards",
+        action="store_true",
+        help="Do not write the card artifact (JSON on stdout only).",
+    )
     args = parser.parse_args()
 
     try:
@@ -362,8 +376,52 @@ def main() -> int:
     if warning:
         result["warning"] = warning
     print(json.dumps(result, ensure_ascii=False))
+    if not args.no_cards:
+        _write_cards(result, args.cards or _default_cards_name(result))
     return 0
 
 
+def _default_cards_name(result: dict[str, Any]) -> str:
+    matches = result.get("matches") or []
+    symbol = ""
+    if matches and isinstance(matches[0], dict):
+        symbol = str(matches[0].get("symbol") or "")
+    slug = re.sub(r"[^A-Za-z0-9._-]", "", symbol) or "lookup"
+    return f"{slug}.cards.json"
+
+
+def _write_cards(result: dict[str, Any], output: str) -> None:
+    """Write the card artifact and announce it on **stderr**.
+
+    On by default rather than opt-in. Both were tried first and both failed the
+    same way: told to run a second piped command, or to pass a flag the docs put
+    in every example, the model ran the bare command anyway and answered with a
+    hand-written table. The only arrangement that actually renders is the one
+    that needs no decision from it at all.
+
+    stdout stays pure JSON so the lookup itself is unchanged; ``exec_command``
+    merges stderr into the captured output, so the publish marker still reaches
+    the auto-publisher.
+
+    Never fatal -- a failed render must not cost the caller the lookup it
+    already paid for.
+    """
+    try:
+        from pathlib import Path  # noqa: PLC0415 - only needed on this path
+
+        import rwa_cards  # noqa: PLC0415 - sibling module, resolved at call time
+
+        payload = rwa_cards.build_payload(result)
+        if not payload["cards"]:
+            return
+        Path(output).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        print(f"publish_artifact path={output} mime={rwa_cards.CARDS_MIME}", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001 - lookup already printed; never fail on the card
+        print(f"[card not written: {exc}]", file=sys.stderr)
+
+
 if __name__ == "__main__":
+    import pathlib
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
     sys.exit(main())

--- a/src/agentos/tools/builtin/artifacts.py
+++ b/src/agentos/tools/builtin/artifacts.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import mimetypes
 import os
+import re
 from difflib import SequenceMatcher
 from pathlib import Path
 
@@ -297,3 +298,80 @@ async def publish_artifact(
         },
         ensure_ascii=False,
     )
+
+
+# ── Inline artifacts announced on stdout ────────────────────────────────────
+#
+# A skill script that produces an inline-rendered payload (a chart, a card grid)
+# ends by printing a marker naming the file it wrote. Publishing used to be left
+# to the model: it had to notice the marker and choose to call publish_artifact.
+# In practice it frequently did not -- the lookup ran, the file was written, and
+# the answer came back as a hand-written markdown table with the artifact
+# stranded in the workspace. The rendering only ever fired when the model felt
+# like it, which is not a contract.
+#
+# exec_command now honours the marker itself, so a skill that writes the file
+# gets the render. The model stays in charge of the *prose*; it is no longer in
+# charge of whether the UI draws.
+
+#: The marker a skill script prints, alone on its own line.
+INLINE_ARTIFACT_MARKER_RE = re.compile(
+    r"^publish_artifact[ \t]+path=(?P<path>\S+)[ \t]+mime=(?P<mime>\S+)[ \t]*$",
+    re.MULTILINE,
+)
+
+#: Only AgentOS's own inline-render mimes auto-publish. A plain file (a report, a
+#: zip) still requires a deliberate publish_artifact call, so stray output that
+#: happens to look like the marker cannot push arbitrary workspace files at the
+#: user. Path containment is enforced by publish_artifact itself.
+INLINE_ARTIFACT_MIME_PREFIX = "application/vnd.agentos."
+
+_MAX_INLINE_ARTIFACTS_PER_CALL = 4
+
+
+async def publish_inline_artifacts(output: str) -> str:
+    """Publish inline artifacts announced in ``output`` and replace the markers.
+
+    Best-effort by construction: a shell command must never fail, or have its
+    output withheld, because a publish did not work out. Anything that goes
+    wrong is reported in place of the marker and the command's own output is
+    returned untouched otherwise.
+    """
+    if not output or "publish_artifact" not in output:
+        return output
+    ctx = current_tool_context.get()
+    if ctx is None or not ctx.workspace_dir:
+        return output
+
+    matches = list(INLINE_ARTIFACT_MARKER_RE.finditer(output))
+    if not matches:
+        return output
+
+    replacements: dict[str, str] = {}
+    published = 0
+    for match in matches:
+        marker = match.group(0)
+        if marker in replacements:
+            continue
+        mime = match.group("mime")
+        if not mime.startswith(INLINE_ARTIFACT_MIME_PREFIX):
+            # Not an inline-render mime: leave the marker alone so the model can
+            # still publish it deliberately if that is what the skill wants.
+            continue
+        if published >= _MAX_INLINE_ARTIFACTS_PER_CALL:
+            replacements[marker] = "[inline artifact skipped: too many in one command]"
+            continue
+        try:
+            await publish_artifact(path=match.group("path"), mime=mime)
+        except ToolError as exc:
+            replacements[marker] = f"[inline artifact not published: {exc}]"
+            continue
+        published += 1
+        replacements[marker] = (
+            "[inline artifact published and already rendered for the user: "
+            f"{match.group('path')}. Do not call publish_artifact for it.]"
+        )
+
+    for marker, note in replacements.items():
+        output = output.replace(marker, note)
+    return output

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -39,6 +39,7 @@ from agentos.sandbox.integration import (
 )
 from agentos.sandbox.policy import build_policy, select_level
 from agentos.sandbox.types import DenialReason, DenialResult, SandboxPolicy, SandboxRequest
+from agentos.tools.builtin.artifacts import publish_inline_artifacts
 from agentos.tools.builtin.shell_policy import check_safe_bin
 from agentos.tools.env_passthrough import build_subprocess_env
 from agentos.tools.path_policy import reject_foreign_host_path
@@ -789,6 +790,7 @@ async def exec_command(
                 output = redact_terminal_output(
                     stdout_bytes.decode("utf-8", errors="replace"), command
                 )
+                output = await publish_inline_artifacts(output)
                 return f"exit_code={proc.returncode}\n{output}"
             except Exception as e:
                 return f"[error] {e}"
@@ -796,6 +798,7 @@ async def exec_command(
         if sandbox_result.stderr:
             output += sandbox_result.stderr
         output = _append_sandbox_network_hint(redact_terminal_output(output, command))
+        output = await publish_inline_artifacts(output)
         return f"exit_code={sandbox_result.returncode}\n{output}"
 
     if elevated_bypass:
@@ -828,6 +831,7 @@ async def exec_command(
             output = redact_terminal_output(
                 output_file.read().decode("utf-8", errors="replace"), command
             )
+            output = await publish_inline_artifacts(output)
             return f"exit_code={proc.returncode}\n{output}"
     except Exception as e:
         return f"[error] {e}"

--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -1111,7 +1111,8 @@ def create_skill_tools(loader: SkillLoader) -> None:
             f"Skill '{name}' created at {skill_file}. "
             "For output that should draw inline in Web chat instead of as a "
             "download chip, have the skill publish_artifact with an inline mime "
-            "(application/vnd.agentos.chart+json renders a candlestick chart); "
+            "(application/vnd.agentos.chart+json renders a candlestick chart, "
+            "application/vnd.agentos.cards+json a grid of record cards); "
             "docs/artifacts-and-media.md documents the payload."
         )
 

--- a/tests/test_skill_robinhood_chain_cards.py
+++ b/tests/test_skill_robinhood_chain_cards.py
@@ -1,0 +1,121 @@
+"""Offline tests for the robinhood-chain-stocks card renderer.
+
+``chain_cards.py`` turns an on-chain reading into the payload the Web chat draws
+as a card. The contract that matters is the badge: the two things a reader can
+act on wrongly -- a **stale price** and an **unverified token** -- must surface
+as the badge, not as a footnote under a green "verified".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py"
+)
+
+_spec = importlib.util.spec_from_file_location("chain_cards", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+chain_cards = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(chain_cards)
+
+
+def _token(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "address": "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9",
+        "chainId": 4663,
+        "onchainSymbol": "AAPL",
+        "symbol": "AAPL",
+        "name": "Apple",
+        "decimals": 18,
+        "totalSupplyFormatted": 12540.64790925,
+        "isStockToken": True,
+        "uiMultiplierFormatted": 1.0005660800610925,
+        "oraclePaused": False,
+        "price": {"usd": 326.68717647, "stale": False, "ageSeconds": 1712},
+    }
+    base.update(overrides)
+    return base
+
+
+def _result(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"query": "Apple", "chainId": 4663, "token": _token()}
+    payload.update(overrides)
+    return payload
+
+
+def test_mime_matches_the_frontend_renderer() -> None:
+    assert chain_cards.CARDS_MIME == "application/vnd.agentos.cards+json"
+
+
+def test_card_carries_price_supply_multiplier_and_address() -> None:
+    card = chain_cards.build_cards(_result())[0]
+    assert card["title"] == "AAPL"
+    assert card["subtitle"] == "Apple"
+    labels = [f["label"] for f in card["fields"]]
+    assert labels == ["Price", "Supply", "Multiplier", "Address", "Chain"]
+    assert card["fields"][0]["value"] == "$326.6872"
+    address = next(f for f in card["fields"] if f["label"] == "Address")
+    assert address["copyable"] is True
+
+
+def test_a_healthy_reading_reads_verified() -> None:
+    assert chain_cards.badge(_token()) == ("verified", "positive")
+
+
+def test_a_stale_price_outranks_verified_on_the_badge() -> None:
+    """Quoting a stale price as current is the misread this guards against."""
+    token = _token(price={"usd": 326.0, "stale": True})
+    assert chain_cards.badge(token) == ("price stale", "warning")
+
+
+def test_a_paused_oracle_shows_as_a_warning() -> None:
+    assert chain_cards.badge(_token(oraclePaused=True)) == ("oracle paused", "warning")
+
+
+def test_a_confirmed_impersonator_reads_danger() -> None:
+    assert chain_cards.badge(_token(isStockToken=False)) == ("not-a-stock-token", "danger")
+
+
+def test_unreachable_chain_is_unverified_never_fake() -> None:
+    """isStockToken is three-state: None means the check did not run."""
+    assert chain_cards.badge(_token(isStockToken=None)) == ("unverified", "neutral")
+
+
+def test_unverified_outranks_a_stale_price() -> None:
+    """Whether the token is real at all matters more than how fresh the price is."""
+    token = _token(isStockToken=None, price={"usd": 1.0, "stale": True})
+    assert chain_cards.badge(token) == ("unverified", "neutral")
+
+
+def test_a_non_positive_feed_answer_is_omitted_not_shown_as_zero() -> None:
+    """The skill forbids reporting a non-positive answer as a price."""
+    for price in ({"usd": 0, "stale": False}, {"usd": -1.5, "stale": False}, {}):
+        card = chain_cards.build_cards(_result(token=_token(price=price)))[0]
+        assert "Price" not in [f["label"] for f in card["fields"]]
+
+
+def test_caveats_ride_along_as_the_subtitle() -> None:
+    stale = chain_cards.build_payload(_result(token=_token(price={"usd": 1.0, "stale": True})))
+    assert "stale" in stale["subtitle"]
+    unreachable = chain_cards.build_payload(_result(token=_token(isStockToken=None)))
+    assert "not disproven" in unreachable["subtitle"]
+    assert chain_cards.build_payload(_result())["subtitle"] == ""
+
+
+def test_title_names_the_query() -> None:
+    assert chain_cards.build_payload(_result())["title"] == "Robinhood Chain — Apple"
+
+
+def test_a_result_without_a_token_renders_nothing() -> None:
+    assert chain_cards.build_cards({"query": "zzz"}) == []
+    assert chain_cards.build_cards({"token": "not-an-object"}) == []
+    assert chain_cards.build_cards({"token": {}}) == []
+
+
+def test_onchain_symbol_is_used_when_the_list_symbol_is_missing() -> None:
+    card = chain_cards.build_cards(_result(token=_token(symbol="", onchainSymbol="TSLA")))[0]
+    assert card["title"] == "TSLA"

--- a/tests/test_skill_robinhood_chain_cards.py
+++ b/tests/test_skill_robinhood_chain_cards.py
@@ -51,6 +51,16 @@ def test_mime_matches_the_frontend_renderer() -> None:
     assert chain_cards.CARDS_MIME == "application/vnd.agentos.cards+json"
 
 
+def test_card_carries_the_token_logo_when_the_list_had_one() -> None:
+    card = chain_cards.build_cards(_result(token=_token(logoURI="https://a.example/n.png")))[0]
+    assert card["logo"] == "https://a.example/n.png"
+
+
+def test_a_token_without_a_logo_renders_an_empty_one() -> None:
+    """The renderer drops an empty logo rather than leaving a torn frame."""
+    assert chain_cards.build_cards(_result())[0]["logo"] == ""
+
+
 def test_card_carries_price_supply_multiplier_and_address() -> None:
     card = chain_cards.build_cards(_result())[0]
     assert card["title"] == "AAPL"

--- a/tests/test_skill_robinhood_rwa_cards.py
+++ b/tests/test_skill_robinhood_rwa_cards.py
@@ -1,0 +1,123 @@
+"""Offline tests for the robinhood-rwa-addresses card-artifact renderer.
+
+``rwa_cards.py`` turns a lookup result into the payload the Web chat renders as
+an inline card grid (`application/vnd.agentos.cards+json`, frontend
+`views/chat/transcript/cards.ts`). The contract that matters here is the badge
+tone: an undeployed listing or an impersonator must not look like a verified
+token at a glance.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py"
+)
+
+_spec = importlib.util.spec_from_file_location("rwa_cards", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+rwa_cards = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rwa_cards)
+
+
+def _match(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": "Apple",
+        "symbol": "AAPL",
+        "address": "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9",
+        "chainId": 4663,
+        "decimals": 18,
+        "isStockToken": True,
+        "logoURI": "https://assets.example/aapl.png",
+        "status": "verified",
+        "beacon": "0xe10b6f6b275de231345c20d14ab812db62151b00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _result(*matches: dict[str, Any], **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"query": "Apple", "matches": list(matches)}
+    payload.update(extra)
+    return payload
+
+
+def test_mime_matches_the_frontend_renderer() -> None:
+    """cards.ts keys off this exact string; a drift here silently degrades."""
+    assert rwa_cards.CARDS_MIME == "application/vnd.agentos.cards+json"
+
+
+def test_card_carries_symbol_name_logo_and_address() -> None:
+    card = rwa_cards.build_cards(_result(_match()))[0]
+    assert card["title"] == "AAPL"
+    assert card["subtitle"] == "Apple"
+    assert card["logo"] == "https://assets.example/aapl.png"
+    assert {"label": "Address", "value": _match()["address"], "copyable": True} in card["fields"]
+    assert {"label": "Chain", "value": "4663"} in card["fields"]
+
+
+def test_status_drives_the_badge_tone() -> None:
+    tones = {
+        "verified": "positive",
+        "not-deployed": "warning",
+        "not-a-stock-token": "danger",
+        "unverified": "neutral",
+    }
+    for status, tone in tones.items():
+        card = rwa_cards.build_cards(_result(_match(status=status)))[0]
+        assert card["badge"] == status
+        assert card["badgeTone"] == tone, status
+
+
+def test_unknown_status_degrades_to_neutral() -> None:
+    """A future status must not crash the renderer or borrow a misleading colour."""
+    card = rwa_cards.build_cards(_result(_match(status="brand-new")))[0]
+    assert card["badgeTone"] == "neutral"
+
+
+def test_warning_rides_along_as_the_subtitle() -> None:
+    """The grid must never show an undeployed address without its caveat."""
+    payload = rwa_cards.build_payload(
+        _result(_match(status="not-deployed"), warning="not deployed: do not send funds")
+    )
+    assert payload["subtitle"] == "not deployed: do not send funds"
+
+
+def test_title_names_the_query() -> None:
+    assert rwa_cards.build_payload(_result(_match()))["title"] == "Robinhood Chain — Apple"
+    assert rwa_cards.build_payload({"matches": []})["title"] == "Robinhood Chain"
+
+
+def test_matches_without_an_identity_are_dropped() -> None:
+    assert rwa_cards.build_cards(_result({"address": "0x1"})) == []
+    assert rwa_cards.build_cards({"matches": ["not-an-object"]}) == []
+    assert rwa_cards.build_cards({}) == []
+
+
+def test_a_match_missing_optional_fields_still_renders() -> None:
+    card = rwa_cards.build_cards(_result({"symbol": "GME"}))[0]
+    assert card["title"] == "GME"
+    assert card["logo"] == ""
+    assert card["fields"] == []
+
+
+def test_name_only_match_uses_the_name_as_the_title() -> None:
+    card = rwa_cards.build_cards(_result({"name": "Apple"}))[0]
+    assert card["title"] == "Apple"
+    # No symbol, so the name is not repeated underneath itself.
+    assert card["subtitle"] == ""
+
+
+def test_match_order_is_preserved() -> None:
+    """rwa_lookup already ranks verified matches first; do not reshuffle them."""
+    cards = rwa_cards.build_cards(
+        _result(
+            _match(symbol="AAPL", status="verified"),
+            _match(symbol="JPM", status="not-deployed"),
+        )
+    )
+    assert [c["title"] for c in cards] == ["AAPL", "JPM"]

--- a/tests/test_tools/test_inline_artifacts.py
+++ b/tests/test_tools/test_inline_artifacts.py
@@ -1,0 +1,161 @@
+"""Auto-publishing of inline artifacts announced on a command's stdout.
+
+A skill script that writes a chart or card payload ends by printing a marker
+naming the file. Publishing used to be the model's call, and in practice it
+routinely skipped it -- the file was written and the UI never drew. These tests
+pin the contract that makes the render deterministic, and the guards that keep
+the marker from becoming a way to publish arbitrary files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentos.tools.builtin import artifacts as artifacts_mod
+from agentos.tools.builtin.artifacts import (
+    INLINE_ARTIFACT_MIME_PREFIX,
+    publish_inline_artifacts,
+)
+from agentos.tools.types import ToolContext, ToolError, current_tool_context
+
+CARDS_MIME = "application/vnd.agentos.cards+json"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    (tmp_path / "apple.cards.json").write_text('{"type":"cards","cards":[]}', encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def ctx(workspace: Path) -> Any:
+    context = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(context)
+    yield context
+    current_tool_context.reset(token)
+
+
+@pytest.fixture
+def published(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, str]]:
+    """Record publish_artifact calls instead of touching the artifact store."""
+    calls: list[dict[str, str]] = []
+
+    async def _fake(path: str, name: str | None = None, mime: str | None = None) -> str:
+        calls.append({"path": path, "mime": mime or ""})
+        return "{}"
+
+    monkeypatch.setattr(artifacts_mod, "publish_artifact", _fake)
+    return calls
+
+
+def marker(path: str = "apple.cards.json", mime: str = CARDS_MIME) -> str:
+    return f"publish_artifact path={path} mime={mime}"
+
+
+# ── The happy path ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_marker_publishes_without_the_model_asking(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    out = await publish_inline_artifacts(marker())
+    assert published == [{"path": "apple.cards.json", "mime": CARDS_MIME}]
+    assert "publish_artifact path=" not in out
+
+
+@pytest.mark.asyncio
+async def test_marker_is_replaced_by_a_do_not_republish_note(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    out = await publish_inline_artifacts(marker())
+    assert "already rendered for the user" in out
+    assert "Do not call publish_artifact" in out
+
+
+@pytest.mark.asyncio
+async def test_surrounding_output_is_preserved(ctx: Any, published: list[dict[str, str]]) -> None:
+    out = await publish_inline_artifacts(f"looked up 683 tokens\n{marker()}\ndone")
+    assert out.startswith("looked up 683 tokens\n")
+    assert out.endswith("\ndone")
+
+
+@pytest.mark.asyncio
+async def test_several_markers_each_publish(ctx: Any, published: list[dict[str, str]]) -> None:
+    out = await publish_inline_artifacts(f"{marker('a.json')}\n{marker('b.json')}")
+    assert [c["path"] for c in published] == ["a.json", "b.json"]
+    assert "publish_artifact path=" not in out
+
+
+# ── Guards ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_only_agentos_inline_mimes_auto_publish(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    """A plain file still needs a deliberate call, so stray output cannot leak one."""
+    out = await publish_inline_artifacts(marker("secrets.zip", "application/zip"))
+    assert published == []
+    # Left intact: the model may still publish it on purpose.
+    assert marker("secrets.zip", "application/zip") in out
+    assert INLINE_ARTIFACT_MIME_PREFIX == "application/vnd.agentos."
+
+
+@pytest.mark.asyncio
+async def test_marker_must_own_its_line(ctx: Any, published: list[dict[str, str]]) -> None:
+    """Prose that merely mentions the marker must not publish anything."""
+    for text in (
+        f"run `{marker()}` to publish it",
+        f"the script prints {marker()} at the end",
+    ):
+        assert await publish_inline_artifacts(text) == text
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_a_capped_number_publishes_per_command(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    out = await publish_inline_artifacts("\n".join(marker(f"c{i}.json") for i in range(9)))
+    assert len(published) == artifacts_mod._MAX_INLINE_ARTIFACTS_PER_CALL
+    # The overflow is reported, not silently dropped.
+    assert "too many in one command" in out
+
+
+@pytest.mark.asyncio
+async def test_publish_failure_is_reported_not_raised(
+    ctx: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shell command must not fail because a publish did not work out."""
+
+    async def _boom(path: str, name: str | None = None, mime: str | None = None) -> str:
+        raise ToolError("artifact path is outside workspace: ../../etc/passwd")
+
+    monkeypatch.setattr(artifacts_mod, "publish_artifact", _boom)
+    out = await publish_inline_artifacts(f"ok\n{marker('../../etc/passwd')}")
+    assert out.startswith("ok\n")
+    assert "not published" in out
+    assert "outside workspace" in out
+
+
+# ── Cheap exits ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_output_without_the_marker_is_returned_unchanged(
+    ctx: Any, published: list[dict[str, str]]
+) -> None:
+    for text in ("", "exit_code=0", "no markers here at all"):
+        assert await publish_inline_artifacts(text) == text
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_no_tool_context_is_a_no_op(published: list[dict[str, str]]) -> None:
+    """CLI/test callers have no workspace; the marker just stays as text."""
+    assert await publish_inline_artifacts(marker()) == marker()
+    assert published == []


### PR DESCRIPTION
## Why

Web chat had one AgentOS-native inline artifact: `application/vnd.agentos.chart+json`. Everything else that is not an image or audio file lands as a download chip.

That leaves the most common skill output shape — a handful of small records — with only a markdown table, which handles it badly. A contract address is 42 characters, so a table of lookup results goes straight into a horizontal scroll.

## What

A second inline mime, `application/vnd.agentos.cards+json`, rendering a responsive grid of record cards: ticker monogram, colour-coded status badge, per-field copy buttons.

Only `cards` and each card's `title` are required:

```json
{
  "type": "cards",
  "title": "Robinhood Chain — Apple",
  "subtitle": "optional caveat carried under the heading",
  "cards": [{
    "title": "AAPL", "subtitle": "Apple",
    "badge": "verified", "badgeTone": "positive",
    "fields": [{ "label": "Address", "value": "0xaf3d…93f9", "copyable": true }]
  }]
}
```

`badgeTone` accepts `positive`/`warning`/`danger`/`neutral` and falls back to `neutral`, so **a skill can introduce a new status without waiting on a frontend release**. At most 24 cards render; the remainder are counted and reported under the grid rather than dropped.

## The renderer alone was not enough

The first version of this PR shipped the renderer and it was dead on arrival: seven live turns across two models (`glm-5.3`, `gpt-5.6-luna`), three escalating documentation fixes, and the grid never appeared once. `~/.agentos/media/artifacts/` stayed empty every time. Two separate model decisions were in the way, and each had to be removed rather than documented around.

**1. Deciding to publish.** `exec_command` now honours the marker a skill script already prints:

```
publish_artifact path=<file> mime=application/vnd.agentos.<x>+json
```

Guards: only the `application/vnd.agentos.` family auto-publishes, so ordinary command output cannot push a workspace file at the user; the marker must own its line, so prose mentioning it is inert; four per command, overflow reported not dropped; path containment unchanged. Best-effort throughout — a shell command never fails, and never loses its output, because a publish did not work out. This also fixes the existing chart artifacts (`gmgn-token`, `gmgn-market`), which had the same failure mode.

**2. Deciding to produce the payload.** Documenting the step as required, then folding it into a flag shown in every example, both failed the same way — the model ran the bare command and answered with a hand-written table. So both Robinhood skills now write the card on **every** run (`<SYMBOL>.cards.json`), with the marker on **stderr** so stdout stays pure JSON. `--no-cards` opts out. The only arrangement that renders reliably is the one that needs no decision from the model at all.

**New:** `robinhood-chain-stocks/scripts/chain_cards.py` — that is the skill a plain *"analyze &lt;ticker&gt;"* question actually routes to. Its badge is worst-case-first: `unverified` (chain unreachable, **never** "fake") → `not-a-stock-token` → `price stale` → `oracle paused` → `verified`.

## Logos: monogram, not a CDN fetch

Cards carry a `logo` slot and the Robinhood skills now plumb `logoURI` through. It still does not render, deliberately. The console's CSP is `img-src 'self' data: https://raw.githubusercontent.com`, so a token-list CDN image is blocked outright — `skills/hub/bankr.py` hit the same wall for author avatars and made the same call. Widening it would also mean every card render tells that CDN which tickers the user is researching, from their IP: a real leak on a finance surface, in exchange for decoration.

So the mark is a **ticker monogram drawn locally**. The `logo` img stays attached and takes over, but only on a real `load`; an `error` leaves the monogram standing instead of an empty slot.

## Security

Card fields carry on-chain metadata, which is fully attacker-controlled on a permissionless chain.

- Every payload string reaches the DOM through `textContent` or `createElement`, **never `innerHTML`**.
- `logo` is restricted to `http(s)`; `javascript:` and `data:` are dropped rather than sanitised.

Both are covered by tests, including a payload whose title is `<img src=x onerror=…>` asserting no element is created.

## Verified live

Asked as a real user would, in a clean session — no instructions about scripts or flags:

> **"Nvidia trên Robinhood Chain đang bao nhiêu vậy?"**

The agent found the skill itself, ran the bare `chain_stocks.py --query NVDA`, and the card rendered: monogram `NV`, badge `verified`, address monospace with a copy button. Same for TSLA and AAPL. When the public RPC timed out mid-test, the card correctly omitted the Price field rather than reporting `$0`.

## Tests

31 frontend cases for the renderer, 10 for the auto-publisher, 13 for `chain_cards`. All offline — RPC and publish results are fixtures, so nothing enters the default test path that needs a network.

Gate: `npm run check` 2041 passed, `ruff` clean, `mypy` clean (621 files), `pytest` 8991 passed, control UI build within bundle budget (CSS 16.4/25 KiB gzip), `uv build --wheel` clean. The one failure (`test_cli_skills_init::test_init_fails_on_existing_files_without_force`) is an ANSI-width assertion that reproduces on a clean tree.