### PR TITLE
fix(tools): detect quoted and unquoted spaced shell write targets (#1230)

### DIFF
--- a/src/agentos/tools/builtin/shell.py
+++ b/src/agentos/tools/builtin/shell.py
@@ -339,7 +339,9 @@ _FD_DUP_PATTERN = re.compile(r"\d*>&\s*(?:\d+-?|-)(?=$|[\s|&;<>)])")
 # ``n>>``, ``&>``, ``&>>``, ``>&file`` and the noclobber override ``>|``. The
 # operator is deliberately *not* anchored to a word boundary — ``echo x>file`` is
 # valid shell and must be caught just like ``echo x > file``.
-_REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\s|&;<>()]+)\1")
+_REDIRECTION_PATTERN = re.compile(
+    r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(?:(['\"])(.*?)\1|([^'\"|&;<>()\r\n]+))"
+)
 
 # ``tee`` is the other write primitive this parser covers, and it needs the same
 # treatment as the redirection operators: ``echo x|tee /etc/passwd`` is valid
@@ -349,14 +351,36 @@ _REDIRECTION_PATTERN = re.compile(r"(?:&>{1,2}|\d*>{1,2}&?)\|?\s*(['\"]?)([^'\"\
 # (``--append``) or long with a value (``--output-error=warn``); all of them are
 # skipped so the first non-option word is the real target.
 _TEE_PATTERN = re.compile(
-    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(['\"]?)([^'\"\s|&;]+)\1"
+    r"(?<![\w-])tee(?:\s+-{1,2}[A-Za-z][\w-]*(?:=[^\s|&;]+)?)*\s+(?:(['\"])(.*?)\1|([^'\"|&;<>()\r\n]+))"
 )
+
+
+def _clean_shell_write_target(match: re.Match[str]) -> str:
+    if match.group(2) is not None:
+        return match.group(2).strip()
+    unquoted = (match.group(3) or "").strip()
+    words = unquoted.split()
+    if len(words) <= 1:
+        return unquoted
+    for count in range(len(words), 0, -1):
+        candidate = " ".join(words[:count])
+        try:
+            p = Path(candidate).expanduser()
+            if p.is_absolute() and (
+                p.exists() or p.parent.exists() or any(parent.exists() for parent in p.parents)
+            ):
+                return candidate
+        except (OSError, ValueError):
+            pass
+    return words[0]
 
 
 def _shell_write_targets(command: str) -> list[str]:
     scanned = _FD_DUP_PATTERN.sub(" ", command)
-    targets: list[str] = [match.group(2) for match in _REDIRECTION_PATTERN.finditer(scanned)]
-    targets.extend(match.group(2) for match in _TEE_PATTERN.finditer(scanned))
+    targets: list[str] = [
+        _clean_shell_write_target(match) for match in _REDIRECTION_PATTERN.finditer(scanned)
+    ]
+    targets.extend(_clean_shell_write_target(match) for match in _TEE_PATTERN.finditer(scanned))
     return targets
 
 

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -524,6 +524,66 @@ def test_shell_write_targets_ignores_words_ending_in_tee(command: str) -> None:
     assert shell._shell_write_targets(command) == []
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo ok > "path with spaces.txt"',
+        "echo ok > 'path with spaces.txt'",
+        'echo ok >> "path with spaces.txt"',
+        'echo ok 2> "path with spaces.txt"',
+        'cat<in>"path with spaces.txt"',
+        'echo ok | tee "path with spaces.txt"',
+        "echo ok | tee 'path with spaces.txt'",
+        'echo ok|tee -a "path with spaces.txt"',
+        'echo ok | tee --append "path with spaces.txt"',
+    ],
+)
+def test_shell_write_targets_detects_quoted_targets_with_spaces(command: str) -> None:
+    assert "path with spaces.txt" in shell._shell_write_targets(command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template",
+    [
+        'echo ok > "{target}"',
+        "echo ok > '{target}'",
+        'echo ok >> "{target}"',
+        'echo ok|tee "{target}"',
+        "echo ok | tee '{target}'",
+    ],
+)
+async def test_workspace_lockdown_blocks_quoted_targets_with_spaces(
+    tmp_path: Path,
+    template: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "outside dir"
+    outside_dir.mkdir()
+    outside = outside_dir / "target with spaces.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        template.format(target=outside),
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+    assert result["resolved_path"] == str(outside)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "template",


### PR DESCRIPTION
Closes #1230

### PROBLEM

In `src/agentos/tools/builtin/shell.py`, `_REDIRECTION_PATTERN` and `_TEE_PATTERN` attempted to match quoted (`"..."`, `'...'`) and unquoted file targets using an inner character class containing `\s` (e.g. `[^'\"\s|&;<>()]+`). Because `\s` was forbidden regardless of whether surrounding quotes matched:

1. **Security / Sandbox Bypass**: Any redirection or `tee` command targeting a quoted path with spaces (e.g. `> "path with spaces.txt"` or `| tee 'path with spaces.txt'`) failed to match completely. `_shell_write_targets()` returned an empty list `[]`, causing `_workspace_lockdown_shell_block()` and `_workspace_write_deny_shell_block()` to find no targets and allow writes outside the workspace or to forbidden paths.
2. **Unquoted Path Truncation**: When unquoted targets with spaces were supplied (e.g. via `{target}` parameter expansions in environments where user profiles or temporary directories contain spaces, such as `C:\Users\IKE CHUKUW EZE\...`), the parser matched only up to the first space token, causing 10 unit test failures in `test_shell_approval_policy.py`.

### FIX

1. **Separate Quoted and Unquoted Target Regexes**:
   - Updated `_REDIRECTION_PATTERN` and `_TEE_PATTERN` to distinguish between quoted targets (`(?:(['\"])(.*?)\1)`) and unquoted targets (`([^'\"|&;<>()\r\n]+)`).
2. **Target Extraction and Multi-word Absolute Path Recovery**:
   - Added `_clean_shell_write_target(match)`:
     - For quoted targets, extracts and strips the inner target string directly, preserving internal spaces and characters.
     - For unquoted targets, checks longest to shortest candidate segments to recover multi-token absolute paths containing spaces across directory components while falling back to the initial token for trailing arguments.
   - Updated `_shell_write_targets()` to clean and extract matches using `_clean_shell_write_target()`.
3. **Regression Tests**:
   - Added `test_shell_write_targets_detects_quoted_targets_with_spaces` covering single- and double-quoted redirection and `tee` targets with spaces.
   - Added `test_workspace_lockdown_blocks_quoted_targets_with_spaces` ensuring workspace lockdown correctly blocks and reports exact resolved paths for quoted targets.

### TESTING

- **Unit Tests**:
  - `uv run pytest tests/test_tools/test_shell_approval_policy.py -q`
  - **Result**: 83 passed in 5.60s (resolved all 10 previous failures + 14 new regression tests passing).
- **Code Quality Gates**:
  - `uv run ruff check src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_approval_policy.py`: Passed.
  - `uv run ruff format --check src/agentos/tools/builtin/shell.py tests/test_tools/test_shell_approval_policy.py`: Passed.
  - `uv run mypy src/agentos/tools/builtin/shell.py --show-error-codes`: Passed (0 issues in 1 source file).
