### PR TITLE
fix(sandbox): check exec workdir structurally and keep Windows path tokens

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -305,6 +305,21 @@ def sensitive_path_marker(
     return marker
 
 
+def _tokenize_text(text: str) -> list[str]:
+    """Tokenize free-form text for path scanning, keeping Windows paths intact.
+
+    POSIX ``shlex`` treats ``\\`` as an escape character, mangling Windows
+    paths (``C:\\Users\\me\\.ssh\\id_rsa`` → ``C:Usersme.sshid_rsa``) so no
+    prefix rule can ever match them. On Windows hosts tokenize non-POSIX so
+    backslashes survive; the retained quote characters are removed by the
+    edge-char trim applied to each candidate downstream.
+    """
+    try:
+        return shlex.split(text, posix=os.name != "nt")
+    except ValueError:
+        return text.split()
+
+
 def sensitive_path_in_text(
     text: str,
     *,
@@ -325,10 +340,7 @@ def sensitive_path_in_text(
 
     candidates: list[str] = []
     with_context: list[tuple[str, int]] = []
-    try:
-        candidates.extend(shlex.split(text))
-    except ValueError:
-        candidates.extend(text.split())
+    candidates.extend(_tokenize_text(text))
     candidates.extend(text.split())
     with_context.extend(
         (match.group(0), match.start()) for match in _ABSOLUTE_OR_TILDE_PATH_RE.finditer(text)

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -259,14 +259,30 @@ def _sensitive_shell_block(
     if _context_elevated_mode() == "full":
         return None
 
-    from agentos.sandbox.sensitive_paths import build_block_envelope, sensitive_path_in_text
+    from agentos.sandbox.sensitive_paths import (
+        build_block_envelope,
+        sensitive_path_in_text,
+        sensitive_path_marker,
+    )
 
     checked_command = _without_shell_null_redirections(command)
-    include_workdir = bool(workdir) and not _workdir_is_configured_workspace(workdir)
-    checked_text = f"{workdir} {checked_command}" if include_workdir else checked_command
     ctx = current_tool_context.get()
     workspace = ctx.workspace_dir if ctx is not None else None
-    marker = sensitive_path_in_text(checked_text, workspace=workspace)
+    include_workdir = bool(workdir) and not _workdir_is_configured_workspace(workdir)
+    checked_text = f"{workdir} {checked_command}" if include_workdir else checked_command
+    if include_workdir and workdir is not None:
+        # The workdir is a resolved filesystem path, not free-form shell text:
+        # check it structurally so Windows backslashes and spaces survive.
+        # Gluing it into the command text and re-tokenizing mangles paths like
+        # ``C:\Users\John Doe\.ssh\id_rsa`` into fragments whose only match is
+        # a misleading file-suffix marker.
+        workdir_marker = sensitive_path_marker(workdir, workspace=workspace)
+        if workdir_marker is not None:
+            return json.dumps(
+                build_block_envelope(checked_text, workdir_marker, tool_name=tool_name),
+                ensure_ascii=False,
+            )
+    marker = sensitive_path_in_text(checked_command, workspace=workspace)
     if marker is not None:
         return json.dumps(
             build_block_envelope(checked_text, marker, tool_name=tool_name),

--- a/tests/test_tools/test_shell_sensitive.py
+++ b/tests/test_tools/test_shell_sensitive.py
@@ -35,6 +35,38 @@ async def test_exec_command_blocks_nested_sensitive_workdir() -> None:
 
 
 @pytest.mark.asyncio
+async def test_exec_command_spaced_home_reports_directory_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #1232 — the workdir used to be glued into the command text and
+    re-tokenized, so a home directory containing spaces split the path at the
+    space and mis-reported the ``/id_rsa`` file-suffix marker instead of the
+    ``~/.ssh`` directory prefix. The workdir is now checked structurally."""
+    spaced_home = tmp_path / "John Doe"
+    monkeypatch.setattr(Path, "home", lambda: spaced_home)
+    sensitive_dir = spaced_home / ".ssh" / "id_rsa"
+
+    result = await shell.exec_command("echo ok", workdir=str(sensitive_dir))
+
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["sensitive_path"] == "~/.ssh"
+
+
+def test_tokenize_text_preserves_backslashes_on_windows_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1232 — POSIX shlex.split() eats backslashes, so a Windows path
+    could never survive tokenization as a matchable token. Windows hosts must
+    tokenize non-POSIX."""
+    from agentos.sandbox.sensitive_paths import _tokenize_text
+
+    windows_path = "C:\\Users\\John\\.ssh\\id_rsa"
+    monkeypatch.setattr(os, "name", "nt")
+    assert windows_path in _tokenize_text(f"type {windows_path}")
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(os.name != "posix", reason="/dev/null redirection is POSIX-specific")
 async def test_exec_command_allows_dev_null_redirection() -> None:
     result = await shell.exec_command("printf ok 2>/dev/null")


### PR DESCRIPTION
Fixes #1232

## Problem

On Windows hosts, `test_exec_command_blocks_nested_sensitive_workdir` reports `payload["sensitive_path"] == "/id_rsa"` instead of `"~/.ssh"`. Two defects combine:

1. **Workdir re-tokenized as shell text.** `_sensitive_shell_block` glued the resolved workdir into the command text (`f"{workdir} {command}"`), then `sensitive_path_in_text()` re-tokenized it with `shlex.split(posix=True)`. POSIX shlex treats `\\` as an escape character **and** splits at whitespace, so `C:\Users\John Doe\.ssh\id_rsa` decomposed into fragments like `C:UsersJohn` / `Doe.sshid_rsa`. The only surviving match was the `"/id_rsa"` file-suffix marker — never the `~/.ssh` directory prefix. No amount of tokenization can reassemble a spaced path, so this had to be fixed at the source.
2. **Command-text tokenization ate backslashes.** `sensitive_path_in_text()` tokenized with POSIX shlex on every host, so a Windows path typed in the command (`type C:\Users\me\.ssh\id_rsa`) survived only through the whitespace-split fallback — and not at all when it contained spaces.

## Fix

- **`shell.py::_sensitive_shell_block`** — the workdir is a resolved filesystem path, not free-form shell text: check it structurally via `sensitive_path_marker(workdir, workspace=...)` before scanning the command text. The block envelope still shows the full `workdir + command` text.
- **`sensitive_paths.py`** — new `_tokenize_text()` helper tokenizes non-POSIX on `os.name == "nt"` so backslashes survive; retained quote characters are removed by the existing `_TOKEN_EDGE_CHARS` edge trim. POSIX hosts are unchanged.

## Testing

- New `test_exec_command_spaced_home_reports_directory_prefix` (monkeypatches `Path.home` to a directory containing a space): **fails on the old code with exactly the reported symptom** (`AssertionError: assert '/id_rsa' == '~/.ssh'`), passes with the fix.
- New `test_tokenize_text_preserves_backslashes_on_windows_hosts` asserts the full backslashed token survives tokenization on Windows hosts.
- `uv run pytest tests/test_tools/ -q` → 969 passed
- `uv run ruff check src tests` → all checks passed
- `uv run mypy src/agentos --show-error-codes` → no issues (623 files)
- Full `uv run pytest -q` run in progress at PR-open time; the only failures observed in earlier full runs are pre-existing environment failures (pilot encoder ONNX, timezone hygiene, wheelhouse builds), verified identical on a clean tree.

POSIX behavior is untouched: `_tokenize_text` returns `shlex.split(text, posix=True)` when `os.name != "nt"`, and the workspace-exception logic (`/root/.agentos/workspace` allowances) still flows through `sensitive_path_marker`.