### PR TITLE
fix(engine): bound usage scope tracking with LRU eviction

### DIFF
--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from collections import OrderedDict
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -377,6 +378,7 @@ class UsageTracker:
         db_path: str | None = None,
         *,
         ledger_db_path: str | None = None,
+        max_scope_entries: int = 2000,
     ) -> None:
         """
         ``db_path`` backs the detailed ``usage_records`` history.
@@ -391,7 +393,8 @@ class UsageTracker:
         """
         global _global_usage_tracker
         self._sessions: dict[str, SessionUsage] = {}
-        self._scopes: dict[tuple[str, str], SessionUsage] = {}
+        self._scopes: OrderedDict[tuple[str, str], SessionUsage] = OrderedDict()
+        self._max_scope_entries = max(1, int(max_scope_entries))
         self._default_provider_id = str(default_provider_id or "").strip().lower()
         self._db_path = db_path
         self._ledger_db_path = ledger_db_path
@@ -728,10 +731,11 @@ class UsageTracker:
             usage.model_id = model_id
         scope_key = _current_usage_scope.get()
         if scope_key:
-            scoped = self._scopes.get((session_key, scope_key))
+            cache_key = (session_key, scope_key)
+            scoped = self._scopes.get(cache_key)
             if scoped is None:
                 scoped = SessionUsage(model_id=model_id, provider_id=effective_provider_id)
-                self._scopes[(session_key, scope_key)] = scoped
+                self._scopes[cache_key] = scoped
             scoped.add(
                 input_tokens,
                 output_tokens,
@@ -743,6 +747,9 @@ class UsageTracker:
             )
             if model_id:
                 scoped.model_id = model_id
+            self._scopes.move_to_end(cache_key)
+            while len(self._scopes) > self._max_scope_entries:
+                self._scopes.popitem(last=False)
 
         # Calculate incremental cost
         price = lookup_price(model_id, provider_id=effective_provider_id)
@@ -877,7 +884,11 @@ class UsageTracker:
 
     def get_scope(self, session_key: str, scope_key: str) -> SessionUsage | None:
         """Return accumulated usage for a session within one attribution scope."""
-        return self._scopes.get((session_key, scope_key))
+        cache_key = (session_key, scope_key)
+        usage = self._scopes.get(cache_key)
+        if usage is not None:
+            self._scopes.move_to_end(cache_key)
+        return usage
 
     def session_snapshot(self, session_key: str) -> SessionTotalsSnapshot | None:
         """Return the current SessionTotalsSnapshot for *session_key*, or None if unknown."""

--- a/tests/test_engine/test_usage_tracker.py
+++ b/tests/test_engine/test_usage_tracker.py
@@ -10,7 +10,7 @@ from agentos.engine.pricing import (
     reset_live_price_cache_for_tests,
     seed_opencap_price_cache,
 )
-from agentos.engine.usage import ModelUsage, SessionUsage, UsageTracker
+from agentos.engine.usage import ModelUsage, SessionUsage, UsageTracker, usage_scope
 
 
 @pytest.fixture(autouse=True)
@@ -186,6 +186,61 @@ def test_usage_tracker_isolates_sessions() -> None:
     assert a.cache_write_tokens == 5
     assert b.cache_read_tokens == 70
     assert b.cache_write_tokens == 15
+
+
+def test_usage_scope_cache_evicts_the_least_recently_updated_entry() -> None:
+    tracker = UsageTracker(max_scope_entries=2)
+
+    with usage_scope("first"):
+        tracker.add("session-a", 1, 0)
+    with usage_scope("second"):
+        tracker.add("session-a", 1, 0)
+
+    assert len(tracker._scopes) == 2
+
+    with usage_scope("first"):
+        tracker.add("session-a", 1, 0)
+    with usage_scope("third"):
+        tracker.add("session-a", 1, 0)
+
+    first = tracker.get_scope("session-a", "first")
+    total = tracker.get("session-a")
+    assert first is not None
+    assert first.input_tokens == 2
+    assert tracker.get_scope("session-a", "second") is None
+    assert tracker.get_scope("session-a", "third") is not None
+    assert len(tracker._scopes) == 2
+    assert total is not None
+    assert total.input_tokens == 4
+
+
+def test_usage_scope_cache_reads_refresh_recency() -> None:
+    tracker = UsageTracker(max_scope_entries=2)
+
+    with usage_scope("first"):
+        tracker.add("session-a", 1, 0)
+    with usage_scope("second"):
+        tracker.add("session-a", 1, 0)
+
+    assert tracker.get_scope("session-a", "first") is not None
+
+    with usage_scope("third"):
+        tracker.add("session-a", 1, 0)
+
+    assert tracker.get_scope("session-a", "first") is not None
+    assert tracker.get_scope("session-a", "second") is None
+    assert tracker.get_scope("session-a", "third") is not None
+
+
+def test_usage_scope_cache_normalizes_non_positive_capacity() -> None:
+    tracker = UsageTracker(max_scope_entries=0)
+
+    with usage_scope("first"):
+        tracker.add("session-a", 1, 0)
+    with usage_scope("second"):
+        tracker.add("session-a", 1, 0)
+
+    assert list(tracker._scopes) == [("session-a", "second")]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Linked issue

Fixes #1098

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

- Bound only `UsageTracker._scopes` with a configurable, keyword-only `max_scope_entries=2000` capacity.
- Use `OrderedDict` recency semantics: both an actual scoped `add()` and a successful `get_scope()` move the entry to MRU before overflow evicts the LRU entry.
- Preserve the lifetime aggregate in `_sessions`; evicting attribution detail does not reduce session totals.
- Normalize non-positive capacities to one and keep exact-capacity behavior stable.

Compared with #1099, this keeps #1084's `_session_metadata` concern out of this PR, makes the limit constructor-configurable for deterministic tests, and implements true LRU rather than insertion-order eviction. On the current #1099 head, refreshing `scope-0` before inserting `scope-new` still evicts `scope-0`; this implementation keeps `scope-0` and evicts the untouched `scope-1`. The tests use the public `usage_scope()` context and real `UsageTracker.add()` path instead of populating the private cache with placeholder objects.

## Tests

- `uv run pytest tests/test_engine/test_usage_tracker.py tests/test_provider_auxiliary.py -q` — 55 passed.
- Clean `origin/main` rejects the new constructor argument and has no eviction; the current #1099 head reproduces insertion-order eviction (`scope-0 retained after update: False`). The same 2002-call reproduction passes here with `scope-0` retained, `scope-1` evicted, 2000 scoped entries, and 2002 tokens preserved in the session total.
- `uv run python scripts/build_control_ui.py build` — passed.
- `npm --prefix frontend run check -- --maxWorkers=4` — 99 files / 2041 tests passed.
- `uv run ruff check src tests` — passed.
- `uv run mypy src/agentos --show-error-codes` — passed (622 source files).
- `uv run pytest -q` — 9330 passed, 32 skipped; the same 6 failures and 3 setup errors reproduce on clean `origin/main` because this checkout has Git LFS ONNX pointer files and host `uv 0.8.15` lacks the test helper's `uv build --clear` option.
- `uv build --wheel` — passed; built `use_agent_os-2026.9.4-py3-none-any.whl`.
- `git diff --check` — passed.

Third-party origin: none.
