### PR TITLE
fix(channels): mark unparseable or empty IMAP messages as seen

### DIFF
--- a/src/agentos/channels/email.py
+++ b/src/agentos/channels/email.py
@@ -540,6 +540,13 @@ class EmailChannel:
             return None
         raw = _first_literal(body_data)
         if raw is None:
+            log.warning(
+                "email.message_unparseable",
+                name=self.config.name,
+                uid=uid,
+                reason="empty_or_missing_literal",
+            )
+            self._mark_seen(client, uid)
             return None
         if len(raw) > self.config.max_message_bytes:
             log.warning(
@@ -552,7 +559,16 @@ class EmailChannel:
             return None
 
         parsed = BytesParser(policy=email_policy).parsebytes(raw)
-        return parsed if isinstance(parsed, EmailMessage) else None
+        if not isinstance(parsed, EmailMessage):
+            log.warning(
+                "email.message_unparseable",
+                name=self.config.name,
+                uid=uid,
+                reason="not_an_email_message",
+            )
+            self._mark_seen(client, uid)
+            return None
+        return parsed
 
     def _mark_seen(self, client: imaplib.IMAP4, uid: str) -> None:
         if not self.config.mark_seen:

--- a/tests/test_channels/test_email_channel.py
+++ b/tests/test_channels/test_email_channel.py
@@ -738,6 +738,39 @@ def test_poll_skips_a_message_larger_than_the_cap(monkeypatch: pytest.MonkeyPatc
     assert fake.stored == [("7", "+FLAGS", "\\Seen")]
 
 
+def test_poll_skips_and_marks_seen_message_with_missing_literal_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    def _fetch(uid: str, spec: str) -> tuple[str, list[Any]]:
+        if "RFC822.SIZE" in spec:
+            return "OK", [b"7 (RFC822.SIZE 100)"]
+        return "OK", [b")"]
+
+    monkeypatch.setattr(fake, "fetch", _fetch)
+
+    assert channel._fetch_unseen() == []
+    assert fake.stored == [("7", "+FLAGS", "\\Seen")]
+
+
+def test_poll_skips_and_marks_seen_non_email_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = EmailChannel(config=_config())
+    fake = _FakeIMAP(_raw().as_bytes())
+    monkeypatch.setattr(channel, "_imap_connect", lambda: fake)
+
+    import email.parser
+
+    monkeypatch.setattr(email.parser.BytesParser, "parsebytes", lambda self, raw: "not_a_message")
+
+    assert channel._fetch_unseen() == []
+    assert fake.stored == [("7", "+FLAGS", "\\Seen")]
+
+
 def test_one_unreadable_message_does_not_sink_the_poll(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
closes #1209 

---

### **Description**

#### Summary
Fixes an infinite polling loop in `EmailChannel` where unseen messages that return `OK` from IMAP but contain no literal byte payload (`_first_literal(body_data)` is `None`) or fail to parse into an `EmailMessage` were returned as `None` without being acknowledged (`_mark_seen`).

#### Root Cause
In `_fetch_unseen`, when `parsed is None`, the loop executed `continue`, bypassing `_mark_seen(client, uid)`. Consequently, on every subsequent poll interval, IMAP `SEARCH UNSEEN` returned the exact same message UID, permanently stalling the poller on corrupt or empty stubs.

#### Solution
- In `EmailChannel._fetch_one`:
  - When `raw is None` after a successful `FETCH (BODY.PEEK[])`, log `email.message_unparseable` with `reason="empty_or_missing_literal"`, invoke `self._mark_seen(client, uid)`, and return `None`.
  - When `BytesParser` returns an object that is not an `EmailMessage`, log `email.message_unparseable` with `reason="not_an_email_message"`, invoke `self._mark_seen(client, uid)`, and return `None`.
- Preserves intentional behavior where unexpected fetch exceptions and transient conversion errors (`_to_incoming`) remain unacknowledged for retries.
- Added regression tests `test_poll_skips_and_marks_seen_message_with_missing_literal_body` and `test_poll_skips_and_marks_seen_non_email_message`.

#### Verification
- `uv run pytest tests/test_channels/test_email_channel.py` (all 83 tests pass)
- `uv run ruff check src/agentos/channels/email.py tests/test_channels/test_email_channel.py`
- `uv run mypy src/agentos/channels/email.py --show-error-codes`
