### PR TITLE
fix(cli): parse unquoted file and image paths with spaces (#1228)

### DIFF
--- a/src/agentos/cli/attachments.py
+++ b/src/agentos/cli/attachments.py
@@ -167,9 +167,21 @@ def _parse_path_prompt(command: str, prefix: str, usage: str) -> tuple[Path, str
         token = rest[1:end]
         prompt = rest[end + 1 :].strip()
     else:
-        parts = rest.split(None, 1)
-        token = parts[0]
-        prompt = parts[1] if len(parts) > 1 else ""
+        words = rest.split()
+        token = ""
+        prompt = ""
+        for count in range(len(words), 0, -1):
+            candidate = " ".join(words[:count])
+            try:
+                if Path(candidate).expanduser().exists():
+                    token = candidate
+                    prompt = " ".join(words[count:]).strip()
+                    break
+            except (OSError, ValueError):
+                continue
+        if not token and words:
+            token = words[0]
+            prompt = rest[len(token) :].strip()
 
     if not token:
         raise ValueError(usage)

--- a/tests/test_cli/test_chat_file_command.py
+++ b/tests/test_cli/test_chat_file_command.py
@@ -78,6 +78,20 @@ def test_file_command_parses_quoted_path_with_spaces(tmp_path: Path) -> None:
     assert base64.b64decode(attachments[0]["data"]) == csv_bytes
 
 
+def test_file_command_parses_unquoted_path_with_spaces(tmp_path: Path) -> None:
+    csv_bytes = b"col_a,col_b\n1,2\n"
+    path = _write(tmp_path, "data set with spaces.csv", csv_bytes)
+
+    prompt, attachments = _file_prompt_and_attachments(
+        f"/file {path} summarise this", upload_callable=None
+    )
+
+    assert prompt == "summarise this"
+    assert attachments[0]["name"] == "data set with spaces.csv"
+    assert attachments[0]["type"] == "text/csv"
+    assert base64.b64decode(attachments[0]["data"]) == csv_bytes
+
+
 def test_file_command_rejects_unclosed_quoted_path() -> None:
     with pytest.raises(ValueError, match=r"Usage: /file"):
         _file_prompt_and_attachments('/file "unterminated', upload_callable=None)
@@ -92,6 +106,19 @@ def test_image_command_parses_quoted_path_with_spaces(tmp_path: Path) -> None:
     assert _image_prompt_from_command(f'/image "{path}" describe it') == "describe it"
     assert prompt == "describe it"
     assert attachments[0]["name"] == "screen shot.png"
+    assert attachments[0]["type"] == "image/png"
+    assert base64.b64decode(attachments[0]["data"]) == png_bytes
+
+
+def test_image_command_parses_unquoted_path_with_spaces(tmp_path: Path) -> None:
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"payload"
+    path = _write(tmp_path, "screen shot with spaces.png", png_bytes)
+
+    prompt, attachments = _image_prompt_and_attachments(f"/image {path} describe it")
+
+    assert _image_prompt_from_command(f"/image {path} describe it") == "describe it"
+    assert prompt == "describe it"
+    assert attachments[0]["name"] == "screen shot with spaces.png"
     assert attachments[0]["type"] == "image/png"
     assert base64.b64decode(attachments[0]["data"]) == png_bytes
 


### PR DESCRIPTION
Closes #1228

## Linked issue

Fixes #1228

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## Summary

In `src/agentos/cli/attachments.py`, `_parse_path_prompt()` previously split unquoted command input using `rest.split(None, 1)`, taking only the first whitespace token as the target path. On systems where files or parent directories contain spaces (e.g., Windows user profiles like `C:\Users\John Doe\...`, directories with spaces, or temporary test directories), unquoted input from terminal drag-and-drop, pasting, or chat commands failed with `ValueError: File not found: <prefix>`, causing 9 test failures in `tests/test_cli/test_chat_file_command.py` and 1 in `tests/unit/cli/repl/test_input_assets.py`.

This PR:
- Updates `_parse_path_prompt()` to greedily scan for existing filesystem paths from longest candidate to shortest (`for count in range(len(words), 0, -1)`), matching the established resolution pattern in `parse_path_command()`.
- Wraps candidate existence checks with `try...except (OSError, ValueError)` to guard against OS-specific path parsing exceptions.
- Falls back to `words[0]` when no existing path matches so downstream file validation and clear error reporting remain intact.
- Adds regression unit tests in `tests/test_cli/test_chat_file_command.py` verifying `/file` and `/image` commands with unquoted paths containing spaces.

## Tests

1. Target unit test suite (verified all 9 previous failures resolved):
   ```bash
   uv run pytest tests/test_cli/test_chat_file_command.py -q
   # 15 passed in 2.95s
REPL input assets test suite (verified wrapped helper test passes):

bash
uv run pytest tests/unit/cli/repl/test_input_assets.py -q
# 5 passed in 2.56s
Full CLI test suite:

bash
uv run pytest tests/test_cli -q
# 743 passed, 4 skipped
Quality gate linting and typing:

bash
uv run ruff check src/agentos/cli/attachments.py tests/test_cli/test_chat_file_command.py
# All checks passed!
uv run mypy src/agentos/cli/attachments.py --show-error-codes
# Success: no issues found in 1 source file


