### PR TITLE
fix(tools): pad empty rows in read_spreadsheet for .xlsx workbooks (#…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `read_spreadsheet` no longer mislabels row numbers or dead-ends its own
+  pagination on a sparse `.xlsx` sheet. OpenXML omits empty rows from
+  `<sheetData>`, storing each present row's real 1-indexed number on its
+  `r` attribute; `_read_xlsx_worksheet` now keys rows by that number
+  directly (a sparse map) instead of padding a list up to it, so a sheet
+  with data at, say, row 1 and row 5000 reports and paginates against the
+  real row numbers throughout, and the tool's own continuation offsets
+  reach row 5000 instead of stalling in the gap. Keying by real row number
+  also means reading no longer costs anything proportional to how large a
+  declared (or crafted/corrupt) row index is, nor does it multiply by how
+  many sheets a workbook has before one is selected.
+  ([#1149](https://github.com/use-agent-os/agent-os/issues/1149))
+
 ## [2026.9.10] - 2026-09-09
 
 ### Added
@@ -277,6 +292,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   omitting an optional one leaves the target on its own default. Compaction
   provider resolution is unified the same way
   ([#1201](https://github.com/use-agent-os/agent-os/issues/1201)).
+
+## [2026.9.7] - 2026-09-07
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,8 +293,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   provider resolution is unified the same way
   ([#1201](https://github.com/use-agent-os/agent-os/issues/1201)).
 
-## [2026.9.7] - 2026-09-07
-
 ### Fixed
 
 - Telegram polling retries failed callbacks before acknowledging their updates,

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -665,6 +665,11 @@ def _read_xlsx_worksheet(raw_xml: bytes, shared_strings: list[str]) -> list[list
     root = ET.fromstring(raw_xml)
     rows: list[list[str]] = []
     for row_el in root.findall(f".//{{{_XLSX_MAIN_NS}}}row"):
+        row_r = row_el.attrib.get("r")
+        if row_r and row_r.isdigit():
+            target_row_idx = max(0, int(row_r) - 1)
+            while len(rows) < target_row_idx:
+                rows.append([])
         row: list[str] = []
         for cell_el in row_el.findall(f"{{{_XLSX_MAIN_NS}}}c"):
             column_index = _xlsx_column_index(cell_el.attrib.get("r", ""))

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -50,6 +50,7 @@ _BINARY_EXTENSIONS = {
 _XLSX_MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 _XLSX_PACKAGE_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 _XLSX_OFFICE_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_XLSX_MAX_ROWS = 1_048_576
 _BOOTSTRAP_SOURCE_FILENAMES = frozenset(BOOTSTRAP_FILENAMES)
 
 
@@ -665,9 +666,14 @@ def _read_xlsx_worksheet(raw_xml: bytes, shared_strings: list[str]) -> list[list
     root = ET.fromstring(raw_xml)
     rows: list[list[str]] = []
     for row_el in root.findall(f".//{{{_XLSX_MAIN_NS}}}row"):
+        if len(rows) >= _XLSX_MAX_ROWS:
+            break
         row_r = row_el.attrib.get("r")
         if row_r and row_r.isdigit():
-            target_row_idx = max(0, int(row_r) - 1)
+            row_num = int(row_r)
+            if row_num < 1 or row_num > _XLSX_MAX_ROWS:
+                continue
+            target_row_idx = min(row_num - 1, _XLSX_MAX_ROWS - 1)
             while len(rows) < target_row_idx:
                 rows.append([])
         row: list[str] = []

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -573,13 +573,7 @@ async def read_spreadsheet(
         delimiter = "\t" if ext == ".tsv" else ","
         sheets = await loop.run_in_executor(None, _read_delimited_rows, p, delimiter)
     elif ext == ".xlsx":
-        # _read_xlsx_sheets parses every sheet before a single one is
-        # selected below, so the materialisation ceiling has to be the
-        # render window this call will actually show -- otherwise a
-        # crafted multi-sheet workbook multiplies the per-sheet row-padding
-        # cost by sheet count even though only one sheet gets rendered.
-        max_rows = row_offset + row_limit - 1
-        sheets = await loop.run_in_executor(None, _read_xlsx_sheets, p, max_rows)
+        sheets = await loop.run_in_executor(None, _read_xlsx_sheets, p)
     else:
         raise ToolError(
             f"Unsupported spreadsheet format: {ext or '(none)'}. Use .csv, .tsv, or .xlsx."
@@ -595,18 +589,17 @@ async def read_spreadsheet(
     )
 
 
-def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[list[str]], int]]:
+def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, dict[int, list[str]], int]]:
     try:
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
-    rows = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
-    return [(path.name, rows, len(rows))]
+    parsed = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
+    rows = dict(enumerate(parsed, start=1))
+    return [(path.name, rows, len(parsed))]
 
 
-def _read_xlsx_sheets(
-    path: Path, max_rows: int = _XLSX_MAX_ROWS
-) -> list[tuple[str, list[list[str]], int]]:
+def _read_xlsx_sheets(path: Path) -> list[tuple[str, dict[int, list[str]], int]]:
     try:
         with zipfile.ZipFile(path) as zf:
             names = set(zf.namelist())
@@ -615,7 +608,7 @@ def _read_xlsx_sheets(
             shared_strings = _read_xlsx_shared_strings(zf, names)
             workbook = ET.fromstring(zf.read("xl/workbook.xml"))
             rels = _read_xlsx_workbook_relationships(zf, names)
-            sheets: list[tuple[str, list[list[str]], int]] = []
+            sheets: list[tuple[str, dict[int, list[str]], int]] = []
             for sheet_el in workbook.findall(f".//{{{_XLSX_MAIN_NS}}}sheet"):
                 sheet_name = sheet_el.attrib.get("name") or f"Sheet{len(sheets) + 1}"
                 rel_id = sheet_el.attrib.get(f"{{{_XLSX_OFFICE_REL_NS}}}id")
@@ -625,9 +618,7 @@ def _read_xlsx_sheets(
                 worksheet_path = _normalize_xlsx_target(target)
                 if worksheet_path not in names:
                     continue
-                rows, total_rows = _read_xlsx_worksheet(
-                    zf.read(worksheet_path), shared_strings, max_rows=max_rows
-                )
+                rows, total_rows = _read_xlsx_worksheet(zf.read(worksheet_path), shared_strings)
                 sheets.append((sheet_name, rows, total_rows))
             if not sheets:
                 raise ToolError(f"No readable worksheets found in {path}")
@@ -673,38 +664,38 @@ def _normalize_xlsx_target(target: str) -> str:
 
 
 def _read_xlsx_worksheet(
-    raw_xml: bytes, shared_strings: list[str], *, max_rows: int = _XLSX_MAX_ROWS
-) -> tuple[list[list[str]], int]:
-    """Parse a worksheet, padding omitted rows so indices stay 1:1 with real
-    row numbers, and return ``(rows, total_row_count)``.
+    raw_xml: bytes, shared_strings: list[str]
+) -> tuple[dict[int, list[str]], int]:
+    """Parse a worksheet into a sparse row map (real row number -> cells).
 
-    ``rows`` is only ever padded/materialised up to ``max_rows`` -- the
-    caller's actual render window, not the sheet's full extent. A crafted or
-    corrupt ``r`` far beyond that window is counted into ``total_row_count``
-    (so the "N rows" header stays accurate) but never turned into empty-list
-    padding, which is what makes a huge declared row index cheap to parse
-    instead of a memory-amplification vector -- and, since a caller reading
-    a multi-sheet workbook selects one sheet only after every sheet has
-    already been parsed, that per-item bound has to be the render window,
-    not just ``_XLSX_MAX_ROWS``, or the cost multiplies by sheet count.
+    OpenXML omits empty rows from ``<sheetData>`` by default, giving each
+    present ``<row>`` its real 1-indexed row number via the ``r`` attribute.
+    Keying the result by that number directly -- instead of padding a list
+    with an empty placeholder for every omitted row up to it -- costs memory
+    proportional to how many ``<row>`` elements the XML actually contains,
+    not to the largest declared row number. A padded-list design lets either
+    a crafted/corrupt ``r`` or, combined with a large enough render window,
+    an entirely ordinary sparse sheet cost memory and time proportional to
+    that number instead of the file's real size (#1149 follow-ups).
+
+    Returns ``(rows, total_row_count)``; a row missing from ``rows`` is
+    exactly that sheet's real empty row, distinguishable from "out of
+    range" only by comparing its number against ``total_row_count``.
     """
     root = ET.fromstring(raw_xml)
-    rows: list[list[str]] = []
+    rows: dict[int, list[str]] = {}
     total_rows = 0
+    next_implicit = 1
     for row_el in root.findall(f".//{{{_XLSX_MAIN_NS}}}row"):
         row_r = row_el.attrib.get("r")
-        row_num: int | None = None
         if row_r and row_r.isdigit():
             row_num = int(row_r)
             if row_num < 1 or row_num > _XLSX_MAX_ROWS:
                 continue
-            total_rows = max(total_rows, row_num)
-            if row_num > max_rows:
-                # Beyond anything this call will render -- counted above,
-                # never materialised.
-                continue
-            while len(rows) < row_num - 1:
-                rows.append([])
+        else:
+            row_num = next_implicit
+        next_implicit = row_num + 1
+        total_rows = max(total_rows, row_num)
         row: list[str] = []
         for cell_el in row_el.findall(f"{{{_XLSX_MAIN_NS}}}c"):
             column_index = _xlsx_column_index(cell_el.attrib.get("r", ""))
@@ -713,8 +704,7 @@ def _read_xlsx_worksheet(
             row.append(_xlsx_cell_value(cell_el, shared_strings))
         while row and row[-1] == "":
             row.pop()
-        rows.append(row)
-        total_rows = max(total_rows, len(rows))
+        rows[row_num] = row
     return rows, total_rows
 
 
@@ -747,9 +737,9 @@ def _xlsx_cell_value(cell_el: ET.Element, shared_strings: list[str]) -> str:
 
 
 def _select_spreadsheet_sheets(
-    sheets: list[tuple[str, list[list[str]], int]],
+    sheets: list[tuple[str, dict[int, list[str]], int]],
     requested: str | int | None,
-) -> list[tuple[str, list[list[str]], int]]:
+) -> list[tuple[str, dict[int, list[str]], int]]:
     if requested is None or requested == "":
         return sheets
 
@@ -773,7 +763,7 @@ def _select_spreadsheet_sheets(
 def _format_spreadsheet(
     *,
     path: Path,
-    sheets: list[tuple[str, list[list[str]], int]],
+    sheets: list[tuple[str, dict[int, list[str]], int]],
     offset: int,
     limit: int,
 ) -> str:
@@ -785,11 +775,7 @@ def _format_spreadsheet(
     start = offset - 1
     multi_sheet = len(sheets) > 1
     for sheet_name, rows, total_rows in sheets:
-        # total_rows (the sheet's real row count) drives the header and
-        # pagination math; rows itself may only be materialised up to the
-        # render window (see _read_xlsx_worksheet) and must never be used
-        # as a stand-in for the sheet's true size.
-        width = max((len(row) for row in rows), default=0)
+        width = max((len(row) for row in rows.values()), default=0)
         parts.append("")
         parts.append(f"Sheet: {sheet_name} ({total_rows} rows x {width} columns)")
         if multi_sheet and total_rows and start >= total_rows:
@@ -800,11 +786,14 @@ def _format_spreadsheet(
                 f"(Offset {offset} exceeds this sheet's {total_rows} rows; no rows shown.)"
             )
             continue
-        selected = rows[start : start + limit]
-        for idx, row in enumerate(selected, start=start + 1):
-            parts.append(f"{idx}\t" + "\t".join(row))
-        if start + limit < total_rows:
-            end = start + len(selected)
+        # Window applied here, at render time, against the sparse map --
+        # not by slicing a materialised prefix. A gap between real rows
+        # wider than `limit` must not stall the continuation offset the
+        # way a materialised-prefix length would (#1149 follow-ups).
+        end = min(start + limit, total_rows)
+        for idx in range(start + 1, end + 1):
+            parts.append(f"{idx}\t" + "\t".join(rows.get(idx, [])))
+        if end < total_rows:
             parts.append(
                 f"(Showing rows {offset}-{end} of {total_rows}. "
                 f"Use offset={end + 1} to continue.)"

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -573,7 +573,13 @@ async def read_spreadsheet(
         delimiter = "\t" if ext == ".tsv" else ","
         sheets = await loop.run_in_executor(None, _read_delimited_rows, p, delimiter)
     elif ext == ".xlsx":
-        sheets = await loop.run_in_executor(None, _read_xlsx_sheets, p)
+        # _read_xlsx_sheets parses every sheet before a single one is
+        # selected below, so the materialisation ceiling has to be the
+        # render window this call will actually show -- otherwise a
+        # crafted multi-sheet workbook multiplies the per-sheet row-padding
+        # cost by sheet count even though only one sheet gets rendered.
+        max_rows = row_offset + row_limit - 1
+        sheets = await loop.run_in_executor(None, _read_xlsx_sheets, p, max_rows)
     else:
         raise ToolError(
             f"Unsupported spreadsheet format: {ext or '(none)'}. Use .csv, .tsv, or .xlsx."
@@ -589,16 +595,18 @@ async def read_spreadsheet(
     )
 
 
-def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[list[str]]]]:
+def _read_delimited_rows(path: Path, delimiter: str) -> list[tuple[str, list[list[str]], int]]:
     try:
         text = path.read_text(encoding="utf-8-sig")
     except UnicodeDecodeError as exc:
         raise ToolError(f"Cannot read spreadsheet as UTF-8 text: {path}") from exc
     rows = [list(row) for row in csv.reader(io.StringIO(text), delimiter=delimiter)]
-    return [(path.name, rows)]
+    return [(path.name, rows, len(rows))]
 
 
-def _read_xlsx_sheets(path: Path) -> list[tuple[str, list[list[str]]]]:
+def _read_xlsx_sheets(
+    path: Path, max_rows: int = _XLSX_MAX_ROWS
+) -> list[tuple[str, list[list[str]], int]]:
     try:
         with zipfile.ZipFile(path) as zf:
             names = set(zf.namelist())
@@ -607,7 +615,7 @@ def _read_xlsx_sheets(path: Path) -> list[tuple[str, list[list[str]]]]:
             shared_strings = _read_xlsx_shared_strings(zf, names)
             workbook = ET.fromstring(zf.read("xl/workbook.xml"))
             rels = _read_xlsx_workbook_relationships(zf, names)
-            sheets: list[tuple[str, list[list[str]]]] = []
+            sheets: list[tuple[str, list[list[str]], int]] = []
             for sheet_el in workbook.findall(f".//{{{_XLSX_MAIN_NS}}}sheet"):
                 sheet_name = sheet_el.attrib.get("name") or f"Sheet{len(sheets) + 1}"
                 rel_id = sheet_el.attrib.get(f"{{{_XLSX_OFFICE_REL_NS}}}id")
@@ -617,8 +625,10 @@ def _read_xlsx_sheets(path: Path) -> list[tuple[str, list[list[str]]]]:
                 worksheet_path = _normalize_xlsx_target(target)
                 if worksheet_path not in names:
                     continue
-                rows = _read_xlsx_worksheet(zf.read(worksheet_path), shared_strings)
-                sheets.append((sheet_name, rows))
+                rows, total_rows = _read_xlsx_worksheet(
+                    zf.read(worksheet_path), shared_strings, max_rows=max_rows
+                )
+                sheets.append((sheet_name, rows, total_rows))
             if not sheets:
                 raise ToolError(f"No readable worksheets found in {path}")
             return sheets
@@ -662,19 +672,38 @@ def _normalize_xlsx_target(target: str) -> str:
     return posixpath.normpath(posixpath.join("xl", target))
 
 
-def _read_xlsx_worksheet(raw_xml: bytes, shared_strings: list[str]) -> list[list[str]]:
+def _read_xlsx_worksheet(
+    raw_xml: bytes, shared_strings: list[str], *, max_rows: int = _XLSX_MAX_ROWS
+) -> tuple[list[list[str]], int]:
+    """Parse a worksheet, padding omitted rows so indices stay 1:1 with real
+    row numbers, and return ``(rows, total_row_count)``.
+
+    ``rows`` is only ever padded/materialised up to ``max_rows`` -- the
+    caller's actual render window, not the sheet's full extent. A crafted or
+    corrupt ``r`` far beyond that window is counted into ``total_row_count``
+    (so the "N rows" header stays accurate) but never turned into empty-list
+    padding, which is what makes a huge declared row index cheap to parse
+    instead of a memory-amplification vector -- and, since a caller reading
+    a multi-sheet workbook selects one sheet only after every sheet has
+    already been parsed, that per-item bound has to be the render window,
+    not just ``_XLSX_MAX_ROWS``, or the cost multiplies by sheet count.
+    """
     root = ET.fromstring(raw_xml)
     rows: list[list[str]] = []
+    total_rows = 0
     for row_el in root.findall(f".//{{{_XLSX_MAIN_NS}}}row"):
-        if len(rows) >= _XLSX_MAX_ROWS:
-            break
         row_r = row_el.attrib.get("r")
+        row_num: int | None = None
         if row_r and row_r.isdigit():
             row_num = int(row_r)
             if row_num < 1 or row_num > _XLSX_MAX_ROWS:
                 continue
-            target_row_idx = min(row_num - 1, _XLSX_MAX_ROWS - 1)
-            while len(rows) < target_row_idx:
+            total_rows = max(total_rows, row_num)
+            if row_num > max_rows:
+                # Beyond anything this call will render -- counted above,
+                # never materialised.
+                continue
+            while len(rows) < row_num - 1:
                 rows.append([])
         row: list[str] = []
         for cell_el in row_el.findall(f"{{{_XLSX_MAIN_NS}}}c"):
@@ -685,7 +714,8 @@ def _read_xlsx_worksheet(raw_xml: bytes, shared_strings: list[str]) -> list[list
         while row and row[-1] == "":
             row.pop()
         rows.append(row)
-    return rows
+        total_rows = max(total_rows, len(rows))
+    return rows, total_rows
 
 
 def _xlsx_column_index(cell_ref: str) -> int:
@@ -717,9 +747,9 @@ def _xlsx_cell_value(cell_el: ET.Element, shared_strings: list[str]) -> str:
 
 
 def _select_spreadsheet_sheets(
-    sheets: list[tuple[str, list[list[str]]]],
+    sheets: list[tuple[str, list[list[str]], int]],
     requested: str | int | None,
-) -> list[tuple[str, list[list[str]]]]:
+) -> list[tuple[str, list[list[str]], int]]:
     if requested is None or requested == "":
         return sheets
 
@@ -729,21 +759,21 @@ def _select_spreadsheet_sheets(
             return [sheets[index]]
 
     requested_name = str(requested)
-    for name, rows in sheets:
+    for name, rows, total_rows in sheets:
         if name == requested_name:
-            return [(name, rows)]
-    for name, rows in sheets:
+            return [(name, rows, total_rows)]
+    for name, rows, total_rows in sheets:
         if name.lower() == requested_name.lower():
-            return [(name, rows)]
+            return [(name, rows, total_rows)]
 
-    available = ", ".join(name for name, _ in sheets)
+    available = ", ".join(name for name, _, _ in sheets)
     raise ToolError(f"Sheet not found: {requested_name}. Available sheets: {available}")
 
 
 def _format_spreadsheet(
     *,
     path: Path,
-    sheets: list[tuple[str, list[list[str]]]],
+    sheets: list[tuple[str, list[list[str]], int]],
     offset: int,
     limit: int,
 ) -> str:
@@ -754,25 +784,29 @@ def _format_spreadsheet(
     offset = max(1, offset)
     start = offset - 1
     multi_sheet = len(sheets) > 1
-    for sheet_name, rows in sheets:
+    for sheet_name, rows, total_rows in sheets:
+        # total_rows (the sheet's real row count) drives the header and
+        # pagination math; rows itself may only be materialised up to the
+        # render window (see _read_xlsx_worksheet) and must never be used
+        # as a stand-in for the sheet's true size.
         width = max((len(row) for row in rows), default=0)
         parts.append("")
-        parts.append(f"Sheet: {sheet_name} ({len(rows)} rows x {width} columns)")
-        if multi_sheet and rows and start >= len(rows):
+        parts.append(f"Sheet: {sheet_name} ({total_rows} rows x {width} columns)")
+        if multi_sheet and total_rows and start >= total_rows:
             # One offset is shared across every sheet in a multi-sheet read,
             # so a sheet smaller than the requested offset would otherwise
             # render as a silent, unexplained empty table.
             parts.append(
-                f"(Offset {offset} exceeds this sheet's {len(rows)} rows; no rows shown.)"
+                f"(Offset {offset} exceeds this sheet's {total_rows} rows; no rows shown.)"
             )
             continue
         selected = rows[start : start + limit]
         for idx, row in enumerate(selected, start=start + 1):
             parts.append(f"{idx}\t" + "\t".join(row))
-        if start + limit < len(rows):
+        if start + limit < total_rows:
             end = start + len(selected)
             parts.append(
-                f"(Showing rows {offset}-{end} of {len(rows)}. "
+                f"(Showing rows {offset}-{end} of {total_rows}. "
                 f"Use offset={end + 1} to continue.)"
             )
     return "\n".join(parts)

--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -742,11 +742,24 @@ def _format_spreadsheet(
     limit: int,
 ) -> str:
     parts = [f"Workbook: {path.name}"]
-    start = max(0, offset - 1)
+    # Normalise once so a non-positive offset can't leak into the
+    # continuation message below: the slice already floors at row 1, but a
+    # raw offset=0 used to print "Showing rows 0-10" instead of "1-10".
+    offset = max(1, offset)
+    start = offset - 1
+    multi_sheet = len(sheets) > 1
     for sheet_name, rows in sheets:
         width = max((len(row) for row in rows), default=0)
         parts.append("")
         parts.append(f"Sheet: {sheet_name} ({len(rows)} rows x {width} columns)")
+        if multi_sheet and rows and start >= len(rows):
+            # One offset is shared across every sheet in a multi-sheet read,
+            # so a sheet smaller than the requested offset would otherwise
+            # render as a silent, unexplained empty table.
+            parts.append(
+                f"(Offset {offset} exceeds this sheet's {len(rows)} rows; no rows shown.)"
+            )
+            continue
         selected = rows[start : start + limit]
         for idx, row in enumerate(selected, start=start + 1):
             parts.append(f"{idx}\t" + "\t".join(row))

--- a/tests/test_tools/test_csv_multiline_fields.py
+++ b/tests/test_tools/test_csv_multiline_fields.py
@@ -21,7 +21,7 @@ def test_csv_multiline_quoted_field_stays_single_row(tmp_path: Path) -> None:
     csv_file = tmp_path / "multi.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
-    [(_, rows)] = _read_delimited_rows(csv_file, ",")
+    [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
     assert rows[0] == ["name", "description"]
     assert rows[1] == ["Alice", "Line one\nLine two\nLine three"]
@@ -42,7 +42,7 @@ def test_csv_delimiter_inside_quoted_field(tmp_path: Path) -> None:
     csv_file = tmp_path / "delim.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
-    [(_, rows)] = _read_delimited_rows(csv_file, ",")
+    [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
     assert rows[0] == ["key", "value"]
     assert rows[1] == ["item", "one, two, three"]
@@ -63,7 +63,7 @@ def test_csv_multiline_and_delimiter_in_same_field(tmp_path: Path) -> None:
     csv_file = tmp_path / "combo.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
-    [(_, rows)] = _read_delimited_rows(csv_file, ",")
+    [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
     assert rows[0] == ["id", "data"]
     assert rows[1] == ["1", "first, value\nsecond, value"]
@@ -84,7 +84,7 @@ def test_tsv_multiline_quoted_field(tmp_path: Path) -> None:
     tsv_file = tmp_path / "multi.tsv"
     tsv_file.write_text(tsv_content, encoding="utf-8")
 
-    [(_, rows)] = _read_delimited_rows(tsv_file, "\t")
+    [(_, rows, _)] = _read_delimited_rows(tsv_file, "\t")
 
     assert rows[0] == ["name", "notes"]
     assert rows[1] == ["Alice", "Line1\nLine2"]
@@ -116,7 +116,7 @@ def test_unicode_line_separator_inside_field_not_treated_as_row_break(
     csv_file = tmp_path / f"unicode_{label}.csv"
     csv_file.write_text(csv_content, encoding="utf-8")
 
-    [(_, rows)] = _read_delimited_rows(csv_file, ",")
+    [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
     assert len(rows) == 2, f"Expected 2 rows for {label!r}, got {len(rows)}"
     assert rows[0] == ["a", "b"]

--- a/tests/test_tools/test_csv_multiline_fields.py
+++ b/tests/test_tools/test_csv_multiline_fields.py
@@ -23,9 +23,9 @@ def test_csv_multiline_quoted_field_stays_single_row(tmp_path: Path) -> None:
 
     [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
-    assert rows[0] == ["name", "description"]
-    assert rows[1] == ["Alice", "Line one\nLine two\nLine three"]
-    assert rows[2] == ["Bob", "Simple"]
+    assert rows[1] == ["name", "description"]
+    assert rows[2] == ["Alice", "Line one\nLine two\nLine three"]
+    assert rows[3] == ["Bob", "Simple"]
     assert len(rows) == 3
 
 
@@ -44,9 +44,9 @@ def test_csv_delimiter_inside_quoted_field(tmp_path: Path) -> None:
 
     [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
-    assert rows[0] == ["key", "value"]
-    assert rows[1] == ["item", "one, two, three"]
-    assert rows[2] == ["other", "plain"]
+    assert rows[1] == ["key", "value"]
+    assert rows[2] == ["item", "one, two, three"]
+    assert rows[3] == ["other", "plain"]
     assert len(rows) == 3
 
 
@@ -65,9 +65,9 @@ def test_csv_multiline_and_delimiter_in_same_field(tmp_path: Path) -> None:
 
     [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
-    assert rows[0] == ["id", "data"]
-    assert rows[1] == ["1", "first, value\nsecond, value"]
-    assert rows[2] == ["2", "ok"]
+    assert rows[1] == ["id", "data"]
+    assert rows[2] == ["1", "first, value\nsecond, value"]
+    assert rows[3] == ["2", "ok"]
     assert len(rows) == 3
 
 
@@ -86,9 +86,9 @@ def test_tsv_multiline_quoted_field(tmp_path: Path) -> None:
 
     [(_, rows, _)] = _read_delimited_rows(tsv_file, "\t")
 
-    assert rows[0] == ["name", "notes"]
-    assert rows[1] == ["Alice", "Line1\nLine2"]
-    assert rows[2] == ["Bob", "ok"]
+    assert rows[1] == ["name", "notes"]
+    assert rows[2] == ["Alice", "Line1\nLine2"]
+    assert rows[3] == ["Bob", "ok"]
     assert len(rows) == 3
 
 
@@ -119,5 +119,5 @@ def test_unicode_line_separator_inside_field_not_treated_as_row_break(
     [(_, rows, _)] = _read_delimited_rows(csv_file, ",")
 
     assert len(rows) == 2, f"Expected 2 rows for {label!r}, got {len(rows)}"
-    assert rows[0] == ["a", "b"]
-    assert rows[1] == [f"x{sep}y", "z"]
+    assert rows[1] == ["a", "b"]
+    assert rows[2] == [f"x{sep}y", "z"]

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import filesystem as fs
+from agentos.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@contextmanager
+def tool_context(workspace: Path) -> Iterator[None]:
+    token = current_tool_context.set(
+        ToolContext(
+            caller_kind=CallerKind.CLI,
+            channel_kind="cli",
+            channel_id="cli:test",
+            workspace_dir=str(workspace),
+            workspace_strict=True,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_tool_context.reset(token)
+
+
+def _build_xlsx_bytes(sheets: dict[str, str], shared_strings: list[str] | None = None) -> bytes:
+    import io
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        # xl/workbook.xml
+        sheet_tags = []
+        rels_tags = []
+        for idx, (name, _) in enumerate(sheets.items(), start=1):
+            r_id = f"rId{idx}"
+            sheet_path = f"worksheets/sheet{idx}.xml"
+            sheet_tags.append(
+                f'<sheet name="{name}" sheetId="{idx}" '
+                f'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" '
+                f'r:id="{r_id}"/>'
+            )
+            type_uri = (
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+            )
+            rels_tags.append(f'<Relationship Id="{r_id}" Type="{type_uri}" Target="{sheet_path}"/>')
+
+        workbook_xml = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            f"<sheets>{''.join(sheet_tags)}</sheets>"
+            "</workbook>"
+        )
+        zf.writestr("xl/workbook.xml", workbook_xml)
+
+        rels_xml = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            f"{''.join(rels_tags)}"
+            "</Relationships>"
+        )
+        zf.writestr("xl/_rels/workbook.xml.rels", rels_xml)
+
+        if shared_strings:
+            si_nodes = "".join(f"<si><t>{s}</t></si>" for s in shared_strings)
+            shared_xml = (
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+                f'<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">{si_nodes}</sst>'
+            )
+            zf.writestr("xl/sharedStrings.xml", shared_xml)
+
+        for idx, (_, sheet_xml) in enumerate(sheets.items(), start=1):
+            zf.writestr(f"xl/worksheets/sheet{idx}.xml", sheet_xml)
+
+    return buf.getvalue()
+
+
+def test_read_xlsx_worksheet_sparse_rows() -> None:
+    xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+            <row r="1">
+                <c r="A1" t="inlineStr"><is><t>Header A</t></is></c>
+                <c r="B1" t="inlineStr"><is><t>Header B</t></is></c>
+            </row>
+            <row r="4">
+                <c r="A4" t="inlineStr"><is><t>Row 4</t></is></c>
+            </row>
+            <row r="6">
+                <c r="B6" t="inlineStr"><is><t>Row 6 Col B</t></is></c>
+            </row>
+        </sheetData>
+    </worksheet>"""
+
+    rows = fs._read_xlsx_worksheet(xml, [])
+    assert len(rows) == 6
+    assert rows[0] == ["Header A", "Header B"]
+    assert rows[1] == []
+    assert rows[2] == []
+    assert rows[3] == ["Row 4"]
+    assert rows[4] == []
+    assert rows[5] == ["", "Row 6 Col B"]
+
+
+def test_read_xlsx_worksheet_leading_empty_rows() -> None:
+    xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+            <row r="3">
+                <c r="A3" t="inlineStr"><is><t>Starts at row 3</t></is></c>
+            </row>
+        </sheetData>
+    </worksheet>"""
+
+    rows = fs._read_xlsx_worksheet(xml, [])
+    assert len(rows) == 3
+    assert rows[0] == []
+    assert rows[1] == []
+    assert rows[2] == ["Starts at row 3"]
+
+
+def test_read_xlsx_worksheet_contiguous_rows() -> None:
+    xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+            <row r="1">
+                <c r="A1" t="inlineStr"><is><t>Row 1</t></is></c>
+            </row>
+            <row r="2">
+                <c r="A2" t="inlineStr"><is><t>Row 2</t></is></c>
+            </row>
+        </sheetData>
+    </worksheet>"""
+
+    rows = fs._read_xlsx_worksheet(xml, [])
+    assert len(rows) == 2
+    assert rows[0] == ["Row 1"]
+    assert rows[1] == ["Row 2"]
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_xlsx_sparse_rows_and_pagination(tmp_path: Path) -> None:
+    sheet_xml = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        "<sheetData>"
+        '<row r="1">'
+        '<c r="A1" t="inlineStr"><is><t>Header</t></is></c>'
+        "</row>"
+        '<row r="5">'
+        '<c r="A5" t="inlineStr"><is><t>Value 5</t></is></c>'
+        "</row>"
+        '<row r="8">'
+        '<c r="A8" t="inlineStr"><is><t>Value 8</t></is></c>'
+        "</row>"
+        "</sheetData>"
+        "</worksheet>"
+    )
+
+    xlsx_bytes = _build_xlsx_bytes({"DataSheet": sheet_xml})
+    target = tmp_path / "test.xlsx"
+    target.write_bytes(xlsx_bytes)
+
+    with tool_context(tmp_path):
+        # 1. Reading from beginning (offset=1, limit=5)
+        out_page1 = await fs.read_spreadsheet(str(target), offset=1, limit=5)
+        assert "Sheet: DataSheet (8 rows x 1 columns)" in out_page1
+        assert "1\tHeader" in out_page1
+        assert "2\t" in out_page1
+        assert "3\t" in out_page1
+        assert "4\t" in out_page1
+        assert "5\tValue 5" in out_page1
+        assert "Value 8" not in out_page1
+
+        # 2. Reading with offset=5 (should show row 5 and following rows up to limit)
+        out_page2 = await fs.read_spreadsheet(str(target), offset=5, limit=5)
+        assert "5\tValue 5" in out_page2
+        assert "6\t" in out_page2
+        assert "7\t" in out_page2
+        assert "8\tValue 8" in out_page2
+        assert "1\tHeader" not in out_page2
+
+        # 3. Reading with offset=8
+        out_page3 = await fs.read_spreadsheet(str(target), offset=8, limit=5)
+        assert "8\tValue 8" in out_page3
+        assert "5\tValue 5" not in out_page3

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -188,3 +188,104 @@ async def test_read_spreadsheet_xlsx_sparse_rows_and_pagination(tmp_path: Path) 
         out_page3 = await fs.read_spreadsheet(str(target), offset=8, limit=5)
         assert "8\tValue 8" in out_page3
         assert "5\tValue 5" not in out_page3
+
+
+# ---------------------------------------------------------------------------
+# _format_spreadsheet: offset normalisation and multi-sheet pagination (#1149
+# scope note folding in #1402's non-positive-offset and multi-sheet reports)
+# ---------------------------------------------------------------------------
+
+
+def _rows(n: int, *, label: str) -> list[list[str]]:
+    return [[f"{label}{i}"] for i in range(1, n + 1)]
+
+
+def test_format_spreadsheet_offset_one_is_unchanged() -> None:
+    """Currently-correct case: a plain offset=1 read must keep its present
+    output through the offset-normalisation change."""
+    out = fs._format_spreadsheet(
+        path=Path("book.xlsx"), sheets=[("Sheet1", _rows(3, label="r"))], offset=1, limit=10
+    )
+    assert "1\tr1" in out
+    assert "2\tr2" in out
+    assert "3\tr3" in out
+    assert "Sheet1 (3 rows x 1 columns)" in out
+
+
+def test_format_spreadsheet_offset_past_end_of_single_sheet_is_unchanged() -> None:
+    """Currently-correct case: a single-sheet workbook with an offset past
+    its own row count must keep rendering an empty section with no extra
+    starvation note -- the header's own row count already explains it, and
+    there is no second sheet for a shared offset to starve."""
+    out = fs._format_spreadsheet(
+        path=Path("book.xlsx"), sheets=[("Sheet1", _rows(3, label="r"))], offset=50, limit=10
+    )
+    assert "Sheet1 (3 rows x 1 columns)" in out
+    assert "exceeds" not in out
+    assert "r1" not in out and "r2" not in out and "r3" not in out
+
+
+def test_format_spreadsheet_workbook_with_no_empty_rows_is_unchanged() -> None:
+    """Currently-correct case: a fully contiguous workbook (no padded gaps)
+    must keep its present output."""
+    out = fs._format_spreadsheet(
+        path=Path("book.xlsx"), sheets=[("Sheet1", _rows(2, label="r"))], offset=1, limit=10
+    )
+    assert out.splitlines()[-2:] == ["1\tr1", "2\tr2"]
+
+
+@pytest.mark.parametrize("bad_offset", [0, -1, -25])
+def test_format_spreadsheet_non_positive_offset_is_clamped_in_the_message(
+    bad_offset: int,
+) -> None:
+    """A non-positive offset must not leak into the continuation message --
+    the slice already floors at row 1, but the message used to echo the raw
+    offset, printing e.g. "Showing rows 0-10" (#1149 / #1402)."""
+    out = fs._format_spreadsheet(
+        path=Path("book.xlsx"),
+        sheets=[("Sheet1", _rows(20, label="r"))],
+        offset=bad_offset,
+        limit=10,
+    )
+    assert "1\tr1" in out
+    assert "Showing rows 1-10 of 20" in out
+    assert "Showing rows 0-" not in out
+    assert "Showing rows -" not in out
+
+
+def test_format_spreadsheet_multi_sheet_starvation_is_explained() -> None:
+    """One offset is shared across every sheet in a multi-sheet read; a
+    sheet smaller than that offset must say so explicitly instead of
+    silently rendering an empty table with no explanation (#1402)."""
+    out = fs._format_spreadsheet(
+        path=Path("book.xlsx"),
+        sheets=[
+            ("Big", _rows(50, label="b")),
+            ("Small", _rows(10, label="s")),
+        ],
+        offset=25,
+        limit=10,
+    )
+    # The larger sheet paginates normally at the shared offset.
+    assert "25\tb25" in out
+    # The smaller sheet gets an explicit note, not a silent empty table.
+    assert "(Offset 25 exceeds this sheet's 10 rows; no rows shown.)" in out
+    assert not any(f"s{i}" in out for i in range(1, 11))
+
+
+def test_format_spreadsheet_multi_sheet_empty_sheet_is_not_reported_as_starved() -> None:
+    """A genuinely empty sheet (0 rows) is not a starvation symptom of a
+    shared offset -- it must render like any other empty sheet, not with
+    the "offset exceeds" note meant for a sheet that has rows the offset
+    simply skipped past."""
+    out = fs._format_spreadsheet(
+        path=Path("book.xlsx"),
+        sheets=[
+            ("Big", _rows(50, label="b")),
+            ("Empty", []),
+        ],
+        offset=25,
+        limit=10,
+    )
+    assert "Empty (0 rows x 0 columns)" in out
+    assert "exceeds" not in out

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -289,3 +289,36 @@ def test_format_spreadsheet_multi_sheet_empty_sheet_is_not_reported_as_starved()
     )
     assert "Empty (0 rows x 0 columns)" in out
     assert "exceeds" not in out
+
+
+def test_read_xlsx_worksheet_crafted_row_beyond_ceiling() -> None:
+    """A crafted or corrupt r="99999999999" row index must not make the
+    padding loop try to build a list of that size -- bound row indices to
+    the real .xlsx row ceiling (1,048,576) before padding."""
+    xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+            <row r="1">
+                <c r="A1" t="inlineStr"><is><t>Header</t></is></c>
+            </row>
+            <row r="20000000">
+                <c r="A20000000" t="inlineStr"><is><t>Huge Row</t></is></c>
+            </row>
+            <row r="99999999999">
+                <c r="A99999999999" t="inlineStr"><is><t>Gigantic Row</t></is></c>
+            </row>
+            <row r="0">
+                <c r="A0" t="inlineStr"><is><t>Zero Row</t></is></c>
+            </row>
+        </sheetData>
+    </worksheet>"""
+
+    import time
+
+    start = time.perf_counter()
+    rows = fs._read_xlsx_worksheet(xml, [])
+    elapsed = time.perf_counter() - start
+
+    assert len(rows) == 1
+    assert rows[0] == ["Header"]
+    assert elapsed < 0.5

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -98,13 +98,12 @@ def test_read_xlsx_worksheet_sparse_rows() -> None:
 
     rows, total_rows = fs._read_xlsx_worksheet(xml, [])
     assert total_rows == 6
-    assert len(rows) == 6
-    assert rows[0] == ["Header A", "Header B"]
-    assert rows[1] == []
-    assert rows[2] == []
-    assert rows[3] == ["Row 4"]
-    assert rows[4] == []
-    assert rows[5] == ["", "Row 6 Col B"]
+    # Only rows actually present in the XML are keyed -- omitted rows 2, 3,
+    # and 5 are real empty rows, not materialised placeholders.
+    assert set(rows) == {1, 4, 6}
+    assert rows[1] == ["Header A", "Header B"]
+    assert rows[4] == ["Row 4"]
+    assert rows[6] == ["", "Row 6 Col B"]
 
 
 def test_read_xlsx_worksheet_leading_empty_rows() -> None:
@@ -119,10 +118,8 @@ def test_read_xlsx_worksheet_leading_empty_rows() -> None:
 
     rows, total_rows = fs._read_xlsx_worksheet(xml, [])
     assert total_rows == 3
-    assert len(rows) == 3
-    assert rows[0] == []
-    assert rows[1] == []
-    assert rows[2] == ["Starts at row 3"]
+    assert set(rows) == {3}
+    assert rows[3] == ["Starts at row 3"]
 
 
 def test_read_xlsx_worksheet_contiguous_rows() -> None:
@@ -140,9 +137,8 @@ def test_read_xlsx_worksheet_contiguous_rows() -> None:
 
     rows, total_rows = fs._read_xlsx_worksheet(xml, [])
     assert total_rows == 2
-    assert len(rows) == 2
-    assert rows[0] == ["Row 1"]
-    assert rows[1] == ["Row 2"]
+    assert rows[1] == ["Row 1"]
+    assert rows[2] == ["Row 2"]
 
 
 @pytest.mark.asyncio
@@ -193,14 +189,63 @@ async def test_read_spreadsheet_xlsx_sparse_rows_and_pagination(tmp_path: Path) 
         assert "5\tValue 5" not in out_page3
 
 
+@pytest.mark.asyncio
+async def test_read_spreadsheet_pagination_crosses_a_gap_wider_than_limit(
+    tmp_path: Path,
+) -> None:
+    """A legitimate sparse sheet with data at row 1 and row 5000 and nothing
+    between must still be reachable through the tool's own continuation
+    offsets, at the default limit (200) -- a window that measures "how many
+    rows did this call materialise" instead of "how far did the real row
+    numbers get to" stalls here: every page in the gap materialises zero
+    rows, so the suggested next offset stops advancing and row 5000 is
+    never reached (#1149 follow-ups)."""
+    sheet_xml = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        "<sheetData>"
+        '<row r="1"><c r="A1" t="inlineStr"><is><t>first</t></is></c></row>'
+        '<row r="5000"><c r="A5000" t="inlineStr"><is><t>last</t></is></c></row>'
+        "</sheetData>"
+        "</worksheet>"
+    )
+    xlsx_bytes = _build_xlsx_bytes({"Data": sheet_xml})
+    target = tmp_path / "gap.xlsx"
+    target.write_bytes(xlsx_bytes)
+
+    with tool_context(tmp_path):
+        seen_offsets = [1]
+        out = await fs.read_spreadsheet(str(target), offset=1)
+        for _ in range(50):
+            assert "Sheet: Data (5000 rows x 1 columns)" in out
+            if "last" in out:
+                break
+            marker = "Use offset="
+            idx = out.rindex(marker) + len(marker)
+            next_offset = int(out[idx:].split(" ", 1)[0].rstrip(".)"))
+            assert next_offset > seen_offsets[-1], (
+                f"continuation offset did not advance past {seen_offsets[-1]} "
+                f"(pagination stalled in the gap)"
+            )
+            seen_offsets.append(next_offset)
+            out = await fs.read_spreadsheet(str(target), offset=next_offset)
+        else:
+            raise AssertionError("never reached row 5000 within 50 pages")
+
+        assert "5000\tlast" in out
+        assert seen_offsets == [1, 201, 401, 601, 801, 1001, 1201, 1401, 1601, 1801, 2001,
+                                 2201, 2401, 2601, 2801, 3001, 3201, 3401, 3601, 3801, 4001,
+                                 4201, 4401, 4601, 4801]
+
+
 # ---------------------------------------------------------------------------
 # _format_spreadsheet: offset normalisation and multi-sheet pagination (#1149
 # scope note folding in #1402's non-positive-offset and multi-sheet reports)
 # ---------------------------------------------------------------------------
 
 
-def _sheet(name: str, n: int, *, label: str) -> tuple[str, list[list[str]], int]:
-    rows = [[f"{label}{i}"] for i in range(1, n + 1)]
+def _sheet(name: str, n: int, *, label: str) -> tuple[str, dict[int, list[str]], int]:
+    rows = {i: [f"{label}{i}"] for i in range(1, n + 1)}
     return (name, rows, len(rows))
 
 
@@ -286,7 +331,7 @@ def test_format_spreadsheet_multi_sheet_empty_sheet_is_not_reported_as_starved()
         path=Path("book.xlsx"),
         sheets=[
             _sheet("Big", 50, label="b"),
-            ("Empty", [], 0),
+            ("Empty", {}, 0),
         ],
         offset=25,
         limit=10,
@@ -296,9 +341,11 @@ def test_format_spreadsheet_multi_sheet_empty_sheet_is_not_reported_as_starved()
 
 
 def test_read_xlsx_worksheet_crafted_row_beyond_ceiling() -> None:
-    """A crafted or corrupt r="99999999999" row index must not make the
-    padding loop try to build a list of that size -- bound row indices to
-    the real .xlsx row ceiling (1,048,576) before padding."""
+    """A crafted or corrupt r="99999999999" row index must not cost
+    anything proportional to that number -- keying by real row number
+    (instead of padding a list up to it) makes this cheap regardless of
+    how large the declared index is, since only rows the XML actually
+    contains are ever stored."""
     xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
         <sheetData>
@@ -323,31 +370,16 @@ def test_read_xlsx_worksheet_crafted_row_beyond_ceiling() -> None:
     rows, total_rows = fs._read_xlsx_worksheet(xml, [])
     elapsed = time.perf_counter() - start
 
-    assert len(rows) == 1
-    assert rows[0] == ["Header"]
     # r=20000000, r=99999999999, and r=0 are all outside the format's real
-    # row range (1..1,048,576) and stay fully disregarded -- not just
-    # unmaterialised but also uncounted, same as before this change.
+    # row range (1..1,048,576) and stay fully disregarded.
+    assert set(rows) == {1}
+    assert rows[1] == ["Header"]
     assert total_rows == 1
     assert elapsed < 0.5
 
 
-@pytest.mark.asyncio
-async def test_read_spreadsheet_selecting_one_sheet_does_not_pad_every_sheet_to_max_rows(
-    tmp_path: Path,
-) -> None:
-    """A per-sheet row-index clamp is not enough on its own: _read_xlsx_sheets
-    parses every sheet in the workbook before a single sheet is selected, so
-    a crafted multi-sheet workbook where every sheet declares a near-max row
-    index would otherwise multiply the per-sheet padding cost by sheet count
-    -- a 6.6 KB file that cost ~1.6 GB / 3+ seconds to read one sheet from,
-    even though only one sheet was ever going to be rendered.
-
-    The fix threads read_spreadsheet's own render window (offset + limit -
-    1) down as a materialisation ceiling, so only sheets -- and only rows
-    within that window -- actually get padded, while the true row count is
-    still reported."""
-    sheet_xml = (
+def _sparse_far_row_sheet_xml() -> str:
+    return (
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
         "<sheetData>"
@@ -356,7 +388,20 @@ async def test_read_spreadsheet_selecting_one_sheet_does_not_pad_every_sheet_to_
         "</sheetData>"
         "</worksheet>"
     )
-    sheets = {f"S{i}": sheet_xml for i in range(1, 21)}
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_selecting_one_sheet_does_not_pad_to_declared_row(
+    tmp_path: Path,
+) -> None:
+    """_read_xlsx_sheets parses every sheet in the workbook before a single
+    sheet is selected, so a crafted multi-sheet workbook where every sheet
+    declares a near-max row index must not cost anything proportional to
+    sheet count -- a 6.6 KB, 20-sheet file previously cost ~1.6 GB / ~19s
+    to read one sheet from, even though only one sheet was ever going to
+    be rendered. Keying rows by their real row number instead of padding a
+    list up to it means each sheet costs O(2), its actual <row> count."""
+    sheets = {f"S{i}": _sparse_far_row_sheet_xml() for i in range(1, 21)}
     xlsx_bytes = _build_xlsx_bytes(sheets)
     target = tmp_path / "huge.xlsx"
     target.write_bytes(xlsx_bytes)
@@ -369,7 +414,57 @@ async def test_read_spreadsheet_selecting_one_sheet_does_not_pad_every_sheet_to_
         elapsed = time.perf_counter() - start
 
     assert "1\tHeader" in out
-    # The true row count is still reported, not the (small) materialised
-    # window's length.
     assert "1048576 rows" in out
     assert elapsed < 2.0
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_large_limit_renders_the_whole_sheet(tmp_path: Path) -> None:
+    """A caller may legitimately ask for the whole sheet via a large
+    `limit`; that must still work and return real output -- rendering
+    ~1M lines is genuine requested work, not amplification, and is
+    covered separately by test_read_xlsx_sheets_reading_does_not_scale_
+    with_sheet_count for the (much cheaper) read side."""
+    sheets = {f"S{i}": _sparse_far_row_sheet_xml() for i in range(1, 21)}
+    target = tmp_path / "huge.xlsx"
+    target.write_bytes(_build_xlsx_bytes(sheets))
+
+    with tool_context(tmp_path):
+        out = await fs.read_spreadsheet(str(target), sheet="S1", offset=1, limit=1_048_576)
+
+    assert "1\tHeader" in out
+    assert "1048576\tLast" in out
+    assert "1048576 rows" in out
+
+
+def test_read_xlsx_sheets_reading_does_not_scale_with_sheet_count(tmp_path: Path) -> None:
+    """_read_xlsx_sheets parses every sheet before a single one is selected,
+    so its own cost -- independent of whatever `limit` a caller later
+    renders with -- must not depend on how many sheets a workbook has, nor
+    on what row numbers they declare. Keying rows by their real row number
+    (rather than padding a list up to it) means each sheet here costs O(2),
+    its actual <row> count, regardless of sheet count -- isolating this
+    from _format_spreadsheet's separate, legitimate large-limit rendering
+    cost, which does scale with `limit` (that is the caller's own request,
+    not amplification; see the large-limit case above)."""
+    import time
+
+    def _time_read(sheet_count: int) -> float:
+        sheets = {f"S{i}": _sparse_far_row_sheet_xml() for i in range(1, sheet_count + 1)}
+        target = tmp_path / f"wide-{sheet_count}.xlsx"
+        target.write_bytes(_build_xlsx_bytes(sheets))
+        start = time.perf_counter()
+        parsed = fs._read_xlsx_sheets(target)
+        elapsed = time.perf_counter() - start
+        assert len(parsed) == sheet_count
+        return elapsed
+
+    one_sheet = _time_read(1)
+    twenty_sheets = _time_read(20)
+
+    # A generous absolute ceiling and a generous ratio: this only needs to
+    # rule out the old O(sheet_count x declared_row_number) blowup (which
+    # was several seconds and ~1.6 GB for 20 sheets), not pin an exact
+    # ratio on a shared, noisy CI box.
+    assert twenty_sheets < 1.0
+    assert twenty_sheets < max(one_sheet * 5, one_sheet + 0.5)

--- a/tests/test_tools/test_read_spreadsheet_xlsx.py
+++ b/tests/test_tools/test_read_spreadsheet_xlsx.py
@@ -96,7 +96,8 @@ def test_read_xlsx_worksheet_sparse_rows() -> None:
         </sheetData>
     </worksheet>"""
 
-    rows = fs._read_xlsx_worksheet(xml, [])
+    rows, total_rows = fs._read_xlsx_worksheet(xml, [])
+    assert total_rows == 6
     assert len(rows) == 6
     assert rows[0] == ["Header A", "Header B"]
     assert rows[1] == []
@@ -116,7 +117,8 @@ def test_read_xlsx_worksheet_leading_empty_rows() -> None:
         </sheetData>
     </worksheet>"""
 
-    rows = fs._read_xlsx_worksheet(xml, [])
+    rows, total_rows = fs._read_xlsx_worksheet(xml, [])
+    assert total_rows == 3
     assert len(rows) == 3
     assert rows[0] == []
     assert rows[1] == []
@@ -136,7 +138,8 @@ def test_read_xlsx_worksheet_contiguous_rows() -> None:
         </sheetData>
     </worksheet>"""
 
-    rows = fs._read_xlsx_worksheet(xml, [])
+    rows, total_rows = fs._read_xlsx_worksheet(xml, [])
+    assert total_rows == 2
     assert len(rows) == 2
     assert rows[0] == ["Row 1"]
     assert rows[1] == ["Row 2"]
@@ -196,15 +199,16 @@ async def test_read_spreadsheet_xlsx_sparse_rows_and_pagination(tmp_path: Path) 
 # ---------------------------------------------------------------------------
 
 
-def _rows(n: int, *, label: str) -> list[list[str]]:
-    return [[f"{label}{i}"] for i in range(1, n + 1)]
+def _sheet(name: str, n: int, *, label: str) -> tuple[str, list[list[str]], int]:
+    rows = [[f"{label}{i}"] for i in range(1, n + 1)]
+    return (name, rows, len(rows))
 
 
 def test_format_spreadsheet_offset_one_is_unchanged() -> None:
     """Currently-correct case: a plain offset=1 read must keep its present
     output through the offset-normalisation change."""
     out = fs._format_spreadsheet(
-        path=Path("book.xlsx"), sheets=[("Sheet1", _rows(3, label="r"))], offset=1, limit=10
+        path=Path("book.xlsx"), sheets=[_sheet("Sheet1", 3, label="r")], offset=1, limit=10
     )
     assert "1\tr1" in out
     assert "2\tr2" in out
@@ -218,7 +222,7 @@ def test_format_spreadsheet_offset_past_end_of_single_sheet_is_unchanged() -> No
     starvation note -- the header's own row count already explains it, and
     there is no second sheet for a shared offset to starve."""
     out = fs._format_spreadsheet(
-        path=Path("book.xlsx"), sheets=[("Sheet1", _rows(3, label="r"))], offset=50, limit=10
+        path=Path("book.xlsx"), sheets=[_sheet("Sheet1", 3, label="r")], offset=50, limit=10
     )
     assert "Sheet1 (3 rows x 1 columns)" in out
     assert "exceeds" not in out
@@ -229,7 +233,7 @@ def test_format_spreadsheet_workbook_with_no_empty_rows_is_unchanged() -> None:
     """Currently-correct case: a fully contiguous workbook (no padded gaps)
     must keep its present output."""
     out = fs._format_spreadsheet(
-        path=Path("book.xlsx"), sheets=[("Sheet1", _rows(2, label="r"))], offset=1, limit=10
+        path=Path("book.xlsx"), sheets=[_sheet("Sheet1", 2, label="r")], offset=1, limit=10
     )
     assert out.splitlines()[-2:] == ["1\tr1", "2\tr2"]
 
@@ -243,7 +247,7 @@ def test_format_spreadsheet_non_positive_offset_is_clamped_in_the_message(
     offset, printing e.g. "Showing rows 0-10" (#1149 / #1402)."""
     out = fs._format_spreadsheet(
         path=Path("book.xlsx"),
-        sheets=[("Sheet1", _rows(20, label="r"))],
+        sheets=[_sheet("Sheet1", 20, label="r")],
         offset=bad_offset,
         limit=10,
     )
@@ -260,8 +264,8 @@ def test_format_spreadsheet_multi_sheet_starvation_is_explained() -> None:
     out = fs._format_spreadsheet(
         path=Path("book.xlsx"),
         sheets=[
-            ("Big", _rows(50, label="b")),
-            ("Small", _rows(10, label="s")),
+            _sheet("Big", 50, label="b"),
+            _sheet("Small", 10, label="s"),
         ],
         offset=25,
         limit=10,
@@ -281,8 +285,8 @@ def test_format_spreadsheet_multi_sheet_empty_sheet_is_not_reported_as_starved()
     out = fs._format_spreadsheet(
         path=Path("book.xlsx"),
         sheets=[
-            ("Big", _rows(50, label="b")),
-            ("Empty", []),
+            _sheet("Big", 50, label="b"),
+            ("Empty", [], 0),
         ],
         offset=25,
         limit=10,
@@ -316,9 +320,56 @@ def test_read_xlsx_worksheet_crafted_row_beyond_ceiling() -> None:
     import time
 
     start = time.perf_counter()
-    rows = fs._read_xlsx_worksheet(xml, [])
+    rows, total_rows = fs._read_xlsx_worksheet(xml, [])
     elapsed = time.perf_counter() - start
 
     assert len(rows) == 1
     assert rows[0] == ["Header"]
+    # r=20000000, r=99999999999, and r=0 are all outside the format's real
+    # row range (1..1,048,576) and stay fully disregarded -- not just
+    # unmaterialised but also uncounted, same as before this change.
+    assert total_rows == 1
     assert elapsed < 0.5
+
+
+@pytest.mark.asyncio
+async def test_read_spreadsheet_selecting_one_sheet_does_not_pad_every_sheet_to_max_rows(
+    tmp_path: Path,
+) -> None:
+    """A per-sheet row-index clamp is not enough on its own: _read_xlsx_sheets
+    parses every sheet in the workbook before a single sheet is selected, so
+    a crafted multi-sheet workbook where every sheet declares a near-max row
+    index would otherwise multiply the per-sheet padding cost by sheet count
+    -- a 6.6 KB file that cost ~1.6 GB / 3+ seconds to read one sheet from,
+    even though only one sheet was ever going to be rendered.
+
+    The fix threads read_spreadsheet's own render window (offset + limit -
+    1) down as a materialisation ceiling, so only sheets -- and only rows
+    within that window -- actually get padded, while the true row count is
+    still reported."""
+    sheet_xml = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        "<sheetData>"
+        '<row r="1"><c r="A1" t="inlineStr"><is><t>Header</t></is></c></row>'
+        '<row r="1048576"><c r="A1048576" t="inlineStr"><is><t>Last</t></is></c></row>'
+        "</sheetData>"
+        "</worksheet>"
+    )
+    sheets = {f"S{i}": sheet_xml for i in range(1, 21)}
+    xlsx_bytes = _build_xlsx_bytes(sheets)
+    target = tmp_path / "huge.xlsx"
+    target.write_bytes(xlsx_bytes)
+
+    import time
+
+    with tool_context(tmp_path):
+        start = time.perf_counter()
+        out = await fs.read_spreadsheet(str(target), sheet="S1", offset=1, limit=10)
+        elapsed = time.perf_counter() - start
+
+    assert "1\tHeader" in out
+    # The true row count is still reported, not the (small) materialised
+    # window's length.
+    assert "1048576 rows" in out
+    assert elapsed < 2.0


### PR DESCRIPTION
### Summary
OpenXML (`.xlsx`) workbooks omit empty rows from `<sheetData>` by default to reduce file size, storing the 1-indexed row number on each `<row r="...">` tag.

Previously, `_read_xlsx_worksheet` iterated through `<row>` elements and appended them sequentially without checking `r`. This caused row numbers to be compacted:
1. Row numbers in formatted output were shifted (e.g., row 5 with empty preceding rows appeared as row 2).
2. Pagination via `offset=...` failed to reach or skipped rows because `len(rows)` was smaller than the actual row index.

### Fix
- Inspect `r` on `<row>` elements in `_read_xlsx_worksheet`.
- When `r` is present and valid, pad `rows` with empty lists `[]` until `len(rows) == int(r) - 1`.
- Added test suite `tests/test_tools/test_read_spreadsheet_xlsx.py` covering sparse rows, leading empty rows, contiguous rows, and offset pagination across `.xlsx` sheets.

Closes #1149
