### PR TITLE
fix(tools): preserve a file's line endings through apply_patch (#1124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This was the intermittent
   `test_approval_queue_wait_denies_once_the_full_default_timeout_elapses`
   failure in the Windows CI job on `main`.
+- `apply_patch` no longer rewrites every line of a CRLF file to LF. The
+  reported symptom — `Context mismatch ... got '...\r'` — is not reachable
+  through the tool: the update path read with `Path.read_text()`, whose
+  universal-newline translation folds `\r\n` to `\n` before `_apply_hunk`
+  ever sees it. The quieter defect is at the same site: the translation is
+  one-way in memory only, so writing back with `write_text()` re-emitted
+  `os.linesep` and a one-line patch to a CRLF file came out as a whole-file
+  diff, with the untouched lines converted too (and the mirror-image damage
+  on Windows, where an LF file came back as CRLF). Both ends of the round
+  trip — the read in `_plan_ops` and the write in `_commit_staged` — now open
+  with `newline=""`, so endings survive verbatim; `_apply_hunk` compares
+  context with `rstrip("\r\n")` so a `\r` cannot fail a match, and an added
+  line takes the file's own ending — majority convention, first-seen breaking
+  a tie — instead of a hardcoded `\n`. An `*** Add File` goes through the
+  same `newline=""` write, so the patch text stays the only authority on what
+  a created file contains
+  ([#1124](https://github.com/use-agent-os/agent-os/issues/1124)).
 
 ## [2026.9.11] - 2026-09-11
 

--- a/src/agentos/tools/builtin/patch.py
+++ b/src/agentos/tools/builtin/patch.py
@@ -454,8 +454,30 @@ def _gate_patch_ops(
 # ---------------------------------------------------------------------------
 
 
-def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
+def _detect_newline(file_lines: list[str]) -> str:
+    """Return the line ending an added line should use for this file.
+
+    Picks the majority convention and breaks a tie with the first ending seen,
+    so a mixed-ending file keeps whichever style already dominates it. A file
+    with no line ending at all falls back to ``"\n"``.
+    """
+    crlf = sum(1 for line in file_lines if line.endswith("\r\n"))
+    lf = sum(1 for line in file_lines if line.endswith("\n") and not line.endswith("\r\n"))
+    if crlf == lf:
+        for line in file_lines:
+            if line.endswith("\r\n"):
+                return "\r\n"
+            if line.endswith("\n"):
+                return "\n"
+        return "\n"
+    return "\r\n" if crlf > lf else "\n"
+
+
+def _apply_hunk(file_lines: list[str], hunk: Hunk, newline: str = "\n") -> list[str]:
     """Apply a single hunk to file_lines (0-indexed list of lines with newlines).
+
+    ``newline`` is the line ending given to added lines; context and untouched
+    lines are copied verbatim so their own endings survive.
 
     Returns the new list of lines.
     """
@@ -477,8 +499,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         if prefix in (" ", "-"):
             if check_pos >= len(result):
                 raise ValueError(f"Hunk context/delete at line {check_pos + 1} exceeds file length")
-            actual = result[check_pos].rstrip("\n")
-            expected = content.rstrip("\n")
+            actual = result[check_pos].rstrip("\r\n")
+            expected = content.rstrip("\r\n")
             if actual != expected:
                 raise ValueError(
                     f"Context mismatch at line {check_pos + 1}: "
@@ -500,11 +522,8 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         elif prefix == "-":
             src_pos += 1  # skip (delete)
         elif prefix == "+":
-            # Preserve newline style: add \n if original lines have it
-            if content.endswith("\n"):
-                new_lines.append(content)
-            else:
-                new_lines.append(content + "\n")
+            # Added lines take the file's own line ending, not a hardcoded \n.
+            new_lines.append(content.rstrip("\r\n") + newline)
 
     # Splice: replace [pos : pos + old_count] with new_lines
     return result[:pos] + new_lines + result[pos + hunk.old_count :]
@@ -513,9 +532,10 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
 def _updated_text(text: str, hunks: list[Hunk]) -> str:
     """Return *text* with every hunk applied, without touching the filesystem."""
     lines = text.splitlines(keepends=True)
+    newline = _detect_newline(lines)
     # Apply hunks in reverse order so earlier line numbers stay valid
     for hunk in sorted(hunks, key=lambda h: h.old_start, reverse=True):
-        lines = _apply_hunk(lines, hunk)
+        lines = _apply_hunk(lines, hunk, newline)
     return "".join(lines)
 
 
@@ -574,7 +594,12 @@ def _plan_ops(
                 # tool never decodes must not start failing on bad UTF-8.
                 current = pending.get(resolved) if resolved in pending else None
                 if current is None:
-                    current = resolved.read_text(encoding="utf-8")
+                    # newline="" disables universal-newline translation so a
+                    # CRLF file arrives with its \r intact; read_text() would
+                    # fold every ending to \n and the write below would then
+                    # re-emit os.linesep on every line of the file.
+                    with resolved.open("r", encoding="utf-8", newline="") as handle:
+                        current = handle.read()
                 content = _updated_text(current, op.hunks)
                 modified += 1
             else:
@@ -625,7 +650,11 @@ def _commit_staged(staged: list[_StagedOp]) -> None:
                 continue
             new_dirs.extend(reversed(_missing_ancestors(item.path)))
             item.path.parent.mkdir(parents=True, exist_ok=True)
-            item.path.write_text(item.content, encoding="utf-8")
+            # newline="" so the staged text is the sole authority on line
+            # endings: an update keeps the file's own convention and an add
+            # keeps the patch's, instead of both being rewritten to os.linesep.
+            with item.path.open("w", encoding="utf-8", newline="") as handle:
+                handle.write(item.content)
     except OSError as exc:
         _restore(backups, new_dirs)
         label = current.label if current is not None else "patch"

--- a/tests/test_tools/test_apply_patch_line_endings.py
+++ b/tests/test_tools/test_apply_patch_line_endings.py
@@ -1,0 +1,169 @@
+"""apply_patch must round-trip a file's line endings, not normalise them.
+
+Every assertion here is on the file's *bytes* after a full ``_apply_ops`` run.
+Calling ``_apply_hunk`` directly and checking its return value passes against
+the unfixed code, because ``read_text()`` already folded the endings away.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos.tools.builtin.patch import _apply_ops, _parse_patch
+
+
+def _apply(patch_text: str, root: Path) -> tuple[int, int, int]:
+    return _apply_ops(_parse_patch(patch_text), root)
+
+
+_UPDATE_WORLD = """*** Begin Patch
+*** Update File: example.txt
+@@@ -1,2 +1,2 @@@
+ hello
+-world
++WORLD
+*** End Patch"""
+
+
+def test_crlf_file_keeps_crlf(tmp_path: Path) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"hello\r\nworld\r\n")
+
+    assert _apply(_UPDATE_WORLD, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"hello\r\nWORLD\r\n"
+
+
+def test_lf_file_keeps_lf(tmp_path: Path) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"hello\nworld\n")
+
+    assert _apply(_UPDATE_WORLD, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"hello\nWORLD\n"
+
+
+def test_crlf_untouched_lines_are_not_rewritten(tmp_path: Path) -> None:
+    """A one-line patch must not produce a whole-file diff."""
+    target = tmp_path / "example.txt"
+    original = b"a\r\nb\r\nc\r\nd\r\ne\r\n"
+    target.write_bytes(original)
+
+    patch_text = """*** Begin Patch
+*** Update File: example.txt
+@@@ -3,1 +3,1 @@@
+-c
++C
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"a\r\nb\r\nC\r\nd\r\ne\r\n"
+
+
+def test_crlf_context_lines_match(tmp_path: Path) -> None:
+    """Context matching ignores the \\r that CRLF leaves on the line."""
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"keep\r\ndrop\r\nkeep2\r\n")
+
+    patch_text = """*** Begin Patch
+*** Update File: example.txt
+@@@ -1,3 +1,2 @@@
+ keep
+-drop
+ keep2
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"keep\r\nkeep2\r\n"
+
+
+def test_added_lines_use_the_file_ending(tmp_path: Path) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"one\r\ntwo\r\n")
+
+    patch_text = """*** Begin Patch
+*** Update File: example.txt
+@@@ -1,1 +1,3 @@@
+ one
++inserted
++also inserted
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"one\r\ninserted\r\nalso inserted\r\ntwo\r\n"
+
+
+@pytest.mark.parametrize(
+    "original,expected",
+    [
+        # CRLF majority -> inserted line is CRLF
+        (b"a\r\nb\r\nc\n", b"a\r\ninserted\r\nb\r\nc\n"),
+        # LF majority -> inserted line is LF
+        (b"a\nb\nc\r\n", b"a\ninserted\nb\nc\r\n"),
+        # Tie -> first ending seen wins
+        (b"a\r\nb\n", b"a\r\ninserted\r\nb\n"),
+        (b"a\nb\r\n", b"a\ninserted\nb\r\n"),
+    ],
+)
+def test_mixed_ending_file_keeps_each_line_and_picks_a_majority(
+    tmp_path: Path, original: bytes, expected: bytes
+) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(original)
+
+    patch_text = """*** Begin Patch
+*** Update File: example.txt
+@@@ -1,1 +1,2 @@@
+ a
++inserted
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == expected
+
+
+def test_file_without_trailing_newline_keeps_its_shape(tmp_path: Path) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"hello\r\nworld")
+
+    assert _apply(_UPDATE_WORLD, tmp_path) == (0, 1, 0)
+    # The last line gains an ending because apply_patch always terminates an
+    # added line; the ending it gains is the file's own CRLF, not a bare \n.
+    assert target.read_bytes() == b"hello\r\nWORLD\r\n"
+
+
+def test_single_line_file_with_no_ending(tmp_path: Path) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"only")
+
+    patch_text = """*** Begin Patch
+*** Update File: example.txt
+@@@ -1,1 +1,1 @@@
+-only
++ONLY
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"ONLY\n"
+
+
+def test_empty_file_is_not_a_crash(tmp_path: Path) -> None:
+    target = tmp_path / "example.txt"
+    target.write_bytes(b"")
+
+    patch_text = """*** Begin Patch
+*** Update File: example.txt
+@@@ -1,0 +1,1 @@@
++first
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (0, 1, 0)
+    assert target.read_bytes() == b"first\n"
+
+
+def test_add_file_emits_lf_on_every_platform(tmp_path: Path) -> None:
+    """The patch text is the authority; os.linesep must not leak in."""
+    patch_text = """*** Begin Patch
+*** Add File: created.txt
++alpha
++beta
+*** End Patch"""
+    assert _apply(patch_text, tmp_path) == (1, 0, 0)
+    # No trailing newline is the parser's behaviour for ``*** Add File`` (the
+    # lines are joined, not terminated) — not something the newline handling
+    # chose. The assertion is about the separator being LF, not the tail.
+    assert (tmp_path / "created.txt").read_bytes() == b"alpha\nbeta"


### PR DESCRIPTION
Fixes #1124.

## The reported symptom is not reachable through the tool — the real defect is quieter

@andreapn's correction is confirmed. `_apply_update` read the target with `Path.read_text()`, whose universal-newline translation folds `\r\n` to `\n`, so `_apply_hunk` never saw a `\r` and `rstrip("\n")` matched fine. `Context mismatch` is only reachable by calling `_apply_hunk` directly with hand-built CRLF lines.

The defect at the same site is worse in a quieter way, and it is **symmetric across platforms**:

| host | file | after a one-line patch |
| --- | --- | --- |
| POSIX | CRLF | every line rewritten to LF |
| Windows | LF | every line rewritten to CRLF |

`write_text()` re-emits `os.linesep`, so the in-memory normalisation becomes a whole-file diff on disk.

## What changed

The load-bearing change is at the I/O boundary, as the issue thread says:

- **`_apply_update`** opens both ends with `newline=""`, so endings round-trip verbatim.
- **`_apply_add`** does the same, so the patch text — not the host's `os.linesep` — decides what a created file contains.

With endings preserved, `_apply_hunk` has to tolerate them:

- context and delete lines compare with `rstrip("\r\n")`, so a `\r` cannot fail a match;
- an added line takes the file's own ending (majority convention, first-seen breaking a tie) instead of a hardcoded `\n`;
- context and untouched lines are copied verbatim, so a mixed-ending file keeps each line as it was.

`Path.read_text` / `write_text` only grew a `newline` argument in 3.13, so this goes through `Path.open()` to stay on the project's `requires-python = ">=3.12"` floor.

## Tests

`tests/test_tools/test_apply_patch_line_endings.py`, 13 cases, **every one asserting on the file's bytes after a full `_apply_ops` run** — a test that calls `_apply_hunk` directly and checks its return value passes against the unfixed code, which is exactly the trap the issue warns about.

Covered: CRLF preserved; LF preserved; untouched CRLF lines not rewritten by a one-line patch; CRLF context matching; added lines taking the file's ending; the four mixed-ending majority/tie cases; a file with no trailing newline; a single line with no ending; an empty file; and `_apply_add` emitting exactly what the patch asked for on every platform.

9 of the 13 fail against the unfixed code on POSIX. `test_add_file_emits_lf_on_every_platform` passes on POSIX unfixed and is the one that catches the Windows half — it fails there without the `newline=""` on `_apply_add`.

Gate: `ruff` clean, `mypy` clean, `9634 passed` (3 pre-existing env failures — `mem0` stubs ×2 and `test_render_html_to_pdf` — reproduce on `upstream/main` untouched).

## Merge independence

Touches only `tools/builtin/patch.py` and one CHANGELOG slot. All 120 merge orderings against my four sibling PRs (#1122, #1126, #1130, #1131) apply with zero conflicts in either direction.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q212jr5m8nFoAwjWgG33dY
