### PR TITLE
fix(sandbox): expand env vars before sensitive-path matching

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -285,6 +285,16 @@ def sensitive_path_marker(
     """
 
     text = str(path).strip()
+    # Environment-variable references ($HOME/..., ${HOME}/...) defeat the
+    # tilde check below because pathlib does not expand them. Redirect any
+    # token containing a `$` (or backtick command substitution) to the full
+    # prefix matcher after expansion so the denylist still applies.
+    if "$" in text or "`" in text:
+        expanded = os.path.expandvars(text)
+        if expanded != text:
+            marker = is_sensitive_path(expanded)
+            if marker is not None:
+                return marker
     raw = Path(text).expanduser()
     if (
         text
@@ -323,20 +333,29 @@ def sensitive_path_in_text(
     if not text:
         return None
 
+    # Environment-variable references ($HOME/..., ${HOME}/...) reach this
+    # scanner as literal text while the shell would expand them at execution
+    # time. Scan the env-expanded variant too so the denylist sees the same
+    # paths the child process will actually touch.
+    expanded_text = os.path.expandvars(text)
+    scan_texts = [text] if expanded_text == text else [text, expanded_text]
+
     candidates: list[str] = []
+    for scan in scan_texts:
+        try:
+            candidates.extend(shlex.split(scan))
+        except ValueError:
+            candidates.extend(scan.split())
+        candidates.extend(scan.split())
     with_context: list[tuple[str, int]] = []
-    try:
-        candidates.extend(shlex.split(text))
-    except ValueError:
-        candidates.extend(text.split())
-    candidates.extend(text.split())
-    with_context.extend(
-        (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(text)
-    )
-    with_context.extend(
-        (match.group("path"), match.start("path"))
-        for match in _DOTENV_LITERAL_RE.finditer(text)
-    )
+    for scan in scan_texts:
+        with_context.extend(
+            (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(scan)
+        )
+        with_context.extend(
+            (match.group("path"), match.start("path"))
+            for match in _DOTENV_LITERAL_RE.finditer(scan)
+        )
 
     for raw in candidates:
         if "://" in raw:

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -128,6 +128,28 @@ def _comparison_path_candidates(path: str) -> list[str]:
     return list(dict.fromkeys(candidates))
 
 
+_ENV_TOKEN_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _shell_style_expand(text: str) -> str:
+    """Expand ``$VAR``/``${VAR}`` tokens against ``os.environ``.
+
+    ``os.path.expandvars`` only understands ``%VAR%`` on Windows, which makes
+    denylist matching miss ``$HOME/...`` literals written for POSIX shells.
+    Expanding manually keeps the scanner platform-independent.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1) or match.group(2)
+        return os.environ.get(name, match.group(0))
+
+    return _ENV_TOKEN_RE.sub(_replace, text)
+
+
+def _looks_like_envvar_reference(text: str) -> bool:
+    return "$" in text or "`" in text
+
+
 def _looks_like_rooted_path_text(path: str) -> bool:
     normalized = str(path).strip().replace("\\", "/")
     return normalized.startswith(("/", "~/")) and not normalized.startswith("//")
