### PR TITLE
fix(router): match C++/C#/.NET targets regardless of surrounding word boundary

### DIFF
--- a/src/agentos/agentos_router/task_type.py
+++ b/src/agentos/agentos_router/task_type.py
@@ -123,11 +123,27 @@ _TRANSLATE_RES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
 #: is the only guard — it exists because the task is different, not because the
 #: translation is judged hard. Suppression is the safe direction: it forfeits a
 #: saving and hands the turn back to ordinary model routing.
+#: ``c++`` and ``c#`` end in a non-word character, and ``.net`` starts with
+#: one, so a plain ``\b(?:...)\b`` around all three names in one alternation
+#: silently requires the *wrong* side to be a word character: it demands a
+#: word character immediately after ``c++``/``c#`` (so "C++." never matches)
+#: and immediately before ``.net`` (so "to .NET" never matches), while a
+#: version suffix or an attached framework name ("C++17", "ASP.NET") happens
+#: to satisfy the wrong-side requirement and matches by accident. These three
+#: names are pulled out of the shared group with no boundary assertion on
+#: their non-word edge — ``+``/``#``/``.`` already can't blend into a
+#: surrounding identifier, so a plain ``\b`` on the word-character edge alone
+#: is enough, and it now matches consistently whether the name sits at a
+#: sentence boundary ("C++.", "to .NET") or has a version/suffix attached
+#: ("C++17", "C#7", "ASP.NET").
 _CODE_TARGET_RE = re.compile(
     r"\b(?:python|javascript|typescript|golang|rust|java|kotlin|swift|scala"
     r"|haskell|ruby|php|perl|sql|bash|powershell|matlab|fortran|cobol"
-    r"|c\+\+|c#|\.net|react|vue|svelte|jquery|regex|assembly|solidity"
-    r"|dart|elixir|erlang|clojure|lua|zig)\b",
+    r"|react|vue|svelte|jquery|regex|assembly|solidity"
+    r"|dart|elixir|erlang|clojure|lua|zig)\b"
+    r"|\bc\+\+"
+    r"|\bc#"
+    r"|\.net\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_agentos_router/test_task_type.py
+++ b/tests/test_agentos_router/test_task_type.py
@@ -121,6 +121,68 @@ class TestProgrammingLanguageTarget:
         verdict = detect_task_type(f"Dịch tài liệu sau sang tiếng Việt:\n\n{body}")
         assert verdict.task_type == TASK_TYPE_TRANSLATE
 
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            # Sentence-final / punctuation-adjacent: the originally reported bug.
+            "Translate this function to C++.",
+            "Translate this code to C#.",
+            "Translate this service to .NET.",
+            "Translate this module to .NET Core.",
+            "Dịch đoạn code này sang C++ giúp tôi.",
+            "Dịch code này sang C# nhé.",
+            # Version/edition suffix directly attached: a following word
+            # character must not defeat the match either.
+            "Translate this to C++17.",
+            "Translate this to C++11, keep behaviour identical.",
+            "Translate this to C#7.",
+            "Translate this to C#9 with pattern matching.",
+            # Framework name directly attached to ".NET" with no space: a
+            # preceding word character must not defeat the match.
+            "We use ASP.NET for the backend, please translate this handler.",
+            "Please translate this class to VB.NET.",
+            # Product name directly attached to "C++" with no space: a
+            # *following* letter (not just a digit) must not defeat the
+            # match either. This guards against narrowing the fix to a
+            # digit-only lookahead exception, which would still miss this.
+            "Please translate this to C++Builder syntax.",
+        ],
+    )
+    def test_programming_language_targets_with_symbols_block(self, prompt: str) -> None:
+        """``c++``/``c#``/``.net`` block regardless of what is on their non-word edge.
+
+        ``+``, ``#``, and the leading ``.`` are never word characters, so a
+        plain ``\\b`` on *that* edge alone is enough — it must not also
+        require the punctuation/version-suffix/attached-name edge to look a
+        particular way.
+        """
+        verdict = detect_task_type(prompt)
+        assert verdict.task_type is None
+        assert verdict.blocked_by == BLOCK_CODE_TARGET
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            # "c++"/"c#" embedded inside a longer identifier must still NOT
+            # match — dropping the boundary assertion on *both* edges would
+            # wrongly block these on the strength of an unrelated substring.
+            "Translate this doc, mention the abc++def helper by name.",
+            "Translate this doc, reference ticket src#123 in the notes.",
+            "Translate this ticket management#42 into French.",
+        ],
+    )
+    def test_embedded_symbol_substrings_do_not_block(self, prompt: str) -> None:
+        """A ``c++``/``c#`` substring embedded in a longer identifier is not a target.
+
+        The leading ``\\b`` on ``c++``/``c#`` must still require a real word
+        boundary before the ``c`` — otherwise any identifier that happens to
+        contain ``c++`` or ``c#`` (e.g. a variable or ticket name) would be
+        misclassified as a code-porting request.
+        """
+        verdict = detect_task_type(prompt)
+        assert verdict.task_type == TASK_TYPE_TRANSLATE
+        assert verdict.blocked_by is None
+
 
 class TestScanWindow:
     """Instructions bracket a pasted body; the middle is not scanned."""


