### PR TITLE
fix(cli,docs): correct printed commands that fail when followed (#840)

### DIFF
--- a/README.product.md
+++ b/README.product.md
@@ -135,7 +135,7 @@ agentos configure router --router recommended
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 agentos configure channels
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -446,7 +446,7 @@ Raw config:
 
 ```sh
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791 --config ~/.agentos/config.toml
 ```
 
 For Ollama models that do not reliably support native tool calls, set

--- a/src/agentos/cli/channels_cmd.py
+++ b/src/agentos/cli/channels_cmd.py
@@ -60,7 +60,7 @@ def _print_restart_notice() -> None:
 
 def _print_channel_verification_next_step(name: str) -> None:
     typer.echo("Next: agentos gateway restart")
-    typer.echo(f"Verify: uv run agentos channels status {name} --json")
+    typer.echo(f"Verify: agentos channels status {name} --json")
 
 
 _SOURCE_LABEL = {


### PR DESCRIPTION
Fixes #840 (umbrella for #835).

## Changes

**1. Wrong key path in docs** — `docs/cli.md:449` and `README.product.md:138` documented `agentos config set gateway.port 18791`. There is no `[gateway]` TOML table (`extra = forbid`), so `gateway.port` does not exist. With `--config` it exits 1; without it persists nothing.

→ Changed both to `agentos config set port 18791 --config ~/.agentos/config.toml`

**2. `uv run` prefix in printed command** — `channels_cmd.py:63` printed `Verify: uv run agentos channels status <name> --json`. On pipx/pip installs (both documented install methods), `uv run agentos` exits 127.

→ Dropped `uv run` to match line 62 which correctly prints plain `agentos gateway restart`.

## Scope

- +3/-3 across 3 files. No code files touched outside `channels_cmd.py`.
- No `[gateway]` TOML table introduced.
- `src/agentos/skills/bundled/agentos/SKILL.md` checked — no `gateway.port` instance found.

Closes #840.