### PR TITLE
fix(tools): preserve CRLF line endings and fix context matching in apply_patch

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -450,7 +450,14 @@ def _gate_patch_ops(
 # ---------------------------------------------------------------------------
 
 
-def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
+def _detect_newline(lines: list[str]) -> str:
+    for line in lines:
+        if line.endswith("\r\n"):
+            return "\r\n"
+    return "\n"
+
+
+def _apply_hunk(file_lines: list[str], hunk: Hunk, newline: str = "\n") -> list[str]:
     """Apply a single hunk to file_lines (0-indexed list of lines with newlines).
 
     Returns the new list of lines.
@@ -469,8 +476,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         if prefix in (" ", "-"):
             if check_pos >= len(result):
                 raise ValueError(f"Hunk context/delete at line {check_pos + 1} exceeds file length")
-            actual = result[check_pos].rstrip("\n")
-            expected = content.rstrip("\n")
+            actual = result[check_pos].rstrip("\r\n")
+            expected = content.rstrip("\r\n")
             if actual != expected:
                 raise ValueError(
                     f"Context mismatch at line {check_pos + 1}: "
@@ -492,11 +499,9 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         elif prefix == "-":
             src_pos += 1  # skip (delete)
         elif prefix == "+":
-            # Preserve newline style: add \n if original lines have it
-            if content.endswith("\n"):
-                new_lines.append(content)
-            else:
-                new_lines.append(content + "\n")
+            # Preserve newline style: use file's newline convention
+            clean = content.rstrip("\r\n")
+            new_lines.append(clean + newline)
 
     # Splice: replace [pos : pos + old_count] with new_lines
     return result[:pos] + new_lines + result[pos + hunk.old_count :]
@@ -507,14 +512,15 @@ def _apply_update(path: str, hunks: list[Hunk], root: Path | None = None) -> Non
     if not resolved.exists():
         raise FileNotFoundError(f"File not found for update: {path}")
 
-    text = resolved.read_text(encoding="utf-8")
+    text = resolved.read_bytes().decode("utf-8")
     lines = text.splitlines(keepends=True)
+    newline = _detect_newline(lines)
 
     # Apply hunks in reverse order so earlier line numbers stay valid
     for hunk in sorted(hunks, key=lambda h: h.old_start, reverse=True):
-        lines = _apply_hunk(lines, hunk)
+        lines = _apply_hunk(lines, hunk, newline=newline)
 
-    resolved.write_text("".join(lines), encoding="utf-8")
+    resolved.write_bytes("".join(lines).encode("utf-8"))
 
 
 def _apply_add(path: str, content: str, root: Path | None = None) -> None:
@@ -522,7 +528,7 @@ def _apply_add(path: str, content: str, root: Path | None = None) -> None:
     if resolved.exists():
         raise FileExistsError(f"File already exists: {path}")
     resolved.parent.mkdir(parents=True, exist_ok=True)
-    resolved.write_text(content, encoding="utf-8")
+    resolved.write_bytes(content.encode("utf-8"))
 
 
 def _apply_delete(path: str, root: Path | None = None) -> None:
@@ -582,7 +588,7 @@ def _apply_ops(ops: list[PatchOp], root: Path | None = None) -> tuple[int, int, 
     record_payload=False,
 )
 async def apply_patch(patch: str, approval_id: str | None = None) -> str:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     root = _default_patch_root()
     ops = _parse_patch(patch)
     blocked = _gate_patch_ops(patch, ops, root, approval_id)

--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -451,9 +451,16 @@ def _gate_patch_ops(
 
 
 def _detect_newline(lines: list[str]) -> str:
+    """Detect predominant newline convention from lines (\r\n vs \n). Defaults to \n."""
+    crlf_count = 0
+    lf_count = 0
     for line in lines:
         if line.endswith("\r\n"):
-            return "\r\n"
+            crlf_count += 1
+        elif line.endswith("\n"):
+            lf_count += 1
+    if crlf_count > lf_count:
+        return "\r\n"
     return "\n"
 
 

--- a/tests/test_tools/test_apply_patch_crlf.py
+++ b/tests/test_tools/test_apply_patch_crlf.py
@@ -1,0 +1,104 @@
+"""Regression tests for apply_patch line ending handling (CRLF / LF)."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import patch as patch_tool
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_updates_crlf_file(tmp_path: Path) -> None:
+    target = tmp_path / "crlf_file.py"
+    # Write file with explicit CRLF line endings
+    target.write_bytes(b"def greet():\r\n    print('hello')\r\n    return True\r\n")
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: crlf_file.py\n"
+        "@@@ -1,3 +1,3 @@@\n"
+        " def greet():\n"
+        "-    print('hello')\n"
+        "+    print('world')\n"
+        "     return True\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) modified" in result
+    raw_content = target.read_bytes()
+    assert b"\r\n" in raw_content
+    # Ensure no lone \n without \r
+    assert raw_content.replace(b"\r\n", b"") == b"def greet():    print('world')    return True"
+    assert raw_content == b"def greet():\r\n    print('world')\r\n    return True\r\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_preserves_lf_file(tmp_path: Path) -> None:
+    target = tmp_path / "lf_file.py"
+    # Write file with explicit LF line endings
+    target.write_bytes(b"def greet():\n    print('hello')\n    return True\n")
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: lf_file.py\n"
+        "@@@ -1,3 +1,3 @@@\n"
+        " def greet():\n"
+        "-    print('hello')\n"
+        "+    print('world')\n"
+        "     return True\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) modified" in result
+    raw_content = target.read_bytes()
+    assert b"\r" not in raw_content
+    assert raw_content == b"def greet():\n    print('world')\n    return True\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_crlf_addition_and_deletion(tmp_path: Path) -> None:
+    target = tmp_path / "multi_line_crlf.py"
+    target.write_bytes(b"line 1\r\nline 2\r\nline 3\r\nline 4\r\n")
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: multi_line_crlf.py\n"
+        "@@@ -1,4 +1,4 @@@\n"
+        " line 1\n"
+        "-line 2\n"
+        "-line 3\n"
+        "+line 2 modified\n"
+        "+line 2.5 inserted\n"
+        " line 4\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) modified" in result
+    raw_content = target.read_bytes()
+    assert raw_content == b"line 1\r\nline 2 modified\r\nline 2.5 inserted\r\nline 4\r\n"

--- a/tests/test_tools/test_apply_patch_crlf.py
+++ b/tests/test_tools/test_apply_patch_crlf.py
@@ -1,4 +1,9 @@
-"""Regression tests for apply_patch line ending handling (CRLF / LF)."""
+"""Regression tests for apply_patch line ending handling (CRLF / LF).
+
+Addresses issue #1124: apply_patch must preserve the target file's native
+newline convention (CRLF vs LF) during update operations without rewriting
+untouched lines or corrupting line endings.
+"""
 
 from __future__ import annotations
 
@@ -16,9 +21,9 @@ def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitabl
 
 
 @pytest.mark.asyncio
-async def test_apply_patch_updates_crlf_file(tmp_path: Path) -> None:
+async def test_apply_patch_updates_crlf_file_preserves_crlf_bytes(tmp_path: Path) -> None:
+    """CRLF file updated via apply_patch preserves CRLF line endings on all lines."""
     target = tmp_path / "crlf_file.py"
-    # Write file with explicit CRLF line endings
     target.write_bytes(b"def greet():\r\n    print('hello')\r\n    return True\r\n")
 
     token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
@@ -47,9 +52,9 @@ async def test_apply_patch_updates_crlf_file(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_apply_patch_preserves_lf_file(tmp_path: Path) -> None:
+async def test_apply_patch_preserves_lf_file_bytes(tmp_path: Path) -> None:
+    """LF file updated via apply_patch preserves LF line endings and contains no CR."""
     target = tmp_path / "lf_file.py"
-    # Write file with explicit LF line endings
     target.write_bytes(b"def greet():\n    print('hello')\n    return True\n")
 
     token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
@@ -77,6 +82,7 @@ async def test_apply_patch_preserves_lf_file(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_apply_patch_crlf_addition_and_deletion(tmp_path: Path) -> None:
+    """Multi-line additions and deletions on CRLF files use CRLF newlines."""
     target = tmp_path / "multi_line_crlf.py"
     target.write_bytes(b"line 1\r\nline 2\r\nline 3\r\nline 4\r\n")
 
@@ -102,3 +108,111 @@ async def test_apply_patch_crlf_addition_and_deletion(tmp_path: Path) -> None:
     assert "1 file(s) modified" in result
     raw_content = target.read_bytes()
     assert raw_content == b"line 1\r\nline 2 modified\r\nline 2.5 inserted\r\nline 4\r\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_mixed_endings_predominant_crlf(tmp_path: Path) -> None:
+    """File with predominantly CRLF line endings detects CRLF and formats added lines with CRLF."""
+    target = tmp_path / "mixed_crlf.py"
+    target.write_bytes(b"a\r\nb\r\nc\nd\r\n")
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: mixed_crlf.py\n"
+        "@@@ -1,4 +1,4 @@@\n"
+        " a\n"
+        "-b\n"
+        "+b_new\n"
+        " c\n"
+        " d\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) modified" in result
+    raw_content = target.read_bytes()
+    assert raw_content == b"a\r\nb_new\r\nc\nd\r\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_mixed_endings_predominant_lf(tmp_path: Path) -> None:
+    """File with predominantly LF line endings detects LF and formats added lines with LF."""
+    target = tmp_path / "mixed_lf.py"
+    target.write_bytes(b"a\nb\nc\r\nd\n")
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: mixed_lf.py\n"
+        "@@@ -1,4 +1,4 @@@\n"
+        " a\n"
+        "-b\n"
+        "+b_new\n"
+        " c\n"
+        " d\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) modified" in result
+    raw_content = target.read_bytes()
+    assert raw_content == b"a\nb_new\nc\r\nd\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_empty_file_handling(tmp_path: Path) -> None:
+    """Empty file returns default LF newline convention on line addition."""
+    target = tmp_path / "empty.txt"
+    target.write_bytes(b"")
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: empty.txt\n"
+        "@@@ -1,0 +1,1 @@@\n"
+        "+first line\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) modified" in result
+    raw_content = target.read_bytes()
+    assert raw_content == b"first line\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_add_file_preserves_exact_lf_bytes(tmp_path: Path) -> None:
+    """_apply_add writes exact content bytes without injecting CRLF on any platform."""
+    target = tmp_path / "new_file.py"
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Add File: new_file.py\n"
+        "+line 1\n"
+        "+line 2\n"
+        "*** End Patch"
+    )
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "1 file(s) added" in result
+    raw_content = target.read_bytes()
+    assert b"\r" not in raw_content
+    assert raw_content == b"line 1\nline 2"


### PR DESCRIPTION
## Summary
Fixes a cross-platform bug in `apply_patch` where files with Windows CRLF (`\r\n`) line endings failed context verification and corrupted newline formatting.

## Problem
1. **Context Mismatch**: `_apply_hunk` previously stripped only `\n` via `result[check_pos].rstrip("\n")`. On files with CRLF line endings (`\r\n`), `actual` retained a trailing `\r`, which failed comparison (`actual != expected`) against normalized patch lines and threw `ValueError: Context mismatch at line X`.
2. **Newline Formatting Corruption**: Hunk insertions (`+`) hardcoded `\n`, producing mixed line endings on CRLF files.
3. **OS Line-Ending Translation**: `read_text()` / `write_text()` without explicit binary preservation allowed default OS line-ending translation to alter files unintentionally.

## Changes Made
- **Context Matching**: Stripped both `\r` and `\n` (`.rstrip("\r\n")`) for hunk context and deletion verification.
- **Newline Preservation**: Added `_detect_newline()` to detect target file line-ending convention (`\r\n` vs `\n`) and maintain it on hunk insertions.
- **Binary Read/Write**: Used binary read/write decoding (`read_bytes().decode("utf-8")` / `write_bytes()`) in `_apply_update` and `_apply_add` to eliminate OS-dependent newline translation.
- **Async Modernization**: Switched `asyncio.get_event_loop()` to `asyncio.get_running_loop()` inside `apply_patch`.
- **Unit Tests**: Added comprehensive regression tests in `tests/test_tools/test_apply_patch_crlf.py` verifying CRLF updates, LF preservation, and multi-line additions/deletions.

## Verification
```sh
uv run pytest tests/test_tools/test_apply_patch_crlf.py tests/test_tools/test_apply_patch_gates.py -q -v
# 35 passed in 4.39s

uv run ruff check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_crlf.py
# All checks passed!

uv run mypy src/agentos/tools/builtin/patch.py --show-error-codes
# Success: no issues found in 1 source file
closes #1124 