### PR TITLE
fix(cli): reuse _safe_archive_part for session export filename saniti…

### DIFF
--- a/src/agentos/cli/sessions_cmd.py
+++ b/src/agentos/cli/sessions_cmd.py
@@ -15,6 +15,7 @@ from agentos.cli.chat.session_state import messages_to_markdown
 from agentos.cli.gateway_rpc import default_gateway_token, default_gateway_url, run_gateway_sync
 from agentos.cli.output import print_json
 from agentos.cli.ui import ACCENT, ACCENT_HEADER, console, error_panel, markup_escape
+from agentos.session.manager import _safe_archive_part
 
 app = typer.Typer(help="Manage chat sessions.")
 
@@ -377,7 +378,7 @@ def sessions_export(
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
         return
-    target = output or Path(f"{session_id.replace(':', '-')}.{format}")
+    target = output or Path(f"{_safe_archive_part(session_id)}.{format}")
     if format == "json":
         target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     else:

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -128,7 +128,7 @@ def _archive_dir() -> Path:
 
 
 def _safe_archive_part(value: str) -> str:
-    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "session"
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-.") or "session"
 
 
 def _stable_json(value: Any) -> str:

--- a/tests/test_cli/test_sessions_export_cmd.py
+++ b/tests/test_cli/test_sessions_export_cmd.py
@@ -1,0 +1,91 @@
+"""Issue #678: ``agentos sessions export`` must not write outside the CWD.
+
+The gateway round-trip is stubbed at ``_with_client`` — these tests cover
+default-filename derivation, where the user-supplied ``session_id`` reaches
+the filesystem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli import sessions_cmd
+from agentos.session.manager import _safe_archive_part
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    async def resolve_session(self, session_id: str) -> dict[str, Any]:
+        return {"session_key": session_id, "status": "done", "model": "gpt-x"}
+
+    async def preview_sessions(self, keys: list[str]) -> dict[str, Any]:
+        return {"previews": [{"lastMessage": "hello"}]}
+
+    async def session_history(self, key: str, limit: int = 1000) -> dict[str, Any]:
+        return {"messages": []}
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    fake = _FakeClient()
+
+    async def _with_client(action: Any) -> Any:
+        return await action(fake)
+
+    monkeypatch.setattr(sessions_cmd, "_with_client", _with_client)
+    return fake
+
+
+@pytest.mark.parametrize(
+    ("session_id", "expected"),
+    [
+        ("agent:main:cli:aaa", "agent-main-cli-aaa"),
+        ("../../etc/pwned", "etc-pwned"),
+        ("..\\..\\Windows\\pwned", "Windows-pwned"),
+        ("/absolute/path", "absolute-path"),
+        ("..", "session"),
+        (".", "session"),
+        ("", "session"),
+        ("---session---", "session"),
+        ("session.v1", "session.v1"),
+        ("my_session", "my_session"),
+    ],
+)
+def test_safe_archive_part_sanitizes_path_separators(session_id: str, expected: str) -> None:
+    """_safe_archive_part strips invalid chars and traversal tokens."""
+    assert _safe_archive_part(session_id) == expected
+
+
+def test_export_writes_inside_the_working_directory(
+    client: _FakeClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A traversal id lands in the CWD under a sanitized name without directory traversal."""
+    monkeypatch.chdir(tmp_path)
+    escaped = tmp_path.parent / "pwned.json"
+
+    result = runner.invoke(sessions_cmd.app, ["export", "../pwned", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert not escaped.exists()
+    assert (tmp_path / "pwned.json").exists()
+
+
+def test_export_honours_an_explicit_output_path(
+    client: _FakeClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit --output path is left untouched as caller's intent."""
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "nested" / "custom.md"
+    target.parent.mkdir()
+
+    result = runner.invoke(
+        sessions_cmd.app, ["export", "agent:main:cli:aaa", "--output", str(target)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert target.exists()


### PR DESCRIPTION
## Description
When `agentos sessions export <session_id>` is called without an explicit `--output`, the default filename was derived using `session_id.replace(':', '-')`. Path separators (`/`, `\`) and traversal tokens (`..`) passed through unchanged, causing the default export to write outside the working directory if traversal characters were present in `session_id`.

Per maintainer guidance on #678:
- Reuses the canonical `_safe_archive_part` helper from `agentos.session.manager` instead of adding duplicate sanitizers.
- Strengthens `_safe_archive_part` with `.strip("-.")` so bare `..` and leading traversal tokens cannot survive as relative paths.
- Adds regression tests covering both the sanitization helper and CLI execution with Typer runner.

Closes #678
