### PR TITLE
fix(application): bound IntentApprovalCache._entries cache (Closes #1109)

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 
 _DEFAULT_TTL_SECONDS = 30 * 60
+_INTENT_CACHE_MAX: int = 2000
 _ALWAYS_TTL_SECONDS = 365 * 24 * 3600  # effectively never expires within a session
 
 
@@ -172,6 +173,7 @@ class IntentApprovalCache:
         with self._lock:
             for intent in intents:
                 self._entries[intent] = (expires, scope)
+            self._evict_stale_entries()
         return intents
 
     def record_always(self, command: str) -> list[tuple[str, str]]:
@@ -206,6 +208,24 @@ class IntentApprovalCache:
         with self._lock:
             for intent in intents:
                 self._entries.pop(intent, None)
+
+    def purge_session(self, intent: tuple[str, str]) -> None:
+        """Evict a specific intent entry."""
+        self._entries.pop(intent, None)
+
+    def _evict_stale_entries(self, *, now: float | None = None) -> None:
+        """Phase 1 (TTL) + Phase 2 (cap) eviction."""
+        if now is None:
+            now = time.monotonic()
+        # Phase 1: remove expired
+        for key, (expires, _scope) in list(self._entries.items()):
+            if expires < now:
+                del self._entries[key]
+        # Phase 2: trim if still over cap
+        if len(self._entries) > _INTENT_CACHE_MAX:
+            excess = len(self._entries) - _INTENT_CACHE_MAX
+            for key in list(self._entries.keys())[:excess]:
+                del self._entries[key]
 
     def clear(self) -> None:
         with self._lock:

--- a/tests/test_application/test_intent_cache_eviction.py
+++ b/tests/test_application/test_intent_cache_eviction.py
@@ -1,0 +1,123 @@
+"""IntentApprovalCache._entries eviction tests — 2-phase (TTL + cap)."""
+
+from __future__ import annotations
+
+from agentos.application.intent_cache import (
+    _INTENT_CACHE_MAX,
+    IntentApprovalCache,
+)
+
+
+class TestEvictStaleEntries:
+    """Unit: _evict_stale_entries — Phase 1 (TTL) + Phase 2 (cap)."""
+
+    def test_evicts_expired_entries(self) -> None:
+        cache = IntentApprovalCache()
+        cache._entries[("delete", "/a")] = (100.0, "once")
+        cache._entries[("delete", "/b")] = (200.0, "once")
+        cache._evict_stale_entries(now=150.0)
+        assert ("delete", "/a") not in cache._entries
+        assert ("delete", "/b") in cache._entries
+
+    def test_evicts_when_over_max(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 10):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache._evict_stale_entries(now=50000.0)
+        assert len(cache._entries) == _INTENT_CACHE_MAX
+
+    def test_empty_is_fine(self) -> None:
+        cache = IntentApprovalCache()
+        cache._evict_stale_entries(now=100.0)
+        assert len(cache._entries) == 0
+
+    def test_at_max_is_fine(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache._evict_stale_entries(now=50000.0)
+        assert len(cache._entries) == _INTENT_CACHE_MAX
+
+    def test_under_max_is_fine(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(10):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache._evict_stale_entries(now=50000.0)
+        assert len(cache._entries) == 10
+
+    def test_removes_oldest_first(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 20):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache._evict_stale_entries(now=50000.0)
+        assert ("k", "t-0") not in cache._entries
+        assert ("k", "t-19") not in cache._entries
+        assert ("k", f"t-{_INTENT_CACHE_MAX + 19}") in cache._entries
+
+    def test_boundary_at_max(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache._evict_stale_entries(now=50000.0)
+        assert len(cache._entries) == _INTENT_CACHE_MAX
+
+    def test_boundary_one_over(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 1):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache._evict_stale_entries(now=50000.0)
+        assert len(cache._entries) == _INTENT_CACHE_MAX
+
+
+class TestPurgeSession:
+    """Unit: purge_session — targeted eviction."""
+
+    def test_purge_removes_existing(self) -> None:
+        cache = IntentApprovalCache()
+        cache._entries[("delete", "/a")] = (99999.0, "once")
+        cache.purge_session(("delete", "/a"))
+        assert ("delete", "/a") not in cache._entries
+
+    def test_purge_nonexistent_is_noop(self) -> None:
+        cache = IntentApprovalCache()
+        cache._entries[("delete", "/a")] = (99999.0, "once")
+        cache.purge_session(("delete", "/b"))
+        assert ("delete", "/a") in cache._entries
+
+
+class TestRecord:
+    """Integration: record triggers eviction on write."""
+
+    def test_record_triggers_eviction(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 5):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache.record("rm /trigger")
+        assert len(cache._entries) <= _INTENT_CACHE_MAX
+
+    def test_record_multiple_targets(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 5):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache.record("rm /a /b /c")
+        assert len(cache._entries) <= _INTENT_CACHE_MAX
+
+    def test_record_always_same_eviction(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 5):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache.record_always("rm /target")
+        assert len(cache._entries) <= _INTENT_CACHE_MAX
+
+    def test_empty_command_noop(self) -> None:
+        cache = IntentApprovalCache()
+        result = cache.record("")
+        assert result == []
+
+    def test_recent_entries_survive_eviction(self) -> None:
+        cache = IntentApprovalCache()
+        for i in range(_INTENT_CACHE_MAX + 10):
+            cache._entries[("k", f"t-{i}")] = (99999.0, "once")
+        cache.record("rm /fresh-target")
+        # Windows normalizes /fresh-target to D:\fresh-target
+        assert any(k[0] == "delete" for k in cache._entries)


### PR DESCRIPTION
## Changes

Bound `IntentApprovalCache._entries` dict (unbounded per-target approval cache).

## Fix

- `_INTENT_CACHE_MAX=2000` constant
- `_evict_stale_entries()` — Phase 1 (TTL) + Phase 2 (cap) eviction with configurable `now`
- Wired into `record()` after insertion (evict-on-write)
- `purge_session()` — targeted eviction for specific intent
- All existing behavior preserved (TTL expiry, scope semantics, check/forget/clear)

## Test Plan

| Class | Test | Criterion |
|---|---|---|
| `TestEvictStaleEntries` | `test_evicts_expired_entries` | TTL Phase 1 expiry eviction |
| | `test_evicts_when_over_max` | Cap Phase 2 eviction |
| | `test_empty_is_fine` | Empty dict |
| | `test_at_max_is_fine` | Boundary: at cap |
| | `test_under_max_is_fine` | Below cap |
| | `test_removes_oldest_first` | LRU ordering |
| | `test_boundary_at_max` | N preserved |
| | `test_boundary_one_over` | N+1 evicts |
| `TestPurgeSession` | `test_purge_removes_existing` | Purge removes key |
| | `test_purge_nonexistent_is_noop` | Missing key safe |
| `TestRecord` | `test_record_triggers_eviction` | Evict-on-write |
| | `test_record_multiple_targets` | Multi-target record |
| | `test_record_always_same_eviction` | record_always path |
| | `test_empty_command_noop` | Empty command |
| | `test_recent_entries_survive_eviction` | Recent survive |

Closes #1109