### PR TITLE
fix(compat): ignore local version labels in dev and post segment parsing (#1130)

### DIFF
--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -27,8 +27,8 @@ _VERSION_RE = re.compile(
     r"^\s*v?"
     r"(?P<release>\d+(?:\.\d+)*)"
     r"(?:[._-]?(?P<pre_l>a|b|c|rc|alpha|beta|pre|preview)[._-]?(?P<pre_n>\d+)?)?"
-    r"(?:[._-]?post[._-]?(?P<post>\d+)?)?"
-    r"(?:[._-]?dev[._-]?(?P<dev>\d+)?)?"
+    r"(?:[._-]?(?P<post_l>post)[._-]?(?P<post_n>\d+)?)?"
+    r"(?:[._-]?(?P<dev_l>dev)[._-]?(?P<dev_n>\d+)?)?"
     r"(?:\+(?P<local>[a-zA-Z0-9.]+))?"
     r"\s*$",
     re.IGNORECASE,
@@ -100,12 +100,8 @@ def parse_version(value: str | None) -> Version:
     if match.group("pre_l"):
         pre_tag = match.group("pre_l").lower()
         pre = (_PRE_ORDER.get(pre_tag, 2), int(match.group("pre_n") or 0))
-    post = int(match.group("post")) if match.group("post") is not None else None
-    if post is None and re.search(r"[._-]?post", raw, re.IGNORECASE):
-        post = 0
-    dev = int(match.group("dev")) if match.group("dev") is not None else None
-    if dev is None and re.search(r"[._-]?dev", raw, re.IGNORECASE):
-        dev = 0
+    post = int(match.group("post_n") or 0) if match.group("post_l") else None
+    dev = int(match.group("dev_n") or 0) if match.group("dev_l") else None
     return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
 
 

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -44,6 +44,12 @@ from agentos.compat.version_utils import compare_versions, is_newer, parse_versi
         ("2026.7.18.POST1", "2026.7.18.post1", 0),
         ("2026.7.18.DEV1", "2026.7.18.dev1", 0),
         ("2026.7.18.DEV", "2026.7.18", -1),
+        # local labels are ignored for ordering even when containing dev or post substrings
+        ("2026.7.18+dev", "2026.7.18", 0),
+        ("2026.7.18+postgres", "2026.7.18", 0),
+        ("2026.7.18+device", "2026.7.18", 0),
+        ("2026.7.18+local.post1", "2026.7.18", 0),
+        ("2026.7.18+unknown", "2026.7.18", 0),
     ],
 )
 def test_compare_versions(a: str, b: str, expected: int) -> None:
@@ -52,6 +58,10 @@ def test_compare_versions(a: str, b: str, expected: int) -> None:
 
 def test_local_label_ignored_for_ordering() -> None:
     assert compare_versions("2026.7.18+abc", "2026.7.18") == 0
+    assert compare_versions("2026.7.18+dev", "2026.7.18") == 0
+    assert compare_versions("2026.7.18+postgres", "2026.7.18") == 0
+    assert compare_versions("2026.7.18+device", "2026.7.18") == 0
+    assert compare_versions("2026.7.18+local.post1", "2026.7.18") == 0
 
 
 def test_unparsable_sorts_below_real_release() -> None:
@@ -81,6 +91,23 @@ def test_parse_version_fields() -> None:
     assert v_dev.release == (2026, 7, 18)
     assert v_dev.dev == 0
     assert v_dev.parsed is True
+
+    v_post = parse_version("2026.7.18.post")
+    assert v_post.release == (2026, 7, 18)
+    assert v_post.post == 0
+    assert v_post.parsed is True
+
+    v_local_dev = parse_version("2026.7.18+dev")
+    assert v_local_dev.release == (2026, 7, 18)
+    assert v_local_dev.dev is None
+    assert v_local_dev.post is None
+    assert v_local_dev.parsed is True
+
+    v_local_post = parse_version("2026.7.18+postgres")
+    assert v_local_post.release == (2026, 7, 18)
+    assert v_local_post.dev is None
+    assert v_local_post.post is None
+    assert v_local_post.parsed is True
 
     v_upper = parse_version("V2026.7.18RC2.POST1.DEV0")
     assert v_upper.release == (2026, 7, 18)


### PR DESCRIPTION
Fixes #1130

## Summary

In `src/agentos/compat/version_utils.py`, `parse_version()` previously relied on unanchored `re.search()` calls (`re.search(r"[._-]?post", raw, re.IGNORECASE)` and `re.search(r"[._-]?dev", raw, re.IGNORECASE)`) to fallback for bare `.post` / `.dev` segments.

Because `[._-]?` makes the leading separator optional, `re.search` inadvertently matched substrings (`dev` or `post`) present inside the local version label (`+local`, e.g. `2026.7.18+dev`, `2026.7.18+postgres`, `2026.7.18+device`, `2026.7.18+local.post1`). This caused local build identifiers to be misclassified as pre-releases (`dev = 0`) or post-releases (`post = 0`), violating PEP 440's contract that local version labels must be ignored for ordering.

## What was changed

- **`src/agentos/compat/version_utils.py`**:
  - Updated `_VERSION_RE` with structured named capturing groups `(?P<post_l>post)` and `(?P<dev_l>dev)` for regex-anchored segment matching.
  - In `parse_version()`, extract `post` and `dev` directly from the structured match groups (`int(match.group("post_n") or 0) if match.group("post_l") else None`), removing the unanchored `re.search` calls entirely.
- **`tests/test_compat/test_version_utils.py`**:
  - Added test cases in `test_compare_versions` and `test_local_label_ignored_for_ordering` verifying local versions containing `dev` and `post` substrings (`+dev`, `+postgres`, `+device`, `+local.post1`, `+unknown`) compare equal to their base release.
  - Added assertions in `test_parse_version_fields` verifying `dev` and `post` fields remain `None` when only local labels are present.

## Quality Gate Verification

- `uv run ruff check src tests` — clean (0 errors)
- `uv run ruff format --check src/agentos/compat/version_utils.py tests/test_compat/test_version_utils.py` — clean (2 files already formatted)
- `uv run mypy src/agentos --show-error-codes` — clean (Success: no issues found in 622 source files)
- `uv run pytest tests/test_compat -q` — 44 passed in 0.16s
- `uv run pytest tests/test_release_consistency.py tests/test_install_scripts.py -q` — 22 passed in 0.26s