### PR TITLE
fix(provider): derive the OpenAI-compat family from the registry (#1126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   resolves to a private or metadata address — otherwise `'base' + '//a/b'`
   would be refused as readily as `'//127.0.0.1/x'`
   ([#1092](https://github.com/use-agent-os/agent-os/issues/1092)).
+- `bankr` and `openai_responses` failures classify like every other
+  OpenAI-compatible provider instead of falling through to `UNKNOWN`. Both are
+  real registered providers, and both declare `failure_family="openai_compat"`
+  in `provider/registry.py`, but neither appeared in the hand-kept
+  `_OPENAI_COMPAT_PROVIDERS` literal in `provider/failures.py`, so their 401,
+  402 and 429 lost the auth / credit / rate-limit semantics the runtime uses to
+  choose `FAIL_CONFIG` or `FALLBACK_PROVIDER`. The literal was the wrong shape
+  rather than merely two names short: it had drifted to six missing providers
+  (`bankr`, `openai_responses`, `github_copilot`, `openai_codex`,
+  `byteplus_coding_plan`, `volcengine_coding_plan`), and #775 reported the
+  `bankr` half a while ago without the fix landing. It is now derived from the
+  registry's own `failure_family` field, with a test asserting the two files
+  agree in both directions
+  ([#1126](https://github.com/use-agent-os/agent-os/issues/1126)).
 - `code_exec` removes its ephemeral working directory on every exit, not just
   the one path that happened to own the cleanup. `execute_code` creates the
   directory with `tempfile.mkdtemp(prefix="agentos_exec_")` whenever no

--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -31,30 +31,24 @@ class ProviderRecoveryAction(StrEnum):
     SURFACE = "surface"
 
 
-_OPENAI_COMPAT_PROVIDERS = {
-    "opencap",
-    "surplus",
-    "openrouter",
-    "openai",
-    "azure",
-    "deepseek",
-    "gemini",
-    "dashscope",
-    "bailian_coding",
-    "moonshot",
-    "mistral",
-    "groq",
-    "zhipu",
-    "qianfan",
-    "siliconflow",
-    "aihubmix",
-    "minimax_openai",
-    "volcengine",
-    "byteplus",
-    "vllm",
-    "lm_studio",
-    "ovms",
-}
+def _openai_compat_provider_ids() -> frozenset[str]:
+    """Provider ids whose registry spec declares the OpenAI-compatible family.
+
+    Derived from ``provider/registry.py`` rather than hand-kept. The literal
+    list this replaces drifted twice — a provider was registered with
+    ``failure_family="openai_compat"`` and never added here, so its 401/402/429
+    fell through to ``UNKNOWN`` and lost the retry and credit semantics every
+    sibling gets. ``failure_family`` is already the field that answers this
+    question; reading it keeps the two files from disagreeing a third time.
+    """
+    from agentos.provider.registry import list_provider_specs
+
+    return frozenset(
+        spec.provider_id for spec in list_provider_specs() if spec.failure_family == "openai_compat"
+    )
+
+
+_OPENAI_COMPAT_PROVIDERS: frozenset[str] = _openai_compat_provider_ids()
 
 _GATEWAY_TRANSIENT_STATUS_CODES = {499, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529}
 _GATEWAY_CODES = r"(?:499|500|502|503|504|520|521|522|523|524|529)"

--- a/tests/test_provider_openai_compat_family_parity.py
+++ b/tests/test_provider_openai_compat_family_parity.py
@@ -1,0 +1,73 @@
+"""``_OPENAI_COMPAT_PROVIDERS`` must not drift from the provider registry.
+
+The hand-kept literal this replaces went stale twice: a provider was registered
+with ``failure_family="openai_compat"`` and never added to the classifier, so
+its 401/402/429 fell through to ``UNKNOWN``. These tests assert the structural
+relationship rather than the two names that happened to be missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentos.provider.failures import (
+    _OPENAI_COMPAT_PROVIDERS,
+    ProviderFailureKind,
+    classify_provider_error,
+)
+from agentos.provider.registry import list_provider_specs
+
+
+def _registry_compat_ids() -> set[str]:
+    return {
+        spec.provider_id for spec in list_provider_specs() if spec.failure_family == "openai_compat"
+    }
+
+
+def test_every_openai_compat_spec_is_classified() -> None:
+    missing = sorted(_registry_compat_ids() - set(_OPENAI_COMPAT_PROVIDERS))
+
+    assert missing == [], (
+        "providers registered with failure_family='openai_compat' but unknown to "
+        f"classify_provider_error: {missing}"
+    )
+
+
+def test_no_classifier_entry_without_a_registered_spec() -> None:
+    extra = sorted(set(_OPENAI_COMPAT_PROVIDERS) - _registry_compat_ids())
+
+    assert extra == [], f"classifier lists providers the registry does not register: {extra}"
+
+
+def test_non_openai_families_are_not_swept_in() -> None:
+    """anthropic- and ollama-family providers keep their own classification."""
+    for spec in list_provider_specs():
+        if spec.failure_family != "openai_compat":
+            assert spec.provider_id not in _OPENAI_COMPAT_PROVIDERS
+
+
+@pytest.mark.parametrize("provider", ["bankr", "openai_responses"])
+@pytest.mark.parametrize(
+    "status_code,message,expected",
+    [
+        (401, "invalid api key", ProviderFailureKind.AUTH_INVALID),
+        (403, "", ProviderFailureKind.AUTH_INVALID),
+        (402, "", ProviderFailureKind.INSUFFICIENT_CREDITS),
+        (429, "", ProviderFailureKind.RATE_LIMITED),
+        (400, "", ProviderFailureKind.BAD_REQUEST),
+        (404, "model not found", ProviderFailureKind.MODEL_NOT_FOUND),
+        (503, "", ProviderFailureKind.PROVIDER_OVERLOADED),
+    ],
+)
+def test_reported_providers_classify_like_their_siblings(
+    provider: str, status_code: int, message: str, expected: ProviderFailureKind
+) -> None:
+    assert classify_provider_error(provider, status_code=status_code, message=message) == expected
+
+
+@pytest.mark.parametrize("status_code", [401, 402, 429, 400])
+def test_every_compat_provider_classifies_the_core_statuses(status_code: int) -> None:
+    """No provider in the family may answer UNKNOWN for a status its siblings map."""
+    for provider in sorted(_OPENAI_COMPAT_PROVIDERS):
+        kind = classify_provider_error(provider, status_code=status_code)
+        assert kind is not ProviderFailureKind.UNKNOWN, f"{provider} @ {status_code}"


### PR DESCRIPTION
Fixes #1126.

## The list was six providers short, not two

`bankr` and `openai_responses` are registered providers that declare `failure_family="openai_compat"` in `provider/registry.py`, but neither appeared in the hand-kept `_OPENAI_COMPAT_PROVIDERS` literal in `provider/failures.py`. Their 401/402/429 skipped the OpenAI-compatible block and fell through to `UNKNOWN`, losing the auth, credit and rate-limit semantics the runtime reads to pick `FAIL_CONFIG` or `FALLBACK_PROVIDER`.

Diffing the two files showed the drift was wider than the report:

```
failure_family == "openai_compat" but missing from _OPENAI_COMPAT_PROVIDERS:
  bankr, openai_responses, github_copilot, openai_codex,
  byteplus_coding_plan, volcengine_coding_plan
```

Adding two strings would have left four more providers silently unclassified and the same drift free to happen again — which, as the issue notes, it already has twice (#775 reported the `bankr` half without a fix landing).

## What changed

`failure_family` is already the field that answers "is this provider OpenAI-compatible". The classifier now reads it instead of keeping a second copy of the answer:

```python
def _openai_compat_provider_ids() -> frozenset[str]:
    from agentos.provider.registry import list_provider_specs

    return frozenset(
        spec.provider_id
        for spec in list_provider_specs()
        if spec.failure_family == "openai_compat"
    )

_OPENAI_COMPAT_PROVIDERS: frozenset[str] = _openai_compat_provider_ids()
```

The registry import sits **inside** the helper, so `provider/__init__.py` importing `.failures` (line 5) before `.registry` (line 24) cannot become a cycle. `registry.py` imports nothing from `agentos`, so the edge is a leaf. Both import orders were checked in a fresh interpreter:

```
$ python -c "import agentos.provider.failures as f; print(len(f._OPENAI_COMPAT_PROVIDERS))"
28
$ python -c "import agentos.provider.registry; import agentos.provider.failures as f; print(len(f._OPENAI_COMPAT_PROVIDERS))"
28
```

Anthropic- and Ollama-family providers keep their own classification blocks; nothing is swept in.

## Tests

Per @andreapn's request, `tests/test_provider_openai_compat_family_parity.py` asserts the **structural relationship** rather than the two names:

- every spec with `failure_family="openai_compat"` is known to the classifier;
- no classifier entry exists without a matching spec (the reverse direction, so a removed provider is caught too);
- no non-`openai_compat` family provider is swept in;
- **no provider in the family answers `UNKNOWN`** for 401/402/429/400 — the property that actually broke;
- plus the reported providers' seven-status behaviour, as a readable regression of the original report.

11 of the 21 cases fail against the unfixed code.

Gate: `ruff` clean, `mypy` clean, `9641 passed` (3 pre-existing env failures — `mem0` stubs ×2 and `test_render_html_to_pdf` — reproduce on `upstream/main` untouched). `tests/test_ci/test_architecture_import_contracts.py` and `test_core_lightweight_contracts.py` pass, so the new intra-package import adds no contract edge.

## Merge independence

Touches only `provider/failures.py` and one CHANGELOG slot. All 120 merge orderings against my four sibling PRs (#1122, #1124, #1130, #1131) apply with zero conflicts in either direction.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q212jr5m8nFoAwjWgG33dY
