### PR TITLE
fix(skills): handle missing args and help flag in gmgn-holder-analysis

### DIFF
--- a/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
+++ b/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
@@ -3,6 +3,10 @@ import json, subprocess, sys, time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
+if len(sys.argv) < 3 or any(arg in ("-h", "--help") for arg in sys.argv[1:]):
+    print("Usage: analyze.py <token_address> <chain> [zh|en]")
+    sys.exit(2)
+
 TOKEN_ADDR = sys.argv[1]
 CHAIN      = sys.argv[2]
 LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'

--- a/tests/test_skill_gmgn_holder_analysis.py
+++ b/tests/test_skill_gmgn_holder_analysis.py
@@ -1,0 +1,52 @@
+"""Regression tests for the gmgn-holder-analysis bundled script."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ANALYZE_SCRIPT = (
+    ROOT
+    / "src"
+    / "agentos"
+    / "skills"
+    / "bundled"
+    / "gmgn-holder-analysis"
+    / "scripts"
+    / "analyze.py"
+)
+
+
+def test_analyze_script_handles_missing_args_gracefully() -> None:
+    """Invoking analyze.py without args prints usage and exits cleanly with code 2."""
+    result = subprocess.run(
+        [sys.executable, str(ANALYZE_SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "Usage: analyze.py" in result.stdout
+
+
+def test_analyze_script_handles_help_flag() -> None:
+    """Invoking analyze.py with --help prints usage and exits with code 2."""
+    result = subprocess.run(
+        [sys.executable, str(ANALYZE_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "Usage: analyze.py" in result.stdout
+
+
+def test_analyze_script_handles_single_arg() -> None:
+    """Invoking analyze.py with only one argument prints usage and exits with code 2."""
+    result = subprocess.run(
+        [sys.executable, str(ANALYZE_SCRIPT), "0x1234"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "Usage: analyze.py" in result.stdout


### PR DESCRIPTION
## Summary

Invoking `src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py` with no arguments, a single argument, or `--help` / `-h` resulted in an unhandled `IndexError: list index out of range` on `sys.argv[1]` and `sys.argv[2]`.

This PR adds argument length and help flag validation matching the convention established in `gmgn-wallet-score`, printing usage instructions and exiting cleanly with code 2.

## Changes

- Guarded `sys.argv` indexing in `src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py`:
  ```python
  if len(sys.argv) < 3 or any(arg in ("-h", "--help") for arg in sys.argv[1:]):
      print("Usage: analyze.py <token_address> <chain> [zh|en]")
      sys.exit(2)
closes #957 