### PR TITLE
fix(cli): mock os.pathsep in Windows PATH tests for cross-platform CI (#1070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `hardened_path_env` performs case-insensitive `PATH` resolution on Windows,
+  preserving existing directories when passed as `Path` or `path` and preventing
+  duplicate conflicting environment keys.
+
 ## [2026.9.4] - 2026-09-04
 
 ### Fixed

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -260,10 +260,25 @@ def hardened_path_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
     """
 
     env = dict(base_env if base_env is not None else os.environ)
-    current = env.get("PATH", "")
+
+    # On Windows, environment variable names are case-insensitive. If base_env
+    # had "Path" or "path", resolve it to avoid duplicate keys and preserve
+    # the operator's existing PATH entries.
+    existing_paths: list[str] = []
+    keys_to_remove: list[str] = []
+    for k, v in env.items():
+        if (sys.platform == "win32" and k.upper() == "PATH") or k == "PATH":
+            if v:
+                existing_paths.append(v)
+            if k != "PATH":
+                keys_to_remove.append(k)
+    for k in keys_to_remove:
+        del env[k]
+
+    current = os.pathsep.join(existing_paths)
     entries = [p for p in current.split(os.pathsep) if p]
     seen = set(entries)
-    home = env.get("HOME") or str(Path.home())
+    home = env.get("HOME") or env.get("USERPROFILE") or str(Path.home())
     login_dirs = list(_LOGIN_PATH_DIRS) + [str(Path(home) / ".local" / "bin")]
     for extra in login_dirs:
         if extra not in seen:

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -146,6 +146,45 @@ def test_hardened_path_no_duplicates() -> None:
     assert parts.count("/opt/homebrew/bin") == 1
 
 
+def test_hardened_path_windows_case_insensitivity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows environment dicts with 'Path' or 'path' must preserve existing entries."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(os, "pathsep", ";")
+    env = {"Path": f"C:\\Program Files\\uv\\bin{os.pathsep}C:\\Windows\\System32"}
+    out = im.hardened_path_env(env)
+    assert "Path" not in out
+    assert "PATH" in out
+    parts = out["PATH"].split(os.pathsep)
+    assert "C:\\Program Files\\uv\\bin" in parts
+    assert "C:\\Windows\\System32" in parts
+
+
+def test_hardened_path_windows_merges_mixed_case_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both 'Path' and 'PATH' are present, merge and deduplicate into 'PATH'."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(os, "pathsep", ";")
+    env = {"Path": "C:\\uv\\bin", "PATH": "C:\\Windows\\System32"}
+    out = im.hardened_path_env(env)
+    assert "Path" not in out
+    assert "PATH" in out
+    parts = out["PATH"].split(os.pathsep)
+    assert "C:\\uv\\bin" in parts
+    assert "C:\\Windows\\System32" in parts
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific Path resolution")
+def test_resolve_tool_finds_tool_with_windows_path_casing(tmp_path: Path) -> None:
+    """resolve_tool must locate tools even when the input environment uses 'Path'."""
+    uv_dir = tmp_path / "custom_tool_dir"
+    uv_dir.mkdir()
+    tool_file = uv_dir / "fake_uv.exe"
+    tool_file.write_text("")
+    resolved = im.resolve_tool("fake_uv", {"Path": str(uv_dir)})
+    assert resolved == str(tool_file.resolve())
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="hardened login-dir PATH semantics are POSIX-specific; "


### PR DESCRIPTION
## Summary

Fixes the **CI failures on PR #1070** (Closes #1069).

PR #1070 adds case-insensitive `PATH` resolution for Windows in `hardened_path_env()`, but the CI fails with **2 test assertion errors** on Ubuntu runners:

```
FAILED tests/test_cli/test_install_method.py::test_hardened_path_windows_case_insensitivity
  AssertionError: assert 'C:\\Program Files\\uv\\bin' in ['C', '\\Program Files\\uv\\bin', 'C', ...]

FAILED tests/test_cli/test_install_method.py::test_hardened_path_windows_merges_mixed_case_duplicates
  AssertionError: assert 'C:\\uv\\bin' in ['C', '\\uv\\bin', 'C', ...]
```

## Root Cause

The tests monkeypatch `sys.platform` to `"win32"` to simulate Windows behavior, but **leave `os.pathsep` as `:`** (the POSIX value). On a real Windows system, `os.pathsep` is `;`.

When the test constructs the env dict using `f"C:\\Program Files\\uv\\bin{os.pathsep}C:\\Windows\\System32"`, the `os.pathsep` expands to `:` on Linux CI, producing:

```
C:\Program Files\uv\bin:C:\Windows\System32
```

When `hardened_path_env()` splits this on `os.pathsep` (`:`), it breaks the Windows paths at the `:` inside the drive letter:

```
['C', '\Program Files\uv\bin', 'C', '\Windows\System32', ...]
```

So `C:\Program Files\uv\bin` is NOT in the resulting list — the test fails.

## Fix

Add `monkeypatch.setattr(os, "pathsep", ";")` to both failing tests, so the Windows path separator is correctly simulated alongside `sys.platform = "win32"`.

## Changes

| File | Change |
|------|--------|
| `tests/test_cli/test_install_method.py` | Added `monkeypatch.setattr(os, "pathsep", ";")` to `test_hardened_path_windows_case_insensitivity` and `test_hardened_path_windows_merges_mixed_case_duplicates` |

## Testing

- `ruff check` ✅
- `ruff format --check` ✅
- `mypy` ✅
- `pytest tests/test_cli/test_install_method.py` ✅ (34 passed, 1 skipped)
- `uv build --wheel` ✅

## Checklist

- [x] Tests pass locally
- [x] Linter passes (`ruff check`)
- [x] Formatter passes (`ruff format --check`)
- [x] Type checker passes (`mypy`)
- [x] Wheel build succeeds (`uv build --wheel`)
- [x] Conventional commit format used
