### PR TITLE
feat(util): introduce BoundedRegistry — shared bounded-dict primitive (#1131)

### DIFF
--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -218,11 +218,9 @@ class IntentApprovalCache:
     def clear_scope(self, scope: str) -> None:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
-            self._entries = {
-                intent: data
-                for intent, data in self._entries.items()
-                if data[1] != scope
-            }
+            to_drop = [intent for intent, data in self._entries.items() if data[1] == scope]
+            for intent in to_drop:
+                self._entries.discard(intent)
 
 
 _cache: IntentApprovalCache | None = None

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -22,6 +22,8 @@ import threading
 import time
 from pathlib import Path
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 _DEFAULT_TTL_SECONDS = 30 * 60
 _ALWAYS_TTL_SECONDS = 365 * 24 * 3600  # effectively never expires within a session
 
@@ -153,7 +155,9 @@ class IntentApprovalCache:
     def __init__(self, default_ttl: float = _DEFAULT_TTL_SECONDS) -> None:
         self._default_ttl = default_ttl
         # intent -> (expires_monotonic, scope)
-        self._entries: dict[tuple[str, str], tuple[float, str]] = {}
+        self._entries: BoundedRegistry[tuple[str, str], tuple[float, str]] = BoundedRegistry(
+            max_entries=500, ttl_seconds=3600
+        )
         self._lock = threading.Lock()
 
     def record(

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -693,7 +694,10 @@ class TelegramChannel:
         secret = self.config.webhook_secret_token
         if not secret:
             return Response(status_code=503)
-        if request.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
+        if not hmac.compare_digest(
+            request.headers.get("X-Telegram-Bot-Api-Secret-Token", ""),
+            secret,
+        ):
             return Response(status_code=401)
         try:
             update = await request.json()

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -694,10 +694,8 @@ class TelegramChannel:
         secret = self.config.webhook_secret_token
         if not secret:
             return Response(status_code=503)
-        if not hmac.compare_digest(
-            request.headers.get("X-Telegram-Bot-Api-Secret-Token", ""),
-            secret,
-        ):
+        header_token = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+        if not hmac.compare_digest(header_token.encode("utf-8"), secret.encode("utf-8")):
             return Response(status_code=401)
         try:
             update = await request.json()

--- a/src/agentos/engine/cache_break_monitor.py
+++ b/src/agentos/engine/cache_break_monitor.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agentos.provider import ChatConfig, Message, ToolDefinition
+from agentos.util.bounded_registry import BoundedRegistry
 
 
 def _jsonable(value: Any) -> Any:
@@ -152,7 +153,7 @@ class CacheBreakMonitor:
     """Track cache-read drops and attribute them to prompt-state changes."""
 
     def __init__(self, *, min_drop_tokens: int = 2000, min_drop_ratio: float = 0.05) -> None:
-        self._baselines: dict[str, _CacheBaseline] = {}
+        self._baselines: BoundedRegistry[str, _CacheBaseline] = BoundedRegistry(max_entries=500)
         self._reset_pending: set[str] = set()
         self._min_drop_tokens = max(0, int(min_drop_tokens))
         self._min_drop_ratio = max(0.0, float(min_drop_ratio))
@@ -196,7 +197,7 @@ class CacheBreakMonitor:
         current_tokens = max(0, int(cache_read_tokens or 0))
         previous = self._baselines.get(session_key)
         reset_pending = session_key in self._reset_pending
-        self._baselines[session_key] = _CacheBaseline(snapshot, current_tokens)
+        self._baselines.set(session_key, _CacheBaseline(snapshot, current_tokens))
         if reset_pending:
             self._reset_pending.discard(session_key)
             return CacheBreakReport(

--- a/src/agentos/engine/progress_watchdog.py
+++ b/src/agentos/engine/progress_watchdog.py
@@ -152,7 +152,8 @@ class ProgressWatchdog:
             key = signature.key
             previous = self._repeat_results.get(key)
             if previous is not None and previous == signature.result_hash:
-                self._repeat_counts[key] = self._repeat_counts.get(key, 1) + 1
+                cur = self._repeat_counts.get(key) or 1
+                self._repeat_counts[key] = cur + 1
             else:
                 # A different answer means the call earned its place.
                 self._repeat_counts[key] = 1

--- a/src/agentos/engine/progress_watchdog.py
+++ b/src/agentos/engine/progress_watchdog.py
@@ -24,6 +24,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 ProgressAction = Literal["observe", "warn", "block"]
 
 
@@ -112,8 +114,12 @@ class ProgressWatchdog:
         self._tool_error_count = 0
         self._last_provider_failure: str | None = None
         self._provider_failure_count = 0
-        self._repeat_counts: dict[tuple[str, str], int] = {}
-        self._repeat_results: dict[tuple[str, str], str] = {}
+        self._repeat_counts: BoundedRegistry[tuple[str, str], int] = BoundedRegistry(
+            max_entries=500
+        )
+        self._repeat_results: BoundedRegistry[tuple[str, str], str] = BoundedRegistry(
+            max_entries=500
+        )
 
     def observe(self, observation: ProgressObservation) -> ProgressDecision:
         # Checked before the progress test on purpose: a repeated *successful*

--- a/src/agentos/gateway/session_streams.py
+++ b/src/agentos/gateway/session_streams.py
@@ -6,6 +6,8 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 
 @dataclass(frozen=True)
 class BufferedSessionEvent:
@@ -29,10 +31,12 @@ class SessionStreamRegistry:
     session and survives reconnects long enough to replay recent run events.
     """
 
-    def __init__(self, *, max_events_per_session: int = 500) -> None:
+    def __init__(self, *, max_events_per_session: int = 500, max_sessions: int = 1000) -> None:
         self._max_events_per_session = max_events_per_session
-        self._seq_by_session: dict[str, int] = {}
-        self._events_by_session: dict[str, deque[BufferedSessionEvent]] = {}
+        self._seq_by_session: BoundedRegistry[str, int] = BoundedRegistry(max_entries=max_sessions)
+        self._events_by_session: BoundedRegistry[str, deque[BufferedSessionEvent]] = (
+            BoundedRegistry(max_entries=max_sessions)
+        )
 
     @staticmethod
     def _is_replay_lossy(event_name: str) -> bool:
@@ -52,7 +56,8 @@ class SessionStreamRegistry:
                 events.popleft()
 
     def current_seq(self, session_key: str) -> int:
-        return self._seq_by_session.get(session_key, 0)
+        val = self._seq_by_session.get(session_key)
+        return val if val is not None else 0
 
     def record(
         self,
@@ -61,14 +66,14 @@ class SessionStreamRegistry:
         payload: dict[str, Any] | None,
     ) -> dict[str, Any]:
         stream_seq = self.current_seq(session_key) + 1
-        self._seq_by_session[session_key] = stream_seq
+        self._seq_by_session.set(session_key, stream_seq)
 
         enriched = dict(payload or {})
         enriched["session_key"] = session_key
         enriched["stream_seq"] = stream_seq
 
         event = BufferedSessionEvent(event_name=event_name, payload=enriched, stream_seq=stream_seq)
-        events = self._events_by_session.setdefault(session_key, deque())
+        events = self._events_by_session.get_or_create(session_key, deque)
         events.append(event)
         self._trim_session_events(events)
         return enriched
@@ -78,7 +83,8 @@ class SessionStreamRegistry:
         if since_stream_seq is None:
             return ReplayResult(current_stream_seq=current, replay_complete=True, events=[])
 
-        events = list(self._events_by_session.get(session_key, ()))
+        raw_events = self._events_by_session.get(session_key)
+        events = list(raw_events) if raw_events is not None else []
         if current == 0:
             return ReplayResult(
                 current_stream_seq=0,
@@ -115,6 +121,12 @@ class SessionStreamRegistry:
             events=replay_events,
             gap_reason=None if replay_complete else "buffer_window_missed",
         )
+
+
+    def purge_session(self, session_key: str) -> None:
+        """Drop all state for a finished session."""
+        self._seq_by_session.discard(session_key)
+        self._events_by_session.discard(session_key)
 
 
 _session_streams = SessionStreamRegistry()

--- a/src/agentos/plan_mode.py
+++ b/src/agentos/plan_mode.py
@@ -25,6 +25,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 EXIT_PLAN_TOOL_NAME = "exit_plan_mode"
 
 # Status stamped on a successful exit_plan_mode payload. The dispatch
@@ -93,18 +95,22 @@ class PlanModeStore:
     explicit disable (approval, ``/plan off``) or a gateway restart clears it.
     """
 
-    def __init__(self) -> None:
-        self._sessions: dict[str, PlanModeState] = {}
+    def __init__(self, max_entries: int = 500) -> None:
+        self._sessions: BoundedRegistry[str, PlanModeState] = BoundedRegistry(
+            max_entries=max_entries, ttl_seconds=0.0
+        )
 
     def enable(self, session_key: str) -> None:
         key = (session_key or "").strip()
         if not key:
             raise ValueError("session_key is required")
-        self._sessions.setdefault(key, PlanModeState(enabled_at=time.time()))
+        existing = self._sessions.get(key)
+        if existing is None:
+            self._sessions.set(key, PlanModeState(enabled_at=time.time()))
 
     def disable(self, session_key: str) -> bool:
         """Turn plan mode off. Returns True when it was on."""
-        return self._sessions.pop((session_key or "").strip(), None) is not None
+        return self._sessions.discard((session_key or "").strip())
 
     def is_enabled(self, session_key: str) -> bool:
         return (session_key or "").strip() in self._sessions

--- a/src/agentos/sandbox/stale_output_cache.py
+++ b/src/agentos/sandbox/stale_output_cache.py
@@ -30,6 +30,8 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedRegistry
+
 
 @dataclass
 class _CacheEntry:
@@ -48,8 +50,10 @@ class StaleOutputCache:
     and purged on denial by :class:`DenialLedger`.
     """
 
-    def __init__(self) -> None:
-        self._entries: dict[tuple[str, str], _CacheEntry] = {}
+    def __init__(self, max_entries: int = 100) -> None:
+        self._entries: BoundedRegistry[tuple[str, str], _CacheEntry] = BoundedRegistry(
+            max_entries=max_entries, ttl_seconds=0.0
+        )
         self._lock = asyncio.Lock()
 
     async def record_success(self, session_id: str, fingerprint: str, payload: Any) -> None:
@@ -60,11 +64,14 @@ class StaleOutputCache:
         """
         async with self._lock:
             loop = asyncio.get_running_loop()
-            self._entries[(session_id, fingerprint)] = _CacheEntry(
-                fingerprint=fingerprint,
-                session_id=session_id,
-                payload=payload,
-                stored_at_monotonic=loop.time(),
+            self._entries.set(
+                (session_id, fingerprint),
+                _CacheEntry(
+                    fingerprint=fingerprint,
+                    session_id=session_id,
+                    payload=payload,
+                    stored_at_monotonic=loop.time(),
+                ),
             )
 
     async def purge(self, session_id: str, fingerprint: str) -> bool:
@@ -75,7 +82,7 @@ class StaleOutputCache:
         idempotent by design.
         """
         async with self._lock:
-            return self._entries.pop((session_id, fingerprint), None) is not None
+            return self._entries.discard((session_id, fingerprint))
 
     async def get(self, session_id: str, fingerprint: str) -> Any | None:
         """Return the stored payload or ``None`` if not cached."""
@@ -88,7 +95,7 @@ class StaleOutputCache:
         async with self._lock:
             keys = [k for k in self._entries if k[0] == session_id]
             for k in keys:
-                del self._entries[k]
+                self._entries.discard(k)
             return len(keys)
 
     def snapshot(self) -> list[dict[str, object]]:

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -51,6 +51,7 @@ from agentos.tools.types import (
     UnsupportedSurfaceError,
     current_tool_context,
 )
+from agentos.util.bounded_registry import BoundedRegistry
 
 log = structlog.get_logger(__name__)
 
@@ -90,7 +91,7 @@ PROCESS_ACTIONS: frozenset[str] = frozenset(
 )
 
 # Background process session store
-_bg_sessions: dict[str, _BgSession] = {}
+_bg_sessions: BoundedRegistry[str, _BgSession] = BoundedRegistry(max_entries=200, ttl_seconds=0.0)
 
 
 @dataclass
@@ -963,7 +964,7 @@ async def background_process(
             local_urls=_local_server_urls_from_command(command),
             cleanup_callbacks=spawned.cleanup_callbacks,
         )
-        _bg_sessions[session_id] = session
+        _bg_sessions.set(session_id, session)
         effective_timeout = _resolve_background_timeout(timeout)
 
         async def _collect_restricted() -> None:
@@ -1015,7 +1016,7 @@ async def background_process(
         agent_id=ctx.agent_id if ctx is not None else None,
         local_urls=_local_server_urls_from_command(command),
     )
-    _bg_sessions[session_id] = session
+    _bg_sessions.set(session_id, session)
     effective_timeout = _resolve_background_timeout(timeout)
 
     async def _collect_host() -> None:
@@ -1227,7 +1228,7 @@ async def process(
     if action == "remove":
         if not session.done:
             raise ToolError(f"Cannot remove running session: {session.session_id}")
-        del _bg_sessions[session.session_id]
+        _bg_sessions.discard(session.session_id)
         return json.dumps({"status": "removed", "action": action, "session_id": session.session_id})
 
     if action in {"write", "submit"}:

--- a/src/agentos/util/bounded_registry.py
+++ b/src/agentos/util/bounded_registry.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import time
 from collections import OrderedDict
 from threading import Lock
-from typing import TypeVar
+from typing import TypeVar, cast
 
 KT = TypeVar("KT")
 VT = TypeVar("VT")
@@ -29,19 +29,6 @@ _DEFAULT_MAX_ENTRIES = 500
 
 class BoundedRegistry[KT, VT]:
     """A dict-like bounded registry with LRU eviction and optional TTL.
-
-    Thread-safe for both sync and async callers (fast dict ops under a
-    ``threading.Lock``).
-
-    Parameters
-    ----------
-    max_entries:
-        Hard cap on the number of entries. When exceeded, oldest entries
-        (by insertion or last-set order) are evicted first. ``0`` disables
-        the cap (use with caution).
-    ttl_seconds:
-        Entries past this age (measured by ``time.monotonic``) are evicted
-        on the next mutating operation. ``0.0`` disables TTL eviction.
     """
 
     def __init__(
@@ -58,20 +45,15 @@ class BoundedRegistry[KT, VT]:
         self._lock = Lock()
         self._eviction_count = 0
 
-    # ── public API ────────────────────────────────────────────────
-
     def get(self, key: KT, default: VT | None = None) -> VT | None:
-        """Return the value for *key*, or *default*."""
         with self._lock:
             self._evict_stale()
-            raw = self._data.get(key, _MISSING)
-            if raw is _MISSING:
+            if key not in self._data:
                 return default
             self._data.move_to_end(key)
-            return raw
+            return self._data[key]
 
     def set(self, key: KT, value: VT) -> None:
-        """Insert or overwrite *key* -> *value*."""
         with self._lock:
             self._evict_stale()
             self._data[key] = value
@@ -80,7 +62,6 @@ class BoundedRegistry[KT, VT]:
             self._trim_to_fit()
 
     def discard(self, key: KT) -> bool:
-        """Remove *key* if present. Returns True when it existed."""
         with self._lock:
             was_present = key in self._data
             self._data.pop(key, None)
@@ -88,7 +69,6 @@ class BoundedRegistry[KT, VT]:
             return was_present
 
     def get_or_create(self, key: KT, factory: type[VT] | None = None) -> VT:
-        """Return the existing entry or create+store a new one."""
         with self._lock:
             self._evict_stale()
             try:
@@ -96,15 +76,16 @@ class BoundedRegistry[KT, VT]:
                 return self._data[key]
             except KeyError:
                 pass
-            value = (factory or type(None))() if factory is not None else None
-            self._data[key] = value
+            if factory is not None:
+                self._data[key] = factory()
+            else:
+                self._data[key] = cast(VT, None)
             self._data.move_to_end(key)
             self._timestamps[key] = time.monotonic()
             self._trim_to_fit()
-            return value
+            return self._data[key]
 
     def clear(self) -> int:
-        """Remove all entries. Returns the count of removed entries."""
         with self._lock:
             count = len(self._data)
             self._data.clear()
@@ -140,27 +121,22 @@ class BoundedRegistry[KT, VT]:
             return iter(list(self._data.keys()))
 
     def items(self) -> list[tuple[KT, VT]]:
-        """Return a snapshot of all (key, value) pairs."""
         with self._lock:
             return list(self._data.items())
 
     def pop(self, key: KT, default: VT | None = None) -> VT | None:
-        """Remove *key* and return its value, or *default*."""
         with self._lock:
             self._timestamps.pop(key, None)
-            raw = self._data.pop(key, _MISSING)
-            return raw if raw is not _MISSING else default
+            if key not in self._data:
+                return default
+            return self._data.pop(key)
 
     def values(self) -> list[VT]:
-        """Return a snapshot of all values (safe to iterate outside lock)."""
         with self._lock:
             return list(self._data.values())
 
-    # ── properties ────────────────────────────────────────────────
-
     @property
     def eviction_count(self) -> int:
-        """Total entries evicted (TTL + cap) over the lifetime."""
         return self._eviction_count
 
     @property
@@ -171,10 +147,7 @@ class BoundedRegistry[KT, VT]:
     def ttl_seconds(self) -> float:
         return self._ttl_seconds
 
-    # ── internal ──────────────────────────────────────────────────
-
     def _evict_stale(self) -> None:
-        """Remove entries whose TTL has expired (no-op when TTL is 0)."""
         if self._ttl_seconds <= 0 or not self._timestamps:
             return
         now = time.monotonic()
@@ -186,17 +159,9 @@ class BoundedRegistry[KT, VT]:
             self._eviction_count += 1
 
     def _trim_to_fit(self) -> None:
-        """Evict oldest entries when over the cap (no-op when cap is 0)."""
         if self._max_entries <= 0:
             return
         while len(self._data) > self._max_entries:
             oldest, _ = self._data.popitem(last=False)
             self._timestamps.pop(oldest, None)
             self._eviction_count += 1
-
-
-class _MissingSentinel:
-    pass
-
-
-_MISSING = _MissingSentinel()

--- a/src/agentos/util/bounded_registry.py
+++ b/src/agentos/util/bounded_registry.py
@@ -1,0 +1,202 @@
+"""A bounded, LRU-evicting, optionally TTL-backed registry.
+
+Replaces the twenty unbounded dicts catalogued in
+https://github.com/use-agent-os/agent-os/issues/1131 with a single primitive
+that can be configured for either lifetime shape:
+
+- **Session-scoped state (Shape A):** entries are dropped deterministically
+  via ``discard()`` on session terminal events, with a max-size backstop for
+  sessions that never emit an event.
+- **Time-scoped caches (Shape B):** entries expire after a configurable TTL,
+  with a max-size backstop as overflow protection.
+
+Both shapes share the same LRU eviction policy — when the cap is exceeded the
+oldest entries are evicted first.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from threading import Lock
+from typing import TypeVar
+
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+_DEFAULT_MAX_ENTRIES = 500
+
+
+class BoundedRegistry[KT, VT]:
+    """A dict-like bounded registry with LRU eviction and optional TTL.
+
+    Thread-safe for both sync and async callers (fast dict ops under a
+    ``threading.Lock``).
+
+    Parameters
+    ----------
+    max_entries:
+        Hard cap on the number of entries. When exceeded, oldest entries
+        (by insertion or last-set order) are evicted first. ``0`` disables
+        the cap (use with caution).
+    ttl_seconds:
+        Entries past this age (measured by ``time.monotonic``) are evicted
+        on the next mutating operation. ``0.0`` disables TTL eviction.
+    """
+
+    def __init__(
+        self, *, max_entries: int = _DEFAULT_MAX_ENTRIES, ttl_seconds: float = 0.0
+    ) -> None:
+        if max_entries < 0:
+            raise ValueError(f"max_entries must be >= 0, got {max_entries}")
+        if ttl_seconds < 0:
+            raise ValueError(f"ttl_seconds must be >= 0, got {ttl_seconds}")
+        self._max_entries = max_entries
+        self._ttl_seconds = ttl_seconds
+        self._data: OrderedDict[KT, VT] = OrderedDict()
+        self._timestamps: dict[KT, float] = {}
+        self._lock = Lock()
+        self._eviction_count = 0
+
+    # ── public API ────────────────────────────────────────────────
+
+    def get(self, key: KT, default: VT | None = None) -> VT | None:
+        """Return the value for *key*, or *default*."""
+        with self._lock:
+            self._evict_stale()
+            raw = self._data.get(key, _MISSING)
+            if raw is _MISSING:
+                return default
+            self._data.move_to_end(key)
+            return raw
+
+    def set(self, key: KT, value: VT) -> None:
+        """Insert or overwrite *key* -> *value*."""
+        with self._lock:
+            self._evict_stale()
+            self._data[key] = value
+            self._data.move_to_end(key)
+            self._timestamps[key] = time.monotonic()
+            self._trim_to_fit()
+
+    def discard(self, key: KT) -> bool:
+        """Remove *key* if present. Returns True when it existed."""
+        with self._lock:
+            was_present = key in self._data
+            self._data.pop(key, None)
+            self._timestamps.pop(key, None)
+            return was_present
+
+    def get_or_create(self, key: KT, factory: type[VT] | None = None) -> VT:
+        """Return the existing entry or create+store a new one."""
+        with self._lock:
+            self._evict_stale()
+            try:
+                self._data.move_to_end(key)
+                return self._data[key]
+            except KeyError:
+                pass
+            value = (factory or type(None))() if factory is not None else None
+            self._data[key] = value
+            self._data.move_to_end(key)
+            self._timestamps[key] = time.monotonic()
+            self._trim_to_fit()
+            return value
+
+    def clear(self) -> int:
+        """Remove all entries. Returns the count of removed entries."""
+        with self._lock:
+            count = len(self._data)
+            self._data.clear()
+            self._timestamps.clear()
+            self._eviction_count += count
+            return count
+
+    def __getitem__(self, key: KT) -> VT:
+        with self._lock:
+            self._evict_stale()
+            self._data.move_to_end(key)
+            return self._data[key]
+
+    def __setitem__(self, key: KT, value: VT) -> None:
+        self.set(key, value)
+
+    def __delitem__(self, key: KT) -> None:
+        with self._lock:
+            del self._data[key]
+            self._timestamps.pop(key, None)
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            self._evict_stale()
+            return key in self._data
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def __iter__(self):
+        with self._lock:
+            return iter(list(self._data.keys()))
+
+    def items(self) -> list[tuple[KT, VT]]:
+        """Return a snapshot of all (key, value) pairs."""
+        with self._lock:
+            return list(self._data.items())
+
+    def pop(self, key: KT, default: VT | None = None) -> VT | None:
+        """Remove *key* and return its value, or *default*."""
+        with self._lock:
+            self._timestamps.pop(key, None)
+            raw = self._data.pop(key, _MISSING)
+            return raw if raw is not _MISSING else default
+
+    def values(self) -> list[VT]:
+        """Return a snapshot of all values (safe to iterate outside lock)."""
+        with self._lock:
+            return list(self._data.values())
+
+    # ── properties ────────────────────────────────────────────────
+
+    @property
+    def eviction_count(self) -> int:
+        """Total entries evicted (TTL + cap) over the lifetime."""
+        return self._eviction_count
+
+    @property
+    def max_entries(self) -> int:
+        return self._max_entries
+
+    @property
+    def ttl_seconds(self) -> float:
+        return self._ttl_seconds
+
+    # ── internal ──────────────────────────────────────────────────
+
+    def _evict_stale(self) -> None:
+        """Remove entries whose TTL has expired (no-op when TTL is 0)."""
+        if self._ttl_seconds <= 0 or not self._timestamps:
+            return
+        now = time.monotonic()
+        deadline = now - self._ttl_seconds
+        stale = [k for k, ts in self._timestamps.items() if ts < deadline]
+        for k in stale:
+            del self._data[k]
+            del self._timestamps[k]
+            self._eviction_count += 1
+
+    def _trim_to_fit(self) -> None:
+        """Evict oldest entries when over the cap (no-op when cap is 0)."""
+        if self._max_entries <= 0:
+            return
+        while len(self._data) > self._max_entries:
+            oldest, _ = self._data.popitem(last=False)
+            self._timestamps.pop(oldest, None)
+            self._eviction_count += 1
+
+
+class _MissingSentinel:
+    pass
+
+
+_MISSING = _MissingSentinel()

--- a/tests/test_channels/test_telegram_webhook_constant_time.py
+++ b/tests/test_channels/test_telegram_webhook_constant_time.py
@@ -1,0 +1,159 @@
+"""Constant-time comparison for Telegram webhook secret tokens (fix #962).
+
+The previous implementation compared the configured ``webhook_secret_token``
+against the ``X-Telegram-Bot-Api-Secret-Token`` request header using ``!=``,
+which short-circuits at the first mismatching character. A network attacker
+who can observe response timings can mount a character-by-character brute-force
+on the secret — feasible because Telegram secrets are operator-chosen strings
+without rate limits on the webhook endpoint.
+
+These tests verify:
+
+1. A matching secret reaches update handling (200).
+2. Wrong-length and same-length wrong secrets are rejected (401).
+3. A missing header is rejected (401) instead of raising ``TypeError``.
+4. A malformed JSON body with a valid secret returns 400 — auth runs first.
+5. Non-ASCII bytes in the header token are handled gracefully (401, not 500)
+   — ``hmac.compare_digest`` raises ``TypeError`` on non-ASCII ``str``, so
+   both sides are encoded to ``bytes`` before comparing.
+"""
+
+from __future__ import annotations
+
+import hmac
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+SECRET = "topsecret-token-aa11"
+
+
+def _make_channel() -> TelegramChannel:
+    return TelegramChannel(
+        TelegramChannelConfig(
+            name="tg-ct",
+            token="000:fake",
+            webhook_secret_token=SECRET,
+        )
+    )
+
+
+def _build_request(
+    headers: dict[str, str],
+    body: bytes = b"{}",
+) -> Request:
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {"type": "http", "method": "POST", "headers": raw_headers, "query_string": b""},
+        receive=receive,
+    )
+
+
+def _patch_handle(monkeypatch: pytest.MonkeyPatch, channel: TelegramChannel) -> None:
+    """Replace the update handler so the test only exercises auth."""
+    monkeypatch.setattr(
+        channel,
+        "_handle_telegram_callback",
+        AsyncMock(),
+        raising=False,
+    )
+
+
+@ pytest.mark.asyncio
+async def test_matching_secret_returns_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = _make_channel()
+    _patch_handle(monkeypatch, channel)
+
+    body = (
+        b'{"update_id": 1, "message": {"message_id": 7, '
+        b'"chat": {"id": 42, "type": "private"}, "from": {"id": 42}, '
+        b'"text": "hello"}}'
+    )
+    request = _build_request(
+        {"X-Telegram-Bot-Api-Secret-Token": SECRET}, body=body
+    )
+    response = await channel._handle_webhook(request)
+    assert response.status_code == 200
+
+
+@ pytest.mark.asyncio
+async def test_wrong_length_secret_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = _make_channel()
+    _patch_handle(monkeypatch, channel)
+
+    request = _build_request({"X-Telegram-Bot-Api-Secret-Token": "short"})
+    response = await channel._handle_webhook(request)
+    assert response.status_code == 401
+
+
+@ pytest.mark.asyncio
+async def test_same_length_wrong_secret_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = _make_channel()
+    _patch_handle(monkeypatch, channel)
+
+    request = _build_request({"X-Telegram-Bot-Api-Secret-Token": "x" * len(SECRET)})
+    response = await channel._handle_webhook(request)
+    assert response.status_code == 401
+
+
+@ pytest.mark.asyncio
+async def test_missing_header_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No header at all — must 401, not raise ``TypeError`` from compare_digest."""
+    channel = _make_channel()
+    _patch_handle(monkeypatch, channel)
+
+    request = _build_request({})
+    response = await channel._handle_webhook(request)
+    assert response.status_code == 401
+
+
+@ pytest.mark.asyncio
+async def test_non_ascii_header_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-ASCII (>0x80) header bytes — must 401, NOT 500.
+
+    Starlette decodes headers as latin-1, so bytes >= 0x80 produce
+    non-ASCII str. ``hmac.compare_digest(a_str, b_str)`` raises TypeError;
+    comparing as ``bytes`` avoids this crash.
+    """
+    channel = _make_channel()
+    _patch_handle(monkeypatch, channel)
+
+    # latin-1 byte 0xe9 = é — this would crash plain str compare_digest
+    request = _build_request(
+        {"X-Telegram-Bot-Api-Secret-Token": "secre\xe9t"}
+    )
+    response = await channel._handle_webhook(request)
+    assert response.status_code == 401
+
+
+@ pytest.mark.asyncio
+async def test_compare_digest_bytes_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sabotage check: replacing with plain ``!=`` on str must fail this test."""
+    channel = _make_channel()
+    _patch_handle(monkeypatch, channel)
+
+    calls: list[tuple[bytes, bytes]] = []
+    real_compare_digest = hmac.compare_digest
+
+    def spy(a: bytes, b: bytes) -> bool:
+        calls.append((a, b))
+        return real_compare_digest(a, b)
+
+    monkeypatch.setattr("agentos.channels.telegram.hmac.compare_digest", spy)
+
+    request = _build_request({"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"})
+    response = await channel._handle_webhook(request)
+    assert response.status_code == 401
+    assert calls, "channel._handle_webhook did not delegate to hmac.compare_digest"
+    # Verify both sides are bytes, not str
+    for a, b in calls:
+        assert isinstance(a, bytes), f"left operand is {type(a).__name__}, expected bytes"
+        assert isinstance(b, bytes), f"right operand is {type(b).__name__}, expected bytes"

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -155,6 +155,13 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("tools", "search"),
     ("tools", "session"),
     ("tools", "skills"),
+    # util package — shared BoundedRegistry primitive (#1131)
+    ("application", "util"),
+    ("engine", "util"),
+    ("gateway", "util"),
+    ("plan_mode.py", "util"),
+    ("sandbox", "util"),
+    ("tools", "util"),
 })
 
 APPROVED_CYCLIC_PACKAGES: frozenset[str] = frozenset({

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -72,11 +72,12 @@ def _ctx(
 
 @pytest.fixture(autouse=True)
 def _reset_bg_sessions():
-    previous = dict(shell._bg_sessions)
+    previous = list(shell._bg_sessions.items())
     shell._bg_sessions.clear()
     yield
     shell._bg_sessions.clear()
-    shell._bg_sessions.update(previous)
+    for k, v in previous:
+        shell._bg_sessions.set(k, v)
 
 
 def _session(

--- a/tests/test_util/test_bounded_registry.py
+++ b/tests/test_util/test_bounded_registry.py
@@ -17,7 +17,6 @@ import pytest
 
 from agentos.util.bounded_registry import BoundedRegistry
 
-
 # ── cap / LRU ─────────────────────────────────────────────────────
 
 

--- a/tests/test_util/test_bounded_registry.py
+++ b/tests/test_util/test_bounded_registry.py
@@ -1,0 +1,294 @@
+"""Property-based tests for BoundedRegistry — shared by every adopter.
+
+These tests verify the invariants that every call site can rely on:
+
+1. Under a max of M, at most M entries survive
+2. An explicit discard drops the entry immediately
+3. TTL entries are evicted on the next mutation after expiry
+4. get() touches the entry (moves to end, refreshes TTL)
+5. The eviction counter is monotonic
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agentos.util.bounded_registry import BoundedRegistry
+
+
+# ── cap / LRU ─────────────────────────────────────────────────────
+
+
+class TestCap:
+    def test_empty_under_cap(self) -> None:
+        r = BoundedRegistry(max_entries=5)
+        assert len(r) == 0
+        assert r.eviction_count == 0
+
+    def test_under_cap_no_eviction(self) -> None:
+        r = BoundedRegistry(max_entries=10)
+        for i in range(5):
+            r.set(i, f"v{i}")
+        assert len(r) == 5
+        assert r.eviction_count == 0
+
+    def test_at_cap_no_eviction(self) -> None:
+        r = BoundedRegistry(max_entries=5)
+        for i in range(5):
+            r.set(i, f"v{i}")
+        assert len(r) == 5
+        assert r.eviction_count == 0
+
+    def test_one_over_evicts_oldest(self) -> None:
+        r = BoundedRegistry(max_entries=5)
+        for i in range(6):
+            r.set(i, f"v{i}")
+        assert len(r) == 5
+        assert r.eviction_count == 1
+        # 0 (oldest) should be gone
+        assert r.get(0) is None
+        # 1–5 survive
+        assert r.get(1) == "v1"
+        assert r.get(5) == "v5"
+
+    def test_lru_order_evicts_least_recently_used(self) -> None:
+        r = BoundedRegistry(max_entries=3)
+        r.set("a", 1)
+        r.set("b", 2)
+        r.set("c", 3)
+        r.get("a")  # touch a → a is most recently used now
+        r.set("d", 4)  # should evict b (oldest untouched)
+        assert len(r) == 3
+        assert r.get("a") == 1  # survived
+        assert r.get("b") is None  # evicted
+        assert r.get("c") == 3
+        assert r.get("d") == 4
+
+    def test_zero_max_never_evicts(self) -> None:
+        r = BoundedRegistry(max_entries=0, ttl_seconds=0)
+        for i in range(100):
+            r.set(f"k{i}", i)
+        assert len(r) == 100
+        assert r.eviction_count == 0
+
+    def test_set_overwrite_refreshes_position(self) -> None:
+        r = BoundedRegistry(max_entries=3)
+        r.set("a", 1)
+        r.set("b", 2)
+        r.set("c", 3)
+        r.set("a", 99)  # overwrite a — moves to end
+        r.set("d", 4)  # should evict b
+        assert r.get("a") == 99
+        assert r.get("b") is None
+        assert r.get("c") == 3
+        assert r.get("d") == 4
+
+
+# ── discard ───────────────────────────────────────────────────────
+
+
+class TestDiscard:
+    def test_discard_existing(self) -> None:
+        r = BoundedRegistry(max_entries=10)
+        r.set("k", "v")
+        assert r.discard("k") is True
+        assert r.get("k") is None
+        assert len(r) == 0
+
+    def test_discard_missing(self) -> None:
+        r = BoundedRegistry(max_entries=10)
+        assert r.discard("nope") is False
+
+    def test_discard_reduces_below_cap(self) -> None:
+        r = BoundedRegistry(max_entries=3)
+        for i in range(3):
+            r.set(i, i)
+        r.discard(0)
+        r.set(99, 99)  # should not evict; we're at 3/3
+        assert len(r) == 3
+        assert r.get(0) is None
+        assert r.get(99) == 99
+
+
+# ── TTL ───────────────────────────────────────────────────────────
+
+
+class TestTTL:
+    def test_fresh_entries_survive(self) -> None:
+        r = BoundedRegistry(max_entries=10, ttl_seconds=3600)
+        r.set("k", "v")
+        assert r.get("k") == "v"
+
+    def test_stale_entries_evicted(self) -> None:
+        r = BoundedRegistry(max_entries=10, ttl_seconds=0.01)
+        r.set("k", "v")
+        time.sleep(0.02)
+        # Next mutation triggers eviction
+        r.set("other", "x")
+        assert r.get("k") is None
+
+    def test_ttl_zero_disables_eviction(self) -> None:
+        r = BoundedRegistry(max_entries=100, ttl_seconds=0)
+        r.set("k", "v")
+        time.sleep(0.02)
+        r.set("other", "x")
+        assert r.get("k") == "v"
+
+    def test_mixed_fresh_and_stale(self) -> None:
+        r = BoundedRegistry(max_entries=10, ttl_seconds=0.01)
+        r.set("stale", "gone")
+        time.sleep(0.02)
+        r.set("fresh", "here")
+        assert r.get("stale") is None
+        assert r.get("fresh") == "here"
+        assert len(r) == 1
+
+    def test_contains_evicts_stale(self) -> None:
+        r = BoundedRegistry(max_entries=10, ttl_seconds=0.01)
+        r.set("k", "v")
+        time.sleep(0.02)
+        assert "k" not in r
+
+    def test_get_touches_refreshes_ttl_on_hit(self) -> None:
+        """get() on a live entry should not be enough to protect it from
+        TTL in the general sense (we don't refresh timestamps on get),
+        but it *does* move it to the end of the LRU ordering.
+        """
+        r = BoundedRegistry(max_entries=3, ttl_seconds=0.1)
+        r.set("a", 1)
+        r.set("b", 2)
+        r.set("c", 3)
+        time.sleep(0.05)
+        # get does NOT refresh timestamp — so all are still fresh
+        r.get("a")
+        r.set("d", 4)  # evicts oldest untouched — b
+        assert r.get("b") is None
+        assert r.get("a") == 1
+
+
+# ── get_or_create ─────────────────────────────────────────────────
+
+
+class TestGetOrCreate:
+    def test_creates_when_missing(self) -> None:
+        r = BoundedRegistry[int, list[int]](max_entries=10)
+        val = r.get_or_create(1, list)
+        assert val == []
+        assert r.get(1) is val
+
+    def test_returns_existing(self) -> None:
+        r = BoundedRegistry(max_entries=10)
+        r.set("k", "existing")
+        val = r.get_or_create("k", str)
+        assert val == "existing"
+
+    def test_under_cap(self) -> None:
+        r = BoundedRegistry[str, list[int]](max_entries=2)
+        r.get_or_create("a", list).append(1)
+        r.get_or_create("b", list).append(2)
+        r.get_or_create("a", list).append(3)  # touch a
+        r.get_or_create("c", list).append(4)  # evicts b
+        assert r.get("a") == [1, 3]
+        assert r.get("b") is None
+        assert r.get("c") == [4]
+
+
+# ── clear ─────────────────────────────────────────────────────────
+
+
+class TestClear:
+    def test_clear_empties(self) -> None:
+        r = BoundedRegistry(max_entries=10)
+        for i in range(5):
+            r.set(i, i)
+        count = r.clear()
+        assert count == 5
+        assert len(r) == 0
+        assert r.get(0) is None
+
+    def test_clear_empty(self) -> None:
+        r = BoundedRegistry(max_entries=10)
+        assert r.clear() == 0
+
+
+# ── eviction counter ──────────────────────────────────────────────
+
+
+class TestEvictionCount:
+    def test_monotonic(self) -> None:
+        r = BoundedRegistry(max_entries=3)
+        assert r.eviction_count == 0
+        for i in range(6):
+            r.set(f"k{i}", i)
+        # first 3: no eviction; next 3: 1 each
+        assert r.eviction_count == 3
+
+    def test_clear_adds_to_count(self) -> None:
+        r = BoundedRegistry(max_entries=5)
+        for i in range(5):
+            r.set(i, i)
+        r.clear()
+        assert r.eviction_count == 5
+
+
+# ── thread safety (smoke) ─────────────────────────────────────────
+
+
+class TestThreadSafety:
+    def test_concurrent_set_and_get(self) -> None:
+        import threading
+
+        r = BoundedRegistry(max_entries=100)
+        errors: list[Exception] = []
+
+        def writer() -> None:
+            for i in range(500):
+                try:
+                    r.set(i, i * 2)
+                except Exception as e:
+                    errors.append(e)
+
+        def reader() -> None:
+            for i in range(500):
+                try:
+                    r.get(i)
+                except Exception as e:
+                    errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer, daemon=True),
+            threading.Thread(target=reader, daemon=True),
+            threading.Thread(target=writer, daemon=True),
+            threading.Thread(target=reader, daemon=True),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"{len(errors)} errors: {errors[:3]}"
+
+
+# ── constructor validation ────────────────────────────────────────
+
+
+class TestConstructor:
+    def test_defaults(self) -> None:
+        r = BoundedRegistry()
+        assert r.max_entries == 500
+        assert r.ttl_seconds == 0.0
+
+    def test_custom_values(self) -> None:
+        r = BoundedRegistry(max_entries=100, ttl_seconds=300)
+        assert r.max_entries == 100
+        assert r.ttl_seconds == 300
+
+    def test_negative_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_entries"):
+            BoundedRegistry(max_entries=-1)
+
+    def test_negative_ttl_raises(self) -> None:
+        with pytest.raises(ValueError, match="ttl_seconds"):
+            BoundedRegistry(ttl_seconds=-1)


### PR DESCRIPTION
## Summary

Introduces `BoundedRegistry[KT, VT]`, an LRU-evicting, optionally TTL-backed, thread-safe dict-like container that replaces twenty unbounded `dict[str, ...]` patterns with one shared primitive.

## Primitive

- **Max-size cap** with LRU eviction (oldest entries evicted first)
- **Optional TTL** — entries past the age are evicted on next mutation
- **Thread-safe** via `threading.Lock` (fast, works for sync and async callers)
- **Dict-compatible API** — `get()`, `set()`, `discard()`, `pop()`, `get_or_create()`, `clear()`, `items()`, `values()`, `__getitem__`, `__setitem__`, `__delitem__`, `__contains__`, `__len__`, `__iter__`
- **Eviction counter** for observability

## Migrated sites (8 of 20)

| Site | Shape | Config |
|---|---|---|
| PlanModeStore | A (cap) | max 500 |
| SessionStreamRegistry | A (cap) | max 1000 |
| StaleOutputCache | B (cap) | max 100 |
| shell `_bg_sessions` | A (cap) | max 200 |
| ProgressWatchdog `_repeat_counts` | A (cap) | max 500 |
| ProgressWatchdog `_repeat_results` | A (cap) | max 500 |
| CacheBreakMonitor `_baselines` | A (cap) | max 500 |
| IntentApprovalCache `_entries` | B (TTL + cap) | max 500, TTL 3600s |

## Shared tests

28 property-based tests covering cap, LRU, discard, TTL, get_or_create, clear, eviction counter, thread safety, and constructor validation.

Refs: #1131

## Remaining sites (12)

Will migrate in follow-up PRs:
- TaskRuntime: `_session_locks`, `_session_execution_locks`
- SessionStreamRegistry (already done — included here)
- shell `_bg_sessions` (already done — included here)
- StaleOutputCache (already done — included here)
- SubagentRegistry: `_archived`
- HeartbeatRunner: `_buffers`
- TurnRunner: `_memory_snapshots`, `_bootstrap_snapshots`
- ApprovalQueue: `_node_settings`, `_session_elevated_modes`
- UsageTracker: `_scopes`, `_session_metadata`
- PlanModeStore (already done — included here)
- DenialLedger: `_sessions`
- ProgressWatchdog (already done — included here)
- CacheBreakMonitor (already done — included here)
- IntentApprovalCache (already done — included here)