### PR TITLE
fix(memory): consume search delta when session indexing is disabled

### DIFF
--- a/src/agentos/memory/sync_manager.py
+++ b/src/agentos/memory/sync_manager.py
@@ -204,11 +204,9 @@ class MemorySyncManager:
                 self._pending_changes or self._pending_deletes or session_sync_failed
             )
 
+        # Disabled session indexing is a successful no-op, not a pending retry.
         if reason == "session-delta" or (
-            is_search_reason
-            and session_delta_pending
-            and self._session_indexer is not None
-            and not session_sync_failed
+            is_search_reason and session_delta_pending and not session_sync_failed
         ):
             self._delta.reset()
 

--- a/tests/test_memory_sessions_source.py
+++ b/tests/test_memory_sessions_source.py
@@ -196,7 +196,8 @@ async def test_sync_manager_indexes_session_source_on_session_delta(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_sync_manager_search_indexes_pending_session_delta(tmp_path):
+@pytest.mark.parametrize("fail_first", [False, True])
+async def test_sync_manager_search_indexes_pending_session_delta(tmp_path, fail_first):
     class NoopStore:
         async def index_file(self, **_kwargs):
             return 0
@@ -210,6 +211,8 @@ async def test_sync_manager_search_indexes_pending_session_delta(tmp_path):
 
         async def sync(self, *, force: bool = False):
             self.calls.append(force)
+            if fail_first and len(self.calls) == 1:
+                raise RuntimeError("temporary session indexing failure")
             return SimpleNamespace(indexed=1, removed=0)
 
     indexer = FakeSessionIndexer()
@@ -221,10 +224,17 @@ async def test_sync_manager_search_indexes_pending_session_delta(tmp_path):
     )
     manager.notify_message(20)
 
+    if fail_first:
+        await manager.sync(reason="search:tool")
+        assert manager._delta.has_pending()
+        assert manager._dirty is True
+
     await manager.sync(reason="search:tool")
     await manager.sync(reason="search:tool")
 
-    assert indexer.calls == [False]
+    assert indexer.calls == [False] * (2 if fail_first else 1)
+    assert not manager._delta.has_pending()
+    assert manager._dirty is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_sync_manager_architecture.py
+++ b/tests/test_memory_sync_manager_architecture.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from unittest.mock import Mock
 
 import pytest
 
@@ -121,6 +122,43 @@ async def test_sync_force_overrides_search_clean_fast_path(tmp_path):
     assert first_count == 1
     assert search_count == first_count
     assert sync_calls == [{"force": True}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ["search", "search:tool", "search:control"])
+@pytest.mark.parametrize("byte_count", [20, 150_000])
+async def test_search_consumes_delta_without_session_indexer(
+    tmp_path, monkeypatch, reason, byte_count
+):
+    manager = MemorySyncManager(
+        store=NoopStore(), workspace_dir=tmp_path, memory_dir=tmp_path / "memory"
+    )
+    scan = Mock(wraps=manager._scan_files)
+    monkeypatch.setattr(manager, "_scan_files", scan)
+    manager.notify_message(byte_count)
+
+    await manager.sync(reason=reason)
+
+    assert scan.call_count == 1
+    assert not manager._delta.has_pending()
+    assert manager._dirty is False
+
+    for search_reason in ("search", "search:tool", "search:control"):
+        await manager.sync(reason=search_reason)
+    assert scan.call_count == 1
+
+    manager.notify_message(20)
+    await manager.sync(reason=reason)
+    assert scan.call_count == 2
+    assert not manager._delta.has_pending()
+
+    manager.mark_dirty()
+    await manager.sync(reason=reason)
+    assert scan.call_count == 3
+    assert manager._dirty is False
+
+    await manager.sync(reason=reason, force=True)
+    assert scan.call_count == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Consume pending session delta after a successful search-time sync even when session indexing is disabled.
- Restore the clean-search fast path after that one sync; keep new-message, dirty-state, and forced sync behavior unchanged.
- Preserve pending delta and dirty state when an enabled session indexer fails during search-time sync, allowing the next search to retry.

Fixes #956

## Cause and scope

Search checks `has_pending()`, so even one small message can bypass the clean fast path. Previously the search reset additionally required an indexer to exist, although disabled session indexing is a successful no-op. Removing that condition prevents repeated recursive file scans on every unchanged search.

This does not change the session-delta threshold, public API, configuration, database schema, or file-index failure requeue behavior. It does not claim unchanged files were re-embedded.

## Tests

- Added six regressions covering `search`, `search:tool`, and `search:control`, with both a small message and one exceeding the byte threshold. All six fail on the original implementation.
- Spy on the real file scan to verify repeated unchanged searches stop scanning; new messages, dirty state, and explicit force still trigger it.
- Extend enabled-indexer coverage with a failure-then-success retry, verifying the delta is retained on failure and consumed on success.
- Focused sync architecture, sessions source, and file retry suites: 25 passed.

## Quality gate

- Control UI production build — passed.
- `npm --prefix frontend run check -- --maxWorkers=1 --minWorkers=1` — passed (2,041 tests across 99 files, plus TypeScript, ESLint, and Prettier).
- `uv run ruff check src tests` — passed.
- `uv run mypy src/agentos --show-error-codes` — passed (622 source files).
- `uv run pytest -q --tb=short` — 9,103 passed, 32 skipped, 6 failed, 3 setup errors. All nine failing/error cases were reproduced on a clean checkout of the same `main@2e4d6ac`: unhydrated Git LFS ONNX assets and local uv 0.8.15 not supporting the wheelhouse tests' `--clear` option. No tests were excluded and no unrelated workaround is included.
- `uv build --wheel` — passed.

## Third-party origins

None.
