### PR TITLE
fix: retain references to background asyncio tasks to prevent premature GC (#1033)

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -143,6 +143,9 @@ class SlackChannel:
         repr=False,
     )
     _socket_task: asyncio.Task | None = field(default=None, init=False, repr=False)
+    _background_tasks: set[asyncio.Task] = field(
+        default_factory=set, init=False, repr=False
+    )
     _socket_stop: asyncio.Event | None = field(default=None, init=False, repr=False)
     supports_slash_commands: bool = True
 
@@ -643,6 +646,12 @@ class SlackChannel:
         if self._client is not None:
             await self._client.aclose()
             self._client = None
+        # Cancel and collect background interactive tasks.
+        if self._background_tasks:
+            for task in self._background_tasks:
+                task.cancel()
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+            self._background_tasks.clear()
         self._connected = False
         log.info("slack.stopped")
 
@@ -722,7 +731,9 @@ class SlackChannel:
             return
         if mtype == "interactive":
             if isinstance(payload, dict):
-                asyncio.create_task(self._handle_slack_interactive(payload))
+                task = asyncio.create_task(self._handle_slack_interactive(payload))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
             return
         if mtype != "events_api":
             return
@@ -794,7 +805,9 @@ class SlackChannel:
                     payload = json.loads(payload_str)
                 except Exception:
                     return Response(status_code=400)
-                asyncio.create_task(self._handle_slack_interactive(payload))
+                task = asyncio.create_task(self._handle_slack_interactive(payload))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
                 return Response(status_code=200)
             if not self._ingest_slash_command(form):
                 return Response(status_code=400)

--- a/src/agentos/cli/tui/backend/runtime.py
+++ b/src/agentos/cli/tui/backend/runtime.py
@@ -38,6 +38,8 @@ async def run_tui_runtime(
             hooks.expose_surface(tui_surface)
         turn_task: asyncio.Task[bool] | None = None
 
+        _background_tasks: set[asyncio.Task] = set()
+
         async def _schedule_abort(abort_turn: Awaitable[None]) -> None:
             with contextlib.suppress(Exception):
                 await abort_turn
@@ -47,7 +49,9 @@ async def run_tui_runtime(
             if task is not None and not task.done():
                 with contextlib.suppress(Exception):
                     abort_turn = hooks.on_cancel_active_turn()
-                    asyncio.create_task(_schedule_abort(abort_turn))
+                    t = asyncio.create_task(_schedule_abort(abort_turn))
+                    _background_tasks.add(t)
+                    t.add_done_callback(_background_tasks.discard)
                 task.cancel()
 
         tui_surface.set_cancel_callback(_cancel_inflight_turn)

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -1568,6 +1568,7 @@ class TurnRunner:
         self._memory_provider_managers = memory_provider_managers
         self._diagnostics_state = diagnostics_state
         self._router_control_hold_store = RouterControlHoldStore()
+        self._background_tasks: set[asyncio.Task] = set()
         # TurnHook surface. The default trace hook reproduces the inline trace
         # event behavior while keeping the event sink replaceable at construction.
         if turn_hooks is None:
@@ -5644,7 +5645,7 @@ class TurnRunner:
         mark_status = getattr(self._session_manager, "mark_compaction_flush_receipt_status", None)
         if not callable(mark_status):
             return
-        asyncio.create_task(
+        task = asyncio.create_task(
             mark_compaction_flush_status_with_retry(
                 mark_status,
                 session_key=session_key,
@@ -5656,6 +5657,8 @@ class TurnRunner:
                 skipped_event=f"{event_prefix}.flush_status_update_skipped",
             )
         )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     def _log_pre_compaction_flush_receipt(
         self,

--- a/src/agentos/gateway/websocket.py
+++ b/src/agentos/gateway/websocket.py
@@ -206,6 +206,9 @@ class WsConnection:
     _writer_queue_maxsize: int = field(default=512, init=False, repr=False)
     _outbox: asyncio.Queue[Any] | None = field(default=None, init=False, repr=False)
     _writer_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+    _background_tasks: set[asyncio.Task] = field(
+        default_factory=set, init=False, repr=False
+    )
     _closing: bool = field(default=False, init=False, repr=False)
 
     @property
@@ -492,10 +495,12 @@ class WsConnection:
             stream_seq=_payload_field(frame.payload, "stream_seq"),
             queue_depth=self._outbox.qsize(),
         )
-        asyncio.create_task(
+        task = asyncio.create_task(
             self._force_close(reason="writer_backpressure", code=1011),
             name=f"ws-force-close-{self.conn_id}",
         )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     def _evict_oldest_same_kind(self, kind: str) -> bool:
         """Evict the oldest queued frame whose ``kind`` matches.


### PR DESCRIPTION
## Summary

Retains references to fire-and-forget `asyncio.create_task()` calls across 4 components to prevent premature garbage collection mid-execution.

## Changes by Component

| Component | File | What Changed |
|-----------|------|-------------|
| SlackChannel | `src/agentos/channels/slack.py` | Interactive payloads (socket mode + webhook) tracked via `_background_tasks` set; `stop()` cancels + awaits remaining tasks |
| TurnRunner | `src/agentos/engine/runtime.py` | Compaction flush status retry task retained in `_background_tasks` |
| WsConnection | `src/agentos/gateway/websocket.py` | Backpressure `_force_close` task retained in `_background_tasks` |
| TUI runtime | `src/agentos/cli/tui/backend/runtime.py` | Cancel-abort task in `_cancel_inflight_turn` tracked via local set |

All tasks use `task.add_done_callback(set.discard)` for clean self-removal.

## Why This Matters

As documented by Python: *"The event loop only keeps weak references to tasks. A task that isnt referenced elsewhere may get garbage collected at any time, even before its done."* Under GC pressure these dropped tasks silently drop approvals, miss compaction status syncs, or hang sockets.

Closes #1033