### PR TITLE
fix(cli): create parent dirs in cost --export (#846)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `agentos cost --export <path>` no longer crashes with `FileNotFoundError` when
+  the parent directory of the export path does not exist — the CLI now creates
+  it automatically before writing.
+
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/cli/cost_cmd.py
+++ b/src/agentos/cli/cost_cmd.py
@@ -66,6 +66,7 @@ def cost(
 
     if export_path:
         path = Path(export_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
         is_csv = csv_output or path.suffix.lower() == ".csv"
         if is_csv:
             import io

--- a/tests/test_cli/test_cost_export_mkdir.py
+++ b/tests/test_cli/test_cost_export_mkdir.py
@@ -1,0 +1,86 @@
+"""`agentos cost --export` creates parent directories automatically."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+FAKE_PAYLOAD: dict[str, Any] = {
+    "totalCostUsd": 0.00123,
+    "breakdown": [
+        {
+            "session": "s1",
+            "model": "gpt-4",
+            "provider": "openai",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cost_usd": 0.00123,
+            "created_at": 1700000000,
+        },
+    ],
+}
+
+
+def _fake_run(*args: Any, **kwargs: Any) -> Any:
+    return FAKE_PAYLOAD
+
+
+def test_export_creates_nested_parent_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cost --export should mkdir parent dirs when they don't exist."""
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _fake_run)
+
+    deep_path = tmp_path / "reports" / "october" / "costs.json"
+    assert not deep_path.parent.exists()
+
+    result = runner.invoke(app, ["cost", "--export", str(deep_path)])
+
+    assert result.exit_code == 0, result.output
+    assert deep_path.exists()
+    data = json.loads(deep_path.read_text(encoding="utf-8"))
+    assert data["totalCostUsd"] == 0.00123
+
+
+def test_export_works_with_existing_parent_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing parent dirs are still fine (idempotent)."""
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _fake_run)
+
+    path = tmp_path / "costs.json"
+    result = runner.invoke(app, ["cost", "--export", str(path)])
+
+    assert result.exit_code == 0, result.output
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["totalCostUsd"] == 0.00123
+
+
+def test_export_csv_creates_nested_parent_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CSV export with non-existent parent dirs also works."""
+    monkeypatch.setattr("agentos.cli.cost_cmd.run_gateway_sync", _fake_run)
+
+    deep_path = tmp_path / "a" / "b" / "costs.csv"
+    assert not deep_path.parent.exists()
+
+    result = runner.invoke(app, ["cost", "--export", str(deep_path)])
+
+    assert result.exit_code == 0, result.output
+    assert deep_path.exists()
+    content = deep_path.read_text(encoding="utf-8")
+    assert "Session" in content
+    assert "s1" in content


### PR DESCRIPTION
Fix `agentos cost --export` crash with `FileNotFoundError` when parent directory does not exist by ensuring `path.parent.mkdir(parents=True, exist_ok=True)` is called before writing the export file.

Closes #846.