### PR TITLE
fix(tools): catch protocol-relative and split-string URLs in browser eval SSRF pre-scan

### DIFF
--- a/src/agentos/tools/browser_eval_policy.py
+++ b/src/agentos/tools/browser_eval_policy.py
@@ -88,6 +88,15 @@ _JS_STRING_LITERAL_RE = re.compile(
 #: a direct fetch that never touches ``location.href``, so pre-screen here.
 _JS_URL_LITERAL_RE = re.compile(r"""https?://[^\s'"`)\]<>]+""", re.IGNORECASE)
 
+#: Protocol-relative targets — ``//host/path`` inherits the page's scheme and
+#: reaches the network exactly like an ``http(s)://`` spelling. The host must
+#: look like a hostname or IP (dotted, or ``localhost``) so a JavaScript line
+#: comment such as ``//todo`` is not mistaken for a URL.
+_JS_PROTOCOL_RELATIVE_RE = re.compile(
+    r"""//(?:localhost|[0-9A-Za-z_-]+(?:\.[0-9A-Za-z_-]+)+)(?::\d+)?(?:/[^\s'"`)\]<>]*)?""",
+    re.IGNORECASE,
+)
+
 
 def _decode_js_string_literal(literal: str) -> str:
     """Best-effort decode of a single quoted JS string literal to its value."""
@@ -188,11 +197,33 @@ def expression_targets_private_url(expression: str) -> str | None:
     Best-effort scan for ``http(s)://…`` literals; returns the first that targets
     a private/internal address or the always-blocked cloud-metadata floor, else
     ``None``.
+
+    Obfuscated spellings are covered too:
+
+    * protocol-relative — ``fetch('//169.254.169.254/…')`` is normalized to an
+      ``http://`` candidate before the same private/internal checks run;
+    * split-string — ``fetch('htt' + 'p://169.254.169.254/…')`` hides the
+      scheme across two literals, so the concatenation of every decoded string
+      literal is scanned the same way
+      ``_sensitive_eval_token_reason`` reconstructs ``document["coo" + "kie"]``.
     """
     if not isinstance(expression, str):
         return None
-    for match in _JS_URL_LITERAL_RE.findall(expression):
-        candidate = str(match).rstrip(".,;")
+    # Scan the raw expression and, separately, the concatenation of every
+    # decoded string literal. The latter reconstructs a scheme split across
+    # literals (`'htt' + 'p://host'`), the same technique
+    # `_sensitive_eval_token_reason` uses for `document["coo" + "kie"]`.
+    haystacks = (expression, "".join(_decoded_js_string_literals(expression)))
+    candidates: list[str] = []
+    for haystack in haystacks:
+        for match in _JS_URL_LITERAL_RE.findall(haystack):
+            candidates.append(str(match).rstrip(".,;"))
+        # Normalize protocol-relative targets to a scheme-bearing URL so the
+        # shared private/internal checks (which require http/https) can judge
+        # them instead of rejecting them on scheme alone.
+        for match in _JS_PROTOCOL_RELATIVE_RE.findall(haystack):
+            candidates.append("http:" + str(match).rstrip(".,;"))
+    for candidate in candidates:
         if _url_is_blocked(candidate):
             return candidate
     return None

--- a/tests/test_tools/test_browser_eval_policy.py
+++ b/tests/test_tools/test_browser_eval_policy.py
@@ -97,6 +97,33 @@ class TestUrlPreScan:
     def test_no_url_literal(self) -> None:
         assert expression_targets_private_url("document.title") is None
 
+    def test_flags_protocol_relative_metadata(self) -> None:
+        # `//host/path` inherits the page's scheme — same target, no scheme word
+        # for the plain-text scanner to see (issue #1092).
+        blocked = expression_targets_private_url("fetch('//169.254.169.254/latest/meta-data/')")
+        assert blocked is not None
+        assert "169.254.169.254" in blocked
+
+    def test_flags_protocol_relative_loopback(self) -> None:
+        blocked = expression_targets_private_url("fetch('//127.0.0.1:8080/admin')")
+        assert blocked is not None
+
+    def test_flags_split_string_scheme(self) -> None:
+        # `'htt' + 'p://…'` hides the scheme across two literals; the
+        # concatenation of decoded literals must reconstruct it (issue #1092).
+        blocked = expression_targets_private_url(
+            "fetch('htt' + 'p://169.254.169.254/latest/meta-data/')"
+        )
+        assert blocked is not None
+        assert "169.254.169.254" in blocked
+
+    def test_ignores_public_protocol_relative(self) -> None:
+        # A public protocol-relative target stays allowed, same as `https://`.
+        assert expression_targets_private_url("fetch('//example.com/api')") is None
+
+    def test_ignores_concatenated_public_url(self) -> None:
+        assert expression_targets_private_url("fetch('htt' + 'ps://example.com/api')") is None
+
 
 class TestRedaction:
     def test_masks_string_secret(self) -> None:


### PR DESCRIPTION
Fixes #1092

## Problem

The browser `eval` SSRF pre-scan matched only plain `http(s)://` literals, so
three obfuscated spellings of a private/metadata target reached the evaluator
unblocked on `main`:

| Expression | main | expected |
|---|---|---|
| `fetch('//169.254.169.254/latest/meta-data/')` | allowed | blocked |
| `fetch('//127.0.0.1:8080/admin')` | allowed | blocked |
| `fetch('htt' + 'p://169.254.169.254/latest/meta-data/')` | allowed | blocked |

`_JS_URL_LITERAL_RE` is `https?://[^\s'"`)\]<>]+`, and
`expression_targets_private_url` fed only those plain matches to
`_url_is_blocked`. Per the comment at `tools/builtin/browser.py:489` this scan is
the eval action's SSRF control; the post-eval page-URL recheck only fires when
the page actually navigates, so a direct `fetch()` never reaches it. The
`risky_eval_reason` denylist is opt-in (`browser.restrict_evaluate`, default
off), so it is not a backstop.

## Approach

Two changes in `browser_eval_policy.py`, both reusing machinery already in the
module:

1. **Split-scheme reconstruction.** Scan the concatenation of every decoded
   string literal alongside the raw expression. This is the same technique
   `_sensitive_eval_token_reason` already uses to catch
   `document["coo" + "kie"]`, applied to the URL scan.
2. **Protocol-relative normalization.** New `_JS_PROTOCOL_RELATIVE_RE` captures
   `//host[:port][/path]` and prefixes `http:` so the existing
   `assert_not_metadata_endpoint` / `validate_http_url_for_fetch` checks judge
   the host instead of rejecting the candidate on scheme alone. The host must be
   dotted or `localhost`, so a JS line comment (`// todo`) is not read as a URL.

No behavior change for expressions the old scan already handled: candidates are
collected then judged by the unchanged `_url_is_blocked`.

## Tests

Added to `TestUrlPreScan` in `tests/test_tools/test_browser_eval_policy.py`:

- `test_flags_protocol_relative_metadata`
- `test_flags_protocol_relative_loopback`
- `test_flags_split_string_scheme`
- `test_ignores_public_protocol_relative` (negative control — `//example.com`)
- `test_ignores_concatenated_public_url` (negative control — split public URL)

Sabotage-verified: with `src/agentos/tools/browser_eval_policy.py` reverted to
`main` and the new tests in place, the three positive tests fail
(`3 failed, 21 passed`); with the fix, `24 passed`.

Quality gate:

- `uv run pytest tests/test_tools/test_browser_eval_policy.py` → 24 passed
- `uv run pytest tests/test_tools -m "not llm"` → 966 passed, 3 skipped;
  the 3 `test_shell_process_isolation.py` failures reproduce identically on a
  clean `main` tree (sandbox/root environment, unrelated to this diff)
- `uv run ruff format`, `uv run ruff check`, `uv run mypy src/agentos/tools/browser_eval_policy.py` → clean

## Scope / exclusions

- `_url_is_private` in `tools/builtin/browser.py` was checked as a sibling and
  ruled out: it judges the browser-resolved `window.location.href`, which is
  always scheme-bearing, so protocol-relative input cannot reach it.
- Percent-encoded and `\x`/`\u` escaped schemes are already caught by the
  existing literal decoding, and are covered by the unchanged positive tests.
