### PR TITLE
fix(search): wrap web_search result titles and snippets in untrusted …

### DIFF
--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -646,6 +646,25 @@ def _classify_search_error(provider_name: str, exc: Exception) -> SearchProvider
     return None
 
 
+def _build_search_result(r: SearchResult) -> dict:
+    """Wrap a search result's model-facing text in the untrusted envelope.
+
+    ``title`` and ``snippet`` are attacker-controlled text fetched from a
+    third-party search index; wrapping them tags the origin the same way
+    web_fetch and browser wrap remote page content, so the model can tell
+    apart operator instructions from a page that got itself ranked.
+    """
+    from agentos.safety.injection_guard import wrap_untrusted_boundary
+
+    source_url = r.url or "unknown-source"
+    return {
+        "title": wrap_untrusted_boundary(r.title, source_url),
+        "url": r.url,
+        "snippet": wrap_untrusted_boundary(r.snippet, source_url),
+        "source": r.source or "",
+    }
+
+
 def _search_payload(
     query: str,
     provider_name: str,
@@ -657,15 +676,7 @@ def _search_payload(
     payload = {
         "query": query,
         "provider": provider_name,
-        "results": [
-            {
-                "title": r.title,
-                "url": r.url,
-                "snippet": r.snippet,
-                "source": r.source or "",
-            }
-            for r in results
-        ],
+        "results": [_build_search_result(r) for r in results],
     }
     if fallback_from:
         payload["fallback_from"] = fallback_from

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -835,7 +835,10 @@ async def test_search_status_and_query_return_structured_payloads():
     assert status.payload["apiKeyConfigured"] is False
     assert query.error is None, query.error
     assert query.payload["ok"] is True
-    assert query.payload["results"][0]["snippet"] == "hello"
+    assert (
+        query.payload["results"][0]["snippet"]
+        == "<untrusted source='https://example.com'>hello</untrusted>"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
_search_payload passed web_search result title/snippet through as raw strings, while every other path that pulls remote text into context (web_fetch, browser) wraps it via wrap_untrusted_boundary. This left a residual hole from #688: an attacker who gets a page ranked for a query controls a title/snippet that reaches the model with no origin boundary.
Adds _build_search_result() in [web.py](vscode-webview://1opjf2u4q67s130bsso836d25k5b1q7homgbt1e4ri2kscdnbflg/src/agentos/tools/builtin/web.py:649), wrapping title and snippet in <untrusted source='<result-url>'>...</untrusted>, matching the pattern used by web_fetch and browser. url and source (provider name) stay raw metadata, unwrapped.
Fixes #1132.

Test plan
 uv run pytest tests/test_search tests/test_gateway/test_rpc_product_cli_gaps.py -q — updated one assertion to expect the wrapped envelope, all 36 pass
 uv run pytest tests/test_tools -k "web or search" -q — 95 passed
 uv run ruff check / uv run mypy on changed files — clean closes #1132 
