### PR TITLE
fix(compat): stop a +local label from parsing as .post/.dev (#1130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   cleanup, so there is one exit path for the tempdir instead of six that skip
   it. A configured workspace still sets no `cleanup_dir` and is never removed
   ([#1010](https://github.com/use-agent-os/agent-os/issues/1010)).
+- A local version label containing `dev` or `post` no longer demotes a final
+  release. `parse_version()` in `compat/version_utils.py` already captured
+  `+local` into its own regex group, but the fallbacks for a bare `.post` /
+  `.dev` segment re-scanned the *whole* raw string with `re.search`, and the
+  optional `[._-]?` delimiter let those patterns match anywhere — including
+  inside the label. `2026.7.18+dev` parsed as `.dev0` and `2026.7.18+postgres`
+  as `.post0`, so a released build sorted as a pre-release and `is_newer()`
+  inverted, producing spurious upgrade notices and wrong version-skew answers.
+  PEP 440 says a local label must not affect ordering. The regex now names the
+  `post` and `dev` literals (`post_l` / `dev_l`), so "was the segment present"
+  is answered by the anchored match instead of a re-scan; a bare `.post` /
+  `.dev` still means 0, and `+dev`, `+postgres`, `+device` and `+local.post1`
+  are ignored for ordering
+  ([#1130](https://github.com/use-agent-os/agent-os/issues/1130)).
 - A replacement agent task stays in `AgentTaskRegistry` when its predecessor
   finishes winding down. Cancellation is not synchronous: `register()` may put
   a new task under a session key while the cancelled one is still settling,

--- a/src/agentos/compat/version_utils.py
+++ b/src/agentos/compat/version_utils.py
@@ -27,8 +27,8 @@ _VERSION_RE = re.compile(
     r"^\s*v?"
     r"(?P<release>\d+(?:\.\d+)*)"
     r"(?:[._-]?(?P<pre_l>a|b|c|rc|alpha|beta|pre|preview)[._-]?(?P<pre_n>\d+)?)?"
-    r"(?:[._-]?post[._-]?(?P<post>\d+)?)?"
-    r"(?:[._-]?dev[._-]?(?P<dev>\d+)?)?"
+    r"(?:[._-]?(?P<post_l>post)[._-]?(?P<post>\d+)?)?"
+    r"(?:[._-]?(?P<dev_l>dev)[._-]?(?P<dev>\d+)?)?"
     r"(?:\+(?P<local>[a-zA-Z0-9.]+))?"
     r"\s*$",
     re.IGNORECASE,
@@ -100,11 +100,15 @@ def parse_version(value: str | None) -> Version:
     if match.group("pre_l"):
         pre_tag = match.group("pre_l").lower()
         pre = (_PRE_ORDER.get(pre_tag, 2), int(match.group("pre_n") or 0))
+    # ``post_l`` / ``dev_l`` mark that the *segment* was present, so a bare
+    # ``.post`` / ``.dev`` with no number still means 0. Re-scanning ``raw``
+    # instead would also match the label in ``+dev``, ``+postgres`` or
+    # ``+local.post1``, which PEP 440 says must not affect ordering.
     post = int(match.group("post")) if match.group("post") is not None else None
-    if post is None and re.search(r"[._-]?post", raw, re.IGNORECASE):
+    if post is None and match.group("post_l"):
         post = 0
     dev = int(match.group("dev")) if match.group("dev") is not None else None
-    if dev is None and re.search(r"[._-]?dev", raw, re.IGNORECASE):
+    if dev is None and match.group("dev_l"):
         dev = 0
     return Version(raw=raw, release=release, pre=pre, post=post, dev=dev, parsed=True)
 

--- a/tests/test_compat/test_version_utils.py
+++ b/tests/test_compat/test_version_utils.py
@@ -113,3 +113,75 @@ def test_ordering_is_total_and_sortable() -> None:
         "2026.7.18.post1",
         "2026.7.19",
     ]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "2026.7.18+dev",
+        "2026.7.18+postgres",
+        "2026.7.18+device",
+        "2026.7.18+local.post1",
+        "2026.7.18+devpost",
+        "2026.7.18+post.dev",
+        "2026.7.18+unknown",
+    ],
+)
+def test_local_label_never_sets_post_or_dev(raw: str) -> None:
+    """A ``+local`` label is metadata; it must not turn a final release into a
+    ``.dev0`` pre-release or a ``.post0`` post-release."""
+    v = parse_version(raw)
+
+    assert v.parsed is True
+    assert v.release == (2026, 7, 18)
+    assert v.post is None
+    assert v.dev is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "2026.7.18+dev",
+        "2026.7.18+postgres",
+        "2026.7.18+device",
+        "2026.7.18+local.post1",
+    ],
+)
+def test_local_label_is_ignored_for_ordering(raw: str) -> None:
+    assert compare_versions("2026.7.18", raw) == 0
+    assert is_newer("2026.7.18", raw) is False
+    assert is_newer(raw, "2026.7.18") is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "post", "dev"),
+    [
+        # Controls: a real .post / .dev segment still parses.
+        ("2026.7.18.post1", 1, None),
+        ("2026.7.18.dev1", None, 1),
+        ("2026.7.18.post", 0, None),
+        ("2026.7.18.dev", None, 0),
+        ("2026.7.18post1", 1, None),
+        ("2026.7.18-dev2", None, 2),
+        ("2026.7.18.post1.dev2", 1, 2),
+        # A real segment plus an unrelated local label.
+        ("2026.7.18.dev1+postgres", None, 1),
+        ("2026.7.18.post1+dev", 1, None),
+    ],
+)
+def test_real_post_and_dev_segments_still_parse(
+    raw: str, post: int | None, dev: int | None
+) -> None:
+    v = parse_version(raw)
+
+    assert v.parsed is True
+    assert v.release == (2026, 7, 18)
+    assert v.post == post
+    assert v.dev == dev
+
+
+def test_local_labelled_release_outranks_a_real_dev_build() -> None:
+    """The regression that inverted ``is_newer``: ``+dev`` sorted as ``.dev0``."""
+    assert is_newer("2026.7.18+dev", "2026.7.18.dev1") is True
+    assert is_newer("2026.7.18.dev1", "2026.7.18+dev") is False
+    assert compare_versions("2026.7.18+postgres", "2026.7.17") == 1


