### PR TITLE
fix(gateway): retain route envelope while session has queued work (Closes #930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- TaskRuntime no longer evicts the routing envelope of a session
+  that still has pending work, ensuring follow-up messages (send)
+  retain channel routing metadata.
+  ([#930](https://github.com/use-agent-os/agent-os/issues/930))
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -1160,7 +1160,8 @@ class TaskRuntime:
             if self._running_by_session.get(task.envelope.session_key) is task:
                 self._running_by_session.pop(task.envelope.session_key, None)
             self._tasks.pop(task.task_id, None)
-            self._last_envelope_by_session.pop(task.envelope.session_key, None)
+            if not self._pending_by_session.get(task.envelope.session_key):
+                self._last_envelope_by_session.pop(task.envelope.session_key, None)
             # Keep the short write lock stable for this session. Popping it can
             # split callers across old/new lock objects while callbacks or
             # late lifecycle events still reference the old one. The dict grows


### PR DESCRIPTION
## Summary

Fixes #930 — `TaskRuntime._mark_terminal()` unconditionally removed the cached route envelope for the session when *any* task reached a terminal state, even when another task for the same session was still pending or running. Subsequent `TaskRuntime.send()` calls would build a generic `SourceKind.SYSTEM` envelope and lose all channel routing metadata (channel, account, recipient, thread, provenance).

## Change

Only evict `_last_envelope_by_session[session_key]` when the session has no more pending or running work — matching the same guard already used for RR deque cleanup.

## Tests

- `test_envelope_cache_preserved_for_queued_same_session_work` — enqueues 2 tasks (concurrency=1 so second blocks), releases first, verifies cache survives, sends a follow-up via `TaskRuntime.send()`.
- `test_envelope_cache_cleared_after_last_task` — verifies cache is cleaned up after the session's final task.