### PR TITLE
fix(engine): evict idle session keys on release in SessionWriteLock

### DIFF
--- a/src/agentos/engine/session_lock.py
+++ b/src/agentos/engine/session_lock.py
@@ -11,17 +11,32 @@ class SessionWriteLock:
 
     def __init__(self) -> None:
         self._locks: dict[str, asyncio.Lock] = {}
+        self._waiters: dict[str, int] = {}
 
     async def acquire(self, session_key: str) -> None:
         """Acquire the lock for a session."""
         if session_key not in self._locks:
             self._locks[session_key] = asyncio.Lock()
-        await self._locks[session_key].acquire()
+            self._waiters[session_key] = 0
+        self._waiters[session_key] += 1
+        try:
+            await self._locks[session_key].acquire()
+        except BaseException:
+            self._waiters[session_key] -= 1
+            if self._waiters[session_key] <= 0 and not self._locks[session_key].locked():
+                self._locks.pop(session_key, None)
+                self._waiters.pop(session_key, None)
+            raise
 
     def release(self, session_key: str) -> None:
-        """Release the lock for a session."""
+        """Release the lock for a session and evict unreferenced locks."""
         if session_key in self._locks:
-            self._locks[session_key].release()
+            lock = self._locks[session_key]
+            lock.release()
+            self._waiters[session_key] -= 1
+            if self._waiters[session_key] <= 0 and not lock.locked():
+                self._locks.pop(session_key, None)
+                self._waiters.pop(session_key, None)
 
     async def __aenter__(self) -> SessionWriteLock:
         return self
@@ -32,6 +47,9 @@ class SessionWriteLock:
     def context(self, session_key: str) -> SessionLockContext:
         """Return a context manager for the session lock."""
         return SessionLockContext(self, session_key)
+
+    def __len__(self) -> int:
+        return len(self._locks)
 
 
 class SessionLockContext:

--- a/tests/test_engine/test_session_write_lock.py
+++ b/tests/test_engine/test_session_write_lock.py
@@ -1,0 +1,75 @@
+"""Tests for SessionWriteLock memory eviction and mutual exclusion."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentos.engine.session_lock import SessionWriteLock
+
+
+@pytest.mark.asyncio
+async def test_session_write_lock_evicts_idle_keys() -> None:
+    lock_mgr = SessionWriteLock()
+    for i in range(50):
+        session_key = f"session-{i}"
+        await lock_mgr.acquire(session_key)
+        assert len(lock_mgr) == 1
+        lock_mgr.release(session_key)
+        assert len(lock_mgr) == 0
+
+    assert len(lock_mgr) == 0
+
+
+@pytest.mark.asyncio
+async def test_session_write_lock_context_manager_prunes_on_exit() -> None:
+    lock_mgr = SessionWriteLock()
+    async with lock_mgr.context("session-ctx"):
+        assert len(lock_mgr) == 1
+    assert len(lock_mgr) == 0
+
+
+@pytest.mark.asyncio
+async def test_session_write_lock_concurrent_waiters_retained_until_last_release() -> None:
+    lock_mgr = SessionWriteLock()
+    order: list[str] = []
+
+    async def task_one() -> None:
+        async with lock_mgr.context("shared-session"):
+            order.append("t1_start")
+            await asyncio.sleep(0.05)
+            order.append("t1_done")
+
+    async def task_two() -> None:
+        await asyncio.sleep(0.01)
+        async with lock_mgr.context("shared-session"):
+            order.append("t2_start")
+            await asyncio.sleep(0.01)
+            order.append("t2_done")
+
+    await asyncio.gather(task_one(), task_two())
+
+    assert order == ["t1_start", "t1_done", "t2_start", "t2_done"]
+    assert len(lock_mgr) == 0
+
+
+@pytest.mark.asyncio
+async def test_session_write_lock_waiter_cancelled_cleans_up() -> None:
+    lock_mgr = SessionWriteLock()
+
+    await lock_mgr.acquire("cancel-session")
+    assert len(lock_mgr) == 1
+
+    async def waiter() -> None:
+        await lock_mgr.acquire("cancel-session")
+
+    task = asyncio.create_task(waiter())
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Release initial holder; lock must be completely evicted
+    lock_mgr.release("cancel-session")
+    assert len(lock_mgr) == 0


### PR DESCRIPTION
## Summary

In `src/agentos/engine/session_lock.py`, `SessionWriteLock` maintains a dictionary of `asyncio.Lock` objects keyed by `session_key`. While `acquire()` instantiated locks on demand, `release()` only released the lock without evicting the session key from `self._locks`. Over the lifetime of long-running daemons handling many sessions, this caused `_locks` to grow monotonically without bound.

This PR adds reference/waiter tracking to safely evict session keys once all waiting acquirers release, handles task cancellation cleanup during `acquire()`, and implements `__len__` for lock introspection.

## Changes

- Updated `SessionWriteLock` in `src/agentos/engine/session_lock.py`:
  - Added `self._waiters: dict[str, int] = {}` to track active holders and queued waiters.
  - Decremented waiters and pruned idle keys in `release()`:
    ```python
    if self._waiters[session_key] <= 0 and not lock.locked():
        self._locks.pop(session_key, None)
        self._waiters.pop(session_key, None)
    ```
  - Added cancellation handling in `acquire()` to prevent leaked waiter counts if an acquiring task is cancelled before completion.
  - Implemented `__len__` returning the count of active tracked locks.
- Added a regression test suite in `tests/test_engine/test_session_write_lock.py` covering:
  - Complete eviction after sequential acquire/release cycles (`len(lock_mgr) == 0`).
  - Automatic eviction upon exiting `async with lock.context(key):`.
  - Retention during concurrent waiter contention until the final holder releases.
  - Cleanup of waiter counts upon task cancellation.

## Verification

```sh
uv run pytest tests/test_engine/test_session_write_lock.py -q
uv run pytest tests/test_engine/ -q
uv run ruff check src tests
uv run mypy src/agentos/engine/session_lock.py --show-error-codes
closes #966