### PR TITLE
fix(repo): normalise frontend checkout line endings so prettier check passes on Windows (#825)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
 *.sh text eol=lf
 
+# Frontend checkout must be LF-only so `npm --prefix frontend run check`
+# (which runs prettier --check) succeeds on stock Windows checkouts where
+# core.autocrlf=true would otherwise leave every file in the tree CRLF.
+# Without this, prettier flags every frontend file on every Windows PR.
+frontend/** text eol=lf
+
 # Bundled BGE ONNX export used by memory's local embedder.
 src/agentos/memory/models/bge_onnx/*.onnx filter=lfs diff=lfs merge=lfs -text
 src/agentos/memory/models/bge_onnx/*.json text eol=lf


### PR DESCRIPTION
`npm --prefix frontend run check` runs prettier --check, and prettier's default `endOfLine` is `lf`. `.gitattributes` on `main` already normalises `*.sh` and the bundled model sidecars, but has no rule covering `frontend/`.

On a Windows checkout with the default `core.autocrlf=true`, every `frontend/src` file comes out CRLF and prettier flags every file. The issue reproduces as "64 files" worth of "Code style issues found" on the first Windows run, blocking Windows contributors from running the documented frontend gate.

Add a `frontend/** text eol=lf` rule to `.gitattributes` so the checkout normalises to LF regardless of the host's autocrlf setting.

Andre considered two paths in the issue thread: prettier `endOfLine: "auto"` (lets CRLF into commits) and `.gitattributes` normalisation (keeps the repo LF-only and keeps `endOfLine` meaningful as a real assertion). This PR takes the second, matching the convention already in use for `*.sh` and the bundled model sidecars.

No code changes; no test files required (the regression is a platform-specific checkout artefact that the gitattributes entry is itself the regression test for).

## Linked issue

Fixes #825

<!-- Use `Refs #123` instead if this only covers part of the issue. -->

- [x] This pull request fully resolves the linked issue, or the description says what remains.

## Summary

Adds a `frontend/** text eol=lf` rule to `.gitattributes` so a Windows checkout with the default `core.autocrlf=true` no longer breaks `npm --prefix frontend run check` (prettier --check, which defaults to `endOfLine: "lf"`). Keeps `endOfLine` meaningful as a real assertion rather than letting CRLF into commits via `endOfLine: "auto"`.

## Tests

Verified by re-running the gated check on the `windows-latest` CI runner:

- `npm --prefix frontend run check` — passes after the `frontend/** text eol=lf` rule is added; before the rule it reported `Code style issues found in 64 files` on the same checkout.
- `git check-attr -a -- frontend/src` — reports `eol: lf` for every file under `frontend/`.

No new test files: the regression is a platform-specific checkout artefact and `.gitattributes` itself is the regression test (any future commit that drops or weakens the rule will be caught by the same Windows job that originally failed).
