### PR TITLE
fix(observability): retain ad-hoc flush task reference to prevent premature GC (#1047)

### DIFF
--- a/src/agentos/observability/otlp.py
+++ b/src/agentos/observability/otlp.py
@@ -96,6 +96,7 @@ class OtlpTraceSink(TraceSink):
         self._queue_lock = threading.Lock()
         self._flush_lock = asyncio.Lock()
         self._flush_task: asyncio.Task[None] | None = None
+        self._adhoc_flush_tasks: set[asyncio.Task] = set()
         self._closed = False
 
     def start(self) -> None:
@@ -146,9 +147,14 @@ class OtlpTraceSink(TraceSink):
             try:
                 loop = asyncio.get_running_loop()
                 if loop.is_running():
-                    loop.create_task(self.flush())
+                    task = loop.create_task(self.flush())
+                    self._adhoc_flush_tasks.add(task)
+                    task.add_done_callback(self._discard_adhoc_task)
             except RuntimeError:
                 pass
+
+    def _discard_adhoc_task(self, task: asyncio.Task) -> None:
+        self._adhoc_flush_tasks.discard(task)
 
     def build_export_payload(self, events: list[TraceEvent]) -> dict[str, Any]:
         """Transform AgentOS TraceEvents into OTLP JSON ExportTraceServiceRequest."""
@@ -283,4 +289,10 @@ class OtlpTraceSink(TraceSink):
             except Exception:
                 pass
             self._flush_task = None
+        # Cancel and collect pending ad-hoc flush tasks.
+        for task in self._adhoc_flush_tasks:
+            task.cancel()
+        if self._adhoc_flush_tasks:
+            await asyncio.gather(*self._adhoc_flush_tasks, return_exceptions=True)
+            self._adhoc_flush_tasks.clear()
         await self.flush()


### PR DESCRIPTION
## Summary

Ad-hoc flush tasks in `OtlpTraceSink.write()` were fire-and-forget via `loop.create_task()` with no retained reference — risking premature garbage collection and silently dropping telemetry.

## Changes

- Added `_adhoc_flush_tasks: set[asyncio.Task[None]]` to retain references
- `task.add_done_callback(self._discard_adhoc_task)` for clean self-removal
- `close()` cancels and awaits remaining ad-hoc tasks during graceful shutdown

## Why It Matters

Python docs: *The event loop only keeps weak references to tasks. A task that isnt referenced elsewhere may get garbage collected at any time, even before its done.*

Under GC pressure, the one-shot flush can be collected mid-`flush()` — dropping OTLP telemetry silently. The periodic flush loop (`_flush_task`) already retained a reference correctly; ad-hoc flushes did not.

## Tests
10/10 OTLP tests GREEN (boot lifecycle test fails pre-existing — missing numpy).

Closes #1047