### PR TITLE
fix(scheduler): close DNS-rebinding SSRF TOCTOU in webhook delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- Cron webhook delivery POSTs through the connect-time SSRF guard, closing the
+  DNS-rebinding TOCTOU window the fetch-tool conversion left open on this path.
+  `validate_webhook_url` resolves the hostname once and clears it;
+  the plain `httpx.AsyncClient` that followed resolved the same name again when
+  it dialled, so a short-TTL domain could answer with a public address for the
+  check and with `169.254.169.254` for the socket — handing the job id, job name
+  and run summary to the cloud metadata service. Delivery now uses
+  `ssrf_guarded_client(validator=validate_metadata_only_address)`, which dials
+  the address it validated, on the first attempt and on every `retry_request`
+  retry. The URL check stays in front of it for the legible `invalid webhook
+  URL` message at add time, and the metadata-only floor keeps localhost and LAN
+  hooks (n8n and friends) working. As with the fetch tools, the guard covers the
+  default connection pool only: a request routed through a configured `HTTP_PROXY`
+  is resolved by the proxy rather than in-process, so there is no local rebinding
+  window there to close
+  ([#725](https://github.com/use-agent-os/agent-os/issues/725)).
+
 ## [2026.9.5] - 2026-09-05
 
 ### Added

--- a/src/agentos/scheduler/delivery.py
+++ b/src/agentos/scheduler/delivery.py
@@ -503,9 +503,11 @@ class DeliveryChain:
             log.warning("delivery.webhook_url_invalid", job_id=job_id, reason=str(exc))
             return _failed(f"invalid webhook URL: {exc}")
 
-        import httpx
-
         from agentos.channels._util import retry_request
+        from agentos.tools.ssrf_client import (
+            ssrf_guarded_client,
+            validate_metadata_only_address,
+        )
 
         headers = {"Content-Type": "application/json"}
         if token:
@@ -517,7 +519,18 @@ class DeliveryChain:
             "deliveredAt": datetime.now(UTC).isoformat(),
         }
         try:
-            async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:
+            # ``validate_webhook_url`` above resolved the hostname once; httpx
+            # would resolve it again when it dials, so a short-TTL rebinding
+            # domain could answer with a public address for the check and with
+            # 169.254.169.254 for the socket. The guarded client dials the
+            # address it validated, and does so on every retry attempt because
+            # ``retry_request`` re-enters ``client.post`` on the same guarded
+            # client. Metadata-only, not the full fetch policy: cron webhooks
+            # are pointed at n8n on localhost and at LAN boxes on purpose.
+            async with ssrf_guarded_client(
+                timeout=_WEBHOOK_TIMEOUT_SECONDS,
+                validator=validate_metadata_only_address,
+            ) as client:
                 # retry_request's defaults (3 retries, 1s base) keep the worst
                 # case near 7s plus jitter — inside the job's own timeout
                 # budget, whose slot is held while we back off.

--- a/tests/test_scheduler/test_failure_destination.py
+++ b/tests/test_scheduler/test_failure_destination.py
@@ -11,10 +11,10 @@ persistence, RPC, and the actual failure-routing decision.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
 from agentos.gateway.rpc import RpcContext
@@ -496,9 +496,9 @@ async def test_dispatcher_exception_does_not_break_state_machine() -> None:
 
 async def test_dispatch_failure_alert_via_webhook(monkeypatch) -> None:
     _RecordingHttpxClient.posts.clear()
-    monkeypatch.setitem(
-        sys.modules, "httpx", type("M", (), {"AsyncClient": _RecordingHttpxClient})
-    )
+    # ``ssrf_guarded_client`` constructs through ``httpx.AsyncClient`` so a
+    # double patched onto that attribute still stands in for the real client.
+    monkeypatch.setattr(httpx, "AsyncClient", _RecordingHttpxClient)
 
     chain = DeliveryChain()
     job = _job_with_delivery(

--- a/tests/test_scheduler/test_webhook_delivery.py
+++ b/tests/test_scheduler/test_webhook_delivery.py
@@ -7,13 +7,21 @@ validated up front and rejected at add time when malformed.
 
 from __future__ import annotations
 
+import ipaddress
+import socket
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
-from agentos.scheduler.delivery import DeliveryChain, validate_webhook_url
+from agentos.scheduler.delivery import (
+    _WEBHOOK_TIMEOUT_SECONDS,
+    DeliveryChain,
+    status_detail,
+    validate_webhook_url,
+)
 from agentos.scheduler.ops import SchedulerOps
 from agentos.scheduler.payloads import make_agent_turn_payload
 from agentos.scheduler.persistence import JobStore
@@ -24,6 +32,7 @@ from agentos.scheduler.types import (
     ScheduleKind,
     SessionTarget,
 )
+from agentos.tools import ssrf_client
 
 # --- URL validation --------------------------------------------------------
 
@@ -256,10 +265,7 @@ class _RecordingAsyncClient:
 async def test_deliver_webhook_posts_json_with_bearer(monkeypatch) -> None:
     _RecordingAsyncClient.instances.clear()
 
-    class _FakeHttpx:
-        AsyncClient = _RecordingAsyncClient
-
-    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+    monkeypatch.setattr(httpx, "AsyncClient", _RecordingAsyncClient)
 
     chain = DeliveryChain()
     status = await chain._deliver_webhook(
@@ -281,10 +287,7 @@ async def test_deliver_webhook_posts_json_with_bearer(monkeypatch) -> None:
 async def test_deliver_webhook_omits_authorization_when_no_token(monkeypatch) -> None:
     _RecordingAsyncClient.instances.clear()
 
-    class _FakeHttpx:
-        AsyncClient = _RecordingAsyncClient
-
-    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+    monkeypatch.setattr(httpx, "AsyncClient", _RecordingAsyncClient)
 
     chain = DeliveryChain()
     status = await chain._deliver_webhook(
@@ -309,10 +312,7 @@ async def test_deliver_webhook_returns_failed_on_http_error(monkeypatch, no_back
 
             return _Resp()
 
-    class _FakeHttpx:
-        AsyncClient = _ErrorClient
-
-    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+    monkeypatch.setattr(httpx, "AsyncClient", _ErrorClient)
     _RecordingAsyncClient.instances.clear()
 
     chain = DeliveryChain()
@@ -346,10 +346,7 @@ def _scripted_httpx(monkeypatch, responses):
                 raise item
             return item
 
-    class _FakeHttpx:
-        AsyncClient = _ScriptedClient
-
-    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+    monkeypatch.setattr(httpx, "AsyncClient", _ScriptedClient)
     _RecordingAsyncClient.instances.clear()
 
 
@@ -417,3 +414,149 @@ async def test_deliver_webhook_honours_retry_after_on_429(monkeypatch, no_backof
 
     assert status == "delivered"
     no_backoff.assert_awaited_once_with(2.0)
+
+
+# --- connect-time SSRF guard (issue #725) ----------------------------------
+#
+# ``validate_webhook_url`` resolves the hostname once and checks the answer;
+# httpx then resolves it again when it opens the socket. A short-TTL rebinding
+# domain can answer with a public address for the check and with
+# ``169.254.169.254`` for the connect, so the job payload lands on the cloud
+# metadata endpoint. The guarded client dials the address that was validated.
+
+METADATA_IP = "169.254.169.254"
+
+
+def _sequence_resolver(*ips: str):
+    """``getaddrinfo`` double that answers with a different address per call.
+
+    IP literals resolve to themselves so the wrapped backend can still dial the
+    literal the guard approved.
+    """
+    calls: list[str] = []
+
+    def resolver(host, port=None, *args, **kwargs):
+        calls.append(host)
+        try:
+            ipaddress.ip_address(str(host).strip("[]"))
+        except ValueError:
+            index = min(len([c for c in calls if c == host]) - 1, len(ips) - 1)
+            answer = ips[index]
+        else:
+            answer = str(host)
+        family = socket.AF_INET6 if ipaddress.ip_address(answer).version == 6 else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, 6, "", (answer, port or 80))]
+
+    resolver.calls = calls  # type: ignore[attr-defined]
+    return resolver
+
+
+class _LocalWebhookServer:
+    """Minimal HTTP/1.1 responder on an ephemeral loopback port.
+
+    Answers every connection it is given rather than just the first, so a
+    regression that reintroduces retries fails on the assertion instead of
+    hanging on an unanswered socket, and takes a timeout on the accept loop so
+    the thread cannot outlive the test on any platform.
+    """
+
+    def __init__(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(8)
+        self._sock.settimeout(0.5)
+        self.port = self._sock.getsockname()[1]
+        self.requests: list[bytes] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except TimeoutError:
+                continue
+            except OSError:  # pragma: no cover - the socket closed under us
+                return
+            with conn:
+                conn.settimeout(5.0)
+                try:
+                    self.requests.append(conn.recv(65536))
+                    conn.sendall(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n"
+                        b"Content-Length: 2\r\nConnection: close\r\n\r\nok"
+                    )
+                    conn.shutdown(socket.SHUT_WR)
+                except OSError:  # pragma: no cover - client went away
+                    pass
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5.0)
+        self._sock.close()
+
+
+async def test_deliver_webhook_uses_the_metadata_only_connect_guard(monkeypatch) -> None:
+    """The POST goes through ``ssrf_guarded_client``, not a bare client."""
+    recorded: dict[str, object] = {}
+
+    def _fake_guarded_client(*, validator, **kwargs):
+        recorded["validator"] = validator
+        recorded["kwargs"] = kwargs
+        return _RecordingAsyncClient(**kwargs)
+
+    monkeypatch.setattr(ssrf_client, "ssrf_guarded_client", _fake_guarded_client)
+    _RecordingAsyncClient.instances.clear()
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("https://hooks.example/cron"),
+        text="x",
+    )
+
+    assert status == "delivered"
+    # Metadata-only, not the full fetch policy: cron webhooks are pointed at
+    # n8n on localhost and LAN boxes on purpose, and must keep working.
+    assert recorded["validator"] is ssrf_client.validate_metadata_only_address
+    assert recorded["kwargs"]["timeout"] == _WEBHOOK_TIMEOUT_SECONDS
+
+
+async def test_deliver_webhook_blocks_dns_rebinding_to_metadata(monkeypatch, no_backoff) -> None:
+    """A name that rebinds to IMDS after URL validation never gets the payload."""
+    resolver = _sequence_resolver("127.0.0.1", METADATA_IP)
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+
+    chain = DeliveryChain()
+    status = await chain._deliver_webhook(
+        _webhook_job("http://rebind.example/hook"),
+        text="secret summary",
+    )
+
+    assert status == "delivery_failed"
+    assert "metadata" in status_detail(status).lower()
+    # The block has to come from the connect guard, not from validate_webhook_url:
+    # SSRFBlockedError is a ValueError, so a check-time block would also mention
+    # metadata — but it would carry the "invalid webhook URL" prefix, and it would
+    # leave the second resolution unmade.
+    assert not status_detail(status).startswith("invalid webhook URL")
+    assert resolver.calls == ["rebind.example", "rebind.example"]
+    # Blocked at connect time, so retry_request never got a transient error to
+    # sleep on — a rebinding target must not be retried into.
+    no_backoff.assert_not_awaited()
+
+
+async def test_deliver_webhook_still_reaches_a_loopback_hook(no_backoff) -> None:
+    """The metadata floor keeps localhost hooks (n8n and friends) working."""
+    server = _LocalWebhookServer()
+    try:
+        chain = DeliveryChain()
+        status = await chain._deliver_webhook(
+            _webhook_job(f"http://127.0.0.1:{server.port}/hook"),
+            text="summary text",
+        )
+    finally:
+        server.close()
+
+    assert status == "delivered"
+    assert server.requests and b"POST /hook" in server.requests[0]


### PR DESCRIPTION
Closes #725.

## The hole

`DeliveryChain._post_to_webhook` validated the URL and then opened a plain client:

```python
validate_webhook_url(url)          # resolves the hostname once, checks the answer
...
async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_SECONDS) as client:   # resolves it AGAIN
    response = await retry_request(client.post, url, json=payload, headers=headers)
```

Two resolutions, and only the first one was checked. A short-TTL domain answers with a public address for `assert_not_metadata_endpoint` and with `169.254.169.254` for the socket, so the job id, job name and run summary get POSTed to the cloud metadata service.

PR #697 closed exactly this window across `web_fetch`, `web.py`, `x_search` and `media.py`. `scheduler/delivery.py` was the path it missed.

## The fix

Route the POST through `ssrf_guarded_client(validator=validate_metadata_only_address)`. The backend resolves once, applies the policy to every address it got, and dials a validated IP literal — the address that was checked is the address the socket uses.

Both points raised in the issue thread are honoured:

- **`validate_webhook_url()` stays.** It is what produces the legible `invalid webhook URL` message at add time; the connect-time backend is the second layer, not a replacement.
- **Every retry re-validates.** `retry_request` wraps `client.post`, so it re-enters the *same guarded client* on each attempt — the guard is not a first-attempt-only check.

**Metadata-only, not the full fetch policy.** `validate_webhook_url` deliberately allows localhost and LAN hooks because operators point cron at n8n and similar. `validate_metadata_only_address` is the address-level half of the same `assert_not_metadata_endpoint` check already applied at add time, so the connect-time policy is now exactly the check-time policy — which is the invariant you want — without breaking those hooks.

`SSRFBlockedError` is a `ValueError`, and `retry_request` catches only `(httpx.ConnectError, httpx.TimeoutException)`, so a blocked target propagates on the first attempt instead of being retried into. The `ssrf_guarded_client(...)` call sits inside the existing `try:`, so if `_install_backend` ever raises (httpx internals changed) delivery fails closed into `delivery_failed` rather than sending unguarded.

## Tests

Three new tests in `tests/test_scheduler/test_webhook_delivery.py`, written before the fix and confirmed red against the old code — the rebinding one genuinely *connected* to the metadata IP:

- the POST goes through `ssrf_guarded_client` with the metadata-only validator and the webhook timeout
- a name rebinding `127.0.0.1` → `169.254.169.254` is blocked at connect: asserted on exactly two resolutions and on the absence of the `invalid webhook URL` prefix, so the test proves the block came from the connect guard and not from the URL check, and asserts `retry_request` never slept
- a real loopback HTTP server still receives the POST — a guard against anyone later tightening this to `validate_fetch_address`

Both changed test files previously faked httpx by swapping `sys.modules["httpx"]`, which `ssrf_guarded_client` cannot see because `ssrf_client.py` holds its own module reference. They now patch the `httpx.AsyncClient` attribute — the seam `_REAL_ASYNC_CLIENT` is documented to support. What those tests assert (payload, bearer, retry semantics) is unchanged.

## Scope

`_post_to_webhook` is the only outbound POST site in `delivery.py`, and the failure-destination path routes through it, so alerts are covered by the same change. `ops.py` webhook checks are add/update-time only and untouched. No CLI surface change, so `docs/cli.md` and the bundled `agentos/SKILL.md` need no update.

The guard covers the default connection pool, matching `web_fetch` and `http_request`: a request routed through a configured `HTTP_PROXY` is resolved by the proxy rather than in-process, so there is no local rebinding window there to close. The CHANGELOG entry says so rather than claiming more than the code gives.

## Verification

- `uv run ruff check src tests` — clean
- `uv run mypy src/agentos --show-error-codes` — clean, 622 source files
- `uv run pytest -q -m "not llm"` — 9353 passed, 23 skipped
- changed test files run 5× consecutively, no flakes

## Note on overlap

#727 is already open against this issue with the same approach, and #873 was closed as a duplicate. Happy for maintainers to take whichever is more useful — closing this one is no problem if #727 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWieor4fjCoUqqJHAEWEkk
