### PR TITLE
fix(ssrf): enforce the cloud-metadata floor on the strict fetch guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- The strict SSRF fetch guard now enforces the cloud-metadata floor directly
+  instead of inferring it from the private/link-local ranges. `ssrf.py` keeps a
+  shared `_METADATA_ADDRESSES` set described as the non-negotiable floor, but
+  only the permissive guard (`assert_not_metadata_endpoint`, used by
+  `http_request`) consulted it. The stricter `assert_address_allowed_for_fetch`
+  — used by `web_fetch`, the media image fetch, browser navigation and
+  skill-dependency downloads — derived its coverage from `is_private` /
+  `is_loopback` / `is_link_local` / `is_reserved` instead.
+
+  That left the two guards inverted for one address. Alibaba Cloud's
+  `100.100.100.200` sits in CGNAT space (`100.64.0.0/10`), which Python
+  classifies as none of those and which no hard-blocked network covers, so the
+  *strict* guard allowed it while the *permissive* one blocked it. On an
+  Alibaba ECS deployment a URL the agent could be steered to fetch — directly,
+  or by prompt injection from page content it reads — returned the instance RAM
+  role credentials into the transcript. The connect-time guard shares the same
+  predicate, so DNS-delivered and redirect-hop variants were equally unguarded.
+
+  The metadata hostname check (`metadata.google.internal` and friends) now runs
+  in `validate_http_url_for_fetch` too, so a resolver answering those names
+  cannot launder the request through a public-looking address. Fetch policy is
+  a strict superset of the metadata-only policy again, and a parametrized test
+  asserts that for every entry in the shared set — the invariant that was
+  missing, rather than the single address that happened to break it.
+
 - The MCP SSE and Streamable HTTP transports now connect through the same
   SSRF guard as the built-in HTTP tools. Both built a bare `httpx.AsyncClient`
   from `MCPServerConfig.url` with no validation at all, so an MCP server entry

