### PR TITLE
fix(skills): stop gmgn-wallet-score clobbering a real 0% return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   read whole, where `readline` would raise and discard it, and a server that
   never sends a delimiter is cut off at 16 MiB rather than buffered without
   bound ([#894](https://github.com/use-agent-os/agent-os/issues/894)).
+- The bundled `gmgn-wallet-score` copy-trade backtest reports `$0.00` for a
+  wallet at exactly 0% return instead of a six-figure fantasy. `score.py`
+  floored the wallet's per-trade return with `wallet_pct or 0.0001`, but
+  `wallet_pct` is always a float, so `or` only ever fired on an exact `0.0` —
+  a real break-even wallet, or a dev wallet whose `bought_cost` is 0 and whose
+  ROI the API reports as 0. That 0.0001 then became the divisor in
+  `copy_7d = realized_profit * (copy_pct / wallet_pct)`, so a wallet that
+  realised $800 on no recorded cost was printed as a $567K copy-trade gain and
+  one that lost $500 as a $567K profit — sign and magnitude both wrong, in the
+  headline number the report shows the user. The floor is gone; the
+  `if wallet_pct else 0.0` guard already next to it now handles a genuine zero,
+  and the clamp still bounds the blow-up the surrounding comment was about
+  ([#971](https://github.com/use-agent-os/agent-os/issues/971)).
 - The MCP bridge clamps the arguments an MCP client supplies instead of
   forwarding them to the gateway verbatim. `events_wait` caps `timeout_ms` at
   5 minutes — applied before the deadline is computed, so the cap reaches

--- a/src/agentos/skills/bundled/gmgn-wallet-score/scripts/score.py
+++ b/src/agentos/skills/bundled/gmgn-wallet-score/scripts/score.py
@@ -300,7 +300,12 @@ copy_disp  = round(copy_score  * SELF_DEAL_DISCOUNT) if self_dealing else copy_s
 
 # ── 7. Copy-trade backtest ───────────────────────────────────
 wallet_pct = (w['realized_profit'] / w['bought_cost']) if w['bought_cost'] > 0 else w['roi']
-wallet_pct = _clamp(wallet_pct or 0.0001, -0.9, 3.0)   # clamp: dev wallets have near-zero bought_cost, ratio blows up
+# clamp: dev wallets have near-zero bought_cost, so the ratio blows up. No
+# `or 0.0001` floor here: wallet_pct is always a float, so `or` only ever fired
+# on an exact 0.0 -- a real 0% ROI -- and 0.0001 then became the divisor below,
+# turning a break-even wallet into a six-figure loss. A genuine 0.0 belongs in
+# the `else 0.0` branch of copy_7d.
+wallet_pct = _clamp(wallet_pct, -0.9, 3.0)
 LOW_MCAP_DRIFT_PER_S = 0.015
 drift_per_s = LOW_MCAP_DRIFT_PER_S * (0.3 + 0.7 * summ['entry_under_100k'])
 drift = LATENCY_S * drift_per_s

--- a/tests/test_skill_gmgn_wallet_score_backtest.py
+++ b/tests/test_skill_gmgn_wallet_score_backtest.py
@@ -8,17 +8,23 @@ break-even wallet into a six-figure loss shown straight to the user. The
 ``if wallet_pct else 0.0`` guard already in the code handles that case
 correctly once the floor is gone.
 
-Everything here is offline: ``gmgn-cli`` is replaced by a stub on ``PATH``.
+``score.py`` is a flat script that does its work at import time, so it is run
+here the way the sibling robinhood-rwa test runs its script: loaded through
+``importlib`` with ``sys.argv`` and ``subprocess.run`` patched, stdout
+captured. Nothing spawns a process and nothing touches the network, which also
+keeps the test honest on Windows.
 """
 
 from __future__ import annotations
 
+import contextlib
+import importlib.util
+import io
 import json
-import os
-import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -27,46 +33,8 @@ SCRIPT = (
     ROOT / "src" / "agentos" / "skills" / "bundled" / "gmgn-wallet-score" / "scripts" / "score.py"
 )
 
-STUB = '''#!/usr/bin/env python3
-"""Stand-in for gmgn-cli: answers from a fixture file, never touches network."""
-import json, os, sys
 
-fixture = json.loads(open(os.environ["GMGN_FIXTURE"], encoding="utf-8").read())
-argv = sys.argv[1:]
-if argv[:2] == ["portfolio", "stats"]:
-    print(json.dumps(fixture["stats"]))
-elif argv[:2] == ["portfolio", "activity"]:
-    print(json.dumps({"activities": [], "next": None}))
-else:
-    print("unexpected gmgn-cli invocation: " + " ".join(argv), file=sys.stderr)
-    sys.exit(1)
-'''
-
-
-def _run_score(tmp_path: Path, stats: dict) -> subprocess.CompletedProcess[str]:
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    stub = bin_dir / "gmgn-cli"
-    stub.write_text(STUB, encoding="utf-8")
-    stub.chmod(0o755)
-
-    fixture = tmp_path / "fixture.json"
-    fixture.write_text(json.dumps({"stats": stats}), encoding="utf-8")
-
-    env = dict(os.environ)
-    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
-    env["GMGN_FIXTURE"] = str(fixture)
-
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), "0xWalletAddress", "bsc", "en"],
-        capture_output=True,
-        text=True,
-        env=env,
-        timeout=120,
-    )
-
-
-def _stats(*, realized_profit: float, bought_cost: float, roi: float) -> dict:
+def _stats(*, realized_profit: float, bought_cost: float, roi: float) -> dict[str, Any]:
     return {
         "buy": 1,
         "sell": 1,
@@ -87,26 +55,69 @@ def _stats(*, realized_profit: float, bought_cost: float, roi: float) -> dict:
     }
 
 
+class _FakeCompleted:
+    def __init__(self, stdout: str) -> None:
+        self.returncode = 0
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _run_score(monkeypatch: pytest.MonkeyPatch, stats: dict[str, Any]) -> str:
+    """Execute score.py with a stubbed ``gmgn-cli`` and return its stdout."""
+    seen: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompleted:
+        seen.append(cmd)
+        assert cmd[0] == "gmgn-cli", cmd
+        argv = cmd[1:]
+        if argv[:2] == ["portfolio", "stats"]:
+            return _FakeCompleted(json.dumps(stats))
+        if argv[:2] == ["portfolio", "activity"]:
+            return _FakeCompleted(json.dumps({"activities": [], "next": None}))
+        raise AssertionError(f"unexpected gmgn-cli invocation: {argv}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT), "0xWalletAddress", "bsc", "en"])
+
+    spec = importlib.util.spec_from_file_location("gmgn_score_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        spec.loader.exec_module(module)
+
+    assert seen, "score.py never called gmgn-cli"
+    return buf.getvalue()
+
+
 def _copy_estimate(stdout: str) -> str:
-    match = re.search(r"copy estimate (\S+)", stdout)
-    assert match is not None, f"no backtest line in output:\n{stdout}"
-    return match.group(1)
+    """Pull the formatted copy-trade estimate out of the backtest line.
+
+    Returned as printed rather than parsed: the buggy value renders as
+    ``$567.0K``, so a string comparison shows exactly what the user would have
+    seen instead of blowing up in a float conversion.
+    """
+    for line in stdout.splitlines():
+        if "copy estimate" in line:
+            return line.split("copy estimate")[1].split("(")[0].strip()
+    raise AssertionError(f"no backtest line in output:\n{stdout}")
 
 
-def test_zero_roi_dev_wallet_reports_a_zero_copy_estimate(tmp_path: Path) -> None:
+def test_zero_roi_dev_wallet_reports_a_zero_copy_estimate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """bought_cost == 0 and roi == 0.0: the divisor guard must fire, not a floor."""
-    result = _run_score(tmp_path, _stats(realized_profit=800.0, bought_cost=0.0, roi=0.0))
+    stdout = _run_score(monkeypatch, _stats(realized_profit=800.0, bought_cost=0.0, roi=0.0))
 
-    assert result.returncode == 0, result.stderr
-    assert "Wallet per-trade return  +0.0%" in result.stdout
-    assert _copy_estimate(result.stdout) == "$0.00"
+    assert "Wallet per-trade return  +0.0%" in stdout
+    assert _copy_estimate(stdout) == "$0.00"
 
 
-def test_zero_roi_with_a_loss_also_reports_zero(tmp_path: Path) -> None:
-    result = _run_score(tmp_path, _stats(realized_profit=-500.0, bought_cost=0.0, roi=0.0))
+def test_zero_roi_with_a_loss_also_reports_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    stdout = _run_score(monkeypatch, _stats(realized_profit=-500.0, bought_cost=0.0, roi=0.0))
 
-    assert result.returncode == 0, result.stderr
-    assert _copy_estimate(result.stdout) == "$0.00"
+    assert _copy_estimate(stdout) == "$0.00"
 
 
 @pytest.mark.parametrize(
@@ -118,12 +129,15 @@ def test_zero_roi_with_a_loss_also_reports_zero(tmp_path: Path) -> None:
     ],
 )
 def test_nonzero_returns_are_unaffected(
-    tmp_path: Path, realized_profit: float, bought_cost: float, roi: float
+    monkeypatch: pytest.MonkeyPatch,
+    realized_profit: float,
+    bought_cost: float,
+    roi: float,
 ) -> None:
     """Removing the floor must not move any wallet whose return is not 0.0."""
-    result = _run_score(
-        tmp_path, _stats(realized_profit=realized_profit, bought_cost=bought_cost, roi=roi)
+    stdout = _run_score(
+        monkeypatch,
+        _stats(realized_profit=realized_profit, bought_cost=bought_cost, roi=roi),
     )
 
-    assert result.returncode == 0, result.stderr
-    assert _copy_estimate(result.stdout) != "$0.00"
+    assert _copy_estimate(stdout) != "$0.00"

--- a/tests/test_skill_gmgn_wallet_score_backtest.py
+++ b/tests/test_skill_gmgn_wallet_score_backtest.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #971.
+
+The copy-trade backtest floored ``wallet_pct`` with ``wallet_pct or 0.0001``.
+``wallet_pct`` is always a float, so ``or`` only ever fired on an exact ``0.0``
+-- a wallet at genuinely 0% ROI -- and 0.0001 then became the divisor in
+``copy_7d = realized_profit * (copy_pct / wallet_pct)``, amplifying a
+break-even wallet into a six-figure loss shown straight to the user. The
+``if wallet_pct else 0.0`` guard already in the code handles that case
+correctly once the floor is gone.
+
+Everything here is offline: ``gmgn-cli`` is replaced by a stub on ``PATH``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT / "src" / "agentos" / "skills" / "bundled" / "gmgn-wallet-score" / "scripts" / "score.py"
+)
+
+STUB = '''#!/usr/bin/env python3
+"""Stand-in for gmgn-cli: answers from a fixture file, never touches network."""
+import json, os, sys
+
+fixture = json.loads(open(os.environ["GMGN_FIXTURE"], encoding="utf-8").read())
+argv = sys.argv[1:]
+if argv[:2] == ["portfolio", "stats"]:
+    print(json.dumps(fixture["stats"]))
+elif argv[:2] == ["portfolio", "activity"]:
+    print(json.dumps({"activities": [], "next": None}))
+else:
+    print("unexpected gmgn-cli invocation: " + " ".join(argv), file=sys.stderr)
+    sys.exit(1)
+'''
+
+
+def _run_score(tmp_path: Path, stats: dict) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "gmgn-cli"
+    stub.write_text(STUB, encoding="utf-8")
+    stub.chmod(0o755)
+
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({"stats": stats}), encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["GMGN_FIXTURE"] = str(fixture)
+
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "0xWalletAddress", "bsc", "en"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def _stats(*, realized_profit: float, bought_cost: float, roi: float) -> dict:
+    return {
+        "buy": 1,
+        "sell": 1,
+        "realized_profit": realized_profit,
+        "bought_cost": bought_cost,
+        "realized_profit_pnl": roi,
+        "pnl_stat": {
+            "token_num": 1,
+            "winrate": 0.5,
+            "avg_holding_period": 3600,
+            "pnl_gt_5x_num": 0,
+            "pnl_2x_5x_num": 0,
+            "pnl_0x_2x_num": 1,
+            "pnl_nd5_0x_num": 0,
+            "pnl_lt_nd5_num": 0,
+        },
+        "common": {"created_token_count": 0},
+    }
+
+
+def _copy_estimate(stdout: str) -> str:
+    match = re.search(r"copy estimate (\S+)", stdout)
+    assert match is not None, f"no backtest line in output:\n{stdout}"
+    return match.group(1)
+
+
+def test_zero_roi_dev_wallet_reports_a_zero_copy_estimate(tmp_path: Path) -> None:
+    """bought_cost == 0 and roi == 0.0: the divisor guard must fire, not a floor."""
+    result = _run_score(tmp_path, _stats(realized_profit=800.0, bought_cost=0.0, roi=0.0))
+
+    assert result.returncode == 0, result.stderr
+    assert "Wallet per-trade return  +0.0%" in result.stdout
+    assert _copy_estimate(result.stdout) == "$0.00"
+
+
+def test_zero_roi_with_a_loss_also_reports_zero(tmp_path: Path) -> None:
+    result = _run_score(tmp_path, _stats(realized_profit=-500.0, bought_cost=0.0, roi=0.0))
+
+    assert result.returncode == 0, result.stderr
+    assert _copy_estimate(result.stdout) == "$0.00"
+
+
+@pytest.mark.parametrize(
+    ("realized_profit", "bought_cost", "roi"),
+    [
+        pytest.param(800.0, 1000.0, 0.8, id="ordinary-profitable-wallet"),
+        pytest.param(-200.0, 1000.0, -0.2, id="losing-wallet"),
+        pytest.param(800.0, 0.0, 0.5, id="dev-wallet-nonzero-roi"),
+    ],
+)
+def test_nonzero_returns_are_unaffected(
+    tmp_path: Path, realized_profit: float, bought_cost: float, roi: float
+) -> None:
+    """Removing the floor must not move any wallet whose return is not 0.0."""
+    result = _run_score(
+        tmp_path, _stats(realized_profit=realized_profit, bought_cost=bought_cost, roi=roi)
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _copy_estimate(result.stdout) != "$0.00"


### PR DESCRIPTION
Fixes #971

## The bug

The copy-trade backtest in `gmgn-wallet-score/scripts/score.py` floored the wallet's per-trade return:

```python
wallet_pct = (w['realized_profit'] / w['bought_cost']) if w['bought_cost'] > 0 else w['roi']
wallet_pct = _clamp(wallet_pct or 0.0001, -0.9, 3.0)   # clamp: dev wallets have near-zero bought_cost, ratio blows up
...
copy_7d = w['realized_profit'] * (copy_pct / wallet_pct) if wallet_pct else 0.0
```

Both branches of `wallet_pct` come from `_f()`, so it is *always* a float — never `None`. `or` therefore only ever fired on an exact `0.0`: a genuinely break-even wallet, or the dev-wallet case the comment above it is about (`bought_cost <= 0`, so `wallet_pct = roi`, and the API reports `roi` as 0 while `realized_profit` is non-zero — an airdrop or dev allocation sold with no recorded purchase cost).

That substituted `0.0001` then became the **divisor** on the next line, and `copy_7d` blew up. Measured end-to-end against the real script with a stubbed `gmgn-cli`:

| `realized_profit` | `bought_cost` | `roi` | printed copy estimate | correct |
|---|---|---|---|---|
| `+800.0` | `0.0` | `0.0` | **`$-567.0K`** | `$0.00` |
| `-500.0` | `0.0` | `0.0` | **`$+567.0K`** | `$0.00` |

Sign and magnitude both wrong, in the headline `7D wallet → copy estimate` figure the report shows the user verbatim. The second row is the worse one: a losing wallet is presented as a half-million-dollar copy-trade gain.

## The fix

Drop the floor. The `if wallet_pct else 0.0` guard on the very next line already handles a genuine zero — it just never got the chance to fire:

```python
wallet_pct = _clamp(wallet_pct, -0.9, 3.0)
```

The `_clamp(..., -0.9, 3.0)` bound the comment was actually written for is untouched, so the dev-wallet ratio blow-up it guards against is still bounded.

## Tests

New `tests/test_skill_gmgn_wallet_score_backtest.py` (5 tests). Fully offline: `gmgn-cli` is replaced by a stub on `PATH` that answers from a JSON fixture, so the real script runs end to end with no network.

- zero-ROI dev wallet with a `+$800` realised profit → `copy estimate $0.00`
- zero-ROI dev wallet with a `-$500` realised loss → `copy estimate $0.00`
- three regression guards that a non-zero return is **unaffected**: an ordinary profitable wallet, a losing wallet, and a dev wallet with non-zero ROI

The two zero-ROI tests fail against the unfixed script (`$0.00` vs `$567.0K`); the three guards pass either way by design.

## Verification

```
uv run pytest tests/test_skill_gmgn_wallet_score_backtest.py \
              tests/test_skill_gmgn_wallet_score.py \
              tests/test_skills_inventory.py -q
43 passed
uv run ruff check + ruff format --check on the changed files — clean
```

## One adjacent case, deliberately left alone

When `bought_cost > 0` the division is exact algebra (`copy_7d == copy_pct * bought_cost`) and cannot blow up. In the `else roi` branch, a *tiny but non-zero* `roi` (say `1e-6`) still amplifies the same way — the class of the bug is wider than exactly `0.0`. Fixing that needs a "how small is too small" threshold, which is a product judgement about what the report should say, not a mechanical correction. Happy to follow up if you want a floor there; this PR stays on what #971 describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAkxcLMF1PcCHVKqiqQzW6