### PR TITLE
fix(sandbox): grade delete intents by destructiveness so a plain approval cannot cover `rm -rf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,16 +79,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `rm -rf /tmp/logs` the same cache key: approving the first — a no-op on a
   directory, since plain `rm` refuses it — let the second run without a prompt,
   and `-rf` had never appeared on anything the user saw. The key now carries a
-  capability set (`delete`, `delete:recursive`, `delete:force`,
-  `delete:recursive+force`) parsed from `-r`/`-R`/`-f`/`--recursive`/`--force`
-  (bundles and `--` terminator included) and from the Python spelling —
-  `shutil.rmtree` and `os.removedirs` are recursive, `os.remove`, `os.rmdir` and
-  `Path.unlink` are not. A cached approval satisfies a retry only when its
+  capability set — `recursive`, `parents`, `force` — parsed from
+  `-r`/`-R`/`-f`/`--recursive`/`--force` (bundles, flags after the target, the
+  `--` terminator, and the abbreviations `getopt_long` accepts all handled) and
+  from the Python spelling: `shutil.rmtree` is recursive, `os.removedirs` is
+  recursive *and* prunes empty ancestors, `os.remove`, `os.rmdir` and
+  `Path.unlink` are neither. A cached approval satisfies a retry only when its
   capability set is a superset, which keeps the module's reason for existing
-  intact: `rm -rf X` still covers `shutil.rmtree("X")` and `rm X` still covers
-  `os.remove("X")`, so paraphrased retries at the same destructiveness do not
-  re-prompt. `/forget <path>` clears every grade for the path, not just the
-  plain one ([#849](https://github.com/use-agent-os/agent-os/issues/849)).
+  intact: every shell-to-Python paraphrase still short-circuits — `rm X` covers
+  `os.remove("X")`, `rm -r X` and `rm -rf X` both cover `shutil.rmtree("X")` —
+  so retries at the same destructiveness do not re-prompt. `/forget <path>`
+  clears every grade for the path, not just the plain one
+  ([#849](https://github.com/use-agent-os/agent-os/issues/849)).
 
 ## [2026.9.5] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   is resolved by the proxy rather than in-process, so there is no local rebinding
   window there to close
   ([#725](https://github.com/use-agent-os/agent-os/issues/725)).
+- The intent approval cache grades a delete by how destructive it is, so an
+  approval never silently covers a stronger operation on the same path. Flags
+  were dropped during normalisation, which made `rm /tmp/logs` and
+  `rm -rf /tmp/logs` the same cache key: approving the first — a no-op on a
+  directory, since plain `rm` refuses it — let the second run without a prompt,
+  and `-rf` had never appeared on anything the user saw. The key now carries a
+  capability set (`delete`, `delete:recursive`, `delete:force`,
+  `delete:recursive+force`) parsed from `-r`/`-R`/`-f`/`--recursive`/`--force`
+  (bundles and `--` terminator included) and from the Python spelling —
+  `shutil.rmtree` and `os.removedirs` are recursive, `os.remove`, `os.rmdir` and
+  `Path.unlink` are not. A cached approval satisfies a retry only when its
+  capability set is a superset, which keeps the module's reason for existing
+  intact: `rm -rf X` still covers `shutil.rmtree("X")` and `rm X` still covers
+  `os.remove("X")`, so paraphrased retries at the same destructiveness do not
+  re-prompt. `/forget <path>` clears every grade for the path, not just the
+  plain one ([#849](https://github.com/use-agent-os/agent-os/issues/849)).
 
 ## [2026.9.5] - 2026-09-05
 

--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -81,6 +81,26 @@ The terminal chat supports:
 Use these commands when you need to inspect or reset cached approval decisions
 during a chat.
 
+### Cached Intents
+
+Approving a destructive action caches the *intent* — kind plus target path —
+rather than the literal command, so a paraphrased retry (`rm /tmp/x` followed by
+`os.remove("/tmp/x")`) proceeds without a second prompt.
+
+The kind carries a destructiveness grade, and an approval only covers a retry
+whose grade it already includes:
+
+| Cached kind | Covers |
+|---|---|
+| `delete` | `rm X`, `os.remove`, `os.rmdir`, `Path(X).unlink()` |
+| `delete:recursive` | the above plus `shutil.rmtree(X)`, `os.removedirs(X)` |
+| `delete:force` | the above plus `rm -f X` |
+| `delete:recursive+force` | everything, including `rm -rf X` |
+
+Escalation always re-prompts: approving `rm /tmp/logs` does **not** authorize
+`rm -rf /tmp/logs`. `/approvals` lists cached entries as `scope kind:target`,
+and `/forget <path>` drops every grade recorded for that path.
+
 The Web UI also provides an approvals surface for reviewing pending actions
 outside the message scrollback.
 

--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -87,19 +87,24 @@ Approving a destructive action caches the *intent* — kind plus target path —
 rather than the literal command, so a paraphrased retry (`rm /tmp/x` followed by
 `os.remove("/tmp/x")`) proceeds without a second prompt.
 
-The kind carries a destructiveness grade, and an approval only covers a retry
-whose grade it already includes:
+The kind carries a set of *escalation capabilities*, and a cached approval
+covers a retry only when its capability set is a superset of the retry's. The
+capabilities are independent — they are not a single ladder:
 
-| Cached kind | Covers |
-|---|---|
-| `delete` | `rm X`, `os.remove`, `os.rmdir`, `Path(X).unlink()` |
-| `delete:recursive` | the above plus `shutil.rmtree(X)`, `os.removedirs(X)` |
-| `delete:force` | the above plus `rm -f X` |
-| `delete:recursive+force` | everything, including `rm -rf X` |
+| Capability | Meaning | Granted by |
+|---|---|---|
+| *(none)* | delete this one path | `rm X`, `os.remove`, `os.unlink`, `os.rmdir`, `Path(X).unlink()`, `Path(X).rmdir()` |
+| `recursive` | delete the whole tree below it | `rm -r`/`-R`/`--recursive`, `shutil.rmtree(X)` |
+| `parents` | may also delete empty *ancestors* | `os.removedirs(X)` |
+| `force` | `rm`'s `-f`/`--force` | `rm -f`/`--force` |
 
-Escalation always re-prompts: approving `rm /tmp/logs` does **not** authorize
-`rm -rf /tmp/logs`. `/approvals` lists cached entries as `scope kind:target`,
-and `/forget <path>` drops every grade recorded for that path.
+So a `delete:recursive` approval covers a plain `rm X`, but a `delete:force`
+approval does **not** cover `shutil.rmtree(X)` — `force` says nothing about
+recursion. Escalation always re-prompts: approving `rm /tmp/logs` does **not**
+authorize `rm -rf /tmp/logs`.
+
+`/approvals` lists cached entries as `scope kind:target`, and `/forget <path>`
+drops every grade recorded for that path.
 
 The Web UI also provides an approvals surface for reviewing pending actions
 outside the message scrollback.

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -8,6 +8,13 @@ module normalizes destructive actions to a semantic key (intent kind + target)
 and remembers approvals for a short window, so paraphrased retries of the same
 intent proceed without another prompt.
 
+The key is graded by *destructiveness*, not spelling: an approval only covers a
+retry that is no more destructive than what the user actually saw. Approving
+``rm /tmp/logs`` does not cover ``rm -rf /tmp/logs`` — on a directory the first
+is a no-op and the second wipes it recursively, and ``-rf`` never appeared on a
+prompt. The reverse direction still short-circuits, so ``rm -rf X`` covers
+``shutil.rmtree("X")``: same effect, different spelling.
+
 Scope: only *delete* intents for now, since that is the bulk of user-observed
 pain. Extend ``_extract_intent`` if other classes (write-outside-workspace,
 network egress) need intent-level memory.
@@ -15,6 +22,7 @@ network egress) need intent-level memory.
 
 from __future__ import annotations
 
+import itertools
 import os
 import re
 import shlex
@@ -43,28 +51,129 @@ def _norm_path(raw: str, *, base_dir: str | Path | None = None) -> str:
         return raw
 
 
-# Regex-based single-capture extractors for Python-flavoured deletes. Each
-# regex uses ``finditer`` so ``shutil.rmtree("a"); os.remove("b")`` yields
-# both paths.
-_PY_DELETE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bos\.(?:remove|unlink|rmdir|removedirs)\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(
-        r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*\.(?:unlink|rmdir)\s*\("
+_DELETE = "delete"
+
+# Escalation capabilities that a delete can carry, in canonical key order. An
+# approval covers a retry only when the cached capability set is a *superset*
+# of the retry's, so a plain delete never satisfies a recursive one.
+_RECURSIVE = "recursive"
+_FORCE = "force"
+_CAPABILITY_ORDER: tuple[str, ...] = (_RECURSIVE, _FORCE)
+
+# Every capability combination, for the superset scan in ``check``/``forget``.
+_CAPABILITY_SETS: tuple[frozenset[str], ...] = tuple(
+    frozenset(combo)
+    for size in range(len(_CAPABILITY_ORDER) + 1)
+    for combo in itertools.combinations(_CAPABILITY_ORDER, size)
+)
+
+
+def _graded_kind(capabilities: frozenset[str], family: str = _DELETE) -> str:
+    """``delete``, ``delete:recursive``, ``delete:recursive+force`` — canonical."""
+    suffix = "+".join(cap for cap in _CAPABILITY_ORDER if cap in capabilities)
+    return f"{family}:{suffix}" if suffix else family
+
+
+# Regex-based single-capture extractors for Python-flavoured deletes, paired
+# with the capabilities each call carries. Each regex uses ``finditer`` so
+# ``shutil.rmtree("a"); os.remove("b")`` yields both paths.
+#
+# ``os.removedirs`` counts as recursive: it deletes the leaf and then prunes
+# empty parents, so it reaches past the path it was handed.
+_PY_DELETE_PATTERNS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
+    (
+        re.compile(r"\bos\.(?:remove|unlink|rmdir)\s*\(\s*[\"']([^\"']+)[\"']"),
+        frozenset(),
+    ),
+    (
+        re.compile(r"\bos\.removedirs\s*\(\s*[\"']([^\"']+)[\"']"),
+        frozenset({_RECURSIVE}),
+    ),
+    (
+        re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
+        frozenset({_RECURSIVE}),
+    ),
+    (
+        re.compile(
+            r"\b(?:pathlib\.)?Path\s*\(\s*[\"']([^\"']+)[\"']\s*\)\s*"
+            r"\.(?:unlink|rmdir)\s*\("
+        ),
+        frozenset(),
     ),
 )
+
+# ``rm`` flags that raise destructiveness. Everything else (``-v``, ``-i``,
+# ``-d``) leaves the intent at the level the user approved.
+#
+# Long options are matched by prefix because ``getopt_long`` accepts any
+# unambiguous abbreviation — ``rm --recu`` is a recursive delete, and grading it
+# as a plain one would reopen the bypass. No other ``rm`` long option starts
+# with ``r`` or ``f``, so the prefix match cannot over-match; where it is
+# uncertain it errs towards the stronger grade, which costs a prompt rather
+# than an unapproved delete.
+_RM_SHORT_CAPABILITIES: dict[str, str] = {"r": _RECURSIVE, "R": _RECURSIVE, "f": _FORCE}
+_RM_LONG_CAPABILITIES: dict[str, str] = {
+    "--recursive": _RECURSIVE,
+    "--force": _FORCE,
+}
 
 # Shell command separators that terminate a single ``rm`` invocation.
 _SHELL_SEPARATORS = (";", "&&", "||", "|", "&")
 
 
-def _extract_rm_targets(command: str) -> list[str]:
-    """Pull every non-flag argument out of every ``rm`` invocation.
+def _rm_invocation_capabilities(tokens: list[str]) -> frozenset[str]:
+    """Grade one ``rm`` argument list by the escalating flags it carries.
+
+    Stops flag parsing at ``--`` so ``rm -- -rf`` treats ``-rf`` as a filename,
+    the way ``rm`` itself does.
+    """
+    capabilities: set[str] = set()
+    for token in tokens:
+        if token == "--":
+            break
+        if token.startswith("--"):
+            name = token.partition("=")[0]
+            capabilities.update(
+                cap
+                for option, cap in _RM_LONG_CAPABILITIES.items()
+                if len(name) > 2 and option.startswith(name)
+            )
+        elif token.startswith("-") and len(token) > 1:
+            for char in token[1:]:
+                cap = _RM_SHORT_CAPABILITIES.get(char)
+                if cap is not None:
+                    capabilities.add(cap)
+    return frozenset(capabilities)
+
+
+def _rm_invocation_targets(tokens: list[str]) -> list[str]:
+    """Non-flag arguments of one ``rm`` invocation, honouring ``--``."""
+    targets: list[str] = []
+    end_of_flags = False
+    for token in tokens:
+        if not token:
+            continue
+        if end_of_flags:
+            targets.append(token)
+            continue
+        if token == "--":
+            end_of_flags = True
+            continue
+        if token.startswith("-"):
+            continue
+        targets.append(token)
+    return targets
+
+
+def _extract_rm_targets(command: str) -> list[tuple[str, frozenset[str]]]:
+    """Pull every ``rm`` argument out, tagged with that invocation's flags.
 
     Handles ``rm a b c``, ``rm -rf /a /b``, quoted paths, and stops at shell
     separators. Uses ``finditer`` so ``rm foo; rm -rf /bar`` yields targets
-    from both invocations independently. Does not try to be a full shell
-    parser — falls back to whitespace split on shlex errors (unbalanced quotes).
+    from both invocations independently — and each keeps its own capability
+    set, so the ``-rf`` on the second does not leak onto the first. Does not
+    try to be a full shell parser — falls back to whitespace split on shlex
+    errors (unbalanced quotes).
     """
     # Match each ``rm`` invocation, stopping at shell separators.
     # ``[^;\n&|]*`` captures everything from ``rm`` up to the next separator
@@ -74,8 +183,8 @@ def _extract_rm_targets(command: str) -> list[str]:
     if not matches:
         return []
 
-    targets: list[str] = []
-    seen: set[str] = set()
+    targets: list[tuple[str, frozenset[str]]] = []
+    seen: set[tuple[str, frozenset[str]]] = set()
 
     for match in matches:
         tail = match.group(1).strip()
@@ -94,11 +203,13 @@ def _extract_rm_targets(command: str) -> list[str]:
                 token_sets.append(tail.split())
 
         for tokens in token_sets:
-            for token in tokens:
-                if not token or token.startswith("-") or token in seen:
+            capabilities = _rm_invocation_capabilities(tokens)
+            for token in _rm_invocation_targets(tokens):
+                entry = (token, capabilities)
+                if entry in seen:
                     continue
-                seen.add(token)
-                targets.append(token)
+                seen.add(entry)
+                targets.append(entry)
 
     return targets
 
@@ -111,19 +222,20 @@ def _extract_intents(
     """Return every recognized destructive intent, deduped and normalized.
 
     ``rm /a /b /c`` -> three tuples; ``shutil.rmtree('a'); os.remove('b')`` ->
-    two tuples; a plain echo returns an empty list.
+    two tuples; a plain echo returns an empty list. The kind carries the
+    destructiveness grade (``delete`` vs ``delete:recursive+force``) so an
+    approval for one level never silently covers a higher one.
     """
     if not command:
         return []
-    paths: list[str] = []
-    paths.extend(_extract_rm_targets(command))
-    for pattern in _PY_DELETE_PATTERNS:
-        paths.extend(m.group(1) for m in pattern.finditer(command))
+    graded: list[tuple[str, frozenset[str]]] = list(_extract_rm_targets(command))
+    for pattern, capabilities in _PY_DELETE_PATTERNS:
+        graded.extend((m.group(1), capabilities) for m in pattern.finditer(command))
 
     result: list[tuple[str, str]] = []
     seen: set[tuple[str, str]] = set()
-    for raw in paths:
-        intent = ("delete", _norm_path(raw, base_dir=base_dir))
+    for raw, capabilities in graded:
+        intent = (_graded_kind(capabilities), _norm_path(raw, base_dir=base_dir))
         if intent in seen:
             continue
         seen.add(intent)
@@ -135,6 +247,24 @@ def _extract_intent(command: str) -> tuple[str, str] | None:
     """First extracted intent, or None. Convenience for single-target callers."""
     intents = _extract_intents(command)
     return intents[0] if intents else None
+
+
+def _split_kind(kind: str) -> tuple[str, frozenset[str]]:
+    """Inverse of :func:`_graded_kind` — ``("delete", {"recursive"})``."""
+    family, _, suffix = kind.partition(":")
+    return family, (frozenset(suffix.split("+")) if suffix else frozenset())
+
+
+def _covering_kinds(kind: str) -> tuple[str, ...]:
+    """Kinds whose approval covers *kind* — itself plus every stronger grade."""
+    family, required = _split_kind(kind)
+    return tuple(_graded_kind(caps, family) for caps in _CAPABILITY_SETS if required <= caps)
+
+
+def _sibling_kinds(kind: str) -> tuple[str, ...]:
+    """Every grade in *kind*'s family, strongest and weakest alike."""
+    family, _ = _split_kind(kind)
+    return tuple(_graded_kind(caps, family) for caps in _CAPABILITY_SETS)
 
 
 class IntentApprovalCache:
@@ -183,29 +313,48 @@ class IntentApprovalCache:
 
         Multi-target commands must have approval for *all* targets — one
         missing path means the whole command needs fresh approval.
+
+        An intent is satisfied by a cached approval whose capability set is a
+        *superset* of its own, so ``rm -rf X`` covers ``rm X`` but never the
+        other way round.
         """
         intents = _extract_intents(command)
         if not intents:
             return False
         now = time.monotonic()
         with self._lock:
-            for intent in intents:
-                entry = self._entries.get(intent)
-                if entry is None:
-                    return False
-                expires, _scope = entry
-                if expires < now:
-                    self._entries.pop(intent, None)
+            for kind, target in intents:
+                if not self._satisfied_locked(kind, target, now):
                     return False
         return True
 
+    def _satisfied_locked(self, kind: str, target: str, now: float) -> bool:
+        """True when some live entry for *target* is at least as permissive."""
+        satisfied = False
+        for candidate in _covering_kinds(kind):
+            entry = self._entries.get((candidate, target))
+            if entry is None:
+                continue
+            expires, _scope = entry
+            if expires < now:
+                self._entries.pop((candidate, target), None)
+                continue
+            satisfied = True
+        return satisfied
+
     def forget(self, command: str) -> None:
+        """Drop approvals for every target in *command*, at every grade.
+
+        ``/forget <path>`` builds a plain ``rm <path>``; it has to clear the
+        recursive entry too or the escalated approval would outlive it.
+        """
         intents = _extract_intents(command)
         if not intents:
             return
         with self._lock:
-            for intent in intents:
-                self._entries.pop(intent, None)
+            for kind, target in intents:
+                for sibling in _sibling_kinds(kind):
+                    self._entries.pop((sibling, target), None)
 
     def clear(self) -> None:
         with self._lock:

--- a/src/agentos/application/intent_cache.py
+++ b/src/agentos/application/intent_cache.py
@@ -57,8 +57,9 @@ _DELETE = "delete"
 # approval covers a retry only when the cached capability set is a *superset*
 # of the retry's, so a plain delete never satisfies a recursive one.
 _RECURSIVE = "recursive"
+_PARENTS = "parents"
 _FORCE = "force"
-_CAPABILITY_ORDER: tuple[str, ...] = (_RECURSIVE, _FORCE)
+_CAPABILITY_ORDER: tuple[str, ...] = (_RECURSIVE, _PARENTS, _FORCE)
 
 # Every capability combination, for the superset scan in ``check``/``forget``.
 _CAPABILITY_SETS: tuple[frozenset[str], ...] = tuple(
@@ -78,8 +79,14 @@ def _graded_kind(capabilities: frozenset[str], family: str = _DELETE) -> str:
 # with the capabilities each call carries. Each regex uses ``finditer`` so
 # ``shutil.rmtree("a"); os.remove("b")`` yields both paths.
 #
-# ``os.removedirs`` counts as recursive: it deletes the leaf and then prunes
-# empty parents, so it reaches past the path it was handed.
+# ``os.removedirs`` carries ``parents`` on top of ``recursive``: it deletes the
+# leaf and then prunes empty ancestors, so it reaches *above* the path it was
+# handed — something no ``rm`` spelling does. Nothing else grants ``parents``,
+# so only a prior ``os.removedirs`` approval for the same target covers it.
+#
+# ``os.rmdir``/``Path.rmdir`` stay plain. They remove an empty directory, which
+# plain ``rm`` refuses, but an empty directory holds nothing; grading it would
+# buy a prompt and no protection. Same reasoning excludes ``rm -d``/``--dir``.
 _PY_DELETE_PATTERNS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
     (
         re.compile(r"\bos\.(?:remove|unlink|rmdir)\s*\(\s*[\"']([^\"']+)[\"']"),
@@ -87,7 +94,7 @@ _PY_DELETE_PATTERNS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
     ),
     (
         re.compile(r"\bos\.removedirs\s*\(\s*[\"']([^\"']+)[\"']"),
-        frozenset({_RECURSIVE}),
+        frozenset({_RECURSIVE, _PARENTS}),
     ),
     (
         re.compile(r"\bshutil\.rmtree\s*\(\s*[\"']([^\"']+)[\"']"),
@@ -102,8 +109,19 @@ _PY_DELETE_PATTERNS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
     ),
 )
 
-# ``rm`` flags that raise destructiveness. Everything else (``-v``, ``-i``,
-# ``-d``) leaves the intent at the level the user approved.
+# ``rm`` flags that raise destructiveness. ``-i``/``-I`` only add prompting and
+# ``-v`` only adds output, so neither is graded. ``-d``/``--dir`` is deliberately
+# ungraded: it removes an *empty* directory that plain ``rm`` refuses, but an
+# empty directory holds nothing, so grading it would cost a prompt and protect
+# nothing — the same call made for ``os.rmdir`` above.
+#
+# The Python spellings carry no ``force`` grade, because ``-f`` has no Python
+# analogue that changes *what* gets deleted. The asymmetry that leaves is
+# one-directional and deliberate: every shell -> Python paraphrase this module
+# exists for still short-circuits (``rm X`` covers ``os.remove("X")``,
+# ``rm -rf X`` and ``rm -r X`` both cover ``shutil.rmtree("X")``), while the
+# rare reverse -- approving ``shutil.rmtree("X")`` and then running ``rm -rf X``
+# -- costs one prompt.
 #
 # Long options are matched by prefix because ``getopt_long`` accepts any
 # unambiguous abbreviation — ``rm --recu`` is a recursive delete, and grading it
@@ -364,9 +382,7 @@ class IntentApprovalCache:
         """Drop every entry whose scope matches, leaving other scopes intact."""
         with self._lock:
             self._entries = {
-                intent: data
-                for intent, data in self._entries.items()
-                if data[1] != scope
+                intent: data for intent, data in self._entries.items() if data[1] != scope
             }
 
 

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -270,7 +270,63 @@ class TestAbbreviatedLongOptions:
         assert cache.check("rm /tmp/a -rf") is False
 
     def test_terminator_shields_a_filename_that_looks_like_flags(self) -> None:
+        """After ``--`` the tokens are filenames, so the delete stays plain."""
         cache = IntentApprovalCache()
+        # Two targets: /tmp/a and a file literally named "-rf". Both stay plain.
+        assert {kind for kind, _ in _extract_intents("rm /tmp/a -- -rf")} == {"delete"}
         cache.record("rm /tmp/a -- -rf")
         assert cache.check("rm /tmp/a") is True
-        assert cache.check("rm -rf") is False
+        assert cache.check("rm -rf /tmp/a") is False
+
+
+class TestParentPruningIsItsOwnEscalation:
+    """``os.removedirs`` reaches *above* its target — no ``rm`` spelling does."""
+
+    def test_recursive_rm_does_not_cover_removedirs(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/build/cache")
+        assert cache.check('shutil.rmtree("/tmp/build/cache")') is True
+        assert cache.check('os.removedirs("/tmp/build/cache")') is False
+
+    def test_removedirs_covers_the_plain_recursive_delete(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record('os.removedirs("/tmp/build/cache")')
+        assert cache.check("rm -r /tmp/build/cache") is True
+        assert cache.check('shutil.rmtree("/tmp/build/cache")') is True
+
+
+class TestDocumentedAsymmetries:
+    """Boundaries that are deliberate, not accidental — pin them so they show up
+    in review if anyone changes the grading table.
+    """
+
+    def test_every_shell_to_python_paraphrase_still_short_circuits(self) -> None:
+        """The direction the module exists for is preserved in full."""
+        for approved, retry in [
+            ("rm /tmp/x", 'os.remove("/tmp/x")'),
+            ("rm /tmp/x", 'Path("/tmp/x").unlink()'),
+            ("rm -f /tmp/x", 'os.remove("/tmp/x")'),
+            ("rm -r /tmp/x", 'shutil.rmtree("/tmp/x")'),
+            ("rm -rf /tmp/x", 'shutil.rmtree("/tmp/x")'),
+        ]:
+            cache = IntentApprovalCache()
+            cache.record(approved)
+            assert cache.check(retry) is True, f"{approved!r} should cover {retry!r}"
+
+    def test_python_recursive_delete_does_not_grant_the_force_flag(self) -> None:
+        """``-f`` has no Python analogue, so the reverse costs one prompt."""
+        cache = IntentApprovalCache()
+        cache.record('shutil.rmtree("/tmp/x")')
+        assert cache.check("rm -r /tmp/x") is True
+        assert cache.check("rm -rf /tmp/x") is False
+
+    def test_empty_directory_removal_is_deliberately_ungraded(self) -> None:
+        """``rm -d`` and ``os.rmdir`` delete an empty dir plain ``rm`` refuses.
+
+        Ungraded on purpose: an empty directory holds nothing, so grading it
+        would cost a prompt and protect nothing.
+        """
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/d")
+        assert cache.check("rm -d /tmp/d") is True
+        assert cache.check('os.rmdir("/tmp/d")') is True

--- a/tests/test_application/test_intent_cache.py
+++ b/tests/test_application/test_intent_cache.py
@@ -10,7 +10,9 @@ See https://github.com/use-agent-os/agent-os/pull/546
 
 from __future__ import annotations
 
-from agentos.application.intent_cache import IntentApprovalCache
+import pytest
+
+from agentos.application.intent_cache import IntentApprovalCache, _extract_intents
 
 
 class TestCompoundCommandSeparatorBypass:
@@ -96,3 +98,179 @@ class TestRecordAndCheck:
         cache.clear()
         assert cache.check("rm /a") is False
         assert cache.check("rm /b") is False
+
+
+class TestDestructivenessEscalation:
+    """Issue #849: a non-recursive approval must not cover a recursive delete.
+
+    ``rm /tmp/logs`` on a directory fails without ``-r``; the user who approved
+    that prompt approved a no-op. The cache must not then let ``rm -rf
+    /tmp/logs`` wipe it without a fresh prompt, because ``-rf`` never appeared
+    on any prompt the user saw.
+    """
+
+    def test_plain_delete_does_not_cover_recursive_force(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm /tmp/a") is True
+        assert cache.check("rm -rf /tmp/a") is False
+
+    @pytest.mark.parametrize(
+        "escalated",
+        [
+            "rm -r /tmp/a",
+            "rm -R /tmp/a",
+            "rm -f /tmp/a",
+            "rm -rf /tmp/a",
+            "rm -fr /tmp/a",
+            "rm -vrf /tmp/a",
+            "rm -r -f /tmp/a",
+            "rm --recursive /tmp/a",
+            "rm --force /tmp/a",
+            "rm --recursive --force /tmp/a",
+            "rm -rf -- /tmp/a",
+        ],
+    )
+    def test_every_escalating_flag_spelling_is_blocked(self, escalated: str) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check(escalated) is False
+
+    def test_recursive_approval_covers_plain_delete(self) -> None:
+        """De-escalation is fine — the user already approved the stronger op."""
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm -rf /tmp/a") is True
+        assert cache.check("rm /tmp/a") is True
+        assert cache.check("rm -r /tmp/a") is True
+
+    def test_force_alone_does_not_cover_recursive(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -f /tmp/a")
+        assert cache.check("rm /tmp/a") is True
+        assert cache.check("rm -rf /tmp/a") is False
+
+    def test_double_dash_terminator_is_not_a_flag(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm -- /tmp/a") is True
+
+    def test_escalated_entry_is_scoped_per_target(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a")
+        assert cache.check("rm -rf /tmp/b") is False
+
+    def test_mixed_invocations_record_each_level(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a; rm -rf /tmp/b")
+        assert cache.check("rm /tmp/a; rm -rf /tmp/b") is True
+        assert cache.check("rm -rf /tmp/a; rm -rf /tmp/b") is False
+
+    def test_expiry_applies_to_escalated_entries(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/a", ttl=-1)
+        assert cache.check("rm /tmp/a") is False
+        assert cache.check("rm -rf /tmp/a") is False
+
+    def test_always_scope_survives_clear_scope_at_every_level(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record_always("rm -rf /tmp/a")
+        cache.clear_scope("once")
+        assert cache.check("rm /tmp/a") is True
+        assert cache.check("rm -rf /tmp/a") is True
+
+
+class TestParaphraseStillWorks:
+    """The module exists to stop prompt fatigue — paraphrases must still hit.
+
+    Equal-destructiveness paraphrases (``rm`` -> ``os.remove``, ``rm -rf`` ->
+    ``shutil.rmtree``) keep matching; only an *increase* in destructiveness
+    re-prompts.
+    """
+
+    def test_plain_rm_covers_os_remove(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/x")
+        assert cache.check('os.remove("/tmp/x")') is True
+        assert cache.check('Path("/tmp/x").unlink()') is True
+        assert cache.check('os.rmdir("/tmp/x")') is True
+
+    def test_recursive_rm_covers_rmtree(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm -rf /tmp/x")
+        assert cache.check('shutil.rmtree("/tmp/x")') is True
+
+    def test_rmtree_covers_os_remove(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record('shutil.rmtree("/tmp/x")')
+        assert cache.check('os.remove("/tmp/x")') is True
+
+    def test_os_remove_does_not_cover_rmtree(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record('os.remove("/tmp/x")')
+        assert cache.check('shutil.rmtree("/tmp/x")') is False
+
+    def test_rmdir_does_not_cover_removedirs(self) -> None:
+        """``os.removedirs`` prunes empty parents — it deletes past its target."""
+        cache = IntentApprovalCache()
+        cache.record('os.rmdir("/tmp/x")')
+        assert cache.check('os.removedirs("/tmp/x")') is False
+
+
+class TestForgetAcrossLevels:
+    """``/forget <path>`` builds a plain ``rm <path>`` — it must clear every level."""
+
+    def test_forget_plain_clears_recursive_entry(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record_always("rm -rf /tmp/a")
+        cache.forget("rm /tmp/a")
+        assert cache.check("rm /tmp/a") is False
+        assert cache.check("rm -rf /tmp/a") is False
+
+    def test_forget_recursive_clears_plain_entry(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record_always("rm /tmp/a")
+        cache.forget("rm -rf /tmp/a")
+        assert cache.check("rm /tmp/a") is False
+
+
+class TestIntentKindWireShape:
+    """The diagnostic ``/approvals`` view renders ``kind:target`` verbatim."""
+
+    def test_kind_encodes_capabilities(self) -> None:
+        assert _extract_intents("rm /tmp/a")[0][0] == "delete"
+        assert _extract_intents("rm -r /tmp/a")[0][0] == "delete:recursive"
+        assert _extract_intents("rm -f /tmp/a")[0][0] == "delete:force"
+        assert _extract_intents("rm -rf /tmp/a")[0][0] == "delete:recursive+force"
+        assert _extract_intents('shutil.rmtree("/tmp/a")')[0][0] == "delete:recursive"
+
+
+class TestAbbreviatedLongOptions:
+    """``getopt_long`` accepts unambiguous abbreviations — so must the grader."""
+
+    @pytest.mark.parametrize(
+        "escalated",
+        ["rm --rec /tmp/a", "rm --recur /tmp/a", "rm --fo /tmp/a", "rm --for --rec /tmp/a"],
+    )
+    def test_abbreviated_flags_are_graded(self, escalated: str) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check(escalated) is False
+
+    def test_unrelated_long_option_is_not_graded(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm --verbose /tmp/a") is True
+        assert cache.check("rm --dir /tmp/a") is True
+
+    def test_flags_after_the_target_still_count(self) -> None:
+        """GNU rm permutes arguments — ``rm X -rf`` is a recursive delete."""
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a")
+        assert cache.check("rm /tmp/a -rf") is False
+
+    def test_terminator_shields_a_filename_that_looks_like_flags(self) -> None:
+        cache = IntentApprovalCache()
+        cache.record("rm /tmp/a -- -rf")
+        assert cache.check("rm /tmp/a") is True
+        assert cache.check("rm -rf") is False


### PR DESCRIPTION
Fixes #849

## The gap

`_extract_rm_targets` drops every flag during normalisation:

```python
if not token or token.startswith("-") or token in seen:
    continue
