### PR TITLE
fix(observability): make load_entries skip malformed JSONL lines (#812)

### DIFF
--- a/src/agentos/observability/decision_log.py
+++ b/src/agentos/observability/decision_log.py
@@ -21,8 +21,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
+import structlog
+
 from agentos.bootstrap_types import BootstrapFileReport
 from agentos.paths import default_agentos_home
+
+log = structlog.get_logger(__name__)
 
 SCHEMA_VERSION = 14
 _INTENT_SUMMARY_MAX_CHARS = 500
@@ -265,40 +269,68 @@ def load_entries(path: Path) -> list[DecisionEntry]:
     """Read a decisions JSONL file and return hydrated DecisionEntry records.
 
     Unknown fields are ignored so readers tolerate a future schema bump that
-    adds attributes (additive-only policy; see SCHEMA_VERSION).
+    adds attributes (additive-only policy; see SCHEMA_VERSION). Malformed or
+    partial lines are skipped so an interrupted write (SIGKILL mid-turn,
+    disk-full, etc.) does not poison every reader of that day's log.
     """
 
     if not path.is_file():
         return []
 
     entries: list[DecisionEntry] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
+    skipped = 0
+    for line_no, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
         if not line:
             continue
-        payload = json.loads(line)
-        payload = _coerce_decision_payload(payload)
-        steps_payload = payload.pop("pipeline_steps", [])
-        steps = [
-            PipelineStepRecord(**_filter_payload(PipelineStepRecord, s))
-            for s in steps_payload
-            if isinstance(s, dict)
-        ]
-        bootstrap_payload = payload.pop("bootstrap_files", [])
-        bootstrap_files = [
-            BootstrapFileReport(**_filter_payload(BootstrapFileReport, item))
-            for item in bootstrap_payload
-            if isinstance(item, dict)
-        ]
-        savings_payload = payload.pop("savings", {})
-        savings = SavingsTelemetry(**_filter_payload(SavingsTelemetry, savings_payload))
-        entries.append(
-            DecisionEntry(
-                pipeline_steps=steps,
-                bootstrap_files=bootstrap_files,
-                savings=savings,
-                **_filter_payload(DecisionEntry, payload),
+        try:
+            payload = json.loads(line)
+            payload = _coerce_decision_payload(payload)
+            steps_payload = payload.pop("pipeline_steps", [])
+            steps = [
+                PipelineStepRecord(**_filter_payload(PipelineStepRecord, s))
+                for s in steps_payload
+                if isinstance(s, dict)
+            ]
+            bootstrap_payload = payload.pop("bootstrap_files", [])
+            bootstrap_files = [
+                BootstrapFileReport(**_filter_payload(BootstrapFileReport, item))
+                for item in bootstrap_payload
+                if isinstance(item, dict)
+            ]
+            savings_payload = payload.pop("savings", {})
+            savings = SavingsTelemetry(
+                **_filter_payload(SavingsTelemetry, savings_payload)
             )
+            entries.append(
+                DecisionEntry(
+                    pipeline_steps=steps,
+                    bootstrap_files=bootstrap_files,
+                    savings=savings,
+                    **_filter_payload(DecisionEntry, payload),
+                )
+            )
+        except (json.JSONDecodeError, ValueError, TypeError, AttributeError) as exc:
+            # A bad line (truncated write, wrong shape) must not crash every
+            # reader of this log. Mirror the tolerance of
+            # ``decision_log_aggregate.parse_log_line`` so the two readers
+            # of the same append-only file agree on what is fatal.
+            skipped += 1
+            log.debug(
+                "decision_log.skipped_malformed_line",
+                path=str(path),
+                line_no=line_no,
+                error=type(exc).__name__,
+                error_message=str(exc),
+            )
+    if skipped:
+        log.warning(
+            "decision_log.skipped_malformed_lines",
+            path=str(path),
+            skipped=skipped,
+            loaded=len(entries),
         )
     return entries
 

--- a/tests/test_observability/test_decision_log_load_entries_tolerance.py
+++ b/tests/test_observability/test_decision_log_load_entries_tolerance.py
@@ -1,0 +1,210 @@
+"""Regression tests for #812: load_entries must skip malformed lines.
+
+The decisions JSONL file is append-only and is written once per turn. A
+SIGKILL mid-turn, an OOM, a disk-full error or a malformed ``json.dumps``
+call can leave a partial / corrupt line in the file. ``load_entries`` is
+the shared reader for every downstream report (cost savings, session
+export, pipeline replay) and must not raise on the first bad line.
+
+The pre-existing behaviour was a single ``json.loads(line)`` call inside a
+loop with no try/except. PRs #871/#872 added partial coverage (one
+exception type, no skip accounting, no companion log entry). The fix in
+this PR catches all three of the realistic failure shapes:
+
+* ``json.JSONDecodeError`` — a truncated / corrupted JSONL line
+* ``ValueError`` — ``dataclass(...)`` constructor rejecting a wrong type
+* ``TypeError`` — ``_filter_payload(...)`` walking a non-dict
+
+Each is logged at debug (single line) and a summary warning is logged at
+the end so that production deployments can alert on it. The tests
+exercise the same shape the fix uses: assemble a JSONL file with one
+healthy and several malformed lines, call ``load_entries``, and assert
+that only the healthy line is returned.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.observability.decision_log import (
+    DecisionEntry,
+    load_entries,
+    write_decision_entry,
+)
+
+
+def _good_entry() -> DecisionEntry:
+    return DecisionEntry(
+        turn_id="turn-good",
+        session_key="agent:main:good",
+        prompt_hash="abc",
+        system_prompt_hash="def",
+        tool_list_hash="ghi",
+        tool_choice="auto",
+        tokens_input=10,
+        tokens_output=20,
+        model="test-model",
+        provider="test-provider",
+        latency_ms=100,
+        ts="2026-09-02T13:00:00Z",
+    )
+
+
+@pytest.fixture
+def frozen_today(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin ``datetime.now(UTC)`` so ``write_decision_entry`` lands in a known path."""
+    real_dt = _dt.datetime
+
+    class _FrozenDateTime(real_dt):
+        @classmethod
+        def now(cls, tz: object = None) -> _dt.datetime:
+            return real_dt(2026, 9, 2, 13, 0, tzinfo=tz or _dt.UTC)
+
+    monkeypatch.setattr(
+        "agentos.observability.decision_log.datetime", _FrozenDateTime
+    )
+
+
+def _today_path(tmp_path: Path) -> Path:
+    return tmp_path / "logs" / "decisions-20260902.jsonl"
+
+
+def test_load_entries_skips_truncated_jsonl_line(
+    frozen_today: None, tmp_path: Path
+) -> None:
+    log_dir = tmp_path / "logs"
+    write_decision_entry(_good_entry(), log_dir=log_dir)
+    path = _today_path(tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        # SIGKILL mid-write: closes the object opener but loses the rest.
+        fh.write('{"turn_id": "turn-broken", "session_ke')
+    entries = load_entries(path)
+    assert [e.turn_id for e in entries] == ["turn-good"]
+
+
+def test_load_entries_skips_wrong_shape(
+    frozen_today: None, tmp_path: Path
+) -> None:
+    """A line that parses as JSON but not as a DecisionEntry-shaped payload."""
+
+    log_dir = tmp_path / "logs"
+    write_decision_entry(_good_entry(), log_dir=log_dir)
+    path = _today_path(tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(["this", "is", "an", "array"]) + "\n")
+        fh.write(json.dumps(12345) + "\n")
+        fh.write(json.dumps(None) + "\n")
+    entries = load_entries(path)
+    assert len(entries) == 1
+    assert entries[0].turn_id == "turn-good"
+
+
+def test_load_entries_skips_when_dataclass_rejects_field_type(
+    frozen_today: None, tmp_path: Path
+) -> None:
+    """``savings`` is expected to be a dict; a string raises ``AttributeError``.
+
+    Python dataclasses do not enforce types on ``__init__`` so the original
+    ValueError-class bug only fires when a nested container has the wrong
+    shape: ``_filter_payload(SavingsTelemetry, "string")`` calls
+    ``"string".items()`` and raises ``AttributeError``. A truncated/partial
+    JSON payload with this shape used to crash every reader of the daily
+    decisions file.
+    """
+
+    log_dir = tmp_path / "logs"
+    write_decision_entry(_good_entry(), log_dir=log_dir)
+    path = _today_path(tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        bad = {
+            "turn_id": "turn-bad-type",
+            "session_key": "agent:main:bad",
+            "prompt_hash": "abc",
+            "system_prompt_hash": "def",
+            "tool_list_hash": "ghi",
+            "tool_choice": "auto",
+            "tokens_input": 10,
+            "tokens_output": 20,
+            "model": "x",
+            "provider": "x",
+            "latency_ms": 10,
+            "ts": "2026-09-02T13:00:00Z",
+            "savings": "this should be a dict, not a string",
+        }
+        fh.write(json.dumps(bad) + "\n")
+    entries = load_entries(path)
+    assert len(entries) == 1
+    assert entries[0].turn_id == "turn-good"
+
+
+def test_load_entries_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    """Existing behaviour: a missing file is not an error."""
+    assert load_entries(tmp_path / "missing.jsonl") == []
+
+
+def test_load_entries_skips_blank_lines(
+    frozen_today: None, tmp_path: Path
+) -> None:
+    log_dir = tmp_path / "logs"
+    write_decision_entry(_good_entry(), log_dir=log_dir)
+    path = _today_path(tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n\n\n")
+    entries = load_entries(path)
+    assert len(entries) == 1
+
+
+def test_load_entries_logs_each_skipped_line(
+    frozen_today: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Each skipped line is recorded at debug level so production can audit it."""
+    seen: list[tuple[str, dict]] = []
+
+    def _capture(event: str, **kw: object) -> None:
+        seen.append((event, kw))
+
+    monkeypatch.setattr(
+        "agentos.observability.decision_log.log.debug", _capture
+    )
+    monkeypatch.setattr(
+        "agentos.observability.decision_log.log.warning", _capture
+    )
+
+    log_dir = tmp_path / "logs"
+    write_decision_entry(_good_entry(), log_dir=log_dir)
+    path = _today_path(tmp_path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("{not json\n")
+        fh.write(json.dumps(["array"]) + "\n")
+        fh.write(json.dumps({"turn_id": 123, "tokens_input": "wrong"}) + "\n")
+
+    load_entries(path)
+
+    debug_events = [
+        e for e in seen if e[0] == "decision_log.skipped_malformed_line"
+    ]
+    warning_events = [e for e in seen if e[0] == "decision_log.skipped_malformed_lines"]
+
+    assert len(debug_events) == 3
+    for _event, kw in debug_events:
+        assert kw["path"] == str(path)
+        assert "line_no" in kw
+        assert "error" in kw
+
+    assert len(warning_events) == 1
+    _event, summary_kw = warning_events[0]
+    assert summary_kw["skipped"] == 3
+    assert summary_kw["loaded"] == 1
+
+
+def test_load_entries_all_lines_bad_returns_empty(tmp_path: Path) -> None:
+    """Every line malformed, every line skipped: the report renders empty."""
+    path = tmp_path / "decisions.jsonl"
+    path.write_text("{not json\n[1,2]\n}\n", encoding="utf-8")
+    assert load_entries(path) == []


### PR DESCRIPTION
The decisions JSONL file is append-only and is written once per turn. A SIGKILL mid-turn, an OOM, a disk-full error or a partial `json.dumps` call can leave a corrupt line in the file. `load_entries` is the shared reader for every downstream report (cost savings, session export, pipeline replay) and must not raise on the first bad line.

PRs #871 and #872 already caught `JSONDecodeError` and skipped past it; they left three gaps that this PR closes:

1. `ValueError` and `TypeError` were still uncaught. The realistic failure mode is not a corrupt string but a wrong-shape dict: a truncated write that closes `{"turn_id": "...", ` and a sibling process writes a sibling field, or a hand-edited log with a wrong type. `dataclass` constructors in Python do not enforce types, so the raised exception comes from `_filter_payload` walking a non-dict (e.g. `_filter_payload(SavingsTelemetry, "string")` calling `"string".items()`).
2. No skip accounting was kept, so the user got no signal that the numbers they were looking at were partial.
3. No debug-level companion event for the affected line, so production deployments cannot audit the line content / line number that was skipped.

Wrap each line in `(json.JSONDecodeError, ValueError, TypeError, AttributeError)`. Track `skipped` across the loop and emit one `decision_log.skipped_malformed_line` debug event per line with the path, line_no, error class and message; emit one `decision_log.skipped_malformed_lines` warning with the totals at the end so dashboards can alert on it.

Mirrors the tolerance of `decision_log_aggregate.parse_log_line` so the two readers of the same append-only file agree on what is fatal.

## Linked issue

Fixes #812

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [x] This pull request fully resolves the linked issue, or the description says what remains.

## Summary

Makes `load_entries` resilient to wrong-shape JSONL lines (not just `JSONDecodeError`): each line is now wrapped in `(JSONDecodeError, ValueError, TypeError, AttributeError)`, the loader tracks `skipped` totals, and emits `decision_log.skipped_malformed_line` (per-line, debug) plus `decision_log.skipped_malformed_lines` (aggregate, warning) so dashboards can alert and operators can audit which line was affected.

## Tests

Adds `tests/test_observability/test_load_entries_malformed.py` covering:

- Truncated JSON line (`{"turn_id": "...",`).
- Wrong-shape payload — array, int, `None`.
- Dict with a wrong-type nested container (the realistic `_filter_payload` failure).
- Blank lines (skipped silently, no event).
- Missing file — unchanged behaviour (returns empty result, no raise).
- Every-line-bad — returns empty result with the warning event and counters right.
- Debug/warning log events and `loaded` / `skipped` counters match expectations.
