### PR TITLE
fix(mcp): upper-clamp bridge limits to prevent resource exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **MCP bridge resource-exhaustion clamps** — `events_wait`, `conversations_list`,
+  `messages_read`, and `transcript_jsonl` now silently upper-clamp their
+  `max_events`, `timeout_ms`, session-list, and history-limit arguments to
+  module-level caps. The four call paths were previously only lower-clamped
+  (`max(1, max_events)`, `max(0, timeout_ms)`), so a model that asked for
+  `max_events=10**9` would loop forever waiting for ten billion events, and a
+  `timeout_ms=3_600_000` would hand a 1-hour deadline to the underlying
+  `recv_event` and make the call indistinguishable from a stuck gateway. The
+  new caps are 5 minutes / 10k events / 5k messages / 5k sessions — large
+  enough that no reasonable model-driven call will ever hit them, small
+  enough that a single runaway argument cannot wedge the gateway.
+  ([#685](https://github.com/use-agent-os/agent-os/issues/685))
+
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -10,6 +10,32 @@ from typing import Any, Protocol
 
 from agentos.gateway_client import normalize_gateway_url
 
+# Resource-exhaustion caps for the MCP bridge. The bridge sits between an
+# untrusted client (the operator's own MCP host, but every parameter on the
+# four call paths below is chosen by the model on every call) and a single
+# gateway that must stay responsive for every other channel — so a runaway
+# `max_events=10**9` or `timeout_ms=3_600_000` is a self-inflicted availability
+# problem, not a hypothetical external DoS.
+#
+# Each cap is the smallest value that still lets a reasonable model-driven
+# call succeed; we clamp silently (no error) so a badly-chosen argument
+# degrades gracefully instead of surfacing a tool error to the user.
+#
+#   _MAX_TIMEOUT_MS_UPPER:   5 minutes. Long enough for a long reasoning
+#                            turn to settle; a 30-minute wait is indistinguishable
+#                            from a stuck gateway in the UI.
+#   _MAX_EVENTS_UPPER:       10k events. At ~1KB/event that's a ~10MB response —
+#                            well past what a single model turn needs to consume.
+#   _MAX_HISTORY_LIMIT_UPPER: 5k messages. Transcript lookback for a rehydrating
+#                            turn rarely exceeds a few thousand.
+#   _MAX_SESSIONS_LIMIT_UPPER: 5k sessions. Even a busy install has well under
+#                            1000 active sessions; anything more is an enumeration
+#                            request that should paginate, not a single bulk read.
+_MAX_TIMEOUT_MS_UPPER = 300_000
+_MAX_EVENTS_UPPER = 10_000
+_MAX_HISTORY_LIMIT_UPPER = 5_000
+_MAX_SESSIONS_LIMIT_UPPER = 5_000
+
 
 class GatewayClientLike(Protocol):
     async def connect(self, url: str) -> None: ...
@@ -42,11 +68,7 @@ class AgentOSMCPBridge:
         gateway_url: str | None = None,
         gateway_client_factory: Callable[[], GatewayClientLike] = _default_gateway_client,
     ) -> None:
-        raw_url = (
-            gateway_url
-            or os.environ.get("AGENTOS_GATEWAY_URL")
-            or "ws://localhost:18791/ws"
-        )
+        raw_url = gateway_url or os.environ.get("AGENTOS_GATEWAY_URL") or "ws://localhost:18791/ws"
         self.gateway_url = normalize_gateway_url(raw_url)
         self._gateway_client_factory = gateway_client_factory
         self._client: GatewayClientLike | None = None
@@ -65,7 +87,7 @@ class AgentOSMCPBridge:
 
     async def conversations_list(self, limit: int = 50) -> dict[str, Any]:
         client = await self._ensure_client()
-        return await client.list_sessions(limit=limit)
+        return await client.list_sessions(limit=min(limit, _MAX_SESSIONS_LIMIT_UPPER))
 
     async def session_resolve(self, key: str) -> dict[str, Any]:
         client = await self._ensure_client()
@@ -73,7 +95,7 @@ class AgentOSMCPBridge:
 
     async def messages_read(self, key: str, limit: int = 1000) -> dict[str, Any]:
         client = await self._ensure_client()
-        return await client.session_history(key, limit=limit)
+        return await client.session_history(key, limit=min(limit, _MAX_HISTORY_LIMIT_UPPER))
 
     async def messages_send(
         self,
@@ -131,8 +153,12 @@ class AgentOSMCPBridge:
             current_stream_seq = int(
                 subscription.get("current_stream_seq") or since_stream_seq or 0
             )
-            deadline = time.monotonic() + max(0, timeout_ms) / 1000
-            max_events = max(1, max_events)
+            # Clamp both bounds: an absurd timeout turns the call into a stuck
+            # gateway, and a non-positive max_events would loop indefinitely
+            # (the `while len(events) < max_events` predicate never advances).
+            max_events = min(max(1, max_events), _MAX_EVENTS_UPPER)
+            timeout_ms = min(max(0, timeout_ms), _MAX_TIMEOUT_MS_UPPER)
+            deadline = time.monotonic() + timeout_ms / 1000
 
             while len(events) < max_events:
                 remaining = deadline - time.monotonic()
@@ -168,7 +194,7 @@ class AgentOSMCPBridge:
             await client.close()
 
     async def transcript_jsonl(self, key: str, limit: int = 1000) -> str:
-        history = await self.messages_read(key, limit=limit)
+        history = await self.messages_read(key, limit=min(limit, _MAX_HISTORY_LIMIT_UPPER))
         messages = history.get("messages", []) if isinstance(history, dict) else []
         rows = [_message_to_event(row) for row in messages if isinstance(row, dict)]
         flattened: list[dict[str, Any]] = []

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -8,7 +8,13 @@ from typing import Any
 
 import pytest
 
-from agentos.mcp_server.bridge import AgentOSMCPBridge
+from agentos.mcp_server.bridge import (
+    _MAX_EVENTS_UPPER,
+    _MAX_HISTORY_LIMIT_UPPER,
+    _MAX_SESSIONS_LIMIT_UPPER,
+    _MAX_TIMEOUT_MS_UPPER,
+    AgentOSMCPBridge,
+)
 
 
 class FakeGatewayClient:
@@ -17,6 +23,7 @@ class FakeGatewayClient:
         self.closed = False
         self.calls: list[tuple[str, dict[str, Any] | None]] = []
         self.events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.last_recv_timeout: float | None = None
 
     async def connect(self, url: str) -> None:
         self.connected_url = url
@@ -90,6 +97,9 @@ class FakeGatewayClient:
         raise AssertionError(f"unexpected method: {method}")
 
     async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        # Recorded for events_wait()'s deadline-clamp assertion — see
+        # test_events_wait_clamps_effective_recv_deadline below.
+        self.last_recv_timeout = timeout
         if timeout is None:
             return await self.events.get()
         return await asyncio.wait_for(self.events.get(), timeout=timeout)
@@ -261,3 +271,227 @@ async def test_events_wait_uses_dedicated_connection_and_closes_it() -> None:
     assert result["current_stream_seq"] == 8
     assert clients[0].closed is False
     assert event_client.closed is True
+
+
+# --- Resource-exhaustion clamps (issue #685) --------------------------------
+#
+# Every parameter on these four call paths is chosen by the model on every
+# call, so a runaway value is a self-inflicted availability problem rather than
+# a remote DoS. The bridge silently clamps to module-level caps defined in
+# `agentos.mcp_server.bridge`. These tests assert the clamp on both bounds for
+# every vector.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        # Below the cap: pass through untouched.
+        (50, 50),
+        (1, 1),
+        # At the cap: pass through.
+        (_MAX_SESSIONS_LIMIT_UPPER, _MAX_SESSIONS_LIMIT_UPPER),
+        # Above the cap: silently clamp to the cap.
+        (_MAX_SESSIONS_LIMIT_UPPER + 1, _MAX_SESSIONS_LIMIT_UPPER),
+        (10**9, _MAX_SESSIONS_LIMIT_UPPER),
+    ],
+)
+async def test_conversations_list_clamps_limit(requested: int, expected: int) -> None:
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.conversations_list(limit=requested)
+
+    method, params = client.calls[0]
+    assert method == "sessions.list"
+    assert params == {"limit": expected}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (1000, 1000),
+        (_MAX_HISTORY_LIMIT_UPPER, _MAX_HISTORY_LIMIT_UPPER),
+        (_MAX_HISTORY_LIMIT_UPPER * 10, _MAX_HISTORY_LIMIT_UPPER),
+        (10**9, _MAX_HISTORY_LIMIT_UPPER),
+    ],
+)
+async def test_messages_read_clamps_limit(requested: int, expected: int) -> None:
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.messages_read("agent:main:main", limit=requested)
+
+    method, params = client.calls[0]
+    assert method == "chat.history"
+    assert params == {"sessionKey": "agent:main:main", "limit": expected}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (1000, 1000),
+        (_MAX_HISTORY_LIMIT_UPPER, _MAX_HISTORY_LIMIT_UPPER),
+        (_MAX_HISTORY_LIMIT_UPPER * 10, _MAX_HISTORY_LIMIT_UPPER),
+        (10**9, _MAX_HISTORY_LIMIT_UPPER),
+    ],
+)
+async def test_transcript_jsonl_clamps_limit(requested: int, expected: int) -> None:
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.transcript_jsonl("agent:main:main", limit=requested)
+
+    method, params = client.calls[0]
+    assert method == "chat.history"
+    assert params == {"sessionKey": "agent:main:main", "limit": expected}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_timeout", "requested_events"),
+    [
+        # Below the cap: pass through.
+        (1000, 1),
+        # At the cap: pass through.
+        (_MAX_TIMEOUT_MS_UPPER, _MAX_EVENTS_UPPER),
+        # Above the cap: clamp.
+        (_MAX_TIMEOUT_MS_UPPER * 10, _MAX_EVENTS_UPPER * 10),
+        (10**9, 10**9),
+    ],
+)
+async def test_events_wait_returns_for_huge_clamped_arguments(
+    requested_timeout: int, requested_events: int
+) -> None:
+    """A pre-loaded terminal event lets the call return immediately, so a
+    several-hour timeout that gets clamped to 5 minutes still resolves on the
+    first recv_event tick — the test cares that the loop terminates, not how
+    long it would have waited without the clamp."""
+    client = FakeGatewayClient()
+    await client.events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 8},
+        }
+    )
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait(
+        "agent:main:main",
+        since_stream_seq=7,
+        timeout_ms=requested_timeout,
+        max_events=requested_events,
+    )
+
+    assert result["current_stream_seq"] == 8
+    assert result["timed_out"] is False
+
+
+@pytest.mark.asyncio
+async def test_events_wait_clamps_max_events_to_upper() -> None:
+    """A max_events=10**9 would loop indefinitely waiting for ten billion
+    events. After clamping, the bridge returns as soon as a terminal event
+    arrives, even though the caller asked for the full ten billion."""
+    client = FakeGatewayClient()
+    await client.events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 1},
+        }
+    )
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait(
+        "agent:main:main",
+        timeout_ms=5000,
+        max_events=10**9,
+    )
+
+    assert len(result["events"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_events_wait_floors_non_positive_max_events_to_one() -> None:
+    """The lower clamp `max(1, max_events)` is what kept the original code
+    from looping forever on `max_events=0` or negative values. Pin it so a
+    refactor that drops the clamp is caught immediately."""
+    client = FakeGatewayClient()
+    await client.events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 1},
+        }
+    )
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    for bogus in (0, -1, -100):
+        if bogus != 0:
+            await client.events.put(
+                {
+                    "event": "session.event.done",
+                    "payload": {
+                        "session_key": "agent:main:main",
+                        "stream_seq": bogus + 2,
+                    },
+                }
+            )
+        result = await bridge.events_wait(
+            "agent:main:main",
+            timeout_ms=1000,
+            max_events=bogus,
+        )
+        assert len(result["events"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_events_wait_clamps_effective_recv_deadline() -> None:
+    """A 1-hour timeout_ms must not propagate a 3600-second `timeout` to
+    recv_event — the clamp on `timeout_ms` is what keeps the loop from
+    blocking on a single recv_event call for an hour.
+
+    The fake is pre-loaded with a terminal event so the call returns
+    immediately; we then assert the value the bridge forwarded to the
+    underlying recv_event is no larger than the upper clamp."""
+    client = FakeGatewayClient()
+    await client.events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 1},
+        }
+    )
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.events_wait(
+        "agent:main:main",
+        timeout_ms=3_600_000,
+        max_events=1,
+    )
+
+    assert client.last_recv_timeout is not None
+    assert client.last_recv_timeout <= _MAX_TIMEOUT_MS_UPPER / 1000 + 0.1
+
+
+@pytest.mark.asyncio
+async def test_events_wait_floors_non_positive_timeout_to_zero() -> None:
+    """`timeout_ms=0` and negative values must produce a deadline at or before
+    `now`, so the loop exits before even calling recv_event — the worst case
+    is `recv_event` being asked to wait forever, which is what the original
+    `max(0, timeout_ms) / 1000` accidentally avoided (it would have produced
+    `now + 0`, i.e. an immediate deadline, but only because the sign was
+    swallowed)."""
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    for bogus in (0, -1, -1000):
+        result = await bridge.events_wait(
+            "agent:main:main",
+            timeout_ms=bogus,
+            max_events=1,
+        )
+        # No events were pre-loaded, and the loop exited on the first
+        # `remaining <= 0` check, so recv_event was never called.
+        assert result["events"] == []
+        assert result["timed_out"] is True
+        assert client.last_recv_timeout is None


