### PR TITLE
fix(tools): clean up the code_exec scratch dir on every return path

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -563,78 +563,35 @@ async def execute_code(
         workdir = tempfile.mkdtemp(prefix="agentos_exec_")
         workdir_path = Path(workdir)
         cleanup_dir = workdir
-    start_ns = time.monotonic_ns()
+    # Everything below can return early — gate denial, backend failure, an
+    # escalation verdict. The cleanup below has to outlive all of them, so it
+    # wraps from the mkdtemp onward rather than sitting on the subprocess try.
+    try:
+        start_ns = time.monotonic_ns()
 
-    safe_env = _build_safe_env()
+        safe_env = _build_safe_env()
 
-    from agentos.tools.builtin.shell import _elevated_mode
+        from agentos.tools.builtin.shell import _elevated_mode
 
-    elevated_bypass = _elevated_mode() in ("on", "bypass", "full")
-    if runtime is None or (runtime.effective.sandbox_enabled and not elevated_bypass):
-        decision, _policy, request = await gate_action(
-            action_kind="code.exec",
-            argv=(python_bin, "-c", code),
-            cwd=workdir_path,
-            env=safe_env,
-        )
-        if isinstance(decision, DenialResult):
-            return json.dumps(decision.to_dict())
-        backend_request = SandboxRequest(
-            argv=(python_bin, "-c", code),
-            cwd=request.cwd,
-            action_kind=request.action_kind,
-            policy=request.policy,
-            env=safe_env,
-        )
-        try:
-            sandbox_result = await run_under_backend(backend_request, runtime=runtime)
-        except Exception as exc:
-            return _execution_result_json(
-                returncode=-1,
-                stdout="",
-                stderr=f"Execution error: {exc}",
-                timed_out=False,
-                elapsed_ms=0,
+        elevated_bypass = _elevated_mode() in ("on", "bypass", "full")
+        if runtime is None or (runtime.effective.sandbox_enabled and not elevated_bypass):
+            decision, _policy, request = await gate_action(
+                action_kind="code.exec",
+                argv=(python_bin, "-c", code),
+                cwd=workdir_path,
+                env=safe_env,
             )
-        if sandbox_result.backend_notes:
-            escalation = await escalate_backend_denial(
-                sandbox_result, request, _policy, runtime=runtime
+            if isinstance(decision, DenialResult):
+                return json.dumps(decision.to_dict())
+            backend_request = SandboxRequest(
+                argv=(python_bin, "-c", code),
+                cwd=request.cwd,
+                action_kind=request.action_kind,
+                policy=request.policy,
+                env=safe_env,
             )
-            if isinstance(escalation, DenialResult):
-                return json.dumps(escalation.to_dict())
             try:
-                proc = await asyncio.create_subprocess_exec(
-                    python_bin,
-                    "-c",
-                    code,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=str(workdir_path),
-                    env=safe_env,
-                )
-                try:
-                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                        proc.communicate(), timeout=timeout
-                    )
-                except TimeoutError:
-                    proc.kill()
-                    await proc.communicate()
-                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-                    return _execution_result_json(
-                        returncode=-1,
-                        stdout="",
-                        stderr=f"Execution timed out after {timeout}s",
-                        timed_out=True,
-                        elapsed_ms=elapsed_ms,
-                    )
-                elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-                return _execution_result_json(
-                    returncode=proc.returncode if proc.returncode is not None else -1,
-                    stdout=stdout_bytes.decode("utf-8", errors="replace"),
-                    stderr=stderr_bytes.decode("utf-8", errors="replace"),
-                    timed_out=False,
-                    elapsed_ms=elapsed_ms,
-                )
+                sandbox_result = await run_under_backend(backend_request, runtime=runtime)
             except Exception as exc:
                 return _execution_result_json(
                     returncode=-1,
@@ -643,61 +600,110 @@ async def execute_code(
                     timed_out=False,
                     elapsed_ms=0,
                 )
-        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-        stdout = sandbox_result.stdout
-        stderr = sandbox_result.stderr
-        stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
-        return _execution_result_json(
-            returncode=sandbox_result.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=sandbox_result.timed_out,
-            elapsed_ms=elapsed_ms,
-        )
-
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            python_bin,
-            "-c",
-            code,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(workdir_path),
-            env=safe_env,
-        )
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            await proc.communicate()
+            if sandbox_result.backend_notes:
+                escalation = await escalate_backend_denial(
+                    sandbox_result, request, _policy, runtime=runtime
+                )
+                if isinstance(escalation, DenialResult):
+                    return json.dumps(escalation.to_dict())
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        python_bin,
+                        "-c",
+                        code,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=str(workdir_path),
+                        env=safe_env,
+                    )
+                    try:
+                        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                            proc.communicate(), timeout=timeout
+                        )
+                    except TimeoutError:
+                        proc.kill()
+                        await proc.communicate()
+                        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                        return _execution_result_json(
+                            returncode=-1,
+                            stdout="",
+                            stderr=f"Execution timed out after {timeout}s",
+                            timed_out=True,
+                            elapsed_ms=elapsed_ms,
+                        )
+                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                    return _execution_result_json(
+                        returncode=proc.returncode if proc.returncode is not None else -1,
+                        stdout=stdout_bytes.decode("utf-8", errors="replace"),
+                        stderr=stderr_bytes.decode("utf-8", errors="replace"),
+                        timed_out=False,
+                        elapsed_ms=elapsed_ms,
+                    )
+                except Exception as exc:
+                    return _execution_result_json(
+                        returncode=-1,
+                        stdout="",
+                        stderr=f"Execution error: {exc}",
+                        timed_out=False,
+                        elapsed_ms=0,
+                    )
             elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+            stdout = sandbox_result.stdout
