### PR TITLE
fix(gateway): defer session stream discard to abort/delete only (#1057)

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1479,6 +1479,7 @@ async def _handle_sessions_abort(params: dict | None, ctx: RpcContext) -> dict:
         setattr(task, "_agentos_terminal_emitted", True)
         await _emit_to_subscribers(ctx, key, "session.event.done", {"reason": "aborted"})
 
+    get_session_streams().discard(key)
     return {"aborted": cancelled, "key": key}
 
 
@@ -1951,6 +1952,7 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     for k in keys:
         try:
             await storage.delete_session(k)
+            get_session_streams().discard(k)
             deleted.append(k)
         except Exception as exc:
             errors.append(f"{k}: {exc}")

--- a/src/agentos/gateway/session_streams.py
+++ b/src/agentos/gateway/session_streams.py
@@ -54,6 +54,14 @@ class SessionStreamRegistry:
     def current_seq(self, session_key: str) -> int:
         return self._seq_by_session.get(session_key, 0)
 
+    def discard(self, session_key: str) -> None:
+        """Remove all state for *session_key*, releasing memory.
+
+        Idempotent — safe to call for unknown keys.
+        """
+        self._seq_by_session.pop(session_key, None)
+        self._events_by_session.pop(session_key, None)
+
     def record(
         self,
         session_key: str,

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -83,3 +83,42 @@ def test_session_stream_registry_reports_reset_when_client_cursor_is_ahead() -> 
     assert replay.replay_complete is False
     assert replay.gap_reason == "stream_buffer_reset"
     assert replay.events == []
+
+
+def test_discard_clears_session_state() -> None:
+    """discard() removes seq and events for a known session."""
+    registry = SessionStreamRegistry(max_events_per_session=10)
+    registry.record("sess-a", "session.event.text_delta", {"text": "hi"})
+    registry.record("sess-b", "session.event.done", {"reason": "stop"})
+
+    registry.discard("sess-a")
+
+    # sess-a is gone
+    assert registry.current_seq("sess-a") == 0
+    replay = registry.replay("sess-a", 0)
+    assert replay.events == []
+    assert replay.gap_reason is None
+
+    # sess-b is untouched
+    assert registry.current_seq("sess-b") == 1
+    replay_b = registry.replay("sess-b", 0)
+    assert len(replay_b.events) == 1
+
+
+def test_discard_is_idempotent() -> None:
+    """discard() for unknown or already-discarded keys does not raise."""
+    registry = SessionStreamRegistry(max_events_per_session=10)
+    registry.discard("never-existed")
+    registry.discard("never-existed")
+    assert registry.current_seq("never-existed") == 0
+
+
+def test_discard_after_replay_preserves_new_data() -> None:
+    """After discard, fresh records start from stream_seq=1."""
+    registry = SessionStreamRegistry(max_events_per_session=10)
+    registry.record("sess", "session.event.text_delta", {"text": "old"})
+    registry.discard("sess")
+
+    entry = registry.record("sess", "session.event.text_delta", {"text": "new"})
+    assert entry["stream_seq"] == 1
+    assert registry.current_seq("sess") == 1


### PR DESCRIPTION
## Summary

Fixes the **CI failures on PR #1057** (Closes #1044).

PR #1057 adds `SessionStreamRegistry.discard()` to evict session stream state and prevent memory leaks. However, it calls `discard(key)` in the `_run()` coroutine's `finally` block — **immediately after** `_emit_terminal_once()` sends the terminal event. This causes the smoke test to timeout:

```
FAILED tests/test_mcp_server/test_protocol_smoke.py::test_bridge_runs_against_real_gateway_websocket_session_flow
  assert events["timed_out"] is False  (got True)
```

## Root Cause

The lifecycle flow is:

1. Agent turn completes → `_emit_terminal_once("session.event.done")` sends terminal event via `_emit_to_subscribers()`
2. `get_session_streams().discard(key)` **immediately destroys** the buffered events + sequence counter
3. Client calls `events_wait(since_stream_seq=X)` → buffer is empty → **timeout**

The client relies on `SessionStreamRegistry.replay()` to buffer events between when they're emitted and when the client polls. Evicting the buffer right after the terminal event means any client that hasn't yet consumed the replay loses all events.

## Fix

Remove `discard(key)` from the `_run()` finally block. Keep it only in the two explicit lifecycle endpoints where the session is truly destroyed:

- `_handle_sessions_abort()` — when user explicitly aborts a session
- `_handle_sessions_delete()` — when user explicitly deletes a session

This still prevents memory leaks (sessions are evicted on explicit destroy) but doesn't break the event replay flow for in-flight sessions.

## Changes

| File | Change |
|------|--------|
| `src/agentos/gateway/rpc_sessions.py` | Removed `get_session_streams().discard(key)` from `_run()` finally block (line ~1375). Kept `discard()` calls in `_handle_sessions_abort` and `_handle_sessions_delete`. |

## Testing

- `ruff check` ✅
- `ruff format --check` ✅
- `mypy` ✅
- `pytest tests/test_gateway/test_session_streams.py` ✅ (8/8 passed — including 3 new discard tests from PR #1057)
- `pytest tests/test_mcp_server/test_protocol_smoke.py` ✅ (2/2 passed — smoke test no longer times out)
- `uv build --wheel` ✅

## Relationship to PR #1057

This PR includes all changes from PR #1057 (the `discard()` method, its call sites, and the 3 new tests) plus the fix that removes the premature eviction from `_run()`. The `discard()` method itself is correct — the bug is only in where it was called.

## Checklist

- [x] Tests pass locally
- [x] Linter passes (`ruff check`)
- [x] Formatter passes (`ruff format --check`)
- [x] Type checker passes (`mypy`)
- [x] Wheel build succeeds (`uv build --wheel`)
- [x] Conventional commit format used
