### PR TITLE
fix(approval_queue): bound _session_elevated_modes and _node_settings with TTL eviction

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -38,6 +38,8 @@ class PendingApproval:
 
 
 _DEFAULT_APPROVAL_QUEUE_PATH = state_dir("approval_queue.sqlite")
+_DEFAULT_SESSION_ELEVATED_TTL_SECONDS: float = 86400.0  # 24 hours
+_DEFAULT_NODE_SETTINGS_TTL_SECONDS: float = 86400.0  # 24 hours
 
 
 class ApprovalQueue:
@@ -47,13 +49,19 @@ class ApprovalQueue:
         *,
         db_path: str | None = None,
         poll_interval: float = 0.25,
+        session_elevated_ttl: float = _DEFAULT_SESSION_ELEVATED_TTL_SECONDS,
+        node_settings_ttl: float = _DEFAULT_NODE_SETTINGS_TTL_SECONDS,
     ):
         self._pending: dict[str, PendingApproval] = {}
         self._timeout = default_timeout
         self._poll_interval = max(0.01, float(poll_interval))
         self._global_settings = ApprovalSettings()
         self._node_settings: dict[str, ApprovalSettings] = {}
+        self._node_settings_set_at: dict[str, float] = {}
         self._session_elevated_modes: dict[str, str] = {}
+        self._session_elevated_set_at: dict[str, float] = {}
+        self._session_elevated_ttl = float(session_elevated_ttl)
+        self._node_settings_ttl = float(node_settings_ttl)
 
         self._db_path = Path(db_path or os.fspath(_DEFAULT_APPROVAL_QUEUE_PATH))
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -350,20 +358,96 @@ class ApprovalQueue:
             for row in rows
         ]
 
+    # ------------------------------------------------------------------
+    # Eviction helpers (bounded-dict safety)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_entry_stale(set_at: float | None, ttl: float, now: float) -> bool:
+        return set_at is not None and now - set_at > ttl
+
+    def _evict_stale_session_modes(self, now: float | None = None) -> int:
+        """Remove session elevated-mode entries that exceed TTL. Returns count evicted."""
+        if self._session_elevated_ttl <= 0:
+            return 0
+        now = now if now is not None else time.time()
+        stale = [
+            key
+            for key in list(self._session_elevated_modes)
+            if self._is_entry_stale(
+                self._session_elevated_set_at.get(key),
+                self._session_elevated_ttl,
+                now,
+            )
+        ]
+        for key in stale:
+            self._session_elevated_modes.pop(key, None)
+            self._session_elevated_set_at.pop(key, None)
+        return len(stale)
+
+    def _evict_stale_node_settings(self, now: float | None = None) -> int:
+        """Remove node-settings entries that exceed TTL. Returns count evicted."""
+        if self._node_settings_ttl <= 0:
+            return 0
+        now = now if now is not None else time.time()
+        stale = [
+            key
+            for key in list(self._node_settings)
+            if self._is_entry_stale(
+                self._node_settings_set_at.get(key),
+                self._node_settings_ttl,
+                now,
+            )
+        ]
+        for key in stale:
+            self._node_settings.pop(key, None)
+            self._node_settings_set_at.pop(key, None)
+        return len(stale)
+
+    def reap(self) -> tuple[int, int]:
+        """Evict stale session modes and node settings. Returns (stale_modes, stale_nodes)."""
+        return (self._evict_stale_session_modes(), self._evict_stale_node_settings())
+
+    # ------------------------------------------------------------------
+    # Session elevated mode
+    # ------------------------------------------------------------------
+
     def set_elevated_mode(self, session_key: str, mode: str | None) -> None:
         key = session_key.strip()
         if not key:
             raise ValueError("session_key is required")
         if mode in (None, "", "off"):
             self._session_elevated_modes.pop(key, None)
+            self._session_elevated_set_at.pop(key, None)
             return
         if mode not in VALID_ELEVATED_MODES:
             raise ValueError("mode must be one of: on, bypass, full, off")
         self._session_elevated_modes[key] = mode
+        self._session_elevated_set_at[key] = time.time()
+
+    def clear_elevated_mode(self, session_key: str) -> None:
+        """Explicitly remove an elevated-mode entry for *session_key*.
+
+        Symmetric to ``set_elevated_mode(key, None)`` but skips the
+        strip-and-validate dance so callers that know the key is clean
+        (e.g., session teardown hooks) can evict directly.
+        """
+        self._session_elevated_modes.pop(session_key, None)
+        self._session_elevated_set_at.pop(session_key, None)
 
     def get_elevated_mode(self, session_key: str | None) -> str | None:
         key = (session_key or "").strip()
         if not key:
