### PR TITLE
fix(skills): reject non-http endpoints in bundled skill scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   what `robinhood-chain-stocks` already does; `raw` still carries whatever
   came back and the dict path is unchanged
   ([#974](https://github.com/use-agent-os/agent-os/issues/974)).
+- Bundled skill scripts refuse endpoints that are not `http(s)`. Every one of
+  them reaches `urllib.request.urlopen`, which speaks `file:`, `ftp:` and
+  `data:` just as happily as HTTP, so an endpoint taken from argv or the
+  environment was an arbitrary local-file read: `watch_http_json.py --url
+  file:///etc/passwd` reported the file's contents on every cron tick, and
+  `--rpc file://…` did the same through the `poolsdotfun-token-launcher` and
+  `senior-unilp-manager` JSON-RPC clients. The `senior-unilp-manager` client
+  was doubly exposed — it took `rpc_url or resolve_rpc_url(chain)`, so an
+  override skipped the resolver and every check in it. Each entry point now
+  validates the scheme and host with `urlsplit` before the URL reaches
+  `urlopen`, matching the guard `robinhood-chain-stocks` already carries, and
+  the watcher tests serve their fixtures over loopback HTTP instead of
+  `file://` ([#1065](https://github.com/use-agent-os/agent-os/issues/1065)).
 - The sensitive-path denylist now expands `$VAR`/`${VAR}` before it decides,
   so the hard block cannot be side-stepped by spelling a home directory as a
   variable. Tool dispatch ends in a shell, so `cat $HOME/.ssh/config` reaches

--- a/src/agentos/skills/bundled/cron-watchers/SKILL.md
+++ b/src/agentos/skills/bundled/cron-watchers/SKILL.md
@@ -37,6 +37,10 @@ All three also take `--limit` (max lines per run, default 10) and
 `--first-run-reports` (report everything on the first run instead of starting
 quiet).
 
+`--url` must be `http://` or `https://`. Any other scheme is refused with exit
+code 1 — `urlopen` speaks `file:`, `ftp:` and `data:` too, and a watcher
+pointed at `file:///etc/passwd` would report the file's contents on every run.
+
 ## Install them first
 
 A cron job may only run files under `~/.agentos/scripts/`, so copy the ones you
@@ -44,12 +48,13 @@ need there before scheduling:
 
 ```sh
 mkdir -p ~/.agentos/scripts
-cp {baseDir}/scripts/_watermark.py ~/.agentos/scripts/
+cp {baseDir}/scripts/_watermark.py {baseDir}/scripts/_url.py ~/.agentos/scripts/
 cp {baseDir}/scripts/watch_rss.py ~/.agentos/scripts/
 ```
 
-`_watermark.py` is shared state-keeping used by all three — copy it alongside
-whichever watcher you install.
+`_watermark.py` (shared state-keeping) and `_url.py` (the `http(s)` check on
+`--url`) are used by all three — copy both alongside whichever watcher you
+install, or it will fail to start with an `ImportError`.
 
 ## Schedule one
 

--- a/src/agentos/skills/bundled/cron-watchers/scripts/_url.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/_url.py
@@ -1,0 +1,35 @@
+"""Shared URL guard for cron watcher scripts.
+
+A watcher's ``--url`` comes from a cron job definition, which an agent can
+write. ``urlopen`` is scheme-agnostic, so without this check a watcher pointed
+at ``file:///etc/passwd`` reads the file and reports its contents on every run.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+
+def require_http_url(url: str, label: str) -> str:
+    """Return *url* if it is an ``http(s)`` URL with a host, else raise ValueError.
+
+    ``urllib.request.urlopen`` also speaks ``file:``, ``ftp:`` and ``data:``, so
+    an unchecked endpoint turns this script into an arbitrary local-file reader:
+    ``file:///etc/passwd`` reads the file and hands the contents back to the
+    agent. Parsed with ``urlsplit`` rather than a ``startswith`` prefix test, so
+    neither ``HTTP://`` casing nor leading whitespace decides the answer.
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty {label}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid {label} {url!r}: {exc}") from exc
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError(
+            f"invalid {label} scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"{label} {url!r} has no host: must be http:// or https://")
+    return cleaned

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_http_json.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_http_json.py
@@ -26,6 +26,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from _url import require_http_url  # noqa: E402
 from _watermark import select_new  # noqa: E402
 
 USER_AGENT = "AgentOS-cron-watcher/1.0"
@@ -84,9 +85,15 @@ def main() -> int:
         if key.strip() and value.strip():
             headers[key.strip()] = value.strip()
 
-    request = urllib.request.Request(args.url, headers=headers)
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        target = require_http_url(args.url, "--url")
+    except ValueError as exc:
+        print(f"Refusing to fetch: {exc}", file=sys.stderr)
+        return 1
+
+    request = urllib.request.Request(target, headers=headers)  # noqa: S310 - http(s) only
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
             payload = json.loads(response.read().decode("utf-8", errors="replace"))
     except (urllib.error.URLError, TimeoutError) as exc:
         print(f"Request failed for {args.url}: {exc}", file=sys.stderr)

--- a/src/agentos/skills/bundled/cron-watchers/scripts/watch_rss.py
+++ b/src/agentos/skills/bundled/cron-watchers/scripts/watch_rss.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from _url import require_http_url  # noqa: E402
 from _watermark import select_new  # noqa: E402
 
 USER_AGENT = "AgentOS-cron-watcher/1.0"
@@ -69,9 +70,17 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    request = urllib.request.Request(args.url, headers={"User-Agent": USER_AGENT})
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        target = require_http_url(args.url, "--url")
+    except ValueError as exc:
+        print(f"Refusing to fetch: {exc}", file=sys.stderr)
+        return 1
+
+    request = urllib.request.Request(  # noqa: S310 - http(s) only
+        target, headers={"User-Agent": USER_AGENT}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
             body = response.read()
     except (urllib.error.URLError, TimeoutError) as exc:
         print(f"Feed fetch failed for {args.url}: {exc}", file=sys.stderr)

--- a/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
+++ b/src/agentos/skills/bundled/poolsdotfun-token-launcher/scripts/poolsfun/chains.py
@@ -19,6 +19,7 @@ the process environment only, never from argv.
 from __future__ import annotations
 
 import os
+import urllib.parse
 from pathlib import Path
 
 # Declared in SKILL.md frontmatter under `requires.env`. Keep the two in sync —
@@ -118,9 +119,36 @@ def load_env() -> None:
         return
 
 
+def require_http_url(url: str, label: str) -> str:
+    """Return *url* if it is an ``http(s)`` URL with a host, else raise ValueError.
+
+    ``urllib.request.urlopen`` also speaks ``file:``, ``ftp:`` and ``data:``, so
+    an unchecked endpoint turns this script into an arbitrary local-file reader:
+    ``file:///etc/passwd`` reads the file and hands the contents back to the
+    agent. Parsed with ``urlsplit`` rather than a ``startswith`` prefix test, so
+    neither ``HTTP://`` casing nor leading whitespace decides the answer.
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty {label}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid {label} {url!r}: {exc}") from exc
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError(
+            f"invalid {label} scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"{label} {url!r} has no host: must be http:// or https://")
+    return cleaned
+
+
 def resolve_rpc_url(override: str | None = None) -> str:
     """The RPC endpoint. Constant unless ``--rpc`` overrides it for debugging."""
-    return override or RPC_URL
+    if not override:
+        return RPC_URL
+    return require_http_url(override, "--rpc")
 
 
 def resolve_paired_asset(value: str | None) -> str:

--- a/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
+++ b/src/agentos/skills/bundled/senior-unilp-manager/SKILL.md
@@ -62,6 +62,8 @@ Every command below is written `python3 "$S"/<script>`. Use that form verbatim �
 `<S>` is not a variable, and in a shell it reads as a redirect from a file named `S`.
 
 Chain endpoints come from `RPC_ROBINHOOD_URL` and `RPC_BASE_URL`; `--rpc <url>` overrides.
+Both must be `http://` or `https://`; any other scheme is refused, because the
+JSON-RPC transport would otherwise read local files through `file://`.
 
 ---
 
@@ -718,6 +720,7 @@ different branches at every layer, and a hook can answer differently on each.
 | Symptom | Cause / fix |
 |---|---|
 | `no RPC url for …` | Set `RPC_ROBINHOOD_URL` / `RPC_BASE_URL`, or pass `--rpc <url>` |
+| `invalid --rpc scheme …` | The endpoint must be `http://` or `https://` |
 | `env var UNIV4_LP_PRIVATE_KEY is not set` | Set it in the agent environment — never as a flag |
 | `Base cannot serve a wide eth_getLogs range …` | Give the PoolKey directly (`--currency0 --currency1 --fee --tick-spacing`), or `--token <addr>` to derive it, or `--scan-logs` |
 | `could not derive the PoolKey for … from token …` | Not a launch pool, and not a hook-less pool at a conventional tier. Spell the PoolKey out, or `--scan-logs` |

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/chains.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/chains.py
@@ -13,6 +13,7 @@ any other module.
 from __future__ import annotations
 
 import os
+import urllib.parse
 from pathlib import Path
 
 # Env var names this skill declares in its SKILL.md frontmatter. Keep the two in
@@ -149,14 +150,39 @@ def resolve_chain(key_or_id: str | int | None = None) -> dict:
     raise ValueError(f'unknown chain "{key_or_id}". Known: {known} (or their chain ids)')
 
 
+def require_http_url(url: str, label: str) -> str:
+    """Return *url* if it is an ``http(s)`` URL with a host, else raise ValueError.
+
+    ``urllib.request.urlopen`` also speaks ``file:``, ``ftp:`` and ``data:``, so
+    an unchecked endpoint turns this script into an arbitrary local-file reader:
+    ``file:///etc/passwd`` reads the file and hands the contents back to the
+    agent. Parsed with ``urlsplit`` rather than a ``startswith`` prefix test, so
+    neither ``HTTP://`` casing nor leading whitespace decides the answer.
+    """
+    cleaned = (url or "").strip()
+    if not cleaned:
+        raise ValueError(f"empty {label}")
+    try:
+        parsed = urllib.parse.urlsplit(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"invalid {label} {url!r}: {exc}") from exc
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError(
+            f"invalid {label} scheme {parsed.scheme!r} in {url!r}: must be http:// or https://"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"{label} {url!r} has no host: must be http:// or https://")
+    return cleaned
+
+
 def resolve_rpc_url(chain: dict, override: str | None = None) -> str:
     if override:
-        return override
+        return require_http_url(override, "--rpc")
     load_env()
     for name in chain["rpcEnv"]:
         value = os.environ.get(name)
         if value:
-            return value
+            return require_http_url(value, name)
     names = " or ".join(chain["rpcEnv"])
     raise RuntimeError(
         f"no RPC url for {chain['name']}. Set {names} in the agent environment "

--- a/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
+++ b/src/agentos/skills/bundled/senior-unilp-manager/scripts/unilp/rpc.py
@@ -89,7 +89,9 @@ class RpcClient:
     def __init__(self, chain: dict, rpc_url: str | None = None, timeout: int = 60,
                  debug: bool = False, allow_batch: bool = True) -> None:
         self.chain = chain
-        self.url = rpc_url or resolve_rpc_url(chain)
+        # Routed through resolve_rpc_url even when overridden, so the
+        # http(s) guard sees --rpc too; it returns the override unchanged.
+        self.url = resolve_rpc_url(chain, rpc_url)
         self.timeout = timeout
         self.debug = debug
         self._allow_batch = allow_batch

--- a/tests/test_skill_bundled_url_scheme.py
+++ b/tests/test_skill_bundled_url_scheme.py
@@ -1,0 +1,174 @@
+"""Bundled skill scripts must refuse non-``http(s)`` endpoints (Issue #1065).
+
+``urllib.request.urlopen`` is scheme-agnostic: it speaks ``file:``, ``ftp:``
+and ``data:`` as happily as HTTP. Every place a bundled script takes an
+endpoint from argv or the environment is therefore an arbitrary local-file
+read — ``--url file:///etc/passwd`` on a cron watcher reports the file's
+contents back to the agent on every run, and ``--rpc file://…`` does the same
+through a JSON-RPC client. Each entry point validates the scheme up front, the
+way ``robinhood-chain-stocks`` already does.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BUNDLED = _REPO_ROOT / "src" / "agentos" / "skills" / "bundled"
+_WATCHERS = _BUNDLED / "cron-watchers" / "scripts"
+
+#: Every scheme that reaches a filesystem, a non-HTTP service, or inline data.
+_REJECTED = [
+    "file:///etc/passwd",
+    "file:///C:/Windows/System32/drivers/etc/hosts",
+    "ftp://example.com/secret",
+    "data:application/json,[]",
+    "/etc/passwd",
+    "",
+    "   ",
+    "http://",
+]
+
+
+def _load_flat(path: Path, name: str) -> ModuleType:
+    """Import a flat script file directly, with its own directory importable.
+
+    Loaded in-process rather than run through ``subprocess``: the scripts are
+    not on ``PATH`` and spawning an interpreter per case is both slow and
+    platform-sensitive on Windows CI.
+    """
+    entry = str(path.parent)
+    added = entry not in sys.path
+    if added:
+        sys.path.insert(0, entry)
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if added:
+            sys.path.remove(entry)
+
+
+def _load_package(package: str, scripts_dir: Path, module: str) -> ModuleType:
+    entry = str(scripts_dir)
+    added = entry not in sys.path
+    if added:
+        sys.path.insert(0, entry)
+    try:
+        return importlib.import_module(f"{package}.{module}")
+    finally:
+        if added:
+            sys.path.remove(entry)
+
+
+# --- the shared cron-watcher guard ---------------------------------------
+
+
+@pytest.mark.parametrize("url", _REJECTED)
+def test_watcher_guard_rejects_non_http(url: str) -> None:
+    guard = _load_flat(_WATCHERS / "_url.py", "cron_watchers_url")
+    with pytest.raises(ValueError):
+        guard.require_http_url(url, "--url")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.example.com/events",
+        "http://localhost:8080/events",
+        "HTTP://Example.COM/events",
+    ],
+)
+def test_watcher_guard_accepts_http(url: str) -> None:
+    guard = _load_flat(_WATCHERS / "_url.py", "cron_watchers_url")
+    assert guard.require_http_url(url, "--url") == url.strip()
+
+
+def test_watcher_guard_strips_surrounding_whitespace() -> None:
+    guard = _load_flat(_WATCHERS / "_url.py", "cron_watchers_url")
+    assert guard.require_http_url("  https://example.com/f  ", "--url") == "https://example.com/f"
+
+
+# --- the watchers themselves ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("script", "module_name"),
+    [
+        ("watch_http_json.py", "watch_http_json_under_test"),
+        ("watch_rss.py", "watch_rss_under_test"),
+    ],
+)
+def test_watcher_refuses_file_url_without_opening_it(
+    script: str,
+    module_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    watcher = _load_flat(_WATCHERS / script, module_name)
+
+    def explode(*args: Any, **kwargs: Any) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("urlopen must not be reached for a file:// target")
+
+    monkeypatch.setattr(watcher.urllib.request, "urlopen", explode)
+    monkeypatch.setattr(sys, "argv", [script, "--url", "file:///etc/passwd", "--name", "probe"])
+
+    assert watcher.main() == 1
+    assert "Refusing to fetch" in capsys.readouterr().err
+
+
+# --- the JSON-RPC skills --------------------------------------------------
+
+
+def test_poolsfun_rpc_override_must_be_http() -> None:
+    scripts = _BUNDLED / "poolsdotfun-token-launcher" / "scripts"
+    chains = _load_package("poolsfun", scripts, "chains")
+    with pytest.raises(ValueError, match="must be http"):
+        chains.resolve_rpc_url("file:///etc/passwd")
+    # The constant default and a real override still resolve.
+    assert chains.resolve_rpc_url().startswith("http")
+    assert chains.resolve_rpc_url("https://rpc.example.com") == "https://rpc.example.com"
+
+
+def test_unilp_rpc_override_must_be_http() -> None:
+    scripts = _BUNDLED / "senior-unilp-manager" / "scripts"
+    chains = _load_package("unilp", scripts, "chains")
+    chain = next(iter(chains.CHAINS.values())) if hasattr(chains, "CHAINS") else None
+    assert chain is not None, "expected a chain registry to test against"
+    with pytest.raises(ValueError, match="must be http"):
+        chains.resolve_rpc_url(chain, "file:///etc/passwd")
+
+
+def test_unilp_rpc_env_value_must_be_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The endpoint can also arrive from the environment, which a skill-config
+    # write reaches just as an argv override does.
+    scripts = _BUNDLED / "senior-unilp-manager" / "scripts"
+    chains = _load_package("unilp", scripts, "chains")
+    chain = next(iter(chains.CHAINS.values()))
+    monkeypatch.setattr(chains, "load_env", lambda: None)
+    for name in chain["rpcEnv"]:
+        monkeypatch.setenv(name, "file:///etc/passwd")
+    with pytest.raises(ValueError, match="must be http"):
+        chains.resolve_rpc_url(chain)
+
+
+def test_unilp_client_validates_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    # RpcClient took `rpc_url or resolve_rpc_url(chain)`, so an override
+    # skipped the resolver — and with it every check the resolver performs.
+    scripts = _BUNDLED / "senior-unilp-manager" / "scripts"
+    rpc = _load_package("unilp", scripts, "rpc")
+    chains = _load_package("unilp", scripts, "chains")
+    chain = next(iter(chains.CHAINS.values()))
+    with pytest.raises(ValueError, match="must be http"):
+        rpc.RpcClient(chain, rpc_url="file:///etc/passwd")

--- a/tests/test_skills/test_cron_watchers.py
+++ b/tests/test_skills/test_cron_watchers.py
@@ -2,7 +2,12 @@
 
 Their whole contract is "print only what is new, print nothing otherwise" —
 that is what makes a cron script job stay quiet — so these drive each script
-end to end over ``file://`` URLs and assert on stdout and exit code.
+end to end and assert on stdout and exit code.
+
+Fixtures are served over a loopback HTTP server rather than ``file://``: the
+watchers only speak ``http(s)`` now, because a watcher that accepts any scheme
+``urlopen`` supports is an arbitrary local-file reader (Issue #1065). Loopback
+keeps the run offline and the port is picked by the OS.
 """
 
 from __future__ import annotations
@@ -10,6 +15,9 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -41,6 +49,25 @@ def state_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+class _QuietHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass  # keep pytest's captured stderr about the test, not the server
+
+
+@pytest.fixture
+def base_url(state_dir):
+    """Serve ``state_dir`` over loopback HTTP and yield its base URL."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), partial(_QuietHandler, directory=str(state_dir)))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=10)
+
+
 def _run(script: str, *args: str, env_home: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(SCRIPTS / script), *args],
@@ -55,17 +82,17 @@ def _run(script: str, *args: str, env_home: Path) -> subprocess.CompletedProcess
     )
 
 
-def _feed(tmp_path: Path, name: str, body: str) -> str:
+def _feed(tmp_path: Path, base: str, name: str, body: str) -> str:
     path = tmp_path / name
     path.write_text(body, encoding="utf-8")
-    return path.as_uri()
+    return f"{base}/{name}"
 
 
 # ── watch_rss ───────────────────────────────────────────────────────────────
 
 
-def test_rss_first_run_is_silent(state_dir):
-    url = _feed(state_dir, "feed.xml", RSS)
+def test_rss_first_run_is_silent(state_dir, base_url):
+    url = _feed(state_dir, base_url, "feed.xml", RSS)
 
     result = _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir)
 
@@ -73,8 +100,8 @@ def test_rss_first_run_is_silent(state_dir):
     assert result.stdout == ""
 
 
-def test_rss_first_run_can_report_everything(state_dir):
-    url = _feed(state_dir, "feed.xml", RSS)
+def test_rss_first_run_can_report_everything(state_dir, base_url):
+    url = _feed(state_dir, base_url, "feed.xml", RSS)
 
     result = _run(
         "watch_rss.py", "--url", url, "--name", "t", "--first-run-reports", env_home=state_dir
@@ -85,12 +112,13 @@ def test_rss_first_run_can_report_everything(state_dir):
     assert "Second post" in result.stdout
 
 
-def test_rss_reports_only_what_is_new(state_dir):
-    url = _feed(state_dir, "feed.xml", RSS)
+def test_rss_reports_only_what_is_new(state_dir, base_url):
+    url = _feed(state_dir, base_url, "feed.xml", RSS)
     _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir)
 
     _feed(
         state_dir,
+        base_url,
         "feed.xml",
         RSS.replace(
             "</channel>",
@@ -105,8 +133,8 @@ def test_rss_reports_only_what_is_new(state_dir):
     assert "First post" not in result.stdout
 
 
-def test_rss_unchanged_feed_stays_silent(state_dir):
-    url = _feed(state_dir, "feed.xml", RSS)
+def test_rss_unchanged_feed_stays_silent(state_dir, base_url):
+    url = _feed(state_dir, base_url, "feed.xml", RSS)
     _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir)
 
     result = _run("watch_rss.py", "--url", url, "--name", "t", env_home=state_dir)
@@ -115,8 +143,8 @@ def test_rss_unchanged_feed_stays_silent(state_dir):
     assert result.stdout == ""
 
 
-def test_rss_reads_atom_entries(state_dir):
-    url = _feed(state_dir, "atom.xml", ATOM)
+def test_rss_reads_atom_entries(state_dir, base_url):
+    url = _feed(state_dir, base_url, "atom.xml", ATOM)
 
     result = _run(
         "watch_rss.py", "--url", url, "--name", "a", "--first-run-reports", env_home=state_dir
@@ -126,8 +154,8 @@ def test_rss_reads_atom_entries(state_dir):
     assert "Atom one" in result.stdout
 
 
-def test_rss_fails_loudly_on_a_broken_feed(state_dir):
-    url = _feed(state_dir, "broken.xml", "not xml at all")
+def test_rss_fails_loudly_on_a_broken_feed(state_dir, base_url):
+    url = _feed(state_dir, base_url, "broken.xml", "not xml at all")
 
     result = _run("watch_rss.py", "--url", url, "--name", "b", env_home=state_dir)
 
@@ -135,8 +163,8 @@ def test_rss_fails_loudly_on_a_broken_feed(state_dir):
     assert "not valid XML" in result.stderr
 
 
-def test_watermarks_are_per_name(state_dir):
-    url = _feed(state_dir, "feed.xml", RSS)
+def test_watermarks_are_per_name(state_dir, base_url):
+    url = _feed(state_dir, base_url, "feed.xml", RSS)
     _run("watch_rss.py", "--url", url, "--name", "one", env_home=state_dir)
 
     result = _run(
@@ -149,24 +177,24 @@ def test_watermarks_are_per_name(state_dir):
 # ── watch_http_json ─────────────────────────────────────────────────────────
 
 
-def _events(tmp_path: Path, items: list[dict]) -> str:
-    return _feed(tmp_path, "events.json", json.dumps({"data": {"events": items}}))
+def _events(tmp_path: Path, base: str, items: list[dict]) -> str:
+    return _feed(tmp_path, base, "events.json", json.dumps({"data": {"events": items}}))
 
 
-def test_json_reports_only_new_items(state_dir):
-    url = _events(state_dir, [{"event_id": "a1", "title": "Deploy finished"}])
+def test_json_reports_only_new_items(state_dir, base_url):
+    url = _events(state_dir, base_url, [{"event_id": "a1", "title": "Deploy finished"}])
     args = ("--url", url, "--name", "j", "--id-field", "event_id", "--items-path", "data.events")
     _run("watch_http_json.py", *args, env_home=state_dir)
 
-    _events(state_dir, [{"event_id": "a2", "title": "Alert cleared"}])
+    _events(state_dir, base_url, [{"event_id": "a2", "title": "Alert cleared"}])
     result = _run("watch_http_json.py", *args, env_home=state_dir)
 
     assert result.returncode == 0
     assert result.stdout.strip() == "- Alert cleared"
 
 
-def test_json_accepts_a_top_level_list(state_dir):
-    url = _feed(state_dir, "list.json", json.dumps([{"id": "x", "name": "thing"}]))
+def test_json_accepts_a_top_level_list(state_dir, base_url):
+    url = _feed(state_dir, base_url, "list.json", json.dumps([{"id": "x", "name": "thing"}]))
 
     result = _run(
         "watch_http_json.py",
@@ -182,8 +210,8 @@ def test_json_accepts_a_top_level_list(state_dir):
     assert "thing" in result.stdout
 
 
-def test_json_reports_the_requested_fields(state_dir):
-    url = _events(state_dir, [{"event_id": "a1", "title": "t", "sev": "high"}])
+def test_json_reports_the_requested_fields(state_dir, base_url):
+    url = _events(state_dir, base_url, [{"event_id": "a1", "title": "t", "sev": "high"}])
 
     result = _run(
         "watch_http_json.py",
@@ -204,8 +232,8 @@ def test_json_reports_the_requested_fields(state_dir):
     assert "sev='high'" in result.stdout
 
 
-def test_json_fails_when_the_path_holds_no_list(state_dir):
-    url = _events(state_dir, [])
+def test_json_fails_when_the_path_holds_no_list(state_dir, base_url):
+    url = _events(state_dir, base_url, [])
 
     result = _run(
         "watch_http_json.py",
@@ -220,6 +248,32 @@ def test_json_fails_when_the_path_holds_no_list(state_dir):
 
     assert result.returncode == 1
     assert "Expected a list" in result.stderr
+
+
+# ── URL scheme guard (Issue #1065) ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("script", ["watch_rss.py", "watch_http_json.py"])
+def test_watcher_refuses_a_file_url(script, state_dir):
+    # urlopen speaks file:// as happily as http://, so an unguarded --url made
+    # every watcher an arbitrary local-file reader that reported the contents
+    # on each run. Asserted at the real entry point, not just at the helper.
+    secret = state_dir / "secret.json"
+    secret.write_text('[{"id": "1", "name": "leaked"}]', encoding="utf-8")
+
+    result = _run(script, "--url", secret.as_uri(), "--name", "t", env_home=state_dir)
+
+    assert result.returncode == 1
+    assert "must be http:// or https://" in result.stderr
+    assert "leaked" not in result.stdout
+
+
+@pytest.mark.parametrize("url", ["ftp://example.com/x", "data:application/json,[]", "/etc/passwd"])
+def test_watcher_refuses_other_non_http_schemes(url, state_dir):
+    result = _run("watch_http_json.py", "--url", url, "--name", "t", env_home=state_dir)
+
+    assert result.returncode == 1
+    assert "Refusing to fetch" in result.stderr
 
 
 # ── watch_github ────────────────────────────────────────────────────────────

--- a/tests/test_skills/test_cron_watchers.py
+++ b/tests/test_skills/test_cron_watchers.py
@@ -13,6 +13,7 @@ keeps the run offline and the port is picked by the OS.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import threading
@@ -69,15 +70,26 @@ def base_url(state_dir):
 
 
 def _run(script: str, *args: str, env_home: Path) -> subprocess.CompletedProcess[str]:
+    # A deliberately small environment, so a watcher cannot reach the
+    # developer's own state. Windows is the exception: a child started without
+    # the system variables cannot initialise Winsock, and every fetch then dies
+    # with `WinError 10106` before it reaches the fixture server. State stays
+    # isolated either way — the watermark store reads AGENTOS_STATE_DIR first.
+    if os.name == "nt":
+        env = dict(os.environ)
+        env["USERPROFILE"] = str(env_home)
+    else:
+        env = {"PATH": "/usr/bin:/bin"}
+    env["AGENTOS_STATE_DIR"] = str(env_home / "state")
+    env["HOME"] = str(env_home)
+    # Loopback must never go through a proxy the runner happens to configure.
+    env["NO_PROXY"] = "127.0.0.1,localhost"
+    env["no_proxy"] = "127.0.0.1,localhost"
     return subprocess.run(
         [sys.executable, str(SCRIPTS / script), *args],
         capture_output=True,
         text=True,
-        env={
-            "PATH": "/usr/bin:/bin",
-            "AGENTOS_STATE_DIR": str(env_home / "state"),
-            "HOME": str(env_home),
-        },
+        env=env,
         timeout=60,
     )
 


### PR DESCRIPTION
## Problem

Every bundled script that takes an endpoint hands it to
`urllib.request.urlopen`, which speaks `file:`, `ftp:` and `data:` as happily
as HTTP. An endpoint that arrives from argv or the environment was therefore an
arbitrary local-file read:

```sh
python .../cron-watchers/scripts/watch_http_json.py \
  --url file:///c:/Users/SHATTER/.vscode/agent-os/frontend/package.json \
  --name test --first-run-reports
```

The cron watchers report the file's contents on every tick; the two JSON-RPC
skills read it through their transport (`--rpc file:///etc/passwd`).
`senior-unilp-manager` was doubly exposed — `RpcClient` took
`rpc_url or resolve_rpc_url(chain)`, so an override skipped the resolver and
with it every check the resolver performs.

`robinhood-rwa-addresses` already carries this guard (fixed separately); the
rest did not.

## Fix

Each entry point validates scheme **and** host with `urlsplit` before the URL
reaches `urlopen`, matching the guard `robinhood-chain-stocks` got in #816:

| Site | Input |
|---|---|
| `cron-watchers/scripts/watch_http_json.py` | `--url` |
| `cron-watchers/scripts/watch_rss.py` | `--url` |
| `poolsdotfun-token-launcher` `chains.resolve_rpc_url` | `--rpc` |
| `senior-unilp-manager` `chains.resolve_rpc_url` | `--rpc`, `RPC_*_URL` |
| `senior-unilp-manager` `RpcClient.__init__` | routed through the resolver |

The two watchers share one `_url.py` next to the existing `_watermark.py`; the
two RPC skills carry their own copy, because bundled scripts must run
standalone. `urlsplit` rather than `startswith`, so neither `HTTP://` casing
nor leading whitespace decides the answer. A watcher exits 1 with
`Refusing to fetch: …` on stderr.

The cron-watcher install instructions in `SKILL.md` now copy `_url.py`
alongside `_watermark.py`, or an installed watcher would fail with an
`ImportError`.

## Test changes

`tests/test_skills/test_cron_watchers.py` drove the scripts over `file://`
fixtures — the very thing being blocked. It now serves those fixtures over a
loopback `ThreadingHTTPServer` on an OS-assigned port: still offline, still
deterministic, and it exercises the real HTTP path the watchers take in
production.

## Verification

- New `tests/test_skill_bundled_url_scheme.py` (18 cases): all 18 fail on `main`, all pass here
- 4 new cases in `test_cron_watchers.py` assert the refusal at the real
  subprocess boundary and that the file's contents never reach stdout
- `uv run pytest tests/test_skills tests/test_skill_bundled_url_scheme.py tests/test_public_release_hygiene.py -q` → 72 passed, 1 skipped
- `uv run ruff check src tests` clean; `uv run mypy src/agentos` clean apart from
  the pre-existing `mem0_provider.py:121` stub error present on `upstream/main`

## Merge order

Touches only files under `src/agentos/skills/bundled/` plus its two test files
and one `CHANGELOG.md` entry at a slot no sibling PR uses. Verified
conflict-free against the other four PRs in this batch in all 120 merge
orderings.

Fixes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYt5ScoBmtFmh9rf8Wp3nX
