### PR TITLE
fix(engine): bound CacheBreakMonitor._baselines cache (Closes #1111)

### DIFF
--- a/src/agentos/engine/cache_break_monitor.py
+++ b/src/agentos/engine/cache_break_monitor.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from agentos.provider import ChatConfig, Message, ToolDefinition
 
+_BASELINE_CACHE_MAX: int = 2000
+
 
 def _jsonable(value: Any) -> Any:
     """Return a stable JSON-ish shape for Pydantic models and dataclasses."""
@@ -197,6 +199,7 @@ class CacheBreakMonitor:
         previous = self._baselines.get(session_key)
         reset_pending = session_key in self._reset_pending
         self._baselines[session_key] = _CacheBaseline(snapshot, current_tokens)
+        self._evict_stale_baselines()
         if reset_pending:
             self._reset_pending.discard(session_key)
             return CacheBreakReport(
@@ -235,6 +238,18 @@ class CacheBreakMonitor:
     def notify_compaction(self, session_key: str) -> None:
         """Treat the next provider response for this session as a new baseline."""
         self._reset_pending.add(session_key)
+
+    def _evict_stale_baselines(self) -> None:
+        """Evict oldest entries when cache exceeds max."""
+        if len(self._baselines) > _BASELINE_CACHE_MAX:
+            excess = len(self._baselines) - _BASELINE_CACHE_MAX
+            for key in list(self._baselines.keys())[:excess]:
+                del self._baselines[key]
+
+    def purge_session(self, session_key: str) -> None:
+        """Evict a specific session baseline."""
+        self._baselines.pop(session_key, None)
+        self._reset_pending.discard(session_key)
 
     def clear(self) -> None:
         self._baselines.clear()

--- a/tests/test_engine/test_cache_baseline_eviction.py
+++ b/tests/test_engine/test_cache_baseline_eviction.py
@@ -1,0 +1,140 @@
+"""CacheBreakMonitor._baselines eviction tests — 2-phase."""
+
+from __future__ import annotations
+
+from agentos.engine.cache_break_monitor import (
+    _BASELINE_CACHE_MAX,
+    CacheBreakMonitor,
+)
+from agentos.provider import ChatConfig
+
+
+def _snapshot(monitor: CacheBreakMonitor) -> object:
+    return monitor.record_prompt_state(
+        messages=[],
+        tools=None,
+        config=ChatConfig(),
+        model="m",
+    )
+
+
+class TestEvictStaleBaselines:
+    """Unit: _evict_stale_baselines — Phase 2 (cap) eviction."""
+
+    def test_evicts_when_over_max(self) -> None:
+        monitor = CacheBreakMonitor()
+        for i in range(_BASELINE_CACHE_MAX + 10):
+            monitor._baselines[f"s-{i}"] = _snapshot(monitor)
+        monitor._evict_stale_baselines()
+        assert len(monitor._baselines) == _BASELINE_CACHE_MAX
+
+    def test_empty_is_fine(self) -> None:
+        monitor = CacheBreakMonitor()
+        monitor._evict_stale_baselines()
+        assert len(monitor._baselines) == 0
+
+    def test_at_max_is_fine(self) -> None:
+        monitor = CacheBreakMonitor()
+        for i in range(_BASELINE_CACHE_MAX):
+            monitor._baselines[f"s-{i}"] = _snapshot(monitor)
+        monitor._evict_stale_baselines()
+        assert len(monitor._baselines) == _BASELINE_CACHE_MAX
+
+    def test_under_max_is_fine(self) -> None:
+        monitor = CacheBreakMonitor()
+        for i in range(10):
+            monitor._baselines[f"s-{i}"] = _snapshot(monitor)
+        monitor._evict_stale_baselines()
+        assert len(monitor._baselines) == 10
+
+    def test_removes_oldest_first(self) -> None:
+        monitor = CacheBreakMonitor()
+        for i in range(_BASELINE_CACHE_MAX + 20):
+            monitor._baselines[f"s-{i}"] = _snapshot(monitor)
+        monitor._evict_stale_baselines()
+        assert "s-0" not in monitor._baselines
+        assert "s-19" not in monitor._baselines
+        last = f"s-{_BASELINE_CACHE_MAX + 19}"
+        assert last in monitor._baselines
+
+    def test_boundary_at_max(self) -> None:
+        monitor = CacheBreakMonitor()
+        for i in range(_BASELINE_CACHE_MAX):
+            monitor._baselines[f"s-{i}"] = _snapshot(monitor)
+        monitor._evict_stale_baselines()
+        assert len(monitor._baselines) == _BASELINE_CACHE_MAX
+
+    def test_boundary_one_over(self) -> None:
+        monitor = CacheBreakMonitor()
+        for i in range(_BASELINE_CACHE_MAX + 1):
+            monitor._baselines[f"s-{i}"] = _snapshot(monitor)
+        monitor._evict_stale_baselines()
+        assert len(monitor._baselines) == _BASELINE_CACHE_MAX
+
+
+class TestPurgeSession:
+    """Unit: purge_session — targeted eviction."""
+
+    def test_purge_removes_existing(self) -> None:
+        monitor = CacheBreakMonitor()
+        monitor._baselines["target"] = _snapshot(monitor)
+        monitor.purge_session("target")
+        assert "target" not in monitor._baselines
+
+    def test_purge_removes_reset_pending(self) -> None:
+        monitor = CacheBreakMonitor()
+        monitor._baselines["s1"] = _snapshot(monitor)
+        monitor._reset_pending.add("s1")
+        monitor.purge_session("s1")
+        assert "s1" not in monitor._reset_pending
+
+    def test_purge_nonexistent_is_noop(self) -> None:
+        monitor = CacheBreakMonitor()
+        monitor._baselines["s1"] = _snapshot(monitor)
+        monitor.purge_session("nonexistent")
+        assert "s1" in monitor._baselines
+
+
+class TestCheckResponseForCacheBreak:
+    """Integration: eviction triggered through real path."""
+
+    def test_eviction_triggered_on_insert(self) -> None:
+        monitor = CacheBreakMonitor()
+        s = _snapshot(monitor)
+        for i in range(_BASELINE_CACHE_MAX + 5):
+            monitor._baselines[f"s-{i}"] = s
+        # Next call triggers eviction
+        report = monitor.check_response_for_cache_break("trigger", s, 100)
+        assert report.baseline_reset is False
+        assert len(monitor._baselines) <= _BASELINE_CACHE_MAX
+
+    def test_creates_new_baseline_on_first_call(self) -> None:
+        monitor = CacheBreakMonitor()
+        s = _snapshot(monitor)
+        report = monitor.check_response_for_cache_break("first-key", s, 100)
+        assert "first-key" in monitor._baselines
+        assert report.reason == "baseline_initialized"
+
+    def test_updates_baseline_on_second_call(self) -> None:
+        monitor = CacheBreakMonitor()
+        s = _snapshot(monitor)
+        monitor.check_response_for_cache_break("sk", s, 100)
+        monitor.check_response_for_cache_break("sk", s, 100)
+        assert "sk" in monitor._baselines
+        assert len(monitor._baselines) == 1
+
+    def test_different_sessions_independent(self) -> None:
+        monitor = CacheBreakMonitor()
+        s = _snapshot(monitor)
+        monitor.check_response_for_cache_break("a", s, 100)
+        monitor.check_response_for_cache_break("b", s, 100)
+        assert len(monitor._baselines) == 2
+
+    def test_keeps_recent_sessions_after_eviction(self) -> None:
+        monitor = CacheBreakMonitor()
+        s = _snapshot(monitor)
+        for i in range(_BASELINE_CACHE_MAX + 10):
+            monitor._baselines[f"old-{i}"] = s
+        monitor.check_response_for_cache_break("recent", s, 100)
+        assert "recent" in monitor._baselines
+        assert len(monitor._baselines) == _BASELINE_CACHE_MAX


### PR DESCRIPTION
## Changes

Bound `CacheBreakMonitor._baselines` dict (unbounded per-session baseline cache in cache_break_monitor.py).

## Fix

- `_BASELINE_CACHE_MAX=2000` constant
- `_evict_stale_baselines()` — cap-based eviction (oldest-first)
- Wired into `check_response_for_cache_break()` after insertion (evict-on-write)
- `purge_session()` — targeted eviction for specific session

## Test Plan

| Class | Test | Criterion |
|---|---|---|
| `TestEvictStaleBaselines` | `test_evicts_when_over_max` | Evicts past cap |
| | `test_empty_is_fine` | Empty dict |
| | `test_at_max_is_fine` | Boundary: at cap |
| | `test_under_max_is_fine` | Below cap |
| | `test_removes_oldest_first` | LRU ordering |
| | `test_boundary_at_max` | N preserved |
| | `test_boundary_one_over` | N+1 evicts |
| `TestPurgeSession` | `test_purge_removes_existing` | Purge removes key |
| | `test_purge_removes_reset_pending` | Clears reset_pending too |
| | `test_purge_nonexistent_is_noop` | Missing key safe |
| `TestCheckResponseForCacheBreak` | `test_eviction_triggered_on_insert` | Evict-on-write |
| | `test_creates_new_baseline_on_first_call` | First call creates |
| | `test_updates_baseline_on_second_call` | Updates existing |
| | `test_different_sessions_independent` | Multiple keys |
| | `test_keeps_recent_sessions_after_eviction` | Recent sessions survive |

Closes #1111