--- a/src/agentos/tools/ssrf.py
+++ b/src/agentos/tools/ssrf.py
@@ -148,7 +148,18 @@ def assert_address_allowed_for_fetch(
     The address-level half of :func:`validate_http_url_for_fetch`, split out so
     the connect-time guard in :mod:`agentos.tools.ssrf_client` applies the exact
     same policy to the address it is about to open a socket to.
+
+    The metadata floor is applied first. Fetch policy is a strict superset of
+    the metadata-only policy, but it used to derive that coverage from the
+    private/link-local ranges rather than from ``_METADATA_ADDRESSES`` itself —
+    so a metadata endpoint outside those ranges fell through. Alibaba Cloud's
+    ``100.100.100.200`` sits in CGNAT space (``100.64.0.0/10``), which is
+    neither private, loopback, link-local nor reserved, and was therefore
+    allowed by the *strict* guard while the permissive one blocked it. Deriving
+    the floor from the same set both guards share keeps them ordered correctly
+    for every address in it, including any added later.
     """
+    assert_address_not_metadata(hostname, addr)
     block_reason = _hard_block_reason(addr)
     if block_reason is not None:
         raise SSRFBlockedError(_blocked_message(hostname, addr, block_reason))
@@ -219,13 +230,24 @@ def validate_http_url_for_fetch(
     *,
     trusted_fake_ip_cidrs: Iterable[str] | None = None,
 ) -> None:
-    """Validate that an HTTP(S) URL does not resolve to a blocked address."""
+    """Validate that an HTTP(S) URL does not resolve to a blocked address.
+
+    Fetch policy is a strict superset of :func:`assert_not_metadata_endpoint`,
+    so the metadata hostname check runs here too: a resolver that answers
+    ``metadata.google.internal`` at all is answering for the credential
+    endpoint, whatever address it hands back.
+    """
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
         raise UnsupportedURLSchemeError("Only HTTP/HTTPS URLs are supported")
     hostname = parsed.hostname
     if not hostname:
         raise ValueError("Invalid URL: no hostname")
+    if is_metadata_hostname(hostname):
+        raise SSRFBlockedError(
+            f"Blocked request to {hostname}: cloud metadata endpoints serve instance "
+            "credentials and are never a valid agent target."
+        )
 
     try:
         infos = socket.getaddrinfo(hostname, None)

--- a/tests/test_security/test_ssrf_metadata_floor.py
+++ b/tests/test_security/test_ssrf_metadata_floor.py
@@ -1,0 +1,123 @@
+"""The metadata floor must hold on *both* SSRF guards, not just the loose one.
+
+``assert_not_metadata_endpoint`` is the permissive guard: ``http_request`` is
+pointed at localhost and LAN services on purpose, so blocking cloud metadata is
+all it can enforce. ``assert_address_allowed_for_fetch`` is the strict guard used
+by ``web_fetch``, the media image fetch, browser navigation and skill-dependency
+downloads — tools that only ever have business on the public internet.
+
+Strict must therefore be a superset of permissive. It was not: the strict guard
+derived its metadata coverage from the private/link-local ranges instead of from
+``_METADATA_ADDRESSES``, so Alibaba Cloud's ``100.100.100.200`` — CGNAT space,
+which is neither private, loopback, link-local nor reserved — was allowed by the
+strict guard while the permissive one blocked it.
+
+The parametrized test below is the invariant that keeps the two ordered for every
+address in the shared set, including any added later.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+import pytest
+
+from agentos.tools import ssrf
+from agentos.tools.ssrf_client import validate_fetch_address, validate_metadata_only_address
+from agentos.tools.types import SSRFBlockedError
+
+_METADATA_ADDRESSES = sorted(ssrf._METADATA_ADDRESSES, key=str)
+_METADATA_HOSTNAMES = sorted(ssrf._METADATA_HOSTNAMES)
+
+
+def _fake_getaddrinfo(ip: str):
+    def resolver(hostname: str, port: int | None, *args, **kwargs):
+        family = socket.AF_INET6 if ipaddress.ip_address(ip).version == 6 else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, 6, "", (ip, port or 443))]
+
+    return resolver
+
+
+@pytest.fixture(autouse=True)
+def reset_trusted_fake_ip_cidrs():
+    ssrf.configure_trusted_fake_ip_cidrs([])
+    yield
+    ssrf.configure_trusted_fake_ip_cidrs([])
+
+
+@pytest.mark.parametrize("addr", _METADATA_ADDRESSES, ids=str)
+def test_every_metadata_address_is_blocked_by_both_guards(addr):
+    """Neither guard may hand an agent an instance-credential endpoint."""
+    with pytest.raises(SSRFBlockedError):
+        ssrf.assert_address_not_metadata("metadata.test", addr)
+    with pytest.raises(SSRFBlockedError):
+        ssrf.assert_address_allowed_for_fetch("metadata.test", addr, ())
+
+
+@pytest.mark.parametrize("addr", _METADATA_ADDRESSES, ids=str)
+def test_every_metadata_address_is_blocked_at_connect_time(addr):
+    """The connect-time guard shares the policy, so it must agree with both."""
+    with pytest.raises(SSRFBlockedError):
+        validate_metadata_only_address("metadata.test", addr)
+    with pytest.raises(SSRFBlockedError):
+        validate_fetch_address("metadata.test", addr)
+
+
+@pytest.mark.parametrize("addr", _METADATA_ADDRESSES, ids=str)
+def test_metadata_address_is_blocked_through_url_validation(addr, monkeypatch):
+    """A hostname that resolves to a metadata address is refused for fetch."""
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo(str(addr)))
+
+    with pytest.raises(SSRFBlockedError):
+        ssrf.validate_http_url_for_fetch("https://attacker.test/steal")
+
+
+@pytest.mark.parametrize("addr", _METADATA_ADDRESSES, ids=str)
+def test_metadata_address_survives_trusted_fake_ip_config(addr, monkeypatch):
+    """The fake-IP escape hatch must not reopen the metadata floor.
+
+    ``trusted_fake_ip_cidrs`` is validated to RFC2544 subnets only, so it can
+    never name a metadata address directly — but the floor is checked before the
+    trusted-network short circuit either way.
+    """
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo(str(addr)))
+
+    with pytest.raises(SSRFBlockedError):
+        ssrf.validate_http_url_for_fetch(
+            "https://attacker.test/steal",
+            trusted_fake_ip_cidrs=["198.18.0.0/15"],
+        )
+
+
+def test_alibaba_metadata_address_is_blocked_for_fetch():
+    """Regression: CGNAT space is not private, so only the shared set catches it."""
+    addr = ipaddress.ip_address("100.100.100.200")
+
+    assert not addr.is_private
+    assert not addr.is_loopback
+    assert not addr.is_link_local
+    assert not addr.is_reserved
+
+    with pytest.raises(SSRFBlockedError):
+        ssrf.assert_address_allowed_for_fetch("alibaba.test", addr, ())
+
+
+@pytest.mark.parametrize("hostname", _METADATA_HOSTNAMES)
+def test_metadata_hostname_is_blocked_for_fetch(hostname, monkeypatch):
+    """A metadata *name* is refused before its answer is even considered.
+
+    A resolver that answers these at all is answering for the credential
+    endpoint, so the public address it returns must not launder the request.
+    """
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+
+    with pytest.raises(SSRFBlockedError):
+        ssrf.validate_http_url_for_fetch(f"http://{hostname}/computeMetadata/v1/")
+
+
+def test_ordinary_public_address_still_allowed(monkeypatch):
+    """The floor must not turn into a blanket denial."""
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+
+    ssrf.validate_http_url_for_fetch("https://example.test/index.html")


