### PR TITLE
fix(engine): evict _fallback_locks closure leak on run() completion (Closes #1040) [v2]

### DIFF
--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -189,6 +189,11 @@ from agentos.session.keys import (
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 from agentos.tools.types import CallerKind, ToolContext
 
+# Fallback lock cache eviction.
+_FALLBACK_LOCK_TTL_SECONDS: Final[float] = 600.0
+_FALLBACK_LOCK_MAX_ENTRIES: Final[int] = 200
+
+
 # Stable user-facing envelope for LLM timeouts.
 _LLM_TIMEOUT_ENVELOPE: dict[str, Any] = {
     "status": "error",
@@ -218,6 +223,36 @@ _ARTIFACT_DELIVERY_TOOL_NAME: Final[str] = "publish_artifact"
 _ARTIFACT_DELIVERY_FAILURE_MAX_CHARS: Final[int] = 360
 
 _HOOKS_FEATURE_ENV: Final[str] = "AGENTOS_HOOKS"
+
+
+def _evict_fallback_lock(
+    locks: dict[str, tuple[asyncio.Lock, float]],
+    key: str,
+    *,
+    now: float | None = None,
+) -> None:
+    """Evict *key* from *locks* after use; purge stale entries when > max.
+
+    Additive guard — existing code calls setdefault + returns lock unchanged.
+    This is called in the else-finally of ``run()`` after the async-with
+    releases the lock, so the entry is safe to remove.
+    """
+    _now = now if now is not None else time.time()
+    locks.pop(key, None)
+    # Stale-entry purge: sweep once per call when the dict exceeds max.
+    if len(locks) > _FALLBACK_LOCK_MAX_ENTRIES:
+        stale_keys = [
+            k for k, (_, ts) in locks.items() if _now - ts > _FALLBACK_LOCK_TTL_SECONDS
+        ]
+        for k in stale_keys:
+            locks.pop(k, None)
+
+
+def _purge_fallback_locks(locks: dict[str, tuple[asyncio.Lock, float]]) -> int:
+    """Remove all entries, return count removed.  Testability hook."""
+    count = len(locks)
+    locks.clear()
+    return count
 
 
 def collect_invoked_skills(
@@ -1707,15 +1742,20 @@ class TurnRunner:
         # Gateway path: task_runtime._get_session_lock_for_turn (wired in boot.py).
         # CLI/standalone path: _standalone_lock_provider from build_turn_runner_from_services.
         # Test/direct-construction path: fallback dict created here inside a closure.
-        # TurnRunner no longer owns a named per-session lock dict as an instance attribute.
-        # The lock dict lives entirely in the provider closure.
+        # _per_session_lock_dict is set by whichever origin path created the dict,
+        # so that run() can evict the session key after the turn completes.
+        self._per_session_lock_dict: dict[str, tuple[asyncio.Lock, float]] | None = None
         if session_lock_provider is None:
-            _fallback_locks: dict[str, asyncio.Lock] = {}
+            _fallback_locks: dict[str, tuple[asyncio.Lock, float]] = {}
 
             def _fallback_provider(key: str) -> asyncio.Lock:
-                return _fallback_locks.setdefault(key, asyncio.Lock())
+                lock, _ = _fallback_locks.setdefault(
+                    key, (asyncio.Lock(), time.time()),
+                )
+                return lock
 
             session_lock_provider = _fallback_provider
+            self._per_session_lock_dict = _fallback_locks
         self._session_lock_provider = session_lock_provider
         # Frozen memory snapshots keyed by (agent_id, session_key).
         # Captured at session start, refreshed on write/compaction.
@@ -2433,6 +2473,17 @@ class TurnRunner:
         """Replace the lock provider at the gateway composition root."""
         self._session_lock_provider = provider
 
+    def set_per_session_lock_dict(
+        self,
+        locks: dict[str, tuple[asyncio.Lock, float]] | None,
+    ) -> None:
+        """Wire the standalone lock dict so run() can evict entries.
+
+        Called by ``build_turn_runner_from_services`` (boot.py) after
+        constructing the standalone lock dict.
+        """
+        self._per_session_lock_dict = locks
+
     @contextlib.asynccontextmanager
     async def _session_write_context(self, session_key: str) -> AsyncIterator[None]:
         lock = self.get_session_lock(session_key)
@@ -2593,6 +2644,8 @@ class TurnRunner:
                 finally:
                     self.clear_compaction_turn_state(session_key)
                     _SESSION_LOCK_OWNER.reset(_token)
+                    if self._per_session_lock_dict is not None:
+                        _evict_fallback_lock(self._per_session_lock_dict, session_key)
 
     async def _run_turn(
         self,

--- a/src/agentos/gateway/boot.py
+++ b/src/agentos/gateway/boot.py
@@ -2037,10 +2037,13 @@ def build_turn_runner_from_services(
     # Standalone lock dict for CLI / test paths (no TaskRuntime involved).
     # Gateway path replaces this with task_runtime._get_session_lock_for_turn
     # immediately after task_runtime is constructed.
-    _standalone_locks: dict[str, _asyncio.Lock] = {}
+    _standalone_locks: dict[str, tuple[_asyncio.Lock, float]] = {}
 
     def _standalone_lock_provider(session_key: str) -> _asyncio.Lock:
-        return _standalone_locks.setdefault(session_key, _asyncio.Lock())
+        lock, _ = _standalone_locks.setdefault(
+            session_key, (_asyncio.Lock(), time.time()),
+        )
+        return lock
 
     runner = TurnRunner(
         provider_selector=svc.provider_selector,
@@ -2062,6 +2065,11 @@ def build_turn_runner_from_services(
         compaction_hooks=getattr(svc, "compaction_hooks", None),
         tool_hooks=getattr(svc, "tool_hooks", None),
     )
+    # Wire the standalone lock dict so run() evicts entries after each turn.
+    # hasattr guard keeps tests that monkey-patch TurnRunner with FakeTurnRunner
+    # passing (FakeTurnRunner doesn't carry the eviction API).
+    if hasattr(runner, "set_per_session_lock_dict"):
+        runner.set_per_session_lock_dict(_standalone_locks)
     ref = getattr(svc, "_turn_runner_ref", None)
     if isinstance(ref, list):
         ref.clear()

--- a/tests/test_engine/test_fallback_lock_eviction.py
+++ b/tests/test_engine/test_fallback_lock_eviction.py
@@ -1,0 +1,182 @@
+"""Fallback lock cache eviction tests — upgraded 2-phase."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentos.engine.runtime import (
+    _FALLBACK_LOCK_MAX_ENTRIES,
+    TurnRunner,
+    _evict_fallback_lock,
+    _purge_fallback_locks,
+)
+from agentos.engine.types import DoneEvent
+from agentos.tools.types import ToolContext
+
+
+class TestEvictFallbackLock:
+    """Unit: _evict_fallback_lock — Phase 1 (TTL) + Phase 2 (cap)."""
+
+    def test_evicts_existing_key(self) -> None:
+        locks = {"s1": (asyncio.Lock(), 100.0), "s2": (asyncio.Lock(), 100.0)}
+        _evict_fallback_lock(locks, "s1", now=200.0)
+        assert "s1" not in locks
+        assert "s2" in locks
+
+    def test_evict_nonexistent_key_is_noop(self) -> None:
+        locks = {"s1": (asyncio.Lock(), 100.0)}
+        _evict_fallback_lock(locks, "s2", now=200.0)
+        assert "s1" in locks
+
+    def test_purges_stale_when_over_max(self) -> None:
+        locks = {}
+        for i in range(_FALLBACK_LOCK_MAX_ENTRIES + 1):
+            locks[f"s{i}"] = (asyncio.Lock(), 100.0)
+        locks["fresh"] = (asyncio.Lock(), 99999.0)
+        _evict_fallback_lock(locks, "s0", now=9999.0)
+        assert "fresh" in locks
+        assert len(locks) <= 2
+
+    def test_max_not_reached_no_purge(self) -> None:
+        locks = {"s1": (asyncio.Lock(), 100.0)}
+        _evict_fallback_lock(locks, "s1", now=200.0)
+        assert len(locks) == 0
+
+    def test_boundary_at_max(self) -> None:
+        locks = {f"s{i}": (asyncio.Lock(), 100.0) for i in range(_FALLBACK_LOCK_MAX_ENTRIES)}
+        key = "s0"
+        _evict_fallback_lock(locks, key, now=9999.0)
+        assert len(locks) == _FALLBACK_LOCK_MAX_ENTRIES - 1
+
+    def test_boundary_over_max_triggers_purge(self) -> None:
+        locks = {f"s{i}": (asyncio.Lock(), 100.0) for i in range(_FALLBACK_LOCK_MAX_ENTRIES + 2)}
+        key = "s0"
+        _evict_fallback_lock(locks, key, now=9999.0)
+        assert len(locks) <= 1
+
+    def test_custom_now(self) -> None:
+        locks = {"s1": (asyncio.Lock(), 100.0)}
+        _evict_fallback_lock(locks, "s1", now=50.0)
+        assert "s1" not in locks
+
+    def test_ttl_not_triggered_below_cap(self) -> None:
+        locks = {"s1": (asyncio.Lock(), 1.0)}
+        _evict_fallback_lock(locks, "s1", now=99999.0)
+        assert len(locks) == 0
+
+    def test_purges_only_stale_not_fresh(self) -> None:
+        locks = {f"s{i}": (asyncio.Lock(), 0.0) for i in range(_FALLBACK_LOCK_MAX_ENTRIES)}
+        locks["fresh"] = (asyncio.Lock(), 99999.0)
+        key = "s0"
+        _evict_fallback_lock(locks, key, now=50000.0)
+        assert "fresh" in locks
+
+
+class TestPurgeFallbackLocks:
+    """Evict-on-write: full purge path."""
+
+    def test_purge_removes_all(self) -> None:
+        locks = {"s1": (asyncio.Lock(), 1.0), "s2": (asyncio.Lock(), 2.0)}
+        count = _purge_fallback_locks(locks)
+        assert count == 2
+        assert len(locks) == 0
+
+    def test_purge_empty(self) -> None:
+        count = _purge_fallback_locks({})
+        assert count == 0
+
+
+class TestTurnRunnerFallbackLockLifecycle:
+    """Integration: TurnRunner creates + evicts fallback locks."""
+
+    @pytest.fixture
+    def runner(self) -> TurnRunner:
+        provider = MagicMock()
+        provider.provider_name = "stub"
+        async def _chat(*a, **kw): yield DoneEvent()
+        provider.chat = _chat
+        selector = MagicMock()
+        selector.resolve.return_value = provider
+        selector.clone.return_value = selector
+        selector.current_config = MagicMock(model="m")
+        session_manager = MagicMock()
+        session_manager.get = AsyncMock(return_value=None)
+        session_manager.append_message = AsyncMock(return_value=None)
+        session_manager.update = AsyncMock(return_value=None)
+        session_manager.get_compaction_summary = AsyncMock(return_value=None)
+        return TurnRunner(
+            provider_selector=selector,
+            session_manager=session_manager,
+            session_lock_provider=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_lock_attr_created(self, runner: TurnRunner) -> None:
+        assert runner._per_session_lock_dict is not None
+        assert len(runner._per_session_lock_dict) == 0
+
+    @pytest.mark.asyncio
+    async def test_run_creates_and_evicts(self, runner: TurnRunner) -> None:
+        sk = "agent:main:test-evict"
+        from agentos.tools.types import ToolContext
+        tc = ToolContext(session_key=sk)
+        async for _ in runner.run(message="hello", session_key=sk, tool_context=tc):
+            assert sk in runner._per_session_lock_dict
+        assert sk not in runner._per_session_lock_dict
+
+    @pytest.mark.asyncio
+    async def test_multiple_sessions_independent(
+        self, runner: TurnRunner
+    ) -> None:
+        keys = ["agent:main:a", "agent:main:b"]
+        for sk in keys:
+            ctx = ToolContext(session_key=sk)
+            async for _ in runner.run(
+                message="hi", session_key=sk, tool_context=ctx
+            ):
+                pass
+        assert "agent:main:a" not in runner._per_session_lock_dict
+        assert "agent:main:b" not in runner._per_session_lock_dict
+
+    @pytest.mark.asyncio
+    async def test_concurrent_50_sessions(
+        self, runner: TurnRunner
+    ) -> None:
+        async def _run(sk: str) -> None:
+            ctx = ToolContext(session_key=sk)
+            async for _ in runner.run(
+                message="x", session_key=sk, tool_context=ctx
+            ):
+                pass
+        keys = [f"agent:main:c-{i:03d}" for i in range(50)]
+        await asyncio.gather(*(_run(k) for k in keys))
+        remaining = [k for k in keys if k in (runner._per_session_lock_dict or {})]
+        assert remaining == [], f"Leaked: {remaining}"
+
+    @pytest.mark.asyncio
+    async def test_purge_after_run(
+        self, runner: TurnRunner
+    ) -> None:
+        ctx = ToolContext(session_key="agent:main:p")
+        async for _ in runner.run(
+            message="x", session_key="agent:main:p", tool_context=ctx
+        ):
+            pass
+        if runner._per_session_lock_dict is not None:
+            _purge_fallback_locks(runner._per_session_lock_dict)
+        assert runner._per_session_lock_dict is not None and len(runner._per_session_lock_dict) == 0
+
+    @pytest.mark.asyncio
+    async def test_reentry_path_does_not_leak(self, runner: TurnRunner) -> None:
+        """Caller-holds-lock path (re-entry) should also evict."""
+        from agentos.tools.types import ToolContext
+        sk = "agent:main:reentry"
+        tc = ToolContext(session_key=sk)
+        lock = runner.get_session_lock(sk)
+        async with lock:
+            async for _ in runner.run(message="x", session_key=sk, tool_context=tc):
+                pass
+        assert sk not in runner._per_session_lock_dict


### PR DESCRIPTION
## Changes

Add cache eviction for `_fallback_locks` dict in `TurnRunner.run()` and `_standalone_locks` in `boot.py`.

**Root cause:** Each `run()` call appends to `_fallback_locks` (a closure dict) which grows unbounded. In the standalone path, `_standalone_locks` in `boot.py` is similarly unbounded.

## Fix

- `_evict_fallback_lock()` — evict-on-read via key removal + Phase 2 (cap-based) purge of stale entries when over `_FALLBACK_LOCK_MAX_ENTRIES`
- `_purge_fallback_locks()` — evict-on-write: full clear with count
- `set_per_session_lock_dict()` — new public setter for standalone lock dict
- `_FALLBACK_LOCK_MAX_ENTRIES=200` constant
- `hasattr` guard in boot.py for `FakeTurnRunner` test compatibility

## Test Plan

| Class | Test | Criterion |
|---|---|---|
| `TestEvictFallbackLock` | `test_evicts_existing_key` | Key is removed from dict |
| | `test_evict_nonexistent_key_is_noop` | Missing key is safe |
| | `test_purges_stale_when_over_max` | Phase 2 cap eviction when past limit |
| | `test_max_not_reached_no_purge` | Below limit, no purge |
| | `test_boundary_at_max` | Exactly at max is preserved |
| | `test_boundary_over_max_triggers_purge` | N+1 triggers purge |
| | `test_custom_now` | `now` param is respected |
| | `test_ttl_not_triggered_below_cap` | TTL not checked when below cap |
| | `test_purges_only_stale_not_fresh` | Fresh entries survive cap purge |
| `TestPurgeFallbackLocks` | `test_purge_removes_all` | Purge clears dict |
| | `test_purge_empty` | Empty dict returns 0 |
| `TestTurnRunner...` | `test_run_creates_and_evicts` | Lock minted then evicted via _evict_fallback_lock |
| | `test_multiple_sessions_independent` | Multiple sessions clean up |
| | `test_concurrent_50_sessions` | 50 concurrent sessions — no leak |
| | `test_purge_after_run` | _purge_fallback_locks after run |
| | `test_reentry_path_does_not_leak` | Caller-held lock also evicted |

Closes #1040