### PR TITLE
fix(skills): create parent directories before writing output in bundled scripts (#1055)

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/inspect_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/inspect_docx.py
@@ -63,6 +63,7 @@ def main() -> int:
     payload = inspect(args.path)
     text = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text, encoding="utf-8")
     else:
         print(text)

--- a/src/agentos/skills/bundled/multi-search-engine/scripts/search.py
+++ b/src/agentos/skills/bundled/multi-search-engine/scripts/search.py
@@ -14,9 +14,7 @@ from pathlib import Path
 import httpx
 from bs4 import BeautifulSoup
 
-USER_AGENT = (
-    "Mozilla/5.0 (compatible; AgentOS-multi-search-engine/0.1)"
-)
+USER_AGENT = "Mozilla/5.0 (compatible; AgentOS-multi-search-engine/0.1)"
 TIMEOUT_S = 8.0
 
 
@@ -76,8 +74,7 @@ def _brave_search(query: str, limit: int) -> list[Result]:
     effective_count = min(max(limit, 1), _BRAVE_MAX_COUNT)
     if limit > _BRAVE_MAX_COUNT:
         print(
-            f"[multi-search-engine] brave count clamped {limit}→{_BRAVE_MAX_COUNT} "
-            f"(API hard-cap)",
+            f"[multi-search-engine] brave count clamped {limit}→{_BRAVE_MAX_COUNT} (API hard-cap)",
             file=sys.stderr,
         )
     with _client() as client:
@@ -225,6 +222,7 @@ def main() -> int:
     payload = search_all(args.query, engines, args.limit, args.strict)
     encoded = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(encoded, encoding="utf-8")
     else:
         sys.stdout.write(encoded)

--- a/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
+++ b/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
@@ -59,6 +59,7 @@ def main() -> int:
     payload = extract(args.path, args.tables_strategy)
     text = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text, encoding="utf-8")
     else:
         print(text)

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
@@ -148,7 +148,8 @@ def main() -> int:
         print("chain_cards: no token to render", file=sys.stderr)
         return 1
 
-    output = Path(args.output)
+    output = Path(args.output).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     print(f"publish_artifact path={output} mime={CARDS_MIME}")
     return 0

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py
@@ -112,7 +112,8 @@ def main() -> int:
         print("rwa_cards: no matches to render", file=sys.stderr)
         return 1
 
-    output = Path(args.output)
+    output = Path(args.output).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     print(f"publish_artifact path={output} mime={CARDS_MIME}")
     return 0

--- a/src/agentos/skills/bundled/xlsx/scripts/inspect_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/inspect_xlsx.py
@@ -82,6 +82,7 @@ def main() -> int:
     payload = inspect(args.path, args.data_only)
     text = json.dumps(payload, ensure_ascii=False, indent=2, default=str)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text, encoding="utf-8")
     else:
         print(text)

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -90,9 +90,9 @@ def test_edit_replace_text(tmp_path: Path) -> None:
         sys.path.pop(0)
 
     src = tmp_path / "src.docx"
-    create_docx.build(
-        {"body": [{"kind": "paragraph", "text": "Hello {{NAME}}, welcome."}]}
-    ).save(str(src))
+    create_docx.build({"body": [{"kind": "paragraph", "text": "Hello {{NAME}}, welcome."}]}).save(
+        str(src)
+    )
 
     from docx import Document
 
@@ -123,3 +123,25 @@ def test_inspect_cli_outputs_json(tmp_path: Path) -> None:
     encoded = json.dumps(payload, ensure_ascii=False)
     assert "paragraphs" in encoded
     assert "tables" in encoded
+
+
+def test_inspect_cli_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_docx  # type: ignore[import-not-found]
+        import inspect_docx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "src.docx"
+    create_docx.build({"body": [{"kind": "paragraph", "text": "x"}]}).save(str(src))
+
+    out_file = tmp_path / "nested" / "reports" / "inspect.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["inspect_docx.py", str(src), "--out", str(out_file)],
+    )
+    rc = inspect_docx.main()
+    assert rc == 0
+    assert out_file.exists()

--- a/tests/test_skill_multi_search_engine.py
+++ b/tests/test_skill_multi_search_engine.py
@@ -160,3 +160,22 @@ def test_unknown_engine_recorded() -> None:
     )
     assert payload["results"] == []
     assert any("unknown engine" in e["reason"] for e in payload["errors"])
+
+
+def test_search_cli_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import search  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    monkeypatch.setitem(search.ENGINES, "fake", lambda _query, _limit: [])
+    out_file = tmp_path / "nested" / "output" / "search_results.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["search.py", "--query", "test", "--engines", "fake", "--out", str(out_file)],
+    )
+    rc = search.main()
+    assert rc == 0
+    assert out_file.exists()

