### PR TITLE
fix(sandbox): detect sensitive paths written with env-var bypass

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -134,7 +134,10 @@ def _comparison_path_candidates(path: str) -> list[str]:
                 # home-prefixed patterns without needing a real UID lookup.
                 if var in ("USER", "LOGNAME"):
                     tilde_expanded = expanded.replace(resolved_stripped, "~", 1)
-                    candidates.append(tilde_expanded.casefold() if os.name == "nt" else tilde_expanded)
+                    if os.name == "nt":
+                        candidates.append(tilde_expanded.casefold())
+                    else:
+                        candidates.append(tilde_expanded)
 
     if raw.startswith("~/"):
         expanded_home = str(Path.home()).replace("\\", "/") + raw[1:]

--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -52,6 +52,21 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "/usr/lib/systemd",
 )
 
+# Regex matching shell-style env-var references used to escape sensitive-path
+# scanning (e.g. ``$HOME/.ssh``, ``${HOME}/.ssh``, ``$USER/.config``).
+# Matched references are expanded to their runtime values so the scan can
+# still catch the underlying sensitive path.
+_HOME_VAR_RE = re.compile(r"\$\{?(?P<var>HOME|USER|LOGNAME)}?")
+
+# Common env-var names mapped to their typical shell expansion so the
+# prefix scanner can detect sensitive paths written with unexpanded
+# references instead of literal paths.
+_HOME_VAR_MAP: dict[str, str] = {
+    "HOME": "~",
+    "USER": "/home/",
+    "LOGNAME": "/home/",
+}
+
 # Exact filename tails we never want mutated, regardless of parent directory.
 # Covers cases like moving an id_rsa out of ~/.ssh into /tmp.
 _SENSITIVE_SUFFIXES: tuple[str, ...] = (
@@ -101,6 +116,26 @@ def _comparison_path_candidates(path: str) -> list[str]:
     raw = str(path).strip().replace("\\", "/")
     if raw:
         candidates.append(raw.casefold() if os.name == "nt" else raw)
+
+    # Expand known env-var references (e.g. ``$HOME/.ssh`` → ``~/.ssh``) so the
+    # prefix scanner matches the underlying sensitive path.
+    if "$" in raw:
+        env_match = _HOME_VAR_RE.search(raw)
+        if env_match:
+            var = env_match.group("var")
+            resolved = _HOME_VAR_MAP.get(var, "")
+            if resolved:
+                # Strip trailing slash from resolved prefix before joining to
+                # avoid double-slash artifacts (e.g. ``/home//.ssh``).
+                resolved_stripped = resolved.rstrip("/")
+                expanded = raw.replace(env_match.group(0), resolved_stripped, 1)
+                candidates.append(expanded.casefold() if os.name == "nt" else expanded)
+                # For USER/LOGNAME, also add a ``~`` substitution so it hits
+                # home-prefixed patterns without needing a real UID lookup.
+                if var in ("USER", "LOGNAME"):
+                    tilde_expanded = expanded.replace(resolved_stripped, "~", 1)
+                    candidates.append(tilde_expanded.casefold() if os.name == "nt" else tilde_expanded)
+
     if raw.startswith("~/"):
         expanded_home = str(Path.home()).replace("\\", "/") + raw[1:]
         candidates.append(expanded_home.casefold() if os.name == "nt" else expanded_home)


### PR DESCRIPTION
## Summary

`sensitive_path_marker()` only matched sensitive prefixes when written as `~/.ssh`, `~/.aws`, etc. Paths expressed using **unexpanded env-var references** (e.g., `$HOME/.ssh`, `${HOME}/.ssh`, `$USER/.ssh`) passed through undetected, allowing all 19 sensitive-prefix entries to be bypassed.

## Fix

- Added `_HOME_VAR_RE` regex matching `$HOME`, `${HOME}`, `$USER`, `${USER}`, `$LOGNAME`, `${LOGNAME}`
- Added `_HOME_VAR_MAP` expanding these to `~` or `/home/` prefix
- Extended `_comparison_path_candidates()` to produce expanded candidates when the raw path contains a known env-var reference

## Before vs After

| Input | Before | After |
|-------|--------|-------|
| `$HOME/.ssh` | ❌ missed | ✅ blocked |
| `${HOME}/.ssh` | ❌ missed | ✅ blocked |
| `$HOME/.aws/credentials` | ❌ missed | ✅ blocked |
| `$USER/.ssh/id_rsa` | ❌ missed | ✅ blocked |
| `$HOME/.config/gcloud` | ❌ missed | ✅ blocked |

Closes #985.