### PR TITLE
fix(engine): bound cache-break baselines with LRU eviction

### DIFF
--- a/src/agentos/engine/cache_break_monitor.py
+++ b/src/agentos/engine/cache_break_monitor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -151,11 +152,18 @@ class _CacheBaseline:
 class CacheBreakMonitor:
     """Track cache-read drops and attribute them to prompt-state changes."""
 
-    def __init__(self, *, min_drop_tokens: int = 2000, min_drop_ratio: float = 0.05) -> None:
-        self._baselines: dict[str, _CacheBaseline] = {}
+    def __init__(
+        self,
+        *,
+        min_drop_tokens: int = 2000,
+        min_drop_ratio: float = 0.05,
+        max_baselines: int = 2000,
+    ) -> None:
+        self._baselines: OrderedDict[str, _CacheBaseline] = OrderedDict()
         self._reset_pending: set[str] = set()
         self._min_drop_tokens = max(0, int(min_drop_tokens))
         self._min_drop_ratio = max(0.0, float(min_drop_ratio))
+        self._max_baselines = max(1, int(max_baselines))
 
     def record_prompt_state(
         self,
@@ -197,6 +205,10 @@ class CacheBreakMonitor:
         previous = self._baselines.get(session_key)
         reset_pending = session_key in self._reset_pending
         self._baselines[session_key] = _CacheBaseline(snapshot, current_tokens)
+        self._baselines.move_to_end(session_key)
+        while len(self._baselines) > self._max_baselines:
+            evicted_session, _ = self._baselines.popitem(last=False)
+            self._reset_pending.discard(evicted_session)
         if reset_pending:
             self._reset_pending.discard(session_key)
             return CacheBreakReport(
@@ -234,7 +246,13 @@ class CacheBreakMonitor:
 
     def notify_compaction(self, session_key: str) -> None:
         """Treat the next provider response for this session as a new baseline."""
-        self._reset_pending.add(session_key)
+        if session_key in self._baselines:
+            self._reset_pending.add(session_key)
+
+    def purge_session(self, session_key: str) -> None:
+        """Discard all cache-break state for one session."""
+        self._baselines.pop(session_key, None)
+        self._reset_pending.discard(session_key)
 
     def clear(self) -> None:
         self._baselines.clear()

--- a/tests/test_engine/test_cache_break_monitor.py
+++ b/tests/test_engine/test_cache_break_monitor.py
@@ -13,6 +13,15 @@ def _tool(name: str) -> ToolDefinition:
     )
 
 
+def _snapshot(monitor: CacheBreakMonitor, system: str = "stable system"):
+    return monitor.record_prompt_state(
+        messages=[Message(role="user", content="old"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system=system),
+        model="model-a",
+    )
+
+
 def test_cache_break_monitor_initializes_then_detects_attributed_drop() -> None:
     monitor = CacheBreakMonitor(min_drop_tokens=10, min_drop_ratio=0.05)
     first = monitor.record_prompt_state(
@@ -125,6 +134,63 @@ def test_cache_break_monitor_resets_baseline_after_compaction() -> None:
     assert report.break_detected is False
     assert report.reason == "baseline_reset_after_compaction"
     assert report.baseline_reset is True
+
+
+def test_cache_break_monitor_evicts_the_least_recently_updated_baseline() -> None:
+    monitor = CacheBreakMonitor(max_baselines=2)
+    snapshot = _snapshot(monitor)
+
+    monitor.check_response_for_cache_break("first", snapshot, 100)
+    monitor.check_response_for_cache_break("second", snapshot, 100)
+    assert len(monitor._baselines) == 2
+
+    monitor.check_response_for_cache_break("first", snapshot, 90)
+    monitor.check_response_for_cache_break("third", snapshot, 100)
+
+    assert list(monitor._baselines) == ["first", "third"]
+
+
+def test_cache_break_monitor_eviction_removes_pending_reset_marker() -> None:
+    monitor = CacheBreakMonitor(max_baselines=2)
+    snapshot = _snapshot(monitor)
+    monitor.check_response_for_cache_break("first", snapshot, 100)
+    monitor.check_response_for_cache_break("second", snapshot, 100)
+    monitor.notify_compaction("first")
+
+    monitor.check_response_for_cache_break("third", snapshot, 100)
+
+    assert "first" not in monitor._baselines
+    assert "first" not in monitor._reset_pending
+
+
+def test_cache_break_monitor_ignores_compaction_for_unknown_session() -> None:
+    monitor = CacheBreakMonitor(max_baselines=2)
+
+    for index in range(10):
+        monitor.notify_compaction(f"unknown-{index}")
+
+    assert monitor._reset_pending == set()
+
+
+def test_cache_break_monitor_purge_session_removes_baseline_and_marker() -> None:
+    monitor = CacheBreakMonitor()
+    monitor.check_response_for_cache_break("session", _snapshot(monitor), 100)
+    monitor.notify_compaction("session")
+
+    monitor.purge_session("session")
+
+    assert "session" not in monitor._baselines
+    assert "session" not in monitor._reset_pending
+
+
+def test_cache_break_monitor_normalizes_non_positive_capacity() -> None:
+    monitor = CacheBreakMonitor(max_baselines=0)
+    snapshot = _snapshot(monitor)
+
+    monitor.check_response_for_cache_break("first", snapshot, 100)
+    monitor.check_response_for_cache_break("second", snapshot, 100)
+
+    assert list(monitor._baselines) == ["second"]
 
 
 def test_notify_compaction_notifies_registered_listeners() -> None:


### PR DESCRIPTION
## Linked issue

Fixes #1111

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

- Bound `CacheBreakMonitor._baselines` with a keyword-only, configurable `max_baselines=2000` limit and true `OrderedDict` LRU semantics.
- Move a session to MRU whenever its response updates the baseline, so active sessions survive pressure.
- Remove the matching compaction reset marker whenever a baseline is evicted.
- Ignore compaction notifications for sessions without a baseline, preventing `_reset_pending` from becoming a second unbounded collection.
- Add `purge_session()` to remove both pieces of per-session state while retaining the existing `clear()` behavior.

Compared with #1112, this distinguishes recency from insertion order and bounds the reset-marker set as part of the same invariant. On the current #1112 head, updating `session-0` before adding a new session still evicts `session-0`; its pending marker remains after eviction, and ten unknown compaction notifications retain ten additional markers. This implementation keeps the active baseline, evicts the actual LRU entry, and leaves no orphan or unknown markers.

## Tests

- `uv run pytest tests/test_engine/test_cache_break_monitor.py -q` — 11 passed, covering true LRU hits, exact capacity, marker cleanup, unknown compaction, per-session purge, capacity normalization, and the existing cache-break report/reset paths.
- The LRU/orphan-marker reproduction fails on the current #1112 head (`session-0 retained: False`, evicted marker retained, 10 unknown markers retained) and passes here.
- `uv run python scripts/build_control_ui.py build` — passed.
- `npm --prefix frontend run check -- --maxWorkers=4` — 99 files / 2041 tests passed.
- `uv run ruff check src tests` — passed.
- `uv run mypy src/agentos --show-error-codes` — passed (622 source files).
- `uv run pytest -q` — 9332 passed, 32 skipped; the same 6 failures and 3 setup errors reproduce on clean `origin/main` because this checkout has Git LFS ONNX pointer files and host `uv 0.8.15` lacks the test helper's `uv build --clear` option.
- `uv build --wheel` — passed; built `use_agent_os-2026.9.4-py3-none-any.whl`.
- `git diff --check` — passed.

Third-party origin: none.
