### PR TITLE
fix(skills): stop clobbering a legitimate 0.0 wallet_pct in the copy-trade backtest

### DIFF
--- a/src/agentos/skills/bundled/gmgn-wallet-score/scripts/score.py
+++ b/src/agentos/skills/bundled/gmgn-wallet-score/scripts/score.py
@@ -35,6 +35,12 @@ def _b(v):
     if isinstance(v, str): return v.strip().lower() in ('1', 'true', 'yes')
     return False
 
+def _or_default(x, default):
+    # `x or default` also replaces a legitimate 0.0 with `default`, which is
+    # wrong when 0.0 is a real, meaningful value (e.g. a wallet at exactly
+    # break-even ROI) rather than missing data. Only None is "missing" here.
+    return default if x is None else x
+
 def fmt_dur(sec):
     sec = _f(sec)
     if sec < 60:    return f"{int(sec)}{_(' 秒','s')}"
@@ -287,7 +293,7 @@ copy_disp  = round(copy_score  * SELF_DEAL_DISCOUNT) if self_dealing else copy_s
 
 # ── 7. Copy-trade backtest ───────────────────────────────────
 wallet_pct = (w['realized_profit'] / w['bought_cost']) if w['bought_cost'] > 0 else w['roi']
-wallet_pct = _clamp(wallet_pct or 0.0001, -0.9, 3.0)   # clamp: dev wallets have near-zero bought_cost, ratio blows up
+wallet_pct = _clamp(_or_default(wallet_pct, 0.0001), -0.9, 3.0)   # clamp: dev wallets have near-zero bought_cost, ratio blows up
 LOW_MCAP_DRIFT_PER_S = 0.015
 drift_per_s = LOW_MCAP_DRIFT_PER_S * (0.3 + 0.7 * summ['entry_under_100k'])
 drift = LATENCY_S * drift_per_s

