### PR TITLE
fix(skills): make xlsx set_cell honour an explicit null

### DIFF
--- a/src/agentos/skills/bundled/xlsx/SKILL.md
+++ b/src/agentos/skills/bundled/xlsx/SKILL.md
@@ -97,6 +97,7 @@ python {baseDir}/scripts/edit_xlsx.py book.xlsx ops.json --out edited.xlsx
 [
   {"op": "set_cell", "sheet": "Q3", "row": 2, "col": 2, "value": "=SUM(B3:B10)"},
   {"op": "set_cell", "sheet": "Q3", "row": 5, "col": 1, "value": "Net margin"},
+  {"op": "set_cell", "sheet": "Q3", "row": 6, "col": 1, "value": null},
   {"op": "rename_sheet", "old": "Sheet1", "new": "Summary"}
 ]
 ```
@@ -104,6 +105,13 @@ python {baseDir}/scripts/edit_xlsx.py book.xlsx ops.json --out edited.xlsx
 Rules:
 
 - Rows and columns are 1-based (Excel convention).
+- An explicit `"value": null` **clears** the cell and keeps its style. It is
+  the only way to empty a cell through this op list.
+- Omitting `value` entirely is a malformed operation: it is skipped and not
+  counted in `applied`, so a typo cannot silently wipe a cell.
+- `0`, `false` and `""` are values, not absence. Note that Excel has no
+  empty-string cell, so `""` reads back as empty — use `null` when you mean
+  "clear this cell".
 - Strings starting with `=` are written as formulas (`cell.value = "=..."`),
   matching openpyxl behavior. To write a literal `=hello`, pass
   `as_text: true` — either as `{"value": "=hello", "as_text": true}` or with

--- a/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
@@ -4,8 +4,17 @@ Operations:
     {"op": "set_cell", "sheet": "Q3", "row": 1, "col": 1, "value": "..."}
     {"op": "set_cell", "sheet": "Q3", "row": 2, "col": 2, "value": "=SUM(B3:B10)"}
     {"op": "set_cell", "sheet": "Q3", "row": 3, "col": 3, "value": "=hello", "as_text": true}
+    {"op": "set_cell", "sheet": "Q3", "row": 4, "col": 1, "value": null}
     {"op": "rename_sheet", "old": "Sheet1", "new": "Summary"}
     {"op": "merge_cells", "sheet": "Q3", "range": "A1:C1"}
+
+`value` semantics for `set_cell`:
+
+* An explicit ``null`` **clears** the cell. It is the only way to express that
+  in this op schema, and the cell's style is left alone.
+* A **missing** ``value`` key is a malformed operation: it is skipped and not
+  counted in ``applied``, so a typo cannot silently wipe data.
+* ``0``, ``false`` and ``""`` are values, not absence, and are written as given.
 """
 
 from __future__ import annotations
@@ -18,6 +27,11 @@ from pathlib import Path
 from typing import Any
 
 from openpyxl import load_workbook
+
+# Distinguishes {"value": null} from an op with no "value" key at all.
+# ``op.get("value")`` collapses both to None, which would make a malformed
+# operation indistinguishable from a deliberate clear.
+_MISSING = object()
 
 
 def _coerce(value: Any, as_text: bool) -> Any:
@@ -60,13 +74,21 @@ def apply_ops(wb: Any, ops: list[dict[str, Any]]) -> int:
             sheet_name = op.get("sheet")
             row = op.get("row")
             col = op.get("col")
-            value = op.get("value")
+            value = op.get("value", _MISSING)
             if sheet_name not in wb.sheetnames or row is None or col is None:
+                continue
+            if value is _MISSING:
                 continue
             ws = wb[sheet_name]
             as_text = bool(op.get("as_text"))
             coerced = _coerce(value, as_text)
-            cell = ws.cell(row=int(row), column=int(col), value=coerced)
+            # Assign through the property, not Worksheet.cell(value=...): that
+            # helper ends with `if value is not None: cell.value = value`, so an
+            # explicit null only *reads* the cell and the old value survives
+            # while this loop still counts the edit as applied. Fetching the
+            # cell first also leaves its style untouched.
+            cell = ws.cell(row=int(row), column=int(col))
+            cell.value = coerced
             if as_text and isinstance(coerced, str):
                 # Assigning a string that starts with ``=`` makes openpyxl mark
                 # the cell as a formula, so the string type has to be restored

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -391,3 +393,181 @@ def test_the_apostrophe_escape_is_not_consumed_without_as_text(tmp_path: Path) -
     sheet = _edit_and_reload(tmp_path, [_set_cell(2, "'=hello")])
 
     assert sheet.cell(row=2, column=1).value == "'=hello"
+
+
+
+def _import_scripts() -> tuple[Any, Any, Any]:
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+        import edit_xlsx  # type: ignore[import-not-found]
+        import inspect_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    return create_xlsx, edit_xlsx, inspect_xlsx
+
+
+def _run_cli(
+    edit_xlsx: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    src: Path,
+    out: Path,
+    ops: list[dict[str, Any]],
+    tmp_path: Path,
+) -> dict[str, Any]:
+    """Drive the script the way a caller does: ops file in, workbook out.
+
+    In-process rather than a subprocess, matching how the other bundled-skill
+    tests are run on Windows. Going through ``main`` is what matters here: the
+    reported ``applied`` count is part of the contract being fixed, and reading
+    the saved file back is the only way to see whether a write really happened
+    -- the in-memory workbook would look right either way.
+    """
+    ops_path = tmp_path / "ops.json"
+    ops_path.write_text(json.dumps(ops), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["edit_xlsx.py", str(src), str(ops_path), "--out", str(out)])
+    assert edit_xlsx.main() == 0
+    return dict(json.loads(capsys.readouterr().out.strip()))
+
+
+def _cell(path: Path, row: int, col: int, sheet: str = "S") -> Any:
+    """Read one cell from the saved file.
+
+    Addressed directly rather than through ``inspect``: clearing the only
+    populated cell leaves the sheet with no used range at all, so a row-indexed
+    read would raise IndexError instead of reporting the value as empty.
+    """
+    from openpyxl import load_workbook
+
+    return load_workbook(str(path))[sheet].cell(row=row, column=col).value
+
+
+def test_set_cell_explicit_null_clears_the_cell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    create_xlsx, edit_xlsx, inspect_xlsx = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["keep me"]]}]}).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [{"op": "set_cell", "sheet": "S", "row": 1, "col": 1, "value": None}],
+        tmp_path,
+    )
+
+    assert report == {"applied": 1}
+    assert _cell(out, 1, 1) is None
+
+
+def test_set_cell_without_a_value_key_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A malformed op must not read as "clear this cell", and must not be
+    # counted -- otherwise a typo silently wipes data and reports success.
+    create_xlsx, edit_xlsx, inspect_xlsx = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["keep me"]]}]}).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [{"op": "set_cell", "sheet": "S", "row": 1, "col": 1}],
+        tmp_path,
+    )
+
+    assert report == {"applied": 0}
+    assert _cell(out, 1, 1) == "keep me"
+
+
+@pytest.mark.parametrize(("value", "expected"), [(0, 0), (False, False)])
+def test_set_cell_writes_falsy_values(
+    value: Any,
+    expected: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Guards the fix: these are values, not absence. The type assertion is the
+    # point -- False must stay a boolean rather than collapse to 0.
+    create_xlsx, edit_xlsx, _ = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["old"]]}]}).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [{"op": "set_cell", "sheet": "S", "row": 1, "col": 1, "value": value}],
+        tmp_path,
+    )
+
+    assert report == {"applied": 1}
+    written = _cell(out, 1, 1)
+    assert written == expected
+    assert isinstance(written, type(expected))
+
+
+def test_set_cell_empty_string_counts_as_an_edit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Excel has no empty-string cell, so openpyxl round-trips "" as None. That
+    # is unchanged by this fix and is why "" is not a substitute for an
+    # explicit null: the op still counts as applied either way, but only the
+    # null path is documented as clearing.
+    create_xlsx, edit_xlsx, _ = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["old"]]}]}).save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    report = _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [{"op": "set_cell", "sheet": "S", "row": 1, "col": 1, "value": ""}],
+        tmp_path,
+    )
+
+    assert report == {"applied": 1}
+    assert _cell(out, 1, 1) is None
+
+
+def test_clearing_a_cell_keeps_its_style(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from openpyxl import load_workbook
+
+    create_xlsx, edit_xlsx, _ = _import_scripts()
+    src = tmp_path / "book.xlsx"
+    wb = create_xlsx.build({"sheets": [{"name": "S", "rows": [["styled"]]}]})
+    wb["S"].cell(row=1, column=1).number_format = "0.00%"
+    wb.save(str(src))
+
+    out = tmp_path / "out.xlsx"
+    _run_cli(
+        edit_xlsx,
+        monkeypatch,
+        capsys,
+        src,
+        out,
+        [{"op": "set_cell", "sheet": "S", "row": 1, "col": 1, "value": None}],
+        tmp_path,
+    )
+
+    cell = load_workbook(str(out))["S"].cell(row=1, column=1)
+    assert cell.value is None
+    assert cell.number_format == "0.00%"


### PR DESCRIPTION
Fixes #1260

## The bug

`edit_xlsx.py` wrote every `set_cell` through openpyxl's helper:

```python
ws.cell(row=int(row), column=int(col), value=_coerce(value, bool(op.get("as_text"))))
applied += 1
```

`Worksheet.cell()` in openpyxl 3.1.5 ends with:

```python
cell = self._get_cell(row, column)
if value is not None:
    cell.value = value
