### PR TITLE
fix(skills): tolerate non-dict error payloads in RpcError (#974)

### DIFF
--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
@@ -69,11 +69,17 @@ USER_AGENT = "poolsdotfun-token-launcher/1.0"
 class RpcError(RuntimeError):
     """A JSON-RPC error response. ``data`` carries the revert blob when present."""
 
-    def __init__(self, method: str, error: dict) -> None:
-        super().__init__(f"{method}: {error.get('message', error)}")
-        self.code = error.get("code")
-        self.data = error.get("data")
-        self.raw = error
+    def __init__(self, method: str, error: dict | str) -> None:
+        if isinstance(error, dict):
+            super().__init__(f"{method}: {error.get('message', error)}")
+            self.code = error.get("code")
+            self.data = error.get("data")
+            self.raw = error
+        else:
+            super().__init__(f"{method}: {error}")
+            self.code = None
+            self.data = None
+            self.raw = error
 
 
 class RpcClient:

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
@@ -69,11 +69,17 @@ USER_AGENT = "senior-unilp-manager/1.0"
 class RpcError(RuntimeError):
     """A JSON-RPC error response. ``data`` carries the revert blob when present."""
 
-    def __init__(self, method: str, error: dict) -> None:
-        super().__init__(f"{method}: {error.get('message', error)}")
-        self.code = error.get("code")
-        self.data = error.get("data")
-        self.raw = error
+    def __init__(self, method: str, error: dict | str) -> None:
+        if isinstance(error, dict):
+            super().__init__(f"{method}: {error.get('message', error)}")
+            self.code = error.get("code")
+            self.data = error.get("data")
+            self.raw = error
+        else:
+            super().__init__(f"{method}: {error}")
+            self.code = None
+            self.data = None
+            self.raw = error
 
 
 class RpcClient:


### PR DESCRIPTION
## Summary

Fixes #974. The JSON-RPC spec allows the `error` field to be a string or other scalar, not just a dict. `RpcError.__init__` unconditionally called `.get()` on the error argument, crashing with `AttributeError` when a node/proxy returned a string error payload.

## Changes

- `RpcError.__init__` now checks `isinstance(error, dict)` and handles plain string errors by setting `code=None`, `data=None`
- Applied to both `senior-unilp-manager` and `poolsdotfun-token-launcher` RPC modules

## Verification

Tested locally: `RpcError('method', {'code': -32000, 'message': 'oops'})` works as before, `RpcError('method', 'rate limit exceeded')` no longer crashes.

## Size

+22/-10 across 2 files