### PR TITLE
fix(skills): respect security scan verdict on skills update

### DIFF
--- a/src/agentos/skills/hub/installer.py
+++ b/src/agentos/skills/hub/installer.py
@@ -299,9 +299,16 @@ class SkillInstaller:
                 )
                 continue
             old_sha = entry.sha256
-            result = await self.install(entry.identifier, entry.source, force=True)
+            # Update must NOT force=True — that would bypass the security scan
+            # verdict, allowing a compromised upstream to push dangerous content
+            # through 'skills update'. The scan verdict is honored here; the
+            # operator can still override with 'skills install --force'.
+            result = await self.install(entry.identifier, entry.source, force=False)
             if result.success:
-                if old_sha and result.sha256 == old_sha:
+                if result.scan and result.scan.verdict == "dangerous":
+                    # Scan rejected the update; surface findings.
+                    pass
+                elif old_sha and result.sha256 == old_sha:
                     result.message = f"'{result.name}' is already up to date"
                 else:
                     result.message = f"Updated '{result.name}' to the latest version"


### PR DESCRIPTION
## Summary

`SkillInstaller.update()` called `self.install(..., force=True)` unconditionally, causing the dangerous-content scan verdict to be silently waived on every update. A compromised upstream could push malicious content and `skills update` would accept it.

## Fix

- Drop `force=True` from `SkillInstaller.update()` so the scan verdict is respected during updates.
- `scan_verdict` and `scan_findings` are already surfaced on `InstallResult.scan` from the `install()` path, so the update RPC response includes them.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `skills update` on skill with dangerous content | ✅ silently installs | ❌ blocked with scan findings |
| `skills install --force` same skill | ✅ overrides | ✅ still overrides (operator intent) |

Closes #988.