### PR TITLE
fix(gateway): filter asyncio.Task instances in _ChannelInFlightSet.cancel_all

### DIFF
--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -155,7 +155,7 @@ class _ChannelInFlightSet:
 
     def __init__(self, cap: int) -> None:
         self._cap = cap
-        self._tasks: set[asyncio.Task[Any]] = set()
+        self._tasks: set[asyncio.Task[Any] | object] = set()
 
     @property
     def cap(self) -> int:
@@ -178,18 +178,18 @@ class _ChannelInFlightSet:
         runs on a single thread, this check-then-add pair is atomic — no await
         occurs between the guard and the mutation.
         """
-        if len(self._tasks) >= self._cap:  # type: ignore[arg-type]
+        if len(self._tasks) >= self._cap:
             return False
-        self._tasks.add(token)  # type: ignore[arg-type]
+        self._tasks.add(token)
         return True
 
     def release(self, token: object) -> None:
         """Release a reservation previously acquired via try_acquire."""
-        self._tasks.discard(token)  # type: ignore[arg-type]
+        self._tasks.discard(token)
 
     async def cancel_all(self) -> None:
         """Cancel every in-flight task and await completion (for shutdown)."""
-        tasks = list(self._tasks)
+        tasks = [t for t in self._tasks if isinstance(t, asyncio.Task)]
         for t in tasks:
             t.cancel()
         if tasks:

--- a/tests/test_gateway/test_channel_concurrent_dispatch.py
+++ b/tests/test_gateway/test_channel_concurrent_dispatch.py
@@ -296,6 +296,43 @@ async def test_close_cancels_inflight() -> None:
     assert all(t.done() for t in tasks), "all tasks must be done after cancel_all"
 
 
+@pytest.mark.asyncio
+async def test_cancel_all_handles_mixed_tasks_and_reservation_tokens() -> None:
+    """_ChannelInFlightSet.cancel_all() handles both asyncio.Task and bare object reservation
+    tokens without AttributeError.
+    """
+    ifs = _ChannelInFlightSet(cap=8)
+
+    cancelled_tasks: list[str] = []
+
+    async def _worker(label: str) -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled_tasks.append(label)
+            raise
+
+    # Add real tasks
+    t1 = asyncio.create_task(_worker("task1"))
+    t2 = asyncio.create_task(_worker("task2"))
+    ifs.add(t1)
+    ifs.add(t2)
+
+    # Acquire slot with bare object reservation token
+    token = object()
+    assert ifs.try_acquire(token) is True
+    assert ifs.full() is False
+
+    await asyncio.sleep(0)
+
+    # cancel_all should safely cancel real tasks and not crash on token
+    await ifs.cancel_all()
+
+    assert set(cancelled_tasks) == {"task1", "task2"}
+    assert t1.done() and t2.done()
+    assert len(ifs._tasks) == 0
+
+
 # ── typing_keepalive lifecycle bound to reply task ──────────────────────────
 
 


### PR DESCRIPTION
### Summary
`_ChannelInFlightSet._tasks` contains both real `asyncio.Task` instances and bare `object()` reservation tokens from `try_acquire()`. Calling `.cancel()` blindly on all elements in `cancel_all()` caused an `AttributeError` on bare reservation tokens during channel shutdown.

### Changes
- Filter for `isinstance(t, asyncio.Task)` before calling `.cancel()` and gathering in `_ChannelInFlightSet.cancel_all()`.
- Added unit regression test in `test_channel_concurrent_dispatch.py`.
closes #1172 