### PR TITLE
fix(skills): handle non-dict RPC error payloads in unilp and poolsfun

### DIFF
--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
@@ -69,10 +69,18 @@ USER_AGENT = "poolsdotfun-token-launcher/1.0"
 class RpcError(RuntimeError):
     """A JSON-RPC error response. ``data`` carries the revert blob when present."""
 
-    def __init__(self, method: str, error: dict) -> None:
-        super().__init__(f"{method}: {error.get('message', error)}")
-        self.code = error.get("code")
-        self.data = error.get("data")
+    def __init__(self, method: str, error: Any) -> None:
+        if isinstance(error, dict):
+            message = str(error.get("message", error))
+            code = error.get("code")
+            data = error.get("data")
+        else:
+            message = str(error)
+            code = None
+            data = None
+        super().__init__(f"{method}: {message}")
+        self.code = code
+        self.data = data
         self.raw = error
 
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
@@ -69,10 +69,18 @@ USER_AGENT = "senior-unilp-manager/1.0"
 class RpcError(RuntimeError):
     """A JSON-RPC error response. ``data`` carries the revert blob when present."""
 
-    def __init__(self, method: str, error: dict) -> None:
-        super().__init__(f"{method}: {error.get('message', error)}")
-        self.code = error.get("code")
-        self.data = error.get("data")
+    def __init__(self, method: str, error: Any) -> None:
+        if isinstance(error, dict):
+            message = str(error.get("message", error))
+            code = error.get("code")
+            data = error.get("data")
+        else:
+            message = str(error)
+            code = None
+            data = None
+        super().__init__(f"{method}: {message}")
+        self.code = code
+        self.data = data
         self.raw = error
 
 

--- a/tests/test_skill_unilp_poolsfun_rpc.py
+++ b/tests/test_skill_unilp_poolsfun_rpc.py
@@ -1,0 +1,76 @@
+"""Unit and regression tests for RpcError handling in unilp and poolsfun."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UNILP_DIR = str(
+    ROOT / "src" / "agentos" / "skills" / "bundled" / "senior-unilp-manager" / "scripts"
+)
+POOLSFUN_DIR = str(
+    ROOT / "src" / "agentos" / "skills" / "bundled" / "poolsdotfun-token-launcher" / "scripts"
+)
+
+if UNILP_DIR not in sys.path:
+    sys.path.insert(0, UNILP_DIR)
+
+if POOLSFUN_DIR not in sys.path:
+    sys.path.insert(0, POOLSFUN_DIR)
+
+import poolsfun.rpc as poolsfun_rpc  # noqa: E402
+import unilp.rpc as unilp_rpc  # noqa: E402
+
+
+@pytest.mark.parametrize("rpc_mod", [unilp_rpc, poolsfun_rpc])
+def test_rpc_error_dict_payload(rpc_mod: Any) -> None:
+    err = rpc_mod.RpcError(
+        "eth_call",
+        {"code": -32000, "message": "execution reverted", "data": "0x1234"},
+    )
+    assert str(err) == "eth_call: execution reverted"
+    assert err.code == -32000
+    assert err.data == "0x1234"
+    assert err.raw == {"code": -32000, "message": "execution reverted", "data": "0x1234"}
+
+
+@pytest.mark.parametrize("rpc_mod", [unilp_rpc, poolsfun_rpc])
+def test_rpc_error_string_payload(rpc_mod: Any) -> None:
+    err = rpc_mod.RpcError("eth_call", "rate limit exceeded")
+    assert str(err) == "eth_call: rate limit exceeded"
+    assert err.code is None
+    assert err.data is None
+    assert err.raw == "rate limit exceeded"
+
+
+@pytest.mark.parametrize("rpc_mod", [unilp_rpc, poolsfun_rpc])
+def test_rpc_error_non_dict_payloads(rpc_mod: Any) -> None:
+    for payload in [None, 42, ["unexpected", "list"]]:
+        err = rpc_mod.RpcError("eth_call", payload)
+        assert str(err) == f"eth_call: {payload}"
+        assert err.code is None
+        assert err.data is None
+        assert err.raw == payload
+
+
+@pytest.mark.parametrize("rpc_mod", [unilp_rpc, poolsfun_rpc])
+def test_rpc_client_request_raises_rpc_error_on_string_error(
+    monkeypatch: pytest.MonkeyPatch, rpc_mod: Any
+) -> None:
+    client = rpc_mod.RpcClient(
+        chain={"name": "test", "chainId": 1, "rpcEnv": ["TEST_RPC"]},
+        rpc_url="http://127.0.0.1:8545",
+    )
+    monkeypatch.setattr(
+        client,
+        "_post",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 1, "error": "rate limit exceeded"},
+    )
+    with pytest.raises(rpc_mod.RpcError) as excinfo:
+        client.request("eth_blockNumber")
+    assert "rate limit exceeded" in str(excinfo.value)
+    assert excinfo.value.raw == "rate limit exceeded"


### PR DESCRIPTION
## Description
Resolves #974 

`RpcError` in `unilp` and `poolsfun` assumed that error payloads were always dictionaries, calling `.get()` unconditionally. When an RPC node or proxy returns a string payload (e.g. rate limit exceeded), this caused an unhandled `AttributeError` crashing batch sweeps and queries.

- Check `isinstance(error, dict)` in `RpcError.__init__` before calling `.get()`.
- Handle strings and non-dict error payloads cleanly, falling back to `str(error)`.
- Added regression tests in `test_skill_unilp_poolsfun_rpc.py` covering dict, string, and non-dict error payloads for both `senior-unilp-manager` and `poolsdotfun-token-launcher`.

Closes #974 
