### PR TITLE
fix(skills): pin robinhood-rwa-addresses --rpc-url to http(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   so retries at the same destructiveness do not re-prompt. `/forget <path>`
   clears every grade for the path, not just the plain one
   ([#849](https://github.com/use-agent-os/agent-os/issues/849)).
+- The bundled `robinhood-rwa-addresses` lookup pins `--rpc-url` to `http` and
+  `https`, closing a local-file read. `rwa_lookup.py` passed the flag straight
+  into `urllib.request.urlopen` under a blanket `# noqa: S310` — and `urlopen`
+  also speaks `file:`, `ftp:` and `data:`, so `--rpc-url file:///etc/hosts`
+  made the process read and parse that path. In an agent workflow the endpoint
+  can be steered by model output, which turns an unchecked flag into arbitrary
+  local reads. A new `validate_rpc_url()` applies the same scheme allowlist the
+  bundled `http_fetch` script uses: `main()` rejects a bad scheme with a usage
+  error and exit 2 before any network or filesystem work, and `_rpc_batch()`
+  re-checks at the one call site that reaches `urlopen`, so no caller can route
+  around it ([#968](https://github.com/use-agent-os/agent-os/issues/968)).
 
 ## [2026.9.5] - 2026-09-05
 

--- a/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
+++ b/src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py
@@ -30,6 +30,7 @@ import json
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -71,6 +72,25 @@ _STATUS_RANK = {
 
 class RpcError(RuntimeError):
     """A JSON-RPC call returned an error or an unusable result."""
+
+
+ALLOWED_RPC_SCHEMES = ("http", "https")
+
+
+def validate_rpc_url(rpc_url: str) -> str:
+    """Return ``rpc_url`` if it is an ``http(s)`` URL, else raise ``ValueError``.
+
+    ``urllib.request.urlopen`` also speaks ``file:``, ``ftp:`` and (via the
+    default opener) ``data:``, so an unchecked ``--rpc-url`` turns this script
+    into a local-file reader: ``--rpc-url file:///etc/passwd`` makes the
+    process read and parse that path. The endpoint can be steered by model
+    output in an agent workflow, so the scheme is pinned here rather than
+    trusted. Same allowlist the bundled ``http_fetch`` script applies.
+    """
+    scheme = urllib.parse.urlsplit(rpc_url.strip()).scheme.lower()
+    if scheme not in ALLOWED_RPC_SCHEMES:
+        raise ValueError(f"invalid --rpc-url {rpc_url!r}: must start with http:// or https://")
+    return rpc_url.strip()
 
 
 def _fetch_tokens(timeout: float) -> list[dict[str, Any]]:
@@ -190,8 +210,12 @@ def _rpc_batch(rpc_url: str, calls: list[dict[str, Any]], timeout: float) -> dic
     candidates are being checked.
     """
     payload = json.dumps(calls).encode("utf-8")
-    req = urllib.request.Request(  # noqa: S310 - operator-supplied RPC endpoint
-        rpc_url,
+    # Re-validated here, not only in main(): this is the only place the URL
+    # reaches urlopen, so the scheme allowlist that makes the S310 suppression
+    # below safe has to hold for every caller.
+    checked_url = validate_rpc_url(rpc_url)
+    req = urllib.request.Request(  # noqa: S310 - scheme pinned to http(s) above
+        checked_url,
         data=payload,
         headers={
             "Content-Type": "application/json",
@@ -344,6 +368,15 @@ def main() -> int:
         help="Do not write the card artifact (JSON on stdout only).",
     )
     args = parser.parse_args()
+
+    # Reject a non-http(s) endpoint before any network or filesystem work, so
+    # the caller gets a usage error rather than a degraded "unverified" result.
+    if not args.no_verify:
+        try:
+            args.rpc_url = validate_rpc_url(args.rpc_url)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
 
     try:
         tokens = _fetch_tokens(args.timeout)

--- a/tests/test_skill_robinhood_rwa_rpc_url.py
+++ b/tests/test_skill_robinhood_rwa_rpc_url.py
@@ -1,0 +1,98 @@
+"""Regression tests for issue #968.
+
+``rwa_lookup.py`` passed ``--rpc-url`` straight into
+``urllib.request.urlopen``, which also speaks ``file:`` and ``ftp:``. Nothing
+checked the scheme, so ``--rpc-url file:///etc/hosts`` made the process read
+and parse a local file. The endpoint can be steered by model output in an agent
+workflow, so the scheme is pinned to ``http``/``https`` -- both at the CLI
+boundary and at the one call site that reaches ``urlopen``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src/agentos/skills/bundled/robinhood-rwa-addresses/scripts/rwa_lookup.py"
+)
+
+_spec = importlib.util.spec_from_file_location("rwa_lookup_rpc_url", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+rwa_lookup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rwa_lookup)
+
+
+REJECTED = [
+    pytest.param("file:///etc/hosts", id="file"),
+    pytest.param("file://localhost/etc/hosts", id="file-with-host"),
+    pytest.param("FILE:///etc/hosts", id="file-uppercase"),
+    pytest.param("ftp://example.invalid/x", id="ftp"),
+    pytest.param("data:text/plain,hello", id="data"),
+    pytest.param("/etc/hosts", id="bare-path"),
+    pytest.param("", id="empty"),
+]
+
+
+@pytest.mark.parametrize("rpc_url", REJECTED)
+def test_validate_rpc_url_rejects_non_http_schemes(rpc_url: str) -> None:
+    with pytest.raises(ValueError, match="must start with http:// or https://"):
+        rwa_lookup.validate_rpc_url(rpc_url)
+
+
+@pytest.mark.parametrize(
+    "rpc_url",
+    ["http://127.0.0.1:8545", "https://rpc.mainnet.chain.robinhood.com", "HTTPS://EXAMPLE/x"],
+)
+def test_validate_rpc_url_accepts_http_and_https(rpc_url: str) -> None:
+    assert rwa_lookup.validate_rpc_url(rpc_url) == rpc_url.strip()
+
+
+def test_validate_rpc_url_accepts_the_shipped_default() -> None:
+    assert rwa_lookup.validate_rpc_url(rwa_lookup.DEFAULT_RPC_URL) == rwa_lookup.DEFAULT_RPC_URL
+
+
+@pytest.mark.parametrize("rpc_url", REJECTED)
+def test_rpc_batch_refuses_to_open_a_non_http_url(rpc_url: str, monkeypatch) -> None:
+    """The guard lives at the call site too, so no caller can route around it."""
+    opened: list[object] = []
+
+    def fail_open(*args: object, **kwargs: object) -> object:
+        opened.append(args)
+        raise AssertionError("urlopen must not be reached for a rejected scheme")
+
+    monkeypatch.setattr(rwa_lookup.urllib.request, "urlopen", fail_open)
+
+    with pytest.raises(ValueError, match="must start with http:// or https://"):
+        rwa_lookup._rpc_batch(rpc_url, [{"id": "1", "method": "eth_getCode"}], 1.0)
+
+    assert opened == []
+
+
+def test_cli_rejects_a_file_url_before_doing_any_work(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("do-not-read-me\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--query",
+            "Apple",
+            "--rpc-url",
+            secret.as_uri(),
+            "--no-cards",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "must start with http:// or https://" in result.stderr
+    assert "do-not-read-me" not in result.stdout
+    assert "do-not-read-me" not in result.stderr


### PR DESCRIPTION
Fixes #968

## The bug

`rwa_lookup.py` handed `--rpc-url` straight to `urllib.request.urlopen` under a blanket suppression:

```python
req = urllib.request.Request(  # noqa: S310 - operator-supplied RPC endpoint
    rpc_url,
    ...
)
with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
```

`urlopen`'s default opener also handles `file:`, `ftp:` and `data:`, and nothing in `main()` checked the scheme. So:

```
$ python .../rwa_lookup.py --query Apple --rpc-url file:///etc/hosts
```

read and parsed a local file. The `# noqa` comment assumed an *operator*-supplied endpoint, but this is a bundled agent skill: in an agent workflow the flag can be steered by model output, which turns it into arbitrary local reads. `http_fetch.py` and `chain_stocks.py` in the same bundled tree already validate their URLs.

## The fix

A new `validate_rpc_url()` next to `RpcError`, applying the same `{"http", "https"}` allowlist `http_fetch.py` uses, enforced in two places:

- **`main()`** — rejects a bad scheme with the usage error on stderr and exit **2**, *before* any network or filesystem work, so the caller gets a clear failure rather than a silently degraded `status: "unverified"` result. Skipped under `--no-verify`, where the URL is never dereferenced.
- **`_rpc_batch()`** — the one call site that reaches `urlopen`, so no caller (including `verify_tokens`) can route around the check. This is what makes the `# noqa: S310` genuinely safe; the comment now says why.

`verify_tokens` already catches `ValueError` and degrades to `unverified`, so the library path stays non-raising as documented.

## Tests

New `tests/test_skill_robinhood_rwa_rpc_url.py` (19 tests, offline):

- `validate_rpc_url` rejects `file://`, `file://localhost/...`, `FILE://` (case), `ftp://`, `data:`, a bare filesystem path, and the empty string
- accepts `http://`, `https://`, mixed case, and the shipped `DEFAULT_RPC_URL`
- `_rpc_batch` raises for every rejected scheme with `urlopen` monkeypatched to fail the test if it is ever reached
- end-to-end: the CLI given a `file://` URI for a real temp file exits 2 and the file's contents appear in neither stdout nor stderr

All 19 fail against the unfixed script.

## Verification

```
uv run pytest tests/test_skill_robinhood_rwa_rpc_url.py \
              tests/test_skill_robinhood_rwa.py \
              tests/test_skill_robinhood_rwa_cards.py \
              tests/test_skills_inventory.py -q
88 passed
uv run ruff check + ruff format --check on the changed files — clean
```

No flag added or removed; `--rpc-url` keeps its default and its documented meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAkxcLMF1PcCHVKqiqQzW6