### PR TITLE
fix(tools): replace deprecated get_event_loop with get_running_loop across async coroutines

### DIFF
--- a/src/agentos/channels/terminal.py
+++ b/src/agentos/channels/terminal.py
@@ -25,7 +25,7 @@ class TerminalChannel:
     async def _get_reader(self) -> asyncio.StreamReader:
         async with self._reader_lock:
             if self._reader is None:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 reader = asyncio.StreamReader()
                 protocol = asyncio.StreamReaderProtocol(reader)
                 await loop.connect_read_pipe(lambda: protocol, sys.stdin)
@@ -46,21 +46,21 @@ class TerminalChannel:
 
     async def send(self, message: OutgoingMessage) -> None:
         """Write message content to stdout."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._write_stdout, message.content)
         log.debug("terminal.send", content=message.content[:80])
 
     async def edit(self, message_id: str, content: str) -> None:
         """Edit is not supported on terminal; re-print with prefix."""
         prefix = f"[edit:{message_id}] "
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._write_stdout, prefix + content)
         log.debug("terminal.edit", message_id=message_id)
 
     async def delete(self, message_id: str) -> None:
         """Delete is not supported on terminal; print a notice."""
         notice = f"[deleted:{message_id}]\n"
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._write_stdout, notice)
         log.debug("terminal.delete", message_id=message_id)
 

--- a/src/agentos/cli/gateway_client.py
+++ b/src/agentos/cli/gateway_client.py
@@ -275,7 +275,7 @@ class GatewayClient:
                 "Gateway connection lost; restart chat or reconnect before sending another command."
             )
         req_id = str(uuid.uuid4())
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         fut: asyncio.Future[dict] = loop.create_future()
         self._pending[req_id] = fut
         try:

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -1561,15 +1561,16 @@ class _RuntimeChannelStreamRelay:
             return first_text, None
         buffer = [first_text]
         size = len(first_text)
+        loop = asyncio.get_running_loop()
         deadline = (
-            asyncio.get_event_loop().time() + self._coalesce_window_s
+            loop.time() + self._coalesce_window_s
             if self._coalesce_window_s > 0
             else None
         )
         while True:
             if self._coalesce_chars and size >= self._coalesce_chars:
                 return "".join(buffer), None
-            remaining = deadline - asyncio.get_event_loop().time() if deadline is not None else None
+            remaining = deadline - loop.time() if deadline is not None else None
             if remaining is not None and remaining <= 0:
                 return "".join(buffer), None
             try:

--- a/src/agentos/gateway_client.py
+++ b/src/agentos/gateway_client.py
@@ -129,7 +129,7 @@ class GatewayRPCClient:
             raise ConnectionError("Gateway connection is not open")
 
         req_id = str(uuid.uuid4())
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         fut: asyncio.Future[dict[str, Any]] = loop.create_future()
         self._pending[req_id] = fut
         try:

--- a/src/agentos/identity/workspace.py
+++ b/src/agentos/identity/workspace.py
@@ -239,7 +239,8 @@ def filter_workspace_files_for_session(
 
 async def load_workspace_files_async(workspace_dir: str | Path) -> dict[str, str]:
     """Async wrapper for workspace file loading."""
-    return await asyncio.get_event_loop().run_in_executor(None, load_workspace_files, workspace_dir)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, load_workspace_files, workspace_dir)
 
 
 def load_daily_notes(

--- a/src/agentos/memory/sync_manager.py
+++ b/src/agentos/memory/sync_manager.py
@@ -423,7 +423,7 @@ class MemorySyncManager:
                     break
 
                 current = self._scan_files()
-                now = asyncio.get_event_loop().time()
+                now = asyncio.get_running_loop().time()
 
                 for path, mtime in current.items():
                     old = self._mtimes.get(path)

--- a/src/agentos/tools/browser_supervisor.py
+++ b/src/agentos/tools/browser_supervisor.py
@@ -688,7 +688,7 @@ class _WebSocketTransport:
             raise RuntimeError("websocket not connected")
         call_id = self._next_id
         self._next_id += 1
-        future: Any = asyncio.get_event_loop().create_future()
+        future: Any = asyncio.get_running_loop().create_future()
         self._pending[call_id] = future
         payload: dict[str, Any] = {"id": call_id, "method": method, "params": params}
         default_session = self._session_id if method != "Target.setAutoAttach" else None
@@ -714,7 +714,7 @@ class _WebSocketTransport:
         if self._ws is not None:
             with contextlib.suppress(Exception):
                 await self._ws.close()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         loop.call_soon(loop.stop)
 
 

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -505,7 +505,7 @@ async def read_file(path: str, offset: int | None = None, limit: int | None = No
     if not p.is_file():
         raise IsADirectoryError(f"Path is a directory: {path}")
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     sample: bytes = await loop.run_in_executor(None, _read_binary_sample, p)
     if not sample:
         return ""
@@ -565,7 +565,7 @@ async def read_spreadsheet(
     ext = p.suffix.lower()
     row_offset = offset if offset and offset > 0 else 1
     row_limit = limit if limit and limit > 0 else 200
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     if ext in {".csv", ".tsv"}:
         delimiter = "\t" if ext == ".tsv" else ","
@@ -777,7 +777,7 @@ async def write_file(path: str, content: str, approval_id: str | None = None) ->
     if approval is not None:
         return json.dumps(approval)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     created = not p.exists()
 
     def _write() -> None:
@@ -850,7 +850,7 @@ async def edit_file(
     if not p.exists():
         raise FileNotFoundError(f"File not found: {path}")
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     original = await loop.run_in_executor(None, p.read_text, "utf-8")
 
     # The matcher is the CPU-bound part of an edit, not the read or the write:
@@ -901,7 +901,7 @@ async def list_dir(path: str) -> str:
     if not p.is_dir():
         raise NotADirectoryError(f"Not a directory: {path}")
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()
     workspace_root = _workspace_root()
 
@@ -955,7 +955,7 @@ async def glob_search(pattern: str, path: str | None = None) -> str:
         return json.dumps(blocked)
     _gate_workspace_strict_read("glob_search", base, path or str(base))
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()
     workspace_root = _workspace_root()
 
@@ -1007,7 +1007,7 @@ async def grep_search(
         return json.dumps(blocked)
     _gate_workspace_strict_read("grep_search", base, path or str(base))
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     strict_roots = _strict_read_roots()
     workspace_root = _workspace_root()
 

--- a/src/agentos/tools/builtin/media.py
+++ b/src/agentos/tools/builtin/media.py
@@ -182,7 +182,7 @@ async def _read_image_file(path: str) -> tuple[bytes, str]:
         )
     ext = p.suffix.lstrip(".").lower()
     if ext == "pdf":
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         rendered_bytes = await loop.run_in_executor(None, _render_pdf_first_page_png, p)
         if len(rendered_bytes) > _IMAGE_SIZE_LIMIT:
             raise SafeToolError("Rendered PDF page exceeds 20MB image size limit")
@@ -192,7 +192,7 @@ async def _read_image_file(path: str) -> tuple[bytes, str]:
             f"Unsupported image format: {ext}. "
             f"Supported: {', '.join(sorted(_SUPPORTED_IMAGE_FORMATS))}"
         )
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     image_bytes: bytes = await loop.run_in_executor(None, p.read_bytes)
     if len(image_bytes) > _IMAGE_SIZE_LIMIT:
         raise SafeToolError("Image exceeds 20MB size limit")
@@ -680,7 +680,7 @@ async def pdf(
     except ImportError as exc:
         raise SafeToolError("pdfplumber is not installed") from exc
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     def _extract() -> dict[str, Any]:
         try:
@@ -971,7 +971,7 @@ async def _resolve_supported_audio_file_for_tool(
             f"Unsupported audio format: {ext}. "
             f"Supported: {', '.join(sorted(_SUPPORTED_AUDIO_FORMATS))}"
         )
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     audio_bytes: bytes = await loop.run_in_executor(None, resolved.read_bytes)
     if len(audio_bytes) > _AUDIO_SIZE_LIMIT:
         raise ToolError("Audio file exceeds 100MB size limit")
@@ -1494,7 +1494,8 @@ async def dubbing_download(
     provider = _elevenlabs_provider(config)
     final_status = "unknown"
     if wait_for_completion:
-        deadline = asyncio.get_event_loop().time() + max(timeout_seconds, 0.0)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(timeout_seconds, 0.0)
         while True:
             status_result = await provider.get_dubbing_status(
                 DubbingStatusRequest(dubbing_id=dubbing_id.strip())
@@ -1505,7 +1506,7 @@ async def dubbing_download(
                 break
             if normalized in _DUBBING_FAILED_STATUSES:
                 raise ToolError(f"Dubbing job {dubbing_id} failed with status {final_status}")
-            if asyncio.get_event_loop().time() >= deadline:
+            if loop.time() >= deadline:
                 raise ToolError(
                     f"Dubbing job {dubbing_id} was not ready before timeout; "
                     f"last status={final_status}"

--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -582,7 +582,7 @@ def _apply_ops(ops: list[PatchOp], root: Path | None = None) -> tuple[int, int, 
     record_payload=False,
 )
 async def apply_patch(patch: str, approval_id: str | None = None) -> str:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     root = _default_patch_root()
     ops = _parse_patch(patch)
     blocked = _gate_patch_ops(patch, ops, root, approval_id)

--- a/tests/test_gateway/test_channel_dispatch_ghost_turn.py
+++ b/tests/test_gateway/test_channel_dispatch_ghost_turn.py
@@ -159,7 +159,7 @@ async def test_ac1_2_3_concurrent_no_ghost_turns() -> None:
     sends_per_iter = 8
     iterations = 50
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     for iteration in range(iterations):
         sm = _FakeSessionManager()

--- a/tests/test_gateway/test_no_head_blocking.py
+++ b/tests/test_gateway/test_no_head_blocking.py
@@ -105,8 +105,9 @@ async def test_no_head_blocking_with_idle_slots() -> None:
         handles.append(h)
 
     # Give the event loop enough ticks for all 4 tasks to reach their handler.
-    deadline = asyncio.get_event_loop().time() + start_deadline
-    while len(started_at) < 4 and asyncio.get_event_loop().time() < deadline:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + start_deadline
+    while len(started_at) < 4 and loop.time() < deadline:
         await asyncio.sleep(0.05)
 
     # Release all tasks so they can finish cleanly.

--- a/tests/test_gateway/test_ws_writer_queue.py
+++ b/tests/test_gateway/test_ws_writer_queue.py
@@ -67,8 +67,9 @@ def _make_conn(*, enabled: bool = True, maxsize: int = 16) -> WsConnection:
 
 async def _flush_writer(conn: WsConnection, *, deadline: float = 1.0) -> None:
     """Wait until the writer's outbox is fully drained or deadline elapses."""
