### PR TITLE
fix(tools): strip the ./ prefix without eating a dot-prefix

### DIFF
--- a/src/agentos/tools/builtin/skill_tools.py
+++ b/src/agentos/tools/builtin/skill_tools.py
@@ -800,7 +800,12 @@ def create_skill_tools(loader: SkillLoader) -> None:
             from agentos.skills.resources import expand_skill_placeholders
 
             if file_path:
-                normalized_path = file_path.strip().lstrip("./")
+                # Strip the ``./`` prefix only. ``lstrip("./")`` would take the
+                # leading dot off ``.eslintrc.json`` too, and read_resource below
+                # never sees the name the caller asked for.
+                normalized_path = file_path.strip()
+                while normalized_path.startswith("./"):
+                    normalized_path = normalized_path[2:]
                 if normalized_path in {"", "SKILL.md"}:
                     if not skill.content:
                         return f"(Skill '{name}' has no body content)"

--- a/src/agentos/tools/write_policy.py
+++ b/src/agentos/tools/write_policy.py
@@ -16,6 +16,19 @@ class WorkspaceWriteDenyMatch:
     resolved_path: str
 
 
+def _strip_leading_path_prefix(value: str) -> str:
+    """Drop leading ``./`` segments and any leading ``/``.
+
+    ``str.lstrip("./")`` treats its argument as a character set, so it also eats
+    the dot that makes ``.env`` a dotfile and the ``..`` that makes a path
+    relative. Only the prefixes are meant to go.
+    """
+    text = value
+    while text.startswith("./"):
+        text = text[2:]
+    return text.lstrip("/")
+
+
 def _workspace_write_deny_globs(ctx: ToolContext | None = None) -> tuple[str, ...]:
     active = ctx if ctx is not None else current_tool_context.get()
     if active is None:
@@ -37,7 +50,7 @@ def _candidate_strings(
     workspace: Path | None,
 ) -> tuple[str, ...]:
     candidates: list[str] = [
-        original_path.replace("\\", "/").lstrip("./"),
+        _strip_leading_path_prefix(original_path.replace("\\", "/")),
         resolved.as_posix(),
     ]
     if workspace is not None:
