### PR TITLE
fix(engine): check budget fit before pruning in _prune_to_fit

### DIFF
--- a/src/agentos/engine/tool_result_store.py
+++ b/src/agentos/engine/tool_result_store.py
@@ -217,6 +217,13 @@ class ToolResultStore:
 
     def _prune_to_fit(self, incoming_bytes: int, disk_budget_bytes: int) -> None:
         budget = max(0, int(disk_budget_bytes))
+        # An oversized incoming payload can never fit, no matter how much is
+        # pruned; reject it before destroying any existing records.
+        if incoming_bytes > budget:
+            raise ToolResultStoreBudgetError(
+                "tool result snapshot exceeds disk budget "
+                f"({incoming_bytes} > {budget})"
+            )
         records = sorted(self._iter_records(), key=lambda item: item.created_at)
         current = sum(record.size_bytes for record in records)
         if current + incoming_bytes <= budget:
@@ -226,11 +233,9 @@ class ToolResultStore:
             current = max(0, current - record.size_bytes)
             if current + incoming_bytes <= budget:
                 return
-        if incoming_bytes > budget:
-            raise ToolResultStoreBudgetError(
-                "tool result snapshot exceeds disk budget "
-                f"({incoming_bytes} > {budget})"
-            )
+        raise ToolResultStoreBudgetError(
+            f"tool results exceed disk budget ({current} + {incoming_bytes} > {budget})"
+        )
 
 
 def _parse_created_at(value: str) -> datetime:

--- a/tests/test_engine/test_tool_result_store_budget.py
+++ b/tests/test_engine/test_tool_result_store_budget.py
@@ -1,0 +1,74 @@
+"""Regression tests for tool_result_store budget enforcement."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentos.engine.tool_result_store import (
+    ToolResultStore,
+    ToolResultStoreBudgetError,
+)
+
+
+class TestPruneToFitDataLoss:
+    """Ensure oversized writes do not destroy existing records.
+
+    Regression for: an incoming payload larger than the total budget would
+    cause _prune_to_fit to delete ALL existing records before raising the
+    budget-exceeded error. The caller only logged a "skipped" metric,
+    unaware that unrelated prior results had already been destroyed.
+    """
+
+    def test_oversized_payload_does_not_destroy_existing_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ToolResultStore(tmpdir)
+            # Write three small records within budget.
+            for i in range(3):
+                store.write(
+                    f"record-{i}",
+                    tool_use_id=f"tu-{i}",
+                    tool_name="x",
+                    session_id="s1",
+                    session_key="k",
+                    agent_id="a",
+                    disk_budget_bytes=500,
+                    retention_seconds=None,
+                )
+            existing = list(Path(tmpdir).rglob("content.txt"))
+
+            # Attempt an oversized write (2 KB against a 500-byte budget).
+            # Must raise WITHOUT deleting the three prior records.
+            with pytest.raises(ToolResultStoreBudgetError):
+                store.write(
+                    "X" * 2000,
+                    tool_use_id="tu-big",
+                    tool_name="x",
+                    session_id="s1",
+                    session_key="k",
+                    agent_id="a",
+                    disk_budget_bytes=500,
+                    retention_seconds=None,
+                )
+
+            remaining = list(Path(tmpdir).rglob("content.txt"))
+            assert len(remaining) == len(existing), (
+                f"expected {len(existing)} records preserved, got {len(remaining)}"
+            )
+
+    def test_normal_payload_within_budget_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ToolResultStore(tmpdir)
+            store.write(
+                "hello",
+                tool_use_id="tu-1",
+                tool_name="x",
+                session_id="s1",
+                session_key="k",
+                agent_id="a",
+                disk_budget_bytes=500,
+                retention_seconds=None,
+            )
+            assert len(list(Path(tmpdir).rglob("content.txt"))) == 1


### PR DESCRIPTION
Fixes #996

## Summary
`_prune_to_fit` deleted ALL existing tool-result records before checking whether the incoming payload itself could fit the disk budget. An oversized single write (e.g. 2 KB against a 500-byte budget) caused total data loss of unrelated prior records, then raised `ToolResultStoreBudgetError`.

## Fix
Check `incoming_bytes > budget` at the top of `_prune_to_fit` and raise immediately — before any deletion. The existing per-record prune loop remains for the normal over-budget-but-recoverable case.

## Regression test
`tests/test_engine/test_tool_result_store_budget.py`:
- `test_oversized_payload_does_not_destroy_existing_records` — writes 3 records, attempts a 2 KB write against a 500-byte budget, asserts all 3 survive.
- `test_normal_payload_within_budget_succeeds` — sanity that normal writes still persist.

## Verification
```
$ uv run pytest tests/test_engine/test_tool_result_store_budget.py -v
2 passed
```

Probe (pre-fix behaviour, now fixed):
```
before=3 after=0   # before
before=3 after=3   # after
```
