### PR TITLE
fix(skills): tolerate non-object JSON-RPC error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A JSON-RPC error whose `error` member is not an object no longer kills the
+  command with an `AttributeError`. `RpcError.__init__` in
+  `senior-unilp-manager` and `poolsdotfun-token-launcher` read the payload as
+  a dict unconditionally — `error.get("message", error)`. The spec says
+  `error` is an object, but nodes and proxies really do answer with a bare
+  string (`{"error": "rate limit exceeded"}`) or null, and each of those
+  raised `AttributeError: 'str' object has no attribute 'get'` *inside the
+  exception constructor*, so the traceback escaped every `except RpcError`
+  that `plan.py`, `pools_write.py` and `rpc.batch()` already have. `batch()`
+  was the worst case: a per-call error is meant to land in its own result slot
+  so one bad pool cannot abort a 40-pool sweep, and a string payload aborted
+  it anyway. The constructor now reads `code`/`data` only when the payload is
+  a mapping and falls back to the payload itself for the message, matching
+  what `robinhood-chain-stocks` already does; `raw` still carries whatever
+  came back and the dict path is unchanged
+  ([#974](https://github.com/use-agent-os/agent-os/issues/974)).
+
 ## [2026.9.6] - 2026-09-06
 
 ### Fixed

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/rpc.py
@@ -67,12 +67,19 @@ USER_AGENT = "poolsdotfun-token-launcher/1.0"
 
 
 class RpcError(RuntimeError):
-    """A JSON-RPC error response. ``data`` carries the revert blob when present."""
+    """A JSON-RPC error response. ``data`` carries the revert blob when present.
 
-    def __init__(self, method: str, error: dict) -> None:
-        super().__init__(f"{method}: {error.get('message', error)}")
-        self.code = error.get("code")
-        self.data = error.get("data")
+    ``error`` is an object in the JSON-RPC spec, but nodes and proxies do answer
+    with a bare string (``"error": "rate limit exceeded"``) or null. Reading it
+    as a dict unconditionally turned every one of those into an AttributeError
+    that killed the whole command instead of the RpcError callers handle.
+    """
+
+    def __init__(self, method: str, error: Any) -> None:
+        fields = error if isinstance(error, dict) else {}
+        super().__init__(f"{method}: {fields.get('message', error)}")
+        self.code = fields.get("code")
+        self.data = fields.get("data")
         self.raw = error
 
 

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
@@ -67,12 +67,19 @@ USER_AGENT = "senior-unilp-manager/1.0"
 
 
 class RpcError(RuntimeError):
-    """A JSON-RPC error response. ``data`` carries the revert blob when present."""
+    """A JSON-RPC error response. ``data`` carries the revert blob when present.
 
-    def __init__(self, method: str, error: dict) -> None:
-        super().__init__(f"{method}: {error.get('message', error)}")
-        self.code = error.get("code")
-        self.data = error.get("data")
+    ``error`` is an object in the JSON-RPC spec, but nodes and proxies do answer
+    with a bare string (``"error": "rate limit exceeded"``) or null. Reading it
+    as a dict unconditionally turned every one of those into an AttributeError
+    that killed the whole command instead of the RpcError callers handle.
+    """
+
+    def __init__(self, method: str, error: Any) -> None:
+        fields = error if isinstance(error, dict) else {}
+        super().__init__(f"{method}: {fields.get('message', error)}")
+        self.code = fields.get("code")
+        self.data = fields.get("data")
         self.raw = error
 
 

--- a/tests/test_skill_rpc_error_non_dict_payload.py
+++ b/tests/test_skill_rpc_error_non_dict_payload.py
@@ -1,0 +1,115 @@
+"""``RpcError`` must survive a non-object JSON-RPC ``error`` payload.
+
+The spec says ``error`` is an object, but nodes and proxies really do answer
+with a bare string (``{"jsonrpc": "2.0", "id": 1, "error": "rate limit
+exceeded"}``) or null. ``senior-unilp-manager`` and
+``poolsdotfun-token-launcher`` read it as a dict unconditionally, so such a
+response raised ``AttributeError: 'str' object has no attribute 'get'`` out of
+the exception constructor and took the whole command down instead of raising
+the ``RpcError`` every caller already handles.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BUNDLED = _REPO_ROOT / "src" / "agentos" / "skills" / "bundled"
+_SKILLS = (
+    ("unilp", _BUNDLED / "senior-unilp-manager" / "scripts"),
+    ("poolsfun", _BUNDLED / "poolsdotfun-token-launcher" / "scripts"),
+)
+
+
+def _load(package: str, scripts_dir: Path):
+    """Import ``<package>.rpc`` from a bundled skill without touching PATH."""
+    entry = str(scripts_dir)
+    added = entry not in sys.path
+    if added:
+        sys.path.insert(0, entry)
+    try:
+        return importlib.import_module(f"{package}.rpc")
+    finally:
+        if added:
+            sys.path.remove(entry)
+
+
+@pytest.fixture(params=_SKILLS, ids=[name for name, _ in _SKILLS])
+def rpc(request: pytest.FixtureRequest):
+    package, scripts_dir = request.param
+    return _load(package, scripts_dir)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["rate limit exceeded", 429, None, ["rate limited"], True],
+    ids=["string", "int", "null", "list", "bool"],
+)
+def test_non_dict_error_payload_raises_rpc_error(rpc, payload: object) -> None:
+    error = rpc.RpcError("eth_call", payload)
+
+    assert isinstance(error, RuntimeError)
+    assert str(error) == f"eth_call: {payload}"
+    assert error.code is None
+    assert error.data is None
+    assert error.raw == payload
+
+
+def test_dict_error_payload_is_unchanged(rpc) -> None:
+    error = rpc.RpcError(
+        "eth_call",
+        {"code": -32000, "message": "execution reverted", "data": "0xdeadbeef"},
+    )
+
+    assert str(error) == "eth_call: execution reverted"
+    assert error.code == -32000
+    assert error.data == "0xdeadbeef"
+    assert error.raw == {"code": -32000, "message": "execution reverted", "data": "0xdeadbeef"}
+
+
+def test_dict_without_message_falls_back_to_the_whole_object(rpc) -> None:
+    error = rpc.RpcError("eth_call", {"code": -32000})
+
+    assert str(error) == "eth_call: {'code': -32000}"
+    assert error.code == -32000
+    assert error.data is None
+
+
+def test_request_raises_rpc_error_for_a_string_error(rpc, monkeypatch) -> None:
+    client = rpc.RpcClient.__new__(rpc.RpcClient)
+    client._next_id = 0
+    monkeypatch.setattr(
+        rpc.RpcClient,
+        "_post",
+        lambda _self, _payload, _label: {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": "rate limit exceeded",
+        },
+    )
+
+    with pytest.raises(rpc.RpcError) as excinfo:
+        client.request("eth_blockNumber")
+
+    assert "rate limit exceeded" in str(excinfo.value)
+    assert excinfo.value.raw == "rate limit exceeded"
+
+
+def test_batch_fallback_records_a_string_error_without_crashing(rpc, monkeypatch) -> None:
+    """A per-call error must land in the result slot, not abort the sweep."""
+    client = rpc.RpcClient.__new__(rpc.RpcClient)
+    client._next_id = 0
+    client._allow_batch = False
+    monkeypatch.setattr(
+        rpc.RpcClient,
+        "_post",
+        lambda _self, _payload, _label: {"jsonrpc": "2.0", "id": 1, "error": "boom"},
+    )
+
+    out = client.batch([{"method": "eth_call", "params": []}])
+
+    assert out == [{"error": "boom"}]


### PR DESCRIPTION
Fixes #974

## The bug

`RpcError.__init__` in `senior-unilp-manager` and `poolsdotfun-token-launcher`
reads the JSON-RPC `error` member as a dict unconditionally:

```python
def __init__(self, method: str, error: dict) -> None:
    super().__init__(f"{method}: {error.get('message', error)}")
```

The spec says `error` is an object, but nodes and proxies really do answer with
a bare string — `{"jsonrpc": "2.0", "id": 1, "error": "rate limit exceeded"}` —
or with null. Each of those raises `AttributeError: 'str' object has no
attribute 'get'` *inside the exception constructor*, so the whole command dies
with an unhandled traceback instead of raising the `RpcError` that
`plan.py`, `pools_write.py` and `rpc.batch()` already catch.

`batch()` is the worst case: a per-call error is meant to land in its result
slot so one bad pool cannot abort a 40-pool sweep. A string payload aborts it.

## The fix

Read `code`/`data` only when the payload is a mapping, and fall back to the
payload itself for the message. This matches what `robinhood-chain-stocks`
already does at its own error site. `raw` still carries whatever came back, and
the dict path is byte-for-byte unchanged.

## Tests

`tests/test_skill_rpc_error_non_dict_payload.py` — 18 tests, run against both
skills through a parametrized fixture: string / int / null / list / bool
payloads, the unchanged dict path, a dict with no `message`, `request()`
raising `RpcError` for a string error, and `batch()` recording it in the result
slot. Reverting the source change fails 14 of the 18.

The skill packages are imported in-process via `importlib` with a scoped
`sys.path` entry — no subprocess, so it behaves the same on the Windows runner.

## Verification

`ruff check src tests`, `mypy src/agentos` and the full `pytest` suite pass.

## Merge-order note

This is one of five independent bug-fix PRs opened together (#974, #985, #996,
#1010, #1026). They touch disjoint files and were verified to merge into
`upstream/main` cleanly in every pairwise and several full sequential orders,
with the whole suite green on the merged tree. This PR carries the
`CHANGELOG.md` entry for the group — `[Unreleased]` was empty on `main`, so
five simultaneous entries would have conflicted whichever landed first. The
four siblings rebase onto this one and add their own bullets afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCuGffFijU6GboABVsRJtj