@@ -72,9 +85,9 @@ def match_workspace_write_deny(
     candidates = _candidate_strings(resolved, original, workspace)
 
     for pattern in patterns:
-        normalized_pattern = pattern.replace("\\", "/").lstrip("./")
+        normalized_pattern = _strip_leading_path_prefix(pattern.replace("\\", "/"))
         for candidate in candidates:
-            normalized_candidate = candidate.replace("\\", "/").lstrip("./")
+            normalized_candidate = _strip_leading_path_prefix(candidate.replace("\\", "/"))
             if fnmatchcase(normalized_candidate, normalized_pattern) or fnmatchcase(
                 f"/{normalized_candidate}", normalized_pattern
             ):
@@ -122,6 +135,5 @@ def gate_workspace_write_deny(
     if match is None:
         return
     raise ToolError(
-        f"{tool_name} blocked by workspace write deny policy: "
-        f"{match.path} matches {match.pattern}."
+        f"{tool_name} blocked by workspace write deny policy: {match.path} matches {match.pattern}."
     )

--- a/tests/test_tools/test_skill_view_resources.py
+++ b/tests/test_tools/test_skill_view_resources.py
@@ -44,13 +44,13 @@ def skill_loader(tmp_path: Path) -> Iterator[SkillLoader]:
     (skill_dir / "scripts").mkdir()
     (skill_dir / "assets").mkdir()
     (skill_dir / "SKILL.md").write_text(
-        "---\nname: deck\ndescription: Deck helper\n---\n"
-        "See [guide](references/guide.md).\n",
+        "---\nname: deck\ndescription: Deck helper\n---\nSee [guide](references/guide.md).\n",
         encoding="utf-8",
     )
     (skill_dir / "references" / "guide.md").write_text("reference body\n", encoding="utf-8")
     (skill_dir / "scripts" / "inspect.py").write_text("print('script body')\n", encoding="utf-8")
     (skill_dir / "assets" / "palette.txt").write_text("blue\n", encoding="utf-8")
+    (skill_dir / "references" / ".eslintrc.json").write_text('{"root": true}\n', encoding="utf-8")
     (skill_dir / "secret.txt").write_text("do not expose\n", encoding="utf-8")
 
     loader = SkillLoader(
@@ -76,6 +76,17 @@ async def test_skill_view_reads_registered_skill_resources_by_relative_path(
     assert "reference body" in await _skill_view("deck", "references/guide.md")
     assert "script body" in await _skill_view("deck", "scripts/inspect.py")
     assert "blue" in await _skill_view("deck", "assets/palette.txt")
+
+
+@pytest.mark.asyncio
+async def test_skill_view_reads_dot_prefixed_resource_names(
+    skill_loader: SkillLoader,
+) -> None:
+    # ``lstrip("./")`` on the caller side turned ".eslintrc.json" into
+    # "eslintrc.json" before read_resource ever saw the requested name.
+    assert '"root": true' in await _skill_view("deck", "references/.eslintrc.json")
+    assert '"root": true' in await _skill_view("deck", "./references/.eslintrc.json")
+    assert '"root": true' in await _skill_view("deck", ".eslintrc.json")
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_write_policy_dot_prefix.py
+++ b/tests/test_tools/test_write_policy_dot_prefix.py
@@ -1,0 +1,62 @@
+"""Workspace write-deny globs must not lose the dot that makes a dotfile.
+
+Regression for the ``lstrip("./")`` character-set/prefix confusion: it stripped
+every leading ``.`` and ``/`` from both the pattern and the candidate, so a rule
+written for ``.env`` also matched ``environment.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos.tools.types import ToolContext
+from agentos.tools.write_policy import match_workspace_write_deny
+
+
+def _ctx(workspace: Path, *patterns: str) -> ToolContext:
+    return ToolContext(
+        workspace_dir=str(workspace),
+        workspace_write_deny_globs=list(patterns),
+    )
+
+
+def _denied(workspace: Path, ctx: ToolContext, name: str) -> bool:
+    return match_workspace_write_deny(workspace / name, original_path=name, ctx=ctx) is not None
+
+
+def test_dotfile_glob_does_not_block_names_sharing_its_stem(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, ".env*")
+
+    assert _denied(tmp_path, ctx, ".env")
+    assert _denied(tmp_path, ctx, ".env.local")
+    assert not _denied(tmp_path, ctx, "environment.md")
+    assert not _denied(tmp_path, ctx, "envoy.yaml")
+    assert not _denied(tmp_path, ctx, "env_setup.py")
+
+
+def test_plain_glob_still_matches_dot_slash_spelling(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, "secrets.json")
+
+    assert _denied(tmp_path, ctx, "secrets.json")
+    assert _denied(tmp_path, ctx, "./secrets.json")
+    assert _denied(tmp_path, ctx, ".//secrets.json")
+
+
+def test_absolute_candidate_still_matches_workspace_relative_glob(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, "generated/**")
+    target = tmp_path / "generated" / "out.txt"
+
+    assert match_workspace_write_deny(target, original_path=str(target), ctx=ctx) is not None
+
+
+def test_glob_written_with_dot_slash_still_matches(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, "./build/*")
+
+    assert _denied(tmp_path, ctx, "build/app.js")
+
+
+def test_dot_directory_glob_matches_only_that_directory(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, ".github/*")
+
+    assert _denied(tmp_path, ctx, ".github/workflows.yml")
+    assert not _denied(tmp_path, ctx, "github/workflows.yml")


### PR DESCRIPTION
Fixes #1244

## The bug

`str.lstrip("./")` takes a **character set**, not a prefix. It removes every leading `.` and `/`, so the dot that makes a dotfile goes with it:

```python
".env".lstrip("./")            # 'env'
"../../etc/passwd".lstrip("./")  # 'etc/passwd'
```

Four call sites use it as if it stripped `./`.

**1. Workspace write-deny globs over-block (`tools/write_policy.py:40,75,77`)**

It runs over the pattern *and* the candidate, so a rule written for `.env` becomes `env`:

```python
normalized_pattern = pattern.replace("\\", "/").lstrip("./")      # '.env*' -> 'env*'
normalized_candidate = candidate.replace("\\", "/").lstrip("./")
```

Measured through `match_workspace_write_deny` with `workspace_write_deny_globs=[".env*"]`:

| file written | blocked, before | blocked, after | intended |
|---|---|---|---|
| `.env` | yes | yes | yes |
| `.env.local` | yes | yes | yes |
| `environment.md` | **yes** | no | no |
| `envoy.yaml` | **yes** | no | no |
| `env_setup.py` | **yes** | no | no |

An operator protecting `.env` silently loses the ability to write any file whose name starts with `env`. The direction is over-blocking, so this fails safe — that is why it is filed publicly rather than through SECURITY.md.

**2. Dot-prefixed skill resources are unreachable (`tools/builtin/skill_tools.py:803`)**

```python
normalized_path = file_path.strip().lstrip("./")
...
content = resources.read_resource(normalized_path)
```

`skill_view(name, ".eslintrc.json")` looks up `eslintrc.json` and answers `File not found in skill '<name>': .eslintrc.json`. The caller mangles the name before the resource layer ever sees it.

## The fix

`skills/resources.py::_normalise_resource_path` already does this correctly, and was the model:

```python
while raw.startswith("./"):
    raw = raw[2:]
```

`write_policy` gets the same loop, wrapped so it keeps the leading-`/` stripping the matcher relies on for absolute candidates:

```python
def _strip_leading_path_prefix(value: str) -> str:
    text = value
    while text.startswith("./"):
        text = text[2:]
    return text.lstrip("/")
```

`skill_tools` gets the bare loop. It does not need to strip `/` for safety: `_normalise_resource_path` rejects absolute paths and any `..` component itself, one layer down.

That is also a small correctness win on an existing test. `test_skill_view_rejects_resource_paths_that_escape_skill_directory` passed before only because `lstrip` rewrote `../secret.txt` into `secret.txt`, which then missed the resource-directory lookup. It now reaches `_normalise_resource_path` as `../secret.txt` and is rejected for containing `..` — the same result, for the intended reason.

## Tests

New `tests/test_tools/test_write_policy_dot_prefix.py` (5 tests, offline, `tmp_path` only):

- `.env*` blocks `.env` and `.env.local` but not `environment.md`, `envoy.yaml`, `env_setup.py`
- `.github/*` blocks `.github/workflows.yml` but not `github/workflows.yml`
- a plain glob still matches the `./name` and `.//name` spellings
- a glob *written* as `./build/*` still matches `build/app.js`
- an absolute candidate still matches a workspace-relative glob — the leading-`/` behaviour the matcher depends on

One test added to `tests/test_tools/test_skill_view_resources.py`: a `.eslintrc.json` reference reads back through `references/.eslintrc.json`, `./references/.eslintrc.json`, and the bare `.eslintrc.json` legacy lookup.

Against the unfixed source 3 of the 12 fail. The other 9 pass either way by design — they are there to catch a fix that stops normalising `./` at all.

## Verification

```
uv run pytest tests/test_tools/test_write_policy_dot_prefix.py \
              tests/test_tools/test_skill_view_resources.py \
              tests/test_tools/test_policy_config_boundary.py \
              tests/test_tools/test_apply_patch_gates.py \
              tests/test_tools/test_shell_approval_policy.py -q
119 passed

uv run mypy src/agentos --show-error-codes
Success: no issues found in 623 source files

uv run ruff check + ruff format --check on the changed files — clean
```

## One adjacent case, deliberately left alone

`skills/bundled/history-explorer/scripts/explore.py:39` also calls `lstrip`, as `raw_path[1:].lstrip("/\\")`. That one is correct: the `~` is already sliced off and the argument contains only separators, so no dot is at risk, and stripping every leading separator is what stops `Path(home, "/abs")` from resolving away from home. Checked and left untouched rather than swept in for symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
