### PR TITLE
fix(channels): bind _send closure accumulated by value in MSTeams streaming (#1046)

### DIFF
--- a/src/agentos/channels/msteams.py
+++ b/src/agentos/channels/msteams.py
@@ -531,8 +531,12 @@ class MSTeamsChannel:
             if message_id is None:
                 holder: dict[str, str | None] = {"id": None}
 
-                async def _send(turn_context: Any, _holder: dict[str, str | None] = holder) -> None:
-                    response = await turn_context.send_activity(accumulated)
+                async def _send(
+                    turn_context: Any,
+                    _holder: dict[str, str | None] = holder,
+                    _text: str = accumulated,
+                ) -> None:
+                    response = await turn_context.send_activity(_text)
                     if response is not None and getattr(response, "id", None):
                         _holder["id"] = response.id
 


### PR DESCRIPTION
## Summary

Fixes B023 (loop variable not bound in closure) in MSTeams `send_streaming`. The `_send` closure accessed `accumulated` directly from the enclosing loop scope without binding the value at creation time — the paired `_edit` closure already used the correct default-arg binding pattern.

## Changes
- Added `_text: str = accumulated` parameter to `_send` (same as `_edit` uses `_text: str = accumulated`)
- `_send` now calls `turn_context.send_activity(_text)` instead of `send_activity(accumulated)`
- Split long function signature across multiple lines to avoid E501

### Before
```python
async def _send(turn_context: Any, _holder: ... = holder) -> None:
    response = await turn_context.send_activity(accumulated)  # B023
```

### After
```python
async def _send(
    turn_context: Any,
    _holder: ... = holder,
    _text: str = accumulated,
) -> None:
    response = await turn_context.send_activity(_text)  # bound by value
```

Closes #1046