### PR TITLE
Fix Telegram webhook secret timing vulnerability (#962)

### DIFF
--- a/docs/features/agentic-trading.md
+++ b/docs/features/agentic-trading.md
@@ -25,6 +25,15 @@ Both run behind the same approval and sandbox layers as every other tool.
 
 The Web UI ships a featured preset for Robinhood Agentic Trading.
 
+> [!IMPORTANT]
+> **US-residency requirement.** Opening a Robinhood account is restricted to
+> US residents — a valid US address, SSN/ITIN, and a US bank account are
+> required for signup and KYC. AgentOS connects to the endpoint your Robinhood
+> account already authorizes; it cannot bypass Robinhood's account-eligibility
+> rules. Teams outside the US that want to trial agentic trading should use the
+> docs and skill as a reference and rely on a US-based colleague for the
+> authenticated trial.
+
 | Setting | Value |
 | --- | --- |
 | Endpoint | `https://agent.robinhood.com/mcp/trading` |

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -17,6 +17,7 @@ from starlette.responses import Response
 from starlette.routing import Route
 
 from agentos.channel_pairing import ChannelPairingStore, PairingStoreError
+import hmac
 from agentos.channels._attachment_io import (
     attachment_limit_for_mime,
     ensure_declared_size_within_limit,
@@ -175,7 +176,6 @@ def _slice_utf16(text: str, offset: int, length: int) -> str:
         return ""
     u16 = text.encode("utf-16-le")
     return u16[offset * 2 : (offset + length) * 2].decode("utf-16-le", errors="replace")
-
 
 
 @dataclass
@@ -692,7 +692,7 @@ class TelegramChannel:
         secret = self.config.webhook_secret_token
         if not secret:
             return Response(status_code=503)
-        if request.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
+        if not hmac.compare_digest(secret, request.headers.get("X-Telegram-Bot-Api-Secret-Token")):
             return Response(status_code=401)
         try:
             update = await request.json()


### PR DESCRIPTION
Fixes #962 - Replace != comparison with hmac.compare_digest() to prevent timing side-channel attacks in Telegram webhook secret verification.

This fix addresses a critical security vulnerability where the original code used standard string comparison, allowing attackers to guess the secret token byte-by-byte by measuring response times.