### PR TITLE
fix(channels): handle ragged Markdown table rows gracefully (#1031)

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -127,7 +127,9 @@ def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
             f"<b>{html.escape(clean_headers[0])} — {html.escape(clean_headers[1])}</b>"
         ]
         for row in rows:
-            label, value = row
+            # Pad ragged rows so single-cell rows do not crash tuple unpack.
+            padded = (row + ["", ""])[:2]
+            label, value = padded
             clean_label = _plain_inline(label)
             if clean_label:
                 rendered.append(f"<b>{html.escape(clean_label)}:</b> {_render_inline(value)}")
@@ -137,9 +139,11 @@ def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
 
     rendered = [f"<b>{' · '.join(html.escape(header) for header in clean_headers)}</b>"]
     for row in rows:
+        # Pad or truncate ragged rows so column-count mismatches do not raise.
+        padded = row[:len(clean_headers)] + [""] * (len(clean_headers) - len(row))
         cells = [
             f"<b>{html.escape(header)}:</b> {_render_inline(value)}"
-            for header, value in zip(clean_headers, row, strict=True)
+            for header, value in zip(clean_headers, padded)
             if value
         ]
         if cells:
@@ -177,8 +181,9 @@ def render_telegram_html(markdown: str) -> str:
             index += 2
             while index < len(lines) and "|" in lines[index] and lines[index].strip():
                 row = _split_table_row(lines[index])
+                # Pad or truncate ragged rows instead of aborting the table.
                 if len(row) != len(headers):
-                    break
+                    row = row[:len(headers)] + [""] * (len(headers) - len(row))
                 rows.append(row)
                 index += 1
             rendered.extend(_render_table(headers, rows))

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -120,3 +120,54 @@ async def test_telegram_send_falls_back_to_plain_text_on_entity_parse_error() ->
         "chat_id": "42",
         "text": "**Ready**: `agentos status`",
     }
+
+
+# ── Ragged / mismatched table rows ─────────────────────────────────────
+
+
+def test_two_column_table_with_single_cell_row_does_not_crash() -> None:
+    """Single-cell rows in a 2-col table pad the missing column."""
+    markdown = """| Header A | Header B |
+| --- | --- |
+| Row 1 Only |
+"""
+    rendered = render_telegram_html(markdown)
+    assert "Header A — Header B" in rendered
+    assert "Row 1 Only" in rendered
+
+
+def test_three_column_table_with_mismatched_row_length_does_not_crash() -> None:
+    """Mismatched column count in a 3-col table pads missing cells."""
+    markdown = """| H1 | H2 | H3 |
+| --- | --- | --- |
+| A | B |
+| C | D | E | F |
+"""
+    rendered = render_telegram_html(markdown)
+    assert rendered
+
+
+def test_three_column_table_with_extra_cells_truncated() -> None:
+    """Extra cells beyond header count are truncated instead of crashing."""
+    markdown = """| Head | Tail |
+| --- | --- |
+| A | B | C | D |
+"""
+    rendered = render_telegram_html(markdown)
+    assert "Head" in rendered
+    assert "Tail" in rendered
+    assert "A" in rendered
+
+
+def test_ragged_rows_preserve_prior_content() -> None:
+    """Mismatched rows after valid rows keep prior parsed content."""
+    markdown = """| Name | Value |
+| --- | --- |
+| **OK** | ✅ Pass |
+| Orphan |
+| **Crit** | ❌ Fail |
+"""
+    rendered = render_telegram_html(markdown)
+    assert "✅ Pass" in rendered
+    assert "❌ Fail" in rendered
+    assert "Orphan" in rendered


### PR DESCRIPTION
## Summary

Fixes unhandled ValueError and table-abort behavior when rendering Markdown tables with ragged rows through Telegram HTML.

## Changes

- **2-col tables**: pad single-cell rows with `["", ""]` before tuple unpack to prevent `ValueError`
- **3+ col tables**: use non-strict `zip` — rows are padded or truncated to match header count
- **Table parser**: replace `break` on column-count mismatch with graceful padding so subsequent rows are still rendered

## Test Coverage (4 new, 10 total)

| Test | Coverage |
|------|----------|
| `test_two_column_table_with_single_cell_row_does_not_crash` | 2-col ragged row pads, no crash |
| `test_three_column_table_with_mismatched_row_length_does_not_crash` | 3-col with missing/extra cells pads |
| `test_three_column_table_with_extra_cells_truncated` | Extra cells truncated silently |
| `test_ragged_rows_preserve_prior_content` | Orphan rows preserve already-parsed rows |

Closes #1031