### PR TITLE
fix(skills): validate rpc-url scheme in robinhood-rwa-addresses lookup

### DIFF
--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
@@ -183,14 +183,22 @@ def lookup(
     return [_shape(t) for _s, t in scored[:limit]]
 
 
+def _validate_http_url(url: str) -> str:
+    cleaned = (url or "").strip()
+    if not (cleaned.startswith("http://") or cleaned.startswith("https://")):
+        raise ValueError(f"invalid url {url!r}: must start with http:// or https://")
+    return cleaned
+
+
 def _rpc_batch(rpc_url: str, calls: list[dict[str, Any]], timeout: float) -> dict[str, str]:
     """Send one batched JSON-RPC request; return ``{id: result}`` for successes.
 
     Batching keeps verification to a single HTTP round-trip no matter how many
     candidates are being checked.
     """
+    rpc_url = _validate_http_url(rpc_url)
     payload = json.dumps(calls).encode("utf-8")
-    req = urllib.request.Request(  # noqa: S310 - operator-supplied RPC endpoint
+    req = urllib.request.Request(
         rpc_url,
         data=payload,
         headers={
@@ -198,7 +206,7 @@ def _rpc_batch(rpc_url: str, calls: list[dict[str, Any]], timeout: float) -> dic
             "User-Agent": "AgentOS-robinhood-rwa-skill/0.2",
         },
     )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - validated http(s) URL
         body = json.loads(resp.read().decode("utf-8", errors="replace"))
     if not isinstance(body, list):
         raise RpcError("expected a batched JSON-RPC response")
@@ -313,37 +321,50 @@ def _warning_for(
     return None
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Robinhood RWA contract-address lookup")
-    parser.add_argument("--query", required=True, help="Company name or ticker (e.g. Apple, AAPL)")
-    parser.add_argument("--limit", type=int, default=5, help="Max matches to return")
-    parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout seconds")
-    parser.add_argument(
-        "--include-community",
-        action="store_true",
-        help="Also match non-stock community tokens (off by default; some impersonate listings)",
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Robinhood tokenized-stock (RWA) address lookup",
     )
+    parser.add_argument("--query", required=True, help="Company name or ticker (Apple, AAPL)")
+    parser.add_argument("--limit", type=int, default=5, help="Maximum candidates to return")
+    parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout seconds")
     parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help="Robinhood Chain JSON-RPC URL")
     parser.add_argument(
         "--no-verify",
         action="store_true",
-        help="Skip the on-chain beacon check (offline; every match is reported unverified)",
+        help="Skip the on-chain beacon check (faster, but marks everything unverified)",
+    )
+    parser.add_argument(
+        "--include-community",
+        action="store_true",
+        help="Include listings that do not look like Robinhood Stock Tokens",
     )
     parser.add_argument(
         "--cards",
         metavar="FILE",
-        help=(
-            "Where to write the Web-chat card artifact. Defaults to <query>.cards.json "
-            "in the working directory; the publish marker goes to stderr so stdout stays "
-            "pure JSON."
-        ),
+        help="Where to write the Web-chat card artifact (default: <symbol>.cards.json)",
     )
     parser.add_argument(
         "--no-cards",
         action="store_true",
         help="Do not write the card artifact (JSON on stdout only).",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    if args.rpc_url and not args.no_verify:
+        try:
+            args.rpc_url = _validate_http_url(args.rpc_url)
+        except ValueError as exc:
+            print(
+                json.dumps(
+                    {
+                        "query": args.query,
+                        "matches": [],
+                        "error": str(exc),
+                    }
+                )
+            )
+            return 0
 
     try:
         tokens = _fetch_tokens(args.timeout)

--- a/tests/test_skill_robinhood_rwa.py
+++ b/tests/test_skill_robinhood_rwa.py
@@ -18,6 +18,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
     / "src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py"
@@ -317,3 +319,60 @@ def test_skipped_verification_is_not_reported_as_a_network_fault() -> None:
 
 def _warning(statuses: list[str]) -> str | None:
     return rwa_lookup._warning_for([{"status": s} for s in statuses])
+
+
+# --------------------------------------------------------------------------
+# RPC URL Scheme Validation
+# --------------------------------------------------------------------------
+
+
+def test_validate_http_url_rejects_non_http_schemes() -> None:
+    for invalid in [
+        "file:///etc/passwd",
+        "file:///c:/windows/win.ini",
+        "ftp://rpc.example.com",
+        "gopher://example.com",
+        "javascript:alert(1)",
+        "/etc/passwd",
+        "relative/path.json",
+        "c:\\windows\\system32",
+        "",
+        "   ",
+    ]:
+        with pytest.raises(ValueError, match="must start with http:// or https://"):
+            rwa_lookup._validate_http_url(invalid)
+
+    assert rwa_lookup._validate_http_url("http://127.0.0.1:8545") == "http://127.0.0.1:8545"
+    assert (
+        rwa_lookup._validate_http_url("https://rpc.mainnet.chain.robinhood.com")
+        == "https://rpc.mainnet.chain.robinhood.com"
+    )
+
+
+def test_rpc_batch_rejects_file_scheme() -> None:
+    with pytest.raises(ValueError, match="must start with http:// or https://"):
+        rwa_lookup._rpc_batch("file:///etc/passwd", [], timeout=5.0)
+
+
+def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    code = rwa_lookup.main(["--query", "Apple", "--rpc-url", "file:///etc/passwd"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "error" in payload
+    assert "must start with http:// or https://" in payload["error"]
+
+
+def test_verify_tokens_handles_invalid_rpc_url() -> None:
+    matches = [
+        {
+            "name": "Apple",
+            "symbol": "AAPL",
+            "address": "0xaf3d76f1834a1d425780943c99ea8a608f8a93f9",
+        }
+    ]
+    verified = rwa_lookup.verify_tokens(matches, "file:///etc/passwd", timeout=1.0)
+    assert verified[0]["status"] == rwa_lookup.STATUS_UNVERIFIED
+    assert verified[0]["beacon"] is None


### PR DESCRIPTION
## Description
Resolves #968 .

`rwa_lookup.py` passed `--rpc-url` straight into `urllib.request.urlopen` without scheme validation, allowing `file://` and other non-http(s) schemes to read arbitrary local files when invoked from an agent context.

- Validated `rpc_url` starts with `http://` or `https://` matching `http_fetch.py:61-66` and `chain_stocks.py`.
- Enforced in both `_rpc_batch()` and `main()`.
- Re-scoped Bandit `S310` suppression to document the validated URL.
- Added regression tests in `test_skill_robinhood_rwa.py` verifying non-http scheme rejection, batch RPC validation, and clean JSON error output.

Closes #968