### PR DESCRIPTION
## Linked issue
Fixes #1198
- [x] This pull request fully resolves the linked issue

## Summary
`_CODE_TARGET_RE` wraps c++/c#/.net inside a single `\b(?:...)\b` group. Since
`+`, `#`, and the leading `.` are non-word characters, that group silently
requires a word character on the *wrong* side: after `c++`/`c#` (so "C++."
never matches punctuation/space/EOL) and before `.net` (so "to .NET" never
matches when preceded by whitespace). That's the reported bug.

PR #1199 is already open on this issue and fixes the reported cases, but it
does so by inverting the assertion to `(?!\w)` for c++/c# and `(?<!\w)` for
.net. That over-corrects: it now requires the *opposite* side to be
non-word, breaking exactly the cases that used to work by accident:
- `(?!\w)` after c++/c# fails whenever anything is directly attached —
  "Translate this to C++17.", "Translate this to C#7.", and
  "Translate this to C++Builder syntax." all stop matching.
- `(?<!\w)` before .net fails whenever a framework name is attached —
  "ASP.NET" and "VB.NET" both stop matching.
Verified empirically against #1199's actual diff (fetched via
`git fetch origin pull/1199/head`) and against a digit-only-exception
variant as a second alternative — both still fail on at least one of these
real phrasings. Version-numbered/attached mentions are at least as common
in real porting requests as the bare "C++." case, so this is a meaningful
regression, not an edge case.

## Fix
`+`, `#`, and the leading `.` can never blend into a surrounding identifier,
so no boundary assertion is needed on that side at all. c++/c#/.net are
pulled out of the shared alternation with a `\b` only on their
word-character edge:
- `\bc\+\+` / `\bc#` — leading `\b` still prevents matching inside a longer
  identifier (e.g. "abc++def", "src#123" do not match); no trailing
  assertion, so "C++.", "C++17", and "C++Builder" all match.
- `\.net\b` — trailing `\b` still prevents matching inside a longer word
  (e.g. ".networking" does not match); no leading assertion, so both
  "to .NET" and "ASP.NET" match.

Minimal, surgical change to one regex and its docstring — nothing else in
the module is touched.

## Tests
Added two parametrized tests:
- `test_programming_language_targets_with_symbols_block` (13 cases): the 3
  originally-reported bug cases, 2 Vietnamese-verb equivalents, 4
  version/edition-suffix cases, 2 attached-framework-name cases, and 1
  attached-product-name case (guards against narrowing the fix to a
  digit-only exception).
- `test_embedded_symbol_substrings_do_not_block` (3 cases): confirms
  `c++`/`c#` embedded inside an unrelated identifier or ticket number does
  NOT trigger the block (guards against a fix that drops the boundary
  assertion on both edges instead of one).

Commands run and results:
  uv run ruff check src/agentos/agentos_router/task_type.py tests/test_agentos_router/test_task_type.py
    -> All checks passed!
  uv run ruff format --check src/agentos/agentos_router/task_type.py tests/test_agentos_router/test_task_type.py
    -> 2 files already formatted
  uv run mypy src/agentos/agentos_router/task_type.py --show-error-codes
    -> Success: no issues found in 1 source file
  uv run pytest tests/test_agentos_router/test_task_type.py -v
    -> 53 passed
  uv run pytest tests/test_agentos_router/ -q (excluding numpy-only pilot-model tests, unrelated to this change)
    -> 138 passed, 2 skipped

Third-party origin: none.