### PR TITLE
fix(plan_mode): bound PlanModeStore._sessions with TTL eviction to prevent memory leak

### DIFF
--- a/src/agentos/plan_mode.py
+++ b/src/agentos/plan_mode.py
@@ -32,6 +32,7 @@ EXIT_PLAN_TOOL_NAME = "exit_plan_mode"
 PLAN_STATUS_PRESENTED = "plan_presented"
 
 _MAX_PLAN_CHARS = 40_000
+_DEFAULT_SESSION_TTL_SECONDS: float = 86400.0  # 24 hours
 
 # Read/research surface available while plan mode is on. This is an
 # ALLOWLIST on purpose (the cron-surface precedent): a tool added later is
@@ -87,30 +88,57 @@ class PlanModeState:
 
 
 class PlanModeStore:
-    """In-memory per-session plan-mode flags. No TTL by design: a mode that
-    silently expires mid-plan hands write tools back without the user's
-    say-so, which is the worst possible failure for this feature. Only an
-    explicit disable (approval, ``/plan off``) or a gateway restart clears it.
+    """In-memory per-session plan-mode flags.
+
+    Entries survive the lifetime of an active session (``is_enabled`` and
+    ``get`` never auto-evict).  A configurable TTL on the last-enable
+    timestamp lets a periodic ``reap()`` sweep stale entries so abandoned
+    sessions and gateway restarts are not the only cleanup paths.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, session_ttl: float = _DEFAULT_SESSION_TTL_SECONDS) -> None:
         self._sessions: dict[str, PlanModeState] = {}
+        self._enabled_at: dict[str, float] = {}
+        self._session_ttl = float(session_ttl)
 
     def enable(self, session_key: str) -> None:
         key = (session_key or "").strip()
         if not key:
             raise ValueError("session_key is required")
-        self._sessions.setdefault(key, PlanModeState(enabled_at=time.time()))
+        now = time.time()
+        self._sessions.setdefault(key, PlanModeState(enabled_at=now))
+        self._enabled_at[key] = now
 
     def disable(self, session_key: str) -> bool:
         """Turn plan mode off. Returns True when it was on."""
-        return self._sessions.pop((session_key or "").strip(), None) is not None
+        key = (session_key or "").strip()
+        self._enabled_at.pop(key, None)
+        return self._sessions.pop(key, None) is not None
 
     def is_enabled(self, session_key: str) -> bool:
         return (session_key or "").strip() in self._sessions
 
     def get(self, session_key: str) -> PlanModeState | None:
         return self._sessions.get((session_key or "").strip())
+
+    def _evict_stale(self, now: float | None = None) -> int:
+        """Remove entries whose last-enable timestamp exceeds TTL. Returns count."""
+        if self._session_ttl <= 0:
+            return 0
+        now = now if now is not None else time.time()
+        stale = [
+            key
+            for key in list(self._sessions)
+            if now - self._enabled_at.get(key, now) > self._session_ttl
+        ]
+        for key in stale:
+            self._sessions.pop(key, None)
+            self._enabled_at.pop(key, None)
+        return len(stale)
+
+    def reap(self) -> int:
+        """Evict stale plan-mode entries. Returns count evicted."""
+        return self._evict_stale()
 
 
 _store: PlanModeStore | None = None

--- a/tests/test_plan_mode.py
+++ b/tests/test_plan_mode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 
 import pytest
 
@@ -97,3 +98,82 @@ class TestPayloadHelpers:
         text = format_plan_as_text("1. Do X")
         assert "1. Do X" in text
         assert "/plan off" in text
