### PR TITLE
fix(cli): use platform-aware quoting in gateway startup recovery hint(1231)

### DIFF
--- a/src/agentos/cli/gateway_cmd.py
+++ b/src/agentos/cli/gateway_cmd.py
@@ -166,8 +166,10 @@ def run_gateway(
         for entry in recovery_entries:
             console.print(f"{entry['label']}: {entry['command']}")
         if config.config_path:
+            from agentos.onboarding.next_steps import _config_cli_arg
+
             console.print(
-                f"Inspect onboarding: agentos onboard status --config {config.config_path}"
+                f"Inspect onboarding: agentos onboard status{_config_cli_arg(config.config_path)}"
             )
         raise typer.Exit(code=1) from exc
     except KeyboardInterrupt:

--- a/src/agentos/onboarding/next_steps.py
+++ b/src/agentos/onboarding/next_steps.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import platform
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -164,10 +165,23 @@ def _missing_env_warning(surface: str, env_key: str) -> str:
     )
 
 
+def quote_cli_arg(value: str | Path) -> str:
+    """Return a shell-quoted token appropriate for the current platform.
+
+    On Windows, uses ``subprocess.list2cmdline`` to generate double-quoted
+    arguments compatible with ``cmd.exe`` and PowerShell. On POSIX systems,
+    delegates to ``shlex.quote``.
+    """
+    text = str(value)
+    if platform.system().lower().startswith("win"):
+        return subprocess.list2cmdline([text])
+    return shlex.quote(text)
+
+
 def _config_cli_arg(config_path: str | Path | None) -> str:
     if not config_path:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return f" --config {quote_cli_arg(config_path)}"
 
 
 def _image_generation_provider_id(config: Any) -> str:

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -126,14 +126,89 @@ def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
         f"Set memory key: {_env_hint('OPENAI_EMBEDDINGS_API_KEY')}".replace(" ", "")
         in compact
     )
-    expected_config = str(target).replace("\\", "/")
+    compact_config = "".join(str(target).replace("\\", "/").split())
     normalized = compact.replace("\\", "/")
     assert "agentosonboardstatus--config" in normalized
-    assert expected_config in normalized
+    assert compact_config in normalized
     assert normalized.index("agentosonboardstatus--config") < normalized.index(
-        expected_config
+        compact_config
     )
     assert "Traceback" not in output