+            stderr = sandbox_result.stderr
+            stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
             return _execution_result_json(
-                returncode=-1,
-                stdout="",
-                stderr=f"Execution timed out after {timeout}s",
-                timed_out=True,
+                returncode=sandbox_result.returncode,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=sandbox_result.timed_out,
                 elapsed_ms=elapsed_ms,
             )
 
-        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-        stdout = stdout_bytes.decode("utf-8", errors="replace")
-        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                python_bin,
+                "-c",
+                code,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(workdir_path),
+                env=safe_env,
+            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=timeout
+                )
+            except TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                return _execution_result_json(
+                    returncode=-1,
+                    stdout="",
+                    stderr=f"Execution timed out after {timeout}s",
+                    timed_out=True,
+                    elapsed_ms=elapsed_ms,
+                )
 
-        return _execution_result_json(
-            returncode=proc.returncode if proc.returncode is not None else -1,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=False,
-            elapsed_ms=elapsed_ms,
-        )
-    except Exception as exc:
-        return _execution_result_json(
-            returncode=-1,
-            stdout="",
-            stderr=f"Execution error: {exc}",
-            timed_out=False,
-            elapsed_ms=0,
-        )
+            elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+            return _execution_result_json(
+                returncode=proc.returncode if proc.returncode is not None else -1,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=False,
+                elapsed_ms=elapsed_ms,
+            )
+        except Exception as exc:
+            return _execution_result_json(
+                returncode=-1,
+                stdout="",
+                stderr=f"Execution error: {exc}",
+                timed_out=False,
+                elapsed_ms=0,
+            )
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/tests/test_tools/test_code_exec_tempdir_cleanup.py
+++ b/tests/test_tools/test_code_exec_tempdir_cleanup.py
@@ -1,0 +1,90 @@
+"""``execute_code`` must not leak its scratch directory on early returns.
+
+Scoped to the only path that can leak: ``runtime is None`` with no
+``workspace_dir``, where ``mkdtemp`` runs and the gate then denies fail-closed.
+The sandbox branch reuses ``runtime.workspace`` and creates no tempdir, so a
+test written against it passes with or without the fix.
+
+``TMPDIR`` is redirected per test rather than globbing the shared system temp
+directory, so the count cannot be disturbed by anything else on the machine.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin import code_exec as code_exec_module
+from agentos.tools.builtin.code_exec import execute_code
+
+
+@pytest.fixture()
+def scratch_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point tempfile at an empty directory this test owns."""
+    target = tmp_path / "tmp"
+    target.mkdir()
+    monkeypatch.setattr(code_exec_module.tempfile, "tempdir", str(target))
+    return target
+
+
+def _scratch_dirs(root: Path) -> list[Path]:
+    return sorted(root.glob("agentos_exec_*"))
+
+
+@pytest.mark.asyncio
+async def test_denied_call_leaves_no_scratch_directory(scratch_tmp: Path) -> None:
+    result = await execute_code("print('hello')")
+
+    assert json.loads(result)["status"] == "denied"
+    assert _scratch_dirs(scratch_tmp) == []
+
+
+@pytest.mark.asyncio
+async def test_repeated_denials_do_not_accumulate_scratch_directories(
+    scratch_tmp: Path,
+) -> None:
+    for _ in range(5):
+        await execute_code("print('hello')")
+
+    assert _scratch_dirs(scratch_tmp) == []
+
+
+@pytest.mark.asyncio
+async def test_scratch_directory_is_created_on_this_path(
+    scratch_tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Guards the test itself: if execute_code ever stops calling mkdtemp here,
+    # the assertions above would pass vacuously and prove nothing.
+    created: list[str] = []
+    real_mkdtemp = code_exec_module.tempfile.mkdtemp
+
+    def _record(*args: object, **kwargs: object) -> str:
+        path = real_mkdtemp(*args, **kwargs)  # type: ignore[arg-type]
+        created.append(path)
+        return path
+
+    monkeypatch.setattr(code_exec_module.tempfile, "mkdtemp", _record)
+
+    await execute_code("print('hello')")
+
+    assert len(created) == 1
+    assert not Path(created[0]).exists()
+
+
+@pytest.mark.asyncio
+async def test_gate_exception_still_propagates_and_cleans_up(
+    scratch_tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The cleanup wrapper must not swallow errors from the gate the way the
+    # inner subprocess handler turns them into an "Execution error" payload.
+    async def _boom(**_kwargs: object) -> None:
+        raise RuntimeError("gate exploded")
+
+    monkeypatch.setattr(code_exec_module, "gate_action", _boom)
+
+    with pytest.raises(RuntimeError, match="gate exploded"):
+        await execute_code("print('hello')")
+
+    assert _scratch_dirs(scratch_tmp) == []


### PR DESCRIPTION
Fixes #1010

## The bug

Scoped to the path @andreapn identified in [his comment](https://github.com/use-agent-os/agent-os/issues/1010#issuecomment-5549716190): `cleanup_dir` is only ever set in the `else` branch — no `workspace_dir` **and** no sandbox-enabled runtime — so the sandbox branch reuses `runtime.workspace` and cannot leak.

```python
else:
    workdir = tempfile.mkdtemp(prefix="agentos_exec_")
    workdir_path = Path(workdir)
    cleanup_dir = workdir
```

The `finally` that removes it belonged to the subprocess `try` ~90 lines further down, so every early return in the gate block above it escaped cleanup: the `DenialResult` from `gate_action`, the `run_under_backend` failure, and the escalation and result returns.

With `runtime is None` the gate denies fail-closed on the very first of those, so this is not an edge case — it is what an ordinary call does on an unconfigured runtime. Measured against `upstream/main` (`0ed6c5c`):

```
sandbox.runtime_unconfigured: action_kind=code.exec — denying fail-closed
5 denied calls -> leaked: 5 scratch directories
```

After the fix, the same probe reports `leaked: 0`.

## The fix

Wrap from the `mkdtemp` onward in a `try` whose `finally` does the cleanup, and leave the inner subprocess `try/except` untouched.

Worth stating because it is the trap in this one: simply *moving* the existing `try` upward is not equivalent. That `try` carries an `except Exception` that converts failures into an `"Execution error: ..."` result payload. Widening it over the gate block would swallow a `gate_action` failure into a normal-looking JSON result instead of letting it propagate — a behaviour change smuggled in under a cleanup fix. A separate wrapper keeps the two concerns apart.

## Tests

New `tests/test_tools/test_code_exec_tempdir_cleanup.py` (4 tests, offline):

- a denied call leaves no scratch directory, and the result really is `status: denied`
- five denials in a row accumulate nothing
- **a guard on the test itself**: `mkdtemp` is wrapped to assert it was called exactly once on this path and that the directory it returned is gone afterwards — without it the two assertions above would pass vacuously if `execute_code` ever stopped creating a tempdir here
- a `gate_action` that raises still propagates its `RuntimeError` *and* cleans up — this pins the semantics the fix was shaped around

Per @andreapn's note, every test is scoped to `runtime is None` + denial; none of them touch the sandbox path, which passes either way.

`TMPDIR` is redirected to a per-test directory (`tempfile.tempdir` patched on the module) rather than globbing the shared system temp dir. That matters for more than hygiene: `tempfile.mkdtemp` honours `TMPDIR`, which on macOS is `/var/folders/.../T`, so a test that globs `/tmp/agentos_exec_*` sees an empty set before and after and passes against the unfixed code.

All 4 fail against the unfixed source.

## Verification

```
uv run pytest tests/test_tools/test_code_exec_tempdir_cleanup.py \
              tests/test_tools/test_code_exec_destructive_ast.py \
              tests/test_tools/test_code_exec_output_redaction.py \
              tests/test_tools/test_code_exec_python_resolution.py -q
43 passed

uv run mypy src/agentos --show-error-codes
Success: no issues found in 623 source files

uv run ruff check + ruff format --check on the changed files — clean
```

The diff is mostly re-indentation of the wrapped block; `git diff -w` shows the real change.

## Related

#1011, #1038 and #1154 are open against this issue. #1011 and #1154 place a `shutil.rmtree` at each return site, which leaves the next added return to leak again. #1038 takes the wrapping approach, and its test is scoped to `runtime is None` as asked — its check globs `/tmp` though, so on a machine where `TMPDIR` is not `/tmp` it passes either way. Landing any of those instead is fine by me; the parts I would keep from here are the `except Exception` distinction and the TMPDIR-independent test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