### PR DESCRIPTION
Fixes #1130.

## Why anchoring alone would not have been enough

`_VERSION_RE` already captured the local label into its own `local` group, but `parse_version()` then re-scanned the *entire* raw string to recover a bare `.post` / `.dev` segment:

```python
if post is None and re.search(r"[._-]?post", raw, re.IGNORECASE):
    post = 0
```

The delimiter is optional, so these matched the label too. `2026.7.18+dev` came back as `.dev0`, `2026.7.18+postgres` as `.post0`. A final release then sorted as a pre-release and `is_newer()` inverted, producing spurious upgrade notices and wrong version-skew answers.

As the issue notes, requiring the delimiter would still not fix `2026.7.18+local.post1` — the label has to be excluded, not just the separator required.

## What changed

The regex now names the `post` and `dev` literals, so "was this segment present" is answered by the anchored match itself and both unanchored re-scans are gone:

```diff
-    r"(?:[._-]?post[._-]?(?P<post>\d+)?)?"
-    r"(?:[._-]?dev[._-]?(?P<dev>\d+)?)?"
+    r"(?:[._-]?(?P<post_l>post)[._-]?(?P<post>\d+)?)?"
+    r"(?:[._-]?(?P<dev_l>dev)[._-]?(?P<dev>\d+)?)?"
```

This is the shape proposed in the issue. A bare `.post` / `.dev` with no number still means 0 — that is what the fallbacks existed for, and `post_l` / `dev_l` answer it without looking outside the matched segment.

Before / after on the reported cases:

| input | before | after |
| --- | --- | --- |
| `2026.7.18+dev` | `dev=0` | `dev=None` |
| `2026.7.18+postgres` | `post=0` | `post=None` |
| `2026.7.18+local.post1` | `post=0` | `post=None` |
| `compare_versions("2026.7.18", "2026.7.18+dev")` | `1` | `0` |
| `2026.7.18.post` | `post=0` | `post=0` |
| `2026.7.18.dev1` | `dev=1` | `dev=1` |

## Tests

Appended to `tests/test_compat/test_version_utils.py`, covering everything the issue asked for: `+dev`, `+postgres`, `+device`, `+local.post1`, plus `+devpost`, `+post.dev` and `+unknown`; the plain `.dev1` / `.post1` controls; the case-insensitivity #756 added is left intact; a real segment carrying an unrelated label (`2026.7.18.dev1+postgres`, `2026.7.18.post1+dev`); and the ordering inversion itself.

13 of the new cases fail against the unfixed code; the existing 40 keep passing.

Gate: `ruff` clean, `mypy` clean, `9642 passed` (3 pre-existing env failures — `mem0` stubs ×2 and `test_render_html_to_pdf` — reproduce on `upstream/main` untouched).

## Merge independence

Touches only `compat/version_utils.py` and one CHANGELOG slot. All 120 merge orderings against my four sibling PRs (#1122, #1124, #1126, #1131) apply with zero conflicts in either direction.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q212jr5m8nFoAwjWgG33dY
