### PR TITLE
fix(gateway): bound per-session lock registries without split-brain

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -910,6 +910,47 @@ class TaskRuntime:
                 error_class=str(getattr(exc, "code", None) or type(exc).__name__),
                 error_message=str(exc),
             )
+        finally:
+            # Keep both per-session lock registries bounded on long-lived
+            # gateways with many sessions (gh-1040), without opening the
+            # split-brain window an unconditional ``pop`` creates.
+            #
+            # A task queued behind this one captured BOTH lock objects at the
+            # top of its own ``_execute`` call, so the entries may only be
+            # dropped while the pair is completely idle.  Evicting under a
+            # waiter would let the next ``setdefault`` mint fresh locks for a
+            # session that still has a turn in flight, running two turns of
+            # one session in parallel.
+            self._evict_session_locks_if_quiescent(session_key)
+
+    @staticmethod
+    def _session_lock_busy(lock: asyncio.Lock | None) -> bool:
+        """True when *lock* has a holder or a queued waiter.
+
+        ``locked()`` alone is not enough: ``release()`` wakes the first waiter
+        but that waiter only sets ``_locked`` once it is scheduled, so there is
+        a window where the lock looks free while a task is already committed
+        to it.
+        """
+        if lock is None:
+            return False
+        waiters = getattr(lock, "_waiters", None)
+        return lock.locked() or bool(waiters)
+
+    def _evict_session_locks_if_quiescent(self, session_key: str) -> None:
+        """Drop the session's lock entries only when both locks are idle.
+
+        Retention is the safe default: keeping an entry one turn too long
+        merely delays reclamation, while dropping one under a waiter breaks
+        per-session mutual exclusion.  The two registries are evicted as a
+        pair so a queued task never sees one stale and one fresh lock.
+        """
+        execution_lock = self._session_execution_locks.get(session_key)
+        write_lock = self._session_locks.get(session_key)
+        if self._session_lock_busy(execution_lock) or self._session_lock_busy(write_lock):
+            return
+        self._session_execution_locks.pop(session_key, None)
+        self._session_locks.pop(session_key, None)
 
     async def _run_turn_handler_with_write_lock_bypass(
         self,

--- a/tests/test_gateway/test_no_split_brain_lock.py
+++ b/tests/test_gateway/test_no_split_brain_lock.py
@@ -1,8 +1,20 @@
-"""Tests for C3 fix: no split-brain lock on rapid re-enqueue after terminal.
+"""Regression tests for per-session lock eviction in TaskRuntime (gh-1040).
 
-AC-C3-1: _session_locks is never popped in _mark_terminal.
-AC-C3-2: rapid enqueue -> terminal -> re-enqueue for same session_key never
-          allows two tasks to run concurrently (max_concurrent_per_session == 1).
+Acceptance criteria:
+
+AC-C3-1 (bounded, revised for gh-1040): after a task reaches terminal state
+and the session lock is quiescent, the ``_session_locks`` and
+``_session_execution_locks`` entries are evicted so the registries do not
+grow with session count on long-lived gateways.
+
+AC-C3-1b (safe eviction): while another task of the same session is queued
+behind the lock, the entry is retained and the lock object identity is
+preserved, so the queued task cannot be handed a fresh lock by a concurrent
+``setdefault`` (the split-brain window observed in #1041's unconditional
+``pop``).
+
+AC-C3-2 (unchanged from upstream): rapid enqueue -> terminal -> re-enqueue
+for the same session_key never runs two of the session's turns concurrently.
 """
 
 from __future__ import annotations
@@ -17,12 +29,36 @@ from agentos.gateway.routing import RouteEnvelope, SourceKind
 from agentos.gateway.task_runtime import TaskRuntime
 from agentos.session.models import AgentTaskRecord
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+
+def _make_storage() -> Any:
+    storage = MagicMock()
+    db: dict[str, AgentTaskRecord] = {}
+
+    async def create(record: AgentTaskRecord) -> None:
+        db[record.task_id] = record
+
+    async def update(task_id: str, **kw: Any) -> None:
+        rec = db.get(task_id)
+        if rec is None:
+            return
+        for k, v in kw.items():
+            if hasattr(rec, k):
+                object.__setattr__(rec, k, v)
+
+    async def get(task_id: str) -> AgentTaskRecord | None:
+        return db.get(task_id)
+
+    async def list_tasks(**_: Any) -> list[AgentTaskRecord]:
+        return list(db.values())
+
+    storage.create_agent_task = create
+    storage.update_agent_task = update
+    storage.get_agent_task = get
+    storage.list_agent_tasks = list_tasks
+    return storage
 
 
-def _make_envelope(session_key: str = "agent-1::sess-1") -> RouteEnvelope:
+def _make_envelope(session_key: str) -> RouteEnvelope:
     return RouteEnvelope(
         source_kind=SourceKind.WEB,
         source_name="test",
@@ -32,42 +68,16 @@ def _make_envelope(session_key: str = "agent-1::sess-1") -> RouteEnvelope:
     )
 
 
-def _make_storage() -> Any:
-    storage = MagicMock()
-    task_db: dict[str, AgentTaskRecord] = {}
-
-    async def create(record: AgentTaskRecord) -> None:
-        task_db[record.task_id] = record
-
-    async def update(task_id: str, **kwargs: Any) -> None:
-        rec = task_db.get(task_id)
-        if rec is None:
-            return
-        for k, v in kwargs.items():
-            if hasattr(rec, k):
-                object.__setattr__(rec, k, v)
-
-    async def get(task_id: str) -> AgentTaskRecord | None:
-        return task_db.get(task_id)
-
-    async def list_tasks(**_: Any) -> list[AgentTaskRecord]:
-        return list(task_db.values())
-
-    storage.create_agent_task = create
-    storage.update_agent_task = update
-    storage.get_agent_task = get
-    storage.list_agent_tasks = list_tasks
-    return storage
-
-
 # ---------------------------------------------------------------------------
-# AC-C3-1: _session_locks never popped in _mark_terminal
+# AC-C3-1: registries stay bounded after terminal (gh-1040 leak)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_session_locks_never_popped_at_terminal() -> None:
-    """After a task reaches terminal state, _session_locks still contains the key."""
+async def test_session_locks_evicted_after_terminal() -> None:
+    """After terminal, both per-session lock registries drop the entry."""
+    session_key = "agent-1::sess-c3"
+    env = _make_envelope(session_key)
 
     async def _instant(_run: Any) -> None:
         pass
@@ -77,18 +87,139 @@ async def test_session_locks_never_popped_at_terminal() -> None:
         turn_handler=_instant,
         max_concurrency=4,
     )
-    env = _make_envelope("agent-1::sess-c3")
     handle = await rt.enqueue(env, "msg")
     await rt.wait(handle.task_id, timeout=5.0)
 
-    # Lock must still be present — C3 fix ensures we never pop it.
-    assert env.session_key in rt._session_locks, (
-        "_session_locks should retain the entry after terminal (C3 fix)"
+    assert session_key not in rt._session_locks, (
+        "_session_locks should evict the entry after terminal (gh-1040)"
+    )
+    assert session_key not in rt._session_execution_locks, (
+        "_session_execution_locks should evict the entry after terminal (gh-1040)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_locks_bounded_across_many_sessions() -> None:
+    """500 sessions through the runtime must not leave 500 registry entries."""
+    sessions = 200
+
+    async def _instant(_run: Any) -> None:
+        pass
+
+    rt = TaskRuntime(
+        storage=_make_storage(),
+        turn_handler=_instant,
+        max_concurrency=4,
+    )
+    for i in range(sessions):
+        env = _make_envelope(f"agent-1::sess-{i}")
+        handle = await rt.enqueue(env, "msg")
+        await rt.wait(handle.task_id, timeout=5.0)
+
+    assert len(rt._session_locks) < sessions / 10, (
+        f"_session_locks grew to {len(rt._session_locks)} after {sessions} sessions"
     )
 
 
 # ---------------------------------------------------------------------------
-# AC-C3-2: no split-brain under rapid enqueue -> terminal -> re-enqueue
+# AC-C3-1b: eviction must never create a split-brain window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lock_entry_retained_while_waiter_queued() -> None:
+    """B queued behind A: the entry must survive A's terminal state.
+
+    Fails against unconditional ``pop`` (#1041 head): there, C enqueued while
+    B runs gets a brand-new lock via ``setdefault`` and runs concurrently.
+    """
+    session_key = "agent-1::sess-c3b"
+    env = _make_envelope(session_key)
+    mid_b = asyncio.Event()
+
+    async def _handler(run: Any) -> None:
+        if run.message == "B":
+            mid_b.set()
+            await asyncio.sleep(0.25)
+        else:
+            await asyncio.sleep(0.05)
+
+    rt = TaskRuntime(
+        storage=_make_storage(),
+        turn_handler=_handler,
+        max_concurrency=4,
+        max_pending_per_session=64,
+    )
+
+    ha = await rt.enqueue(env, "A")
+    await asyncio.sleep(0.02)  # A mid-turn; B queues behind the lock
+    hb = await rt.enqueue(env, "B")
+    await rt.wait(ha.task_id, timeout=5.0)
+
+    # A terminal, B queued or running: entry retained, identity preserved.
+    assert session_key in rt._session_locks
+    assert session_key in rt._session_execution_locks
+    assert not mid_b.is_set()
+
+    await rt.wait(hb.task_id, timeout=5.0)
+    await asyncio.sleep(0.02)  # let B's finally run
+
+    # B done, registry quiescent again: entry evicted.
+    assert session_key not in rt._session_locks
+    assert session_key not in rt._session_execution_locks
+
+
+@pytest.mark.asyncio
+async def test_no_split_brain_when_message_arrives_mid_turn() -> None:
+    """The #1041 failure mode as a test: C arriving mid-turn of B stays serial.
+
+    Ordinary chat pattern: A runs, B queued behind A, C sent while B runs.
+    With an unconditional pop, C mints a new lock and overlaps B.
+    """
+    session_key = "agent-1::sess-c3c"
+    env = _make_envelope(session_key)
+
+    running: set[str] = set()
+    peak = 0
+    b_running = asyncio.Event()
+
+    async def _handler(run: Any) -> None:
+        nonlocal peak
+        label = run.message
+        running.add(label)
+        peak = max(peak, len(running))
+        if label == "B":
+            b_running.set()
+            await asyncio.sleep(0.25)
+        else:
+            await asyncio.sleep(0.05)
+        running.discard(label)
+
+    rt = TaskRuntime(
+        storage=_make_storage(),
+        turn_handler=_handler,
+        max_concurrency=4,
+        max_pending_per_session=64,
+    )
+
+    ha = await rt.enqueue(env, "A")
+    await asyncio.sleep(0.02)
+    hb = await rt.enqueue(env, "B")  # queued behind A on the same lock
+    await rt.wait(ha.task_id, timeout=5.0)
+    async with asyncio.timeout(5.0):
+        await b_running.wait()  # B now holds the pre-terminal lock object
+    hc = await rt.enqueue(env, "C")  # must not mint a fresh lock and overlap B
+
+    await asyncio.gather(
+        rt.wait(hb.task_id, timeout=5.0),
+        rt.wait(hc.task_id, timeout=5.0),
+    )
+
+    assert peak == 1, f"Split-brain: two turns of one session ran concurrently (max={peak})"
+
+
+# ---------------------------------------------------------------------------
+# AC-C3-2 (unchanged): rapid enqueue -> terminal -> re-enqueue stays serial
 # ---------------------------------------------------------------------------
 
 
@@ -100,7 +231,7 @@ async def test_rapid_enqueue_after_terminal_no_split_brain() -> None:
     max_concurrent_per_session must always be 1.
     """
     iterations = 100
-    session_key = "agent-1::sess-rapid"
+    session_key = "agent-1::sess-c3-rapid"
     env = _make_envelope(session_key)
 
     concurrent_count = 0


### PR DESCRIPTION
Refs #1040

`TaskRuntime._session_locks` and `_session_execution_locks` grow with the number
of distinct sessions and are never reclaimed. Measured on `upstream/main` with a
real `TaskRuntime`, 500 sessions run to terminal:

```
sessions run              : 500
_session_locks entries    : 500
_session_execution_locks  : 500
```

#1041 is already open for this issue. It evicts both entries with an
unconditional `pop()` in `_execute`'s `finally`, which is where this PR differs,
so I am submitting the alternative rather than commenting only.

## Why eviction has to be conditional

Both lock objects are captured at the top of `_execute`:

```python
write_lock = self._session_locks.setdefault(session_key, asyncio.Lock())
execution_lock = self._session_execution_locks.setdefault(session_key, asyncio.Lock())
```

A task queued behind the current one is therefore holding a reference to the
*old* objects. Popping the entries unconditionally lets the next `setdefault`
mint fresh locks for a session that still has a turn in flight:

1. A takes the lock and runs
2. B arrives mid-turn and waits on that same lock object
3. A reaches terminal, the `finally` pops the entry, B wakes and starts its turn
4. C arrives, `setdefault` creates a **new** lock, C acquires it immediately

B and C then run concurrently on one session. The window is as wide as a turn,
so any message arriving during a live turn lands in it.

Measured with the production defaults from `gateway/config.py`
(`max_concurrency=4`, `max_pending_per_session=64`, as wired in `boot.py`
~line 2274), same script both sides:

```
unconditional pop -> max_concurrent_per_session = 2   ['B','C'] running together
this PR           -> max_concurrent_per_session = 1   serialized
```

## The fix

Evict only when both registries are quiescent, and drop the pair together so a
queued task never sees one stale and one fresh lock:

```python
@staticmethod
def _session_lock_busy(lock: asyncio.Lock | None) -> bool:
    if lock is None:
        return False
    waiters = getattr(lock, "_waiters", None)
    return lock.locked() or bool(waiters)
```

`locked()` alone is not sufficient. `release()` wakes the first waiter, but that
waiter only sets `_locked` once it is scheduled, so there is a window where the
lock looks free while a task is already committed to it. `_waiters` closes it.

Retention is the safe default here: keeping an entry one turn too long only
delays reclamation, while dropping one under a waiter breaks per-session mutual
exclusion.

This is the same shape as the `SessionWriteLock` eviction in #983, which is why
that PR deliberately stopped at `engine/session_lock.py` and left `TaskRuntime`
alone.

## Tests

`tests/test_gateway/test_no_split_brain_lock.py`, 5 tests:

- `test_session_locks_evicted_after_terminal` — both registries drop the entry
  (the gh-1040 requirement; replaces the old
  `test_session_locks_never_popped_at_terminal`, whose invariant this issue
  supersedes)
- `test_session_locks_bounded_across_many_sessions` — 200 sessions do not leave
  200 entries
- `test_lock_entry_retained_while_waiter_queued` — entry survives while a task
  is queued, then evicts once idle
- `test_no_split_brain_when_message_arrives_mid_turn` — the A/B/C sequence above;
  fails against an unconditional `pop`
- `test_rapid_enqueue_after_terminal_no_split_brain` — AC-C3-2, unchanged from
  upstream

## Verification

- `ruff check src/agentos/gateway/task_runtime.py tests/test_gateway/test_no_split_brain_lock.py` clean
- `mypy src/agentos/gateway/task_runtime.py --show-error-codes` clean
- `pytest tests/test_gateway -q -m "not llm"` → **1356 passed**
- `pytest tests/test_gateway/test_task_runtime_terminal_cleanup.py -q` → 5 passed,
  unmodified

Metric names in `gateway/task_runtime.py` are untouched.

Happy to close this if #1041 is preferred; the split-brain repro script is
available either way.
