### PR TITLE
fix(gateway): raise RpcUnavailableError instead of KeyError for missing session manager

### DIFF
--- a/src/agentos/gateway/rpc/registry.py
+++ b/src/agentos/gateway/rpc/registry.py
@@ -296,10 +296,10 @@ async def _config_get(params: Any, ctx: RpcContext) -> Any:
 
 async def _sessions_get(params: Any, ctx: RpcContext) -> dict[str, Any]:
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
     if not isinstance(params, dict) or "key" not in params:
         raise ValueError("params.key is required")
     session = await storage.get_session(params["key"])

--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -581,7 +581,7 @@ async def _handle_chat_inject(params: dict | None, ctx: RpcContext) -> dict:
     session_key = _canonical_webchat_session_key(params["sessionKey"])
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = getattr(ctx.session_manager, "_storage", None)
     if storage is not None:

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -959,11 +959,11 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
         raise ValueError(f"Invalid session intent: {params.get('intent')}") from exc
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await storage.get_session(key)
     if session is None and session_intent is SessionIntent.CONTINUE:
@@ -1511,11 +1511,11 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
     key = _require_key(params)
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await storage.get_session(key)
     if session is None:
@@ -1608,11 +1608,11 @@ async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
     name = normalize_session_name(params.get("name", params.get("displayName")))
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await _resolve_session_node(storage, key)
     resolved_key = str(getattr(session, "session_key", "") or key)
@@ -1710,11 +1710,11 @@ async def _handle_sessions_reset(params: dict | None, ctx: RpcContext) -> dict[s
     key = _require_key(params)
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     task_runtime = getattr(ctx, "task_runtime", None)
     # Drain MUST run before any branch that clears session state — including the
@@ -1953,11 +1953,11 @@ def _reset_response(
 async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     """Delete one or more sessions. Accepts {key} for single or {keys} for bulk."""
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     # Support both single key and bulk keys
     keys: list[str] = []
@@ -2009,7 +2009,7 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
 async def _handle_sessions_context_compact(params: dict | None, ctx: RpcContext) -> dict:
     key = _require_key(params)
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     context_window_tokens = _context_window_tokens(params, ctx)
     custom_instructions = (params or {}).get("instructions")
@@ -2249,7 +2249,7 @@ async def _handle_sessions_truncate(params: dict | None, ctx: RpcContext) -> dic
 
     key = _require_key(params)
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     max_messages = (params or {}).get("maxMessages", 20)
     force = bool((params or {}).get("force", False))
@@ -2427,11 +2427,11 @@ async def _handle_sessions_resolve(params: dict | None, ctx: RpcContext) -> dict
     key = _require_key(params)
 
     if ctx.session_manager is None:
-        raise KeyError("No session manager available")
+        raise RpcUnavailableError("No session manager available")
 
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
-        raise KeyError("No session storage available")
+        raise RpcUnavailableError("No session storage available")
 
     session = await _resolve_session_node(storage, key)
 

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2852,3 +2852,40 @@ class TestSessionsResolve:
         res = await dispatcher.dispatch("r1", "sessions.create", {"agentId": "test"}, ctx)
         assert res.ok is False
         assert res.error.code == "UNAUTHORIZED"
+
+    @pytest.mark.asyncio
+    async def test_sessions_send_missing_session_manager_returns_unavailable(
+        self, dispatcher, ctx_no_manager
+    ):
+        res = await dispatcher.dispatch(
+            "r1", "sessions.send", {"key": "agent:main:s1", "message": "hello"}, ctx_no_manager
+        )
+        assert res.ok is False
+        assert res.error.code == "UNAVAILABLE"
+        assert res.error.retryable is True
+        assert "No session manager available" in res.error.message
+
+    @pytest.mark.asyncio
+    async def test_sessions_patch_missing_session_manager_returns_unavailable(
+        self, dispatcher, ctx_no_manager
+    ):
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.patch",
+            {"key": "agent:main:s1", "displayName": "Renamed"},
+            ctx_no_manager,
+        )
+        assert res.ok is False
+        assert res.error.code == "UNAVAILABLE"
+        assert res.error.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_sessions_delete_missing_session_manager_returns_unavailable(
+        self, dispatcher, ctx_no_manager
+    ):
+        res = await dispatcher.dispatch(
+            "r1", "sessions.delete", {"key": "agent:main:s1"}, ctx_no_manager
+        )
+        assert res.ok is False
+        assert res.error.code == "UNAVAILABLE"
+        assert res.error.retryable is True


### PR DESCRIPTION
## Summary
Replaces semantically incorrect `KeyError` with `RpcUnavailableError` when a required `session_manager` or `storage` service is unconfigured or unavailable.

## Details
- In `src/agentos/gateway/rpc_sessions.py`, `src/agentos/gateway/rpc_chat.py`, and `src/agentos/gateway/rpc/registry.py`, missing session managers or storage instances previously raised `KeyError("No session manager available")`.
- Raising `KeyError` resulted in the RPC dispatcher returning a `NOT_FOUND` error code instead of `UNAVAILABLE` (with `retryable=True`), and risked being miscaught by caller `except KeyError:` blocks designed for nonexistent session lookups.
- Updated all occurrences to raise `RpcUnavailableError`, aligning with the existing patterns in `rpc_projects.py`, `rpc_memory.py`, `rpc_cron.py`, and `rpc_agents.py`.
- Added unit tests in `tests/test_gateway/test_rpc_sessions.py` to verify that missing session managers correctly yield `UNAVAILABLE` response frames.

## Verification
- `uv run ruff check src tests` (passed)
- `uv run mypy src/agentos --show-error-codes` (passed, 0 issues across 622 files)
- `uv run pytest tests/test_gateway/test_rpc_sessions.py -q` (99/99 passed)
closes #1192 