### PR TITLE
fix(skills): create parent directories before writing output in bundl…

### DIFF
--- a/src/agentos/skills/bundled/docx/scripts/inspect_docx.py
+++ b/src/agentos/skills/bundled/docx/scripts/inspect_docx.py
@@ -63,6 +63,7 @@ def main() -> int:
     payload = inspect(args.path)
     text = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text, encoding="utf-8")
     else:
         print(text)

--- a/src/agentos/skills/bundled/multi-search-engine/scripts/search.py
+++ b/src/agentos/skills/bundled/multi-search-engine/scripts/search.py
@@ -225,6 +225,7 @@ def main() -> int:
     payload = search_all(args.query, engines, args.limit, args.strict)
     encoded = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(encoded, encoding="utf-8")
     else:
         sys.stdout.write(encoded)

--- a/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
+++ b/src/agentos/skills/bundled/pdf-toolkit/scripts/extract.py
@@ -59,6 +59,7 @@ def main() -> int:
     payload = extract(args.path, args.tables_strategy)
     text = json.dumps(payload, ensure_ascii=False, indent=2)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text, encoding="utf-8")
     else:
         print(text)

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py
@@ -149,6 +149,7 @@ def main() -> int:
         return 1
 
     output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     print(f"publish_artifact path={output} mime={CARDS_MIME}")
     return 0

--- a/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
+++ b/src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_stocks.py
@@ -551,7 +551,9 @@ def _write_cards(result: dict[str, Any], output: str) -> None:
         payload = chain_cards.build_payload(result)
         if not payload["cards"]:
             return
-        Path(output).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
         print(
             f"publish_artifact path={output} mime={chain_cards.CARDS_MIME}",
             file=sys.stderr,

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py
@@ -113,6 +113,7 @@ def main() -> int:
         return 1
 
     output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     print(f"publish_artifact path={output} mime={CARDS_MIME}")
     return 0

--- a/src/agentos/skills/bundled/xlsx/scripts/inspect_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/inspect_xlsx.py
@@ -82,6 +82,7 @@ def main() -> int:
     payload = inspect(args.path, args.data_only)
     text = json.dumps(payload, ensure_ascii=False, indent=2, default=str)
     if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text, encoding="utf-8")
     else:
         print(text)

--- a/tests/test_skill_docx.py
+++ b/tests/test_skill_docx.py
@@ -90,9 +90,9 @@ def test_edit_replace_text(tmp_path: Path) -> None:
         sys.path.pop(0)
 
     src = tmp_path / "src.docx"
-    create_docx.build(
-        {"body": [{"kind": "paragraph", "text": "Hello {{NAME}}, welcome."}]}
-    ).save(str(src))
+    create_docx.build({"body": [{"kind": "paragraph", "text": "Hello {{NAME}}, welcome."}]}).save(
+        str(src)
+    )
 
     from docx import Document
 
@@ -123,3 +123,22 @@ def test_inspect_cli_outputs_json(tmp_path: Path) -> None:
     encoded = json.dumps(payload, ensure_ascii=False)
     assert "paragraphs" in encoded
     assert "tables" in encoded
+
+
+def test_inspect_docx_creates_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_docx  # type: ignore[import-not-found]
+        import inspect_docx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "src.docx"
+    create_docx.build({"body": [{"kind": "paragraph", "text": "x"}]}).save(str(src))
+
+    out = tmp_path / "nested" / "dir" / "out.json"
+    monkeypatch.setattr(sys, "argv", ["inspect_docx.py", str(src), "--out", str(out)])
+    assert inspect_docx.main() == 0
+    assert out.is_file()

--- a/tests/test_skill_multi_search_engine.py
+++ b/tests/test_skill_multi_search_engine.py
@@ -160,3 +160,21 @@ def test_unknown_engine_recorded() -> None:
     )
     assert payload["results"] == []
     assert any("unknown engine" in e["reason"] for e in payload["errors"])
