### PR TITLE
refactor(compat): extract shared accepts_keyword_arg utility and unify fallback behavior

### DIFF
--- a/src/agentos/compat/__init__.py
+++ b/src/agentos/compat/__init__.py
@@ -1,6 +1,6 @@
 """Compatibility helpers used by runtime-facing modules."""
 
-from . import aiosqlite, pypi_client, version_utils
+from . import aiosqlite, inspect_utils, pypi_client, version_utils
 
-__all__ = ["aiosqlite", "pypi_client", "version_utils"]
+__all__ = ["aiosqlite", "inspect_utils", "pypi_client", "version_utils"]
 

--- a/src/agentos/compat/inspect_utils.py
+++ b/src/agentos/compat/inspect_utils.py
@@ -1,0 +1,26 @@
+"""Introspection and callable signature compatibility helpers."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+
+def accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
+    """Return True when callable accepts keyword argument `name` explicitly or via `**kwargs`.
+
+    Returns False if `callable_obj` is not a callable or if inspect.signature
+    raises TypeError or ValueError.
+    """
+    try:
+        params = inspect.signature(callable_obj).parameters
+    except (TypeError, ValueError):
+        return False
+    if name in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+_accepts_keyword_arg = accepts_keyword_arg
+
+__all__ = ["_accepts_keyword_arg", "accepts_keyword_arg"]

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -35,6 +35,7 @@ from agentos.attachment_refs import (
     transcript_material_path,
 )
 from agentos.bootstrap_types import BootstrapFileReport
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.contracts.attachments import (
     ALLOWED_MEDIA_TYPES as _ALLOWED_ENGINE_MEDIA_TYPES,
 )
@@ -640,14 +641,6 @@ _SAFETY_MODULES: Final[tuple[Any, ...]] = (
 )
 
 log = structlog.get_logger(__name__)
-
-
-def _accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
-    """Return True when callable accepts `name` explicitly or via `**kwargs`."""
-    params = inspect.signature(callable_obj).parameters
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def _strip_context_summary_marker(content: str) -> str:

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -48,6 +48,7 @@ from agentos.channels.artifact_delivery import (
 )
 from agentos.channels.stream_policy import resolve_channel_stream_policy
 from agentos.channels.types import IncomingMessage, OutgoingMessage
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.engine.start_turn import start_turn_via_runtime
 from agentos.engine.types import (
     ArtifactEvent,
@@ -292,16 +293,6 @@ class _DirectiveTagStreamSanitizer:
         pending = self._pending
         self._pending = ""
         return _strip_internal_compaction_markers(_strip_inline_directive_tags(pending))
-
-
-def _accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
-    try:
-        params = inspect.signature(callable_obj).parameters
-    except (TypeError, ValueError):
-        return False
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 @contextlib.asynccontextmanager

--- a/src/agentos/gateway/context_overflow.py
+++ b/src/agentos/gateway/context_overflow.py
@@ -23,12 +23,12 @@ The three policies:
 
 from __future__ import annotations
 
-import inspect
 from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
 
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.gateway.config import ContextOverflowPolicy, GatewayConfig
 from agentos.session.compaction import (
@@ -52,19 +52,6 @@ from agentos.session.context_view import build_compaction_context_records
 from agentos.session.tokenizer import estimate_tokens
 
 log = structlog.get_logger(__name__)
-
-
-def _accepts_keyword_arg(func: Any, name: str) -> bool:
-    try:
-        signature = inspect.signature(func)
-    except (TypeError, ValueError):
-        return False
-    if name in signature.parameters:
-        return True
-    return any(
-        param.kind is inspect.Parameter.VAR_KEYWORD
-        for param in signature.parameters.values()
-    )
 
 
 @dataclass

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import time
 import uuid
 from dataclasses import asdict, replace
@@ -11,6 +10,7 @@ from typing import Any, cast
 
 import structlog
 
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.engine.start_turn import start_turn_via_runtime
 from agentos.gateway import attachment_ingest as _attachment_ingest
@@ -60,16 +60,6 @@ _MAX_STAGED_PDF_BYTES = _attachment_ingest.MAX_STAGED_PDF_BYTES
 _MAX_TEXT_ATTACHMENT_BYTES = _attachment_ingest.TEXT_ATTACHMENT_BYTES
 _MAX_TOTAL_ATTACHMENT_BYTES = _attachment_ingest.MAX_TOTAL_ATTACHMENT_BYTES
 _MAX_ATTACHMENTS = _attachment_ingest.MAX_ATTACHMENTS
-
-
-def _accepts_keyword_arg(func: Any, name: str) -> bool:
-    try:
-        params = inspect.signature(func).parameters
-    except (TypeError, ValueError):
-        return True
-    return name in params or any(
-        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
-    )
 
 
 def _clean_cancel_source(value: Any, default: str) -> str:

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -36,6 +36,7 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("cli", "tools"),
     ("engine", "agents"),
     ("engine", "channels"),
+    ("engine", "compat"),
     ("engine", "contracts"),
     ("engine", "gateway"),
     ("engine", "identity"),

--- a/tests/test_compat_inspect_utils.py
+++ b/tests/test_compat_inspect_utils.py
@@ -1,0 +1,55 @@
+"""Unit tests for agentos.compat.inspect_utils."""
+
+from __future__ import annotations
+
+from agentos.compat.inspect_utils import _accepts_keyword_arg, accepts_keyword_arg
+
+
+def test_accepts_keyword_arg_explicit_arg() -> None:
+    def fn(a: int, b: str, target: bool = False) -> None:
+        pass
+
+    assert accepts_keyword_arg(fn, "target") is True
+    assert accepts_keyword_arg(fn, "a") is True
+    assert accepts_keyword_arg(fn, "missing") is False
+
+
+def test_accepts_keyword_arg_kwargs() -> None:
+    def fn_var(a: int, **kwargs: object) -> None:
+        pass
+
+    assert accepts_keyword_arg(fn_var, "any_name") is True
+    assert accepts_keyword_arg(fn_var, "target") is True
+
+
+def test_accepts_keyword_arg_keyword_only() -> None:
+    def fn_kwonly(*, target: str) -> None:
+        pass
+
+    assert accepts_keyword_arg(fn_kwonly, "target") is True
+    assert accepts_keyword_arg(fn_kwonly, "other") is False
+
+
+def test_accepts_keyword_arg_non_callable_returns_false() -> None:
+    assert accepts_keyword_arg(None, "target") is False
+    assert accepts_keyword_arg(123, "target") is False
+    assert accepts_keyword_arg("string", "target") is False
+    assert accepts_keyword_arg({}, "target") is False
+
+
+def test_accepts_keyword_arg_class_and_method() -> None:
+    class MyHandler:
+        def handle(self, message: str, *, flush_receipt_status: bool = False) -> None:
+            pass
+
+    handler = MyHandler()
+    assert accepts_keyword_arg(handler.handle, "flush_receipt_status") is True
+    assert accepts_keyword_arg(handler.handle, "unknown") is False
+
+
+def test_accepts_keyword_arg_private_alias() -> None:
+    def sample(token: str) -> None:
+        pass
+
+    assert _accepts_keyword_arg(sample, "token") is True
+    assert _accepts_keyword_arg(sample, "other") is False


### PR DESCRIPTION
### Summary
The `_accepts_keyword_arg` helper was copy-pasted across 4 different modules with divergent exception-fallback behaviors (e.g. `rpc_sessions.py` returning `True` on `TypeError`/`ValueError`, `engine/runtime.py` unhandled, others returning `False`).

### Changes
- Created [`agentos.compat.inspect_utils`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/compat/inspect_utils.py) exporting canonical `accepts_keyword_arg` (and `_accepts_keyword_arg` alias) with consistent `(TypeError, ValueError) -> False` handling.
- Replaced all 4 duplicate definitions in `rpc_sessions.py`, `channel_dispatch.py`, `context_overflow.py`, and `engine/runtime.py` with imports from the shared module.
- Added full unit test coverage in [`tests/test_compat_inspect_utils.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_compat_inspect_utils.py).
closes #1181 