### PR TITLE
fix(gateway): correct run_kind empty check in _normalize_memory_capture_controls

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -369,7 +369,7 @@ def _normalize_memory_capture_controls(params: dict[str, Any]) -> dict[str, Any]
     return {
         "no_memory_capture": bool(no_memory_capture),
         "input_provenance": input_provenance,
-        "run_kind": str(run_kind) if run_kind is not None and str(run_kind) else None,
+        "run_kind": str(run_kind) if run_kind is not None and run_kind != "" else None,
     }
 
 

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2798,3 +2798,26 @@ class TestSessionsResolve:
         res = await dispatcher.dispatch("r1", "sessions.create", {"agentId": "test"}, ctx)
         assert res.ok is False
         assert res.error.code == "UNAUTHORIZED"
+
+
+class TestNormalizeMemoryCaptureControls:
+    def test_run_kind_none_returns_none(self) -> None:
+        controls = rpc_sessions._normalize_memory_capture_controls({})
+        assert controls["run_kind"] is None
+
+    def test_run_kind_empty_string_returns_none(self) -> None:
+        controls = rpc_sessions._normalize_memory_capture_controls({"run_kind": ""})
+        assert controls["run_kind"] is None
+
+    def test_run_kind_valid_string_preserved(self) -> None:
+        controls = rpc_sessions._normalize_memory_capture_controls({"run_kind": "subagent"})
+        assert controls["run_kind"] == "subagent"
+
+    def test_run_kind_camel_case_and_source_fallback(self) -> None:
+        controls = rpc_sessions._normalize_memory_capture_controls({"_source": {"runKind": "cron"}})
+        assert controls["run_kind"] == "cron"
+
+    def test_run_kind_numeric_zero_preserved_as_string(self) -> None:
+        controls = rpc_sessions._normalize_memory_capture_controls({"run_kind": 0})
+        assert controls["run_kind"] == "0"
+


### PR DESCRIPTION
### Summary
In `_normalize_memory_capture_controls`, `run_kind` was evaluated via `str(run_kind) if run_kind is not None and str(run_kind) else None`, which performed double string conversions and relied on truthiness rather than checking for empty string values.

### Changes
- Updated [`_normalize_memory_capture_controls`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/gateway/rpc_sessions.py#L331-L374) in [`rpc_sessions.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/gateway/rpc_sessions.py) to check `run_kind is not None and run_kind != ""`.
- Added unit tests in `TestNormalizeMemoryCaptureControls` in `test_rpc_sessions.py`.
closes #1178 