### PR TITLE
[Bug]: Duplicated compaction provider resolution helpers in rpc_chat.py and rpc_sessions.py create drift risk

### DIFF
--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -14,7 +14,11 @@ from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
 from agentos.gateway.config import GatewayConfig
 from agentos.gateway.context_overflow import apply_context_overflow_policy
 from agentos.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
-from agentos.session.compaction import build_compaction_config_from_provider
+from agentos.session.compaction import (
+    _effective_compaction_model,
+    _resolve_compaction_provider,
+    build_compaction_config_from_provider,
+)
 from agentos.session.keys import build_webchat_key, canonicalize_session_key, parse_agent_id
 
 _d = get_dispatcher()
@@ -225,43 +229,6 @@ async def _chat_history_summaries(
     except Exception:  # noqa: BLE001 - summaries are optional display metadata
         return []
     return [_session_summary_to_chat_payload(summary) for summary in summaries or []]
-
-
-def _effective_compaction_model(session: object | None) -> str | None:
-    if session is None:
-        return None
-    return getattr(session, "model_override", None) or getattr(session, "model", None)
-
-
-def _resolve_compaction_provider(ctx: RpcContext, session: object | None) -> object | None:
-    selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
-        return None
-
-    resolved_selector = selector
-    clone = getattr(selector, "clone", None)
-    if callable(clone):
-        try:
-            resolved_selector = clone()
-        except Exception:  # noqa: BLE001
-            resolved_selector = selector
-
-    model = _effective_compaction_model(session)
-    if model and resolved_selector is not selector:
-        override = getattr(resolved_selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model)
-            except Exception:  # noqa: BLE001
-                pass
-
-    resolver = getattr(resolved_selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return cast(object | None, resolver())
-    except Exception:  # noqa: BLE001
-        return None
 
 
 async def _build_context_overflow_compaction_config(ctx: RpcContext, session_key: str):

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -32,6 +32,8 @@ from agentos.gateway.session_services import (
 from agentos.gateway.session_streams import get_session_streams
 from agentos.paths import media_root_from_config
 from agentos.session.compaction import (
+    _effective_compaction_model,
+    _resolve_compaction_provider,
     build_compaction_config_from_provider,
     call_compact_with_optional_config,
 )
@@ -412,43 +414,6 @@ def _context_window_tokens(params: dict | None, ctx: RpcContext) -> int:
     if value <= 0:
         raise ValueError("contextWindowTokens must be a positive integer")
     return value
-
-
-def _effective_compaction_model(session: Any | None) -> str | None:
-    if session is None:
-        return None
-    return getattr(session, "model_override", None) or getattr(session, "model", None)
-
-
-def _resolve_compaction_provider(ctx: RpcContext, session: Any | None) -> Any | None:
-    selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
-        return None
-
-    resolved_selector = selector
-    clone = getattr(selector, "clone", None)
-    if callable(clone):
-        try:
-            resolved_selector = clone()
-        except Exception:  # noqa: BLE001
-            resolved_selector = selector
-
-    model = _effective_compaction_model(session)
-    if model and resolved_selector is not selector:
-        override = getattr(resolved_selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model)
-            except Exception:  # noqa: BLE001
-                pass
-
-    resolver = getattr(resolved_selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return resolver()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 def _enum_value(value: Any) -> Any:

--- a/src/agentos/session/compaction.py
+++ b/src/agentos/session/compaction.py
@@ -107,6 +107,49 @@ def build_compaction_config_from_provider(
     return cfg
 
 
+def effective_compaction_model(session: object | None) -> str | None:
+    """Return the effective model for compaction from a session instance."""
+    if session is None:
+        return None
+    return getattr(session, "model_override", None) or getattr(session, "model", None)
+
+
+def resolve_compaction_provider(ctx: Any, session: object | None) -> Any | None:
+    """Resolve a provider from context with model override applied for compaction."""
+    selector = getattr(ctx, "provider_selector", None)
+    if selector is None:
+        return None
+
+    resolved_selector = selector
+    clone = getattr(selector, "clone", None)
+    if callable(clone):
+        try:
+            resolved_selector = clone()
+        except Exception:  # noqa: BLE001
+            resolved_selector = selector
+
+    model = effective_compaction_model(session)
+    if model and resolved_selector is not selector:
+        override = getattr(resolved_selector, "override_model", None)
+        if callable(override):
+            try:
+                override(model)
+            except Exception:  # noqa: BLE001
+                pass
+
+    resolver = getattr(resolved_selector, "resolve", None)
+    if not callable(resolver):
+        return None
+    try:
+        return resolver()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+_effective_compaction_model = effective_compaction_model
+_resolve_compaction_provider = resolve_compaction_provider
+
+
 def compact_accepts_config(compact_fn: Any) -> bool:
     """Return whether a compact callable can accept the optional config arg."""
 

--- a/tests/test_session/test_compaction.py
+++ b/tests/test_session/test_compaction.py
@@ -367,3 +367,61 @@ async def test_custom_instructions_are_user_scoped_and_identifier_policy_stays_s
     assert "Focus on deployment decisions." not in messages[0]["content"]
     assert messages[1]["role"] == "user"
     assert "Focus on deployment decisions." in messages[1]["content"]
+
+
+def test_effective_compaction_model() -> None:
+    from agentos.session.compaction import effective_compaction_model
+
+    assert effective_compaction_model(None) is None
+
+    class FakeSession:
+        def __init__(self, model: str | None = None, model_override: str | None = None) -> None:
+            self.model = model
+            self.model_override = model_override
+
+    assert effective_compaction_model(FakeSession(model="claude-3-5-sonnet")) == "claude-3-5-sonnet"
+    assert (
+        effective_compaction_model(
+            FakeSession(model="claude-3-5-sonnet", model_override="gpt-4o")
+        )
+        == "gpt-4o"
+    )
+
+
+def test_resolve_compaction_provider() -> None:
+    from types import SimpleNamespace
+
+    from agentos.session.compaction import resolve_compaction_provider
+
+    # No selector on context
+    ctx = SimpleNamespace(provider_selector=None)
+    assert resolve_compaction_provider(ctx, None) is None
+
+    # Selector with clone and override_model
+    class FakeProvider:
+        def __init__(self, model: str) -> None:
+            self.model = model
+
+    class FakeSelector:
+        def __init__(self, model: str = "default-model") -> None:
+            self.model = model
+
+        def clone(self) -> "FakeSelector":
+            return FakeSelector(self.model)
+
+        def override_model(self, model: str) -> None:
+            self.model = model
+
+        def resolve(self) -> FakeProvider:
+            return FakeProvider(self.model)
+
+    selector = FakeSelector()
+    ctx = SimpleNamespace(provider_selector=selector)
+    session = SimpleNamespace(model=None, model_override="custom-override")
+
+    provider = resolve_compaction_provider(ctx, session)
+    assert provider is not None
+    assert provider.model == "custom-override"
+    # Original selector should remain unmodified
+    assert selector.model == "default-model"
+


### PR DESCRIPTION
### Describe the bug
`_effective_compaction_model` and `_resolve_compaction_provider` are duplicated between `src/agentos/gateway/rpc_chat.py` (lines 230, 236) and `src/agentos/gateway/rpc_sessions.py` (lines 417, 423). If one RPC surface is updated with new provider or override behavior, the other will silently drift.

### Location
- `src/agentos/gateway/rpc_chat.py`
- `src/agentos/gateway/rpc_sessions.py`

### Expected Behavior
Both RPC endpoints should share a single canonical provider/model resolution helper located in `agentos.session.compaction`.

### Proposed Fix
Extract `effective_compaction_model` and `resolve_compaction_provider` to `agentos.session.compaction` and import them in `rpc_chat.py` and `rpc_sessions.py`.
closes #1183 