### PR TITLE
fix(skills): withhold Chainlink price for proven impersonator tokens

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -318,6 +318,17 @@ def inspect_token(
         if isinstance(onchain_symbol, str) and onchain_symbol:
             feed = find_feed(onchain_symbol, feeds)
 
+    # A confirmed impersonator must not be decorated with a genuine quote.
+    # `isStockToken: False` means uiMultiplier() reverted — the contract is
+    # PROVEN not a Stock Token, and the feed lookup above trusts a string the
+    # contract reports itself. Withhold the price (and the derived holding
+    # value) and record why. `None` (unreachable node) stays eligible — the
+    # existing "unverified is not disproven" rule applies.
+    if out["isStockToken"] is False:
+        if feed is not None:
+            errors["price"] = "withheld: uiMultiplier() proved this is not a Stock Token"
+        feed = None
+
     if feed is not None:
         price = _try(
             lambda: _read_price(rpc_url, str(feed["proxyAddress"]), timeout, now), errors, "price"

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -227,6 +227,117 @@ def test_inspect_token_flags_a_token_that_cannot_answer_ui_multiplier(
     assert "uiMultiplier" in state["readErrors"]
 
 
+def test_confirmed_impersonator_does_not_get_a_genuine_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #866: a proven-fake contract must not carry a real Chainlink quote.
+
+    An impersonator can self-report a real ticker via `symbol()`; the feed
+    lookup trusts that string, so without a cross-check a confirmed fake
+    would be decorated with a genuine, accurate price. `isStockToken: False`
+    (uiMultiplier reverted) must withhold the price and record why.
+    """
+    proxy = str(_FEEDS[0]["proxyAddress"]).lower()
+    chain = _FakeChain(
+        {
+            # Impersonator self-reports AAPL's real ticker...
+            (FAKE_GME, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32)
+            + _word_hex(4)
+            + b"AAPL".hex().ljust(64, "0"),
+            # ...but uiMultiplier() reverts: proven not a Stock Token.
+            (FAKE_GME, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(18),
+            (FAKE_GME, chain_stocks.SEL_TOTAL_SUPPLY): "0x" + _word_hex(10**24),
+            (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
+            + "".join(_word_hex(v) for v in (1, 31747461437, 0, 1788206389, 1)),
+            (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),
+        }
+    )
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+
+    state = chain_stocks.inspect_token("rpc", FAKE_GME, 5.0, feeds=_FEEDS, now=1788206389 + 60)
+
+    assert state["isStockToken"] is False
+    assert "price" not in state
+    assert (
+        state["readErrors"]["price"] == "withheld: uiMultiplier() proved this is not a Stock Token"
+    )
+
+
+def test_confirmed_impersonator_with_holder_skips_value_usd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Holding balance is on-chain data and still reported; the derived USD
+    value must not be attached to a proven impersonator."""
+    proxy = str(_FEEDS[0]["proxyAddress"]).lower()
+    holder = "0x1111111111111111111111111111111111111111"
+    chain = _FakeChain(
+        {
+            (FAKE_GME, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32)
+            + _word_hex(4)
+            + b"AAPL".hex().ljust(64, "0"),
+            (FAKE_GME, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(18),
+            (FAKE_GME, chain_stocks.SEL_TOTAL_SUPPLY): "0x" + _word_hex(10**24),
+            (FAKE_GME, chain_stocks.SEL_BALANCE_OF): "0x" + _word_hex(2 * 10**18),
+            (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
+            + "".join(_word_hex(v) for v in (1, 31747461437, 0, 1788206389, 1)),
+            (proxy, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(8),
+        }
+    )
+    monkeypatch.setattr(chain_stocks, "_eth_call", chain)
+
+    state = chain_stocks.inspect_token(
+        "rpc", FAKE_GME, 5.0, holder=holder, feeds=_FEEDS, now=1788206389 + 60
+    )
+
+    assert state["isStockToken"] is False
+    assert "price" not in state
+    assert state["holding"]["balanceFormatted"] == pytest.approx(2.0)
+    assert "valueUsd" not in state["holding"]
+
+
+def test_unverified_stock_status_still_gets_a_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`isStockToken: None` (unreachable node) must NOT withhold price.
+
+    Only a *confirmed* impersonator (uiMultiplier reverted) is refused. A
+    network fault that leaves the status unknown must not strip a genuine
+    listing's price — same "unverified is not disproven" rule.
+    """
+    proxy = str(_FEEDS[0]["proxyAddress"]).lower()
+
+    def _partial(_rpc: str, to: str, data: str, _timeout: float) -> str:
+        to_lower = to.lower()
+        data_prefix = data[:10]
+        # Symbol, decimals, supply and feed reads succeed; only uiMultiplier
+        # raises a transport error, leaving isStockToken None (unverified).
+        if to_lower == AAPL.lower() and data_prefix == chain_stocks.SEL_SYMBOL[:10]:
+            return "0x" + _word_hex(32) + _word_hex(4) + b"AAPL".hex().ljust(64, "0")
+        if to_lower == AAPL.lower() and data_prefix == chain_stocks.SEL_DECIMALS[:10]:
+            return "0x" + _word_hex(18)
+        if to_lower == AAPL.lower() and data_prefix == chain_stocks.SEL_TOTAL_SUPPLY[:10]:
+            return "0x" + _word_hex(10**24)
+        if to_lower == AAPL.lower() and data_prefix == chain_stocks.SEL_UI_MULTIPLIER[:10]:
+            raise OSError("connection refused")
+        if to_lower == proxy and data_prefix == chain_stocks.SEL_LATEST_ROUND_DATA[:10]:
+            return "0x" + "".join(_word_hex(v) for v in (1, 31747461437, 0, 1788206389, 1))
+        if to_lower == proxy and data_prefix == chain_stocks.SEL_DECIMALS[:10]:
+            return "0x" + _word_hex(8)
+        if to_lower == proxy and data_prefix == chain_stocks.SEL_ORACLE_PAUSED[:10]:
+            return "0x" + _word_hex(0)
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(chain_stocks, "_eth_call", _partial)
+
+    state = chain_stocks.inspect_token("rpc", AAPL, 5.0, feeds=_FEEDS, now=1788206389 + 60)
+
+    assert state["isStockToken"] is None
+    assert "uiMultiplier" in state["readErrors"]
+    assert state["price"]["usd"] == pytest.approx(317.47461437)
+
+
 def test_address_only_run_resolves_its_feed_from_the_onchain_symbol(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -269,6 +380,9 @@ def _price_chain(answer: int, updated_at: int, paused: int = 0) -> _FakeChain:
     proxy = str(_FEEDS[0]["proxyAddress"]).lower()
     return _FakeChain(
         {
+            # A genuine Stock Token answers uiMultiplier() — without it the
+            # price would be (correctly) withheld as a confirmed impersonator.
+            (AAPL, chain_stocks.SEL_UI_MULTIPLIER): "0x" + _word_hex(chain_stocks.WAD),
             (AAPL, chain_stocks.SEL_ORACLE_PAUSED): "0x" + _word_hex(paused),
             (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
             + "".join(_word_hex(v) for v in (1, answer, 0, updated_at, 1)),


### PR DESCRIPTION
## Summary

`inspect_token()` in `robinhood-chain-stocks` resolves a Chainlink price feed using the contract's **self-reported** `symbol()`. A confirmed impersonator (`uiMultiplier()` reverts → `isStockToken: False`) can still self-report a real ticker (e.g. `AAPL`) and be decorated with a genuine, accurate quote — lending borrowed credibility to a fake contract.

## Fix

When `isStockToken` is proven `False`:
- **Withhold the price feed entirely** — skip feed resolution and the price read (no wasted RPC call to the oracle).
- Record the reason in `readErrors`: `"withheld: uiMultiplier() proved this is not a Stock Token"`.
- Still report the on-chain balance (`holding.balanceFormatted`) but **omit the derived `holding.valueUsd`** (there is no price to compute it from).
- `isStockToken: None` (unreachable node) **remains eligible** — the existing "unverified is not disproven" rule applies, so a genuine listing behind a flaky RPC still gets its price.

## Why this approach

Skipping the feed resolution entirely (rather than only gating the price read) means a proven impersonator never even resolves/reads an oracle — cheaper and avoids attaching any price-shaped data. The unverified (`None`) case is explicitly covered so the fix doesn't over-withhold.

## Tests

3 new tests:
- `test_confirmed_impersonator_does_not_get_a_genuine_price` — the exact issue repro (fake contract self-reports AAPL, uiMultiplier reverts → no price, reason recorded).
- `test_confirmed_impersonator_with_holder_skips_value_usd` — balance still reported, `valueUsd` omitted.
- `test_unverified_stock_status_still_gets_a_price` — flaky RPC (`isStockToken: None`) does not withhold.

Existing `_price_chain` helper updated to answer `uiMultiplier()` (a genuine token) so the price math tests still exercise the price path.

Fixes #866