### PR TITLE
fix(session): evict in-memory runtime state on every session removal path (#750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Every session removal path drops the in-memory runtime state keyed by that
+  session, not just `SessionManager.finish()`. `sessions.delete` (the Web UI
+  "Delete Chat"), `SessionManager.cap_entries()`, `prune_stale()` and the cron
+  `SessionReaper` all went straight to `storage.delete_session()`, leaving
+  orphaned entries in three process-global stores — `SpawnGroupTracker`'s
+  closed/woken sets, the Pilot router's per-session routing history, and the
+  per-parent spawn locks. On a gateway that stays up for weeks, every deleted
+  or pruned session leaked another entry with nothing to bound the growth.
+  Eviction now lives in `agentos.session.runtime_state`, is idempotent, and
+  runs on all of them. `sessions.delete` also cancels and drains the session's
+  active and queued tasks first, so an in-flight turn handler can no longer
+  write to a session whose rows are about to disappear or repopulate the state
+  just evicted; `prune_stale` collects the stale keys via the new
+  `SessionStorage.list_stale_session_keys()` before deleting, since the
+  storage-level prune returned only a count
+  ([#750](https://github.com/use-agent-os/agent-os/issues/750)).
+
 ## [2026.9.5] - 2026-09-05
 
 ### Added

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -48,6 +48,7 @@ from agentos.session.compaction_lifecycle import (
 )
 from agentos.session.keys import canonicalize_session_key, normalize_agent_id, parse_agent_id
 from agentos.session.naming import normalize_session_name
+from agentos.session.runtime_state import evict_session_runtime_state
 from agentos.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 
 _d = get_dispatcher()
@@ -207,6 +208,29 @@ async def _drain_task_runtime_for_reset(task_runtime: Any, session_key: str) -> 
     before issuing cancellation so reset does not append a false
     ``[interrupted]`` marker into the transcript being flushed.
     """
+    await _drain_task_runtime_for_session(
+        task_runtime,
+        session_key,
+        source="sessions_reset",
+        reason="session_reset",
+        op="reset",
+    )
+
+
+async def _drain_task_runtime_for_session(
+    task_runtime: Any,
+    session_key: str,
+    *,
+    source: str,
+    reason: str,
+    op: str,
+) -> None:
+    """Settle, cancel, and drain the runtime tasks of one session.
+
+    Shared by reset and delete: both need the session to stop producing work
+    before they touch its rows. ``op`` only names the log events so the two
+    callers stay distinguishable in the gateway log.
+    """
     has_runtime_listing = hasattr(task_runtime, "list") and hasattr(task_runtime, "wait")
 
     if has_runtime_listing:
@@ -223,13 +247,13 @@ async def _drain_task_runtime_for_reset(task_runtime: Any, session_key: str) -> 
                 except TimeoutError:
                     pass
         except Exception:
-            log.warning("sessions.reset.task_runtime_settle_failed", session_key=session_key)
+            log.warning(f"sessions.{op}.task_runtime_settle_failed", session_key=session_key)
 
     await _cancel_task_runtime(
         task_runtime,
         session_key=session_key,
-        source="sessions_reset",
-        reason="session_reset",
+        source=source,
+        reason=reason,
     )
 
     if not has_runtime_listing:
@@ -244,9 +268,9 @@ async def _drain_task_runtime_for_reset(task_runtime: Any, session_key: str) -> 
                     timeout=_RESET_RUNTIME_CANCEL_DRAIN_SECONDS,
                 )
     except TimeoutError:
-        log.warning("sessions.reset.task_runtime_drain_timeout", session_key=session_key)
+        log.warning(f"sessions.{op}.task_runtime_drain_timeout", session_key=session_key)
     except Exception:
-        log.warning("sessions.reset.task_runtime_drain_failed", session_key=session_key)
+        log.warning(f"sessions.{op}.task_runtime_drain_failed", session_key=session_key)
 
 
 def _optional_positive_timeout(config: Any, attr: str, default: float) -> float | None:
@@ -1946,11 +1970,34 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     if not keys:
         raise ValueError("params.key or params.keys is required")
 
+    task_runtime = getattr(ctx, "task_runtime", None)
+
     deleted: list[str] = []
     errors: list[str] = []
     for k in keys:
         try:
-            await storage.delete_session(k)
+            # Runtime state and the task runtime are keyed by the canonical
+            # form, the same one storage.delete_session normalizes to; evicting
+            # the raw request key would miss every entry.
+            canonical = canonicalize_session_key(k)
+            # Cancel first: an in-flight turn handler would otherwise keep
+            # writing to a session whose rows are about to disappear, and it
+            # could repopulate the runtime state evicted on the next line.
+            # Best effort — a task runtime that fails to cancel must not turn
+            # "Delete Chat" into an error and leave the session in place.
+            if task_runtime is not None:
+                try:
+                    await _drain_task_runtime_for_session(
+                        task_runtime,
+                        canonical,
+                        source="sessions_delete",
+                        reason="session_deleted",
+                        op="delete",
+                    )
+                except Exception:
+                    log.warning("sessions.delete.task_cancel_failed", session_key=canonical)
+            evict_session_runtime_state(canonical)
+            await storage.delete_session(canonical)
             deleted.append(k)
         except Exception as exc:
             errors.append(f"{k}: {exc}")

--- a/src/agentos/scheduler/reaper.py
+++ b/src/agentos/scheduler/reaper.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import time
 
+from agentos.session.runtime_state import evict_session_runtime_state
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,6 +66,10 @@ class SessionReaper:
             logger.warning("reaper.page_cap_reached pages=%d", self.MAX_PAGES)
 
         for key in to_delete:
+            # Same leak as the other removal paths: the reaper talks straight
+            # to storage, so the process-global runtime state keyed by session
+            # has to be dropped here too.
+            evict_session_runtime_state(key)
             await self._session_store.delete_session(key)
 
         if to_delete:

--- a/src/agentos/session/manager.py
+++ b/src/agentos/session/manager.py
@@ -40,6 +40,7 @@ from agentos.session.models import (
     SessionSummary,
     TranscriptEntry,
 )
+from agentos.session.runtime_state import evict_session_runtime_state
 from agentos.session.storage import SessionStorage
 from agentos.session.tokenizer import estimate_tokens
 
@@ -430,18 +431,7 @@ class SessionManager:
             child_key = getattr(child, "session_key", None)
             if not child_key:
                 continue
-            if self._task_runtime is not None:
-                try:
-                    await self._task_runtime.cancel(
-                        session_key=child_key,
-                        source="parent_session_kill",
-                        reason="parent_session_kill",
-                    )
-                except TypeError:
-                    with contextlib.suppress(Exception):
-                        await self._task_runtime.cancel(session_key=child_key)
-                except Exception:
-                    pass
+            await self._cancel_task_runtime(child_key, reason="parent_session_kill")
             try:
                 await self.kill_session(child_key)
             except KeyError:
@@ -820,30 +810,51 @@ class SessionManager:
     def _evict_session_runtime_state(session_key: str) -> None:
         """Drop in-memory subagent and routing bookkeeping for ``session_key``.
 
-        Called from ``finish`` so terminal sessions don't leak unbounded
-        entries in long-running gateway processes. Imports are local to
-        avoid import cycles with engine/gateway packages.
+        Called from ``finish`` and from every deletion path so neither
+        terminal nor deleted sessions leak unbounded entries in long-running
+        gateway processes. Idempotent, so the two overlapping callers are
+        safe. See :mod:`agentos.session.runtime_state`.
         """
-        try:
-            from agentos.gateway.subagent_announce import _tracker as _spawn_tracker
+        evict_session_runtime_state(session_key)
 
-            _spawn_tracker.evict(session_key)
-        except Exception:
-            pass
+    async def _cancel_task_runtime(self, session_key: str, *, reason: str) -> None:
+        """Cancel active/queued runtime tasks for ``session_key``, best effort.
+
+        Runs before a session row is removed so an in-flight turn handler does
+        not keep writing to a session that no longer exists. Task runtimes are
+        duck-typed across gateway and test composition, so a runtime without
+        the keyword-only signature falls back to the positional-free form.
+        """
+        if self._task_runtime is None:
+            return
         try:
-            from agentos.engine.steps.agentos_router import (
-                _history_store as _routing_store,
+            await self._task_runtime.cancel(
+                session_key=session_key,
+                source=reason,
+                reason=reason,
+            )
+        except TypeError:
+            with contextlib.suppress(Exception):
+                await self._task_runtime.cancel(session_key=session_key)
+        except Exception:
+            import structlog as _structlog
+
+            _structlog.get_logger(__name__).warning(
+                "session.task_cancel_failed", session_key=session_key, reason=reason
             )
 
-            _routing_store.evict(session_key)
-        except Exception:
-            pass
-        try:
-            from agentos.tools.builtin.sessions import evict_spawn_lock
+    async def delete(self, session_key: str) -> None:
+        """Remove a session: cancel its tasks, evict runtime state, then delete.
 
-            evict_spawn_lock(session_key)
-        except Exception:
-            pass
+        The single removal choke point for maintenance paths. Ordering matters:
+        cancelling first stops an in-flight turn from repopulating the very
+        runtime state being evicted, and eviction before the storage delete
+        keeps the process-global stores from outliving the row.
+        """
+        session_key = canonicalize_session_key(session_key)
+        await self._cancel_task_runtime(session_key, reason="session_delete")
+        evict_session_runtime_state(session_key)
+        await self._storage.delete_session(session_key)
 
     async def branch(
         self,
@@ -1530,9 +1541,18 @@ class SessionManager:
     # ── Maintenance ──────────────────────────────────────────────────────────
 
     async def prune_stale(self, max_age_ms: int) -> int:
-        """Delete sessions older than max_age_ms. Returns number pruned."""
+        """Delete sessions older than max_age_ms. Returns number pruned.
+
+        The keys are collected up front rather than delegating to
+        ``storage.prune_stale_sessions``: that helper deletes inside the
+        storage layer and returns only a count, leaving nothing to evict the
+        process-global runtime state against.
+        """
         cutoff = _now_ms() - max_age_ms
-        return await self._storage.prune_stale_sessions(cutoff)
+        session_keys = await self._storage.list_stale_session_keys(cutoff)
+        for session_key in session_keys:
+            await self.delete(session_key)
+        return len(session_keys)
 
     async def cap_entries(self, max_entries: int = 500) -> int:
         """Delete oldest sessions beyond max_entries. Returns number deleted."""
@@ -1543,7 +1563,7 @@ class SessionManager:
         # sorted by updated_at asc — oldest first
         to_delete = sorted(sessions, key=lambda s: s.updated_at)[: total - max_entries]
         for s in to_delete:
-            await self._storage.delete_session(s.session_key)
+            await self.delete(s.session_key)
         return len(to_delete)
 
     async def archive(self, session_key: str) -> None:

--- a/src/agentos/session/runtime_state.py
+++ b/src/agentos/session/runtime_state.py
@@ -1,0 +1,51 @@
+"""Process-global runtime bookkeeping keyed by session.
+
+Several long-lived stores hang off module globals rather than the session
+row: spawn-group state in the gateway, routing history in the engine router,
+and the per-parent spawn locks in the sessions builtin. None of them are
+reachable from storage, so deleting a session row leaves them behind. On a
+gateway that runs for weeks, every deleted or pruned session leaks another
+entry — an unbounded leak.
+
+:func:`evict_session_runtime_state` is the single choke point every session
+removal path calls. Imports are local so this module stays importable from
+``agentos.session`` without pulling in engine/gateway packages (and without
+creating an import cycle).
+"""
+
+from __future__ import annotations
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+def evict_session_runtime_state(session_key: str) -> None:
+    """Drop in-memory subagent, routing, and spawn-lock bookkeeping.
+
+    Idempotent and never raises: it runs on both the terminal path
+    (``SessionManager.finish``) and every deletion path, and a missing or
+    already-evicted entry is the normal case rather than an error. A store
+    that fails to import (partial install, trimmed distribution) must not
+    block the deletion it is attached to.
+    """
+    try:
+        from agentos.gateway.subagent_announce import _tracker as _spawn_tracker
+
+        _spawn_tracker.evict(session_key)
+    except Exception:
+        log.debug("session.runtime_state.spawn_tracker_evict_failed", session_key=session_key)
+    try:
+        from agentos.engine.steps.agentos_router import (
+            _history_store as _routing_store,
+        )
+
+        _routing_store.evict(session_key)
+    except Exception:
+        log.debug("session.runtime_state.routing_history_evict_failed", session_key=session_key)
+    try:
+        from agentos.tools.builtin.sessions import evict_spawn_lock
+
+        evict_spawn_lock(session_key)
+    except Exception:
+        log.debug("session.runtime_state.spawn_lock_evict_failed", session_key=session_key)

--- a/src/agentos/session/storage.py
+++ b/src/agentos/session/storage.py
@@ -765,14 +765,27 @@ class SessionStorage:
             await self.conn.rollback()
             raise
 
-    async def prune_stale_sessions(self, before_ms: int) -> int:
-        """Delete sessions not updated since before_ms epoch ms. Returns count deleted."""
+    async def list_stale_session_keys(self, before_ms: int) -> list[str]:
+        """Return keys of sessions not updated since ``before_ms`` epoch ms.
+
+        Split out of :meth:`prune_stale_sessions` so callers that need to drop
+        per-session state outside storage (in-memory runtime bookkeeping, live
+        tasks) can see the keys before the rows are gone.
+        """
         async with self.conn.execute(
             "SELECT session_key FROM sessions WHERE updated_at < ?",
             (before_ms,),
         ) as cur:
             rows = await cur.fetchall()
-        session_keys = [row[0] for row in rows]
+        return [row[0] for row in rows]
+
+    async def prune_stale_sessions(self, before_ms: int) -> int:
+        """Delete sessions not updated since before_ms epoch ms. Returns count deleted.
+
+        Storage-only: it does not evict the process-global runtime state keyed
+        by session. Prefer ``SessionManager.prune_stale``, which does.
+        """
+        session_keys = await self.list_stale_session_keys(before_ms)
         for session_key in session_keys:
             await self.delete_session(session_key)
         return len(session_keys)

--- a/src/agentos/tools/builtin/sessions.py
+++ b/src/agentos/tools/builtin/sessions.py
@@ -195,9 +195,9 @@ async def _count_active_children(mgr: object, parent_session_key: str) -> int:
 # Per-parent-session locks serialize the check-then-create critical
 # section so two concurrent ``sessions_spawn`` calls cannot both read
 # active < max_children, both pass the gate, and both create children.
-# Entries are evicted by ``SessionManager.finish`` via
-# :func:`evict_spawn_lock` so a long-running gateway does not leak one
-# Lock per parent session that ever spawned.
+# Entries are evicted via :func:`evict_spawn_lock` on every session
+# removal path (finish, delete, prune, cap) so a long-running gateway
+# does not leak one Lock per parent session that ever spawned.
 _spawn_locks: dict[str, asyncio.Lock] = {}
 
 
@@ -212,7 +212,8 @@ def _get_spawn_lock(parent_session_key: str) -> asyncio.Lock:
 def evict_spawn_lock(parent_session_key: str) -> bool:
     """Drop the per-parent spawn lock for ``parent_session_key``.
 
-    Called from ``SessionManager.finish`` when a session goes terminal.
+    Called from ``agentos.session.runtime_state`` whenever a session goes
+    terminal or is removed.
     Safe under contention: any in-flight ``async with`` already holds a
     strong reference to the Lock object; this only removes the dict
     entry, so future spawns for a (now terminal) parent get a fresh

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2006,6 +2006,60 @@ class TestSessionsDelete:
         assert res.payload["deleted"] == []
         assert len(res.payload["errors"]) == 1
 
+    @pytest.mark.asyncio
+    async def test_delete_cancels_tasks_and_evicts_runtime_state(
+        self, dispatcher, session, monkeypatch
+    ):
+        """Deleting a session must not leave process-global state behind (#750)."""
+        from agentos.engine.steps.agentos_router import _history_store
+        from agentos.gateway.subagent_announce import _tracker
+        from agentos.tools.builtin.sessions import _get_spawn_lock, _spawn_locks
+
+        key = session.session_key
+        _tracker.mark_closed(key, "task-1")
+        _history_store.set(key, [{"turn_index": 0}])
+        _get_spawn_lock(key)
+
+        cancelled: list[str] = []
+
+        class _Runtime:
+            async def cancel(self, *, session_key: str, source: str = "", reason: str = "") -> int:
+                cancelled.append(session_key)
+                return 1
+
+        ctx = make_ctx(session_manager=FakeSessionManager([session]), task_runtime=_Runtime())
+        try:
+            res = await dispatcher.dispatch("r1", "sessions.delete", {"key": key}, ctx)
+
+            assert res.ok is True
+            assert res.payload["deleted"] == [key]
+            assert cancelled == [key]
+            assert not _tracker.is_closed(key, "task-1")
+            assert _history_store.get(key) is None
+            assert key not in _spawn_locks
+        finally:
+            _tracker._closed.discard((key, "task-1"))
+            _history_store.clear()
+            _spawn_locks.pop(key, None)
+
+    @pytest.mark.asyncio
+    async def test_delete_survives_a_task_runtime_that_cannot_cancel(self, dispatcher, session):
+        """A failing cancel must not turn "Delete Chat" into an error (#750)."""
+
+        class _BrokenRuntime:
+            async def cancel(self, **_kwargs) -> int:
+                raise RuntimeError("runtime is down")
+
+        ctx = make_ctx(session_manager=FakeSessionManager([session]), task_runtime=_BrokenRuntime())
+
+        res = await dispatcher.dispatch(
+            "r1", "sessions.delete", {"key": session.session_key}, ctx
+        )
+
+        assert res.ok is True
+        assert res.payload["deleted"] == [session.session_key]
+        assert res.payload["errors"] == []
+
 
 class TestSessionsCompact:
     @pytest.mark.asyncio

--- a/tests/test_session/test_runtime_state_eviction.py
+++ b/tests/test_session/test_runtime_state_eviction.py
@@ -1,0 +1,170 @@
+"""Every session removal path must drop the process-global runtime state.
+
+``SessionManager.finish`` used to be the only caller of the eviction hook, so
+deleting or pruning a session left its spawn-group, routing-history, and
+spawn-lock entries behind forever — an unbounded leak on a gateway that runs
+for weeks (issue #750).
+"""
+
+import pytest
+import pytest_asyncio
+
+from agentos.engine.steps.agentos_router import _history_store
+from agentos.gateway.subagent_announce import _tracker
+from agentos.session.manager import SessionManager
+from agentos.session.storage import SessionStorage
+from agentos.tools.builtin.sessions import _get_spawn_lock, _spawn_locks
+
+
+@pytest_asyncio.fixture
+async def manager():
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    yield SessionManager(storage, inject_time_prefix=False)
+    await storage.close()
+
+
+def _seed_runtime_state(session_key: str) -> None:
+    _tracker.mark_closed(session_key, "task-1")
+    _tracker.mark_woken((session_key, "task-1"))
+    _history_store.set(session_key, [{"turn_index": 0}])
+    _get_spawn_lock(session_key)
+
+
+def _runtime_state_present(session_key: str) -> bool:
+    return (
+        _tracker.is_closed(session_key, "task-1")
+        or _tracker.is_woken((session_key, "task-1"))
+        or _history_store.get(session_key) is not None
+        or session_key in _spawn_locks
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime_state():
+    yield
+    for key in list(_spawn_locks):
+        _spawn_locks.pop(key, None)
+    _history_store.clear()
+    _tracker._closed.clear()
+    _tracker._woken.clear()
+
+
+class _RecordingTaskRuntime:
+    def __init__(self) -> None:
+        self.cancelled: list[str] = []
+
+    async def cancel(self, *, session_key: str, source: str = "", reason: str = "") -> int:
+        self.cancelled.append(session_key)
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_delete_evicts_runtime_state_and_cancels_tasks(manager):
+    key = "agent:main:direct:u1"
+    runtime = _RecordingTaskRuntime()
+    manager.attach_task_runtime(runtime)
+    await manager.create(key)
+    _seed_runtime_state(key)
+
+    await manager.delete(key)
+
+    assert not _runtime_state_present(key)
+    assert runtime.cancelled == [key]
+    assert await manager._storage.get_session(key) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_is_idempotent_after_finish(manager):
+    key = "agent:main:direct:u1"
+    await manager.create(key)
+    _seed_runtime_state(key)
+
+    await manager.finish(key)
+    await manager.delete(key)
+
+    assert not _runtime_state_present(key)
+
+
+@pytest.mark.asyncio
+async def test_delete_tolerates_a_task_runtime_without_kwargs(manager):
+    """Duck-typed runtimes without source/reason must not block the delete."""
+
+    class _MinimalRuntime:
+        def __init__(self) -> None:
+            self.cancelled: list[str] = []
+
+        async def cancel(self, *, session_key: str) -> int:
+            self.cancelled.append(session_key)
+            return 0
+
+    key = "agent:main:direct:u1"
+    runtime = _MinimalRuntime()
+    manager.attach_task_runtime(runtime)
+    await manager.create(key)
+    _seed_runtime_state(key)
+
+    await manager.delete(key)
+
+    assert runtime.cancelled == [key]
+    assert not _runtime_state_present(key)
+
+
+@pytest.mark.asyncio
+async def test_cap_entries_evicts_runtime_state(manager):
+    keys = [f"agent:main:direct:u{i}" for i in range(3)]
+    for key in keys:
+        await manager.create(key)
+        _seed_runtime_state(key)
+
+    deleted = await manager.cap_entries(max_entries=1)
+
+    assert deleted == 2
+    remaining = {s.session_key for s in await manager._storage.list_sessions(limit=10)}
+    for key in keys:
+        assert _runtime_state_present(key) is (key in remaining)
+
+
+@pytest.mark.asyncio
+async def test_prune_stale_evicts_runtime_state(manager):
+    stale = "agent:main:direct:stale"
+    fresh = "agent:main:direct:fresh"
+    node = await manager.create(stale)
+    node.updated_at = 1
+    await manager._storage.upsert_session(node)
+    await manager.create(fresh)
+    _seed_runtime_state(stale)
+    _seed_runtime_state(fresh)
+
+    pruned = await manager.prune_stale(max_age_ms=1000)
+
+    assert pruned == 1
+    assert not _runtime_state_present(stale)
+    assert _runtime_state_present(fresh)
+    assert await manager._storage.get_session(stale) is None
+
+
+@pytest.mark.asyncio
+async def test_list_stale_session_keys_returns_keys_before_delete(manager):
+    node = await manager.create("agent:main:direct:stale")
+    node.updated_at = 1
+    await manager._storage.upsert_session(node)
+    await manager.create("agent:main:direct:fresh")
+
+    assert await manager._storage.list_stale_session_keys(1000) == ["agent:main:direct:stale"]
+
+
+@pytest.mark.asyncio
+async def test_reaper_evicts_runtime_state_for_expired_cron_sessions(manager):
+    from agentos.scheduler.reaper import SessionReaper
+
+    key = "cron:job1:run:r1"
+    node = await manager.create(key)
+    node.updated_at = 1
+    await manager._storage.upsert_session(node)
+    _seed_runtime_state(key)
+
+    await SessionReaper(manager._storage, retention_seconds=1)._do_reap()
+
+    assert not _runtime_state_present(key)
+    assert await manager._storage.get_session(key) is None


### PR DESCRIPTION
Fixes #750.

## Problem

`_evict_session_runtime_state()` had exactly one caller — `SessionManager.finish()` (`session/manager.py:816`). Every other removal path went straight to `storage.delete_session()`, so three process-global stores kept their entries forever:

| Store | Module | What leaked |
|---|---|---|
| `SpawnGroupTracker._closed` / `._woken` | `gateway/subagent_announce.py` | closed/woken spawn groups keyed by `(parent_session_key, parent_task_id)` |
| `_history_store` | `engine/steps/agentos_router.py` | per-session Pilot routing history |
| `_spawn_locks` | `tools/builtin/sessions.py` | per-session `asyncio.Lock` guarding concurrent subagent spawns |

On a gateway that stays up for weeks — the normal production deployment — every deleted or pruned session leaked another entry with nothing to bound the growth.

`sessions.delete` also removed the session from storage without cancelling its active or queued tasks, so an in-flight turn handler could keep writing to a session whose rows were already gone.

## Change

Eviction moves to a new `agentos.session.runtime_state` module as a single idempotent choke point (`evict_session_runtime_state`). All four removal paths now call it:

- `sessions.delete` RPC — `gateway/rpc_sessions.py` (the Web UI "Delete Chat")
- `SessionManager.cap_entries()`
- `SessionManager.prune_stale()`
- the cron `SessionReaper` — `scheduler/reaper.py`, which is the same leak and was not listed in the issue

`SessionManager.finish()` keeps calling it, which is safe because eviction is idempotent.

Ordering follows the issue: **cancel tasks → evict runtime state → delete from storage**. Cancelling first matters — otherwise an in-flight turn can repopulate the very state being evicted.

Specifics worth reviewing:

- **`sessions.delete` cancels and drains first.** The reset path's `_drain_task_runtime_for_reset` was generalized into `_drain_task_runtime_for_session(...)` rather than duplicated; `_drain_task_runtime_for_reset` stays as a thin wrapper so the reset call site and its test are untouched. The drain is **best effort** — a task runtime that fails to cancel must not turn "Delete Chat" into an error and leave the session in place.
- **Keys are canonicalized** before evicting and cancelling, since the runtime stores and the task runtime are keyed by the canonical form that `storage.delete_session` normalizes to. Evicting the raw request key would miss every entry. The response still echoes the caller's key.
- **`prune_stale` collects keys up front** via the new `SessionStorage.list_stale_session_keys(before_ms)`. As noted on the issue, `storage.prune_stale_sessions()` deletes inside the storage layer and returns only a count, leaving nothing to evict against. That method is kept (public storage API) and now documents that it is storage-only.
- **`SessionManager.delete()`** is the new removal choke point for the maintenance paths, and `SessionManager._cancel_task_runtime()` is shared with `kill_session()`'s child-cancel loop, which had the same duck-typed `TypeError` fallback inline.

## Tests

New `tests/test_session/test_runtime_state_eviction.py` seeds all three stores and asserts each removal path drains them — `delete`, `cap_entries`, `prune_stale`, the reaper, `delete` after `finish` (idempotence), and a task runtime whose `cancel` takes no `source`/`reason`. Sessions that survive `cap_entries`/`prune_stale` keep their state, so the tests would catch over-eviction too.

Two tests added to `tests/test_gateway/test_rpc_sessions.py`: `sessions.delete` cancels the task runtime and evicts all three stores, and a runtime whose `cancel` raises still yields a successful delete with an empty `errors` list.

## Verification

```
uv run ruff check src tests                 # All checks passed
uv run mypy src/agentos --show-error-codes  # Success: no issues found in 623 source files
uv run pytest -q                            # 9360 passed, 27 skipped in 204.87s
```

No CLI surface change, so `docs/cli.md` and `agentos/SKILL.md` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUNp1V6vukCeBNatezzwq