### PR TITLE
fix(cli): quote config path in gateway startup recovery hint

### DIFF
--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shlex
 import sys
 
 import typer
@@ -166,9 +167,8 @@ def run_gateway(
         for entry in recovery_entries:
             console.print(f"{entry['label']}: {entry['command']}")
         if config.config_path:
-            console.print(
-                f"Inspect onboarding: agentos onboard status --config {config.config_path}"
-            )
+            quoted_path = shlex.quote(str(config.config_path))
+            console.print(f"Inspect onboarding: agentos onboard status --config {quoted_path}")
         raise typer.Exit(code=1) from exc
     except KeyboardInterrupt:
         console.print("\n[yellow]Gateway stopped.[/yellow]")

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -136,6 +136,34 @@ def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
     assert "Traceback" not in output
 
 
+def test_gateway_run_recovery_hint_quotes_config_path_with_spaces(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Issue #1231 — the startup-failure hint must be copy-pasteable when the
+    config path contains spaces, so it is emitted shell-quoted."""
+    spaced_dir = tmp_path / "John Doe"
+    spaced_dir.mkdir()
+    target = spaced_dir / "custom.toml"
+    target.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+
+    async def fail_start_gateway_server(**_kwargs):
+        raise ValueError("startup boom")
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fail_start_gateway_server)
+
+    result = runner.invoke(app, ["gateway", "run", "--config", str(target)])
+
+    assert result.exit_code == 1
+    output = result.stdout + (result.stderr or "")
+    compact = "".join(output.split())
+    assert "Gateway could not start" in output
+    # The hint must be shell-quoted so the path survives copy-paste. The rich
+    # console wraps long lines, so compare with all whitespace removed.
+    assert f"--config '{str(target)}'".replace(" ", "") in compact
+
+
 def test_gateway_run_refuses_wildcard_bind_without_auth(tmp_path, monkeypatch) -> None:
     """auth.mode="none" + non-loopback bind fails closed at startup (issue #18, V3)."""
     target = tmp_path / "agentos.toml"


### PR DESCRIPTION
Fixes #1231

## Problem

The `Inspect onboarding` recovery hint, printed when the gateway fails to start, interpolated the config path verbatim:

```
Inspect onboarding: agentos onboard status --config C:\Users\John Doe\custom.toml
```

On any config path containing spaces (e.g. `C:\Users\John Doe\custom.toml`), the printed command is not copy-pasteable — the shell splits it at the first space.

## Fix

Apply `shlex.quote` to the config path, matching the existing convention used by the sibling recovery hints:

- `src/agentos/onboarding/next_steps.py` (`_config_cli_arg`)
- `src/agentos/onboarding/flow.py`
- `src/agentos/health/recovery_commands.py` (`command_with_config`)

## Testing

- New regression test `test_gateway_run_recovery_hint_quotes_config_path_with_spaces` in `tests/test_cli/test_gateway_cmd.py` invokes `gateway run --config <spaced path>`, forces a startup failure, and asserts the emitted hint shell-quotes the path. It compares whitespace-stripped output since the rich console wraps long lines.
- `uv run pytest tests/test_cli/test_gateway_cmd.py -q` → 32 passed
- `uv run ruff check src tests` → all checks passed
- `uv run mypy src/agentos --show-error-codes` → no issues (623 files)
- Full `uv run pytest -q`: 9486 passed; the failures/errors present are pre-existing environment failures (pilot encoder ONNX, timezone hygiene, wheelhouse builds) — verified identical on a clean tree.

No CLI surface/contract change (message text only), so `docs/cli.md` and the bundled skill are unaffected.