### PR TITLE
fix(telegram): retry polling callbacks before advancing offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Telegram polling retries failed callbacks before acknowledging their updates,
+  with at most three handling attempts per update. Exhausted updates are logged
+  at error level and skipped so later messages can proceed; repeated callback
+  IDs are deduplicated before approval handling.
+  ([#1027](https://github.com/use-agent-os/agent-os/issues/1027))
+
 - Day-of-week ranges that end at `SUN` parse again. `_parse_field` substituted
   every day name with a single number, and `sun` is always 0 there, so
   `SAT-SUN` reached the range check as `6-0` and `MON-SUN` as `1-0` — reversed

--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -117,6 +117,10 @@ class EventDedupeCache:
             self._seen.popitem(last=False)
         return True
 
+    def discard(self, event_id: str) -> None:
+        """Allow an event whose handling failed to be retried."""
+        self._seen.pop(event_id, None)
+
 
 @dataclass
 class RateLimiter:

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -641,20 +641,24 @@ class TelegramChannel:
                 if not isinstance(update, dict):
                     continue
                 update_id = update.get("update_id")
-                if isinstance(update_id, int):
-                    self._update_offset = update_id + 1
                 if "callback_query" in update:
                     try:
                         await self._handle_telegram_callback(update["callback_query"])
                     except Exception as exc:
                         log.warning("telegram.callback_query_handle_failed", error=str(exc))
-                    continue
-                try:
-                    msg = self.parse_incoming(update)
-                except ValueError:
-                    log.debug("telegram.unsupported_update_ignored", update_id=update_id)
-                    continue
-                self.enqueue(msg)
+                        # Do not acknowledge this update or process later ones in
+                        # the batch. Telegram will return it again next poll.
+                        await asyncio.sleep(self.config.poll_idle_sleep_s)
+                        break
+                else:
+                    try:
+                        msg = self.parse_incoming(update)
+                    except ValueError:
+                        log.debug("telegram.unsupported_update_ignored", update_id=update_id)
+                    else:
+                        self.enqueue(msg)
+                if isinstance(update_id, int):
+                    self._update_offset = update_id + 1
             if not updates:
                 await asyncio.sleep(self.config.poll_idle_sleep_s)
 

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -82,6 +82,7 @@ _TRANSPORT_FAILURE_MARKERS = (
     "returned an invalid response",
 )
 _DEDUPE_SIZE = 4096
+_CALLBACK_MAX_ATTEMPTS = 3
 _ALLOWED_UPDATES = (
     "message",
     "edited_message",
@@ -619,6 +620,9 @@ class TelegramChannel:
         )
 
     async def _poll_loop(self) -> None:
+        callback_dedupe = EventDedupeCache(max_size=self.config.event_dedupe_size)
+        failed_update_id: int | None = None
+        callback_failures = 0
         while True:
             try:
                 updates = await self._api(
@@ -641,15 +645,41 @@ class TelegramChannel:
                 if not isinstance(update, dict):
                     continue
                 update_id = update.get("update_id")
+                if (
+                    isinstance(update_id, int)
+                    and self._update_offset is not None
+                    and update_id < self._update_offset
+                ):
+                    continue
                 if "callback_query" in update:
+                    callback = update["callback_query"]
+                    callback_id = callback.get("id") if isinstance(callback, dict) else None
+                    dedupe_key = callback_id if isinstance(callback_id, str) else ""
                     try:
-                        await self._handle_telegram_callback(update["callback_query"])
+                        if not dedupe_key or callback_dedupe.check_and_add(dedupe_key):
+                            await self._handle_telegram_callback(callback)
                     except Exception as exc:
-                        log.warning("telegram.callback_query_handle_failed", error=str(exc))
-                        # Do not acknowledge this update or process later ones in
-                        # the batch. Telegram will return it again next poll.
-                        await asyncio.sleep(self.config.poll_idle_sleep_s)
-                        break
+                        callback_failures = (
+                            callback_failures + 1 if update_id == failed_update_id else 1
+                        )
+                        failed_update_id = update_id if isinstance(update_id, int) else None
+                        if callback_failures < _CALLBACK_MAX_ATTEMPTS:
+                            callback_dedupe.discard(dedupe_key)
+                            log.warning(
+                                "telegram.callback_query_handle_failed",
+                                update_id=update_id,
+                                attempts=callback_failures,
+                                error=str(exc),
+                            )
+                            # Retry this update before processing the rest of the batch.
+                            await asyncio.sleep(self.config.poll_idle_sleep_s)
+                            break
+                        log.error(
+                            "telegram.callback_query_retries_exhausted",
+                            update_id=update_id,
+                            attempts=callback_failures,
+                            error=str(exc),
+                        )
                 else:
                     try:
                         msg = self.parse_incoming(update)
@@ -657,6 +687,8 @@ class TelegramChannel:
                         log.debug("telegram.unsupported_update_ignored", update_id=update_id)
                     else:
                         self.enqueue(msg)
+                failed_update_id = None
+                callback_failures = 0
                 if isinstance(update_id, int):
                     self._update_offset = update_id + 1
             if not updates:

--- a/tests/test_channels/test_telegram_polling_offset.py
+++ b/tests/test_channels/test_telegram_polling_offset.py
@@ -1,0 +1,87 @@
+"""Telegram polling acknowledges updates only after local handling succeeds."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+
+def _message_update(update_id: int) -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": update_id,
+            "chat": {"id": 42, "type": "private"},
+            "from": {"id": 7},
+            "text": "after callback",
+        },
+    }
+
+
+async def test_failed_callback_is_retried_before_later_batch_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token", poll_idle_sleep_s=0.25))
+    callback_update = {"update_id": 10, "callback_query": {"id": "callback-10"}}
+    later_update = _message_update(11)
+    payloads: list[dict[str, Any]] = []
+    queue_sizes_before_poll: list[int] = []
+
+    async def api(method: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        assert method == "getUpdates"
+        payloads.append(dict(payload))
+        queue_sizes_before_poll.append(channel._queue.qsize())
+        if len(payloads) <= 2:
+            return [callback_update, later_update]
+        raise asyncio.CancelledError
+
+    callback_attempts = 0
+
+    async def handle_callback(payload: dict[str, Any]) -> None:
+        nonlocal callback_attempts
+        assert payload == callback_update["callback_query"]
+        callback_attempts += 1
+        if callback_attempts == 1:
+            raise RuntimeError("transient callback dependency failure")
+
+    sleep = AsyncMock()
+    monkeypatch.setattr("agentos.channels.telegram.asyncio.sleep", sleep)
+    channel._api = api  # type: ignore[method-assign]
+    channel._handle_telegram_callback = handle_callback  # type: ignore[method-assign]
+
+    with pytest.raises(asyncio.CancelledError):
+        await channel._poll_loop()
+
+    assert callback_attempts == 2
+    assert "offset" not in payloads[1]
+    assert payloads[2]["offset"] == 12
+    assert queue_sizes_before_poll == [0, 0, 1]
+    message = channel._queue.get_nowait()
+    assert message.content == "after callback"
+    assert channel._queue.empty()
+    sleep.assert_awaited_once_with(0.25)
+
+
+async def test_unsupported_update_is_acknowledged(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    payloads: list[dict[str, Any]] = []
+
+    async def api(method: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        assert method == "getUpdates"
+        payloads.append(dict(payload))
+        if len(payloads) == 1:
+            return [{"update_id": 20, "poll": {"id": "unsupported"}}]
+        raise asyncio.CancelledError
+
+    channel._api = api  # type: ignore[method-assign]
+
+    with pytest.raises(asyncio.CancelledError):
+        await channel._poll_loop()
+
+    assert payloads[1]["offset"] == 21
+    assert channel._queue.empty()

--- a/tests/test_channels/test_telegram_polling_offset.py
+++ b/tests/test_channels/test_telegram_polling_offset.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from structlog.testing import capture_logs
 
+from agentos.channel_pairing import ChannelAdmission
 from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+from agentos.gateway.approval_queue import ApprovalQueue
 
 
 def _message_update(update_id: int) -> dict[str, Any]:
@@ -85,3 +89,114 @@ async def test_unsupported_update_is_acknowledged(monkeypatch: pytest.MonkeyPatc
 
     assert payloads[1]["offset"] == 21
     assert channel._queue.empty()
+
+
+async def test_permanent_callback_failure_is_bounded_and_next_update_gets_its_own_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token", poll_idle_sleep_s=0.25))
+    channel._update_offset = 10
+    updates = [
+        {"update_id": 10, "callback_query": {"id": "bad"}},
+        {"update_id": 11, "callback_query": {"id": "recoverable"}},
+        _message_update(12),
+    ]
+    offsets: list[int] = []
+    attempts = {"bad": 0, "recoverable": 0}
+
+    async def api(method: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        assert method == "getUpdates"
+        offsets.append(payload["offset"])
+        if len(offsets) > 5:
+            raise asyncio.CancelledError
+        return [update for update in updates if update["update_id"] >= payload["offset"]]
+
+    async def handle_callback(callback: dict[str, Any]) -> None:
+        key = callback["id"]
+        attempts[key] += 1
+        if key == "bad" or attempts[key] < 3:
+            raise RuntimeError("callback dependency failed")
+
+    sleep = AsyncMock()
+    monkeypatch.setattr("agentos.channels.telegram.asyncio.sleep", sleep)
+    monkeypatch.setattr(channel, "_api", api)
+    monkeypatch.setattr(channel, "_handle_telegram_callback", handle_callback)
+
+    with capture_logs() as logs, pytest.raises(asyncio.CancelledError):
+        await channel._poll_loop()
+
+    assert attempts == {"bad": 3, "recoverable": 3}
+    assert offsets == [10, 10, 10, 11, 11, 13]
+    assert sleep.await_count == 4
+    assert channel._queue.get_nowait().content == "after callback"
+    assert channel._queue.empty()
+    errors = [entry for entry in logs if entry["log_level"] == "error"]
+    assert len(errors) == 1
+    assert errors[0]["update_id"] == 10
+    assert errors[0]["attempts"] == 3
+
+
+@pytest.mark.parametrize("fail_first", [False, True])
+async def test_repeated_callback_resolves_and_delivers_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, fail_first: bool
+) -> None:
+    queue = ApprovalQueue(db_path=str(tmp_path / "approvals.sqlite"))
+    approval_id = queue.request("exec", {"sessionKey": "agent:main:telegram:dm:7"})
+    channel = TelegramChannel(TelegramChannelConfig(token="test-token"))
+    monkeypatch.setattr("agentos.gateway.approval_queue.get_approval_queue", lambda: queue)
+    monkeypatch.setattr(
+        channel.pairing_store,
+        "admission",
+        lambda *_a: ChannelAdmission("telegram", "7", "grant", 1),
+    )
+    resolve = Mock(wraps=queue.resolve)
+    monkeypatch.setattr(queue, "resolve", resolve)
+    callback = {
+        "id": "callback-10",
+        "from": {"id": 7},
+        "message": {"message_id": 42, "chat": {"id": 7, "type": "private"}, "text": "Allow?"},
+        "data": f"approve:{approval_id}",
+    }
+    update = {"update_id": 10, "callback_query": callback}
+    batches = [[update], [update, {"update_id": 11, "callback_query": callback}]]
+    if fail_first:
+        batches.insert(0, [update])
+    poll_payloads: list[dict[str, Any]] = []
+    callback_api_calls: list[str] = []
+
+    async def api(method: str, payload: dict[str, Any]) -> Any:
+        if method == "getUpdates":
+            poll_payloads.append(dict(payload))
+            if not batches:
+                raise asyncio.CancelledError
+            return batches.pop(0)
+        callback_api_calls.append(method)
+        return True
+
+    get = queue.get
+    get_attempts = 0
+
+    def transient_get(key: str) -> Any:
+        nonlocal get_attempts
+        get_attempts += 1
+        if fail_first and get_attempts == 1:
+            raise RuntimeError("temporary approval storage failure")
+        return get(key)
+
+    monkeypatch.setattr(queue, "get", transient_get)
+    monkeypatch.setattr(channel, "_api", api)
+    monkeypatch.setattr("agentos.channels.telegram.asyncio.sleep", AsyncMock())
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await channel._poll_loop()
+
+        resolve.assert_called_once_with(approval_id, True)
+        assert callback_api_calls == ["answerCallbackQuery", "editMessageText"]
+        assert queue.get(approval_id).approved is True
+        assert channel._queue.get_nowait().content == "Approve"
+        assert channel._queue.empty()
+        assert poll_payloads[-1]["offset"] == 12
+        if fail_first:
+            assert "offset" not in poll_payloads[1]
+    finally:
+        queue._conn.close()


### PR DESCRIPTION
Fixes #1027

Telegram polling previously acknowledged a callback before running its handler, so a transient handler failure could permanently lose a button press. Polling now advances the offset after successful handling or deliberate discard.

- Retry each failed callback up to three handling attempts, holding later updates in the batch until it succeeds or exhausts its budget. After exhaustion, log at error level and advance so a permanently failing update cannot stall the channel.
- Deduplicate completed callbacks by callback ID and skip already-acknowledged update IDs. Failed attempts remain eligible for retry.
- Regression tests exercise the real polling loop and ApprovalQueue, including transient failure, exhausted retries, batch ordering, and approval/message delivery only once after redelivery.

Rebased onto `main` at `cfba23c`. The changelog conflict was resolved by retaining the upstream entries and this PR's #1027 entry under `[Unreleased]`. `git range-diff` confirms the implementation and tests are unchanged by the rebase.

Validation after rebase:

- `uv run ruff check src tests`: passed.
- `uv run mypy src/agentos --show-error-codes`: passed, 623 source files.
- `uv run pytest tests/test_channels -q --tb=short`: **429 passed**.
- `git diff --check origin/main...HEAD`: passed.
- [GitHub CI](https://github.com/use-agent-os/agent-os/actions/runs/34101820039): **passed** on Ubuntu and Windows with Python 3.12, including the full test suites. The Ubuntu job also passed frontend checks, lint, type checking, leak smoke, and wheel build.

Third-party origins: none.
