### PR TITLE
fix(scheduler): resolve SUN to 7 in DOW name map so ranges like SAT-SUN work

### DIFF
--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -45,7 +45,7 @@ _MONTH_NAMES = {
 }
 
 _DOW_NAMES = {
-    "sun": 0,
+    "sun": 7,
     "mon": 1,
     "tue": 2,
     "wed": 3,

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -199,3 +199,25 @@ def test_parse_iso_at_rejects_empty() -> None:
 def test_parse_iso_at_rejects_non_string() -> None:
     with pytest.raises(CronParseError, match="Expected ISO-8601 string"):
         parse_iso_at(12345)  # type: ignore[arg-type]
+
+
+# ── Issue #1063: DOW ranges ending in SUN ───────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_days"),
+    [
+        ("0 0 * * SAT-SUN", {0, 6}),
+        ("0 0 * * MON-SUN", {0, 1, 2, 3, 4, 5, 6}),
+        ("0 0 * * WED-SUN", {0, 3, 4, 5, 6}),
+        ("0 0 * * FRI-SUN", {0, 5, 6}),
+        ("0 0 * * SUN", {0}),
+        ("0 0 * * 6-7", {0, 6}),
+        ("0 0 * * 0", {0}),
+    ],
+)
+def test_dow_range_ending_in_sun_resolves_correctly(expr: str, expected_days: set[int]) -> None:
+    """Ranges ending in SUN must not raise CronParseError (issue #1063)."""
+    cron = parse_cron(expr)
+    assert cron.day_of_week.values == frozenset(expected_days)
+


### PR DESCRIPTION
## Summary

`_DOW_NAMES` mapped `sun` to `0` unconditionally, so any range whose upper bound was Sunday (e.g. `SAT-SUN`, `MON-SUN`) became `N-0` and failed the `start > end` check with `CronParseError`.

## Changes

### `src/agentos/scheduler/parser.py`

```diff
 _DOW_NAMES = {
-    "sun": 0,
+    "sun": 7,
     "mon": 1,
```

Map `sun` to `7` instead of `0`. The existing normalisation at lines 169-175 already collapses `7` back to `0` after range expansion, so:
- Bare `SUN` → `7` → normalised to `{0}` ✅
- `SAT-SUN` → `6-7` → `{6, 7}` → normalised to `{0, 6}` ✅
- `MON-SUN` → `1-7` → `{1..7}` → normalised to `{0, 1, 2, 3, 4, 5, 6}` ✅

### `tests/test_scheduler/test_parser.py`

7 parametrized regression cases (all requested in review):

| Expression | Expected days |
|---|---|
| `SAT-SUN` | `{0, 6}` |
| `MON-SUN` | `{0, 1, 2, 3, 4, 5, 6}` |
| `WED-SUN` | `{0, 3, 4, 5, 6}` |
| `FRI-SUN` | `{0, 5, 6}` |
| bare `SUN` | `{0}` |
| numeric `6-7` | `{0, 6}` |
| numeric `0` | `{0}` |

All 34 tests pass ✅ | ruff ✅ | mypy ✅

Fixes #1063