### PR TITLE
fix(skills): fail skills publish when gh fork fails

### DIFF
--- a/src/agentos/cli/skills_cmd.py
+++ b/src/agentos/cli/skills_cmd.py
@@ -535,6 +535,7 @@ def skills_publish(
             console.print(f"[green]OK:[/] {result.message}")
         else:
             console.print(f"[red]Failed:[/] {result.message}")
+            raise typer.Exit(1)
 
     asyncio.run(_publish())
 

--- a/src/agentos/skills/hub/publisher.py
+++ b/src/agentos/skills/hub/publisher.py
@@ -105,7 +105,9 @@ async def publish_skill(
     branch = f"skill/{skill_name}"
 
     try:
-        # Fork + clone + add skill + push + create PR
+        # Fork the target so a PR can be opened from the contributor fork.
+        # Clone/add/push/PR remain manual; this step must not claim success
+        # when `gh` fails (missing repo, auth, network).
         proc = await asyncio.create_subprocess_exec(
             "gh",
             "repo",
@@ -115,7 +117,20 @@ async def publish_skill(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        await proc.wait()
+        _stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            detail = (stderr or b"").decode("utf-8", errors="replace").strip() or f"exit {proc.returncode}"
+            log.warning(
+                "publish.fork_failed",
+                repo=target_repo,
+                skill=skill_name,
+                returncode=proc.returncode,
+            )
+            return PublishResult(
+                success=False,
+                message=f"Failed to fork {target_repo}: {detail}",
+                skill_name=skill_name,
+            )
 
         log.info("publish.fork_created", repo=target_repo, skill=skill_name)
         return PublishResult(

--- a/src/agentos/skills/hub/publisher.py
+++ b/src/agentos/skills/hub/publisher.py
@@ -119,7 +119,9 @@ async def publish_skill(
         )
         _stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            detail = (stderr or b"").decode("utf-8", errors="replace").strip() or f"exit {proc.returncode}"
+            detail = (stderr or b"").decode("utf-8", errors="replace").strip()
+            if not detail:
+                detail = f"exit {proc.returncode}"
             log.warning(
                 "publish.fork_failed",
                 repo=target_repo,

--- a/src/agentos/skills/hub/publisher.py
+++ b/src/agentos/skills/hub/publisher.py
@@ -67,10 +67,11 @@ async def publish_skill(
     skill_dir: Path,
     target_repo: str | None = None,
 ) -> PublishResult:
-    """Validate and publish a skill.
+    """Validate a skill and optionally fork the target repo via ``gh``.
 
-    If target_repo is provided (owner/repo), creates a fork and PR.
-    Otherwise just validates.
+    With ``target_repo`` (owner/repo), this step only runs ``gh repo fork``.
+    Clone, add the skill, push a branch, and open a PR remain manual.
+    Without ``target_repo``, validation only.
     """
     errors = validate_skill_dir(skill_dir)
     if errors:
@@ -101,13 +102,9 @@ async def publish_skill(
     if len(parts) != 2:
         return PublishResult(success=False, message=f"Invalid repo format: {target_repo}")
 
-    owner, repo = parts
-    branch = f"skill/{skill_name}"
-
     try:
-        # Fork the target so a PR can be opened from the contributor fork.
-        # Clone/add/push/PR remain manual; this step must not claim success
-        # when `gh` fails (missing repo, auth, network).
+        # Only forks. Do not claim clone/add/push/PR happened.
+        # communicate() drains pipes so a large gh error cannot deadlock.
         proc = await asyncio.create_subprocess_exec(
             "gh",
             "repo",
@@ -137,8 +134,10 @@ async def publish_skill(
         log.info("publish.fork_created", repo=target_repo, skill=skill_name)
         return PublishResult(
             success=True,
-            message=f"Skill '{skill_name}' ready for PR to {target_repo}. "
-            f"Fork created, use branch '{branch}' to submit.",
+            message=(
+                f"Skill '{skill_name}' validated; fork of {target_repo} created. "
+                "Next: clone your fork, add the skill, push a branch, and open a PR."
+            ),
             skill_name=skill_name,
         )
     except FileNotFoundError:

--- a/tests/test_skills_hub_publish.py
+++ b/tests/test_skills_hub_publish.py
@@ -34,13 +34,18 @@ async def test_publish_skill_fails_when_gh_fork_returns_nonzero(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     skill_dir = _write_skill(tmp_path)
+    seen_returncode: dict[str, int] = {}
 
     class FakeProc:
         def __init__(self) -> None:
             self.returncode = 1
 
         async def communicate(self) -> tuple[bytes, bytes]:
+            seen_returncode["code"] = self.returncode
             return b"", b"failed to fork: HTTP 404: Not Found\n"
+
+        async def wait(self) -> int:
+            raise AssertionError("use communicate(), not wait()")
 
     async def fake_exec(*_args, **_kwargs):
         return FakeProc()
@@ -52,6 +57,7 @@ async def test_publish_skill_fails_when_gh_fork_returns_nonzero(
 
     result = await publish_skill(skill_dir, target_repo="use-agent-os/missing-repo")
     assert result.success is False
+    assert seen_returncode.get("code") == 1
     assert "Failed to fork" in result.message
     assert "404" in result.message
 
@@ -69,6 +75,9 @@ async def test_publish_skill_succeeds_when_gh_fork_returns_zero(
         async def communicate(self) -> tuple[bytes, bytes]:
             return b"", b""
 
+        async def wait(self) -> int:
+            raise AssertionError("use communicate(), not wait()")
+
     async def fake_exec(*_args, **_kwargs):
         return FakeProc()
 
@@ -76,7 +85,10 @@ async def test_publish_skill_succeeds_when_gh_fork_returns_zero(
 
     result = await publish_skill(skill_dir, target_repo="use-agent-os/agent-os")
     assert result.success is True
-    assert "Fork created" in result.message
+    assert "fork of use-agent-os/agent-os created" in result.message
+    # Do not claim a branch that was never created.
+    assert "use branch" not in result.message.lower()
+    assert "skill/demo-skill" not in result.message
 
 
 def test_skills_publish_cli_exits_nonzero_on_validation_failure(tmp_path: Path) -> None:

--- a/tests/test_skills_hub_publish.py
+++ b/tests/test_skills_hub_publish.py
@@ -1,0 +1,108 @@
+"""CLI/hub tests for ``agentos skills publish``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli.skills_cmd import skills_app
+from agentos.skills.hub.publisher import publish_skill
+
+runner = CliRunner()
+
+
+def _write_skill(root: Path) -> Path:
+    skill_dir = root / "demo-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: demo-skill\n"
+        "description: Reproduce skills publish false success\n"
+        "---\n\n"
+        "# Demo\n\n"
+        "Body long enough to pass validation.\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+@pytest.mark.asyncio
+async def test_publish_skill_fails_when_gh_fork_returns_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    skill_dir = _write_skill(tmp_path)
+
+    class FakeProc:
+        def __init__(self) -> None:
+            self.returncode = 1
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b"failed to fork: HTTP 404: Not Found\n"
+
+    async def fake_exec(*_args, **_kwargs):
+        return FakeProc()
+
+    monkeypatch.setattr(
+        "asyncio.create_subprocess_exec",
+        fake_exec,
+    )
+
+    result = await publish_skill(skill_dir, target_repo="use-agent-os/missing-repo")
+    assert result.success is False
+    assert "Failed to fork" in result.message
+    assert "404" in result.message
+
+
+@pytest.mark.asyncio
+async def test_publish_skill_succeeds_when_gh_fork_returns_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    skill_dir = _write_skill(tmp_path)
+
+    class FakeProc:
+        def __init__(self) -> None:
+            self.returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def fake_exec(*_args, **_kwargs):
+        return FakeProc()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    result = await publish_skill(skill_dir, target_repo="use-agent-os/agent-os")
+    assert result.success is True
+    assert "Fork created" in result.message
+
+
+def test_skills_publish_cli_exits_nonzero_on_validation_failure(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-dir"
+    result = runner.invoke(skills_app, ["publish", str(missing)])
+    assert result.exit_code == 1
+    assert "Failed:" in result.output
+    assert "Not a directory" in result.output
+
+
+def test_skills_publish_cli_exits_nonzero_when_fork_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    skill_dir = _write_skill(tmp_path)
+
+    async def fake_publish(_path, target_repo=None):
+        return SimpleNamespace(
+            success=False,
+            message=f"Failed to fork {target_repo}: HTTP 404",
+            skill_name="demo-skill",
+        )
+
+    monkeypatch.setattr("agentos.skills.hub.publisher.publish_skill", fake_publish)
+    result = runner.invoke(
+        skills_app,
+        ["publish", str(skill_dir), "--repo", "use-agent-os/missing-repo"],
+    )
+    assert result.exit_code == 1
+    assert "Failed:" in result.output


### PR DESCRIPTION
Fixes #1050

## Summary
- `publish_skill` now checks `gh repo fork` returncode and returns `success=False` with stderr when the fork fails.
- `agentos skills publish` raises exit code 1 when `PublishResult.success` is false (including validation failures).
- Adds focused tests for both paths.

## Test plan
- [x] unit: fork nonzero → Failed message
- [x] unit: fork zero → Fork created
- [x] CLI: missing directory exits 1
- [x] CLI: failed publish exits 1
- [ ] `uv run pytest tests/test_skills_hub_publish.py -q`

Default tests stay offline and credential-free.

Third-party origin: none