### PR TITLE
fix(scheduler): escape parens and tolerate whitespace in fork-bomb regex

### DIFF
--- a/src/agentos/scheduler/prompt_safety.py
+++ b/src/agentos/scheduler/prompt_safety.py
@@ -14,7 +14,7 @@ _HARD_BLOCK_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"(curl|wget)\s+.*(\{\{|\\$[\w{])", re.IGNORECASE),
     re.compile(r"rm\s+-rf\s+/", re.IGNORECASE),
     re.compile(r"mkfs\.", re.IGNORECASE),
-    re.compile(r":(){ :\|:& };:", re.IGNORECASE),
+    re.compile(r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:", re.IGNORECASE),
 ]
 
 _BLOCKED_INVISIBLE_MARKS: frozenset[int] = frozenset(

--- a/tests/test_scheduler/test_prompt_safety.py
+++ b/tests/test_scheduler/test_prompt_safety.py
@@ -82,3 +82,25 @@ def test_allowed_whitespace_controls_remain_allowed(character: str) -> None:
 
     assert blocked is False
     assert reason == ""
+
+
+# ── Issue #998: fork-bomb regex ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        ":(){ :|:& };:",       # canonical
+        ":(){:|:&};:",         # no spaces
+        ":() { :|:& };:",     # space after ()
+        ":(){ :|:& } ;:",     # space before ;
+        ":(){ :|:& }; :",     # space after ;
+    ],
+)
+def test_fork_bomb_variants_are_blocked(task: str) -> None:
+    """All common whitespace variants of the bash fork bomb must be caught."""
+    blocked, reason = scan_cron_prompt(task)
+
+    assert blocked is True
+    assert "dangerous pattern" in reason
+


### PR DESCRIPTION
## Summary

The fork-bomb hard-block pattern in `_HARD_BLOCK_PATTERNS[4]` used bare `()` which Python's `re` treats as an empty capture group. The regex only matched the literal mutant `:{ :|:& };:` — every real fork-bomb variant passed through unblocked.

## Changes

### `src/agentos/scheduler/prompt_safety.py`

```diff
-    re.compile(r":(){ :\|:& };:", re.IGNORECASE),
+    re.compile(r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:", re.IGNORECASE),
```

- Escaped `()` → `\(\)` so they match literal parentheses
- Inserted `\s*` between all tokens to tolerate whitespace variants
- Covers `};:` variants (`} ;:`, `}; :`) per review guidance

### `tests/test_scheduler/test_prompt_safety.py`

5 parametrized regression cases asserting on `scan_cron_prompt` output (not pattern compilation):
- `:(){ :|:& };:` — canonical
- `:(){:|:&};:` — no spaces
- `:() { :|:& };:` — space after `()`
- `:(){ :|:& } ;:` — space before `;`
- `:(){ :|:& }; :` — space after `;`

All 25 tests pass ✅ | ruff ✅ | mypy ✅

Fixes #998