### PR TITLE
fix(code_exec): clean up tempdirs on denied sandbox calls

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -375,70 +375,24 @@ async def execute_code(
 
     elevated_bypass = _elevated_mode() in ("on", "bypass", "full")
     if runtime is None or (runtime.effective.sandbox_enabled and not elevated_bypass):
-        decision, _policy, request = await gate_action(
-            action_kind="code.exec",
-            argv=(python_bin, "-c", code),
-            cwd=workdir_path,
-            env=safe_env,
-        )
-        if isinstance(decision, DenialResult):
-            return json.dumps(decision.to_dict())
-        backend_request = SandboxRequest(
-            argv=(python_bin, "-c", code),
-            cwd=request.cwd,
-            action_kind=request.action_kind,
-            policy=request.policy,
-            env=safe_env,
-        )
         try:
-            sandbox_result = await run_under_backend(backend_request, runtime=runtime)
-        except Exception as exc:
-            return _execution_result_json(
-                returncode=-1,
-                stdout="",
-                stderr=f"Execution error: {exc}",
-                timed_out=False,
-                elapsed_ms=0,
+            decision, _policy, request = await gate_action(
+                action_kind="code.exec",
+                argv=(python_bin, "-c", code),
+                cwd=workdir_path,
+                env=safe_env,
             )
-        if sandbox_result.backend_notes:
-            escalation = await escalate_backend_denial(
-                sandbox_result, request, _policy, runtime=runtime
+            if isinstance(decision, DenialResult):
+                return json.dumps(decision.to_dict())
+            backend_request = SandboxRequest(
+                argv=(python_bin, "-c", code),
+                cwd=request.cwd,
+                action_kind=request.action_kind,
+                policy=request.policy,
+                env=safe_env,
             )
-            if isinstance(escalation, DenialResult):
-                return json.dumps(escalation.to_dict())
             try:
-                proc = await asyncio.create_subprocess_exec(
-                    python_bin,
-                    "-c",
-                    code,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=str(workdir_path),
-                    env=safe_env,
-                )
-                try:
-                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                        proc.communicate(), timeout=timeout
-                    )
-                except TimeoutError:
-                    proc.kill()
-                    await proc.communicate()
-                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-                    return _execution_result_json(
-                        returncode=-1,
-                        stdout="",
-                        stderr=f"Execution timed out after {timeout}s",
-                        timed_out=True,
-                        elapsed_ms=elapsed_ms,
-                    )
-                elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-                return _execution_result_json(
-                    returncode=proc.returncode if proc.returncode is not None else -1,
-                    stdout=stdout_bytes.decode("utf-8", errors="replace"),
-                    stderr=stderr_bytes.decode("utf-8", errors="replace"),
-                    timed_out=False,
-                    elapsed_ms=elapsed_ms,
-                )
+                sandbox_result = await run_under_backend(backend_request, runtime=runtime)
             except Exception as exc:
                 return _execution_result_json(
                     returncode=-1,
@@ -447,18 +401,68 @@ async def execute_code(
                     timed_out=False,
                     elapsed_ms=0,
                 )
-        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-        stdout = sandbox_result.stdout
-        stderr = sandbox_result.stderr
-        stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
-        return _execution_result_json(
-            returncode=sandbox_result.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=sandbox_result.timed_out,
-            elapsed_ms=elapsed_ms,
-        )
+            if sandbox_result.backend_notes:
+                escalation = await escalate_backend_denial(
+                    sandbox_result, request, _policy, runtime=runtime
+                )
+                if isinstance(escalation, DenialResult):
+                    return json.dumps(escalation.to_dict())
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        python_bin,
+                        "-c",
+                        code,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=str(workdir_path),
+                        env=safe_env,
+                    )
+                    try:
+                        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                            proc.communicate(), timeout=timeout
+                        )
+                    except TimeoutError:
+                        proc.kill()
+                        await proc.communicate()
+                        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                        return _execution_result_json(
+                            returncode=-1,
+                            stdout="",
+                            stderr=f"Execution timed out after {timeout}s",
+                            timed_out=True,
+                            elapsed_ms=elapsed_ms,
+                        )
+                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                    return _execution_result_json(
+                        returncode=proc.returncode if proc.returncode is not None else -1,
+                        stdout=stdout_bytes.decode("utf-8", errors="replace"),
+                        stderr=stderr_bytes.decode("utf-8", errors="replace"),
+                        timed_out=False,
+                        elapsed_ms=elapsed_ms,
+                    )
+                except Exception as exc:
+                    return _execution_result_json(
+                        returncode=-1,
+                        stdout="",
+                        stderr=f"Execution error: {exc}",
+                        timed_out=False,
+                        elapsed_ms=0,
+                    )
+            elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+            stdout = sandbox_result.stdout
+            stderr = sandbox_result.stderr
+            stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
+            return _execution_result_json(
+                returncode=sandbox_result.returncode,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=sandbox_result.timed_out,
+                elapsed_ms=elapsed_ms,
+            )
 
+        finally:
+            if cleanup_dir:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
     try:
         proc = await asyncio.create_subprocess_exec(
             python_bin,


### PR DESCRIPTION
## Summary

Closes #1010

```
agentos.tools.builtin.code_exec.execute_code` allocates a tempdir via
`tempfile.mkdtemp(prefix="agentos_exec_") when workspace is None and sandbox
is enabled.  The cleanup (`shutil.rmtree`) was only in the non-sandbox
`finally` block, so every early return in the sandbox path leaked the tempdir.
```

### Early returns that now clean up properly

| Return point | Bug line | Fixed |
|---|---|---|
| `DenialResult` from `gate_action` | ~384 | ✅ |
| Exception from `run_under_backend` | ~395 | ✅ |
| Escalation `DenialResult` | ~407 | ✅ |
| `TimeoutError` from subprocess | ~429 | ✅ |
| Generic `Exception` from subprocess | ~442 | ✅ |

### Fix

Wrapped the entire sandbox execution body in `try/finally` so `shutil.rmtree` runs on every exit path.

### Test coverage

13 new tests in `tests/test_tools/test_code_exec_tempdir_cleanup.py` covering:

1. Direct gate\_action denial (cleanup + response shape)
2. Backend exception (cleanup + error JSON)
3. Escalation denial (cleanup + denial JSON shape)
4. Subprocess `TimeoutError` (cleanup + timeout JSON)
5. Generic subprocess exception (cleanup + error JSON)
6. Non-sandbox path still cleans up (regression)
7. `cleanup_dir=None` does not crash
8. Normal sandbox path cleans up (happy path)

### Verification

- `13/13` new tests pass (tempdir leak tests)
- `5/5` existing code\_exec tests pass (regression)
- `ruff check --fix` clean on modified/new files
- `ruff format` applied