### PR TITLE
fix(intent): detect rmdir, rd, del, erase, unlink, Remove-Item in destructive-intent extraction (Closes #1015)

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -58,18 +58,25 @@ _PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
 _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
-def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of every ``rm`` invocation.
+def _extract_destructive_targets(command: str) -> list[str]:
+    """Pull every non-flag argument from common shell / PowerShell deletion commands.
 
-    Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
-    separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
+    Recognises ``rm``, ``rmdir``, ``rd``, ``del``, ``erase``, ``unlink``,
+    and ``Remove-Item`` (PowerShell), then extracts their target paths.
+
+    Handles ``rm a b c``, ``rm -rf /a /b``, ``rmdir /s /q /``,
+    ``del /f /q ~/.ssh/id_rsa``, ``Remove-Item -Recurse -Force /``,
+    quoted paths, and stops at shell separators.
+    Uses ``finditer`` so ``rm foo; rmdir /s /q /bar`` yields targets
     from both invocations independently. Does not try to be a full shell
     parser — falls back to whitespace split on shlex errors (unbalanced quotes).
     """
-    # Match each ``rm`` invocation, stopping at shell separators.
-    # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
-    # or end-of-expression, so each ``rm`` is tokenized independently.
-    pattern = re.compile(r"\brm\b([^;\n&|]*)")
+    # Match each destructive command invocation, stopping at shell separators.
+    # Group 1 captures the command name, group 2 the arguments.
+    pattern = re.compile(
+        r"\b(rm|rmdir|rd|del|erase|unlink|Remove\-Item)\b([^;\n&|]*)",
+        re.IGNORECASE,
+    )
     matches = list(pattern.finditer(command))
     if not matches:
         return []
@@ -78,8 +85,9 @@ def _extract_rm_targets(command: str) -> list[str]:
     seen: set[str] = set()
 
     for match in matches:
-        tail = match.group(1).strip()
+        tail = match.group(2).strip()
         if not tail:
+            # ``rm`` alone or ``del`` alone — no target to extract
             continue
 
         token_sets: list[list[str]] = []
@@ -116,7 +124,7 @@ def _extract_intents(
     if not command:
         return []
     paths: list[str] = []
-    paths.extend(_extract_rm_targets(command))
+    paths.extend(_extract_destructive_targets(command))
     for pattern in _PY_DELETE_PATTERNS:
         paths.extend(m.group(1) for m in pattern.finditer(command))
 

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -96,3 +96,80 @@ class TestRecordAndCheck:
         cache.clear()
         assert cache.check("rm /a") is False
         assert cache.check("rm /b") is False
+
+
+class TestDestructiveCommands:
+    """Non-rm deletion commands must be recognised by the intent cache."""
+
+    def test_rmdir_recognised(self) -> None:
+        """rmdir /s /q / extracts root target."""
+        cache = IntentApprovalCache()
+        cache.record("rmdir /s /q /")
+        assert cache.check("rmdir /s /q /") is True
+
+    def test_rmdir_separator_bypass(self) -> None:
+        """rmdir /a approved -> rmdir /a; rmdir /b is blocked."""
+        cache = IntentApprovalCache()
+        cache.record("rmdir /a")
+        assert cache.check("rmdir /a") is True
+        assert cache.check("rmdir /a; rmdir /b") is False
+
+    def test_rd_recognised(self) -> None:
+        """rd /s /q / extracts root target."""
+        cache = IntentApprovalCache()
+        cache.record("rd /s /q /")
+        assert cache.check("rd /s /q /") is True
+
+    def test_del_recognised(self) -> None:
+        """del /f /q ~/.ssh/id_rsa extracts sensitive path."""
+        cache = IntentApprovalCache()
+        cache.record("del /f /q ~/.ssh/id_rsa")
+        assert cache.check("del /f /q ~/.ssh/id_rsa") is True
+
+    def test_del_sensitive_path_blocked(self) -> None:
+        """del /f approved -> del /f; del /f /etc/passwd not approved."""
+        cache = IntentApprovalCache()
+        cache.record("del /f /tmp/foo")
+        assert cache.check("del /f /tmp/foo") is True
+        assert cache.check("del /f /tmp/foo; del /f /etc/passwd") is False
+
+    def test_erase_recognised(self) -> None:
+        """erase /f /q C:\\ extracts target (Windows)."""
+        cache = IntentApprovalCache()
+        cache.record("erase /f /q C:\\")
+        assert cache.check("erase /f /q C:\\") is True
+
+    def test_unlink_recognised(self) -> None:
+        """unlink target.txt extracts target."""
+        cache = IntentApprovalCache()
+        cache.record("unlink target.txt")
+        assert cache.check("unlink target.txt") is True
+
+    def test_remove_item_recognised(self) -> None:
+        """Remove-Item -Recurse -Force / extracts root target."""
+        cache = IntentApprovalCache()
+        cache.record("Remove-Item -Recurse -Force /")
+        assert cache.check("Remove-Item -Recurse -Force /") is True
+
+    def test_remove_item_separator_bypass(self) -> None:
+        """Remove-Item /a -> Remove-Item /a; Remove-Item /b blocked."""
+        cache = IntentApprovalCache()
+        cache.record("Remove-Item /a")
+        assert cache.check("Remove-Item /a") is True
+        assert cache.check("Remove-Item /a; Remove-Item /b") is False
+
+    def test_mixed_commands_independent(self) -> None:
+        """rm /a; rmdir /b; Remove-Item /c each parsed independently."""
+        cache = IntentApprovalCache()
+        cache.record("rm /a")
+        assert cache.check("rm /a; rmdir /b") is False  # /b not approved
+        cache.record("rmdir /b")
+        assert cache.check("rm /a; rmdir /b") is True  # both now approved
+
+    def test_non_rm_returns_false(self) -> None:
+        """Commands without destructive intent still return False."""
+        cache = IntentApprovalCache()
+        assert cache.check("rmdir") is False  # rmdir alone, no target
+        assert cache.check("del \n") is False  # del alone, no target
+        assert cache.check("echo hello") is False
+        assert cache.check("") is False


### PR DESCRIPTION
### Summary

_\`_extract_rm_targets\`_ renamed to _\`_extract_destructive_targets\`_ and extended to recognise **all** common shell / PowerShell deletion commands:

- ``rm``, ``rmdir``, ``rd``, ``del``, ``erase``, ``unlink``, ``Remove-Item``

Previously only ``\brm\b`` was matched by the regex. Any agent that said ``rmdir /s /q /``, ``del /f /q ~/.ssh/id_rsa``, or ``Remove-Item -Recurse -Force /`` would completely bypass the destructive-intent and sensitive-path hard-blocks.

### Changes

- **`src/agentos/application/intent_cache.py`** —  `_extract_rm_targets` → `_extract_destructive_targets` with case-insensitive regex for all 7 commands
- **`tests/test_application/test_intent_cache.py`** — 11 new tests in a `TestDestructiveCommands` class

### Verification

- 24/24 tests pass (13 existing + 11 new)
- Root detection confirmed: `sensitive_target_in_command("rmdir /s /q /")` returns "/"
- Sensitive path detection confirmed: `sensitive_target_in_command("del /f /q ~/.ssh/id_rsa")` returns "~/.ssh"

Closes #1015