+
+
+def test_search_creates_parent_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import search  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    monkeypatch.setattr(
+        search,
+        "search_all",
+        lambda *args, **kwargs: {"query": "q", "results": [], "errors": []},
+    )
+    out = tmp_path / "nested" / "dir" / "out.json"
+    monkeypatch.setattr(sys, "argv", ["search.py", "--query", "test", "--out", str(out)])
+    assert search.main() == 0
+    assert out.is_file()

--- a/tests/test_skill_pdf_toolkit.py
+++ b/tests/test_skill_pdf_toolkit.py
@@ -107,3 +107,23 @@ def test_merge_range_parsing() -> None:
     assert merge.parse_ranges("1-3", 5) == [1, 2, 3]
     # Out-of-range pages are filtered.
     assert merge.parse_ranges("1,99", 4) == [1]
+
+
+def test_extract_creates_parent_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import extract  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    pdf_file = tmp_path / "doc.pdf"
+    _make_one_page_pdf(pdf_file, "TEST")
+
+    out_file = tmp_path / "nested" / "dir" / "out.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["extract.py", str(pdf_file), "--out", str(out_file)],
+    )
+    assert extract.main() == 0
+    assert out_file.is_file()

--- a/tests/test_skill_robinhood_chain_cards.py
+++ b/tests/test_skill_robinhood_chain_cards.py
@@ -12,6 +12,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
     / "src/agentos/skills/bundled/robinhood-chain-stocks/scripts/chain_cards.py"
@@ -129,3 +131,18 @@ def test_a_result_without_a_token_renders_nothing() -> None:
 def test_onchain_symbol_is_used_when_the_list_symbol_is_missing() -> None:
     card = chain_cards.build_cards(_result(token=_token(symbol="", onchainSymbol="TSLA")))[0]
     assert card["title"] == "TSLA"
+
+
+def test_chain_cards_creates_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import io
+    import json
+    import sys
+
+    out = tmp_path / "nested" / "dir" / "cards.json"
+    payload = _result()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv", ["chain_cards.py", "--output", str(out)])
+    assert chain_cards.main() == 0
+    assert out.is_file()

--- a/tests/test_skill_robinhood_chain_stocks.py
+++ b/tests/test_skill_robinhood_chain_stocks.py
@@ -573,9 +573,15 @@ def test_http_json_rejects_empty_url() -> None:
 
 def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> None:
     import json
-    code = chain_stocks.main(["--address",
-        "0x0000000000000000000000000000000000000000",
-        "--rpc-url", "file:///etc/passwd"])
+
+    code = chain_stocks.main(
+        [
+            "--address",
+            "0x0000000000000000000000000000000000000000",
+            "--rpc-url",
+            "file:///etc/passwd",
+        ]
+    )
     assert code == 0
     out, _ = capsys.readouterr()
     payload = json.loads(out)
@@ -585,9 +591,10 @@ def test_main_rejects_invalid_rpc_url(capsys: pytest.CaptureFixture[str]) -> Non
 
 def test_main_rejects_missing_host_url(capsys: pytest.CaptureFixture[str]) -> None:
     import json
-    code = chain_stocks.main(["--address",
-        "0x0000000000000000000000000000000000000000",
-        "--rpc-url", "http://"])
+
+    code = chain_stocks.main(
+        ["--address", "0x0000000000000000000000000000000000000000", "--rpc-url", "http://"]
+    )
     assert code == 0
     out, _ = capsys.readouterr()
     payload = json.loads(out)
@@ -603,8 +610,9 @@ def test_eth_call_handle_nondict_error() -> None:
 
     with patch.object(chain_stocks, "_http_json", side_effect=mock_http_json):
         with pytest.raises(chain_stocks.RpcError) as exc:
-            chain_stocks._eth_call("http://127.0.0.1:8545",
-                "0x0000000000000000000000000000000000000000", "0x", 5.0)
+            chain_stocks._eth_call(
+                "http://127.0.0.1:8545", "0x0000000000000000000000000000000000000000", "0x", 5.0
+            )
         assert "something went wrong" in str(exc.value)
 
 
