### PR TITLE
fix(scheduler): serialize writes and add rollback handling to JobStore.transaction

### DIFF
--- a/src/agentos/scheduler/persistence.py
+++ b/src/agentos/scheduler/persistence.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from typing import Any
 
 import structlog
 
@@ -357,12 +359,47 @@ def _parse_delivery(raw: str | None) -> DeliveryConfig:
         return DeliveryConfig()
 
 
+class _AsyncReentrantLock:
+    """Async reentrant lock bound to asyncio.current_task()."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._owner: asyncio.Task[Any] | None = None
+        self._depth = 0
+
+    async def acquire(self) -> None:
+        current_task = asyncio.current_task()
+        if self._owner is not None and self._owner is current_task:
+            self._depth += 1
+            return
+        await self._lock.acquire()
+        self._owner = current_task
+        self._depth = 1
+
+    def release(self) -> None:
+        current_task = asyncio.current_task()
+        if self._owner is not current_task:
+            raise RuntimeError("Cannot release un-owned lock")
+        self._depth -= 1
+        if self._depth == 0:
+            self._owner = None
+            self._lock.release()
+
+    async def __aenter__(self) -> None:
+        await self.acquire()
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.release()
+
+
 class JobStore:
     """Async SQLite store for CronJob records."""
 
     def __init__(self, db_path: str = ":memory:") -> None:
         self._db_path = db_path
         self._conn: aiosqlite.Connection | None = None
+        self._write_lock = _AsyncReentrantLock()
+        self._in_transaction = False
 
     async def open(self) -> None:
         if self._conn is None:
@@ -602,18 +639,36 @@ class JobStore:
         )
 
     async def save(self, job: CronJob) -> None:
-        await self._execute_save(job)
-        await self._db().commit()
+        async with self._write_lock:
+            await self._execute_save(job)
+            if not self._in_transaction:
+                await self._db().commit()
 
     async def save_no_commit(self, job: CronJob) -> None:
         """Insert/update a job without committing — use inside transaction()."""
         await self._execute_save(job)
 
     @asynccontextmanager
-    async def transaction(self):
-        """Batch multiple save_no_commit() calls into a single commit."""
-        yield self
-        await self._db().commit()
+    async def transaction(self) -> AsyncIterator[JobStore]:
+        """Batch multiple save_no_commit() calls into a single commit with rollback on failure."""
+        async with self._write_lock:
+            nested = self._in_transaction
+            if not nested:
+                self._in_transaction = True
+            try:
+                yield self
+                if not nested:
+                    await self._db().commit()
+            except BaseException:
+                if not nested:
+                    try:
+                        await self._db().rollback()
+                    except Exception:
+                        pass
+                raise
+            finally:
+                if not nested:
+                    self._in_transaction = False
 
     async def get(self, job_id: str) -> CronJob | None:
         async with self._db().execute(
@@ -680,28 +735,30 @@ class JobStore:
         if require_due:
             params.append(now_iso)
 
-        cur = await self._db().execute(
-            f"""
-            UPDATE scheduler_jobs
-            SET status = ?,
-                reservation_token = ?,
-                reserved_at = ?,
-                reserved_by = ?,
-                reservation_source = ?,
-                scheduled_run_at = next_run_at,
-                last_run_at = ?,
-                updated_at = ?,
-                last_error = NULL
-            WHERE id = ?
-              AND enabled = 1
-              AND status = ?
-              AND reservation_token = ''
-              AND (backoff_until IS NULL OR backoff_until <= ?)
-              {due_predicate}
-            """,
-            [JobStatus.RUNNING.value, *params],
-        )
-        await self._db().commit()
+        async with self._write_lock:
+            cur = await self._db().execute(
+                f"""
+                UPDATE scheduler_jobs
+                SET status = ?,
+                    reservation_token = ?,
+                    reserved_at = ?,
+                    reserved_by = ?,
+                    reservation_source = ?,
+                    scheduled_run_at = next_run_at,
+                    last_run_at = ?,
+                    updated_at = ?,
+                    last_error = NULL
+                WHERE id = ?
+                  AND enabled = 1
+                  AND status = ?
+                  AND reservation_token = ''
+                  AND (backoff_until IS NULL OR backoff_until <= ?)
+                  {due_predicate}
+                """,
+                [JobStatus.RUNNING.value, *params],
+            )
+            if not self._in_transaction:
+                await self._db().commit()
 
         if cur.rowcount == 1:
             job = await self.get(job_id)
@@ -793,8 +850,10 @@ class JobStore:
         return True
 
     async def delete(self, job_id: str) -> None:
-        await self._db().execute("DELETE FROM scheduler_jobs WHERE id = ?", (job_id,))
-        await self._db().commit()
+        async with self._write_lock:
+            await self._db().execute("DELETE FROM scheduler_jobs WHERE id = ?", (job_id,))
+            if not self._in_transaction:
+                await self._db().commit()
 
     async def list_active(self) -> list[CronJob]:
         """Return all jobs that are not deleted."""
@@ -839,26 +898,28 @@ class JobStore:
             return None
 
     async def save_execution(self, execution: JobExecution) -> None:
-        await self._db().execute(
-            """
-            INSERT INTO scheduler_runs
-                (id, job_id, started_at, finished_at, success, error,
-                 summary, session_key, delivery_status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                execution.id,
-                execution.job_id,
-                execution.started_at.isoformat(),
-                self._iso(execution.finished_at),
-                1 if execution.success else 0,
-                execution.error,
-                execution.summary,
-                execution.session_key,
-                execution.delivery_status,
-            ),
-        )
-        await self._db().commit()
+        async with self._write_lock:
+            await self._db().execute(
+                """
+                INSERT INTO scheduler_runs
+                    (id, job_id, started_at, finished_at, success, error,
+                     summary, session_key, delivery_status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    execution.id,
+                    execution.job_id,
+                    execution.started_at.isoformat(),
+                    self._iso(execution.finished_at),
+                    1 if execution.success else 0,
+                    execution.error,
+                    execution.summary,
+                    execution.session_key,
+                    execution.delivery_status,
+                ),
+            )
+            if not self._in_transaction:
+                await self._db().commit()
 
     async def list_executions(self, job_id: str, limit: int = 20) -> list[JobExecution]:
         async with self._db().execute(
@@ -886,38 +947,40 @@ class JobStore:
 
     async def prune_runs(self, max_age_days: int = 30, max_per_job: int = 100) -> int:
         """Delete old execution records. Returns total rows deleted."""
-        from datetime import UTC, timedelta
+        async with self._write_lock:
+            from datetime import timedelta
 
-        cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).isoformat()
+            cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).isoformat()
 
-        # Delete by age
-        cur = await self._db().execute(
-            "DELETE FROM scheduler_runs WHERE started_at < ?",
-            (cutoff,),
-        )
-        deleted = cur.rowcount
-
-        # Delete excess per job (keep newest max_per_job)
-        async with self._db().execute("SELECT DISTINCT job_id FROM scheduler_runs") as cur2:
-            job_ids = [r[0] for r in await cur2.fetchall()]
-
-        for job_id in job_ids:
-            cur3 = await self._db().execute(
-                """
-                DELETE FROM scheduler_runs
-                WHERE job_id = ? AND id NOT IN (
-                    SELECT id FROM scheduler_runs
-                    WHERE job_id = ?
-                    ORDER BY started_at DESC
-                    LIMIT ?
-                )
-                """,
-                (job_id, job_id, max_per_job),
+            # Delete by age
+            cur = await self._db().execute(
+                "DELETE FROM scheduler_runs WHERE started_at < ?",
+                (cutoff,),
             )
-            deleted += cur3.rowcount
+            deleted = cur.rowcount
 
-        await self._db().commit()
-        return deleted
+            # Delete excess per job (keep newest max_per_job)
+            async with self._db().execute("SELECT DISTINCT job_id FROM scheduler_runs") as cur2:
+                job_ids = [r[0] for r in await cur2.fetchall()]
+
+            for job_id in job_ids:
+                cur3 = await self._db().execute(
+                    """
+                    DELETE FROM scheduler_runs
+                    WHERE job_id = ? AND id NOT IN (
+                        SELECT id FROM scheduler_runs
+                        WHERE job_id = ?
+                        ORDER BY started_at DESC
+                        LIMIT ?
+                    )
+                    """,
+                    (job_id, job_id, max_per_job),
+                )
+                deleted += cur3.rowcount
+
+            if not self._in_transaction:
+                await self._db().commit()
+            return deleted
 
     async def iter_due(self, now: datetime) -> AsyncIterator[CronJob]:
         """Yield jobs whose next_run_at <= now, status pending, enabled, and not backing off."""

--- a/tests/test_scheduler/test_jobstore_transaction.py
+++ b/tests/test_scheduler/test_jobstore_transaction.py
@@ -1,0 +1,122 @@
+"""Tests for JobStore transaction serialization, rollback, and reentrancy."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agentos.scheduler.persistence import JobStore
+from agentos.scheduler.types import CronJob
+
+
+def _dummy_job(job_id: str, name: str = "Test Job") -> CronJob:
+    return CronJob(
+        id=job_id,
+        name=name,
+        cron_expr="*/5 * * * *",
+        schedule_raw="*/5 * * * *",
+        handler_key="agent_run",
+    )
+
+
+@pytest.mark.asyncio
+async def test_transaction_commits_all_jobs_on_success(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        async with store.transaction():
+            await store.save_no_commit(_dummy_job("job-1", "Job One"))
+            await store.save_no_commit(_dummy_job("job-2", "Job Two"))
+
+        assert await store.get("job-1") is not None
+        assert await store.get("job-2") is not None
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_transaction_rolls_back_on_exception(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        with pytest.raises(RuntimeError, match="abort"):
+            async with store.transaction():
+                await store.save_no_commit(_dummy_job("job-rollback", "Rollback Job"))
+                raise RuntimeError("abort")
+
+        # The uncommitted job must not exist in the store
+        assert await store.get("job-rollback") is None
+
+        # Subsequent independent save must not commit the rolled-back job
+        await store.save(_dummy_job("job-after", "After Job"))
+        assert await store.get("job-after") is not None
+        assert await store.get("job-rollback") is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_nested_transaction_reentrant(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        async with store.transaction():
+            await store.save_no_commit(_dummy_job("outer", "Outer Job"))
+            async with store.transaction():
+                await store.save_no_commit(_dummy_job("inner", "Inner Job"))
+
+        assert await store.get("outer") is not None
+        assert await store.get("inner") is not None
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_nested_transaction_rollback(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        with pytest.raises(ValueError, match="fail inside"):
+            async with store.transaction():
+                await store.save_no_commit(_dummy_job("outer", "Outer Job"))
+                async with store.transaction():
+                    await store.save_no_commit(_dummy_job("inner", "Inner Job"))
+                    raise ValueError("fail inside")
+
+        assert await store.get("outer") is None
+        assert await store.get("inner") is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_save_serialized_with_transaction(tmp_path: Path) -> None:
+    store = JobStore(str(tmp_path / "test.db"))
+    await store.open()
+    try:
+        order: list[str] = []
+
+        async def run_transaction():
+            async with store.transaction():
+                await store.save_no_commit(_dummy_job("tx-job", "Tx Job"))
+                order.append("tx_saved")
+                await asyncio.sleep(0.05)
+                order.append("tx_committing")
+
+        async def run_concurrent_save():
+            # Wait briefly to let transaction start first
+            await asyncio.sleep(0.01)
+            order.append("concurrent_saving")
+            await store.save(_dummy_job("direct-job", "Direct Job"))
+            order.append("concurrent_saved")
+
+        await asyncio.gather(run_transaction(), run_concurrent_save())
+
+        # Concurrent save must wait until transaction completes
+        assert order == ["tx_saved", "concurrent_saving", "tx_committing", "concurrent_saved"]
+        assert await store.get("tx-job") is not None
+        assert await store.get("direct-job") is not None
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary

`JobStore.transaction()` in `src/agentos/scheduler/persistence.py` batched calls via `save_no_commit()` and committed upon context exit. However:
1. **No rollback on failure**: Unhandled exceptions inside the context block bypassed `commit()` but never issued `rollback()`, leaving uncommitted writes in the shared SQLite connection buffer to be committed by subsequent calls.
2. **Missing write serialization**: Concurrent calls to `save()`, `delete()`, `save_execution()`, or `_reserve_job_for_run()` called `await self._db().commit()` directly on the shared connection, prematurely committing incomplete batch state before `transaction()` completed.

This PR adds an `_AsyncReentrantLock`, guards write operations, defers intermediate commits when inside an active transaction, and guarantees automatic rollback on error.

## Changes

- Added `_AsyncReentrantLock` bound to `asyncio.current_task()` in `src/agentos/scheduler/persistence.py`.
- Hardened `JobStore.transaction()`:
  ```python
  @asynccontextmanager
  async def transaction(self) -> AsyncIterator[JobStore]:
      async with self._write_lock:
          nested = self._in_transaction
          if not nested:
              self._in_transaction = True
          try:
              yield self
              if not nested:
                  await self._db().commit()
          except BaseException:
              if not nested:
                  try:
                      await self._db().rollback()
                  except Exception:
                      pass
              raise
          finally:
              if not nested:
                  self._in_transaction = False
closes #964