### PR TITLE
fix(skills): check gh repo fork exit code before reporting success

### DIFF
--- a/src/agentos/skills/hub/publisher.py
+++ b/src/agentos/skills/hub/publisher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -95,7 +96,6 @@ async def publish_skill(
         )
 
     # GitHub publish via gh CLI
-    import asyncio
 
     parts = target_repo.split("/")
     if len(parts) != 2:
@@ -116,14 +116,6 @@ async def publish_skill(
             stderr=asyncio.subprocess.PIPE,
         )
         await proc.wait()
-
-        log.info("publish.fork_created", repo=target_repo, skill=skill_name)
-        return PublishResult(
-            success=True,
-            message=f"Skill '{skill_name}' ready for PR to {target_repo}. "
-            f"Fork created, use branch '{branch}' to submit.",
-            skill_name=skill_name,
-        )
     except FileNotFoundError:
         return PublishResult(
             success=False,
@@ -131,3 +123,32 @@ async def publish_skill(
         )
     except Exception as exc:
         return PublishResult(success=False, message=f"Publish failed: {exc}")
+
+    if proc.returncode != 0:
+        stderr_bytes = await proc.stderr.read() if proc.stderr is not None else b""
+        stderr = stderr_bytes.decode("utf-8", errors="replace").strip() or "(no stderr)"
+        log.warning(
+            "publish.fork_failed",
+            repo=target_repo,
+            skill=skill_name,
+            returncode=proc.returncode,
+            stderr=stderr,
+        )
+        return PublishResult(
+            success=False,
+            message=(
+                f"Failed to fork {target_repo} (gh exit {proc.returncode}): {stderr}. "
+                "Check gh auth (`gh auth status`) and that the repo exists and is forkable."
+            ),
+            skill_name=skill_name,
+        )
+
+    log.info("publish.fork_created", repo=target_repo, skill=skill_name)
+    return PublishResult(
+        success=True,
+        message=(
+            f"Skill '{skill_name}' ready for PR to {target_repo}. "
+            f"Fork created, use branch '{branch}' to submit."
+        ),
+        skill_name=skill_name,
+    )

--- a/tests/test_skills_hub_publisher.py
+++ b/tests/test_skills_hub_publisher.py
@@ -1,0 +1,122 @@
+"""Regression tests for skills hub publisher — gh fork exit code handling."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agentos.skills.hub.publisher import publish_skill
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def wait(self) -> int:
+        return self.returncode
+
+    async def read(self) -> bytes:
+        return self._stderr
+
+    @property
+    def stderr(self) -> _FakeProc:
+        return self
+
+
+@pytest.mark.asyncio
+async def test_publish_skill_forks_and_returns_success_on_zero_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_subprocess(*args: str, **kwargs: object) -> _FakeProc:
+        captured["argv"] = args
+        return _FakeProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A test skill.\n---\n\n# My Skill\nSome content here.",
+        encoding="utf-8",
+    )
+
+    result = await publish_skill(skill_dir, target_repo="owner/repo")
+
+    assert result.success is True
+    assert "ready for PR" in result.message
+    assert captured.get("argv") == ("gh", "repo", "fork", "owner/repo", "--clone=false")
+
+
+@pytest.mark.asyncio
+async def test_publish_skill_reports_failure_on_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_subprocess(*args: str, **kwargs: object) -> _FakeProc:
+        return _FakeProc(1, b"GraphQL: resource not accessible (http 403): repository not forkable")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A test skill.\n---\n\n# My Skill\nSome content here.",
+        encoding="utf-8",
+    )
+
+    result = await publish_skill(skill_dir, target_repo="owner/repo")
+
+    assert result.success is False
+    assert "Failed to fork" in result.message
+    assert "owner/repo" in result.message
+    assert "http 403" in result.message
+    assert "gh auth status" in result.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_publish_skill_reports_failure_on_fork_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_subprocess(*args: str, **kwargs: object) -> _FakeProc:
+        return _FakeProc(1, b"API rate limit exceeded. Please retry in 60 seconds.")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A test skill.\n---\n\n# My Skill\nSome content here.",
+        encoding="utf-8",
+    )
+
+    result = await publish_skill(skill_dir, target_repo="owner/repo")
+
+    assert result.success is False
+    assert "rate limit" in result.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_publish_skill_reports_failure_when_gh_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_subprocess(*args: str, **kwargs: object) -> None:
+        raise FileNotFoundError("gh not found")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A test skill.\n---\n\n# My Skill\nSome content here.",
+        encoding="utf-8",
+    )
+
+    result = await publish_skill(skill_dir, target_repo="owner/repo")
+
+    assert result.success is False
+    assert "gh" in result.message.lower()
+    assert "not found" in result.message.lower()


### PR DESCRIPTION
Fixes #1053

## Summary

`publish_skill()` in `src/agentos/skills/hub/publisher.py` called `gh repo fork`
without inspecting `proc.returncode`. A non-zero exit (rate-limit, auth failure,
non-forkable repo) raised no exception, so the function always returned
`PublishResult(success=True)` regardless of the actual outcome.

The fix checks `proc.returncode` after `await proc.wait()`. On non-zero it
decodes `proc.stderr`, emits `log.warning("publish.fork_failed")` and returns
`PublishResult(success=False)` with a actionable message.

## What

- `src/agentos/skills/hub/publisher.py` — check `proc.returncode != 0` after
  `await proc.wait()`; on failure decode stderr, log at WARNING, return
  `success=False` with the decoded error and a hint to check `gh auth status`
- `tests/test_skills_hub_publisher.py` — regression suite covering zero exit
  (success path), non-zero exit (failure with decoded message), rate-limit
  stderr, and `FileNotFoundError` for missing `gh` CLI

## Verification

- `uv run ruff check src/agentos/skills/hub/publisher.py` — clean
- `uv run mypy src/agentos/skills/hub/publisher.py --show-error-codes` — no issues
- `uv run pytest tests/test_skills_hub_publisher.py -v` — 4 passed in 0.69s
- `uv run pytest tests/test_skills_hub_publisher.py tests/test_skills_hub_installer_update.py -q` — 7 passed in 0.60s
