### PR TITLE
fix(tools): preserve CRLF when apply_patch updates files (#1124)

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -450,11 +450,24 @@ def _gate_patch_ops(
 # ---------------------------------------------------------------------------
 
 
+def _detect_line_ending(file_lines: list[str]) -> str:
+    """Return the dominant newline style used in file_lines.
+
+    Returns "\r\n" when any line uses CRLF, otherwise "\n". Falls back to "\n"
+    for empty input (newly added files).
+    """
+    return "\r\n" if any(line.endswith("\r\n") for line in file_lines) else "\n"
+
+
 def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     """Apply a single hunk to file_lines (0-indexed list of lines with newlines).
 
-    Returns the new list of lines.
+    Returns the new list of lines. Tolerates CRLF/LF mismatches in the target
+    file by stripping any trailing newline from both actual and expected lines
+    before comparison, and uses the file's dominant newline style when
+    appending newly added lines.
     """
+    newline = _detect_line_ending(file_lines)
     # old_start is 1-indexed; convert to 0-indexed
     pos = hunk.old_start - 1
     result = list(file_lines)
@@ -469,8 +482,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         if prefix in (" ", "-"):
             if check_pos >= len(result):
                 raise ValueError(f"Hunk context/delete at line {check_pos + 1} exceeds file length")
-            actual = result[check_pos].rstrip("\n")
-            expected = content.rstrip("\n")
+            actual = result[check_pos].rstrip("\r\n")
+            expected = content.rstrip("\r\n")
             if actual != expected:
                 raise ValueError(
                     f"Context mismatch at line {check_pos + 1}: "
@@ -492,11 +505,12 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         elif prefix == "-":
             src_pos += 1  # skip (delete)
         elif prefix == "+":
-            # Preserve newline style: add \n if original lines have it
+            # Preserve newline style: if the line already ends with \n use as-is,
+            # otherwise append the file's dominant line ending.
             if content.endswith("\n"):
                 new_lines.append(content)
             else:
-                new_lines.append(content + "\n")
+                new_lines.append(content + newline)
 
     # Splice: replace [pos : pos + old_count] with new_lines
     return result[:pos] + new_lines + result[pos + hunk.old_count :]
@@ -507,14 +521,17 @@ def _apply_update(path: str, hunks: list[Hunk], root: Path | None = None) -> Non
     if not resolved.exists():
         raise FileNotFoundError(f"File not found for update: {path}")
 
-    text = resolved.read_text(encoding="utf-8")
+    # Read with newline="" so that CRLF line endings are preserved verbatim and
+    # the hunk applier can detect and respect the file's native newline style.
+    raw = resolved.read_bytes()
+    text = raw.decode("utf-8")
     lines = text.splitlines(keepends=True)
 
     # Apply hunks in reverse order so earlier line numbers stay valid
     for hunk in sorted(hunks, key=lambda h: h.old_start, reverse=True):
         lines = _apply_hunk(lines, hunk)
 
-    resolved.write_text("".join(lines), encoding="utf-8")
+    resolved.write_bytes("".join(lines).encode("utf-8"))
 
 
 def _apply_add(path: str, content: str, root: Path | None = None) -> None:

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -551,6 +551,58 @@ async def test_apply_patch_supports_hunk_header_without_explicit_counts(
     assert existing.read_text(encoding="utf-8") == "line1\nline2\n"
 
 
+@pytest.mark.asyncio
+async def test_apply_patch_handles_crlf_line_endings(tmp_path: Path) -> None:
+    """apply_patch must match context and preserve CRLF when the target file uses CRLF."""
+    existing = tmp_path / "hello.txt"
+    existing.write_bytes(b"line1\r\nline2\r\n")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: hello.txt
+@@@ -2 +2,2 @@@
+ line2
++inserted
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert existing.read_bytes() == b"line1\r\nline2\r\ninserted\r\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_added_line_uses_crlf_when_target_file_is_crlf(
+    tmp_path: Path,
+) -> None:
+    """Added lines written by apply_patch should use the target file's native line ending.
+
+    When the target file uses CRLF, an added line that lacks a trailing newline in
+    the patch text must be appended with CRLF rather than LF.
+    """
+    existing = tmp_path / "hello.txt"
+    existing.write_bytes(b"line1\r\nline2\r\n")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            "*** Begin Patch\n"
+            "*** Update File: hello.txt\n"
+            "@@@ -2 +2,2 @@@\n"
+            " line2\n"
+            "+line3-without-newline\n"
+            "*** End Patch"
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert existing.read_bytes() == b"line1\r\nline2\r\nline3-without-newline\r\n"
+
+
 @pytest.mark.parametrize(
     "header",
     [


### PR DESCRIPTION
## Linked issue

Fixes #1124

- [x] This pull request fully resolves the linked issue, or the description says what remains.

## Summary

When the target file uses CRLF (`\r\n`) line endings, `apply_patch` failed with `Context mismatch` because `_apply_hunk` only stripped trailing `\n` from context lines, leaving a stray `\r` on lines read from CRLF files. Additionally, any added line was hard-coded with a trailing `\n`, corrupting CRLF files with mixed line endings.

- Read the target file as raw bytes and decode explicitly so CRLF is preserved end-to-end (`read_text` uses universal newlines that would translate `\r\n` away before `_detect_line_ending` could observe it).
- `_apply_hunk` now strips both `\r` and `\n` from context and expected lines during match comparison.
- Added `_detect_line_ending` to choose the file's dominant line ending (CRLF if any line uses CRLF, otherwise LF) and use it when appending added lines that lacked a trailing newline.

## Changes

| File | Change |
|------|--------|
| `src/agentos/tools/builtin/patch.py` | Detect line endings, preserve CRLF during read/write, and strip both `\r` and `\n` in context comparison |
| `tests/test_tools/test_apply_patch_gates.py` | Add regression tests for CRLF context match and CRLF-preserving added lines |

## Tests

- `uv run pytest tests/test_tools/test_apply_patch_gates.py -q` (34 passed)
- `uv run ruff check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_gates.py` (All checks passed)
- `uv run mypy src/agentos/tools/builtin/patch.py` (Success: no issues found)