### PR TITLE
fix(channels): bind the MSTeams first-chunk text by value

### DIFF
--- a/src/agentos/channels/msteams.py
+++ b/src/agentos/channels/msteams.py
@@ -531,8 +531,12 @@ class MSTeamsChannel:
             if message_id is None:
                 holder: dict[str, str | None] = {"id": None}
 
-                async def _send(turn_context: Any, _holder: dict[str, str | None] = holder) -> None:
-                    response = await turn_context.send_activity(accumulated)
+                async def _send(
+                    turn_context: Any,
+                    _holder: dict[str, str | None] = holder,
+                    _text: str = accumulated,
+                ) -> None:
+                    response = await turn_context.send_activity(_text)
                     if response is not None and getattr(response, "id", None):
                         _holder["id"] = response.id
 

--- a/tests/test_channels/test_msteams_streaming_closures.py
+++ b/tests/test_channels/test_msteams_streaming_closures.py
@@ -1,0 +1,119 @@
+"""The MS Teams streaming callbacks must capture their text by value.
+
+``send_streaming`` hands four callbacks to ``continue_conversation`` and keeps
+mutating ``accumulated`` as chunks arrive. A callback that reads ``accumulated``
+as a free variable sends whatever the loop has reached by the time the adapter
+runs it, not the text it was built for.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import AsyncIterator
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture()
+def botbuilder_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Satisfy ``send_streaming``'s lazy ``botbuilder.schema`` import.
+
+    Registered through ``monkeypatch`` so it is removed again afterwards; a
+    module-level ``sys.modules`` assignment would leak into every later test.
+    """
+    if "botbuilder.schema" in sys.modules:
+        return
+
+    class _Activity:
+        def __init__(self, **fields: Any) -> None:
+            self.__dict__.update(fields)
+
+    package = ModuleType("botbuilder")
+    schema = ModuleType("botbuilder.schema")
+    schema.Activity = _Activity  # type: ignore[attr-defined]
+    package.schema = schema  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "botbuilder", package)
+    monkeypatch.setitem(sys.modules, "botbuilder.schema", schema)
+
+
+async def _stream(*chunks: str) -> AsyncIterator[str]:
+    for chunk in chunks:
+        yield chunk
+
+
+class _RecordingTurnContext:
+    def __init__(self, sent: list[str], updated: list[str]) -> None:
+        self._sent = sent
+        self._updated = updated
+
+    async def send_activity(self, payload: Any) -> Any:
+        self._sent.append(str(payload))
+        return SimpleNamespace(id="msg-1")
+
+    async def update_activity(self, activity: Any) -> Any:
+        self._updated.append(str(getattr(activity, "text", "")))
+        return None
+
+
+class _CapturingAdapter:
+    """Runs each callback and keeps the first one for later replay."""
+
+    def __init__(self, sent: list[str], updated: list[str]) -> None:
+        self.sent = sent
+        self.updated = updated
+        self.first_callback: Any = None
+
+    async def continue_conversation(self, ref: Any, callback: Any, bot_id: Any = None) -> None:
+        if self.first_callback is None:
+            self.first_callback = callback
+        await callback(_RecordingTurnContext(self.sent, self.updated))
+
+
+def _channel(adapter: _CapturingAdapter) -> Any:
+    from agentos.channels.msteams import MSTeamsChannel, MSTeamsChannelConfig
+
+    channel = MSTeamsChannel(config=MSTeamsChannelConfig(name="msteams"))
+    channel._references["conv-1"] = SimpleNamespace()
+    channel._adapter = adapter
+    return channel
+
+
+@pytest.mark.asyncio
+async def test_first_chunk_sends_the_first_chunk_text(botbuilder_schema: None) -> None:
+    sent: list[str] = []
+    adapter = _CapturingAdapter(sent, [])
+
+    await _channel(adapter).send_streaming(_stream("first", "second"), reply_to="conv-1")
+
+    assert sent[0] == "first"
+
+
+@pytest.mark.asyncio
+async def test_first_send_callback_replayed_late_still_sends_its_own_text(
+    botbuilder_schema: None,
+) -> None:
+    # The adapter is free to run a callback whenever it likes. Replaying the
+    # first-chunk callback after the stream has finished is what separates a
+    # by-value capture from a free variable: `accumulated` is "firstsecond" by
+    # now, but this callback was built to send "first".
+    sent: list[str] = []
+    adapter = _CapturingAdapter(sent, [])
+
+    await _channel(adapter).send_streaming(_stream("first", "second"), reply_to="conv-1")
+    assert adapter.first_callback is not None
+
+    await adapter.first_callback(_RecordingTurnContext(sent, []))
+
+    assert sent[-1] == "first"
+
+
+@pytest.mark.asyncio
+async def test_single_chunk_stream_sends_that_chunk(botbuilder_schema: None) -> None:
+    sent: list[str] = []
+    adapter = _CapturingAdapter(sent, [])
+
+    await _channel(adapter).send_streaming(_stream("only"), reply_to="conv-1")
+
+    assert sent[0] == "only"


