### PR TITLE
refactor(common): unify _accepts_keyword_arg and compaction provider resolution

### DIFF
--- a/src/agentos/cli/tui/adapters/slash_standalone.py
+++ b/src/agentos/cli/tui/adapters/slash_standalone.py
@@ -25,6 +25,7 @@ from agentos.engine.commands import Surface
 from agentos.session.compaction import (
     build_compaction_config_from_provider,
     call_compact_with_optional_config,
+    resolve_compaction_provider,
 )
 from agentos.session.naming import normalize_session_name
 
@@ -207,33 +208,7 @@ async def handle_image_command_turnrunner(
     raise RuntimeError("standalone image dependency was not configured")
 
 
-def _resolve_compaction_provider(
-    provider_selector: Any,
-    model_override: str | None = None,
-) -> Any | None:
-    if provider_selector is None:
-        return None
-    selector = provider_selector
-    clone = getattr(provider_selector, "clone", None)
-    if callable(clone):
-        try:
-            selector = clone()
-        except Exception:  # noqa: BLE001
-            selector = provider_selector
-    if model_override and selector is not provider_selector:
-        override = getattr(selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model_override)
-            except Exception:  # noqa: BLE001
-                pass
-    resolver = getattr(selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return resolver()
-    except Exception:  # noqa: BLE001
-        return None
+_resolve_compaction_provider = resolve_compaction_provider
 
 
 def _coerce_transcript_result(result: Any) -> list[Any] | None:

--- a/src/agentos/compat/__init__.py
+++ b/src/agentos/compat/__init__.py
@@ -1,6 +1,6 @@
 """Compatibility helpers used by runtime-facing modules."""
 
-from . import aiosqlite, pypi_client, version_utils
+from . import aiosqlite, inspect_utils, pypi_client, version_utils
 
-__all__ = ["aiosqlite", "pypi_client", "version_utils"]
+__all__ = ["aiosqlite", "inspect_utils", "pypi_client", "version_utils"]
 

--- a/src/agentos/compat/inspect_utils.py
+++ b/src/agentos/compat/inspect_utils.py
@@ -1,0 +1,34 @@
+"""Signature and callable introspection helpers."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+def accepts_keyword_arg(target: Callable[..., Any], arg_name: str) -> bool:
+    """Check whether a callable accepts *arg_name* as a keyword argument.
+
+    Returns ``True`` if the target's signature includes *arg_name* (either as
+    a named parameter or through a ``**kwargs`` variadic parameter).
+
+    Returns ``False`` if the parameter is not accepted, if the target is not a
+    callable, or if signature introspection fails (e.g. on uninspectable C-builtins
+    or invalid objects). Returning ``False`` on failure is the deliberate, fail-safe
+    choice: it ensures callers do not blindly pass unexpected keyword arguments that
+    could trigger ``TypeError`` at runtime when parameter acceptance cannot be proven.
+    """
+    try:
+        sig = inspect.signature(target)
+    except (TypeError, ValueError):
+        return False
+
+    return any(
+        (p.name == arg_name and p.kind != inspect.Parameter.POSITIONAL_ONLY)
+        or p.kind == inspect.Parameter.VAR_KEYWORD
+        for p in sig.parameters.values()
+    )
+
+
+_accepts_keyword_arg = accepts_keyword_arg

--- a/src/agentos/engine/runtime.py
+++ b/src/agentos/engine/runtime.py
@@ -35,6 +35,7 @@ from agentos.attachment_refs import (
     transcript_material_path,
 )
 from agentos.bootstrap_types import BootstrapFileReport
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.contracts.attachments import (
     ALLOWED_MEDIA_TYPES as _ALLOWED_ENGINE_MEDIA_TYPES,
 )
@@ -640,14 +641,6 @@ _SAFETY_MODULES: Final[tuple[Any, ...]] = (
 )
 
 log = structlog.get_logger(__name__)
-
-
-def _accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
-    """Return True when callable accepts `name` explicitly or via `**kwargs`."""
-    params = inspect.signature(callable_obj).parameters
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def _strip_context_summary_marker(content: str) -> str:

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -48,6 +48,7 @@ from agentos.channels.artifact_delivery import (
 )
 from agentos.channels.stream_policy import resolve_channel_stream_policy
 from agentos.channels.types import IncomingMessage, OutgoingMessage
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.engine.start_turn import start_turn_via_runtime
 from agentos.engine.types import (
     ArtifactEvent,
@@ -292,16 +293,6 @@ class _DirectiveTagStreamSanitizer:
         pending = self._pending
         self._pending = ""
         return _strip_internal_compaction_markers(_strip_inline_directive_tags(pending))
-
-
-def _accepts_keyword_arg(callable_obj: Any, name: str) -> bool:
-    try:
-        params = inspect.signature(callable_obj).parameters
-    except (TypeError, ValueError):
-        return False
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 @contextlib.asynccontextmanager

--- a/src/agentos/gateway/context_overflow.py
+++ b/src/agentos/gateway/context_overflow.py
@@ -23,12 +23,12 @@ The three policies:
 
 from __future__ import annotations
 
-import inspect
 from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
 
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.gateway.config import ContextOverflowPolicy, GatewayConfig
 from agentos.session.compaction import (
@@ -52,19 +52,6 @@ from agentos.session.context_view import build_compaction_context_records
 from agentos.session.tokenizer import estimate_tokens
 
 log = structlog.get_logger(__name__)
-
-
-def _accepts_keyword_arg(func: Any, name: str) -> bool:
-    try:
-        signature = inspect.signature(func)
-    except (TypeError, ValueError):
-        return False
-    if name in signature.parameters:
-        return True
-    return any(
-        param.kind is inspect.Parameter.VAR_KEYWORD
-        for param in signature.parameters.values()
-    )
 
 
 @dataclass

--- a/src/agentos/gateway/rpc_chat.py
+++ b/src/agentos/gateway/rpc_chat.py
@@ -14,7 +14,11 @@ from agentos.gateway.access import CONTROL_AND_CHANNEL, CONTROL_ONLY
 from agentos.gateway.config import GatewayConfig
 from agentos.gateway.context_overflow import apply_context_overflow_policy
 from agentos.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
-from agentos.session.compaction import build_compaction_config_from_provider
+from agentos.session.compaction import (
+    _effective_compaction_model,
+    _resolve_compaction_provider,
+    build_compaction_config_from_provider,
+)
 from agentos.session.keys import build_webchat_key, canonicalize_session_key, parse_agent_id
 
 _d = get_dispatcher()
@@ -225,43 +229,6 @@ async def _chat_history_summaries(
     except Exception:  # noqa: BLE001 - summaries are optional display metadata
         return []
     return [_session_summary_to_chat_payload(summary) for summary in summaries or []]
-
-
-def _effective_compaction_model(session: object | None) -> str | None:
-    if session is None:
-        return None
-    return getattr(session, "model_override", None) or getattr(session, "model", None)
-
-
-def _resolve_compaction_provider(ctx: RpcContext, session: object | None) -> object | None:
-    selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
-        return None
-
-    resolved_selector = selector
-    clone = getattr(selector, "clone", None)
-    if callable(clone):
-        try:
-            resolved_selector = clone()
-        except Exception:  # noqa: BLE001
-            resolved_selector = selector
-
-    model = _effective_compaction_model(session)
-    if model and resolved_selector is not selector:
-        override = getattr(resolved_selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model)
-            except Exception:  # noqa: BLE001
-                pass
-
-    resolver = getattr(resolved_selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return cast(object | None, resolver())
-    except Exception:  # noqa: BLE001
-        return None
 
 
 async def _build_context_overflow_compaction_config(ctx: RpcContext, session_key: str):

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import time
 import uuid
 from dataclasses import asdict, replace
@@ -11,6 +10,7 @@ from typing import Any, cast
 
 import structlog
 
+from agentos.compat.inspect_utils import _accepts_keyword_arg
 from agentos.engine.cache_break_monitor import notify_compaction
 from agentos.engine.start_turn import start_turn_via_runtime
 from agentos.gateway import attachment_ingest as _attachment_ingest
@@ -32,6 +32,8 @@ from agentos.gateway.session_services import (
 from agentos.gateway.session_streams import get_session_streams
 from agentos.paths import media_root_from_config
 from agentos.session.compaction import (
+    _effective_compaction_model,
+    _resolve_compaction_provider,
     build_compaction_config_from_provider,
     call_compact_with_optional_config,
 )
@@ -61,16 +63,6 @@ _MAX_STAGED_PDF_BYTES = _attachment_ingest.MAX_STAGED_PDF_BYTES
 _MAX_TEXT_ATTACHMENT_BYTES = _attachment_ingest.TEXT_ATTACHMENT_BYTES
 _MAX_TOTAL_ATTACHMENT_BYTES = _attachment_ingest.MAX_TOTAL_ATTACHMENT_BYTES
 _MAX_ATTACHMENTS = _attachment_ingest.MAX_ATTACHMENTS
-
-
-def _accepts_keyword_arg(func: Any, name: str) -> bool:
-    try:
-        params = inspect.signature(func).parameters
-    except (TypeError, ValueError):
-        return True
-    return name in params or any(
-        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
-    )
 
 
 def _clean_cancel_source(value: Any, default: str) -> str:
@@ -436,43 +428,6 @@ def _context_window_tokens(params: dict | None, ctx: RpcContext) -> int:
     if value <= 0:
         raise ValueError("contextWindowTokens must be a positive integer")
     return value
-
-
-def _effective_compaction_model(session: Any | None) -> str | None:
-    if session is None:
-        return None
-    return getattr(session, "model_override", None) or getattr(session, "model", None)
-
-
-def _resolve_compaction_provider(ctx: RpcContext, session: Any | None) -> Any | None:
-    selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
-        return None
-
-    resolved_selector = selector
-    clone = getattr(selector, "clone", None)
-    if callable(clone):
-        try:
-            resolved_selector = clone()
-        except Exception:  # noqa: BLE001
-            resolved_selector = selector
-
-    model = _effective_compaction_model(session)
-    if model and resolved_selector is not selector:
-        override = getattr(resolved_selector, "override_model", None)
-        if callable(override):
-            try:
-                override(model)
-            except Exception:  # noqa: BLE001
-                pass
-
-    resolver = getattr(resolved_selector, "resolve", None)
-    if not callable(resolver):
-        return None
-    try:
-        return resolver()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 def _enum_value(value: Any) -> Any:

--- a/src/agentos/session/compaction.py
+++ b/src/agentos/session/compaction.py
@@ -107,6 +107,64 @@ def build_compaction_config_from_provider(
     return cfg
 
 
+def effective_compaction_model(session: Any | None) -> str | None:
+    """Return the effective model configured on a session object."""
+    if session is None:
+        return None
+    return getattr(session, "model_override", None) or getattr(session, "model", None)
+
+
+def resolve_compaction_provider(
+    ctx_or_selector: Any = None,
+    session: Any | None = None,
+    *,
+    model_override: str | None = None,
+) -> Any | None:
+    """Resolve the LLM provider for compaction.
+
+    Supports both:
+    1. RPC contexts with attached session objects:
+       ``resolve_compaction_provider(ctx, session)``
+    2. Direct provider selector instances with optional model overrides:
+       ``resolve_compaction_provider(provider_selector, model_override=model)``
+    """
+    if ctx_or_selector is None:
+        return None
+
+    selector = getattr(ctx_or_selector, "provider_selector", ctx_or_selector)
+    if selector is None:
+        return None
+
+    resolved_selector = selector
+    clone = getattr(selector, "clone", None)
+    if callable(clone):
+        try:
+            resolved_selector = clone()
+        except Exception:  # noqa: BLE001
+            resolved_selector = selector
+
+    model = model_override or effective_compaction_model(session)
+    if model and resolved_selector is not selector:
+        override = getattr(resolved_selector, "override_model", None)
+        if callable(override):
+            try:
+                override(model)
+            except Exception:  # noqa: BLE001
+                pass
+
+    resolver = getattr(resolved_selector, "resolve", None)
+    if not callable(resolver):
+        return None
+    try:
+        return cast(object | None, resolver())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+_effective_compaction_model = effective_compaction_model
+_resolve_compaction_provider = resolve_compaction_provider
+
+
 def compact_accepts_config(compact_fn: Any) -> bool:
     """Return whether a compact callable can accept the optional config arg."""
 

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -36,6 +36,7 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("cli", "tools"),
     ("engine", "agents"),
     ("engine", "channels"),
+    ("engine", "compat"),
     ("engine", "contracts"),
     ("engine", "gateway"),
     ("engine", "identity"),

--- a/tests/test_compat_inspect_utils.py
+++ b/tests/test_compat_inspect_utils.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from agentos.compat.inspect_utils import _accepts_keyword_arg, accepts_keyword_arg
+
+
+def test_accepts_named_keyword_arg():
+    def sample_fn(a: int, b: str = "default") -> None:
+        pass
+
+    assert accepts_keyword_arg(sample_fn, "a") is True
+    assert accepts_keyword_arg(sample_fn, "b") is True
+    assert accepts_keyword_arg(sample_fn, "c") is False
+
+
+def test_accepts_var_keyword_kwargs():
+    def sample_kwargs(a: int, **kwargs) -> None:
+        pass
+
+    assert accepts_keyword_arg(sample_kwargs, "a") is True
+    assert accepts_keyword_arg(sample_kwargs, "anything") is True
+    assert _accepts_keyword_arg(sample_kwargs, "anything") is True
+
+
+def test_handles_non_callables_and_builtin_objects_gracefully():
+    assert accepts_keyword_arg(object(), "foo") is False
+    assert accepts_keyword_arg(None, "foo") is False  # type: ignore[arg-type]
+    assert accepts_keyword_arg("string", "foo") is False  # type: ignore[arg-type]
+
+
+def test_handles_inspect_signature_exceptions(monkeypatch):
+    import inspect
+
+    def dummy_fn(x: int) -> None:
+        pass
+
+    def broken_signature(_target):
+        raise TypeError("unsupported callable type")
+
+    monkeypatch.setattr(inspect, "signature", broken_signature)
+    assert accepts_keyword_arg(dummy_fn, "x") is False
+
+    def value_error_signature(_target):
+        raise ValueError("corrupt signature")
+
+    monkeypatch.setattr(inspect, "signature", value_error_signature)
+    assert accepts_keyword_arg(dummy_fn, "x") is False
+
+
+def test_positional_only_args():
+    def pos_only(a, /, b):
+        pass
+
+    assert accepts_keyword_arg(pos_only, "b") is True
+    assert accepts_keyword_arg(pos_only, "a") is False
+
+
+def test_bound_methods_and_partials():
+    from functools import partial
+
+    class Target:
+        def method(self, x: int, y: str = "default") -> None:
+            pass
+
+    t = Target()
+    assert accepts_keyword_arg(t.method, "x") is True
+    assert accepts_keyword_arg(t.method, "y") is True
+    assert accepts_keyword_arg(t.method, "self") is False
+
+    p = partial(t.method, 1)
+    assert accepts_keyword_arg(p, "y") is True
+

--- a/tests/test_session/test_compaction.py
+++ b/tests/test_session/test_compaction.py
@@ -367,3 +367,57 @@ async def test_custom_instructions_are_user_scoped_and_identifier_policy_stays_s
     assert "Focus on deployment decisions." not in messages[0]["content"]
     assert messages[1]["role"] == "user"
     assert "Focus on deployment decisions." in messages[1]["content"]
+
+
+def test_effective_compaction_model():
+    from types import SimpleNamespace
+
+    from agentos.session.compaction import effective_compaction_model
+
+    assert effective_compaction_model(None) is None
+    assert effective_compaction_model(SimpleNamespace()) is None
+    assert effective_compaction_model(SimpleNamespace(model="gpt-4o")) == "gpt-4o"
+    assert (
+        effective_compaction_model(
+            SimpleNamespace(model="gpt-4o", model_override="anthropic/claude-3-5-sonnet")
+        )
+        == "anthropic/claude-3-5-sonnet"
+    )
+
+
+def test_resolve_compaction_provider():
+    from types import SimpleNamespace
+
+    from agentos.session.compaction import resolve_compaction_provider
+
+    assert resolve_compaction_provider(SimpleNamespace(), None) is None
+
+    class FakeSelector:
+        def __init__(self, model="default"):
+            self.model = model
+
+        def clone(self):
+            return FakeSelector(self.model)
+
+        def override_model(self, model):
+            self.model = model
+
+        def resolve(self):
+            return f"provider:{self.model}"
+
+    ctx = SimpleNamespace(provider_selector=FakeSelector())
+    session = SimpleNamespace(model="anthropic/claude-3-5-sonnet")
+    resolved = resolve_compaction_provider(ctx, session)
+    assert resolved == "provider:anthropic/claude-3-5-sonnet"
+
+    # Test direct selector with model_override keyword argument (slash_standalone usage)
+    direct_resolved = resolve_compaction_provider(
+        FakeSelector(), model_override="openai/gpt-4o"
+    )
+    assert direct_resolved == "provider:openai/gpt-4o"
+
+    # Test direct selector without override
+    default_resolved = resolve_compaction_provider(FakeSelector())
+    assert default_resolved == "provider:default"
+
+


### PR DESCRIPTION
### Summary
Consolidates duplicated helper functions across the gateway, session, and engine packages into single canonical utilities:
1. **`_accepts_keyword_arg`** (Bug 12 DRY refactor)
2. **`_effective_compaction_model` / `_resolve_compaction_provider`** (Bug 13 DRY refactor)

### Problem & Motivation
- **`_accepts_keyword_arg`** was duplicated across 4 different modules (`rpc_sessions.py`, `channel_dispatch.py`, `context_overflow.py`, and `engine/runtime.py`) with conflicting fallback behaviors on introspection failure (`True` in `rpc_sessions`, `False` elsewhere).
- **`_effective_compaction_model`** and **`_resolve_compaction_provider`** were duplicated between `rpc_chat.py` and `rpc_sessions.py`, risking logic drift during compaction configuration and provider resolution updates.

### Key Changes
- **Extracted `accepts_keyword_arg`**: Created [`src/agentos/compat/inspect_utils.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/compat/inspect_utils.py) to reliably check named params, `**kwargs`, and positional-only arguments while gracefully handling un-inspectable objects and built-ins.
- **Extracted compaction provider helpers**: Added `effective_compaction_model` and `resolve_compaction_provider` (with `_` aliases) directly to [`src/agentos/session/compaction.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/src/agentos/session/compaction.py).
- **Replaced duplicates with imports**:
  - `src/agentos/gateway/rpc_sessions.py`
  - `src/agentos/gateway/rpc_chat.py`
  - `src/agentos/gateway/channel_dispatch.py`
  - `src/agentos/gateway/context_overflow.py`
  - `src/agentos/engine/runtime.py`
- **Added comprehensive test suites**:
  - Added [`tests/test_compat_inspect_utils.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_compat_inspect_utils.py) for signature introspection edge cases.
  - Added unit tests in [`tests/test_session/test_compaction.py`](file:///c:/Users/Administrator/.antigravity-ide/agent-os/tests/test_session/test_compaction.py) for model extraction and provider resolution.

### Verification
- `uv run ruff check` (passed)
- `uv run mypy src/agentos --show-error-codes` (0 issues across 623 files)
- `uv run pytest tests/test_compat_inspect_utils.py tests/test_session/test_compaction.py tests/test_gateway/test_rpc_sessions.py tests/test_gateway/test_channel_concurrent_dispatch.py tests/test_gateway/test_context_overflow.py -q` (167 passed)
closes #1201 