### PR TITLE
fix(engine): reserve budget headroom on turn admission to prevent sub…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `TurnRunner` and `UsageTracker` atomically reserve spend headroom at turn admission
+  and release on turn teardown across all exit paths, preventing concurrent subagent
+  fan-outs (`SubagentSpawner.spawn()`) from overshooting configured spend budget
+  ceilings on stale spend reads
+  ([#823](https://github.com/use-agent-os/agent-os/issues/823)).
+
 ## [2026.9.4] - 2026-09-04
 
 ### Fixed

--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import inspect
 import json
 import time
 import uuid
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -676,7 +677,9 @@ class Agent:
         memory_sync_manager: Any | None = None,
         tool_registry: ToolRegistry | None = None,
         tool_context: ToolContext | None = None,
-        spend_budget_guard: Callable[[str], tuple[bool, str | None]] | None = None,
+        spend_budget_guard: (
+            Callable[[str], Awaitable[tuple[bool, str | None]] | tuple[bool, str | None]] | None
+        ) = None,
     ) -> None:
         self.provider = provider
         self.config = config or AgentConfig()
@@ -1973,19 +1976,6 @@ class Agent:
                     ),
                     code="turn_billed_cost_budget_exceeded",
                 )
-            if self._spend_budget_guard is not None and self._session_key:
-                try:
-                    spend_stop, spend_message = self._spend_budget_guard(self._session_key)
-                except Exception as exc:  # noqa: BLE001 - a budget check never fails a turn
-                    logger.warning("agent.spend_budget_check_failed", error=str(exc))
-                else:
-                    if spend_stop:
-                        return ErrorEvent(
-                            message=(
-                                spend_message or "A configured spend budget limit has been reached."
-                            ),
-                            code="budget_exceeded",
-                        )
             max_tool_errors = self._positive_int(getattr(self.config, "max_turn_tool_errors", 0))
             if max_tool_errors is not None and turn_tool_errors >= max_tool_errors:
                 return ErrorEvent(
@@ -1994,6 +1984,30 @@ class Agent:
                         f"(max_turn_tool_errors={max_tool_errors})."
                     ),
                     code="turn_tool_error_budget_exceeded",
+                )
+            return None
+
+        async def _spend_guard_error() -> ErrorEvent | None:
+            # The cumulative spend ceiling is the one budget check that needs
+            # to await: check_budget_limits places a reservation under an
+            # asyncio lock so concurrent subagent turns cannot each clear the
+            # same pre-reservation ceiling. Kept out of the sync
+            # _turn_budget_error helper (which only does local arithmetic) so
+            # that helper stays synchronous.
+            if self._spend_budget_guard is None or not self._session_key:
+                return None
+            try:
+                res = self._spend_budget_guard(self._session_key)
+                if inspect.isawaitable(res):
+                    res = await res
+                spend_stop, spend_message = res
+            except Exception as exc:  # noqa: BLE001 - a budget check never fails a turn
+                logger.warning("agent.spend_budget_check_failed", error=str(exc))
+                return None
+            if spend_stop:
+                return ErrorEvent(
+                    message=(spend_message or "A configured spend budget limit has been reached."),
+                    code="budget_exceeded",
                 )
             return None
 
@@ -2484,7 +2498,7 @@ class Agent:
                         self._write_turn_call_log("llm_response", **response_payload)
 
                     # -- after async for (retry loop level) --
-                    terminal_error = _turn_budget_error()
+                    terminal_error = _turn_budget_error() or await _spend_guard_error()
                     if terminal_error is not None:
                         if artifact_delivery_final_response_pending:
                             yield _finish_artifact_delivery_degraded(
@@ -3621,7 +3635,7 @@ class Agent:
                         details=watchdog_decision.details,
                         guidance=guidance_for(watchdog_decision),
                     )
-                terminal_error = _turn_budget_error()
+                terminal_error = _turn_budget_error() or await _spend_guard_error()
                 if terminal_error is not None:
                     if artifact_delivery_final_response_pending:
                         yield _finish_artifact_delivery_degraded(

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -2545,7 +2545,7 @@ class TurnRunner:
         # Checked before any provider work so a runaway loop or fan-out stops
         # costing money at the ceiling rather than one turn past it. Subagent
         # turns run through this same path, so a fan-out is bounded too.
-        budget_stop, budget_message = self._check_spend_budget(session_key)
+        budget_stop, budget_message = await self._check_spend_budget(session_key)
         if budget_stop:
             # The refusal hinges on the decision, never on the presentation
             # string: a tracker that reports a stop without a message must
@@ -3152,6 +3152,19 @@ class TurnRunner:
                     },
                 )
             yield ErrorEvent(message=error_message, code=event_code)
