### PR TITLE
docs(cli): fix config set port example and add regression test (#840)

### DIFF
--- a/README.product.md
+++ b/README.product.md
@@ -135,7 +135,7 @@ agentos configure router --router recommended
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 agentos configure channels
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -446,7 +446,7 @@ Raw config:
 
 ```sh
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 For Ollama models that do not reliably support native tool calls, set

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -191,6 +191,36 @@ def test_config_set_explicit_config_path_persists_to_target(tmp_path: Path):
     assert "True" in check.stdout
 
 
+def test_config_set_port_persists_to_target(tmp_path: Path):
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["config", "set", "port", "18792", "--config", str(target)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Config:" in result.stdout
+    assert "Restart the gateway" in result.stdout
+    check = runner.invoke(app, ["config", "get", "port", "--config", str(target)])
+    assert check.exit_code == 0, check.stdout
+    assert "18792" in check.stdout
+
+
+def test_config_set_gateway_port_fails_key_not_found(tmp_path: Path):
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["config", "set", "gateway.port", "18791", "--config", str(target)],
+    )
+
+    assert result.exit_code == 1
+    assert "Key not found: gateway.port" in result.stdout
+
+
 def test_gateway_json_errors_go_to_stderr(monkeypatch):
     _install_fake_gateway(monkeypatch, FailingConnectGatewayClient)
 


### PR DESCRIPTION
## Description
The documented command `agentos config set gateway.port 18791` fails with `Key not found: gateway.port`. The listen port is top-level `port` on `GatewayConfig`; there is no `[gateway]` TOML table (`extra = "forbid"`).

This PR:
1. Updates the documentation examples in `README.product.md` and `docs/cli.md` to use `agentos config set port 18791 --config ~/.agentos/config.toml`.
2. Verifies `src/agentos/skills/bundled/agentos/SKILL.md` (does not contain any `gateway.port` references).
3. Adds CLI regression tests in `tests/test_cli/test_cli_product_completeness.py`:
   - `test_config_set_port_persists_to_target`: verifies setting `port` correctly updates and persists the TOML file.
   - `test_config_set_gateway_port_fails_key_not_found`: pins #840 to ensure trying to set `gateway.port` exits 1 with `Key not found: gateway.port`.

*Note: The silent-success behavior of `config set` without `--config` (printing `export AGENTOS_GATEWAY_...` for arbitrary keys) is coordinated with #834.*

Closes #840 
