### PR TITLE
fix(tools): handle CRLF line endings and preserve newlines in apply_p…

### DIFF
--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -459,6 +459,9 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
     pos = hunk.old_start - 1
     result = list(file_lines)
 
+    # Detect newline style of the file (defaulting to \n if empty or no CRLF)
+    newline = "\r\n" if any(line.endswith("\r\n") for line in result) else "\n"
+
     # Verify context and deleted lines match
     check_pos = pos
     for raw in hunk.lines:
@@ -469,8 +472,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         if prefix in (" ", "-"):
             if check_pos >= len(result):
                 raise ValueError(f"Hunk context/delete at line {check_pos + 1} exceeds file length")
-            actual = result[check_pos].rstrip("\n")
-            expected = content.rstrip("\n")
+            actual = result[check_pos].rstrip("\r\n")
+            expected = content.rstrip("\r\n")
             if actual != expected:
                 raise ValueError(
                     f"Context mismatch at line {check_pos + 1}: "
@@ -492,11 +495,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         elif prefix == "-":
             src_pos += 1  # skip (delete)
         elif prefix == "+":
-            # Preserve newline style: add \n if original lines have it
-            if content.endswith("\n"):
-                new_lines.append(content)
-            else:
-                new_lines.append(content + "\n")
+            # Preserve newline style: add newline if original lines have it
+            new_lines.append(content.rstrip("\r\n") + newline)
 
     # Splice: replace [pos : pos + old_count] with new_lines
     return result[:pos] + new_lines + result[pos + hunk.old_count :]
@@ -507,14 +507,15 @@ def _apply_update(path: str, hunks: list[Hunk], root: Path | None = None) -> Non
     if not resolved.exists():
         raise FileNotFoundError(f"File not found for update: {path}")
 
-    text = resolved.read_text(encoding="utf-8")
+    raw = resolved.read_bytes()
+    text = raw.decode("utf-8")
     lines = text.splitlines(keepends=True)
 
     # Apply hunks in reverse order so earlier line numbers stay valid
     for hunk in sorted(hunks, key=lambda h: h.old_start, reverse=True):
         lines = _apply_hunk(lines, hunk)
 
-    resolved.write_text("".join(lines), encoding="utf-8")
+    resolved.write_text("".join(lines), encoding="utf-8", newline="")
 
 
 def _apply_add(path: str, content: str, root: Path | None = None) -> None:
@@ -522,7 +523,7 @@ def _apply_add(path: str, content: str, root: Path | None = None) -> None:
     if resolved.exists():
         raise FileExistsError(f"File already exists: {path}")
     resolved.parent.mkdir(parents=True, exist_ok=True)
-    resolved.write_text(content, encoding="utf-8")
+    resolved.write_text(content, encoding="utf-8", newline="")
 
 
 def _apply_delete(path: str, root: Path | None = None) -> None:

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -574,3 +574,66 @@ def test_parse_hunk_header_rejects_malformed_input(header: str) -> None:
 
     with pytest.raises(ValueError, match="Invalid hunk header"):
         _parse_hunk_header(header)
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_handles_crlf_file_line_endings(tmp_path: Path) -> None:
+    target = tmp_path / "crlf_file.txt"
+    target.write_bytes(b"first line\r\nsecond line\r\n")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: crlf_file.txt
+@@@ -1,2 +1,3 @@@
+ first line
+-second line
++modified line
++added line
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert target.read_bytes() == b"first line\r\nmodified line\r\nadded line\r\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_preserves_lf_file_line_endings_on_all_platforms(tmp_path: Path) -> None:
+    target = tmp_path / "lf_file.txt"
+    target.write_bytes(b"first line\nsecond line\n")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        result = await apply_patch(
+            """*** Begin Patch
+*** Update File: lf_file.txt
+@@@ -1,2 +1,3 @@@
+ first line
+-second line
++modified line
++added line
+*** End Patch"""
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result == "Applied patch: 1 file(s) modified"
+    assert target.read_bytes() == b"first line\nmodified line\nadded line\n"
+
+
+def test_apply_hunk_crlf_matching_and_preservation() -> None:
+    from agentos.tools.builtin.patch import Hunk, _apply_hunk
+
+    file_lines = ["header\r\n", "remove_me\r\n", "footer\r\n"]
+    hunk = Hunk(
+        old_start=1,
+        old_count=3,
+        new_start=1,
+        new_count=3,
+        lines=[" header", "-remove_me", "+added_line", " footer"],
+    )
+    result = _apply_hunk(file_lines, hunk)
+    assert result == ["header\r\n", "added_line\r\n", "footer\r\n"]


### PR DESCRIPTION
closes #1197 
### Description

Fixes an issue where `apply_patch` failed with `ValueError: Context mismatch` when attempting to patch any file with CRLF (`\r\n`) line endings, and prevents line ending conversion/corruption on Windows.

### Problem
1. **Context Mismatch**: In `_apply_hunk`, lines were stripped using `.rstrip("\n")`. On files with `\r\n` line endings, the trailing `\r` remained (`"line\r"`), whereas lines parsed from `patch_text.splitlines()` had all line endings stripped (`"line"`). This caused `'line\r' != 'line'` context comparison failures across all CRLF files.
2. **Line Ending Corruption**:
   - Added lines (`+`) in `_apply_hunk` unconditionally appended `\n`, introducing mixed line endings into CRLF files.
   - `_apply_update` and `_apply_add` wrote files using `Path.write_text` without `newline=""`. On Windows, Python's default newline translation converted LF files to CRLF or doubled existing `\r\n` into `\r\r\n`.

### Solution
- Updated `_apply_hunk` context verification to strip both `\r` and `\n` via `.rstrip("\r\n")`.
- Detected the file's native newline format (`\r\n` vs `\n`) and ensured added lines match existing file conventions.
- Read files using raw bytes decoded to text and wrote files with `newline=""` in `_apply_update` and `_apply_add`, preserving exact disk line endings across platforms.

### Verification
- Added regression tests in `tests/test_tools/test_apply_patch_gates.py`:
  - `test_apply_patch_handles_crlf_file_line_endings`
  - `test_apply_patch_preserves_lf_file_line_endings_on_all_platforms`
  - `test_apply_hunk_crlf_matching_and_preservation`
- Ran full tool test suite: 953 passed, 17 skipped.
- Lint (`ruff`) and static types (`mypy`) passed clean.