### PR TITLE
fix(engine): reject an oversized tool result before pruning the store

### DIFF
--- a/src/agentos/engine/tool_result_store.py
+++ b/src/agentos/engine/tool_result_store.py
@@ -217,6 +217,15 @@ class ToolResultStore:
 
     def _prune_to_fit(self, incoming_bytes: int, disk_budget_bytes: int) -> None:
         budget = max(0, int(disk_budget_bytes))
+        # A snapshot larger than the whole budget can never be made to fit, so
+        # pruning first only destroys unrelated records on the way to the same
+        # error. The caller records a `skipped` metric and carries on, which
+        # made that loss silent.
+        if incoming_bytes > budget:
+            raise ToolResultStoreBudgetError(
+                "tool result snapshot exceeds disk budget "
+                f"({incoming_bytes} > {budget})"
+            )
         records = sorted(self._iter_records(), key=lambda item: item.created_at)
         current = sum(record.size_bytes for record in records)
         if current + incoming_bytes <= budget:
@@ -226,11 +235,6 @@ class ToolResultStore:
             current = max(0, current - record.size_bytes)
             if current + incoming_bytes <= budget:
                 return
-        if incoming_bytes > budget:
-            raise ToolResultStoreBudgetError(
-                "tool result snapshot exceeds disk budget "
-                f"({incoming_bytes} > {budget})"
-            )
 
 
 def _parse_created_at(value: str) -> datetime:

