### PR TITLE
fix(skills): reject non-http(s) RPC URLs in bundled crypto skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- Bundled crypto skills (`robinhood-rwa-addresses`, `poolsdotfun-token-launcher`,
+  `senior-unilp-manager`) reject non-`http(s)` RPC URLs, closing the `file://`
+  local-file-read vulnerability.
+
 ## [2026.9.4] - 2026-09-04
 
 ### Fixed

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
@@ -19,6 +19,7 @@ the process environment only, never from argv.
 from __future__ import annotations
 
 import os
+import urllib.parse
 from pathlib import Path
 
 # Declared in SKILL.md frontmatter under `requires.env`. Keep the two in sync —
@@ -118,9 +119,32 @@ def load_env() -> None:
         return
 
 
+def validate_http_url(url: str) -> str:
+    """Validate and return a URL that must be http:// or https://.
+
+    Rejects ``file://``, ``ftp://``, and any custom scheme that could leak
+    local data or be abused as an SSRF oracle. Uses ``urlsplit`` for robust
+    scheme detection (not a fragile ``startswith`` prefix check).
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty URL: {url!r}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid URL {url!r}: {exc}") from exc
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"invalid URL scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"URL missing host {url!r}: must be http:// or https://")
+    return cleaned
+
+
 def resolve_rpc_url(override: str | None = None) -> str:
     """The RPC endpoint. Constant unless ``--rpc`` overrides it for debugging."""
-    return override or RPC_URL
+    return validate_http_url(override or RPC_URL)
 
 
 def resolve_paired_asset(value: str | None) -> str:

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
@@ -73,6 +73,29 @@ class RpcError(RuntimeError):
     """A JSON-RPC call returned an error or an unusable result."""
 
 
+def _validate_http_url(url: str) -> str:
+    """Validate and return a URL that must be http:// or https://.
+
+    Rejects ``file://``, ``ftp://``, and any custom scheme that could leak
+    local data or be abused as an SSRF oracle. Uses ``urlsplit`` for robust
+    scheme detection (not a fragile ``startswith`` prefix check).
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty URL: {url!r}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid URL {url!r}: {exc}") from exc
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"invalid URL scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"URL missing host {url!r}: must be http:// or https://")
+    return cleaned
+
+
 def _fetch_tokens(timeout: float) -> list[dict[str, Any]]:
     req = urllib.request.Request(  # noqa: S310 - fixed trusted CoinGecko endpoint
         TOKEN_LIST_URL,
@@ -189,8 +212,9 @@ def _rpc_batch(rpc_url: str, calls: list[dict[str, Any]], timeout: float) -> dic
     Batching keeps verification to a single HTTP round-trip no matter how many
     candidates are being checked.
     """
+    rpc_url = _validate_http_url(rpc_url)
     payload = json.dumps(calls).encode("utf-8")
-    req = urllib.request.Request(  # noqa: S310 - operator-supplied RPC endpoint
+    req = urllib.request.Request(  # noqa: S310 - validated http/https above
         rpc_url,
         data=payload,
         headers={
@@ -313,7 +337,7 @@ def _warning_for(
     return None
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Robinhood RWA contract-address lookup")
     parser.add_argument("--query", required=True, help="Company name or ticker (e.g. Apple, AAPL)")
     parser.add_argument("--limit", type=int, default=5, help="Max matches to return")
@@ -343,7 +367,19 @@ def main() -> int:
         action="store_true",
         help="Do not write the card artifact (JSON on stdout only).",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    if not args.no_verify:
+        try:
+            args.rpc_url = _validate_http_url(args.rpc_url)
+        except ValueError as exc:
+            print(
+                json.dumps(
+                    {"query": args.query, "matches": [], "error": f"invalid rpc-url: {exc}"},
+                    ensure_ascii=False,
+                )
+            )
+            return 0
 
     try:
         tokens = _fetch_tokens(args.timeout)

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/chains.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/chains.py
@@ -13,6 +13,7 @@ any other module.
 from __future__ import annotations
 
 import os
+import urllib.parse
 from pathlib import Path
 
 # Env var names this skill declares in its SKILL.md frontmatter. Keep the two in
@@ -149,14 +150,37 @@ def resolve_chain(key_or_id: str | int | None = None) -> dict:
     raise ValueError(f'unknown chain "{key_or_id}". Known: {known} (or their chain ids)')
 
 
+def validate_http_url(url: str) -> str:
+    """Validate and return a URL that must be http:// or https://.
+
+    Rejects ``file://``, ``ftp://``, and any custom scheme that could leak
+    local data or be abused as an SSRF oracle. Uses ``urlsplit`` for robust
+    scheme detection (not a fragile ``startswith`` prefix check).
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty URL: {url!r}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid URL {url!r}: {exc}") from exc
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"invalid URL scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"URL missing host {url!r}: must be http:// or https://")
+    return cleaned
+
+
 def resolve_rpc_url(chain: dict, override: str | None = None) -> str:
     if override:
-        return override
+        return validate_http_url(override)
     load_env()
     for name in chain["rpcEnv"]:
         value = os.environ.get(name)
         if value:
-            return value
+            return validate_http_url(value)
     names = " or ".join(chain["rpcEnv"])
     raise RuntimeError(
         f"no RPC url for {chain['name']}. Set {names} in the agent environment "

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
@@ -82,7 +82,7 @@ class RpcClient:
     def __init__(self, chain: dict, rpc_url: str | None = None, timeout: int = 60,
                  debug: bool = False, allow_batch: bool = True) -> None:
         self.chain = chain
-        self.url = rpc_url or resolve_rpc_url(chain)
+        self.url = resolve_rpc_url(chain, rpc_url)
         self.timeout = timeout
         self.debug = debug
         self._allow_batch = allow_batch

--- a/tests/test_skill_robinhood_rwa.py
+++ b/tests/test_skill_robinhood_rwa.py
@@ -18,6 +18,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
     / "src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py"
@@ -317,3 +319,65 @@ def test_skipped_verification_is_not_reported_as_a_network_fault() -> None:
 
 def _warning(statuses: list[str]) -> str | None:
     return rwa_lookup._warning_for([{"status": s} for s in statuses])
+
+
+# --------------------------------------------------------------------------
+# --rpc-url validation
+# --------------------------------------------------------------------------
+
+
+def test_validate_http_url_rejects_non_http_schemes() -> None:
+    """file://, ftp://, gopher://, javascript: are all rejected."""
+    for invalid in [
+        "file:///etc/passwd",
+        "file:///c:/windows/system32/drivers/etc/hosts",
+        "ftp://rpc.example.com",
+        "gopher://example.com",
+        "javascript:alert(1)",
+    ]:
+        with pytest.raises(ValueError, match="must be http:// or https://"):
+            rwa_lookup._validate_http_url(invalid)
+    for empty in ["", "   "]:
+        with pytest.raises(ValueError, match="empty URL"):
+            rwa_lookup._validate_http_url(empty)
+    assert rwa_lookup._validate_http_url("http://127.0.0.1:8545") == "http://127.0.0.1:8545"
+    assert (
+        rwa_lookup._validate_http_url("https://rpc.mainnet.chain.robinhood.com")
+        == "https://rpc.mainnet.chain.robinhood.com"
+    )
+
+
+def test_validate_http_url_rejects_missing_host() -> None:
+    with pytest.raises(ValueError, match="missing host"):
+        rwa_lookup._validate_http_url("http://")
+
+
+def test_validate_http_url_accepts_valid_variants() -> None:
+    assert rwa_lookup._validate_http_url("http://example.com") == "http://example.com"
+    assert (
+        rwa_lookup._validate_http_url("https://user:pass@host.com:8545")
+        == "https://user:pass@host.com:8545"
+    )
+    assert rwa_lookup._validate_http_url("http://[::1]:7545") == "http://[::1]:7545"
+    assert rwa_lookup._validate_http_url(rwa_lookup.DEFAULT_RPC_URL)
+
+
+def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    code = rwa_lookup.main(["--query", "AAPL", "--rpc-url", "file:///etc/passwd"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "invalid rpc-url" in payload.get("error", "")
+    assert "must be http:// or https://" in payload.get("error", "")
+
+
+def test_main_rejects_missing_host_url(capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    code = rwa_lookup.main(["--query", "AAPL", "--rpc-url", "http://"])
+    assert code == 0
+    out, _ = capsys.readouterr()
+    payload = json.loads(out)
+    assert "missing host" in payload.get("error", "")

--- a/tests/test_skill_rpc_url_validation.py
+++ b/tests/test_skill_rpc_url_validation.py
@@ -1,0 +1,102 @@
+"""Regression tests for RPC URL scheme validation in poolsdotfun and senior-unilp-manager."""
+
+from __future__ import annotations
+
+# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+import pytest
+
+_POOLS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts"
+)
+_UNILP_DIR = (
+    Path(__file__).resolve().parents[1] / "src/agentos/skills/bundled/senior-unilp-manager/scripts"
+)
+
+if str(_POOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_POOLS_DIR))
+if str(_UNILP_DIR) not in sys.path:
+    sys.path.insert(0, str(_UNILP_DIR))
+
+from poolsfun.chains import (  # noqa: E402
+    resolve_rpc_url as pools_resolve,
+)
+from poolsfun.chains import (
+    validate_http_url as pools_validate,
+)
+from poolsfun.rpc import RpcClient as PoolsRpcClient  # noqa: E402
+from unilp.chains import (  # noqa: E402
+    CHAINS,
+)
+from unilp.chains import (
+    resolve_rpc_url as unilp_resolve,
+)
+from unilp.chains import (
+    validate_http_url as unilp_validate,
+)
+from unilp.rpc import RpcClient as UnilpRpcClient  # noqa: E402
+
+
+@pytest.mark.parametrize("validator", [pools_validate, unilp_validate])
+def test_validate_http_url_rejects_non_http_schemes(validator) -> None:
+    """file://, ftp://, gopher://, javascript: are all rejected."""
+    for invalid in [
+        "file:///etc/passwd",
+        "file:///c:/windows/system32/drivers/etc/hosts",
+        "ftp://rpc.example.com",
+        "gopher://example.com",
+        "javascript:alert(1)",
+    ]:
+        with pytest.raises(ValueError, match="must be http:// or https://"):
+            validator(invalid)
+    for empty in ["", "   "]:
+        with pytest.raises(ValueError, match="empty URL"):
+            validator(empty)
+
+
+@pytest.mark.parametrize("validator", [pools_validate, unilp_validate])
+def test_validate_http_url_rejects_missing_host(validator) -> None:
+    with pytest.raises(ValueError, match="missing host"):
+        validator("http://")
+    with pytest.raises(ValueError, match="missing host"):
+        validator("https://")
+
+
+@pytest.mark.parametrize("validator", [pools_validate, unilp_validate])
+def test_validate_http_url_accepts_valid_urls(validator) -> None:
+    assert validator("http://example.com") == "http://example.com"
+    assert validator("http://127.0.0.1:8545") == "http://127.0.0.1:8545"
+    assert validator("http://[::1]:8545") == "http://[::1]:8545"
+    assert (
+        validator("https://rpc.mainnet.chain.robinhood.com")
+        == "https://rpc.mainnet.chain.robinhood.com"
+    )
+    assert validator("https://user:pass@host.com:8545") == "https://user:pass@host.com:8545"
+
+
+def test_poolsfun_resolve_rpc_url_override_validation() -> None:
+    with pytest.raises(ValueError, match="must be http:// or https://"):
+        pools_resolve("file:///etc/passwd")
+    assert pools_resolve("http://localhost:8545") == "http://localhost:8545"
+    # Default without override returns validated default RPC_URL
+    assert pools_resolve() == "https://rpc.mainnet.chain.robinhood.com/"
+
+
+def test_unilp_resolve_rpc_url_override_validation() -> None:
+    chain = CHAINS["base"]
+    with pytest.raises(ValueError, match="must be http:// or https://"):
+        unilp_resolve(chain, "file:///etc/passwd")
+    assert unilp_resolve(chain, "http://localhost:8545") == "http://localhost:8545"
+
+
+def test_poolsfun_rpc_client_rejects_file_scheme() -> None:
+    with pytest.raises(ValueError, match="must be http:// or https://"):
+        PoolsRpcClient(rpc_url="file:///etc/shadow")
+
+
+def test_unilp_rpc_client_rejects_file_scheme() -> None:
+    with pytest.raises(ValueError, match="must be http:// or https://"):
+        UnilpRpcClient(chain=CHAINS["base"], rpc_url="file:///etc/shadow")


### PR DESCRIPTION

### Title
`fix(skills): reject non-http(s) RPC URLs in bundled crypto skills`

### Description

#### Problem
Following the precedent in commit `82169f96` ([#816](https://github.com/use-agent-os/agent-os/issues/816)), bundled crypto skills accepting configurable RPC URLs could be provided non-HTTP schemes (such as `file://`, `ftp://`, or SSRF targets) via CLI arguments or environment variables, potentially allowing local file reads or unintended internal requests during RPC lookups.

#### Changes
- **`robinhood-rwa-addresses`**: Added `_validate_http_url()` using `urllib.parse.urlsplit` to enforce `http://` or `https://` with a non-empty host. Enforced in `_rpc_batch()` and `main()` (gracefully returning an error JSON payload when `--rpc-url` is invalid).
- **`poolsdotfun-token-launcher`**: Added `validate_http_url()` in `chains.py` and validated both override and default RPC URLs in `resolve_rpc_url()`.
- **`senior-unilp-manager`**: Added `validate_http_url()` in `chains.py`, validated override and environment RPC URLs in `resolve_rpc_url()`, and ensured `RpcClient` routes user-supplied URLs through `resolve_rpc_url()`.
- **Tests**: Added unit tests in `tests/test_skill_robinhood_rwa.py` and created `tests/test_skill_rpc_url_validation.py` to verify scheme rejection (`file://`, `ftp://`, etc.), missing host detection, and `RpcClient` failure behavior across all affected skills.
- **Changelog**: Added entry under `[Unreleased] -> ### Security`.

#### Verification
- `uv run ruff check` passed on all touched files.
- `uv run pytest tests/test_skill_robinhood_rwa.py tests/test_skill_robinhood_chain_stocks.py tests/test_skill_rpc_url_validation.py -q` passed (73 tests).
- `uv run pytest tests/test_skills/ -q` passed (34 passed, 1 skipped).

Ran command: `git push -u origin fix/skills-rpc-url-scheme-validation` closes #1065 