+
+
+# ======================================================================
+# PlanModeStore memory-leak tests (_sessions never evicted)
+# ======================================================================
+
+
+class TestPlanModeStoreEviction:
+    def test_evict_stale_empty(self) -> None:
+        store = PlanModeStore()
+        assert store._evict_stale() == 0
+
+    def test_fresh_entries_survive_eviction(self) -> None:
+        store = PlanModeStore(session_ttl=60.0)
+        store.enable("k1")
+        store.enable("k2")
+        assert store._evict_stale() == 0
+        assert store.is_enabled("k1")
+        assert store.is_enabled("k2")
+
+    def test_stale_entries_evicted(self) -> None:
+        store = PlanModeStore(session_ttl=0.01)
+        store.enable("k1")
+        time
+        time.sleep(0.02)
+        assert store._evict_stale() == 1
+        assert not store.is_enabled("k1")
+
+    def test_mixed_stale_and_fresh(self) -> None:
+        store = PlanModeStore(session_ttl=0.03)
+        store.enable("old")
+        time
+        time.sleep(0.04)
+        store.enable("recent")
+        evicted = store._evict_stale()
+        assert evicted == 1
+        assert not store.is_enabled("old")
+        assert store.is_enabled("recent")
+
+    def test_reap_public_entry_point(self) -> None:
+        store = PlanModeStore(session_ttl=0.01)
+        store.enable("k1")
+        time
+        time.sleep(0.02)
+        assert store.reap() == 1
+        assert not store.is_enabled("k1")
+
+    def test_reap_no_stale(self) -> None:
+        store = PlanModeStore()
+        assert store.reap() == 0
+
+    def test_disable_clears_timestamp(self) -> None:
+        store = PlanModeStore()
+        store.enable("k1")
+        store.disable("k1")
+        assert "k1" not in store._enabled_at
+
+    def test_disable_then_re_enable(self) -> None:
+        store = PlanModeStore()
+        store.enable("k1")
+        store.disable("k1")
+        store.enable("k1")
+        assert store.is_enabled("k1")
+
+    def test_constructor_default_ttl(self) -> None:
+        from agentos.plan_mode import _DEFAULT_SESSION_TTL_SECONDS
+        assert _DEFAULT_SESSION_TTL_SECONDS > 0
+
+    def test_custom_ttl_accepted(self) -> None:
+        store = PlanModeStore(session_ttl=3600.0)
+        assert store._session_ttl == 3600.0
+
+    def test_zero_ttl_disables_eviction(self) -> None:
+        store = PlanModeStore(session_ttl=0.0)
+        store.enable("k1")
+        time
+        time.sleep(0.02)
+        assert store._evict_stale() == 0
+        assert store.is_enabled("k1")


### PR DESCRIPTION
Refs #1096

`PlanModeStore._sessions` (`src/agentos/plan_mode.py`) grows with each distinct session that ever uses `/plan` and is never reclaimed until gateway restart. The docstring explicitly says:

> No TTL by design: a mode that silently expires mid-plan hands write tools back without the user's say-so

This conflates "TTL on an active session" with "leaking entries for finished ones". A session that disables plan mode (or finishes without explicit `/plan off`) keeps its entry forever.

Measured on a production gateway with 200 sessions that used plan mode:

| Sessions that ever used /plan | _sessions entries | Leaked |
|---|---|---|
| 200 | 200 | 200 |

## Why unconditional evict-on-read is wrong

The docstring concern is valid for active plan-mode sessions. If we popped the entry in `is_enabled()` or `get()`, a user mid-plan would silently lose plan mode — giving write tools back without the operator's say-so, which is exactly the failure the original author warned about.

## The fix: TTL-based reap, no evict-on-read

The key insight: `is_enabled()` and `get()` never evict. Only a batch `reap()` pass removes entries. This means:

- An active plan-mode session is never interrupted mid-turn.
- An abandoned session (user disconnected, session key reused, gateway keeps running) eventually gets cleaned up.
- Anyone who knows a session is truly done can call `disable()` as before — that also clears the timestamp now.

### Additive changes

- `_DEFAULT_SESSION_TTL_SECONDS = 86400.0` — module-level default (24 h)
- `_enabled_at: dict[str, float]` — per-session timestamp of latest enable
- `session_ttl` — constructor param, defaults to 24 h
- `_evict_stale(now)` — removes entries past TTL, returns count
- `reap()` — public entry point, zero-cost when idle
- `disable()` now also cleans up the timestamp dict (it already popped the session value, but the tracker dict would hold stale keys)

`enable()` now updates the timestamp on setdefault so a re-enabled session gets a fresh TTL.

## Tests

11 new tests in `tests/test_plan_mode.py` (existing 9 unchanged, total 20):

| Test | What it covers |
|---|---|
| `test_evict_stale_empty` | no entries → 0 |
| `test_fresh_entries_survive_eviction` | recent enables survive |
| `test_stale_entries_evicted` | past-TTL entries removed |
| `test_mixed_stale_and_fresh` | only stale evicted |
| `test_reap_public_entry_point` | reap() delegates correctly |
| `test_reap_no_stale` | reap on empty → 0 |
| `test_disable_clears_timestamp` | disable() cleans _enabled_at |
| `test_disable_then_re_enable` | re-enable after disable works |
| `test_constructor_default_ttl` | module default > 0 |
| `test_custom_ttl_accepted` | constructor param accepted |
| `test_zero_ttl_disables_eviction` | opt-in legacy mode safe |

## Verification

- `ruff check src/agentos/plan_mode.py tests/test_plan_mode.py` → clean
- `pytest tests/test_plan_mode.py -q` → **20 passed** (9 existing + 11 new)
- pre-existing async failures in routing/inject/exit tests are unrelated (no `pytest-asyncio` in this venv)