```

so `rm /tmp/logs` and `rm -rf /tmp/logs` collapse to the same `("delete", path)` key, and `check()` returns `True` for the second after `record()` on the first.

Following the analysis in the issue thread, the severity is the directory case, not the file case: `rm /tmp/logs` on a directory is refused, so a user who approves that prompt has approved a no-op. The cache then lets `rm -rf /tmp/logs` wipe it recursively, and `-rf` never appeared on anything the user saw.

## Why not "store the full command string"

That would defeat the module. Its whole point, per its own docstring, is that approving `rm /tmp/x` also covers `os.remove("/tmp/x")` so the user is not pressing `y` at every paraphrase — and prompt fatigue is itself a security problem. So the key stays semantic and gains a **destructiveness grade** instead.

## The fix

The intent kind now carries a set of escalation capabilities, and a cached approval satisfies a retry **only when its capability set is a superset** of the retry's.

| Capability | Meaning | Granted by |
|---|---|---|
| *(none)* | delete this one path | `rm X`, `os.remove`, `os.unlink`, `os.rmdir`, `Path(X).unlink()`, `Path(X).rmdir()` |
| `recursive` | delete the tree below it | `rm -r`/`-R`/`--recursive`, `shutil.rmtree(X)` |
| `parents` | may also delete empty *ancestors* | `os.removedirs(X)` |
| `force` | `rm`'s `-f`/`--force` | `rm -f`/`--force` |

Rendered as `delete`, `delete:recursive`, `delete:recursive+force`, `delete:recursive+parents`, …

Flag parsing handles bundles (`-vrf`), flags after the target (GNU `rm` permutes arguments), the `--` terminator (`rm -- -rf` treats `-rf` as a filename), and the **unambiguous abbreviations `getopt_long` accepts** — `rm --recu` is a recursive delete, and grading it as plain would have reopened the bypass. No other `rm` long option starts with `r` or `f`, so the prefix match cannot over-match.

`forget()` clears every grade for a target, because `/forget <path>` builds a plain `rm <path>` and would otherwise leave an escalated approval standing.

Both directions asked for in the issue thread hold:

```
                    checked ->  delete   :recursive   :force   :recursive+force
