### PR TITLE
fix(skills): accept string XLSX merge ranges

### DIFF
--- a/src/agentos/skills/bundled/xlsx/SKILL.md
+++ b/src/agentos/skills/bundled/xlsx/SKILL.md
@@ -141,6 +141,13 @@ Spec:
 }
 ```
 
+`merged` accepts range strings (`["A1:C1"]`), objects with a `range` key
+(`[{"range": "A1:C1"}]`), or a mixture of both. The string format matches
+the `merged` list returned by `inspect_xlsx.py`. This compatibility applies
+to merge metadata only; inspected `rows` contain cell objects rather than
+the plain values required by the creation spec. Invalid range coordinates
+raise an error from openpyxl.
+
 For programmatic use:
 
 ```python

--- a/src/agentos/skills/bundled/xlsx/scripts/create_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/create_xlsx.py
@@ -11,6 +11,8 @@ Spec:
         }
       ]
     }
+Entries in "merged" may also be range strings, e.g. "A1:B1", as returned by
+inspect_xlsx. Strings and {"range": ...} objects can be mixed in the same list.
 """
 
 from __future__ import annotations
@@ -54,7 +56,9 @@ def build(spec: dict[str, Any]) -> Workbook:
             ws.append([_coerce(v) for v in row])
 
         for merged in sheet_spec.get("merged") or []:
-            if isinstance(merged, dict) and "range" in merged:
+            if isinstance(merged, str):
+                ws.merge_cells(merged)
+            elif isinstance(merged, dict) and "range" in merged:
                 ws.merge_cells(str(merged["range"]))
 
         freeze = sheet_spec.get("freeze")

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -36,7 +36,14 @@ def test_eligibility_with_python(monkeypatch: pytest.MonkeyPatch) -> None:
     assert check_eligibility(spec, EligibilityContext.auto())
 
 
-def test_round_trip_with_formula_and_merge(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "merged",
+    [
+        pytest.param([{"range": "A1:B1"}], id="dictionary"),
+        pytest.param(["A1:B1"], id="string"),
+    ],
+)
+def test_round_trip_with_formula_and_merge(tmp_path: Path, merged: list[object]) -> None:
     sys.path.insert(0, str(SCRIPTS))
     try:
         import create_xlsx  # type: ignore[import-not-found]
@@ -55,7 +62,7 @@ def test_round_trip_with_formula_and_merge(tmp_path: Path) -> None:
                     ["EU", 850_000],
                     ["Total", "=SUM(B2:B3)"],
                 ],
-                "merged": [{"range": "A1:B1"}],
+                "merged": merged,
                 "freeze": "A2",
             }
         ]
@@ -68,7 +75,7 @@ def test_round_trip_with_formula_and_merge(tmp_path: Path) -> None:
     sheet = next(s for s in inspected["sheets"] if s["name"] == "Sales")
     assert sheet["max_row"] == 4
     assert sheet["max_col"] == 2
-    assert any("A1:B1" in r for r in sheet["merged"])
+    assert sheet["merged"] == ["A1:B1"]
     assert sheet["freeze"] == "A2"
 
     last_row = sheet["rows"][3]
@@ -91,6 +98,62 @@ def test_round_trip_with_formula_and_merge(tmp_path: Path) -> None:
     re_inspected = inspect_xlsx.inspect(out, data_only=False)
     sheet_q3 = next(s for s in re_inspected["sheets"] if s["name"] == "Q3")
     assert sheet_q3["rows"][1][0]["value"] == "Americas"
+
+
+@pytest.mark.parametrize(
+    ("merged", "expected"),
+    [
+        pytest.param(["A1:B1", {"range": "A3:B3"}], ["A1:B1", "A3:B3"], id="mixed"),
+        pytest.param([], [], id="empty"),
+        pytest.param(None, [], id="null"),
+        pytest.param([None, 42, {}, {"other": "A1:B1"}], [], id="unsupported-entries"),
+    ],
+)
+def test_create_merge_formats(tmp_path: Path, merged: object, expected: list[str]) -> None:
+    from agentos.skills.bundled.xlsx.scripts.create_xlsx import build
+    from agentos.skills.bundled.xlsx.scripts.inspect_xlsx import inspect
+
+    path = tmp_path / "merges.xlsx"
+    wb = build({"sheets": [{"name": "Merges", "merged": merged}, {"name": "Plain"}]})
+    wb.save(path)
+    wb.close()
+
+    sheets = inspect(path, data_only=False)["sheets"]
+    assert sheets[0]["merged"] == expected
+    assert sheets[1]["merged"] == []
+
+
+@pytest.mark.parametrize("merged", [["not-a-range"], [{"range": "not-a-range"}]])
+def test_create_rejects_invalid_merge_ranges(merged: list[object]) -> None:
+    from agentos.skills.bundled.xlsx.scripts.create_xlsx import build
+
+    with pytest.raises(ValueError, match="not a valid coordinate or range"):
+        build({"sheets": [{"merged": merged}]})
+
+
+def test_create_accepts_inspected_merge_ranges(tmp_path: Path) -> None:
+    from openpyxl import Workbook
+
+    from agentos.skills.bundled.xlsx.scripts.create_xlsx import build
+    from agentos.skills.bundled.xlsx.scripts.inspect_xlsx import inspect
+
+    original = Workbook()
+    ws = original.active
+    assert ws is not None
+    ws.merge_cells("A1:C1")
+    ws.merge_cells("B3:B5")
+    source = tmp_path / "source.xlsx"
+    original.save(source)
+    original.close()
+    merges = inspect(source, data_only=False)["sheets"][0]["merged"]
+    assert merges == ["A1:C1", "B3:B5"]
+
+    # Reuse only merge metadata: inspector rows have a different schema.
+    rebuilt = build({"sheets": [{"merged": merges}]})
+    target = tmp_path / "rebuilt.xlsx"
+    rebuilt.save(target)
+    rebuilt.close()
+    assert inspect(target, data_only=False)["sheets"][0]["merged"] == merges
 
 
 def test_text_escapes_formula(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Fixes #1250.

Accept string entries in `create_xlsx`'s `merged` list in addition to the existing `{"range": ...}` objects. Both forms use openpyxl's merge validation; dictionary handling and unsupported non-string entry behavior remain unchanged.

Document both formats and explicitly limit inspector compatibility to merge metadata, not the inspector's different row schema.

## Regression coverage
- Parameterize existing formula/freeze/create-inspect-edit test across dictionary and string merge inputs.
- Mixed formats, empty/null merge lists, omitted merge metadata on a second sheet, and existing unsupported-entry behavior.
- Invalid coordinates raise for both supported forms.
- Save/reload merge metadata from an independently created workbook, then reuse the inspector's merge list in a new creation spec.

## Verification completed
- Before implementation: new/expanded XLSX suite had 4 failures and 8 passes on original source.
- After implementation: 12 XLSX tests pass on Python 3.14 and Python 3.12.
- Python 3.12 CLI smoke: nested output created, both merge formats survive reload, formula and freeze panes preserved.
- Control UI build passes.
- Frontend quality gate passes: 99 test files, 2041 tests.
- Repository-wide Ruff passes.
- Mypy passes: 623 source files.
- Changed Python files pass Ruff formatting check; git diff --check passes.

## Full-suite and packaging results
- Full Python 3.14 suite: 9509 passed, 31 skipped, 8 failed, 3 errors (301.18s).
- Re-ran all 11 failing/erroring test nodes in a clean detached upstream worktree at `0ed6c5c`, with PYTHONPATH pointing to the clean source: the same 8 failures and 3 errors reproduced (6.92s). They concern ONNX/model assets and shell process isolation in this environment; they are not introduced by this XLSX change. The full gate is not green.
- `uv build --wheel` passes.

## Scope and dependencies
No dependency or lockfile changes. npm installation reports 7 dependency vulnerabilities (2 moderate, 5 high); these are outside this focused XLSX fix.

## Third-party origin
No newly copied/adapted/vendored third-party material or new dependency. This modifies an existing bundled skill whose provenance and notices remain unchanged.
