### PR TITLE
fix(sandbox): guard gh, Anthropic, OpenAI and Vault credential files

### DIFF
--- a/src/agentos/sandbox/sensitive_paths.py
+++ b/src/agentos/sandbox/sensitive_paths.py
@@ -26,14 +26,22 @@ _DISABLED = os.environ.get(
 ).lower() in ("1", "true", "yes", "on")
 
 
-# Directory prefixes whose contents must not be read/written/deleted by the agent
+# Path prefixes whose contents must not be read/written/deleted by the agent
 # in default mode. Strings starting with ``~`` expand to the current user's
-# home at check time.
+# home at check time. Matching is anchored at a path segment boundary (an
+# entry matches the path itself or the path plus ``/``), so ``~/.config/gh``
+# guards the GitHub CLI directory without reaching ``~/.config/gh-dash`` or
+# ``~/.config`` at large.
 _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "~/.ssh",
     "~/.aws",
     "~/.azure",
     "~/.config/gcloud",
+    # Agents run ``gh`` routinely, so a live GitHub token sits in
+    # ``~/.config/gh/hosts.yml`` next to entries that already guard ``~/.npmrc``.
+    "~/.config/gh",
+    "~/.anthropic",
+    "~/.openai",
     "~/.docker/config",
     "~/.kube",
     "~/.npmrc",
