### PR TITLE
fix(sandbox): preserve Windows backslashes and spaces in sensitive path detection (#1232)

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -96,7 +96,9 @@ _GLOB_ONLY_CHARS = frozenset("*?.")
 _DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
 
 _TOKEN_EDGE_CHARS = " \t\r\n'\"`$(){}[]<>;,|&"
-_ABSOLUTE_OR_TILDE_PATH_RE = re.compile(r"(?:~)?/(?:[^\s'\"`$(){}\[\]<>;,|&]+)")
+_ABSOLUTE_OR_TILDE_PATH_RE = re.compile(
+    r"(?:~|[A-Za-z]:)?[/\\](?:[^\s'\"`$(){}\[\]<>;,|&]+)"
+)
 _DOTENV_LITERAL_RE = re.compile(
     r"(?i)(?:^|[\s'\"`$(){}\[\]<>;,|&])"
     r"(?P<path>(?:[^\s'\"`$(){}\[\]<>;,|&]*/)?\.env(?:\.[A-Za-z0-9_.-]+)?)"
@@ -326,7 +328,20 @@ def sensitive_path_in_text(
     candidates: list[str] = []
     with_context: list[tuple[str, int]] = []
     try:
-        candidates.extend(shlex.split(text))
+        home_str = str(Path.home())
+        if home_str:
+            home_pat = re.escape(home_str).replace(r"\\", r"[/\\]")
+            home_re = re.compile(
+                home_pat + r"(?:[/\\][^\s'\"`$(){}\[\]<>;,|&]+)?",
+                re.IGNORECASE if os.name == "nt" else 0,
+            )
+            for match in home_re.finditer(text):
+                candidates.append(match.group(0))
+    except (OSError, RuntimeError):
+        pass
+
+    try:
+        candidates.extend(shlex.split(text, posix=os.name != "nt"))
     except ValueError:
         candidates.extend(text.split())
     candidates.extend(text.split())

--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -263,7 +263,11 @@ def _sensitive_shell_block(
 
     checked_command = _without_shell_null_redirections(command)
     include_workdir = bool(workdir) and not _workdir_is_configured_workspace(workdir)
-    checked_text = f"{workdir} {checked_command}" if include_workdir else checked_command
+    if include_workdir and workdir:
+        workdir_token = workdir if workdir.startswith(('"', "'")) else f'"{workdir}"'
+        checked_text = f"{workdir_token} {checked_command}"
+    else:
+        checked_text = checked_command
     ctx = current_tool_context.get()
     workspace = ctx.workspace_dir if ctx is not None else None
     marker = sensitive_path_in_text(checked_text, workspace=workspace)

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -22,6 +22,10 @@ def test_sensitive_path_in_text_matches_native_separator_paths() -> None:
     assert sensitive_path_in_text(f"type {key_path}") == "~/.ssh"
 
 
+def test_sensitive_path_in_text_preserves_windows_backslashes() -> None:
+    assert sensitive_path_in_text(r"type C:\Users\target\.ssh\id_rsa") == "/id_rsa"
+
+
 def test_active_workspace_under_root_is_not_blocked_by_root_prefix() -> None:
     workspace = Path("/root/.agentos/workspace")
 


### PR DESCRIPTION
Closes #1232

## Linked issue

Fixes #1232

- [x] This pull request fully resolves the linked issue, or the description
      says what remains.

## PROBLEM

In `src/agentos/sandbox/sensitive_paths.py`, `sensitive_path_in_text()` tokenized command text using `shlex.split(text)` with default `posix=True`.
On Windows hosts:
1. `shlex.split(text, posix=True)` treats backslashes (`\`) as escape characters, stripping directory separators from paths (e.g. `C:\Users\John\.ssh\id_rsa` was corrupted into `C:UsersJohn.sshid_rsa`). This caused prefix comparisons against `_SENSITIVE_PREFIXES` (such as `~/.ssh`) to fail.
2. Paths containing spaces (such as user home directories `C:\Users\John Doe\...` or `C:\Users\IKE CHUKUW EZE\...`) were split into separate tokens by `shlex.split()` and `text.split()`, breaking full path recognition and causing sensitive paths to be misclassified as leaf markers (e.g. `/id_rsa`) instead of directory prefixes (`~/.ssh`).
3. `_ABSOLUTE_OR_TILDE_PATH_RE` only looked for forward slashes (`(?:~)?/`) and did not match Windows drive prefixes (`[A-Za-z]:[/\\]`).
4. In `src/agentos/tools/builtin/shell.py`, `_sensitive_shell_block()` concatenated `workdir` into `checked_text` unquoted (`f"{workdir} {checked_command}"`), causing `workdir` paths containing spaces to be fragmented during tokenization.

These issues caused `test_exec_command_blocks_nested_sensitive_workdir` in `tests/test_tools/test_shell_sensitive.py` and `test_sensitive_path_in_text_matches_native_separator_paths` in `tests/test_sandbox/test_sensitive_paths.py` to fail on Windows with:
`AssertionError: assert '/id_rsa' == '~/.ssh'`

## FIX

1. **Windows-aware shlex tokenization**:
   In `src/agentos/sandbox/sensitive_paths.py`, passed `posix=os.name != "nt"` to `shlex.split()` so that backslashes are preserved as literal path separators on Windows while maintaining standard POSIX escaping on Linux and macOS.

2. **Home path scanning**:
   Added a matcher in `sensitive_path_in_text()` for paths rooted at `Path.home()` to reliably capture paths even when user profiles contain spaces.

3. **Windows drive and separator regex support**:
   Updated `_ABSOLUTE_OR_TILDE_PATH_RE` to match Windows drive letters and both separator styles: `r"(?:~|[A-Za-z]:)?[/\\](?:[^\s'\"`$(){}\[\]<>;,|&]+)"`.

4. **Workdir quoting**:
   In `src/agentos/tools/builtin/shell.py`, quoted `workdir` in `_sensitive_shell_block()` when composing `checked_text` (`f'"{workdir}" {checked_command}'`), ensuring directory paths with spaces are tokenized as a single unit.

5. **Regression test**:
   Added `test_sensitive_path_in_text_preserves_windows_backslashes` in `tests/test_sandbox/test_sensitive_paths.py` to verify unquoted Windows paths with backslashes are preserved and evaluated correctly.

## TESTING

1. **Target shell tool sensitive test suite**:
   ```bash
   uv run pytest tests/test_tools/test_shell_sensitive.py -q
   # 13 passed, 1 skipped in 7.92s

Target sandbox sensitive paths test suite:

bash
uv run pytest tests/test_sandbox/test_sensitive_paths.py -q
# 18 passed in 1.50s
(Resolves failure in test_sensitive_path_in_text_matches_native_separator_paths)

Full sandbox test suite:

bash
uv run pytest tests/test_sandbox/ -q
# 32 passed, 26 skipped in 7.60s
Quality gate checks:

bash
uv run ruff check src/agentos/sandbox/sensitive_paths.py src/agentos/tools/builtin/shell.py tests/test_sandbox/test_sensitive_paths.py
# All checks passed!
uv run mypy src/agentos/sandbox/sensitive_paths.py src/agentos/tools/builtin/shell.py --show-error-codes
# Success: no issues found in 2 source files