### PR TITLE
fix(channels): preserve falsy values and support subcommands in Disco…

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -667,6 +667,28 @@ class DiscordChannel:
         )
         self.enqueue(msg)
 
+    @staticmethod
+    def _flatten_interaction_options(options: list[Any]) -> list[str]:
+        """Recursively flatten Discord slash command options, preserving subcommands,
+        subcommand groups, and falsy values (e.g. 0, 0.0, False)."""
+        parts: list[str] = []
+        for opt in options:
+            if not isinstance(opt, dict):
+                continue
+            opt_type = opt.get("type")
+            sub_options = opt.get("options")
+            if opt_type in (1, 2) or "value" not in opt:
+                name = opt.get("name")
+                if name:
+                    parts.append(str(name))
+                if isinstance(sub_options, list):
+                    parts.extend(DiscordChannel._flatten_interaction_options(sub_options))
+            else:
+                val = opt.get("value")
+                if val is not None and val != "":
+                    parts.append(str(val))
+        return parts
+
     async def _handle_interaction(self, data: dict[str, Any]) -> None:
         """Parse a slash command interaction into IncomingMessage."""
         interaction_data = data.get("data")
@@ -692,10 +714,8 @@ class DiscordChannel:
         # Build content from command name and options
         raw_options = interaction_data.get("options")
         options = raw_options if isinstance(raw_options, list) else []
-        option_parts = [
-            opt.get("value", "") for opt in options if isinstance(opt, dict) and opt.get("value")
-        ]
-        content = f"/{command_name} {' '.join(str(v) for v in option_parts)}".strip()
+        option_parts = self._flatten_interaction_options(options)
+        content = f"/{command_name} {' '.join(option_parts)}".strip()
         channel_type = self._channel_type(data.get("channel_type"))
         thread_id = self._native_thread_id(data, channel_type)
         conversation_kind = self._conversation_kind(data, channel_type, thread_id)

