### PR TITLE
fix(engine): reject oversized tool results before pruning the store

### DIFF
--- a/src/agentos/engine/agent.py
+++ b/src/agentos/engine/agent.py
@@ -1487,7 +1487,7 @@ class Agent:
                 self.config.metadata.get("tool_result_store_skips", 0) + 1
             )
             logger.info(
-                "tool_result_store.skipped",
+                "tool_result_store.budget_rejected",
                 tool_use_id=tool_use_id,
                 tool_name=tool_name,
                 reason=str(exc),

--- a/src/agentos/engine/tool_result_store.py
+++ b/src/agentos/engine/tool_result_store.py
@@ -217,6 +217,13 @@ class ToolResultStore:
 
     def _prune_to_fit(self, incoming_bytes: int, disk_budget_bytes: int) -> None:
         budget = max(0, int(disk_budget_bytes))
+        # A snapshot larger than the whole budget can never fit, however much we
+        # prune. Reject it before deleting anything, otherwise the loop below
+        # evicts every existing record and the write is refused anyway.
+        if incoming_bytes > budget:
+            raise ToolResultStoreBudgetError(
+                f"tool result snapshot exceeds disk budget ({incoming_bytes} > {budget})"
+            )
         records = sorted(self._iter_records(), key=lambda item: item.created_at)
         current = sum(record.size_bytes for record in records)
         if current + incoming_bytes <= budget:
@@ -226,11 +233,6 @@ class ToolResultStore:
             current = max(0, current - record.size_bytes)
             if current + incoming_bytes <= budget:
                 return
-        if incoming_bytes > budget:
-            raise ToolResultStoreBudgetError(
-                "tool result snapshot exceeds disk budget "
-                f"({incoming_bytes} > {budget})"
-            )
 
 
 def _parse_created_at(value: str) -> datetime:

--- a/tests/test_engine/test_tool_result_store_budget.py
+++ b/tests/test_engine/test_tool_result_store_budget.py
@@ -64,6 +64,42 @@ def test_oversized_write_preserves_existing_records(tmp_path: Path) -> None:
         assert store.read(handle, session_id="s1").content == f"record-{index}"
 
 
+def test_oversized_write_does_not_evict_another_session(tmp_path: Path) -> None:
+    # The disk budget is global: _iter_records walks every session bucket, so a
+    # rejected write in one session used to take unrelated sessions down with it.
+    store = ToolResultStore(tmp_path)
+    others = [
+        store.write(
+            f"data-{session}",
+            tool_use_id=f"tu-{session}",
+            tool_name="x",
+            session_id=session,
+            session_key="k",
+            agent_id="a",
+            max_bytes=None,
+            disk_budget_bytes=500,
+            retention_seconds=None,
+        ).handle
+        for session in ("session-a", "session-b")
+    ]
+
+    with pytest.raises(ToolResultStoreBudgetError):
+        store.write(
+            "X" * 2000,
+            tool_use_id="tu-big",
+            tool_name="x",
+            session_id="session-a",
+            session_key="k",
+            agent_id="a",
+            max_bytes=None,
+            disk_budget_bytes=500,
+            retention_seconds=None,
+        )
+
+    assert _handles_on_disk(tmp_path) == set(others)
+    assert store.read(others[1], session_id="session-b").content == "data-session-b"
+
+
 def test_per_result_rejection_keeps_existing_records(tmp_path: Path) -> None:
     store = ToolResultStore(tmp_path)
     handle = _write(store, "keep-me", tool_use_id="tu-0", disk_budget_bytes=500)

--- a/tests/test_engine/test_tool_result_store_budget.py
+++ b/tests/test_engine/test_tool_result_store_budget.py
@@ -1,0 +1,151 @@
+"""Budget-rejection regression tests for the raw tool-result store.
+
+Covers the data-loss bug where ``_prune_to_fit`` ran its eviction loop to
+completion before it evaluated the oversized case, so a write that could never
+fit destroyed every existing record and was then refused anyway.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentos.engine import agent as agent_module
+from agentos.engine.agent import Agent
+from agentos.engine.tool_result_store import (
+    TOOL_RESULT_META_NAME,
+    ToolResultStore,
+    ToolResultStoreBudgetError,
+)
+
+
+def _write(
+    store: ToolResultStore,
+    content: str,
+    *,
+    tool_use_id: str,
+    disk_budget_bytes: int,
+    max_bytes: int | None = None,
+) -> str:
+    record = store.write(
+        content,
+        tool_use_id=tool_use_id,
+        tool_name="x",
+        session_id="s1",
+        session_key="k",
+        agent_id="a",
+        max_bytes=max_bytes,
+        disk_budget_bytes=disk_budget_bytes,
+        retention_seconds=None,
+    )
+    return record.handle
+
+
+def _handles_on_disk(root: Path) -> set[str]:
+    return {path.parent.name for path in root.rglob(TOOL_RESULT_META_NAME)}
+
+
+def test_oversized_write_preserves_existing_records(tmp_path: Path) -> None:
+    store = ToolResultStore(tmp_path)
+    handles = [
+        _write(store, f"record-{index}", tool_use_id=f"tu-{index}", disk_budget_bytes=500)
+        for index in range(3)
+    ]
+    assert _handles_on_disk(tmp_path) == set(handles)
+
+    with pytest.raises(ToolResultStoreBudgetError):
+        _write(store, "X" * 2000, tool_use_id="tu-big", disk_budget_bytes=500)
+
+    assert _handles_on_disk(tmp_path) == set(handles)
+    for index, handle in enumerate(handles):
+        assert store.read(handle, session_id="s1").content == f"record-{index}"
+
+
+def test_per_result_rejection_keeps_existing_records(tmp_path: Path) -> None:
+    store = ToolResultStore(tmp_path)
+    handle = _write(store, "keep-me", tool_use_id="tu-0", disk_budget_bytes=500)
+
+    with pytest.raises(ToolResultStoreBudgetError, match="per-result budget"):
+        _write(
+            store,
+            "Y" * 50,
+            tool_use_id="tu-big",
+            disk_budget_bytes=500,
+            max_bytes=10,
+        )
+
+    assert _handles_on_disk(tmp_path) == {handle}
+
+
+def test_prune_still_evicts_oldest_when_write_fits(tmp_path: Path) -> None:
+    store = ToolResultStore(tmp_path)
+    # Three 8-byte records against a 30-byte budget; a 10-byte write fits once
+    # the oldest record is evicted, so pruning must still happen.
+    handles = [
+        _write(store, f"record-{index}", tool_use_id=f"tu-{index}", disk_budget_bytes=30)
+        for index in range(3)
+    ]
+
+    new_handle = _write(store, "Y" * 10, tool_use_id="tu-new", disk_budget_bytes=30)
+
+    assert _handles_on_disk(tmp_path) == {handles[1], handles[2], new_handle}
+
+
+def test_write_exactly_at_budget_prunes_and_succeeds(tmp_path: Path) -> None:
+    store = ToolResultStore(tmp_path)
+    for index in range(3):
+        _write(store, f"record-{index}", tool_use_id=f"tu-{index}", disk_budget_bytes=20)
+
+    # incoming == budget is storable, but only after the store is cleared.
+    new_handle = _write(store, "Z" * 20, tool_use_id="tu-new", disk_budget_bytes=20)
+
+    assert _handles_on_disk(tmp_path) == {new_handle}
+
+
+def test_budget_rejection_logs_distinct_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = ToolResultStore(tmp_path)
+    handle = _write(store, "keep-me", tool_use_id="tu-0", disk_budget_bytes=500)
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        agent_module,
+        "logger",
+        SimpleNamespace(
+            info=lambda event, **kw: events.append((event, kw)),
+            warning=lambda event, **kw: events.append((event, kw)),
+        ),
+    )
+
+    config = SimpleNamespace(
+        tool_result_store_dir=str(tmp_path),
+        tool_result_store_session_id="s1",
+        tool_result_store_session_key="k",
+        tool_result_store_agent_id="a",
+        tool_result_store_max_bytes=None,
+        tool_result_store_disk_budget_bytes=500,
+        tool_result_store_retention_seconds=None,
+        metadata={},
+    )
+    holder = SimpleNamespace(config=config, _session_key="k")
+
+    record = Agent._store_tool_result_snapshot(
+        holder,  # type: ignore[arg-type]
+        "X" * 2000,
+        tool_use_id="tu-big",
+        tool_name="x",
+    )
+
+    assert record is None
+    assert config.metadata["tool_result_store_skips"] == 1
+    assert len(events) == 1
+    event, fields = events[0]
+    assert event == "tool_result_store.budget_rejected"
+    assert fields["tool_use_id"] == "tu-big"
+    assert "exceeds disk budget" in fields["reason"]
+    # The rejected write must not have cost us the record already on disk.
+    assert _handles_on_disk(tmp_path) == {handle}


### PR DESCRIPTION
Fixes #996

## The bug

`_prune_to_fit` (`src/agentos/engine/tool_result_store.py`) ran its eviction loop to completion *before* it evaluated the oversized case:

```python
for record in records:
    _remove_record_dir(record.record_dir)          # unconditional delete
    current = max(0, current - record.size_bytes)
    if current + incoming_bytes <= budget:
        return
if incoming_bytes > budget:                        # only checked after
    raise ToolResultStoreBudgetError(...)
```

When `incoming_bytes > budget` the loop can never satisfy its exit condition, so it deletes every record and *then* the write is rejected anyway. The deletions buy nothing — the write fails either way.

The blast radius is wider than the failing turn. `_iter_records` walks the whole `s/` tree, so the disk budget is global across sessions and the loop evicts oldest-first regardless of who owns the record. Measured against the unfixed `_prune_to_fit`, with one record stored under each of two sessions and a 2 KB write attempted in `session-a` against a 500-byte budget:

| | records on disk | `session-b` survivors |
|---|---|---|
| before the write | 2 | 1 |
| after, unfixed | **0** | **0** |
| after, fixed | 2 | 1 |

An unrelated session loses its stored tool results because a different session tried to write something too large. The caller only logged this, so nothing surfaced it.

## The fix

Hoist the check above the loop, per @andreapn's direction in [this comment](https://github.com/use-agent-os/agent-os/issues/996#issuecomment-5549715807), so an unstorable write is refused before anything is touched:

```python
budget = max(0, int(disk_budget_bytes))
if incoming_bytes > budget:
    raise ToolResultStoreBudgetError(
        f"tool result snapshot exceeds disk budget ({incoming_bytes} > {budget})"
    )
```

The trailing `raise` is removed rather than left in place: after the hoist it is unreachable. Once the loop exhausts `records`, `current` is 0, and `incoming_bytes <= budget` is guaranteed above, so the loop always returns first.

Eviction itself is untouched. A write that *can* fit still prunes oldest-first, and `incoming == budget` still clears the store and succeeds — there the deletions genuinely buy something.

## Operator visibility

@andreapn also asked for a distinct log event, noting the caller "only logs a `skipped` metric". One judgement call worth flagging: it already logged at `logger.info`, but under the event name `tool_result_store.skipped` — which reads as generic, and sits a few lines below an unrelated missing-identity skip that increments the same `tool_result_store_skips` counter and logs nothing at all.

I read "a distinct log event" as *rename the generic event* rather than *add a second one beside it*, since two log lines for one rejection seemed worse. It is now `tool_result_store.budget_rejected`; level and fields are unchanged, and the counter is untouched because `runtime.py` and `decision_log.py` consume it. The old name has no other references in the tree. Happy to make it additive instead if that was the intent.

## Tests

New `tests/test_engine/test_tool_result_store_budget.py` (6 tests, offline, `tmp_path` only):

- the issue's exact repro — 3 records, one 2 KB write against a 500-byte budget — asserting the content is still readable via `store.read`, not merely that directories survived
- **the cross-session case**: a rejected write in `session-a` leaves `session-b`'s record intact and readable
- per-result-budget rejection likewise touches nothing
- normal eviction still evicts oldest-first — guards against "fixing" this by disabling pruning
- `incoming == budget` still clears the store and succeeds
- `agent.py` emits `tool_result_store.budget_rejected`

Against the unfixed source, 4 of the 6 fail. The two survivors are the eviction and boundary cases, which pass either way by design — they exist to catch a fix that quietly stops pruning.

## Verification

```
uv run pytest tests/test_engine/test_tool_result_store_budget.py -q
6 passed

uv run pytest tests/test_engine -q
1070 passed

uv run mypy src/agentos --show-error-codes
Success: no issues found in 623 source files

uv run ruff check + ruff format --check on the changed files — clean
```

## One adjacent case, deliberately left alone

Normal eviction — records dropped because the store is legitimately full — still logs nothing at all. An operator has no signal there either, which is arguably closer to the underlying concern in @andreapn's comment than the rejection path is. I left it out because #996 is about the failed write, and an eviction log needs a rate-limiting decision (a busy store prunes constantly) that belongs in its own change. Happy to follow up if you want it.

## Related

Three PRs already propose the same hoist — #997 (@Carlys17, who claimed the issue), #1003, #1004 — none covering the logging half of the comment. If you would rather land one of those and take just the log rename and tests from here, that is completely fine by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
