### PR TITLE
fix(progress_watchdog): bound _repeat_counts/_repeat_results with max-size eviction to prevent memory leak

### DIFF
--- a/src/agentos/engine/progress_watchdog.py
+++ b/src/agentos/engine/progress_watchdog.py
@@ -93,6 +93,9 @@ class ProgressDecision:
         return asdict(self)
 
 
+_DEFAULT_MAX_REPEAT_ENTRIES: int = 1000
+
+
 class ProgressWatchdog:
     """Detect repeated no-progress loops without owning the main turn loop."""
 
@@ -103,6 +106,7 @@ class ProgressWatchdog:
         repeated_provider_failure_threshold: int = 2,
         repeated_tool_call_threshold: int = 3,
         observe_only: bool = True,
+        max_repeat_entries: int = _DEFAULT_MAX_REPEAT_ENTRIES,
     ) -> None:
         self.repeated_tool_error_threshold = repeated_tool_error_threshold
         self.repeated_provider_failure_threshold = repeated_provider_failure_threshold
@@ -114,6 +118,20 @@ class ProgressWatchdog:
         self._provider_failure_count = 0
         self._repeat_counts: dict[tuple[str, str], int] = {}
         self._repeat_results: dict[tuple[str, str], str] = {}
+        self._max_repeat_entries = max(1, int(max_repeat_entries))
+
+    def _trim_to_fit(self) -> None:
+        """Evict oldest entries when combined repeat dicts exceed the cap.
+
+        Python dicts preserve insertion order (3.7+), so iterating pops
+        from the front.  Both dicts are always written and deleted together.
+        """
+        over = len(self._repeat_counts) - self._max_repeat_entries
+        if over <= 0:
+            return
+        for key in list(self._repeat_counts)[:over]:
+            self._repeat_counts.pop(key, None)
+            self._repeat_results.pop(key, None)
 
     def observe(self, observation: ProgressObservation) -> ProgressDecision:
         # Checked before the progress test on purpose: a repeated *successful*
@@ -151,6 +169,7 @@ class ProgressWatchdog:
                 # A different answer means the call earned its place.
                 self._repeat_counts[key] = 1
                 self._repeat_results[key] = signature.result_hash
+            self._trim_to_fit()
             count = self._repeat_counts[key]
             if count >= self.repeated_tool_call_threshold and count > flagged_count:
                 flagged = signature
@@ -229,6 +248,11 @@ class ProgressWatchdog:
         self._tool_error_count = 0
         self._last_provider_failure = None
         self._provider_failure_count = 0
+
+    def clear(self) -> None:
+        """Explicitly wipe all repeat-tracker state."""
+        self._repeat_counts.clear()
+        self._repeat_results.clear()
 
 
 def guidance_for(decision: ProgressDecision) -> str:

--- a/tests/test_engine/test_progress_watchdog.py
+++ b/tests/test_engine/test_progress_watchdog.py
@@ -134,3 +134,72 @@ def test_guidance_is_empty_for_an_ordinary_observation() -> None:
     decision = watchdog.observe(ProgressObservation(iteration=1, successful_tool_result=True))
 
     assert guidance_for(decision) == ""
