### PR TITLE
fix(tools): detect quoted and unquoted spaced shell write targets

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -339,7 +339,7 @@ _FD_DUP_PATTERN = re.compile(r"\d*>&\s*(?:\d+-?|-)(?=$|[\s|&;<>)])")
 # ``n>>``, ``&>``, ``&>>``, ``>&file`` and the noclobber override ``>|``. The
 # operator is deliberately *not* anchored to a word boundary — ``echo x>file`` is
 # valid shell and must be caught just like ``echo x > file``.
-_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
+_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"|&;<>()]*)\1")
 
 # ``tee`` is the other write primitive this parser covers, and it needs the same
 # treatment as the redirection operators: ``echo x|tee /etc/passwd`` is valid
@@ -349,14 +349,25 @@ _REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\
 # (``--append``) or long with a value (``--output-error=warn``); all of them are
 # skipped so the first non-option word is the real target.
 _TEE_PATTERN = re.compile(
-    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"\s|&;]+)\1"
+    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"|&;]*)\1"
 )
 
 
 def _shell_write_targets(command: str) -> list[str]:
     scanned = _FD_DUP_PATTERN.sub(" ", command)
-    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
-    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
+    # Quoted targets may contain spaces (the quote group pins the extent),
+    # and unquoted targets are read greedily up to the next shell
+    # metacharacter, so a spaced path is never truncated at its first
+    # whitespace token. Empty captures (bare operator, ``> ""``) are skipped.
+    targets: list[str] = []
+    for match in _REDIRECTION_PATTERN.finditer(scanned):
+        target = match.group(2).strip()
+        if target:
+            targets.append(target)
+    for match in _TEE_PATTERN.finditer(scanned):
+        target = match.group(2).strip()
+        if target:
+            targets.append(target)
     return targets
 
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -524,6 +524,63 @@ def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
     assert shell._shell_write_targets(command) == []
 
 
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ('echo payload > "/tmp/my custom folder/outside.txt"', "/tmp/my custom folder/outside.txt"),
+        ("echo payload > '/tmp/other dir/outside.txt'", "/tmp/other dir/outside.txt"),
+        ('echo payload | tee "/tmp/John Doe/outside.txt"', "/tmp/John Doe/outside.txt"),
+        ("echo payload | tee '/tmp/a b/c.txt'", "/tmp/a b/c.txt"),
+    ],
+)
+def test_shell_write_targets_captures_quoted_paths_with_spaces(
+    command: str,
+    expected: str,
+) -> None:
+    """Issue #1230 — quoted targets containing spaces used to be dropped by
+    the ``[^\\s...]`` character class, silently bypassing workspace lockdown."""
+    assert shell._shell_write_targets(command) == [expected]
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("echo payload > /tmp/my folder/outside.txt", "/tmp/my folder/outside.txt"),
+        ("echo payload | tee /tmp/John Doe/outside.txt", "/tmp/John Doe/outside.txt"),
+    ],
+)
+def test_shell_write_targets_captures_unquoted_paths_with_spaces(
+    command: str,
+    expected: str,
+) -> None:
+    assert shell._shell_write_targets(command) == [expected]
+
+
+def test_shell_write_targets_skips_empty_targets() -> None:
+    assert shell._shell_write_targets('echo payload > ""') == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_blocks_quoted_spaced_write_outside_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "my custom folder"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell.exec_command(
+        f'echo payload > "{outside}/outside.txt"',
+        workdir=str(workspace),
+    )
+
+    assert "workspace lockdown" in result
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "template",


### PR DESCRIPTION
Fixes #1230

## Problem

`_REDIRECTION_PATTERN` and `_TEE_PATTERN` in `src/agentos/tools/builtin/shell.py` excluded whitespace inside the target character class (`[^'"\s|&;<>()]+`) **regardless of whether the target was quoted**. Any quoted path containing a space therefore matched nothing:

```
echo payload > "/tmp/my custom folder/outside.txt"   ->  no target
echo payload | tee "/tmp/John Doe/outside.txt"        ->  no target
```

`_shell_write_targets()` returned `[]`, so `_workspace_lockdown_shell_block()` and `_workspace_write_deny_shell_block()` had nothing to inspect and the command executed unimpeded — a silent **workspace lockdown bypass**.

## Fix

- Both character classes drop `\s`: quoted extents are pinned by the quote backreference (`(['"]?)([^'"|&;<>()]*)\1`), and unquoted targets run greedily to the next shell metacharacter, so they are no longer truncated at their first whitespace token either (issue expectation #3).
- `_shell_write_targets()` now strips each capture and skips empty matches, preserving the non-empty semantics of the old `+`-quantified classes (`> ""` and bare operators still yield no targets).
- Group indices (`group(2)` = target) are unchanged; the consumer was the only caller.

## Testing

8 new cases in `tests/test_tools/test_shell_approval_policy.py`:

- 4 parametrized quoted-with-spaces captures (double + single quotes, redirection + tee) — **all fail on old code with `[]`** (verified via stash), the exact bypass symptom from the issue
- 2 parametrized unquoted-with-spaces captures (no first-token truncation)
- empty-target skip (`> ""`)
- end-to-end `test_workspace_lockdown_blocks_quoted_spaced_write_outside_workspace`: `exec_command('echo payload > "<outside spaced dir>/outside.txt"')` under UNATTENDED + `workspace_lockdown` + bypass is **blocked**; on old code it wrote through

`uv run pytest tests/test_tools/ -q` → 967 passed · `ruff check src tests` → clean · `mypy src/agentos` → clean (623 files)