### PR TITLE
fix(engine): resolve mypy type errors in snapshot cache eviction (#1081)

### DIFF
--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -19,7 +19,7 @@ import os
 import platform
 import time
 import uuid
-from collections.abc import AsyncIterator, Callable, Hashable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Hashable, Mapping, MutableMapping, Sequence
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -216,6 +216,29 @@ _IMAGE_GENERATION_TOOL_NAMES: Final[frozenset[str]] = frozenset({"image_generate
 _ARTIFACT_DELIVERY_FAILURE_MARKER: Final[str] = "File delivery failed:"
 _ARTIFACT_DELIVERY_TOOL_NAME: Final[str] = "publish_artifact"
 _ARTIFACT_DELIVERY_FAILURE_MAX_CHARS: Final[int] = 360
+
+_SNAPSHOT_CACHE_TTL_SECONDS: Final[float] = 3600.0  # 1 hour
+_SNAPSHOT_CACHE_MAX_ENTRIES: Final[int] = 500
+
+
+def _evict_stale_snapshot_entries(
+    snaps: MutableMapping[Any, Any],
+    *,
+    now: float | None = None,
+) -> int:
+    """Evict entries from *snaps* when the dict exceeds max entries.
+
+    Returns the number of entries evicted.  Additive guard - callers
+    that set/refresh snapshots are unchanged.  Uses dict insertion order
+    (Python 3.7+) for simple oldest-first eviction.
+    """
+    if len(snaps) <= _SNAPSHOT_CACHE_MAX_ENTRIES:
+        return 0
+    excess = len(snaps) - _SNAPSHOT_CACHE_MAX_ENTRIES
+    for key in list(snaps.keys())[:excess]:
+        del snaps[key]
+    return excess
+
 
 _HOOKS_FEATURE_ENV: Final[str] = "AGENTOS_HOOKS"
 
@@ -1851,6 +1874,7 @@ class TurnRunner:
         for key in list(self._memory_snapshots):
             if key[0] == agent_id:
                 self._memory_snapshots[key] = new_snap
+        _evict_stale_snapshot_entries(self._memory_snapshots)
 
     def _handle_memory_source_write(self, agent_id: str, path: str) -> None:
         """Refresh memory index/snapshots after a source Markdown file write."""
@@ -1867,6 +1891,7 @@ class TurnRunner:
         for key in list(self._bootstrap_snapshots):
             if key[0] == agent_id:
                 del self._bootstrap_snapshots[key]
+        _evict_stale_snapshot_entries(self._bootstrap_snapshots)
 
     def _with_runtime_write_callbacks(
         self, tool_context: ToolContext, agent_id: str

--- a/tests/test_engine/test_snapshot_cache_eviction.py
+++ b/tests/test_engine/test_snapshot_cache_eviction.py
@@ -1,0 +1,120 @@
+"""Snapshot cache eviction tests.
+
+Verifies that _memory_snapshots and _bootstrap_snapshots don't grow
+without bound in TurnRunner.  Additive guard - existing behavior unchanged.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agentos.engine.runtime import (
+    _SNAPSHOT_CACHE_MAX_ENTRIES,
+    TurnRunner,
+    _evict_stale_snapshot_entries,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for _evict_stale_snapshot_entries
+# ---------------------------------------------------------------------------
+
+
+class TestEvictStaleSnapshotEntries:
+    """Direct unit tests for the eviction function."""
+
+    def test_no_eviction_when_at_max(self) -> None:
+        snaps = {f"k{i}": object() for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES)}
+        count = _evict_stale_snapshot_entries(snaps)
+        assert count == 0
+        assert len(snaps) == _SNAPSHOT_CACHE_MAX_ENTRIES
+
+    def test_evicts_oldest_when_over_max(self) -> None:
+        snaps = {f"k{i}": object() for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES + 10)}
+        count = _evict_stale_snapshot_entries(snaps)
+        assert count == 10
+        assert len(snaps) == _SNAPSHOT_CACHE_MAX_ENTRIES
+        assert "k0" not in snaps  # oldest evicted
+        assert "k9" not in snaps
+        assert f"k{_SNAPSHOT_CACHE_MAX_ENTRIES - 1}" in snaps  # newest kept
+
+    def test_empty_dict_is_noop(self) -> None:
+        count = _evict_stale_snapshot_entries({})
+        assert count == 0
+
+    def test_small_dict_is_noop(self) -> None:
+        snaps = {"a": object()}
+        count = _evict_stale_snapshot_entries(snaps)
+        assert count == 0
+        assert len(snaps) == 1
+
+    def test_evicts_exact_excess(self) -> None:
+        snaps = {f"k{i}": object() for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES + 50)}
+        count = _evict_stale_snapshot_entries(snaps)
+        assert count == 50
+        assert len(snaps) == _SNAPSHOT_CACHE_MAX_ENTRIES
+
+    def test_preserves_remaining_entries(self) -> None:
+        snaps = {f"k{i}": object() for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES + 3)}
+        count = _evict_stale_snapshot_entries(snaps)
+        assert count == 3
+        remaining_keys = set(snaps.keys())
+        assert len(remaining_keys) == _SNAPSHOT_CACHE_MAX_ENTRIES
+        assert "k0" not in remaining_keys
+        assert "k2" not in remaining_keys
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: called during boot + refresh
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotCacheIntegration:
+    """Integration tests: memory_snapshots eviction via TurnRunner methods."""
+
+    def test_refresh_memory_snapshot_triggers_eviction(self) -> None:
+        runner = TurnRunner(provider_selector=None)
+        # Fill past max
+        for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES + 10):
+            runner._memory_snapshots[(f"agent-{i}", f"session-{i}")] = SimpleNamespace(  # type: ignore[assignment]
+                memory_md="",
+                daily_notes={},
+            )
+        # Refresh for one agent -> triggers eviction
+        runner.refresh_memory_snapshot("agent-0")
+        assert len(runner._memory_snapshots) <= _SNAPSHOT_CACHE_MAX_ENTRIES
+
+    def test_bootstrap_source_write_triggers_eviction(self) -> None:
+        from agentos.bootstrap_types import BootstrapFileReport
+        from agentos.engine.runtime import BootstrapSnapshot
+
+        runner = TurnRunner(provider_selector=None)
+        report = [BootstrapFileReport(filename="USER.md", raw_chars=4, injected_chars=4)]
+        bootstrap = BootstrapSnapshot(workspace_files={"USER.md": "x"}, report=report)
+        # Fill past max
+        for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES + 10):
+            runner._bootstrap_snapshots[(f"agent-{i}", f"session-{i}", "full")] = bootstrap
+        # Write triggers eviction
+        runner._handle_bootstrap_source_write("agent-0", "USER.md")
+        assert len(runner._bootstrap_snapshots) <= _SNAPSHOT_CACHE_MAX_ENTRIES
+
+    def test_mixed_snapshots_evict_independently(self) -> None:
+        runner = TurnRunner(provider_selector=None)
+        from agentos.bootstrap_types import BootstrapFileReport
+        from agentos.engine.runtime import BootstrapSnapshot
+
+        report = [BootstrapFileReport(filename="USER.md", raw_chars=4, injected_chars=4)]
+        bootstrap = BootstrapSnapshot(workspace_files={"USER.md": "x"}, report=report)
+
+        # Fill both past max
+        for i in range(_SNAPSHOT_CACHE_MAX_ENTRIES + 5):
+            runner._memory_snapshots[(f"agent-{i}", f"session-{i}")] = SimpleNamespace(  # type: ignore[assignment]
+                memory_md="",
+                daily_notes={},
+            )
+            runner._bootstrap_snapshots[(f"agent-{i}", f"session-{i}", "full")] = bootstrap
+
+        # Refresh memory only
+        runner.refresh_memory_snapshot("agent-0")
+        assert len(runner._memory_snapshots) <= _SNAPSHOT_CACHE_MAX_ENTRIES
+        # Bootstrap should still be over (no write triggered yet)
+        assert len(runner._bootstrap_snapshots) == _SNAPSHOT_CACHE_MAX_ENTRIES + 5


### PR DESCRIPTION
## Summary

Fixes the **CI failures on PR #1081** (Closes #1082).

PR #1081 adds `_evict_stale_snapshot_entries()` to bound `_memory_snapshots` and `_bootstrap_snapshots` caches, but the CI fails with **2 mypy type errors**:

```
src/agentos/engine/runtime.py:1877: error: Argument 1 to "_evict_stale_snapshot_entries" has incompatible type
    "dict[tuple[str, str], MemorySnapshot]"; expected "dict[tuple[str, ...], object]"  [arg-type]

src/agentos/engine/runtime.py:1894: error: Argument 1 to "_evict_stale_snapshot_entries" has incompatible type
    "dict[tuple[str, str, str], BootstrapSnapshot]"; expected "dict[tuple[str, ...], object]"  [arg-type]
```

## Root Cause

Python's `dict` type is **invariant** — `dict[tuple[str, str], MemorySnapshot]` is NOT a subtype of `dict[tuple[str, ...], object]`, even though `tuple[str, str]` is a subtype of `tuple[str, ...]` and `MemorySnapshot` is a subtype of `object`. mypy correctly rejects this.

## Fix

Change the `_evict_stale_snapshot_entries()` parameter type from `dict[tuple[str, ...], object]` to `MutableMapping[Any, Any]`. This is the correct abstraction:

- `MutableMapping` is covariant in its value type (it's an interface, not a concrete dict)
- Using `Any` for both key and value types accepts any dict variant without false positives
- The function only uses `len()`, `keys()`, and `del` — all `MutableMapping` operations

## Changes

| File | Change |
|------|--------|
| `src/agentos/engine/runtime.py` | Changed `_evict_stale_snapshot_entries` signature: `dict[tuple[str, ...], object]` → `MutableMapping[Any, Any]`. Added `MutableMapping` to `collections.abc` import. |
| `tests/test_engine/test_snapshot_cache_eviction.py` | Added `# type: ignore[assignment]` on 2 lines where `SimpleNamespace` is used as a lightweight mock for `MemorySnapshot` in integration tests. |

## Testing

- `ruff check` ✅
- `ruff format --check` ✅
- `mypy` ✅ (0 errors — was 2 before fix)
- `pytest tests/test_engine/test_snapshot_cache_eviction.py` ✅ (9/9 passed)
- `uv build --wheel` ✅

## Relationship to PR #1081

This PR includes all changes from PR #1081 plus the mypy fixes. If maintainers prefer, these changes can be cherry-picked onto PR #1081's branch instead.

## Checklist

- [x] Tests pass locally
- [x] Linter passes (`ruff check`)
- [x] Formatter passes (`ruff format --check`)
- [x] Type checker passes (`mypy`)
- [x] Wheel build succeeds (`uv build --wheel`)
- [x] Conventional commit format used
