### PR TITLE
fix(channels): bind _send closure accumulated by value in MSTeams str…

### DIFF
--- a/src/agentos/channels/msteams.py
+++ b/src/agentos/channels/msteams.py
@@ -531,8 +531,12 @@ class MSTeamsChannel:
             if message_id is None:
                 holder: dict[str, str | None] = {"id": None}
 
-                async def _send(turn_context: Any, _holder: dict[str, str | None] = holder) -> None:
-                    response = await turn_context.send_activity(accumulated)
+                async def _send(
+                    turn_context: Any,
+                    _holder: dict[str, str | None] = holder,
+                    _text: str = accumulated,
+                ) -> None:
+                    response = await turn_context.send_activity(_text)
                     if response is not None and getattr(response, "id", None):
                         _holder["id"] = response.id
 

--- a/tests/test_channels/test_msteams_streaming.py
+++ b/tests/test_channels/test_msteams_streaming.py
@@ -1,0 +1,90 @@
+"""Streaming reply behavior for the MS Teams adapter."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock botbuilder before importing msteams channel
+sys.modules.setdefault("botbuilder", MagicMock())
+sys.modules.setdefault("botbuilder.schema", MagicMock())
+
+from agentos.channels.msteams import MSTeamsChannel, MSTeamsChannelConfig  # noqa: E402
+
+
+async def _stream(*chunks: str) -> AsyncIterator[str]:
+    for chunk in chunks:
+        yield chunk
+
+
+@pytest.mark.asyncio
+async def test_msteams_send_streaming_first_chunk_binds_accumulated_by_value() -> None:
+    """The _send closure must bind _text=accumulated by value (GH #1046)."""
+    channel = MSTeamsChannel(config=MSTeamsChannelConfig(name="msteams"))
+    channel._references["conv-1"] = SimpleNamespace()
+
+    sent_texts: list[str] = []
+    saved_send_callback: Any = None
+
+    class FakeTurnContext:
+        async def send_activity(self, text_or_activity: Any) -> Any:
+            sent_texts.append(str(text_or_activity))
+            return SimpleNamespace(id="msg-101")
+
+        async def update_activity(self, activity: Any) -> Any:
+            return None
+
+    class FakeAdapter:
+        async def continue_conversation(
+            self,
+            ref: Any,
+            callback: Any,
+            bot_id: Any = None,
+        ) -> None:
+            nonlocal saved_send_callback
+            if saved_send_callback is None:
+                saved_send_callback = callback
+            # Run the callback
+            await callback(FakeTurnContext())
+
+    channel._adapter = FakeAdapter()  # type: ignore[assignment]
+
+    await channel.send_streaming(_stream("chunk1", "chunk2"), reply_to="conv-1")
+
+    # Verify first chunk was sent with "chunk1"
+    assert sent_texts[0] == "chunk1"
+
+    # Verify that the closure parameter _text was bound by value with default="chunk1"
+    assert saved_send_callback is not None
+    import inspect
+
+    sig = inspect.signature(saved_send_callback)
+    assert "_text" in sig.parameters
+    assert sig.parameters["_text"].default == "chunk1"
+
+    # If invoked directly after accumulated has changed to "chunk1chunk2",
+    # it still uses the bound _text ("chunk1") rather than the mutated outer variable
+    second_context = FakeTurnContext()
+    await saved_send_callback(second_context)
+    assert sent_texts[-1] == "chunk1"
+
+
+@pytest.mark.asyncio
+async def test_msteams_send_streaming_requires_start() -> None:
+    channel = MSTeamsChannel(config=MSTeamsChannelConfig(name="msteams"))
+    with pytest.raises(RuntimeError, match="requires start"):
+        await channel.send_streaming(_stream("hello"))
+
+
+@pytest.mark.asyncio
+async def test_msteams_send_streaming_no_cached_reference_raises() -> None:
+    channel = MSTeamsChannel(config=MSTeamsChannelConfig(name="msteams"))
+    channel._adapter = MagicMock()
+    with pytest.raises(RuntimeError, match="no conversation reference cached"):
+        await channel.send_streaming(_stream("hello"))
+


### PR DESCRIPTION


Closes #1046 

#### Problem
In `src/agentos/channels/msteams.py:534-535`, the `_send` closure in `send_streaming` accessed `accumulated` directly from the enclosing scope as a free variable without binding it. In contrast, its three sibling closures in the same method (`_edit`, `_final_send`, `_retry_send`) all bound `_text: str = accumulated` by default argument value.

While `_send` is scheduled on the first chunk iteration, accessing it as a free variable makes content correctness dependent on synchronous execution: if `continue_conversation` defers execution or the control flow changes, `accumulated` mutates before `_send` runs, causing the first activity to contain unexpected text.

#### Solution
- Added `_text: str = accumulated` parameter to `_send` in `send_streaming`, capturing the first chunk's accumulated text by value at closure definition time:
  ```python
  async def _send(
      turn_context: Any,
      _holder: dict[str, str | None] = holder,
      _text: str = accumulated,
  ) -> None:
      response = await turn_context.send_activity(_text)
  ```
- Added comprehensive regression tests in `tests/test_channels/test_msteams_streaming.py`:
  - Verifies that `_send` binds `_text` by value with default matching the first chunk.
  - Verifies that invoking the closure after subsequent chunks have accumulated sends the bound first chunk text rather than the mutated outer variable.
  - Verifies `requires_start` and missing reference error handling.

#### Verification
- `uv run pytest tests/test_channels/test_msteams_streaming.py -q` (3 passed)
- `uv run ruff check src/agentos/channels/msteams.py tests/test_channels/test_msteams_streaming.py`
- `uv run mypy src/agentos/channels/msteams.py --show-error-codes`