### PR TITLE
fix(mcp): use persistent SSE transport lifecycle

### DIFF
--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from contextlib import AsyncExitStack
 from datetime import timedelta
@@ -47,28 +48,33 @@ class MCPSSEClient(MCPClient):
 
         stack = AsyncExitStack()
         try:
-            read_stream, write_stream = await stack.enter_async_context(
-                sse_client(
-                    self.config.url,
-                    headers=self.config.headers,
-                    timeout=self.config.tool_timeout_seconds,
-                    sse_read_timeout=self.config.tool_timeout_seconds,
-                    httpx_client_factory=httpx_client_factory,
+            # HTTP read timeouts alone do not bound waiting for the SDK's
+            # endpoint event or initialization on its internal streams.
+            async with asyncio.timeout(self.config.tool_timeout_seconds):
+                read_stream, write_stream = await stack.enter_async_context(
+                    sse_client(
+                        self.config.url,
+                        headers=self.config.headers,
+                        timeout=self.config.tool_timeout_seconds,
+                        sse_read_timeout=self.config.tool_timeout_seconds,
+                        httpx_client_factory=httpx_client_factory,
+                    )
                 )
-            )
-            session = await stack.enter_async_context(
-                ClientSession(
-                    read_stream,
-                    write_stream,
-                    read_timeout_seconds=timedelta(seconds=self.config.tool_timeout_seconds),
+                session = await stack.enter_async_context(
+                    ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=timedelta(seconds=self.config.tool_timeout_seconds),
+                    )
                 )
-            )
-            await session.initialize()
+                await session.initialize()
         except BaseException as exc:
             await stack.aclose()
             failure = exc
             while isinstance(failure, BaseExceptionGroup) and len(failure.exceptions) == 1:
                 failure = failure.exceptions[0]
+            if isinstance(failure, TimeoutError):
+                raise TimeoutError("MCP SSE handshake timed out") from failure
             if failure is exc:
                 raise
             raise failure from exc

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -56,7 +56,8 @@ class MCPSSEClient(MCPClient):
                         self.config.url,
                         headers=self.config.headers,
                         timeout=self.config.tool_timeout_seconds,
-                        sse_read_timeout=self.config.tool_timeout_seconds,
+                        # Keep the SDK's idle-stream timeout independent of
+                        # the per-operation timeout between agent turns.
                         httpx_client_factory=httpx_client_factory,
                     )
                 )

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -1,161 +1,119 @@
-"""MCP SSE transport client."""
+"""MCP legacy HTTP+SSE transport client."""
 
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+from contextlib import AsyncExitStack
+from datetime import timedelta
+from typing import Any
 
 import httpx
 
-from agentos import __version__
 from agentos.mcp.client import MCPClient
-from agentos.mcp.http import mcp_http_client
+from agentos.mcp.http import assert_supported_mcp_url, mcp_http_client
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 
 
 class MCPSSEClient(MCPClient):
-    """MCP client using SSE transport (HTTP POST for calls, SSE for responses)."""
+    """MCP SDK-backed client for the legacy HTTP+SSE transport."""
 
     def __init__(self, config: MCPServerConfig) -> None:
         super().__init__(config)
-        self._client: httpx.AsyncClient | None = None
-        self._request_id = 0
-        self._message_endpoint = config.message_endpoint or "/message"
-
-    @staticmethod
-    def _parse_sse_event(raw: str) -> dict[str, Any] | None:
-        """Parse a single SSE event block into a JSON dict."""
-        if not raw or raw.startswith(":"):
-            return None
-
-        data_lines: list[str] = []
-        for line in raw.splitlines():
-            if line.startswith("data:"):
-                data_lines.append(line[5:].lstrip(" "))
-            # Ignore event:, id:, retry: fields
-
-        if not data_lines:
-            return None
-
-        combined = "".join(data_lines)
-        try:
-            return cast(dict[str, Any], json.loads(combined))
-        except json.JSONDecodeError:
-            return None
-
-    @staticmethod
-    def _parse_sse_stream(stream: str) -> list[dict[str, Any]]:
-        """Parse a full SSE stream into a list of JSON events."""
-        events = []
-        for block in stream.split("\n\n"):
-            block = block.strip()
-            if block:
-                event = MCPSSEClient._parse_sse_event(block)
-                if event is not None:
-                    events.append(event)
-        return events
-
-    def _next_id(self) -> int:
-        self._request_id += 1
-        return self._request_id
-
-    @property
-    def _base_url(self) -> str:
-        assert self.config.url is not None
-        return self.config.url.rstrip("/")
-
-    @property
-    def _message_url(self) -> str:
-        return f"{self._base_url}{self._message_endpoint}"
+        self._stack: AsyncExitStack | None = None
+        self._session: Any = None
 
     async def connect(self) -> None:
