### PR TITLE
fix(channels): safely handle table row column mismatch in Telegram formatting (Closes #1031)

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -127,7 +127,8 @@ def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
             f"<b>{html.escape(clean_headers[0])} — {html.escape(clean_headers[1])}</b>"
         ]
         for row in rows:
-            label, value = row
+            label = row[0] if len(row) > 0 else ""
+            value = row[1] if len(row) > 1 else ""
             clean_label = _plain_inline(label)
             if clean_label:
                 rendered.append(f"<b>{html.escape(clean_label)}:</b> {_render_inline(value)}")
@@ -139,7 +140,7 @@ def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
     for row in rows:
         cells = [
             f"<b>{html.escape(header)}:</b> {_render_inline(value)}"
-            for header, value in zip(clean_headers, row, strict=True)
+            for header, value in zip(clean_headers, row)
             if value
         ]
         if cells:
@@ -177,8 +178,6 @@ def render_telegram_html(markdown: str) -> str:
             index += 2
             while index < len(lines) and "|" in lines[index] and lines[index].strip():
                 row = _split_table_row(lines[index])
-                if len(row) != len(headers):
-                    break
                 rows.append(row)
                 index += 1
             rendered.extend(_render_table(headers, rows))

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -120,3 +120,24 @@ async def test_telegram_send_falls_back_to_plain_text_on_entity_parse_error() ->
         "chat_id": "42",
         "text": "**Ready**: `agentos status`",
     }
+
+
+def test_telegram_markdown_handles_table_row_column_mismatch() -> None:
+    # 2-column table with 1-item row
+    markdown_2col = """| Header A | Header B |
+| --- | --- |
+| Row 1 Only |
+"""
+    rendered_2col = render_telegram_html(markdown_2col)
+    assert "<b>Header A — Header B</b>" in rendered_2col
+    assert "<b>Row 1 Only:</b>" in rendered_2col
+
+    # 3-column table with 2-item row
+    markdown_3col = """| Col 1 | Col 2 | Col 3 |
+| --- | --- | --- |
+| Val 1 | Val 2 |
+"""
+    rendered_3col = render_telegram_html(markdown_3col)
+    assert "<b>Col 1 · Col 2 · Col 3</b>" in rendered_3col
+    assert "<b>Col 1:</b> Val 1 · <b>Col 2:</b> Val 2" in rendered_3col
+


### PR DESCRIPTION
### Summary

Fixes an issue where `render_telegram_html` and `_render_table` raise an unhandled `ValueError` exception or stop parsing Markdown tables when encountering table rows with mismatched column counts.

### Changes

- In `_telegram_formatting._render_table`:
  - Safe indexing/fallback for 2-column tables to avoid `ValueError: not enough values to unpack`.
  - Remove `strict=True` from `zip(clean_headers, row)` in multi-column tables to gracefully ignore missing or extra cells per row.
- In `_telegram_formatting.render_telegram_html`:
  - Removed premature `break` in table row iteration so ragged table rows are processed gracefully.
- Added comprehensive unit tests in `tests/test_channels/test_telegram_formatting.py`.

Closes #1031
