### PR TITLE
fix(gateway): validate dict params explicitly instead of assert in RPC handlers

### DIFF
--- a/src/agentos/gateway/rpc_env.py
+++ b/src/agentos/gateway/rpc_env.py
@@ -124,7 +124,8 @@ async def _handle_env_list(params: dict | None, ctx: RpcContext) -> dict[str, An
 async def _handle_env_set(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Write one variable. Returns its new state, without echoing the value."""
     name = _require_name(params)
-    assert isinstance(params, dict)
+    if not isinstance(params, dict):
+        raise ValueError("params must be a dictionary")
     if "value" not in params:
         raise ValueError("params.value is required")
     value = params["value"]
@@ -169,7 +170,8 @@ async def _handle_env_import(params: dict | None, ctx: RpcContext) -> dict[str, 
     get. The value goes source → store; it is not returned here.
     """
     name = _require_name(params)
-    assert isinstance(params, dict)
+    if not isinstance(params, dict):
+        raise ValueError("params must be a dictionary")
     source_id = str(params.get("sourceId") or "").strip()
     if not source_id:
         raise ValueError("params.sourceId is required")

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1522,7 +1522,8 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
         raise KeyError(f"Session not found: {key}")
 
     update_values: dict[str, Any] = {}
-    assert isinstance(params, dict)
+    if not isinstance(params, dict):
+        raise ValueError("params must be a dictionary")
     field_map = {
         "displayName": "display_name",
         "model": "model",
@@ -1602,7 +1603,8 @@ async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
     custom name and lets ``derived_title`` fall back to the short session id.
     """
     key = _require_key(params)
-    assert isinstance(params, dict)
+    if not isinstance(params, dict):
+        raise ValueError("params must be a dictionary")
     if "name" not in params and "displayName" not in params:
         raise ValueError("sessions.rename requires a 'name'")
     name = normalize_session_name(params.get("name", params.get("displayName")))

--- a/tests/test_gateway/test_rpc_env.py
+++ b/tests/test_gateway/test_rpc_env.py
@@ -145,6 +145,7 @@ class TestSet:
 
     @pytest.mark.asyncio
     async def test_requires_name_and_value(self) -> None:
+        assert (await call("env.set", None)).error is not None
         assert (await call("env.set", {"value": "x"})).error is not None
         assert (await call("env.set", {"name": "K"})).error is not None
         assert (await call("env.set", {"name": "K", "value": 5})).error is not None
@@ -332,6 +333,7 @@ class TestImport:
 
     @pytest.mark.asyncio
     async def test_requires_a_source(self) -> None:
+        assert (await call("env.import", None)).error is not None
         res = await call("env.import", {"name": "GITHUB_TOKEN"})
         assert res.error is not None
 

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -1849,6 +1849,17 @@ class TestSessionsPatch:
         assert res.ok is False
         assert res.error.code == "NOT_FOUND"
 
+    @pytest.mark.asyncio
+    async def test_patch_invalid_params(self, dispatcher, ctx_with_sessions):
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.patch",
+            None,
+            ctx_with_sessions,
+        )
+        assert res.ok is False
+        assert res.error.code == "INVALID_REQUEST"
+
 
 class TestSessionsReset:
     @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_sessions_rename.py
+++ b/tests/test_gateway/test_rpc_sessions_rename.py
@@ -237,3 +237,11 @@ async def test_an_exact_name_wins_over_session_key_prefix_matches(dispatcher, ma
     other = await manager.get_session("agent:main:cli:other")
     assert other is not None
     assert other.display_name is None
+
+
+@pytest.mark.asyncio
+async def test_rename_with_invalid_params(dispatcher, manager):
+    ctx = make_ctx(manager)
+    res = await dispatcher.dispatch("r1", "sessions.rename", None, ctx)
+    assert res.ok is False
+    assert res.error.code == "INVALID_REQUEST"


### PR DESCRIPTION
### Description
Replaces `assert isinstance(params, dict)` with explicit `if not isinstance(params, dict): raise ValueError(...)` validation across gateway RPC handlers (`sessions.patch`, `sessions.rename`, `env.set`, `env.import`).

### Motivation
`assert` statements are stripped when running Python in optimized mode (`-O` / `PYTHONOPTIMIZE`). Explicit validation ensures guards remain active across all runtime environments and return structured `INVALID_REQUEST` RPC responses instead of unhandled runtime crashes.

### Changes
- Updated [`src/agentos/gateway/rpc_sessions.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/gateway/rpc_sessions.py) (`_handle_sessions_patch`, `_handle_sessions_rename`).
- Updated [`src/agentos/gateway/rpc_env.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/gateway/rpc_env.py) (`_handle_env_set`, `_handle_env_import`).
- Added regression tests in [`tests/test_gateway/test_rpc_sessions.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_gateway/test_rpc_sessions.py) and [`tests/test_gateway/test_rpc_sessions_rename.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_gateway/test_rpc_sessions_rename.py).

### Verification
- `uv run ruff check src tests` (All passed)
- `uv run mypy src/agentos --show-error-codes` (0 issues across 622 files)
- `uv run pytest tests/test_gateway/test_rpc_sessions.py tests/test_gateway/test_rpc_sessions_rename.py tests/test_gateway/test_rpc_env.py -q` (141 passed)
closes #1194  