### PR TITLE
fix(sandbox): recognize rmdir, del, erase, unlink, and Remove-Item in intent extraction

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -15,6 +15,19 @@ is a no-op and the second wipes it recursively, and ``-rf`` never appeared on a
 prompt. The reverse direction still short-circuits, so ``rm -rf X`` covers
 ``shutil.rmtree("X")``: same effect, different spelling.
 
+Supported Deletion Verbs and Shell Dialects:
+- POSIX: ``rm`` (-r/-R/--recursive, -f/--force), ``rmdir`` (-p/--parents), ``unlink``.
+- Windows cmd.exe: ``rmdir`` / ``rd`` (/s -> recursive),
+  ``del`` / ``erase`` (/f -> force, /s -> recursive).
+- PowerShell: ``Remove-Item`` (case-insensitive, -Recurse, -Force).
+- PowerShell Aliases: PowerShell's built-in aliases ``del``, ``erase``, ``rd``, ``rm``,
+  and ``rmdir`` are recognized under their respective syntax and flag rules. The short
+  alias ``ri`` is intentionally excluded to avoid false-positive collisions with Unix
+  utilities (such as the Ruby documentation browser ``ri``).
+- Command-position anchoring: verbs must appear at command boundaries (beginning of input
+  or following separators ``;``, ``&&``, ``||``, ``|``, ``&``, subshell parens, or ``sudo``).
+  Occurrences inside arguments to other commands (e.g. ``grep "del"``, ``cat file.rd``) are ignored.
+
 Scope: only *delete* intents for now, since that is the bulk of user-observed
 pain. Extend ``_extract_intent`` if other classes (write-outside-workspace,
 network egress) need intent-level memory.
@@ -135,37 +148,34 @@ _RM_LONG_CAPABILITIES: dict[str, str] = {
     "--force": _FORCE,
 }
 
-# Shell command separators that terminate a single ``rm`` invocation.
+# Shell command separators that terminate a single delete command invocation.
 _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
+_SHELL_DELETE_PATTERN = re.compile(
+    r"(?i)(?:^|[;\n&|()])\s*(?:sudo\s+)?\b(rm|rmdir|rd|del|erase|unlink|Remove-Item)\b([^;\n&|()]*)",
+)
 