@@ -41,6 +49,13 @@ _SENSITIVE_PREFIXES: tuple[str, ...] = (
     "~/.netrc",
     "~/.gnupg",
     "~/.password-store",
+    # A file, not a directory — the entries above all name directories, but the
+    # prefix match already accepts an exact path, so a bare file works here and
+    # covers the token in its documented home location. Outside home the Vault
+    # token can live anywhere, which the paired ``/.vault-token`` entry in
+    # :data:`_SENSITIVE_SUFFIXES` catches; the two together are what make the
+    # file sensitive wherever it is written.
+    "~/.vault-token",
     "/etc",
     "/boot",
     "/sys",
@@ -70,6 +85,10 @@ _SENSITIVE_SUFFIXES: tuple[str, ...] = (
     "/.zsh_history",
     "/.mysql_history",
     "/.psql_history",
+    # Pairs with ``~/.vault-token`` above: this entry is what guards a Vault
+    # token written outside home. The leading dot is part of the match, so a
+    # file merely named ``vault-token`` is left alone.
+    "/.vault-token",
 )
 
 _WORKSPACE_PARENT_EXCEPTION_MARKERS: tuple[str, ...] = ("/root",)

--- a/tests/test_sandbox/test_sensitive_paths.py
+++ b/tests/test_sandbox/test_sensitive_paths.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from agentos.sandbox.sensitive_paths import (
     _is_root_target,
     is_sensitive_path,
@@ -239,3 +241,137 @@ def test_root_target_detection_covers_windows_drive_roots() -> None:
         "relative/path",
     ):
         assert _is_root_target(target) is False, target
+
+
+@pytest.mark.parametrize(
+    ("relative", "marker"),
+    [
+        (".config/gh/hosts.yml", "~/.config/gh"),
+        (".config/gh/config.yml", "~/.config/gh"),
+        (".anthropic/token", "~/.anthropic"),
+        (".openai/api_key", "~/.openai"),
+        (".vault-token", "~/.vault-token"),
+    ],
+)
+def test_developer_credential_paths_in_home_are_sensitive(relative: str, marker: str) -> None:
+    """The gh/Anthropic/OpenAI/Vault credential paths are guarded by default.
+
+    ``gh`` in particular is run routinely by agents, so a live GitHub token
+    lives in a path that used to sit outside the denylist.
+    """
+    target = Path.home()
+    for part in relative.split("/"):
+        target = target / part
+
+    assert is_sensitive_path(str(target)) == marker
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/var/secrets/.vault-token",
+        "/opt/vault/.vault-token",
+        r"C:\secrets\.vault-token",
+    ],
+)
+def test_vault_token_outside_home_matches_the_suffix_entry(path: str) -> None:
+    """``~/.vault-token`` only covers the documented home location.
+
+    A Vault token written anywhere else is caught by the paired
+    ``/.vault-token`` suffix entry, which is why both exist. Backslash
+    spellings normalize, so this holds on every platform.
+    """
+    assert is_sensitive_path(path) == "/.vault-token"
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        ".config/ghost/config.json",
+        ".config/gh-dash/config.yml",
+        ".config/github/settings",
+        ".anthropic-backup/token",
+        ".openairc",
+    ],
+)
+def test_new_prefixes_are_anchored_at_a_segment_boundary(relative: str) -> None:
+    """A prefix must match a whole path segment, not a string prefix.
+
+    Without segment anchoring ``~/.config/gh`` would swallow ``~/.config/ghost``
+    and ``~/.config/gh-dash``, and ``~/.openai`` would swallow ``~/.openairc``.
+    """
+    target = Path.home()
+    for part in relative.split("/"):
+        target = target / part
+
+    assert is_sensitive_path(str(target)) is None
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        ".config",
+        ".config/nvim/init.lua",
+        ".config/htop/htoprc",
+        ".config/starship.toml",
+    ],
+)
+def test_adding_config_gh_does_not_block_config_generally(relative: str) -> None:
+    """``~/.config`` holds mostly harmless state and must stay readable.
+
+    Only the ``gh`` subdirectory is sensitive; the parent and its siblings are
+    not, so editor and shell configuration keeps working.
+    """
+    target = Path.home()
+    for part in relative.split("/"):
+        target = target / part
+
+    assert is_sensitive_path(str(target)) is None
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/var/secrets/vault-token",
+        "/etc/vault/vault-token.bak",
+    ],
+)
+def test_a_file_merely_named_vault_token_is_not_sensitive(path: str) -> None:
+    """The leading dot is part of the suffix match.
+
+    ``vault-token`` without it is an ordinary filename and must not be blocked,
+    or the entry would over-reach onto unrelated files.
+    """
+    if path.startswith("/etc"):
+        # ``/etc`` is already a sensitive prefix on its own account, so this
+        # spelling proves nothing about the suffix; assert the reason instead.
+        assert is_sensitive_path(path) == "/etc"
+        return
+
+    assert is_sensitive_path(path) is None
+
+
+def test_new_credential_paths_are_caught_in_free_form_text() -> None:
+    """The text scanner is a separate code path from :func:`is_sensitive_path`.
+
+    Shell commands reach the sandbox as free-form strings, so each new entry
+    has to be reachable through the token scan as well as a resolved path.
+    """
+    home = Path.home()
+
+    assert sensitive_path_in_text(f"cat {home / '.config' / 'gh' / 'hosts.yml'}") == (
+        "~/.config/gh"
+    )
+    assert sensitive_path_in_text(f"cat {home / '.anthropic' / 'token'}") == "~/.anthropic"
+    assert sensitive_path_in_text(f"cat {home / '.openai' / 'api_key'}") == "~/.openai"
+    assert sensitive_path_in_text(f"cat {home / '.vault-token'}") == "~/.vault-token"
+    assert sensitive_path_in_text("cat /var/secrets/.vault-token") == "/.vault-token"
+
+    # ``$HOME`` survives the token scan as the relative-looking
+    # ``HOME/.vault-token`` once ``$`` is stripped as a token edge, so it
+    # resolves through the leaf fallback onto the paired suffix entry rather
+    # than the home prefix. Either marker means blocked.
+    assert sensitive_path_in_text("cat $HOME/.vault-token") == "/.vault-token"
+
+    assert sensitive_path_in_text(f"nvim {home / '.config' / 'nvim' / 'init.lua'}") is None
+    assert sensitive_path_in_text("cat /var/secrets/vault-token") is None


### PR DESCRIPTION
## Summary

`_SENSITIVE_PREFIXES` in `src/agentos/sandbox/sensitive_paths.py` guarded `~/.ssh`, `~/.aws`, `~/.azure`, `~/.config/gcloud`, `~/.docker/config`, `~/.kube`, `~/.npmrc`, `~/.pypirc`, `~/.netrc`, `~/.gnupg` and `~/.password-store`, but none of `~/.config/gh`, `~/.anthropic`, `~/.openai` or `~/.vault-token`.

`~/.config/gh/hosts.yml` is the one that matters most, exactly as the review note says: AgentOS agents run `gh` routinely, so a live GitHub token sat in a path the sandbox did not consider sensitive — immediately next to a denylist that already protects `~/.npmrc`.

Verified on `upstream/main` (`cfba23c`) before the change; all five paths returned `None`:

```
~/.config/gh/hosts.yml     -> None
~/.anthropic/token         -> None
~/.openai/api_key          -> None
~/.vault-token             -> None
/var/secrets/.vault-token  -> None
```

## Changes

**`src/agentos/sandbox/sensitive_paths.py`** (+21/-2, no behaviour code touched — data entries and comments only)

