### PR TITLE
fix(skills): create parent dirs before writing chain cards artifact

### DIFF
--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
@@ -149,6 +149,7 @@ def main() -> int:
         return 1
 
     output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     print(f"publish_artifact path={output} mime={CARDS_MIME}")
     return 0

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -551,7 +551,9 @@ def _write_cards(result: dict[str, Any], output: str) -> None:
         payload = chain_cards.build_payload(result)
         if not payload["cards"]:
             return
-        Path(output).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
         print(
             f"publish_artifact path={output} mime={chain_cards.CARDS_MIME}",
             file=sys.stderr,

--- a/tests/test_skill_robinhood_chain_cards.py
+++ b/tests/test_skill_robinhood_chain_cards.py
@@ -129,3 +129,31 @@ def test_a_result_without_a_token_renders_nothing() -> None:
 def test_onchain_symbol_is_used_when_the_list_symbol_is_missing() -> None:
     card = chain_cards.build_cards(_result(token=_token(symbol="", onchainSymbol="TSLA")))[0]
     assert card["title"] == "TSLA"
+
+
+def test_main_creates_nested_parent_dirs_for_output(tmp_path: Path) -> None:
+    """main() must create parent directories when the output path is nested.
+
+    Without ``parent.mkdir(parents=True, exist_ok=True)``, ``Path.write_text``
+    raises ``FileNotFoundError`` when the parent directory does not exist —
+    the same gap fixed for the CLI cost exporter in PR #923.
+    """
+    import json
+    import subprocess
+    import sys
+
+    nested = tmp_path / "nested" / "deep" / "cards.json"
+    payload_in = _result()  # a valid chain_stocks object with a token
+
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--output", str(nested)],
+        input=json.dumps(payload_in),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert nested.exists()
+    written = json.loads(nested.read_text(encoding="utf-8"))
+    assert written["type"] == "cards"
+    assert len(written["cards"]) == 1


### PR DESCRIPTION
## Summary

Fixes #1089

When the `chain_cards.py` or `chain_stocks.py` scripts write their output to a path whose parent directories don't exist yet, they crash with `FileNotFoundError` (or in the case of `chain_stocks.py`, silently fail because the error is swallowed by a broad `try/except`).

## Changes

| File | Change |
|------|--------|
| `src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py` | Added `output.parent.mkdir(parents=True, exist_ok=True)` before `write_text()` |
| `src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py` | Same fix at line 554; also moved `Path(output)` to a local variable for clarity |
| `tests/test_skill_robinhood_chain_cards.py` | Added `test_main_creates_nested_parent_dirs_for_output` — verifies output is written when parent dirs don't exist |

## Testing

- **Red phase:** New test fails with `FileNotFoundError` before the fix
- **Green phase:** All 16 tests pass after the fix (15 existing + 1 new)
- `ruff check` ✅
- `ruff format --check` ✅
- `mypy` ✅ (touched files)
- `uv build --wheel` ✅

## Checklist

- [x] Tests pass locally
- [x] Linter passes (`ruff check`)
- [x] Formatter passes (`ruff format --check`)
- [x] Type checker passes (`mypy`)
- [x] Wheel build succeeds (`uv build --wheel`)
- [x] Conventional commit format used