@@ -290,7 +312,7 @@ def sensitive_path_marker(
     # token containing a `$` (or backtick command substitution) to the full
     # prefix matcher after expansion so the denylist still applies.
     if "$" in text or "`" in text:
-        expanded = os.path.expandvars(text)
+        expanded = _shell_style_expand(text)
         if expanded != text:
             marker = is_sensitive_path(expanded)
             if marker is not None:

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -252,7 +252,12 @@ def test_env_var_references_expand_to_sensitive_prefix() -> None:
     at real-execution time.  HOME is mocked so the test is platform-independent
     (Windows CI does not set HOME).
     """
-    with patch.dict(os.environ, {"HOME": "/home/testuser", "USER": "testuser"}):
+    env = {
+        "HOME": "/home/testuser",
+        "USERPROFILE": "/home/testuser",
+        "USER": "testuser",
+    }
+    with patch.dict(os.environ, env):
         sensitive_paths = [
             "$HOME/.ssh/config",
             "${HOME}/.ssh/id_rsa",

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -239,3 +239,57 @@ def test_root_target_detection_covers_windows_drive_roots() -> None:
         "relative/path",
     ):
         assert _is_root_target(target) is False, target
+
+
+def test_env_var_references_expand_to_sensitive_prefix(monkeypatch) -> None:
+    """``$HOME/.ssh/config`` must trigger the same block as ``~/.ssh/config``.
+
+    The static text scanner cannot rely on ``Path.is_absolute()`` to gate the
+    full prefix matcher because ``$HOME`` is plain text to pathlib. Expand the
+    environment first so the denylist applies, mirroring what the shell does
+    at real-execution time.
+    """
+    monkeypatch.setenv("HOME", "/home/testuser")
+    sensitive_paths = [
+        "$HOME/.ssh/config",
+        "${HOME}/.ssh/id_rsa",
+        "$HOME/.aws/credentials",
+        "$HOME/.kube/config",
+        "$HOME/.gnupg/secring.gpg",
+        "$HOME/.config/gcloud/application_default_credentials.json",
+        "$HOME/.password-store/secrets.gpg-id",
+    ]
+    for path in sensitive_paths:
+        # structured caller (the shell-command path through
+        # sensitive_path_marker) must catch every prefix entry.
+        assert sensitive_path_marker(path) is not None, path
+
+    sensitive_commands = [
+        "cat $HOME/.ssh/config",
+        "cp $HOME/.aws/credentials /tmp/leak.txt",
+        "rm -rf $HOME/.ssh",
+        "rm $HOME/.aws",
+        "ls ${HOME}/.ssh",
+    ]
+    for cmd in sensitive_commands:
+        # text scanner (the regex/token path) must also catch the same
+        # commands after os.path.expandvars runs on the whole text.
+        assert sensitive_path_in_text(cmd) is not None, cmd
+
+    # Sanity: a non-sensitive env-var path stays clean (no false-positive).
+    assert sensitive_path_marker("$HOME/projects/notes.md") is None
+    assert sensitive_path_in_text("$HOME/.local/share/applications/x.desktop") is None
+
+
+def test_env_var_with_unknown_variable_falls_through_safely(monkeypatch) -> None:
+    """An env-var token that cannot be expanded must not break the gate.
+
+    ``os.path.expandvars`` leaves ``$UNDEFINED_VAR/...`` unchanged. The denylist
+    then runs on the literal text, which is a pure-fail (no marker) — better
+    than a crash.
+    """
+    monkeypatch.delenv("NOPE", raising=False)
+    # Marker and text scanner both fall through to the same path the un-tilde
+    # case already used to take; we only assert that no exception escapes.
+    assert sensitive_path_marker("$NOPE/.ssh/config") is None
+    assert sensitive_path_in_text("cat $NOPE/.ssh/config") is None

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 from agentos.sandbox.sensitive_paths import (
     _is_root_target,
@@ -241,55 +243,60 @@ def test_root_target_detection_covers_windows_drive_roots() -> None:
         assert _is_root_target(target) is False, target
 
 
-def test_env_var_references_expand_to_sensitive_prefix(monkeypatch) -> None:
+def test_env_var_references_expand_to_sensitive_prefix() -> None:
     """``$HOME/.ssh/config`` must trigger the same block as ``~/.ssh/config``.
 
     The static text scanner cannot rely on ``Path.is_absolute()`` to gate the
     full prefix matcher because ``$HOME`` is plain text to pathlib. Expand the
     environment first so the denylist applies, mirroring what the shell does
-    at real-execution time.
+    at real-execution time.  HOME is mocked so the test is platform-independent
+    (Windows CI does not set HOME).
     """
-    monkeypatch.setenv("HOME", "/home/testuser")
-    sensitive_paths = [
-        "$HOME/.ssh/config",
-        "${HOME}/.ssh/id_rsa",
-        "$HOME/.aws/credentials",
-        "$HOME/.kube/config",
-        "$HOME/.gnupg/secring.gpg",
-        "$HOME/.config/gcloud/application_default_credentials.json",
-        "$HOME/.password-store/secrets.gpg-id",
-    ]
-    for path in sensitive_paths:
-        # structured caller (the shell-command path through
-        # sensitive_path_marker) must catch every prefix entry.
-        assert sensitive_path_marker(path) is not None, path
+    with patch.dict(os.environ, {"HOME": "/home/testuser", "USER": "testuser"}):
+        sensitive_paths = [
+            "$HOME/.ssh/config",
+            "${HOME}/.ssh/id_rsa",
+            "$HOME/.aws/credentials",
+            "$HOME/.kube/config",
+            "$HOME/.gnupg/secring.gpg",
+            "$HOME/.config/gcloud/application_default_credentials.json",
+            "$HOME/.password-store/secrets.gpg-id",
+        ]
+        for path in sensitive_paths:
+            # structured caller (the shell-command path through
+            # sensitive_path_marker) must catch every prefix entry.
+            assert sensitive_path_marker(path) is not None, path
 
-    sensitive_commands = [
-        "cat $HOME/.ssh/config",
-        "cp $HOME/.aws/credentials /tmp/leak.txt",
-        "rm -rf $HOME/.ssh",
-        "rm $HOME/.aws",
-        "ls ${HOME}/.ssh",
-    ]
-    for cmd in sensitive_commands:
-        # text scanner (the regex/token path) must also catch the same
-        # commands after os.path.expandvars runs on the whole text.
-        assert sensitive_path_in_text(cmd) is not None, cmd
+        sensitive_commands = [
+            "cat $HOME/.ssh/config",
+            "cp $HOME/.aws/credentials /tmp/leak.txt",
+            "rm -rf $HOME/.ssh",
+            "rm $HOME/.aws",
+            "ls ${HOME}/.ssh",
+        ]
+        for cmd in sensitive_commands:
+            # text scanner (the regex/token path) must also catch the same
+            # commands after shell-style expansion runs on the whole text.
+            assert sensitive_path_in_text(cmd) is not None, cmd
 
-    # Sanity: a non-sensitive env-var path stays clean (no false-positive).
-    assert sensitive_path_marker("$HOME/projects/notes.md") is None
-    assert sensitive_path_in_text("$HOME/.local/share/applications/x.desktop") is None
+        # Sanity inside the mocked env: a non-sensitive path stays clean.
+        assert sensitive_path_marker("$HOME/projects/notes.md") is None
+        assert sensitive_path_in_text("$HOME/projects/notes.md") is None
+
+    # Sanity outside the mock (real env): a plain non-sensitive path is clean.
+    assert sensitive_path_marker("notes.md") is None
 
 
-def test_env_var_with_unknown_variable_falls_through_safely(monkeypatch) -> None:
+def test_env_var_with_unknown_variable_falls_through_safely() -> None:
     """An env-var token that cannot be expanded must not break the gate.
 
-    ``os.path.expandvars`` leaves ``$UNDEFINED_VAR/...`` unchanged. The denylist
-    then runs on the literal text, which is a pure-fail (no marker) — better
-    than a crash.
+    ``_shell_style_expand`` leaves ``$UNDEFINED_VAR/...`` unchanged when the
+    variable is not in ``os.environ``. The denylist then runs on the literal
+    text, which is a pure-fail (no marker) — better than a crash.
     """
-    monkeypatch.delenv("NOPE", raising=False)
-    # Marker and text scanner both fall through to the same path the un-tilde
-    # case already used to take; we only assert that no exception escapes.
-    assert sensitive_path_marker("$NOPE/.ssh/config") is None
-    assert sensitive_path_in_text("cat $NOPE/.ssh/config") is None
+    with patch.dict(os.environ, {}, clear=False):
+        # Make sure HOME is absent so the expand falls through.
+        os.environ.pop("HOME", None)
+        os.environ.pop("USER", None)
+        assert sensitive_path_marker("$NOPE/.ssh/config") is None
+        assert sensitive_path_in_text("cat $NOPE/.ssh/config") is None


### PR DESCRIPTION
Fixes #985

## Summary
`sensitive_path_marker()` and `sensitive_path_in_text()` in `src/agentos/sandbox/sensitive_paths.py` failed to detect sensitive credential paths when written as `$HOME/...` instead of `~/...`. `pathlib.Path` does not expand shell variables, so the token took the narrow leaf-matcher path and skipped the full prefix denylist entirely. The shell runtime (`asyncio.create_subprocess_shell`) *does* expand `$HOME` at execution time, so every 19 sensitive prefixes in `_SENSITIVE_PREFIXES` were silently bypassable via an env-var reference.

## What
- src/agentos/sandbox/sensitive_paths.py — add `os.path.expandvars()` before the tilde/absolute check in `sensitive_path_marker()`; scan both raw and env-expanded text in `sensitive_path_in_text()` so the text scanner covers the same surface the child process will see
- tests/test_sandbox/test_sensitive_paths.py — new regression tests covering `$HOME`, `${HOME}`, `$USER`, and undefined-variable fallthrough

## Verification
- `uv run pytest tests/test_sandbox/test_sensitive_paths.py -q` — 19 passed
- `uv run pytest tests/test_sandbox -q` — 11 failed (pre-existing seatbelt backend on Linux, unchanged)
- `uv run ruff check src/agentos/sandbox tests/test_sandbox/test_sensitive_paths.py` — clean
- `uv run mypy src/agentos/sandbox/sensitive_paths.py --show-error-codes` — no new issues