-    end = asyncio.get_event_loop().time() + deadline
-    while asyncio.get_event_loop().time() < end:
+    loop = asyncio.get_running_loop()
+    end = loop.time() + deadline
+    while loop.time() < end:
         if conn._outbox is None or conn._outbox.empty():
             await asyncio.sleep(0)
             return
@@ -248,9 +249,10 @@ async def test_writer_cancel_during_blocked_send_within_budget() -> None:
         await asyncio.wait_for(fake._send_event.wait(), timeout=1.0)
 
         with structlog.testing.capture_logs() as logs:
-            start = asyncio.get_event_loop().time()
+            loop = asyncio.get_running_loop()
+            start = loop.time()
             await conn._force_close(reason="test_stuck", code=1011)
-            elapsed = asyncio.get_event_loop().time() - start
+            elapsed = loop.time() - start
 
         # Bounded by wait_for(2.0) + close overhead. Allow up to 3s.
         assert elapsed < 3.0, f"force_close took {elapsed:.2f}s, exceeded 3s"


### PR DESCRIPTION
## Summary
Replaces deprecated `asyncio.get_event_loop()` calls with `asyncio.get_running_loop()` across all builtin tools, async workspace loaders, supervisor websockets, and background poll loops.

## Problem
In Python 3.10+, invoking `asyncio.get_event_loop()` from within an active coroutine is deprecated and can fail with a `RuntimeError` if executed in background worker threads that lack an OS-thread default loop.