-        """Create the HTTP client session and perform MCP initialization handshake."""
+        """Open the SSE stream and perform the MCP initialization handshake."""
         if not self.config.url:
             raise ValueError("SSE MCP server requires a URL")
-        self._client = mcp_http_client(self.config.url)
+        url = self.config.url
+        assert_supported_mcp_url(url)
 
-        # Send initialize request (response is acknowledged server-side;
-        # we don't inspect it — the MCP spec only requires us to send the
-        # handshake and follow up with the initialized notification).
-        await self._send_and_receive(
-            "initialize",
-            {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "agentos", "version": __version__},
-            },
-        )
-        # Send initialized notification
-        await self._send_notification("notifications/initialized")
+        from mcp.client.session import ClientSession
+        from mcp.client.sse import sse_client
+
+        def httpx_client_factory(
+            headers: dict[str, str] | None = None,
+            timeout: httpx.Timeout | None = None,
+            auth: httpx.Auth | None = None,
+        ) -> httpx.AsyncClient:
+            return mcp_http_client(
+                url,
+                headers=headers,
+                timeout=timeout,
+                auth=auth,
+                follow_redirects=True,
+            )
+
+        stack = AsyncExitStack()
+        try:
+            read_stream, write_stream = await stack.enter_async_context(
+                sse_client(
+                    self.config.url,
+                    headers=self.config.headers,
+                    timeout=self.config.tool_timeout_seconds,
+                    sse_read_timeout=self.config.tool_timeout_seconds,
+                    httpx_client_factory=httpx_client_factory,
+                )
+            )
+            session = await stack.enter_async_context(
+                ClientSession(
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=timedelta(seconds=self.config.tool_timeout_seconds),
+                )
+            )
+            await session.initialize()
+        except BaseException as exc:
+            await stack.aclose()
+            failure = exc
+            while isinstance(failure, BaseExceptionGroup) and len(failure.exceptions) == 1:
+                failure = failure.exceptions[0]
+            if failure is exc:
+                raise
+            raise failure from exc
+
+        self._stack = stack
+        self._session = session
 
     async def close(self) -> None:
