### PR TITLE
fix(tools): record workspace file writes on write_file overwrites for…

### DIFF
--- a/src/agentos/tools/builtin/filesystem.py
+++ b/src/agentos/tools/builtin/filesystem.py
@@ -779,15 +779,13 @@ async def write_file(path: str, content: str, approval_id: str | None = None) ->
         return json.dumps(approval)
 
     loop = asyncio.get_running_loop()
-    created = not p.exists()
 
     def _write() -> None:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
 
     await loop.run_in_executor(None, _write)
-    if created:
-        record_workspace_file_write(p)
+    record_workspace_file_write(p)
     _notify_memory_source_write(p)
     _notify_bootstrap_source_write(p)
     return f"Written {len(content)} bytes to {p}"

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -837,6 +837,64 @@ async def test_turn_runner_auto_publishes_deliverable_file_when_model_omits_publ
 
 
 @pytest.mark.asyncio
+async def test_turn_runner_auto_publishes_overwritten_deliverable_file(tmp_path) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:webchat:artifact-overwrite-omitted"
+    session = await manager.create(session_key)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "manual-big-write.html").write_text(
+        "<!doctype html><title>Old</title>", encoding="utf-8"
+    )
+
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(_OmittedPublishProvider()),
+        tool_registry=_write_file_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            agentos_router=AgentOSRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        allowed_tools={"write_file"},
+        elevated="full",
+    )
+
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "update the html page",
+                session_key,
+                tool_context=tool_context,
+                history_has_persisted_user=False,
+                no_memory_capture=True,
+            )
+        ]
+
+        artifact_events = [event for event in events if isinstance(event, ArtifactEvent)]
+        assert len(artifact_events) == 1
+        assert artifact_events[0].name == "manual-big-write.html"
+        assert artifact_events[0].mime == "text/html"
+        assert artifact_events[0].session_id == session.session_id
+
+        transcript = await manager.get_transcript(session_key)
+        assistant = [entry for entry in transcript if entry.role == "assistant"][-1]
+        payload = json.loads(assistant.content)
+        assert payload["text"] == "Created manual-big-write.html for you."
+        assert payload["artifacts"][0]["name"] == "manual-big-write.html"
+        assert payload["artifacts"][0]["source"] == "auto_publish_omitted"
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
 async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) -> None:
     storage = SessionStorage(":memory:")
     await storage.connect()

--- a/tests/test_tools/test_filesystem_read_workspace.py
+++ b/tests/test_tools/test_filesystem_read_workspace.py
@@ -410,3 +410,28 @@ async def test_list_dir_broken_symlink_does_not_crash(tmp_path: Path) -> None:
     assert "[file] valid.txt" in output
     assert "broken_link.txt" in output
 
+
+@pytest.mark.asyncio
+async def test_write_file_records_workspace_write_on_both_create_and_overwrite(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = ToolContext(workspace_dir=str(workspace))
+    token = current_tool_context.set(ctx)
+    raw_write_file = fs.write_file.__wrapped__.__wrapped__
+    target = workspace / "report.html"
+    try:
+        # First write: file is created
+        await raw_write_file(str(target), "<h1>Initial</h1>")
+        assert len(ctx.workspace_file_writes) == 1
+        assert ctx.workspace_file_writes[0]["name"] == "report.html"
+
+        # Second write: file already exists and is overwritten
+        await raw_write_file(str(target), "<h1>Updated</h1>")
+        assert len(ctx.workspace_file_writes) == 2
+        assert ctx.workspace_file_writes[1]["name"] == "report.html"
+    finally:
+        current_tool_context.reset(token)
+
+


### PR DESCRIPTION
closes #1205 

---

### Description

Fixes an issue where `write_file` only recorded workspace writes when creating new files, causing file overwrites to be omitted from write tracking and preventing updated deliverable artifacts from being auto-published.

### Problem
In `write_file` ([`src/agentos/tools/builtin/filesystem.py`](file:///c:/Users/SHATTER/.vscode/agent-os/src/agentos/tools/builtin/filesystem.py)), `record_workspace_file_write(p)` was guarded by `if created:` where `created = not p.exists()`.

When an agent updated or regenerated an existing workspace deliverable (e.g. overwriting `report.html` or `summary.csv` with fresh content):
- Because the file already existed, `created` was `False`.
- `record_workspace_file_write(p)` was skipped.
- At turn conclusion, `publish_omitted_turn_workspace_artifacts` inspected `ctx.workspace_file_writes` and found no record of the update, failing to publish or deliver the updated artifact to the user/channel.

### Solution
- Removed the `created = not p.exists()` check and the `if created:` guard in `write_file`.
- Called `record_workspace_file_write(p)` unconditionally on all file writes, ensuring all workspace modifications (creates and overwrites alike) are recorded in `ctx.workspace_file_writes`.

### Verification
- Added regression tests:
  - `tests/test_tools/test_filesystem_read_workspace.py::test_write_file_records_workspace_write_on_both_create_and_overwrite`
  - `tests/test_engine/test_runtime_artifacts.py::test_turn_runner_auto_publishes_overwritten_deliverable_file`
- Target test suites passed clean (`28 passed, 4 skipped`).
- Lint (`ruff`) and static types (`mypy`) passed clean.