### PR TITLE
fix(metrics,sessions): unify _emit_metric helper and fix preview title fallback

### DIFF
--- a/src/agentos/gateway/channel_dispatch.py
+++ b/src/agentos/gateway/channel_dispatch.py
@@ -62,6 +62,7 @@ from agentos.execution_status import normalize_execution_status
 from agentos.gateway.attachment_ingest import AttachmentIngestResult, ingest_attachments
 from agentos.gateway.audio_transcription import MAX_TRANSCRIPTION_BYTES
 from agentos.gateway.session_events import build_sessions_changed_payload
+from agentos.observability.metrics import _emit_metric
 from agentos.paths import media_root_from_config
 from agentos.permissions import configured_default_elevated
 from agentos.plan_mode import format_plan_as_text, plan_from_tool_result
@@ -99,17 +100,6 @@ def _terminal_payload_from_error_event(event: ErrorEvent) -> dict[str, str | Non
 
 def _terminal_reply_suffix(message: str) -> str:
     return f"\n\n({message})"
-
-
-def _emit_metric(name: str, value: int = 1, **labels: Any) -> None:
-    """Emit a structured log line for a core metric (mirrors task_runtime._emit_metric).
-
-    Format: event=<name> metric=<name> value=<int> [labels...]
-    Used here for channel-adapter-level counters (queue_full_errors_total,
-    turn_cancellations_total) that originate outside task_runtime.  Kept as a
-    local copy to avoid a routing→task_runtime→channel_dispatch import cycle.
-    """
-    log.info(name, metric=name, value=value, **labels)
 
 
 def _resolve_channel_overflow_policy(channel: Any, config: Any) -> str | None:

--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -2350,7 +2350,8 @@ async def _handle_sessions_preview(params: dict | None, ctx: RpcContext) -> dict
         title = (
             getattr(s, "display_name", None)
             or getattr(s, "derived_title", None)
-            or s.session_id[:8]
+            or getattr(s, "session_id", None)
+            or getattr(s, "session_key", "")
         )
         last_msg = ""
         try:

--- a/src/agentos/gateway/task_runtime.py
+++ b/src/agentos/gateway/task_runtime.py
@@ -31,6 +31,7 @@ import structlog
 from agentos.engine.outcome import completed_outcome, outcome_from_error
 from agentos.gateway.routing import RouteEnvelope, SourceKind
 from agentos.gateway.session_lifecycle import TaskLifecycleEvent, TaskLifecycleListener
+from agentos.observability.metrics import _emit_metric
 from agentos.session.keys import canonicalize_session_key, normalize_agent_id, parse_agent_id
 from agentos.session.models import AgentTaskRecord, AgentTaskStatus
 from agentos.session.terminal_reply import (
@@ -49,25 +50,6 @@ log = structlog.get_logger(__name__)
 #   turn_cancellations_total  (counter) — cumulative cancel/interrupt/timeout
 #   queue_full_errors_total   (counter) — cumulative TaskQueueFullError raises
 # ---------------------------------------------------------------------------
-
-
-def _emit_metric(name: str, value: int = 1, **labels: Any) -> None:
-    """Emit a structured log line for a core metric.
-
-    Format: event=<name> metric=<name> value=<int> [labels...]
-    Grep pattern: ``metric=<name>``
-    """
-    log.info(name, metric=name, value=value, **labels)
-    try:
-        from agentos.observability.metrics import record_metric
-
-        # Drop session_key and unbounded session identifiers from exported Prometheus labels
-        metric_labels = {
-            k: v for k, v in labels.items() if k not in {"session_key", "session_id", "turn_id"}
-        }
-        record_metric(name, value, **metric_labels)
-    except Exception:
-        pass
 
 
 TERMINAL_STATUSES = frozenset(

--- a/src/agentos/observability/metrics.py
+++ b/src/agentos/observability/metrics.py
@@ -395,3 +395,23 @@ def record_metric(name: str, value: float = 1.0, **labels: Any) -> None:
 def format_prometheus_metrics() -> str:
     """Return Prometheus text exposition for all registered metrics."""
     return get_metrics_registry().format_prometheus()
+
+
+def emit_metric(name: str, value: int = 1, **labels: Any) -> None:
+    """Emit a structured log line and Prometheus recording for a core metric.
+
+    Format: event=<name> metric=<name> value=<int> [labels...]
+    Grep pattern: ``metric=<name>``
+    """
+    log.info(name, metric=name, value=value, **labels)
+    try:
+        # Drop session_key and unbounded session identifiers from exported Prometheus labels
+        metric_labels = {
+            k: v for k, v in labels.items() if k not in {"session_key", "session_id", "turn_id"}
+        }
+        record_metric(name, value, **metric_labels)
+    except Exception as exc:
+        log.debug("record_metric_failed", metric=name, error=str(exc), exc_info=True)
+
+
+_emit_metric = emit_metric

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2715,6 +2715,17 @@ class TestSessionsPreview:
         assert res.ok is True
         assert res.payload["previews"] == []
 
+    @pytest.mark.asyncio
+    async def test_preview_fallback_title_preserves_full_identifier(self, dispatcher):
+        mock_sess = FakeSession()
+        mock_sess.session_id = "uuid-1234-5678-abcdef"
+        mock_sess.display_name = None
+        mock_sess.derived_title = None
+        ctx = make_ctx(session_manager=FakeSessionManager([mock_sess]))
+        res = await dispatcher.dispatch("r1", "sessions.preview", None, ctx)
+        assert res.ok is True
+        assert res.payload["previews"][0]["title"] == "uuid-1234-5678-abcdef"
+
 
 class TestSessionsResolve:
     @pytest.mark.asyncio

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -161,3 +161,20 @@ def test_gateway_config_rejects_metrics_path_under_control_ui_base_path() -> Non
                 "observability": {"metrics_path": "/control/metrics"},
             }
         )
+
+
+def test_emit_metric_records_and_strips_session_identifiers() -> None:
+    from agentos.observability.metrics import _emit_metric, get_metrics_registry
+
+    _emit_metric(
+        "turn_cancellations_total",
+        value=1,
+        reason="reply_task_error",
+        session_key="agent:main:123",
+        session_id="sess-456",
+        turn_id="turn-789",
+    )
+    formatted = get_metrics_registry().format_prometheus()
+    assert 'turn_cancellations_total{reason="reply_task_error"}' in formatted
+    assert "session_key" not in formatted
+    assert "session_id" not in formatted


### PR DESCRIPTION
### Summary
This PR addresses two related maintenance and reliability issues:

1. **Unify `_emit_metric` duplicate implementations (Bug 14):**
   - `_emit_metric` was defined redundantly in both `agentos.gateway.task_runtime` and `agentos.gateway.channel_dispatch` (noted as duplicated to avoid circular imports).
   - Consolidated `emit_metric` / `_emit_metric` in `agentos.observability.metrics` to ensure structured logging, Prometheus metric recording, and unbounded session label filtering (`session_key`, `session_id`, `turn_id`) remain in one central place without circular dependencies.
   - Replaced duplicate implementations with imports in `task_runtime.py` and `channel_dispatch.py`.

2. **Fix `sessions.preview` title truncation collision risk (Bug 15):**
   - In `agentos.gateway.rpc_sessions._handle_sessions_preview`, when neither `display_name` nor `derived_title` was present, the title fell back to `s.session_id[:8]`.
   - For UUID-based session IDs, the 8-character prefix carries collision risks across large numbers of sessions.
   - Updated the fallback chain to preserve the full session identifier (`getattr(s, "session_id", None) or getattr(s, "session_key", "")`).

### Changes
- `src/agentos/observability/metrics.py`: Added canonical `emit_metric` and `_emit_metric` alias with label filtering and failure debug logging.
- `src/agentos/gateway/task_runtime.py`: Removed duplicate `_emit_metric` definition and imported from `agentos.observability.metrics`.
- `src/agentos/gateway/channel_dispatch.py`: Removed duplicate `_emit_metric` definition and imported from `agentos.observability.metrics`.
- `src/agentos/gateway/rpc_sessions.py`: Updated `_handle_sessions_preview` fallback title logic.
- `tests/test_observability_metrics.py`: Added `test_emit_metric_records_and_strips_session_identifiers`.
- `tests/test_gateway/test_rpc_sessions.py`: Added `test_preview_fallback_title_preserves_full_identifier`.

### Verification
- `uv run ruff check src tests` (All passed)
- `uv run ruff format src/agentos/gateway/channel_dispatch.py src/agentos/gateway/rpc_sessions.py src/agentos/gateway/task_runtime.py src/agentos/observability/metrics.py tests/test_observability_metrics.py tests/test_gateway/test_rpc_sessions.py` (Clean)
- `uv run mypy src/agentos --show-error-codes` (0 issues across 622 source files)
- `uv run pytest tests/test_observability_metrics.py tests/test_gateway/test_rpc_sessions.py tests/test_gateway/test_channel_concurrent_dispatch.py -q` (129 passed)
closes #1210 