### PR TITLE
fix(memory): consume the session delta after a search-time sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   files through the CLI and fails if one does not exit 0
   ([#840](https://github.com/use-agent-os/agent-os/issues/840),
   [#835](https://github.com/use-agent-os/agent-os/issues/835)).
+- Memory search stops re-scanning the workspace on every query once a session
+  delta is pending. `MemorySyncManager.sync()` lets a pending delta bypass the
+  clean-search fast path, but it consumed that delta only when a session
+  indexer was configured. Session indexing is off by default, and with it off
+  `_do_session_sync()` is a successful no-op, so nothing ever cleared the
+  delta: after a single message every later search took the slow path and
+  walked the workspace tree again, even with no new messages and no file
+  changes. The reset now keys off whether the sync succeeded rather than
+  whether an indexer exists, so one completed search-time sync settles the
+  delta and the next unchanged search takes the fast path. New message
+  notifications, dirty file state, and `force=True` still sync as before, and
+  an enabled indexer that fails mid-search still keeps its delta pending for
+  the next retry
+  ([#956](https://github.com/use-agent-os/agent-os/issues/956)).
 - Turn admission reserves spend headroom instead of only checking it, so a
   concurrent subagent fan-out can no longer overshoot a `[budgets]` ceiling by
   the width of the fan-out. Spend is recorded by `UsageTracker.add()` only as a

--- a/src/agentos/memory/sync_manager.py
+++ b/src/agentos/memory/sync_manager.py
@@ -204,11 +204,16 @@ class MemorySyncManager:
                 self._pending_changes or self._pending_deletes or session_sync_failed
             )
 
+        # Consume the delta whenever the sync that just ran covered it. A
+        # search-time sync with session indexing disabled is a successful
+        # no-op, not a skipped one: gating the reset on an indexer being
+        # present left the delta pending forever, so every later search --
+        # unchanged workspace, no new messages -- took the slow path and
+        # rescanned the tree again. ``_do_session_sync`` reports failure
+        # only when an indexer actually ran and raised, so an enabled
+        # indexer still keeps its delta pending for the next retry.
         if reason == "session-delta" or (
-            is_search_reason
-            and session_delta_pending
-            and self._session_indexer is not None
-            and not session_sync_failed
+            is_search_reason and session_delta_pending and not session_sync_failed
         ):
             self._delta.reset()
 

--- a/tests/test_memory_sync_manager_search_delta.py
+++ b/tests/test_memory_sync_manager_search_delta.py
@@ -1,0 +1,188 @@
+"""Regression tests for issue #956.
+
+``sync()`` lets a pending session delta bypass the clean-search fast path,
+but the reset that consumes the delta used to require a session indexer.
+With session indexing disabled -- the default -- ``_do_session_sync()`` is
+a successful no-op, so nothing ever cleared the delta and every later
+search rescanned the workspace even though neither files nor messages had
+changed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentos.memory.sync_manager import MemorySyncManager
+
+
+class RecordingStore:
+    """Minimal store that records what the sync manager asked it to do."""
+
+    def __init__(self) -> None:
+        self.indexed: list[str] = []
+        self.removed: list[str] = []
+
+    async def index_file(
+        self,
+        *,
+        path: str,
+        content: str,
+        source: object,
+        mtime: float | None = None,
+    ) -> int:
+        self.indexed.append(path)
+        return 1
+
+    async def remove_file(self, path: str) -> None:
+        self.removed.append(path)
+
+
+class StubSessionIndexer:
+    """Session indexer whose ``sync`` can be made to fail on demand."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.fail = False
+
+    async def sync(self, *, force: bool = False) -> Any:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("session index unavailable")
+        return type("Result", (), {"indexed": 0, "removed": 0, "skipped": 0})()
+
+
+def _make_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    memory = workspace / "memory"
+    memory.mkdir(parents=True)
+    (workspace / "MEMORY.md").write_text("root\n", encoding="utf-8")
+    return workspace, memory
+
+
+class ScanCounter:
+    """Wrap ``_scan_files`` so tests can count recursive workspace walks."""
+
+    def __init__(self, manager: MemorySyncManager) -> None:
+        self.count = 0
+        self._inner = manager._scan_files
+        manager._scan_files = self  # type: ignore[method-assign]
+
+    def __call__(self) -> dict[str, float]:
+        self.count += 1
+        return self._inner()
+
+
+def _manager(store, workspace, memory, *, session_indexer=None) -> MemorySyncManager:
+    return MemorySyncManager(
+        store=store,
+        workspace_dir=workspace,
+        memory_dir=memory,
+        session_indexer=session_indexer,
+    )
+
+
+SEARCH_REASONS = ["search", "search:tool", "search:control"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", SEARCH_REASONS)
+@pytest.mark.parametrize("byte_count", [20, 200_000])
+async def test_one_search_sync_consumes_the_delta_without_an_indexer(
+    tmp_path, reason: str, byte_count: int
+) -> None:
+    """A small message and one past the byte threshold both settle after one sync."""
+    workspace, memory = _make_workspace(tmp_path)
+    manager = _manager(RecordingStore(), workspace, memory)
+    scans = ScanCounter(manager)
+
+    manager.notify_message(byte_count)
+    await manager.sync(reason=reason)
+    assert scans.count == 1
+
+    # Nothing changed: every later search must take the clean fast path.
+    await manager.sync(reason=reason)
+    await manager.sync(reason=reason)
+    assert scans.count == 1
+    assert manager._delta.has_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_a_new_message_after_a_search_syncs_again(tmp_path) -> None:
+    workspace, memory = _make_workspace(tmp_path)
+    manager = _manager(RecordingStore(), workspace, memory)
+    scans = ScanCounter(manager)
+
+    manager.notify_message(20)
+    await manager.sync(reason="search:tool")
+    await manager.sync(reason="search:tool")
+    assert scans.count == 1
+
+    manager.notify_message(20)
+    await manager.sync(reason="search:tool")
+    assert scans.count == 2
+
+
+@pytest.mark.asyncio
+async def test_dirty_state_still_syncs_after_the_delta_is_consumed(tmp_path) -> None:
+    workspace, memory = _make_workspace(tmp_path)
+    manager = _manager(RecordingStore(), workspace, memory)
+    scans = ScanCounter(manager)
+
+    manager.notify_message(20)
+    await manager.sync(reason="search:tool")
+    assert scans.count == 1
+
+    manager._dirty = True
+    await manager.sync(reason="search:tool")
+    assert scans.count == 2
+
+
+@pytest.mark.asyncio
+async def test_forced_search_still_syncs_after_the_delta_is_consumed(tmp_path) -> None:
+    workspace, memory = _make_workspace(tmp_path)
+    manager = _manager(RecordingStore(), workspace, memory)
+    scans = ScanCounter(manager)
+
+    manager.notify_message(20)
+    await manager.sync(reason="search:tool")
+    assert scans.count == 1
+
+    await manager.sync(reason="search:tool", force=True)
+    assert scans.count == 2
+
+
+@pytest.mark.asyncio
+async def test_enabled_session_indexing_still_runs_on_a_search(tmp_path) -> None:
+    workspace, memory = _make_workspace(tmp_path)
+    indexer = StubSessionIndexer()
+    manager = _manager(RecordingStore(), workspace, memory, session_indexer=indexer)
+
+    manager.notify_message(20)
+    await manager.sync(reason="search:tool")
+
+    assert indexer.calls == 1
+    assert manager._delta.has_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_failed_search_session_sync_keeps_the_delta_pending_until_it_succeeds(
+    tmp_path,
+) -> None:
+    workspace, memory = _make_workspace(tmp_path)
+    indexer = StubSessionIndexer()
+    indexer.fail = True
+    manager = _manager(RecordingStore(), workspace, memory, session_indexer=indexer)
+
+    manager.notify_message(20)
+    await manager.sync(reason="search:tool")
+
+    assert indexer.calls == 1
+    assert manager._delta.has_pending() is True
+
+    indexer.fail = False
+    await manager.sync(reason="search:tool")
+
+    assert indexer.calls == 2
+    assert manager._delta.has_pending() is False


### PR DESCRIPTION
Fixes #956

## The bug

`MemorySyncManager.sync()` lets a pending session delta bypass the clean-search fast path:

```python
if is_search_reason and not self._dirty and not force and not session_delta_pending:
    return
```

but it consumed that delta only when a session indexer was configured:

```python
if reason == "session-delta" or (
    is_search_reason
    and session_delta_pending
    and self._session_indexer is not None   # <-- here
    and not session_sync_failed
):
    self._delta.reset()
```

Session indexing is off by default (`session_indexer=None`). With it off, `_do_session_sync()` returns early with `False` — a *successful* no-op — so nothing ever cleared the delta. One small message was enough: from then on every search fell through the fast path and ran a full `_scan_files()` walk of the workspace, forever, with no new messages and no file changes.

Reproduced with the real manager and a spy around the file scan:

```text
search 1: scans=1, pending=True
search 2: scans=2, pending=True
search 3: scans=3, pending=True
```

Note this is repeated filesystem work and search latency, not re-embedding of unchanged files.

## The fix

One condition removed. The reset now keys off whether the sync **succeeded**, not whether an indexer exists:

```python
if reason == "session-delta" or (
    is_search_reason and session_delta_pending and not session_sync_failed
):
    self._delta.reset()
```

`_do_session_sync()` reports failure only when an indexer actually ran and raised, so the indexer-enabled semantics are untouched: a search-time session sync that fails still keeps its delta pending for the next retry.

## Tests

New `tests/test_memory_sync_manager_search_delta.py` (11 tests, offline and deterministic):

- `search`, `search:tool` and `search:control` with no indexer, parameterised over a small message (20 B) and one past the 100 KB delta threshold — one sync consumes the delta, and two further unchanged searches scan zero more times.
- A new `notify_message` after a settled search syncs again.
- `_dirty` state still syncs.
- `force=True` still syncs.
- With an indexer enabled, a search still runs the session sync.
- A failing search-time session sync retains the pending delta until a later retry succeeds.

Reverting the source change fails 7 of the 11; the other 4 are the over-correction guards (dirty / force / indexer-enabled) and pass either way by design.

## Verification

```
uv run pytest tests/test_memory_sync_manager_search_delta.py \
              tests/test_memory_sync_manager_architecture.py \
              tests/test_memory_sync_manager_index_retry.py \
              tests/test_memory_search_defaults.py \
              tests/test_memory_sessions_source.py -q
45 passed
uv run ruff check + ruff format --check + mypy on the changed files — clean
```

No API, config, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAkxcLMF1PcCHVKqiqQzW6