### PR TITLE
fix(tools): prevent git_commit from staging entire repository when fi…

### DIFF
--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -204,10 +204,11 @@ async def git_commit(
     workdir: str | None = None,
 ) -> str:
     cwd = _effective_workdir(workdir)
-    if files:
-        for file_path in files:
-            _reject_foreign_git_path(file_path)
-        await _run_git("add", "--", *files, cwd=cwd)
+    if files is not None:
+        if files:
+            for file_path in files:
+                _reject_foreign_git_path(file_path)
+            await _run_git("add", "--", *files, cwd=cwd)
     else:
         await _run_git("add", "-A", cwd=cwd)
     return await _run_git("commit", "-m", message, cwd=cwd)

--- a/src/agentos/tools/builtin/git.py
+++ b/src/agentos/tools/builtin/git.py
@@ -211,6 +211,16 @@ async def git_commit(
             await _run_git("add", "--", *files, cwd=cwd)
     else:
         await _run_git("add", "-A", cwd=cwd)
+
+    # files=[] deliberately stages nothing new, so the index may still be
+    # empty (or unchanged from before this call). `git commit` would fail
+    # with its own "nothing to commit" text as an uncaught RuntimeError from
+    # _run_git; checking first lets an empty commit attempt return a plain
+    # result instead.
+    staged = await _run_git("diff", "--cached", "--name-only", cwd=cwd)
+    if not staged.strip():
+        return "Nothing staged to commit."
+
     return await _run_git("commit", "-m", message, cwd=cwd)
 
 

--- a/tests/test_tools/test_git_workdir_policy.py
+++ b/tests/test_tools/test_git_workdir_policy.py
@@ -79,3 +79,60 @@ def test_git_diff_argv_staged_with_path() -> None:
         "--",
         "src/main.py",
     )
