### PR TITLE
fix(scheduler): resolve Sunday at upper bound of named day-of-week range (Closes #1063)

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -122,6 +123,11 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
             # separators are unaffected by lower().
             part = part.lower()
             sub_parts = part.replace("/", "§").replace("-", "¶")
+            if field_name == "day_of_week":
+                # In day-of-week ranges, Sunday as the upper bound (e.g. SAT-SUN,
+                # WED-SUN, MON-SUN) represents 7 (hi) rather than 0 (lo),
+                # so the range does not invert into start > 0 and reject.
+                sub_parts = re.sub(r"¶sun\b", "¶7", sub_parts)
             for name, val in names.items():
                 sub_parts = sub_parts.replace(name, str(val))
             part = sub_parts.replace("§", "/").replace("¶", "-")
@@ -201,9 +207,7 @@ def parse_iso_at(raw: str) -> datetime:
     except ValueError as exc:
         raise CronParseError(f"Invalid ISO-8601 timestamp: {raw!r}") from exc
     if dt.tzinfo is None or dt.utcoffset() is None:
-        raise CronParseError(
-            f"ISO-8601 timestamp must include a timezone offset: {raw!r}"
-        )
+        raise CronParseError(f"ISO-8601 timestamp must include a timezone offset: {raw!r}")
     return dt
 
 

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -65,6 +65,17 @@ def test_parse_cron_dow_ranges_may_end_at_7() -> None:
     assert expr.day_of_week.values == frozenset({0, 3, 4, 5, 6})
 
 
+def test_parse_cron_dow_ranges_ending_in_named_sunday() -> None:
+    # Sunday at the end of a named day-of-week range represents 7 (POSIX),
+    # resolving into the full range without inverting into start > 0.
+    assert parse_cron("0 0 * * WED-SUN").day_of_week.values == frozenset({0, 3, 4, 5, 6})
+    assert parse_cron("0 0 * * SAT-SUN").day_of_week.values == frozenset({0, 6})
+    assert parse_cron("0 0 * * Sat-Sun").day_of_week.values == frozenset({0, 6})
+    assert parse_cron("0 0 * * MON-SUN").day_of_week.values == frozenset({0, 1, 2, 3, 4, 5, 6})
+    assert parse_cron("0 0 * * FRI-SUN/2").day_of_week.values == frozenset({0, 5})
+    assert parse_cron("0 0 * * SUN-SUN").day_of_week.values == frozenset({0, 1, 2, 3, 4, 5, 6})
+
+
 def test_parse_cron_dow_7_dedups_with_0_and_names() -> None:
     assert parse_cron("0 0 * * 0,7").day_of_week.values == frozenset({0})
     assert parse_cron("0 0 * * MON,7").day_of_week.values == frozenset({0, 1})


### PR DESCRIPTION
## Summary

Closes #1063.

In `src/agentos/scheduler/parser.py`, `_DOW_NAMES` maps `"sun"` to `0`. When parsing day-of-week ranges, `sub_parts.replace(name, str(val))` unconditionally replaced `"sun"` with `"0"`, turning ranges like `SAT-SUN`, `WED-SUN`, and `MON-SUN` into `6-0`, `3-0`, and `1-0`. Since `start > end`, `_parse_field` raised `CronParseError: Range start > end in field 'day_of_week'`.

This fix recognizes Sunday at the upper bound of a range (e.g. `SAT-SUN`, `WED-SUN`, `MON-SUN`, `FRI-SUN/2`, `SUN-SUN`) and maps it to `7` (`hi`), which subsequent normalization converts back to `0`, matching POSIX cron semantics and the scheduler's documented intent.

## Changes

- `src/agentos/scheduler/parser.py`: when parsing `day_of_week`, substitute `¶sun\b` with `¶7` before name mapping so that upper-bound Sunday evaluates to `7` instead of crashing on inverted bounds.
- `tests/test_scheduler/test_parser.py`: added regression tests covering `WED-SUN`, `SAT-SUN`, `Sat-Sun`, `MON-SUN`, `FRI-SUN/2`, and `SUN-SUN`.

## Verification

- `uv run pytest tests/test_scheduler/test_parser.py -q` (all 28 passed)
- `uv run ruff check src/agentos/scheduler/parser.py tests/test_scheduler/test_parser.py` (passed)
- `uv run mypy src/agentos/scheduler/parser.py --show-error-codes` (passed)
