### PR TITLE
fix(session): preserve Unicode letters in FTS5 query sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **FTS5 query sanitizer now preserves Unicode letters and digits** —
+  `SessionStorage.sanitize_fts_query` was an ASCII-only whitelist that
+  turned every non-ASCII letter into a space, silently emptying queries
+  in every non-English locale (CJK, Cyrillic, Vietnamese, accented
+  Latin, Arabic, …) and additionally producing **wrong** matches by
+  truncating accented tokens to their ASCII prefix (`café` → `"caf"`
+  then matched unrelated content). The sanitizer now uses a blocklist
+  that strips FTS5 syntax characters (`"`, `(`, `)`, `*`, `^`, `:`) and
+  control / format / private-use codepoints, while letting every letter
+  or digit of any script through untouched. The two existing safety
+  properties — per-token double-quoting and the 20-token cap — are
+  preserved and asserted in the regression tests.
+  ([#903](https://github.com/use-agent-os/agent-os/issues/903))
+
 - Telegram Bot API calls now retry `ConnectTimeout` and `PoolTimeout` alongside
   `ConnectError`. All three happen before any request bytes reach Telegram — a
   DNS/TLS handshake that never completed, or a wait for a pooled connection —

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -109,15 +109,12 @@ CREATE TABLE IF NOT EXISTS projects (
 )
 """
 
-_CREATE_IDX_PROJECTS_AGENT = (
-    "CREATE INDEX IF NOT EXISTS idx_projects_agent ON projects(agent_id)"
-)
+_CREATE_IDX_PROJECTS_AGENT = "CREATE INDEX IF NOT EXISTS idx_projects_agent ON projects(agent_id)"
 
 # Backstop for the advisory Python-side name check (closes the concurrent
 # create race). NOCASE folds ASCII only; the casefold check stays primary.
 _CREATE_UNIQUE_IDX_PROJECTS_NAME = (
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_name_nocase "
-    "ON projects(name COLLATE NOCASE)"
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_name_nocase ON projects(name COLLATE NOCASE)"
 )
 
 _CREATE_IDX_SESSIONS_PROJECT = (
@@ -493,15 +490,11 @@ class SessionStorage:
             )
             await self._conn.commit()
         # Defensive: zero-out any NULL epoch rows left by a partial migration.
-        async with self._conn.execute(
-            "SELECT COUNT(*) FROM sessions WHERE epoch IS NULL"
-        ) as cur:
+        async with self._conn.execute("SELECT COUNT(*) FROM sessions WHERE epoch IS NULL") as cur:
             row = await cur.fetchone()
         null_count = row[0] if row else 0
         if null_count > 0:
-            await self._conn.execute(
-                "UPDATE sessions SET epoch = 0 WHERE epoch IS NULL"
-            )
+            await self._conn.execute("UPDATE sessions SET epoch = 0 WHERE epoch IS NULL")
             await self._conn.commit()
 
     async def _migrate_transcript_reasoning_content_column(self) -> None:
@@ -521,9 +514,7 @@ class SessionStorage:
         async with self._conn.execute("PRAGMA table_info(transcript_entries)") as cur:
             columns = [row[1] for row in await cur.fetchall()]
         if "turn_usage" not in columns:
-            await self._conn.execute(
-                "ALTER TABLE transcript_entries ADD COLUMN turn_usage TEXT"
-            )
+            await self._conn.execute("ALTER TABLE transcript_entries ADD COLUMN turn_usage TEXT")
             await self._conn.commit()
 
     async def _migrate_summary_metadata_columns(self) -> None:
@@ -556,8 +547,7 @@ class SessionStorage:
             "tokens_before": "ALTER TABLE session_summaries ADD COLUMN tokens_before INTEGER",
             "tokens_after": "ALTER TABLE session_summaries ADD COLUMN tokens_after INTEGER",
             "removed_count": (
-                "ALTER TABLE session_summaries ADD COLUMN "
-                "removed_count INTEGER NOT NULL DEFAULT 0"
+                "ALTER TABLE session_summaries ADD COLUMN removed_count INTEGER NOT NULL DEFAULT 0"
             ),
             "kept_count": (
                 "ALTER TABLE session_summaries ADD COLUMN kept_count INTEGER NOT NULL DEFAULT 0"
@@ -587,9 +577,7 @@ class SessionStorage:
             "coverage_turn_id": (
                 "ALTER TABLE memory_durable_receipts ADD COLUMN coverage_turn_id TEXT"
             ),
-            "coverage_hash": (
-                "ALTER TABLE memory_durable_receipts ADD COLUMN coverage_hash TEXT"
-            ),
+            "coverage_hash": ("ALTER TABLE memory_durable_receipts ADD COLUMN coverage_hash TEXT"),
             "coverage_entry_count": (
                 "ALTER TABLE memory_durable_receipts ADD COLUMN coverage_entry_count INTEGER"
             ),
@@ -875,9 +863,7 @@ class SessionStorage:
                 "UPDATE sessions SET project_id = NULL WHERE project_id = ?",
                 (project_id,),
             )
-            await self.conn.execute(
-                "DELETE FROM projects WHERE project_id = ?", (project_id,)
-            )
+            await self.conn.execute("DELETE FROM projects WHERE project_id = ?", (project_id,))
             await self.conn.commit()
         except Exception:
             await self.conn.rollback()
@@ -967,8 +953,7 @@ class SessionStorage:
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         params += [limit, offset]
         sql = (
-            f"SELECT * FROM agent_tasks {where} "
-            "ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
+            f"SELECT * FROM agent_tasks {where} ORDER BY created_at ASC, rowid ASC LIMIT ? OFFSET ?"
         )
         async with self.conn.execute(sql, params) as cur:
             rows = await cur.fetchall()
@@ -1065,9 +1050,7 @@ class SessionStorage:
         allowed = set(MemoryDurableReceipt.model_fields) - {"receipt_id", "created_at"}
         unknown = sorted(set(fields) - allowed)
         if unknown:
-            raise ValueError(
-                f"Unknown memory durable receipt fields: {', '.join(unknown)}"
-            )
+            raise ValueError(f"Unknown memory durable receipt fields: {', '.join(unknown)}")
         if "session_key" in fields:
             fields["session_key"] = canonicalize_session_key(fields["session_key"])
         fields.setdefault("updated_at", _now_ms())
@@ -1180,7 +1163,7 @@ class SessionStorage:
                 raise StaleEpochError(
                     f"Epoch mismatch for {entry.session_key}: "
                     f"expected {expected_epoch}, got {actual}"
-            )
+                )
             await self.conn.commit()
         else:
             sql = f"INSERT INTO transcript_entries ({', '.join(cols)}) VALUES ({placeholders})"
@@ -1257,9 +1240,7 @@ class SessionStorage:
             ORDER BY created_at ASC, id ASC
             LIMIT ? OFFSET ?
         """
-        async with self.conn.execute(
-            sql, (session_id, session_id, limit_val, offset)
-        ) as cur:
+        async with self.conn.execute(sql, (session_id, session_id, limit_val, offset)) as cur:
             rows = await cur.fetchall()
         return [TranscriptEntry(**_deserialize_row(dict(r))) for r in rows]
 
@@ -1333,9 +1314,7 @@ class SessionStorage:
             row = await cur.fetchone()
         return row[0] if row else 0
 
-    async def count_transcript_entries_batch(
-        self, session_ids: list[str]
-    ) -> dict[str, int]:
+    async def count_transcript_entries_batch(self, session_ids: list[str]) -> dict[str, int]:
         """Count transcript entries for many sessions in one round trip.
 
         Used by ``sessions.list`` (rpc_sessions.py) to avoid the N+1 pattern
@@ -1493,9 +1472,7 @@ class SessionStorage:
                 node=node,
                 entries=archived_entries or [],
                 compaction_id=summary.compaction_id if summary is not None else None,
-                compaction_index=summary.compaction_index
-                if summary is not None
-                else None,
+                compaction_index=summary.compaction_index if summary is not None else None,
             )
 
             await self.conn.execute(
@@ -1669,9 +1646,7 @@ class SessionStorage:
 
     # ── SessionContextState CRUD ─────────────────────────────────────────────
 
-    async def save_context_state(
-        self, state: SessionContextState
-    ) -> SessionContextState:
+    async def save_context_state(self, state: SessionContextState) -> SessionContextState:
         """Persist portable or provider-native context state for later replay."""
         state.session_key = canonicalize_session_key(state.session_key)
         data = state.model_dump(exclude={"id"})
@@ -1679,8 +1654,7 @@ class SessionStorage:
         placeholders = ", ".join("?" for _ in cols)
         values = [_serialize(data[c]) for c in cols]
         async with self.conn.execute(
-            "INSERT INTO session_context_states "
-            f"({', '.join(cols)}) VALUES ({placeholders})",
+            f"INSERT INTO session_context_states ({', '.join(cols)}) VALUES ({placeholders})",
             values,
         ) as cur:
             state.id = cur.lastrowid
@@ -1708,8 +1682,7 @@ class SessionStorage:
             clauses.append("valid = 1")
         where = " AND ".join(clauses)
         async with self.conn.execute(
-            "SELECT * FROM session_context_states "
-            f"WHERE {where} ORDER BY created_at ASC, id ASC",
+            f"SELECT * FROM session_context_states WHERE {where} ORDER BY created_at ASC, id ASC",
             params,
         ) as cur:
             rows = await cur.fetchall()
@@ -1748,17 +1721,59 @@ class SessionStorage:
     def sanitize_fts_query(raw: str) -> str:
         """Sanitize a user query for safe FTS5 MATCH.
 
-        Strips FTS5 operators and special chars, wraps each token in quotes.
+        The FTS5 ``unicode61`` tokenizer (used by default on the
+        ``transcript_fts`` virtual table) indexes and matches any Unicode
+        letter or digit, so the sanitizer is the *only* layer that decides
+        which characters survive into the MATCH expression. The previous
+        ASCII whitelist turned every non-ASCII letter into a space, which
+        silently emptied queries in every non-English locale (CJK, Cyrillic,
+        Vietnamese, accented Latin, Arabic, …) and additionally produced
+        **wrong** matches by truncating accented tokens to their ASCII
+        prefix (``café`` → ``"caf"`` then matched unrelated content).
+
+        Approach:
+          * Block FTS5 syntax characters that change MATCH semantics
+            (``"`` ``(`` ``)`` ``*`` ``^`` ``:``) and ASCII control/format
+            characters. Replace each with a single space so the surrounding
+            words do not fuse.
+          * Let every letter or digit of any script through untouched.
+          * Preserve the two existing safety properties: per-token
+            double-quoting (so FTS5 treats the token as a literal, not as
+            syntax) and the 20-token cap.
+
+        The empty-guard at the bottom still fires for queries that are pure
+        syntax / control characters, returning ``""`` so ``search_transcript``
+        short-circuits to ``[]`` rather than issuing a MATCH for nothing.
         """
         import re as _re
 
-        # Whitelist: only allow alphanumeric and whitespace through
-        cleaned = _re.sub(r"[^a-zA-Z0-9\s]", " ", raw)
-        # Collapse whitespace and split into tokens
+        # Strip the characters that carry FTS5 syntax or are ASCII
+        # control codepoints. Every other character — Unicode letters and
+        # digits of any script — passes through as part of a token. We do
+        # NOT collapse consecutive whitespace here; the split() below
+        # already does that.
+        #
+        # We avoid the ``\p{C}`` Unicode-property class because the
+        # stdlib ``re`` module does not support it (that syntax is in the
+        # third-party ``regex`` module). The explicit character class
+        # below covers the same categories the sanitizer actually needs to
+        # block: the six FTS5 syntax characters, the ASCII C0 control
+        # range, DEL, the most common zero-width / format codepoints
+        # (ZWJ, ZWNJ, LRM, RLM, ZWSP, BOM), and the surrogate/private-use
+        # range. Other Unicode ``Cf``/``Co`` codepoints are rare enough
+        # in user input that blocking them here would be a surprise.
+        cleaned = _re.sub(
+            r'["()*:^]'
+            r"|[\x00-\x1f\x7f]"  # C0 controls + DEL
+            r"|[\u200b-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff9-\ufffb]"  # common Cf
+            r"|[\ue000-\uf8ff]",  # private-use area (Co)
+            " ",
+            raw,
+        )
         tokens = cleaned.split()
         if not tokens:
             return '""'
-        # Wrap each token in double-quotes for literal matching
+        # Wrap each token in double-quotes for literal matching.
         return " ".join(f'"{t}"' for t in tokens[:20])  # cap at 20 terms
 
     async def search_transcript(

--- a/tests/test_session/test_fts_unicode_sanitize.py
+++ b/tests/test_session/test_fts_unicode_sanitize.py
@@ -1,0 +1,281 @@
+"""Regression tests for the FTS5 query sanitizer and the search_transcript path.
+
+The sanitizer used to be an ASCII-only whitelist, which turned every
+non-ASCII letter into a space and silently emptied queries in every
+non-English locale (CJK, Cyrillic, Vietnamese, accented Latin, Arabic,
+…). The FTS5 ``unicode61`` tokenizer handles the data side correctly, so
+the bug is a pure query-side defect: a query that is well-formed Unicode
+arrives at FTS5 as ``""`` (or a partial / wrong token), and
+``search_transcript`` short-circuits to ``[]`` on the empty-guard.
+
+These tests pin down the contract at two layers:
+
+  * Pure unit tests on ``SessionStorage.sanitize_fts_query`` covering the
+    individual behaviours (Unicode passes through, FTS5 syntax stripped,
+    empty-guard preserved, 20-token cap preserved).
+  * Integration tests against a real in-memory FTS5 index — the
+    sanitizer output is an implementation detail, the hit count is the
+    contract. Each integration case indexes a transcript in a different
+    script and asserts the matching CJK / accented / Cyrillic / Vietnamese
+    query actually returns the row.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+
+from agentos.session.manager import SessionManager
+from agentos.session.storage import SessionStorage
+
+# ── Unit tests on the sanitizer (string-level contract) ──────────────────────
+
+
+class TestSanitizeFtsQueryUnit:
+    """String-level assertions for ``SessionStorage.sanitize_fts_query``.
+
+    These guard the implementation details: which characters survive,
+    which are stripped, and the empty-query / token-cap invariants. The
+    integration tests below then verify the contract (hit count) on a
+    real FTS5 index.
+    """
+
+    def test_ascii_queries_pass_through_literally(self) -> None:
+        result = SessionStorage.sanitize_fts_query("quantum widget")
+        assert result == '"quantum" "widget"'
+
+    def test_accented_latin_passes_through_intact(self) -> None:
+        """``café déploiement`` must NOT be truncated to ``caf déploiement``
+        — the previous ASCII whitelist produced ``"caf" "d" "ploiement"``
+        which could match unrelated content."""
+        result = SessionStorage.sanitize_fts_query("café déploiement")
+        assert result == '"café" "déploiement"'
+
+    def test_cjk_queries_pass_through_intact(self) -> None:
+        """Chinese / Japanese / Korean characters must survive verbatim.
+        The previous implementation collapsed these to an empty query."""
+        result = SessionStorage.sanitize_fts_query("中文 报告")
+        assert result == '"中文" "报告"'
+
+    def test_cyrillic_queries_pass_through_intact(self) -> None:
+        result = SessionStorage.sanitize_fts_query("отчёт готов")
+        assert result == '"отчёт" "готов"'
+
+    def test_vietnamese_with_diacritics_passes_through_intact(self) -> None:
+        """The previous behaviour split ``triển khai`` into
+        ``"tri" "n" "khai"`` — the ``ể`` broke the token and the two halves
+        each matched unrelated content."""
+        result = SessionStorage.sanitize_fts_query("triển khai")
+        assert result == '"triển" "khai"'
+
+    def test_arabic_queries_pass_through_intact(self) -> None:
+        result = SessionStorage.sanitize_fts_query("مرحبا بالعالم")
+        assert result == '"مرحبا" "بالعالم"'
+
+    def test_mixed_script_queries_pass_through_intact(self) -> None:
+        result = SessionStorage.sanitize_fts_query("hello café 中文 отчёт")
+        assert result == '"hello" "café" "中文" "отчёт"'
+
+    def test_fts5_syntax_characters_are_stripped(self) -> None:
+        """``"``, ``(``, ``)``, ``*``, ``^`` and ``:`` are FTS5 operators
+        and must NOT survive into the MATCH expression. The sanitizer
+        replaces them with spaces so the surrounding words do not fuse."""
+        for raw, expected in (
+            ('"hello"', '"hello"'),
+            ("hello*world", '"hello" "world"'),
+            ("(foo OR bar)", '"foo" "OR" "bar"'),
+            ("^anchor", '"anchor"'),
+            ("field:value", '"field" "value"'),
+        ):
+            assert SessionStorage.sanitize_fts_query(raw) == expected
+
+    def test_control_and_format_characters_are_stripped(self) -> None:
+        """Control codepoints (Cc), format codepoints (Cf), and other
+        ``\\p{C}`` categories must not survive — a query built from a
+        string with stray formatting (zero-width joiners, RTL marks,
+        NULL bytes from a corrupted log) must not inject MATCH syntax."""
+        # Zero-width joiner (U+200D, Cf), right-to-left mark (U+200F, Cf),
+        # NULL (U+0000, Cc), and a stray bell (U+0007, Cc).
+        raw = "hello\u200dworld\u200ftest\u0000cafe\u0007baz"
+        result = SessionStorage.sanitize_fts_query(raw)
+        # All four control/format codepoints become spaces; words fuse
+        # only where the joiner is removed.
+        assert "\u200d" not in result
+        assert "\u200f" not in result
+        assert "\x00" not in result
+        assert "\x07" not in result
+
+    def test_punctuation_only_query_returns_empty_guard(self) -> None:
+        """A query that is pure FTS5 syntax / control characters must
+        short-circuit to the ``""`` empty-guard, not issue a MATCH for
+        nothing. ``search_transcript`` relies on this to return ``[]``."""
+        assert SessionStorage.sanitize_fts_query('"*^:()') == '""'
+        assert SessionStorage.sanitize_fts_query("") == '""'
+        assert SessionStorage.sanitize_fts_query("   ") == '""'
+
+    def test_unicode_punctuation_passes_through_as_literal(self) -> None:
+        """FTS5's ``unicode61`` tokenizer treats non-ASCII punctuation as
+        a literal codepoint, not as MATCH syntax — so the sanitizer
+        leaves it in place and the surviving token is quoted as a
+        literal. This pins the contract that we are *not* over-stripping:
+        a query like ``「量子」`` (Japanese full-width brackets) must
+        still find a row whose transcript contains those brackets,
+        rather than silently returning ``[]`` via the empty-guard."""
+        # Full-width colon (U+FF1A), em dash (U+2014), bullet (U+2022),
+        # full-width brackets (U+300C, U+300D) — all literal in FTS5.
+        result = SessionStorage.sanitize_fts_query("：—•「量子」")
+        assert result == '"：—•「量子」"'
+
+    def test_token_cap_is_preserved(self) -> None:
+        """The 20-token cap is part of the documented safety contract and
+        must not regress when the sanitizer is changed to a blocklist."""
+        raw = " ".join(f"word{i}" for i in range(30))
+        result = SessionStorage.sanitize_fts_query(raw)
+        assert len(result.split()) == 20
+
+    def test_cap_counts_tokens_not_raw_words(self) -> None:
+        """The cap is on the *post-sanitization* token count, so a long
+        string of syntax characters that collapse to nothing must not
+        waste the cap."""
+        raw = "a" + "()" * 50 + "b"
+        result = SessionStorage.sanitize_fts_query(raw)
+        # The "()" runs become spaces; the only surviving tokens are
+        # "a" and "b".
+        assert result == '"a" "b"'
+
+
+# ── Integration tests against a real in-memory FTS5 index ──────────────────
+
+
+@pytest_asyncio.fixture
+async def storage() -> AsyncGenerator[SessionStorage, None]:
+    store = SessionStorage(":memory:")
+    await store.connect()
+    yield store
+    await store.close()
+
+
+@pytest_asyncio.fixture
+async def manager(storage: SessionStorage) -> SessionManager:
+    return SessionManager(storage, inject_time_prefix=False)
+
+
+async def _seed(manager: SessionManager, session_key: str, content: str) -> None:
+    await manager.create(session_key, agent_id="main")
+    await manager.append_message(session_key, role="user", content=content)
+
+
+class TestSearchTranscriptUnicode:
+    """End-to-end coverage on a real in-memory FTS5 index.
+
+    The sanitizer string is an implementation detail; the *contract* is
+    that a query in any script finds the row whose transcript contains
+    that script. Each case below indexes one row in a different script
+    and asserts the script-specific query returns exactly that row.
+    """
+
+    @pytest.mark.asyncio
+    async def test_accented_latin_query_finds_accented_row(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        await _seed(manager, "agent:main:webchat:cafe0001", "Le café est ouvert.")
+        await _seed(manager, "agent:main:webchat:cafe0002", "Nothing relevant here.")
+
+        hits = await storage.search_transcript("café")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:cafe0001"]
+
+    @pytest.mark.asyncio
+    async def test_accented_query_does_not_match_ascii_fallback(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        """Regression for the wrong-match symptom called out in the
+        issue: ``café`` previously sanitized to ``"caf"`` and would
+        match a row containing only the ASCII prefix ``caf`` — i.e.
+        it returned a *wrong* row instead of zero."""
+        await _seed(manager, "agent:main:webchat:cafe0010", "Buy a cafeteria ticket.")
+        await _seed(manager, "agent:main:webchat:cafe0011", "Le café est ouvert.")
+
+        hits = await storage.search_transcript("café")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:cafe0011"]
+
+    @pytest.mark.asyncio
+    async def test_cjk_query_finds_cjk_row(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        await _seed(manager, "agent:main:webchat:cjk00001", "中文 报告 已发布")
+        await _seed(manager, "agent:main:webchat:cjk00002", "Plain English row.")
+
+        hits = await storage.search_transcript("中文 报告")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:cjk00001"]
+
+    @pytest.mark.asyncio
+    async def test_cyrillic_query_finds_cyrillic_row(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        await _seed(manager, "agent:main:webchat:cyr00001", "Отчёт готов к отправке.")
+        await _seed(manager, "agent:main:webchat:cyr00002", "English placeholder.")
+
+        hits = await storage.search_transcript("отчёт")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:cyr00001"]
+
+    @pytest.mark.asyncio
+    async def test_vietnamese_query_finds_vietnamese_row(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        await _seed(manager, "agent:main:webchat:vie00001", "Triển khai dự án mới.")
+        await _seed(manager, "agent:main:webchat:vie00002", "Decoy transcript.")
+
+        hits = await storage.search_transcript("triển khai")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:vie00001"]
+
+    @pytest.mark.asyncio
+    async def test_arabic_query_finds_arabic_row(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        await _seed(manager, "agent:main:webchat:ara00001", "مرحبا بالعالم الجديد")
+        await _seed(manager, "agent:main:webchat:ara00002", "English decoy row.")
+
+        hits = await storage.search_transcript("مرحبا")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:ara00001"]
+
+    @pytest.mark.asyncio
+    async def test_fts5_syntax_in_query_does_not_break_match(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        """A user who pastes a raw FTS5 query (e.g. ``"quantum"*`` from
+        a snippet of a manual) must still get the matching row, not an
+        empty result or a parse error. The sanitizer strips the syntax
+        characters and the surviving token still matches."""
+        await _seed(manager, "agent:main:webchat:fts00001", "quantum widget alpha")
+        await _seed(manager, "agent:main:webchat:fts00002", "unrelated content")
+
+        hits = await storage.search_transcript("quantum*")
+        assert [hit["session_key"] for hit in hits] == ["agent:main:webchat:fts00001"]
+
+    @pytest.mark.asyncio
+    async def test_punctuation_only_query_returns_empty_list(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        """A query that is pure FTS5 syntax / control characters must
+        short-circuit to ``[]`` via the ``""`` empty-guard, not raise."""
+        hits = await storage.search_transcript('"*^:()')
+        assert hits == []
+
+    @pytest.mark.asyncio
+    async def test_existing_ascii_behaviour_is_unchanged(
+        self, manager: SessionManager, storage: SessionStorage
+    ) -> None:
+        """Regression guard: the blocklist must NOT change behaviour for
+        pure-ASCII queries — the only safe way to change the sanitizer
+        is to fix the Unicode bug without regressing the ASCII path."""
+        await _seed(manager, "agent:main:webchat:asc00001", "quantum widget alpha")
+        await _seed(manager, "agent:main:webchat:asc00002", "quantum widget beta")
+        await _seed(manager, "agent:main:webchat:asc00003", "irrelevant")
+
+        hits = await storage.search_transcript("quantum widget")
+        assert {hit["session_key"] for hit in hits} == {
+            "agent:main:webchat:asc00001",
+            "agent:main:webchat:asc00002",
+        }


### PR DESCRIPTION
Fixes #903

### Summary
`SessionStorage.sanitize_fts_query` was an ASCII-only whitelist that turned every non-ASCII letter into a space, silently emptying queries in every non-English locale (CJK, Cyrillic, Vietnamese, accented Latin, Arabic, …) and additionally producing **wrong** matches by truncating accented tokens to their ASCII prefix (`café` → `"caf"` then matched unrelated content). FTS5's `unicode61` tokenizer indexes the transcript content correctly, so the sanitizer is the only layer that throws the query away.

The fix replaces the whitelist with a blocklist that strips FTS5 syntax characters (`"`, `(`, `)`, `*`, `^`, `:`) and control / format / private-use codepoints, while letting every letter or digit of any script through untouched. The two existing safety properties — per-token double-quoting and the 20-token cap — are preserved.

### Root cause
`_re.sub(r"[^a-zA-Z0-9\s]", " ", raw)` is an ASCII-only whitelist that pre-dates Unicode content. FTS5's `unicode61` tokenizer handles non-ASCII fine, so this is purely a sanitizer defect. The worst symptom is not an exception but a **silent wrong answer**: `café` → `"caf"` then matches unrelated content, and CJK / Cyrillic queries return `[]` via the `safe_q == '""'` short-circuit at `storage.py:1778`.

### Proposed solution
Replace the whitelist with a blocklist of FTS5 syntax + control codepoints. No public API change. The stdlib `re` module does not support `\p{C}`, so use an explicit character class instead of pulling in the third-party `regex` module.

The blocklist covers:
  * FTS5 operators: `"`, `(`, `)`, `*`, `^`, `:`
  * ASCII C0 controls + DEL: `\x00-\x1f`, `\x7f`
  * Common Unicode format codepoints: ZWJ, ZWNJ, LRM, RLM, ZWSP, BOM, etc.
  * Private-use area: U+E000–U+F8FF

Letters and digits of every script (Latin, CJK, Cyrillic, Vietnamese, Arabic, etc.) pass through verbatim. Non-ASCII punctuation is also passed through — FTS5's `unicode61` tokenizer treats it as a literal codepoint, so it is safe inside the per-token double quotes.

### Files
- `src/agentos/session/storage.py` — `sanitize_fts_query` rewritten with the blocklist
- `tests/test_session/test_fts_unicode_sanitize.py` — 22 new regression tests (13 unit, 9 integration)
- `CHANGELOG.md` — single `[Unreleased] / Fixed` entry

### Verification
- [x] `uv run pytest tests/test_session/test_fts_unicode_sanitize.py -q` — 22 passed
- [x] `uv run pytest tests/test_session/ -q` — 218 passed (no regression in sibling tests)
- [x] `uv run ruff check src/agentos/session/storage.py tests/test_session/test_fts_unicode_sanitize.py` — clean
- [x] `uv run mypy src/agentos/session/storage.py --show-error-codes` — no issues
- [x] `uv run ruff format --check` — clean
- [x] Stash-verify dance: with the blocklist reverted to the ASCII whitelist, 13 of the 22 new tests fail (all 4 Unicode-script integration tests + the 5 non-ASCII unit tests + the wrong-match regression + the mixed-script + the unicode-punctuation-passthrough cases); restored, all 22 pass

### Test coverage
**Unit (string-level contract)**
  * ASCII passthrough
  * Latin (café, déploiement), CJK (中文 报告), Cyrillic (отчёт), Vietnamese (triển khai), Arabic (مرحبا), mixed-script
  * FTS5 syntax stripping: `"`, `*`, `(`, `)`, `^`, `:`
  * Control / format / private-use codepoint stripping
  * Empty-guard preserved for pure-syntax / empty / whitespace queries
  * 20-token cap preserved
  * Cap counts post-sanitization tokens, not raw input words
  * Non-ASCII punctuation passes through as literal (over-stripping guard)

**Integration (real in-memory FTS5)**
  * Accented Latin query finds the accented row, not the ASCII-prefix decoy
  * CJK / Cyrillic / Vietnamese / Arabic each find their own row
  * FTS5 syntax in a raw query (e.g. `quantum*`) does not break the match
  * Punctuation-only query short-circuits to `[]`
  * Existing pure-ASCII behaviour is unchanged (regression guard)

### Third-party origins
None — all changes are original to this PR.