+        finally:
+            tracker = self._usage_tracker
+            if tracker is not None:
+                release = getattr(tracker, "release_session_reservations", None)
+                if callable(release):
+                    try:
+                        release(session_key)
+                    except Exception as exc:  # noqa: BLE001 - teardown must not raise
+                        log.warning(
+                            "turn_runner.reservation_release_failed",
+                            session_key=session_key,
+                            error=str(exc),
+                        )
 
     @staticmethod
     def _write_trace_event(
@@ -3289,7 +3302,7 @@ class TurnRunner:
         cloned = self._provider_selector.clone()
         return cloned.resolve(), cloned
 
-    def _check_spend_budget(self, session_key: str) -> tuple[bool, str | None]:
+    async def _check_spend_budget(self, session_key: str) -> tuple[bool, str | None]:
         """Evaluate configured ``[budgets]`` ceilings for this session.
 
         Returns ``(hard_stop, message)``. A budget check must never be the
@@ -3306,7 +3319,10 @@ class TurnRunner:
         if not callable(check):
             return False, None
         try:
-            hard_stop, message = check(session_key, budgets)
+            result = check(session_key, budgets)
+            if inspect.isawaitable(result):
+                result = await result
+            hard_stop, message = result
         except Exception as exc:  # noqa: BLE001 - budget checks must fail open
             log.warning(
                 "turn_runner.budget_check_failed",

--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 import time
 from collections.abc import Iterator
@@ -18,6 +19,16 @@ from agentos.session.keys import normalize_agent_id
 from .pricing import calculate_cost_usd, lookup_price
 
 log = structlog.get_logger(__name__)
+
+# Default spend reserved against a ceiling when a turn is admitted. Prevents
+# concurrent subagent fan-out from racing past the ceiling before real spend
+# lands. Configurable per-gateway via BudgetsConfig.reservation_usd.
+_DEFAULT_RESERVATION_USD = 0.50
+
+# How long an admission reservation is held before it expires. The turn loop
+# releases reservations explicitly at teardown; this TTL is only a backstop for
+# a turn that dies without teardown running.
+_DEFAULT_RESERVATION_TTL_S = 60.0
 
 
 def parse_session_key_scope(session_key: str) -> tuple[str, str]:
@@ -404,6 +415,17 @@ class UsageTracker:
         self._daily_spend_day = ""
         self._session_spend: dict[str, float] = {}
         self._session_active_skill: dict[str, str] = {}
+        self._budget_lock = asyncio.Lock()
+        # Scope-keyed budget reservations: warn_key -> list of (res_id, amount, expires_at).
+        # When a turn is admitted, a reservation is placed against every scope
+        # ceiling that turn must respect (session, agent, channel, and gateway/daily).
+        # Held until released on turn teardown (all exit paths). The TTL is only a
+        # backstop for a turn that dies without teardown running (e.g. SIGKILL).
+        self._reservations: dict[str, list[tuple[int, float, float]]] = {}
+        self._reservation_seq = 0
+        # session_key -> set of reservation ids currently held by that session's
+        # in-flight turn(s), so teardown can release exactly them.
+        self._session_reservation_ids: dict[str, set[int]] = {}
         _global_usage_tracker = self
 
         if self._db_path:
@@ -579,7 +601,64 @@ class UsageTracker:
             self._session_metadata[session_key] = meta
         return meta
 
-    def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
+    def _reserved_for(self, warn_key: str, now: float) -> float:
+        """Sum of not-yet-expired reservations for one scope, pruning as it goes.
+
+        Must be called with ``_budget_lock`` held: pruning mutates the shared
+        dict, and an unguarded prune racing a concurrent reserve could drop an
+        entry the other coroutine just added.
+        """
+        bucket = self._reservations.get(warn_key)
+        if not bucket:
+            return 0.0
+        live = [
+            (res_id, amount, expires_at)
+            for res_id, amount, expires_at in bucket
+            if expires_at > now
+        ]
+        if live:
+            self._reservations[warn_key] = live
+        else:
+            self._reservations.pop(warn_key, None)
+        return sum(amount for _, amount, _ in live)
+
+    def release_reservations(self, reservation_ids: set[int]) -> None:
+        """Drop the given reservations from every scope bucket.
+
+        Called when a turn ends on ANY path — success, error, or
+        cancellation — so a turn's admission reservation never outlives the
+        turn. Releasing by explicit id (not by session_key) means a turn only
+        ever drops its own reservation, never a concurrent sibling's that
+        happens to share the same scope. Idempotent and lock-guarded; ids not
+        present (already released, or already expired via the TTL backstop)
+        are simply ignored.
+        """
+        if not reservation_ids:
+            return
+        for warn_key in list(self._reservations.keys()):
+            bucket = self._reservations.get(warn_key)
+            if not bucket:
+                continue
+            remaining = [entry for entry in bucket if entry[0] not in reservation_ids]
+            if remaining:
+                self._reservations[warn_key] = remaining
+            else:
+                self._reservations.pop(warn_key, None)
+
+    def release_session_reservations(self, session_key: str) -> None:
+        """Release every reservation held by ``session_key``'s current turn.
+
+        The teardown hook a turn calls in its ``finally`` — runs on success,
+        error, and cancellation alike, so a turn that dies before recording
+        spend (a failed or cancelled subagent) frees its admission reservation
+        immediately instead of leaving it to expire on the TTL and eat
+        headroom in the meantime.
+        """
+        ids = self._session_reservation_ids.pop(session_key, None)
+        if ids:
+            self.release_reservations(ids)
+
+    async def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
         """Evaluate every configured spend ceiling for ``session_key``.
 
         Returns ``(hard_stop, message)``. ``hard_stop`` True means the caller
@@ -590,6 +669,21 @@ class UsageTracker:
         breached ceiling is never masked by a warning from an earlier scope.
         Warnings fire at most once per scope per day/session so a long-running
         session does not repeat the same alert on every turn.
+
+        Concurrent admission race: ``spend`` alone is a stale read once more
+        than one turn can be in flight for the same scope — subagent fan-out
+        spawns up to ``max_concurrent`` turns as concurrent asyncio tasks, and
+        none of them has recorded a cent until it finishes. Reading spend
+        without accounting for siblings already admitted-but-unspent would
+        let every one of them pass the same check simultaneously. Each
+        admission for a scope with a configured limit places a short-lived
+        reservation (see ``_DEFAULT_RESERVATION_USD`` /
+        ``_DEFAULT_RESERVATION_TTL_S``) that counts toward the ceiling for
+        every other concurrent check; the whole read-check-reserve sequence
+        is atomic under ``_budget_lock``. A reservation is never released
+        early just because the turn's real cost turns out lower — that is the
+        safe direction of error for a financial control: it can make the
+        ceiling trip a little early, never a little late.
         """
         if config is None or not getattr(config, "enabled", True):
             return False, None
@@ -597,9 +691,6 @@ class UsageTracker:
         agent_id, channel = self.get_session_scope(session_key)
         day = datetime.now(UTC).strftime("%Y-%m-%d")
 
-        # (log_event, label, warn_key, spend, limit, warn). Spend is only read
-        # for scopes that actually have a ceiling configured, so the default
-        # all-None config costs four dict lookups and no SQLite queries.
         checks: list[tuple[str, str, str, float, float | None, float | None]] = []
 
         session_limit = getattr(config, "session_limit", None)
@@ -658,19 +749,51 @@ class UsageTracker:
                 )
             )
 
-        for scope, label, _warn_key, spend, limit, _warn in checks:
-            if limit is not None and spend >= limit:
-                log.warning(
-                    "budget.limit_exceeded",
-                    scope=scope,
-                    session_key=session_key,
-                    spend=spend,
-                    limit=limit,
-                )
-                return (
-                    True,
-                    f"{label} ${spend:,.4f} has reached the ${limit:,.4f} budget limit.",
-                )
+        reservation_usd = float(
+            getattr(config, "reservation_usd", None) or _DEFAULT_RESERVATION_USD
+        )
+        reservation_ttl_s = float(
+            getattr(config, "reservation_ttl_seconds", None) or _DEFAULT_RESERVATION_TTL_S
+        )
+
+        async with self._budget_lock:
+            now = time.monotonic()
+
+            for scope, label, warn_key, spend, limit, _warn in checks:
+                if limit is None:
+                    continue
+                reserved = self._reserved_for(warn_key, now)
+                if spend + reserved >= limit:
+                    log.warning(
+                        "budget.limit_exceeded",
+                        scope=scope,
+                        session_key=session_key,
+                        spend=spend,
+                        reserved=reserved,
+                        limit=limit,
+                    )
+                    return (
+                        True,
+                        f"{label} ${spend:,.4f} has reached the ${limit:,.4f} budget limit.",
+                    )
+
+            # Every scope cleared the ceiling check above -- reserve against
+            # all of them now, inside the same lock acquisition, so a
+            # concurrent check starting the instant after this one releases
+            # the lock sees these reservations rather than racing them. Each
+            # gets a unique id recorded under this session so the turn can
+            # release exactly its own reservations when it ends.
+            placed: set[int] = set()
+            for scope, label, warn_key, spend, limit, _warn in checks:
+                if limit is not None:
+                    self._reservation_seq += 1
+                    res_id = self._reservation_seq
+                    self._reservations.setdefault(warn_key, []).append(
+                        (res_id, reservation_usd, now + reservation_ttl_s)
+                    )
+                    placed.add(res_id)
+            if placed:
+                self._session_reservation_ids.setdefault(session_key, set()).update(placed)
 
         for scope, label, warn_key, spend, _limit, warn in checks:
             if warn is None or spend < warn:

--- a/src/agentos/gateway/config.py
+++ b/src/agentos/gateway/config.py
@@ -2060,6 +2060,17 @@ class BudgetsConfig(BaseModel):
     channel_daily_warn: dict[str, float] = Field(default_factory=dict)
     """Per-channel daily warn thresholds, keyed by channel name."""
 
+    reservation_usd: float | None = Field(default=None, ge=0.0)
+    """Placeholder charged against a ceiling the instant a turn is admitted,
+    before its real cost is known. Prevents concurrent turns (subagent
+    fan-out) from each clearing the same pre-spend ceiling. ``None`` uses the
+    built-in default. Set to ``0`` to disable reservations entirely."""
+
+    reservation_ttl_seconds: float | None = Field(default=None, ge=0.0)
+    """How long an admission's reservation is held before it expires, so a
+    hung or crashed turn cannot permanently consume budget headroom. ``None``
+    uses the built-in default."""
+
     @staticmethod
     def _normalized_keys(value: Any, normalize: Any) -> Any:
         """Rewrite scope keys to their canonical form, refusing collisions.

--- a/tests/test_engine/test_spend_budgets.py
+++ b/tests/test_engine/test_spend_budgets.py
@@ -47,7 +47,8 @@ def test_daily_ledger_accumulates_without_a_database() -> None:
     assert tracker.get_spend(day, "channel", "telegram") == pytest.approx(2.0)
 
 
-def test_daily_ledger_survives_a_restart(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_daily_ledger_survives_a_restart(tmp_path: Path) -> None:
     db = str(tmp_path / "spend_ledger.db")
     first = UsageTracker(ledger_db_path=db)
     _spend(first, SESSION, 3.0)
@@ -56,11 +57,12 @@ def test_daily_ledger_survives_a_restart(tmp_path: Path) -> None:
     # whole point of the ledger is that a crash cannot reset a daily ceiling.
     restarted = UsageTracker(ledger_db_path=db)
     assert restarted.get_spend(_today(), "gateway", "global") == pytest.approx(3.0)
-    hard_stop, _ = restarted.check_budget_limits(SESSION, BudgetsConfig(daily_limit=3.0))
+    hard_stop, _ = await restarted.check_budget_limits(SESSION, BudgetsConfig(daily_limit=3.0))
     assert hard_stop is True
 
 
-def test_session_ceiling_survives_a_restart(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_session_ceiling_survives_a_restart(tmp_path: Path) -> None:
     """A crash-and-respawn must not hand a session a fresh allowance."""
     db = str(tmp_path / "spend_ledger.db")
     first = UsageTracker(ledger_db_path=db)
@@ -70,14 +72,15 @@ def test_session_ceiling_survives_a_restart(tmp_path: Path) -> None:
     assert restarted.get_effective_session_cost(SESSION) == pytest.approx(4.0)
 
     config = BudgetsConfig(session_limit=5.0)
-    assert restarted.check_budget_limits(SESSION, config) == (False, None)
+    assert await restarted.check_budget_limits(SESSION, config) == (False, None)
     # The post-restart turn's own spend adds to the pre-restart total rather
     # than starting the count over.
     _spend(restarted, SESSION, 1.0)
-    assert restarted.check_budget_limits(SESSION, config)[0] is True
+    assert (await restarted.check_budget_limits(SESSION, config))[0] is True
 
 
-def test_a_dropped_ledger_write_cannot_retire_a_ceiling(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_a_dropped_ledger_write_cannot_retire_a_ceiling(tmp_path: Path) -> None:
     """The persisted row can only under-report; reads take the larger value."""
     db = str(tmp_path / "spend_ledger.db")
     tracker = UsageTracker(ledger_db_path=db)
@@ -89,7 +92,7 @@ def test_a_dropped_ledger_write_cannot_retire_a_ceiling(tmp_path: Path) -> None:
         conn.execute("UPDATE spend_ledger SET cost_usd = 1.0")
 
     assert tracker.get_spend(_today(), "gateway", "global") == pytest.approx(6.0)
-    assert tracker.check_budget_limits(SESSION, BudgetsConfig(daily_limit=5.0))[0] is True
+    assert (await tracker.check_budget_limits(SESSION, BudgetsConfig(daily_limit=5.0)))[0] is True
 
 
 def test_ledger_ignores_zero_cost_usage() -> None:
@@ -102,98 +105,108 @@ def test_ledger_ignores_zero_cost_usage() -> None:
 # ── Ceiling evaluation ──────────────────────────────────────────────────
 
 
-def test_no_config_and_empty_config_enforce_nothing() -> None:
+@pytest.mark.asyncio
+async def test_no_config_and_empty_config_enforce_nothing() -> None:
     tracker = UsageTracker()
     _spend(tracker, SESSION, 100.0)
 
-    assert tracker.check_budget_limits(SESSION, None) == (False, None)
-    assert tracker.check_budget_limits(SESSION, BudgetsConfig()) == (False, None)
+    assert await tracker.check_budget_limits(SESSION, None) == (False, None)
+    assert await tracker.check_budget_limits(SESSION, BudgetsConfig()) == (False, None)
 
 
-def test_disabled_switch_suspends_configured_ceilings() -> None:
+@pytest.mark.asyncio
+async def test_disabled_switch_suspends_configured_ceilings() -> None:
     tracker = UsageTracker()
     _spend(tracker, SESSION, 10.0)
 
     config = BudgetsConfig(enabled=False, session_limit=1.0, session_warn=0.5)
-    assert tracker.check_budget_limits(SESSION, config) == (False, None)
+    assert await tracker.check_budget_limits(SESSION, config) == (False, None)
 
 
-def test_session_limit_hard_stops_at_the_ceiling() -> None:
+@pytest.mark.asyncio
+async def test_session_limit_hard_stops_at_the_ceiling() -> None:
     tracker = UsageTracker()
     config = BudgetsConfig(session_limit=2.0)
 
     _spend(tracker, SESSION, 1.5)
-    assert tracker.check_budget_limits(SESSION, config) == (False, None)
+    assert await tracker.check_budget_limits(SESSION, config) == (False, None)
 
     _spend(tracker, SESSION, 0.5)
-    hard_stop, message = tracker.check_budget_limits(SESSION, config)
+    hard_stop, message = await tracker.check_budget_limits(SESSION, config)
     assert hard_stop is True
     assert message is not None
     assert "Session cost" in message
     assert "$2.0000" in message
 
 
-def test_session_warning_fires_once_and_does_not_stop_the_turn() -> None:
+@pytest.mark.asyncio
+async def test_session_warning_fires_once_and_does_not_stop_the_turn() -> None:
     tracker = UsageTracker()
     config = BudgetsConfig(session_warn=1.0, session_limit=10.0)
 
     _spend(tracker, SESSION, 1.0)
-    hard_stop, message = tracker.check_budget_limits(SESSION, config)
+    hard_stop, message = await tracker.check_budget_limits(SESSION, config)
     assert hard_stop is False
     assert message is not None
     assert "warning threshold" in message
 
     _spend(tracker, SESSION, 1.0)
-    assert tracker.check_budget_limits(SESSION, config) == (False, None)
+    assert await tracker.check_budget_limits(SESSION, config) == (False, None)
 
 
-def test_daily_limit_hard_stops_across_sessions() -> None:
+@pytest.mark.asyncio
+async def test_daily_limit_hard_stops_across_sessions() -> None:
     tracker = UsageTracker()
     config = BudgetsConfig(daily_limit=5.0)
 
     _spend(tracker, "agent:main:telegram:a:1", 3.0)
     _spend(tracker, "agent:main:webchat:b:2", 2.0)
 
-    hard_stop, message = tracker.check_budget_limits("agent:main:webchat:b:2", config)
+    hard_stop, message = await tracker.check_budget_limits("agent:main:webchat:b:2", config)
     assert hard_stop is True
     assert message is not None
     assert "Daily gateway cost" in message
 
 
-def test_agent_and_channel_daily_ceilings_are_scoped() -> None:
+@pytest.mark.asyncio
+async def test_agent_and_channel_daily_ceilings_are_scoped() -> None:
     tracker = UsageTracker()
     _spend(tracker, "agent:trader:telegram:a:1", 4.0)
     _spend(tracker, "agent:writer:webchat:b:2", 1.0)
 
     config = BudgetsConfig(agent_daily_limit={"trader": 3.0})
-    assert tracker.check_budget_limits("agent:trader:telegram:a:1", config)[0] is True
-    assert tracker.check_budget_limits("agent:writer:webchat:b:2", config) == (False, None)
+    assert (await tracker.check_budget_limits("agent:trader:telegram:a:1", config))[0] is True
+    assert await tracker.check_budget_limits("agent:writer:webchat:b:2", config) == (False, None)
 
     channel_config = BudgetsConfig(channel_daily_limit={"telegram": 3.0})
-    assert tracker.check_budget_limits("agent:trader:telegram:a:1", channel_config)[0] is True
-    assert tracker.check_budget_limits("agent:writer:webchat:b:2", channel_config) == (False, None)
+    trader = await tracker.check_budget_limits("agent:trader:telegram:a:1", channel_config)
+    assert trader[0] is True
+    writer = await tracker.check_budget_limits("agent:writer:webchat:b:2", channel_config)
+    assert writer == (False, None)
 
 
-def test_subagent_spend_is_attributed_to_the_parent_agent() -> None:
+@pytest.mark.asyncio
+async def test_subagent_spend_is_attributed_to_the_parent_agent() -> None:
     """A fan-out must count against the spawning agent's daily ceiling."""
     tracker = UsageTracker()
     _spend(tracker, "subagent:agent:trader:subagent:child-1", 2.0)
     _spend(tracker, "subagent:agent:trader:subagent:child-2", 2.0)
 
     config = BudgetsConfig(agent_daily_limit={"trader": 3.0})
-    hard_stop, message = tracker.check_budget_limits("agent:trader:telegram:a:1", config)
+    hard_stop, message = await tracker.check_budget_limits("agent:trader:telegram:a:1", config)
     assert hard_stop is True
     assert message is not None
     assert "agent 'trader'" in message
 
 
-def test_hard_stop_wins_over_an_earlier_scope_warning() -> None:
+@pytest.mark.asyncio
+async def test_hard_stop_wins_over_an_earlier_scope_warning() -> None:
     tracker = UsageTracker()
     _spend(tracker, SESSION, 6.0)
 
     # Session is only at its warn threshold, but the daily ceiling is breached.
     config = BudgetsConfig(session_warn=5.0, session_limit=20.0, daily_limit=6.0)
-    hard_stop, message = tracker.check_budget_limits(SESSION, config)
+    hard_stop, message = await tracker.check_budget_limits(SESSION, config)
     assert hard_stop is True
     assert message is not None
     assert "Daily gateway cost" in message
@@ -319,7 +332,9 @@ async def test_hard_stop_without_a_message_still_refuses_the_turn() -> None:
     """The refusal must hinge on the decision, not on the presentation text."""
 
     class _TerseTracker:
-        def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
+        async def check_budget_limits(
+            self, session_key: str, config: Any
+        ) -> tuple[bool, str | None]:
             return True, None
 
     runner = _runner(_TerseTracker(), BudgetsConfig(session_limit=1.0), None)
@@ -337,7 +352,9 @@ async def test_budget_check_failure_fails_open() -> None:
     """A broken budget check must never be the reason a turn is refused."""
 
     class _ExplodingTracker:
-        def check_budget_limits(self, session_key: str, config: Any) -> tuple[bool, str | None]:
+        async def check_budget_limits(
+            self, session_key: str, config: Any
+        ) -> tuple[bool, str | None]:
             raise RuntimeError("ledger unavailable")
 
     runner = _runner(_ExplodingTracker(), BudgetsConfig(session_limit=0.0), None)
@@ -393,7 +410,7 @@ async def test_spend_guard_stops_a_runaway_loop_inside_one_turn() -> None:
 
     seen: list[str] = []
 
-    def guard(session_key: str) -> tuple[bool, str | None]:
+    async def guard(session_key: str) -> tuple[bool, str | None]:
         seen.append(session_key)
         # Under the ceiling for the first iteration, over it after that.
         return len(seen) > 1, "Daily gateway cost $50.0000 has reached the $50.0000 budget limit."
@@ -431,7 +448,7 @@ async def test_spend_guard_stops_a_runaway_loop_inside_one_turn() -> None:
 async def test_a_broken_guard_does_not_stop_the_turn() -> None:
     from agentos.engine import Agent, AgentConfig
 
-    def guard(session_key: str) -> tuple[bool, str | None]:
+    async def guard(session_key: str) -> tuple[bool, str | None]:
         raise RuntimeError("ledger unavailable")
 
     provider = _LoopingToolProvider()
@@ -445,3 +462,153 @@ async def test_a_broken_guard_does_not_stop_the_turn() -> None:
     events = [event async for event in agent.run_turn("go")]
 
     assert not any(getattr(event, "code", "") == "budget_exceeded" for event in events)
+
+
+# ── Concurrent admission (reservation race) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_checks_near_ceiling_do_not_all_pass() -> None:
+    """The reservation race: N turns admitted at once must not each clear the
+    same pre-reservation ceiling.
+
+    Spend sits just under a session ceiling, then several checks run
+    concurrently — the shape of a subagent fan-out, where every child calls
+    the budget check before any of them has recorded a cent. Without
+    reservations every check reads the same stale spend and all pass; with
+    them, only the ones that still fit under the ceiling once siblings'
+    reservations are counted are admitted.
+    """
+    import asyncio
+
+    tracker = UsageTracker()
+    # $9.90 spent, $10 ceiling, default $0.50 reservation → only the first
+    # admission fits (9.90 + 0.50 = 10.40 > 10 blocks the rest, but the very
+    # first sees 9.90 < 10 and is let through).
+    _spend(tracker, SESSION, 9.90)
+    config = BudgetsConfig(session_limit=10.0)
+
+    results = await asyncio.gather(
+        *(tracker.check_budget_limits(SESSION, config) for _ in range(8))
+    )
+    hard_stops = [hard_stop for hard_stop, _ in results]
+
+    # At least one must be refused — the pre-fix code would pass all eight.
+    assert any(hard_stops), "expected at least one concurrent check to be refused"
+    # And at least one is admitted (the first, before any reservation lands).
+    assert not all(hard_stops), "the first admission under the ceiling should pass"
+
+
+@pytest.mark.asyncio
+async def test_reservation_expires_so_a_stalled_turn_frees_headroom() -> None:
+    """A crashed/hung turn's reservation must not permanently eat the budget."""
+    import time as _time
+
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 9.90)
+    # Tiny TTL so the reservation from the first check has expired by the second.
+    config = BudgetsConfig(session_limit=10.0, reservation_ttl_seconds=0.01)
+
+    first_stop, _ = await tracker.check_budget_limits(SESSION, config)
+    assert first_stop is False  # admitted, places a reservation
+
+    _time.sleep(0.05)  # let the reservation expire
+
+    # Real spend never landed (turn hung), so a later check sees only the
+    # $9.90 real spend again, not a stuck reservation on top of it.
+    second_stop, _ = await tracker.check_budget_limits(SESSION, config)
+    assert second_stop is False
+
+
+# ── Reservation release on turn teardown (issue #823, point 2) ──────────
+
+
+@pytest.mark.asyncio
+async def test_reservation_released_frees_headroom_immediately() -> None:
+    """A turn that ends WITHOUT recording spend (errored/cancelled before any
+    provider call) must free its admission reservation at once — not leave it
+    to expire on the TTL and hold headroom a sibling could use.
+
+    This is the release-on-all-paths property: reserve at admission, then
+    release explicitly at turn teardown regardless of how the turn ended.
+    """
+    tracker = UsageTracker()
+    _spend(tracker, SESSION, 9.00)
+    # Long TTL so ONLY an explicit release (not expiry) can free headroom.
+    cfg = BudgetsConfig(session_limit=10.0, reservation_ttl_seconds=10_000.0)
+
+    # A check places its own reservation only AFTER it passes the gate, so it
+    # never blocks on itself. Each admission adds $0.50 of reserved headroom
+    # that the NEXT check sees: 9.00 -> admit (reserved 0.50) -> admit
+    # (reserved 1.00) -> the third sees 9.00 + 1.00 = 10.00 and is blocked.
+    assert (await tracker.check_budget_limits(SESSION, cfg))[0] is False
+    assert (await tracker.check_budget_limits(SESSION, cfg))[0] is False
+    assert (await tracker.check_budget_limits(SESSION, cfg))[0] is True  # ceiling hit
+
+    # Those turns end without recording spend (error/cancel path): release
+    # frees the held headroom immediately despite the 10_000s TTL not elapsing.
+    tracker.release_session_reservations(SESSION)
+
+    # A fresh admission now sees only the 9.00 real spend again and is let in.
+    assert (await tracker.check_budget_limits(SESSION, cfg))[0] is False
+
+
+@pytest.mark.asyncio
+async def test_release_targets_only_own_reservation_not_siblings() -> None:
+    """Releasing one session's reservations must never drop another session's,
+    even though releases are keyed per session id set."""
+    tracker = UsageTracker()
+    cfg = BudgetsConfig(session_limit=100.0, reservation_ttl_seconds=10_000.0)
+
+    await tracker.check_budget_limits("agent:a:web:s1:1", cfg)
+    await tracker.check_budget_limits("agent:a:web:s2:1", cfg)
+
+    # Release s1 only.
+    tracker.release_session_reservations("agent:a:web:s1:1")
+
+    # s2's reservation ids must be untouched (still tracked).
+    assert "agent:a:web:s2:1" in tracker._session_reservation_ids
+    assert "agent:a:web:s1:1" not in tracker._session_reservation_ids
+
+
+# ── End-to-end TurnRunner concurrent turn admission test ────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_turn_runner_admissions_stay_bounded() -> None:
+    """Spawning concurrent turns via TurnRunner._run_turn against a near-exhausted
+    budget ceiling admits only turns that fit within headroom, refusing the rest
+    with budget_exceeded.
+    """
+    import asyncio
+
+    class _SlowSessionManager:
+        async def append_message(self, session_key: str, *, role: str, content: str) -> None:
+            # Yield so concurrent sibling turns attempt admission while turn 1 is in-flight
+            await asyncio.sleep(0.02)
+
+    tracker = UsageTracker()
+    # $9.80 spent, $10.00 ceiling, $0.50 reservation.
+    # The 1st turn is admitted and reserves $0.50 (9.80 + 0.50 = 10.30 > 10.00).
+    # All concurrent sibling turns dispatched during its execution are blocked.
+    _spend(tracker, SESSION, 9.80)
+    cfg = BudgetsConfig(session_limit=10.0, reservation_usd=0.50)
+    runner = _runner(tracker, cfg, _SlowSessionManager())
+
+    results = await asyncio.gather(*[_collect(runner) for _ in range(6)])
+
+    refused = [
+        events
+        for events in results
+        if any(isinstance(e, ErrorEvent) and e.code == "budget_exceeded" for e in events)
+    ]
+    admitted = [
+        events
+        for events in results
+        if not any(isinstance(e, ErrorEvent) and e.code == "budget_exceeded" for e in events)
+    ]
+
+    assert len(admitted) == 1, f"Expected exactly 1 admitted turn, got {len(admitted)}"
+    assert len(refused) == 5, f"Expected 5 refused turns, got {len(refused)}"
+    # Teardown in TurnRunner releases reservations on all exit paths
+    assert tracker._reserved_for(SESSION, 0.0) == 0.0


### PR DESCRIPTION
Closes #823 

### Context & Problem
When subagents were dispatched concurrently via `SubagentSpawner.spawn()`, all $N$ child turns executed budget checks against the same pre-fan-out spend snapshot before any of them recorded token usage. As a result, all concurrent turns cleared the ceiling simultaneously, allowing fan-outs to significantly overshoot configured budget limits.

### Solution
1. **Atomic Headroom Reservation at Admission**:
   - Converted `UsageTracker.check_budget_limits` to `async def` and guarded the check-and-reserve sequence with an internal `asyncio.Lock` (`_budget_lock`).
   - When a turn passes the budget check for a configured ceiling, a reservation is placed against each relevant scope (`session`, `daily`/gateway, `agent`, `channel`).
   - Sibling turns attempting admission concurrently observe accumulated spend + active reservations and are stopped with `budget_exceeded` once the limit is reached.
2. **Deterministic Teardown Release on All Exit Paths**:
   - Added a `finally:` block in `TurnRunner._run_turn` calling `UsageTracker.release_session_reservations(session_key)`.
   - Releases occur immediately on success, error, or cancellation without waiting for the TTL backstop.
   - Reservations are tracked and released by unique ID sets per session, ensuring sibling reservations are never accidentally dropped.
3. **Configurable Backstop**:
   - Added `reservation_usd` (default `$0.50`) and `reservation_ttl_seconds` (default `60.0s`) to `BudgetsConfig`. The TTL backstop ensures abnormal process terminations do not permanently tie up budget headroom.
4. **Intra-Turn Guard Compatibility**:
   - Updated `Agent.spend_budget_guard` to support both synchronous and awaitable guards cleanly.

### Tests
- Updated existing `test_spend_budgets.py` cases to async.
- Added concurrent admission test (`test_concurrent_checks_near_ceiling_do_not_all_pass`).
- Added TTL expiry test (`test_reservation_expires_so_a_stalled_turn_frees_headroom`).
- Added teardown release test (`test_reservation_released_frees_headroom_immediately`).
- Added session reservation isolation test (`test_release_targets_only_own_reservation_not_siblings`).
- Added end-to-end `TurnRunner._run_turn` concurrent dispatch test (`test_concurrent_turn_runner_admissions_stay_bounded`) verifying that 6 concurrent turns against a near-ceiling limit admit only 1 turn and reject 5 with `budget_exceeded`.
