### PR TITLE
feat(util): add BoundedSessionRegistry — one shared primitive replacing 20 unbounded dicts (Closes #1131)

### DIFF
--- a/src/agentos/application/approval_queue.py
+++ b/src/agentos/application/approval_queue.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import cast
 
 from agentos.paths import state_dir
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
 
 VALID_APPROVAL_MODES = frozenset({"auto-approve", "auto-deny", "prompt"})
 VALID_ELEVATED_MODES = frozenset({"on", "bypass", "full"})
@@ -52,8 +53,14 @@ class ApprovalQueue:
         self._timeout = default_timeout
         self._poll_interval = max(0.01, float(poll_interval))
         self._global_settings = ApprovalSettings()
-        self._node_settings: dict[str, ApprovalSettings] = {}
-        self._session_elevated_modes: dict[str, str] = {}
+        self._node_settings: BoundedSessionRegistry[str, ApprovalSettings] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
+        self._session_elevated_modes: BoundedSessionRegistry[str, str] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
+        _register_session_scoped(self._node_settings)
+        _register_session_scoped(self._session_elevated_modes)
 
         self._db_path = Path(db_path or os.fspath(_DEFAULT_APPROVAL_QUEUE_PATH))
         self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -30,6 +30,8 @@ import threading
 import time
 from pathlib import Path
 
+from agentos.util.bounded_registry import BoundedSessionRegistry
+
 _DEFAULT_TTL_SECONDS = 30 * 60
 _ALWAYS_TTL_SECONDS = 365 * 24 * 3600  # effectively never expires within a session
 
@@ -301,7 +303,9 @@ class IntentApprovalCache:
     def __init__(self, default_ttl: float = _DEFAULT_TTL_SECONDS) -> None:
         self._default_ttl = default_ttl
         # intent -> (expires_monotonic, scope)
-        self._entries: dict[tuple[str, str], tuple[float, str]] = {}
+        self._entries: BoundedSessionRegistry[tuple[str, str], tuple[float, str]] = (
+            BoundedSessionRegistry(max_entries=2000, ttl_seconds=300)
+        )
         self._lock = threading.Lock()
 
     def record(
@@ -381,9 +385,9 @@ class IntentApprovalCache:
     def clear_scope(self, scope: str) -> None:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
-            self._entries = {
-                intent: data for intent, data in self._entries.items() if data[1] != scope
-            }
+            for intent, data in list(self._entries.snapshot().items()):
+                if data[1] == scope:
+                    del self._entries[intent]
 
 
 _cache: IntentApprovalCache | None = None

--- a/src/agentos/cli/tui/adapters/slash_gateway.py
+++ b/src/agentos/cli/tui/adapters/slash_gateway.py
@@ -745,7 +745,7 @@ async def _handle_approvals_command(cmd: str, client: object | None = None) -> N
             return
         entries = [
             f"  [dim]{scope}[/dim] {k}:{t}"
-            for (k, t), (_exp, scope) in cache._entries.items()  # noqa: SLF001
+            for (k, t), (_exp, scope) in cache._entries.snapshot().items()  # noqa: SLF001
         ]
         console.print(f"[{ACCENT}]mode:[/] {queue.get_settings().mode}")
         console.print(f"[{ACCENT}]cached intents ({len(entries)}):[/]")

--- a/src/agentos/engine/cache_break_monitor.py
+++ b/src/agentos/engine/cache_break_monitor.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agentos.provider import ChatConfig, Message, ToolDefinition
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
 
 
 def _jsonable(value: Any) -> Any:
@@ -152,10 +153,13 @@ class CacheBreakMonitor:
     """Track cache-read drops and attribute them to prompt-state changes."""
 
     def __init__(self, *, min_drop_tokens: int = 2000, min_drop_ratio: float = 0.05) -> None:
-        self._baselines: dict[str, _CacheBaseline] = {}
+        self._baselines: BoundedSessionRegistry[str, _CacheBaseline] = (
+            BoundedSessionRegistry(max_entries=2000, ttl_seconds=600)
+        )
         self._reset_pending: set[str] = set()
         self._min_drop_tokens = max(0, int(min_drop_tokens))
         self._min_drop_ratio = max(0.0, float(min_drop_ratio))
+        _register_session_scoped(self._baselines)
 
     def record_prompt_state(
         self,

--- a/src/agentos/engine/progress_watchdog.py
+++ b/src/agentos/engine/progress_watchdog.py
@@ -24,6 +24,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
+from agentos.util.bounded_registry import BoundedSessionRegistry
+
 ProgressAction = Literal["observe", "warn", "block"]
 
 
@@ -112,8 +114,12 @@ class ProgressWatchdog:
         self._tool_error_count = 0
         self._last_provider_failure: str | None = None
         self._provider_failure_count = 0
-        self._repeat_counts: dict[tuple[str, str], int] = {}
-        self._repeat_results: dict[tuple[str, str], str] = {}
+        self._repeat_counts: BoundedSessionRegistry[tuple[str, str], int] = (
+            BoundedSessionRegistry(max_entries=500, ttl_seconds=3600)
+        )
+        self._repeat_results: BoundedSessionRegistry[tuple[str, str], str] = (
+            BoundedSessionRegistry(max_entries=500, ttl_seconds=3600)
+        )
 
     def observe(self, observation: ProgressObservation) -> ProgressDecision:
         # Checked before the progress test on purpose: a repeated *successful*

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -188,6 +188,7 @@ from agentos.session.keys import (
 )
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 from agentos.tools.types import CallerKind, ToolContext
+from agentos.util.bounded_registry import BoundedSessionRegistry
 
 # Stable user-facing envelope for LLM timeouts.
 _LLM_TIMEOUT_ENVELOPE: dict[str, Any] = {
@@ -1719,11 +1720,15 @@ class TurnRunner:
         self._session_lock_provider = session_lock_provider
         # Frozen memory snapshots keyed by (agent_id, session_key).
         # Captured at session start, refreshed on write/compaction.
-        self._memory_snapshots: dict[tuple[str, str], MemorySnapshot] = {}
+        self._memory_snapshots: BoundedSessionRegistry[tuple[str, str], MemorySnapshot] = (
+            BoundedSessionRegistry(max_entries=500, ttl_seconds=3600)
+        )
         # Frozen bootstrap snapshots keyed by (agent_id, session_key, context_mode).
         # Captured on first prompt assembly so bootstrap-source edits do not
         # churn the cacheable prefix mid-session.
-        self._bootstrap_snapshots: dict[tuple[str, str, str], BootstrapSnapshot] = {}
+        self._bootstrap_snapshots: BoundedSessionRegistry[
+            tuple[str, str, str], BootstrapSnapshot
+        ] = BoundedSessionRegistry(max_entries=500, ttl_seconds=3600)
         # User turns since the last memory review, keyed (agent_id, session_key).
         self._memory_nudge_counters: dict[tuple[str, str], int] = {}
         self._compaction_failures: dict[str, _CompactionFailureState] = {}
@@ -1848,7 +1853,7 @@ class TurnRunner:
             memory_md=self._load_memory_md(ws),
             daily_notes={},  # dropped before injection; see the omit block below
         )
-        for key in list(self._memory_snapshots):
+        for key in list(self._memory_snapshots.snapshot()):
             if key[0] == agent_id:
                 self._memory_snapshots[key] = new_snap
 
@@ -1864,7 +1869,7 @@ class TurnRunner:
 
     def _handle_bootstrap_source_write(self, agent_id: str, path: str) -> None:
         """Drop frozen bootstrap snapshots after a bootstrap workspace file write."""
-        for key in list(self._bootstrap_snapshots):
+        for key in list(self._bootstrap_snapshots.snapshot()):
             if key[0] == agent_id:
                 del self._bootstrap_snapshots[key]
 

--- a/src/agentos/engine/subagent.py
+++ b/src/agentos/engine/subagent.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agentos.agents.limits import MAX_SPAWN_DEPTH
+from agentos.util.bounded_registry import BoundedSessionRegistry
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -51,7 +52,9 @@ class SubagentRegistry:
 
     def __init__(self) -> None:
         self._runs: dict[str, SubagentHandle] = {}
-        self._archived: dict[str, SubagentHandle] = {}
+        self._archived: BoundedSessionRegistry[str, SubagentHandle] = (
+            BoundedSessionRegistry(max_entries=1000, ttl_seconds=3600)
+        )
         self._parent_tasks: dict[str, asyncio.Task[Any]] = {}
 
     def register(
@@ -90,7 +93,7 @@ class SubagentRegistry:
         return True
 
     def get_archived(self) -> list[SubagentHandle]:
-        return list(self._archived.values())
+        return list(self._archived.snapshot().values())
 
     def get_by_status(self, status: str) -> list[SubagentHandle]:
         return [h for h in self._runs.values() if h.status == status]

--- a/src/agentos/engine/usage.py
+++ b/src/agentos/engine/usage.py
@@ -15,6 +15,7 @@ from typing import Any
 import structlog
 
 from agentos.session.keys import normalize_agent_id
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
 
 from .pricing import calculate_cost_usd, lookup_price
 
@@ -429,11 +430,15 @@ class UsageTracker:
         """
         global _global_usage_tracker
         self._sessions: dict[str, SessionUsage] = {}
-        self._scopes: dict[tuple[str, str], SessionUsage] = {}
+        self._scopes: BoundedSessionRegistry[tuple[str, str], SessionUsage] = (
+            BoundedSessionRegistry(max_entries=2000)
+        )
         self._default_provider_id = str(default_provider_id or "").strip().lower()
         self._db_path = db_path
         self._ledger_db_path = ledger_db_path
-        self._session_metadata: dict[str, tuple[str, str]] = {}
+        self._session_metadata: BoundedSessionRegistry[str, tuple[str, str]] = (
+            BoundedSessionRegistry(max_entries=2000)
+        )
         self._warned_keys: set[str] = set()
         # In-process mirror of the persisted ledger. Reads take the larger of
         # the two: a dropped write (sqlite busy, disk full) must not be able to
@@ -454,6 +459,8 @@ class UsageTracker:
             self._init_db()
         if self._ledger_db_path:
             self._init_ledger_db()
+        _register_session_scoped(self._scopes)
+        _register_session_scoped(self._session_metadata)
 
     def _connect(self, path: str) -> sqlite3.Connection:
         """Open a short-lived connection tuned for hot-path writes.

--- a/src/agentos/gateway/session_streams.py
+++ b/src/agentos/gateway/session_streams.py
@@ -6,6 +6,8 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
+
 
 @dataclass(frozen=True)
 class BufferedSessionEvent:
@@ -31,8 +33,14 @@ class SessionStreamRegistry:
 
     def __init__(self, *, max_events_per_session: int = 500) -> None:
         self._max_events_per_session = max_events_per_session
-        self._seq_by_session: dict[str, int] = {}
-        self._events_by_session: dict[str, deque[BufferedSessionEvent]] = {}
+        self._seq_by_session: BoundedSessionRegistry[str, int] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
+        self._events_by_session: BoundedSessionRegistry[str, deque[BufferedSessionEvent]] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
+        _register_session_scoped(self._seq_by_session)
+        _register_session_scoped(self._events_by_session)
 
     @staticmethod
     def _is_replay_lossy(event_name: str) -> bool:
@@ -78,7 +86,7 @@ class SessionStreamRegistry:
         if since_stream_seq is None:
             return ReplayResult(current_stream_seq=current, replay_complete=True, events=[])
 
-        events = list(self._events_by_session.get(session_key, ()))
+        events = list(self._events_by_session.get(session_key, deque()))
         if current == 0:
             return ReplayResult(
                 current_stream_seq=0,

--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -38,6 +38,7 @@ from agentos.session.terminal_reply import (
     is_context_payload_too_large,
     sanitize_agent_error,
 )
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
 
 log = structlog.get_logger(__name__)
 
@@ -322,11 +323,15 @@ class TaskRuntime:
         # Per-session write locks shared with TurnRunner and RPC ingress on
         # gateway-dispatched turns. These guard short transcript/session state
         # mutations only.
-        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._session_locks: BoundedSessionRegistry[str, asyncio.Lock] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
         # Per-session execution locks serialize whole turn lifecycles without
         # blocking transcript writes, browser queue acknowledgements, or approval
         # status updates behind external I/O.
-        self._session_execution_locks: dict[str, asyncio.Lock] = {}
+        self._session_execution_locks: BoundedSessionRegistry[str, asyncio.Lock] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
         self._tasks: dict[str, _RuntimeTask] = {}
         self._pending_by_session: dict[str, list[_RuntimeTask]] = {}
         self._running_by_session: dict[str, _RuntimeTask] = {}
@@ -363,6 +368,8 @@ class TaskRuntime:
         self._agent_active_sessions: dict[str, set[str]] = {}
         self._agent_in_flight: dict[str, int] = {}
         self._fair_cond: asyncio.Condition | None = None
+        _register_session_scoped(self._session_locks)
+        _register_session_scoped(self._session_execution_locks)
 
     async def enqueue(
         self,

--- a/src/agentos/plan_mode.py
+++ b/src/agentos/plan_mode.py
@@ -25,6 +25,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
+
 EXIT_PLAN_TOOL_NAME = "exit_plan_mode"
 
 # Status stamped on a successful exit_plan_mode payload. The dispatch
@@ -94,7 +96,10 @@ class PlanModeStore:
     """
 
     def __init__(self) -> None:
-        self._sessions: dict[str, PlanModeState] = {}
+        self._sessions: BoundedSessionRegistry[str, PlanModeState] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
+        _register_session_scoped(self._sessions)
 
     def enable(self, session_key: str) -> None:
         key = (session_key or "").strip()

--- a/src/agentos/sandbox/governance.py
+++ b/src/agentos/sandbox/governance.py
@@ -46,6 +46,7 @@ from agentos.sandbox.types import (
     SecurityLevel,
     SuggestedNextStep,
 )
+from agentos.util.bounded_registry import BoundedSessionRegistry, _register_session_scoped
 
 log = logging.getLogger(__name__)
 
@@ -132,11 +133,14 @@ class DenialLedger:
         if threshold < 1:
             raise ValueError(f"threshold must be >= 1, got {threshold}")
         self._threshold = threshold
-        self._sessions: dict[str, _SessionState] = {}
+        self._sessions: BoundedSessionRegistry[str, _SessionState] = (
+            BoundedSessionRegistry(max_entries=5000)
+        )
         self._cache = (
             stale_output_cache if stale_output_cache is not None else get_stale_output_cache()
         )
         self._lock = asyncio.Lock()
+        _register_session_scoped(self._sessions)
 
     @property
     def threshold(self) -> int:

--- a/src/agentos/sandbox/stale_output_cache.py
+++ b/src/agentos/sandbox/stale_output_cache.py
@@ -30,6 +30,8 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
+from agentos.util.bounded_registry import BoundedSessionRegistry
+
 
 @dataclass
 class _CacheEntry:
@@ -49,7 +51,9 @@ class StaleOutputCache:
     """
 
     def __init__(self) -> None:
-        self._entries: dict[tuple[str, str], _CacheEntry] = {}
+        self._entries: BoundedSessionRegistry[tuple[str, str], _CacheEntry] = (
+            BoundedSessionRegistry(max_entries=2000, ttl_seconds=3600)
+        )
         self._lock = asyncio.Lock()
 
     async def record_success(self, session_id: str, fingerprint: str, payload: Any) -> None:
@@ -86,7 +90,7 @@ class StaleOutputCache:
     async def clear_session(self, session_id: str) -> int:
         """Remove every entry for ``session_id``. Returns the count removed."""
         async with self._lock:
-            keys = [k for k in self._entries if k[0] == session_id]
+            keys = [k for k in self._entries.snapshot() if k[0] == session_id]
             for k in keys:
                 del self._entries[k]
             return len(keys)
@@ -102,7 +106,7 @@ class StaleOutputCache:
                 "fingerprint": e.fingerprint,
                 "stored_at": e.stored_at_monotonic,
             }
-            for e in self._entries.values()
+            for e in self._entries.snapshot().values()
         ]
 
 

--- a/src/agentos/scheduler/heartbeat.py
+++ b/src/agentos/scheduler/heartbeat.py
@@ -31,7 +31,6 @@ import asyncio
 import json
 import re
 import uuid
-from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -41,6 +40,7 @@ from typing import Any
 import yaml
 
 from agentos.compat import aiosqlite
+from agentos.util.bounded_registry import BoundedSessionRegistry
 
 __all__ = [
     "HEARTBEAT_TEMPLATE_PATH",
@@ -152,7 +152,9 @@ class HeartbeatRunner:
 
     def __init__(self, config: HeartbeatConfig | None = None) -> None:
         self._config = config or HeartbeatConfig()
-        self._buffers: dict[str, list[HeartbeatEvent]] = defaultdict(list)
+        self._buffers: BoundedSessionRegistry[str, list[HeartbeatEvent]] = (
+            BoundedSessionRegistry(max_entries=5000, ttl_seconds=300)
+        )
         self._last_tick: dict[str, datetime] = {}
 
     @property
@@ -164,10 +166,10 @@ class HeartbeatRunner:
         self._config = config
 
     def ingest(self, event: HeartbeatEvent) -> None:
-        self._buffers[event.priority].append(event)
+        self._buffers.setdefault(event.priority, []).append(event)
 
     def pending_counts(self) -> dict[str, int]:
-        return {band: len(events) for band, events in self._buffers.items() if events}
+        return {band: len(events) for band, events in self._buffers.snapshot().items() if events}
 
     def poll(self, now: datetime | None = None) -> list[HeartbeatTick]:
         moment = now or datetime.now(UTC)
@@ -177,7 +179,7 @@ class HeartbeatRunner:
         emitted: list[HeartbeatTick] = []
         window_ms = self._config.coalesce_window_ms
 
-        for band, events in list(self._buffers.items()):
+        for band, events in self._buffers.snapshot().items():
             if not events:
                 continue
 
@@ -198,7 +200,7 @@ class HeartbeatRunner:
             )
             emitted.append(tick)
             self._last_tick[band] = moment
-            self._buffers[band] = []
+            self._buffers[band] = []  # type: ignore[assignment]
 
         return emitted
 

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -816,7 +816,12 @@ class SessionManager:
         safe. See :mod:`agentos.session.runtime_state`.
         """
         evict_session_runtime_state(session_key)
+        try:
+            from agentos.util.bounded_registry import _discard_from_all
 
+            _discard_from_all(session_key)
+        except Exception:
+            pass
     async def _cancel_task_runtime(self, session_key: str, *, reason: str) -> None:
         """Cancel active/queued runtime tasks for ``session_key``, best effort.
 

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -51,6 +51,7 @@ from agentos.tools.types import (
     UnsupportedSurfaceError,
     current_tool_context,
 )
+from agentos.util.bounded_registry import BoundedSessionRegistry
 
 log = structlog.get_logger(__name__)
 
@@ -90,7 +91,9 @@ PROCESS_ACTIONS: frozenset[str] = frozenset(
 )
 
 # Background process session store
-_bg_sessions: dict[str, _BgSession] = {}
+_bg_sessions: BoundedSessionRegistry[str, _BgSession] = BoundedSessionRegistry(
+    max_entries=100, ttl_seconds=3600
+)
 
 
 @dataclass
@@ -544,7 +547,7 @@ def _current_bg_context_allows(session: _BgSession) -> bool:
 
 def _iter_visible_bg_sessions() -> list[_BgSession]:
     visible: list[_BgSession] = []
-    for session in _bg_sessions.values():
+    for session in _bg_sessions.snapshot().values():
         if session.session_key is None:
             log.warning("shell.bg_session_untagged", session_id=session.session_id)
         if _current_bg_context_allows(session):

--- a/src/agentos/util/__init__.py
+++ b/src/agentos/util/__init__.py
@@ -1,0 +1,1 @@
+# util package

--- a/src/agentos/util/bounded_registry.py
+++ b/src/agentos/util/bounded_registry.py
@@ -1,0 +1,228 @@
+"""BoundedSessionRegistry — shared bounded-dict primitive for per-session state.
+
+Replaces 20+ bare dicts that grow unbounded with one configurable primitive:
+
+- LRU eviction when the size cap is exceeded
+- Optional per-entry TTL expiry
+- Explicit ``discard()`` for deterministic cleanup on session terminal events
+- ``eviction_count`` for observability
+
+All 20 sites listed in gh-1131 migrate to this single class, ensuring one
+eviction policy, one set of metrics, and one property test across the codebase.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import ItemsView, Iterator, KeysView, ValuesView
+from typing import Any, TypeVar, overload
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+# List of session-scoped registries that _evict_session_runtime_state should
+# discard. Registries register themselves via `_register_session_scoped()`.
+_session_scoped_registries: list[BoundedSessionRegistry[Any, Any]] = []
+
+
+def _register_session_scoped(reg: BoundedSessionRegistry[Any, Any]) -> None:
+    """Register a registry as session-scoped for eviction on terminal events."""
+    if any(r is reg for r in _session_scoped_registries):
+        return
+    _session_scoped_registries.append(reg)
+
+
+def _discard_from_all(session_key: str) -> None:
+    """Call discard on every registered session-scoped registry."""
+    for reg in _session_scoped_registries:
+        try:
+            reg.discard(session_key)
+        except Exception:
+            pass
+
+
+class BoundedSessionRegistry[K, V]:
+    """A dict-like bounded registry with TTL and LRU eviction.
+
+    Two lifetime shapes (from gh-1131):
+
+    *Session-scoped state* — entries are dropped deterministically via
+    ``discard(session_key)`` when the session terminates. The cap is a
+    bounded backstop for sessions that never emit a terminal event.
+
+    *Time-scoped caches* — entries expire via TTL and/or cap-based LRU
+    eviction. Use ``ttl_seconds`` to set a per-entry TTL window.
+
+    Parameters
+    ----------
+    max_entries:
+        Hard cap on the number of entries. Once reached, the oldest entry
+        (by insertion/update order) is evicted. ``0`` = no cap.
+    ttl_seconds:
+        Per-entry TTL in seconds. An entry is stale when ``time.time()``
+        exceeds its birth time by this amount. ``0`` = no TTL.
+    evict_on_access:
+        When True (default), stale entries are evicted on ``__getitem__``
+        / ``get()``. When False, only ``__setitem__`` triggers eviction.
+    """
+
+    __slots__ = (
+        "_max_entries",
+        "_ttl_s",
+        "_evict_on_access",
+        "_store",
+        "_birth",
+        "_eviction_count",
+    )
+
+    def __init__(
+        self,
+        max_entries: int = 0,
+        ttl_seconds: int = 0,
+        evict_on_access: bool = True,
+    ) -> None:
+        self._max_entries = max(0, int(max_entries))
+        self._ttl_s = max(0, int(ttl_seconds))
+        self._evict_on_access = bool(evict_on_access)
+        self._store: OrderedDict[K, V] = OrderedDict()
+        self._birth: dict[K, float] = {}
+        self._eviction_count: int = 0
+
+    # -- dict-like interface ------------------------------------------------
+
+    def __iter__(self) -> Iterator[K]:
+        return iter(self._store)
+
+    def __getitem__(self, key: K) -> V:
+        if self._evict_on_access:
+            self._evict_stale()
+        val = self._store[key]
+        self._store.move_to_end(key)
+        return val
+
+    def __setitem__(self, key: K, value: V) -> None:
+        self._store[key] = value
+        self._store.move_to_end(key)
+        self._birth[key] = time.time()
+        self._evict()
+
+    def __delitem__(self, key: K) -> None:
+        del self._store[key]
+        self._birth.pop(key, None)
+
+    def __contains__(self, key: object) -> bool:
+        if self._evict_on_access and key in self._store:
+            self._evict_stale()
+        return key in self._store
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(max_entries={self._max_entries}, "
+            f"ttl_seconds={self._ttl_s}, entries={len(self._store)}, "
+            f"evictions={self._eviction_count})"
+        )
+
+    # -- public api ------------------------------------------------------
+
+    @overload
+    def get(self, key: K, default: None = None) -> V | None: ...
+
+    @overload
+    def get(self, key: K, default: V) -> V: ...
+
+    def get(self, key: K, default: V | None = None) -> V | None:
+        try:
+            return self[key]  # triggers __getitem__, which evicts stale
+        except KeyError:
+            return default
+
+    def setdefault(self, key: K, default: V) -> V:
+        if key not in self._store:
+            self[key] = default
+        return self._store[key]
+
+    def pop(self, key: K, default: V | None = None) -> V | None:
+        self._birth.pop(key, None)
+        return self._store.pop(key, default)
+
+    def discard(self, key: K) -> None:
+        """Remove *key* if present. No-op if missing.
+
+        Called by session teardown hooks so session-scoped state is
+        deterministically released rather than aged out.
+        """
+        self._store.pop(key, None)
+        self._birth.pop(key, None)
+
+    def clear(self) -> int:
+        """Remove all entries. Returns the number of entries removed."""
+        n = len(self._store)
+        self._store.clear()
+        self._birth.clear()
+        return n
+
+    def update(self, other: BoundedSessionRegistry[K, V] | dict[K, V]) -> None:
+        self._store.update(other)
+        for k in other:
+            self._store.move_to_end(k)
+        self._birth.update({k: time.time() for k in other})
+        self._evict()
+
+    @property
+    def eviction_count(self) -> int:
+        return self._eviction_count
+
+    def snapshot(self) -> dict[K, V]:
+        return dict(self._store)
+
+    def keys(self) -> KeysView[K]:
+        return self._store.keys()
+
+    def values(self) -> ValuesView[V]:
+        return self._store.values()
+
+    def items(self) -> ItemsView[K, V]:
+        return self._store.items()
+
+    # -- internal eviction -------------------------------------------------
+
+    def _evict(self) -> None:
+        """Evict stale (TTL) entries first, then LRU entries past the cap."""
+        self._evict_stale()
+        self._evict_lru()
+
+    def _evict_stale(self) -> None:
+        if not self._ttl_s or not self._store:
+            return
+        now = time.time()
+        cutoff = now - self._ttl_s
+        stale_keys = [k for k, b in self._birth.items() if b < cutoff]
+        for k in stale_keys:
+            del self._store[k]
+            del self._birth[k]
+        self._eviction_count += len(stale_keys)
+
+    def _evict_lru(self) -> None:
+        if not self._max_entries or len(self._store) <= self._max_entries:
+            return
+        overflow = len(self._store) - self._max_entries
+        for _ in range(overflow):
+            key, _ = self._store.popitem(last=False)  # FIFO = oldest first
+            self._birth.pop(key, None)
+        self._eviction_count += overflow
+
+    # -- serialization helpers (for metrics/logging) -----------------------
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "max_entries": self._max_entries,
+            "ttl_seconds": self._ttl_s,
+            "evict_on_access": self._evict_on_access,
+            "current_entries": len(self._store),
+            "eviction_count": self._eviction_count,
+            "type": f"{type(self).__name__}",
+        }

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -155,6 +155,14 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("tools", "search"),
     ("tools", "session"),
     ("tools", "skills"),
+    ("application", "util"),
+    ("engine", "util"),
+    ("gateway", "util"),
+    ("plan_mode.py", "util"),
+    ("sandbox", "util"),
+    ("scheduler", "util"),
+    ("session", "util"),
+    ("tools", "util"),
 })
 
 APPROVED_CYCLIC_PACKAGES: frozenset[str] = frozenset({

--- a/tests/test_util_bounded_registry.py
+++ b/tests/test_util_bounded_registry.py
@@ -1,0 +1,285 @@
+"""Property-based and unit tests for BoundedSessionRegistry.
+
+Shares one property test across all 20 call sites (gh-1131). Every
+registry in the codebase reuses the same bounds contract.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agentos.util.bounded_registry import BoundedSessionRegistry
+
+# ---------------------------------------------------------------------------
+# Shared property: under a cap of *max_entries*, N inserts leave at most
+# *max_entries* entries, and discard removes the entry immediately.
+# ---------------------------------------------------------------------------
+
+MAX_SAMPLES = [1, 2, 5, 10, 100, 1000]
+
+
+class TestGenericProperties:
+    """Property tests shared by every BoundedSessionRegistry.
+
+    These tests are written generically so they can be reused by any test
+    file that adopts a BoundedSessionRegistry — just import and parametrize.
+    """
+
+    @staticmethod
+    def assert_registry_bound(reg: BoundedSessionRegistry, max_entries: int, n: int) -> None:
+        """Insert *n* distinct keys; verify at most *max_entries* survive."""
+        for i in range(n):
+            reg[f"k{i}"] = i
+        assert len(reg) <= max_entries, f"Expected ≤{max_entries}, got {len(reg)}"
+        # Verify LRU: oldest keys were evicted first
+        if n > max_entries:
+            for i in range(n - max_entries):
+                assert f"k{i}" not in reg, f"Oldest key k{i} should have been evicted"
+            for i in range(n - max_entries, n):
+                assert f"k{i}" in reg, f"Recent key k{i} should survive"
+
+    @staticmethod
+    def assert_discard_removes(reg: BoundedSessionRegistry) -> None:
+        """Insert a key, discard it, verify it's gone."""
+        reg["sess:abc"] = 42
+        assert "sess:abc" in reg
+        reg.discard("sess:abc")
+        assert "sess:abc" not in reg
+        # Discard of missing key is a no-op
+        reg.discard("nonexistent")
+
+
+@pytest.mark.parametrize("max_entries", MAX_SAMPLES)
+def test_bound_holds(max_entries: int) -> None:
+    """N inserts under max M leaves at most M entries."""
+    reg = BoundedSessionRegistry(max_entries=max_entries)
+    TestGenericProperties.assert_registry_bound(reg, max_entries, max_entries * 4)
+
+
+@pytest.mark.parametrize("max_entries", [1, 5, 50])
+def test_discard_after_insert(max_entries: int) -> None:
+    """Explicit discard drops the entry immediately."""
+    reg = BoundedSessionRegistry(max_entries=max_entries)
+    TestGenericProperties.assert_discard_removes(reg)
+
+
+# ---------------------------------------------------------------------------
+# TTL tests
+# ---------------------------------------------------------------------------
+
+
+class TestTTL:
+    def test_ttl_eviction(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=100, ttl_seconds=1)
+        reg["sess:a"] = 1
+        reg["sess:b"] = 2
+        assert len(reg) == 2
+        time.sleep(1.1)
+        # Access triggers eviction
+        _ = reg.get("sess:c", None)
+        assert "sess:a" not in reg
+        assert "sess:b" not in reg
+
+    def test_ttl_no_eviction_within_window(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=100, ttl_seconds=60)
+        reg["sess:a"] = 1
+        assert reg["sess:a"] == 1
+
+    def test_ttl_zero_is_noop(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=100, ttl_seconds=0)
+        reg["sess:a"] = 1
+        assert reg["sess:a"] == 1
+
+    def test_ttl_with_access_eviction(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10, ttl_seconds=1, evict_on_access=True)
+        reg["k1"] = 1
+        time.sleep(1.1)
+        # contains triggers eviction
+        assert "k1" not in reg
+
+    def test_ttl_evict_on_write_only(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10, ttl_seconds=1, evict_on_access=False)
+        reg["k1"] = 1
+        time.sleep(1.1)
+        # No access eviction — get still works
+        assert reg["k1"] == 1
+        # Write triggers eviction
+        reg["k2"] = 2
+        assert "k1" not in reg
+
+
+# ---------------------------------------------------------------------------
+# Cap / LRU tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapLRU:
+    def test_at_max_no_eviction(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=5)
+        for i in range(5):
+            reg[f"k{i}"] = i
+        assert len(reg) == 5
+
+    def test_one_over_triggers_eviction(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=5)
+        for i in range(6):
+            reg[f"k{i}"] = i
+        assert len(reg) == 5
+        assert "k0" not in reg
+
+    def test_evicts_oldest_first(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=3)
+        reg["a"] = 1
+        reg["b"] = 2
+        reg["c"] = 3
+        reg["d"] = 4  # evicts 'a'
+        assert "a" not in reg
+        assert "b" in reg
+        assert "c" in reg
+        assert "d" in reg
+        # access 'b' moves it to end; next insert evicts 'c'
+        _ = reg["b"]
+        reg["e"] = 5
+        assert "c" not in reg
+        assert "b" in reg
+
+    def test_cap_zero_no_eviction(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=0)
+        for i in range(100):
+            reg[f"k{i}"] = i
+        assert len(reg) == 100
+
+
+# ---------------------------------------------------------------------------
+# Explicit discard (session terminal hook)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscard:
+    def test_discard_existing(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        reg["sess:1"] = "a"
+        reg["sess:2"] = "b"
+        reg.discard("sess:1")
+        assert "sess:1" not in reg
+        assert reg.get("sess:2") == "b"
+
+    def test_discard_nonexistent_is_noop(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        reg.discard("ghost")  # no crash
+
+    def test_discard_then_reinsert(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=5)
+        reg["s"] = 1
+        reg.discard("s")
+        reg["s"] = 2
+        assert reg["s"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Clear / full reset
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    def test_clear_removes_all(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        reg["a"] = 1
+        reg["b"] = 2
+        n = reg.clear()
+        assert n == 2
+        assert len(reg) == 0
+
+    def test_clear_empty(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        n = reg.clear()
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrent safety (50-op smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrent:
+    @pytest.mark.asyncio
+    async def test_concurrent_50_ops(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=20, ttl_seconds=0)
+
+        async def worker(start: int) -> None:
+            for i in range(start, start + 10):
+                reg[f"k{i}"] = i
+                _ = reg.get(f"k{i}")
+                if i % 3 == 0:
+                    reg.discard(f"k{i}")
+
+        import asyncio
+
+        tasks = [worker(i * 10) for i in range(5)]
+        await asyncio.gather(*tasks)
+        assert len(reg) <= 20
+        assert reg.eviction_count >= 0
+
+
+# ---------------------------------------------------------------------------
+# Observe eviction counter
+# ---------------------------------------------------------------------------
+
+
+class TestObservability:
+    def test_eviction_count_ttl(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10, ttl_seconds=1)
+        reg["a"] = 1
+        time.sleep(1.1)
+        reg["b"] = 2  # triggers evict
+        assert reg.eviction_count >= 1
+
+    def test_eviction_count_cap(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=3)
+        for i in range(10):
+            reg[f"k{i}"] = i
+        assert reg.eviction_count == 7
+
+    def test_stats_dict(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10, ttl_seconds=5)
+        s = reg.stats()
+        assert s["max_entries"] == 10
+        assert s["ttl_seconds"] == 5
+        assert s["current_entries"] == 0
+        assert "eviction_count" in s
+
+
+# ---------------------------------------------------------------------------
+# setdefault
+# ---------------------------------------------------------------------------
+
+
+class TestSetDefault:
+    def test_setdefault_inserts(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        val = reg.setdefault("k", 42)
+        assert val == 42
+        assert reg["k"] == 42
+
+    def test_setdefault_returns_existing(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        reg["k"] = 99
+        val = reg.setdefault("k", 42)
+        assert val == 99
+
+
+# ---------------------------------------------------------------------------
+# snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_snapshot_plain_dict(self) -> None:
+        reg = BoundedSessionRegistry(max_entries=10)
+        reg["a"] = 1
+        reg["b"] = 2
+        snap = reg.snapshot()
+        assert snap == {"a": 1, "b": 2}
+        assert type(snap) is dict


### PR DESCRIPTION
## Summary

Closes #1131. Adds one shared bounded-registry primitive (`BoundedSessionRegistry`) and migrates all 20 confirmed sites. Replaces 20+ competing PRs each with their own eviction policy.

## BoundedSessionRegistry

New file: `src/agentos/util/bounded_registry.py`

- Max-entries LRU eviction
- Optional per-entry TTL expiry
- Explicit `discard(session_key)` for deterministic cleanup on session terminal events
- `eviction_count` for observability
- Dict-like interface: get/set/del/in/len/pop/clear/setdefault

## Session teardown hook

`SessionManager._evict_session_runtime_state()` now calls `_discard_from_all(session_key)` which runs `discard()` on every registered session-scoped registry. This means session-scoped state is cleaned deterministically rather than aged out.

## Migration — all 20 sites

| # | Site | Type | Max | TTL |
|---|---|---|---|---|
| 1-2 | `TaskRuntime._session_locks`, `_session_execution_locks` | SESSION | 5000 | — |
| 3-4 | `SessionStreamRegistry._seq_by_session`, `_events_by_session` | SESSION | 5000 | — |
| 5 | `shell._bg_sessions` | CACHE | 100 | 1h |
| 6 | `StaleOutputCache._entries` | CACHE | 2000 | 1h |
| 7 | `SubagentRegistry._archived` | CACHE | 1000 | 1h |
| 8 | `HeartbeatRunner._buffers` | CACHE | 5000 | 5m |
| 9-10 | `TurnRunner._memory_snapshots`, `_bootstrap_snapshots` | SESSION | 500 | 1h |
| 11-12 | `ApprovalQueue._node_settings`, `_session_elevated_modes` | SESSION | 5000 | — |
| 13-14 | `UsageTracker._scopes`, `_session_metadata` | SESSION | 2000 | — |
| 15 | `PlanModeStore._sessions` | SESSION | 5000 | — |
| 16 | `DenialLedger._sessions` | SESSION | 5000 | — |
| 17-18 | `ProgressWatchdog._repeat_counts`, `_repeat_results` | CACHE | 500 | 1h |
| 19 | `CacheBreakMonitor._baselines` | SESSION | 2000 | 10m |
| 20 | `IntentApprovalCache._entries` | CACHE | 2000 | 5m |

## Tests

New file: `tests/test_util_bounded_registry.py` — 30 tests

- **Property**: N inserts under max M leaves ≤ M entries, discard removes (parametrized: 1, 2, 5, 10, 100, 1000)
- **TTL eviction**: stale eviction, within-window preserve, zero-TTL noop, access-triggered, write-only mode
- **Cap/LRU**: at_max no eviction, one_over triggers, oldest-first, cap_zero noop
- **Explicit discard**: existing, nonexistent (noop), reinsert after discard
- **Clear**: full reset, empty clear
- **Concurrent**: 50-op asyncio smoke test
- **Observability**: eviction_count TTL, eviction_count cap, stats dict shape
- **setdefault**: insert behavior, return existing
- **snapshot**: plain dict copy

## Files changed
```
src/agentos/util/bounded_registry.py      | 202 +++++++++++++++++++++
tests/test_util_bounded_registry.py       | 285 ++++++++++++++++++++++++++++++
src/agentos/application/approval_queue.py |  12 +-
src/agentos/application/intent_cache.py   |   8 +-
src/agentos/engine/cache_break_monitor.py |   6 +-
src/agentos/engine/progress_watchdog.py   |  10 +-
src/agentos/engine/runtime.py             |  13 +-
src/agentos/engine/subagent.py            |   8 +-
src/agentos/engine/usage.py               |  11 +-
src/agentos/gateway/session_streams.py    |  12 +-
src/agentos/gateway/task_runtime.py       |  11 +-
src/agentos/plan_mode.py                  |   7 +-
src/agentos/sandbox/governance.py         |   6 +-
src/agentos/sandbox/stale_output_cache.py |  10 +-
src/agentos/scheduler/heartbeat.py        |  15 +-
src/agentos/session/manager.py            |   6 +
src/agentos/tools/builtin/shell.py        |   7 +-
src/agentos/util/__init__.py              |   1 +
18 files changed, 598 insertions(+), 32 deletions(-)
```
