### PR TITLE
fix(gateway): evict completed-session state from SessionStreamRegistry

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1371,6 +1371,8 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
                     )
                 except Exception:
                     pass
+            # Evict session stream state to prevent memory leak (#1044).
+            get_session_streams().discard(key)
 
     task = asyncio.create_task(_run())
     setattr(task, "_agentos_started", False)
@@ -1479,6 +1481,7 @@ async def _handle_sessions_abort(params: dict | None, ctx: RpcContext) -> dict:
         setattr(task, "_agentos_terminal_emitted", True)
         await _emit_to_subscribers(ctx, key, "session.event.done", {"reason": "aborted"})
 
+    get_session_streams().discard(key)
     return {"aborted": cancelled, "key": key}
 
 
@@ -1951,6 +1954,7 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     for k in keys:
         try:
             await storage.delete_session(k)
+            get_session_streams().discard(k)
             deleted.append(k)
         except Exception as exc:
             errors.append(f"{k}: {exc}")

--- a/src/agentos/gateway/session_streams.py
+++ b/src/agentos/gateway/session_streams.py
@@ -54,6 +54,14 @@ class SessionStreamRegistry:
     def current_seq(self, session_key: str) -> int:
         return self._seq_by_session.get(session_key, 0)
 
+    def discard(self, session_key: str) -> None:
+        """Remove all state for *session_key*, releasing memory.
+
+        Idempotent — safe to call for unknown keys.
+        """
+        self._seq_by_session.pop(session_key, None)
+        self._events_by_session.pop(session_key, None)
+
     def record(
         self,
         session_key: str,

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -83,3 +83,42 @@ def test_session_stream_registry_reports_reset_when_client_cursor_is_ahead() -> 
     assert replay.replay_complete is False
     assert replay.gap_reason == "stream_buffer_reset"
     assert replay.events == []
+
+
+def test_discard_clears_session_state() -> None:
+    """discard() removes seq and events for a known session."""
+    registry = SessionStreamRegistry(max_events_per_session=10)
+    registry.record("sess-a", "session.event.text_delta", {"text": "hi"})
+    registry.record("sess-b", "session.event.done", {"reason": "stop"})
+
+    registry.discard("sess-a")
+
+    # sess-a is gone
+    assert registry.current_seq("sess-a") == 0
+    replay = registry.replay("sess-a", 0)
+    assert replay.events == []
+    assert replay.gap_reason is None
+
+    # sess-b is untouched
+    assert registry.current_seq("sess-b") == 1
+    replay_b = registry.replay("sess-b", 0)
+    assert len(replay_b.events) == 1
+
+
+def test_discard_is_idempotent() -> None:
+    """discard() for unknown or already-discarded keys does not raise."""
+    registry = SessionStreamRegistry(max_events_per_session=10)
+    registry.discard("never-existed")
+    registry.discard("never-existed")
+    assert registry.current_seq("never-existed") == 0
+
+
+def test_discard_after_replay_preserves_new_data() -> None:
+    """After discard, fresh records start from stream_seq=1."""
+    registry = SessionStreamRegistry(max_events_per_session=10)
+    registry.record("sess", "session.event.text_delta", {"text": "old"})
+    registry.discard("sess")
+
+    entry = registry.record("sess", "session.event.text_delta", {"text": "new"})
+    assert entry["stream_seq"] == 1
+    assert registry.current_seq("sess") == 1


### PR DESCRIPTION
Closes #1044

- Add `SessionStreamRegistry.discard(session_key)` to remove seq + events
- Call `discard()` in three lifecycle hooks: `_run()` finally block, `_handle_sessions_abort`, `_handle_sessions_delete`
- 3 tests: discard clears state, idempotent, replay-after-discard