### PR TITLE
fix(telegram): pad/truncate ragged table rows instead of aborting parse

### DIFF
--- a/src/agentos/channels/_telegram_formatting.py
+++ b/src/agentos/channels/_telegram_formatting.py
@@ -120,14 +120,24 @@ def _is_table_start(lines: list[str], index: int) -> bool:
     )
 
 
+def _normalize_row(row: list[str], column_count: int) -> list[str]:
+    """Pad short rows or truncate long ones to exactly *column_count* cells."""
+    if len(row) < column_count:
+        return row + [""] * (column_count - len(row))
+    return row[:column_count]
+
+
 def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
     clean_headers = [_plain_inline(header) for header in headers]
-    if len(headers) == 2:
+    column_count = len(headers)
+    if column_count == 2:
         rendered = [
             f"<b>{html.escape(clean_headers[0])} — {html.escape(clean_headers[1])}</b>"
         ]
         for row in rows:
-            label, value = row
+            normalised = _normalize_row(row, column_count)
+            label = normalised[0]
+            value = normalised[1]
             clean_label = _plain_inline(label)
             if clean_label:
                 rendered.append(f"<b>{html.escape(clean_label)}:</b> {_render_inline(value)}")
@@ -137,9 +147,10 @@ def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
 
     rendered = [f"<b>{' · '.join(html.escape(header) for header in clean_headers)}</b>"]
     for row in rows:
+        normalised = _normalize_row(row, column_count)
         cells = [
             f"<b>{html.escape(header)}:</b> {_render_inline(value)}"
-            for header, value in zip(clean_headers, row, strict=True)
+            for header, value in zip(clean_headers, normalised)
             if value
         ]
         if cells:
@@ -177,8 +188,6 @@ def render_telegram_html(markdown: str) -> str:
             index += 2
             while index < len(lines) and "|" in lines[index] and lines[index].strip():
                 row = _split_table_row(lines[index])
-                if len(row) != len(headers):
-                    break
                 rows.append(row)
                 index += 1
             rendered.extend(_render_table(headers, rows))

--- a/tests/test_channels/test_telegram_formatting.py
+++ b/tests/test_channels/test_telegram_formatting.py
@@ -120,3 +120,90 @@ async def test_telegram_send_falls_back_to_plain_text_on_entity_parse_error() ->
         "chat_id": "42",
         "text": "**Ready**: `agentos status`",
     }
+
+
+# ── Issue #1031: ragged table rows ──────────────────────────────────────
+
+
+def test_two_column_table_with_short_row_pads_missing_cell() -> None:
+    """A 2-column table row with only 1 cell should be padded, not dropped."""
+    markdown = (
+        "| Header A | Header B |\n"
+        "| --- | --- |\n"
+        "| Row 1 Only |\n"
+        "| x | y |\n"
+    )
+    rendered = render_telegram_html(markdown)
+
+    # Both rows must appear — the old `break` dropped "| x | y |".
+    assert "<b>Header A — Header B</b>" in rendered
+    assert "<b>Row 1 Only:</b>" in rendered
+    assert "<b>x:</b> y" in rendered
+    # No raw pipe characters should leak through.
+    assert "| x | y |" not in rendered
+    assert "| Row 1 Only |" not in rendered
+
+
+def test_three_column_table_with_short_row_pads_missing_cells() -> None:
+    """A 3-column table row missing trailing cells should be padded."""
+    markdown = (
+        "| A | B | C |\n"
+        "| --- | --- | --- |\n"
+        "| only-a |\n"
+        "| x | y | z |\n"
+    )
+    rendered = render_telegram_html(markdown)
+
+    assert "<b>A · B · C</b>" in rendered
+    # The short row has only column A filled; B and C are empty → filtered out.
+    assert "<b>A:</b> only-a" in rendered
+    # The well-formed row after the ragged one must also render.
+    assert "<b>A:</b> x" in rendered
+    assert "<b>B:</b> y" in rendered
+    assert "<b>C:</b> z" in rendered
+    assert "| x | y | z |" not in rendered
+
+
+def test_table_row_with_extra_columns_is_truncated() -> None:
+    """A row with more cells than headers should be truncated, not break."""
+    markdown = (
+        "| A | B |\n"
+        "| --- | --- |\n"
+        "| 1 | 2 | 3 | 4 |\n"
+        "| x | y |\n"
+    )
+    rendered = render_telegram_html(markdown)
+
+    assert "<b>A — B</b>" in rendered
+    # Extra columns (3, 4) should be silently truncated.
+    assert "<b>1:</b> 2" in rendered
+    assert "<b>x:</b> y" in rendered
+    assert "3" not in rendered
+    assert "4" not in rendered
+
+
+def test_mixed_ragged_rows_all_render_without_raw_pipes() -> None:
+    """Mix of short, exact, and long rows — none should leak raw Markdown."""
+    markdown = (
+        "| Name | Status | Notes |\n"
+        "| --- | --- | --- |\n"
+        "| alpha | ok | fine |\n"
+        "| beta |\n"
+        "| gamma | fail | bad | extra |\n"
+        "| delta | ok | good |\n"
+    )
+    rendered = render_telegram_html(markdown)
+
+    # All four data rows must be rendered (no break/abort).
+    assert "<b>Name:</b> alpha" in rendered
+    assert "<b>Status:</b> ok" in rendered
+    assert "<b>Notes:</b> fine" in rendered
+    assert "<b>Name:</b> beta" in rendered
+    assert "<b>Name:</b> gamma" in rendered
+    assert "<b>Status:</b> fail" in rendered
+    assert "<b>Notes:</b> bad" in rendered
+    assert "<b>Name:</b> delta" in rendered
+    # "extra" from the long row should be truncated.
+    assert "extra" not in rendered
+    # No raw pipe characters.
+    assert "|" not in rendered


### PR DESCRIPTION
## Summary

The `break` in `render_telegram_html` abandoned table parsing at the first row whose column count differed from the headers, emitting every subsequent well-formed row as raw Markdown (pipe characters visible in Telegram messages).

## Changes

- **`_normalize_row`** (new) — pads short rows with empty strings and truncates long rows to the header column count so the entire table is rendered.
- **`_render_table`** — uses safe indexing instead of tuple unpacking (`label, value = row`) and drops `strict=True` from `zip`.
- **`render_telegram_html`** — removes the `if len(row) != len(headers): break` guard; all rows are now collected and normalised.

## Tests

Four regression tests on rendered HTML output (per review guidance — no exception-based assertions):
- `test_two_column_table_with_short_row_pads_missing_cell`
- `test_three_column_table_with_short_row_pads_missing_cells`
- `test_table_row_with_extra_columns_is_truncated`
- `test_mixed_ragged_rows_all_render_without_raw_pipes`

All 10 tests pass ✅ | ruff ✅ | mypy ✅

Fixes #1031