### PR TITLE
fix(sandbox): hard-block host credential files missing from sensitive paths (Closes #981)

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -39,6 +39,10 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "~/.npmrc",
     "~/.pypirc",
     "~/.netrc",
+    "~/.git-credentials",
+    "~/.pgpass",
+    "~/.dockercfg",
+    "~/.htpasswd",
     "~/.gnupg",
     "~/.password-store",
     "/etc",
@@ -70,6 +74,13 @@ _SENSITIVE_SUFFIXES: tuple[str, ...] = (
     "/.zsh_history",
     "/.mysql_history",
     "/.psql_history",
+    "/.git-credentials",
+    "/.pgpass",
+    "/.dockercfg",
+    "/.htpasswd",
+    "/.netrc",
+    "/.npmrc",
+    "/.pypirc",
 )
 
 _WORKSPACE_PARENT_EXCEPTION_MARKERS: tuple[str, ...] = ("/root",)


### PR DESCRIPTION
## Fix

Added `~/.git-credentials`, `~/.pgpass`, `~/.dockercfg`, `~/.htpasswd` to `_SENSITIVE_PREFIXES` and their filename tails to `_SENSITIVE_SUFFIXES` so these host credential files are hard-blocked from reading, mutation, or deletion — inside or outside home.

## Test coverage

- Marker and in-text detection for each new credential file
- Suffix rules block credential filenames in arbitrary directories (e.g. /tmp/.git-credentials)