### PR TITLE
fix(engine): budget reservations to prevent subagent fan-out overshoot (#823)

### DIFF
--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -20,6 +20,20 @@ from .pricing import calculate_cost_usd, lookup_price
 log = structlog.get_logger(__name__)
 
 
+@dataclass
+class _BudgetSlot:
+    """One admitted-but-unspent turn's reservation against budget ceilings."""
+
+    session_key: str
+    amount: float
+    created_at: float
+    ttl_seconds: float = 30.0
+
+    @property
+    def expired(self) -> bool:
+        return time.monotonic() - self.created_at > self.ttl_seconds
+
+
 def parse_session_key_scope(session_key: str) -> tuple[str, str]:
     """Parse (agent_id, channel) from session_key."""
     key = str(session_key or "").strip()
@@ -404,6 +418,7 @@ class UsageTracker:
         self._daily_spend_day = ""
         self._session_spend: dict[str, float] = {}
         self._session_active_skill: dict[str, str] = {}
+        self._budget_slots: list[_BudgetSlot] = []
         _global_usage_tracker = self
 
         if self._db_path:
@@ -520,22 +535,25 @@ class UsageTracker:
         """
         mirror = self._daily_spend.get((day, scope_kind, scope_id), 0.0)
         if not self._ledger_db_path:
-            return mirror
-        conn = self._connect(self._ledger_db_path)
-        try:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT cost_usd FROM spend_ledger "
-                "WHERE day = ? AND scope_kind = ? AND scope_id = ?",
-                (day, scope_kind, scope_id),
-            )
-            row = cursor.fetchone()
-            return max(mirror, float(row[0])) if row else mirror
-        except Exception as e:
-            log.warning("usage_tracker.ledger_query_failed", error=str(e))
-            return mirror
-        finally:
-            conn.close()
+            base = mirror
+        else:
+            conn = self._connect(self._ledger_db_path)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT cost_usd FROM spend_ledger "
+                    "WHERE day = ? AND scope_kind = ? AND scope_id = ?",
+                    (day, scope_kind, scope_id),
+                )
+                row = cursor.fetchone()
+                base = max(mirror, float(row[0])) if row else mirror
+            except Exception as e:
+                log.warning("usage_tracker.ledger_query_failed", error=str(e))
+                base = mirror
+            finally:
+                conn.close()
+        reserved = self._get_reserved_for_scope(day, scope_kind, scope_id)
+        return base + reserved
 
     def get_session_db_cost(self, session_key: str) -> float:
         """Return the persisted lifetime cost recorded for one session."""
@@ -570,7 +588,9 @@ class UsageTracker:
             persisted = self.get_session_db_cost(session_key)
         mem_usage = self._sessions.get(session_key)
         in_memory = mem_usage.total_cost if mem_usage is not None else 0.0
-        return max(in_memory, persisted)
+        base = max(in_memory, persisted)
+        reserved = self._get_reserved_for_session(session_key)
+        return base + reserved
 
     def get_session_scope(self, session_key: str) -> tuple[str, str]:
         meta = self._session_metadata.get(session_key)
@@ -578,6 +598,37 @@ class UsageTracker:
             meta = parse_session_key_scope(session_key)
             self._session_metadata[session_key] = meta
         return meta
+
+    # ── budget reservation helpers ──────────────────────────────────────
+
+    def _purge_expired_slots(self) -> None:
+        """Remove budget slots whose TTL has elapsed."""
+        self._budget_slots[:] = [s for s in self._budget_slots if not s.expired]
+
+    def _get_reserved_for_session(self, session_key: str) -> float:
+        """Sum of all active reservations for one session."""
+        self._purge_expired_slots()
+        total = 0.0
+        for slot in self._budget_slots:
+            if not slot.expired and slot.session_key == session_key:
+                total += slot.amount
+        return total
+
+    def _get_reserved_for_scope(self, day: str, scope_kind: str, scope_id: str) -> float:
+        """Sum of reservations whose session maps to a daily scope."""
+        self._purge_expired_slots()
+        total = 0.0
+        for slot in self._budget_slots:
+            if slot.expired:
+                continue
+            sk_agent, sk_channel = self.get_session_scope(slot.session_key)
+            if scope_kind == "gateway":
+                total += slot.amount
+            elif scope_kind == "agent" and sk_agent == scope_id:
+                total += slot.amount
+            elif scope_kind == "channel" and sk_channel == scope_id:
+                total += slot.amount
+        return total
 
     def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
         """Evaluate every configured spend ceiling for ``session_key``.
@@ -690,6 +741,19 @@ class UsageTracker:
                 f"{label} ${spend:,.4f} has reached the ${warn:,.4f} budget warning threshold.",
             )
 