- `_SENSITIVE_PREFIXES`: added `~/.config/gh`, `~/.anthropic`, `~/.openai`, `~/.vault-token`.
- `_SENSITIVE_SUFFIXES`: added `/.vault-token`.
- Addressed the three review notes on the issue, each documented where the constant is defined:
  - **`~/.vault-token` is a file, not a directory.** The comment says so, explains that the prefix match already accepts an exact path, and states that the paired `/.vault-token` suffix is what catches the token outside home — the two entries together are what make the file sensitive wherever it is written. The suffix entry carries a back-reference to the prefix.
  - **Segment-boundary anchoring confirmed and documented.** `is_sensitive_path` matches `expanded == normalized or expanded.startswith(normalized + "/")`, so `~/.config/gh` cannot become a de facto block on `~/.config`. The block comment on `_SENSITIVE_PREFIXES` now states this explicitly, and tests prove it rather than leaving it to be re-derived.
  - **Negative tests added**, not only positives — see below.
- The header comment said "Directory prefixes"; it now says "Path prefixes", since the tuple holds one file.

## Tests

**`tests/test_sandbox/test_sensitive_paths.py`** — 20 new cases across 6 functions. No `skipif`: every case runs on every platform. Backslash spellings are exercised as plain strings, which normalize on POSIX too.

*Regression tests — these 9 fail on `upstream/main` and pass with the fix:*

| Test | Covers |
|---|---|
| `test_developer_credential_paths_in_home_are_sensitive` | 5 cases: `~/.config/gh/hosts.yml`, `~/.config/gh/config.yml`, `~/.anthropic/token`, `~/.openai/api_key`, `~/.vault-token` — each asserting the exact marker |
| `test_vault_token_outside_home_matches_the_suffix_entry` | 3 cases: `/var/secrets/.vault-token`, `/opt/vault/.vault-token`, `C:\secrets\.vault-token` → `/.vault-token` |
| `test_new_credential_paths_are_caught_in_free_form_text` | `sensitive_path_in_text` — a separate code path from `is_sensitive_path`, since shell commands reach the sandbox as free-form strings |

*Guard tests — these pass in both states by construction; they exist to catch a future over-broad entry, and I am flagging that rather than presenting them as regressions:*

| Test | Covers |
|---|---|
| `test_new_prefixes_are_anchored_at_a_segment_boundary` | `~/.config/ghost/config.json`, `~/.config/gh-dash/config.yml`, `~/.config/github/settings`, `~/.anthropic-backup/token`, `~/.openairc` → all `None` |
| `test_adding_config_gh_does_not_block_config_generally` | `~/.config` itself, `~/.config/nvim/init.lua`, `~/.config/htop/htoprc`, `~/.config/starship.toml` → all `None` |
| `test_a_file_merely_named_vault_token_is_not_sensitive` | `/var/secrets/vault-token` (no dot) → `None`; `/etc/vault/vault-token.bak` asserts `/etc` instead, because `/etc` is already sensitive on its own account and that spelling would otherwise prove nothing about the suffix |

One honest note on the text scanner: `sensitive_path_in_text("cat $HOME/.vault-token")` reports `/.vault-token`, not `~/.vault-token`. `_scan_text_for_marker` runs on the raw text first, `$` is stripped as a token edge, and the relative-looking `HOME/.vault-token` resolves through the leaf fallback onto the suffix entry before the expanded scan runs. It is blocked either way; the test asserts the marker that is actually returned and the comment explains why.

Also checked that AgentOS does not read any of these paths itself — it uses `~/.agentos`, `~/.agents`, `~/.openclaw`, `~/.hermes` — so nothing in the product blocks itself. The four existing test files that reference `_SENSITIVE_PREFIXES` all monkeypatch-replace the whole tuple with `(str(tmp_path),)`, so the new entries cannot affect them.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9706 passed, 30 skipped**, 0 failed
- Self-check: reverted `sensitive_paths.py` with `git checkout upstream/main -- <file>` and confirmed the 9 regression cases fail without the fix.

`ruff format` was deliberately **not** run — it wants to reformat pre-existing `_DISABLED`, `_path_contains` and `_workspace_contains` blocks that this change does not touch. The additions here are already format-clean on their own (`ruff format --diff` reports no hunk past line 256).

## Note on overlap

I have PR #982 open against #981, which touches these same three files. The changes are orthogonal — #982 derives credential *filename* entries from `redact.CREDENTIAL_FILE_NAMES`, this one adds literal directory prefixes — but whichever lands second will need a trivial rebase, and I am happy to do that.

Fixes #1138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
