### PR TITLE
fix: normalize empty artifact name to 'unnamed_artifact' in _named_artifact_delivery_path (#742)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- ``_named_artifact_delivery_path`` now defaults to ``"unnamed_artifact"`` when
+  the artifact name has an empty leaf (``""`` or ``"."``), instead of resolving to
+  the directory root and causing downstream failures.
+  ([#742](https://github.com/use-agent-os/agent-os/issues/742))
+
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/channels/artifact_delivery.py
+++ b/src/agentos/channels/artifact_delivery.py
@@ -143,7 +143,8 @@ def can_deliver_channel_files(channel: Any) -> bool:
 @contextlib.contextmanager
 def _named_artifact_delivery_path(source: Path, filename: str) -> Iterator[Path]:
     with tempfile.TemporaryDirectory(prefix="agentos-artifact-") as tmp_dir:
-        target = Path(tmp_dir) / Path(filename).name
+        name = Path(filename).name or "unnamed_artifact"
+        target = Path(tmp_dir) / name
         try:
             target.hardlink_to(source)
         except OSError:

--- a/tests/test_channels/test_named_artifact_delivery_path.py
+++ b/tests/test_channels/test_named_artifact_delivery_path.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.channels.artifact_delivery import _named_artifact_delivery_path
+
+
+def test_named_artifact_delivery_path_uses_filename() -> None:
+    source = Path(__file__)
+    with _named_artifact_delivery_path(source, "report.txt") as delivery_path:
+        assert delivery_path.name == "report.txt"
+        assert delivery_path.exists()
+
+
+def test_named_artifact_delivery_path_falls_back_for_empty_filename() -> None:
+    source = Path(__file__)
+    with _named_artifact_delivery_path(source, "") as delivery_path:
+        assert delivery_path.name == "unnamed_artifact"
+        assert delivery_path.exists()
+
+
+def test_named_artifact_delivery_path_falls_back_for_dot_filename() -> None:
+    source = Path(__file__)
+    with _named_artifact_delivery_path(source, ".") as delivery_path:
+        assert delivery_path.name == "unnamed_artifact"
+        assert delivery_path.exists()


### PR DESCRIPTION
## Summary

When an artifact ref filename is empty (`""`) or resolves to a dot (`"."`), `Path(filename).name` returns an empty string. The `target = Path(tmp_dir) / Path(filename).name` expression then resolves to `tmp_dir` itself — the temp directory root — instead of a real file path. Downstream consumers that try to stat or open the path get a directory where they expected a file.

## Fix

Normalize the empty name to `"unnamed_artifact"` before constructing the target path. Three cases are covered:

| Input | Before | After |
|---|---|---|
| `"report.txt"` | `<tmp>/report.txt` | `<tmp>/report.txt` |
| `""` | `<tmp>` (the directory!) | `<tmp>/unnamed_artifact` |
| `"."` | `<tmp>` (the directory!) | `<tmp>/unnamed_artifact` |

## Changes

- **src**: one-line guard in `_named_artifact_delivery_path`  
- **test**: 3 cases covering normal, empty, and dot filenames  
- **CHANGELOG**: entry under Unreleased → Fixed

Fixes #742