### PR TITLE
fix(skills): guard holder analysis arguments

### DIFF
--- a/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
+++ b/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
@@ -3,6 +3,16 @@ import json, subprocess, sys, time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
+USAGE = f"Usage: {sys.argv[0]} <token_address> <chain> [zh|en]"
+
+if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help"):
+    print(USAGE)
+    sys.exit(0)
+
+if len(sys.argv) < 3:
+    print(USAGE, file=sys.stderr)
+    sys.exit(2)
+
 TOKEN_ADDR = sys.argv[1]
 CHAIN      = sys.argv[2]
 LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'

--- a/tests/test_skill_gmgn_holder_analysis.py
+++ b/tests/test_skill_gmgn_holder_analysis.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "src"
+    / "agentos"
+    / "skills"
+    / "bundled"
+    / "gmgn-holder-analysis"
+    / "scripts"
+    / "analyze.py"
+)
+
+
+@pytest.mark.parametrize("args", [[], ["0x1234"]])
+def test_missing_required_arguments_prints_usage_without_traceback(args: list[str]) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "Usage:" in result.stderr
+    assert "<token_address> <chain>" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+def test_help_prints_usage_without_running_analysis(flag: str) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), flag],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "<token_address> <chain>" in result.stdout
+    assert result.stderr == ""
+    assert "Traceback" not in result.stdout


### PR DESCRIPTION
## Linked issue

Fixes #1087

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

- Handle `-h` and `--help` before reading positional arguments, printing usage to stdout with exit code 0.
- Handle a missing token or chain before reading `sys.argv`, printing usage to stderr with exit code 2 and no traceback.
- Keep the existing 400+ line analysis implementation byte-for-byte unchanged beyond the 10-line argument guard.

Compared with #1088, this intentionally uses a narrowly scoped runtime diff instead of reformatting the full script. The regression tests exercise the real script in subprocesses and verify exit status, stdout/stderr routing, and absence of tracebacks for all four entry paths.

## Tests

- `uv run pytest tests/test_skill_gmgn_holder_analysis.py -q` — 4 passed.
- The no-argument and `--help` reproductions both exit 1 with `IndexError` on clean `origin/main`; the new tests cover those failures plus the one-argument and `-h` variants.
- `uv run python scripts/build_control_ui.py build` — passed (the host has no standalone `python` shim, so the repository script was invoked through uv).
- `npm --prefix frontend run check -- --maxWorkers=4` — 99 files / 2041 tests passed. Two earlier full-concurrency runs each exposed a different timing-only frontend test failure; both affected tests passed in isolation and in the bounded-worker rerun.
- `uv run ruff check src tests` — passed.
- `uv run mypy src/agentos --show-error-codes` — passed (622 source files).
- `uv run pytest -q` — 9331 passed, 32 skipped; 6 failures and 3 setup errors are reproduced unchanged on clean `origin/main` and come from unhydrated Git LFS ONNX pointers plus host `uv 0.8.15` not supporting the test helper's `uv build --clear` flag.
- `uv build --wheel` — passed; built `use_agent_os-2026.9.4-py3-none-any.whl`.
- `git diff --check` — passed.

Third-party origin: none.
