### PR TITLE
fix(tools): clean up the code_exec tempdir on every exit

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -563,78 +563,36 @@ async def execute_code(
         workdir = tempfile.mkdtemp(prefix="agentos_exec_")
         workdir_path = Path(workdir)
         cleanup_dir = workdir
-    start_ns = time.monotonic_ns()
+    # Every exit from here on has to drop the ephemeral workdir. The
+    # sandbox branch below returns early on denial, backend failure,
+    # escalation denial, timeout and error, and each of those used to skip
+    # the cleanup that only guarded the non-sandbox path.
+    try:
+        start_ns = time.monotonic_ns()
 
-    safe_env = _build_safe_env()
+        safe_env = _build_safe_env()
 
-    from agentos.tools.builtin.shell import _elevated_mode
+        from agentos.tools.builtin.shell import _elevated_mode
 
-    elevated_bypass = _elevated_mode() in ("on", "bypass", "full")
-    if runtime is None or (runtime.effective.sandbox_enabled and not elevated_bypass):
-        decision, _policy, request = await gate_action(
-            action_kind="code.exec",
-            argv=(python_bin, "-c", code),
-            cwd=workdir_path,
-            env=safe_env,
-        )
-        if isinstance(decision, DenialResult):
-            return json.dumps(decision.to_dict())
-        backend_request = SandboxRequest(
-            argv=(python_bin, "-c", code),
-            cwd=request.cwd,
-            action_kind=request.action_kind,
-            policy=request.policy,
-            env=safe_env,
-        )
-        try:
-            sandbox_result = await run_under_backend(backend_request, runtime=runtime)
-        except Exception as exc:
-            return _execution_result_json(
-                returncode=-1,
-                stdout="",
-                stderr=f"Execution error: {exc}",
-                timed_out=False,
-                elapsed_ms=0,
+        elevated_bypass = _elevated_mode() in ("on", "bypass", "full")
+        if runtime is None or (runtime.effective.sandbox_enabled and not elevated_bypass):
+            decision, _policy, request = await gate_action(
+                action_kind="code.exec",
+                argv=(python_bin, "-c", code),
+                cwd=workdir_path,
+                env=safe_env,
             )
-        if sandbox_result.backend_notes:
-            escalation = await escalate_backend_denial(
-                sandbox_result, request, _policy, runtime=runtime
+            if isinstance(decision, DenialResult):
+                return json.dumps(decision.to_dict())
+            backend_request = SandboxRequest(
+                argv=(python_bin, "-c", code),
+                cwd=request.cwd,
+                action_kind=request.action_kind,
+                policy=request.policy,
+                env=safe_env,
             )
-            if isinstance(escalation, DenialResult):
-                return json.dumps(escalation.to_dict())
             try:
-                proc = await asyncio.create_subprocess_exec(
-                    python_bin,
-                    "-c",
-                    code,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=str(workdir_path),
-                    env=safe_env,
-                )
-                try:
-                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                        proc.communicate(), timeout=timeout
-                    )
-                except TimeoutError:
-                    proc.kill()
-                    await proc.communicate()
-                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-                    return _execution_result_json(
-                        returncode=-1,
-                        stdout="",
-                        stderr=f"Execution timed out after {timeout}s",
-                        timed_out=True,
-                        elapsed_ms=elapsed_ms,
-                    )
-                elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-                return _execution_result_json(
-                    returncode=proc.returncode if proc.returncode is not None else -1,
-                    stdout=stdout_bytes.decode("utf-8", errors="replace"),
-                    stderr=stderr_bytes.decode("utf-8", errors="replace"),
-                    timed_out=False,
-                    elapsed_ms=elapsed_ms,
-                )
+                sandbox_result = await run_under_backend(backend_request, runtime=runtime)
             except Exception as exc:
                 return _execution_result_json(
                     returncode=-1,
@@ -643,61 +601,110 @@ async def execute_code(
                     timed_out=False,
                     elapsed_ms=0,
                 )
-        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-        stdout = sandbox_result.stdout
-        stderr = sandbox_result.stderr
-        stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
-        return _execution_result_json(
-            returncode=sandbox_result.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=sandbox_result.timed_out,
-            elapsed_ms=elapsed_ms,
-        )
-
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            python_bin,
-            "-c",
-            code,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(workdir_path),
-            env=safe_env,
-        )
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            await proc.communicate()
+            if sandbox_result.backend_notes:
+                escalation = await escalate_backend_denial(
+                    sandbox_result, request, _policy, runtime=runtime
+                )
+                if isinstance(escalation, DenialResult):
+                    return json.dumps(escalation.to_dict())
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        python_bin,
+                        "-c",
+                        code,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=str(workdir_path),
+                        env=safe_env,
+                    )
+                    try:
+                        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                            proc.communicate(), timeout=timeout
+                        )
+                    except TimeoutError:
+                        proc.kill()
+                        await proc.communicate()
+                        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                        return _execution_result_json(
+                            returncode=-1,
+                            stdout="",
+                            stderr=f"Execution timed out after {timeout}s",
+                            timed_out=True,
+                            elapsed_ms=elapsed_ms,
+                        )
+                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                    return _execution_result_json(
+                        returncode=proc.returncode if proc.returncode is not None else -1,
+                        stdout=stdout_bytes.decode("utf-8", errors="replace"),
+                        stderr=stderr_bytes.decode("utf-8", errors="replace"),
+                        timed_out=False,
+                        elapsed_ms=elapsed_ms,
+                    )
+                except Exception as exc:
+                    return _execution_result_json(
+                        returncode=-1,
+                        stdout="",
+                        stderr=f"Execution error: {exc}",
+                        timed_out=False,
+                        elapsed_ms=0,
+                    )
             elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+            stdout = sandbox_result.stdout
