### PR TITLE
fix(mcp): follow the legacy SSE endpoint lifecycle (#922)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   instead of hanging the caller. The unused `MCPServerConfig.message_endpoint`
   field, which no configuration surface ever set, is gone
   ([#922](https://github.com/use-agent-os/agent-os/issues/922)).
+- Both SDK-backed MCP HTTP transports open and unwind their transport in a task
+  the client owns. The SDK transports and `ClientSession` are built on anyio
+  task groups, and an anyio cancel scope may only be exited by the task that
+  entered it — but nothing closes an MCP client from the task that opened it:
+  `discover_and_register` runs during boot or in an RPC handler while
+  `close_active_clients` runs from gateway shutdown or a later `mcp.disconnect`.
+  Closing therefore raised `RuntimeError: Attempted to exit cancel scope in a
+  different task`, which `close_active_clients` swallows, leaking the stream and
+  its connection for the life of the process. This was already reachable on
+  `streamable_http`; the shared `MCPSessionClient` base fixes it for both
+  ([#922](https://github.com/use-agent-os/agent-os/issues/922)).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `SessionStorage.list_stale_session_keys()` before deleting, since the
   storage-level prune returned only a count
   ([#750](https://github.com/use-agent-os/agent-os/issues/750)).
+- The legacy MCP `sse` transport follows the 2024-11-05 HTTP+SSE lifecycle
+  instead of inverting it. `MCPSSEClient.connect()` POSTed the `initialize`
+  request before any stream existed, sent it to a guessed `/message` path, and
+  then opened a fresh `GET` per request — so a compliant server, which picks its
+  own message URI and announces it in an `endpoint` event on a stream the client
+  must open first, either rejected the handshake or emitted the response into a
+  window with nothing listening. The client now drives `mcp.client.sse`, the
+  sibling of the SDK transport the Streamable HTTP client already uses: the
+  stream opens first, the advertised endpoint is resolved against the configured
+  URL and is the only POST target, one receive stream serves the connection with
+  responses correlated by JSON-RPC id, and `close()` cancels the reader task. An
+  endpoint pointing at a different origin is refused before anything is posted,
+  and both channels — the stream and the POST — dial through the same
+  connect-time SSRF guard as before, which matters more now that the server
+  chooses the POST target. The handshake is bounded by `tool_timeout_seconds`,
+  so a server that opens the stream and never advertises an endpoint fails
+  instead of hanging the caller. The unused `MCPServerConfig.message_endpoint`
+  field, which no configuration surface ever set, is gone
+  ([#922](https://github.com/use-agent-os/agent-os/issues/922)).
 
 ### Security
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -777,6 +777,15 @@ reference `@modelcontextprotocol/server-*` servers work unmodified. Replies are
 matched to their request id, so notifications a server interleaves with them are
 skipped rather than mistaken for a result.
 
+`sse` is the legacy HTTP+SSE transport from the 2024-11-05 spec revision; prefer
+`streamable_http` for new servers. On `sse`, `url` is the endpoint AgentOS opens
+the event stream against — the URI it POSTs JSON-RPC to is chosen by the server
+and announced in the stream's `endpoint` event, so there is nothing to configure
+for it. A relative endpoint resolves against `url`; one pointing at a different
+scheme or host is refused and nothing is posted to it. If the server opens the
+stream but never advertises an endpoint, the connection fails after
+`tool_timeout_seconds`.
+
 The HTTP transports accept `http://` and `https://` URLs only, and both connect
 through the same SSRF guard the built-in HTTP tools use. `http://localhost:PORT`
 and LAN-hosted servers keep working — the guard blocks cloud metadata endpoints

--- a/src/agentos/mcp/client.py
+++ b/src/agentos/mcp/client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
@@ -38,8 +40,20 @@ class MCPSessionClient(MCPClient):
 
     Streamable HTTP and legacy SSE differ only in the transport they enter:
     both hold it in an ``AsyncExitStack``, talk to the server through an
-    ``mcp.ClientSession``, and unwrap the same result shapes. ``connect()``
-    stays with each transport; everything downstream of it lives here.
+    ``mcp.ClientSession``, and unwrap the same result shapes. Only
+    :meth:`_open_session` is transport-specific.
+
+    The transport is entered and exited by a task this class owns, not by the
+    caller of ``connect()``. Both the SDK transports and ``ClientSession`` are
+    built on anyio task groups, and an anyio cancel scope may only be exited by
+    the task that entered it — but nothing in AgentOS closes an MCP client from
+    the task that opened it. ``discover_and_register`` runs during boot or in an
+    RPC handler while ``close_active_clients`` runs from gateway shutdown or a
+    later ``mcp.disconnect`` call, so entering the stack inline would make every
+    real close raise ``RuntimeError: Attempted to exit cancel scope in a
+    different task``, and ``close_active_clients`` swallows that and leaks the
+    connection. Here ``connect()`` waits for a runner task to report the session,
+    and ``close()`` asks that same task to unwind, from wherever it is called.
     """
 
     #: Used in the "not connected" error so a caller can tell the two apart.
@@ -47,15 +61,79 @@ class MCPSessionClient(MCPClient):
 
     def __init__(self, config: MCPServerConfig) -> None:
         super().__init__(config)
-        self._stack: AsyncExitStack | None = None
         self._session: Any = None
+        self._runner: asyncio.Task[None] | None = None
+        self._closing: asyncio.Event | None = None
+
+    @abstractmethod
+    async def _open_session(self, stack: AsyncExitStack) -> Any:
+        """Enter this transport's contexts on *stack* and return a live session.
+
+        Cleanup is not this method's job: whatever was entered before a failure
+        is unwound by the runner task, in the task that entered it.
+        """
+
+    async def connect(self) -> None:
+        """Open the transport in a task this client owns, then hand back the session."""
+        if self._runner is not None:
+            raise RuntimeError(f"{self.transport_label} client is already connected")
+        loop = asyncio.get_running_loop()
+        ready: asyncio.Future[Any] = loop.create_future()
+        closing = asyncio.Event()
+        self._closing = closing
+        self._runner = loop.create_task(
+            self._run(ready, closing), name=f"mcp-transport-{self.config.name}"
+        )
+        try:
+            self._session = await ready
+        except BaseException:
+            await self._teardown()
+            raise
+
+    async def _run(self, ready: asyncio.Future[Any], closing: asyncio.Event) -> None:
+        """Own the transport stack for the life of the connection."""
+        stack = AsyncExitStack()
+        try:
+            try:
+                session = await self._open_session(stack)
+            except asyncio.CancelledError:
+                if not ready.done():
+                    ready.cancel()
+                raise
+            except BaseException as exc:
+                if not ready.done():
+                    ready.set_exception(exc)
+                return
+            if ready.done():
+                # ``connect()`` gave up while the handshake was in flight.
+                return
+            ready.set_result(session)
+            await closing.wait()
+        finally:
+            await stack.aclose()
+
+    async def _teardown(self) -> None:
+        """Cancel the runner and forget the connection, swallowing its unwind."""
+        runner, self._runner = self._runner, None
+        self._closing = None
+        self._session = None
+        if runner is None:
+            return
+        runner.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await runner
 
     async def close(self) -> None:
-        """Close the transport, which cancels the SDK's reader task."""
-        if self._stack is not None:
-            await self._stack.aclose()
-        self._stack = None
+        """Ask the runner to unwind the transport, which cancels the SDK reader task."""
+        runner, self._runner = self._runner, None
+        closing, self._closing = self._closing, None
         self._session = None
+        if runner is None:
+            return
+        if closing is not None:
+            closing.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await runner
 
     def _require_session(self) -> Any:
         if self._session is None:

--- a/src/agentos/mcp/client.py
+++ b/src/agentos/mcp/client.py
@@ -80,46 +80,74 @@ class MCPSessionClient(MCPClient):
         loop = asyncio.get_running_loop()
         ready: asyncio.Future[Any] = loop.create_future()
         closing = asyncio.Event()
+        handed_off = asyncio.Event()
         self._closing = closing
         self._runner = loop.create_task(
-            self._run(ready, closing), name=f"mcp-transport-{self.config.name}"
+            self._run(ready, closing, handed_off), name=f"mcp-transport-{self.config.name}"
         )
         try:
             self._session = await ready
         except BaseException:
-            await self._teardown()
+            # A handshake that failed on its own is already unwinding its stack
+            # in the runner; cancelling it there would cut that unwind short at
+            # the first ``__aexit__`` that suspends. Only work still inside
+            # ``_open_session`` — which nothing will finish once we give up —
+            # has to be interrupted.
+            await self._teardown(cancel=not handed_off.is_set())
             raise
 
-    async def _run(self, ready: asyncio.Future[Any], closing: asyncio.Event) -> None:
-        """Own the transport stack for the life of the connection."""
+    async def _run(
+        self,
+        ready: asyncio.Future[Any],
+        closing: asyncio.Event,
+        handed_off: asyncio.Event,
+    ) -> None:
+        """Own the transport stack for the life of the connection.
+
+        ``handed_off`` is set the moment the handshake is over, however it
+        ended: past that point the unwind belongs to this task and ``connect()``
+        must not cancel it.
+        """
         stack = AsyncExitStack()
         try:
             try:
                 session = await self._open_session(stack)
             except asyncio.CancelledError:
+                handed_off.set()
                 if not ready.done():
                     ready.cancel()
                 raise
             except BaseException as exc:
+                handed_off.set()
                 if not ready.done():
                     ready.set_exception(exc)
                 return
+            handed_off.set()
             if ready.done():
                 # ``connect()`` gave up while the handshake was in flight.
+                return
+            if closing.is_set():
+                # ``close()`` disowned this client mid-handshake. Publishing the
+                # session now would hand ``connect()`` a live-looking session
+                # that the ``finally`` below is about to tear down.
+                ready.set_exception(
+                    RuntimeError(f"{self.transport_label} client was closed while connecting")
+                )
                 return
             ready.set_result(session)
             await closing.wait()
         finally:
             await stack.aclose()
 
-    async def _teardown(self) -> None:
-        """Cancel the runner and forget the connection, swallowing its unwind."""
+    async def _teardown(self, *, cancel: bool) -> None:
+        """Forget the connection and let the runner unwind, swallowing its failure."""
         runner, self._runner = self._runner, None
         self._closing = None
         self._session = None
         if runner is None:
             return
-        runner.cancel()
+        if cancel:
+            runner.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await runner
 
@@ -132,8 +160,14 @@ class MCPSessionClient(MCPClient):
             return
         if closing is not None:
             closing.set()
-        with contextlib.suppress(asyncio.CancelledError):
+        try:
             await runner
+        except asyncio.CancelledError:
+            # The runner ending cancelled is an unwind we asked for; this task
+            # being cancelled while waiting on it is the caller's business —
+            # absorbing that would let a shutdown deadline pass unnoticed.
+            if not runner.cancelled():
+                raise
 
     def _require_session(self) -> Any:
         if self._session is None:

--- a/src/agentos/mcp/client.py
+++ b/src/agentos/mcp/client.py
@@ -1,8 +1,10 @@
-"""MCPClient abstract base class."""
+"""MCPClient abstract base class and the shared SDK-session base."""
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
+from contextlib import AsyncExitStack
 from typing import Any
 
 from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
@@ -29,3 +31,64 @@ class MCPClient(ABC):
     @abstractmethod
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         """Call a tool on the MCP server."""
+
+
+class MCPSessionClient(MCPClient):
+    """Shared plumbing for the two SDK-session-backed HTTP transports.
+
+    Streamable HTTP and legacy SSE differ only in the transport they enter:
+    both hold it in an ``AsyncExitStack``, talk to the server through an
+    ``mcp.ClientSession``, and unwrap the same result shapes. ``connect()``
+    stays with each transport; everything downstream of it lives here.
+    """
+
+    #: Used in the "not connected" error so a caller can tell the two apart.
+    transport_label = "MCP"
+
+    def __init__(self, config: MCPServerConfig) -> None:
+        super().__init__(config)
+        self._stack: AsyncExitStack | None = None
+        self._session: Any = None
+
+    async def close(self) -> None:
+        """Close the transport, which cancels the SDK's reader task."""
+        if self._stack is not None:
+            await self._stack.aclose()
+        self._stack = None
+        self._session = None
+
+    def _require_session(self) -> Any:
+        if self._session is None:
+            raise RuntimeError(f"{self.transport_label} client is not connected")
+        return self._session
+
+    async def list_tools(self) -> list[MCPToolDef]:
+        """List tools from the MCP server."""
+        result = await self._require_session().list_tools()
+        return [
+            MCPToolDef(
+                name=tool.name,
+                description=tool.description or "",
+                input_schema=tool.inputSchema,
+            )
+            for tool in result.tools
+        ]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
+        """Call a tool on the MCP server."""
+        result = await self._require_session().call_tool(name, arguments)
+        chunks: list[str] = []
+        for block in result.content:
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                chunks.append(text)
+                continue
+            if hasattr(block, "model_dump_json"):
+                chunks.append(block.model_dump_json())
+        structured = getattr(result, "structuredContent", None)
+        if not chunks and structured is not None:
+            chunks.append(json.dumps(structured, ensure_ascii=False))
+        return MCPToolResult(
+            content="\n".join(chunks),
+            is_error=bool(getattr(result, "isError", False)),
+        )

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -121,7 +121,8 @@ class MCPSSEClient(MCPSessionClient):
             if isinstance(unwrapped, TimeoutError):
                 raise TimeoutError(
                     f"MCP SSE handshake with {self.config.url} did not complete within "
-                    f"{timeout}s; the server never advertised a usable endpoint"
+                    f"{timeout}s: the server never advertised a usable endpoint, or "
+                    f"never answered initialize"
                 ) from exc
             if unwrapped is not exc:
                 raise unwrapped

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -1,161 +1,133 @@
-"""MCP SSE transport client."""
+"""MCP legacy HTTP+SSE transport client (spec revision 2024-11-05).
+
+``HTTP with SSE`` is a two-channel protocol: the client opens a long-lived
+``GET`` stream *first*, the server answers with an ``endpoint`` event naming the
+URI to post to, and every JSON-RPC response comes back on the stream that is
+already open. This module used to do the opposite — it posted to a guessed
+``/message`` path and then opened a fresh ``GET`` per request — so a compliant
+server either rejected the initialization or emitted the response into a window
+where nothing was listening (issue #922).
+
+Rather than re-derive that lifecycle, the client now drives ``mcp.client.sse``,
+the sibling of the SDK transport ``streamable_http.py`` already uses. The SDK
+owns the ordering, the ``endpoint`` resolution (``urljoin`` against the
+configured URL, with a scheme/netloc mismatch refused before any POST is made),
+the single correlated receive stream, and the reader-task cancellation on close.
+
+The SSRF guard from #662 survives the swap because the SDK builds no HTTP client
+of its own: ``httpx_client_factory`` is the hook it dials through, and the
+factory installed here returns :func:`mcp_http_client`. Both channels — the
+``GET`` stream and the POST to the server-advertised endpoint — therefore go
+through the same connect-time, address-pinning guard. That matters more under
+this transport than under Streamable HTTP, because the POST target is chosen by
+the server rather than by the operator's configuration.
+"""
 
 from __future__ import annotations
 
-import json
-from typing import Any, cast
+import asyncio
+from contextlib import AsyncExitStack
+from datetime import timedelta
+from typing import Any
 
 import httpx
 
-from agentos import __version__
-from agentos.mcp.client import MCPClient
-from agentos.mcp.http import mcp_http_client
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.client import MCPSessionClient
+from agentos.mcp.http import assert_supported_mcp_url, mcp_http_client
+from agentos.mcp.streamable_http import MCPDependencyError
+
+# How long the receive stream may sit idle before the transport gives up. This
+# is a keep-alive ceiling for a connection that is expected to stay open between
+# tool calls, not a per-request deadline — that one is ``tool_timeout_seconds``.
+SSE_READ_TIMEOUT_SECONDS = 300.0
 
 
-class MCPSSEClient(MCPClient):
-    """MCP client using SSE transport (HTTP POST for calls, SSE for responses)."""
+def _unwrap_single_exception(exc: BaseException) -> BaseException:
+    """Peel single-member groups off an SDK failure.
 
-    def __init__(self, config: MCPServerConfig) -> None:
-        super().__init__(config)
-        self._client: httpx.AsyncClient | None = None
-        self._request_id = 0
-        self._message_endpoint = config.message_endpoint or "/message"
+    The SDK runs the transport inside an anyio task group, which repackages
+    whatever the connection raised as an ``ExceptionGroup``. Callers of this
+    client — and the SSRF tests — expect the same ``SSRFBlockedError`` or
+    ``HTTPError`` the transport used to raise directly, so a group carrying one
+    exception is unwrapped back to it. Genuine multi-error groups are left
+    alone.
+    """
+    while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
+        exc = exc.exceptions[0]
+    return exc
 
-    @staticmethod
-    def _parse_sse_event(raw: str) -> dict[str, Any] | None:
-        """Parse a single SSE event block into a JSON dict."""
-        if not raw or raw.startswith(":"):
-            return None
 
-        data_lines: list[str] = []
-        for line in raw.splitlines():
-            if line.startswith("data:"):
-                data_lines.append(line[5:].lstrip(" "))
-            # Ignore event:, id:, retry: fields
+class MCPSSEClient(MCPSessionClient):
+    """MCP SDK-backed client for the legacy HTTP+SSE transport."""
 
-        if not data_lines:
-            return None
+    transport_label = "MCP SSE"
 
-        combined = "".join(data_lines)
-        try:
-            return cast(dict[str, Any], json.loads(combined))
-        except json.JSONDecodeError:
-            return None
+    def _http_client_factory(self, url: str) -> Any:
+        """Return the SDK client factory, bound to the guarded constructor."""
 
-    @staticmethod
-    def _parse_sse_stream(stream: str) -> list[dict[str, Any]]:
-        """Parse a full SSE stream into a list of JSON events."""
-        events = []
-        for block in stream.split("\n\n"):
-            block = block.strip()
-            if block:
-                event = MCPSSEClient._parse_sse_event(block)
-                if event is not None:
-                    events.append(event)
-        return events
+        def factory(
+            headers: dict[str, str] | None = None,
+            timeout: httpx.Timeout | None = None,
+            auth: httpx.Auth | None = None,
+        ) -> httpx.AsyncClient:
+            return mcp_http_client(url, headers=headers, timeout=timeout, auth=auth)
 
-    def _next_id(self) -> int:
-        self._request_id += 1
-        return self._request_id
-
-    @property
-    def _base_url(self) -> str:
-        assert self.config.url is not None
-        return self.config.url.rstrip("/")
-
-    @property
-    def _message_url(self) -> str:
-        return f"{self._base_url}{self._message_endpoint}"
+        return factory
 
     async def connect(self) -> None:
-        """Create the HTTP client session and perform MCP initialization handshake."""
+        """Open the SSE stream, adopt the advertised endpoint, then initialize."""
         if not self.config.url:
             raise ValueError("SSE MCP server requires a URL")
-        self._client = mcp_http_client(self.config.url)
+        # Checked here as well as inside ``mcp_http_client`` so an unusable URL
+        # fails before the SDK starts a task group around it.
+        assert_supported_mcp_url(self.config.url)
 
-        # Send initialize request (response is acknowledged server-side;
-        # we don't inspect it — the MCP spec only requires us to send the
-        # handshake and follow up with the initialized notification).
-        await self._send_and_receive(
-            "initialize",
-            {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "agentos", "version": __version__},
-            },
-        )
-        # Send initialized notification
-        await self._send_notification("notifications/initialized")
+        try:
+            from mcp.client.session import ClientSession
+            from mcp.client.sse import sse_client
+        except ImportError as exc:
+            raise MCPDependencyError(
+                "SSE support is unavailable because the MCP SDK is missing. "
+                "Reinstall or upgrade AgentOS."
+            ) from exc
 
-    async def close(self) -> None:
-        """Close the HTTP client session."""
-        if self._client is not None:
-            await self._client.aclose()
-            self._client = None
+        timeout = self.config.tool_timeout_seconds
+        stack = AsyncExitStack()
+        try:
+            # The whole handshake is bounded, not just the HTTP calls inside it.
+            # A server that opens the stream and then never emits an ``endpoint``
+            # event leaves the SDK waiting on an internal stream with no deadline
+            # of its own, and a rejected endpoint reports the same way, so an
+            # unbounded connect would hang the caller instead of failing it.
+            async with asyncio.timeout(timeout):
+                read_stream, write_stream = await stack.enter_async_context(
+                    sse_client(
+                        self.config.url,
+                        headers=dict(self.config.headers),
+                        timeout=timeout,
+                        sse_read_timeout=SSE_READ_TIMEOUT_SECONDS,
+                        httpx_client_factory=self._http_client_factory(self.config.url),
+                    )
+                )
+                session = await stack.enter_async_context(
+                    ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=timedelta(seconds=timeout),
+                    )
+                )
+                await session.initialize()
+        except BaseException as exc:
+            await stack.aclose()
+            unwrapped = _unwrap_single_exception(exc)
+            if isinstance(unwrapped, TimeoutError):
+                raise TimeoutError(
+                    f"MCP SSE handshake with {self.config.url} did not complete within "
+                    f"{timeout}s; the server never advertised a usable endpoint"
+                ) from exc
+            if unwrapped is not exc:
+                raise unwrapped
+            raise
 
-    async def _send_and_receive(
-        self, method: str, params: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """POST a JSON-RPC request and receive response via SSE."""
-        assert self._client is not None
-
-        req_id = self._next_id()
-        request: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
-        if params is not None:
-            request["params"] = params
-
-        # POST the request
-        await self._client.post(self._message_url, json=request)
-
-        # GET SSE stream for response
-        async with self._client.stream("GET", self._base_url) as response:
-            buffer = ""
-            async for line in response.aiter_lines():
-                if line:
-                    buffer += line + "\n"
-                else:
-                    # Empty line = end of event
-                    event = self._parse_sse_event(buffer.strip())
-                    buffer = ""
-                    if event is not None and event.get("id") == req_id:
-                        return event
-
-        return {}
-
-    async def _send_notification(self, method: str) -> None:
-        """Send a JSON-RPC notification (no response expected)."""
-        assert self._client is not None
-
-        notification: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
-        await self._client.post(self._message_url, json=notification)
-
-    async def list_tools(self) -> list[MCPToolDef]:
-        """List tools from the MCP server."""
-        response = await self._send_and_receive("tools/list")
-        tools_data = response.get("result", {}).get("tools", [])
-        return [
-            MCPToolDef(
-                name=t["name"],
-                description=t.get("description", ""),
-                input_schema=t.get("inputSchema", {}),
-            )
-            for t in tools_data
-        ]
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
-        """Call a tool on the MCP server."""
-        response = await self._send_and_receive(
-            "tools/call", {"name": name, "arguments": arguments}
-        )
-
-        if "error" in response:
-            return MCPToolResult(
-                content=response["error"].get("message", "Unknown error"),
-                is_error=True,
-            )
-
-        result = response.get("result", {})
-        content_list = result.get("content", [])
-        text = "\n".join(c.get("text", "") for c in content_list if c.get("type") == "text")
-        return MCPToolResult(content=text)
+        self._stack = stack
+        self._session = session

--- a/src/agentos/mcp/sse.py
+++ b/src/agentos/mcp/sse.py
@@ -74,7 +74,7 @@ class MCPSSEClient(MCPSessionClient):
 
         return factory
 
-    async def connect(self) -> None:
+    async def _open_session(self, stack: AsyncExitStack) -> Any:
         """Open the SSE stream, adopt the advertised endpoint, then initialize."""
         if not self.config.url:
             raise ValueError("SSE MCP server requires a URL")
@@ -92,7 +92,6 @@ class MCPSSEClient(MCPSessionClient):
             ) from exc
 
         timeout = self.config.tool_timeout_seconds
-        stack = AsyncExitStack()
         try:
             # The whole handshake is bounded, not just the HTTP calls inside it.
             # A server that opens the stream and then never emits an ``endpoint``
@@ -118,7 +117,6 @@ class MCPSSEClient(MCPSessionClient):
                 )
                 await session.initialize()
         except BaseException as exc:
-            await stack.aclose()
             unwrapped = _unwrap_single_exception(exc)
             if isinstance(unwrapped, TimeoutError):
                 raise TimeoutError(
@@ -128,6 +126,4 @@ class MCPSSEClient(MCPSessionClient):
             if unwrapped is not exc:
                 raise unwrapped
             raise
-
-        self._stack = stack
-        self._session = session
+        return session

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -16,9 +16,9 @@ from typing import Any
 import httpx
 
 from agentos import __version__
-from agentos.mcp.client import MCPClient
+from agentos.mcp.client import MCPSessionClient
 from agentos.mcp.http import assert_supported_mcp_url, mcp_http_client
-from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
+from agentos.mcp.types import MCPServerConfig
 from agentos.paths import state_dir as default_state_dir
 
 
@@ -117,8 +117,10 @@ class FileOAuthStorage:
             pass
 
 
-class MCPStreamableHTTPClient(MCPClient):
+class MCPStreamableHTTPClient(MCPSessionClient):
     """MCP SDK-backed Streamable HTTP client."""
+
+    transport_label = "MCP Streamable HTTP"
 
     def __init__(
         self,
@@ -130,8 +132,6 @@ class MCPStreamableHTTPClient(MCPClient):
         super().__init__(config)
         self._redirect_handler = redirect_handler
         self._callback_handler = callback_handler
-        self._stack: AsyncExitStack | None = None
-        self._session: Any = None
 
     def oauth_storage(self) -> FileOAuthStorage:
         if not self.config.url:
@@ -205,42 +205,3 @@ class MCPStreamableHTTPClient(MCPClient):
 
         self._stack = stack
         self._session = session
-
-    async def close(self) -> None:
-        if self._stack is not None:
-            await self._stack.aclose()
-        self._stack = None
-        self._session = None
-
-    async def list_tools(self) -> list[MCPToolDef]:
-        if self._session is None:
-            raise RuntimeError("MCP Streamable HTTP client is not connected")
-        result = await self._session.list_tools()
-        return [
-            MCPToolDef(
-                name=tool.name,
-                description=tool.description or "",
-                input_schema=tool.inputSchema,
-            )
-            for tool in result.tools
-        ]
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
-        if self._session is None:
-            raise RuntimeError("MCP Streamable HTTP client is not connected")
-        result = await self._session.call_tool(name, arguments)
-        chunks: list[str] = []
-        for block in result.content:
-            text = getattr(block, "text", None)
-            if isinstance(text, str):
-                chunks.append(text)
-                continue
-            if hasattr(block, "model_dump_json"):
-                chunks.append(block.model_dump_json())
-        structured = getattr(result, "structuredContent", None)
-        if not chunks and structured is not None:
-            chunks.append(json.dumps(structured, ensure_ascii=False))
-        return MCPToolResult(
-            content="\n".join(chunks),
-            is_error=bool(getattr(result, "isError", False)),
-        )

--- a/src/agentos/mcp/streamable_http.py
+++ b/src/agentos/mcp/streamable_http.py
@@ -142,7 +142,7 @@ class MCPStreamableHTTPClient(MCPSessionClient):
             self.config.state_dir,
         )
 
-    async def connect(self) -> None:
+    async def _open_session(self, stack: AsyncExitStack) -> Any:
         if not self.config.url:
             raise ValueError("Streamable HTTP MCP server requires a URL")
         # Checked here as well as inside ``mcp_http_client`` so an unusable URL
@@ -178,30 +178,23 @@ class MCPStreamableHTTPClient(MCPSessionClient):
                 callback_handler=self._callback_handler,
             )
 
-        stack = AsyncExitStack()
-        try:
-            http_client = await stack.enter_async_context(
-                mcp_http_client(
-                    self.config.url,
-                    auth=auth,
-                    headers=self.config.headers,
-                    timeout=httpx.Timeout(self.config.tool_timeout_seconds),
-                )
+        http_client = await stack.enter_async_context(
+            mcp_http_client(
+                self.config.url,
+                auth=auth,
+                headers=self.config.headers,
+                timeout=httpx.Timeout(self.config.tool_timeout_seconds),
             )
-            read_stream, write_stream, _ = await stack.enter_async_context(
-                streamable_http_client(self.config.url, http_client=http_client)
+        )
+        read_stream, write_stream, _ = await stack.enter_async_context(
+            streamable_http_client(self.config.url, http_client=http_client)
+        )
+        session = await stack.enter_async_context(
+            ClientSession(
+                read_stream,
+                write_stream,
+                read_timeout_seconds=timedelta(seconds=self.config.tool_timeout_seconds),
             )
-            session = await stack.enter_async_context(
-                ClientSession(
-                    read_stream,
-                    write_stream,
-                    read_timeout_seconds=timedelta(seconds=self.config.tool_timeout_seconds),
-                )
-            )
-            await session.initialize()
-        except BaseException:
-            await stack.aclose()
-            raise
-
-        self._stack = stack
-        self._session = session
+        )
+        await session.initialize()
+        return session

--- a/src/agentos/mcp/types.py
+++ b/src/agentos/mcp/types.py
@@ -13,7 +13,6 @@ class MCPServerConfig:
     command: str | None = None  # for stdio
     args: list[str] = field(default_factory=list)  # for stdio
     url: str | None = None  # for HTTP transports
-    message_endpoint: str | None = None  # for sse, default "/message"
     env: dict[str, str] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
     oauth: bool = False

--- a/tests/test_mcp/test_mcp_ssrf.py
+++ b/tests/test_mcp/test_mcp_ssrf.py
@@ -70,16 +70,45 @@ def _resolver(mapping: dict[str, str]):
 async def test_sse_client_installs_the_connect_time_guard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _noop(self: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        return {}
+    """The SDK dials through the factory it is handed, so the guard rides both channels.
 
-    monkeypatch.setattr(MCPSSEClient, "_send_and_receive", _noop)
-    monkeypatch.setattr(MCPSSEClient, "_send_notification", _noop)
+    ``sse_client`` builds no client of its own: the same instance carries the
+    long-lived ``GET`` stream and the POST to the server-advertised endpoint, so
+    checking the factory's product covers the endpoint the server picks as well
+    as the URL the operator configured.
+    """
+    from mcp.client import session as session_module
+    from mcp.client import sse as transport_module
+
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def fake_transport(url: str, *, httpx_client_factory: Any, **_kwargs: Any):
+        captured["url"] = url
+        captured["http_client"] = httpx_client_factory()
+        try:
+            yield object(), object()
+        finally:
+            await captured["http_client"].aclose()
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def initialize(self) -> None:
+            return None
+
+    monkeypatch.setattr(transport_module, "sse_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_a, **_k: FakeSession())
 
     client = MCPSSEClient(_sse_config("http://localhost:9999/sse"))
     await client.connect()
     try:
-        backend = _installed_backend(client._client)
+        assert captured["url"] == "http://localhost:9999/sse"
+        backend = _installed_backend(captured["http_client"])
         assert isinstance(backend, ValidatingNetworkBackend)
         assert backend._validator is validate_metadata_only_address
     finally:

--- a/tests/test_mcp/test_sse_client.py
+++ b/tests/test_mcp/test_sse_client.py
@@ -13,6 +13,7 @@ transport would happily accept the old order.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from collections.abc import Callable
 from typing import Any
@@ -54,7 +55,12 @@ class LegacySSEServer:
 
     async def stop(self) -> None:
         self._server.close()
-        await self._server.wait_closed()
+        # ``wait_closed()`` does not return while a connection is still live, so
+        # a test that failed before closing its client would hang the run here
+        # instead of reporting the assertion.
+        with contextlib.suppress(TimeoutError):
+            async with asyncio.timeout(5):
+                await self._server.wait_closed()
 
     @property
     def url(self) -> str:
@@ -278,9 +284,10 @@ async def test_concurrent_calls_are_correlated_by_request_id(
 async def test_close_ends_the_receive_stream(server: LegacySSEServer) -> None:
     client = MCPSSEClient(_config(server.url))
     await client.connect()
-    assert not server.stream_closed.is_set()
-
-    await client.close()
+    try:
+        assert not server.stream_closed.is_set()
+    finally:
+        await client.close()
 
     async with asyncio.timeout(5):
         await server.stream_closed.wait()
@@ -302,9 +309,10 @@ async def test_close_works_from_a_different_task_than_connect(
     """
     client = MCPSSEClient(_config(server.url))
     await asyncio.create_task(client.connect())
-    assert await asyncio.create_task(client.list_tools())
-
-    await asyncio.create_task(client.close())
+    try:
+        assert await asyncio.create_task(client.list_tools())
+    finally:
+        await asyncio.create_task(client.close())
 
     async with asyncio.timeout(5):
         await server.stream_closed.wait()

--- a/tests/test_mcp/test_sse_client.py
+++ b/tests/test_mcp/test_sse_client.py
@@ -285,7 +285,53 @@ async def test_close_ends_the_receive_stream(server: LegacySSEServer) -> None:
     async with asyncio.timeout(5):
         await server.stream_closed.wait()
     assert client._session is None
-    assert client._stack is None
+    assert client._runner is None
+
+
+@pytest.mark.asyncio
+async def test_close_works_from_a_different_task_than_connect(
+    server: LegacySSEServer,
+) -> None:
+    """The gateway never closes an MCP client from the task that opened it.
+
+    ``discover_and_register`` runs during boot or in an RPC handler;
+    ``close_active_clients`` runs from shutdown or a later ``mcp.disconnect``.
+    Entering the SDK's anyio task groups inline would make this raise
+    ``RuntimeError: Attempted to exit cancel scope in a different task``, which
+    ``close_active_clients`` swallows — leaking the connection.
+    """
+    client = MCPSSEClient(_config(server.url))
+    await asyncio.create_task(client.connect())
+    assert await asyncio.create_task(client.list_tools())
+
+    await asyncio.create_task(client.close())
+
+    async with asyncio.timeout(5):
+        await server.stream_closed.wait()
+
+
+@pytest.mark.asyncio
+async def test_connecting_twice_is_refused(server: LegacySSEServer) -> None:
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    try:
+        with pytest.raises(RuntimeError, match="already connected"):
+            await client.connect()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_connect_leaves_nothing_to_close(server: LegacySSEServer) -> None:
+    """After a refused handshake the client is reusable and ``close()`` is a no-op."""
+    client = MCPSSEClient(_config("http://127.0.0.1:1/sse", timeout=1.0))
+    with pytest.raises(Exception) as excinfo:
+        await client.connect()
+    assert not isinstance(excinfo.value, BaseExceptionGroup)
+    await client.close()
+
+    assert client._runner is None
+    assert client._session is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp/test_sse_client.py
+++ b/tests/test_mcp/test_sse_client.py
@@ -1,0 +1,374 @@
+"""The legacy HTTP+SSE transport follows the 2024-11-05 lifecycle (issue #922).
+
+The client used to POST to a guessed ``/message`` path and only then open a
+``GET`` stream, one per request. Against a compliant server that loses the
+handshake outright: the server picks its own message URI and announces it in an
+``endpoint`` event on a stream the client is required to open *first*.
+
+These tests drive the real client against a real (loopback, in-process) legacy
+SSE server rather than a mock, because the ordering is the defect. A stubbed
+transport would happily accept the old order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from agentos.mcp.sse import MCPSSEClient
+from agentos.mcp.types import MCPServerConfig
+
+TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {"text": {"type": "string"}},
+    "required": ["text"],
+}
+
+
+class LegacySSEServer:
+    """A minimal, spec-shaped MCP HTTP+SSE server on an ephemeral loopback port.
+
+    It answers ``GET /sse`` with a long-lived ``text/event-stream``, advertises
+    its message URI in an ``endpoint`` event, accepts JSON-RPC over ``POST`` at
+    that URI only, and returns every response on the already-open stream.
+    """
+
+    def __init__(self, *, endpoint: Callable[[int], str] | None = None) -> None:
+        self._endpoint_for = endpoint or (lambda _port: "/mcp/messages?sessionId=s1")
+        self.log: list[tuple[str, str]] = []
+        self.posted: list[dict[str, Any]] = []
+        self.stream_ready = asyncio.Event()
+        self.stream_closed = asyncio.Event()
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self._held: list[str] = []
+        self.hold = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        self.endpoint = self._endpoint_for(self.port)
+
+    async def stop(self) -> None:
+        self._server.close()
+        await self._server.wait_closed()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/sse"
+
+    async def wait_for_posts(self, count: int, timeout: float = 5.0) -> None:
+        """Block until *count* POSTs have landed.
+
+        ``connect()`` returns once the SDK has handed the ``initialized``
+        notification to its writer task; the POST itself completes a moment
+        later, so assertions about it need this instead of a bare read.
+        """
+        async with asyncio.timeout(timeout):
+            while len(self.posted) < count:
+                await asyncio.sleep(0.01)
+
+    # --- request dispatch -------------------------------------------------
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            request_line = await reader.readline()
+            if not request_line:
+                return
+            method, target, _ = request_line.decode().split()
+            headers: dict[str, str] = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                key, _, value = line.decode().partition(":")
+                headers[key.strip().lower()] = value.strip()
+
+            self.log.append((method, target))
+            if method == "GET":
+                await self._serve_stream(reader, writer)
+            elif method == "POST":
+                body = await reader.readexactly(int(headers.get("content-length", "0")))
+                await self._serve_post(writer, target, body)
+            else:  # pragma: no cover - no other verb is ever sent
+                writer.write(b"HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
+                await writer.drain()
+        except (ConnectionResetError, asyncio.IncompleteReadError):  # pragma: no cover
+            pass
+        finally:
+            writer.close()
+
+    async def _serve_stream(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/event-stream\r\n"
+            b"Cache-Control: no-cache\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        writer.write(f"event: endpoint\ndata: {self.endpoint}\n\n".encode())
+        await writer.drain()
+        self.stream_ready.set()
+
+        pump = asyncio.create_task(self._pump(writer))
+        eof = asyncio.create_task(reader.read())
+        try:
+            _, pending = await asyncio.wait({pump, eof}, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+        finally:
+            self.stream_closed.set()
+
+    async def _pump(self, writer: asyncio.StreamWriter) -> None:
+        while True:
+            payload = await self._queue.get()
+            writer.write(f"event: message\ndata: {payload}\n\n".encode())
+            await writer.drain()
+
+    async def _serve_post(self, writer: asyncio.StreamWriter, target: str, body: bytes) -> None:
+        message = json.loads(body)
+        self.posted.append({"target": target, "message": message})
+        response = self._respond(message)
+        if response is not None:
+            self._held.append(json.dumps(response))
+            if len(self._held) > self.hold:
+                # Deliberately reversed so a client that assumed responses
+                # arrive in request order would fail the correlation tests.
+                for payload in reversed(self._held):
+                    self._queue.put_nowait(payload)
+                self._held.clear()
+        writer.write(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        await writer.drain()
+
+    def _respond(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        if "id" not in message:  # a notification expects no reply
+            return None
+        method = message["method"]
+        if method == "initialize":
+            result: dict[str, Any] = {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "legacy-sse", "version": "1.0"},
+            }
+        elif method == "tools/list":
+            result = {
+                "tools": [{"name": "echo", "description": "Echo back", "inputSchema": TOOL_SCHEMA}]
+            }
+        elif method == "tools/call":
+            text = message["params"]["arguments"]["text"]
+            result = {"content": [{"type": "text", "text": f"echo:{text}"}], "isError": False}
+        else:  # pragma: no cover - the client sends nothing else
+            return {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "error": {"code": -32601, "message": f"unknown method {method}"},
+            }
+        return {"jsonrpc": "2.0", "id": message["id"], "result": result}
+
+
+@pytest.fixture
+async def server() -> Any:
+    srv = LegacySSEServer()
+    await srv.start()
+    try:
+        yield srv
+    finally:
+        await srv.stop()
+
+
+def _config(url: str, *, timeout: float = 10.0) -> MCPServerConfig:
+    return MCPServerConfig(name="legacy", transport="sse", url=url, tool_timeout_seconds=timeout)
+
+
+@pytest.mark.asyncio
+async def test_stream_opens_before_the_first_post(server: LegacySSEServer) -> None:
+    """The regression itself: initialization used to be POSTed with no stream open."""
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    try:
+        await server.wait_for_posts(2)
+        assert server.log[0] == ("GET", "/sse")
+        assert [entry[0] for entry in server.log[1:]] == ["POST", "POST"]
+        assert [item["message"]["method"] for item in server.posted] == [
+            "initialize",
+            "notifications/initialized",
+        ]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_posts_go_to_the_advertised_endpoint_not_a_guessed_path(
+    server: LegacySSEServer,
+) -> None:
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    try:
+        await client.list_tools()
+    finally:
+        await client.close()
+
+    targets = {item["target"] for item in server.posted}
+    assert targets == {"/mcp/messages?sessionId=s1"}
+    assert not any(target == "/message" for _method, target in server.log)
+
+
+@pytest.mark.asyncio
+async def test_notifications_are_sent_to_the_advertised_endpoint(
+    server: LegacySSEServer,
+) -> None:
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    try:
+        await server.wait_for_posts(2)
+        notification = next(
+            item for item in server.posted if item["message"]["method"].startswith("notifications/")
+        )
+    finally:
+        await client.close()
+
+    assert notification["target"] == "/mcp/messages?sessionId=s1"
+    assert "id" not in notification["message"]
+
+
+@pytest.mark.asyncio
+async def test_tools_are_listed_and_called_over_the_open_stream(
+    server: LegacySSEServer,
+) -> None:
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    try:
+        tools = await client.list_tools()
+        assert [tool.name for tool in tools] == ["echo"]
+        assert tools[0].description == "Echo back"
+        assert tools[0].input_schema == TOOL_SCHEMA
+
+        result = await client.call_tool("echo", {"text": "hi"})
+        assert result.content == "echo:hi"
+        assert result.is_error is False
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_are_correlated_by_request_id(
+    server: LegacySSEServer,
+) -> None:
+    """One receive stream, two in-flight calls, responses emitted in reverse order."""
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    try:
+        server.hold = 1  # release the pair only once both responses exist
+        first, second = await asyncio.gather(
+            client.call_tool("echo", {"text": "one"}),
+            client.call_tool("echo", {"text": "two"}),
+        )
+        assert first.content == "echo:one"
+        assert second.content == "echo:two"
+        assert server.log.count(("GET", "/sse")) == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_close_ends_the_receive_stream(server: LegacySSEServer) -> None:
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    assert not server.stream_closed.is_set()
+
+    await client.close()
+
+    async with asyncio.timeout(5):
+        await server.stream_closed.wait()
+    assert client._session is None
+    assert client._stack is None
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent(server: LegacySSEServer) -> None:
+    client = MCPSSEClient(_config(server.url))
+    await client.connect()
+    await client.close()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_calls_before_connect_are_refused(server: LegacySSEServer) -> None:
+    client = MCPSSEClient(_config(server.url))
+    with pytest.raises(RuntimeError, match="MCP SSE client is not connected"):
+        await client.list_tools()
+    with pytest.raises(RuntimeError, match="MCP SSE client is not connected"):
+        await client.call_tool("echo", {"text": "hi"})
+
+
+# --- endpoint resolution --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_absolute_same_origin_endpoint_is_accepted() -> None:
+    srv = LegacySSEServer(endpoint=lambda port: f"http://127.0.0.1:{port}/rpc")
+    await srv.start()
+    try:
+        client = MCPSSEClient(_config(srv.url))
+        await client.connect()
+        try:
+            assert await client.list_tools()
+        finally:
+            await client.close()
+        assert {item["target"] for item in srv.posted} == {"/rpc"}
+    finally:
+        await srv.stop()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_pointing_at_another_origin_never_receives_a_post() -> None:
+    """A compromised server must not be able to redirect the POST channel.
+
+    The SDK refuses the mismatched origin inside its reader, which leaves the
+    handshake with nothing to complete; the bounded connect turns that into a
+    timeout instead of a hang. What matters for security is the second
+    assertion: nothing was posted anywhere.
+    """
+    srv = LegacySSEServer(endpoint=lambda _port: "http://169.254.169.254/latest/meta-data")
+    await srv.start()
+    try:
+        client = MCPSSEClient(_config(srv.url, timeout=1.0))
+        with pytest.raises(TimeoutError):
+            await client.connect()
+        await client.close()
+
+        assert srv.posted == []
+        assert [method for method, _target in srv.log] == ["GET"]
+    finally:
+        await srv.stop()
+
+
+@pytest.mark.asyncio
+async def test_connect_is_bounded_when_no_endpoint_event_arrives() -> None:
+    """A server that opens the stream and goes quiet must not hang the caller."""
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        await reader.readline()
+        while (await reader.readline()) not in (b"\r\n", b"\n", b""):
+            pass
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n"
+        )
+        await writer.drain()
+        await reader.read()
+        writer.close()
+
+    silent = await asyncio.start_server(handle, "127.0.0.1", 0)
+    port = silent.sockets[0].getsockname()[1]
+    try:
+        client = MCPSSEClient(_config(f"http://127.0.0.1:{port}/sse", timeout=1.0))
+        with pytest.raises(TimeoutError, match="did not complete"):
+            await client.connect()
+        await client.close()
+    finally:
+        silent.close()
+        await silent.wait_closed()

--- a/tests/test_mcp/test_streamable_http_client.py
+++ b/tests/test_mcp/test_streamable_http_client.py
@@ -6,6 +6,7 @@ import stat
 from contextlib import asynccontextmanager
 from typing import Any
 
+import anyio
 import pytest
 
 from agentos.mcp.discovery import create_client
@@ -126,3 +127,47 @@ async def test_calls_before_connect_name_this_transport() -> None:
         await client.list_tools()
     with pytest.raises(RuntimeError, match="MCP Streamable HTTP client is not connected"):
         await client.call_tool("anything", {})
+
+
+@pytest.mark.asyncio
+async def test_close_works_from_a_different_task_than_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same task-affinity requirement as the SSE transport; same shared base."""
+    from mcp.client import session as session_module
+    from mcp.client import streamable_http as transport_module
+
+    closed: list[str] = []
+
+    @asynccontextmanager
+    async def fake_transport(_url: str, **_kwargs: Any):
+        async with anyio.create_task_group():
+            try:
+                yield object(), object(), None
+            finally:
+                closed.append("transport")
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            closed.append("session")
+
+        async def initialize(self) -> None:
+            return None
+
+    monkeypatch.setattr(transport_module, "streamable_http_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_a, **_k: FakeSession())
+
+    client = MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="remote",
+            transport="streamable_http",
+            url="https://example.test/mcp",
+        )
+    )
+    await asyncio.create_task(client.connect())
+    await asyncio.create_task(client.close())
+
+    assert closed == ["session", "transport"]

--- a/tests/test_mcp/test_streamable_http_client.py
+++ b/tests/test_mcp/test_streamable_http_client.py
@@ -171,3 +171,116 @@ async def test_close_works_from_a_different_task_than_connect(
     await asyncio.create_task(client.close())
 
     assert closed == ["session", "transport"]
+
+
+def _patch_transport(monkeypatch: pytest.MonkeyPatch, session: Any, closed: list[str]) -> None:
+    """Wire fakes whose ``__aexit__`` suspends, which is what exposes a cut unwind."""
+    from mcp.client import session as session_module
+    from mcp.client import streamable_http as transport_module
+
+    @asynccontextmanager
+    async def fake_http_client(**_kwargs: Any):
+        try:
+            yield object()
+        finally:
+            await asyncio.sleep(0)
+            closed.append("http")
+
+    @asynccontextmanager
+    async def fake_transport(_url: str, **_kwargs: Any):
+        try:
+            yield object(), object(), None
+        finally:
+            await asyncio.sleep(0)
+            closed.append("transport")
+
+    monkeypatch.setattr("agentos.mcp.streamable_http.httpx.AsyncClient", fake_http_client)
+    monkeypatch.setattr(transport_module, "streamable_http_client", fake_transport)
+    monkeypatch.setattr(session_module, "ClientSession", lambda *_a, **_k: session)
+
+
+def _client() -> MCPStreamableHTTPClient:
+    return MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="remote",
+            transport="streamable_http",
+            url="https://example.test/mcp",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_handshake_unwinds_every_entered_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A handshake that fails on its own must finish its own unwind.
+
+    Handing the failure to ``connect()`` wakes it while the runner is still
+    suspended inside ``aclose()``; cancelling the runner from there stops the
+    unwind at the first ``__aexit__`` that awaits.
+    """
+    closed: list[str] = []
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            await asyncio.sleep(0)
+            closed.append("session")
+
+        async def initialize(self) -> None:
+            raise RuntimeError("server refused the handshake")
+
+    _patch_transport(monkeypatch, FakeSession(), closed)
+
+    client = _client()
+    with pytest.raises(RuntimeError, match="server refused the handshake"):
+        await client.connect()
+
+    assert closed == ["session", "transport", "http"]
+    assert client._session is None
+    assert client._runner is None
+
+
+@pytest.mark.asyncio
+async def test_closing_mid_handshake_never_publishes_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``close()`` during a handshake must not leave a torn-down session behind.
+
+    ``_require_session()`` is the only connectedness gate the rest of the code
+    has, so publishing a session the runner is about to unwind would turn the
+    next tool call into a ``ClosedResourceError``.
+    """
+    closed: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            closed.append("session")
+
+        async def initialize(self) -> None:
+            started.set()
+            await release.wait()
+
+    _patch_transport(monkeypatch, FakeSession(), closed)
+
+    client = _client()
+    connecting = asyncio.create_task(client.connect())
+    await started.wait()
+    closing = asyncio.create_task(client.close())
+    await asyncio.sleep(0)
+    release.set()
+
+    with pytest.raises(RuntimeError, match="was closed while connecting"):
+        await connecting
+    await closing
+
+    assert client._session is None
+    assert client._runner is None
+    assert closed == ["session", "transport", "http"]

--- a/tests/test_mcp/test_streamable_http_client.py
+++ b/tests/test_mcp/test_streamable_http_client.py
@@ -110,3 +110,19 @@ async def test_cancelled_connect_closes_all_partial_transport_contexts(
         await client.connect()
 
     assert closed == ["session", "transport", "http"]
+
+
+@pytest.mark.asyncio
+async def test_calls_before_connect_name_this_transport() -> None:
+    """Both SDK-backed transports share one base; the error still says which one."""
+    client = MCPStreamableHTTPClient(
+        MCPServerConfig(
+            name="remote",
+            transport="streamable_http",
+            url="https://example.test/mcp",
+        )
+    )
+    with pytest.raises(RuntimeError, match="MCP Streamable HTTP client is not connected"):
+        await client.list_tools()
+    with pytest.raises(RuntimeError, match="MCP Streamable HTTP client is not connected"):
+        await client.call_tool("anything", {})


### PR DESCRIPTION
Fixes #922.

> **Note for maintainers:** #924 is already open against this issue and takes the same SDK route. This is an independent implementation, not a follow-up — pick whichever you prefer rather than merging both. What is here beyond the acceptance criteria is the task-affinity fix in the second commit, which #924's approach is also exposed to.

## The defect

The 2024-11-05 `HTTP with SSE` transport is a two-channel protocol: the client opens the long-lived `GET` stream **first**, the server names its own message URI in an `endpoint` event on that stream, and JSON-RPC responses come back on the stream that is already open.

`MCPSSEClient` did the reverse. `connect()` called `_send_and_receive()` before any stream existed; `_send_and_receive()` POSTed to `config.message_endpoint or "/message"` — a guess, never the advertised URI — and then opened a *fresh* `GET` per request. A compliant server either refuses the initialization or emits the response into the window between the POST and the `GET`, where nothing is listening.

## The fix

`MCPSSEClient` drives `mcp.client.sse`, the sibling of the SDK transport `streamable_http.py` already uses, per @andreapn's "reuse over rewrite". Against each acceptance criterion:

| Criterion | Where |
|---|---|
| Open the SSE stream before sending initialization | `sse_client` blocks on `tg.start(sse_reader)` until the `endpoint` event lands; nothing is written before that |
| Parse the `endpoint` event, resolve relative against the configured URL | `urljoin(url, sse.data)` inside the SDK reader |
| One receive stream, responses correlated by JSON-RPC id | one `read_stream` for the connection; `ClientSession` matches on id |
| Notifications go to the advertised endpoint | the SDK's `post_writer` is the only writer, and it only knows `endpoint_url` |
| Close and cancel the receive task cleanly | `tg.cancel_scope.cancel()` on stack unwind |
| Deterministic offline lifecycle tests | `tests/test_mcp/test_sse_client.py` |

### How the SSRF guard is preserved (asked for explicitly)

The SDK builds **no** HTTP client of its own — `httpx_client_factory` is the single hook it dials through, and the factory installed here returns `mcp_http_client(...)`, i.e. `ssrf_guarded_client(validator=validate_metadata_only_address)`. `sse_client` uses that one instance for **both** channels: the `GET` stream and `client.post(endpoint_url, ...)`. So the server-chosen POST target goes through the same connect-time, address-pinning guard as the operator-configured URL — the check runs against the address the socket dials, not once against URL text.

Beyond the guard, a cross-origin endpoint never reaches a socket at all: the SDK compares the endpoint's scheme and netloc against the connection URL and refuses a mismatch inside the reader, before `post_writer` is ever started. `test_endpoint_pointing_at_another_origin_never_receives_a_post` asserts the server records **zero** POSTs in that case.

`tests/test_mcp/test_mcp_ssrf.py::test_sse_client_installs_the_connect_time_guard` was rewritten to assert on the factory's product rather than the removed `_client` attribute; the metadata-address, DNS-resolves-to-metadata, and metadata-hostname tests are unchanged and still pass.

Two supporting changes fall out of the swap:

- **Bounded handshake.** The SDK has no deadline of its own for a stream that opens and then never advertises an endpoint (its reader parks on an internal memory stream), so the whole handshake is wrapped in `asyncio.timeout(tool_timeout_seconds)`. Without it, `connect()` hangs instead of failing.
- **Exception unwrapping.** The SDK's anyio task group repackages a single failure as an `ExceptionGroup`. Callers — and the existing SSRF tests — expect `SSRFBlockedError` itself, so single-member groups are peeled back. Genuine multi-error groups are left alone.

`MCPServerConfig.message_endpoint` is removed. No config schema, doc, CLI flag, or `MCPServerConfig(...)` call site ever set it (`gateway/rpc_mcp.py:56` and `gateway/boot.py:1359` are the only two, both explicit-kwarg); it existed only to hold the guess.

## Second commit: a real bug the swap surfaced

Both SDK transports **and** `ClientSession` are built on anyio task groups, and an anyio cancel scope may only be exited by the task that entered it. Nothing in AgentOS closes an MCP client from the task that opened it: `discover_and_register` runs during boot or in an RPC handler, while `close_active_clients` runs from gateway shutdown or a later `mcp.disconnect`. Entering the stack inline therefore makes every real close raise

```
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
```

which `close_active_clients` swallows in its bare `except Exception: pass` — leaking the stream and its connection for the life of the process. Reproduced directly (connect in one task, close in another).

**This is already reachable on `streamable_http` today**, which is why the shared `MCPSessionClient` base fixes it for both rather than for SSE alone. `connect()` waits on a runner task that owns the transport stack; `close()` asks that task to unwind, from wherever it is called. That base also absorbs the `close`/`list_tools`/`call_tool` bodies that were previously identical in both transports, so the new file does not copy them.

## Third commit: review pass

A review of the first two commits produced five findings; all are applied, and the first two are pinned by tests that fail against the previous commit.

1. **Truncated unwind.** `connect()` cancelled a runner that was already unwinding after a failed handshake — `ready.set_exception()` wakes `connect()` while the runner is suspended inside `aclose()`, so `runner.cancel()` stopped the unwind at the first `__aexit__` that awaits (observed: `['transport', 'http']`, no `session`). It now only interrupts work still inside `_open_session`.
2. **Zombie session.** `close()` racing an in-flight `connect()` let the runner publish a session it was about to tear down, so `_require_session()` handed out a dead one and the next tool call raised `ClosedResourceError` instead of the intended `RuntimeError`. The runner now fails `connect()` instead.
3. **Swallowed cancellation.** `close()` absorbed the caller's own cancellation along with the runner's, so a shutdown deadline could pass unnoticed. Only a runner that actually ended cancelled is swallowed.
4. **Overstated error.** The handshake timeout claimed the server "never advertised a usable endpoint" even when it had, and then simply never answered `initialize`. The message names both possibilities.
5. **CI hazard.** Two tests connected without a `try/finally` close, so a failed assertion would leave the stream open and hang `Server.wait_closed()` — a timeout with no failure report. Both are wrapped, and `LegacySSEServer.stop()` bounds the wait regardless.

## Tests

`tests/test_mcp/test_sse_client.py` drives the real client against an in-process **legacy SSE server on an ephemeral loopback port** — a real `text/event-stream`, a real `endpoint` event, JSON-RPC over POST at that URI only, responses on the open stream. A mock transport would have accepted the old ordering, which is the whole defect.

Covered: stream-before-POST ordering; POST target is the advertised URI and never `/message`; notifications to the advertised endpoint; list/call round-trip; two concurrent calls answered in **reverse** order and still correlated; `close()` ending the stream; close from a different task; double-connect refused; calls before connect; relative *and* absolute same-origin endpoints; cross-origin endpoint posting nothing; bounded connect when no endpoint event arrives.

**9 of the 11 original tests fail against the previous implementation** (verified by reverting `sse.py`/`types.py` and re-running).

Offline, deterministic, credential-free, ephemeral-port, no fixtures shared across processes.

## Verification

```
uv run ruff check src tests          # All checks passed!
uv run mypy src/agentos              # Success: no issues found in 622 source files
uv run pytest -q                     # 9369 passed, 27 skipped
uv build --wheel                     # Successfully built
```

No `frontend/**` files touched, so the Node lane was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGtbVdmchrWKjaUCbxTNog
