### PR TITLE
fix(tools): clean up tempdir on denied code_exec calls

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -375,13 +375,20 @@ async def execute_code(
 
     elevated_bypass = _elevated_mode() in ("on", "bypass", "full")
     if runtime is None or (runtime.effective.sandbox_enabled and not elevated_bypass):
-        decision, _policy, request = await gate_action(
-            action_kind="code.exec",
-            argv=(python_bin, "-c", code),
-            cwd=workdir_path,
-            env=safe_env,
-        )
+        try:
+            decision, _policy, request = await gate_action(
+                action_kind="code.exec",
+                argv=(python_bin, "-c", code),
+                cwd=workdir_path,
+                env=safe_env,
+            )
+        except Exception:
+            if cleanup_dir:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
+            raise
         if isinstance(decision, DenialResult):
+            if cleanup_dir:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
             return json.dumps(decision.to_dict())
         backend_request = SandboxRequest(
             argv=(python_bin, "-c", code),
@@ -393,6 +400,8 @@ async def execute_code(
         try:
             sandbox_result = await run_under_backend(backend_request, runtime=runtime)
         except Exception as exc:
+            if cleanup_dir:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
             return _execution_result_json(
                 returncode=-1,
                 stdout="",
@@ -405,6 +414,8 @@ async def execute_code(
                 sandbox_result, request, _policy, runtime=runtime
             )
             if isinstance(escalation, DenialResult):
+                if cleanup_dir:
+                    shutil.rmtree(cleanup_dir, ignore_errors=True)
                 return json.dumps(escalation.to_dict())
             try:
                 proc = await asyncio.create_subprocess_exec(
@@ -424,6 +435,8 @@ async def execute_code(
                     proc.kill()
                     await proc.communicate()
                     elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                    if cleanup_dir:
+                        shutil.rmtree(cleanup_dir, ignore_errors=True)
                     return _execution_result_json(
                         returncode=-1,
                         stdout="",
@@ -432,6 +445,8 @@ async def execute_code(
                         elapsed_ms=elapsed_ms,
                     )
                 elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                if cleanup_dir:
+                    shutil.rmtree(cleanup_dir, ignore_errors=True)
                 return _execution_result_json(
                     returncode=proc.returncode if proc.returncode is not None else -1,
                     stdout=stdout_bytes.decode("utf-8", errors="replace"),
@@ -440,6 +455,8 @@ async def execute_code(
                     elapsed_ms=elapsed_ms,
                 )
             except Exception as exc:
+                if cleanup_dir:
+                    shutil.rmtree(cleanup_dir, ignore_errors=True)
                 return _execution_result_json(
                     returncode=-1,
                     stdout="",
@@ -451,6 +468,8 @@ async def execute_code(
         stdout = sandbox_result.stdout
         stderr = sandbox_result.stderr
         stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
+        if cleanup_dir:
+            shutil.rmtree(cleanup_dir, ignore_errors=True)
         return _execution_result_json(
             returncode=sandbox_result.returncode,
             stdout=stdout,

--- a/tests/test_tools/test_code_exec_tempdir_cleanup.py
+++ b/tests/test_tools/test_code_exec_tempdir_cleanup.py
@@ -18,6 +18,14 @@ from agentos.tools.builtin import code_exec
 from agentos.tools.types import current_tool_context
 
 
+@pytest.fixture(autouse=True)
+def _reset_tool_context() -> None:
+    """Reset global tool context before and after each test to prevent pollution."""
+    current_tool_context.set(None)
+    yield
+    current_tool_context.set(None)
+
+
 def _cleanup_agentos_tempdirs() -> list[str]:
     """Remove any pre-existing agentos_exec tempdirs and return what was there."""
     existing = glob.glob("/tmp/agentos_exec_*")

--- a/tests/test_tools/test_code_exec_tempdir_cleanup.py
+++ b/tests/test_tools/test_code_exec_tempdir_cleanup.py
@@ -1,0 +1,90 @@
+"""Regression test for code_exec tempdir leak on denied sandbox calls.
+
+Before the fix, every denied call to ``code_exec.execute_code`` left a
+``/tmp/agentos_exec_*`` directory on disk because early returns inside
+the sandbox block (DenialResult from gate_action, escalation denial,
+subprocess timeout, exception) bypassed the ``finally`` clause attached
+to the outer non-sandbox path.
+"""
+
+from __future__ import annotations
+
+import glob
+import shutil
+
+import pytest
+
+from agentos.tools.builtin import code_exec
+from agentos.tools.types import current_tool_context
+
+
+def _cleanup_agentos_tempdirs() -> list[str]:
+    """Remove any pre-existing agentos_exec tempdirs and return what was there."""
+    existing = glob.glob("/tmp/agentos_exec_*")
+    for d in existing:
+        shutil.rmtree(d, ignore_errors=True)
+    return existing
+
+
+def test_denied_code_exec_call_does_not_leak_tempdir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A denied sandbox call must clean up its ephemeral workdir.
+
+    Each call with no runtime configured creates ``/tmp/agentos_exec_<rand>``
+    and must remove it before returning, even on the deny path.
+    """
+    _cleanup_agentos_tempdirs()
+    current_tool_context.set(None)
+
+    async def run() -> None:
+        result = await code_exec.execute_code("print('x')")
+        # Runtime unconfigured → denial JSON.  We don't care about the content,
+        # only that the tempdir is gone.
+        assert "denied" in result or "unconfigured" in result
+
+    import asyncio
+
+    asyncio.run(run())
+
+    leaked = glob.glob("/tmp/agentos_exec_*")
+    assert leaked == [], f"leaked tempdirs after denied call: {leaked}"
+
+
+def test_multiple_denied_calls_do_not_leak(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Five denied calls in a row must leave zero tempdirs behind."""
+    _cleanup_agentos_tempdirs()
+    current_tool_context.set(None)
+
+    import asyncio
+
+    async def run() -> None:
+        for _ in range(5):
+            result = await code_exec.execute_code("print('x')")
+            assert "denied" in result or "unconfigured" in result
+
+    asyncio.run(run())
+
+    leaked = glob.glob("/tmp/agentos_exec_*")
+    assert leaked == [], f"leaked {len(leaked)} tempdirs after 5 denied calls: {leaked}"
+
+
+def test_workspace_path_does_not_create_tempdir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a workspace is configured, no ``/tmp/agentos_exec_*`` tempdir is created."""
+    _cleanup_agentos_tempdirs()
+    # Use a real workspace via ToolContext so we hit the "workspace is not None" branch.
+    # Use a real workspace via ToolContext so we hit the "workspace is not None" branch.
+    from agentos.tools.types import ToolContext
+
+    ctx = ToolContext(workspace_dir="/tmp/agentos_test_workspace")
+    current_tool_context.set(ctx)
+
+    import asyncio
+
+    async def run() -> None:
+        result = await code_exec.execute_code("print('x')")
+        # Even if denied, the workspace path is reused — no tempdir created.
+        assert "denied" in result or "unconfigured" in result
+
+    asyncio.run(run())
+
+    leaked = glob.glob("/tmp/agentos_exec_*")
+    assert leaked == [], f"workspace-path call still created tempdir: {leaked}"


### PR DESCRIPTION
Fixes #1010

## Summary
`code_exec.execute_code` creates `tempfile.mkdtemp(prefix="agentos_exec_")` when no workspace is configured (line 367). Cleanup via `shutil.rmtree` lives in the `finally` clause of the **outer** try/except (line 505-507), which only runs for the non-sandbox path. Every early return inside the sandbox block — DenialResult, subprocess timeout, unhandled exception, escalation denial — bypasses cleanup and leaks the tempdir.

## What
- src/agentos/tools/builtin/code_exec.py — per-return cleanup before each early return in sandbox block (lines 384, 395, 407, 429, 442); exception guard around `gate_action()` so unhandled exceptions also trigger cleanup
- tests/test_tools/test_code_exec_tempdir_cleanup.py — 3 regression tests: single denied call, 5 denied calls, workspace path no tempdir

## Verification
- `uv run pytest tests/test_tools/test_code_exec_tempdir_cleanup.py -v` — 3 passed
- `uv run ruff check src/agentos/tools/builtin/code_exec.py tests/test_tools/test_code_exec_tempdir_cleanup.py` — clean
- `uv run mypy src/agentos/tools/builtin/code_exec.py --show-error-codes` — no issues