--- a/tests/test_skill_gmgn_wallet_score.py
+++ b/tests/test_skill_gmgn_wallet_score.py
@@ -1,0 +1,81 @@
+"""Regression test for a `0.0 vs missing` bug in the GMGN wallet-score skill.
+
+score.py is a linear, argv-driven CLI script (reads sys.argv at module level,
+then shells out to `gmgn-cli`), not structured for import-based testing the
+way chain_stocks.py is. The bug under test lives entirely in two small, pure
+helper functions, so this test extracts just their source rather than
+executing -- or mocking an entire CLI invocation for -- the whole script.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = (
+    ROOT / "src" / "agentos" / "skills" / "bundled" / "gmgn-wallet-score" / "scripts" / "score.py"
+)
+
+
+def _load_helpers() -> dict[str, Callable[..., Any]]:
+    """Exec just the `_clamp` and `_or_default` function defs from score.py.
+
+    Avoids executing the rest of the script, which reads sys.argv and shells
+    out to the gmgn-cli binary at module level.
+    """
+    tree = ast.parse(_SCRIPT.read_text())
+    wanted = {"_clamp", "_or_default"}
+    found = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    }
+    assert found.keys() == wanted, f"expected {wanted}, found {found.keys()}"
+    module = ast.Module(body=list(found.values()), type_ignores=[])
+    namespace: dict[str, Any] = {}
+    exec(compile(module, filename=str(_SCRIPT), mode="exec"), namespace)
+    return {name: namespace[name] for name in wanted}
+
+
+_helpers = _load_helpers()
+_clamp = _helpers["_clamp"]
+_or_default = _helpers["_or_default"]
+
+
+def test_or_default_preserves_a_genuine_zero() -> None:
+    # The bug: `x or default` also replaces a legitimate 0.0 with `default`,
+    # not just None. A wallet at exactly break-even ROI (0.0) is a real,
+    # meaningful value -- not missing data -- and must be preserved.
+    assert _or_default(0.0, 0.0001) == 0.0
+
+
+def test_or_default_still_substitutes_for_none() -> None:
+    assert _or_default(None, 0.0001) == 0.0001
+
+
+def test_or_default_passes_through_other_values() -> None:
+    assert _or_default(0.42, 0.0001) == 0.42
+    assert _or_default(-0.15, 0.0001) == -0.15
+
+
+def test_wallet_pct_zero_no_longer_gets_amplified_into_a_huge_backtest_number() -> None:
+    """End-to-end shape of the actual bug: a dev wallet with bought_cost <= 0
+    and roi == 0.0 exactly must produce copy_7d == 0.0, not an absurdly
+    amplified figure from dividing by a clamped-up 0.0001 in place of the
+    real 0.0.
+    """
+    bought_cost = 0.0
+    realized_profit = 800.0
+    roi = 0.0
+
+    wallet_pct = (realized_profit / bought_cost) if bought_cost > 0 else roi
+    wallet_pct = _clamp(_or_default(wallet_pct, 0.0001), -0.9, 3.0)
+    assert wallet_pct == 0.0
+
+    drift, slip, gas_pct = 0.012, 0.006, 0.004
+    copy_pct = wallet_pct - drift - slip - gas_pct
+    copy_7d = realized_profit * (copy_pct / wallet_pct) if wallet_pct else 0.0
+    assert copy_7d == 0.0


### PR DESCRIPTION
## Linked issue

Fixes #971

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

`gmgn-wallet-score`'s copy-trade backtest computes:

    wallet_pct = (realized_profit / bought_cost) if bought_cost > 0 else roi
    wallet_pct = _clamp(wallet_pct or 0.0001, -0.9, 3.0)

`wallet_pct or 0.0001` treats a genuine `0.0` identically to `None`,
silently substituting `0.0001` — Python's `or` can't distinguish
"missing" from "legitimately zero." This matters here specifically
because `wallet_pct` is used as a **divisor** immediately afterward:

    copy_pct = wallet_pct - drift - slip - gas_pct
    copy_7d = realized_profit * (copy_pct / wallet_pct) if wallet_pct else 0.0

For a "dev wallet" (`bought_cost <= 0`, so `wallet_pct = roi`) where `roi`
is exactly `0.0` and `realized_profit` is nonzero — e.g. a wallet that
sold an airdrop/dev allocation with no recorded purchase cost, exactly
the scenario the surrounding comment already calls out
("dev wallets have near-zero bought_cost, ratio blows up") — the
clobbered `0.0001` divisor produces a wildly amplified, nonsensical
result instead of the correct `0.0`:

    bought_cost, realized_profit, roi = 0.0, 800.0, 0.0
    # ... produces copy_7d = -175199.99999999997, instead of 0.0

This is a real financial figure shown directly to the user in the
wallet report.

## Fix

Adds `_or_default(x, default)`, matching this file's existing
small-helper style (alongside `_f`, `_clamp`, `_b`), which only
substitutes on `None` and correctly preserves a genuine `0.0`.

I checked for the same pattern elsewhere in the file
(`dev.get('score') or 0`, used twice) — that one is safe, since its
fallback (`0`) is numerically identical to what a legitimate zero would
produce anyway, so it was left unchanged. This fix is scoped to the one
place where the fallback value actually differs from a real zero.

## Tests

`score.py` is a linear, argv-driven CLI script (reads `sys.argv` at
module level, then shells out to the `gmgn-cli` binary) with no existing
test coverage and no clean import path the way `chain_stocks.py` has.
Since the bug is isolated entirely to two small, pure helper functions,
the new test file extracts just their source via `ast` rather than
executing (or mocking an entire CLI invocation for) the whole script:

- `test_or_default_preserves_a_genuine_zero` — the exact bug: `0.0` must
  stay `0.0`, not become `0.0001`.
- `test_or_default_still_substitutes_for_none` — confirms the intended
  `None`-guarding behavior is preserved.
- `test_or_default_passes_through_other_values` — sanity check for
  ordinary nonzero values.
- `test_wallet_pct_zero_no_longer_gets_amplified_into_a_huge_backtest_number`
  — end-to-end shape of the actual bug: the dev-wallet scenario now
  correctly produces `copy_7d == 0.0`.

Note: `score.py` intentionally fails `ruff format --check` even in its
original, untouched state (it's a bundled skill script not held to the
standard formatter — `ruff check`, i.e. linting, is what applies).
This PR does not introduce any new formatting debt to that file; only
the new test file is run through the full `ruff format` treatment.

Commands run locally:
uv sync --extra dev
uv run ruff check src/agentos/skills/bundled/gmgn-wallet-score/scripts/score.py tests/test_skill_gmgn_wallet_score.py
uv run ruff format --check tests/test_skill_gmgn_wallet_score.py
uv run mypy tests/test_skill_gmgn_wallet_score.py --show-error-codes
uv run pytest tests/test_skill_gmgn_wallet_score.py -v


Results: `ruff check` — clean on both files. `ruff format --check` —
clean on the test file (score.py's pre-existing formatting state is
unchanged by this PR). `mypy` — no issues found. `pytest` — 4 passed
(all new, no prior tests existed for this skill).

Third-party origin: none.