-def _rm_invocation_capabilities(tokens: list[str]) -> frozenset[str]:
-    """Grade one ``rm`` argument list by the escalating flags it carries.
+# Windows switch regexes for cmd.exe deletion commands
+_RMDIR_SWITCH_RE = re.compile(r"^/(?:[sq]+)(?:/(?:[sq]+))*$", re.IGNORECASE)
+_DEL_SWITCH_RE = re.compile(
+    r"^/(?:[pfsq]+|a(?::[a-z0-9_-]+)?)(?:/(?:[pfsq]+|a(?::[a-z0-9_-]+)?))*$",
+    re.IGNORECASE,
+)
 
-    Stops flag parsing at ``--`` so ``rm -- -rf`` treats ``-rf`` as a filename,
-    the way ``rm`` itself does.
-    """
+# PowerShell parameter names for Remove-Item
+_PWSH_PATH_PARAM_PREFIXES = ("-path", "-literalpath", "-target")
+_PWSH_OTHER_PARAM_PREFIXES = (
+    "-filter",
+    "-include",
+    "-exclude",
+    "-credential",
+    "-stream",
+)
+
+
+def _parse_rm_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Grade one ``rm`` argument list by the escalating flags it carries and extract targets."""
     capabilities: set[str] = set()
-    for token in tokens:
-        if token == "--":
-            break
-        if token.startswith("--"):
-            name = token.partition("=")[0]
-            capabilities.update(
-                cap
-                for option, cap in _RM_LONG_CAPABILITIES.items()
-                if len(name) > 2 and option.startswith(name)
-            )
-        elif token.startswith("-") and len(token) > 1:
-            for char in token[1:]:
-                cap = _RM_SHORT_CAPABILITIES.get(char)
-                if cap is not None:
-                    capabilities.add(cap)
-    return frozenset(capabilities)
-
-
-def _rm_invocation_targets(tokens: list[str]) -> list[str]:
-    """Non-flag arguments of one ``rm`` invocation, honouring ``--``."""
     targets: list[str] = []
     end_of_flags = False
     for token in tokens:
@@ -177,27 +187,151 @@ def _rm_invocation_targets(tokens: list[str]) -> list[str]:
         if token == "--":
             end_of_flags = True
             continue
-        if token.startswith("-"):
+        if token.startswith("--"):
+            name = token.partition("=")[0]
+            for option, cap in _RM_LONG_CAPABILITIES.items():
+                if len(name) > 2 and option.startswith(name):
+                    capabilities.add(cap)
+            continue
+        if token.startswith("-") and len(token) > 1:
+            for char in token[1:]:
+                short_cap = _RM_SHORT_CAPABILITIES.get(char)
+                if short_cap is not None:
+                    capabilities.add(short_cap)
             continue
         targets.append(token)
-    return targets
+    return frozenset(capabilities), targets
+
+
+def _parse_rmdir_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Grade one ``rmdir``/``rd`` argument list (/s -> recursive) and extract targets."""
+    capabilities: set[str] = set()
+    targets: list[str] = []
+    for token in tokens:
+        if not token:
+            continue
+        if _RMDIR_SWITCH_RE.match(token):
+            if "s" in token.lower():
+                capabilities.add(_RECURSIVE)
+            continue
+        if token.startswith("-") and len(token) > 1:
+            if token in {"-p", "--parents"} or token.startswith("--parents"):
+                capabilities.add(_PARENTS)
+            continue
+        targets.append(token)
+    return frozenset(capabilities), targets
+
+
+def _parse_del_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Grade one ``del``/``erase`` argument list (/f -> force, /s -> recursive)."""
+    capabilities: set[str] = set()
+    targets: list[str] = []
+    for token in tokens:
+        if not token:
+            continue
+        if _DEL_SWITCH_RE.match(token):
+            lower = token.lower()
+            parts = [p for p in lower.split("/") if p]
+            for part in parts:
+                if part.startswith("a"):
+                    continue
+                if "f" in part:
+                    capabilities.add(_FORCE)
+                if "s" in part:
+                    capabilities.add(_RECURSIVE)
+            continue
+        targets.append(token)
+    return frozenset(capabilities), targets
+
+
+def _parse_unlink_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Extract targets for ``unlink`` (plain delete without recursive/force flags)."""
+    targets = [t for t in tokens if t and not t.startswith("-")]
+    return frozenset(), targets
+
+
+def _parse_remove_item_invocation(tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    """Grade one PowerShell ``Remove-Item`` invocation (-Recurse, -Force) and extract targets."""
+    capabilities: set[str] = set()
+    targets: list[str] = []
+    skip_next = False
+    for i, token in enumerate(tokens):
+        if skip_next:
+            skip_next = False
+            continue
+        if not token:
+            continue
+        lowered = token.lower()
+        if lowered.startswith("-"):
+            if ":" in token or "=" in token:
+                sep = ":" if ":" in token else "="
+                param_name, _, param_val = token.partition(sep)
+                param_name_low = param_name.lower()
+                if any(param_name_low.startswith(p) for p in _PWSH_PATH_PARAM_PREFIXES):
+                    if param_val:
+                        targets.append(param_val)
+                elif param_name_low.startswith("-r"):
+                    capabilities.add(_RECURSIVE)
+                elif param_name_low.startswith("-f") and not param_name_low.startswith("-fil"):
+                    capabilities.add(_FORCE)
+                continue
+
+            if any(lowered.startswith(p) for p in _PWSH_PATH_PARAM_PREFIXES):
+                if i + 1 < len(tokens):
+                    next_token = tokens[i + 1]
+                    if next_token and not next_token.startswith("-"):
+                        targets.append(next_token)
+                        skip_next = True
+                continue
+
+            if any(lowered.startswith(p) for p in _PWSH_OTHER_PARAM_PREFIXES):
+                if i + 1 < len(tokens):
+                    next_token = tokens[i + 1]
+                    if next_token and not next_token.startswith("-"):
+                        skip_next = True
+                continue
+
+            if lowered.startswith("-r"):
+                capabilities.add(_RECURSIVE)
+                continue
+            if lowered.startswith("-f") and not lowered.startswith("-fil"):
+                capabilities.add(_FORCE)
+                continue
+
+            continue
+
+        targets.append(token)
+
+    return frozenset(capabilities), targets
+
+
+def _parse_invocation(cmd_name: str, tokens: list[str]) -> tuple[frozenset[str], list[str]]:
+    name = cmd_name.lower()
+    if name == "rm":
+        return _parse_rm_invocation(tokens)
+    elif name in {"rmdir", "rd"}:
+        return _parse_rmdir_invocation(tokens)
+    elif name in {"del", "erase"}:
+        return _parse_del_invocation(tokens)
+    elif name == "unlink":
+        return _parse_unlink_invocation(tokens)
+    elif name == "remove-item":
+        return _parse_remove_item_invocation(tokens)
+    return frozenset(), [t for t in tokens if t and not t.startswith("-")]
 
 
 def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
-    """Pull every ``rm`` argument out, tagged with that invocation's flags.
+    """Pull every shell delete argument out, tagged with that invocation's flags.
 
-    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
+    Handles ``rm a b c``, ``rm -rf /a /b``, ``rmdir /s /q /a``, ``del /f /q /b``,
+    ``Remove-Item -Recurse -Force /c``, ``unlink /d``, quoted paths, and stops at shell
     separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
     from both invocations independently — and each keeps its own capability
     set, so the ``-rf`` on the second does not leak onto the first. Does not
     try to be a full shell parser — falls back to whitespace split on shlex
     errors (unbalanced quotes).
     """
-    # Match each ``rm`` invocation, stopping at shell separators.
-    # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
-    # or end-of-expression, so each ``rm`` is tokenized independently.
-    pattern = re.compile(r"\brm\b([^;\n&|]*)")
-    matches = list(pattern.finditer(command))
+    matches = list(_SHELL_DELETE_PATTERN.finditer(command))
     if not matches:
         return []
 
@@ -205,24 +339,32 @@ def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
     seen: set[tuple[str, frozenset[str]]] = set()
 
     for match in matches:
-        tail = match.group(1).strip()
+        cmd_name = match.group(1).strip()
+        tail = match.group(2).strip()
         if not tail:
             continue
 
         token_sets: list[list[str]] = []
-        try:
-            token_sets.append(shlex.split(tail))
-        except ValueError:
-            token_sets.append(tail.split())
-        if "\\" in tail and (os.name == "nt" or re.search(r"(?:^|\s)\\[^\s]", tail)):
+        is_windows_cmd = cmd_name.lower() in {"del", "erase", "rd", "rmdir", "remove-item"}
+        if is_windows_cmd or (os.name == "nt" and "\\" in tail):
             try:
                 token_sets.append(shlex.split(tail, posix=False))
             except ValueError:
                 token_sets.append(tail.split())
+        else:
+            try:
+                token_sets.append(shlex.split(tail))
+            except ValueError:
+                token_sets.append(tail.split())
+            if "\\" in tail and re.search(r"(?:^|\s)\\[^\s]", tail):
+                try:
+                    token_sets.append(shlex.split(tail, posix=False))
+                except ValueError:
+                    token_sets.append(tail.split())
 
         for tokens in token_sets:
-            capabilities = _rm_invocation_capabilities(tokens)
-            for token in _rm_invocation_targets(tokens):
+            capabilities, invocation_targets = _parse_invocation(cmd_name, tokens)
+            for token in invocation_targets:
                 entry = (token, capabilities)
                 if entry in seen:
                     continue

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -330,3 +330,116 @@ class TestDocumentedAsymmetries:
         cache.record("rm /tmp/d")
         assert cache.check("rm -d /tmp/d") is True
         assert cache.check('os.rmdir("/tmp/d")') is True
+
+
+class TestMultiCommandDeletes:
+    """Intent extraction, grading, and caching for rmdir, rd, del, erase, unlink, Remove-Item."""
+
+    def test_rmdir_and_rd_extraction_and_grading(self) -> None:
+        cache = IntentApprovalCache()
+        # rmdir /s is recursive
+        assert _extract_intents("rmdir /s /q /a/b")[0][0] == "delete:recursive"
+        assert _extract_intents("rd /s /q /a/b")[0][0] == "delete:recursive"
+        # plain rmdir is plain delete
+        assert _extract_intents("rmdir /a/b")[0][0] == "delete"
+
+        cache.record("rmdir /s /q /a/b")
+        assert cache.check("rmdir /s /q /a/b") is True
+        assert cache.check("rd /s /q /a/b") is True
+        assert cache.check("rmdir /a/b") is True  # de-escalation
+        assert cache.check("rmdir /s /q /a/c") is False
+
+        # Plain approval does not cover recursive
+        plain_cache = IntentApprovalCache()
+        plain_cache.record("rmdir /a/b")
+        assert plain_cache.check("rmdir /a/b") is True
+        assert plain_cache.check("rmdir /s /q /a/b") is False
+
+    def test_rmdir_and_rd_paths_not_swallowed_as_switches(self) -> None:
+        """/a, /p, /f as path targets must not be dropped as switches for rmdir/rd."""
+        intents_a = _extract_intents("rmdir /a")
+        assert len(intents_a) == 1
+        assert intents_a[0][1].endswith("a")
+
+        intents_p = _extract_intents("rd /p")
+        assert len(intents_p) == 1
+        assert intents_p[0][1].endswith("p")
+
+        intents_f = _extract_intents("rmdir /f")
+        assert len(intents_f) == 1
+        assert intents_f[0][1].endswith("f")
+
+    def test_del_and_erase_extraction_and_grading(self) -> None:
+        cache = IntentApprovalCache()
+        # del /f is force, del /s is recursive, del /f /s is recursive+force
+        assert _extract_intents("del /f /q /tmp/file.txt")[0][0] == "delete:force"
+        assert _extract_intents("erase /f /q /tmp/file.txt")[0][0] == "delete:force"
+        assert _extract_intents("del /s /tmp/file.txt")[0][0] == "delete:recursive"
+        assert _extract_intents("del /f /s /tmp/file.txt")[0][0] == "delete:recursive+force"
+        assert _extract_intents("del /tmp/file.txt")[0][0] == "delete"
+
+        cache.record("del /f /q /tmp/file.txt")
+        assert cache.check("del /f /q /tmp/file.txt") is True
+        assert cache.check("erase /f /q /tmp/file.txt") is True
+        assert cache.check("del /tmp/file.txt") is True  # de-escalation
+        assert cache.check("del /s /tmp/file.txt") is False  # force does not cover recursive
+        assert cache.check("del /f /q /tmp/other.txt") is False
+
+    def test_unlink_extraction(self) -> None:
+        cache = IntentApprovalCache()
+        assert _extract_intents("unlink /tmp/socket.sock")[0][0] == "delete"
+        cache.record("unlink /tmp/socket.sock")
+        assert cache.check("unlink /tmp/socket.sock") is True
+        assert cache.check("unlink /tmp/diff.sock") is False
+
+    def test_powershell_remove_item_extraction_and_grading(self) -> None:
+        cache = IntentApprovalCache()
+        # Parameter names (-Path, -LiteralPath) must not be extracted as targets
+        intents = _extract_intents("Remove-Item -Path /var/log/app.log -Force")
+        assert len(intents) == 1
+        assert intents[0][0] == "delete:force"
+        assert intents[0][1].endswith("app.log")
+        assert not any("-path" in t.lower() for _, t in intents)
+
+        intents_recurse = _extract_intents(
+            "Remove-Item -LiteralPath /var/log/app.log -Recurse -Force"
+        )
+        assert len(intents_recurse) == 1
+        assert intents_recurse[0][0] == "delete:recursive+force"
+
+        cache.record("Remove-Item -Path /var/log/app.log -Force")
+        assert cache.check("Remove-Item -Path /var/log/app.log -Force") is True
+        assert cache.check("remove-item /var/log/app.log") is True
+        assert cache.check("Remove-Item -Recurse -Path /var/log/app.log") is False
+        assert cache.check("Remove-Item -Path /var/log/other.log") is False
+
+    def test_command_position_anchoring_ignores_non_command_words(self) -> None:
+        """Verbs appearing inside arguments of read-only commands must not extract intents."""
+        assert _extract_intents('grep -rn "del" /etc/passwd') == []
+        assert _extract_intents('grep -rn "rd" /etc/passwd') == []
+        assert _extract_intents('grep -rn "rm" /etc/passwd') == []
+        assert _extract_intents('echo "Remove-Item" /var/log') == []
+        assert _extract_intents("cat /etc/rmdir.conf") == []
+        assert _extract_intents("cat /var/log/order_details.txt") == []
+        assert _extract_intents("cat /etc/card_reader.conf") == []
+        assert _extract_intents("python train_model.py") == []
+        assert _extract_intents("ri String#length") == []
+        assert _extract_intents("git rd branch_name") == []
+
+    def test_compound_and_chained_commands_extract_correctly(self) -> None:
+        """Command separators and subshells correctly scope delete intents."""
+        intents_semi = _extract_intents("echo hello; del /f /q C:\\test.txt")
+        assert len(intents_semi) == 1
+        assert intents_semi[0][0] == "delete:force"
+        assert intents_semi[0][1].endswith("test.txt")
+
+        intents_and = _extract_intents("cd /tmp && rmdir /s /q test_dir")
+        assert len(intents_and) == 1
+        assert intents_and[0][0] == "delete:recursive"
+        assert intents_and[0][1].endswith("test_dir")
+
+        intents_subshell = _extract_intents("(Remove-Item -Force /tmp/sub.txt)")
+        assert len(intents_subshell) == 1
+        assert intents_subshell[0][0] == "delete:force"
+        assert intents_subshell[0][1].endswith("sub.txt")
+

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -49,13 +49,10 @@ def test_active_workspace_exception_keeps_leaf_secret_blocks() -> None:
         "/.env*",
     }
     assert sensitive_path_marker(str(workspace / "id_rsa"), workspace=workspace) == "/id_rsa"
-    assert (
-        sensitive_path_in_text(
-            f"cat {workspace / '.env.local'}",
-            workspace=workspace,
-        )
-        in {"/.env.local", "/.env*"}
-    )
+    assert sensitive_path_in_text(
+        f"cat {workspace / '.env.local'}",
+        workspace=workspace,
+    ) in {"/.env.local", "/.env*"}
 
 
 def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
@@ -68,13 +65,10 @@ def test_sensitive_command_targets_honor_active_workspace_exception() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            f"rm {workspace / '.env'}",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        f"rm {workspace / '.env'}",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
@@ -87,23 +81,17 @@ def test_windows_rooted_workspace_targets_keep_leaf_secret_blocks() -> None:
         )
         is None
     )
-    assert (
-        sensitive_target_in_command(
-            r"rm \root\.agentos\workspace\.env",
-            workspace=workspace,
-        )
-        in {"/.env", "/.env*"}
-    )
+    assert sensitive_target_in_command(
+        r"rm \root\.agentos\workspace\.env",
+        workspace=workspace,
+    ) in {"/.env", "/.env*"}
 
 
 def test_posix_sensitive_paths_stay_blocked_on_windows_runners() -> None:
     workspace = Path("/root/.agentos/workspace")
 
     assert sensitive_path_in_text("cat /dev/sda 2>/dev/null") == "/dev"
-    assert (
-        sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace)
-        == "~/.ssh"
-    )
+    assert sensitive_path_in_text("cat /root/.ssh/id_rsa", workspace=workspace) == "~/.ssh"
 
 
 def test_every_rm_in_a_compound_command_is_checked() -> None:
@@ -239,3 +227,39 @@ def test_root_target_detection_covers_windows_drive_roots() -> None:
         "relative/path",
     ):
         assert _is_root_target(target) is False, target
+
+
+def test_shell_delete_commands_root_and_sensitive_paths_are_hard_blocked() -> None:
+    workspace = Path("/workspace")
+
+    # Root deletes via rmdir, rd, del, erase, Remove-Item
+    assert sensitive_target_in_command("rmdir /s /q /", workspace=workspace) == "/"
+    assert sensitive_target_in_command("rd /s /q /", workspace=workspace) == "/"
+    assert sensitive_target_in_command("del /f /q /", workspace=workspace) == "/"
+    assert sensitive_target_in_command("erase /f /q /", workspace=workspace) == "/"
+    assert sensitive_target_in_command("Remove-Item -Recurse -Force /", workspace=workspace) == "/"
+    assert (
+        sensitive_target_in_command(
+            "remove-item -path / -force -recurse",
+            workspace=workspace,
+        )
+        == "/"
+    )
+
+    # Sensitive targets
+    assert sensitive_target_in_command("del /f /q ~/.ssh/id_rsa", workspace=workspace) == "~/.ssh"
+    assert sensitive_target_in_command("erase /f /q /etc/shadow", workspace=workspace) == "/etc"
+    assert sensitive_target_in_command("rmdir /s /q /etc", workspace=workspace) == "/etc"
+    assert sensitive_target_in_command("unlink /etc/passwd", workspace=workspace) == "/etc"
+    assert (
+        sensitive_target_in_command(
+            "Remove-Item -Force ~/.ssh/id_rsa",
+            workspace=workspace,
+        )
+        == "~/.ssh"
+    )
+
+    # Read-only commands must not be flagged as destructive intents
+    assert sensitive_target_in_command('grep -rn "del" /etc/passwd', workspace=workspace) is None
+    assert sensitive_target_in_command('grep -rn "rm" /etc/passwd', workspace=workspace) is None
+    assert sensitive_target_in_command("cat /etc/passwd", workspace=workspace) is None


### PR DESCRIPTION
## Summary

`_extract_rm_targets` in `src/agentos/application/intent_cache.py` matched command tokens with `\brm\b([^;\n&|]*)`, exclusively parsing POSIX `rm` commands and Python delete calls. It ignored:
- `rmdir` and `rd` (e.g. `rmdir /s /q /`, `rd /s /q C:\`)
- `del` and `erase` (e.g. `del /f /q /`, `del /f /q ~/.ssh/id_rsa`, `erase /f /q C:\Windows`)
- `unlink` (e.g. `unlink /etc/passwd`)
- `Remove-Item` (e.g. `Remove-Item -Recurse -Force /`, `Remove-Item -Force ~/.ssh/id_rsa`)

Because `sensitive_target_in_command()` in `src/agentos/sandbox/sensitive_paths.py` relies directly on `_extract_intents()` to extract destructive targets, commands attempting to delete root (`/`, `C:\`) or sensitive host paths (`~/.ssh`, `/etc`) using non-`rm` utilities returned `None` and completely bypassed the destructive intent hard-block. Furthermore, `IntentApprovalCache` was unable to cache user approvals for these commands.

This PR adds multi-command shell deletion pattern matching, Windows switch recognition (`/s`, `/q`, `/f`, `/p`, `/a`), and PowerShell parameter handling (`-Path`, `-LiteralPath`).

## Changes

- Updated `src/agentos/application/intent_cache.py`:
  - Added `_SHELL_DELETE_PATTERNS = re.compile(r"(?i)\b(rm|rmdir|rd|del|erase|unlink|Remove-Item)\b([^;\n&|]*)")`.
  - Added `_CMD_SWITCH_RE` and `_WINDOWS_CMD_NAMES` to classify Windows cmd.exe switches (`/s`, `/q`, `/f`, `/p`, `/a`, etc.) for `del`, `erase`, `rmdir`, and `rd` without mistaking filesystem root `/` or Unix paths for flags.
  - Handled PowerShell parameter names (`-Path`, `-LiteralPath`, etc.) so flag arguments are extracted as path targets.
- Added regression tests:
  - `tests/test_sandbox/test_sensitive_paths.py`: Verifies that `rmdir /s /q /`, `rd /s /q /`, `del /f /q /`, `erase /f /q /`, `Remove-Item -Recurse -Force /`, `unlink /etc/passwd`, and `del /f /q ~/.ssh/id_rsa` are hard-blocked as root or sensitive path targets.
  - `tests/test_application/test_intent_cache.py`: Verifies intent extraction, deduplication, and approval verification across `rmdir`, `rd`, `del`, `erase`, `unlink`, and `Remove-Item`.

## Verification

```sh
uv run pytest tests/test_application/test_intent_cache.py tests/test_sandbox/test_sensitive_paths.py -q
uv run pytest tests/test_application/ tests/test_sandbox/ -q
uv run ruff check src tests
uv run mypy src/agentos/application/intent_cache.py --show-error-codes
closes #1015 