### PR TITLE
fix(gateway): keep replacement tasks registered after predecessor exit

### DIFF
--- a/src/agentos/gateway/agent_tasks.py
+++ b/src/agentos/gateway/agent_tasks.py
@@ -46,7 +46,8 @@ class AgentTaskRegistry:
         self._tasks[session_key] = task
 
         def _on_done(t: asyncio.Task) -> None:
-            self._tasks.pop(session_key, None)
+            if self._tasks.get(session_key) is t:
+                self._tasks.pop(session_key, None)
             try:
                 if t.cancelled():
                     log.info("agent_task.cancelled", session_key=session_key)

--- a/tests/test_gateway/test_agent_task_registry.py
+++ b/tests/test_gateway/test_agent_task_registry.py
@@ -1,0 +1,30 @@
+"""Task registry cleanup must not remove a newer task for the same session."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agentos.gateway.agent_tasks import AgentTaskRegistry
+
+
+async def test_cancelled_predecessor_callback_keeps_replacement_registered() -> None:
+    registry = AgentTaskRegistry()
+    blocker = asyncio.Event()
+    predecessor = asyncio.create_task(blocker.wait())
+    registry.register("agent:main:ws:dm:peer", predecessor)
+
+    replacement = asyncio.create_task(blocker.wait())
+    registry.register("agent:main:ws:dm:peer", replacement)
+    await asyncio.gather(predecessor, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert replacement.done() is False
+    assert registry.get("agent:main:ws:dm:peer") is replacement
+    assert registry.is_running("agent:main:ws:dm:peer") is True
+
+    replacement.cancel()
+    await asyncio.gather(replacement, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert registry.get("agent:main:ws:dm:peer") is None
+    assert registry.is_running("agent:main:ws:dm:peer") is False


### PR DESCRIPTION
## Linked issue

Fixes #1026

- [x] This pull request fully resolves the linked issue.

## Summary

When `AgentTaskRegistry.register()` replaces a running task, cancellation of the predecessor schedules its done callback after the replacement has already been stored under the same session key. The old callback unconditionally popped that key, leaving a live replacement invisible to abort/status queries.

This change makes cleanup ownership-aware: a done callback removes the mapping only when the registry still points to that exact task. Outcome logging remains unchanged, so replaced tasks are still logged as cancelled. The replacement cleans itself up normally when it later completes.

The regression covers the ordinary cancellation/replacement race and verifies that the replacement later cleans itself up normally.

## Tests

Regression test before implementation: **1 failed**.

After the fix:

- `uv run pytest tests/test_gateway/test_agent_task_registry.py tests/test_gateway/test_rpc_sessions.py -q --tb=short`: **97 passed**.
- `uv run python scripts/build_control_ui.py build`: passed.
- `npm --prefix frontend run check -- --maxWorkers=1 --minWorkers=1`: passed, **2,041 tests in 99 files**. Single-worker execution avoids local CPU-contention timing flakes; no tests are excluded.
- `uv run ruff check src tests`: passed.
- `uv run mypy src/agentos --show-error-codes`: passed, **622 source files**.
- `uv run pytest -q --tb=short`: **9,174 passed, 32 skipped, 6 failed, 3 setup errors**; 21 snapshots passed.
- `uv build --wheel`: passed, `use_agent_os-2026.9.3-py3-none-any.whl` built.

Local baseline note: a clean worktree at the same base commit (`009cc9e`) reproduces the same **6 failures and 3 setup errors** in `test_pilot_encoder.py`, `test_pilot_benchmark.py`, and `test_build_wheelhouse_zip.py`. This checkout has unhydrated ONNX Git LFS pointers, and local uv 0.8.15 does not support those packaging tests' `uv build --clear` flag. No exclusions or unrelated fixes are included here.

Third-party origins: none. No dependencies, config, schema, persistence, frontend, or public API changes.
