### PR TITLE
fix(config): accept skills.config.* keys in config set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`agentos config set` now accepts `skills.config.*` keys** — the dot-notation
+  setter rejected keys like `skills.config.wiki.prompt` because intermediate
+  dicts (`wiki`) didn't exist yet. `_set_key` now auto-vivifies missing
+  intermediate paths before setting the leaf value, and the standard Pydantic
+  validation catches any invalid structures afterward.
+  ([#834](https://github.com/use-agent-os/agent-os/issues/834))
+
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/cli/config_cmd.py
+++ b/src/agentos/cli/config_cmd.py
@@ -99,10 +99,12 @@ def _set_key(data: dict[str, Any], key: str, value: Any) -> bool:
     cursor: Any = data
     parts = key.split(".")
     for part in parts[:-1]:
-        if not isinstance(cursor, dict) or part not in cursor:
+        if not isinstance(cursor, dict):
             return False
+        if part not in cursor:
+            cursor[part] = {}
         cursor = cursor[part]
-    if not isinstance(cursor, dict) or parts[-1] not in cursor:
+    if not isinstance(cursor, dict):
         return False
     cursor[parts[-1]] = value
     return True

--- a/tests/test_cli/test_config_set_skills_keys.py
+++ b/tests/test_cli/test_config_set_skills_keys.py
@@ -1,0 +1,35 @@
+"""Tests for agentos config set with skills.config.* keys."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+runner = CliRunner()
+
+
+def test_config_set_skills_config_keys_auto_vivifies(tmp_path: Path) -> None:
+    """config set skills.config.wiki.prompt should auto-vivify missing intermediate dicts."""
+    target = tmp_path / "test.toml"
+    target.write_text("[skills]\nconfig = {}\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["config", "set", "skills.config.wiki.prompt", "test-prompt", "--config", str(target)],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    check = runner.invoke(
+        app,
+        ["config", "get", "skills.config.wiki.prompt", "--config", str(target)],
+    )
+    assert check.exit_code == 0, check.stdout
+    assert "test-prompt" in check.stdout
+
+    check_all = runner.invoke(app, ["config", "get", "", "--config", str(target)])
+    assert check_all.exit_code == 0, check_all.stdout
+    assert "skills.config.wiki.prompt" in check_all.stdout
+


### PR DESCRIPTION
**Closes #834**

`agentos config set` rejected keys like `skills.config.wiki.prompt` because the `_set_key` function required every intermediate key to already exist. This broke the workflow documented in the wiki skill's README, which tells users to `agentos config set skills.config.wiki.prompt ...`.

### Changes

1. **src/agentos/cli/config_cmd.py** — `_set_key` now auto-vivifies missing intermediate dicts, then lets the standard Pydantic `GatewayConfig.model_validate` catch any invalid structures afterward.
2. **CHANGELOG.md** — entry under `[Unreleased] > Fixed`.
3. **tests/test_cli/test_config_set_skills_keys.py** — new test verifying `config set skills.config.wiki.prompt` works end-to-end with a fresh config file.