### PR TITLE
fix(cli): resolve PATH case-insensitively on Windows in hardened_path…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `hardened_path_env` performs case-insensitive `PATH` resolution on Windows,
+  preserving existing directories when passed as `Path` or `path` and preventing
+  duplicate conflicting environment keys.
+
 ## [2026.9.4] - 2026-09-04
 
 ### Fixed

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -260,10 +260,25 @@ def hardened_path_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
     """
 
     env = dict(base_env if base_env is not None else os.environ)
-    current = env.get("PATH", "")
+
+    # On Windows, environment variable names are case-insensitive. If base_env
+    # had "Path" or "path", resolve it to avoid duplicate keys and preserve
+    # the operator's existing PATH entries.
+    existing_paths: list[str] = []
+    keys_to_remove: list[str] = []
+    for k, v in env.items():
+        if (sys.platform == "win32" and k.upper() == "PATH") or k == "PATH":
+            if v:
+                existing_paths.append(v)
+            if k != "PATH":
+                keys_to_remove.append(k)
+    for k in keys_to_remove:
+        del env[k]
+
+    current = os.pathsep.join(existing_paths)
     entries = [p for p in current.split(os.pathsep) if p]
     seen = set(entries)
-    home = env.get("HOME") or str(Path.home())
+    home = env.get("HOME") or env.get("USERPROFILE") or str(Path.home())
     login_dirs = list(_LOGIN_PATH_DIRS) + [str(Path(home) / ".local" / "bin")]
     for extra in login_dirs:
         if extra not in seen:

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -146,6 +146,43 @@ def test_hardened_path_no_duplicates() -> None:
     assert parts.count("/opt/homebrew/bin") == 1
 
 
+def test_hardened_path_windows_case_insensitivity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows environment dicts with 'Path' or 'path' must preserve existing entries."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    env = {"Path": f"C:\\Program Files\\uv\\bin{os.pathsep}C:\\Windows\\System32"}
+    out = im.hardened_path_env(env)
+    assert "Path" not in out
+    assert "PATH" in out
+    parts = out["PATH"].split(os.pathsep)
+    assert "C:\\Program Files\\uv\\bin" in parts
+    assert "C:\\Windows\\System32" in parts
+
+
+def test_hardened_path_windows_merges_mixed_case_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both 'Path' and 'PATH' are present, merge and deduplicate into 'PATH'."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    env = {"Path": "C:\\uv\\bin", "PATH": "C:\\Windows\\System32"}
+    out = im.hardened_path_env(env)
+    assert "Path" not in out
+    assert "PATH" in out
+    parts = out["PATH"].split(os.pathsep)
+    assert "C:\\uv\\bin" in parts
+    assert "C:\\Windows\\System32" in parts
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific Path resolution")
+def test_resolve_tool_finds_tool_with_windows_path_casing(tmp_path: Path) -> None:
+    """resolve_tool must locate tools even when the input environment uses 'Path'."""
+    uv_dir = tmp_path / "custom_tool_dir"
+    uv_dir.mkdir()
+    tool_file = uv_dir / "fake_uv.exe"
+    tool_file.write_text("")
+    resolved = im.resolve_tool("fake_uv", {"Path": str(uv_dir)})
+    assert resolved == str(tool_file.resolve())
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="hardened login-dir PATH semantics are POSIX-specific; "

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -149,6 +149,7 @@ def test_hardened_path_no_duplicates() -> None:
 def test_hardened_path_windows_case_insensitivity(monkeypatch: pytest.MonkeyPatch) -> None:
     """Windows environment dicts with 'Path' or 'path' must preserve existing entries."""
     monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(os, "pathsep", ";")
     env = {"Path": f"C:\\Program Files\\uv\\bin{os.pathsep}C:\\Windows\\System32"}
     out = im.hardened_path_env(env)
     assert "Path" not in out
@@ -163,6 +164,7 @@ def test_hardened_path_windows_merges_mixed_case_duplicates(
 ) -> None:
     """When both 'Path' and 'PATH' are present, merge and deduplicate into 'PATH'."""
     monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(os, "pathsep", ";")
     env = {"Path": "C:\\uv\\bin", "PATH": "C:\\Windows\\System32"}
     out = im.hardened_path_env(env)
     assert "Path" not in out


### PR DESCRIPTION
closes #1069 

### Description

#### Problem
In `src/agentos/cli/install_method.py`, `hardened_path_env()` performed a case-sensitive lookup via `env.get("PATH", "")`. On Windows, environment variable dictionaries passed by callers, tests, or subprocess wrappers frequently use `"Path"` or `"path"`. When passed such an environment:
1. `env.get("PATH", "")` evaluated to `""`, completely ignoring the user's existing directories in `"Path"`.
2. `env["PATH"]` was assigned containing only fallback paths, leaving both `"Path"` and `"PATH"` as duplicate conflicting keys in the returned dictionary.
3. Subsequent operations like `resolve_tool("uv", env)` (which searches `hardened.get("PATH")`) failed to locate tools present in the user's `Path`.

#### Changes
- **`src/agentos/cli/install_method.py`**: Updated `hardened_path_env()` to resolve all case variants of `PATH` on Windows (`k.upper() == "PATH"`). Existing path entries are preserved and merged into canonical `env["PATH"]`, and non-canonical keys (`"Path"`, `"path"`) are removed to prevent duplicate conflicting keys. Added `USERPROFILE` fallback when resolving the home directory on Windows.
- **`tests/test_cli/test_install_method.py`**: Added regression tests:
  - `test_hardened_path_windows_case_insensitivity`: Verifies that `"Path"` entries are preserved and canonicalized to `"PATH"`.
  - `test_hardened_path_windows_merges_mixed_case_duplicates`: Verifies that mixed-case duplicates are cleanly merged and deduplicated into `"PATH"`.
  - `test_resolve_tool_finds_tool_with_windows_path_casing`: Verifies that `resolve_tool()` successfully locates binaries on Windows when passed an environment dictionary with `"Path"`.
- **`CHANGELOG.md`**: Added entry under `[Unreleased] -> ### Fixed`.

#### Verification
- `uv run ruff check` and `uv run ruff format --check` passed.
- `uv run pytest tests/test_cli/test_install_method.py tests/test_cli/test_upgrade_cmd.py -q` passed (50 passed, 4 skipped).
- Verified Windows behavior before and after fix:
  - Before: `Path in env: True | PATH in env: True | In PATH: False`
  - After: `Path in env: False | PATH in env: True | In PATH: True`
