### PR TITLE
fix(channels): retain Slack interactive approval tasks and drain on s…

### DIFF
--- a/src/agentos/channels/slack.py
+++ b/src/agentos/channels/slack.py
@@ -144,6 +144,9 @@ class SlackChannel:
     )
     _socket_task: asyncio.Task | None = field(default=None, init=False, repr=False)
     _socket_stop: asyncio.Event | None = field(default=None, init=False, repr=False)
+    _interactive_tasks: set[asyncio.Task[Any]] = field(
+        default_factory=set, init=False, repr=False
+    )
     supports_slash_commands: bool = True
 
     @property
@@ -640,11 +643,29 @@ class SlackChannel:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._socket_task
             self._socket_task = None
+        if self._interactive_tasks:
+            pending = list(self._interactive_tasks)
+            for task in pending:
+                task.cancel()
+            for task in pending:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+            self._interactive_tasks.clear()
         if self._client is not None:
             await self._client.aclose()
             self._client = None
         self._connected = False
         log.info("slack.stopped")
+
+    def _spawn_interactive_task(self, payload: dict[str, Any]) -> asyncio.Task[Any]:
+        """Spawn and retain a strong reference to an interactive approval task."""
+        task = asyncio.create_task(
+            self._handle_slack_interactive(payload),
+            name=f"slack-interactive-{id(payload)}",
+        )
+        self._interactive_tasks.add(task)
+        task.add_done_callback(self._interactive_tasks.discard)
+        return task
 
     # ------------------------------------------------------------------
     # Socket Mode transport (no public Request URL required)
@@ -722,7 +743,7 @@ class SlackChannel:
             return
         if mtype == "interactive":
             if isinstance(payload, dict):
-                asyncio.create_task(self._handle_slack_interactive(payload))
+                self._spawn_interactive_task(payload)
             return
         if mtype != "events_api":
             return
@@ -794,7 +815,7 @@ class SlackChannel:
                     payload = json.loads(payload_str)
                 except Exception:
                     return Response(status_code=400)
-                asyncio.create_task(self._handle_slack_interactive(payload))
+                self._spawn_interactive_task(payload)
                 return Response(status_code=200)
             if not self._ingest_slash_command(form):
                 return Response(status_code=400)

--- a/tests/test_channels/test_channel_approvals.py
+++ b/tests/test_channels/test_channel_approvals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 from typing import Any
@@ -533,3 +534,46 @@ async def test_channel_turn_survives_approval_prompt_rendering_failure() -> None
     assert "ls -l" in sent[0].content
     assert "reply_markup" not in sent[0].metadata
     assert "waiting for approval" in sent[-1].content
+
+
+@pytest.mark.asyncio
+async def test_slack_interactive_task_retained_and_cleaned_up() -> None:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C123")
+    proceed = asyncio.Event()
+
+    async def _mock_interactive(_payload: dict[str, Any]) -> None:
+        await proceed.wait()
+
+    channel._handle_slack_interactive = _mock_interactive  # type: ignore[method-assign]
+    payload = {"type": "interactive", "id": 1}
+    task = channel._spawn_interactive_task(payload)
+
+    assert task in channel._interactive_tasks
+    assert len(channel._interactive_tasks) == 1
+
+    proceed.set()
+    await task
+
+    assert task not in channel._interactive_tasks
+    assert len(channel._interactive_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_slack_channel_stop_drains_interactive_tasks() -> None:
+    channel = SlackChannel(token="xoxb-test", slack_channel_id="C123")
+
+    async def _mock_interactive(_payload: dict[str, Any]) -> None:
+        await asyncio.Event().wait()
+
+    channel._handle_slack_interactive = _mock_interactive  # type: ignore[method-assign]
+    task = channel._spawn_interactive_task({"type": "interactive"})
+
+    assert task in channel._interactive_tasks
+    assert not task.done()
+
+    await channel.stop()
+
+    assert task.done()
+    assert task.cancelled()
+    assert len(channel._interactive_tasks) == 0
+


### PR DESCRIPTION
closes #1171 

### Description

#### Problem
When handling Slack interactive payloads (e.g. human button clicks for approvals/denials from Slack UI blocks), `SlackChannel` dispatched `_handle_slack_interactive` via fire-and-forget `asyncio.create_task` with no strong reference retained.

Per Python official `asyncio` documentation, the event loop only keeps weak references to tasks created via `create_task`. An unreferenced task can be garbage collected mid-execution during `await` suspension points (e.g. while making `httpx` calls to update Slack message blocks), silently destroying the task with `Task was destroyed but it is still pending!` and dropping human approval resolutions. Furthermore, on `SlackChannel.stop()`, in-flight interactive tasks were not tracked or drained, leading to abrupt truncation during shutdown.

#### Solution
- Added an internal task set `_interactive_tasks: set[asyncio.Task[Any]]` on `SlackChannel`.
- Implemented `_spawn_interactive_task(payload)`:
  - Spawns named tasks and retains a strong reference in `_interactive_tasks`.
  - Discards completed tasks via `task.add_done_callback(self._interactive_tasks.discard)`.
- Updated call sites in `_handle_message` and `_handle_webhook` to use `_spawn_interactive_task`.
- Updated `SlackChannel.stop()` to cancel and gracefully await all pending interactive tasks before shutting down the HTTP client.
- Added regression tests verifying task retention while in-flight, automatic cleanup on completion, and cancellation/drain on `channel.stop()`.

#### Verification
- `uv run pytest tests/test_channels/test_channel_approvals.py -q` (16 passed)
- `uv run pytest tests/test_channels/test_slack_socket_mode.py tests/test_channels/test_slack_retry.py tests/test_channels/test_slack_signature_bytes.py -q` (40 passed)
- `uv run ruff check src/agentos/channels/slack.py tests/test_channels/test_channel_approvals.py`
- `uv run mypy src/agentos/channels/slack.py --show-error-codes`