### PR TITLE
fix(gateway): reject bool for projects.update expectedUpdatedAt

### DIFF
--- a/src/agentos/gateway/rpc_projects.py
+++ b/src/agentos/gateway/rpc_projects.py
@@ -127,7 +127,7 @@ async def _handle_projects_update(params: dict | None, ctx: RpcContext) -> dict:
         raise ValueError("params.name must be a string")
     if knowledge is not None and not isinstance(knowledge, str):
         raise ValueError("params.knowledge must be a string")
-    if expected is not None and not isinstance(expected, int):
+    if expected is not None and (isinstance(expected, bool) or not isinstance(expected, int)):
         raise ValueError("params.expectedUpdatedAt must be an integer timestamp")
 
     try:

--- a/tests/test_gateway/test_rpc_projects.py
+++ b/tests/test_gateway/test_rpc_projects.py
@@ -141,6 +141,34 @@ class TestProjectsListGetUpdateDelete:
         assert winner.payload["project"]["knowledge"] == "v3"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_expected", [True, False])
+    async def test_update_rejects_bool_expected_updated_at(self, dispatcher, ctx, bad_expected):
+        # bool is a subclass of int in Python, so a naive `isinstance(x, int)`
+        # check accepts True/False as if they were real ms timestamps. That
+        # previously reached the storage compare-and-swap as 1/0, which never
+        # matches a real updated_at and surfaces the misleading
+        # "project.conflict" / reload-and-retry error instead of a clear
+        # INVALID_REQUEST for the caller's bad param.
+        project = await _create_project(dispatcher, ctx)
+        res = await dispatcher.dispatch(
+            "r1",
+            "projects.update",
+            {
+                "projectId": project["project_id"],
+                "knowledge": "v2",
+                "expectedUpdatedAt": bad_expected,
+            },
+            ctx,
+        )
+        assert res.ok is False
+        assert res.error.code == "INVALID_REQUEST"
+        # The rejected write must not have landed.
+        fresh = await dispatcher.dispatch(
+            "r2", "projects.get", {"projectId": project["project_id"]}, ctx
+        )
+        assert fresh.payload["project"]["knowledge"] == "Shared facts."
+
+    @pytest.mark.asyncio
     async def test_delete_reports_detached_sessions(self, dispatcher, ctx, manager):
         project = await _create_project(dispatcher, ctx)
         await manager.create(


### PR DESCRIPTION
## Linked issue
Fixes #1261
- [x] This pull request fully resolves the linked issue

## Summary
`projects.update`'s `expectedUpdatedAt` validation used a bare
`isinstance(expected, int)` check. Since `bool` is a subclass of `int` in
Python, `expectedUpdatedAt: true` or `false` passes validation untouched.
The value then reaches `SessionStorage.update_project_fields`, which binds
it straight into `AND updated_at = ?` — SQLite stores it as `1` or `0`,
which essentially never matches a real millisecond timestamp. The caller
gets back `project.conflict` ("changed since it was read; reload and
retry") for what is actually a malformed request, and a naive retry loop
would spin forever since resending the same boolean never resolves.

The gateway already has the correct pattern for this exact footgun in
`rpc_system.py` (`timeoutMs`, `intervalMs`, `ackMaxChars` all explicitly
exclude `bool` before the `int` check) — `rpc_projects.py` was just
inconsistent with its own codebase.

## Fix
Added the same `isinstance(expected, bool)` exclusion used elsewhere in
the gateway, so a bool now raises the correct `INVALID_REQUEST`
("params.expectedUpdatedAt must be an integer timestamp") instead of a
misleading `project.conflict`.

## Tests
Added `test_update_rejects_bool_expected_updated_at` (parametrized over
`True`/`False`) to `tests/test_gateway/test_rpc_projects.py`, asserting:
- the call fails with `error.code == "INVALID_REQUEST"`
- the rejected write did not land (knowledge unchanged)

Confirmed the test is a real regression guard by reverting the fix locally
and rerunning — it fails with `project.conflict` on the old code, passes
with the fix.

Commands run:
  uv run ruff check src/agentos/gateway/rpc_projects.py tests/test_gateway/test_rpc_projects.py
  uv run ruff format --check src/agentos/gateway/rpc_projects.py tests/test_gateway/test_rpc_projects.py
  uv run mypy src/agentos/gateway/rpc_projects.py --show-error-codes
  uv run pytest tests/test_gateway/test_rpc_projects.py -v

Results: ruff clean, format clean, mypy "Success: no issues found in 1
source file", pytest 15 passed (13 existing + 2 new).

Third-party origin: none.