### PR TITLE
fix(mcp): frame stdio messages by newline, not Content-Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   iterations inside a turn still weighs recorded spend only, so no turn is
   stopped by its own reservation
   ([#823](https://github.com/use-agent-os/agent-os/issues/823)).
+- The MCP `stdio` client speaks the transport's newline framing instead of
+  LSP-style `Content-Length` headers. `MCPStdioClient` wrote
+  `Content-Length: N\r\n\r\n<body>` to the server's stdin and rejected any
+  reply that did not carry the same header (`Missing Content-Length header in
+  response`), so no spec-compliant MCP stdio server could be used at all —
+  the reference `@modelcontextprotocol/server-*` implementations included.
+  Requests now go out as one compact JSON-RPC object per line, and a reply is
+  read up to the newline delimiter and matched to its request id, so a server
+  that interleaves `notifications/message` or `notifications/tools/list_changed`
+  with its replies is followed rather than being reported as the result of
+  whichever request was in flight. The existing short-read guarantees are kept:
+  a message split across pipe writes is reassembled rather than truncated, and
+  EOF before the delimiter raises a clear error instead of reaching
+  `json.loads` as a partial line. A message past the 64 KiB asyncio pipe
+  buffer — a large tool result, or a `tools/list` from a large catalog — is
+  read whole, where `readline` would raise and discard it, and a server that
+  never sends a delimiter is cut off at 16 MiB rather than buffered without
+  bound ([#894](https://github.com/use-agent-os/agent-os/issues/894)).
 - The MCP bridge clamps the arguments an MCP client supplies instead of
   forwarding them to the gateway verbatim. `events_wait` caps `timeout_ms` at
   5 minutes — applied before the deadline is computed, so the cap reaches

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -770,6 +770,13 @@ Supported transports are `stdio`, `sse`, and `streamable_http`. The MCP SDK is
 included in the standard AgentOS installation, so Streamable HTTP and OAuth work
 without installing an additional package extra.
 
+`stdio` servers are spoken to with the framing the MCP stdio transport defines:
+one compact JSON-RPC message per line on the subprocess's stdin and stdout.
+AgentOS neither sends nor expects the LSP-style `Content-Length` header, so the
+reference `@modelcontextprotocol/server-*` servers work unmodified. Replies are
+matched to their request id, so notifications a server interleaves with them are
+skipped rather than mistaken for a result.
+
 The HTTP transports accept `http://` and `https://` URLs only, and both connect
 through the same SSRF guard the built-in HTTP tools use. `http://localhost:PORT`
 and LAN-hosted servers keep working — the guard blocks cloud metadata endpoints

--- a/src/agentos/mcp/stdio.py
+++ b/src/agentos/mcp/stdio.py
@@ -13,9 +13,18 @@ from agentos.mcp.types import MCPServerConfig, MCPToolDef, MCPToolResult
 
 
 class MCPStdioClient(MCPClient):
-    """MCP client using stdio transport (subprocess + Content-Length framing)."""
+    """MCP client using stdio transport (subprocess + newline-delimited JSON-RPC).
+
+    The MCP stdio transport frames messages by newline: each JSON-RPC message is
+    written as a single line on stdin and read back as a single line from
+    stdout. ``Content-Length`` headers are the Language Server Protocol
+    convention, not this one, and a spec-compliant server never sends them.
+    """
 
     _CLOSE_TIMEOUT_SECONDS = 2.0
+    # A message is read until its delimiter, so a server that never sends one
+    # would otherwise grow the buffer without bound.
+    _MAX_MESSAGE_BYTES = 16 * 1024 * 1024
 
     def __init__(self, config: MCPServerConfig) -> None:
         super().__init__(config)
@@ -23,34 +32,67 @@ class MCPStdioClient(MCPClient):
         self._request_id = 0
 
     @staticmethod
-    def _encode_request(request: dict[str, Any]) -> bytes:
-        """Encode a JSON-RPC request with Content-Length framing."""
-        body = json.dumps(request)
-        header = f"Content-Length: {len(body)}\r\n\r\n"
-        return header.encode() + body.encode()
+    def _encode_message(message: dict[str, Any]) -> bytes:
+        """Encode one JSON-RPC message as a single newline-terminated line.
+
+        ``json.dumps`` escapes newlines inside strings, so the payload cannot
+        contain the delimiter no matter what a tool argument holds. Compact
+        separators keep the frame to what the transport needs.
+        """
+        return json.dumps(message, separators=(",", ":")).encode() + b"\n"
 
     @staticmethod
     def _decode_response(data: bytes) -> dict[str, Any]:
-        """Decode a Content-Length framed response."""
-        if b"\r\n\r\n" not in data:
-            raise ValueError("Missing header/body separator in response")
+        """Decode one newline-delimited JSON-RPC message."""
+        try:
+            decoded = json.loads(data.decode().strip())
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ValueError(f"MCP server sent a line that is not valid JSON: {exc}") from exc
+        if not isinstance(decoded, dict):
+            raise ValueError(
+                f"MCP server response is not a JSON-RPC object: {type(decoded).__name__}"
+            )
+        return cast(dict[str, Any], decoded)
 
-        header_part, body = data.split(b"\r\n\r\n", 1)
-        headers = header_part.decode()
+    @classmethod
+    async def _read_line(cls, stream: asyncio.StreamReader) -> bytes:
+        """Read one newline-terminated line of any length.
 
-        content_length: int | None = None
-        for line in headers.splitlines():
-            if line.lower().startswith("content-length:"):
-                content_length = int(line.split(":", 1)[1].strip())
-                break
+        ``StreamReader.readline`` raises *and drops the data* once a line
+        exceeds the stream buffer limit — 64 KiB for an asyncio subprocess
+        pipe, which a real ``tools/list`` or tool result passes easily. Draining
+        ``readuntil``'s ``LimitOverrunError`` instead keeps the frame whole.
 
-        if content_length is None:
-            raise ValueError("Missing Content-Length header")
-
-        if len(body) < content_length:
-            raise ValueError(f"Truncated body: expected {content_length} bytes, got {len(body)}")
-
-        return cast(dict[str, Any], json.loads(body[:content_length].decode()))
+        Returns a non-empty, newline-terminated line, or raises ``ValueError``:
+        EOF before the delimiter is a short read, reported as one rather than
+        handed to ``json.loads`` as a partial line, and a server that keeps
+        sending without ever delimiting is cut off at ``_MAX_MESSAGE_BYTES``.
+        """
+        chunks: list[bytes] = []
+        size = 0
+        while True:
+            try:
+                chunks.append(await stream.readuntil(b"\n"))
+            except asyncio.LimitOverrunError as exc:
+                # No delimiter within the buffer yet: take what is buffered and
+                # keep looking. ``exc.consumed`` never exceeds what is buffered,
+                # so this cannot block.
+                chunks.append(await stream.readexactly(exc.consumed))
+                size += len(chunks[-1])
+                if size > cls._MAX_MESSAGE_BYTES:
+                    raise ValueError(
+                        f"MCP server message exceeds {cls._MAX_MESSAGE_BYTES} bytes "
+                        "with no newline delimiter"
+                    ) from exc
+                continue
+            except asyncio.IncompleteReadError as exc:
+                partial = b"".join([*chunks, exc.partial])
+                if not partial:
+                    raise ValueError("MCP server closed stdout without sending a response") from exc
+                raise ValueError(
+                    f"Truncated message: EOF after {len(partial)} bytes with no newline delimiter"
+                ) from exc
+            return b"".join(chunks)
 
     def _next_id(self) -> int:
         self._request_id += 1
@@ -118,11 +160,10 @@ class MCPStdioClient(MCPClient):
         if params is not None:
             request["params"] = params
 
-        encoded = self._encode_request(request)
-        self._process.stdin.write(encoded)
+        self._process.stdin.write(self._encode_message(request))
         await self._process.stdin.drain()
 
-        return await self._read_response()
+        return await self._read_response(req_id)
 
     async def _send_notification(self, method: str) -> None:
         """Send a JSON-RPC notification (no response expected)."""
@@ -130,45 +171,33 @@ class MCPStdioClient(MCPClient):
         assert self._process.stdin is not None
 
         notification = {"jsonrpc": "2.0", "method": method}
-        encoded = self._encode_request(notification)
-        self._process.stdin.write(encoded)
+        self._process.stdin.write(self._encode_message(notification))
         await self._process.stdin.drain()
 
-    async def _read_response(self) -> dict[str, Any]:
-        """Read and decode a Content-Length framed response from stdout."""
+    async def _read_response(self, req_id: int) -> dict[str, Any]:
+        """Read newline-delimited messages until the reply to ``req_id`` arrives.
+
+        A server may interleave its own traffic with the reply — a
+        ``notifications/message`` log line, ``notifications/tools/list_changed``
+        after a catalog change, or a request of its own. Returning whatever
+        arrived first would hand a notification back as the result and leave
+        every later read one message behind, so replies are matched on their
+        JSON-RPC id the way the SSE client does. Each iteration consumes at
+        least one byte and EOF raises, so this cannot spin.
+        """
         assert self._process is not None
         assert self._process.stdout is not None
 
-        # Read header lines until blank line
-        header_lines: list[str] = []
         while True:
-            line = await self._process.stdout.readline()
-            decoded = line.decode().rstrip("\r\n")
-            if decoded == "":
-                break
-            header_lines.append(decoded)
-
-        content_length: int | None = None
-        for h in header_lines:
-            if h.lower().startswith("content-length:"):
-                content_length = int(h.split(":", 1)[1].strip())
-                break
-
-        if content_length is None:
-            raise ValueError("Missing Content-Length header in response")
-
-        # ``StreamReader.read(n)`` returns *up to* n bytes and yields as soon as
-        # any data is buffered, so a body split across pipe writes (large tool
-        # results, chunked flushes) would be truncated and fail ``json.loads``.
-        # ``readexactly`` enforces the Content-Length framing contract, matching
-        # the guard in the sibling ``_decode_response`` helper.
-        try:
-            body = await self._process.stdout.readexactly(content_length)
-        except asyncio.IncompleteReadError as exc:
-            raise ValueError(
-                f"Truncated body: expected {content_length} bytes, got {len(exc.partial)}"
-            ) from exc
-        return cast(dict[str, Any], json.loads(body.decode()))
+            line = await self._read_line(self._process.stdout)
+            # Servers occasionally flush a bare newline between messages.
+            if not line.strip():
+                continue
+            message = self._decode_response(line)
+            # A server-originated request carries ``method`` next to an id from
+            # the server's own id space; only a reply can match ours.
+            if "method" not in message and message.get("id") == req_id:
+                return message
 
     async def list_tools(self) -> list[MCPToolDef]:
         """List tools from the MCP server."""

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -33,7 +36,7 @@ class _FakeProcess:
         return self.returncode
 
 
-def _client_with_process(process: _FakeProcess) -> MCPStdioClient:
+def _client_with_process(process: _FakeProcess | _PipeProcess) -> MCPStdioClient:
     client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
     client._process = process  # type: ignore[assignment]
     return client
@@ -65,47 +68,193 @@ async def test_close_kills_stdio_process_when_terminate_times_out(
     assert process.wait_calls == 2
 
 
-class _StdoutOnlyProcess:
-    """Minimal process stub exposing only a ``stdout`` StreamReader."""
+class _FakeStdin:
+    """Collects everything the client writes to the subprocess."""
+
+    def __init__(self) -> None:
+        self.written = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.written.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+
+class _PipeProcess:
+    """Process stub with a collecting stdin and a readable stdout."""
 
     def __init__(self, stdout: asyncio.StreamReader) -> None:
+        self.stdin = _FakeStdin()
         self.stdout = stdout
-        self.stdin = None
 
 
-def _framed(payload: bytes) -> bytes:
-    return f"Content-Length: {len(payload)}\r\n\r\n".encode() + payload
+def _reader(
+    *, data: bytes = b"", eof: bool = True, limit: int | None = None
+) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader() if limit is None else asyncio.StreamReader(limit=limit)
+    if data:
+        reader.feed_data(data)
+    if eof:
+        reader.feed_eof()
+    return reader
+
+
+def _client_reading(data: bytes, *, limit: int | None = None) -> MCPStdioClient:
+    return _client_with_process(_PipeProcess(_reader(data=data, limit=limit)))
+
+
+# --- request framing -------------------------------------------------------
+
+
+def test_encode_message_emits_one_compact_json_line() -> None:
+    """The MCP stdio transport frames messages by newline, not Content-Length."""
+    encoded = MCPStdioClient._encode_message({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+    assert b"Content-Length" not in encoded
+    assert encoded.endswith(b"\n")
+    assert encoded.count(b"\n") == 1
+    assert encoded == b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n'
+
+
+def test_encode_message_escapes_newlines_in_payload() -> None:
+    """A newline inside an argument must not split the frame."""
+    encoded = MCPStdioClient._encode_message(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"body": "a\nb"}}
+    )
+
+    assert encoded.count(b"\n") == 1
+    assert json.loads(encoded)["params"]["body"] == "a\nb"
 
 
 @pytest.mark.asyncio
-async def test_read_response_handles_body_split_across_reads() -> None:
-    """A body delivered in multiple pipe writes must not be truncated.
+async def test_send_request_writes_newline_framed_request() -> None:
+    """End to end: one line out, one line in, no headers on either side."""
+    client = _client_reading(b'{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}\n')
 
-    ``StreamReader.read(n)`` returns as soon as *any* data is buffered, so the
-    pre-fix code truncated bodies that did not arrive in a single read and then
-    failed ``json.loads``. The fix uses ``readexactly`` to honor the
-    Content-Length frame.
+    response = await client._send_request("tools/list")
+
+    written = bytes(client._process.stdin.written)  # type: ignore[union-attr]
+    assert written == b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n'
+    assert response == {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+
+
+@pytest.mark.asyncio
+async def test_send_notification_writes_newline_framed_message() -> None:
+    client = _client_reading(b"")
+
+    await client._send_notification("notifications/initialized")
+
+    written = bytes(client._process.stdin.written)  # type: ignore[union-attr]
+    assert written == b'{"jsonrpc":"2.0","method":"notifications/initialized"}\n'
+
+
+# --- response reading ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_response_accepts_newline_delimited_message() -> None:
+    """The exact frame a spec-compliant MCP stdio server writes (issue #894)."""
+    client = _client_reading(b'{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}\n')
+
+    assert await client._read_response(1) == {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+
+
+@pytest.mark.asyncio
+async def test_read_response_rejects_content_length_framing() -> None:
+    """LSP-style framing is not an MCP stdio message and must not be accepted."""
+    body = b'{"jsonrpc":"2.0","id":1,"result":{}}'
+    client = _client_reading(b"Content-Length: %d\r\n\r\n" % len(body) + body + b"\n")
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        await client._read_response(1)
+
+
+@pytest.mark.asyncio
+async def test_read_response_stops_at_the_first_delimiter() -> None:
+    """A second buffered message stays in the stream for the next read."""
+    client = _client_reading(
+        b'{"jsonrpc":"2.0","id":1,"result":{"a":1}}\n{"jsonrpc":"2.0","id":2,"result":{"b":2}}\n'
+    )
+
+    first = await client._read_response(1)
+    second = await client._read_response(2)
+
+    assert first["result"] == {"a": 1}
+    assert second["result"] == {"b": 2}
+
+
+@pytest.mark.asyncio
+async def test_read_response_skips_blank_lines() -> None:
+    client = _client_reading(b"\n\r\n" + b'{"jsonrpc":"2.0","id":1,"result":{}}\n')
+
+    assert (await client._read_response(1))["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_response_skips_notifications_before_the_reply() -> None:
+    """A notification is not the answer to a request (issue #894 follow-on).
+
+    Returning the first line read would report the notification as the result
+    and leave every later read one message behind.
     """
-    payload = json.dumps(
-        {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "x"} for _ in range(50)]}}
-    ).encode()
-    frame = _framed(payload)
-    # Split mid-body so the first read cannot see the whole payload.
-    split = len(frame) - (len(payload) // 2)
+    client = _client_reading(
+        b'{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}\n'
+        b'{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}\n'
+        b'{"jsonrpc":"2.0","id":7,"result":{"tools":[]}}\n'
+    )
 
-    reader = asyncio.StreamReader()
-    process = _StdoutOnlyProcess(reader)
-    client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
-    client._process = process  # type: ignore[assignment]
+    assert await client._read_response(7) == {"jsonrpc": "2.0", "id": 7, "result": {"tools": []}}
+
+
+@pytest.mark.asyncio
+async def test_read_response_skips_a_reply_to_another_request() -> None:
+    client = _client_reading(
+        b'{"jsonrpc":"2.0","id":6,"result":{"stale":true}}\n'
+        b'{"jsonrpc":"2.0","id":7,"result":{"fresh":true}}\n'
+    )
+
+    assert (await client._read_response(7))["result"] == {"fresh": True}
+
+
+@pytest.mark.asyncio
+async def test_read_response_skips_a_server_request_reusing_the_id() -> None:
+    """A server request has its own id space; ``method`` tells it from a reply."""
+    client = _client_reading(
+        b'{"jsonrpc":"2.0","id":7,"method":"sampling/createMessage","params":{}}\n'
+        b'{"jsonrpc":"2.0","id":7,"result":{"ok":true}}\n'
+    )
+
+    assert (await client._read_response(7))["result"] == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_read_response_handles_message_split_across_reads() -> None:
+    """A message delivered in many pipe writes must not be truncated.
+
+    ``StreamReader.read(n)`` returns as soon as *any* data is buffered, so a
+    reader that does not wait for the delimiter truncates messages that do not
+    arrive in a single read and then fails ``json.loads``. The stream limit is
+    shrunk well below the message so the over-limit recovery has to run and
+    join repeatedly, which is what a >64 KiB result does on a real pipe.
+    """
+    frame = (
+        json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "x"} for _ in range(50)]}}
+        ).encode()
+        + b"\n"
+    )
+    stdout = _reader(eof=False, limit=64)
+    client = _client_with_process(_PipeProcess(stdout))
 
     async def feed() -> None:
-        reader.feed_data(frame[:split])
-        await asyncio.sleep(0)  # force a scheduler yield between chunks
-        reader.feed_data(frame[split:])
-        reader.feed_eof()
+        for start in range(0, len(frame), 7):  # many chunks, each under the limit
+            stdout.feed_data(frame[start : start + 7])
+            await asyncio.sleep(0)  # force a scheduler yield between chunks
+        stdout.feed_eof()
 
     feeder = asyncio.create_task(feed())
-    response = await client._read_response()
+    response = await client._read_response(1)
     await feeder
 
     assert response["id"] == 1
@@ -113,17 +262,134 @@ async def test_read_response_handles_body_split_across_reads() -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_response_raises_on_truncated_body() -> None:
+async def test_read_response_reads_message_longer_than_the_stream_limit() -> None:
+    """``readline`` raises and *discards* past the buffer limit; we must not.
+
+    ``asyncio`` subprocess pipes cap a buffered line at 64 KiB, which a real
+    ``tools/list`` or tool result exceeds. The limit is shrunk here so the test
+    stays fast and deterministic.
+    """
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": 1, "result": {"text": "x" * 4096}}
+    client = _client_reading(json.dumps(payload).encode() + b"\n", limit=64)
+
+    assert await client._read_response(1) == payload
+
+
+@pytest.mark.asyncio
+async def test_read_response_gives_up_on_a_message_with_no_delimiter_in_sight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reading to a delimiter must not buffer without bound."""
+    monkeypatch.setattr(MCPStdioClient, "_MAX_MESSAGE_BYTES", 256)
+    # Four times the cap, and EOF after it, so the cap is what has to fire:
+    # without it the read ends in the short-read error instead.
+    client = _client_reading(b"x" * 1024, limit=8)
+
+    with pytest.raises(ValueError, match="exceeds 256 bytes"):
+        await client._read_response(1)
+
+
+@pytest.mark.asyncio
+async def test_read_response_raises_when_eof_arrives_before_the_delimiter() -> None:
     """Premature EOF must surface as a clear ValueError, not a JSON error."""
-    payload = b'{"jsonrpc":"2.0","id":1,"result":{}}'
-    frame = _framed(payload)[:-5]  # drop the tail so EOF arrives early
+    client = _client_reading(b'{"jsonrpc":"2.0","id":1,"result":{}')  # no newline delimiter
 
-    reader = asyncio.StreamReader()
-    reader.feed_data(frame)
-    reader.feed_eof()
-    process = _StdoutOnlyProcess(reader)
-    client = MCPStdioClient(MCPServerConfig(name="demo", transport="stdio", command="demo"))
-    client._process = process  # type: ignore[assignment]
+    with pytest.raises(ValueError, match="Truncated message"):
+        await client._read_response(1)
 
-    with pytest.raises(ValueError, match="Truncated body"):
-        await client._read_response()
+
+@pytest.mark.asyncio
+async def test_read_response_raises_when_partial_message_exceeds_stream_limit() -> None:
+    """The short-read guard still fires for a partial message past the limit."""
+    client = _client_reading(b'{"jsonrpc":"2.0","id":1,"result":"' + b"x" * 4096, limit=64)
+
+    with pytest.raises(ValueError, match="Truncated message"):
+        await client._read_response(1)
+
+
+@pytest.mark.asyncio
+async def test_read_response_raises_when_server_closes_stdout() -> None:
+    client = _client_reading(b"")
+
+    with pytest.raises(ValueError, match="closed stdout"):
+        await client._read_response(1)
+
+
+@pytest.mark.asyncio
+async def test_read_response_reports_undecodable_bytes_as_a_bad_line() -> None:
+    """Invalid UTF-8 must give the same framing diagnostic as invalid JSON."""
+    client = _client_reading(b"\xff\xfe{}\n")
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        await client._read_response(1)
+
+
+@pytest.mark.asyncio
+async def test_read_response_rejects_non_object_message() -> None:
+    client = _client_reading(b"[1, 2, 3]\n")
+
+    with pytest.raises(ValueError, match="not a JSON-RPC object"):
+        await client._read_response(1)
+
+
+# --- end to end against a real subprocess ----------------------------------
+
+
+_SPEC_COMPLIANT_SERVER = """
+import json
+import sys
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    if "id" not in message:  # notification: no response
+        continue
+    method = message["method"]
+    if method == "tools/list":
+        # A real server interleaves its own traffic with replies.
+        sys.stdout.write(
+            json.dumps({"jsonrpc": "2.0", "method": "notifications/tools/list_changed"}) + "\\n"
+        )
+        sys.stdout.flush()
+    if method == "initialize":
+        result = {"protocolVersion": "2024-11-05", "capabilities": {}}
+    elif method == "tools/list":
+        result = {
+            "tools": [
+                {"name": "echo", "description": "Echo text", "inputSchema": {"type": "object"}}
+            ]
+        }
+    elif method == "tools/call":
+        result = {"content": [{"type": "text", "text": message["params"]["arguments"]["text"]}]}
+    else:
+        result = {}
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}) + "\\n")
+    sys.stdout.flush()
+"""
+
+
+@pytest.mark.asyncio
+async def test_connects_to_a_spec_compliant_newline_delimited_server(tmp_path: Path) -> None:
+    """Issue #894's repro: a server that speaks only newline-delimited JSON-RPC.
+
+    The server parses each stdin line as JSON, so ``Content-Length`` headers
+    make it raise before it ever answers.
+    """
+    server = tmp_path / "server.py"
+    server.write_text(_SPEC_COMPLIANT_SERVER)
+    client = MCPStdioClient(
+        MCPServerConfig(name="demo", transport="stdio", command=sys.executable, args=[str(server)])
+    )
+
+    try:
+        await client.connect()
+        tools = await client.list_tools()
+        result = await client.call_tool("echo", {"text": "multi\nline"})
+    finally:
+        await client.close()
+
+    assert [t.name for t in tools] == ["echo"]
+    assert result.content == "multi\nline"
+    assert result.is_error is False


### PR DESCRIPTION
Closes #894.

## The bug

`MCPStdioClient` framed stdio traffic the way the Language Server Protocol does, not the way the MCP stdio transport does:

```python
header = f"Content-Length: {len(body)}\r\n\r\n"
```

and refused any reply that did not carry the same header (`ValueError: Missing Content-Length header in response`). The MCP stdio transport is newline-delimited, so the failure is not an interop edge case: **no spec-compliant MCP stdio server could be used at all**, the reference `@modelcontextprotocol/server-*` implementations included.

## The fix

- **Requests** go out as one compact JSON-RPC object per line. `json.dumps` escapes newlines inside strings, so no tool argument can split a frame.
- **Replies** are read up to the newline delimiter and **matched to their request id**. A server that interleaves `notifications/message` or `notifications/tools/list_changed` with its replies is now followed; previously the first message read was returned as the result, which left the stream permanently one message behind and reported empty tool results with `is_error=False`. This mirrors what the SSE client already does (`sse.py:121`).
- **The short-read guarantees the header framing gave us are kept**, per the acceptance criteria:
  - a message split across pipe writes is reassembled, not truncated;
  - EOF before the delimiter raises a clear `ValueError` instead of reaching `json.loads` as a partial line;
  - a message past the **64 KiB** asyncio pipe buffer — a large tool result, or a `tools/list` from a large catalog — is read whole. `StreamReader.readline` raises *and discards the buffer* past the limit, so the reader drains `readuntil`'s `LimitOverrunError` and joins instead;
  - a server that never sends a delimiter is cut off at 16 MiB rather than buffered without bound.

## Transport choice

@andreapn asked which of the two directions this takes. **This keeps the hand-rolled client rather than moving to `mcp.client.stdio.stdio_client`** — subprocess ownership, environment handling, and the terminate-then-kill cleanup stay exactly as they are, and the diff stays reviewable against the reported defect. The SDK remains the better long-term home (it also handles id correlation, notification routing, and stderr), but adopting it changes the session and request lifecycle and deserves its own change rather than riding along with a framing fix. Happy to follow up with that migration, which would cover the SSE client in #922 too.

## Verification

- `tests/test_mcp/test_stdio_client.py`: 22 tests — request/notification framing, newline-delimited reads, notification and stale-id skipping, a server request that reuses our id, chunked arrival past the stream limit, both short-read paths, undecodable bytes, the size cap, and both shutdown paths (kept unchanged).
- An **end-to-end test spawns a real subprocess server that speaks only newline-delimited JSON-RPC** and emits a notification before its first reply — issue #894's exact reproduction. It fails against the pre-fix client with `Missing Content-Length header in response` and passes here.
- Reverting the implementation fails 15 of the 22 tests; each individual guard (id matching, the `method` check, the chunked read, the size cap, the decode wrapper) was mutation-tested and is independently caught, with no test that hangs instead of failing.
- The `readuntil`/`LimitOverrunError` recipe was checked against the CPython 3.12 source for both branches that raise it (separator absent, and separator found past the limit): each leaves the data buffered and reports a `consumed` count within what is buffered, so `readexactly(exc.consumed)` cannot block and always makes progress.
- Full gate green: `ruff check src tests`, `mypy src/agentos` (622 files), `pytest -q` → **9368 passed, 23 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTF9UU1pAaL2Hki3D1uZz8
