### PR TITLE
fix(tools): record UpdateFile writes for auto-publish and accept opti…

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -123,18 +123,22 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
 
 
 def _parse_hunk_header(header: str) -> Hunk:
-    """Parse '@@@ -old_start,old_count +new_start,new_count @@@'."""
-    # Format: @@@ -10,3 +10,4 @@@
+    """Parse '@@@ -old_start[,old_count] +new_start[,new_count] @@@'."""
+    # Format: @@@ -10,3 +10,4 @@@ or @@@ -10 +10,4 @@@
     import re
 
-    m = re.match(r"@@@\s+-(\d+),(\d+)\s+\+(\d+),(\d+)\s+@@@", header.strip())
+    m = re.fullmatch(r"@@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@@", header.strip())
     if not m:
         raise ValueError(f"Invalid hunk header: {header!r}")
+    old_start = int(m.group(1))
+    old_count = int(m.group(2)) if m.group(2) is not None else (0 if old_start == 0 else 1)
+    new_start = int(m.group(3))
+    new_count = int(m.group(4)) if m.group(4) is not None else (0 if new_start == 0 else 1)
     return Hunk(
-        old_start=int(m.group(1)),
-        old_count=int(m.group(2)),
-        new_start=int(m.group(3)),
-        new_count=int(m.group(4)),
+        old_start=old_start,
+        old_count=old_count,
+        new_start=new_start,
+        new_count=new_count,
     )
 
 
@@ -217,7 +221,7 @@ def _notify_bootstrap_source_writes(ops: list[PatchOp], root: Path) -> None:
 
 def _record_workspace_file_writes(ops: list[PatchOp], root: Path) -> None:
     for op in ops:
-        if isinstance(op, AddFile):
+        if isinstance(op, (AddFile, UpdateFile)):
             record_workspace_file_write(_validate_path(op.path, root))
 
 

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -495,3 +495,109 @@ async def test_apply_patch_add_file_refuses_existing_file(tmp_path: Path) -> Non
     finally:
         current_tool_context.reset(token)
     assert target.read_text(encoding="utf-8") == "old\n"
+
+
+# ---------------------------------------------------------------------------
+# Issue #753: UpdateFile in workspace_file_writes & optional hunk header counts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_records_workspace_file_writes_for_add_and_update(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "existing.csv"
+    existing.write_text("a,b\n1,2\n", encoding="utf-8")
+    ctx = ToolContext(workspace_dir=str(tmp_path))
+    token = current_tool_context.set(ctx)
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Add File: created.json
++{"hello": "world"}
+*** Update File: existing.csv
+@@@ -1,2 +1,3 @@@
+ a,b
+ 1,2
++3,4
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) added, 1 file(s) modified" in result
+    written_relative_paths = [w["relative_path"] for w in ctx.workspace_file_writes]
+    assert "created.json" in written_relative_paths
+    assert "existing.csv" in written_relative_paths
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_supports_hunk_header_without_explicit_counts(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "hello.txt"
+    existing.write_text("line1\n", encoding="utf-8")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: hello.txt
+@@@ -1 +1,2 @@@
+ line1
++line2
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert existing.read_text(encoding="utf-8") == "line1\nline2\n"
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        ("@@@ -10,3 +10,4 @@@", (10, 3, 10, 4)),
+        ("@@@ -1 +1,2 @@@", (1, 1, 1, 2)),
+        ("@@@ -1,2 +1 @@@", (1, 2, 1, 1)),
+        ("@@@ -5 +5 @@@", (5, 1, 5, 1)),
+        ("@@@ -0 +1 @@@", (0, 0, 1, 1)),
+        ("@@@ -1 +0 @@@", (1, 1, 0, 0)),
+    ],
+)
+def test_parse_hunk_header_accepts_valid_headers(
+    header: str, expected: tuple[int, int, int, int]
+) -> None:
+    from agentos.tools.builtin.patch import _parse_hunk_header
+
+    hunk = _parse_hunk_header(header)
+    assert (hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count) == expected
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "@@@",
+        "@@@ @@@",
+        "@@@ -abc +def @@@",
+        "@@@ - +1 @@@",
+        "@@@ -1 + @@@",
+        "@@@ -1,2 @@@",
+        "@@@ +1,2 @@@",
+        "@@@ -1 +1",
+        "-1 +1 @@@",
+        "@@@ -1, +1,2 @@@",
+        "@@@ -1,2 +1, @@@",
+        "@@@ -1 +1 @@@ trailing garbage",
+        "@@@ -10,3 +10,4 @@@ extra text",
+        "",
+        "not a header at all",
+    ],
+)
+def test_parse_hunk_header_rejects_malformed_input(header: str) -> None:
+    from agentos.tools.builtin.patch import _parse_hunk_header
+
+    with pytest.raises(ValueError, match="Invalid hunk header"):
+        _parse_hunk_header(header)


### PR DESCRIPTION
## Description
Resolves both defects accepted in #753:

1. **`UpdateFile` write tracking**: Added `UpdateFile` to `_record_workspace_file_writes()` in `src/agentos/tools/builtin/patch.py` so files modified via `apply_patch` are recorded in `ctx.workspace_file_writes` and auto-published.
2. **Optional count specifiers in hunk headers**: Enhanced `_parse_hunk_header()` to support omitted counts (defaulting to 1, or 0 if start is 0).
3. **Strict matching**: Per maintainer guidance, used `re.fullmatch` rather than unanchored `re.match` to ensure headers with trailing garbage (e.g. `@@@ -1 +1 @@@ extra`) are strictly rejected with `ValueError`.
4. **Regression tests**: Added tests covering both write recording, omitted count parsing, and parameterized malformed/trailing-garbage rejection.

Closes #753 