+
+
+def test_gateway_run_recovery_hint_quotes_config_path_with_spaces(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    spaced_dir = tmp_path / "spaced workspace"
+    spaced_dir.mkdir(parents=True, exist_ok=True)
+    target = spaced_dir / "custom.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n'
+        "\n"
+        "[memory.embedding]\n"
+        'provider = "openai"\n'
+        "\n"
+        "[memory.embedding.remote]\n"
+        'api_key_env = "OPENAI_EMBEDDINGS_API_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTOS_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    async def fail_start_gateway_server(**_kwargs):
+        raise ValueError("memory.embedding.remote.api_key missing")
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fail_start_gateway_server)
+
+    result = runner.invoke(app, ["gateway", "run", "--config", str(target)])
+
+    assert result.exit_code == 1
+    output = result.stdout + (result.stderr or "")
+    from agentos.onboarding.next_steps import quote_cli_arg
+
+    expected_quoted = quote_cli_arg(str(target))
+    compact = "".join(output.split())
+    compact_expected = "".join(f"--config{expected_quoted}".split()).replace("\\", "/")
+    assert compact_expected in compact.replace("\\", "/")
+
+    # Ensure platform-appropriate quotation marks were used:
+    # Windows requires double quotes for cmd.exe/PowerShell compatibility
+    if platform.system().lower().startswith("win"):
+        assert compact_expected.startswith('--config"') and compact_expected.endswith(
+            'custom.toml"'
+        )
+        assert "'" not in compact_expected
+    else:
+        assert compact_expected.startswith("--config'") and compact_expected.endswith(
+            "custom.toml'"
+        )
+
+
+def test_quote_cli_arg_platform_behavior(monkeypatch) -> None:
+    from agentos.onboarding.next_steps import _config_cli_arg, quote_cli_arg
+
+    # On Windows: paths with spaces must use double quotes for cmd.exe / PowerShell compatibility
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert quote_cli_arg(r"C:\Users\John Doe\custom.toml") == r'"C:\Users\John Doe\custom.toml"'
+    assert (
+        _config_cli_arg(r"C:\Users\John Doe\custom.toml")
+        == r' --config "C:\Users\John Doe\custom.toml"'
+    )
+    # On Windows: paths without spaces remain unquoted
+    assert quote_cli_arg(r"C:\Users\John\custom.toml") == r"C:\Users\John\custom.toml"
+    assert _config_cli_arg(r"C:\Users\John\custom.toml") == r" --config C:\Users\John\custom.toml"
+    assert _config_cli_arg(None) == ""
+
+    # On POSIX: shlex.quote standard behavior
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert quote_cli_arg("/home/john doe/custom.toml") == "'/home/john doe/custom.toml'"
+    assert _config_cli_arg("/home/john doe/custom.toml") == " --config '/home/john doe/custom.toml'"
+    assert quote_cli_arg("/home/john/custom.toml") == "/home/john/custom.toml"
+    assert _config_cli_arg("/home/john/custom.toml") == " --config /home/john/custom.toml"
 
 
 def test_gateway_run_refuses_wildcard_bind_without_auth(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #1231


### PROBLEM

In `src/agentos/cli/gateway_cmd.py` (lines 169–171), the recovery command hint printed when the gateway fails to start interpolated `config.config_path` directly without shell quoting:

Inspect onboarding: agentos onboard status --config C:\Users\John Doe\custom.toml
```

1. **Broken Copy-Paste on Windows**: When configuration files reside in directory paths containing whitespace (e.g. `C:\Users\John Doe\custom.toml`), the printed command emits unquoted spaces. Copying and pasting the command into Windows Command Prompt (`cmd.exe`) or PowerShell causes the shell to split arguments at the first space token (`C:\Users\John`), producing argument parsing errors.
2. **Flaw in Naive `shlex.quote` (PR #1235)**: Naively applying `shlex.quote` to the path fails on Windows because `shlex.quote` wraps arguments in POSIX single quotes (`'...'`). Windows `cmd.exe` does not recognize single quotes as delimiters; it treats them as literal characters and still splits at the space, causing `cmd.exe` to fail with `Error: Invalid value for '--config': Path ''C:\Users\John' does not exist.`
3. **Test Failures in Workspaces with Spaces**: `test_gateway_run_turns_missing_onboarding_env_into_recovery_hint` in `tests/test_cli/test_gateway_cmd.py` stripped whitespace from console output via `"".join(output.split())`, but compared it against unstripped `expected_config`, causing test assertions to fail on any machine where temporary or user directories contain spaces.

### FIX

1. **Platform-Aware CLI Argument Quoting (`quote_cli_arg`)**:
   - Implemented `quote_cli_arg(value: str | Path) -> str` in `src/agentos/onboarding/next_steps.py`:
     - **Windows**: Uses `subprocess.list2cmdline([text])` to format double-quoted arguments compatible with both `cmd.exe` and PowerShell (e.g. `--config "C:\Users\John Doe\custom.toml"`).
     - **POSIX**: Uses `shlex.quote(text)` to generate standard single-quoted tokens (e.g. `--config '/home/john doe/custom.toml'`).
   - Updated `_config_cli_arg(config_path)` in `next_steps.py` to use `quote_cli_arg`.
2. **Gateway Startup Failure Recovery Hint**:
   - Updated `run_gateway` in `src/agentos/cli/gateway_cmd.py` to format the config path using `_config_cli_arg(config.config_path)`, emitting platform-quoted options.
3. **Workspace Path Robustness & Regression Tests**:
   - Updated `test_gateway_run_turns_missing_onboarding_env_into_recovery_hint` in `tests/test_cli/test_gateway_cmd.py` to compare against whitespace-normalized `compact_config`, ensuring robustness in directories with spaces.
   - Added `test_gateway_run_recovery_hint_quotes_config_path_with_spaces` verifying the recovery hint quotes paths with spaces using platform-appropriate quotation marks (`"` on Windows, `'` on POSIX).
   - Added `test_quote_cli_arg_platform_behavior` asserting Windows double-quoting and POSIX single-quoting behavior across spaced and unspaced paths.

### TESTING

- **Automated Tests**:
  - `uv run pytest tests/test_cli/test_gateway_cmd.py -q`
  - **Result**: 33 passed in 9.11s (fixed existing failure on spaced paths + 2 new regression tests passing).
- **Code Quality & Linting**:
  - `uv run ruff check src/agentos/cli/gateway_cmd.py src/agentos/onboarding/next_steps.py tests/test_cli/test_gateway_cmd.py`: Passed (0 errors).
  - `uv run ruff format --check src/agentos/cli/gateway_cmd.py src/agentos/onboarding/next_steps.py tests/test_cli/test_gateway_cmd.py`: Passed.
  - `uv run mypy src/agentos/cli/gateway_cmd.py src/agentos/onboarding/next_steps.py --show-error-codes`: Passed (0 issues in 2 source files).
```