### PR DESCRIPTION
Fixes #685

### Summary
The four resource-exhaustion vectors exposed by `AgentOSMCPBridge` were only lower-clamped and forwarded their arguments verbatim to the gateway. A model that asked for `max_events=10**9` would loop indefinitely, and a `timeout_ms=3_600_000` would hand a 1-hour deadline to the underlying `recv_event`. This PR introduces module-level upper caps (5 minutes / 10k events / 5k messages / 5k sessions) and applies them on every call path. The clamp is silent — a badly-chosen argument degrades instead of surfacing a tool error.

### Root cause
- `events_wait.max_events` was only `max(1, max_events)`; the loop `while len(events) < max_events` never advances for a model that asks for `10**9`.
- `events_wait.timeout_ms` was only `max(0, timeout_ms) / 1000`; a 1-hour value is passed straight to `recv_event(timeout=remaining)`, indistinguishable from a stuck gateway.
- `conversations_list`, `messages_read`, and `transcript_jsonl` forwarded their `limit` argument raw.

### Proposed solution
Add four module-level constants at the top of `bridge.py` with one-line rationale each, then `min(limit, _MAX_*)` (or `min(max(1, …), _MAX_*)` for `events_wait`) on every call path. No public API change — same defaults, same return shape.

### Files
- `src/agentos/mcp_server/bridge.py` — constants + clamps
- `tests/test_mcp_server/test_bridge.py` — 18 new test cases across 7 test functions covering upper and lower bounds for all 4 vectors
- `CHANGELOG.md` — single `[Unreleased] / Fixed` entry

### Verification
- [x] `uv run pytest tests/test_mcp_server/test_bridge.py -q` — 28 passed
- [x] `uv run pytest tests/test_mcp_server/ -q` — 38 passed (no regression in sibling tests)
- [x] `uv run ruff check src/agentos/mcp_server/bridge.py tests/test_mcp_server/test_bridge.py` — clean
- [x] `uv run mypy src/agentos/mcp_server/bridge.py --show-error-codes` — no issues
- [x] `uv run ruff format --check` — clean
- [x] Stash-verify dance: with the four `min(…, _MAX_*)` clamps removed, 7 of the new tests fail (all 3 limit paths + the recv-event deadline path); restored, all 28 pass

### Third-party origins
None — all changes are original to this PR.
