### PR TITLE
fix(cli): create parent directories when exporting cost data

### DIFF
--- a/src/agentos/cli/cost_cmd.py
+++ b/src/agentos/cli/cost_cmd.py
@@ -66,6 +66,7 @@ def cost(
 
     if export_path:
         path = Path(export_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
         is_csv = csv_output or path.suffix.lower() == ".csv"
         if is_csv:
             import io

--- a/tests/test_cli/test_cost_savings_cmd.py
+++ b/tests/test_cli/test_cost_savings_cmd.py
@@ -153,3 +153,53 @@ def test_bare_cost_still_queries_the_gateway(monkeypatch: pytest.MonkeyPatch) ->
 
     assert result.exit_code == 0, result.output
     assert calls == [True]
+
+
+def test_cost_export_creates_parent_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "breakdown": [
+                {
+                    "session": "s1",
+                    "model": "gpt-5.6-luna",
+                    "provider": "openrouter",
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cost_usd": 0.01,
+                    "created_at": 1700000000,
+                }
+            ],
+            "totalCostUsd": 0.01,
+        }
+
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _fake_run)
+
+    # 1. JSON export creates nested parent directories
+    json_export = tmp_path / "nested" / "reports" / "cost.json"
+    assert not json_export.parent.exists()
+    result_json = runner.invoke(app, ["cost", "--export", str(json_export)])
+    assert result_json.exit_code == 0, result_json.output
+    assert json_export.exists()
+    payload = json.loads(json_export.read_text(encoding="utf-8"))
+    assert payload["totalCostUsd"] == 0.01
+
+    # 2. CSV export by extension creates deep nested parent directories
+    csv_export = tmp_path / "deep" / "nested" / "cost.csv"
+    assert not csv_export.parent.exists()
+    result_csv = runner.invoke(app, ["cost", "--export", str(csv_export)])
+    assert result_csv.exit_code == 0, result_csv.output
+    assert csv_export.exists()
+    content = csv_export.read_text(encoding="utf-8")
+    assert "Session,Model,Provider" in content
+    assert "gpt-5.6-luna" in content
+
+    # 3. CSV export by --csv flag with custom extension creates parent directories
+    flag_csv_export = tmp_path / "flag" / "output" / "cost.txt"
+    assert not flag_csv_export.parent.exists()
+    result_flag = runner.invoke(app, ["cost", "--csv", "--export", str(flag_csv_export)])
+    assert result_flag.exit_code == 0, result_flag.output
+    assert flag_csv_export.exists()
+    assert "Session,Model,Provider" in flag_csv_export.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #846 

### Summary
`agentos cost --export <path>` crashed with `FileNotFoundError` when `<path>` pointed to a non-existent directory (e.g. `reports/usage.json`).

### Fix
- Added `path.parent.mkdir(parents=True, exist_ok=True)` upon parsing `export_path`, matching the precedent in `render_savings_pdf`.
- Covers both JSON and CSV export branches (via extension or `--csv` flag).
- Added regression tests in `test_cost_savings_cmd.py` verifying parent directory creation for JSON and CSV exports.
