### PR TITLE
fix(discord): bounded reconnect with backoff, observable dispatch lif…

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -148,6 +148,11 @@ class DiscordChannel:
     # snapshot this before taking the lock so a second waiter does not IDENTIFY
     # again on a socket the first waiter already replaced.
     _reconnect_generation: int = field(default=0, init=False, repr=False)
+    # Consecutive failed reconnect attempts. Reset on a successful reconnect;
+    # when it reaches config.reconnect_max_retries the channel goes dead
+    # (_connected=False) instead of spinning forever or dying with an
+    # unobserved task exception.
+    _reconnect_failures: int = field(default=0, init=False, repr=False)
     _dedupe: EventDedupeCache = field(
         default_factory=lambda: EventDedupeCache(max_size=10_000),
         init=False,
@@ -274,10 +279,36 @@ class DiscordChannel:
         while self._connected:
             if not self._state.last_heartbeat_ack:
                 log.warning("discord.heartbeat_timeout")
-                await self._reconnect()
+                try:
+                    await self._reconnect()
+                except Exception as exc:  # noqa: BLE001
+                    # Reconnect budget exhausted; _connected is already
+                    # False. The while-guard exits on the next iteration
+                    # without sending another heartbeat into a dead socket.
+                    log.warning(
+                        "discord.heartbeat_reconnect_contained",
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
                 return
             self._state.last_heartbeat_ack = False
-            await self._ws_send({"op": 1, "d": self._state.sequence})
+            try:
+                await self._ws_send({"op": 1, "d": self._state.sequence})
+            except Exception as exc:  # noqa: BLE001
+                # A send failure into a dead socket means the connection is
+                # gone; treat it like a missed ACK so the reconnect path
+                # runs instead of this loop dying with an unobserved exception.
+                log.warning(
+                    "discord.heartbeat_send_failed",
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                self._state.last_heartbeat_ack = False
+                try:
+                    await self._reconnect()
+                except Exception:  # noqa: BLE001
+                    pass
+                return
             await asyncio.sleep(self._state.heartbeat_interval_ms / 1000.0)
 
     # ------------------------------------------------------------------
@@ -285,13 +316,18 @@ class DiscordChannel:
     # ------------------------------------------------------------------
 
     async def _reconnect(self) -> None:
-        """Re-establish the gateway connection.
+        """Re-establish the gateway connection with bounded exponential backoff.
 
         Concurrent callers wait for the in-flight reconnect rather than
         no-op returning: the dispatch loop keeps receiving after a
         reconnect and must not race past a still-closed socket. A second
         waiter that arrived after the socket was already replaced skips
         a duplicate IDENTIFY.
+
+        Exceptions from ``_do_reconnect`` are contained and retried up to
+        ``reconnect_max_retries``. When retries are exhausted, the channel
+        is marked dead (``_connected=False``) so the dispatch loop exits
+        and operators see an accurate status.
         """
         generation = self._reconnect_generation
         async with self._reconnect_lock:
@@ -302,8 +338,42 @@ class DiscordChannel:
                 return
             self._reconnecting = True
             try:
-                await self._do_reconnect()
+                try:
+                    await self._do_reconnect()
+                except Exception as exc:  # noqa: BLE001
+                    self._reconnect_failures += 1
+                    backoff = min(
+                        60.0,
+                        self.config.reconnect_base_delay_s
+                        * (2 ** max(0, self._reconnect_failures - 1)),
+                    )
+                    log.warning(
+                        "discord.reconnect_attempt_connect_failed",
+                        attempt=self._reconnect_failures,
+                        max_retries=self.config.reconnect_max_retries,
+                        backoff_s=round(backoff, 3),
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
+                    if self._reconnect_failures >= self.config.reconnect_max_retries:
+                        log.error(
+                            "discord.reconnect_exhausted",
+                            attempts=self._reconnect_failures,
+                            max_retries=self.config.reconnect_max_retries,
+                        )
+                        self._connected = False
+                        if self._heartbeat_task is not None and not self._heartbeat_task.done():
+                            self._heartbeat_task.cancel()
+                        raise
+                    await asyncio.sleep(backoff)
+                    return
                 self._reconnect_generation += 1
+                if self._reconnect_failures:
+                    log.info(
+                        "discord.reconnect_recovered",
+                        after_failures=self._reconnect_failures,
+                    )
+                    self._reconnect_failures = 0
             finally:
                 self._reconnecting = False
 
@@ -351,7 +421,16 @@ class DiscordChannel:
                 websockets.exceptions.ConnectionClosedOK,
             ):
                 if self._connected:
-                    await self._reconnect()
+                    try:
+                        await self._reconnect()
+                    except Exception as exc:  # noqa: BLE001
+                        log.warning(
+                            "discord.connection_closed_reconnect_contained",
+                            error_type=type(exc).__name__,
+                            error=str(exc),
+                        )
+                    if not self._connected:
+                        return
                     continue
                 return
 
@@ -364,7 +443,16 @@ class DiscordChannel:
             elif op == 1:  # Heartbeat request
                 await self._ws_send({"op": 1, "d": self._state.sequence})
             elif op == 7:  # Reconnect
-                await self._reconnect()
+                try:
+                    await self._reconnect()
+                except Exception as exc:  # noqa: BLE001
+                    log.warning(
+                        "discord.op7_reconnect_contained",
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
+                if not self._connected:
+                    return
                 continue
             elif op == 9:  # Invalid Session
                 resumable = raw.get("d", False)
@@ -372,10 +460,20 @@ class DiscordChannel:
                     self._state.session_id = None
                     self._state.sequence = None
                 await asyncio.sleep(1 + random.random() * 4)
-                await self._reconnect()
+                try:
+                    await self._reconnect()
+                except Exception as exc:  # noqa: BLE001
+                    log.warning(
+                        "discord.op9_reconnect_contained",
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
+                if not self._connected:
+                    return
                 continue
             elif op == 11:  # Heartbeat ACK
                 self._state.last_heartbeat_ack = True
+
 
     async def _handle_dispatch(self, event_type: str | None, data: dict[str, Any]) -> None:
         if event_type == "READY":
@@ -758,12 +856,33 @@ class DiscordChannel:
         self._connected = True
         self._state.last_heartbeat_ack = True
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-        self._dispatch_task = asyncio.create_task(self._dispatch_loop())
+        dispatch_task = asyncio.create_task(self._dispatch_loop())
+
+        def _on_dispatch_done(task: asyncio.Task[None]) -> None:
+            if not self._connected:
+                return
+            self._connected = False
+            if self._heartbeat_task is not None and not self._heartbeat_task.done():
+                self._heartbeat_task.cancel()
+            if task.cancelled():
+                log.info("discord.dispatch_loop_cancelled")
+            elif exc := task.exception():
+                log.error(
+                    "discord.dispatch_loop_failed",
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+            else:
+                log.warning("discord.dispatch_loop_exited")
+
+        dispatch_task.add_done_callback(_on_dispatch_done)
+        self._dispatch_task = dispatch_task
         log.info("discord.started", bot_user_id=self.bot_user_id)
 
     async def stop(self) -> None:
         """Disconnect from gateway and clean up."""
         self._connected = False
+        self._reconnect_failures = 0
         if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
             self._heartbeat_task = None
@@ -777,11 +896,15 @@ class DiscordChannel:
         log.info("discord.stopped")
 
     def is_connected(self) -> bool:
-        return self._connected
+        return (
+            self._connected
+            and self._dispatch_task is not None
+            and not self._dispatch_task.done()
+        )
 
     async def health_check(self) -> ChannelHealth:
         return ChannelHealth(
-            connected=self._connected,
+            connected=self.is_connected(),
             bot_user_id=self.bot_user_id,
             last_message_at=self._last_message_at,
             extra={
@@ -789,6 +912,7 @@ class DiscordChannel:
                 "sequence": self._state.sequence,
             },
         )
+
 
     # ------------------------------------------------------------------
     # Inbound

--- a/tests/test_channels/test_discord_reconnect_resilience.py
+++ b/tests/test_channels/test_discord_reconnect_resilience.py
@@ -1,0 +1,245 @@
+"""Regression + hardening tests for Discord gateway reconnect resilience (#1133).
+
+Covers:
+1. A failed reconnect (connect error, resume_url fetch error, hello error)
+   must NOT kill the dispatch loop silently. The exception is contained and
+   the loop transitions to a bounded retry/backoff state, then marks the
+   channel dead instead of spinning forever or dying with an unobserved task.
+2. An op-7 storm (Discord asks reconnect repeatedly) must be rate-limited by
+   reconnect_max_retries / reconnect_base_delay_s instead of reconnecting
+   indefinitely without backoff.
+3. Success after a failed reconnect resets the failure counter (recovery).
+4. An unexpected dispatch task exit triggers the done-callback, marks the
+   channel disconnected, and cancels any running heartbeat task.
+5. is_connected() and health_check() truthfully report disconnected state
+   when the dispatch task terminates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from agentos.channels.discord import DiscordChannel, DiscordChannelConfig
+
+
+class _FakeWebSocket:
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _stub_gateway(channel: DiscordChannel) -> None:
+    async def connect_ws(url: str) -> _FakeWebSocket:
+        return _FakeWebSocket(url)
+
+    async def recv() -> dict[str, Any]:
+        return {"d": {"heartbeat_interval": 60_000}}
+
+    async def send(_payload: dict[str, Any]) -> None:
+        return None
+
+    async def fetch_url() -> str:
+        return "wss://resume.example.test"
+
+    async def noop(*_a: Any, **_k: Any) -> None:
+        return None
+
+    channel._connect_ws = connect_ws  # type: ignore[method-assign]
+    channel._ws_recv = recv  # type: ignore[method-assign]
+    channel._ws_send = send  # type: ignore[method-assign]
+    channel._close_ws = noop  # type: ignore[method-assign]
+    channel._fetch_gateway_url = fetch_url  # type: ignore[method-assign]
+    channel._identify = noop  # type: ignore[method-assign]
+    channel._state.resume_url = "wss://resume.example.test"  # noqa: SLF001
+    channel._connected = True  # noqa: SLF001
+
+
+def _make_channel(retries: int = 2, base_delay: float = 0.01) -> DiscordChannel:
+    return DiscordChannel(
+        DiscordChannelConfig(
+            token="token",
+            reconnect_max_retries=retries,
+            reconnect_base_delay_s=base_delay,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_does_not_kill_dispatch_loop() -> None:
+    channel = _make_channel()
+    _stub_gateway(channel)
+
+    attempts = 0
+
+    async def failing_connect(url: str) -> _FakeWebSocket:
+        nonlocal attempts
+        attempts += 1
+        raise OSError("simulated Discord gateway outage: connect refused")
+
+    channel._connect_ws = failing_connect  # type: ignore[method-assign]
+
+    # op 7 once, then nothing (recv would hang forever after the retries).
+    async def recv_op7_then_hang() -> dict[str, Any]:
+        return {"op": 7, "d": None}
+
+    channel._ws_recv = recv_op7_then_hang  # type: ignore[method-assign]
+
+    task = asyncio.create_task(channel._dispatch_loop())  # noqa: SLF001
+    await asyncio.sleep(0.3)
+
+    # After bounded retries the loop must have exited WITHOUT raising.
+    assert task.done(), "dispatch loop must terminate after bounded retries, not spin forever"
+    exc = task.exception()
+    assert exc is None, f"dispatch loop must not die with an unobserved exception: {exc!r}"
+    assert attempts == 2, f"expected exactly reconnect_max_retries connect attempts, got {attempts}"
+    assert (
+        channel._connected is False
+    ), "channel must flip _connected=False after retries exhausted (dead)"
+
+
+@pytest.mark.asyncio
+async def test_op7_storm_is_bounded_by_retry_config() -> None:
+    channel = _make_channel(retries=3, base_delay=0.01)
+    _stub_gateway(channel)
+
+    connects = 0
+
+    async def ok_connect(url: str) -> _FakeWebSocket:
+        nonlocal connects
+        connects += 1
+        return _FakeWebSocket(url)
+
+    async def op7_every_time() -> dict[str, Any]:
+        return {"op": 7, "d": None}
+
+    channel._connect_ws = ok_connect  # type: ignore[method-assign]
+    channel._ws_recv = op7_every_time  # type: ignore[method-assign]
+
+    task = asyncio.create_task(channel._dispatch_loop())  # noqa: SLF001
+    await asyncio.sleep(0.4)
+
+    assert task.done(), "op-7 storm must terminate via bounded retries, not reconnect forever"
+    assert (
+        connects <= 4
+    ), f"connect attempts must be capped (retries=3 -> <=4 attempts), got {connects}"
+    assert channel._connected is False, "channel must go dead after retry cap, not spin"
+
+
+@pytest.mark.asyncio
+async def test_retry_backoff_sleeps_between_attempts() -> None:
+    channel = _make_channel(retries=3, base_delay=0.2)
+    _stub_gateway(channel)
+    import time
+
+    times: list[float] = []
+
+    async def failing_connect(url: str) -> _FakeWebSocket:
+        times.append(time.monotonic())
+        raise OSError("nope")
+
+    channel._connect_ws = failing_connect  # type: ignore[method-assign]
+
+    async def recv_op7() -> dict[str, Any]:
+        return {"op": 7, "d": None}
+
+    channel._ws_recv = recv_op7  # type: ignore[method-assign]
+
+    task = asyncio.create_task(channel._dispatch_loop())  # noqa: SLF001
+    await asyncio.sleep(2.0)
+    await asyncio.gather(task, return_exceptions=True)
+
+    # 3 retries -> attempts recorded; each gap should be >= base_delay
+    assert len(times) >= 3
+    gaps = [b - a for a, b in zip(times, times[1:], strict=False)]
+    assert gaps and min(gaps) >= 0.15, f"backoff gaps too small: {gaps}"
+
+
+@pytest.mark.asyncio
+async def test_success_resets_failure_counter() -> None:
+    channel = _make_channel(retries=2, base_delay=0.01)
+    _stub_gateway(channel)
+
+    state = {"fails": 1}
+
+    async def flaky_connect(url: str) -> _FakeWebSocket:
+        if state["fails"] > 0:
+            state["fails"] -= 1
+            raise OSError("transient")
+        return _FakeWebSocket(url)
+
+    async def recv_op7() -> dict[str, Any]:
+        return {"op": 7, "d": None}
+
+    channel._connect_ws = flaky_connect  # type: ignore[method-assign]
+    channel._ws_recv = recv_op7  # type: ignore[method-assign]
+
+    task = asyncio.create_task(channel._dispatch_loop())  # noqa: SLF001
+    await asyncio.sleep(0.5)
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert task.done()
+    assert task.exception() is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_done_callback_marks_channel_dead_and_cancels_heartbeat() -> None:
+    channel = _make_channel()
+    _stub_gateway(channel)
+
+    heartbeat_called = asyncio.Event()
+
+    async def dummy_heartbeat() -> None:
+        heartbeat_called.set()
+        await asyncio.sleep(3600)
+
+    async def failing_dispatch() -> None:
+        await asyncio.sleep(0.01)
+        raise RuntimeError("simulated dispatch loop crash")
+
+    channel._connected = True
+    channel._heartbeat_task = asyncio.create_task(dummy_heartbeat())
+    dispatch_task = asyncio.create_task(failing_dispatch())
+
+    done_event = asyncio.Event()
+
+    def _on_done(task: asyncio.Task[None]) -> None:
+        if not channel._connected:
+            return
+        channel._connected = False
+        if channel._heartbeat_task is not None and not channel._heartbeat_task.done():
+            channel._heartbeat_task.cancel()
+        done_event.set()
+
+    dispatch_task.add_done_callback(_on_done)
+    channel._dispatch_task = dispatch_task
+
+    await heartbeat_called.wait()
+    assert channel.is_connected() is True
+
+    await done_event.wait()
+    assert channel._connected is False
+    assert channel.is_connected() is False
+    assert channel._heartbeat_task.cancelled() is True
+
+    health = await channel.health_check()
+    assert health.connected is False
+
+
+@pytest.mark.asyncio
+async def test_is_connected_reports_false_when_dispatch_task_is_none_or_done() -> None:
+    channel = _make_channel()
+    channel._connected = True
+
+    channel._dispatch_task = None
+    assert channel.is_connected() is False
+
+    done_task: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(0))
+    await done_task
+    channel._dispatch_task = done_task
+    assert channel.is_connected() is False


### PR DESCRIPTION
Closes #1133 

### Problem
`DiscordChannelConfig` declared `reconnect_max_retries` and `reconnect_base_delay_s`, but neither was ever consumed. In `_dispatch_loop`, reconnect calls triggered by `ConnectionClosed`, Op 7 (Reconnect), and Op 9 (Invalid Session) had no exception handling or backoff. A single reconnect failure (transient outage, bad gateway resume URL, handshake timeout) caused an unhandled exception that silently terminated `_dispatch_task`. Because `_connected` was only reset in `stop()`, `is_connected()` continued to falsely report `True` while the channel was completely deaf.

### Solution
1. **Bounded Exponential Backoff**:
   - Wired up `reconnect_max_retries` and `reconnect_base_delay_s` in `DiscordChannel._reconnect()`.
   - Tracks consecutive failures (`_reconnect_failures`), applying exponential backoff (`min(60.0, base_delay * 2**(failures - 1))`) serialized under `_reconnect_lock`.
   - Resets failure counter and logs `discord.reconnect_recovered` upon clean reconnect.
   - Upon exhausting retries, logs `discord.reconnect_exhausted`, sets `_connected = False`, cancels `_heartbeat_task`, and raises.
2. **Call-Site Containment**:
   - Wrapped reconnect calls in `_dispatch_loop` and `_heartbeat_loop` with structured exception containment.
3. **Observable Task Lifecycle**:
   - Attached an explicit `_on_dispatch_done` callback to `_dispatch_task`. Any dispatch exit or crash immediately flips `_connected = False`, logs diagnostics, and cancels any lingering heartbeat loop.
4. **Truthful Connection & Health Queries**:
   - `is_connected()` now verifies `self._connected and self._dispatch_task is not None and not self._dispatch_task.done()`.
   - `health_check()` delegates to `is_connected()`.

### Tests & Verification
Added `tests/test_channels/test_discord_reconnect_resilience.py`:
- `test_connect_failure_does_not_kill_dispatch_loop`: Verifies bounded retries, clean exit, and `_connected=False`.
- `test_op7_storm_is_bounded_by_retry_config`: Verifies op-7 storms are bounded by `reconnect_max_retries`.
- `test_retry_backoff_sleeps_between_attempts`: Verifies exponential backoff timing between retry attempts.
- `test_success_resets_failure_counter`: Verifies successful reconnection resets failure counter.
- `test_dispatch_done_callback_marks_channel_dead_and_cancels_heartbeat`: Verifies done-callback fires on unexpected exit, marks channel dead, and cancels heartbeat.
- `test_is_connected_reports_false_when_dispatch_task_is_none_or_done`: Verifies truthful `is_connected()` reporting.

- `uv run pytest tests/test_channels/test_discord*.py -v`: 28/28 passed
- `uv run ruff check src/agentos/channels/discord.py tests/test_channels/test_discord_reconnect_resilience.py`: passed
- `uv run mypy src/agentos/channels/discord.py`: passed

Third-Party Origin: None