return cell
```

So an explicit `{"value": null}` only *reads* the cell. The previous value survives, and the loop still counts the edit — the script exits 0 reporting `{"applied": 1}`. As @andreapn put it in the issue, the part that makes this worth fixing is not the null semantics but that **the script reports a successful edit for an operation it did not perform**, with no way for a caller to notice short of reopening the workbook.

Measured through the CLI on `upstream/main` (`ef2739e`), one cell containing `keep me`:

| ops | reported | cell after, before | cell after, this PR |
|---|---|---|---|
| `{"value": null}` | `{"applied": 1}` | `"keep me"` | *(empty)* |
| `{"value": null}` on a `0.00%` cell | `{"applied": 1}` | value kept | cleared, format kept |
| no `value` key | `{"applied": 1}` | `"keep me"` | `{"applied": 0}`, `"keep me"` |

## The fix

Follows the contract @andreapn set out in the issue, point for point.

**Explicit null clears the cell** — assign through the property rather than the `value=` keyword:

```python
cell = ws.cell(row=int(row), column=int(col))
cell.value = _coerce(value, bool(op.get("as_text")))
```

Fetching the cell first is also what keeps its style: `_get_cell` returns the existing cell, and assigning `.value` does not touch formatting.

**A missing `value` key is rejected, not treated as a clear.** This is the half that makes the first half safe. `op.get("value")` collapsed *no key* and *explicit null* to the same `None`, so making null mean "clear" without separating them would have turned a typo into silent data loss. A sentinel separates them, and the malformed op is skipped without being counted — consistent with the `sheet`/`row`/`col` guards directly above it:

```python
_MISSING = object()
...
value = op.get("value", _MISSING)
if value is _MISSING:
    continue
