### PR TITLE
fix(gateway): preserve route envelope for queued tasks

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -1160,7 +1160,6 @@ class TaskRuntime:
             if self._running_by_session.get(task.envelope.session_key) is task:
                 self._running_by_session.pop(task.envelope.session_key, None)
             self._tasks.pop(task.task_id, None)
-            self._last_envelope_by_session.pop(task.envelope.session_key, None)
             # Keep the short write lock stable for this session. Popping it can
             # split callers across old/new lock objects while callbacks or
             # late lifecycle events still reference the old one. The dict grows
@@ -1171,6 +1170,7 @@ class TaskRuntime:
                 not self._pending_by_session.get(session_key)
                 and self._running_by_session.get(session_key) is None
             ):
+                self._last_envelope_by_session.pop(session_key, None)
                 agent_id = task.envelope.agent_id
                 active = self._agent_active_sessions.get(agent_id)
                 if active is not None:

--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -1165,7 +1165,8 @@ class TaskRuntime:
             # late lifecycle events still reference the old one. The dict grows
             # at most by unique session_keys, which is acceptable.
             session_key = task.envelope.session_key
-            # Clean up RR deque entry when session has no more work.
+            # Drop cached routing and RR state only when both pending and
+            # running work are gone, so later sends cannot reuse stale routing.
             if (
                 not self._pending_by_session.get(session_key)
                 and self._running_by_session.get(session_key) is None

--- a/tests/test_gateway/test_task_runtime_terminal_cleanup.py
+++ b/tests/test_gateway/test_task_runtime_terminal_cleanup.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agentos.gateway import task_runtime
-from agentos.gateway.routing import RouteEnvelope, SourceKind
+from agentos.gateway.routing import ReplyTarget, RouteEnvelope, SourceKind
 from agentos.gateway.task_runtime import TaskRuntime
 from agentos.session.models import AgentTaskRecord
 
@@ -183,6 +183,70 @@ async def test_session_lock_kept_during_pending() -> None:
 
     # _session_locks is intentionally retained after all tasks complete;
     # do not assert its absence here.
+
+
+@pytest.mark.asyncio
+async def test_terminal_keeps_route_envelope_while_same_session_has_work() -> None:
+    """A completed task must not erase routing needed by queued follow-ups."""
+    first_started = asyncio.Event()
+    first_release = asyncio.Event()
+    remaining_release = asyncio.Event()
+
+    async def _blocking_handler(run: Any) -> None:
+        if run.message == "first":
+            first_started.set()
+            await first_release.wait()
+            return
+        await remaining_release.wait()
+
+    rt = _make_runtime(turn_handler=_blocking_handler, max_concurrency=1)
+    session_key = "agent-1::sess-channel"
+    reply_target = ReplyTarget(
+        kind="channel",
+        channel_name="slack-work",
+        channel_type="slack",
+        to="C123",
+        account_id="work",
+        thread_id="1712345.6789",
+    )
+    envelope = RouteEnvelope(
+        source_kind=SourceKind.CHANNEL,
+        source_name="slack",
+        agent_id="agent-1",
+        session_key=session_key,
+        account_id="work",
+        channel_type="slack",
+        channel_name="slack-work",
+        channel_id="C123",
+        thread_id="1712345.6789",
+        reply_target=reply_target,
+        input_provenance={"kind": "channel_message", "source": "slack"},
+    )
+
+    first = await rt.enqueue(envelope, "first")
+    await asyncio.wait_for(first_started.wait(), timeout=2.0)
+    second = await rt.enqueue(envelope, "second")
+
+    first_release.set()
+    await rt.wait(first.task_id, timeout=2.0)
+    cached_after_first = rt._last_envelope_by_session.get(session_key)
+
+    followup = await rt.send(session_key, "follow-up")
+    routed_followup = rt._tasks[followup.task_id].envelope
+
+    remaining_release.set()
+    await rt.wait(second.task_id, timeout=2.0)
+    await rt.wait(followup.task_id, timeout=2.0)
+
+    assert cached_after_first == envelope
+    assert routed_followup.source_kind is SourceKind.CHANNEL
+    assert routed_followup.account_id == "work"
+    assert routed_followup.channel_name == "slack-work"
+    assert routed_followup.channel_id == "C123"
+    assert routed_followup.thread_id == "1712345.6789"
+    assert routed_followup.reply_target == reply_target
+    assert routed_followup.input_provenance == {"kind": "channel_message", "source": "slack"}
+    assert session_key not in rt._last_envelope_by_session
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway/test_task_runtime_terminal_cleanup.py
+++ b/tests/test_gateway/test_task_runtime_terminal_cleanup.py
@@ -231,14 +231,20 @@ async def test_terminal_keeps_route_envelope_while_same_session_has_work() -> No
     await rt.wait(first.task_id, timeout=2.0)
     cached_after_first = rt._last_envelope_by_session.get(session_key)
 
+    override = {"kind": "runtime_send", "source_tool": "test"}
+    overridden = await rt.send(session_key, "override", provenance=override)
+    overridden_envelope = rt._tasks[overridden.task_id].envelope
     followup = await rt.send(session_key, "follow-up")
     routed_followup = rt._tasks[followup.task_id].envelope
 
     remaining_release.set()
     await rt.wait(second.task_id, timeout=2.0)
+    await rt.wait(overridden.task_id, timeout=2.0)
     await rt.wait(followup.task_id, timeout=2.0)
 
     assert cached_after_first == envelope
+    assert overridden_envelope.input_provenance == override
+    assert overridden_envelope.reply_target == reply_target
     assert routed_followup.source_kind is SourceKind.CHANNEL
     assert routed_followup.account_id == "work"
     assert routed_followup.channel_name == "slack-work"
@@ -247,6 +253,25 @@ async def test_terminal_keeps_route_envelope_while_same_session_has_work() -> No
     assert routed_followup.reply_target == reply_target
     assert routed_followup.input_provenance == {"kind": "channel_message", "source": "slack"}
     assert session_key not in rt._last_envelope_by_session
+
+    # Once the last task finishes, sends must not reuse the old channel route
+    # or the earlier one-shot provenance override.
+    remaining_release.clear()
+    try:
+        later = await rt.send(session_key, "after-terminal")
+        generic = rt._tasks[later.task_id].envelope
+        assert generic.source_kind is SourceKind.SYSTEM
+        assert generic.source_name == "task_runtime"
+        assert generic.account_id is None
+        assert generic.channel_type is None
+        assert generic.channel_name is None
+        assert generic.channel_id is None
+        assert generic.thread_id is None
+        assert generic.reply_target is None
+        assert generic.input_provenance == {"kind": "runtime_send"}
+    finally:
+        remaining_release.set()
+        await rt.shutdown(cancel=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- retain the latest `RouteEnvelope` while a session still has pending or running work
- keep the pending/running predicate and cache eviction under the same `_state_lock`
- preserve channel routing for queued follow-ups, but evict the cache after the final task
- extend the regression test to verify that a later `send()` builds a generic `SYSTEM` envelope with no stale account, channel, recipient, thread, or reply target
- verify that an explicit provenance override remains one-shot and does not replace the original provenance for subsequent sends

Fixes #930

## Testing

- [GitHub CI](https://github.com/use-agent-os/agent-os/actions/runs/33655634516) — passed on Ubuntu and Windows (Python 3.12), commit `8b985bb`.
- `uv run pytest tests/test_gateway/test_task_runtime_terminal_cleanup.py -q` — 6 passed
- Control UI production build — passed
- `npm --prefix frontend run check` — 2,010 passed
- `uv run ruff check src tests` — passed
- `uv run mypy src/agentos --show-error-codes` — passed
- `uv run pytest -q` — 9,035 passed, 32 skipped; 8 failures and 3 setup errors reproduced on a clean `main` checkout at `4ca6e60`: unhydrated Git LFS ONNX assets, uv 0.8.15 lacking `uv build --clear`, and two native macOS Seatbelt tests exceeding their 100 ms subprocess deadline. No test exclusions or unrelated code changes were applied.
- `uv build --wheel` — passed

## Third-party origins

None.
