### PR TITLE
fix(provider): degrade BreakerSettings to defaults on non-numeric config instead of raising at boot

### DIFF
--- a/src/agentos/provider/circuit_breaker.py
+++ b/src/agentos/provider/circuit_breaker.py
@@ -36,6 +36,22 @@ class BreakerState(StrEnum):
     HALF_OPEN = "half_open"
 
 
+def _coerce_int(value: Any, default: int) -> int:
+    """Best-effort int conversion; falls back to ``default`` instead of raising."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    """Best-effort float conversion; falls back to ``default`` instead of raising."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 #: Failure kinds that mean *this provider is unhealthy right now*.
 #:
 #: Deliberately narrow. ``MODEL_NOT_FOUND`` / ``UNSUPPORTED_FEATURE`` /
@@ -74,9 +90,11 @@ class BreakerSettings:
     max_cooldown_seconds: float = DEFAULT_MAX_COOLDOWN_SECONDS
 
     def __post_init__(self) -> None:
-        threshold = max(1, int(self.failure_threshold))
-        cooldown = max(1.0, float(self.cooldown_seconds))
-        max_cooldown = max(cooldown, float(self.max_cooldown_seconds))
+        threshold = max(1, _coerce_int(self.failure_threshold, DEFAULT_FAILURE_THRESHOLD))
+        cooldown = max(1.0, _coerce_float(self.cooldown_seconds, DEFAULT_COOLDOWN_SECONDS))
+        max_cooldown = max(
+            cooldown, _coerce_float(self.max_cooldown_seconds, DEFAULT_MAX_COOLDOWN_SECONDS)
+        )
         object.__setattr__(self, "failure_threshold", threshold)
         object.__setattr__(self, "cooldown_seconds", cooldown)
         object.__setattr__(self, "max_cooldown_seconds", max_cooldown)
@@ -86,20 +104,19 @@ class BreakerSettings:
         """Build settings from a config object exposing the same field names.
 
         Missing attributes fall back to the defaults, so this accepts both the
-        real ``llm.circuit_breaker`` config model and ``None``.
+        real ``llm.circuit_breaker`` config model and ``None``. Values are
+        passed through unconverted -- ``__post_init__`` does the coercion, so
+        a non-numeric value degrades to the default there instead of raising
+        here before construction even completes.
         """
         if config is None:
             return cls()
         return cls(
             enabled=bool(getattr(config, "enabled", True)),
-            failure_threshold=int(
-                getattr(config, "failure_threshold", DEFAULT_FAILURE_THRESHOLD)
-            ),
-            cooldown_seconds=float(
-                getattr(config, "cooldown_seconds", DEFAULT_COOLDOWN_SECONDS)
-            ),
-            max_cooldown_seconds=float(
-                getattr(config, "max_cooldown_seconds", DEFAULT_MAX_COOLDOWN_SECONDS)
+            failure_threshold=getattr(config, "failure_threshold", DEFAULT_FAILURE_THRESHOLD),
+            cooldown_seconds=getattr(config, "cooldown_seconds", DEFAULT_COOLDOWN_SECONDS),
+            max_cooldown_seconds=getattr(
+                config, "max_cooldown_seconds", DEFAULT_MAX_COOLDOWN_SECONDS
             ),
         )
 

--- a/tests/test_provider_circuit_breaker.py
+++ b/tests/test_provider_circuit_breaker.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import pytest
 
 from agentos.provider.circuit_breaker import (
+    DEFAULT_COOLDOWN_SECONDS,
+    DEFAULT_FAILURE_THRESHOLD,
+    DEFAULT_MAX_COOLDOWN_SECONDS,
     BreakerSettings,
     BreakerState,
     ProviderCircuitBreaker,
@@ -476,3 +479,33 @@ def test_failover_from_the_primary_still_starts_at_the_first_fallback() -> None:
 
     selector.next_fallback_after_failure(RuntimeError("503"))
     assert selector.active_provider_id == "deepseek"
+
+
+def test_settings_degrade_to_defaults_on_non_numeric_config() -> None:
+    settings = BreakerSettings(
+        failure_threshold="not-a-number",  # type: ignore[arg-type]
+        cooldown_seconds=None,  # type: ignore[arg-type]
+        max_cooldown_seconds="also-bad",  # type: ignore[arg-type]
+    )
+    assert settings.failure_threshold == DEFAULT_FAILURE_THRESHOLD
+    assert settings.cooldown_seconds == DEFAULT_COOLDOWN_SECONDS
+    assert settings.max_cooldown_seconds == DEFAULT_MAX_COOLDOWN_SECONDS
+
+
+def test_settings_still_clamp_out_of_range_numeric_config() -> None:
+    settings = BreakerSettings(failure_threshold=-5, cooldown_seconds=0.0)
+    assert settings.failure_threshold == 1
+    assert settings.cooldown_seconds == 1.0
+
+
+def test_from_config_degrades_to_defaults_on_non_numeric_attrs() -> None:
+    class BadConfig:
+        enabled = True
+        failure_threshold = "oops"
+        cooldown_seconds = "oops"
+        max_cooldown_seconds = "oops"
+
+    settings = BreakerSettings.from_config(BadConfig())
+    assert settings.failure_threshold == DEFAULT_FAILURE_THRESHOLD
+    assert settings.cooldown_seconds == DEFAULT_COOLDOWN_SECONDS
+    assert settings.max_cooldown_seconds == DEFAULT_MAX_COOLDOWN_SECONDS


### PR DESCRIPTION
Fixes #702

Supersedes #703, which bundled this fix with unrelated cron and Telegram
changes; this is the circuit-breaker fix on its own, cleanly rebased on
current main. `BreakerSettings.__post_init__`/`from_config` called
`int()`/`float()` directly, so a non-numeric `[llm.circuit_breaker]` config
value raised at boot — contradicting the class's own docstring, which
promises such values degrade to defaults. Fixed by coercing with a fallback
to the default on TypeError/ValueError. 3 new regression tests; suite green,
ruff + mypy clean.