```

**`0`, `false`, `""` unchanged.** They were already written (`0 is not None`) and still are.

**Documented** in the module docstring, and in `src/agentos/skills/bundled/xlsx/SKILL.md` — that file carries the op schema operators actually read, and AGENTS.md asks for bundled-skill docs to move with the behaviour.

## Tests

Five cases added to `tests/test_skill_xlsx.py`. Three fail against the unfixed script:

- an explicit null clears the cell, and the report says `applied: 1`
- an op with **no** `value` key leaves the cell alone and reports `applied: 0`
- clearing keeps the cell's `number_format`

Two pass either way, as guards rather than evidence:

- `0` and `false` are still written, asserting the **type** as well as the value — `False` must not collapse to `0`
- `""` still counts as an applied edit

Per @andreapn's note, each case goes **through the CLI** and reads the saved file back: `main()` is driven with a real ops file and `sys.argv`, so the reported `applied` count — part of the contract being fixed — is asserted alongside the cell. Asserting on the in-memory workbook would pass either way.

Two details worth flagging, both found by the tests failing for the wrong reason first:

- Reads go through `load_workbook`, not `inspect_xlsx`. Clearing the only populated cell leaves the sheet with no used range, so a row-indexed read raises `IndexError` instead of reporting the cell as empty.
- `""` round-trips as empty, not as `""` — Excel has no empty-string cell. That is openpyxl behaviour, unchanged here, and it is why `""` is not a substitute for `null`. The test asserts the real result rather than the one I first assumed.

In-process rather than a subprocess, matching 50ec47d ("run score.py in-process so the backtest test works on Windows").

## Verification

```
uv run pytest tests/test_skill_xlsx.py tests/test_skills_inventory.py \
              tests/test_skills_availability.py -q
58 passed

uv run ruff check src tests
All checks passed!

uv run mypy src/agentos --show-error-codes
Success: no issues found in 623 source files
```

## One adjacent case, deliberately left alone

`int(row)` / `int(col)` still raise on a non-numeric `row`, since the guard above only rejects `None`. That crashes the script with a traceback instead of skipping the op, which is a different defect from this one — the ops here are wrong-result, that one is wrong-failure-mode — and #1260 does not describe it. Happy to follow up separately rather than widen this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