recorded delete                 True     False        False    False
recorded delete:recursive       True     True         False    False
recorded delete:force           True     False        True     False
recorded delete:recursive+force True     True         True     True
```

Escalation is blocked, and every shell-to-Python paraphrase the module exists for still short-circuits: `rm X` covers `os.remove("X")`, and `rm -r X` and `rm -rf X` both cover `shutil.rmtree("X")`.

## Deliberate boundaries

Flagged explicitly so they can be argued with rather than discovered later:

- **`rm -d` / `os.rmdir` are not graded.** By the same logic as `-r`, they remove an empty directory that plain `rm` refuses. Left ungraded because an empty directory holds nothing, so grading it costs a prompt and protects nothing. Say the word and it becomes a fourth capability.
- **Python spellings carry no `force` grade,** because `-f` has no Python analogue that changes *what* gets deleted. The asymmetry is one-directional: approving `shutil.rmtree("X")` and then running `rm -rf X` costs one prompt. Every direction the module exists for is unaffected.
- **`os.removedirs` gets its own `parents` capability** rather than being lumped in with `recursive`, since it deletes ancestors of the approved target.
- **Out of scope, pre-existing:** the extractor matches `rm` inside quoted strings and comments, so `record('grep -n "rm -rf" deploy.sh')` records a delete intent for `deploy.sh`. Verified identical on `main` (there it records `("delete", deploy.sh)` and `check("rm -rf deploy.sh")` is already `True`), so this change neither introduces nor widens it. Narrowing the extractor to command position would also narrow `sensitive_paths.first_sensitive_marker`, which uses it as a *blocking* guard — false negatives there are worse than false positives, so that belongs in its own change.

## Compatibility

Intents stay `(kind, target)` two-tuples, so `sensitive_paths.first_sensitive_marker`, `approval_snapshot_rpc_payload` and the `/approvals` view are unchanged apart from the richer kind string. No frontend consumer parses it.

## Tests

37 new tests: the issue's repro, every escalating flag spelling, abbreviations, terminator, flags-after-target, per-target scoping, expiry and `always`-scope at every grade, `forget` across grades, the parent-pruning axis, the wire shape of the kind string, and — in both directions — that the paraphrase behaviour the module exists for still works.

## Verification

```
uv run ruff check src tests                 # All checks passed!
uv run mypy src/agentos --show-error-codes  # Success: no issues found in 622 source files
uv run pytest -q                            # 9390 passed, 27 skipped
```

The four-grade subsumption lattice was also verified exhaustively against the superset relation (0 violations).

## Note on duplicates

#853 and #854 are already open against this issue, plus claims from two other contributors in the thread. Posting this in case the grading model or the flag-parsing edge cases (abbreviations, `--`, argument permutation, parent pruning) are useful — happy to close it in favour of another PR, or to fold these cases into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8VYGEPyKBdhGVzdr3N9fM