### PR TITLE
fix(search): raise classified SearchProviderError from DuckDuckGo on HTTP/network failures

### DIFF
--- a/src/agentos/search/providers/duckduckgo.py
+++ b/src/agentos/search/providers/duckduckgo.py
@@ -47,18 +47,33 @@ class DuckDuckGoProvider:
                     headers=_HEADERS,
                 )
                 response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="timeout",
+                message=str(exc) or "DuckDuckGo search request timed out.",
+                retryable=True,
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code == 429:
+                kind: SearchErrorKind = "rate_limit"
+            else:
+                kind = "http"
+            raise SearchProviderError(
+                provider=self.name,
+                kind=kind,
+                message=str(exc) or f"DuckDuckGo search failed with HTTP {status_code}.",
+                retryable=kind == "rate_limit",
+                status_code=status_code,
+            ) from exc
         except httpx.HTTPError as exc:
-            if self._diagnostics:
-                kind: SearchErrorKind = (
-                    "timeout" if isinstance(exc, httpx.TimeoutException) else "network"
-                )
-                raise SearchProviderError(
-                    provider=self.name,
-                    kind=kind,
-                    message=str(exc) or "DuckDuckGo search network request failed.",
-                    retryable=True,
-                ) from exc
-            return []
+            raise SearchProviderError(
+                provider=self.name,
+                kind="network",
+                message=str(exc) or "DuckDuckGo search network request failed.",
+                retryable=True,
+            ) from exc
 
         soup = BeautifulSoup(response.text, "html.parser")
         results: list[SearchResult] = []

--- a/tests/test_search/test_duckduckgo_provider_errors.py
+++ b/tests/test_search/test_duckduckgo_provider_errors.py
@@ -1,0 +1,143 @@
+"""DuckDuckGo provider raises classified SearchProviderError on upstream failures.
+
+Regression for #1122: the provider used to swallow every ``httpx.HTTPError``
+when ``diagnostics`` was off (the default) and return ``[]``, making a real
+HTTP/network failure indistinguishable from "0 organic results found" and
+preventing the search fallback policy from cascading to a secondary provider.
+
+It must now align with the Brave and Tavily providers and always raise a
+structured ``SearchProviderError`` with a classified ``kind``
+(``timeout`` / ``rate_limit`` / ``http`` / ``network``).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from agentos.search.providers.duckduckgo import DuckDuckGoProvider
+from agentos.search.types import SearchProviderError
+
+
+def _client_raising(exc: Exception):
+    """Build an httpx.AsyncClient stand-in whose post() always raises *exc*."""
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self) -> _Client.Inner:
+            return self.Inner()
+
+        async def __aexit__(self, *args) -> None:
+            return None
+
+        class Inner:
+            def __init__(self) -> None:
+                pass
+
+            async def post(self, *args, **kwargs):
+                raise exc
+
+    return _Client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "kind", "retryable"),
+    [
+        (httpx.TimeoutException("t"), "timeout", True),
+        (
+            httpx.HTTPStatusError(
+                "429",
+                request=httpx.Request("POST", "x"),
+                response=httpx.Response(429),
+            ),
+            "rate_limit",
+            True,
+        ),
+        (
+            httpx.HTTPStatusError(
+                "500",
+                request=httpx.Request("POST", "x"),
+                response=httpx.Response(500),
+            ),
+            "http",
+            False,
+        ),
+        (httpx.ConnectError("boom"), "network", True),
+    ],
+)
+async def test_error_raises_classified(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: Exception,
+    kind: str,
+    retryable: bool,
+) -> None:
+    """A provider error is surfaced as a classified SearchProviderError."""
+    import agentos.search.providers.duckduckgo as mod
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", _client_raising(exc))
+    provider = DuckDuckGoProvider()  # diagnostics off (default)
+
+    with pytest.raises(SearchProviderError) as info:
+        await provider.search("hello")
+
+    assert info.value.provider == "duckduckgo"
+    assert info.value.kind == kind
+    assert info.value.retryable is retryable
+
+
+@pytest.mark.asyncio
+async def test_error_raises_with_diagnostics_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raising (not returning []) holds even when diagnostics is enabled."""
+    import agentos.search.providers.duckduckgo as mod
+
+    exc = httpx.ConnectError("boom")
+    monkeypatch.setattr(mod.httpx, "AsyncClient", _client_raising(exc))
+    provider = DuckDuckGoProvider(diagnostics=True)
+
+    with pytest.raises(SearchProviderError) as info:
+        await provider.search("hello")
+
+    assert info.value.kind == "network"
+
+
+@pytest.mark.asyncio
+async def test_success_still_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 200 response still yields parsed results (happy path unchanged)."""
+    import agentos.search.providers.duckduckgo as mod
+
+    html = (
+        '<div class="result web-result">'
+        '<h2 class="result__title"><a href="https://example.com/a">Example</a></h2>'
+        '<div class="result__snippet">snippet text</div>'
+        "</div>"
+    )
+
+    class _Inner:
+        async def post(self, *args, **kwargs):
+            resp = httpx.Response(200, text=html)
+            resp.request = httpx.Request("POST", "x")
+            return resp
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self) -> _Inner:
+            return _Inner()
+
+        async def __aexit__(self, *args) -> None:
+            return None
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", _Client)
+    provider = DuckDuckGoProvider()
+
+    results = await provider.search("hello")
+    assert len(results) == 1
+    assert results[0].title == "Example"
+    assert results[0].url == "https://example.com/a"
+    assert results[0].source == "duckduckgo"


### PR DESCRIPTION
Fixes #1122

## Summary

`DuckDuckGoProvider.search()` swallowed every `httpx.HTTPError` when `diagnostics` was off (the default) and returned `[]`. This made a real upstream HTTP 429, 5xx, timeout, or connection failure indistinguishable from a legitimate zero-result response — and prevented the search fallback policy from cascading to a secondary provider.

Align with Brave and Tavily: always raise `SearchProviderError` with a classified `kind` (`timeout` / `rate_limit` / `http` / `network`), `status_code` where applicable, and a matching `retryable` flag.

## What

- src/agentos/search/providers/duckduckgo.py — split the single `httpx.HTTPError` catch into three specific except blocks (`TimeoutException`, `HTTPStatusError`, `HTTPError`), each raising `SearchProviderError` with the correct kind and `retryable` flag
- tests/test_search/test_duckduckgo_provider_errors.py — regression suite: parametrised test covering all four error shapes (timeout, rate_limit=429, http=500, network) plus diagnostics-on and happy-path assertions

## Verification

- `uv run --with pytest-asyncio pytest tests/test_search/test_duckduckgo_provider_errors.py -q` — 6 passed
- `uv run ruff check src/agentos/search/providers/duckduckgo.py tests/test_search/test_duckduckgo_provider_errors.py` — clean
- `uv run mypy src/agentos/search/providers/duckduckgo.py --show-error-codes` — pre-existing bs4 stub gap (same as brave/tavily baseline)
- Empirical probe (3 error shapes): timeout → `kind=timeout`, HTTP 429 → `kind=rate_limit`, network → `kind=network` — all raise correctly