+        # All ceilings pass — reserve headroom so concurrent fan-out turns
+        # see this admitted turn's budget.
+        reservation_amount = getattr(config, "max_turn_billed_cost_usd", None)
+        if reservation_amount is None or reservation_amount <= 0:
+            reservation_amount = 0.001
+        self._purge_expired_slots()
+        self._budget_slots.append(
+            _BudgetSlot(
+                session_key=session_key,
+                amount=reservation_amount,
+                created_at=time.monotonic(),
+            )
+        )
         return False, None
 
     def add(
@@ -768,6 +832,13 @@ class UsageTracker:
                 self._session_spend[session_key] = self.get_session_db_cost(session_key)
             self._session_spend[session_key] += effective_cost
             self._persist_ledger(day, ledger_scopes, session_key, effective_cost)
+
+        # Release one budget slot for this session (FIFO — pop oldest).
+        self._purge_expired_slots()
+        for i, slot in enumerate(self._budget_slots):
+            if slot.session_key == session_key:
+                self._budget_slots.pop(i)
+                break
 
         if not self._db_path:
             return

--- a/tests/test_engine/test_spend_budgets.py
+++ b/tests/test_engine/test_spend_budgets.py
@@ -445,3 +445,127 @@ async def test_a_broken_guard_does_not_stop_the_turn() -> None:
     events = [event async for event in agent.run_turn("go")]
 
     assert not any(getattr(event, "code", "") == "budget_exceeded" for event in events)
+
+
+# ── Budget reservations (concurrent fan-out protection) ────────────────
+
+
+def test_check_budget_limits_creates_a_reservation() -> None:
+    """check_budget_limits must reserve headroom when ceilings pass."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(
+        enabled=True,
+        max_turn_billed_cost_usd=1.0,
+        session_limit=10.0,
+    )
+    assert len(tracker._budget_slots) == 0
+    tracker.check_budget_limits(SESSION, config)
+    assert len(tracker._budget_slots) == 1
+    assert tracker._budget_slots[0].session_key == SESSION
+    assert tracker._budget_slots[0].amount == 1.0
+
+
+def test_add_releases_one_reservation_per_call() -> None:
+    """add() must release exactly one slot per call (FIFO), not all."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(
+        enabled=True,
+        max_turn_billed_cost_usd=1.0,
+        session_limit=10.0,
+    )
+
+    tracker.check_budget_limits("session:a:1", config)
+    tracker.check_budget_limits("session:a:2", config)
+    tracker.check_budget_limits("session:a:3", config)
+    assert len(tracker._budget_slots) == 3
+
+    tracker.add("session:a:1", input_tokens=10, output_tokens=1, model_id="t", billed_cost=0.5)
+    assert len(tracker._budget_slots) == 2
+
+    tracker.add("session:a:2", input_tokens=10, output_tokens=1, model_id="t", billed_cost=0.5)
+    assert len(tracker._budget_slots) == 1
+
+    tracker.add("session:a:3", input_tokens=10, output_tokens=1, model_id="t", billed_cost=0.5)
+    assert len(tracker._budget_slots) == 0
+
+
+def test_reservation_prevents_concurrent_fan_out_overshoot() -> None:
+    """5 concurrent turns with $9.90/$10 spent must admit exactly 1."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(
+        enabled=True,
+        max_turn_billed_cost_usd=0.10,
+        session_limit=10.00,
+    )
+
+    _spend(tracker, SESSION, 9.90)
+
+    admit_count = 0
+    for _ in range(5):
+        hard_stop, _ = tracker.check_budget_limits(SESSION, config)
+        if not hard_stop:
+            admit_count += 1
+
+    assert admit_count == 1, f"Expected 1 admission, got {admit_count}"
+
+    tracker.add(SESSION, input_tokens=10, output_tokens=1, model_id="t", billed_cost=0.05)
+    assert len(tracker._budget_slots) == 0
+
+
+def test_ttl_prevents_eternal_leak_from_broken_turns() -> None:
+    """Slots must expire so cancelled turns do not leak."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(
+        enabled=True,
+        max_turn_billed_cost_usd=1.0,
+        session_limit=10.0,
+    )
+
+    tracker.check_budget_limits(SESSION, config)
+    assert len(tracker._budget_slots) == 1
+
+    tracker._budget_slots[0].created_at = 0.0  # expire
+
+    hs, _ = tracker.check_budget_limits(SESSION, config)
+    assert hs is False  # should admit, old slot purged
+
+
+def test_reservation_default_amount_works_without_max_turn_cost() -> None:
+    """When max_turn_billed_cost_usd is not set, fall back to 0.001."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(
+        enabled=True,
+        session_limit=10.0,
+    )
+
+    tracker.check_budget_limits(SESSION, config)
+    assert len(tracker._budget_slots) == 1
+    assert tracker._budget_slots[0].amount == 0.001
+
+
+def test_reservations_count_across_all_daily_scopes() -> None:
+    """Reservations inflate daily/agent/channel spend too."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(
+        enabled=True,
+        max_turn_billed_cost_usd=2.0,
+        daily_limit=5.0,
+    )
+
+    _spend(tracker, SESSION, 4.0)
+
+    hs, _ = tracker.check_budget_limits(SESSION, config)
+    assert hs is False, "First turn passes: $4 < $5"
+
+    hs, _ = tracker.check_budget_limits(SESSION, config)
+    assert hs is True, "Second turn blocked: $4 + $2 reserve = $6 > $5"
+
+
+def test_reservation_does_not_break_empty_budgets() -> None:
+    """No configured budgets must still work."""
+    tracker = UsageTracker()
+    config = SimpleNamespace(enabled=True)
+
+    hs, _ = tracker.check_budget_limits(SESSION, config)
+    assert hs is False
+    assert len(tracker._budget_slots) == 1


