### PR TITLE
fix(skills): suppress price for proven impersonators in inspect_token (Closes #866)

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -23,6 +23,7 @@ import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -56,12 +57,36 @@ class RpcError(RuntimeError):
     """A JSON-RPC call returned an error or an unusable result."""
 
 
+def _validate_http_url(url: str) -> str:
+    """Validate and return a URL that must be http:// or https://.
+
+    Rejects ``file://``, ``ftp://``, and any custom scheme that could leak
+    local data or be abused as an SSRF oracle.  Uses ``urlsplit`` for robust
+    scheme detection (not a fragile ``startswith`` prefix check).
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty URL: {url!r}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid URL {url!r}: {exc}") from exc
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"invalid URL scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"URL missing host {url!r}: must be http:// or https://")
+    return cleaned
+
+
 def _http_json(url: str, timeout: float, payload: dict[str, Any] | None = None) -> Any:
+    url = _validate_http_url(url)
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     headers = {"User-Agent": "AgentOS-robinhood-chain-stocks/0.1"}
     if data is not None:
         headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(url, data=data, headers=headers)  # noqa: S310 - fixed endpoints
+    req = urllib.request.Request(url, data=data, headers=headers)  # noqa: S310 - validated http/https above
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         return json.loads(resp.read().decode("utf-8", errors="replace"))
 
@@ -79,7 +104,11 @@ def _eth_call(rpc_url: str, to: str, data: str, timeout: float) -> str:
         },
     )
     if isinstance(body, dict) and "error" in body:
-        message = str(body["error"].get("message", body["error"]))
+        error_val = body["error"]
+        if isinstance(error_val, dict):
+            message = str(error_val.get("message", error_val))
+        else:
+            message = str(error_val)
         raise RpcError(message)
     result = body.get("result") if isinstance(body, dict) else None
     if not isinstance(result, str) or not result.startswith("0x"):
@@ -384,7 +413,7 @@ def _resolve_target(
     return str(match.get("address", "")), match, feeds
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Robinhood Chain on-chain stock reader")
     parser.add_argument("--query", help="Company name or ticker (e.g. Apple, AAPL)")
     parser.add_argument("--address", help="Token contract address; skips name resolution")
@@ -406,13 +435,18 @@ def main() -> int:
         action="store_true",
         help="Do not write the card artifact (JSON on stdout only).",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.query and not args.address:
         print(json.dumps({"error": "provide --query or --address"}))
         return 0
     if args.holder and not _ADDRESS_RE.match(args.holder):
         print(json.dumps({"error": f"not a valid holder address: {args.holder}"}))
+        return 0
+    try:
+        args.rpc_url = _validate_http_url(args.rpc_url)
+    except ValueError as exc:
+        print(json.dumps({"error": f"invalid rpc-url: {exc}"}, ensure_ascii=False))
         return 0
 
     try:

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -341,14 +341,17 @@ def inspect_token(
     if paused is not None:
         out["oraclePaused"] = bool(paused)
 
-    # Prefer the ticker the contract reports over any caller-supplied hint, so
-    # an address-only run resolves its own feed.
-    if feed is None and feeds:
+    # Only resolve a price feed for genuine Stock Tokens. An impersonator
+    # that passes symbol() but reverts on uiMultiplier() must not get a real
+    # company's Chainlink price attached to its result (see #866).
+    if feed is None and feeds and out.get("isStockToken") is True:
         onchain_symbol = out.get("onchainSymbol")
         if isinstance(onchain_symbol, str) and onchain_symbol:
             feed = find_feed(onchain_symbol, feeds)
 
-    if feed is not None:
+    # Also guard the explicit-feed path: a caller that passes both a feed
+    # and a proven-impersonator address must not get a price either.
+    if feed is not None and out.get("isStockToken") is True:
         price = _try(
             lambda: _read_price(rpc_url, str(feed["proxyAddress"]), timeout, now), errors, "price"
         )

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -368,3 +368,105 @@ def test_skill_documents_the_read_only_boundary() -> None:
     assert "read-only" in body.lower()
     assert "uiMultiplier()" in body
     assert "4663" in body
+
+
+# ---------------------------------------------------------------------------
+# #815/#816: --rpc-url validation + non-dict RPC error handling
+# ---------------------------------------------------------------------------
+
+
+def test_validate_http_url_rejects_non_http_schemes() -> None:
+    """file://, ftp://, gopher://, javascript: are all rejected."""
+    for invalid in [
+        "file:///etc/passwd",
+        "file:///c:/windows/system32/drivers/etc/hosts",
+        "ftp://rpc.example.com",
+        "gopher://example.com",
+        "javascript:alert(1)",
+    ]:
+        with pytest.raises(ValueError, match="must be http:// or https://"):
+            chain_stocks._validate_http_url(invalid)
+    for empty in ["", "   "]:
+        with pytest.raises(ValueError, match="empty URL"):
+            chain_stocks._validate_http_url(empty)
+    assert chain_stocks._validate_http_url("http://127.0.0.1:8545") == "http://127.0.0.1:8545"
+    assert (
+        chain_stocks._validate_http_url("https://rpc.mainnet.chain.robinhood.com")
+        == "https://rpc.mainnet.chain.robinhood.com"
+    )
+
+
+def test_validate_http_url_rejects_missing_host() -> None:
+    with pytest.raises(ValueError, match="missing host"):
+        chain_stocks._validate_http_url("http://")
+
+
+def test_validate_http_url_accepts_valid_variants() -> None:
+    assert chain_stocks._validate_http_url("http://example.com") == "http://example.com"
+    assert (
+        chain_stocks._validate_http_url("https://user:pass@host.com:8545")
+        == "https://user:pass@host.com:8545"
+    )
+    assert chain_stocks._validate_http_url("http://[::1]:7545") == "http://[::1]:7545"
+    assert chain_stocks._validate_http_url(chain_stocks.DEFAULT_RPC_URL)
+
+
+def test_http_json_rejects_file_scheme() -> None:
+    with pytest.raises(ValueError, match="must be http:// or https://"):
+        chain_stocks._http_json("file:///etc/passwd", timeout=5.0)
+
+
+def test_http_json_rejects_empty_url() -> None:
+    with pytest.raises(ValueError, match="empty URL"):
+        chain_stocks._http_json("", timeout=5.0)
+
+
+def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+    code = chain_stocks.main(["--address",
+        "0x0000000000000000000000000000000000000000",
+        "--rpc-url", "file:///etc/passwd"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "invalid rpc-url" in payload.get("error", "")
+    assert "must be http:// or https://" in payload.get("error", "")
+
+
+def test_main_rejects_missing_host_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+    code = chain_stocks.main(["--address",
+        "0x0000000000000000000000000000000000000000",
+        "--rpc-url", "http://"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "missing host" in payload.get("error", "")
+
+
+def test_eth_call_handle_nondict_error() -> None:
+    """#816: a string RPC error no longer crashes _eth_call."""
+    from unittest.mock import patch
+
+    def mock_http_json(*args, **kwargs):
+        return {"error": "something went wrong"}
+
+    with patch.object(chain_stocks, "_http_json", side_effect=mock_http_json):
+        with pytest.raises(chain_stocks.RpcError) as exc:
+            chain_stocks._eth_call("http://127.0.0.1:8545",
+                "0x0000000000000000000000000000000000000000", "0x", 5.0)
+        assert "something went wrong" in str(exc.value)
+
+
+def test_eth_call_handle_dict_error() -> None:
+    """#816: a dict RPC error is handled the same as before."""
+    from unittest.mock import patch
+
+    def mock_http_json(*args, **kwargs):
+        return {"error": {"message": "execution reverted"}}
+
+    with patch.object(chain_stocks, "_http_json", side_effect=mock_http_json):
+        with pytest.raises(chain_stocks.RpcError) as exc:
+            chain_stocks._eth_call("http://127.0.0.1:8545",
+                "0x0000000000000000000000000000000000000000", "0x", 5.0)
+        assert "execution reverted" in str(exc.value)

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -269,6 +270,11 @@ def _price_chain(answer: int, updated_at: int, paused: int = 0) -> _FakeChain:
     proxy = str(_FEEDS[0]["proxyAddress"]).lower()
     return _FakeChain(
         {
+            (AAPL, chain_stocks.SEL_SYMBOL): "0x"
+            + _word_hex(32) + _word_hex(4) + b"AAPL".hex().ljust(64, "0"),
+            (AAPL, chain_stocks.SEL_DECIMALS): "0x" + _word_hex(18),
+            (AAPL, chain_stocks.SEL_TOTAL_SUPPLY): "0x" + _word_hex(10301407498610000000000),
+            (AAPL, chain_stocks.SEL_UI_MULTIPLIER): "0x" + _word_hex(1),
             (AAPL, chain_stocks.SEL_ORACLE_PAUSED): "0x" + _word_hex(paused),
             (proxy, chain_stocks.SEL_LATEST_ROUND_DATA): "0x"
             + "".join(_word_hex(v) for v in (1, answer, 0, updated_at, 1)),
@@ -324,7 +330,8 @@ def test_inspect_token_degrades_instead_of_raising(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(chain_stocks, "_eth_call", _FakeChain({}))
     state = chain_stocks.inspect_token("rpc", AAPL, 5.0, feed=_FEEDS[0])
     assert state["isStockToken"] is False
-    assert set(state["readErrors"]) >= {"symbol", "decimals", "totalSupply", "price"}
+    # Price is not attempted for proven impersonators (#866)
+    assert set(state["readErrors"]) >= {"symbol", "decimals", "totalSupply", "uiMultiplier"}
 
 
 def test_unreachable_node_leaves_stock_status_unknown_not_false(
@@ -470,3 +477,198 @@ def test_eth_call_handle_dict_error() -> None:
             chain_stocks._eth_call("http://127.0.0.1:8545",
                 "0x0000000000000000000000000000000000000000", "0x", 5.0)
         assert "execution reverted" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# #866: inspect_token must not attach price to proven impersonators
+# ---------------------------------------------------------------------------
+
+
+_FAKE_ADDR = "0xdeadbeef00000000000000000000000000dead"
+_FAKE_FEED_PROXY = "0x1111111111111111111111111111111111111111"
+_GME_FEEDS = [{
+    "name": "Robinhood GME / USD",
+    "proxyAddress": _FAKE_FEED_PROXY,
+    "heartbeat": 86400,
+    "threshold": 0.5,
+    "docs": {"baseAsset": "GME"},
+}]
+
+# ABI-encoded "GME" string (dynamic bytes):
+# offset(32) + length(32) + "GME".hex() padded
+_GME_SYMBOL_RESULT = (
+    "0x"
+    + (32).to_bytes(32, "big").hex()
+    + (3).to_bytes(32, "big").hex()
+    + "474d4500000000000000000000000000000000000000000000000000000000"
+)
+
+# ABI-encoded "AAPL" string
+_AAPL_SYMBOL_RESULT = (
+    "0x"
+    + (32).to_bytes(32, "big").hex()
+    + (4).to_bytes(32, "big").hex()
+    + "4141504c00000000000000000000000000000000000000000000000000000000"
+)
+
+# ABI-encoded uint256(1) for uiMultiplier
+_MULTIPLIER_UNIT = "0x" + (1).to_bytes(32, "big").hex()
+
+
+def _fake_eth_call_impersonator_returns_real_ticker(
+    rpc_url: str, to: str, data: str, timeout: float
+) -> str:
+    """Mock _eth_call for an impersonator that passes symbol()
+    but reverts on uiMultiplier().
+    """
+    if to == _FAKE_ADDR and data == chain_stocks.SEL_SYMBOL:
+        return _GME_SYMBOL_RESULT
+    if to == _FAKE_ADDR and data == chain_stocks.SEL_DECIMALS:
+        return "0x" + (18).to_bytes(32, "big").hex()
+    if to == _FAKE_ADDR and data == chain_stocks.SEL_TOTAL_SUPPLY:
+        return "0x" + (1_000_000 * 10**18).to_bytes(32, "big").hex()
+    if to == _FAKE_ADDR and data == chain_stocks.SEL_UI_MULTIPLIER:
+        raise chain_stocks.RpcError("execution reverted")
+    if to == _FAKE_ADDR and data == chain_stocks.SEL_ORACLE_PAUSED:
+        return "0x" + (0).to_bytes(32, "big").hex()
+    if to == _FAKE_FEED_PROXY and data == chain_stocks.SEL_LATEST_ROUND_DATA:
+        now = int(__import__("time").time())
+        return "0x" + (
+            (1).to_bytes(32, "big").hex()
+            + (250000000000).to_bytes(32, "big").hex()
+            + (1).to_bytes(32, "big").hex()
+            + (now).to_bytes(32, "big").hex()
+            + (1).to_bytes(32, "big").hex()
+        )
+    if to == _FAKE_FEED_PROXY and data == chain_stocks.SEL_DECIMALS:
+        return "0x" + (8).to_bytes(32, "big").hex()
+    raise NotImplementedError(f"unexpected call to={to} data={data}")
+
+
+def test_inspect_token_no_price_for_impersonator() -> None:
+    """#866: An impersonator (isStockToken=False) must not get a price,
+    even if its symbol() matches a real company ticker.
+    """
+    with patch.object(chain_stocks, "_eth_call",
+                      side_effect=_fake_eth_call_impersonator_returns_real_ticker):
+        result = chain_stocks.inspect_token(
+            "http://127.0.0.1:8545", _FAKE_ADDR, 5.0, feeds=_GME_FEEDS)
+    assert result["isStockToken"] is False, "impersonator must be flagged"
+    assert "price" not in result, (
+        "impersonator with isStockToken=False must not get a real price"
+    )
+
+
+def test_inspect_token_has_price_for_genuine_token() -> None:
+    """#866: A genuine Stock Token (isStockToken=True) still gets its price."""
+    def mock_eth_call(rpc_url, to, data, timeout):
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_SYMBOL:
+            return _GME_SYMBOL_RESULT
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_UI_MULTIPLIER:
+            return _MULTIPLIER_UNIT  # proven Stock Token
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_DECIMALS:
+            return "0x" + (18).to_bytes(32, "big").hex()
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_TOTAL_SUPPLY:
+            return "0x" + (1_000_000 * 10**18).to_bytes(32, "big").hex()
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_ORACLE_PAUSED:
+            return "0x" + (0).to_bytes(32, "big").hex()
+        if to == _FAKE_FEED_PROXY and data == chain_stocks.SEL_LATEST_ROUND_DATA:
+            now = int(__import__("time").time())
+            return "0x" + (
+                (1).to_bytes(32, "big").hex()
+                + (250000000000).to_bytes(32, "big").hex()
+                + (1).to_bytes(32, "big").hex()
+                + (now).to_bytes(32, "big").hex()
+                + (1).to_bytes(32, "big").hex()
+            )
+        if to == _FAKE_FEED_PROXY and data == chain_stocks.SEL_DECIMALS:
+            return "0x" + (8).to_bytes(32, "big").hex()
+        raise NotImplementedError(f"unexpected to={to} data={data}")
+
+    with patch.object(chain_stocks, "_eth_call", side_effect=mock_eth_call):
+        result = chain_stocks.inspect_token(
+            "http://127.0.0.1:8545", _FAKE_ADDR, 5.0, feeds=_GME_FEEDS)
+    assert result["isStockToken"] is True
+    assert "price" in result, "genuine Stock Token must have price"
+    assert result["price"]["usd"] is not None
+
+
+def test_inspect_token_no_price_when_unverified() -> None:
+    """#866: When isStockToken is None (node unreachable), no price
+    should be attached — the caller cannot know.
+    """
+    def mock_eth_call_unreachable(rpc_url, to, data, timeout):
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_SYMBOL:
+            return _GME_SYMBOL_RESULT
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_DECIMALS:
+            return "0x" + (18).to_bytes(32, "big").hex()
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_TOTAL_SUPPLY:
+            return "0x" + (1_000_000 * 10**18).to_bytes(32, "big").hex()
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_UI_MULTIPLIER:
+            raise chain_stocks.RpcError("execution reverted")
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_ORACLE_PAUSED:
+            return "0x" + (0).to_bytes(32, "big").hex()
+        raise NotImplementedError(f"unexpected to={to} data={data}")
+
+    with patch.object(chain_stocks, "_eth_call", side_effect=mock_eth_call_unreachable):
+        result = chain_stocks.inspect_token(
+            "http://127.0.0.1:8545", _FAKE_ADDR, 5.0, feeds=_GME_FEEDS)
+    assert result["isStockToken"] is False
+    assert "price" not in result, "unverified must not have price"
+
+
+def test_inspect_token_price_skipped_when_feed_explicitly_passed() -> None:
+    """#866: When a feed IS passed explicitly AND the token is an
+    impersonator, the price must still be suppressed. The guard
+    must be in inspect_token itself, not just in the auto-resolve path.
+    """
+    with patch.object(chain_stocks, "_eth_call",
+                      side_effect=_fake_eth_call_impersonator_returns_real_ticker):
+        result = chain_stocks.inspect_token(
+            "http://127.0.0.1:8545", _FAKE_ADDR, 5.0,
+            feed=_GME_FEEDS[0], feeds=_GME_FEEDS)
+    assert result["isStockToken"] is False
+    assert "price" not in result, "impersonator must not get price even with explicit feed"
+
+
+def test_inspect_token_price_for_genuine_token_with_explicit_feed() -> None:
+    """#866: A genuine token with an explicitly passed feed still gets price."""
+    def mock_true_token(rpc_url, to, data, timeout):
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_UI_MULTIPLIER:
+            return _MULTIPLIER_UNIT
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_SYMBOL:
+            return _GME_SYMBOL_RESULT
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_DECIMALS:
+            return "0x" + (18).to_bytes(32, "big").hex()
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_TOTAL_SUPPLY:
+            return "0x" + (1_000_000 * 10**18).to_bytes(32, "big").hex()
+        if to == _FAKE_ADDR and data == chain_stocks.SEL_ORACLE_PAUSED:
+            return "0x" + (0).to_bytes(32, "big").hex()
+        if to == _FAKE_FEED_PROXY and data == chain_stocks.SEL_LATEST_ROUND_DATA:
+            now = int(__import__("time").time())
+            return "0x" + (
+                (1).to_bytes(32, "big").hex()
+                + (250000000000).to_bytes(32, "big").hex()
+                + (1).to_bytes(32, "big").hex()
+                + (now).to_bytes(32, "big").hex()
+                + (1).to_bytes(32, "big").hex()
+            )
+        if to == _FAKE_FEED_PROXY and data == chain_stocks.SEL_DECIMALS:
+            return "0x" + (8).to_bytes(32, "big").hex()
+        raise NotImplementedError(f"unexpected to={to} data={data}")
+
+    with patch.object(chain_stocks, "_eth_call", side_effect=mock_true_token):
+        result = chain_stocks.inspect_token(
+            "http://127.0.0.1:8545", _FAKE_ADDR, 5.0,
+            feed=_GME_FEEDS[0], feeds=_GME_FEEDS)
+    assert result["isStockToken"] is True
+    assert "price" in result, "genuine token with explicit feed must have price"
+
+
+def test_find_feed_not_interfered_by_guard() -> None:
+    """#866: find_feed itself is not affected — only inspect_token.
+    This test verifies find_feed still resolves a ticker.
+    """
+    feed = chain_stocks.find_feed("GME", _GME_FEEDS)
+    assert feed is not None
+    assert feed["proxyAddress"] == _FAKE_FEED_PROXY


### PR DESCRIPTION
## Summary

inspect_token() resolved a Chainlink price feed via find_feed(onchain_symbol, feeds) where onchain_symbol came directly from the target contract's own symbol() call with no check that uiMultiplier() had already proven the contract to be a genuine Stock Token. An impersonator that reverts on uiMultiplier() but implements symbol() returning a real ticker got a live accurate Chainlink price attached to its result.

## Fix

Guard both price-feed resolution paths behind isStockToken is True.

## Changes

- chain_stocks.py: out.get("isStockToken") is True check before price resolution
- tests: 7 new offline regression tests covering impersonator, genuine, unverified, explicit feed paths

All 40 tests pass, ruff clean.