## Changes Made
- Updated all `async def` tool functions in `src/agentos/tools/builtin/filesystem.py` (`read_file`, `read_spreadsheet`, `write_file`, `edit_file`, `list_dir`, `glob_search`, `grep_search`).
- Updated media tool functions in `src/agentos/tools/builtin/media.py` (`_read_image_file`, `pdf`, `_resolve_supported_audio_file_for_tool`, `dubbing_download`).
- Updated `apply_patch` in `src/agentos/tools/builtin/patch.py`.
- Updated CDP supervisor routines in `src/agentos/tools/browser_supervisor.py`.
- Updated `load_workspace_files_async` in `src/agentos/identity/workspace.py`.
- Updated memory sync polling in `src/agentos/memory/sync_manager.py`.
- Updated coalesced message draining in `src/agentos/gateway/channel_dispatch.py`.

## Verification
```sh
uv run pytest tests/test_tools/test_filesystem_read_workspace.py tests/test_tools/test_media_image.py tests/test_tools/test_apply_patch_gates.py -q
# 53 passed in 27.22s

uv run ruff check src/agentos/tools/builtin src/agentos/identity src/agentos/memory src/agentos/gateway
# All checks passed!

uv run mypy src/agentos/tools/builtin/filesystem.py src/agentos/tools/builtin/media.py src/agentos/tools/builtin/patch.py src/agentos/identity/workspace.py src/agentos/memory/sync_manager.py --show-error-codes
# Success: no issues found in 5 source files
closes #1136 