### PR TITLE
feat(tools): add whitespace-tolerant context and deletion matching to apply_patch

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -450,6 +450,19 @@ def _gate_patch_ops(
 # ---------------------------------------------------------------------------
 
 
+def _lines_match_tolerant(actual: str, expected: str) -> bool:
+    """Compare an actual file line with an expected hunk context/delete line.
+
+    Matches strictly without line endings, or flexibly by stripping trailing
+    whitespace (handling trailing spaces/tabs differences from editors/LLMs).
+    """
+    actual_clean = actual.rstrip("\r\n")
+    expected_clean = expected.rstrip("\r\n")
+    if actual_clean == expected_clean:
+        return True
+    return actual_clean.rstrip() == expected_clean.rstrip()
+
+
 def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     """Apply a single hunk to file_lines (0-indexed list of lines with newlines).
 
@@ -458,6 +471,16 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     # old_start is 1-indexed; convert to 0-indexed
     pos = hunk.old_start - 1
     result = list(file_lines)
+
+    # Detect file newline style from first non-empty line or default to "\n"
+    newline = "\n"
+    for line in file_lines:
+        if line.endswith("\r\n"):
+            newline = "\r\n"
+            break
+        elif line.endswith("\n"):
+            newline = "\n"
+            break
 
     # Verify context and deleted lines match
     check_pos = pos
@@ -469,12 +492,11 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         if prefix in (" ", "-"):
             if check_pos >= len(result):
                 raise ValueError(f"Hunk context/delete at line {check_pos + 1} exceeds file length")
-            actual = result[check_pos].rstrip("\n")
-            expected = content.rstrip("\n")
-            if actual != expected:
+            actual = result[check_pos]
+            if not _lines_match_tolerant(actual, content):
                 raise ValueError(
                     f"Context mismatch at line {check_pos + 1}: "
-                    f"expected {expected!r}, got {actual!r}"
+                    f"expected {content.rstrip('\r\n')!r}, got {actual.rstrip('\r\n')!r}"
                 )
             check_pos += 1
 
@@ -492,11 +514,11 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         elif prefix == "-":
             src_pos += 1  # skip (delete)
         elif prefix == "+":
-            # Preserve newline style: add \n if original lines have it
-            if content.endswith("\n"):
+            # Preserve newline style: add newline if original lines have it
+            if content.endswith("\r\n") or content.endswith("\n"):
                 new_lines.append(content)
             else:
-                new_lines.append(content + "\n")
+                new_lines.append(content + newline)
 
     # Splice: replace [pos : pos + old_count] with new_lines
     return result[:pos] + new_lines + result[pos + hunk.old_count :]

--- a/tests/test_tools/test_apply_patch_whitespace_tolerance.py
+++ b/tests/test_tools/test_apply_patch_whitespace_tolerance.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import patch as patch_tool
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    return fn.__wrapped__.__wrapped__  # type: ignore[attr-defined, no-any-return]
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_whitespace_tolerant_context(tmp_path: Path) -> None:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    file_path = tmp_path / "hello.py"
+    # Target file has trailing spaces on context lines
+    file_path.write_text(
+        "def hello():   \n    greeting = 'hi'  \n    return greeting\n", encoding="utf-8"
+    )
+
+    # Patch context does not have trailing whitespace
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: hello.py\n"
+        "@@@ -1,3 +1,3 @@@\n"
+        " def hello():\n"
+        "-    greeting = 'hi'\n"
+        "+    greeting = 'hello world'\n"
+        "     return greeting\n"
+        "*** End Patch\n"
+    )
+
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "Applied patch: 1 file(s) modified" in result
+    content = file_path.read_text(encoding="utf-8")
+    assert "greeting = 'hello world'" in content
+    # First line should retain original file format
+    assert content.startswith("def hello():   \n")
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_whitespace_tolerant_hunk_trailing_spaces(tmp_path: Path) -> None:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    file_path = tmp_path / "calc.py"
+    file_path.write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    # Patch has trailing spaces on context and delete line
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: calc.py\n"
+        "@@@ -1,2 +1,2 @@@\n"
+        " def add(a, b):   \n"
+        "-    return a + b  \t \n"
+        "+    return a + b + 0\n"
+        "*** End Patch\n"
+    )
+
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)
+
+    assert "Applied patch: 1 file(s) modified" in result
+    content = file_path.read_text(encoding="utf-8")
+    assert "return a + b + 0" in content
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_rejects_actual_content_mismatch(tmp_path: Path) -> None:
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    file_path = tmp_path / "config.py"
+    file_path.write_text("DEBUG = False\nPORT = 8080\n", encoding="utf-8")
+
+    # Patch expects different variable name
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: config.py\n"
+        "@@@ -1,2 +1,2 @@@\n"
+        " DEBUG_MODE = False\n"
+        "-PORT = 8080\n"
+        "+PORT = 9090\n"
+        "*** End Patch\n"
+    )
+
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        with pytest.raises(ValueError, match="Context mismatch at line 1"):
+            await apply_patch(patch_text)
+    finally:
+        current_tool_context.reset(token)


### PR DESCRIPTION
## Summary
Implements whitespace-tolerant context and deletion line matching in `apply_patch` ([`src/agentos/tools/builtin/patch.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/tools/builtin/patch.py)). Patches where context or deletion lines differ from the target file only by trailing whitespace (e.g., spaces or tabs introduced or stripped by formatting or LLM generation) are now accepted cleanly while preserving the target file's verbatim line content and newline conventions.

## Changes
- **[`src/agentos/tools/builtin/patch.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/tools/builtin/patch.py)**:
  - Added `_lines_match_tolerant(actual, expected)` to match lines directly or with trailing whitespace stripped.
  - Updated `_apply_hunk` to use tolerant matching for context (` `) and deletion (`-`) lines.
  - Added file newline style detection (`\r\n` vs `\n`) when appending added (`+`) lines.
- **[`tests/test_tools/test_apply_patch_whitespace_tolerance.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_tools/test_apply_patch_whitespace_tolerance.py)**: Added unit test coverage for trailing-whitespace tolerant context lines, trailing-whitespace in hunk lines, and negative tests for actual content mismatches.

## Verification
- Ran `uv run pytest tests/test_tools/test_apply_patch_whitespace_tolerance.py tests/test_tools/test_apply_patch_gates.py -q` (35 passed)
- Ran full tools test suite `uv run pytest tests/test_tools/ -q` (920 passed, 13 skipped)
- Ran `uv run ruff check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_whitespace_tolerance.py` (Passed)
- Ran `uv run mypy src/agentos/tools/builtin/patch.py --show-error-codes` (Success: no issues found)
closes #1140 