### PR TITLE
fix(cli): use platform-aware quoting for onboarding command hints (#1180)

### DIFF
--- a/src/agentos/cli/doctor_cmd.py
+++ b/src/agentos/cli/doctor_cmd.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import os
-import shlex
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -19,15 +18,11 @@ from agentos.cli.output import print_json
 from agentos.cli.url_utils import normalize_gateway_url
 from agentos.health.model import FixStep, HealthFinding, build_report
 from agentos.health.recovery_commands import command_with_config as _command_with_config
+from agentos.onboarding.next_steps import _config_cli_arg as _config_option
+from agentos.onboarding.next_steps import quote_cli_arg
 
 _LOCAL_GATEWAY_HOSTS = {"127.0.0.1", "::1", "localhost", "0.0.0.0"}
 _API_KEY_PLACEHOLDER = "YOUR_API_KEY"
-
-
-def _config_option(config_path: str | Path | None) -> str:
-    if config_path is None:
-        return ""
-    return f" --config {shlex.quote(str(config_path))}"
 
 
 def _onboard_status_command(config_path: str | Path | None) -> str:
@@ -48,7 +43,7 @@ def _gateway_commands(
     host = parsed.hostname or "127.0.0.1"
     port = parsed.port or (443 if parsed.scheme == "wss" else 18791)
     if host not in _LOCAL_GATEWAY_HOSTS:
-        remote_target = shlex.quote(gateway_url)
+        remote_target = quote_cli_arg(gateway_url)
         return [
             {
                 "label": "Inspect remote gateway",

--- a/src/agentos/cli/onboard_cmd.py
+++ b/src/agentos/cli/onboard_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json as _json
-import shlex
 import tomllib
 from pathlib import Path
 
@@ -29,6 +28,7 @@ from agentos.onboarding.flow import (
     run_noninteractive_provider_configure,
 )
 from agentos.onboarding.next_steps import (
+    _config_cli_arg,
     env_recovery_commands,
     env_reference_warnings,
     format_next_steps,
@@ -224,12 +224,6 @@ def _status_cockpit_summary(status: OnboardingStatus) -> str:
         f"Blocking setup: {_format_section_names(status, blocking)}"
         f" · Optional later: {_format_section_names(status, optional_later)}"
     )
-
-
-def _config_cli_arg(config_path: Path | None) -> str:
-    if config_path is None:
-        return ""
-    return f" --config {shlex.quote(str(config_path))}"
 
 
 def _headless_section_paths(

--- a/src/agentos/health/recovery_commands.py
+++ b/src/agentos/health/recovery_commands.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import shlex
 from pathlib import Path
+
+from agentos.onboarding.next_steps import _config_cli_arg
 
 CONFIG_AWARE_COMMAND_PREFIXES = (
     "agentos gateway restart",
@@ -36,4 +37,4 @@ def supports_config_option(command: str) -> bool:
 def command_with_config(command: str, config_path: str | Path | None) -> str:
     if not config_path or " --config " in command or not supports_config_option(command):
         return command
-    return f"{command} --config {shlex.quote(str(config_path))}"
+    return f"{command}{_config_cli_arg(config_path)}"

--- a/src/agentos/onboarding/flow.py
+++ b/src/agentos/onboarding/flow.py
@@ -6,7 +6,6 @@ import importlib
 import importlib.util
 import os
 import re
-import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -44,6 +43,7 @@ from agentos.onboarding.mutations import (
     upsert_search_provider,
 )
 from agentos.onboarding.next_steps import (
+    _config_cli_arg,
     headless_setup_command,
     headless_setup_commands,
     setup_catalog_command,
@@ -200,12 +200,6 @@ def run_noninteractive_search_configure(
         diagnostics=bool(values.get("diagnostics", False)),
     )
     return persist_config(result.config, path=path, restart_required=False)
-
-
-def _config_cli_arg(config_path: str | Path | None) -> str:
-    if config_path is None:
-        return ""
-    return f" --config {shlex.quote(str(config_path))}"
 
 
 def _first_blocking_setup_section(cfg: Any) -> str:

--- a/src/agentos/onboarding/next_steps.py
+++ b/src/agentos/onboarding/next_steps.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import platform
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -164,10 +165,23 @@ def _missing_env_warning(surface: str, env_key: str) -> str:
     )
 
 
+def quote_cli_arg(value: str | Path) -> str:
+    """Return a shell-quoted token appropriate for the current platform.
+
+    On Windows, uses ``subprocess.list2cmdline`` to generate double-quoted
+    arguments compatible with ``cmd.exe`` and PowerShell. On POSIX systems,
+    delegates to ``shlex.quote``.
+    """
+    text = str(value)
+    if platform.system().lower().startswith("win"):
+        return subprocess.list2cmdline([text])
+    return shlex.quote(text)
+
+
 def _config_cli_arg(config_path: str | Path | None) -> str:
     if not config_path:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return f" --config {quote_cli_arg(config_path)}"
 
 
 def _image_generation_provider_id(config: Any) -> str:

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import json
-import shlex
 from typing import Any
 
 from typer.testing import CliRunner
 
 from agentos.cli.main import app
+from agentos.onboarding.next_steps import quote_cli_arg
 
 runner = CliRunner()
 
 
 def _config_arg(path: Any) -> str:
-    return shlex.quote(str(path))
+    return quote_cli_arg(path)
 
 
 class _FakeGatewayClient:
@@ -34,8 +34,7 @@ class _FakeGatewayClient:
                     {
                         "label": "Configure provider",
                         "command": (
-                            "agentos providers configure openrouter "
-                            "--api-key YOUR_API_KEY"
+                            "agentos providers configure openrouter --api-key YOUR_API_KEY"
                         ),
                     }
                 ],
@@ -143,9 +142,7 @@ def test_doctor_config_derived_gateway_recovery_preserves_config_target(
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
     finding = next(
-        finding
-        for finding in payload["findings"]
-        if finding["id"] == "gateway.unavailable"
+        finding for finding in payload["findings"] if finding["id"] == "gateway.unavailable"
     )
     commands = [step["command"] for step in finding["fixSteps"] if "command" in step]
     assert commands[:2] == [
@@ -308,9 +305,7 @@ def test_doctor_bad_config_reports_config_recovery(tmp_path, monkeypatch) -> Non
     assert _FakeGatewayClient.calls == []
 
 
-def test_doctor_bad_gateway_config_env_reports_config_recovery(
-    tmp_path, monkeypatch
-) -> None:
+def test_doctor_bad_gateway_config_env_reports_config_recovery(tmp_path, monkeypatch) -> None:
     _FakeGatewayClient.calls = []
     target = tmp_path / "broken-env.toml"
     target.write_text("[llm\n", encoding="utf-8")
@@ -322,17 +317,13 @@ def test_doctor_bad_gateway_config_env_reports_config_recovery(
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
     config_finding = next(
-        finding
-        for finding in payload["findings"]
-        if finding["id"] == "config.local.unreadable"
+        finding for finding in payload["findings"] if finding["id"] == "config.local.unreadable"
     )
     assert config_finding["evidence"]["configPath"] == str(target)
     assert _FakeGatewayClient.calls == []
 
 
-def test_doctor_explicit_gateway_context_ignores_env_config_path(
-    tmp_path, monkeypatch
-) -> None:
+def test_doctor_explicit_gateway_context_ignores_env_config_path(tmp_path, monkeypatch) -> None:
     _ReadyGatewayClient.calls = []
     target = tmp_path / "env.toml"
     target.write_text('host = "127.0.0.1"\nport = 20004\n', encoding="utf-8")
@@ -452,19 +443,14 @@ def test_doctor_config_reports_running_gateway_config_mismatch(
     assert payload["requestedConfigPath"] == str(requested)
     assert payload["configPath"] == str(running)
     finding = next(
-        finding
-        for finding in payload["findings"]
-        if finding["id"] == "gateway.config.mismatch"
+        finding for finding in payload["findings"] if finding["id"] == "gateway.config.mismatch"
     )
     assert finding["readinessImpact"] == "blocks_ready"
     assert finding["evidence"]["requestedConfigPath"] == str(requested)
     assert finding["evidence"]["runningConfigPath"] == str(running)
     commands = [step["command"] for step in finding["fixSteps"] if "command" in step]
     assert f"agentos gateway restart --config {_config_arg(requested)}" in commands
-    assert (
-        f"agentos gateway status --json --config {_config_arg(requested)}"
-        in commands
-    )
+    assert f"agentos gateway status --json --config {_config_arg(requested)}" in commands
 
 
 def test_doctor_config_mismatch_prioritizes_requested_gateway_recovery(
@@ -532,9 +518,7 @@ def test_doctor_config_mismatch_keeps_running_findings_scoped_to_running_config(
         f"--config {_config_arg(running)}"
     ]
     mismatch_finding = next(
-        finding
-        for finding in payload["findings"]
-        if finding["id"] == "gateway.config.mismatch"
+        finding for finding in payload["findings"] if finding["id"] == "gateway.config.mismatch"
     )
     mismatch_commands = [
         step["command"] for step in mismatch_finding["fixSteps"] if "command" in step
@@ -918,16 +902,13 @@ def test_doctor_gateway_unavailable_uses_requested_config_path(
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
     gateway_finding = next(
-        finding
-        for finding in payload["findings"]
-        if finding["id"] == "gateway.unavailable"
+        finding for finding in payload["findings"] if finding["id"] == "gateway.unavailable"
     )
     gateway_commands = [
         step["command"] for step in gateway_finding["fixSteps"] if "command" in step
     ]
     assert gateway_commands[:2] == [
-        "agentos gateway start --bind 127.0.0.1 --port 19999 "
-        f"--config {_config_arg(target)}",
+        f"agentos gateway start --bind 127.0.0.1 --port 19999 --config {_config_arg(target)}",
         (
             "agentos gateway status --bind 127.0.0.1 --port 19999 "
             f"--json --config {_config_arg(target)}"
@@ -996,9 +977,7 @@ def test_doctor_gateway_unavailable_does_not_start_remote_gateway(monkeypatch) -
     assert finding["evidence"]["gatewayUrl"] == "wss://cap.example.com/ws"
     commands = [step["command"] for step in finding["fixSteps"] if "command" in step]
     assert all("gateway start" not in command for command in commands)
-    assert commands[0] == (
-        "agentos gateway status --gateway wss://cap.example.com/ws --json"
-    )
+    assert commands[0] == ("agentos gateway status --gateway wss://cap.example.com/ws --json")
     details = [step.get("detail", "") for step in finding["fixSteps"]]
     assert any("remote" in detail.lower() for detail in details)
 
@@ -1085,10 +1064,7 @@ def test_local_config_findings_explain_missing_llm_env(monkeypatch) -> None:
     assert finding.readiness_impact == "blocks_ready"
     assert finding.evidence["sections"]["llm"] == "degraded"
     assert "CUSTOM_LLM_KEY" in finding.detail
-    assert any(
-        step.detail and "CUSTOM_LLM_KEY" in step.detail
-        for step in finding.fix_steps
-    )
+    assert any(step.detail and "CUSTOM_LLM_KEY" in step.detail for step in finding.fix_steps)
     assert [step.command for step in finding.fix_steps if step.command][-2:] == [
         "agentos onboard status --json",
         "agentos onboard --if-needed",

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import json as _json
 import platform
 import re
-import shlex
 import tomllib
 
 import pytest
 from typer.testing import CliRunner
 
 from agentos.cli.main import app
+from agentos.onboarding.next_steps import quote_cli_arg
 
 runner = CliRunner()
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -32,7 +32,11 @@ def _env_hint(env_key: str) -> str:
 
 
 def _config_arg(path) -> str:
-    return shlex.quote(str(path))
+    return quote_cli_arg(path)
+
+
+def _compact_arg(path) -> str:
+    return "".join(_config_arg(path).split())
 
 
 def test_onboard_noninteractive_provider(tmp_path, monkeypatch):
@@ -42,10 +46,14 @@ def test_onboard_noninteractive_provider(tmp_path, monkeypatch):
         app,
         [
             "onboard",
-            "--provider", "openrouter",
-            "--model", "deepseek/deepseek-v4-flash",
-            "--api-key", "sk",
-            "--skip-channels", "--skip-search",
+            "--provider",
+            "openrouter",
+            "--model",
+            "deepseek/deepseek-v4-flash",
+            "--api-key",
+            "sk",
+            "--skip-channels",
+            "--skip-search",
         ],
     )
     assert result.exit_code == 0, result.stdout
@@ -88,10 +96,7 @@ def test_onboard_finish_commands_remain_copyable_with_long_config_path(
     assert result.exit_code == 0, result.stdout
     assert f"agentos gateway run --config {_config_arg(target)}" in result.stdout
     assert f"agentos gateway start --json --config {_config_arg(target)}" in result.stdout
-    assert (
-        f"agentos gateway restart --json --config {_config_arg(target)}"
-        in result.stdout
-    )
+    assert f"agentos gateway restart --json --config {_config_arg(target)}" in result.stdout
 
 
 def test_onboard_status_paths_remain_copyable_with_long_config_path(
@@ -107,14 +112,12 @@ def test_onboard_status_paths_remain_copyable_with_long_config_path(
 
     assert result.exit_code == 0, result.stdout
     assert (
-        f"Guided CLI: agentos onboard --if-needed --config {_config_arg(target)}"
-        in result.stdout
+        f"Guided CLI: agentos onboard --if-needed --config {_config_arg(target)}" in result.stdout
     )
     assert f"Web UI: agentos gateway run --config {_config_arg(target)}" in result.stdout
     assert (
         "Provider recipes: "
-        f"agentos onboard catalog providers --config {_config_arg(target)}"
-        in result.stdout
+        f"agentos onboard catalog providers --config {_config_arg(target)}" in result.stdout
     )
 
 
@@ -287,9 +290,14 @@ def test_onboard_if_needed_skips_when_configured(tmp_path, monkeypatch):
         app,
         [
             "onboard",
-            "--provider", "openrouter",
-            "--model", "x", "--api-key", "k",
-            "--skip-channels", "--skip-search",
+            "--provider",
+            "openrouter",
+            "--model",
+            "x",
+            "--api-key",
+            "k",
+            "--skip-channels",
+            "--skip-search",
         ],
     )
     mtime_before = target.stat().st_mtime
@@ -306,7 +314,7 @@ def test_onboard_if_needed_uses_explicit_config_path(tmp_path, monkeypatch):
     default_target = tmp_path / "default.toml"
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -320,14 +328,14 @@ def test_onboard_if_needed_uses_explicit_config_path(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "core setup is ready" in result.stdout.lower()
     assert "Optional next moves:" in result.stdout
-    assert f"--config{_config_arg(target)}" in "".join(result.stdout.split())
+    assert f"--config{_compact_arg(target)}" in "".join(result.stdout.split())
     assert not default_target.exists()
 
 
 def test_onboard_if_needed_skips_when_key_comes_from_env(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "OPENROUTER_API_KEY"\n',
@@ -362,9 +370,7 @@ def test_onboard_if_needed_does_not_treat_env_as_config_without_config_file(
 def test_onboard_if_needed_requires_config_to_reference_env_key(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     target.write_text(
-        '[llm]\n'
-        'provider = "openrouter"\n'
-        'model = "deepseek/deepseek-v4-flash"\n',
+        '[llm]\nprovider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash"\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-from-env")
@@ -383,9 +389,7 @@ def test_onboard_if_needed_does_not_accept_settings_env_without_config_reference
 ):
     target = tmp_path / "c.toml"
     target.write_text(
-        '[llm]\n'
-        'provider = "openrouter"\n'
-        'model = "deepseek/deepseek-v4-flash"\n',
+        '[llm]\nprovider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash"\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("AGENTOS_LLM_API_KEY", "sk-from-settings-env")
@@ -420,7 +424,7 @@ def test_onboard_if_needed_requires_referenced_env_even_with_settings_env(
 ):
     target = tmp_path / "c.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "OPENROUTER_API_KEY"\n',
@@ -441,7 +445,7 @@ def test_onboard_status_uses_explicit_config_path(tmp_path, monkeypatch):
     default_target = tmp_path / "default.toml"
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -462,7 +466,7 @@ def test_onboard_status_uses_explicit_config_path(tmp_path, monkeypatch):
 def test_onboard_status_json_exposes_provider_section_alias(tmp_path, monkeypatch):
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -498,9 +502,8 @@ def test_onboard_status_reports_invalid_config_without_traceback(tmp_path):
     assert _compact_text(str(target)) in _compact_text(result.stderr)
     assert "search" in result.stderr
     assert "Fix:" in result.stderr
-    assert (
-        f"agentosonboard--if-needed--config{_config_arg(target)}"
-        in "".join(result.stderr.split())
+    assert f"agentosonboard--if-needed--config{_compact_arg(target)}" in "".join(
+        result.stderr.split()
     )
     assert "Traceback" not in result.stderr
     assert "pydantic_core" not in result.stderr
@@ -513,7 +516,7 @@ def test_onboard_status_table_keeps_explicit_config_path_in_next_step(
     default_target = tmp_path / "default.toml"
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -525,9 +528,8 @@ def test_onboard_status_table_keeps_explicit_config_path_in_next_step(
     result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
 
     assert result.exit_code == 0, result.stdout
-    assert (
-        f"agentosonboard--if-needed--config{_config_arg(target)}"
-        in "".join(result.stdout.split())
+    assert f"agentosonboard--if-needed--config{_compact_arg(target)}" in "".join(
+        result.stdout.split()
     )
     assert not default_target.exists()
 
@@ -546,28 +548,15 @@ def test_onboard_status_table_offers_cli_web_and_recipe_setup_paths(
     collapsed = "".join(result.stdout.split()).replace("│", "")
     assert "Setup paths:" in result.stdout
     assert "Guided CLI:" in result.stdout
-    assert (
-        f"agentosonboard--if-needed--config{_config_arg(target)}"
-        in collapsed
-    )
+    assert f"agentosonboard--if-needed--config{_compact_arg(target)}" in collapsed
     assert "Web UI:" in result.stdout
-    assert (
-        f"agentosgatewayrun--config{_config_arg(target)}"
-        in collapsed
-    )
+    assert f"agentosgatewayrun--config{_compact_arg(target)}" in collapsed
     assert "http://127.0.0.1:18791/control/setup" in result.stdout
     assert "Explore options:" in result.stdout
-    assert (
-        f"agentosonboardcatalog--config{_config_arg(target)}"
-        in collapsed
-    )
+    assert f"agentosonboardcatalog--config{_compact_arg(target)}" in collapsed
     assert "agentos onboard catalog --json" not in result.stdout
     assert "Provider recipes:" in result.stdout
-    assert (
-        "agentosonboardcatalogproviders"
-        f"--config{_config_arg(target)}"
-        in collapsed
-    )
+    assert f"agentosonboardcatalogproviders--config{_compact_arg(target)}" in collapsed
     assert "--provider<id>" not in collapsed
     assert "--model<model>" not in collapsed
     assert "--api-key-env<ENV_NAME>" not in collapsed
@@ -587,10 +576,7 @@ def test_onboard_status_points_missing_provider_to_provider_recipes(
     assert result.exit_code == 0, result.stdout
     collapsed = "".join(result.stdout.split()).replace("│", "")
     assert "Provider recipes:" in result.stdout
-    assert (
-        f"agentosonboardcatalogproviders--config{_config_arg(target)}"
-        in collapsed
-    )
+    assert f"agentosonboardcatalogproviders--config{_compact_arg(target)}" in collapsed
     assert "Headless provider:" not in result.stdout
     assert "--provider <id>" not in result.stdout
     assert "--model <model>" not in result.stdout
@@ -609,14 +595,9 @@ def test_onboard_status_leads_with_recommended_next_move(tmp_path, monkeypatch):
     collapsed = "".join(result.stdout.split()).replace("│", "")
     assert "Recommended next move:" in result.stdout
     assert "Guided CLI:" in result.stdout
-    assert (
-        f"GuidedCLI:agentosonboard--if-needed--config{_config_arg(target)}"
-        in collapsed
-    )
+    assert f"GuidedCLI:agentosonboard--if-needed--config{_compact_arg(target)}" in collapsed
     assert result.stdout.count("Guided CLI:") == 1
-    assert result.stdout.index("Recommended next move:") < result.stdout.index(
-        "Setup paths:"
-    )
+    assert result.stdout.index("Recommended next move:") < result.stdout.index("Setup paths:")
     assert not default_target.exists()
 
 
@@ -626,11 +607,7 @@ def test_onboard_status_web_path_uses_gateway_and_control_ui_config(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        'host = "0.0.0.0"\n'
-        "port = 19999\n"
-        "\n"
-        "[control_ui]\n"
-        'base_path = "/ops"\n',
+        'host = "0.0.0.0"\nport = 19999\n\n[control_ui]\nbase_path = "/ops"\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(tmp_path / "default.toml"))
@@ -649,8 +626,7 @@ def test_onboard_status_does_not_offer_disabled_web_ui_path(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        "[control_ui]\n"
-        "enabled = false\n",
+        "[control_ui]\nenabled = false\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("AGENTOS_GATEWAY_CONFIG_PATH", str(tmp_path / "default.toml"))
@@ -671,7 +647,7 @@ def test_onboard_status_table_uses_product_labels_and_scope_column(
     default_target = tmp_path / "default.toml"
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -706,7 +682,7 @@ def test_onboard_status_prioritizes_missing_env_recovery(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -717,9 +693,7 @@ def test_onboard_status_prioritizes_missing_env_recovery(
     result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
 
     assert result.exit_code == 0, result.stdout
-    assert f"Set provider key: {_env_hint('CUSTOM_LLM_KEY')}" in _plain_text(
-        result.stdout
-    )
+    assert f"Set provider key: {_env_hint('CUSTOM_LLM_KEY')}" in _plain_text(result.stdout)
     assert result.stdout.index("Set provider key:") < result.stdout.index("Guided CLI:")
 
 
@@ -729,7 +703,7 @@ def test_onboard_status_prints_action_guide_without_squeezing_detail(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -757,10 +731,7 @@ def test_onboard_help_exposes_configure_command():
     compact = _compact_text(result.stdout)
     assert "Listonboardingsetupoptionsforeveryconfigurablesection." in compact
     assert "configure" in result.stdout
-    assert (
-        "Reconfigureprovider,router,channels,search,imagegeneration,ormemory."
-        in compact
-    )
+    assert "Reconfigureprovider,router,channels,search,imagegeneration,ormemory." in compact
 
 
 def test_onboard_catalog_json_exposes_all_setup_options(tmp_path, monkeypatch):
@@ -860,9 +831,7 @@ def test_onboard_catalog_provider_rows_name_agentos_router_tier_support():
     assert openrouter_row.index("route Pilot Router ready") < openrouter_row.index(
         "key OPENROUTER_API_KEY"
     )
-    assert anthropic_row.index("route Direct only") < anthropic_row.index(
-        "key ANTHROPIC_API_KEY"
-    )
+    assert anthropic_row.index("route Direct only") < anthropic_row.index("key ANTHROPIC_API_KEY")
     assert "Pilot Router tiers yes" not in result.stdout
     assert "Pilot Router tiers no" not in result.stdout
     assert "router yes" not in result.stdout
@@ -999,9 +968,7 @@ def test_onboard_catalog_focused_capability_examples_match_key_requirements(
     duckduckgo_line = next(
         line
         for line in search.stdout.splitlines()
-        if line.startswith(
-            "  Try: agentos onboard configure search --search-provider duckduckgo"
-        )
+        if line.startswith("  Try: agentos onboard configure search --search-provider duckduckgo")
     )
     assert "--api-key-env" not in duckduckgo_line
 
@@ -1018,9 +985,7 @@ def test_onboard_catalog_focused_capability_examples_match_key_requirements(
     auto_line = next(
         line
         for line in memory.stdout.splitlines()
-        if line.startswith(
-            "  Try: agentos onboard configure memory --memory-provider auto"
-        )
+        if line.startswith("  Try: agentos onboard configure memory --memory-provider auto")
     )
     assert "--api-key-env" not in auto_line
     assert "--model" not in auto_line
@@ -1076,9 +1041,7 @@ def test_onboard_catalog_focused_image_and_metadata_search_examples_are_specific
 
     assert search.exit_code == 0, search.stdout
     assert "- exa: Exa | metadata only" in search.stdout
-    assert "Try: agentos onboard configure search --search-provider exa" not in (
-        search.stdout
-    )
+    assert "Try: agentos onboard configure search --search-provider exa" not in (search.stdout)
     assert "Try: not configurable in this build" in search.stdout
     assert not target.exists()
 
@@ -1094,38 +1057,12 @@ def test_onboard_catalog_overview_commands_keep_active_config_path(
 
     assert result.exit_code == 0, result.stdout
     compact = result.stdout.replace(" ", "").replace("\n", "")
-    assert (
-        f"agentosonboardcatalogproviders--config{_config_arg(target)}".replace(
-            " ", ""
-        )
-        in compact
-    )
-    assert (
-        f"agentosonboardcatalogchannels--config{_config_arg(target)}".replace(
-            " ", ""
-        )
-        in compact
-    )
-    assert (
-        f"agentosonboardcatalogrouter--config{_config_arg(target)}".replace(" ", "")
-        in compact
-    )
-    assert (
-        f"agentosonboardcatalogsearch--config{_config_arg(target)}".replace(" ", "")
-        in compact
-    )
-    assert (
-        f"agentosonboardcatalogimage--config{_config_arg(target)}".replace(
-            " ", ""
-        )
-        in compact
-    )
-    assert (
-        f"agentosonboardcatalogmemory--config{_config_arg(target)}".replace(
-            " ", ""
-        )
-        in compact
-    )
+    assert f"agentosonboardcatalogproviders--config{_compact_arg(target)}" in compact
+    assert f"agentosonboardcatalogchannels--config{_compact_arg(target)}" in compact
+    assert f"agentosonboardcatalogrouter--config{_compact_arg(target)}" in compact
+    assert f"agentosonboardcatalogsearch--config{_compact_arg(target)}" in compact
+    assert f"agentosonboardcatalogimage--config{_compact_arg(target)}" in compact
+    assert f"agentosonboardcatalogmemory--config{_compact_arg(target)}" in compact
     assert "Open section" in result.stdout
     assert "option-specific Try commands" in result.stdout
     assert not target.exists()
@@ -1195,7 +1132,7 @@ def test_onboard_status_summarizes_blocking_and_optional_sections(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key_env = "CUSTOM_LLM_KEY"\n',
@@ -1235,10 +1172,7 @@ def test_onboard_status_explains_router_ready_before_provider_setup(
     )
     assert json_result.exit_code == 0, json_result.stdout
     payload = _json.loads(json_result.stdout)
-    assert (
-        payload["sectionDetails"]["router"]["detail"]
-        == "uses Pilot Router after provider setup"
-    )
+    assert payload["sectionDetails"]["router"]["detail"] == "uses Pilot Router after provider setup"
 
 
 def test_onboard_status_table_hides_image_generation_internal_source(
@@ -1247,13 +1181,13 @@ def test_onboard_status_table_hides_image_generation_internal_source(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        '[llm]\n'
+        "[llm]\n"
         'provider = "openrouter"\n'
         'model = "deepseek/deepseek-v4-flash"\n'
         'api_key = "sk-or"\n'
-        '\n'
-        '[image_generation]\n'
-        'enabled = true\n'
+        "\n"
+        "[image_generation]\n"
+        "enabled = true\n"
         'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n',
         encoding="utf-8",
     )
@@ -1314,9 +1248,7 @@ def test_onboard_status_table_names_missing_env_keys_for_optional_capabilities(
     stdout_plain = _plain_text(result.stdout)
     assert f"Set search key: {_env_hint('BRAVE_SEARCH_API_KEY')}" in stdout_plain
     assert f"Set image key: {_env_hint('OPENAI_IMAGE_KEY')}" in stdout_plain
-    assert (
-        f"Set memory key: {_env_hint('OPENAI_EMBEDDINGS_API_KEY')}" in stdout_plain
-    )
+    assert f"Set memory key: {_env_hint('OPENAI_EMBEDDINGS_API_KEY')}" in stdout_plain
     assert "Fix now:" in result.stdout
     assert result.stdout.index("Fix now:") < result.stdout.index("Set memory key:")
     assert result.stdout.index("Set image key:") < result.stdout.index("Setup paths:")
@@ -1341,10 +1273,7 @@ def test_onboard_status_offers_optional_capability_paths_when_core_ready(
 ):
     target = tmp_path / "custom.toml"
     target.write_text(
-        "[llm]\n"
-        'provider = "openrouter"\n'
-        'model = "deepseek/deepseek-v4-flash"\n'
-        'api_key = "sk-or"\n',
+        '[llm]\nprovider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash"\napi_key = "sk-or"\n',
         encoding="utf-8",
     )
 
@@ -1359,17 +1288,14 @@ def test_onboard_status_offers_optional_capability_paths_when_core_ready(
     assert "agentos onboard catalog --json" not in result.stdout
     assert "Channel recipes:" in result.stdout
     compact = "".join(result.stdout.split())
-    assert f"agentosonboardcatalog--config{_config_arg(target)}" in compact
-    assert f"agentosonboardcatalogchannels--config{_config_arg(target)}" in compact
+    assert f"agentosonboardcatalog--config{_compact_arg(target)}" in compact
+    assert f"agentosonboardcatalogchannels--config{_compact_arg(target)}" in compact
     assert "agentoschannelsdescribe<type>--json" not in compact
     assert "agentosonboardconfigurechannels--channel-type<type>" not in compact
     assert "Image recipes:" in result.stdout
-    assert (
-        f"agentosonboardcatalogimage--config{_config_arg(target)}"
-        in compact
-    )
+    assert f"agentosonboardcatalogimage--config{_compact_arg(target)}" in compact
     assert "agentosonboardconfigureimage--image-provider<provider>" not in compact
-    assert f"--config{_config_arg(target)}" in compact
+    assert f"--config{_compact_arg(target)}" in compact
     assert "Provider recipes:" not in result.stdout
 
 
@@ -1520,10 +1446,7 @@ def test_onboard_if_needed_non_tty_hint_targets_blocking_memory_section(
     assert result.exit_code == 2
     assert "Use a runnable setup path from this shell:" in result.stdout
     assert "Headless memory embedding:" in result.stdout
-    assert (
-        "agentos onboard configure memory --memory-provider auto"
-        in result.stdout
-    )
+    assert "agentos onboard configure memory --memory-provider auto" in result.stdout
     assert f"--config {_config_arg(target)}" in result.stdout
     assert "Provider recipes:" not in result.stdout
 
@@ -1778,9 +1701,8 @@ def test_configure_provider_reports_invalid_config_without_schema_traceback(tmp_
     assert "AgentOS config error" in result.stderr
     assert _compact_text(str(target)) in _compact_text(result.stderr)
     assert "search" in result.stderr
-    assert (
-        f"agentosonboard--if-needed--config{_config_arg(target)}"
-        in "".join(result.stderr.split())
+    assert f"agentosonboard--if-needed--config{_compact_arg(target)}" in "".join(
+        result.stderr.split()
     )
     assert "pydantic.dev" not in result.stderr
     assert "Traceback" not in result.stderr
@@ -1821,9 +1743,7 @@ def test_configure_router_noninteractive_can_set_default_tier(tmp_path, monkeypa
     assert data["agentos_router"]["default_tier"] == "c2"
 
 
-def test_configure_router_rejects_invalid_default_tier_without_writing(
-    tmp_path, monkeypatch
-):
+def test_configure_router_rejects_invalid_default_tier_without_writing(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     target.write_text(
         '[llm]\nprovider = "ollama"\nmodel = "llama3"\n',
@@ -2278,3 +2198,26 @@ def test_onboard_without_tty_prints_hint_without_writing_config(tmp_path, monkey
 def test_init_help_mentions_onboard():
     result = runner.invoke(app, ["init", "--help"])
     assert "onboard" in result.stdout.lower()
+
+
+def test_quote_cli_arg_platform_behavior(monkeypatch):
+    from agentos.onboarding.next_steps import _config_cli_arg, quote_cli_arg
+
+    # On Windows: paths with spaces must use double quotes for cmd.exe / PowerShell compatibility
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert quote_cli_arg(r"C:\Users\John Doe\custom.toml") == r'"C:\Users\John Doe\custom.toml"'
+    assert (
+        _config_cli_arg(r"C:\Users\John Doe\custom.toml")
+        == r' --config "C:\Users\John Doe\custom.toml"'
+    )
+    # On Windows: paths without spaces remain unquoted
+    assert quote_cli_arg(r"C:\Users\John\custom.toml") == r"C:\Users\John\custom.toml"
+    assert _config_cli_arg(r"C:\Users\John\custom.toml") == r" --config C:\Users\John\custom.toml"
+    assert _config_cli_arg(None) == ""
+
+    # On POSIX: shlex.quote standard behavior
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert quote_cli_arg("/home/john doe/custom.toml") == "'/home/john doe/custom.toml'"
+    assert _config_cli_arg("/home/john doe/custom.toml") == " --config '/home/john doe/custom.toml'"
+    assert quote_cli_arg("/home/john/custom.toml") == "/home/john/custom.toml"
+    assert _config_cli_arg("/home/john/custom.toml") == " --config /home/john/custom.toml"


### PR DESCRIPTION
Closes #1180

### Summary of Changes
- Replaced POSIX-only `shlex.quote()` with platform-aware `quote_cli_arg()`:
  - On Windows, uses `subprocess.list2cmdline([arg])` so that arguments with spaces are wrapped in double quotes (`"..."`), compatible with both `cmd.exe` and PowerShell.
  - On POSIX, continues to delegate to `shlex.quote(arg)`.
- Consolidated `_config_cli_arg` helper across onboarding and doctor CLI modules (`next_steps.py`, `flow.py`, `onboard_cmd.py`, `doctor_cmd.py`, `recovery_commands.py`).
- Added regression test `test_quote_cli_arg_platform_behavior` covering Windows (`"..."`) and POSIX (`'...'`) behavior for paths with and without spaces.
- Resolved all 8 prior test assertion failures in `tests/test_cli/test_onboard_cmd.py` when tests run in environments with spaces in directory paths.

### Verification
- `pytest tests/test_cli/test_onboard_cmd.py tests/test_cli/test_doctor_cmd.py -q`: 137 passed
- `ruff check src/agentos/onboarding src/agentos/cli src/agentos/health tests/test_cli`: Passed
- `mypy src/agentos/onboarding src/agentos/cli --show-error-codes`: Passed