--- a/tests/test_engine/test_tool_result_store_budget.py
+++ b/tests/test_engine/test_tool_result_store_budget.py
@@ -1,0 +1,128 @@
+"""An oversized write must not take the existing records down with it.
+
+``_prune_to_fit`` used to delete every stored record while trying to make room
+for a snapshot that could never fit, and only then raise. The caller in
+``agent.py`` logs a ``skipped`` metric and moves on, so the loss was silent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.engine.tool_result_store import (
+    ToolResultStore,
+    ToolResultStoreBudgetError,
+)
+
+
+def _store(tmp_path) -> ToolResultStore:
+    return ToolResultStore(tmp_path / "tool-results")
+
+
+def _write(store: ToolResultStore, content: str, *, handle_hint: str, budget: int | None):
+    return store.write(
+        content,
+        tool_use_id=f"tu-{handle_hint}",
+        tool_name="x",
+        session_id="s1",
+        session_key="k",
+        agent_id="a",
+        disk_budget_bytes=budget,
+        retention_seconds=None,
+    )
+
+
+def _handles(store: ToolResultStore) -> set[str]:
+    return {record.handle for record in store._iter_records()}
+
+
+def test_oversized_write_leaves_prior_records_intact(tmp_path) -> None:
+    store = _store(tmp_path)
+    for index in range(3):
+        _write(store, f"record-{index}", handle_hint=str(index), budget=500)
+    before = _handles(store)
+    assert len(before) == 3
+
+    with pytest.raises(ToolResultStoreBudgetError, match="exceeds disk budget"):
+        _write(store, "X" * 2000, handle_hint="big", budget=500)
+
+    assert _handles(store) == before
+
+
+def test_oversized_write_against_a_zero_budget_keeps_records(tmp_path) -> None:
+    store = _store(tmp_path)
+    _write(store, "keep me", handle_hint="0", budget=500)
+    before = _handles(store)
+
+    with pytest.raises(ToolResultStoreBudgetError):
+        _write(store, "anything", handle_hint="1", budget=0)
+
+    assert _handles(store) == before
+
+
+def test_oversized_write_is_rejected_on_an_empty_store(tmp_path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(ToolResultStoreBudgetError, match="exceeds disk budget"):
+        _write(store, "X" * 2000, handle_hint="big", budget=500)
+    assert _handles(store) == set()
+
+
+def test_a_fitting_write_still_prunes_the_oldest_records(tmp_path) -> None:
+    store = _store(tmp_path)
+    first = _write(store, "A" * 100, handle_hint="0", budget=250)
+    second = _write(store, "B" * 100, handle_hint="1", budget=250)
+
+    third = _write(store, "C" * 100, handle_hint="2", budget=250)
+
+    handles = _handles(store)
+    assert third.handle in handles
+    assert first.handle not in handles
+    # Only as much as needed comes off: 100 + 100 fits inside 250.
+    assert second.handle in handles
+
+
+def test_a_write_that_fits_prunes_nothing(tmp_path) -> None:
+    store = _store(tmp_path)
+    first = _write(store, "A" * 100, handle_hint="0", budget=10_000)
+    second = _write(store, "B" * 100, handle_hint="1", budget=10_000)
+    assert _handles(store) == {first.handle, second.handle}
+
+
+def test_unbounded_budget_never_prunes(tmp_path) -> None:
+    store = _store(tmp_path)
+    handles = {
+        _write(store, "X" * 5000, handle_hint=str(index), budget=None).handle
+        for index in range(3)
+    }
+    assert _handles(store) == handles
+
+
+def test_records_survive_when_the_per_result_cap_rejects_the_write(tmp_path) -> None:
+    store = _store(tmp_path)
+    _write(store, "keep me", handle_hint="0", budget=500)
+    before = _handles(store)
+
+    with pytest.raises(ToolResultStoreBudgetError, match="per-result budget"):
+        store.write(
+            "X" * 2000,
+            tool_use_id="tu-big",
+            tool_name="x",
+            session_id="s1",
+            session_key="k",
+            agent_id="a",
+            max_bytes=10,
+            disk_budget_bytes=500,
+            retention_seconds=None,
+        )
+
+    assert _handles(store) == before
+
+
+def test_read_back_after_a_rejected_oversized_write(tmp_path) -> None:
+    store = _store(tmp_path)
+    kept = _write(store, "still here", handle_hint="0", budget=500)
+
+    with pytest.raises(ToolResultStoreBudgetError):
+        _write(store, "X" * 2000, handle_hint="big", budget=500)
+
+    assert store.read(kept.handle, session_id="s1").content == "still here"


### PR DESCRIPTION
Fixes #996

## The bug

`ToolResultStore._prune_to_fit` deleted every stored record while trying to make
room for a snapshot that could never fit — one larger than the whole disk
budget — and only raised `ToolResultStoreBudgetError` once the store was empty:

```python
for record in records:
    _remove_record_dir(record.record_dir)      # deletes everything
    ...
if incoming_bytes > budget:                    # only then gives up
    raise ToolResultStoreBudgetError(...)
```

The caller in `agent.py` logs a `skipped` metric and moves on, so three healthy
records went to zero with nothing in the transcript to say so — `before=3
after=0` for a single rejected write.

## The fix

Move the budget check ahead of the pruning loop. A snapshot bigger than the
budget is refused without touching anything on disk; the error text is
unchanged.

Pruning is unchanged for writes that *can* fit: the oldest records still come
off, and only as many as needed. The trailing `raise` this replaces was
unreachable in every other case — an emptied store always satisfies the loop's
own exit test, since `0 + incoming_bytes <= budget` whenever the incoming write
fits at all.

## Tests

`tests/test_engine/test_tool_result_store_budget.py` — 8 tests:

- the issue's exact repro: three records survive a rejected 2 KB write against a
  500-byte budget
- a zero budget rejects without deleting
- an oversized write on an empty store still raises
- a write that needs room still evicts the oldest, and **only** the oldest
- a write that fits prunes nothing; `disk_budget_bytes=None` never prunes
- the per-result cap (`max_bytes`) rejection also leaves records alone
- a surviving record still reads back with its original content

Reverting the source change fails 3 of the 8.

## Verification

`ruff check src tests`, `mypy src/agentos`, `pytest tests/test_engine`
(1072 passed) and the full suite (9521 passed) all green.

## Merge-order note

This is one of five independent bug-fix PRs opened together (#974, #985, #996,
#1010, #1026). They touch disjoint files and were verified to merge into
`upstream/main` cleanly in every pairwise and several full sequential orders,
with the whole suite green on the merged tree. No `CHANGELOG.md` entry is
included for exactly that reason — five entries in an empty `[Unreleased]`
section conflict with each other whichever one lands first. Happy to add one to
whichever of them you merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCuGffFijU6GboABVsRJtj