### PR TITLE
fix(cli): correct two printed/documented commands that fail when followed (#840)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Two commands AgentOS printed or documented now work when followed.
+  `docs/cli.md` and `README.product.md` told users to run `agentos config set
+  gateway.port 18791`; there is no `[gateway]` table — the listen port is
+  top-level `port` on `GatewayConfig`, which is `extra = forbid` — so the
+  copy-pasted line exited 1 with `Key not found` and never changed the port.
+  Both examples now say `agentos config set port 18791`. They deliberately do
+  not pass `--config ~/.agentos/config.toml`: `resolve_config_path()` loads the
+  *first* of `AGENTOS_GATEWAY_CONFIG_PATH`, `./agentos.toml` and
+  `~/.agentos/config.toml` that exists, so hardcoding the last of the three
+  writes to a file the gateway may not read — exiting 0 and printing "Restart
+  the gateway to apply this setting" while the port silently does not change,
+  which is harder to debug than the original error. Separately, `channels add`
+  and `channels edit` printed `Verify: uv run agentos channels status <name>
+  --json`; `uv` is not present on a pipx or pip install — both documented
+  install methods — so that hint exited 127, while the line directly above it
+  already printed a plain `agentos gateway restart`. The `uv run ` prefix is
+  dropped. A test now runs every `agentos config set` example in both docs
+  files through the CLI and fails if one does not exit 0
+  ([#840](https://github.com/use-agent-os/agent-os/issues/840),
+  [#835](https://github.com/use-agent-os/agent-os/issues/835)).
 - Turn admission reserves spend headroom instead of only checking it, so a
   concurrent subagent fan-out can no longer overshoot a `[budgets]` ceiling by
   the width of the fan-out. Spend is recorded by `UsageTracker.add()` only as a

--- a/README.product.md
+++ b/README.product.md
@@ -135,7 +135,7 @@ agentos configure router --router recommended
 agentos configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 agentos configure channels
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -446,7 +446,7 @@ Raw config:
 
 ```sh
 agentos config get llm.provider
-agentos config set gateway.port 18791
+agentos config set port 18791
 ```
 
 For Ollama models that do not reliably support native tool calls, set

--- a/src/agentos/cli/channels_cmd.py
+++ b/src/agentos/cli/channels_cmd.py
@@ -60,7 +60,7 @@ def _print_restart_notice() -> None:
 
 def _print_channel_verification_next_step(name: str) -> None:
     typer.echo("Next: agentos gateway restart")
-    typer.echo(f"Verify: uv run agentos channels status {name} --json")
+    typer.echo(f"Verify: agentos channels status {name} --json")
 
 
 _SOURCE_LABEL = {

--- a/tests/test_cli/test_channels_cmd.py
+++ b/tests/test_cli/test_channels_cmd.py
@@ -423,6 +423,24 @@ def test_channels_add_prints_status_verification_next_step(tmp_path, monkeypatch
     out = result.stdout.lower()
     assert "agentos gateway restart" in out
     assert "agentos channels status w --json" in out
+    # The verify hint must be runnable on a pipx/pip install, where `uv` is not
+    # present and `uv run agentos ...` exits 127.
+    assert "uv run" not in out
+
+
+def test_channels_edit_prints_status_verification_next_step(tmp_path, monkeypatch):
+    _setenv(monkeypatch, tmp_path)
+    add = runner.invoke(
+        app,
+        ["channels", "add", "slack", "--name", "w", "--token", "x", "--field", "signing_secret=ss"],
+    )
+    assert add.exit_code == 0, add.stdout
+    result = runner.invoke(app, ["channels", "edit", "w", "--field", "signing_secret=ss2"])
+    assert result.exit_code == 0, result.stdout
+    out = result.stdout.lower()
+    assert "agentos gateway restart" in out
+    assert "agentos channels status w --json" in out
+    assert "uv run" not in out
 
 
 def test_channels_add_echoes_resolved_path_and_source(tmp_path, monkeypatch):

--- a/tests/test_cli/test_documented_config_set_keys.py
+++ b/tests/test_cli/test_documented_config_set_keys.py
@@ -1,0 +1,87 @@
+"""Every ``agentos config set`` example in the docs must run when followed.
+
+`docs/cli.md` and `README.product.md` both documented
+``agentos config set gateway.port 18791``. There is no ``[gateway]`` table —
+the listen port is top-level ``port`` on ``GatewayConfig``, which is
+``extra = forbid`` — so the copy-pasted command exited 1 with ``Key not found``
+instead of changing the port
+(https://github.com/use-agent-os/agent-os/issues/840).
+
+The guard runs each documented example through the CLI rather than pinning the
+one bad string, so the next wrong key fails here instead of in a user's
+terminal.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agentos.cli.main import app
+
+ROOT = Path(__file__).resolve().parents[2]
+# Scoped to the two files issue #840 names. The bundled SKILL.md is
+# deliberately not scanned yet: it documents `config set auth.token`, which
+# also exits 1 — but because `to_toml_dict()` omits an unset secret, which is
+# the `_set_key` limitation tracked separately in #834.
+DOCS = ("docs/cli.md", "README.product.md")
+
+# Matches anywhere, so a fenced block, an inline `agentos config set x.y` in
+# prose and a `$`-prefixed shell line are all covered. Stops at the end of the
+# line; a placeholder such as `config set <dot.key>` is skipped below.
+_CONFIG_SET = re.compile(r"agentos config set ([^\n`]+)")
+
+runner = CliRunner()
+
+
+def _documented_commands() -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    for rel in DOCS:
+        path = ROOT / rel
+        if not path.is_file():
+            # Do not raise at collection time: that would also disable the
+            # meta-guard below, which exists to catch exactly this drift.
+            found.append((rel, ""))
+            continue
+        for raw in _CONFIG_SET.findall(path.read_text(encoding="utf-8")):
+            args = raw.strip().rstrip(".")
+            # `<dot.key>`-style placeholders are prose, not runnable examples.
+            if args.startswith("<"):
+                continue
+            found.append((rel, args))
+    return found
+
+
+def test_every_documented_file_exists_and_has_examples() -> None:
+    """Guard the scanner: a missing file or zero matches must not pass silently."""
+    for rel in DOCS:
+        assert (ROOT / rel).is_file(), f"{rel} moved — update DOCS in this test"
+    assert any(args for _, args in _documented_commands()), (
+        "no `agentos config set` examples found — the regex is stale"
+    )
+
+
+@pytest.mark.parametrize(("doc", "args"), _documented_commands(), ids=lambda v: v or "<missing>")
+def test_documented_config_set_command_runs(doc: str, args: str, tmp_path, monkeypatch) -> None:
+    assert args, f"{doc} is missing or unreadable"
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.delenv("AGENTOS_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    argv = shlex.split(args)
+    # An example that names its own `--config` target is pointed at a tmp file
+    # so the test never touches the developer's real config.
+    if "--config" in argv:
+        argv[argv.index("--config") + 1] = str(tmp_path / "config.toml")
+
+    result = runner.invoke(app, ["config", "set", *argv])
+
+    assert result.exit_code == 0, (
+        f"{doc} documents `agentos config set {args}`, but it exits "
+        f"{result.exit_code}:\n{result.output}"
+    )
+    assert "Key not found" not in result.output


### PR DESCRIPTION
Closes #840 (which folds in #835). Both halves of the umbrella, in one PR, per the scope in the maintainer's consolidation comment.

## 1. `agentos config set gateway.port 18791` — `docs/cli.md:449`, `README.product.md:138`

`gateway.port` is not a key. The listen port is top-level `port` on `GatewayConfig` (`config.py:2176`), and there is no `[gateway]` table — the model is `extra = forbid`, so inventing one would fail `model_validate`. Reproduced on `upstream/main`:

```
$ agentos config set gateway.port 18791
Key not found: gateway.port          # exit 1

$ agentos config set gateway.port 18791 --config "$CFG"
Key not found: gateway.port          # exit 1
```

Both examples become `agentos config set port 18791`.

### Why not `--config ~/.agentos/config.toml`

The issue's suggested fix appended `--config ~/.agentos/config.toml`. I implemented that first, then backed it out — it introduces a **new, worse** failure mode, which I confirmed empirically.

`resolve_config_path()` loads the *first* of `AGENTOS_GATEWAY_CONFIG_PATH` → `./agentos.toml` → `~/.agentos/config.toml` that exists. Hardcoding the last of the three writes to a file the gateway may not read:

```
$ cat ./agentos.toml
port = 9999
$ agentos config get port
port = 9999
$ agentos config set port 18791 --config ~/.agentos/config.toml
Config: /…/home/.agentos/config.toml
Restart the gateway to apply this setting.     # exit 0
$ agentos config get port
port = 9999                                    # unchanged
```

Exit 0, an explicit "Restart the gateway to apply this setting", and nothing changed. That is strictly harder to debug than the `Key not found` it replaced, and it contradicts the precedence list printed 15 lines above the example in `README.product.md`. The bare form exits 0 and prints an accurate, working `export AGENTOS_GATEWAY_PORT=18791` in that same scenario.

This also matches the operative scope line — "`gateway.port` → `port` in both docs files" — and keeps the production diff to one word per file.

Note: the silent-`export` half of the original report is already fixed. #834 landed in 2026.9.4 and made both paths exit 1, so only the docs half remained.

## 2. `Verify: uv run agentos channels status <name> --json` — `channels_cmd.py:63`

Printed by `channels add` and `channels edit`. `uv` is absent on a pipx or pip install — both documented install methods — so the hint exits 127, while line 62 immediately above already prints a plain `agentos gateway restart`. The `uv run ` prefix is dropped.

## Tests

The existing `test_channels_add_prints_status_verification_next_step` did **not** catch this: it asserted `"agentos channels status w --json" in out`, which the broken `uv run agentos channels status …` form also satisfies. It now rejects the prefix, and `channels edit` — the second, previously untested call site — gets its own test. Both were written failing first.

`tests/test_cli/test_documented_config_set_keys.py` scans both docs for `agentos config set` examples and **runs each one through the CLI**, asserting exit 0. It checks real behaviour rather than a model lookup, so it also catches keys that exist on the model but are unsettable. Mutation-tested: it fails on `gateway.port`, `auth.token` and `skills.config.wiki.path`, in bare, `$`-prefixed, indented and inline-backtick forms; it passes a valid new key and correctly skips `<dot.key>` placeholders. The scanner has a meta-guard so a renamed doc or a stale regex fails loudly instead of vacuously passing.

## Scope

Deliberately untouched, per the consolidation comment:

- **`_set_key` / `config_cmd.py`** — coordinated with #834, not fixed twice.
- **`_debounce.py`, `_util.py`** — the out-of-scope files called out on #867.
- **`src/agentos/skills/bundled/agentos/SKILL.md`** — checked per `CLAUDE.md`; it contains no `gateway.port` and no `uv run`, so nothing to sync.

**One related finding I did not fix.** That same `SKILL.md` documents `agentos config set auth.token "<long random secret>"`, which also exits 1 with `Key not found`. `auth.token` *is* a real `AuthConfig` field, but `to_toml_dict()` omits an unset secret, so `_set_key` cannot create it — that is the #834 root cause, not this one. It is a third instance of this defect class and worth tracking there; I left it alone rather than widen this PR, and noted why in a comment on the test's `DOCS` tuple.

## Verification

- `uv run ruff check src tests` — clean.
- `uv run mypy src` — one error, the pre-existing `mem0` missing-stubs one on `main`.
- `uv run pytest -m "not llm"` — **9352 passed**, 3 failed. All three (`test_mem0_provider`, `test_provider_config`, `test_skill_html_to_pdf`) are environment failures that reproduce unmodified on `upstream/main`; I confirmed the `mem0` one by stashing. Zero regressions.
- The corrected command was run end-to-end on an existing config, a fresh `$HOME` with no `.agentos/`, and the `./agentos.toml` precedence case above.

Supersedes #841, #926 and #867, which each cover only the docs half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1c1sofJbukPSBhpxLbGAi