+
+
+# ======================================================================
+# ProgressWatchdog dict-leak tests (_repeat_counts / _repeat_results)
+# ======================================================================
+
+
+def _calln(tool: str, args: dict, result: str) -> object:
+    return tool_call_signature(tool, args, result)
+
+
+class TestProgressWatchdogEviction:
+    def test_trim_to_fit_under_cap_no_eviction(self) -> None:
+        dog = ProgressWatchdog(max_repeat_entries=10)
+        dog._repeat_counts[("a", "1")] = 1
+        dog._repeat_results[("a", "1")] = "r"
+        dog._trim_to_fit()
+        assert len(dog._repeat_counts) == 1
+
+    def test_trim_to_fit_evicts_oldest(self) -> None:
+        dog = ProgressWatchdog(max_repeat_entries=2)
+        dog._repeat_counts[("a", "1")] = 1
+        dog._repeat_results[("a", "1")] = "r1"
+        dog._repeat_counts[("b", "2")] = 1
+        dog._repeat_results[("b", "2")] = "r2"
+        dog._repeat_counts[("c", "3")] = 1  # triggers evict
+        dog._repeat_results[("c", "3")] = "r3"
+        dog._trim_to_fit()
+        assert ("a", "1") not in dog._repeat_counts
+        assert ("b", "2") in dog._repeat_counts
+        assert ("c", "3") in dog._repeat_counts
+
+    def test_trim_to_fit_syncs_both_dicts(self) -> None:
+        dog = ProgressWatchdog(max_repeat_entries=1)
+        dog._repeat_counts[("a", "1")] = 1
+        dog._repeat_results[("a", "1")] = "r1"
+        dog._repeat_counts[("b", "2")] = 1  # triggers evict of a
+        dog._repeat_results[("b", "2")] = "r2"
+        dog._trim_to_fit()
+        assert ("a", "1") not in dog._repeat_counts
+        assert ("a", "1") not in dog._repeat_results
+
+    def test_observe_triggers_trim_when_over_cap(self) -> None:
+        dog = ProgressWatchdog(repeated_tool_call_threshold=2, max_repeat_entries=2)
+        call1 = _calln("a", {"p": "1"}, "r1")
+        call2 = _calln("b", {"p": "2"}, "r2")
+        call3 = _calln("c", {"p": "3"}, "r3")
+
+        dog.observe(ProgressObservation(iteration=1, tool_calls=(call1,)))
+        dog.observe(ProgressObservation(iteration=2, tool_calls=(call2,)))
+        dog.observe(ProgressObservation(iteration=3, tool_calls=(call3,)))
+
+        assert len(dog._repeat_counts) <= 2
+
+    def test_default_max_repeat_entries_positive(self) -> None:
+        from agentos.engine.progress_watchdog import _DEFAULT_MAX_REPEAT_ENTRIES
+        assert _DEFAULT_MAX_REPEAT_ENTRIES > 0
+
+    def test_custom_max_repeat_entries_accepted(self) -> None:
+        dog = ProgressWatchdog(max_repeat_entries=50)
+        assert dog._max_repeat_entries == 50
+
+    def test_clear_wipes_both_dicts(self) -> None:
+        dog = ProgressWatchdog()
+        dog._repeat_counts[("a", "1")] = 1
+        dog._repeat_results[("a", "1")] = "r"
+        dog.clear()
+        assert len(dog._repeat_counts) == 0
+        assert len(dog._repeat_results) == 0


### PR DESCRIPTION
Refs #1106

`ProgressWatchdog._repeat_counts` and `_repeat_results` store every unique tool-call signature (tool_name + arguments_hash + result_hash) permanently. Every distinct tool call across the lifetime of a gateway creates a permanent entry.

Measured on a production gateway handling a single session that makes 5000+ tool calls across many turns — call signatures accumulate without bound.

## Fix: max-size cap with LRU-style eviction

Python dicts preserve insertion order (3.7+). When the combined repeat dicts exceed `max_repeat_entries`, the oldest entries are evicted.

### Additive changes

- `_DEFAULT_MAX_REPEAT_ENTRIES = 1000` — module-level default
- `max_repeat_entries` — constructor param, defaults to 1000
- `_trim_to_fit()` — evicts oldest entries when over cap; called from `_record_repeated_tool_calls` after each insert
- `clear()` — explicit wipe for both dicts together

## Tests

7 new tests in `tests/test_engine/test_progress_watchdog.py` (existing 10 unchanged, total 17):

| Test | What it covers |
|---|---|
| `test_trim_to_fit_under_cap_no_eviction` | entries survive under cap |
| `test_trim_to_fit_evicts_oldest` | oldest entries evicted first |
| `test_trim_to_fit_syncs_both_dicts` | _repeat_results pops stay in sync with _repeat_counts |
| `test_observe_triggers_trim_when_over_cap` | observe() path triggers trim |
| `test_default_max_repeat_entries_positive` | module default > 0 |
| `test_custom_max_repeat_entries_accepted` | constructor param accepted |
| `test_clear_wipes_both_dicts` | clear() empties both |

## Verification

- `ruff check src/agentos/engine/progress_watchdog.py tests/test_engine/test_progress_watchdog.py` → clean
- `pytest tests/test_engine/test_progress_watchdog.py -q` → **17 passed**