### PR TITLE
fix(cli): use agentos instead of uv run agentos in channel verify msg (#835)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- CLI: changed printed verification command from
+  `uv run agentos` to `agentos` so it works on pipx/pip installs
+  without `uv` on PATH.
+  ([#835](https://github.com/use-agent-os/agent-os/issues/835))
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/cli/channels_cmd.py
+++ b/src/agentos/cli/channels_cmd.py
@@ -60,7 +60,7 @@ def _print_restart_notice() -> None:
 
 def _print_channel_verification_next_step(name: str) -> None:
     typer.echo("Next: agentos gateway restart")
-    typer.echo(f"Verify: uv run agentos channels status {name} --json")
+    typer.echo(f"Verify: agentos channels status {name} --json")
 
 
 _SOURCE_LABEL = {

--- a/tests/test_cli/test_channels_cmd_verify_msg.py
+++ b/tests/test_cli/test_channels_cmd_verify_msg.py
@@ -1,0 +1,21 @@
+"""Test that channel verification message uses agentos (not uv run agentos).
+
+Issue #835: the printed Verify: message must work on pipx/pip installs
+that don't have uv on PATH.
+"""
+
+from __future__ import annotations
+
+from agentos.cli.channels_cmd import _print_channel_verification_next_step
+
+
+def test_channel_verify_msg_uses_agentos_not_uv_run(capsys) -> None:
+    """The verify message should use 'agentos' directly."""
+    _print_channel_verification_next_step("test")
+    captured = capsys.readouterr()
+    assert "uv run agentos" not in captured.out, (
+        f"Verify message uses uv run, output: {captured.out!r}"
+    )
+    assert "agentos channels status" in captured.out, (
+        f"Verify message missing 'agentos channels status', got: {captured.out!r}"
+    )


### PR DESCRIPTION
## Summary

The verification command printed after `agentos channels add` and `channels edit` uses `uv run agentos`, which fails on pipx/pip installs that don't have `uv` on PATH.

## Fix

Changed the printed message from `uv run agentos channels status` to `agentos channels status`, consistent with adjacent `Next:` lines and docs.

Closes #835.