### PR TITLE
fix(mcp): clamp bridge event-wait and history limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The MCP bridge clamps the arguments an MCP client supplies instead of
+  forwarding them to the gateway verbatim. `events_wait` caps `timeout_ms` at
+  5 minutes — applied before the deadline is computed, so the cap reaches
+  `recv_event` — and `max_events` at 10,000; `conversations_list` and
+  `messages_read` (and therefore the `transcript_export` tool) clamp `limit`
+  into `1..5000`. These arguments were unclamped, or lower-clamped only, and
+  they are chosen by a model on every call: a `timeout_ms=3_600_000` held the
+  tool call for an hour, indistinguishable from a stuck gateway, and a negative
+  `conversations_list` limit reached SQLite as `LIMIT -1`, which means *no*
+  limit and loaded every session row. The `messages_read` ceiling is defence in
+  depth — the gateway already normalises `chat.history` into `1..200`. Clamping
+  is silent, so a badly chosen argument degrades instead of surfacing a tool
+  error ([#685](https://github.com/use-agent-os/agent-os/issues/685)).
+
 ## [2026.9.5] - 2026-09-05
 
 ### Added

--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -27,6 +27,27 @@ class GatewayClientLike(Protocol):
     async def recv_event(self, timeout: float | None = None) -> dict[str, Any]: ...
 
 
+# Upper bounds for the bridge arguments an MCP client supplies. The client is the
+# operator's own MCP host rather than a remote attacker, but every one of these
+# arguments is chosen by a model on each call, so a bad pick has to degrade
+# rather than hang the tool call: a `timeout_ms=3_600_000` holds the call open
+# for an hour, which the user cannot tell apart from a stuck gateway.
+#
+# The ceilings sit above this bridge's own defaults (50 sessions, 1000 messages)
+# so ordinary calls are untouched. That is why they are not the 200/100 used by
+# the `sessions_list` / `sessions_history` builtins, whose defaults are 50 and
+# 20. The gateway applies its own, tighter cap to `chat.history`, so the history
+# ceiling here is defence in depth rather than the only guard.
+_MAX_EVENTS_WAIT_TIMEOUT_MS = 300_000  # 5 minutes
+_MAX_EVENTS_WAIT_EVENTS = 10_000
+_MAX_HISTORY_LIMIT = 5_000
+_MAX_SESSION_LIST_LIMIT = 5_000
+
+
+def _clamp_limit(limit: int, upper: int) -> int:
+    return min(max(1, limit), upper)
+
+
 def _default_gateway_client() -> GatewayClientLike:
     from agentos.gateway_client import GatewayRPCClient
 
@@ -65,7 +86,10 @@ class AgentOSMCPBridge:
 
     async def conversations_list(self, limit: int = 50) -> dict[str, Any]:
         client = await self._ensure_client()
-        return await client.list_sessions(limit=limit)
+        # The lower bound matters as much as the ceiling here: `sessions.list`
+        # passes the limit into a SQL `LIMIT ?`, and SQLite reads a negative
+        # limit as no limit at all, so a negative argument loaded every row.
+        return await client.list_sessions(limit=_clamp_limit(limit, _MAX_SESSION_LIST_LIMIT))
 
     async def session_resolve(self, key: str) -> dict[str, Any]:
         client = await self._ensure_client()
@@ -73,7 +97,7 @@ class AgentOSMCPBridge:
 
     async def messages_read(self, key: str, limit: int = 1000) -> dict[str, Any]:
         client = await self._ensure_client()
-        return await client.session_history(key, limit=limit)
+        return await client.session_history(key, limit=_clamp_limit(limit, _MAX_HISTORY_LIMIT))
 
     async def messages_send(
         self,
@@ -131,8 +155,9 @@ class AgentOSMCPBridge:
             current_stream_seq = int(
                 subscription.get("current_stream_seq") or since_stream_seq or 0
             )
-            deadline = time.monotonic() + max(0, timeout_ms) / 1000
-            max_events = max(1, max_events)
+            max_events = _clamp_limit(max_events, _MAX_EVENTS_WAIT_EVENTS)
+            timeout_ms = min(max(0, timeout_ms), _MAX_EVENTS_WAIT_TIMEOUT_MS)
+            deadline = time.monotonic() + timeout_ms / 1000
 
             while len(events) < max_events:
                 remaining = deadline - time.monotonic()

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from agentos.mcp_server import bridge as bridge_module
 from agentos.mcp_server.bridge import AgentOSMCPBridge
 
 
@@ -261,3 +262,131 @@ async def test_events_wait_uses_dedicated_connection_and_closes_it() -> None:
     assert result["current_stream_seq"] == 8
     assert clients[0].closed is False
     assert event_client.closed is True
+
+
+class RecordingEventClient(FakeGatewayClient):
+    """Fake client that records the timeout handed to each ``recv_event`` call."""
+
+    def __init__(self, *, event: dict[str, Any] | None = None) -> None:
+        super().__init__()
+        self.recv_timeouts: list[float | None] = []
+        self._event = event or {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 1},
+        }
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        self.recv_timeouts.append(timeout)
+        return dict(self._event)
+
+
+class EndlessEventClient(FakeGatewayClient):
+    """Fake client that yields non-terminal events forever."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.recv_count = 0
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        self.recv_count += 1
+        return {
+            "event": "session.event.text_delta",
+            "payload": {
+                "session_key": "agent:main:main",
+                "stream_seq": self.recv_count,
+                "text": "x",
+            },
+        }
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [(10**9, bridge_module._MAX_SESSION_LIST_LIMIT), (0, 1), (-5, 1), (10, 10)],
+)
+@pytest.mark.asyncio
+async def test_conversations_list_clamps_limit(requested: int, expected: int) -> None:
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.conversations_list(limit=requested)
+
+    assert client.calls == [("sessions.list", {"limit": expected})]
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [(10**9, bridge_module._MAX_HISTORY_LIMIT), (0, 1), (-5, 1), (25, 25)],
+)
+@pytest.mark.asyncio
+async def test_messages_read_clamps_limit(requested: int, expected: int) -> None:
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.messages_read("agent:main:main", limit=requested)
+
+    assert client.calls == [("chat.history", {"sessionKey": "agent:main:main", "limit": expected})]
+
+
+@pytest.mark.asyncio
+async def test_transcript_jsonl_clamps_limit_through_messages_read() -> None:
+    client = FakeGatewayClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.transcript_jsonl("agent:main:main", limit=10**9)
+
+    assert client.calls == [
+        (
+            "chat.history",
+            {"sessionKey": "agent:main:main", "limit": bridge_module._MAX_HISTORY_LIMIT},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_events_wait_clamps_effective_deadline() -> None:
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.events_wait("agent:main:main", timeout_ms=3_600_000)
+
+    assert client.recv_timeouts
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout is not None
+    # The deadline must come from the clamped timeout, not the requested hour.
+    assert first_timeout <= bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
+
+
+@pytest.mark.asyncio
+async def test_events_wait_preserves_timeout_below_the_cap() -> None:
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.events_wait("agent:main:main", timeout_ms=2_000)
+
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout is not None
+    assert 1.0 < first_timeout <= 2.0
+
+
+@pytest.mark.asyncio
+async def test_events_wait_clamps_max_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bridge_module, "_MAX_EVENTS_WAIT_EVENTS", 3)
+    client = EndlessEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    # Keep the deadline short: if the clamp regresses, the loop honours 10**9
+    # against an endless client, and the test should fail fast rather than
+    # allocate events until the runner dies.
+    result = await bridge.events_wait("agent:main:main", timeout_ms=200, max_events=10**9)
+
+    assert len(result["events"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_events_wait_preserves_max_events_below_the_cap() -> None:
+    client = EndlessEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=200, max_events=2)
+
+    assert len(result["events"]) == 2


### PR DESCRIPTION
Closes #685

## Summary

The MCP bridge forwarded client-supplied arguments to the gateway verbatim — unclamped, or lower-clamped only. Following the threat model in the issue triage: the client is the operator's own MCP host, but these arguments are chosen **by the model** on every call, so the case worth defending is ordinary model error (or an injected instruction), not an external DoS. All four are now clamped silently at the bridge, which is the single choke point for both the `@mcp.tool` and the `@mcp.resource` layers.

| Argument | Before | After |
| --- | --- | --- |
| `events_wait.timeout_ms` | `max(0, …)` | `0..300_000` (5 min) |
| `events_wait.max_events` | `max(1, …)` | `1..10_000` |
| `conversations_list.limit` | forwarded raw | `1..5_000` |
| `messages_read.limit` (and `transcript_export`) | forwarded raw | `1..5_000` |

## What each clamp actually fixes

- **`timeout_ms` — the real one.** The deadline was computed from the raw value, so `timeout_ms=3_600_000` handed a one-hour timeout to `recv_event` and held the tool call open for the duration, indistinguishable from a stuck gateway. The clamp is applied **before** `deadline` is computed, so it reaches `recv_event`.
- **`conversations_list.limit` — a second, unlisted vector.** `sessions.list` passes the limit straight into a SQL `LIMIT ?` (`rpc_sessions.py:752` → `session/storage.py:696`) with no validation. SQLite reads a **negative** limit as *no limit at all*, so a negative argument loaded every session row. The lower bound matters as much as the ceiling here.
- **`max_events`** is already bounded in wall-clock by its own deadline, so it cannot run away on its own; the cap is belt-and-braces.
- **`messages_read.limit` is defence in depth, not a hole being closed.** The gateway already normalises `chat.history` into `1..200` (`_normalize_chat_history_limit`, `rpc_chat.py:44-54`). I'd rather state that than imply the bridge was the only guard.

## On the chosen ceilings

5000/10000 sit **above the bridge's own defaults** (50 sessions, 1000 messages), so no ordinary call changes behaviour. That is deliberately not the 200/100 used by the `sessions_list` / `sessions_history` builtins — those default to 50 and 20, so their tighter ceilings would clamp this bridge's own 1000-message default.

Two judgement calls I'd welcome your view on:

1. The 5-minute `events_wait` cap sits below the gateway's own `agent_stream_idle_timeout_ms` default of `600_000`. A turn legitimately running past 5 minutes now always returns `timed_out: true` (recoverable by re-calling with `current_stream_seq`). `300_000` is the number from the issue; `600_000` would be the number with a reason behind it. Happy to switch.
2. The only behavioural change from the lower clamp is `conversations_list(limit=0)`, which returned an empty list and now returns one row. `messages_read(limit=0)` already became 1 at the gateway.

## Building on the earlier review rounds

This picks up the feedback left on #813/#686 rather than re-litigating it: the `timeout_ms` clamp is placed inside the deadline path (not assigned after it, where it was dead code), lower clamps are on `conversations_list` and `messages_read`, clamping is silent, rationale is in `#` comments, and the CHANGELOG entry lands once inside `[Unreleased]`. The redundant `transcript_jsonl` clamp is left out — it delegates to `messages_read`, which clamps.

## Verification

- `uv run --all-extras pytest tests/test_mcp_server -q` → **30 passed**
- `uv run --all-extras pytest -q -m "not llm"` → **9361 passed**, 2 failed; both (`test_provider_config.py::test_enabled_but_module_missing_boots_with_none`, `test_skill_html_to_pdf.py::test_render_html_to_pdf`) reproduce identically on a clean `upstream/main` in this environment and are unrelated
- `uv run --all-extras ruff check src tests` → clean; `mypy src/agentos/mcp_server` → clean
- **Mutation-tested each clamp**, since a test that passes either way was the gap last time:
  - restoring the old ordering (deadline from raw `timeout_ms`) → `test_events_wait_clamps_effective_deadline` fails
  - dropping the `max_events` cap → `test_events_wait_clamps_max_events` fails
  - dropping the two limit clamps → 7 cases fail

The deadline test asserts the timeout **actually handed to `recv_event`** is `<= 300`, so it cannot pass with the clamp removed. The `max_events` test deliberately runs a 200 ms deadline: if that clamp regresses, the loop would honour `10**9` against an endless client, and the test should fail in milliseconds rather than allocate until the runner dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtNA3M1D1r5L61x1dGyZzp