### PR TITLE
fix(channels): use IMAP UID commands instead of sequence numbers in email adapter (#1162)

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -493,7 +493,7 @@ class EmailChannel:
         client = self._imap_connect()
         try:
             client.select(_quote_imap_mailbox(self.config.imap_folder))
-            status, data = client.search(None, "UNSEEN")
+            status, data = client.uid("SEARCH", "UNSEEN")
             if status != "OK":
                 raise RuntimeError(f"IMAP search failed: {status}")
             raw_uids = (data[0] or b"").split()[: max(1, self.config.max_messages_per_poll)]
@@ -522,7 +522,7 @@ class EmailChannel:
     def _fetch_one(self, client: imaplib.IMAP4, uid: str) -> EmailMessage | None:
         """Fetch one message, refusing oversized bodies before downloading them."""
 
-        status, size_data = client.fetch(uid, "(RFC822.SIZE)")
+        status, size_data = client.uid("FETCH", uid, "(RFC822.SIZE)")
         if status == "OK" and size_data:
             declared = _parse_rfc822_size(size_data)
             if declared is not None and declared > self.config.max_message_bytes:
@@ -535,7 +535,7 @@ class EmailChannel:
                 self._mark_seen(client, uid)
                 return None
 
-        status, body_data = client.fetch(uid, "(BODY.PEEK[])")
+        status, body_data = client.uid("FETCH", uid, "(BODY.PEEK[])")
         if status != "OK":
             return None
         raw = _first_literal(body_data)
@@ -558,7 +558,7 @@ class EmailChannel:
         if not self.config.mark_seen:
             return
         with contextlib.suppress(Exception):
-            client.store(uid, "+FLAGS", "\\Seen")
+            client.uid("STORE", uid, "+FLAGS", "\\Seen")
 
     def _reply_target(self, sender: str, reply_to_header: str) -> str:
         """Return the address replies should go to, honouring the allowlist.

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -670,6 +670,19 @@ class _FakeIMAP:
         self.stored.append((uid, command, flags))
         return "OK", [b""]
 
+    def uid(self, command: str, *args: Any) -> tuple[str, list[Any]]:
+        """Dispatch UID-prefixed commands to the underlying methods."""
+        cmd = command.upper()
+        if cmd == "SEARCH":
+            if len(args) == 1:
+                return self.search(None, args[0])
+            return self.search(*args)
+        if cmd == "FETCH":
+            return self.fetch(*args)
+        if cmd == "STORE":
+            return self.store(*args)
+        raise ValueError(f"unsupported UID command: {command}")
+
     def close(self) -> None:
         self.closed = True
 

--- a/tests/test_channels/test_email_imap_uid.py
+++ b/tests/test_channels/test_email_imap_uid.py
@@ -1,0 +1,235 @@
+"""Verify the email adapter polls IMAP via UID commands, not sequence numbers.
+
+IMAP sequence numbers are ephemeral — they renumber when any message in the
+mailbox is expunged by another client (RFC 3501 §2.3.1.2).  Using bare
+``search``/``fetch``/``store`` operates on sequence numbers; the adapter must
+use ``client.uid("SEARCH", ...)`` etc. to reference messages by their stable,
+monotonically-increasing UIDs.
+"""
+
+from __future__ import annotations
+
+import imaplib
+from email.message import EmailMessage
+from email.policy import default as email_policy
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from agentos.channels.email import EmailChannel, EmailChannelConfig
+
+
+def _config(**overrides: Any) -> EmailChannelConfig:
+    base: dict[str, Any] = {
+        "name": "inbox",
+        "imap_host": "imap.example.com",
+        "imap_username": "agent@example.com",
+        "imap_password": "secret",
+        "smtp_host": "smtp.example.com",
+        "smtp_username": "agent@example.com",
+        "smtp_password": "secret",
+        "from_address": "agent@example.com",
+        "from_name": "Agent",
+        "allowed_senders": ["owner@example.com"],
+    }
+    base.update(overrides)
+    return EmailChannelConfig(**base)
+
+
+def _build_rfc822_message(
+    *,
+    sender: str = "owner@example.com",
+    subject: str = "Hello",
+    body: str = "test body",
+    message_id: str = "abc123@example.com",
+) -> bytes:
+    """Return a minimal RFC 822 message as raw bytes."""
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["To"] = "agent@example.com"
+    msg["Subject"] = subject
+    msg["Message-ID"] = f"<{message_id}>"
+    msg.set_content(body)
+    return msg.as_bytes(policy=email_policy)
+
+
+def _make_mock_client(
+    uids: list[bytes],
+    message_bytes: bytes,
+    message_size: int | None = None,
+) -> MagicMock:
+    """Return a mock IMAP4_SSL client that records uid() calls.
+
+    The mock responds to uid("SEARCH", ...), uid("FETCH", ...), and
+    uid("STORE", ...) so that ``_fetch_unseen`` can run end-to-end.
+    """
+    client = MagicMock(spec=imaplib.IMAP4_SSL)
+
+    # select returns OK
+    client.select.return_value = ("OK", [b"1"])
+
+    # uid("SEARCH", "UNSEEN") → list of UIDs
+    uid_line = b" ".join(uids) if uids else b""
+
+    size = message_size or len(message_bytes)
+
+    def _uid_dispatch(command: str, *args: Any) -> tuple[str, list[Any]]:
+        cmd = command.upper()
+        if cmd == "SEARCH":
+            return ("OK", [uid_line])
+        if cmd == "FETCH":
+            uid_val = args[0] if args else b""
+            data_part = args[1] if len(args) > 1 else ""
+            if "RFC822.SIZE" in str(data_part):
+                return (
+                    "OK",
+                    [(f"{uid_val} (RFC822.SIZE {size})".encode(),)],
+                )
+            if "BODY.PEEK" in str(data_part) or "BODY" in str(data_part):
+                return ("OK", [(b"1 (BODY[]", message_bytes), b")"])
+            return ("OK", [])
+        if cmd == "STORE":
+            return ("OK", [])
+        return ("OK", [])
+
+    client.uid.side_effect = _uid_dispatch
+
+    # close and logout should not raise
+    client.close.return_value = ("OK", [])
+    client.logout.return_value = ("BYE", [])
+
+    return client
+
+
+class TestEmailImapUidCommands:
+    """Assert that _fetch_unseen uses client.uid() instead of bare methods."""
+
+    def test_fetch_unseen_uses_uid_search(self) -> None:
+        """client.uid('SEARCH', ...) must be called, not client.search()."""
+        raw = _build_rfc822_message()
+        mock_client = _make_mock_client([b"42"], raw)
+
+        channel = EmailChannel(config=_config())
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            channel._fetch_unseen()
+
+        # uid("SEARCH", ...) must have been called
+        uid_calls = [
+            call for call in mock_client.uid.call_args_list
+            if call[0][0].upper() == "SEARCH"
+        ]
+        assert uid_calls, "Expected client.uid('SEARCH', ...) to be called"
+
+        # bare search() must NOT have been called
+        mock_client.search.assert_not_called()
+
+    def test_fetch_unseen_uses_uid_fetch(self) -> None:
+        """client.uid('FETCH', ...) must be called, not client.fetch()."""
+        raw = _build_rfc822_message()
+        mock_client = _make_mock_client([b"42"], raw)
+
+        channel = EmailChannel(config=_config())
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            channel._fetch_unseen()
+
+        # uid("FETCH", ...) must have been called
+        fetch_calls = [
+            call for call in mock_client.uid.call_args_list
+            if call[0][0].upper() == "FETCH"
+        ]
+        assert fetch_calls, "Expected client.uid('FETCH', ...) to be called"
+
+        # bare fetch() must NOT have been called
+        mock_client.fetch.assert_not_called()
+
+    def test_mark_seen_uses_uid_store(self) -> None:
+        """client.uid('STORE', ...) must be called, not client.store()."""
+        raw = _build_rfc822_message()
+        mock_client = _make_mock_client([b"42"], raw)
+
+        channel = EmailChannel(config=_config(mark_seen=True))
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            channel._fetch_unseen()
+
+        # uid("STORE", ...) must have been called
+        store_calls = [
+            call for call in mock_client.uid.call_args_list
+            if call[0][0].upper() == "STORE"
+        ]
+        assert store_calls, "Expected client.uid('STORE', ...) to be called"
+
+        # bare store() must NOT have been called
+        mock_client.store.assert_not_called()
+
+    def test_fetch_unseen_returns_parsed_message(self) -> None:
+        """The full pipeline should return an IncomingMessage from a UID fetch."""
+        raw = _build_rfc822_message(
+            sender="owner@example.com",
+            subject="Check status",
+            body="What is the status?",
+            message_id="msg-uid-test@example.com",
+        )
+        mock_client = _make_mock_client([b"100"], raw)
+
+        channel = EmailChannel(config=_config())
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            messages = channel._fetch_unseen()
+
+        assert len(messages) == 1
+        msg = messages[0]
+        assert "What is the status?" in msg.content
+        assert msg.sender_id == "owner@example.com"
+
+    def test_empty_unseen_returns_empty_list(self) -> None:
+        """No UNSEEN messages → empty list, no FETCH or STORE calls."""
+        mock_client = _make_mock_client([], b"")
+
+        channel = EmailChannel(config=_config())
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            messages = channel._fetch_unseen()
+
+        assert messages == []
+        fetch_calls = [
+            call for call in mock_client.uid.call_args_list
+            if call[0][0].upper() == "FETCH"
+        ]
+        assert not fetch_calls
+
+    def test_oversized_message_skipped_via_uid(self) -> None:
+        """Oversized messages are skipped, and _mark_seen uses uid('STORE')."""
+        raw = _build_rfc822_message()
+        # Declare a size larger than the limit
+        mock_client = _make_mock_client(
+            [b"99"],
+            raw,
+            message_size=100 * 1024 * 1024,  # 100 MB — exceeds default 25 MB
+        )
+
+        channel = EmailChannel(config=_config())
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            messages = channel._fetch_unseen()
+
+        # The oversized message is skipped
+        assert messages == []
+
+        # The oversized message should still be marked seen via uid("STORE")
+        store_calls = [
+            call for call in mock_client.uid.call_args_list
+            if call[0][0].upper() == "STORE"
+        ]
+        assert store_calls, "Oversized message should be marked seen via uid('STORE')"
+        mock_client.store.assert_not_called()
+
+    def test_mark_seen_disabled_skips_uid_store(self) -> None:
+        """When mark_seen=False, no STORE calls should be made."""
+        raw = _build_rfc822_message()
+        mock_client = _make_mock_client([b"42"], raw)
+
+        channel = EmailChannel(config=_config(mark_seen=False))
+        with patch.object(channel, "_imap_connect", return_value=mock_client):
+            channel._fetch_unseen()
+
+        store_calls = [
+            call for call in mock_client.uid.call_args_list
+            if call[0][0].upper() == "STORE"
+        ]
+        assert not store_calls, "mark_seen=False should skip uid('STORE') calls"


### PR DESCRIPTION
Fixes #1162

### Description

The email channel adapter (`src/agentos/channels/email.py`) used `client.search(...)`, `client.fetch(...)`, and `client.store(...)` during its poll loop. These operate on ephemeral IMAP **sequence numbers**, which shift whenever another IMAP client (webmail, mobile client, or another agent instance) expunges messages in the monitored mailbox (RFC 3501 §2.3.1.2).

As a result, if an expunge occurred during polling:
1. `_fetch_one` could fetch the wrong message content using a shifted sequence number.
2. `_mark_seen` could mark the wrong message as `\Seen`.
3. Oversized messages that are flagged and skipped could cause sequence numbers to shift for remaining messages in the poll batch.

### Changes

- Replaced `client.search(None, "UNSEEN")` with `client.uid("SEARCH", "UNSEEN")` in `_fetch_unseen`.
- Replaced `client.fetch(...)` with `client.uid("FETCH", ...)` in `_fetch_one`.
- Replaced `client.store(...)` with `client.uid("STORE", ...)` in `_mark_seen`.
- Updated `_FakeIMAP` in `test_email_channel.py` with a `uid` dispatcher covering UID commands.
- Added comprehensive test suite `tests/test_channels/test_email_imap_uid.py` verifying that all IMAP interactions use UID-prefixed commands and properly handle fetch, oversized messages, empty inboxes, and seen flags.

### Verification

- `uv run ruff check src/agentos/channels/email.py tests/test_channels/test_email_channel.py tests/test_channels/test_email_imap_uid.py` passes.
- `uv run mypy src/agentos/channels/email.py --show-error-codes` passes.
- `uv run pytest tests/test_channels/test_email_channel.py tests/test_channels/test_email_imap_uid.py -q` passes (88/88 tests).