### PR TITLE
fix(sandbox): expand env vars before the sensitive-path hard block

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -128,6 +128,25 @@ def _comparison_path_candidates(path: str) -> list[str]:
     return list(dict.fromkeys(candidates))
 
 
+def _expand_env_vars(text: str) -> str:
+    """Expand ``$VAR`` / ``${VAR}`` the way the shell will before execution.
+
+    Tool dispatch ends in a shell (``create_subprocess_shell``), so the text
+    this module scans is not what the kernel eventually opens:
+    ``cat $HOME/.ssh/config`` reaches the syscall as ``~/.ssh/config``.
+    Scanning only the literal text let every prefix in
+    :data:`_SENSITIVE_PREFIXES` be side-stepped by spelling the home directory
+    as a variable. Undefined names are left as written, so nothing new matches
+    on a host where the variable does not exist.
+    """
+    if "$" not in text and "%" not in text:
+        return text
+    try:
+        return os.path.expandvars(text)
+    except (KeyError, TypeError, ValueError):
+        return text
+
+
 def _looks_like_rooted_path_text(path: str) -> bool:
     normalized = str(path).strip().replace("\\", "/")
     return normalized.startswith(("/", "~/")) and not normalized.startswith("//")
@@ -169,7 +188,9 @@ def _is_root_target(path: str) -> bool:
     covering ``/``, ``//``, ``/.``, ``/..``, ``/*``, ``/**``, ``/.*`` and
     ``/*/*``.
     """
-    normalized = str(path).strip().replace("\\", "/")
+    # Expanded first for the same reason the prefix scan does it: the shell
+    # resolves `rm -rf $ROOTDIR` to a root wipe that the literal text hides.
+    normalized = _expand_env_vars(str(path).strip()).replace("\\", "/")
     normalized = _DRIVE_PREFIX_RE.sub("", normalized, count=1)
     if not normalized.startswith("/"):
         return False
@@ -284,7 +305,10 @@ def sensitive_path_marker(
     such as ``.env`` and private-key names remain blocked.
     """
 
-    text = str(path).strip()
+    # Expand first: `$HOME/.ssh` is a relative-looking token that the shell
+    # turns into an absolute sensitive path, and the narrow leaf-marker
+    # fallback below would be the only check it ever faced.
+    text = _expand_env_vars(str(path).strip())
     raw = Path(text).expanduser()
     if (
         text
@@ -294,35 +318,22 @@ def sensitive_path_marker(
     ):
         return _sensitive_leaf_marker(text)
 
-    marker = is_sensitive_path(path)
+    marker = is_sensitive_path(text)
     if marker is None:
         return None
-    if _workspace_contains(path, workspace) and _workspace_nested_under_marker(
+    if _workspace_contains(text, workspace) and _workspace_nested_under_marker(
         workspace, marker
     ):
-        leaf_marker = _sensitive_leaf_marker(path)
+        leaf_marker = _sensitive_leaf_marker(text)
         return leaf_marker
     return marker
 
 
-def sensitive_path_in_text(
+def _scan_text_for_marker(
     text: str,
     *,
     workspace: str | Path | None = None,
 ) -> str | None:
-    """Return the first sensitive path marker appearing in free-form text.
-
-    This is intentionally conservative glue for shell/Python-code scanners.
-    Structured callers should still resolve concrete paths and call
-    :func:`is_sensitive_path` directly.
-
-    Honors :data:`_DISABLED` (env var ``AGENTOS_SENSITIVE_PATHS_DISABLED``).
-    """
-    if _DISABLED:
-        return None
-    if not text:
-        return None
-
     candidates: list[str] = []
     with_context: list[tuple[str, int]] = []
     try:
@@ -358,6 +369,36 @@ def sensitive_path_in_text(
         if marker is not None:
             return marker
 
+    return None
+
+
+def sensitive_path_in_text(
+    text: str,
+    *,
+    workspace: str | Path | None = None,
+) -> str | None:
+    """Return the first sensitive path marker appearing in free-form text.
+
+    This is intentionally conservative glue for shell/Python-code scanners.
+    Structured callers should still resolve concrete paths and call
+    :func:`is_sensitive_path` directly.
+
+    Honors :data:`_DISABLED` (env var ``AGENTOS_SENSITIVE_PATHS_DISABLED``).
+    """
+    if _DISABLED:
+        return None
+    if not text:
+        return None
+
+    marker = _scan_text_for_marker(text, workspace=workspace)
+    if marker is not None:
+        return marker
+    # `$HOME/.ssh/config` survives token scanning as the relative-looking
+    # `HOME/.ssh/config` (the leading `$` is stripped as a token edge), so the
+    # expanded spelling has to be scanned in its own right.
+    expanded = _expand_env_vars(text)
+    if expanded != text:
+        return _scan_text_for_marker(expanded, workspace=workspace)
     return None
 
 

--- a/tests/test_sandbox/test_sensitive_paths_env_vars.py
+++ b/tests/test_sandbox/test_sensitive_paths_env_vars.py
@@ -1,0 +1,139 @@
+"""Environment-variable spellings must not slip past the sensitive-path block.
+
+Tool dispatch ends in a shell, so `$HOME/.ssh/config` is the real
+`~/.ssh/config` by the time anything opens it. The static scanner only ever saw
+the literal text, so every prefix in ``_SENSITIVE_PREFIXES`` had a second,
+unguarded spelling — a display-vs-executor drift on a layer documented as a
+hard block that survives user approval.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.sandbox.sensitive_paths import (
+    sensitive_path_in_text,
+    sensitive_path_marker,
+    sensitive_target_in_command,
+)
+
+
+@pytest.fixture
+def home(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin ``$HOME`` to the same directory ``~`` expands to.
+
+    Windows resolves ``~`` through ``USERPROFILE``, so the two spellings only
+    line up once ``HOME`` is set explicitly.
+    """
+    resolved = Path.home()
+    monkeypatch.setenv("HOME", str(resolved))
+    return resolved
+
+
+@pytest.mark.parametrize(
+    ("suffix", "marker"),
+    [
+        (".ssh/config", "~/.ssh"),
+        (".aws/credentials", "~/.aws"),
+        (".azure/accessTokens.json", "~/.azure"),
+        (".config/gcloud/application_default_credentials.json", "~/.config/gcloud"),
+        (".kube/config", "~/.kube"),
+        (".gnupg/secring.gpg", "~/.gnupg"),
+        (".password-store/bank.gpg", "~/.password-store"),
+        (".netrc", "~/.netrc"),
+        (".npmrc", "~/.npmrc"),
+    ],
+)
+@pytest.mark.parametrize("spelling", ["$HOME", "${HOME}"])
+def test_env_var_home_reads_are_blocked_like_tilde(
+    home: Path, suffix: str, marker: str, spelling: str
+) -> None:
+    assert sensitive_path_in_text(f"cat ~/{suffix}") == marker
+    assert sensitive_path_in_text(f"cat {spelling}/{suffix}") == marker
+
+
+def test_env_var_home_exfiltration_is_blocked(home: Path) -> None:
+    assert sensitive_path_in_text("cp $HOME/.aws/credentials /tmp/leak.txt") == "~/.aws"
+    assert sensitive_path_in_text("cat ${HOME}/.docker/config") == "~/.docker/config"
+
+
+@pytest.mark.parametrize("spelling", ["$HOME", "${HOME}"])
+def test_env_var_home_deletes_are_blocked(home: Path, spelling: str) -> None:
+    assert sensitive_target_in_command(f"rm {spelling}/.ssh") == "~/.ssh"
+    assert sensitive_target_in_command(f"rm -rf {spelling}/.aws") == "~/.aws"
+
+
+def test_custom_exported_variable_is_expanded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MYHOME", str(Path.home()))
+
+    assert sensitive_path_in_text("cat $MYHOME/.ssh/config") == "~/.ssh"
+    assert sensitive_target_in_command("rm -rf ${MYHOME}/.gnupg") == "~/.gnupg"
+
+
+def test_variable_pointing_at_a_system_prefix_is_expanded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SYSCONF", "/etc")
+
+    assert sensitive_path_in_text("cat $SYSCONF/shadow") == "/etc"
+    assert sensitive_target_in_command("rm $SYSCONF/hosts") == "/etc"
+
+
+def test_sensitive_path_marker_expands_a_bare_token(home: Path) -> None:
+    assert sensitive_path_marker("$HOME/.ssh/config") == "~/.ssh"
+    assert sensitive_path_marker("${HOME}/.aws/credentials") == "~/.aws"
+
+
+def test_undefined_variables_stay_unexpanded_and_do_not_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENTOS_NOT_A_REAL_VAR", raising=False)
+
+    assert sensitive_path_in_text("cat $AGENTOS_NOT_A_REAL_VAR/notes.txt") is None
+    assert sensitive_path_in_text("ls ${AGENTOS_NOT_A_REAL_VAR}") is None
+
+
+def test_ordinary_text_with_a_dollar_sign_is_untouched(home: Path) -> None:
+    assert sensitive_path_in_text("echo 'total is $5'") is None
+    assert sensitive_path_in_text("git commit -m 'cost $3 per run'") is None
+    assert sensitive_path_in_text("ls $HOME") is None
+
+
+def test_workspace_exception_survives_the_variable_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = Path("/root/.agentos/workspace")
+    monkeypatch.setenv("WS", str(workspace))
+
+    assert sensitive_path_in_text("cat $WS/notes/plan.md", workspace=workspace) is None
+    assert sensitive_path_marker("$WS/notes/plan.md", workspace=workspace) is None
+    # The leaf blocks inside the workspace stay in force.
+    assert sensitive_path_marker("$WS/id_rsa", workspace=workspace) == "/id_rsa"
+
+
+def test_variable_spelling_is_blocked_at_the_shell_tool_boundary(home: Path) -> None:
+    """The report's real exploit path: `exec_command` must refuse the command."""
+    from agentos.tools.builtin.shell import _sensitive_shell_block
+
+    for command in (
+        "cat $HOME/.aws/credentials",
+        "cp $HOME/.kube/config /tmp/leak.txt",
+        "cat ${HOME}/.gnupg/secring.gpg",
+        "rm -rf $HOME/.ssh",
+    ):
+        blocked = _sensitive_shell_block("exec_command", command)
+        assert blocked is not None, command
+        assert '"reason": "sensitive_path"' in blocked
+
+
+def test_root_wipe_hidden_behind_a_variable_is_still_a_root_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ROOTDIR", "/")
+
+    assert sensitive_target_in_command("rm -rf /") == "/"
+    assert sensitive_target_in_command("rm -rf $ROOTDIR") == "/"
+    assert sensitive_target_in_command("rm -rf ${ROOTDIR}") == "/"
+    assert sensitive_target_in_command("rm -rf /tmp/scratch") is None


### PR DESCRIPTION
Fixes #985

## The bug

The sensitive-path denylist is documented as a hard block that holds
"regardless of user approval" and is overridable only by `/elevated full`. It
only ever saw the literal command text. Tool dispatch ends in a shell, so
`cat $HOME/.ssh/config` reaches the syscall as `~/.ssh/config` — a
display-vs-executor drift that gave every one of the 19 entries in
`_SENSITIVE_PREFIXES` a second, unguarded spelling.

Reproduced at the real tool boundary (`shell._sensitive_shell_block`, the entry
point `exec_command` actually uses), not just in the matcher:

```
'cat ~/.ssh/config'                        boundary=BLOCKED
'cat $HOME/.ssh/config'                    boundary=ALLOWED   <-- bypass
'cp $HOME/.aws/credentials /tmp/leak.txt'  boundary=ALLOWED   <-- bypass
'cat ${HOME}/.aws/credentials'             boundary=ALLOWED   <-- bypass
'cat $HOME/.kube/config'                   boundary=ALLOWED   <-- bypass
'cat $HOME/.gnupg/secring.gpg'             boundary=ALLOWED   <-- bypass
'rm -rf $HOME/.aws'                        boundary=ALLOWED   <-- bypass
```

The mechanism: `$` is in `_TOKEN_EDGE_CHARS`, so `$HOME/.ssh/config` is stripped
to the relative-looking `HOME/.ssh/config` before matching, and a relative token
only ever faces the narrow leaf-marker fallback — never `is_sensitive_path` and
its prefix list.

## The fix

- `_expand_env_vars()` — expands `$VAR` / `${VAR}` (and `%VAR%` on Windows, via
  `os.path.expandvars`). Undefined names are left exactly as written, so nothing
  new matches on a host where the variable does not exist.
- `sensitive_path_marker()` expands **before** choosing between the full prefix
  matcher and the leaf fallback, so a structured caller passing `$HOME/.ssh`
  gets the prefix matcher. The downstream `is_sensitive_path` /
  `_workspace_contains` / `_sensitive_leaf_marker` calls use the expanded text.
- `sensitive_path_in_text()` scans the literal text first (unchanged path) and
  re-scans the expanded text only when that finds nothing.
- `_is_root_target()` expands for the same reason: `rm -rf $ROOTDIR` is a root
  wipe that the literal text hides.

Every `~`-prefixed entry and its `$HOME` / `${HOME}` spelling now return the
same marker — verified programmatically across all 11 home-relative prefixes,
zero mismatches. The workspace exception still applies to the expanded path, so
a workspace configured under `/root` stays usable when named through a variable.

### Deliberate consequence

Where `~` is already blocked, its variable spelling now is too — including
`ls $HOME` on a container deployment where `HOME=/root`, which mirrors `ls ~`
being blocked there today. That is the parity the fix is for.

## Tests

`tests/test_sandbox/test_sensitive_paths_env_vars.py` — 29 tests:

- every home-relative prefix in both `$HOME` and `${HOME}` form, against the
  `~` baseline
- the `rm` path via `sensitive_target_in_command`
- a custom exported variable (`$MYHOME`) and one pointing at a system prefix
  (`SYSCONF=/etc`)
- `sensitive_path_marker` on a bare `$HOME/...` token
- **negative cases**: an undefined variable stays unmatched; `echo 'total is $5'`
  and `git commit -m 'cost $3 per run'` still pass; the workspace exception
  survives the variable spelling while its leaf blocks stay in force
- a root wipe hidden behind a variable
- the exploit path end to end through `shell._sensitive_shell_block`

Reverting the source change fails 25 of the 29.

`HOME` is pinned to `Path.home()` in a fixture so the `~` and `$HOME` spellings
line up on Windows too, where `~` resolves through `USERPROFILE`.

## Verification

`ruff check src tests`, `mypy src/agentos`, `pytest tests/test_sandbox
tests/test_tools` (1054 passed) and the full suite (9543 passed) all green.

## Merge-order note

This is one of five independent bug-fix PRs opened together (#974, #985, #996,
#1010, #1026). They touch disjoint files and were verified to merge into
`upstream/main` cleanly in every pairwise and several full sequential orders,
with the whole suite green on the merged tree. No `CHANGELOG.md` entry is
included for exactly that reason — five entries in an empty `[Unreleased]`
section conflict with each other whichever one lands first. Happy to add one to
whichever of them you merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCuGffFijU6GboABVsRJtj