### PR TITLE
fix(provider): classify bankr & openai_responses as OpenAI-compatible (#1126)

### DIFF
--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -54,6 +54,8 @@ _OPENAI_COMPAT_PROVIDERS = {
     "vllm",
     "lm_studio",
     "ovms",
+    "bankr",
+    "openai_responses",
 }
 
 _GATEWAY_TRANSIENT_STATUS_CODES = {499, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529}

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -26,6 +26,8 @@ from agentos.provider.failures import ProviderFailureKind, classify_provider_err
         "vllm",
         "lm_studio",
         "ovms",
+        "bankr",
+        "openai_responses",
     ],
 )
 def test_openai_compatible_providers_share_common_failure_classification(provider: str) -> None:


### PR DESCRIPTION
## Linked issue

Fixes #1126

- [x] This pull request fully resolves the linked issue, or the description says what remains.

## Summary

Both `bankr` and `openai_responses` providers expose an OpenAI-compatible HTTP surface and produce the same error shapes (HTTP 401, 402, 429, 404, 400). Adding them to `_OPENAI_COMPAT_PROVIDERS` ensures `classify_provider_error` returns specific `ProviderFailureKind` values (`AUTH_INVALID`, `INSUFFICIENT_CREDITS`, `RATE_LIMITED`, `MODEL_NOT_FOUND`, `UNSUPPORTED_FEATURE`) instead of falling through to `UNKNOWN`, enabling runtime recovery actions (`FAIL_CONFIG`, `FALLBACK_PROVIDER`).

## Changes

| File | Change |
|------|--------|
| `src/agentos/provider/failures.py` | Add `"bankr"` and `"openai_responses"` to `_OPENAI_COMPAT_PROVIDERS` |
| `tests/test_provider_failure_classification.py` | Add test assertions for `"bankr"` and `"openai_responses"` |

## Tests

- `uv run pytest tests/test_provider_failure_classification.py -q` (108 passed)
- `uv run ruff check src/agentos/provider/failures.py tests/test_provider_failure_classification.py` (All checks passed)
- `uv run mypy src/agentos/provider/failures.py` (Success: no issues found)