### PR TITLE
fix(gateway): log metric recording failures at debug level in task runtime

### DIFF
--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -66,8 +66,14 @@ def _emit_metric(name: str, value: int = 1, **labels: Any) -> None:
             k: v for k, v in labels.items() if k not in {"session_key", "session_id", "turn_id"}
         }
         record_metric(name, value, **metric_labels)
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "record_metric_failed",
+            metric=name,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
 
 
 TERMINAL_STATUSES = frozenset(

--- a/tests/test_gateway/test_metrics_counters.py
+++ b/tests/test_gateway/test_metrics_counters.py
@@ -288,3 +288,27 @@ async def test_agentos_queue_depth_decrements_to_zero() -> None:
     assert qd_events[-1]["value"] == 0, (
         f"Final agentos_queue_depth should be 0, got {qd_events[-1]['value']}"
     )
+
+
+def test_emit_metric_logs_debug_on_record_metric_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agentos.gateway.task_runtime import _emit_metric
+
+    def _broken_record_metric(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("Invalid metric label type")
+
+    import agentos.observability.metrics
+
+    monkeypatch.setattr(agentos.observability.metrics, "record_metric", _broken_record_metric)
+
+    with _capture_metric_logs() as captured:
+        _emit_metric("test_metric_failure", value=1, label_a="val")
+
+    # The metric event was logged at info level
+    assert any(e.get("metric") == "test_metric_failure" for e in captured)
+
+    # The failure was captured at debug level
+    debug_events = [e for e in captured if e.get("event") == "record_metric_failed"]
+    assert len(debug_events) == 1
+    assert debug_events[0]["metric"] == "test_metric_failure"
+    assert "Invalid metric label type" in debug_events[0]["error"]
+    assert debug_events[0]["error_type"] == "ValueError"


### PR DESCRIPTION
## Summary
Logs Prometheus metric recording failures at debug level in `task_runtime._emit_metric` rather than silently swallowing all exceptions.

## Details
- `src/agentos/gateway/task_runtime.py` previously had a bare `except Exception: pass` block around `record_metric()`, silently hiding issues such as metric name collisions, invalid label types, or metric registry errors.
- Added structured debug logging (`log.debug("record_metric_failed", metric=name, error=str(exc), exc_info=True)`) so operators can diagnose missing Prometheus metrics without impacting request execution.
- Added regression test `test_emit_metric_logs_debug_on_record_metric_failure` in `tests/test_gateway/test_metrics_counters.py`.

## Verification
- `uv run ruff check src tests` (passed)
- `uv run mypy src/agentos --show-error-codes` (passed, 0 issues across 622 files)
- `uv run pytest tests/test_gateway/test_metrics_counters.py -q` (5/5 passed)
closes #1188 