### PR TITLE
fix(gateway): notify channel and log details on debounce delivery failure

### DIFF
--- a/src/agentos/gateway/_debounce.py
+++ b/src/agentos/gateway/_debounce.py
@@ -102,5 +102,5 @@ class _DefaultDebounceCoordinator:
             await on_fire(combined)
         except asyncio.CancelledError:
             raise
-        except Exception:
-            log.exception("channel_dispatch.debounce_enqueue_failed", reason="unexpected")
+        except Exception as exc:
+            log.exception("channel_dispatch.debounce_enqueue_failed", session_key=session_key, reason="unexpected", error=str(exc))

--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -899,10 +899,17 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
         if isinstance(exc, TaskQueueFullError):
             await status_reactor.failed(msg)
             log.warning("channel_dispatch.debounce_enqueue_failed", session_key=session_key, reason="queue_full", coalesced_count=combined.coalesced_count)  # noqa: E501
-            await channel.send(_route_envelope_reply_message("Your messages couldn't be processed because the queue is full. Please retry.", route_envelope))  # noqa: E501
+            try:
+                await channel.send(_route_envelope_reply_message("Your messages couldn't be processed because the queue is full. Please retry.", route_envelope))  # noqa: E501
+            except Exception:
+                log.warning("channel_dispatch.debounce_error_reply_failed", session_key=session_key, reason="queue_full")  # noqa: E501
             return
         log.exception("channel_dispatch.debounce_enqueue_failed", session_key=session_key, reason="unexpected")  # noqa: E501
         await status_reactor.failed(msg)
+        try:
+            await channel.send(_route_envelope_reply_message("An unexpected error occurred while processing your message. Please retry.", route_envelope))  # noqa: E501
+        except Exception:
+            log.warning("channel_dispatch.debounce_error_reply_failed", session_key=session_key, reason="unexpected")  # noqa: E501
         return
 
     # Enqueue succeeded — release the placeholder reservation now that the real

--- a/tests/test_gateway/test_debounce_buffer_cap.py
+++ b/tests/test_gateway/test_debounce_buffer_cap.py
@@ -115,3 +115,27 @@ async def test_debounce_cap_flush_isolates_next_window():
     counts = [getattr(c, "coalesced_count", 0) for c in fired]
     assert counts.count(MAX_COALESCED_MESSAGES) == 1
     assert counts.count(1) == 1
+
+
+async def test_debounce_deliver_handles_on_fire_exception():
+    """An exception in on_fire is logged and does not crash the debounce coordinator."""
+    coord = _DefaultDebounceCoordinator()
+
+    async def failing_on_fire(combined: object) -> None:
+        raise RuntimeError("Database connection failed")
+
+    # Scheduling and triggering delivery should not raise uncaught exception
+    await coord.schedule("tg:chat1", _msg("hello"), window_s=0.01, on_fire=failing_on_fire)
+    await asyncio.sleep(0.05)
+
+    # Coordinator remains functional for subsequent messages
+    fired: list[object] = []
+
+    async def ok_on_fire(combined: object) -> None:
+        fired.append(combined)
+
+    await coord.schedule("tg:chat1", _msg("next"), window_s=0.01, on_fire=ok_on_fire)
+    await asyncio.sleep(0.05)
+    assert len(fired) == 1
+    assert getattr(fired[0], "content") == "next"
+


### PR DESCRIPTION
### Summary
Ensures proper exception logging and user notification when debounced channel message delivery encounters unexpected failures.

### Problem
1. In `src/agentos/gateway/_debounce.py`, `_DefaultDebounceCoordinator._deliver` swallowed all non-`CancelledError` exceptions with a bare log missing the `session_key` and exception details.
2. In `src/agentos/gateway/channel_dispatch.py`, `_dispatch_combined_message_after_debounce` marked the status reactor as failed on unexpected exceptions but never sent a reply to the channel (unlike `TaskQueueFullError`), causing coalesced user messages to vanish silently without user feedback.

### Changes
- **`src/agentos/gateway/_debounce.py`**: Updated `_deliver` exception handling to log `session_key`, `reason="unexpected"`, and `error=str(exc)`.
- **`src/agentos/gateway/channel_dispatch.py`**: Added an error reply message via `channel.send()` in `_dispatch_combined_message_after_debounce` so users receive actionable feedback on unexpected errors.
- **`tests/test_gateway/test_debounce_buffer_cap.py`**: Added unit test `test_debounce_deliver_handles_on_fire_exception` verifying delivery exception handling and subsequent debounce window isolation.

### Verification
- `uv run ruff check src tests` (passed)
- `uv run mypy src/agentos --show-error-codes` (0 issues across 622 files)
- `uv run pytest tests/test_gateway/test_debounce_buffer_cap.py tests/test_gateway/test_channel_concurrent_dispatch.py -q` (27 passed)
closes #1206 