-        """Close the HTTP client session."""
-        if self._client is not None:
-            await self._client.aclose()
-            self._client = None
-
-    async def _send_and_receive(
-        self, method: str, params: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """POST a JSON-RPC request and receive response via SSE."""
-        assert self._client is not None
-
-        req_id = self._next_id()
-        request: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
-        if params is not None:
-            request["params"] = params
-
-        # POST the request
-        await self._client.post(self._message_url, json=request)
-
-        # GET SSE stream for response
-        async with self._client.stream("GET", self._base_url) as response:
-            buffer = ""
-            async for line in response.aiter_lines():
-                if line:
-                    buffer += line + "\n"
-                else:
-                    # Empty line = end of event
-                    event = self._parse_sse_event(buffer.strip())
-                    buffer = ""
-                    if event is not None and event.get("id") == req_id:
-                        return event
-
-        return {}
-
-    async def _send_notification(self, method: str) -> None:
-        """Send a JSON-RPC notification (no response expected)."""
-        assert self._client is not None
-
-        notification: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
-        await self._client.post(self._message_url, json=notification)
+        """Close the MCP session and its long-lived SSE stream."""
+        if self._stack is not None:
+            await self._stack.aclose()
+        self._stack = None
+        self._session = None
 
     async def list_tools(self) -> list[MCPToolDef]:
         """List tools from the MCP server."""
-        response = await self._send_and_receive("tools/list")
-        tools_data = response.get("result", {}).get("tools", [])
+        if self._session is None:
+            raise RuntimeError("SSE MCP client is not connected")
+        result = await self._session.list_tools()
         return [
             MCPToolDef(
-                name=t["name"],
-                description=t.get("description", ""),
-                input_schema=t.get("inputSchema", {}),
+                name=tool.name,
+                description=tool.description or "",
+                input_schema=tool.inputSchema,
             )
-            for t in tools_data
+            for tool in result.tools
         ]
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         """Call a tool on the MCP server."""
-        response = await self._send_and_receive(
-            "tools/call", {"name": name, "arguments": arguments}
+        if self._session is None:
+            raise RuntimeError("SSE MCP client is not connected")
+        result = await self._session.call_tool(name, arguments)
+        chunks: list[str] = []
+        for block in result.content:
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                chunks.append(text)
+                continue
+            if hasattr(block, "model_dump_json"):
+                chunks.append(block.model_dump_json())
+        structured = getattr(result, "structuredContent", None)
+        if not chunks and structured is not None:
+            chunks.append(json.dumps(structured, ensure_ascii=False))
+        return MCPToolResult(
+            content="\n".join(chunks),
+            is_error=bool(getattr(result, "isError", False)),
         )
-
-        if "error" in response:
-            return MCPToolResult(
-                content=response["error"].get("message", "Unknown error"),
-                is_error=True,
-            )
-
-        result = response.get("result", {})
-        content_list = result.get("content", [])
-        text = "\n".join(c.get("text", "") for c in content_list if c.get("type") == "text")
-        return MCPToolResult(content=text)

--- a/src/agentos/mcp/types.py
+++ b/src/agentos/mcp/types.py
@@ -13,7 +13,7 @@ class MCPServerConfig:
     command: str | None = None  # for stdio
     args: list[str] = field(default_factory=list)  # for stdio
     url: str | None = None  # for HTTP transports
-    message_endpoint: str | None = None  # for sse, default "/message"
+    message_endpoint: str | None = None  # legacy; ignored by SSE (server advertises endpoint)
     env: dict[str, str] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
     oauth: bool = False

--- a/tests/test_mcp/test_mcp_ssrf.py
+++ b/tests/test_mcp/test_mcp_ssrf.py
@@ -13,12 +13,14 @@ two approaches.
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import socket
 import threading
 from contextlib import asynccontextmanager
 from typing import Any
 
+import httpcore
 import pytest
 
 from agentos.mcp.http import assert_supported_mcp_url, mcp_http_client
@@ -108,6 +110,76 @@ async def test_sse_client_installs_the_connect_time_guard(
     finally:
         await guarded_client.aclose()
         await client.close()
+
+
+@pytest.mark.asyncio
+async def test_real_sse_sdk_revalidates_the_advertised_post_connection(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Keep the SDK and network validator real; no socket is opened."""
+    from agentos.mcp import sse as client_module
+
+    class EventStream(httpcore.AsyncNetworkStream):
+        def __init__(self) -> None:
+            self.first_read = True
+            self.closed = False
+
+        async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+            if self.first_read:
+                self.first_read = False
+                return (
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+                    b"event: endpoint\ndata: /messages?session_id=test\n\n"
+                )
+            await asyncio.Event().wait()
+            return b""  # pragma: no cover
+
+        async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+            pass
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    stream = EventStream()
+    answers = {"mcp.example": "203.0.113.10"}
+    resolver = _resolver(answers)
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    dialed: list[str] = []
+
+    class NetworkBackend:
+        async def connect_tcp(self, host: str, port: int, **_kwargs: Any) -> EventStream:
+            dialed.append(host)
+            # The GET occupies the first connection. Its relative endpoint
+            # needs a second connection whose new DNS answer must be checked.
+            answers["mcp.example"] = METADATA_IP
+            return stream
+
+    def guarded_factory(url: str, **kwargs: Any) -> Any:
+        http_client = mcp_http_client(url, trust_env=False, **kwargs)
+        backend = _installed_backend(http_client)
+        assert isinstance(backend, ValidatingNetworkBackend)
+        backend._backend = NetworkBackend()
+        return http_client
+
+    monkeypatch.setattr(client_module, "mcp_http_client", guarded_factory)
+    config = _sse_config("http://mcp.example/sse")
+    config.tool_timeout_seconds = 1.0
+    client = MCPSSEClient(config)
+
+    async with asyncio.timeout(3):
+        try:
+            with pytest.raises(TimeoutError, match="MCP SSE handshake timed out"):
+                await client.connect()
+        finally:
+            await client.close()
+
+    assert resolver.calls == ["mcp.example", "mcp.example"]
+    assert dialed == ["203.0.113.10"]
+    assert METADATA_IP in caplog.text
+    assert "SSRFBlockedError" in caplog.text
+    assert stream.closed
+    assert client._stack is None
+    assert client._session is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp/test_mcp_ssrf.py
+++ b/tests/test_mcp/test_mcp_ssrf.py
@@ -70,19 +70,43 @@ def _resolver(mapping: dict[str, str]):
 async def test_sse_client_installs_the_connect_time_guard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _noop(self: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        return {}
+    from mcp.client import session as session_module
+    from mcp.client import sse as transport_module
 
-    monkeypatch.setattr(MCPSSEClient, "_send_and_receive", _noop)
-    monkeypatch.setattr(MCPSSEClient, "_send_notification", _noop)
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def fake_transport(
+        _url: str,
+        *,
+        httpx_client_factory: Any = None,
+        **_kwargs: Any,
+    ):
+        captured["httpx_client_factory"] = httpx_client_factory
+        yield object(), object()
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def initialize(self) -> None:
+            return None
+
+    monkeypatch.setattr(transport_module, "sse_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_a, **_k: FakeSession())
 
     client = MCPSSEClient(_sse_config("http://localhost:9999/sse"))
     await client.connect()
+    guarded_client = captured["httpx_client_factory"]()
     try:
-        backend = _installed_backend(client._client)
+        backend = _installed_backend(guarded_client)
         assert isinstance(backend, ValidatingNetworkBackend)
         assert backend._validator is validate_metadata_only_address
     finally:
+        await guarded_client.aclose()
         await client.close()
 
 

--- a/tests/test_mcp/test_sse_client.py
+++ b/tests/test_mcp/test_sse_client.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.mcp.discovery import create_client
+from agentos.mcp.sse import MCPSSEClient
+from agentos.mcp.types import MCPServerConfig
+
+
+def _config() -> MCPServerConfig:
+    return MCPServerConfig(
+        name="legacy-sse",
+        transport="sse",
+        url="https://example.test/sse",
+        headers={"Authorization": "Bearer test"},
+        tool_timeout_seconds=17.0,
+    )
+
+
+def test_factory_builds_sse_client() -> None:
+    assert isinstance(create_client(_config()), MCPSSEClient)
+
+
+@pytest.mark.asyncio
+async def test_connect_keeps_one_sse_transport_open_until_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp.client import session as session_module
+    from mcp.client import sse as transport_module
+
+    events: list[str] = []
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def fake_transport(url: str, **kwargs: Any):
+        captured["url"] = url
+        captured.update(kwargs)
+        events.append("transport_enter")
+        try:
+            yield object(), object()
+        finally:
+            events.append("transport_exit")
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            events.append("session_enter")
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            events.append("session_exit")
+
+        async def initialize(self) -> None:
+            events.append("initialize")
+
+    monkeypatch.setattr(transport_module, "sse_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_args, **_kwargs: FakeSession())
+    client = MCPSSEClient(_config())
+
+    await client.connect()
+
+    assert events == ["transport_enter", "session_enter", "initialize"]
+    assert captured["url"] == "https://example.test/sse"
+    assert captured["headers"] == {"Authorization": "Bearer test"}
+    assert captured["timeout"] == 17.0
+    assert captured["sse_read_timeout"] == 17.0
+    assert callable(captured["httpx_client_factory"])
+
+    await client.close()
+
+    assert events == [
+        "transport_enter",
+        "session_enter",
+        "initialize",
+        "session_exit",
+        "transport_exit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_connect_closes_partial_sse_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp.client import session as session_module
+    from mcp.client import sse as transport_module
+
+    closed: list[str] = []
+
+    @asynccontextmanager
+    async def fake_transport(_url: str, **_kwargs: Any):
+        try:
+            yield object(), object()
+        finally:
+            closed.append("transport")
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            closed.append("session")
+
+        async def initialize(self) -> None:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(transport_module, "sse_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_args, **_kwargs: FakeSession())
+    client = MCPSSEClient(_config())
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.connect()
+
+    assert closed == ["session", "transport"]
+
+
+@pytest.mark.asyncio
+async def test_tools_use_the_connected_mcp_session() -> None:
+    class FakeSession:
+        async def list_tools(self) -> Any:
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(
+                        name="lookup",
+                        description=None,
+                        inputSchema={"type": "object"},
+                    )
+                ]
+            )
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+            assert name == "lookup"
+            assert arguments == {"query": "agentos"}
+            return SimpleNamespace(
+                content=[SimpleNamespace(text="found")],
+                structuredContent=None,
+                isError=False,
+            )
+
+    client = MCPSSEClient(_config())
+    client._session = FakeSession()
+
+    tools = await client.list_tools()
+    result = await client.call_tool("lookup", {"query": "agentos"})
+
+    assert [(tool.name, tool.description, tool.input_schema) for tool in tools] == [
+        ("lookup", "", {"type": "object"})
+    ]
+    assert result.content == "found"
+    assert result.is_error is False

--- a/tests/test_mcp/test_sse_client.py
+++ b/tests/test_mcp/test_sse_client.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
 
 from agentos.mcp.discovery import create_client
@@ -151,3 +154,147 @@ async def test_tools_use_the_connected_mcp_session() -> None:
     ]
     assert result.content == "found"
     assert result.is_error is False
+
+
+class _EventStream(httpx.AsyncByteStream):
+    """An in-memory server stream; the real SDK parses and consumes its events."""
+
+    def __init__(self, endpoint: str) -> None:
+        self.messages: asyncio.Queue[bytes] = asyncio.Queue()
+        self.messages.put_nowait(f"event: endpoint\ndata: {endpoint}\n\n".encode())
+        self.closed = False
+        self.reader_stopped = False
+
+    def respond(self, request_id: int, result: dict[str, Any]) -> None:
+        payload = {"jsonrpc": "2.0", "id": request_id, "result": result}
+        self.messages.put_nowait(f"event: message\ndata: {json.dumps(payload)}\n\n".encode())
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            while True:
+                yield await self.messages.get()
+        finally:
+            self.reader_stopped = True
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _SSEServer:
+    def __init__(self, endpoint: str) -> None:
+        self.stream = _EventStream(endpoint)
+        self.requests: list[httpx.Request] = []
+        self.calls: list[dict[str, Any]] = []
+
+    async def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if request.method == "GET":
+            return httpx.Response(
+                200, headers={"content-type": "text/event-stream"}, stream=self.stream
+            )
+        payload = json.loads(request.content)
+        if payload["method"] == "initialize":
+            self.stream.respond(
+                payload["id"],
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "test", "version": "1"},
+                },
+            )
+        elif payload["method"] == "tools/list":
+            self.stream.respond(
+                payload["id"],
+                {
+                    "tools": [
+                        {"name": name, "inputSchema": {"type": "object"}}
+                        for name in ("first", "second")
+                    ]
+                },
+            )
+        elif payload["method"] == "tools/call":
+            self.calls.append(payload)
+            if len(self.calls) == 2:
+                # Reverse arrival order: responses must match ids, not readers.
+                for call in reversed(self.calls):
+                    self.stream.respond(
+                        call["id"],
+                        {"content": [{"type": "text", "text": call["params"]["name"]}]},
+                    )
+        return httpx.Response(202)
+
+
+def _install_sse_server(monkeypatch: pytest.MonkeyPatch, server: _SSEServer) -> None:
+    from agentos.mcp import sse as client_module
+
+    def client_factory(_url: str, **kwargs: Any) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(server.handle), **kwargs)
+
+    # Mock only the HTTP boundary; keep sse_client and ClientSession real.
+    monkeypatch.setattr(client_module, "mcp_http_client", client_factory)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint",
+    ["../messages?session_id=test", "https://example.test/messages?session_id=test"],
+)
+async def test_real_sdk_uses_advertised_endpoint_and_correlates_responses(
+    monkeypatch: pytest.MonkeyPatch, endpoint: str
+) -> None:
+    server = _SSEServer(endpoint)
+    _install_sse_server(monkeypatch, server)
+    config = _config()
+    config.url = "https://example.test/legacy/sse"
+    client = MCPSSEClient(config)
+
+    async with asyncio.timeout(3):
+        try:
+            await client.connect()
+            assert len(await client.list_tools()) == 2
+            first, second = await asyncio.gather(
+                client.call_tool("first", {}), client.call_tool("second", {})
+            )
+            assert first.content == "first"
+            assert second.content == "second"
+            assert not server.stream.closed
+            assert [r.method for r in server.requests] == ["GET"] + ["POST"] * 5
+            assert all(
+                str(r.url) == "https://example.test/messages?session_id=test"
+                for r in server.requests[1:]
+            )
+            assert json.loads(server.requests[1].content)["method"] == "initialize"
+            assert json.loads(server.requests[2].content)["method"] == "notifications/initialized"
+        finally:
+            await client.close()
+
+    assert server.stream.closed
+    assert server.stream.reader_stopped
+    assert client._session is None
+    assert client._stack is None
+
+
+@pytest.mark.asyncio
+async def test_real_sdk_refuses_an_endpoint_on_another_origin(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    server = _SSEServer("https://other.test/messages")
+    _install_sse_server(monkeypatch, server)
+    config = _config()
+    config.tool_timeout_seconds = 1.0
+    client = MCPSSEClient(config)
+
+    async with asyncio.timeout(3):
+        try:
+            # The SDK rejects the origin before POSTing, but can wait on its
+            # error stream before yielding. Our handshake deadline bounds it.
+            with pytest.raises(TimeoutError, match="MCP SSE handshake timed out"):
+                await client.connect()
+        finally:
+            await client.close()
+
+    assert [r.method for r in server.requests] == ["GET"]
+    assert "Endpoint origin does not match connection origin" in caplog.text
+    assert server.stream.closed
+    assert client._session is None
+    assert client._stack is None

--- a/tests/test_mcp/test_sse_client.py
+++ b/tests/test_mcp/test_sse_client.py
@@ -70,7 +70,7 @@ async def test_connect_keeps_one_sse_transport_open_until_close(
     assert captured["url"] == "https://example.test/sse"
     assert captured["headers"] == {"Authorization": "Bearer test"}
     assert captured["timeout"] == 17.0
-    assert captured["sse_read_timeout"] == 17.0
+    assert "sse_read_timeout" not in captured
     assert callable(captured["httpx_client_factory"])
 
     await client.close()
@@ -246,6 +246,7 @@ async def test_real_sdk_uses_advertised_endpoint_and_correlates_responses(
     _install_sse_server(monkeypatch, server)
     config = _config()
     config.url = "https://example.test/legacy/sse"
+    config.message_endpoint = "/ignored-legacy-endpoint"
     client = MCPSSEClient(config)
 
     async with asyncio.timeout(3):
@@ -272,6 +273,38 @@ async def test_real_sdk_uses_advertised_endpoint_and_correlates_responses(
     assert server.stream.reader_stopped
     assert client._session is None
     assert client._stack is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_timeout", [30.0, 600.0])
+async def test_real_sdk_separates_stream_idle_timeout_from_tool_timeout(
+    monkeypatch: pytest.MonkeyPatch, tool_timeout: float
+) -> None:
+    server = _SSEServer("/messages")
+    _install_sse_server(monkeypatch, server)
+    config = _config()
+    config.tool_timeout_seconds = tool_timeout
+    client = MCPSSEClient(config)
+
+    async with asyncio.timeout(3):
+        try:
+            await client.connect()
+            assert len(await client.list_tools()) == 2
+            # Inspect the real SDK's HTTP request, not a fake transport's kwargs.
+            stream_request = server.requests[0]
+            assert stream_request.method == "GET"
+            assert stream_request.extensions["timeout"] == {
+                "connect": tool_timeout,
+                "read": 300.0,
+                "write": tool_timeout,
+                "pool": tool_timeout,
+            }
+            assert not server.stream.closed
+        finally:
+            await client.close()
+
+    assert server.stream.closed
+    assert server.stream.reader_stopped
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Replace the hand-rolled POST-then-GET flow with the existing MCP SDK's legacy SSE transport and `ClientSession`.
- Open one long-lived SSE stream before initialization, use the server-advertised endpoint, and correlate JSON-RPC responses by request ID on that stream.
- Preserve the connect-time SSRF guard through the SDK's HTTP client factory.
- Bound the complete endpoint/initialization handshake with the configured timeout, and clean up partial session/transport state on failure.

- Keep the SDK's 300-second SSE idle timeout independent of the per-operation tool timeout; the complete handshake and individual MCP requests retain their existing bounds.
- Retain the legacy `message_endpoint` field for compatibility, documenting that the server-advertised endpoint takes precedence.

Fixes #922

## SDK reuse and SSRF preservation

The implementation uses `mcp.client.sse.sse_client` and `ClientSession` from the already-installed MCP SDK, rather than duplicating its endpoint parsing, receive loop, and request dispatch. The SDK resolves relative endpoint events against the configured URL and rejects an endpoint whose scheme or authority differs before sending a POST.

The SDK receives an `httpx_client_factory` that returns AgentOS's `mcp_http_client`, forwarding headers, authentication, and timeouts. Both the initial GET and advertised-endpoint POSTs therefore use the guarded transport. Its network backend validates and pins the address actually dialed for each new connection, including the separate POST connection while the GET remains open. The existing metadata-only policy is unchanged: configured localhost/LAN MCP servers remain supported; metadata endpoints remain blocked.

Real-SDK coverage exposed a failed-handshake edge case: after rejecting an endpoint or encountering a POST transport failure, the SDK can remain waiting on its internal streams. HTTP read timeouts alone do not bound that wait. The wrapper now applies the existing configured timeout to the whole handshake and raises `MCP SSE handshake timed out`, closing partial state. The SDK logs the underlying rejection; no request reaches the rejected destination.

## Regression coverage

All new tests are offline and open no sockets. They retain the real SDK transport and session, mocking only the HTTP or low-level network boundary:

- Relative and absolute same-origin endpoint events route every POST to the advertised URL.
- Initialization precedes the initialized notification; one GET stays open for multiple requests.
- Concurrent calls receive the correct results even when responses arrive in reverse order.
- Closing stops the receive stream and clears session/transport state.
- A foreign-origin endpoint causes no POST, times out within the handshake bound, and cleans up.
- A separate advertised-endpoint POST connection re-resolves DNS through the real `ValidatingNetworkBackend`; a changed metadata address is rejected before the low-level backend can dial it.

- The real SDK's GET request uses a 300-second read timeout with both 30-second and 600-second tool timeouts; connect/write/pool timeouts retain the configured value.
- A configured legacy `message_endpoint` does not override the server's advertised endpoint.

## Validation

- [GitHub CI for `823b48d`](https://github.com/use-agent-os/agent-os/actions/runs/33843168778).
- `uv run pytest tests/test_mcp -q` — 38 passed. The two new real-SDK timeout cases and the updated transport-arguments assertion fail on the previous PR head and pass after this change.
- `uv run ruff check src tests` — passed.
- `uv run mypy src/agentos --show-error-codes` — passed (622 source files).
- Control UI production build — passed.
- `npm --prefix frontend run check -- --maxWorkers=1 --no-file-parallelism` — passed: type checking, lint, formatting, and all 2,010 tests across 98 files. An earlier attempt was interrupted by system sleep and produced timeouts; the complete rerun passed without frontend changes.
- `uv run pytest -q --tb=short` — 9,031 passed, 32 skipped, 6 failed, 3 setup errors; 21 snapshots passed. The identical six failures and three setup errors were reproduced on clean upstream commit `2e4d6ac`: unhydrated ONNX/LFS assets and local uv 0.8.15 rejecting the wheelhouse tests' `--clear` option. No unrelated workaround is included.
- `uv build --wheel` — passed.

## Third-party origins

Uses the existing [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk/tree/v1.27.0), licensed under MIT. No upstream implementation is copied or vendored, and no dependency or lockfile changes are introduced.

Protocol reference: [MCP 2024-11-05 HTTP+SSE transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse).
