### PR TITLE
fix(tools): handle multiline quoted fields in read_spreadsheet

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -6,6 +6,7 @@ import asyncio
 import csv
 import fnmatch
 import functools
+import io
 import json
 import os
 import posixpath
@@ -314,8 +315,7 @@ def _workspace_strict_read_block(
             "workspace": str(roots[0]),
             "allowed_roots": [str(root) for root in roots],
             "message": (
-                f"{tool_name} blocked: {candidate} is outside active read roots "
-                f"({root_labels})."
+                f"{tool_name} blocked: {candidate} is outside active read roots ({root_labels})."
             ),
             "retryable": False,
         }
@@ -592,7 +592,7 @@ def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[lis
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
-    rows = [[cell for cell in row] for row in csv.reader(text.splitlines(), delimiter=delimiter)]
+    rows = [[cell for cell in row] for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
     return [(path.name, rows)]
 
 
@@ -747,8 +747,7 @@ def _format_spreadsheet(
         if start + limit < len(rows):
             end = start + len(selected)
             parts.append(
-                f"(Showing rows {offset}-{end} of {len(rows)}. "
-                f"Use offset={end + 1} to continue.)"
+                f"(Showing rows {offset}-{end} of {len(rows)}. Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)
 
@@ -840,9 +839,7 @@ def _locate_edit(original: str, old_text: str, new_text: str, *, path: str) -> F
     argv_factory=lambda a: ("fs.edit", str(a.get("path", ""))),
     record_payload=False,
 )
-async def edit_file(
-    path: str, old_text: str, new_text: str, approval_id: str | None = None
-) -> str:
+async def edit_file(path: str, old_text: str, new_text: str, approval_id: str | None = None) -> str:
     p = _resolve_path(path)
     approval = await _gate_out_of_workspace_write("edit_file", p, path, approval_id)
     if approval is not None:

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -393,3 +393,18 @@ async def test_sensitive_path_priority_over_workspace_strict(
     assert dir_result["reason"] == "sensitive_path"
     assert "workspace_strict" not in file_result.get("message", "")
     assert "workspace_strict" not in dir_result.get("message", "")
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_multiline_csv_fields(tmp_path: Path) -> None:
+    csv_file = tmp_path / "multiline.csv"
+    csv_file.write_text(
+        'id,name,description\n1,"Widget A","Line 1\nLine 2"\n2,"Widget B","Single line"\n',
+        encoding="utf-8",
+    )
+    with tool_context(tmp_path):
+        content = await fs.read_spreadsheet(str(csv_file))
+    assert "Sheet: multiline.csv (3 rows x 3 columns)" in content
+    assert "1\tid\tname\tdescription" in content
+    assert "2\t1\tWidget A\tLine 1\nLine 2" in content
+    assert "3\t2\tWidget B\tSingle line" in content


### PR DESCRIPTION
### Summary

Fixes `read_spreadsheet` tool parsing for `.csv` and `.tsv` files containing multiline quoted fields.

Fixes #1023

### Changes Made

- **`src/agentos/tools/builtin/filesystem.py`**: Imported `io` and updated `_read_delimited_rows` to feed `io.StringIO(text)` into `csv.reader` instead of pre-splitting text with `text.splitlines()`.
- **`tests/test_tools/test_filesystem_read_workspace.py`**: Added unit test `test_read_spreadsheet_multiline_csv_fields` covering multiline CSV quoted field parsing.

### Quality Verification

- `uv run pytest tests/test_tools/test_filesystem_read_workspace.py -q` (Pass)
- `uv run ruff check src tests` (Pass)
- `uv run ruff format src tests` (Pass)
- `uv run mypy src/agentos --show-error-codes` (Pass)