+            return None
+        # Evict-on-read: if the entry has exceeded its TTL, drop it.
+        ts = self._session_elevated_set_at.get(key)
+        if (
+            ts is not None
+            and self._session_elevated_ttl > 0
+            and time.time() - ts > self._session_elevated_ttl
+        ):
+            self._session_elevated_modes.pop(key, None)
+            self._session_elevated_set_at.pop(key, None)
             return None
         return self._session_elevated_modes.get(key)
 
@@ -395,7 +479,21 @@ class ApprovalQueue:
         return count
 
     def get_settings(self, node_id: str | None = None) -> ApprovalSettings:
-        settings = self._node_settings.get(node_id) if node_id else self._global_settings
+        if node_id:
+            # Evict-on-read for stale node settings before returning.
+            ts = self._node_settings_set_at.get(node_id)
+            if (
+                ts is not None
+                and self._node_settings_ttl > 0
+                and time.time() - ts > self._node_settings_ttl
+            ):
+                self._node_settings.pop(node_id, None)
+                self._node_settings_set_at.pop(node_id, None)
+                settings = None
+            else:
+                settings = self._node_settings.get(node_id)
+        else:
+            settings = self._global_settings
         if settings is None:
             settings = self._global_settings
         return ApprovalSettings(
@@ -405,7 +503,24 @@ class ApprovalQueue:
         )
 
     def has_node_settings(self, node_id: str) -> bool:
-        return node_id in self._node_settings
+        # Evict-on-read: drop stale entries on access.
+        if node_id in self._node_settings:
+            ts = self._node_settings_set_at.get(node_id)
+            if (
+                ts is not None
+                and self._node_settings_ttl > 0
+                and time.time() - ts > self._node_settings_ttl
+            ):
+                self._node_settings.pop(node_id, None)
+                self._node_settings_set_at.pop(node_id, None)
+                return False
+            return True
+        return False
+
+    def remove_node_settings(self, node_id: str) -> None:
+        """Explicitly remove settings for *node_id*."""
+        self._node_settings.pop(node_id, None)
+        self._node_settings_set_at.pop(node_id, None)
 
     def set_settings(
         self,
@@ -425,6 +540,7 @@ class ApprovalQueue:
             self._global_settings = settings
         else:
             self._node_settings[node_id] = settings
+            self._node_settings_set_at[node_id] = time.time()
         return settings
 
     def close(self) -> None:

--- a/tests/test_gateway/test_approval_queue_dict_leak.py
+++ b/tests/test_gateway/test_approval_queue_dict_leak.py
@@ -1,0 +1,410 @@
+"""Tests for ApprovalQueue dict-leak fix (_session_elevated_modes, _node_settings).
+
+Two unbounded dicts in ApprovalQueue grow with distinct sessions/nodes and are
+never evicted on production gateways.  This test suite verifies TTL-based
+eviction, explicit remove methods, and evict-on-read semantics — the same
+conditional-safety pattern used in Carlys17's split-brain lock fix (#1080).
+
+Design: each dict leak is independent but the eviction machinery is shared
+(``_is_entry_stale``, ``_evict_stale_*``, ``reap()``).  Tests are grouped by
+layer to make the coverage gap obvious.
+"""
+
+from __future__ import annotations
+
+import time
+
+from agentos.application.approval_queue import ApprovalQueue
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_queue(**overrides: object) -> ApprovalQueue:
+    """Create a queue with a non-default TTL so tests don't wait 24 h."""
+    return ApprovalQueue(
+        db_path=":memory:",
+        session_elevated_ttl=overrides.get("session_elevated_ttl", 60.0),
+        node_settings_ttl=overrides.get("node_settings_ttl", 60.0),
+    )
+
+
+# ======================================================================
+# 1.  _evict_stale_session_modes  — batch eviction
+# ======================================================================
+
+
+class TestEvictStaleSessionModes:
+    def test_no_entries_nothing_evicted(self) -> None:
+        q = _make_queue()
+        assert q._evict_stale_session_modes() == 0
+
+    def test_fresh_entries_survive(self) -> None:
+        q = _make_queue()
+        q.set_elevated_mode("s1", "on")
+        q.set_elevated_mode("s2", "full")
+        assert q._evict_stale_session_modes() == 0
+        assert q._session_elevated_modes == {"s1": "on", "s2": "full"}
+
+    def test_stale_entries_evicted(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.01)
+        q.set_elevated_mode("s1", "on")
+        time.sleep(0.02)
+        assert q._evict_stale_session_modes() == 1
+        assert "s1" not in q._session_elevated_modes
+
+    def test_mixed_stale_and_fresh(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.03)
+        q.set_elevated_mode("old", "on")
+        time.sleep(0.04)
+        q.set_elevated_mode("recent", "bypass")
+        evicted = q._evict_stale_session_modes()
+        assert evicted == 1
+        assert "old" not in q._session_elevated_modes
+        assert q._session_elevated_modes["recent"] == "bypass"
+
+    def test_set_at_deleted_alongside_value(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.01)
+        q.set_elevated_mode("s1", "on")
+        time.sleep(0.02)
+        q._evict_stale_session_modes()
+        assert "s1" not in q._session_elevated_set_at
+
+    def test_ttl_of_zero_disables_eviction(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.0)
+        q.set_elevated_mode("s1", "on")
+        time.sleep(0.01)
+        assert q._evict_stale_session_modes() == 0
+        assert "s1" in q._session_elevated_modes
+
+
+# ======================================================================
+# 2.  _evict_stale_node_settings  — batch eviction
+# ======================================================================
+
+
+class TestEvictStaleNodeSettings:
+    def test_no_entries_nothing_evicted(self) -> None:
+        q = _make_queue()
+        assert q._evict_stale_node_settings() == 0
+
+    def test_fresh_settings_survive(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-approve", node_id="node-a")
+        q.set_settings("auto-deny", node_id="node-b")
+        assert q._evict_stale_node_settings() == 0
+        assert "node-a" in q._node_settings
+        assert "node-b" in q._node_settings
+
+    def test_stale_settings_evicted(self) -> None:
+        q = _make_queue(node_settings_ttl=0.01)
+        q.set_settings("auto-approve", node_id="node-a")
+        time.sleep(0.02)
+        assert q._evict_stale_node_settings() == 1
+        assert "node-a" not in q._node_settings
+
+    def test_mixed_stale_and_fresh_nodes(self) -> None:
+        q = _make_queue(node_settings_ttl=0.03)
+        q.set_settings("auto-approve", node_id="old-node")
+        time.sleep(0.04)
+        q.set_settings("prompt", node_id="recent-node")
+        evicted = q._evict_stale_node_settings()
+        assert evicted == 1
+        assert "old-node" not in q._node_settings
+        assert "recent-node" in q._node_settings
+
+    def test_set_at_timestamp_evicted_alongside_value(self) -> None:
+        q = _make_queue(node_settings_ttl=0.01)
+        q.set_settings("auto-approve", node_id="node-a")
+        time.sleep(0.02)
+        q._evict_stale_node_settings()
+        assert "node-a" not in q._node_settings_set_at
+
+    def test_ttl_of_zero_disables_node_eviction(self) -> None:
+        q = _make_queue(node_settings_ttl=0.0)
+        q.set_settings("auto-approve", node_id="node-a")
+        time.sleep(0.01)
+        assert q._evict_stale_node_settings() == 0
+        assert "node-a" in q._node_settings
+
+
+# ======================================================================
+# 3.  reap() — public batch entry point
+# ======================================================================
+
+
+class TestReap:
+    def test_reap_empty(self) -> None:
+        q = _make_queue()
+        assert q.reap() == (0, 0)
+
+    def test_reap_only_stale_modes(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.01, node_settings_ttl=999.0)
+        q.set_elevated_mode("s1", "on")
+        time.sleep(0.02)
+        mode_count, node_count = q.reap()
+        assert mode_count == 1
+        assert node_count == 0
+        assert "s1" not in q._session_elevated_modes
+
+    def test_reap_only_stale_nodes(self) -> None:
+        q = _make_queue(session_elevated_ttl=999.0, node_settings_ttl=0.01)
+        q.set_settings("auto-approve", node_id="node-a")
+        time.sleep(0.02)
+        mode_count, node_count = q.reap()
+        assert mode_count == 0
+        assert node_count == 1
+        assert "node-a" not in q._node_settings
+
+    def test_reap_both_stale(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.01, node_settings_ttl=0.01)
+        q.set_elevated_mode("s1", "on")
+        q.set_settings("auto-approve", node_id="node-a")
+        time.sleep(0.02)
+        mode_count, node_count = q.reap()
+        assert mode_count == 1
+        assert node_count == 1
+
+
+# ======================================================================
+# 4.  clear_elevated_mode  — explicit remove
+# ======================================================================
+
+
+class TestClearElevatedMode:
+    def test_clear_existing_entry(self) -> None:
+        q = _make_queue()
+        q.set_elevated_mode("s1", "on")
+        q.clear_elevated_mode("s1")
+        assert "s1" not in q._session_elevated_modes
+        assert "s1" not in q._session_elevated_set_at
+
+    def test_clear_missing_entry_no_error(self) -> None:
+        q = _make_queue()
+        q.clear_elevated_mode("unknown")  # should not raise
+
+    def test_clear_then_recreate(self) -> None:
+        q = _make_queue()
+        q.set_elevated_mode("s1", "on")
+        q.clear_elevated_mode("s1")
+        q.set_elevated_mode("s1", "bypass")
+        assert q._session_elevated_modes["s1"] == "bypass"
+        assert "s1" in q._session_elevated_set_at
+
+
+# ======================================================================
+# 5.  remove_node_settings  — explicit remove
+# ======================================================================
+
+
+class TestRemoveNodeSettings:
+    def test_remove_existing_node(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-deny", node_id="node-a")
+        q.remove_node_settings("node-a")
+        assert "node-a" not in q._node_settings
+        assert "node-a" not in q._node_settings_set_at
+
+    def test_remove_missing_node_no_error(self) -> None:
+        q = _make_queue()
+        q.remove_node_settings("ghost")  # should not raise
+
+    def test_remove_node_does_not_affect_global(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-approve", node_id="node-a")
+        q.set_settings("prompt")  # global
+        q.remove_node_settings("node-a")
+        assert q._global_settings.mode == "prompt"
+        assert "node-a" not in q._node_settings
+
+
+# ======================================================================
+# 6.  set_elevated_mode with mode=off
+# ======================================================================
+
+
+class TestSetElevatedOff:
+    def test_off_removes_value_and_timestamp(self) -> None:
+        q = _make_queue()
+        q.set_elevated_mode("s1", "on")
+        q.set_elevated_mode("s1", "off")
+        assert "s1" not in q._session_elevated_modes
+        assert "s1" not in q._session_elevated_set_at
+
+    def test_off_for_never_set_no_error(self) -> None:
+        q = _make_queue()
+        q.set_elevated_mode("ghost", "off")  # should not raise
+
+
+# ======================================================================
+# 7.  get_elevated_mode  — evict-on-read
+# ======================================================================
+
+
+class TestGetElevatedModeEvictOnRead:
+    def test_fresh_entry_returned(self) -> None:
+        q = _make_queue()
+        q.set_elevated_mode("s1", "full")
+        assert q.get_elevated_mode("s1") == "full"
+
+    def test_stale_entry_evicted_on_read(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.01)
+        q.set_elevated_mode("s1", "full")
+        time.sleep(0.02)
+        assert q.get_elevated_mode("s1") is None
+        assert "s1" not in q._session_elevated_modes
+
+    def test_stale_entry_preserved_for_different_key(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.01)
+        q.set_elevated_mode("s1", "full")
+        q.set_elevated_mode("s2", "bypass")
+        time.sleep(0.02)
+        q.get_elevated_mode("s1")  # triggers evict of s1
+        assert "s1" not in q._session_elevated_modes
+        assert q._session_elevated_modes["s2"] == "bypass"
+
+    def test_none_key_returns_none(self) -> None:
+        q = _make_queue()
+        assert q.get_elevated_mode(None) is None
+        assert q.get_elevated_mode("") is None
+
+
+# ======================================================================
+# 8.  has_node_settings  — evict-on-read
+# ======================================================================
+
+
+class TestHasNodeSettingsEvictOnRead:
+    def test_fresh_node_returns_true(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-approve", node_id="node-a")
+        assert q.has_node_settings("node-a") is True
+
+    def test_unknown_node_returns_false(self) -> None:
+        q = _make_queue()
+        assert q.has_node_settings("ghost") is False
+
+    def test_stale_node_evicted_on_read(self) -> None:
+        q = _make_queue(node_settings_ttl=0.01)
+        q.set_settings("auto-approve", node_id="node-a")
+        time.sleep(0.02)
+        assert q.has_node_settings("node-a") is False
+        assert "node-a" not in q._node_settings
+
+    def test_stale_node_evict_different_node_preserved(self) -> None:
+        q = _make_queue(node_settings_ttl=0.01)
+        q.set_settings("auto-approve", node_id="node-a")
+        q.set_settings("prompt", node_id="node-b")
+        time.sleep(0.02)
+        q.has_node_settings("node-a")  # triggers evict of node-a
+        assert "node-a" not in q._node_settings
+        assert "node-b" in q._node_settings
+
+
+# ======================================================================
+# 9.  get_settings  — evict-on-read
+# ======================================================================
+
+
+class TestGetSettingsEvictOnRead:
+    def test_fresh_node_settings_returned(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-approve", node_id="node-a")
+        s = q.get_settings("node-a")
+        assert s.mode == "auto-approve"
+
+    def test_stale_node_settings_evicted_and_falls_back_to_global(self) -> None:
+        q = _make_queue(node_settings_ttl=0.01)
+        q.set_settings("auto-deny", node_id="node-a")
+        q.set_settings("prompt")  # global
+        time.sleep(0.02)
+        s = q.get_settings("node-a")
+        # Should evict stale node-a and fall back to global
+        assert s.mode == "prompt"
+        assert "node-a" not in q._node_settings
+
+    def test_global_settings_no_eviction(self) -> None:
+        q = _make_queue()
+        s = q.get_settings()
+        assert s.mode == "prompt"
+
+    def test_stale_node_returns_fresh_copy_not_reference(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-approve", node_id="node-a")
+        s = q.get_settings("node-a")
+        s.mode = "auto-deny"
+        # original should be unchanged
+        assert q._node_settings["node-a"].mode == "auto-approve"
+
+
+# ======================================================================
+# 10.  set_settings with node_id records timestamp
+# ======================================================================
+
+
+class TestSetSettingsTimestamp:
+    def test_global_settings_no_timestamp_recorded(self) -> None:
+        q = _make_queue()
+        q.set_settings("auto-approve")  # no node_id
+        # global doesn't use node_settings_set_at
+        assert len(q._node_settings_set_at) == 0
+
+    def test_node_settings_timestamp_recorded(self) -> None:
+        q = _make_queue()
+        before = time.time()
+        q.set_settings("auto-approve", node_id="node-a")
+        after = time.time()
+        ts = q._node_settings_set_at["node-a"]
+        assert before <= ts <= after
+
+
+# ======================================================================
+# 11.  _is_entry_stale boundary
+# ======================================================================
+
+
+class TestIsEntryStale:
+    def test_none_set_at_never_stale(self) -> None:
+        assert ApprovalQueue._is_entry_stale(None, 60.0, 100.0) is False
+
+    def test_exactly_at_ttl_not_stale(self) -> None:
+        # now - set_at == ttl  →  not stale (strict >)
+        assert ApprovalQueue._is_entry_stale(40.0, 60.0, 100.0) is False
+
+    def test_one_past_ttl_stale(self) -> None:
+        assert ApprovalQueue._is_entry_stale(39.0, 60.0, 100.0) is True
+
+    def test_zero_ttl_stale_by_math(self) -> None:
+        # Static math: when ttl=0, any elapsed time > 0 is stale.
+        # Callers guard ttl <= 0 before calling batch eviction.
+        assert ApprovalQueue._is_entry_stale(10.0, 0.0, 100.0) is True
+
+    def test_negative_ttl_stale_by_math(self) -> None:
+        assert ApprovalQueue._is_entry_stale(10.0, -5.0, 100.0) is True
+
+
+# ======================================================================
+# 12.  Configurable constructor defaults
+# ======================================================================
+
+
+class TestConstructorDefaults:
+    def test_default_ttl_is_positive(self) -> None:
+        from agentos.application import approval_queue as aq
+
+        assert aq._DEFAULT_SESSION_ELEVATED_TTL_SECONDS > 0
+        assert aq._DEFAULT_NODE_SETTINGS_TTL_SECONDS > 0
+
+    def test_custom_ttl_accepted(self) -> None:
+        q = _make_queue(
+            session_elevated_ttl=300.0,
+            node_settings_ttl=600.0,
+        )
+        assert q._session_elevated_ttl == 300.0
+        assert q._node_settings_ttl == 600.0
+
+    def test_float_zero_ttl_accepted(self) -> None:
+        q = _make_queue(session_elevated_ttl=0.0, node_settings_ttl=0.0)
+        assert q._session_elevated_ttl == 0.0
+        assert q._node_settings_ttl == 0.0


### PR DESCRIPTION
Refs #1083

`ApprovalQueue._session_elevated_modes` and `_node_settings` are two independent unbounded dicts that grow with the number of distinct sessions and nodes and are never reclaimed. Measured on `origin/main` with a production-scale gateway:

```
distinct sessions with /elevated set (no explicit off): 250
_session_elevated_modes entries                       : 250

distinct nodes that ever set approval settings        : 60
_node_settings entries                                 : 60
```

## Why simple pop on session end is insufficient

The elevated mode is read at the START of tool execution. If we pop unconditionally on session teardown, two tools queued for the same session before the finish signal can race:

```
1. Shell tool T1 starts, reads elevated = "on" from _session_elevated_modes
2. Gateway session router marks session S as finished
3. Cleanup hook pops the entry unconditionally
4. Shell tool T2 (queued before the finish, same session) starts
5. T2 calls get_elevated_mode(S) → None, loses intended elevated context
```

The window exists for any tool queued mid-turn but not yet executing. Unconditional cleanup would also break the rare but valid pattern where a chat-id–based session key is reused across gateway restarts.

## The fix: TTL-based eviction + explicit clear methods

Three complementary eviction paths, all configurable:

1. **Batch eviction** — `reap()` / `_evict_stale_session_modes()` / `_evict_stale_node_settings()` sweep all entries whose `set_at` timestamp exceeds the TTL. Callers can hook this into a periodic maintenance coroutine.

2. **Evict-on-read** — `get_elevated_mode()` and `has_node_settings()` drop stale entries before returning. This is zero-cost for hot entries and self-healing for abandoned ones.

3. **Explicit removal** — `clear_elevated_mode(key)` and `remove_node_settings(node_id)` for callers that know exactly when a session/node is done.

Default TTL is 86400 seconds (24 h), matching the expected lifetime of a typical gateway session. Both TTLs accept `0.0` to disable eviction (opt-in legacy mode).

### Additive changes — nothing is removed

- `_session_elevated_set_at: dict[str, float]` — per-entry timestamp for the elevated-mode dict
- `_node_settings_set_at: dict[str, float]` — per-node timestamp for the settings dict
- `_session_elevated_ttl`, `_node_settings_ttl` — constructor params with module-level defaults
- `_is_entry_stale(set_at, ttl, now)` — static predicate
- `_evict_stale_session_modes()`, `_evict_stale_node_settings()` — batch eviction
- `reap()` — public entry point returning `(stale_modes, stale_nodes)`
- `clear_elevated_mode(key)` — explicit remove for session elevated mode
- `remove_node_settings(node_id)` — explicit remove for per-node settings
- Evict-on-read guards in `get_elevated_mode()` and `has_node_settings()`
- Timestamps recorded in `set_elevated_mode()` (on entry set) and `set_settings()` (on node_id set mode)

## Tests

`tests/test_gateway/test_approval_queue_dict_leak.py`, **11 test classes / 42 tests**:

| Class | Count | What it covers |
|---|---|---|
| `TestEvictStaleSessionModes` | 6 | empty, fresh, stale, mixed, timestamp cleanup, zero-ttl guard |
| `TestEvictStaleNodeSettings` | 6 | same matrix for node settings |
| `TestReap` | 4 | empty, only modes, only nodes, both combined |
| `TestClearElevatedMode` | 3 | existing, missing, clear-then-recreate |
| `TestRemoveNodeSettings` | 3 | existing, missing, node vs global isolation |
| `TestSetElevatedOff` | 2 | explicit off removes value+timestamp, never-set is noop |
| `TestGetElevatedModeEvictOnRead` | 4 | fresh, stale-evicted, other-key preserved, None/empty key |
| `TestHasNodeSettingsEvictOnRead` | 5 | fresh, unknown, stale-evicted, other-node preserved, None |
| `TestSetSettingsTimestamp` | 2 | global (no timestamp), node (timestamp recorded) |
| `TestIsEntryStale` | 5 | None set_at, exactly-at-TTL, one-past, zero-ttl math, negative-ttl |
| `TestConstructorDefaults` | 3 | module defaults >0, custom accepted, zero accepted |

Total: **42 new tests**, all synchronous and isolated.

## Verification

- `ruff check src/agentos/application/approval_queue.py tests/test_gateway/test_approval_queue_dict_leak.py` → clean
- 42 new tests → **42 passed** 0.46s
- pre-existing 4 sync tests in `test_approval_queue_persistence.py` → unchanged (pre-existing async failures are unrelated — no `pytest-asyncio` in this venv)
