### PR TITLE
fix(skills): respect security scan verdict on skills update (Closes #988)

### DIFF
--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -625,7 +625,15 @@ async def _handle_skills_update(params: dict | None, ctx: RpcContext) -> dict[st
     if any(r.success for r in results):
         _invalidate_loader(ctx)
     return {
-        "results": [{"success": r.success, "name": r.name, "message": r.message} for r in results]
+        "results": [
+            {
+                "success": r.success,
+                "name": r.name,
+                "message": r.message,
+                **({"scan_verdict": r.scan.verdict, "scan_findings": [f.__dict__ for f in r.scan.findings]} if r.scan else {}),
+            }
+            for r in results
+        ]
     }
 
 

--- a/src/agentos/gateway/rpc_skills.py
+++ b/src/agentos/gateway/rpc_skills.py
@@ -624,17 +624,18 @@ async def _handle_skills_update(params: dict | None, ctx: RpcContext) -> dict[st
         }
     if any(r.success for r in results):
         _invalidate_loader(ctx)
-    return {
-        "results": [
-            {
-                "success": r.success,
-                "name": r.name,
-                "message": r.message,
-                **({"scan_verdict": r.scan.verdict, "scan_findings": [f.__dict__ for f in r.scan.findings]} if r.scan else {}),
-            }
-            for r in results
-        ]
-    }
+    result_list = []
+    for r in results:
+        item = {
+            "success": r.success,
+            "name": r.name,
+            "message": r.message,
+        }
+        if r.scan:
+            item["scan_verdict"] = r.scan.verdict
+            item["scan_findings"] = [f.__dict__ for f in r.scan.findings]
+        result_list.append(item)
+    return {"results": result_list}
 
 
 @_d.method("skills.uninstall")

--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -299,7 +299,7 @@ class SkillInstaller:
                 )
                 continue
             old_sha = entry.sha256
-            result = await self.install(entry.identifier, entry.source, force=True)
+            result = await self.install(entry.identifier, entry.source, force=False)
             if result.success:
                 if old_sha and result.sha256 == old_sha:
                     result.message = f"'{result.name}' is already up to date"


### PR DESCRIPTION
## Bug

`skills update` called `install()` with `force=True`, bypassing the dangerous-content scan that `skills install` enforces.

## Fix

Two changes:
1. `installer.py::update()` — use `force=False` so dangerous updates are blocked, matching fresh install behavior.
2. `rpc_skills.py::_handle_skills_update()` — surface `scan_verdict` and `scan_findings` in results (matching `_handle_skills_install`), so CLI/RPC consumers see the verdict.