### PR TITLE
fix(engine): evict idle session locks to bound SessionWriteLock memory

### DIFF
--- a/src/agentos/engine/session_lock.py
+++ b/src/agentos/engine/session_lock.py
@@ -7,21 +7,30 @@ from typing import Any
 
 
 class SessionWriteLock:
-    """Async lock per session_key to serialize writes."""
+    """Async lock per session_key to serialize writes.
+
+    Entries are evicted from the internal dict as soon as the lock is fully
+    idle (released with no pending waiters), so the dict does not grow
+    unboundedly with the number of unique session keys.
+    """
 
     def __init__(self) -> None:
         self._locks: dict[str, asyncio.Lock] = {}
 
     async def acquire(self, session_key: str) -> None:
-        """Acquire the lock for a session."""
         if session_key not in self._locks:
             self._locks[session_key] = asyncio.Lock()
         await self._locks[session_key].acquire()
 
     def release(self, session_key: str) -> None:
-        """Release the lock for a session."""
         if session_key in self._locks:
-            self._locks[session_key].release()
+            lock = self._locks[session_key]
+            # Evict if no waiter is queued: the next acquire() will create a
+            # fresh lock for this session_key.  If waiters exist, keep the entry
+            # so they can acquire the already-released lock.
+            if not lock._waiters:
+                del self._locks[session_key]
+            lock.release()
 
     async def __aenter__(self) -> SessionWriteLock:
         return self

--- a/tests/test_engine/test_session_lock_eviction.py
+++ b/tests/test_engine/test_session_lock_eviction.py
@@ -1,0 +1,99 @@
+"""Regression tests for SessionWriteLock memory leak fix (issue #966).
+
+Before the fix, ``SessionWriteLock._locks`` grew without bound: every
+session_key that was ever acquired stayed in the dict forever, even after
+the lock was released.  The fix evicts an entry as soon as it has no
+pending waiters, so the dict is bounded by the number of *active* sessions,
+not by all sessions ever seen.
+
+Two properties are pinned:
+1. Leak regression: sequential acquire/release of N distinct keys leaves the
+   dict empty so it does not grow with session count.
+2. Concurrent safety: concurrent acquire() calls for the same session_key are
+   serialized — no two tasks hold the lock simultaneously (no split-brain).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from agentos.engine.session_lock import SessionWriteLock
+
+
+@pytest.mark.asyncio
+async def test_sequential_acquire_release_evicts_all_keys():
+    """After sequential acquire/release of N distinct session_keys, the
+    internal dict must be empty so it does not grow with session count."""
+    lock_mgr = SessionWriteLock()
+    for i in range(100):
+        await lock_mgr.acquire(f"session-{i}")
+        lock_mgr.release(f"session-{i}")
+    assert len(lock_mgr._locks) == 0, (
+        f"expected 0 locks after sequential release, got {len(lock_mgr._locks)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_acquires_are_serialized():
+    """Two concurrent tasks acquiring the same session_key must not run their
+    critical sections simultaneously — the lock serializes them (no split-brain).
+
+    Strategy: task A acquires the lock and holds it; task B calls acquire()
+    and is queued as a waiter.  The critical-section timestamp of B must be
+    strictly after A's, proving B was blocked while A held the lock.
+    """
+    lock_mgr = SessionWriteLock()
+    timestamps: list[float] = []
+
+    async def task_a() -> None:
+        await lock_mgr.acquire("shared-key")
+        timestamps.append(time.monotonic())
+        await asyncio.sleep(0.05)  # hold lock long enough for task_b to queue
+        lock_mgr.release("shared-key")
+
+    async def task_b() -> None:
+        await asyncio.sleep(0.01)  # ensure task_a acquires first
+        await lock_mgr.acquire("shared-key")
+        timestamps.append(time.monotonic())
+        lock_mgr.release("shared-key")
+
+    await asyncio.gather(task_a(), task_b())
+    assert len(timestamps) == 2, f"expected 2 timestamps, got {len(timestamps)}"
+    assert timestamps[1] > timestamps[0] + 0.04, (
+        f"task_b ran before task_a released the lock (split-brain): {timestamps}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_manager_evicts_after_release():
+    """Using the lock via the context manager also evicts idle entries."""
+    lock_mgr = SessionWriteLock()
+    for i in range(50):
+        async with lock_mgr.context(f"ctx-session-{i}"):
+            pass
+    assert len(lock_mgr._locks) == 0
+
+
+@pytest.mark.asyncio
+async def test_double_release_is_safe():
+    """Calling release() twice on the same key must not raise."""
+    lock_mgr = SessionWriteLock()
+    await lock_mgr.acquire("session-double")
+    lock_mgr.release("session-double")
+    lock_mgr.release("session-double")  # must not raise RuntimeError
+    assert len(lock_mgr._locks) == 0
+
+
+@pytest.mark.asyncio
+async def test_many_sessions_all_evicted():
+    """1000 sequential sessions must all be evicted, bounding dict to O(1)."""
+    lock_mgr = SessionWriteLock()
+    for i in range(1000):
+        await lock_mgr.acquire(f"key-{i}")
+        lock_mgr.release(f"key-{i}")
+    assert len(lock_mgr._locks) == 0
+    # Even mid-batch, dict should never exceed a small constant.
+    assert len(lock_mgr._locks) <= 1


### PR DESCRIPTION
Fixes #966

## Summary
`SessionWriteLock._locks` never evicted entries: every session_key that was ever acquired stayed in the dict for the life of the process, leaking one `asyncio.Lock` per unique session. This PR pops the entry on `release()` when no waiter is queued, bounding the dict by *currently active* session keys instead of all sessions ever seen.

## What
- src/agentos/engine/session_lock.py — evict the entry in `release()` when `lock._waiters` is empty (no pending acquirer); entries with queued waiters are kept so handoff still works.
- tests/test_engine/test_session_lock_eviction.py — new regression tests (5 tests):
  - sequential acquire/release of 100 distinct keys → dict ends empty
  - concurrent acquires on the same key are serialized (split-brain guard: waiter's critical section strictly after holder's)
  - `lock_mgr.context()` path also evicts
  - double-release is a no-op (no RuntimeError)
  - 1000-session stress: dict stays O(1)

## Verification
- `uv run pytest tests/test_engine/test_session_lock_eviction.py -v` — 5 passed
- `uv run pytest tests/test_engine -q` — 1014 passed (full engine subsystem, includes existing `test_session_lock_no_reentry.py` 4/4)
- `uv run mypy src/agentos/engine/session_lock.py tests/test_engine/test_session_lock_eviction.py --show-error-codes` — no issues
- `uv run ruff check` on both changed files — clean

Note: `TaskRuntime._session_locks` (gateway path) is intentionally untouched — its retention across terminal state is a separate, deliberate design (split-brain prevention, covered by `tests/test_gateway/test_no_split_brain_lock.py`).
