### PR TITLE
fix(telegram): bound callback retries and deduplicate redelivery (#1027)

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -117,6 +117,9 @@ class EventDedupeCache:
             self._seen.popitem(last=False)
         return True
 
+    def __contains__(self, event_id: object) -> bool:
+        return event_id in self._seen
+
 
 @dataclass
 class RateLimiter:

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -67,6 +67,7 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
 _DEFAULT_TIMEOUT_S = 30.0
 _POLL_TIMEOUT_HEADROOM_S = 5.0
 _CONNECT_RETRY_DELAYS_S = (0.25, 0.5)
+_MAX_CALLBACK_RETRIES = 3
 #: Transport failures that happen before any request bytes are written, and so
 #: can be retried without risking a duplicate Bot API call.
 _PRE_SEND_CONNECT_ERRORS = (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)
@@ -203,6 +204,7 @@ class TelegramChannel:
     _owns_client: bool = field(default=False, init=False, repr=False)
     _poll_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _update_offset: int | None = field(default=None, init=False, repr=False)
+    _callback_retries: dict[int, int] = field(default_factory=dict, init=False, repr=False)
     _dedupe: EventDedupeCache = field(init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
     _last_message_at: datetime | None = field(default=None, init=False, repr=False)
@@ -640,20 +642,77 @@ class TelegramChannel:
                 if not isinstance(update, dict):
                     continue
                 update_id = update.get("update_id")
-                if isinstance(update_id, int):
-                    self._update_offset = update_id + 1
                 if "callback_query" in update:
+                    cb = update["callback_query"]
+                    cb_id = str(cb.get("id") or "") if isinstance(cb, dict) else ""
+                    dedupe_key = (
+                        f"cb:{cb_id}"
+                        if cb_id
+                        else (f"cb_up:{update_id}" if isinstance(update_id, int) else "")
+                    )
+                    if dedupe_key and dedupe_key in self._dedupe:
+                        log.debug("telegram.callback_duplicate_dropped", key=dedupe_key)
+                        if isinstance(update_id, int):
+                            self._callback_retries.pop(update_id, None)
+                            self._update_offset = update_id + 1
+                        continue
+
                     try:
-                        await self._handle_telegram_callback(update["callback_query"])
+                        await self._handle_telegram_callback(cb)
                     except Exception as exc:
-                        log.warning("telegram.callback_query_handle_failed", error=str(exc))
+                        retries = (
+                            self._callback_retries.get(update_id, 0) + 1
+                            if isinstance(update_id, int)
+                            else 1
+                        )
+                        if isinstance(update_id, int):
+                            self._callback_retries[update_id] = retries
+                        if retries <= _MAX_CALLBACK_RETRIES:
+                            log.warning(
+                                "telegram.callback_query_handle_failed",
+                                update_id=update_id,
+                                attempt=retries,
+                                error=str(exc),
+                            )
+                            await asyncio.sleep(self.config.poll_idle_sleep_s)
+                            break
+                        log.error(
+                            "telegram.callback_query_retries_exhausted",
+                            update_id=update_id,
+                            attempts=retries,
+                            error=str(exc),
+                        )
+                        if isinstance(update_id, int):
+                            self._callback_retries.pop(update_id, None)
+                            self._update_offset = update_id + 1
+                        continue
+
+                    if dedupe_key:
+                        self._dedupe.check_and_add(dedupe_key)
+                    if isinstance(update_id, int):
+                        self._callback_retries.pop(update_id, None)
+                        self._update_offset = update_id + 1
                     continue
+
                 try:
                     msg = self.parse_incoming(update)
                 except ValueError:
                     log.debug("telegram.unsupported_update_ignored", update_id=update_id)
+                    if isinstance(update_id, int):
+                        self._update_offset = update_id + 1
+                    continue
+                except Exception as exc:
+                    log.warning(
+                        "telegram.update_parse_failed",
+                        update_id=update_id,
+                        error=str(exc),
+                    )
+                    if isinstance(update_id, int):
+                        self._update_offset = update_id + 1
                     continue
                 self.enqueue(msg)
+                if isinstance(update_id, int):
+                    self._update_offset = update_id + 1
             if not updates:
                 await asyncio.sleep(self.config.poll_idle_sleep_s)
 
@@ -702,10 +761,19 @@ class TelegramChannel:
         if not isinstance(update, dict):
             return Response(status_code=400)
         if "callback_query" in update:
+            cb = update["callback_query"]
+            cb_id = str(cb.get("id") or "") if isinstance(cb, dict) else ""
+            dedupe_key = f"cb:{cb_id}" if cb_id else ""
+            if dedupe_key and dedupe_key in self._dedupe:
+                log.debug("telegram.callback_duplicate_dropped", key=dedupe_key)
+                return Response(status_code=200)
             try:
-                await self._handle_telegram_callback(update["callback_query"])
+                await self._handle_telegram_callback(cb)
             except Exception as exc:
                 log.warning("telegram.callback_query_handle_failed", error=str(exc))
+            else:
+                if dedupe_key:
+                    self._dedupe.check_and_add(dedupe_key)
             return Response(status_code=200)
         try:
             msg = self.parse_incoming(update)

--- a/tests/test_channels/test_telegram_poll_offset.py
+++ b/tests/test_channels/test_telegram_poll_offset.py
@@ -1,0 +1,264 @@
+"""Regression tests for Telegram polling offset advancement and callback retry (Issue #1027)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+
+def _callback_update(update_id: int = 10, cb_id: str = "cb_1") -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "callback_query": {
+            "id": cb_id,
+            "data": "approve:req_1",
+            "from": {"id": 123, "username": "alice"},
+            "message": {
+                "message_id": 456,
+                "chat": {"id": 123, "type": "private"},
+                "text": "Please approve",
+            },
+        },
+    }
+
+
+def _message_update(update_id: int = 20, message_id: int = 555) -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": message_id,
+            "from": {"id": 123, "username": "alice"},
+            "chat": {"id": 123, "type": "private"},
+            "text": "hello",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_poll_retains_offset_and_retries_failed_callback() -> None:
+    """Callback handling failure retains offset; retry succeeds and advances offset."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token", poll_idle_sleep_s=0.1))
+    attempts = 0
+    poll_payloads: list[dict[str, Any]] = []
+
+    async def _mock_handle_callback(cb: dict[str, Any]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient internal error")
+
+    channel._handle_telegram_callback = _mock_handle_callback  # type: ignore[method-assign]
+
+    async def _mock_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        if method == "getUpdates":
+            poll_payloads.append(dict(payload or {}))
+            if len(poll_payloads) == 1:
+                return [_callback_update(update_id=10, cb_id="cb_1")]
+            if len(poll_payloads) == 2:
+                # Retrying update 10
+                return [_callback_update(update_id=10, cb_id="cb_1")]
+            # After success, subsequent poll
+            raise asyncio.CancelledError()
+        return {}
+
+    channel._api = _mock_api  # type: ignore[method-assign]
+
+    with (
+        patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await channel._poll_loop()
+
+    assert attempts == 2
+    # First poll had no offset. Second poll retried with still no offset past 10.
+    # Third poll sent offset=11 because update 10 succeeded on retry!
+    assert "offset" not in poll_payloads[0]
+    assert "offset" not in poll_payloads[1]
+    assert poll_payloads[2]["offset"] == 11
+    assert channel._update_offset == 11
+
+
+@pytest.mark.asyncio
+async def test_poll_stops_processing_later_updates_when_callback_fails() -> None:
+    """A later update in the same batch must not be processed before the failed update succeeds."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+
+    async def _failing_handle_callback(cb: dict[str, Any]) -> None:
+        raise RuntimeError("dependency unavailable")
+
+    channel._handle_telegram_callback = _failing_handle_callback  # type: ignore[method-assign]
+
+    poll_payloads: list[dict[str, Any]] = []
+
+    async def _mock_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        if method == "getUpdates":
+            poll_payloads.append(dict(payload or {}))
+            if len(poll_payloads) == 1:
+                return [
+                    _callback_update(update_id=10, cb_id="cb_1"),
+                    _message_update(update_id=11, message_id=555),
+                ]
+            raise asyncio.CancelledError()
+        return {}
+
+    channel._api = _mock_api  # type: ignore[method-assign]
+
+    with (
+        patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await channel._poll_loop()
+
+    # The later message update (11) must NOT be enqueued because update 10 failed
+    assert channel._queue.empty()
+    # The offset was not advanced to 11 or 12
+    assert channel._update_offset is None
+    # Next getUpdates call did not advance past update 10
+    assert "offset" not in poll_payloads[1]
+
+
+@pytest.mark.asyncio
+async def test_poll_deduplicates_redelivered_callback_query() -> None:
+    """After successful processing, re-delivery of the same callback query is not double-handled."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    calls = 0
+
+    async def _mock_handle_callback(cb: dict[str, Any]) -> None:
+        nonlocal calls
+        calls += 1
+
+    channel._handle_telegram_callback = _mock_handle_callback  # type: ignore[method-assign]
+
+    poll_count = 0
+
+    async def _mock_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        nonlocal poll_count
+        if method == "getUpdates":
+            poll_count += 1
+            if poll_count == 1:
+                return [_callback_update(update_id=10, cb_id="cb_1")]
+            if poll_count == 2:
+                # Re-delivery of the same callback query
+                return [_callback_update(update_id=10, cb_id="cb_1")]
+            raise asyncio.CancelledError()
+        return {}
+
+    channel._api = _mock_api  # type: ignore[method-assign]
+
+    with (
+        patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await channel._poll_loop()
+
+    # Callback was handled exactly once, despite being returned in both polls
+    assert calls == 1
+    assert channel._update_offset == 11
+
+
+@pytest.mark.asyncio
+async def test_poll_bounds_retries_and_advances_on_permanent_failure() -> None:
+    """A persistently failing callback is retried up to the limit, then advances past it."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    attempts = 0
+    poll_payloads: list[dict[str, Any]] = []
+
+    async def _always_fails(cb: dict[str, Any]) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("permanent corruption")
+
+    channel._handle_telegram_callback = _always_fails  # type: ignore[method-assign]
+
+    async def _mock_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        if method == "getUpdates":
+            poll_payloads.append(dict(payload or {}))
+            if len(poll_payloads) <= 4:
+                return [_callback_update(update_id=10, cb_id="cb_1")]
+            raise asyncio.CancelledError()
+        return {}
+
+    channel._api = _mock_api  # type: ignore[method-assign]
+
+    with (
+        patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await channel._poll_loop()
+
+    # Initial attempt + 3 retries = 4 total attempts
+    assert attempts == 4
+    # On the 4th failure (exhausted), offset advanced to 11
+    assert channel._update_offset == 11
+    assert poll_payloads[-1]["offset"] == 11
+
+
+@pytest.mark.asyncio
+async def test_poll_advances_offset_for_normal_messages_and_unsupported_updates() -> None:
+    """Normal messages and deliberately unsupported updates retain existing offset advancement."""
+    channel = TelegramChannel(TelegramChannelConfig(token="token"))
+    poll_payloads: list[dict[str, Any]] = []
+
+    async def _mock_api(method: str, payload: dict[str, Any] | None = None) -> Any:
+        if method == "getUpdates":
+            poll_payloads.append(dict(payload or {}))
+            if len(poll_payloads) == 1:
+                return [
+                    _message_update(update_id=20, message_id=555),
+                    {"update_id": 21, "inline_query": {"id": "iq1"}},  # unsupported update
+                ]
+            raise asyncio.CancelledError()
+        return {}
+
+    channel._api = _mock_api  # type: ignore[method-assign]
+
+    with (
+        patch("agentos.channels.telegram.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await channel._poll_loop()
+
+    # Message was enqueued
+    assert channel._queue.qsize() == 1
+    # Offset was advanced past both the message (20) and the unsupported update (21)
+    assert channel._update_offset == 22
+    assert poll_payloads[1]["offset"] == 22
+
+
+@pytest.mark.asyncio
+async def test_webhook_deduplicates_callback_query() -> None:
+    """Webhook mode deduplicates repeated callback queries without re-handling."""
+    channel = TelegramChannel(
+        TelegramChannelConfig(
+            token="token",
+            transport="webhook",
+            webhook_secret_token="secret-123",
+        )
+    )
+    calls = 0
+
+    async def _mock_handle_callback(cb: dict[str, Any]) -> None:
+        nonlocal calls
+        calls += 1
+
+    channel._handle_telegram_callback = _mock_handle_callback  # type: ignore[method-assign]
+
+    request = MagicMock(spec=Request)
+    request.headers = {"X-Telegram-Bot-Api-Secret-Token": "secret-123"}
+    request.json = AsyncMock(return_value=_callback_update(update_id=10, cb_id="cb_web_1"))
+
+    # First delivery
+    resp1 = await channel._handle_webhook(request)
+    assert resp1.status_code == 200
+    assert calls == 1
+
+    # Second delivery (duplicate)
+    resp2 = await channel._handle_webhook(request)
+    assert resp2.status_code == 200
+    assert calls == 1  # Not invoked again


### PR DESCRIPTION
Closes #1027

### **Pull Request Description**

#### **Summary**
Defers Telegram polling offset advancement until after an update is successfully processed or deliberately discarded, adds bounded retries with batch-order preservation for transient callback failures, and guards callback paths against duplicate execution.

#### **Root Cause & Impact**
In `TelegramChannel._poll_loop()`, `self._update_offset = update_id + 1` was set before invoking `_handle_telegram_callback()`. When a callback failed due to an unexpected transient error (e.g., database timeout or internal service hiccup), the exception was caught and logged, but the next poll sent the advanced offset. Telegram considered the update acknowledged, permanently dropping the user's approval or denial button press.

#### **Changes Made**
1. **Deferred Offset Advancement ([`src/agentos/channels/telegram.py`](file:///c:/Users/IKE%20CHUKUW%20EZE/.vscode/agent-os/src/agentos/channels/telegram.py))**:
   - Offset is now advanced only after an update is handled or deliberately ignored.
   - If callback handling raises an exception, the offset is retained and processing of later updates in the current batch is halted.
2. **Bounded Retries**:
   - Retries for failing callbacks are bounded to 3 attempts (`_MAX_CALLBACK_RETRIES = 3`).
   - If an update persistently fails across all retries, an error is logged (`telegram.callback_query_retries_exhausted`), retry state is cleared, and the offset advances past the bad update so the poll loop never stalls indefinitely.
3. **Callback Deduplication**:
   - Added `__contains__` to `EventDedupeCache` in [`src/agentos/channels/_util.py`](file:///c:/Users/IKE%20CHUKUW%20EZE/.vscode/agent-os/src/agentos/channels/_util.py).
   - Covered the callback query path with deduplication in both polling and webhook modes to guard against double-handling on re-delivery.
4. **Message & Unsupported Update Compatibility**:
   - Retained immediate acknowledgement behavior for successfully enqueued messages and deliberately unsupported updates (`ValueError`).

#### **Test Coverage ([`tests/test_channels/test_telegram_poll_offset.py`](file:///c:/Users/IKE%20CHUKUW%20EZE/.vscode/agent-os/tests/test_channels/test_telegram_poll_offset.py))**
Added 6 offline unit tests matching the issue's acceptance criteria:
- `test_poll_retains_offset_and_retries_failed_callback`: Verifies offset retention on transient failure and advancement on successful retry.
- `test_poll_stops_processing_later_updates_when_callback_fails`: Verifies updates later in the batch are not handled before the failed update succeeds.
- `test_poll_deduplicates_redelivered_callback_query`: Verifies re-delivered callbacks are not double-handled.
- `test_poll_bounds_retries_and_advances_on_permanent_failure`: Verifies the circuit breaker advances offset after retry exhaustion.
- `test_poll_advances_offset_for_normal_messages_and_unsupported_updates`: Verifies standard messages and unsupported updates advance offset as expected.
- `test_webhook_deduplicates_callback_query`: Verifies webhook callback deduplication.

#### **Verification**
- `pytest tests/test_channels/test_telegram_poll_offset.py -v`: 6 passed
- `pytest tests/test_channels/ -k "telegram" -q`: 92 passed
- `pytest tests/test_channels/ -q`: 414 passed
- `ruff check src tests`: Clean
- `mypy src/agentos/channels/telegram.py src/agentos/channels/_util.py`: Clean (0 errors)

Closes #1027