### PR TITLE
fix(tools): avoid stopping running event loop in browser supervisor _close_async

### DIFF
--- a/src/agentos/tools/browser_supervisor.py
+++ b/src/agentos/tools/browser_supervisor.py
@@ -575,6 +575,7 @@ class _WebSocketTransport:
         if self._loop is not None and self._loop.is_running():
             with contextlib.suppress(Exception):
                 asyncio.run_coroutine_threadsafe(self._close_async(), self._loop).result(timeout=5)
+            self._loop.call_soon_threadsafe(self._loop.stop)
         if self._thread is not None:
             self._thread.join(timeout=5)
 
@@ -688,7 +689,7 @@ class _WebSocketTransport:
             raise RuntimeError("websocket not connected")
         call_id = self._next_id
         self._next_id += 1
-        future: Any = asyncio.get_event_loop().create_future()
+        future: Any = asyncio.get_running_loop().create_future()
         self._pending[call_id] = future
         payload: dict[str, Any] = {"id": call_id, "method": method, "params": params}
         default_session = self._session_id if method != "Target.setAutoAttach" else None
@@ -709,13 +710,9 @@ class _WebSocketTransport:
         return result
 
     async def _close_async(self) -> None:
-        import asyncio
-
         if self._ws is not None:
             with contextlib.suppress(Exception):
                 await self._ws.close()
-        loop = asyncio.get_event_loop()
-        loop.call_soon(loop.stop)
 
 
 __all__ = [

--- a/tests/test_tools/test_browser_supervisor.py
+++ b/tests/test_tools/test_browser_supervisor.py
@@ -6,6 +6,7 @@ Chromium required.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -16,6 +17,7 @@ from agentos.tools.browser_supervisor import (
     DEFAULT_DIALOG_TIMEOUT_S,
     CDPSupervisor,
     SupervisorRegistry,
+    _WebSocketTransport,
     parse_dialog_policy,
 )
 
@@ -348,3 +350,25 @@ class TestDialogWatchdog:
         transport.push_dialog("alert", "hi")
         sup.stop()
         assert sup._watchdogs == {}
+
+
+@pytest.mark.asyncio
+async def test_close_async_does_not_stop_running_event_loop() -> None:
+    """_WebSocketTransport._close_async() must not stop the active asyncio event loop."""
+    transport = _WebSocketTransport("ws://127.0.0.1:9222")
+    loop = asyncio.get_running_loop()
+
+    # Calling _close_async in an async context must execute without stopping the running loop
+    await transport._close_async()
+
+    # Verify loop is still running by yielding and scheduling work
+    called = False
+
+    def _callback() -> None:
+        nonlocal called
+        called = True
+
+    loop.call_soon(_callback)
+    await asyncio.sleep(0.01)
+    assert called is True
+    assert loop.is_running() is True


### PR DESCRIPTION
### Summary
`_WebSocketTransport._close_async()` was calling `loop = asyncio.get_event_loop(); loop.call_soon(loop.stop)`. When `_close_async()` was called from an async context, this stopped the entire ambient asyncio event loop, bringing down the gateway process.

### Changes
- Removed `loop.call_soon(loop.stop)` from `_WebSocketTransport._close_async()`.
- Updated `_WebSocketTransport.stop()` to explicitly stop its dedicated background loop via `self._loop.call_soon_threadsafe(self._loop.stop)`.
- Replaced `asyncio.get_event_loop().create_future()` with `asyncio.get_running_loop().create_future()`.
- Added unit test in `test_browser_supervisor.py` ensuring `_close_async()` leaves the running loop active.
closes #1175 