### PR TITLE
fix(tools): fix apply_patch prepending hunk position calculation for …

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -455,8 +455,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
 
     Returns the new list of lines.
     """
-    # old_start is 1-indexed; convert to 0-indexed
-    pos = hunk.old_start - 1
+    # old_start is 1-indexed (or 0 for prepending/empty files); convert to 0-indexed
+    pos = max(0, hunk.old_start - 1)
     result = list(file_lines)
 
     # Verify context and deleted lines match

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -574,3 +574,47 @@ def test_parse_hunk_header_rejects_malformed_input(header: str) -> None:
 
     with pytest.raises(ValueError, match="Invalid hunk header"):
         _parse_hunk_header(header)
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_prepends_at_line_zero(tmp_path: Path) -> None:
+    target = tmp_path / "document.txt"
+    target.write_text("line1\nline2\nline3\n", encoding="utf-8")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: document.txt
+@@@ -0,0 +1,1 @@@
++header
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert target.read_text(encoding="utf-8") == "header\nline1\nline2\nline3\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_applies_to_empty_file(tmp_path: Path) -> None:
+    target = tmp_path / "empty.txt"
+    target.write_text("", encoding="utf-8")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: empty.txt
+@@@ -0,0 +1,2 @@@
++alpha
++beta
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
+


### PR DESCRIPTION
closes #1166 

### Description

#### Problem
In standard unified diff format, hunks prepending lines at line 0 (or writing into empty files) specify `old_start = 0` (e.g. `@@@ -0,0 +1,1 @@@`). 

Previously, `_apply_hunk` converted this to a 0-indexed position via `pos = hunk.old_start - 1`, which evaluated to `pos = -1`. In Python list slicing, `result[:pos] + new_lines + result[pos + hunk.old_count :]` resolved to `result[:-1] + new_lines + result[-1:]`, inserting the prepended lines right before the last line of the file rather than at line 0, silently corrupting file content.

#### Solution
- Changed position calculation in `_apply_hunk` to `pos = max(0, hunk.old_start - 1)`.
- When `old_start == 0`, `pos` correctly maps to index `0` (the beginning of the file), cleanly prepending new lines.
- Added regression tests covering prepending at line 0 on multi-line files and applying hunks to empty files.

#### Verification
- `uv run pytest tests/test_tools/test_apply_patch_gates.py -q` (34 passed)
- `uv run ruff check src/agentos/tools/builtin/patch.py tests/test_tools/test_apply_patch_gates.py`
- `uv run mypy src/agentos/tools/builtin/patch.py --show-error-codes`