### PR TITLE
fix(channels): use constant-time comparison for telegram webhook secret

### DIFF
--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -680,7 +681,8 @@ class TelegramChannel:
         secret = self.config.webhook_secret_token
         if not secret:
             return Response(status_code=503)
-        if request.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
+        candidate = request.headers.get("X-Telegram-Bot-Api-Secret-Token") or ""
+        if not hmac.compare_digest(candidate.encode("utf-8"), secret.encode("utf-8")):
             return Response(status_code=401)
         try:
             update = await request.json()

--- a/tests/test_channels/test_telegram_webhook_auth.py
+++ b/tests/test_channels/test_telegram_webhook_auth.py
@@ -1,0 +1,123 @@
+"""Tests for Telegram channel webhook secret token verification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from agentos.channel_pairing import ChannelPairingStore
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+
+@pytest.fixture
+def pairing_store(tmp_path: Path) -> ChannelPairingStore:
+    return ChannelPairingStore(tmp_path / "pairing")
+
+
+def _make_app(channel: TelegramChannel) -> Starlette:
+    app = Starlette()
+    app.routes.append(channel.create_webhook_route())
+    return app
+
+
+def test_telegram_webhook_valid_secret(pairing_store: ChannelPairingStore) -> None:
+    config = TelegramChannelConfig(
+        name="tg",
+        webhook_secret_token="super_secret_token_123",
+        webhook_path="/telegram/webhook",
+    )
+    channel = TelegramChannel(config, pairing_store=pairing_store)
+    app = _make_app(channel)
+
+    client = TestClient(app)
+    response = client.post(
+        "/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "super_secret_token_123"},
+        json={
+            "update_id": 1,
+            "message": {
+                "message_id": 1,
+                "from": {"id": 100, "username": "alice"},
+                "chat": {"id": 100, "type": "private"},
+                "text": "hi",
+            },
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_telegram_webhook_invalid_secret(pairing_store: ChannelPairingStore) -> None:
+    config = TelegramChannelConfig(
+        name="tg",
+        webhook_secret_token="super_secret_token_123",
+        webhook_path="/telegram/webhook",
+    )
+    channel = TelegramChannel(config, pairing_store=pairing_store)
+    app = _make_app(channel)
+
+    client = TestClient(app)
+    response = client.post(
+        "/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "wrong_secret"},
+        json={"update_id": 1},
+    )
+    assert response.status_code == 401
+
+
+def test_telegram_webhook_prefix_secret_rejected(pairing_store: ChannelPairingStore) -> None:
+    config = TelegramChannelConfig(
+        name="tg",
+        webhook_secret_token="super_secret_token_123",
+        webhook_path="/telegram/webhook",
+    )
+    channel = TelegramChannel(config, pairing_store=pairing_store)
+    app = _make_app(channel)
+
+    client = TestClient(app)
+    response = client.post(
+        "/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "super_secret_token_123_extra"},
+        json={"update_id": 1},
+    )
+    assert response.status_code == 401
+
+
+def test_telegram_webhook_missing_header_rejected(pairing_store: ChannelPairingStore) -> None:
+    config = TelegramChannelConfig(
+        name="tg",
+        webhook_secret_token="super_secret_token_123",
+        webhook_path="/telegram/webhook",
+    )
+    channel = TelegramChannel(config, pairing_store=pairing_store)
+    app = _make_app(channel)
+
+    client = TestClient(app)
+    response = client.post(
+        "/telegram/webhook",
+        json={"update_id": 1},
+    )
+    assert response.status_code == 401
+
+
+def test_telegram_webhook_unconfigured_secret_returns_503(
+    pairing_store: ChannelPairingStore,
+) -> None:
+    config = TelegramChannelConfig(
+        name="tg",
+        webhook_secret_token="temp_for_route_creation",
+        webhook_path="/telegram/webhook",
+    )
+    channel = TelegramChannel(config, pairing_store=pairing_store)
+    app = _make_app(channel)
+
+    channel.config.webhook_secret_token = ""
+    client = TestClient(app)
+    response = client.post(
+        "/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "temp_for_route_creation"},
+        json={"update_id": 1},
+    )
+    assert response.status_code == 503


### PR DESCRIPTION
## Summary

In `TelegramChannel._handle_webhook`, the inbound `X-Telegram-Bot-Api-Secret-Token` header was compared to `self.config.webhook_secret_token` using direct string inequality (`!=`). Python's default string comparison short-circuits on the first mismatched byte, creating a timing side-channel that allows remote callers to infer the secret token character by character.

This PR updates the check to use constant-time comparison via `hmac.compare_digest` on UTF-8 encoded bytes, matching the security pattern enforced across `src/agentos/gateway/auth.py` and `src/agentos/channels/slack.py`.

## Changes

- Updated `TelegramChannel._handle_webhook` in `src/agentos/channels/telegram.py`:
  ```python
  candidate = request.headers.get("X-Telegram-Bot-Api-Secret-Token") or ""
  if not hmac.compare_digest(candidate.encode("utf-8"), secret.encode("utf-8")):
      return Response(status_code=401)
  Added a dedicated regression test suite in tests/test_channels/test_telegram_webhook_auth.py covering:
  Correct secret token accepts incoming payload (200 OK).
  Mismatched secret token rejected (401 Unauthorized).
  Partial/prefix match rejected (401 Unauthorized).
  Missing secret token header rejected (401 Unauthorized).
  Unconfigured webhook secret token returns 503 Service Unavailable.
## Verification
sh
uv run pytest tests/test_channels/test_telegram_webhook_auth.py -q
uv run pytest tests/test_channels/ -q
uv run ruff check src tests
uv run mypy src/agentos/channels/telegram.py --show-error-codes
closes #961 