### PR TITLE
fix(cli): drop uv run from channel verify and fix config set port example

### DIFF
--- a/README.product.md
+++ b/README.product.md
@@ -135,7 +135,7 @@ agentos configure router --router recommended
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 agentos configure channels
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/README.product.md
+++ b/README.product.md
@@ -135,7 +135,7 @@ agentos configure router --router recommended
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 agentos configure channels
 agentos config get llm.provider
-agentos config set port 18791 --config ~/.agentos/config.toml
+agentos config set port 18791
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -446,7 +446,7 @@ Raw config:
 
 ```sh
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 For Ollama models that do not reliably support native tool calls, set

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -446,7 +446,7 @@ Raw config:
 
 ```sh
 agentos config get llm.provider
-agentos config set port 18791 --config ~/.agentos/config.toml
+agentos config set port 18791
 ```
 
 For Ollama models that do not reliably support native tool calls, set

--- a/src/agentos/cli/channels_cmd.py
+++ b/src/agentos/cli/channels_cmd.py
@@ -60,7 +60,7 @@ def _print_restart_notice() -> None:
 
 def _print_channel_verification_next_step(name: str) -> None:
     typer.echo("Next: agentos gateway restart")
-    typer.echo(f"Verify: uv run agentos channels status {name} --json")
+    typer.echo(f"Verify: agentos channels status {name} --json")
 
 
 _SOURCE_LABEL = {

--- a/tests/test_cli/test_channels_cmd.py
+++ b/tests/test_cli/test_channels_cmd.py
@@ -423,6 +423,7 @@ def test_channels_add_prints_status_verification_next_step(tmp_path, monkeypatch
     out = result.stdout.lower()
     assert "agentos gateway restart" in out
     assert "agentos channels status w --json" in out
+    assert "uv run agentos" not in out
 
 
 def test_channels_add_echoes_resolved_path_and_source(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #840

## Summary
- Combined #836 and #841 per the consolidation on #840.
- `channels add` / `edit` now print `Verify: agentos channels status …` instead of `uv run agentos …`, matching the adjacent `Next:` line and documented pipx/pip installs.
- `docs/cli.md` and `README.product.md` now use `agentos config set port 18791 --config ~/.agentos/config.toml`. There is no `[gateway]` table (`GatewayConfig` is `extra = forbid`).
- Keeps the `uv run agentos` regression assert from #836.

No other files. The env-hint silent-success path stays on #834 / #839.

## Test plan
- [x] `test_channels_add_prints_status_verification_next_step` asserts `uv run agentos` is absent
- Default tests stay offline and credential-free.

Third-party origin: none