### PR DESCRIPTION
## What

`assert_address_allowed_for_fetch` now applies the cloud-metadata floor directly, and `validate_http_url_for_fetch` now runs the metadata *hostname* check. Fetch policy is a strict superset of the metadata-only policy again.

## Why

`ssrf.py` keeps a shared `_METADATA_ADDRESSES` set and describes it as the non-negotiable floor — *"unlike ordinary private ranges they have no legitimate agent use, on any tool, under any configuration."* Only the permissive guard consulted it.

The strict guard used by `web_fetch`, the media image fetch, browser navigation and skill-dependency downloads derived its metadata coverage from `is_private` / `is_loopback` / `is_link_local` / `is_reserved` plus `_HARD_BLOCKED_NETWORKS`. For one address that inverts the two guards — Alibaba Cloud's `100.100.100.200` is in CGNAT space (`100.64.0.0/10`), which Python classifies as none of those and which no hard-blocked network covers:

```
100.100.100.200          fetch_guard=ALLOWED  metadata_guard=blocked
::ffff:100.100.100.200   fetch_guard=ALLOWED  metadata_guard=blocked
```

So the guard meant for tools that "only ever have business on the public internet" was the one that let it through, while `http_request` — which is pointed at localhost and LAN services on purpose — correctly refused.

On an Alibaba ECS deployment this let a URL the agent could be steered to fetch (directly, or via prompt injection from page content it reads) return the instance RAM role credentials into the transcript:

```
http://100.100.100.200/latest/meta-data/ram/security-credentials/
```

`validate_fetch_address` wraps the same predicate, so the connect-time guard did not catch the DNS-delivered or redirect-hop variants either. `skills/hub/deps.py` revalidates every redirect hop with the same function.

## How

- Call `assert_address_not_metadata` first in `assert_address_allowed_for_fetch`, rather than special-casing the one address — the floor then holds for any entry added to `_METADATA_ADDRESSES` later.
- Run `is_metadata_hostname` in `validate_http_url_for_fetch`: a resolver that answers `metadata.google.internal` at all is answering for the credential endpoint, and should not be able to launder the request through a public-looking address.

Affected callers, all unchanged at their call sites: `tools/builtin/web_fetch.py`, `tools/builtin/media.py`, `tools/builtin/browser.py`, `skills/hub/deps.py`, `tools/ssrf_client.py`.

## Tests

`tests/test_security/test_ssrf_metadata_floor.py` parametrizes over `_METADATA_ADDRESSES` and `_METADATA_HOSTNAMES` and asserts that both guards, the connect-time pair, and URL-level validation reject every entry — plus that an ordinary public address still passes, and that the `trusted_fake_ip_cidrs` escape hatch cannot reopen the floor.

The invariant is the point: what was missing was "strict ⊇ permissive for the whole shared set", not a rule about one address.

## Verification

- `tests/test_security/test_ssrf_metadata_floor.py` — 25 passed. Confirmed they **fail on the unfixed tree**: 8 failures, exactly the two gap classes (the Alibaba address across all four assertions, and the three metadata hostnames).
- `uv run pytest -q` — 9109 passed, 27 skipped, 1 failed.
  The failure is `tests/test_cli_skills_init.py::test_init_fails_on_existing_files_without_force`, which fails identically on a clean tree — it is one of the pre-existing ANSI-width failures AGENTS.md calls out (the assertion breaks on a terminal-wrapped path in the error string).
- `uv run ruff check src tests` — clean. `uv run ruff format --check` — clean.
- `uv run mypy src/agentos` — Success, no issues in 622 source files.
- Frontend gate not run: no `frontend/**` files touched.
