### PR TITLE
fix(scheduler): accept day-of-week ranges ending at SUN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Day-of-week ranges that end at `SUN` parse again. `_parse_field` substituted
+  every day name with a single number, and `sun` is always 0 there, so
+  `SAT-SUN` reached the range check as `6-0` and `MON-SUN` as `1-0` — reversed
+  ranges, rejected with `CronParseError: Range start > end in field
+  'day_of_week'`. POSIX cron spells Sunday both 0 and 7 and reads the trailing
+  one as 7, which the parser already honoured for the numeric spelling: `WED-7`
+  worked while the `WED-SUN` a user would actually type did not. Names are now
+  substituted per token instead of by whole-string replace, so a `SUN` at the
+  upper bound of a range resolves to 7 unless the range already starts at
+  Sunday — `SAT-SUN` is `{0, 6}`, `MON-SUN` the whole week, and `SUN-WED` /
+  `SUN-SUN` keep the days they name
+  ([#1063](https://github.com/use-agent-os/agent-os/issues/1063)).
 - A JSON-RPC error whose `error` member is not an object no longer kills the
   command with an `AttributeError`. `RpcError.__init__` in
   `senior-unilp-manager` and `poolsdotfun-token-launcher` read the payload as

--- a/src/agentos/scheduler/parser.py
+++ b/src/agentos/scheduler/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -109,6 +110,37 @@ class CronExpression:
         return day_of_month_ok or day_of_week_ok
 
 
+_NAME_TOKEN_SPLIT_RE = re.compile(r"([-/])")
+
+
+def _substitute_names(part: str, names: dict[str, int], field_name: str) -> str:
+    """Replace month / day-of-week names in one comma-free field token.
+
+    POSIX: month and day-of-week names are case-insensitive ("case doesn't
+    matter"), so the token is lowercased before lookup and Mon-Fri / JAN / jan
+    all resolve. Substitution is per *token* rather than a whole-string
+    replace, because the numeric value a name maps to depends on where it sits:
+    Sunday is both 0 and 7, and only the position tells them apart.
+    """
+
+    tokens = _NAME_TOKEN_SPLIT_RE.split(part.lower())
+    values = [names.get(token) for token in tokens]
+
+    # POSIX lets Sunday be written 0 or 7, and cron/croniter read a trailing
+    # SUN as 7 — "SAT-SUN" is 6-7, not the reversed 6-0 that _parse_field would
+    # reject outright. Only the *upper* bound flips, and only when the range
+    # does not already start at Sunday, so "SUN-WED" stays 0-3 and "SUN-SUN"
+    # stays the single day it names.
+    if field_name == "day_of_week" and len(tokens) >= 3 and tokens[1] == "-":
+        if tokens[2] == "sun" and tokens[0] not in ("sun", "0", "7"):
+            values[2] = 7
+
+    return "".join(
+        str(value) if value is not None else token
+        for token, value in zip(tokens, values, strict=True)
+    )
+
+
 def _parse_field(token: str, field_name: str, names: dict[str, int] | None = None) -> CronField:
     lo, hi = _FIELD_RANGES[field_name]
     values: set[int] = set()
@@ -116,15 +148,7 @@ def _parse_field(token: str, field_name: str, names: dict[str, int] | None = Non
     for part in token.split(","):
         part = part.strip()
         if names:
-            # POSIX: month and day-of-week names are case-insensitive ("case
-            # doesn't matter"). Lowercase the token before substituting so
-            # Mon-Fri / JAN / jan all resolve; digits and the -, /, * ,
-            # separators are unaffected by lower().
-            part = part.lower()
-            sub_parts = part.replace("/", "§").replace("-", "¶")
-            for name, val in names.items():
-                sub_parts = sub_parts.replace(name, str(val))
-            part = sub_parts.replace("§", "/").replace("¶", "-")
+            part = _substitute_names(part, names, field_name)
 
         if "/" in part:
             range_part, step_str = part.split("/", 1)

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -65,6 +65,44 @@ def test_parse_cron_dow_ranges_may_end_at_7() -> None:
     assert expr.day_of_week.values == frozenset({0, 3, 4, 5, 6})
 
 
+def test_parse_cron_dow_ranges_may_end_at_sun_by_name() -> None:
+    # POSIX spells Sunday 0 or 7, and at the *upper* bound of a range it is 7 —
+    # "SAT-SUN" is 6-7. Substituting the name with 0 unconditionally made it
+    # 6-0, which _parse_field rejects as reversed, so every weekend-ish
+    # schedule a user would write by name died with CronParseError while its
+    # numeric spelling parsed fine.
+    assert parse_cron("0 0 * * SAT-SUN").day_of_week.values == frozenset({0, 6})
+    assert parse_cron("0 0 * * WED-SUN").day_of_week.values == frozenset({0, 3, 4, 5, 6})
+    assert parse_cron("0 0 * * MON-SUN").day_of_week.values == frozenset({0, 1, 2, 3, 4, 5, 6})
+    # Named and numeric spellings of the same range must agree.
+    assert parse_cron("0 0 * * WED-SUN").day_of_week.values == (
+        parse_cron("0 0 * * WED-7").day_of_week.values
+    )
+    assert parse_cron("0 0 * * sat-sun").day_of_week.values == frozenset({0, 6})
+
+
+def test_parse_cron_dow_sun_at_range_start_is_still_zero() -> None:
+    # Only the upper bound flips to 7. A range that *starts* at Sunday keeps
+    # 0, so "SUN-WED" stays four days and "SUN-SUN" stays one — reading the
+    # trailing SUN as 7 there would silently turn it into the whole week.
+    assert parse_cron("0 0 * * SUN-WED").day_of_week.values == frozenset({0, 1, 2, 3})
+    assert parse_cron("0 0 * * SUN-SUN").day_of_week.values == frozenset({0})
+    assert parse_cron("0 0 * * 0-SUN").day_of_week.values == frozenset({0})
+
+
+def test_parse_cron_dow_sun_range_with_step() -> None:
+    # The step branch parses the same range, so it must see 6-7 too.
+    assert parse_cron("0 0 * * SAT-SUN/2").day_of_week.values == frozenset({6})
+    assert parse_cron("0 0 * * MON-SUN/2").day_of_week.values == frozenset({0, 1, 3, 5})
+
+
+def test_parse_cron_sat_sun_matches_the_weekend() -> None:
+    expr = parse_cron("0 0 * * SAT-SUN")
+    assert expr.matches(datetime(2026, 8, 29, 0, 0))  # a Saturday
+    assert expr.matches(datetime(2026, 8, 30, 0, 0))  # the Sunday after it
+    assert not expr.matches(datetime(2026, 8, 31, 0, 0))  # the Monday after that
+
+
 def test_parse_cron_dow_7_dedups_with_0_and_names() -> None:
     assert parse_cron("0 0 * * 0,7").day_of_week.values == frozenset({0})
     assert parse_cron("0 0 * * MON,7").day_of_week.values == frozenset({0, 1})


### PR DESCRIPTION
## Problem

`parse_cron` rejects every day-of-week range that ends at `SUN`:

```python
parse_cron("0 0 * * SAT-SUN")   # CronParseError: Range start > end in field 'day_of_week'
parse_cron("0 0 * * WED-SUN")   # same
parse_cron("0 0 * * MON-SUN")   # same
```

`_parse_field` substituted each day name with a single number and `_DOW_NAMES`
maps `sun` to 0 unconditionally, so `SAT-SUN` reached the range check as `6-0`
and `MON-SUN` as `1-0` — reversed ranges, refused outright.

POSIX cron spells Sunday both `0` and `7` and reads the trailing one as 7. The
parser already honoured that for the numeric spelling (`_FIELD_RANGES` allows
0–7, and a literal 7 collides onto 0 after parsing), so `WED-7` worked while
the `WED-SUN` a user would actually type did not. Both `parser.py` and
`test_parser.py` already carry comments calling `SAT-SUN` a valid range.

## Fix

Day and month names are substituted **per token** instead of by whole-string
replace, so the position of a name is available when its value is chosen. A
`SUN` at the upper bound of a range resolves to 7 — unless the range already
starts at Sunday, where 0 is the only sensible reading:

| Expression | Weekdays |
|---|---|
| `SAT-SUN` | `{0, 6}` |
| `WED-SUN` | `{0, 3, 4, 5, 6}` |
| `MON-SUN` | `{0, 1, 2, 3, 4, 5, 6}` |
| `SUN-WED` | `{0, 1, 2, 3}` |
| `SUN-SUN` | `{0}` |

Named and numeric spellings now agree (`WED-SUN` == `WED-7`).

Month names, case-insensitive matching (`Mon-Fri`), the step branch
(`SAT-SUN/2`), and the reversed-range rejection (`FRI-TUE`) are unchanged.

## Verification

- 7 new assertions across 4 regression tests in `tests/test_scheduler/test_parser.py`
- `uv run pytest tests/test_scheduler -q` → 497 passed
- `uv run ruff check src tests`, `uv run mypy src/agentos/scheduler` → clean

## Merge order

Touches only `src/agentos/scheduler/parser.py`, its test file, and one
`CHANGELOG.md` entry inserted at a slot no sibling PR uses. Verified
conflict-free against the other four PRs in this batch in all 120 merge
orderings.

Fixes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYt5ScoBmtFmh9rf8Wp3nX
