### PR TITLE
fix(channels): keep falsy slash option values and reconstruct subcommands

### DIFF
--- a/src/agentos/channels/discord.py
+++ b/src/agentos/channels/discord.py
@@ -111,6 +111,35 @@ class _GatewayState:
     last_heartbeat_ack: bool = True
 
 
+_SUBCOMMAND_OPTION_TYPES = frozenset({1, 2})  # SUB_COMMAND, SUBCOMMAND_GROUP
+
+
+def _command_content_from_options(command_name: str, options: object) -> str:
+    """Reconstruct the normalized ``/command`` string from interaction data.
+
+    Keeps falsy option values (``0``, ``False``, ``""``) instead of dropping
+    them, and descends into subcommands (type 1) and subcommand groups
+    (type 2), whose names belong to the command path rather than the
+    argument list.
+    """
+    parts = [f"/{command_name}"]
+
+    def _walk(opts: object) -> None:
+        if not isinstance(opts, list):
+            return
+        for opt in opts:
+            if not isinstance(opt, dict):
+                continue
+            if opt.get("type") in _SUBCOMMAND_OPTION_TYPES and isinstance(opt.get("name"), str):
+                parts.append(opt["name"])
+                _walk(opt.get("options"))
+            elif "value" in opt:
+                parts.append(str(opt["value"]))
+
+    _walk(options)
+    return " ".join(parts).strip()
+
+
 @dataclass
 class DiscordChannel:
     """Channel adapter for Discord via Gateway WebSocket and REST API.
@@ -692,10 +721,7 @@ class DiscordChannel:
         # Build content from command name and options
         raw_options = interaction_data.get("options")
         options = raw_options if isinstance(raw_options, list) else []
-        option_parts = [
-            opt.get("value", "") for opt in options if isinstance(opt, dict) and opt.get("value")
-        ]
-        content = f"/{command_name} {' '.join(str(v) for v in option_parts)}".strip()
+        content = _command_content_from_options(command_name, options)
         channel_type = self._channel_type(data.get("channel_type"))
         thread_id = self._native_thread_id(data, channel_type)
         conversation_kind = self._conversation_kind(data, channel_type, thread_id)

--- a/tests/test_channels/test_discord_interactions.py
+++ b/tests/test_channels/test_discord_interactions.py
@@ -94,6 +94,87 @@ async def test_discord_application_command_is_deferred_before_group_dispatch() -
     )
 
 
+async def test_discord_slash_command_preserves_falsy_option_values() -> None:
+    """Issue #1229 — option values 0 and False are falsy but real: the old
+    truthiness filter dropped them from the reconstructed command string."""
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(
+        DiscordChannelConfig(token="bot-token", application_id="configured-app-id")
+    )
+    channel._client = client
+    payload = _application_command()
+    payload["data"] = {
+        "type": 1,
+        "name": "temperature",
+        "options": [
+            {"name": "temp", "type": 4, "value": 0},
+            {"name": "verbose", "type": 5, "value": False},
+            {"name": "query", "type": 3, "value": "test"},
+        ],
+    }
+
+    await channel._handle_dispatch("INTERACTION_CREATE", payload)
+
+    message = await channel.receive()
+    assert message.content == "/temperature 0 False test"
+
+
+async def test_discord_slash_command_reconstructs_subcommand() -> None:
+    """Issue #1229 — a type-1 SUB_COMMAND extends the command path."""
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(
+        DiscordChannelConfig(token="bot-token", application_id="configured-app-id")
+    )
+    channel._client = client
+    payload = _application_command()
+    payload["data"] = {
+        "type": 1,
+        "name": "agentos",
+        "options": [
+            {
+                "name": "configure",
+                "type": 1,
+                "options": [{"name": "provider", "type": 3, "value": "openrouter"}],
+            }
+        ],
+    }
+
+    await channel._handle_dispatch("INTERACTION_CREATE", payload)
+
+    message = await channel.receive()
+    assert message.content == "/agentos configure openrouter"
+
+
+async def test_discord_slash_command_reconstructs_subcommand_group() -> None:
+    """Issue #1229 — a type-2 SUBCOMMAND_GROUP descends into its subcommand
+    and keeps falsy leaf values (0)."""
+    client = _FakeDiscordClient()
+    channel = DiscordChannel(
+        DiscordChannelConfig(token="bot-token", application_id="configured-app-id")
+    )
+    channel._client = client
+    payload = _application_command()
+    payload["data"] = {
+        "type": 1,
+        "name": "config",
+        "options": [
+            {
+                "name": "set",
+                "type": 2,
+                "options": [
+                    {"name": "key", "type": 3, "value": "temperature"},
+                    {"name": "value", "type": 4, "value": 0},
+                ],
+            }
+        ],
+    }
+
+    await channel._handle_dispatch("INTERACTION_CREATE", payload)
+
+    message = await channel.receive()
+    assert message.content == "/config set temperature 0"
+
+
 async def test_discord_command_reply_completes_original_interaction_response() -> None:
     client = _FakeDiscordClient()
     channel = DiscordChannel(


### PR DESCRIPTION
Fixes #1229

## Problem

`DiscordChannel._handle_interaction()` built the normalized command string with a truthiness filter:

```python
option_parts = [
    opt.get("value", "") for opt in options if isinstance(opt, dict) and opt.get("value")
]
content = f"/{command_name} {' '.join(str(v) for v in option_parts)}".strip()
```

Two defects:

1. **Falsy values dropped** — `opt.get("value")` is falsy for `0`, `0.0`, and `False`, so `/temperature value: 0` arrived as `/temperature` and `/verbose enabled: False` as `/verbose`.
2. **Subcommands lost** — type-1 `SUB_COMMAND` and type-2 `SUBCOMMAND_GROUP` options have no `value` key at all; their `name` (the actual command path, e.g. `/agentos status`) was silently discarded, along with all nested options.

## Fix

New module-level helper `_command_content_from_options()` in `src/agentos/channels/discord.py`:

- Appends the leading `/` once, then every leaf `value` **as-is** (`"value" in opt` membership test, not truthiness) via `str()`.
- Recursively walks subcommand (type 1) and subcommand group (type 2) options, inserting their names into the command path and descending into their nested `options`.
- Non-list / non-dict payloads and missing names are tolerated (defensive, same as before).

| Interaction | Before | After |
|---|---|---|
| `/temperature value: 0` | `/temperature` | `/temperature 0` |
| `/verbose enabled: False` | `/verbose` | `/verbose False` |
| `/agentos status` | `/agentos` | `/agentos status` |
| `/config set key: temperature value: 0` | `/config set` | `/config set temperature 0` |

## Testing

3 new tests in `tests/test_channels/test_discord_interactions.py` (full dispatch → `channel.receive()` path with the existing fake client):

- `test_discord_slash_command_preserves_falsy_option_values` — **fails on old code** (`'/temperature test'`) — verified via stash
- `test_discord_slash_command_reconstructs_subcommand` — **fails on old code** (`'/agentos'`)
- `test_discord_slash_command_reconstructs_subcommand_group` — nested group + falsy leaf

`uv run pytest tests/test_channels/ -q` → 420 passed · `ruff check src tests` → clean · `mypy src/agentos` → clean (623 files)