### PR TITLE
feat(sandbox): expand sensitive path denylist with gh, anthropic, openai, and vault credentials

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -34,6 +34,9 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "~/.aws",
     "~/.azure",
     "~/.config/gcloud",
+    "~/.config/gh",
+    "~/.anthropic",
+    "~/.openai",
     "~/.docker/config",
     "~/.kube",
     "~/.npmrc",
@@ -41,6 +44,9 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "~/.netrc",
     "~/.gnupg",
     "~/.password-store",
+    # Single file in home root; paired with /.vault-token in _SENSITIVE_SUFFIXES
+    # to catch Vault tokens stored in non-home directory locations.
+    "~/.vault-token",
     "/etc",
     "/boot",
     "/sys",
@@ -70,6 +76,8 @@ _SENSITIVE_SUFFIXES: tuple[str, ...] = (
     "/.zsh_history",
     "/.mysql_history",
     "/.psql_history",
+    # Catches Vault CLI token files located outside home (e.g. /var/secrets/.vault-token).
+    "/.vault-token",
 )
 
 _WORKSPACE_PARENT_EXCEPTION_MARKERS: tuple[str, ...] = ("/root",)

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -14,6 +14,29 @@ from agentos.sandbox.sensitive_paths import (
 def test_sensitive_path_matches_nested_home_prefixes_with_native_separators() -> None:
     assert is_sensitive_path(str(Path.home() / ".ssh" / "id_rsa")) == "~/.ssh"
     assert is_sensitive_path(str(Path.home() / ".aws" / "credentials")) == "~/.aws"
+    assert is_sensitive_path(str(Path.home() / ".config" / "gh" / "hosts.yml")) == "~/.config/gh"
+    assert is_sensitive_path(str(Path.home() / ".anthropic" / "token")) == "~/.anthropic"
+    assert is_sensitive_path(str(Path.home() / ".openai" / "api_key")) == "~/.openai"
+    assert is_sensitive_path(str(Path.home() / ".vault-token")) == "~/.vault-token"
+
+
+def test_sensitive_path_suffix_matches_vault_token() -> None:
+    assert is_sensitive_path("/var/secrets/.vault-token") == "/.vault-token"
+    assert is_sensitive_path(r"C:\secrets\.vault-token") == "/.vault-token"
+
+
+def test_sensitive_path_negative_cases_allow_benign_config_and_unrelated_files() -> None:
+    """Ensure segment boundaries prevent broad false positives under ~/.config and non-secrets."""
+    # Benign ~/.config subdirectories must not be blocked by ~/.config/gh or ~/.config/gcloud
+    assert is_sensitive_path(str(Path.home() / ".config")) is None
+    assert is_sensitive_path(str(Path.home() / ".config" / "nvim" / "init.lua")) is None
+    assert is_sensitive_path(str(Path.home() / ".config" / "git" / "config")) is None
+    assert is_sensitive_path(str(Path.home() / ".config" / "ghostty" / "config")) is None
+
+    # Files named vault-token without leading dot must not match the .vault-token sensitive pattern
+    assert is_sensitive_path(str(Path.home() / "vault-token")) is None
+    assert is_sensitive_path("/var/secrets/vault-token") is None
+    assert is_sensitive_path(r"C:\workspace\vault-token.txt") is None
 
 
 def test_sensitive_path_in_text_matches_native_separator_paths() -> None:


### PR DESCRIPTION
## Summary
Expands the sandbox filesystem protection denylist in [`src/agentos/sandbox/sensitive_paths.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/sandbox/sensitive_paths.py) to cover essential developer and AI provider credential paths:
- GitHub CLI authentication config (`~/.config/gh`, e.g., `hosts.yml`)
- Anthropic configuration and tokens (`~/.anthropic`)
- OpenAI CLI and configuration files (`~/.openai`)
- HashiCorp Vault token files (`~/.vault-token` and generic `/.vault-token` suffix)

## Changes
- **[`src/agentos/sandbox/sensitive_paths.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/sandbox/sensitive_paths.py)**: Added `~/.config/gh`, `~/.anthropic`, `~/.openai`, `~/.vault-token` to `_SENSITIVE_PREFIXES` and `/.vault-token` to `_SENSITIVE_SUFFIXES`.
- **[`tests/test_sandbox/test_sensitive_paths.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_sandbox/test_sensitive_paths.py)**: Added unit test coverage validating that paths under these prefixes and suffixes resolve to the expected sensitive markers.

## Verification
- Ran `uv run pytest tests/test_sandbox/test_sensitive_paths.py -q` (18 passed)
- Ran `uv run pytest tests/test_sandbox -q` (33 passed, 26 skipped)
- Ran `uv run ruff check src/agentos/sandbox/sensitive_paths.py tests/test_sandbox/test_sensitive_paths.py` (Passed)
- Ran `uv run mypy src/agentos/sandbox/sensitive_paths.py --show-error-codes` (Success: no issues found)
closes #1138 