### PR TITLE
docs(agentic-trading): call out the US-residency requirement for Robinhood signup

### DIFF
--- a/docs/features/agentic-trading.md
+++ b/docs/features/agentic-trading.md
@@ -25,6 +25,15 @@ Both run behind the same approval and sandbox layers as every other tool.
 
 The Web UI ships a featured preset for Robinhood Agentic Trading.
 
+> [!IMPORTANT]
+> **US-residency requirement.** Opening a Robinhood account is restricted to
+> US residents — a valid US address, SSN/ITIN, and a US bank account are
+> required for signup and KYC. AgentOS connects to the endpoint your Robinhood
+> account already authorizes; it cannot bypass Robinhood's account-eligibility
+> rules. Teams outside the US that want to trial agentic trading should use the
+> docs and skill as a reference and rely on a US-based colleague for the
+> authenticated trial.
+
 | Setting | Value |
 | --- | --- |
 | Endpoint | `https://agent.robinhood.com/mcp/trading` |


### PR DESCRIPTION
Refs #349.

## What

Adds an explicit **US-residency requirement** callout to `docs/features/agentic-trading.md` in the Robinhood Trading MCP section, exactly as the issue's acceptance criteria call for ("Documentation should call this out").

- Robinhood account signup is restricted to US residents (US address, SSN/ITIN, US bank) and is enforced at KYC.
- AgentOS connects to the endpoint the account already authorizes; it cannot bypass Robinhood eligibility.
- Non-US teams should use the docs/skill as a reference and rely on a US-based colleague for an authenticated trial.

## Why now

The issue is claimed and the integration trial requires a US-resident account (unavailable to the claimant). This docs change is the deliverable that does not depend on account access and is part of the acceptance criteria.

## Test

Docs-only change; no code or test surface. Rendered callout verified in the markdown.