### PR TITLE
fix(gateway): keep replacement task registered when predecessor's cal…

### DIFF
--- a/src/agentos/gateway/agent_tasks.py
+++ b/src/agentos/gateway/agent_tasks.py
@@ -46,7 +46,11 @@ class AgentTaskRegistry:
         self._tasks[session_key] = task
 
         def _on_done(t: asyncio.Task) -> None:
-            self._tasks.pop(session_key, None)
+            # Only remove the entry if it still points to this task: a
+            # cancelled predecessor's late callback must not evict the
+            # replacement registered under the same session key.
+            if self._tasks.get(session_key) is t:
+                self._tasks.pop(session_key, None)
             try:
                 if t.cancelled():
                     log.info("agent_task.cancelled", session_key=session_key)

--- a/tests/test_gateway/test_agent_task_registry.py
+++ b/tests/test_gateway/test_agent_task_registry.py
@@ -1,0 +1,166 @@
+"""Regression tests for AgentTaskRegistry replacement-callback race (#1026).
+
+Verifies that a cancelled predecessor's completion callback does not evict
+a replacement task registered under the same session key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentos.gateway.agent_tasks import AgentTaskRegistry
+
+
+@pytest.mark.asyncio
+async def test_cancelled_predecessor_does_not_evict_replacement() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:ws:dm:peer"
+
+    blocker1 = asyncio.Event()
+    task1 = asyncio.create_task(blocker1.wait())
+    registry.register(session_key, task1)
+
+    # Attach callback to wait deterministically for task1's done callbacks
+    task1_done = asyncio.Event()
+    task1.add_done_callback(lambda _: task1_done.set())
+
+    blocker2 = asyncio.Event()
+    task2 = asyncio.create_task(blocker2.wait())
+    registry.register(session_key, task2)
+
+    # Wait for task1 cancellation to complete and its done callbacks to fire
+    await task1_done.wait()
+
+    # Replacement task must remain registered and reported as running
+    assert registry.is_running(session_key) is True
+    assert registry.get(session_key) is task2
+
+    # When replacement task finishes, it must be removed normally
+    task2_done = asyncio.Event()
+    task2.add_done_callback(lambda _: task2_done.set())
+    blocker2.set()
+    await task2_done.wait()
+
+    assert registry.is_running(session_key) is False
+    assert registry.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_chained_multiple_replacements() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:ws:dm:chain"
+
+    blocker1 = asyncio.Event()
+    task1 = asyncio.create_task(blocker1.wait())
+    registry.register(session_key, task1)
+    task1_done = asyncio.Event()
+    task1.add_done_callback(lambda _: task1_done.set())
+
+    blocker2 = asyncio.Event()
+    task2 = asyncio.create_task(blocker2.wait())
+    registry.register(session_key, task2)
+    task2_done = asyncio.Event()
+    task2.add_done_callback(lambda _: task2_done.set())
+
+    blocker3 = asyncio.Event()
+    task3 = asyncio.create_task(blocker3.wait())
+    registry.register(session_key, task3)
+    task3_done = asyncio.Event()
+    task3.add_done_callback(lambda _: task3_done.set())
+
+    # Wait for both cancelled predecessors to settle
+    await task1_done.wait()
+    await task2_done.wait()
+
+    assert registry.is_running(session_key) is True
+    assert registry.get(session_key) is task3
+
+    blocker3.set()
+    await task3_done.wait()
+
+    assert registry.is_running(session_key) is False
+    assert registry.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_cleans_up() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:ws:dm:normal"
+
+    blocker = asyncio.Event()
+    task = asyncio.create_task(blocker.wait())
+    registry.register(session_key, task)
+
+    assert registry.is_running(session_key) is True
+
+    done_event = asyncio.Event()
+    task.add_done_callback(lambda _: done_event.set())
+    blocker.set()
+    await done_event.wait()
+
+    assert registry.is_running(session_key) is False
+    assert registry.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_failed_task_cleans_up() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:ws:dm:fail"
+
+    async def _failing() -> None:
+        raise ValueError("boom")
+
+    task = asyncio.create_task(_failing())
+    registry.register(session_key, task)
+
+    done_event = asyncio.Event()
+    task.add_done_callback(lambda _: done_event.set())
+    with pytest.raises(ValueError, match="boom"):
+        await task
+
+    await done_event.wait()
+    assert registry.is_running(session_key) is False
+    assert registry.get(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_existing_false_refuses_orphaning() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:ws:dm:no-cancel"
+
+    blocker = asyncio.Event()
+    task1 = asyncio.create_task(blocker.wait())
+    registry.register(session_key, task1)
+
+    task2 = asyncio.create_task(blocker.wait())
+    with pytest.raises(RuntimeError, match="called while a task is still running"):
+        registry.register(session_key, task2, cancel_existing=False)
+
+    # task1 must still be running and registered
+    assert registry.get(session_key) is task1
+    task1.cancel()
+    task2.cancel()
+
+
+@pytest.mark.asyncio
+async def test_cancel_method() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:ws:dm:cancel"
+
+    # No task registered
+    assert registry.cancel(session_key) is False
+
+    blocker = asyncio.Event()
+    task = asyncio.create_task(blocker.wait())
+    registry.register(session_key, task)
+
+    done_event = asyncio.Event()
+    task.add_done_callback(lambda _: done_event.set())
+
+    assert registry.cancel(session_key) is True
+    await done_event.wait()
+
+    assert task.cancelled() is True
+    assert registry.is_running(session_key) is False


### PR DESCRIPTION
Closes #1026 

### Problem
When `AgentTaskRegistry.register()` is called with `cancel_existing=True` (default), the new replacement task is stored under `session_key` before attaching a completion callback. Previously, the done callback unconditionally executed `self._tasks.pop(session_key, None)`. 

When the predecessor task finished cancellation, its late completion callback ran and evicted the active replacement task from the registry under that same key. As a result, subsequent `get()` and `is_running()` queries reported no running task, causing status lookups and cancellation/abort requests for that active session to silently no-op.

### Solution
- Added an identity guard in `_on_done`:
  ```python
  if self._tasks.get(session_key) is t:
      self._tasks.pop(session_key, None)
