### PR TITLE
fix(cli): resolve PATH case-insensitively on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   variable does not exist, and the workspace exception still applies to the
   expanded path
   ([#985](https://github.com/use-agent-os/agent-os/issues/985)).
+- `agentos upgrade` keeps the operator's real `PATH` on Windows. Windows
+  environment variables are case-insensitive and the OS spells the search path
+  `Path`, but `hardened_path_env` copied the environment into a plain dict —
+  which is case-*sensitive* — then read `env.get("PATH", "")` and got nothing.
+  It wrote the fallback login dirs back under a brand-new `PATH` key, so the
+  environment carried two competing variables and the one the upgrade
+  subprocess reads no longer contained `uv`, `pipx`, or anything else the user
+  had installed. `resolve_tool` compounded it by reading `hardened["PATH"]`
+  directly: the miss handed `shutil.which` a `None` path, falling back to the
+  un-hardened process environment the helper exists to replace. Both now
+  resolve the key case-insensitively on Windows and write back to whichever
+  spelling was already there; POSIX still treats `PATH` and `Path` as the
+  different variables they are
+  ([#1069](https://github.com/use-agent-os/agent-os/issues/1069)).
 - A tool result too large for the whole disk budget is refused before the
   store is pruned, instead of after every record in it has been deleted.
   `_prune_to_fit` took the oldest records off one at a time chasing room for a

--- a/src/agentos/cli/install_method.py
+++ b/src/agentos/cli/install_method.py
@@ -252,24 +252,53 @@ def detect_install_method(
     return InstallMethod.UNKNOWN
 
 
+#: Windows environment variables are case-insensitive; POSIX ones are not.
+#: Read through this rather than ``os.name`` so the case rule can be exercised
+#: from either platform's test run.
+_CASE_INSENSITIVE_ENV_KEYS = os.name == "nt"
+
+
+def _env_key(env: dict[str, str], name: str) -> str:
+    """The key in ``env`` that spells ``name``, honouring Windows case rules.
+
+    Windows environment variables are case-insensitive and the OS hands the
+    canonical ``Path`` spelling to child processes. Copying such an environment
+    into a plain ``dict`` makes it case-*sensitive*, so a literal ``"PATH"``
+    lookup misses and a literal ``"PATH"`` assignment adds a second, competing
+    key. POSIX keeps the exact-match behaviour: there ``PATH`` and ``Path`` are
+    genuinely different variables and only ``PATH`` is the search path.
+    """
+
+    if name in env or not _CASE_INSENSITIVE_ENV_KEYS:
+        return name
+    folded = name.casefold()
+    for key in env:
+        if key.casefold() == folded:
+            return key
+    return name
+
+
 def hardened_path_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
     """Return an env copy whose ``PATH`` includes the standard login dirs.
 
     The augmented directories are *appended* so an operator's own ordering is
-    preserved; only genuinely-missing login locations are added.
+    preserved; only genuinely-missing login locations are added. The existing
+    key is reused verbatim, so a Windows environment spelling it ``Path`` keeps
+    its real entries instead of being shadowed by an empty ``PATH``.
     """
 
     env = dict(base_env if base_env is not None else os.environ)
-    current = env.get("PATH", "")
+    path_key = _env_key(env, "PATH")
+    current = env.get(path_key, "")
     entries = [p for p in current.split(os.pathsep) if p]
     seen = set(entries)
-    home = env.get("HOME") or str(Path.home())
+    home = env.get(_env_key(env, "HOME")) or str(Path.home())
     login_dirs = list(_LOGIN_PATH_DIRS) + [str(Path(home) / ".local" / "bin")]
     for extra in login_dirs:
         if extra not in seen:
             entries.append(extra)
             seen.add(extra)
-    env["PATH"] = os.pathsep.join(entries)
+    env[path_key] = os.pathsep.join(entries)
     return env
 
 
@@ -282,7 +311,11 @@ def resolve_tool(tool: str, env: dict[str, str] | None = None) -> str | None:
     """
 
     hardened = hardened_path_env(env)
-    resolved = shutil.which(tool, path=hardened.get("PATH"))
+    # Same case rule as the hardening itself: on Windows the search path may be
+    # spelled ``Path``, and a literal ``"PATH"`` miss here would silently hand
+    # ``shutil.which`` a ``None`` path and fall back to the un-hardened
+    # ``os.environ``, which is the PATH gap this function exists to close.
+    resolved = shutil.which(tool, path=hardened.get(_env_key(hardened, "PATH")))
     if resolved:
         return str(Path(resolved).resolve())
     return None

--- a/tests/test_cli/test_install_method.py
+++ b/tests/test_cli/test_install_method.py
@@ -140,6 +140,61 @@ def test_hardened_path_appends_login_dirs() -> None:
     assert "/home/u/.local/bin" in parts
 
 
+def test_hardened_path_preserves_windows_path_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Windows env vars are case-insensitive and the OS spells the search path
+    # "Path". Copying that environment into a plain dict makes it
+    # case-sensitive, so env.get("PATH") returned "" and env["PATH"] = ... added
+    # a *second* key holding only the fallback dirs — the operator's real
+    # binaries were dropped from the PATH the upgrade subprocess reads.
+    monkeypatch.setattr(im, "_CASE_INSENSITIVE_ENV_KEYS", True)
+    env = {"Path": r"C:\Program Files\uv\bin", "HOME": "/home/u"}
+    out = im.hardened_path_env(env)
+    assert "PATH" not in out  # no competing duplicate key
+    # Asserted with startswith rather than a pathsep split: os.pathsep is ":"
+    # when this runs on POSIX, which would cut the drive letter off.
+    assert out["Path"].startswith(r"C:\Program Files\uv\bin")
+    assert "/opt/homebrew/bin" in out["Path"]  # fallback dirs still appended
+
+
+def test_hardened_path_windows_prefers_exact_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An exact "PATH" wins even when a differently-cased key is also present,
+    # so the lookup never silently moves to the wrong variable.
+    monkeypatch.setattr(im, "_CASE_INSENSITIVE_ENV_KEYS", True)
+    env = {"Path": "/wrong", "PATH": "/right", "HOME": "/home/u"}
+    out = im.hardened_path_env(env)
+    assert out["Path"] == "/wrong"
+    assert out["PATH"].split(os.pathsep)[0] == "/right"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX treats PATH and Path as different variables; the case-folding "
+    "lookup is Windows-only by design",
+)
+def test_hardened_path_posix_does_not_case_fold() -> None:
+    env = {"Path": "/not/the/search/path", "HOME": "/home/u"}
+    out = im.hardened_path_env(env)
+    assert out["Path"] == "/not/the/search/path"  # untouched
+    assert "/not/the/search/path" not in out["PATH"].split(os.pathsep)
+
+
+def test_resolve_tool_uses_windows_path_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # resolve_tool read hardened["PATH"] directly, so on Windows it handed
+    # shutil.which a None path and fell back to the process environment —
+    # exactly the un-hardened PATH this helper exists to replace.
+    monkeypatch.setattr(im, "_CASE_INSENSITIVE_ENV_KEYS", True)
+    seen: dict[str, str | None] = {}
+
+    def fake_which(tool: str, path: str | None = None) -> str | None:
+        seen["path"] = path
+        return None
+
+    monkeypatch.setattr(im.shutil, "which", fake_which)
+    assert im.resolve_tool("uv", {"Path": "/some/bin", "HOME": "/home/u"}) is None
+    assert seen["path"] is not None
+    assert "/some/bin" in str(seen["path"]).split(os.pathsep)
+
+
 def test_hardened_path_no_duplicates() -> None:
     env = {"PATH": "/opt/homebrew/bin:/x", "HOME": "/home/u"}
     parts = im.hardened_path_env(env)["PATH"].split(os.pathsep)


### PR DESCRIPTION
## Problem

Windows environment variables are case-insensitive and the OS spells the search
path `Path`. `hardened_path_env` copies the environment into a plain `dict` —
which is case-**sensitive** — so `env.get("PATH", "")` returned nothing and
`env["PATH"] = …` wrote the fallback login dirs into a brand-new key:

```console
$ python -c "from agentos.cli.install_method import hardened_path_env; \
    env = hardened_path_env({'Path': 'C:\\Program Files\\uv\\bin'}); \
    print('Path in env:', 'Path' in env, '| PATH in env:', 'PATH' in env, \
          '| In PATH:', 'C:\\Program Files\\uv\\bin' in env['PATH'])"
Path in env: True | PATH in env: True | In PATH: False
```

The environment then carried two competing variables, and the one the upgrade
subprocess reads no longer contained `uv`, `pipx`, or anything else the
operator had installed — the exact PATH gap this helper exists to close.

`resolve_tool` compounds it: `hardened.get("PATH")` misses for the same reason
and hands `shutil.which` a `None` path, which falls back to the un-hardened
process environment.

## Fix

A small `_env_key` helper resolves the key case-insensitively **on Windows
only**, preferring an exact match when one exists, and both call sites use it.
`hardened_path_env` writes back to whichever spelling was already there, so no
duplicate key is created. `HOME` is looked up the same way.

POSIX behaviour is untouched: there `PATH` and `Path` really are different
variables and only `PATH` is the search path, so the lookup stays exact. The
platform check reads a module constant rather than `os.name` directly, so the
case rule is exercisable from either platform's CI run (monkeypatching
`os.name` itself makes `pathlib.Path` construct a `WindowsPath` and blow up on
POSIX).

## Verification

- 4 new tests in `tests/test_cli/test_install_method.py`; the three that assert
  the new behaviour fail on `main`
- Covers: the `Path`-only env, an exact `PATH` winning over a differently-cased
  key, POSIX **not** case-folding, and `resolve_tool` passing the hardened path
  to `shutil.which`
- `uv run pytest tests/test_cli -q` → 762 passed
- `uv run ruff check src tests`, `uv run mypy src/agentos/cli` → clean

## Merge order

Touches only `src/agentos/cli/install_method.py`, its test file, and one
`CHANGELOG.md` entry at a slot no sibling PR uses. Verified conflict-free
against the other four PRs in this batch in all 120 merge orderings.

Fixes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYt5ScoBmtFmh9rf8Wp3nX
