### PR TITLE
fix(tools): fail-before-prune in _prune_to_fit to prevent data loss

### DIFF
--- a/src/agentos/engine/tool_result_store.py
+++ b/src/agentos/engine/tool_result_store.py
@@ -217,6 +217,13 @@ class ToolResultStore:
 
     def _prune_to_fit(self, incoming_bytes: int, disk_budget_bytes: int) -> None:
         budget = max(0, int(disk_budget_bytes))
+        # Fail fast: if the incoming write itself is larger than the entire
+        # budget, reject it without touching existing records.
+        if incoming_bytes > budget:
+            raise ToolResultStoreBudgetError(
+                "tool result snapshot exceeds disk budget "
+                f"({incoming_bytes} > {budget})"
+            )
         records = sorted(self._iter_records(), key=lambda item: item.created_at)
         current = sum(record.size_bytes for record in records)
         if current + incoming_bytes <= budget:
@@ -226,11 +233,6 @@ class ToolResultStore:
             current = max(0, current - record.size_bytes)
             if current + incoming_bytes <= budget:
                 return
-        if incoming_bytes > budget:
-            raise ToolResultStoreBudgetError(
-                "tool result snapshot exceeds disk budget "
-                f"({incoming_bytes} > {budget})"
-            )
 
 
 def _parse_created_at(value: str) -> datetime:


### PR DESCRIPTION
## Summary

`_prune_to_fit` could destroy all existing records before raising `ToolResultStoreBudgetError` when the incoming write exceeded the entire disk budget. Existing data was deleted but the write was rejected, causing **silent data loss**.

See #996 for reproduction.

## Fix

Moved the `incoming_bytes > budget` guard to the **top** of `_prune_to_fit` — before any pruning happens. If the incoming write itself is larger than the entire budget, it is rejected immediately without touching existing records.

The remaining loop that prunes oldest records until there is room is unchanged.

Closes #996.