### PR TITLE
fix(telegram): verify the webhook secret in constant time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   is resolved by the proxy rather than in-process, so there is no local rebinding
   window there to close
   ([#725](https://github.com/use-agent-os/agent-os/issues/725)).
+- The Telegram webhook verifies its secret token in constant time.
+  `TelegramChannel._handle_webhook` compared the inbound
+  `X-Telegram-Bot-Api-Secret-Token` header with `!=`, which returns as soon as
+  two bytes differ; the response latency then tracks how long a prefix matched,
+  letting an unauthenticated remote caller recover the configured token one
+  byte at a time and post forged updates into the channel. The header now goes
+  through `hmac.compare_digest` over UTF-8 bytes, with a missing header
+  treated as an empty candidate rather than skipping the comparison — the same
+  guarantee `gateway/auth.py` and `channels/slack.py` already give
+  ([#962](https://github.com/use-agent-os/agent-os/issues/962)).
 - The intent approval cache grades a delete by how destructive it is, so an
   approval never silently covers a stronger operation on the same path. Flags
   were dropped during normalisation, which made `rm /tmp/logs` and

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -693,7 +694,12 @@ class TelegramChannel:
         secret = self.config.webhook_secret_token
         if not secret:
             return Response(status_code=503)
-        if request.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
+        # Constant-time: ``!=`` returns as soon as two bytes differ, which
+        # leaks the length of the matching prefix through response latency and
+        # lets a remote caller walk the secret out one byte at a time. Same
+        # guarantee ``gateway/auth.py`` and ``channels/slack.py`` already give.
+        provided = request.headers.get("X-Telegram-Bot-Api-Secret-Token") or ""
+        if not hmac.compare_digest(provided.encode("utf-8"), secret.encode("utf-8")):
             return Response(status_code=401)
         try:
             update = await request.json()

--- a/tests/test_channels/test_telegram_webhook_secret.py
+++ b/tests/test_channels/test_telegram_webhook_secret.py
@@ -1,0 +1,121 @@
+"""Regression tests for issue #962.
+
+``_handle_webhook`` compared the inbound ``X-Telegram-Bot-Api-Secret-Token``
+header with ``!=``, which short-circuits on the first differing byte. The
+resulting latency difference lets a remote caller recover the secret one byte
+at a time. The comparison must be constant-time, matching what
+``gateway/auth.py`` and ``channels/slack.py`` already do.
+"""
+
+from __future__ import annotations
+
+import hmac
+from typing import Any
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+SECRET = "s3cr3t-webhook-token"
+
+
+def _client(channel: TelegramChannel) -> TestClient:
+    app = Starlette(routes=[channel.create_webhook_route()])
+    return TestClient(app)
+
+
+def _channel() -> TelegramChannel:
+    return TelegramChannel(
+        TelegramChannelConfig(token="token", mode="webhook", webhook_secret_token=SECRET)
+    )
+
+
+def _update() -> dict[str, Any]:
+    return {
+        "update_id": 1,
+        "message": {
+            "message_id": 10,
+            "date": 1_700_000_000,
+            "chat": {"id": 42, "type": "private"},
+            "from": {"id": 42, "is_bot": False, "first_name": "Ada"},
+            "text": "hello",
+        },
+    }
+
+
+def test_matching_secret_is_accepted() -> None:
+    with _client(_channel()) as client:
+        resp = client.post(
+            "/telegram/events",
+            json=_update(),
+            headers={"X-Telegram-Bot-Api-Secret-Token": SECRET},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("x", id="single-byte"),
+        pytest.param(SECRET[:-1], id="matching-prefix"),
+        pytest.param(SECRET + "extra", id="matching-prefix-then-longer"),
+        pytest.param(SECRET.upper(), id="wrong-case"),
+    ],
+)
+def test_wrong_secret_is_rejected(candidate: str) -> None:
+    with _client(_channel()) as client:
+        resp = client.post(
+            "/telegram/events",
+            json=_update(),
+            headers={"X-Telegram-Bot-Api-Secret-Token": candidate},
+        )
+    assert resp.status_code == 401
+
+
+def test_missing_header_is_rejected() -> None:
+    with _client(_channel()) as client:
+        resp = client.post("/telegram/events", json=_update())
+    assert resp.status_code == 401
+
+
+def test_verification_goes_through_compare_digest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The attacker-controlled side must never reach a short-circuiting ``!=``.
+
+    Timing safety is not observable from a response, so this asserts the
+    mechanism: the handler must route the header through
+    ``hmac.compare_digest``. Patching the attribute on the shared ``hmac``
+    module (rather than a dotted path into ``telegram``) means a handler that
+    went back to ``!=`` records no call and fails on the assertion below.
+    """
+    calls: list[tuple[bytes, bytes]] = []
+    real = hmac.compare_digest
+
+    def spy(a: Any, b: Any) -> bool:
+        calls.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr(hmac, "compare_digest", spy)
+
+    with _client(_channel()) as client:
+        resp = client.post(
+            "/telegram/events",
+            json=_update(),
+            headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+        )
+
+    assert resp.status_code == 401
+    assert (b"wrong", SECRET.encode("utf-8")) in calls
+
+
+def test_rejected_update_is_not_enqueued() -> None:
+    channel = _channel()
+    with _client(channel) as client:
+        client.post(
+            "/telegram/events",
+            json=_update(),
+            headers={"X-Telegram-Bot-Api-Secret-Token": SECRET[:-1] + "!"},
+        )
+    assert channel._queue.empty()  # noqa: SLF001

--- a/tests/test_channels/test_telegram_webhook_secret.py
+++ b/tests/test_channels/test_telegram_webhook_secret.py
@@ -28,7 +28,7 @@ def _client(channel: TelegramChannel) -> TestClient:
 
 def _channel() -> TelegramChannel:
     return TelegramChannel(
-        TelegramChannelConfig(token="token", mode="webhook", webhook_secret_token=SECRET)
+        TelegramChannelConfig(token="token", transport_name="webhook", webhook_secret_token=SECRET)
     )
 
 


### PR DESCRIPTION
Fixes #962

## The bug

`TelegramChannel._handle_webhook` (`src/agentos/channels/telegram.py`) compared the inbound secret-token header with `!=`:

```python
if request.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
    return Response(status_code=401)
```

Python's `str.__ne__` short-circuits at the first differing byte. The 401 therefore comes back measurably sooner for a candidate that mismatches at byte 0 than for one that matches a 15-byte prefix, and the webhook path is reachable by any unauthenticated caller who can hit the gateway. That is a remote oracle for recovering `webhook_secret_token` one byte at a time — and the token is the only thing standing between an attacker and injecting forged `Update` payloads (arbitrary messages attributed to arbitrary chat ids) into the channel queue.

`gateway/auth.py::token_matches` and `channels/slack.py::_verify_signature` already use `hmac.compare_digest`; this call site was the outlier.

## The fix

```python
provided = request.headers.get("X-Telegram-Bot-Api-Secret-Token") or ""
if not hmac.compare_digest(provided.encode("utf-8"), secret.encode("utf-8")):
    return Response(status_code=401)
```

A missing header becomes an empty candidate that still goes through `compare_digest`, rather than skipping the comparison on a separate branch — mirroring how `gateway/auth.py` handles `provided is None`. The empty-secret case above it (503) is unchanged.

## Tests

New `tests/test_channels/test_telegram_webhook_secret.py` (9 tests, offline, via `starlette.testclient`):

- matching secret → 200
- wrong secret → 401 for empty, single byte, matching-prefix, matching-prefix-then-longer, and wrong-case candidates
- missing header → 401
- a rejected update is not enqueued
- **the mechanism test**: `hmac.compare_digest` is patched on the shared `hmac` module and must be called with the header bytes and the configured secret bytes

Timing safety is not observable from a response, so that last test is what actually pins the fix: against the unfixed handler it fails with `assert (b'wrong', b's3cr3t-webhook-token') in []`. The eight behavioural tests pass either way by design — they guard against a fix that changes the accept/reject semantics.

## Verification

```
uv run pytest tests/test_channels/test_telegram_webhook_secret.py -q
9 passed
uv run ruff check + ruff format --check + mypy on the changed files — clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAkxcLMF1PcCHVKqiqQzW6