--- a/tests/test_channels/test_discord_interactions.py
+++ b/tests/test_channels/test_discord_interactions.py
@@ -44,6 +44,8 @@ def _application_command(
     *,
     interaction_id: str = "interaction-1",
     interaction_type: int = 2,
+    command_name: str = "status",
+    options: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     return {
         "id": interaction_id,
@@ -56,8 +58,8 @@ def _application_command(
         "member": {"user": {"id": "user-1"}},
         "data": {
             "type": 1,
-            "name": "status",
-            "options": [],
+            "name": command_name,
+            "options": [] if options is None else options,
         },
     }
 
@@ -179,3 +181,116 @@ async def test_discord_non_command_interaction_types_are_ignored(
 
     assert channel._queue.empty()
     assert client.calls == []
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_content"),
+    [
+        ([{"name": "value", "type": 4, "value": 0}], "/temperature 0"),
+        ([{"name": "value", "type": 10, "value": 0.0}], "/temperature 0.0"),
+        ([{"name": "enabled", "type": 5, "value": False}], "/temperature False"),
+        (
+            [
+                {"name": "temp", "value": 0},
+                {"name": "verbose", "value": False},
+                {"name": "query", "value": "test"},
+            ],
+            "/temperature 0 False test",
+        ),
+    ],
+)
+async def test_discord_slash_command_preserves_falsy_values(
+    options: list[dict[str, Any]], expected_content: str
+) -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token"))
+    channel._client = client
+
+    payload = _application_command(command_name="temperature", options=options)
+    await channel._handle_dispatch("INTERACTION_CREATE", payload)
+
+    message = await channel.receive()
+    assert message.content == expected_content
+
+
+async def test_discord_slash_command_traverses_subcommands() -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token"))
+    channel._client = client
+
+    # Subcommand with no arguments: /agentos status
+    payload1 = _application_command(
+        interaction_id="subcmd-1",
+        command_name="agentos",
+        options=[{"name": "status", "type": 1, "options": []}],
+    )
+    await channel._handle_dispatch("INTERACTION_CREATE", payload1)
+    message1 = await channel.receive()
+    assert message1.content == "/agentos status"
+
+    # Subcommand with arguments: /agentos configure openrouter
+    payload2 = _application_command(
+        interaction_id="subcmd-2",
+        command_name="agentos",
+        options=[
+            {
+                "name": "configure",
+                "type": 1,
+                "options": [{"name": "provider", "type": 3, "value": "openrouter"}],
+            }
+        ],
+    )
+    await channel._handle_dispatch("INTERACTION_CREATE", payload2)
+    message2 = await channel.receive()
+    assert message2.content == "/agentos configure openrouter"
+
+
+async def test_discord_slash_command_traverses_subcommand_groups() -> None:
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token"))
+    channel._client = client
+
+    # Subcommand with key-value arguments including 0: /config set temperature 0
+    payload1 = _application_command(
+        interaction_id="group-1",
+        command_name="config",
+        options=[
+            {
+                "name": "set",
+                "type": 1,
+                "options": [
+                    {"name": "key", "type": 3, "value": "temperature"},
+                    {"name": "value", "type": 4, "value": 0},
+                ],
+            }
+        ],
+    )
+    await channel._handle_dispatch("INTERACTION_CREATE", payload1)
+    message1 = await channel.receive()
+    assert message1.content == "/config set temperature 0"
+
+    # Subcommand group (type 2) nesting subcommand (type 1) and options:
+    # /config server set 8080 False
+    payload2 = _application_command(
+        interaction_id="group-2",
+        command_name="config",
+        options=[
+            {
+                "name": "server",
+                "type": 2,
+                "options": [
+                    {
+                        "name": "set",
+                        "type": 1,
+                        "options": [
+                            {"name": "port", "type": 4, "value": 8080},
+                            {"name": "debug", "type": 5, "value": False},
+                        ],
+                    }
+                ],
+            }
+        ],
+    )
+    await channel._handle_dispatch("INTERACTION_CREATE", payload2)
+    message2 = await channel.receive()
+    assert message2.content == "/config server set 8080 False"


### PR DESCRIPTION
Closes #1229

Fixes #1229
- [x] This pull request fully resolves the linked issue, or the description
      says what remains.
## Summary
In `src/agentos/channels/discord.py`, `DiscordChannel._handle_interaction()` previously extracted slash command options using:
```python
option_parts = [
    opt.get("value", "") for opt in options if isinstance(opt, dict) and opt.get("value")
]
Because this relied on Python truthiness (and opt.get("value")), legitimate falsy argument values (numeric 0, 0.0, and boolean False) were silently discarded. Additionally, Discord subcommands (Type 1) and subcommand groups (Type 2)—which contain child options rather than a top-level value—were completely dropped.

This PR:

Adds DiscordChannel._flatten_interaction_options() to recursively traverse Discord subcommand (type: 1) and subcommand group (type: 2) trees, appending the subcommand/group name and flattening child options.
Preserves falsy option values (0, 0.0, False) by checking val is not None and val != "" instead of Python truthiness.
Reconstructs normalized slash command strings (e.g. /temperature 0, /verbose False, /agentos status, and /config set temperature 0).
Adds unit tests in tests/test_channels/test_discord_interactions.py covering falsy values, subcommands without arguments, subcommands with arguments, and nested subcommand groups.
Tests
Target Discord interactions test suite:

bash
uv run pytest tests/test_channels/test_discord_interactions.py -q
# 14 passed in 3.46s
Full channel test suite:

bash
uv run pytest tests/test_channels/ -q
# 414 passed in 47.70s
Quality gate linting and typing:

bash
uv run ruff check src/agentos/channels/discord.py tests/test_channels/test_discord_interactions.py
# All checks passed!
uv run mypy src/agentos/channels/discord.py --show-error-codes
# Success: no issues found in 1 source file