--- a/tests/test_skill_pdf_toolkit.py
+++ b/tests/test_skill_pdf_toolkit.py
@@ -107,3 +107,24 @@ def test_merge_range_parsing() -> None:
     assert merge.parse_ranges("1-3", 5) == [1, 2, 3]
     # Out-of-range pages are filtered.
     assert merge.parse_ranges("1,99", 4) == [1]
+
+
+def test_extract_cli_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import extract  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    pdf_path = tmp_path / "doc.pdf"
+    _make_one_page_pdf(pdf_path, "TEST")
+
+    out_file = tmp_path / "nested" / "output" / "extracted.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["extract.py", str(pdf_path), "--out", str(out_file)],
+    )
+    rc = extract.main()
+    assert rc == 0
+    assert out_file.exists()

--- a/tests/test_skill_robinhood_chain_cards.py
+++ b/tests/test_skill_robinhood_chain_cards.py
@@ -12,6 +12,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
     / "src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py"
@@ -129,3 +131,21 @@ def test_a_result_without_a_token_renders_nothing() -> None:
 def test_onchain_symbol_is_used_when_the_list_symbol_is_missing() -> None:
     card = chain_cards.build_cards(_result(token=_token(symbol="", onchainSymbol="TSLA")))[0]
     assert card["title"] == "TSLA"
+
+
+def test_chain_cards_cli_creates_parent_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import json
+    import sys
+    from io import StringIO
+
+    dummy_input = json.dumps(_result())
+    monkeypatch.setattr(sys, "stdin", StringIO(dummy_input))
+
+    out_file = tmp_path / "nested" / "cards" / "chain_cards.json"
+    monkeypatch.setattr(sys, "argv", ["chain_cards.py", "--output", str(out_file)])
+
+    rc = chain_cards.main()
+    assert rc == 0
+    assert out_file.exists()

--- a/tests/test_skill_robinhood_rwa_cards.py
+++ b/tests/test_skill_robinhood_rwa_cards.py
@@ -13,6 +13,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
     / "src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py"
@@ -121,3 +123,19 @@ def test_match_order_is_preserved() -> None:
         )
     )
     assert [c["title"] for c in cards] == ["AAPL", "JPM"]
+
+
+def test_rwa_cards_cli_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+    import sys
+    from io import StringIO
+
+    dummy_input = json.dumps(_result(_match()))
+    monkeypatch.setattr(sys, "stdin", StringIO(dummy_input))
+
+    out_file = tmp_path / "nested" / "cards" / "rwa_cards.json"
+    monkeypatch.setattr(sys, "argv", ["rwa_cards.py", "--output", str(out_file)])
+
+    rc = rwa_cards.main()
+    assert rc == 0
+    assert out_file.exists()

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -129,3 +129,25 @@ def test_text_escapes_formula(tmp_path: Path) -> None:
     cell_value = sheet["rows"][1][0]["value"]
     assert isinstance(cell_value, str)
     assert cell_value.lstrip("'") == "=hello"
+
+
+def test_inspect_cli_creates_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+        import inspect_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["a"]]}]}).save(str(src))
+
+    out_file = tmp_path / "nested" / "analysis" / "inspect.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["inspect_xlsx.py", str(src), "--out", str(out_file)],
+    )
+    rc = inspect_xlsx.main()
+    assert rc == 0
+    assert out_file.exists()


### PR DESCRIPTION
Fixes #1055

### Summary

Ensure bundled skill CLI scripts create any missing parent directories before saving/writing output files when an `--out` or `--output` path is provided.

### Changes

- In `src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py`: ensure `args.out.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- In `src/agentos/skills/bundled/docx/scripts/inspect_docx.py`: ensure `args.out.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- In `src/agentos/skills/bundled/xlsx/scripts/inspect_xlsx.py`: ensure `args.out.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- In `src/agentos/skills/bundled/multi-search-engine/scripts/search.py`: ensure `args.out.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- In `src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py`: ensure `output.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- In `src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py`: ensure `output.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- Added public regression tests across the corresponding skill test suites (`test_skill_pdf_toolkit.py`, `test_skill_docx.py`, `test_skill_xlsx.py`, `test_skill_multi_search_engine.py`, `test_skill_robinhood_rwa_cards.py`, and `test_skill_robinhood_chain_cards.py`).

### Verification

- `uv run ruff check src tests` (passed)
- `uv run mypy src/agentos --show-error-codes` (passed, 0 issues across 622 files)
- `uv run pytest tests/test_skills/ tests/test_skill_*.py -q` (206 passed)