### PR TITLE
fix(cli): write JSON output as UTF-8 bytes to avoid UnicodeEncodeError on non-UTF-8 terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CLI JSON output no longer crashes on non-UTF-8 terminals** — 
+  and  now write UTF-8 bytes to  and
+   instead of relying on . Falls back to
+   if the buffer itself raises .
+  ([#764](https://github.com/use-agent-os/agent-os/issues/764))
+
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/cli/output.py
+++ b/src/agentos/cli/output.py
@@ -3,15 +3,28 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
 
 import typer
 
 
 def print_json(payload: Any) -> None:
-    """Print JSON payload to stdout using the AgentOS CLI contract."""
+    """Print JSON payload to stdout using the AgentOS CLI contract.
 
-    typer.echo(json.dumps(payload, ensure_ascii=False, default=str))
+    Writes UTF-8 bytes directly to stdout.buffer to avoid
+    UnicodeEncodeError on terminals with non-UTF-8 encoding (e.g.
+    Windows cp1252/cp437). Falls back to ensure_ascii=True on error.
+    """
+
+    try:
+        text = json.dumps(payload, ensure_ascii=False, default=str)
+        sys.stdout.buffer.write((text + "\n").encode("utf-8"))
+        sys.stdout.buffer.flush()
+    except UnicodeEncodeError:
+        text = json.dumps(payload, ensure_ascii=True, default=str)
+        sys.stdout.buffer.write((text + "\n").encode("utf-8", errors="replace"))
+        sys.stdout.buffer.flush()
 
 
 def error_payload(
@@ -40,13 +53,21 @@ def emit_error(
     """Emit an error to stderr without polluting JSON stdout."""
 
     if json_output:
-        typer.echo(
-            json.dumps(
+        try:
+            text = json.dumps(
                 error_payload(message, code=code, details=details),
                 ensure_ascii=False,
                 default=str,
-            ),
-            err=True,
-        )
+            )
+            sys.stderr.buffer.write((text + "\n").encode("utf-8"))
+            sys.stderr.buffer.flush()
+        except UnicodeEncodeError:
+            text = json.dumps(
+                error_payload(message, code=code, details=details),
+                ensure_ascii=True,
+                default=str,
+            )
+            sys.stderr.buffer.write((text + "\n").encode("utf-8", errors="replace"))
+            sys.stderr.buffer.flush()
     else:
         typer.secho(f"Error: {message}", fg=typer.colors.RED, err=True)

--- a/tests/test_cli/test_output_helpers.py
+++ b/tests/test_cli/test_output_helpers.py
@@ -1,25 +1,40 @@
 from __future__ import annotations
 
 import json
+import sys
 
 from agentos.cli.output import emit_error, print_json
 
 
-def test_print_json_uses_stdout(capsys):
-    print_json({"text": "héllo", "value": object()})
+def test_print_json_with_ascii(capfd):
+    """Simple ASCII payload round-trips correctly."""
+    print_json({"msg": "hello"})
+    out, err = capfd.readouterr()
+    payload = json.loads(out)
+    assert payload["msg"] == "hello"
+    assert err == ""
 
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
-    assert payload["text"] == "héllo"
-    assert captured.err == ""
+
+def test_print_json_with_non_ascii(capfd):
+    """Non-ASCII UTF-8 characters survive the round trip."""
+    print_json({"text": "héllo wörld 🔥", "value": object()})
+    out, err = capfd.readouterr()
+    payload = json.loads(out)
+    assert payload["text"] == "héllo wörld 🔥"
+    assert err == ""
 
 
-def test_emit_error_json_uses_stderr(capsys):
-    emit_error("bad input", json_output=True, code="INVALID_REQUEST", details={"field": "x"})
+def test_emit_error_json_uses_stderr(capfd):
+    emit_error(
+        "bad input",
+        json_output=True,
+        code="INVALID_REQUEST",
+        details={"field": "x"},
+    )
 
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    payload = json.loads(captured.err)
+    out, err = capfd.readouterr()
+    assert out == ""
+    payload = json.loads(err)
     assert payload == {
         "error": {
             "message": "bad input",
@@ -27,3 +42,75 @@ def test_emit_error_json_uses_stderr(capsys):
             "details": {"field": "x"},
         }
     }
+
+
+def test_emit_error_with_non_ascii(capfd):
+    """Non-ASCII characters in error payloads also survive."""
+    emit_error(
+        "não é possível — é o fim 🔥",
+        json_output=True,
+        code="INVALID_REQUEST",
+    )
+    out, err = capfd.readouterr()
+    assert out == ""
+    payload = json.loads(err)
+    assert payload["error"]["message"] == "não é possível — é o fim 🔥"
+
+
+class _FailingBinaryBuffer:
+    """A mock binary buffer that rejects non-ASCII bytes.
+
+    Write is atomic — if any byte > 127 is encountered the entire
+    write is rejected and the buffer is untouched.
+    """
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def write(self, data: bytes) -> None:
+        for b in data:
+            if b > 127:
+                raise UnicodeEncodeError(
+                    "utf-8",
+                    "simulated",
+                    0,
+                    1,
+                    "simulated terminal that cannot handle non-ASCII",
+                )
+        self._buf.extend(data)
+
+    def flush(self) -> None:
+        pass
+
+    def getvalue(self) -> bytes:
+        return bytes(self._buf)
+
+
+class _RestrictedStdout:
+    """A fake sys.stdout whose .buffer raises on non-ASCII bytes."""
+
+    def __init__(self) -> None:
+        self.buffer = _FailingBinaryBuffer()
+        self.encoding = "utf-8"
+
+    def flush(self) -> None:
+        self.buffer.flush()
+
+
+def test_print_json_fallback_ensure_ascii():
+    """When even the buffer cannot encode, fall back to ensure_ascii=True."""
+    original_stdout = sys.stdout
+    mock = _RestrictedStdout()
+    try:
+        sys.stdout = mock
+        print_json({"text": "héllo café 100€"})
+        sys.stdout.flush()
+    finally:
+        sys.stdout = original_stdout
+
+    payload = json.loads(
+        mock.buffer.getvalue().decode("utf-8")
+    )
+    assert payload == {"text": "héllo café 100€"}
+    raw = mock.buffer.getvalue()
+    assert all(b < 128 for b in raw), "expected only ASCII bytes in fallback output"


### PR DESCRIPTION
## Summary

`print_json` and `emit_error` in `src/agentos/cli/output.py` used `typer.echo()` which encodes JSON through `sys.stdout.encoding`. On Windows cp1252/cp437 terminals this crashed with `UnicodeEncodeError` when non-ASCII characters were present.

## Fix

- Write UTF-8 bytes directly to `sys.stdout.buffer` and `sys.stderr.buffer`, bypassing the terminal text encoding.
- Falls back to `ensure_ascii=True` if even the buffer cannot handle non-ASCII bytes.
- Updated tests to use `capfd` (FD-level capture) instead of `capsys` and added a fallback test.
- Added CHANGELOG entry.

Closes #764