@@ -617,6 +625,30 @@ def test_eth_call_handle_dict_error() -> None:
 
     with patch.object(chain_stocks, "_http_json", side_effect=mock_http_json):
         with pytest.raises(chain_stocks.RpcError) as exc:
-            chain_stocks._eth_call("http://127.0.0.1:8545",
-                "0x0000000000000000000000000000000000000000", "0x", 5.0)
+            chain_stocks._eth_call(
+                "http://127.0.0.1:8545", "0x0000000000000000000000000000000000000000", "0x", 5.0
+            )
         assert "execution reverted" in str(exc.value)
+
+
+def test_write_cards_creates_parent_directory(tmp_path: Path) -> None:
+    sys.path.insert(0, str(_SCRIPT.parent))
+    try:
+        out = tmp_path / "nested" / "dir" / "cards.json"
+        result = {
+            "query": "Apple",
+            "chainId": 4663,
+            "token": {
+                "address": AAPL,
+                "chainId": 4663,
+                "onchainSymbol": "AAPL",
+                "symbol": "AAPL",
+                "name": "Apple",
+                "decimals": 18,
+                "isStockToken": True,
+            },
+        }
+        chain_stocks._write_cards(result, str(out))
+        assert out.is_file()
+    finally:
+        sys.path.remove(str(_SCRIPT.parent))

--- a/tests/test_skill_robinhood_rwa_cards.py
+++ b/tests/test_skill_robinhood_rwa_cards.py
@@ -13,6 +13,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _SCRIPT = (
     Path(__file__).resolve().parents[1]
     / "src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_cards.py"
@@ -121,3 +123,18 @@ def test_match_order_is_preserved() -> None:
         )
     )
     assert [c["title"] for c in cards] == ["AAPL", "JPM"]
+
+
+def test_rwa_cards_creates_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import io
+    import json
+    import sys
+
+    out = tmp_path / "nested" / "dir" / "cards.json"
+    payload = _result(_match())
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv", ["rwa_cards.py", "--output", str(out)])
+    assert rwa_cards.main() == 0
+    assert out.is_file()

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -129,3 +129,22 @@ def test_text_escapes_formula(tmp_path: Path) -> None:
     cell_value = sheet["rows"][1][0]["value"]
     assert isinstance(cell_value, str)
     assert cell_value.lstrip("'") == "=hello"
+
+
+def test_inspect_xlsx_creates_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+        import inspect_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["a"]]}]}).save(str(src))
+
+    out = tmp_path / "nested" / "dir" / "out.json"
+    monkeypatch.setattr(sys, "argv", ["inspect_xlsx.py", str(src), "--out", str(out)])
+    assert inspect_xlsx.main() == 0
+    assert out.is_file()


### PR DESCRIPTION
Fixes #1055 

### Summary
Ensure bundled skill CLI scripts create any missing parent directories before writing output files when an `--out`, `--output`, or `--cards` path is provided.

### Context & Scope
As confirmed on `main` by maintainer @andreapn, 7 bundled scripts were calling `write_text()` without ensuring parent directories exist:
- `pdf-toolkit/scripts/extract.py`
- `docx/scripts/inspect_docx.py`
- `xlsx/scripts/inspect_xlsx.py`
- `multi-search-engine/scripts/search.py`
- `robinhood-rwa-addresses/scripts/rwa_cards.py`
- `robinhood-chain-stocks/scripts/chain_cards.py`
- `robinhood-chain-stocks/scripts/chain_stocks.py`

In particular, `chain_stocks.py:554` called `Path(output).write_text()` inside a broad `try/except` handler, causing `FileNotFoundError` to be swallowed and leading to silent failure where the card artifact was never written.

### Changes
- Added `parent.mkdir(parents=True, exist_ok=True)` before `write_text()` in all 7 scripts.
- Added public regression tests for each of the 7 scripts verifying that writing to uncreated nested parent directories succeeds.

### Verification
- `uv run ruff check src/agentos/skills/bundled/ tests/test_skill_*.py` (passed)
- `uv run mypy src/agentos/skills/bundled --show-error-codes` (passed, 0 issues)
- `uv run pytest tests/test_skill_*.py` (91 passed)