### PR DESCRIPTION
Fixes #1046

## The bug

`src/agentos/channels/msteams.py:534-535` — `_send` reads `accumulated` as a free variable:

```python
async def _send(turn_context: Any, _holder: dict[str, str | None] = holder) -> None:
    response = await turn_context.send_activity(accumulated)   # free variable
```

Its siblings in the same function all bind by value: `_edit` (`_text=accumulated`), `_final_update`, `_final_send`, `_retry_send`. This call site is the outlier.

Per @andreapn's [note](https://github.com/use-agent-os/agent-os/issues/1046#issuecomment-5549717267), the practical impact today is bounded and worth stating plainly rather than inflating: `_send` is scheduled on the first iteration and the loop `continue`s immediately after, so `accumulated` has not moved by the time the adapter runs it. The defect is that correctness rests on that control flow rather than on the closure. Any change that lets `continue_conversation` defer the call turns it into a wrong-content bug.

Replaying the captured callback after the stream finishes shows what it holds, against `upstream/main` (`0ed6c5c`):

```
- first
+ firstsecond
```

## The fix

The one-line default @andreapn asked for, matching the four closures around it:

```python
async def _send(
    turn_context: Any,
    _holder: dict[str, str | None] = holder,
    _text: str = accumulated,
) -> None:
    response = await turn_context.send_activity(_text)
```

Nothing else in `send_streaming` is touched.

## Tests

New `tests/test_channels/test_msteams_streaming_closures.py` (3 tests, offline):

- **the first chunk sends the first chunk's text** — the assertion @andreapn asked for
- a single-chunk stream sends that chunk
- **the one that pins the fix**: the first-chunk callback is captured, then replayed after the stream has finished. `accumulated` is `"firstsecond"` by then, but the callback was built to send `"first"`. This fails against unfixed source with `- first / + firstsecond`

The first two pass either way by design — as @andreapn observed, present control flow already makes them true. They are guards against a fix that changes what the first send emits, not evidence of the bug.

Assertions are on what reaches `send_activity`. The test does not inspect the closure's signature or the name of its default parameter, so a different by-value capture would still satisfy it.

`send_streaming` lazily imports `botbuilder.schema`, which is not a dev dependency. The stub is installed with `monkeypatch.setitem(sys.modules, ...)` inside a fixture so it is torn down afterwards, rather than a module-level `sys.modules` assignment that would leak into every test running after it in the same session.

## Verification

```
uv run pytest tests/test_channels -q
420 passed

uv run mypy src/agentos --show-error-codes
Success: no issues found in 623 source files

uv run ruff check + ruff format --check on the changed files — clean
```

## Related

#1049 and #1196 are open against this issue with the same one-line source change. #1049 carries no test. #1196 adds one; its behavioural half is sound, and the parts I would do differently are the `inspect.signature` assertion on the parameter name and default — which pins the implementation shape rather than the behaviour — and the module-level `sys.modules.setdefault("botbuilder", MagicMock())`, which is not reverted and stays in `sys.modules` for everything that imports afterwards (`botbuilder` is not installed in the dev extra, so the stub really does take effect). Landing either of those instead is fine by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
