### PR TITLE
fix(router): fix word boundary matching for C++, C#, and .NET in task_type detector

### DIFF
--- a/src/agentos/agentos_router/task_type.py
+++ b/src/agentos/agentos_router/task_type.py
@@ -126,8 +126,10 @@ _TRANSLATE_RES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
 _CODE_TARGET_RE = re.compile(
     r"\b(?:python|javascript|typescript|golang|rust|java|kotlin|swift|scala"
     r"|haskell|ruby|php|perl|sql|bash|powershell|matlab|fortran|cobol"
-    r"|c\+\+|c#|\.net|react|vue|svelte|jquery|regex|assembly|solidity"
-    r"|dart|elixir|erlang|clojure|lua|zig)\b",
+    r"|react|vue|svelte|jquery|regex|assembly|solidity"
+    r"|dart|elixir|erlang|clojure|lua|zig)\b"
+    r"|\b(?:c\+\+|c#)(?!\w)"
+    r"|(?<!\w)\.net\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_agentos_router/test_task_type.py
+++ b/tests/test_agentos_router/test_task_type.py
@@ -115,6 +115,24 @@ class TestProgrammingLanguageTarget:
         assert verdict.task_type is None
         assert verdict.blocked_by == BLOCK_CODE_TARGET
 
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "Translate this Python function to C++.",
+            "Translate this algorithm to C++, preserving performance.",
+            "Translate this class to C#.",
+            "Translate this code to C# with async/await.",
+            "Translate this service to .NET.",
+            "Translate this module to .NET Core.",
+            "Dịch đoạn code này sang C++ giúp tôi.",
+            "Dịch code này sang C# nhé.",
+        ],
+    )
+    def test_programming_language_targets_with_symbols_block(self, prompt: str) -> None:
+        verdict = detect_task_type(prompt)
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
     def test_language_named_only_in_the_body_does_not_block(self) -> None:
         """A document mentioning Python is not a porting request."""
         body = ("The team migrated the Python service last quarter. " * 40) + ("z" * 1500)


### PR DESCRIPTION
Closes #1198

### Problem
In `src/agentos/agentos_router/task_type.py`, `_CODE_TARGET_RE` groups language names inside a single word-boundary pair `\b(?:...)\b`:
```python
_CODE_TARGET_RE = re.compile(
    r"\b(?:python|javascript|...|c\+\+|c#|\.net|...)\b",
    re.IGNORECASE,
)
```
Because `+`, `#`, and `.` are non-word characters (`\W`):
- `c\+\+\b` and `c#\b` only match if followed by a word character (`\w`). When a user prompt ends with or has punctuation/spaces after C++ or C# (e.g. `"Translate this function to C++."`), `\b` fails.
- `\b\.net` only matches if preceded by a word character (`\w`). Preceded by spaces, `\b` fails.

Consequently, code porting requests targeting C++, C#, or .NET were erroneously classified as natural language translation (`task_type='translate'`) rather than being blocked by `programming_language_target`, causing them to be capped to the cheapest model tier (`c0`/`R0`).

### Solution
- Refactored `_CODE_TARGET_RE` so symbols with non-word character boundaries match correctly:
  - Standard word languages: `\b(?:...)\b`
  - `C++` and `C#`: `\b(?:c\+\+|c#)(?!\w)`
  - `.NET`: `(?<!\w)\.net\b`
- Added regression tests in `tests/test_agentos_router/test_task_type.py` covering C++, C#, and .NET code target blocking across multiple phrasing and language variants.