### PR TITLE
fix(channels): enforce per-adapter file size ceilings in send_file (#…

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import os
 import random
 import time
 from collections import OrderedDict
@@ -308,6 +309,29 @@ def _retry_after_delay(header: str | None, fallback: float) -> float:
     if not math.isfinite(delay) or delay < 0.0:
         return fallback
     return min(delay, MAX_RETRY_AFTER_S)
+
+
+def check_channel_file_size(
+    path: str | os.PathLike[str],
+    limit_bytes: int,
+    adapter_name: str,
+) -> int:
+    """Check that *path* does not exceed *limit_bytes*.
+
+    Returns the file size in bytes on success.
+    Raises ValueError with an actionable message if the file exceeds the ceiling.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError as exc:
+        raise ValueError(f"Cannot read file size for {path}: {exc}") from exc
+    if size > limit_bytes:
+        limit_mb = limit_bytes // (1024 * 1024)
+        raise ValueError(
+            f"File too large: {size:,} bytes exceeds {adapter_name} "
+            f"{limit_mb} MB upload ceiling ({limit_bytes:,} bytes)"
+        )
+    return size
 
 
 async def retry_request(

--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import httpx
 import structlog
@@ -29,6 +29,7 @@ from agentos.channels._util import (
     EventDedupeCache,
     RateLimiter,
     StreamThrottle,
+    check_channel_file_size,
     retry_request,
 )
 from agentos.channels.contract import (
@@ -1016,12 +1017,15 @@ class DiscordChannel:
             provider_message_id=str(data.get("id", "")),
         )
 
+    MAX_FILE_BYTES: ClassVar[int] = 10 * 1024 * 1024
+
     async def send_file(
         self,
         channel_id: str,
         file_path: str,
         content: str = "",
     ) -> ChannelSendResult:
+        check_channel_file_size(file_path, self.MAX_FILE_BYTES, "Discord")
         await self._rate_limiter.acquire()
         client = self._get_client()
         with open(file_path, "rb") as f:

--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -47,7 +47,7 @@ from email.message import EmailMessage
 from email.parser import BytesParser
 from email.policy import default as email_policy
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import structlog
 from pydantic import BaseModel, Field
@@ -60,6 +60,7 @@ from agentos.channels._util import (
     AccessDecision,
     ChannelAccessPolicy,
     EventDedupeCache,
+    check_channel_file_size,
 )
 from agentos.channels.contract import (
     ChannelCapabilities,
@@ -311,6 +312,7 @@ class EmailChannel:
     """
 
     config: EmailChannelConfig
+    MAX_ATTACHMENT_BYTES: ClassVar[int] = 25 * 1024 * 1024
 
     _queue: asyncio.Queue[IncomingMessage] = field(
         default_factory=asyncio.Queue, init=False, repr=False
@@ -786,6 +788,7 @@ class EmailChannel:
 
         path = Path(file_path)
         try:
+            check_channel_file_size(path, self.MAX_ATTACHMENT_BYTES, "Email")
             payload = path.read_bytes()
             to_address, subject, in_reply_to, references = self._resolve_target(
                 OutgoingMessage(content="", reply_to=thread_id)

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -30,6 +30,7 @@ from agentos.channels._util import (
     EventDedupeCache,
     FloodStrikeBackoff,
     StreamThrottle,
+    check_channel_file_size,
 )
 from agentos.channels.contract import (
     ChannelCapabilities,
@@ -177,7 +178,6 @@ def _slice_utf16(text: str, offset: int, length: int) -> str:
     return u16[offset * 2 : (offset + length) * 2].decode("utf-16-le", errors="replace")
 
 
-
 @dataclass
 class TelegramChannel:
     """Managed adapter for Telegram Bot API polling or webhooks."""
@@ -187,6 +187,7 @@ class TelegramChannel:
 
     supports_slash_commands: bool = True
     typing_keepalive_interval_s: ClassVar[float] = 4.0
+    MAX_FILE_BYTES: ClassVar[int] = 50 * 1024 * 1024
     policy: ChannelAccessPolicy = field(
         default_factory=lambda: ChannelAccessPolicy(
             dm_allowed=True,
@@ -1424,6 +1425,7 @@ class TelegramChannel:
         if not self.config.token:
             raise ValueError("telegram.send_file requires token")
         path = Path(file_path)
+        check_channel_file_size(path, self.MAX_FILE_BYTES, "Telegram")
         payload = {"chat_id": str(chat_id)}
         if content:
             payload["caption"] = render_telegram_html(content)

--- a/tests/test_channels/test_send_file_size_limits.py
+++ b/tests/test_channels/test_send_file_size_limits.py
@@ -1,0 +1,120 @@
+"""Regression tests for per-adapter file size ceilings in channel send_file (#683).
+
+Verifies that:
+- Check helper enforces limits and formats actionable error messages.
+- DiscordChannel enforces its 10 MB ceiling.
+- TelegramChannel enforces its 50 MB ceiling (and does not reject 30 MB files).
+- EmailChannel enforces its 25 MB ceiling and returns a failed ChannelSendResult.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentos.channels._util import check_channel_file_size
+from agentos.channels.contract import ChannelSendStatus
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+from agentos.channels.email import EmailChannel, EmailChannelConfig
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+
+class TestCheckChannelFileSize:
+    def test_accepts_file_under_limit(self, tmp_path: Path) -> None:
+        f = tmp_path / "small.txt"
+        f.write_bytes(b"x" * 100)
+        assert check_channel_file_size(f, 200, "TestAdapter") == 100
+
+    def test_accepts_file_at_exact_limit(self, tmp_path: Path) -> None:
+        f = tmp_path / "exact.txt"
+        f.write_bytes(b"x" * 200)
+        assert check_channel_file_size(f, 200, "TestAdapter") == 200
+
+    def test_rejects_file_exceeding_limit(self, tmp_path: Path) -> None:
+        f = tmp_path / "oversized.txt"
+        f.write_bytes(b"x" * 300)
+        with pytest.raises(ValueError) as exc_info:
+            check_channel_file_size(f, 200, "CustomService")
+        msg = str(exc_info.value)
+        assert "300 bytes" in msg
+        assert "CustomService" in msg
+        assert "200 bytes" in msg
+
+    def test_raises_on_nonexistent_path(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist.bin"
+        with pytest.raises(ValueError, match="Cannot read file size"):
+            check_channel_file_size(missing, 1024, "TestAdapter")
+
+
+class TestDiscordFileSizeCeiling:
+    def test_discord_ceiling_is_10_mb(self) -> None:
+        assert DiscordChannel.MAX_FILE_BYTES == 10 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_send_file_rejects_oversized_before_rate_limiting(self, tmp_path: Path) -> None:
+        f = tmp_path / "large_audio.wav"
+        f.write_bytes(b"x" * 10)
+
+        channel = DiscordChannel(config=DiscordChannelConfig(token="test-token"))
+
+        with patch("os.path.getsize", return_value=11 * 1024 * 1024):
+            with pytest.raises(ValueError, match="exceeds Discord 10 MB upload ceiling"):
+                await channel.send_file(channel_id="123", file_path=str(f))
+
+
+class TestTelegramFileSizeCeiling:
+    def test_telegram_ceiling_is_50_mb(self) -> None:
+        assert TelegramChannel.MAX_FILE_BYTES == 50 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_send_file_rejects_oversized_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "huge_doc.pdf"
+        f.write_bytes(b"x" * 10)
+
+        channel = TelegramChannel(config=TelegramChannelConfig(token="fake-token"))
+
+        with patch("os.path.getsize", return_value=51 * 1024 * 1024):
+            with pytest.raises(ValueError, match="exceeds Telegram 50 MB upload ceiling"):
+                await channel.send_file(chat_id="123", file_path=str(f))
+
+    @pytest.mark.asyncio
+    async def test_send_file_permits_30_mb_file(self, tmp_path: Path) -> None:
+        """30 MB document is accepted by Telegram (50 MB limit), unlike blanket 25 MB limits."""
+        f = tmp_path / "medium_doc.pdf"
+        f.write_bytes(b"x" * 10)
+
+        channel = TelegramChannel(config=TelegramChannelConfig(token="fake-token"))
+
+        with patch("os.path.getsize", return_value=30 * 1024 * 1024):
+            mock_client = AsyncMock()
+            mock_client.post.return_value.json.return_value = {"ok": True, "result": {}}
+            with patch.object(channel, "_get_client", return_value=mock_client):
+                with patch.object(channel, "_parse_api_response", return_value={"message_id": "1"}):
+                    res = await channel.send_file(chat_id="123", file_path=str(f))
+                    assert res.status == ChannelSendStatus.SENT
+
+
+class TestEmailFileSizeCeiling:
+    def test_email_ceiling_is_25_mb(self) -> None:
+        assert EmailChannel.MAX_ATTACHMENT_BYTES == 25 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_send_file_fails_gracefully_on_oversized_attachment(self, tmp_path: Path) -> None:
+        f = tmp_path / "oversized_attachment.zip"
+        f.write_bytes(b"x" * 10)
+
+        channel = EmailChannel(
+            config=EmailChannelConfig(
+                imap_host="localhost",
+                smtp_host="localhost",
+                username="test@example.com",
+            )
+        )
+
+        with patch("os.path.getsize", return_value=26 * 1024 * 1024):
+            result = await channel.send_file(thread_id="thread-123", file_path=str(f))
+
+        assert result.status == ChannelSendStatus.FAILED
+        assert "exceeds Email 25 MB upload ceiling" in result.reason


### PR DESCRIPTION
## Description
In `send_file`, files were opened/streamed without a pre-read file size check, causing memory exhaustion on `EmailChannel` (`read_bytes()` base64-expanding oversized payloads) or wasted bandwidth/errors on Discord and Telegram.

Per maintainer guidance on #683, rather than applying a blanket 25 MB constant across all adapters, this PR enforces per-adapter constants matching each service's actual upload boundary:
- `DiscordChannel`: **10 MB** (`MAX_FILE_BYTES = 10_485_760`)
- `TelegramChannel`: **50 MB** (`MAX_FILE_BYTES = 52_428_800`)
- `EmailChannel`: **25 MB** (`MAX_ATTACHMENT_BYTES = 26_214_400`)

Files are pre-checked with `stat()` via `check_channel_file_size` in `agentos.channels._util` and fail fast with actionable error messages indicating the specific service limit.

Closes #683 