### PR DESCRIPTION
## Summary

Add per-turn budget reservations to `UsageTracker` so concurrent subagent fan-out turns cannot collectively exceed configured budget ceilings.

## Key Changes

- **`_BudgetSlot` dataclass** with TTL (30s) — one per admitted turn
- **Reservation on admission** in `check_budget_limits()` using `max_turn_billed_cost_usd` from config (default fallback: $0.001)
- **FIFO release** in `add()` — pops the oldest slot for the session on every cost recording call
- **Scope coverage** — reservations inflate `get_effective_session_cost()` (session level) AND `get_spend()` (daily/agent/channel scopes) so all ceiling types see pending headroom
- **TTL auto-purge** prevents permanent leaks from errored/cancelled turns

## Test Coverage (7 new, 32 total)

| Test | What it covers |
|------|----------------|
| `test_check_budget_limits_creates_a_reservation` | Reservation created with correct session_key and amount |
| `test_add_releases_one_reservation_per_call` | FIFO — one slot released per `add()`, not all |
| `test_reservation_prevents_concurrent_fan_out_overshoot` | 5 turns at $9.90/$10 ceiling — exactly 1 admitted |
| `test_ttl_prevents_eternal_leak_from_broken_turns` | Expired slots are purged, not leaked |
| `test_reservation_default_amount_works_without_max_turn_cost` | Falls back to $0.001 when config omits it |
| `test_reservations_count_across_all_daily_scopes` | Reserves inflate daily gatewayspend too |
| `test_reservation_does_not_break_empty_budgets` | No-configured-budgets still works fine |

Closes #823