### PR TITLE
fix(compat): stop local version labels from leaking into post/dev par…

### DIFF
--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -27,8 +27,8 @@ _VERSION_RE = re.compile(
     r"^\s*v?"
     r"(?P<release>\d+(?:\.\d+)*)"
     r"(?:[._-]?(?P<pre_l>a|b|c|rc|alpha|beta|pre|preview)[._-]?(?P<pre_n>\d+)?)?"
-    r"(?:[._-]?post[._-]?(?P<post>\d+)?)?"
-    r"(?:[._-]?dev[._-]?(?P<dev>\d+)?)?"
+    r"(?:[._-]?(?P<post_kw>post)[._-]?(?P<post>\d+)?)?"
+    r"(?:[._-]?(?P<dev_kw>dev)[._-]?(?P<dev>\d+)?)?"
     r"(?:\+(?P<local>[a-zA-Z0-9.]+))?"
     r"\s*$",
     re.IGNORECASE,
@@ -100,12 +100,18 @@ def parse_version(value: str | None) -> Version:
     if match.group("pre_l"):
         pre_tag = match.group("pre_l").lower()
         pre = (_PRE_ORDER.get(pre_tag, 2), int(match.group("pre_n") or 0))
-    post = int(match.group("post")) if match.group("post") is not None else None
-    if post is None and re.search(r"[._-]?post", raw, re.IGNORECASE):
+    if match.group("post") is not None:
+        post = int(match.group("post"))
+    elif match.group("post_kw") is not None:
         post = 0
-    dev = int(match.group("dev")) if match.group("dev") is not None else None
-    if dev is None and re.search(r"[._-]?dev", raw, re.IGNORECASE):
+    else:
+        post = None
+    if match.group("dev") is not None:
+        dev = int(match.group("dev"))
+    elif match.group("dev_kw") is not None:
         dev = 0
+    else:
+        dev = None
     return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
 
 

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -54,6 +54,36 @@ def test_local_label_ignored_for_ordering() -> None:
     assert compare_versions("2026.7.18+abc", "2026.7.18") == 0
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected_post", "expected_dev"),
+    [
+        # local labels containing "dev"/"post" substrings must not leak into
+        # the parsed post/dev fields (#1130).
+        ("2026.7.18+dev", None, None),
+        ("2026.7.18+postgres", None, None),
+        ("2026.7.18+device", None, None),
+        ("2026.7.18+local.post1", None, None),
+        # bare .post / .dev (no trailing digit) still default to 0.
+        ("2026.7.18.post1", 1, None),
+        ("2026.7.18.dev1", None, 1),
+    ],
+)
+def test_local_label_does_not_leak_into_post_or_dev(
+    raw: str, expected_post: int | None, expected_dev: int | None
+) -> None:
+    v = parse_version(raw)
+    assert v.release == (2026, 7, 18)
+    assert v.post == expected_post
+    assert v.dev == expected_dev
+
+
+def test_local_label_with_dev_does_not_invert_ordering() -> None:
+    # A local/build-tagged final release must not sort as older than the
+    # same final release (it would if "+dev" were misread as ".dev0").
+    assert compare_versions("2026.7.18", "2026.7.18+dev") == 0
+    assert compare_versions("2026.7.18+postgres", "2026.7.18") == 0
+
+
 def test_unparsable_sorts_below_real_release() -> None:
     assert compare_versions("0.0.0+unknown", "2026.7.18") == -1
     assert compare_versions("garbage", "2026.7.18") == -1


### PR DESCRIPTION
Summary
parse_version()'s .post/.dev fallback used an unanchored re.search over the entire raw version string whenever the anchored match left post/dev unset (the bare .post/.dev-with-no-digit case). That scan reached past the + local-label delimiter, so +dev, +postgres, +device, or +local.post1 were misread as .dev0/.post0 of the same final release — inverting is_newer() for local/build-tagged versions.
Fixes it by capturing the post/dev keyword itself in the anchored regex (post_kw/dev_kw groups) instead of re-scanning raw text, so the local segment can never contribute to either field. The bare .post/.dev (no digit) case still correctly defaults to 0, now via the keyword group.
Fixes #1130 

Test plan
 Added regression cases for +dev, +postgres, +device, +local.post1, plus .post1/.dev1 controls, per the issue's ask
 uv run pytest tests/test_compat/test_version_utils.py -q — 39 passed
 uv run ruff check / uv run mypy on changed files — clean
 Manually confirmed the issue's exact repro now parses correctly and compare_versions("2026.7.18", "2026.7.18+dev") == 0