+            stderr = sandbox_result.stderr
+            stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
             return _execution_result_json(
-                returncode=-1,
-                stdout="",
-                stderr=f"Execution timed out after {timeout}s",
-                timed_out=True,
+                returncode=sandbox_result.returncode,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=sandbox_result.timed_out,
                 elapsed_ms=elapsed_ms,
             )
 
-        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-        stdout = stdout_bytes.decode("utf-8", errors="replace")
-        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                python_bin,
+                "-c",
+                code,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(workdir_path),
+                env=safe_env,
+            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=timeout
+                )
+            except TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                return _execution_result_json(
+                    returncode=-1,
+                    stdout="",
+                    stderr=f"Execution timed out after {timeout}s",
+                    timed_out=True,
+                    elapsed_ms=elapsed_ms,
+                )
 
-        return _execution_result_json(
-            returncode=proc.returncode if proc.returncode is not None else -1,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=False,
-            elapsed_ms=elapsed_ms,
-        )
-    except Exception as exc:
-        return _execution_result_json(
-            returncode=-1,
-            stdout="",
-            stderr=f"Execution error: {exc}",
-            timed_out=False,
-            elapsed_ms=0,
-        )
+            elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+            return _execution_result_json(
+                returncode=proc.returncode if proc.returncode is not None else -1,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=False,
+                elapsed_ms=elapsed_ms,
+            )
+        except Exception as exc:
+            return _execution_result_json(
+                returncode=-1,
+                stdout="",
+                stderr=f"Execution error: {exc}",
+                timed_out=False,
+                elapsed_ms=0,
+            )
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/tests/test_tools/test_code_exec_tempdir_cleanup.py
+++ b/tests/test_tools/test_code_exec_tempdir_cleanup.py
@@ -1,0 +1,201 @@
+"""The ephemeral ``agentos_exec_*`` workdir must not survive an early return.
+
+``execute_code`` makes a temporary workdir whenever no workspace is configured,
+but the cleanup used to hang off the ``finally`` of the *non-sandbox* branch
+only. Every early return inside the sandbox branch — denial, backend failure,
+escalation denial, timeout, error — skipped it and left one directory behind per
+call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agentos.sandbox.types import (
+    DenialReason,
+    DenialResult,
+    SandboxResult,
+    SecurityLevel,
+    SuggestedNextStep,
+)
+from agentos.tools.builtin import code_exec
+from agentos.tools.types import ToolContext, current_tool_context
+
+
+def _denial() -> DenialResult:
+    return DenialResult(
+        reason=DenialReason.POLICY_DENIED,
+        suggested_next_step=SuggestedNextStep.REPLAN,
+        level=SecurityLevel.STANDARD,
+        action_fingerprint="fp",
+        message="denied",
+    )
+
+
+def _sandbox_result(*, notes: tuple[str, ...] = ()) -> SandboxResult:
+    return SandboxResult(
+        returncode=0,
+        stdout="ok",
+        stderr="",
+        wall_time_s=0.0,
+        backend_used="none",
+        backend_notes=notes,
+    )
+
+
+@pytest.fixture
+def temp_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``tempfile.mkdtemp`` at an empty directory we can count."""
+    root = tmp_path / "tmp"
+    root.mkdir()
+    monkeypatch.setattr(code_exec.tempfile, "tempdir", str(root))
+    monkeypatch.setattr(code_exec, "get_runtime", lambda: None)
+    token = current_tool_context.set(None)
+    try:
+        yield root
+    finally:
+        current_tool_context.reset(token)
+
+
+def _leaked(root: Path) -> list[Path]:
+    return sorted(root.glob("agentos_exec_*"))
+
+
+def _gate(monkeypatch: pytest.MonkeyPatch, result: object) -> None:
+    async def _fake_gate(**_kwargs: object) -> tuple[object, object, object]:
+        request = code_exec.SandboxRequest(
+            argv=("python", "-c", "pass"),
+            cwd=Path("."),
+            action_kind="code.exec",
+            policy=None,
+        )
+        return result, None, request
+
+    monkeypatch.setattr(code_exec, "gate_action", _fake_gate)
+
+
+def test_denied_calls_leave_no_tempdir(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _gate(monkeypatch, _denial())
+
+    for index in range(5):
+        out = asyncio.run(code_exec.execute_code(f"print({index})"))
+        assert '"status": "denied"' in out
+
+    assert _leaked(temp_root) == []
+
+
+def test_backend_failure_leaves_no_tempdir(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _gate(monkeypatch, code_exec.SandboxRequest)  # any non-DenialResult
+
+    async def _boom(*_args: object, **_kwargs: object) -> SandboxResult:
+        raise RuntimeError("backend exploded")
+
+    monkeypatch.setattr(code_exec, "run_under_backend", _boom)
+
+    out = asyncio.run(code_exec.execute_code("print(1)"))
+    assert "backend exploded" in out
+    assert _leaked(temp_root) == []
+
+
+def test_escalation_denial_leaves_no_tempdir(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _gate(monkeypatch, code_exec.SandboxRequest)
+
+    async def _noted(*_args: object, **_kwargs: object) -> SandboxResult:
+        return _sandbox_result(notes=("backend denied",))
+
+    async def _escalate(*_args: object, **_kwargs: object) -> DenialResult:
+        return _denial()
+
+    monkeypatch.setattr(code_exec, "run_under_backend", _noted)
+    monkeypatch.setattr(code_exec, "escalate_backend_denial", _escalate)
+
+    out = asyncio.run(code_exec.execute_code("print(1)"))
+    assert '"status": "denied"' in out
+    assert _leaked(temp_root) == []
+
+
+def test_sandbox_success_leaves_no_tempdir(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _gate(monkeypatch, code_exec.SandboxRequest)
+
+    async def _ok(*_args: object, **_kwargs: object) -> SandboxResult:
+        return _sandbox_result()
+
+    monkeypatch.setattr(code_exec, "run_under_backend", _ok)
+
+    out = asyncio.run(code_exec.execute_code("print(1)"))
+    assert '"exit_code": 0' in out
+    assert _leaked(temp_root) == []
+
+
+def test_escalated_subprocess_timeout_leaves_no_tempdir(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _gate(monkeypatch, code_exec.SandboxRequest)
+
+    async def _noted(*_args: object, **_kwargs: object) -> SandboxResult:
+        return _sandbox_result(notes=("backend denied",))
+
+    async def _escalate(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(code_exec, "run_under_backend", _noted)
+    monkeypatch.setattr(code_exec, "escalate_backend_denial", _escalate)
+
+    out = asyncio.run(
+        code_exec.execute_code("import time\ntime.sleep(30)", timeout=1)
+    )
+    assert '"timed_out": true' in out
+    assert _leaked(temp_root) == []
+
+
+def test_escalated_subprocess_error_leaves_no_tempdir(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _gate(monkeypatch, code_exec.SandboxRequest)
+
+    async def _noted(*_args: object, **_kwargs: object) -> SandboxResult:
+        return _sandbox_result(notes=("backend denied",))
+
+    async def _escalate(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def _spawn_fails(*_args: object, **_kwargs: object) -> object:
+        raise OSError("no fork for you")
+
+    monkeypatch.setattr(code_exec, "run_under_backend", _noted)
+    monkeypatch.setattr(code_exec, "escalate_backend_denial", _escalate)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn_fails)
+
+    out = asyncio.run(code_exec.execute_code("print(1)"))
+    assert "no fork for you" in out
+    assert _leaked(temp_root) == []
+
+
+def test_configured_workspace_is_never_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    keeper = workspace / "keep.txt"
+    keeper.write_text("keep", encoding="utf-8")
+    monkeypatch.setattr(code_exec, "get_runtime", lambda: None)
+    _gate(monkeypatch, _denial())
+
+    token = current_tool_context.set(ToolContext(workspace_dir=str(workspace)))
+    try:
+        asyncio.run(code_exec.execute_code("print(1)"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert keeper.read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
Fixes #1010

## The bug

`execute_code` creates an ephemeral workdir with
`tempfile.mkdtemp(prefix="agentos_exec_")` whenever no workspace is configured,
but the `shutil.rmtree` that removes it hung off the `finally` of the
**non-sandbox** branch alone. Every exit from the sandbox branch returned past
it:

| Early return | Cleaned up before |
|---|---|
| `DenialResult` from `gate_action` | no |
| exception from `run_under_backend` | no |
| escalation `DenialResult` | no |
| `TimeoutError` in the escalated subprocess | no |
| generic exception in the escalated subprocess | no |
| **sandbox success path** | no |

The last row is broader than the report: even a *successful* sandbox run leaked
its workdir. One directory per call, no upper bound, on a path every agent with
the default sandbox policy takes.

## The fix

Wrap the whole execution in the `try` whose `finally` owns the cleanup, so the
tempdir has one exit path instead of six that skip it. A configured workspace
still sets no `cleanup_dir` and is never removed.

The diff is mostly re-indentation. The only other change is wrapping one
`asyncio.wait_for(...)` line that crossed the 100-column limit after the shift.

## Tests

`tests/test_tools/test_code_exec_tempdir_cleanup.py` — 7 tests, each asserting
`agentos_exec_*` is empty afterwards, with `tempfile.tempdir` pointed at a
per-test directory:

- 5 consecutive denied calls (the issue's repro shape, which printed `Leaked: 5`)
- a backend that raises
- an escalation denial
- the sandbox success path
- a timeout and a spawn failure in the escalated subprocess path
- a configured workspace is **not** deleted (a file in it survives)

Reverting the source change fails 6 of the 7 — the workspace guard is the one
that passes either way, which is the point of including it.

## Verification

`ruff check src tests`, `mypy src/agentos`, `pytest tests/test_tools
tests/test_sandbox` (1032 passed) and the full suite (9520 passed) all green.

## Merge-order note

This is one of five independent bug-fix PRs opened together (#974, #985, #996,
#1010, #1026). They touch disjoint files and were verified to merge into
`upstream/main` cleanly in every pairwise and several full sequential orders,
with the whole suite green on the merged tree. No `CHANGELOG.md` entry is
included for exactly that reason — five entries in an empty `[Unreleased]`
section conflict with each other whichever one lands first. Happy to add one to
whichever of them you merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCuGffFijU6GboABVsRJtj