### PR TITLE
fix(cli): validate config set env-hint and create skills.config.* keys

### DIFF
--- a/src/agentos/cli/config_cmd.py
+++ b/src/agentos/cli/config_cmd.py
@@ -83,6 +83,24 @@ def config_set(
         console.print("[yellow]Restart the gateway to apply this setting.[/yellow]")
         return
 
+    # Issue #834: the no-``--config`` branch previously string-mangled any
+    # key into an env var name and printed it as if it were actionable,
+    # even for keys (like ``skills.config.*``) that do not bind to a
+    # ``GatewayConfig`` pydantic-settings field. Validate the key against
+    # the live model first so a typo or free-form-map key fails loudly
+    # rather than producing a misleading ``export`` line that would not
+    # actually take effect.
+    from agentos.gateway.config import GatewayConfig
+
+    try:
+        GatewayConfig.model_validate(_probe_key_value(key))
+    except _UnknownConfigKeyError:
+        console.print(f"[red]Key not found: {escape(key)}[/red]")
+        raise typer.Exit(1) from None
+    except Exception as exc:  # noqa: BLE001 - same rationale as the --config branch.
+        console.print(f"[red]Invalid value for {escape(key)}:[/red] {escape(str(exc))}")
+        raise typer.Exit(2) from exc
+
     env_key = "AGENTOS_GATEWAY_" + key.upper().replace(".", "__")
     console.print("[dim]To persist this setting, export:[/dim]")
     console.print(f"  [bold]export {env_key}={value}[/bold]")
@@ -96,8 +114,31 @@ def _parse_config_value(value: str) -> Any:
 
 
 def _set_key(data: dict[str, Any], key: str, value: Any) -> bool:
-    cursor: Any = data
+    # Issue #834: ``_set_key`` previously refused to create any new keys,
+    # which made the documented ``agentos config set
+    # skills.config.wiki.path /srv/wiki`` fail with ``Key not found``
+    # because ``to_toml_dict()`` omits the empty ``skills.config`` map.
+    # The free-form ``SkillsConfig.config`` (``dict[str, Any]``) is the
+    # one place we relax creation: any key under ``skills.config.*`` may
+    # materialize missing intermediate dicts, and the final key may be
+    # brand new. Every other top-level branch keeps the typo guard — a
+    # misspelled ``skillz.max_skills_prompt_chars`` must still fail so we
+    # do not silently persist nonsense into a near-collision path.
     parts = key.split(".")
+    if len(parts) >= 2 and parts[0] == "skills" and parts[1] == "config":
+        cursor: Any = data
+        for part in parts[:-1]:
+            if not isinstance(cursor, dict):
+                return False
+            if part not in cursor or cursor[part] in (None, {}):
+                cursor[part] = {}
+            cursor = cursor[part]
+        if not isinstance(cursor, dict):
+            return False
+        cursor[parts[-1]] = value
+        return True
+
+    cursor = data
     for part in parts[:-1]:
         if not isinstance(cursor, dict) or part not in cursor:
             return False
@@ -106,6 +147,72 @@ def _set_key(data: dict[str, Any], key: str, value: Any) -> bool:
         return False
     cursor[parts[-1]] = value
     return True
+
+
+class _UnknownConfigKeyError(KeyError):
+    """Raised when a key does not bind to a ``GatewayConfig`` field or to
+    the ``skills.config`` free-form map. Used by the no-``--config`` env
+    hint branch in ``config_set`` to fail loudly rather than print an
+    invented ``export`` line (issue #834)."""
+
+
+def _probe_key_value(key: str) -> Any:
+    """Build a dict payload that ``GatewayConfig.model_validate`` will
+    accept for the given key path, so the no-``--config`` env-hint branch
+    can probe without printing an invented ``export`` line.
+
+    For known model fields the probe reconstructs a nested ``{top:
+    {middle: ..., leaf: default}}`` dict by walking the actual model so
+    the validator never sees an ``extra=forbid`` violation on a sibling
+    field. For ``skills.config.*`` the free-form map accepts any value,
+    so a single empty-string sentinel is enough."""
+    parts = key.split(".")
+    from agentos.gateway.config import GatewayConfig  # local import: keep --config path light
+
+    if len(parts) >= 2 and parts[0] == "skills" and parts[1] == "config":
+        # Build a nested dict from the path so deep keys like
+        # ``skills.config.wiki.path`` round-trip through
+        # ``GatewayConfig.model_validate`` with each intermediate dict
+        # materialized.
+        sub: dict[str, Any] = {}
+        cursor: Any = sub
+        for i, part in enumerate(parts[2:]):
+            if i == len(parts) - 3:
+                cursor[part] = ""
+            else:
+                cursor[part] = {}
+                cursor = cursor[part]
+        return {"skills": {"config": sub}}
+
+    cfg = GatewayConfig()
+    # Walk the key path against the model. Build a nested dict of
+    # defaults so ``model_validate`` round-trips cleanly under
+    # ``extra=forbid``. If any segment is not a model attribute, the key
+    # does not bind to a ``GatewayConfig`` field.
+    payload: dict[str, Any] = {}
+    cursor_cfg: Any = cfg
+    cursor_payload: Any = payload
+    for i, part in enumerate(parts):
+        is_last = i == len(parts) - 1
+        if not hasattr(cursor_cfg, part):
+            raise _UnknownConfigKeyError(key)
+        value = getattr(cursor_cfg, part)
+        if is_last:
+            cursor_payload[part] = value
+        else:
+            # Intermediate segment must be a pydantic model or a dict;
+            # flatten its own subfields so the validator does not see an
+            # ``extra_forbidden`` violation when the caller only asked
+            # for a deep subkey.
+            if hasattr(value, "model_dump"):
+                cursor_payload[part] = value.model_dump()
+            elif isinstance(value, dict):
+                cursor_payload[part] = dict(value)
+            else:
+                raise _UnknownConfigKeyError(key)
+            cursor_payload = cursor_payload[part]
+            cursor_cfg = value
+    return payload
 
 
 def _add_flat(table: Table, data: dict, prefix: str = "") -> None:

--- a/tests/test_cli/test_config_cmd.py
+++ b/tests/test_cli/test_config_cmd.py
@@ -1,0 +1,232 @@
+"""Regression tests for ``agentos config set`` (issue #834).
+
+Three things to lock down, per Andre's acceptance criteria:
+
+1. ``_set_key`` may create new keys **only** under ``skills.config.*``.
+   The free-form ``SkillsConfig.config`` map is the documented escape
+   hatch for skill-declared settings, and the docs example
+   ``agentos config set skills.config.wiki.path /srv/wiki`` is the
+   proof case. Every other branch keeps the typo guard so a misspelled
+   ``skillz.max_skills_prompt_chars`` does not silently persist.
+2. The no-``--config`` env-hint branch must validate the key against
+   ``GatewayConfig`` before printing the ``export`` line. A previous
+   version of the code string-mangled any key into an env var name and
+   printed it as if it were actionable, even for keys (like
+   ``skills.config.*``) that do not bind to a pydantic-settings field
+   — silent success with nothing persisted.
+3. Round-trip coverage: an existing model key still works, a new
+   ``skills.config.*`` key works, and a typo outside ``skills.config``
+   still fails. Without these the next refactor will silently regress
+   one of the three paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli.config_cmd import _probe_key_value, _set_key, _UnknownConfigKeyError
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# _set_key — direct unit tests (Andre: "Add tests for _set_key")
+# ---------------------------------------------------------------------------
+
+
+def test_set_key_creates_new_skills_config_subkey() -> None:
+    """Documented command ``agentos config set skills.config.wiki.path /srv/wiki``
+    must persist. Pre-fix this returned False because ``to_toml_dict()``
+    omitted the empty ``skills.config`` map."""
+    data: dict[str, Any] = {"skills": {"max_skills_prompt_chars": 4000}}
+    assert _set_key(data, "skills.config.wiki.path", "/srv/wiki") is True
+    assert data == {
+        "skills": {
+            "max_skills_prompt_chars": 4000,
+            "config": {"wiki": {"path": "/srv/wiki"}},
+        }
+    }
+
+
+def test_set_key_creates_brand_new_top_level_skill_config() -> None:
+    """Even when ``skills`` is absent from the loaded dict, the free-form
+    map can be created from scratch (so the cold-start ``agentos config
+    set skills.config.<skill>.<key>`` works without a pre-existing
+    section)."""
+    data: dict[str, Any] = {}
+    assert _set_key(data, "skills.config.notes.dir", "/var/notes") is True
+    assert data == {"skills": {"config": {"notes": {"dir": "/var/notes"}}}}
+
+
+def test_set_key_overwrites_existing_skills_config_leaf() -> None:
+    """A repeat ``set`` against an existing leaf must overwrite in place
+    rather than fail the typo guard."""
+    data: dict[str, Any] = {"skills": {"config": {"wiki": {"path": "/old"}}}}
+    assert _set_key(data, "skills.config.wiki.path", "/new") is True
+    assert data["skills"]["config"]["wiki"]["path"] == "/new"
+
+
+def test_set_key_still_rejects_typo_outside_skills_config() -> None:
+    """Andre: "preserve the typo guard everywhere else". A misspelled
+    ``skillz.max_skills_prompt_chars`` must still fail rather than
+    silently land in a near-collision path."""
+    data: dict[str, Any] = {"skills": {"max_skills_prompt_chars": 4000}}
+    assert _set_key(data, "skillz.max_skills_prompt_chars", 8000) is False
+    assert data == {"skills": {"max_skills_prompt_chars": 4000}}
+
+
+def test_set_key_still_overwrites_existing_model_field() -> None:
+    """The happy path for an existing model field must not regress."""
+    data: dict[str, Any] = {"skills": {"max_skills_prompt_chars": 4000}}
+    assert _set_key(data, "skills.max_skills_prompt_chars", 8000) is True
+    assert data == {"skills": {"max_skills_prompt_chars": 8000}}
+
+
+def test_set_key_rejects_unknown_top_level_key() -> None:
+    """A typo on a top-level key (e.g. ``agentos.config.set
+    sklls.config.x /y``) must still fail rather than create a new
+    top-level map."""
+    data: dict[str, Any] = {"skills": {"max_skills_prompt_chars": 4000}}
+    assert _set_key(data, "sklls.config.x", "/y") is False
+
+
+def test_set_key_rejects_brand_new_outside_skills_config() -> None:
+    """Outside ``skills.config.*``, new intermediate dicts are not
+    created. The pre-existing typo guard is preserved."""
+    data: dict[str, Any] = {"gateway": {"host": "127.0.0.1"}}
+    assert _set_key(data, "gateway.runtime.new_field", True) is False
+
+
+# ---------------------------------------------------------------------------
+# _probe_key_value — used by the no-``--config`` env-hint branch
+# ---------------------------------------------------------------------------
+
+
+def test_probe_known_model_field_round_trips() -> None:
+    """Probing an existing model field produces a value ``GatewayConfig``
+    can validate, so the env-hint branch accepts it."""
+    from agentos.gateway.config import GatewayConfig
+
+    payload = _probe_key_value("skills.max_skills_prompt_chars")
+    cfg = GatewayConfig.model_validate(payload)
+    assert cfg.skills.max_skills_prompt_chars >= 0
+
+
+def test_probe_skills_config_subkey_accepted() -> None:
+    """Probing ``skills.config.wiki.path`` must not raise — the env-hint
+    branch must accept documented free-form-map keys."""
+    from agentos.gateway.config import GatewayConfig
+
+    payload = _probe_key_value("skills.config.wiki.path")
+    cfg = GatewayConfig.model_validate(payload)
+    assert cfg.skills.config["wiki"]["path"] == ""
+
+
+def test_probe_unknown_top_level_key_raises() -> None:
+    """A typo on the top-level key must raise ``_UnknownConfigKeyError``
+    so the env-hint branch fails loudly rather than printing an
+    invented env var name."""
+    with pytest.raises(_UnknownConfigKeyError):
+        _probe_key_value("sklls.config.x")
+
+
+def test_probe_unknown_subkey_raises() -> None:
+    """A typo on a sub-key (not under ``skills.config``) must also
+    raise so the env-hint branch fails loudly."""
+    with pytest.raises(_UnknownConfigKeyError):
+        _probe_key_value("skillz.max_skills_prompt_chars")
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — the full ``agentos config set`` command
+# ---------------------------------------------------------------------------
+
+
+def test_config_set_skills_config_subkey_persists_to_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: the documented command must persist and survive a
+    round-trip load."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text("")
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+
+    result = runner.invoke(
+        app,
+        ["config", "set", "skills.config.wiki.path", "/srv/wiki", "--config", str(config_path)],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    from agentos.gateway.config import GatewayConfig
+
+    cfg = GatewayConfig.model_validate(__import__("tomllib").loads(config_path.read_text()))
+    assert cfg.skills.config["wiki"]["path"] == "/srv/wiki"
+
+
+def test_config_set_rejects_typo_outside_skills_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ``--config`` persist path must still fail loudly on a typo
+    outside ``skills.config`` so the user gets a signal rather than a
+    silent near-collision write."""
+    config_path = tmp_path / "agentos.toml"
+    config_path.write_text("")
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+
+    result = runner.invoke(
+        app,
+        ["config", "set", "skillz.max_skills_prompt_chars", "8000", "--config", str(config_path)],
+    )
+    assert result.exit_code == 1, result.stdout
+    assert "key not found" in result.stdout.lower()
+
+
+def test_config_set_without_config_validates_known_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The no-``--config`` env-hint branch must accept an existing
+    model field and print the export line."""
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+
+    result = runner.invoke(
+        app, ["config", "set", "skills.max_skills_prompt_chars", "8000"]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "AGENTOS_GATEWAY_SKILLS__MAX_SKILLS_PROMPT_CHARS" in result.stdout
+
+
+def test_config_set_without_config_accepts_skills_config_subkey(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The no-``--config`` env-hint branch must accept documented
+    ``skills.config.*`` keys (the probe rounds them through
+    ``GatewayConfig.model_validate``)."""
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+
+    result = runner.invoke(
+        app, ["config", "set", "skills.config.wiki.path", "/srv/wiki"]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "AGENTOS_GATEWAY_SKILLS__CONFIG__WIKI__PATH" in result.stdout
+
+
+def test_config_set_without_config_rejects_typo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The no-``--config`` env-hint branch must fail loudly on a typo
+    rather than print a misleading ``export`` line."""
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+
+    result = runner.invoke(
+        app, ["config", "set", "sklls.config.x", "/y"]
+    )
+    assert result.exit_code == 1, result.stdout
+    assert "key not found" in result.stdout.lower()
+    # The export line must NOT be printed when the key is invalid —
+    # that was the original bug (silent success with no actual binding).
+    assert "export AGENTOS_GATEWAY" not in result.stdout


### PR DESCRIPTION
Issue #834. The free-form SkillsConfig.config map documented at `docs/configuration.md` is the one place where keys belong to skills rather than AgentOS, and the documented command `agentos config set skills.config.wiki.path /srv/wiki` is the proof case. It failed with `Key not found` because `_set_key` only overwrote existing keys, and `to_toml_dict()` omits the empty `skills.config` map.

The pre-existing PR #839 (under review) covered the persist path. This commit addresses the two remaining acceptance items Andre called out in the issue comment.

`_set_key` (`src/agentos/cli/config_cmd.py`): now creates missing intermediate dicts **only** for keys under `skills.config.*`. Every other branch keeps the typo guard so a misspelled
`skillz.max_skills_prompt_chars` does not silently land in a near-collision path. The free-form `SkillsConfig.config` field is `dict[str, Any]` by design — the keys belong to the skills, not to AgentOS — so a runtime validation pass is not possible here.

No-``--config`` env-hint branch: previously string-mangled any key into an env var name and printed it as if it were actionable, even for keys (like `skills.config.*`) that do not bind to a pydantic-settings field. Now probes the key against `GatewayConfig` via a new `_probe_key_value` helper that walks the model, builds a nested default dict for known model fields, and materializes a nested dict for `skills.config.*` paths. A typo raises `_UnknownConfigKeyError` and the CLI exits 1 with a `Key not found` line — the export line is no longer printed when the key is invalid, which was the original bug (silent success with nothing persisted).

Tests in `tests/test_cli/test_config_cmd.py` (new file — no `_set_key` tests existed before):
- `_set_key` creates a new `skills.config.wiki.path` even when `skills` is absent from the loaded dict (cold-start case).
- `_set_key` still rejects `skillz.max_skills_prompt_chars` and other typos outside `skills.config` (typo guard preserved).
- `_set_key` overwrites an existing `skills.config` leaf and an existing model field (happy paths).
- `_probe_key_value` accepts an existing model field, accepts `skills.config.*` (including deep paths), and raises `_UnknownConfigKeyError` on typos.
- CLI integration: `--config` persist path persists a new `skills.config.wiki.path` and round-trips through `GatewayConfig.model_validate`; the same path with a typo exits 1.
- No-``--config`` env-hint: accepts a model field, accepts `skills.config.wiki.path`, and rejects a typo with exit 1 (the misleading `export` line is no longer printed).

Fixes #834

## Linked issue

Fixes #

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [ ] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

What does this change and why?

## Tests

How was this verified? Include the commands you ran and their results.
