### PR TITLE
fix(mcp): hold the events_wait clamp against deadline rounding

### DIFF
--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -157,10 +157,17 @@ class AgentOSMCPBridge:
             )
             max_events = _clamp_limit(max_events, _MAX_EVENTS_WAIT_EVENTS)
             timeout_ms = min(max(0, timeout_ms), _MAX_EVENTS_WAIT_TIMEOUT_MS)
-            deadline = time.monotonic() + timeout_ms / 1000
+            budget_s = timeout_ms / 1000
+            deadline = time.monotonic() + budget_s
 
             while len(events) < max_events:
-                remaining = deadline - time.monotonic()
+                # Cap against the budget as well as the deadline. Adding
+                # budget_s to a large monotonic reading rounds up, so
+                # ``deadline - now`` can exceed the budget by a few
+                # picoseconds when the clock has not ticked between the two
+                # readings -- routine on a coarse timer. Harmless to wait on,
+                # but it means the clamp does not actually hold.
+                remaining = min(deadline - time.monotonic(), budget_s)
                 if remaining <= 0:
                     break
                 try:

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -342,8 +342,19 @@ async def test_transcript_jsonl_clamps_limit_through_messages_read() -> None:
     ]
 
 
+# A monotonic reading for which ``(t + 300.0) - t`` rounds to slightly MORE
+# than 300.0. Real clocks land on values like this routinely; pinning one makes
+# the rounding deterministic instead of a rare CI failure.
+_ROUNDS_UP_MONOTONIC = 16330.771337564662
+
+
 @pytest.mark.asyncio
-async def test_events_wait_clamps_effective_deadline() -> None:
+async def test_events_wait_clamps_effective_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Frozen clock: the reading is identical on both calls, which is what a
+    # coarse timer does and what makes the float rounding observable.
+    monkeypatch.setattr(bridge_module.time, "monotonic", lambda: _ROUNDS_UP_MONOTONIC)
     client = RecordingEventClient()
     bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
 
@@ -353,6 +364,8 @@ async def test_events_wait_clamps_effective_deadline() -> None:
     first_timeout = client.recv_timeouts[0]
     assert first_timeout is not None
     # The deadline must come from the clamped timeout, not the requested hour.
+    # Exact, not approximate: with this clock the unclamped subtraction yields
+    # 300.0000000000018, so a tolerance here would hide the defect.
     assert first_timeout <= bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
 
 


### PR DESCRIPTION
Fixes #1264

## The bug

`events_wait` clamps the requested timeout, then derives each `recv_event` wait from a deadline (`src/agentos/mcp_server/bridge.py`):

```python
timeout_ms = min(max(0, timeout_ms), _MAX_EVENTS_WAIT_TIMEOUT_MS)
deadline = time.monotonic() + timeout_ms / 1000
...
remaining = deadline - time.monotonic()
```

`deadline` is a rounded double. When the clock does not tick between the two `time.monotonic()` calls — routine on a coarse timer — `deadline - now` is the rounding error of the addition, and it can land just *above* the budget.

`test_events_wait_clamps_effective_deadline` asserts the clamp with no tolerance, so it fails whenever that happens:

```
E       assert 300.00000000000006 <= (300000 / 1000)
E        +  where 300000 = bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS
```

Measured, with a pinned monotonic reading of `16330.771337564662`:

| | value |
|---|---|
| budget | `300.0` |
| `deadline - now`, before | `300.0000000000018` |
| `deadline - now`, after | `300.0` |

Sampling 400k plausible `time.monotonic()` readings, about **1 in 1,700** rounds up. That matches how it presents: an occasional red `Lint, test, and build (windows-latest, 3.12)` on pull requests that touch nothing nearby. It reddened CI on an unrelated PR of mine, which is how I found it.

The clamping code and this test arrived with the fix for #685 — this is a residual rounding defect in it, not a regression from a later change.

## The fix

Cap `remaining` against the budget as well as the deadline, so the clamp is exact rather than approximate:

```python
budget_s = timeout_ms / 1000
deadline = time.monotonic() + budget_s
...
remaining = min(deadline - time.monotonic(), budget_s)
```

Deliberately **not** a tolerance on the assertion. The invariant the test states — the wait never exceeds the clamp — is the correct invariant; it just was not true. Loosening the assertion would have kept the test green while leaving the clamp leaky.

## Tests

`test_events_wait_clamps_effective_deadline` now pins a monotonic reading that rounds up, instead of sampling whatever the machine's clock happens to be:

```python
_ROUNDS_UP_MONOTONIC = 16330.771337564662
monkeypatch.setattr(bridge_module.time, "monotonic", lambda: _ROUNDS_UP_MONOTONIC)
```

A frozen reading is exactly what a coarse timer produces across two adjacent calls, so this is the real condition rather than an artificial one. Two consequences worth stating:

- Against the unfixed source the test now **fails every run** (`300.0000000000018 <= 300.0`). Before this change it passed on almost every run and failed rarely — it was asserting something it could not reliably detect.
- The flake is gone by construction, not by widening the bound.

The assertion itself is unchanged.

## Verification

```
uv run pytest tests/test_mcp_server tests/test_mcp -q
96 passed

uv run ruff check src tests
All checks passed!

uv run mypy src/agentos --show-error-codes
Success: no issues found in 623 source files
```

`ruff format` also wants to collapse an unrelated multi-line `raw_url` assignment two hunks above (99 chars, so it fits). That is pre-existing drift and CI runs `ruff check`, not `ruff format --check`, so I reverted it rather than ship a restyle of code this change does not touch.

## One adjacent case, deliberately left alone

`transcript_jsonl` and the other clamped limits in this file are integer comparisons, so they cannot drift this way. Nothing else in `bridge.py` derives a bound by subtracting two float clock readings — checked before deciding this was a one-site fix rather than a pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
