### PR TITLE
fix(skills): print usage instead of crashing in gmgn-holder-analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   iterations inside a turn still weighs recorded spend only, so no turn is
   stopped by its own reservation
   ([#823](https://github.com/use-agent-os/agent-os/issues/823)).
+- The bundled `gmgn-holder-analysis` script prints usage instead of crashing
+  when it is run without arguments. `analyze.py` read `sys.argv[1]` and
+  `sys.argv[2]` at import time with no length check, so `analyze.py` on its own
+  and `analyze.py --help` both died with an unhandled `IndexError` traceback
+  rather than telling the caller what the script wants. It now answers `-h` and
+  `--help` on stdout with exit 0, and a missing token address or chain with
+  `Usage: analyze.py <token_address> <chain> [zh|en]` on stderr and exit 2 —
+  the same guard its sibling `gmgn-wallet-score` script already carries
+  ([#957](https://github.com/use-agent-os/agent-os/issues/957)).
 - The MCP `stdio` client speaks the transport's newline framing instead of
   LSP-style `Content-Length` headers. `MCPStdioClient` wrote
   `Content-Length: N\r\n\r\n<body>` to the server's stdin and rejected any

--- a/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
+++ b/src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py
@@ -3,6 +3,16 @@ import json, subprocess, sys, time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
+USAGE = f"Usage: {sys.argv[0]} <token_address> <chain> [zh|en]"
+
+if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help"):
+    print(USAGE)
+    sys.exit(0)
+
+if len(sys.argv) < 3:
+    print(USAGE, file=sys.stderr)
+    sys.exit(2)
+
 TOKEN_ADDR = sys.argv[1]
 CHAIN      = sys.argv[2]
 LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'

--- a/tests/test_skill_gmgn_holder_analysis.py
+++ b/tests/test_skill_gmgn_holder_analysis.py
@@ -1,0 +1,57 @@
+"""Offline regression tests for the gmgn-holder-analysis script (issue #957).
+
+``analyze.py`` indexed ``sys.argv[1]`` and ``sys.argv[2]`` at import time with
+no length check, so running it with no arguments -- or with ``--help`` -- died
+with an unhandled ``IndexError`` traceback instead of printing usage. Mirrors
+the guard the sibling gmgn-wallet-score script already carries.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "src"
+    / "agentos"
+    / "skills"
+    / "bundled"
+    / "gmgn-holder-analysis"
+    / "scripts"
+    / "analyze.py"
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [pytest.param((), id="no-args"), pytest.param(("0xabc",), id="one-arg")],
+)
+def test_missing_args_print_usage_and_exit_2(args: tuple[str, ...]) -> None:
+    result = _run(*args)
+    assert result.returncode == 2
+    assert "Usage:" in result.stderr
+    assert "<token_address>" in result.stderr
+    assert "<chain>" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+def test_help_flag_prints_usage_and_exits_0(flag: str) -> None:
+    result = _run(flag)
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "<token_address>" in result.stdout
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
Fixes #957

## The bug

`src/agentos/skills/bundled/gmgn-holder-analysis/scripts/analyze.py` read its arguments at import time with no length check:

```python
TOKEN_ADDR = sys.argv[1]
CHAIN      = sys.argv[2]
LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'
```

So both of these died with an unhandled `IndexError` traceback instead of telling the caller what the script wants:

```
$ python .../scripts/analyze.py
IndexError: list index out of range

$ python .../scripts/analyze.py --help
IndexError: list index out of range
```

## The fix

The same guard the sibling `gmgn-wallet-score/scripts/score.py` already carries, placed before the first index:

- `-h` / `--help` → usage on **stdout**, exit **0**
- fewer than two positional arguments → usage on **stderr**, exit **2**

```
Usage: .../analyze.py <token_address> <chain> [zh|en]
```

Nothing else in the script changes; the argument shape is exactly what `SKILL.md` already documents.

## Tests

New `tests/test_skill_gmgn_holder_analysis.py` — 4 offline subprocess tests: no args, one arg, `-h`, `--help`. Each asserts the exit code, the usage text, and that no `Traceback` reaches stderr. All 4 fail against the unfixed script.

## Verification

```
uv run pytest tests/test_skill_gmgn_holder_analysis.py \
              tests/test_skills_inventory.py \
              tests/test_skills_provenance_contract.py \
              tests/test_skills_script_paths.py -q
45 passed
uv run ruff check + ruff format --check on the changed files — clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAkxcLMF1PcCHVKqiqQzW6