+
+
+@pytest.mark.asyncio
+async def test_git_commit_empty_files_skips_git_add(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded_commands: list[tuple[tuple[str, ...], str | None]] = []
+
+    async def _mock_run_git(*args: str, cwd: str | None = None) -> str:
+        recorded_commands.append((args, cwd))
+        return "ok"
+
+    monkeypatch.setattr(git, "_run_git", _mock_run_git)
+    raw_git_commit = git.git_commit.__wrapped__.__wrapped__
+    result = await raw_git_commit(message="commit only staged", files=[], workdir="/repo")
+    assert result == "ok"
+    assert recorded_commands == [(("commit", "-m", "commit only staged"), "/repo")]
+
+
+@pytest.mark.asyncio
+async def test_git_commit_omitted_files_runs_git_add_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded_commands: list[tuple[tuple[str, ...], str | None]] = []
+
+    async def _mock_run_git(*args: str, cwd: str | None = None) -> str:
+        recorded_commands.append((args, cwd))
+        return "ok"
+
+    monkeypatch.setattr(git, "_run_git", _mock_run_git)
+    raw_git_commit = git.git_commit.__wrapped__.__wrapped__
+    result = await raw_git_commit(message="stage all", files=None, workdir="/repo")
+    assert result == "ok"
+    assert recorded_commands == [
+        (("add", "-A"), "/repo"),
+        (("commit", "-m", "stage all"), "/repo"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_git_commit_specific_files_stages_only_specified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_commands: list[tuple[tuple[str, ...], str | None]] = []
+
+    async def _mock_run_git(*args: str, cwd: str | None = None) -> str:
+        recorded_commands.append((args, cwd))
+        return "ok"
+
+    monkeypatch.setattr(git, "_run_git", _mock_run_git)
+    monkeypatch.setattr(git, "_reject_foreign_git_path", lambda p: None)
+    raw_git_commit = git.git_commit.__wrapped__.__wrapped__
+    result = await raw_git_commit(
+        message="stage some", files=["file1.py", "file2.py"], workdir="/repo"
+    )
+    assert result == "ok"
+    assert recorded_commands == [
+        (("add", "--", "file1.py", "file2.py"), "/repo"),
+        (("commit", "-m", "stage some"), "/repo"),
+    ]
+

--- a/tests/test_tools/test_git_workdir_policy.py
+++ b/tests/test_tools/test_git_workdir_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -93,7 +94,10 @@ async def test_git_commit_empty_files_skips_git_add(monkeypatch: pytest.MonkeyPa
     raw_git_commit = git.git_commit.__wrapped__.__wrapped__
     result = await raw_git_commit(message="commit only staged", files=[], workdir="/repo")
     assert result == "ok"
-    assert recorded_commands == [(("commit", "-m", "commit only staged"), "/repo")]
+    assert recorded_commands == [
+        (("diff", "--cached", "--name-only"), "/repo"),
+        (("commit", "-m", "commit only staged"), "/repo"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -110,6 +114,7 @@ async def test_git_commit_omitted_files_runs_git_add_all(monkeypatch: pytest.Mon
     assert result == "ok"
     assert recorded_commands == [
         (("add", "-A"), "/repo"),
+        (("diff", "--cached", "--name-only"), "/repo"),
         (("commit", "-m", "stage all"), "/repo"),
     ]
 
@@ -133,6 +138,92 @@ async def test_git_commit_specific_files_stages_only_specified(
     assert result == "ok"
     assert recorded_commands == [
         (("add", "--", "file1.py", "file2.py"), "/repo"),
+        (("diff", "--cached", "--name-only"), "/repo"),
         (("commit", "-m", "stage some"), "/repo"),
     ]
 
+
+@pytest.mark.asyncio
+async def test_git_commit_reports_nothing_staged_instead_of_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_commands: list[tuple[tuple[str, ...], str | None]] = []
+
+    async def _mock_run_git(*args: str, cwd: str | None = None) -> str:
+        recorded_commands.append((args, cwd))
+        if args[0] == "diff":
+            return ""  # nothing staged
+        return "ok"
+
+    monkeypatch.setattr(git, "_run_git", _mock_run_git)
+    raw_git_commit = git.git_commit.__wrapped__.__wrapped__
+    result = await raw_git_commit(message="commit only staged", files=[], workdir="/repo")
+
+    assert result == "Nothing staged to commit."
+    # No commit was attempted against an empty index.
+    assert recorded_commands == [(("diff", "--cached", "--name-only"), "/repo")]
+
+
+def _init_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "file1.txt").write_text("original\n", encoding="utf-8")
+    subprocess.run(["git", "add", "file1.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=repo, check=True)
+
+
+def _porcelain_status(repo: Path, path: str) -> str:
+    return subprocess.run(
+        ["git", "status", "--porcelain", path],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+async def test_git_commit_empty_files_does_not_stage_untracked_files(tmp_path: Path) -> None:
+    """End-to-end regression for #1203: files=[] must not fall through to
+    `git add -A` and sweep an untracked file (e.g. a stray secrets file)
+    into the commit."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    (repo / "file1.txt").write_text("modified\n", encoding="utf-8")
+    subprocess.run(["git", "add", "file1.txt"], cwd=repo, check=True)
+    (repo / "secret.txt").write_text("do-not-commit\n", encoding="utf-8")
+
+    raw_git_commit = git.git_commit.__wrapped__.__wrapped__
+    result = await raw_git_commit(message="commit staged only", files=[], workdir=str(repo))
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.splitlines()
+    assert "secret.txt" not in tracked
+    assert _porcelain_status(repo, "secret.txt") == "?? secret.txt\n"
+    assert "commit staged only" in result
+
+    committed_file1 = subprocess.run(
+        ["git", "show", "HEAD:file1.txt"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+    assert committed_file1 == "modified\n"
+
+
+async def test_git_commit_omitted_files_does_stage_untracked_files(tmp_path: Path) -> None:
+    """Contrast case: files=None (omitted) is the one input that should
+    still sweep in untracked files, per the documented `git add -A` default."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    (repo / "new_file.txt").write_text("brand new\n", encoding="utf-8")
+
+    raw_git_commit = git.git_commit.__wrapped__.__wrapped__
+    await raw_git_commit(message="stage everything", files=None, workdir=str(repo))
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.splitlines()
+    assert "new_file.txt" in tracked


### PR DESCRIPTION
closes #1203 
### Description

Fixes an issue in the `git_commit` built-in tool where explicitly passing `files=[]` caused the entire working tree to be staged and committed via `git add -A` instead of committing only already-staged changes.

### Problem
The `git_commit` tool parameter documentation specifies:
> `files: "Files to stage. If omitted, stages all changes (git add -A)."`

However, the implementation used a truthiness check:
```python
if files:
    await _run_git("add", "--", *files, cwd=cwd)
else:
    await _run_git("add", "-A", cwd=cwd)
```
When a caller or model explicitly provided `files=[]` (e.g. intending to commit already staged files without adding untracked/modified changes, or when an internal filter yielded zero files), `bool([])` evaluated to `False`. The code fell through to `else:`, executing `git add -A` and staging the entire working tree without consent.

### Solution
- Differentiated between `files is not None` (explicit parameter provided) and `files is None` (omitted parameter):
  - When `files is None`: runs `git add -A`.
  - When `files` is a non-empty list: stages each specified file via `git add -- *files`.
  - When `files` is `[]`: bypasses `git add` and directly executes `git commit -m <message>`.

### Verification
- Added unit regression tests in [`tests/test_tools/test_git_workdir_policy.py`](file:///c:/Users/SHATTER/.vscode/agent-os/tests/test_tools/test_git_workdir_policy.py):
  - `test_git_commit_empty_files_skips_git_add`: verifies that `files=[]` skips staging and only commits.
  - `test_git_commit_omitted_files_runs_git_add_all`: verifies that `files=None` stages all changes.
  - `test_git_commit_specific_files_stages_only_specified`: verifies that passing specific files stages only those files.
- All tests in `tests/test_tools/test_git_workdir_policy.py` passed (11/11).
- Lint (`ruff`) and static types (`mypy`) passed clean.