### PR TITLE
fix(search): report DuckDuckGo HTTP failures instead of returning [] (#1122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `urlopen`, matching the guard `robinhood-chain-stocks` already carries, and
   the watcher tests serve their fixtures over loopback HTTP instead of
   `file://` ([#1065](https://github.com/use-agent-os/agent-os/issues/1065)).
+- A DuckDuckGo outage now reads as an outage instead of a quiet zero-result
+  search. `DuckDuckGoProvider.search()` swallowed every `httpx.HTTPError` and
+  returned `[]` unless it was built with `diagnostics=True`, so a 403, a 429 or
+  a timeout was indistinguishable from "nothing matched" — and nothing set that
+  flag: `_search_provider_kwargs()` in `tools/builtin/web.py` singled
+  DuckDuckGo out to receive `diagnostics=_active_search_diagnostics`, which is
+  `False` on a default gateway, so the constructor default was overridden to
+  off at the one call site that mattered. Both layers move: the provider
+  defaults to reporting and classifies the failure the way its Brave and Tavily
+  siblings already do (401/403 `auth`, 429 `rate_limit`, other statuses `http`,
+  plus `timeout` and `network`, each carrying `status_code` and `retryable`),
+  and the tool boundary only ever turns diagnostics *on*. `diagnostics=False`
+  stays as an explicit opt-out for a caller that depends on `search()` never
+  raising; `run_web_search_payload` already routes anything raised into its
+  `ok: false` envelope, so the tool contract is unchanged
+  ([#1122](https://github.com/use-agent-os/agent-os/issues/1122)).
 - The sensitive-path denylist now expands `$VAR`/`${VAR}` before it decides,
   so the hard block cannot be side-stepped by spelling a home directory as a
   variable. Tool dispatch ends in a shell, so `cat $HOME/.ssh/config` reaches

--- a/src/agentos/search/providers/duckduckgo.py
+++ b/src/agentos/search/providers/duckduckgo.py
@@ -28,10 +28,14 @@ class DuckDuckGoProvider:
         self,
         proxy: str = "",
         use_env_proxy: bool = False,
-        diagnostics: bool = False,
+        diagnostics: bool = True,
     ) -> None:
         self._proxy = proxy or None
         self._trust_env = bool(use_env_proxy) and not self._proxy
+        # Default on, so an upstream 403/429/timeout is distinguishable from
+        # "no organic results" the way Brave and Tavily already make it.
+        # ``diagnostics=False`` is the explicit opt-out for a caller that
+        # relies on ``search()`` never raising.
         self._diagnostics = bool(diagnostics)
 
     async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
@@ -47,18 +51,41 @@ class DuckDuckGoProvider:
                     headers=_HEADERS,
                 )
                 response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            if not self._diagnostics:
+                return []
+            raise SearchProviderError(
+                provider=self.name,
+                kind="timeout",
+                message=str(exc) or "DuckDuckGo search request timed out.",
+                retryable=True,
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            if not self._diagnostics:
+                return []
+            status_code = exc.response.status_code
+            if status_code in {401, 403}:
+                kind: SearchErrorKind = "auth"
+            elif status_code == 429:
+                kind = "rate_limit"
+            else:
+                kind = "http"
+            raise SearchProviderError(
+                provider=self.name,
+                kind=kind,
+                message=str(exc) or f"DuckDuckGo search failed with HTTP {status_code}.",
+                retryable=kind in {"rate_limit", "http"},
+                status_code=status_code,
+            ) from exc
         except httpx.HTTPError as exc:
-            if self._diagnostics:
-                kind: SearchErrorKind = (
-                    "timeout" if isinstance(exc, httpx.TimeoutException) else "network"
-                )
-                raise SearchProviderError(
-                    provider=self.name,
-                    kind=kind,
-                    message=str(exc) or "DuckDuckGo search network request failed.",
-                    retryable=True,
-                ) from exc
-            return []
+            if not self._diagnostics:
+                return []
+            raise SearchProviderError(
+                provider=self.name,
+                kind="network",
+                message=str(exc) or "DuckDuckGo search network request failed.",
+                retryable=True,
+            ) from exc
 
         soup = BeautifulSoup(response.text, "html.parser")
         results: list[SearchResult] = []

--- a/src/agentos/tools/builtin/web.py
+++ b/src/agentos/tools/builtin/web.py
@@ -466,8 +466,11 @@ def _search_provider_kwargs(provider_name: str) -> dict[str, object]:
     }
     if provider_name in {"brave", "tavily"} and _active_search_api_key:
         kwargs["api_key"] = _active_search_api_key
-    if _active_search_diagnostics or provider_name == "duckduckgo":
-        kwargs["diagnostics"] = _active_search_diagnostics
+    # Only ever turns diagnostics *on*. Passing the flag through when it is off
+    # used to force ``diagnostics=False`` onto DuckDuckGo, which re-buried the
+    # HTTP failure the provider now reports by default.
+    if _active_search_diagnostics:
+        kwargs["diagnostics"] = True
     return kwargs
 
 

--- a/tests/test_search/test_duckduckgo_errors.py
+++ b/tests/test_search/test_duckduckgo_errors.py
@@ -1,0 +1,127 @@
+"""DuckDuckGo failures are structured errors, not an empty result list."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from agentos.search.providers.duckduckgo import DuckDuckGoProvider
+from agentos.search.types import SearchProviderError
+from agentos.tools.builtin import web
+
+
+@pytest.fixture(autouse=True)
+def clean_search_runtime():
+    web.reset_search_runtime()
+    yield
+    web.reset_search_runtime()
+
+
+def _mock_transport(monkeypatch, error: Exception) -> None:
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = error
+    monkeypatch.setattr("httpx.AsyncClient.__aenter__", AsyncMock(return_value=mock_client))
+
+
+def _status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://html.duckduckgo.com/html")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("HTTP Status Error", request=request, response=response)
+
+
+def test_duckduckgo_diagnostics_default_is_on() -> None:
+    assert DuckDuckGoProvider()._diagnostics is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code,expected_kind,retryable",
+    [
+        (401, "auth", False),
+        (403, "auth", False),
+        (429, "rate_limit", True),
+        (500, "http", True),
+        (503, "http", True),
+    ],
+)
+async def test_duckduckgo_http_status_errors(
+    monkeypatch, status_code: int, expected_kind: str, retryable: bool
+) -> None:
+    _mock_transport(monkeypatch, _status_error(status_code))
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await DuckDuckGoProvider().search("hello")
+
+    assert exc_info.value.kind == expected_kind
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.retryable is retryable
+    assert exc_info.value.provider == "duckduckgo"
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_timeout_error(monkeypatch) -> None:
+    request = httpx.Request("POST", "https://html.duckduckgo.com/html")
+    _mock_transport(monkeypatch, httpx.TimeoutException("Timeout Error", request=request))
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await DuckDuckGoProvider().search("hello")
+
+    assert exc_info.value.kind == "timeout"
+    assert exc_info.value.retryable is True
+    assert exc_info.value.status_code is None
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_network_error(monkeypatch) -> None:
+    _mock_transport(monkeypatch, httpx.HTTPError("HTTP Error"))
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await DuckDuckGoProvider().search("hello")
+
+    assert exc_info.value.kind == "network"
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        _status_error(429),
+        httpx.TimeoutException("Timeout Error"),
+        httpx.HTTPError("HTTP Error"),
+    ],
+)
+async def test_duckduckgo_opt_out_still_swallows(monkeypatch, error: Exception) -> None:
+    """``diagnostics=False`` keeps the historical never-raises contract."""
+    _mock_transport(monkeypatch, error)
+
+    assert await DuckDuckGoProvider(diagnostics=False).search("hello") == []
+
+
+def test_search_kwargs_no_longer_force_diagnostics_off() -> None:
+    """The tool boundary must not re-bury what the provider now reports."""
+    web.configure_search("duckduckgo", diagnostics=False)
+
+    assert "diagnostics" not in web._search_provider_kwargs("duckduckgo")
+
+
+def test_search_kwargs_still_enable_diagnostics() -> None:
+    web.configure_search("duckduckgo", diagnostics=True)
+
+    assert web._search_provider_kwargs("duckduckgo")["diagnostics"] is True
+
+
+@pytest.mark.asyncio
+async def test_web_search_payload_reports_rate_limit(monkeypatch) -> None:
+    """End-to-end: an upstream 429 surfaces as a classified tool failure."""
+    web.configure_search("duckduckgo")
+    _mock_transport(monkeypatch, _status_error(429))
+
+    payload = await web.run_web_search_payload("hello")
+
+    assert payload["ok"] is False
+    assert payload["error"]["kind"] == "rate_limit"
+    assert payload["error"]["retryable"] is True
+    assert payload["results"] == []


### PR DESCRIPTION
Fixes #1122.

## The bug has two layers, and only fixing one changes nothing

`DuckDuckGoProvider.search()` caught every `httpx.HTTPError` and returned `[]` unless it was constructed with `diagnostics=True`. A 403, a rate limit or a timeout was therefore indistinguishable from "no organic results", and the search fallback policy had nothing to classify.

The flag was never on in practice. `_search_provider_kwargs()` in `tools/builtin/web.py` singled DuckDuckGo out:

```python
if _active_search_diagnostics or provider_name == "duckduckgo":
    kwargs["diagnostics"] = _active_search_diagnostics
```

`_active_search_diagnostics` is `False` on a default gateway, so this **overrode the constructor default at the one call site that matters**. Flipping the provider default alone would have fixed nothing observable through the tool.

## What changed

- **`search/providers/duckduckgo.py`** — `diagnostics` defaults to `True`, and the failure is classified the way `BraveSearchProvider` and `TavilySearchProvider` already do: 401/403 → `auth`, 429 → `rate_limit`, any other status → `http`, plus `timeout` and `network`. Each error carries `status_code` and `retryable`.
- **`tools/builtin/web.py`** — `_search_provider_kwargs()` only ever turns diagnostics *on*, so the off state cannot re-bury what the provider reports.

## On the design question in the issue thread

@andreapn asked for an explicit decision between flipping the default and removing the branch. This takes the lower-risk shape you recommended: `diagnostics=False` remains as an explicit opt-out for a caller that relies on `search()` never raising.

Call sites were checked. The only runtime consumer is `run_web_search_payload()`, which already funnels anything raised through `_classify_search_error` into its `ok: false` envelope with the classified `kind` and `retryable`, so the **tool-level contract is unchanged** — a caller that used to see `results: []` now sees `ok: false` with `error.kind == "rate_limit"`. The `network` fallback policy skips DuckDuckGo by design (`provider_name != "duckduckgo"`), so it is unaffected.

## Tests

`tests/test_search/test_duckduckgo_errors.py`, 14 cases: the five status classifications with their `retryable` values, timeout, network, the `diagnostics=False` opt-out still swallowing all three error shapes, both kwargs behaviours, and one end-to-end assertion that an upstream 429 reaches `run_web_search_payload` as `ok: false` / `kind: rate_limit`.

10 of the 14 fail against the unfixed code. The 4 that pass are the opt-out cases, which document behaviour this PR deliberately keeps.

Gate: `ruff` clean, `mypy` clean, `9635 passed` (3 pre-existing env failures — `mem0` stubs ×2 and `test_render_html_to_pdf` — reproduce on `upstream/main` untouched).

## Merge independence

Touches `search/providers/duckduckgo.py`, `tools/builtin/web.py` and one CHANGELOG slot. All 120 merge orderings against my four sibling PRs (#1124, #1126, #1130, #1131) apply with zero conflicts in either direction.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q212jr5m8nFoAwjWgG33dY
