### PR TITLE
fix(tools): close indirect destructive calls in the code_exec gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   cleanup, so there is one exit path for the tempdir instead of six that skip
   it. A configured workspace still sets no `cleanup_dir` and is never removed
   ([#1010](https://github.com/use-agent-os/agent-os/issues/1010)).
+- Three residual bypasses of the `code_exec` destructive gate are closed.
+  `compile()` was invisible to it: `_eval_const_str` returned `None` for every
+  `ast.Call`, so `exec(compile('os.re' + 'move("/x")', '', 'exec'))` carried
+  the payload past a scanner that never read the source argument. The module
+  resolver understood `__import__("os")` as a bare name and
+  `importlib.import_module("os")` as an attribute, but not
+  `getattr(__builtins__, "__import__")("os")` — a nested call — so the module
+  it produced stayed unresolved and `.system("rm -rf …")` on the result went
+  unnoticed. And `os.system`, `os.popen` and `subprocess.run`/`Popen` are
+  deliberately absent from `_ALL_DESTRUCTIVE_NAMES`, because only their argv is
+  destructive, which meant the `getattr` branch skipped them outright while the
+  attribute branch never saw `getattr(os, "sys" + "tem")("…")` at all — its
+  callee is a call, not an attribute. `compile()` now resolves to its source
+  argument, the resolver reads `getattr`-obtained `__import__`, and an
+  indirect-callee check covers the shell-exec entry points
+  ([#1102](https://github.com/use-agent-os/agent-os/issues/1102)).
 - A replacement agent task stays in `AgentTaskRegistry` when its predecessor
   finishes winding down. Cancellation is not synchronous: `register()` may put
   a new task under a session key while the cancelled one is still settling,

--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -55,6 +55,9 @@ _ALL_DESTRUCTIVE_NAMES: frozenset[str] = frozenset(
 _SUBPROCESS_CALL_NAMES: frozenset[str] = frozenset(
     {"run", "call", "Popen", "check_output", "check_call"}
 )
+#: Shell-exec entry points. Not destructive on their own — only the argv is —
+#: so they are deliberately kept out of ``_ALL_DESTRUCTIVE_NAMES``.
+_OS_SHELL_EXEC_ATTRS: frozenset[str] = frozenset({"system", "popen"})
 
 
 def _eval_const_str(node: ast.AST) -> str | None:
@@ -76,6 +79,18 @@ def _eval_const_str(node: ast.AST) -> str | None:
                 return None
             parts.append(part)
         return "".join(parts)
+    if isinstance(node, ast.Call):
+        # compile("os.rem" + "ove('/x')", "", "exec") is a code carrier: what
+        # exec()/eval() receives is the compiled form of this string, so the
+        # source argument has to be read here or the inner code is never
+        # scanned at all.
+        if isinstance(node.func, ast.Name) and node.func.id == "compile":
+            source: ast.AST | None = node.args[0] if node.args else None
+            for keyword in node.keywords:
+                if keyword.arg == "source":
+                    source = keyword.value
+            if source is not None:
+                return _eval_const_str(source)
     return None
 
 
@@ -96,7 +111,55 @@ def _resolve_module_from_node(node: ast.AST, aliases: dict[str, str]) -> str | N
                 mod = _eval_const_str(node.args[0])
                 if mod:
                     return aliases.get(mod, mod)
+        # builtins.__import__("os") and getattr(__builtins__, "__import__")("os"):
+        # the callee is an Attribute or a nested Call, so neither branch above
+        # sees it and the resulting module went unresolved.
+        callee_attr: str | None = None
+        if isinstance(node.func, ast.Attribute):
+            callee_attr = node.func.attr
+        else:
+            target = _resolve_getattr_target(node.func, aliases)
+            if target is not None:
+                callee_attr = target[1]
+        if callee_attr == "__import__" and node.args:
+            mod = _eval_const_str(node.args[0])
+            if mod:
+                return aliases.get(mod, mod)
     return None
+
+
+def _resolve_getattr_target(
+    node: ast.AST, aliases: dict[str, str]
+) -> tuple[str | None, str] | None:
+    """Return ``(module, attr)`` when *node* is a statically readable ``getattr``.
+
+    ``getattr(os, "sys" + "tem")`` resolves to ``("os", "system")``. The module
+    is ``None`` when the object is not one of the tracked modules, which still
+    lets callers act on the attribute name alone.
+    """
+    if not isinstance(node, ast.Call):
+        return None
+    if not (isinstance(node.func, ast.Name) and node.func.id == "getattr"):
+        return None
+    if len(node.args) < 2:
+        return None
+    attr = _eval_const_str(node.args[1])
+    if attr is None:
+        return None
+    return _resolve_module_from_node(node.args[0], aliases), attr
+
+
+def _argv_removes(node: ast.AST) -> bool:
+    """True when a command argument statically resolves to an ``rm``/``rmdir``.
+
+    Handles both argv shapes a shell-exec call takes: a list of parts, and a
+    single command string.
+    """
+    if isinstance(node, ast.List):
+        parts = [_eval_const_str(elt) for elt in node.elts]
+        return any(part in ("rm", "rmdir") for part in parts if part is not None)
+    command = _eval_const_str(node)
+    return bool(command and re.search(r"\b(rm|rmdir)\b", command))
 
 
 class _DestructiveCodeVisitor(ast.NodeVisitor):
@@ -143,8 +206,37 @@ class _DestructiveCodeVisitor(ast.NodeVisitor):
                     self.destructive_funcs[target] = f"shutil.{name}()"
         self.generic_visit(node)
 
+    def _indirect_call_reason(self, node: ast.Call) -> str | None:
+        """Reason when the callee is a ``getattr`` result rather than a name.
+
+        ``getattr(os, "system")("rm -rf /etc")`` puts an ``ast.Call`` in the
+        callee position, so neither the ``ast.Name`` branch nor the
+        ``ast.Attribute`` branch below ever inspects it. The plain ``getattr``
+        branch does not help either: it only matches attributes in
+        ``_ALL_DESTRUCTIVE_NAMES``, and the shell-exec entry points are
+        deliberately not in that set because only their argv is destructive.
+        """
+        resolved = _resolve_getattr_target(node.func, self.module_aliases)
+        if resolved is None:
+            return None
+        mod, attr = resolved
+        if not node.args:
+            return None
+        if mod == "os" and attr in _OS_SHELL_EXEC_ATTRS and _argv_removes(node.args[0]):
+            return f"destructive Python operation detected: os.{attr} with rm via getattr"
+        if mod == "subprocess" and attr in _SUBPROCESS_CALL_NAMES and _argv_removes(node.args[0]):
+            return "destructive Python operation detected: subprocess invoking rm via getattr"
+        return None
+
     def visit_Call(self, node: ast.Call) -> None:
         if self.warning is not None:
+            return
+
+        # 0. Indirect callee: getattr(os, "system")("rm -rf /") — an ast.Call
+        #    sits where a Name or Attribute normally would.
+        indirect = self._indirect_call_reason(node)
+        if indirect is not None:
+            self.warning = indirect
             return
 
         # 1. Direct function call: remove(), r(), etc.
@@ -209,28 +301,23 @@ class _DestructiveCodeVisitor(ast.NodeVisitor):
                 self.warning = f"destructive Python operation detected: Path.{attr_name}()"
                 return
 
-            if mod == "os" and attr_name in ("system", "popen") and node.args:
-                cmd_str = _eval_const_str(node.args[0])
-                if cmd_str and re.search(r"\b(rm|rmdir)\b", cmd_str):
-                    self.warning = f"destructive Python operation detected: os.{attr_name} with rm"
-                    return
+            if (
+                mod == "os"
+                and attr_name in _OS_SHELL_EXEC_ATTRS
+                and node.args
+                and _argv_removes(node.args[0])
+            ):
+                self.warning = f"destructive Python operation detected: os.{attr_name} with rm"
+                return
 
-            if mod == "subprocess" and attr_name in _SUBPROCESS_CALL_NAMES and node.args:
-                first_arg = node.args[0]
-                if isinstance(first_arg, ast.List):
-                    parts = [_eval_const_str(elt) for elt in first_arg.elts]
-                    if any(p in ("rm", "rmdir") for p in parts if p is not None):
-                        self.warning = (
-                            "destructive Python operation detected: subprocess invoking rm"
-                        )
-                        return
-                else:
-                    cmd_str = _eval_const_str(first_arg)
-                    if cmd_str and re.search(r"\b(rm|rmdir)\b", cmd_str):
-                        self.warning = (
-                            "destructive Python operation detected: subprocess invoking rm"
-                        )
-                        return
+            if (
+                mod == "subprocess"
+                and attr_name in _SUBPROCESS_CALL_NAMES
+                and node.args
+                and _argv_removes(node.args[0])
+            ):
+                self.warning = "destructive Python operation detected: subprocess invoking rm"
+                return
 
         self.generic_visit(node)
 

--- a/tests/test_tools/test_code_exec_destructive_ast.py
+++ b/tests/test_tools/test_code_exec_destructive_ast.py
@@ -80,6 +80,62 @@ def test_benign_code_does_not_trigger_warning(code: str) -> None:
     assert warning is None, f"Unexpected warning for safe code: {warning}"
 
 
+@pytest.mark.parametrize(
+    ("code", "expected_keyword"),
+    [
+        # compile() as a code carrier: exec()/eval() receive the compiled form,
+        # so the source argument has to be read or the inner code is never
+        # scanned. _eval_const_str returned None for every ast.Call.
+        ("exec(compile('os.re' + 'move(\"/tmp/x\")', '', 'exec'))", "remove"),
+        ("eval(compile('os.remove(\"/tmp/x\")', '', 'eval'))", "remove"),
+        ("exec(compile(source='os.remove(\"/tmp/x\")', filename='', mode='exec'))", "remove"),
+        # getattr(__builtins__, "__import__")("os") — the module resolver
+        # handled __import__ as a bare Name and importlib.import_module as an
+        # Attribute, but not this nested-Call spelling.
+        ('getattr(__builtins__, "__import__")("os").system("rm -rf /tmp/x")', "os.system"),
+        ('import builtins; builtins.__import__("os").remove("/tmp/x")', "remove"),
+        ('getattr(__builtins__, "__im" + "port__")("shutil").rmtree("/tmp/x")', "rmtree"),
+        # Shell-exec attrs via getattr: os.system/os.popen and subprocess.* are
+        # deliberately not in _ALL_DESTRUCTIVE_NAMES (only their argv is
+        # destructive), so the getattr branch skipped them, and the callee is
+        # an ast.Call rather than an ast.Attribute so that branch missed it too.
+        ('import os; getattr(os, "system")("rm -rf /tmp/x")', "os.system"),
+        ('import os; getattr(os, "sys" + "tem")("rm -rf /tmp/x")', "os.system"),
+        ('import os; getattr(os, "popen")("rm -rf /tmp/x")', "os.popen"),
+        (
+            'import subprocess; getattr(subprocess, "run")(["rm", "-rf", "/tmp/x"])',
+            "subprocess invoking rm",
+        ),
+        (
+            'import subprocess as sp; getattr(sp, "Popen")("rm -rf /tmp/x")',
+            "subprocess invoking rm",
+        ),
+    ],
+)
+def test_indirect_destructive_calls_detected(code: str, expected_keyword: str) -> None:
+    # Residual bypasses of the Issue #848 gate (Issue #1102).
+    warning = _check_code_destructive(code)
+    assert warning is not None, f"Expected warning for: {code}"
+    assert "destructive Python operation detected:" in warning
+    assert expected_keyword.lower() in warning.lower()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # compile()/getattr are ordinary tools; only destructive payloads count.
+        "exec(compile('print(1)', '', 'exec'))",
+        "code = compile('x = 1 + 1', '<gen>', 'exec')",
+        "import os; getattr(os, 'system')('ls -la')",
+        "import subprocess; getattr(subprocess, 'run')(['ls', '-la'])",
+        "import os; fn = getattr(os, 'popen')",
+        "getattr(__builtins__, '__import__')('math').sqrt(16)",
+    ],
+)
+def test_benign_indirect_calls_do_not_trigger(code: str) -> None:
+    assert _check_code_destructive(code) is None, f"Unexpected warning for: {code}"
+
+
 def test_syntax_error_code_falls_back_to_regex() -> None:
     # Syntax error with os.remove() still caught by regex fallback
     bad_syntax_destructive = "os.remove( unclosed string"


### PR DESCRIPTION
## Problem

#848 / #890 closed the direct `getattr` / `__import__` / `exec` evasions
against the `code_exec` destructive gate. Three shapes were left unguarded and
still pass on `main`:

```python
_check_code_destructive("exec(compile('os.re' + 'move(\"/etc/passwd\")', '', 'exec'))")
# None  ← should be caught

_check_code_destructive("getattr(__builtins__, '__import__')('os').system('rm -rf /etc')")
# None  ← should be caught

_check_code_destructive("import os; getattr(os, 'system')('rm -rf /etc')")
# None  ← should be caught
```

Root causes:

1. **`compile()` as a code carrier.** `_eval_const_str` returned `None` for
   every `ast.Call`, so the source argument was never read and the inner code
   never scanned.
2. **`getattr(__builtins__, "__import__")("os")`.** `_resolve_module_from_node`
   handled `__import__` as a bare `ast.Name` and `importlib.import_module` as an
   `ast.Attribute`, but not this nested `ast.Call`, so the resulting module
   stayed unresolved and `.system(…)` on it went unnoticed.
3. **Shell-exec attrs via `getattr`.** `os.system`, `os.popen` and
   `subprocess.run`/`Popen` are deliberately absent from
   `_ALL_DESTRUCTIVE_NAMES` — only their argv is destructive — so the `getattr`
   branch skipped them, and `getattr(os, "sys" + "tem")("…")` also escaped the
   `ast.Attribute` branch because its callee is a call, not an attribute.

## Fix

- `_eval_const_str` resolves `compile(...)` to its source argument, positional
  or `source=`, recursively — a compiled carrier is scanned like a literal.
- `_resolve_module_from_node` reads a `getattr`-obtained `__import__` (and
  `builtins.__import__(…)`) via a new `_resolve_getattr_target` helper.
- A new `_indirect_call_reason` covers the shell-exec entry points when the
  callee is a `getattr` result, checked before the `Name`/`Attribute` branches.
- The list-vs-string argv handling `os.system` and `subprocess.*` each carried
  is shared as `_argv_removes`, so the two paths cannot drift.

Existing detections and messages are unchanged; `getattr(os, "remove")(…)` is
still caught by the existing branch.

## Verification

- 11 new detection cases and 6 new benign cases in
  `tests/test_tools/test_code_exec_destructive_ast.py`
- 9 of the 11 fail on `main` (the other 2 are already caught by the regex
  fast-path and pin that they stay caught)
- Benign set covers `exec(compile('print(1)', …))`, `getattr(os, 'system')('ls -la')`,
  `getattr(subprocess, 'run')(['ls', '-la'])` and
  `getattr(__builtins__, '__import__')('math').sqrt(16)`
- `uv run pytest tests/test_tools -q` → 1003 passed
- `uv run ruff check src tests`, `uv run mypy src/agentos/tools` → clean

## Merge order

Touches only `src/agentos/tools/builtin/code_exec.py`, its test file, and one
`CHANGELOG.md` entry at a slot no sibling PR uses. Verified conflict-free
against the other four PRs in this batch in all 120 merge orderings — including
#1092, which touches a different file in the same package.

Fixes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYt5ScoBmtFmh9rf8Wp3nX
