### PR TITLE
fix(tools): validate arguments in gmgn-holder-analysis script (#957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+-  script now validates argument presence and
+  prints usage instead of crashing with IndexError.
+  ([#957](https://github.com/use-agent-os/agent-os/issues/957))
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
+++ b/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
@@ -3,9 +3,16 @@ import json, subprocess, sys, time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
-TOKEN_ADDR = sys.argv[1]
-CHAIN      = sys.argv[2]
+TOKEN_ADDR = sys.argv[1] if len(sys.argv) > 1 else None
+CHAIN      = sys.argv[2] if len(sys.argv) > 2 else None
 LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'
+
+if not TOKEN_ADDR or TOKEN_ADDR in ('-h', '--help', '-help'):
+    print(f"Usage: {sys.argv[0]} <token_address> <chain> [zh|en]", file=sys.stderr)
+    sys.exit(2)
+if not CHAIN:
+    print(f"Usage: {sys.argv[0]} <token_address> <chain> [zh|en]", file=sys.stderr)
+    sys.exit(2)
 
 # EVM 地址自动探测链（0x... 且 chain 传入 'auto' 或未明确指定时）
 KNOWN_CHAINS = ('bsc', 'eth', 'base', 'sol', 'robinhood', 'arc', 'stable')

--- a/tests/test_skills/test_gmgn_holder_analysis_args.py
+++ b/tests/test_skills/test_gmgn_holder_analysis_args.py
@@ -1,0 +1,34 @@
+"""Test gmgn-holder-analysis argument validation."""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+SCRIPT = "src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py"
+
+
+class TestArgumentValidation:
+    def test_no_args_exits_with_usage(self) -> None:
+        result = subprocess.run(
+            [sys.executable, SCRIPT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert "Usage:" in result.stderr
+
+    def test_help_flag_exits_with_usage(self) -> None:
+        for flag in ("-h", "--help", "-help"):
+            result = subprocess.run(
+                [sys.executable, SCRIPT, flag],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 2, f"flag {flag} should exit 2"
+            assert "Usage:" in result.stderr
+
+    def test_only_token_exits_with_usage(self) -> None:
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "0xabc"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert "Usage:" in result.stderr


### PR DESCRIPTION
## Summary

`gmgn-holder-analysis/scripts/analyze.py` crashes with IndexError when invoked without arguments or with --help / -h, because it indexes sys.argv[1] and sys.argv[2] without length checks.

## Changes

1. **analyze.py** — Added argument validation: checks len(sys.argv), detects help flags, prints usage and exits with code 2
2. **tests/test_skills/test_gmgn_holder_analysis_args.py** — Tests for no args, help flags, missing chain

Closes #957.