### PR TITLE
fix(skills): make xlsx as_text produce a text cell, not a quoted value

### DIFF
--- a/src/agentos/skills/bundled/xlsx/SKILL.md
+++ b/src/agentos/skills/bundled/xlsx/SKILL.md
@@ -105,11 +105,13 @@ Rules:
 
 - Rows and columns are 1-based (Excel convention).
 - Strings starting with `=` are written as formulas (`cell.value = "=..."`),
-  matching openpyxl behavior. To write a literal `=hello` use `'=hello`
-  (Excel's leading-apostrophe escape) or pass an explicit `as_text: true`.
+  matching openpyxl behavior. To write a literal `=hello`, pass
+  `as_text: true`: the value is stored unchanged as a text cell, and Excel's
+  leading-apostrophe escape is carried on the cell's `quotePrefix` style flag
+  rather than inside the value.
 - Datetimes go in as ISO 8601 strings (`"2026-05-06T09:00:00"`); the helper
   parses them back to `datetime` objects so Excel renders the cell with date
-  format.
+  format. Pass `as_text: true` to keep such a string as text instead.
 - Editing a cell does not recalculate dependent formulas. Excel and
   LibreOffice recalculate on open. If you need cached values immediately,
   use a calculation engine (out of scope here).

--- a/src/agentos/skills/bundled/xlsx/SKILL.md
+++ b/src/agentos/skills/bundled/xlsx/SKILL.md
@@ -106,9 +106,12 @@ Rules:
 - Rows and columns are 1-based (Excel convention).
 - Strings starting with `=` are written as formulas (`cell.value = "=..."`),
   matching openpyxl behavior. To write a literal `=hello`, pass
-  `as_text: true`: the value is stored unchanged as a text cell, and Excel's
-  leading-apostrophe escape is carried on the cell's `quotePrefix` style flag
-  rather than inside the value.
+  `as_text: true` — either as `{"value": "=hello", "as_text": true}` or with
+  Excel's leading-apostrophe escape, `{"value": "'=hello", "as_text": true}`.
+  Both produce the same cell: the value is stored as `=hello` in a text cell,
+  and the apostrophe is carried on the cell's `quotePrefix` style flag rather
+  than inside the value. The apostrophe is only consumed when it escapes a
+  formula, so a value that genuinely begins with one (`'tis`) keeps it.
 - Datetimes go in as ISO 8601 strings (`"2026-05-06T09:00:00"`); the helper
   parses them back to `datetime` objects so Excel renders the cell with date
   format. Pass `as_text: true` to keep such a string as text instead.

--- a/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
@@ -32,6 +32,15 @@ def _coerce(value: Any, as_text: bool) -> Any:
     where the caller asked for ``=hello``.
     """
     if as_text:
+        if isinstance(value, str) and value.startswith("'="):
+            # ``SKILL.md`` offers ``'=hello`` and ``as_text: true`` as two
+            # spellings of one request, so the two have to land on one cell.
+            # Excel's leading apostrophe is the input escape for a
+            # formula-looking value, so it is consumed here and carried as the
+            # ``quotePrefix`` style flag by :func:`apply_ops` instead of being
+            # stored as data. Scoped to ``'=``: a value that legitimately opens
+            # with an apostrophe (``'tis``) keeps it.
+            return value[1:]
         return value
     if isinstance(value, str) and len(value) >= 19 and value[10] == "T":
         try:

--- a/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
+++ b/src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py
@@ -21,8 +21,18 @@ from openpyxl import load_workbook
 
 
 def _coerce(value: Any, as_text: bool) -> Any:
-    if as_text and isinstance(value, str) and value.startswith("="):
-        return "'" + value
+    """Return the value to assign, honouring an explicit ``as_text`` request.
+
+    ``as_text`` means "store exactly what I passed", so it suppresses the
+    ISO-8601 coercion below as well as the formula interpretation. The cell
+    *type* is what carries the distinction and that needs the cell object, so
+    :func:`apply_ops` applies it after assignment; nothing is prepended to the
+    data here. Excel's leading apostrophe is an input-mode escape rather than
+    content, and writing it into the string left the cell holding ``'=hello``
+    where the caller asked for ``=hello``.
+    """
+    if as_text:
+        return value
     if isinstance(value, str) and len(value) >= 19 and value[10] == "T":
         try:
             return datetime.fromisoformat(value)
@@ -45,7 +55,18 @@ def apply_ops(wb: Any, ops: list[dict[str, Any]]) -> int:
             if sheet_name not in wb.sheetnames or row is None or col is None:
                 continue
             ws = wb[sheet_name]
-            ws.cell(row=int(row), column=int(col), value=_coerce(value, bool(op.get("as_text"))))
+            as_text = bool(op.get("as_text"))
+            coerced = _coerce(value, as_text)
+            cell = ws.cell(row=int(row), column=int(col), value=coerced)
+            if as_text and isinstance(coerced, str):
+                # Assigning a string that starts with ``=`` makes openpyxl mark
+                # the cell as a formula, so the string type has to be restored
+                # afterwards. ``quotePrefix`` is the stored form of Excel's
+                # apostrophe escape, which is why it belongs on the style and
+                # not in the value.
+                cell.data_type = "s"
+                if coerced.startswith("="):
+                    cell.quotePrefix = True
             applied += 1
         elif kind == "rename_sheet":
             old = op.get("old")

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -211,3 +211,137 @@ def test_inspect_xlsx_creates_parent_directory(
     monkeypatch.setattr(sys, "argv", ["inspect_xlsx.py", str(src), "--out", str(out)])
     assert inspect_xlsx.main() == 0
     assert out.is_file()
+
+
+def _edit_and_reload(tmp_path: Path, ops: list[dict[str, object]]) -> object:
+    """Run ``ops`` against a one-cell workbook and reload the saved result."""
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+        import edit_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    from openpyxl import load_workbook
+
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["a"]]}]}).save(str(src))
+    wb = load_workbook(str(src))
+    edit_xlsx.apply_ops(wb, ops)
+    out = tmp_path / "out.xlsx"
+    wb.save(str(out))
+    return load_workbook(str(out))["S"]
+
+
+def _set_cell(row: int, value: object, **extra: object) -> dict[str, object]:
+    return {"op": "set_cell", "sheet": "S", "row": row, "col": 1, "value": value, **extra}
+
+
+def test_as_text_keeps_the_formula_string_out_of_the_cell_value(tmp_path: Path) -> None:
+    """``as_text: true`` stores ``=hello``, not Excel's input-mode apostrophe.
+
+    The apostrophe is an escape typed into Excel's formula bar, not cell
+    content. Prepending it left the cell holding ``'=hello`` — seven characters
+    where the caller passed six — so a round-trip comparison against the
+    original string failed and both Excel and LibreOffice rendered a stray
+    apostrophe.
+    """
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "=hello", as_text=True)])
+    cell = sheet.cell(row=2, column=1)
+
+    assert cell.value == "=hello"
+    assert cell.data_type == "s"
+    assert cell.quotePrefix is True
+
+
+def test_inspect_reports_the_escaped_formula_without_an_apostrophe(
+    tmp_path: Path,
+) -> None:
+    """The skill's own inspector is where a caller reads the value back.
+
+    ``inspect_xlsx`` reported ``'=hello``, so the corruption was visible
+    through the documented read path and not only through openpyxl directly.
+    """
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        import create_xlsx  # type: ignore[import-not-found]
+        import edit_xlsx  # type: ignore[import-not-found]
+        import inspect_xlsx  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    from openpyxl import load_workbook
+
+    src = tmp_path / "book.xlsx"
+    create_xlsx.build({"sheets": [{"name": "S", "rows": [["a"]]}]}).save(str(src))
+    wb = load_workbook(str(src))
+    edit_xlsx.apply_ops(wb, [_set_cell(2, "=hello", as_text=True)])
+    out = tmp_path / "out.xlsx"
+    wb.save(str(out))
+
+    reported = inspect_xlsx.inspect(out, data_only=False)["sheets"][0]["rows"][1][0]
+
+    assert reported["value"] == "=hello"
+    assert reported["type"] == "s"
+
+
+def test_without_as_text_a_formula_string_stays_a_formula(tmp_path: Path) -> None:
+    """The default path is unchanged: openpyxl still records a formula cell."""
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "=SUM(A1:A1)")])
+    cell = sheet.cell(row=2, column=1)
+
+    assert cell.value == "=SUM(A1:A1)"
+    assert cell.data_type == "f"
+    assert cell.quotePrefix is False
+
+
+def test_as_text_suppresses_the_iso_datetime_coercion(tmp_path: Path) -> None:
+    """An explicit ``as_text`` request must win over the ISO-8601 heuristic.
+
+    ``_coerce`` only consulted the flag on the formula branch, so there was no
+    way to store a timestamp as text: every 19-character string with ``T`` at
+    index 10 became a ``datetime`` cell regardless.
+    """
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "2026-05-06T09:00:00", as_text=True)])
+    cell = sheet.cell(row=2, column=1)
+
+    assert cell.value == "2026-05-06T09:00:00"
+    assert isinstance(cell.value, str)
+    assert cell.data_type == "s"
+
+
+def test_without_as_text_an_iso_string_still_becomes_a_datetime(tmp_path: Path) -> None:
+    """The documented datetime convenience keeps working untouched."""
+    from datetime import datetime
+
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "2026-05-06T09:00:00")])
+    cell = sheet.cell(row=2, column=1)
+
+    assert cell.value == datetime(2026, 5, 6, 9, 0)
+    assert cell.data_type == "d"
+
+
+def test_as_text_does_not_flag_an_ordinary_string(tmp_path: Path) -> None:
+    """``quotePrefix`` only stands in for the escape a formula string needs.
+
+    A plain string must not pick up the flag, or every text cell written with
+    ``as_text`` would carry a style Excel attributes to manual escaping.
+    """
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "plain", as_text=True)])
+    cell = sheet.cell(row=2, column=1)
+
+    assert cell.value == "plain"
+    assert cell.data_type == "s"
+    assert cell.quotePrefix is False
+
+
+def test_as_text_leaves_non_string_values_alone(tmp_path: Path) -> None:
+    """Numbers and booleans keep their own cell types; the flag is about text."""
+    sheet = _edit_and_reload(
+        tmp_path, [_set_cell(2, 42, as_text=True), _set_cell(3, True, as_text=True)]
+    )
+
+    assert sheet.cell(row=2, column=1).value == 42
+    assert sheet.cell(row=2, column=1).data_type == "n"
+    assert sheet.cell(row=3, column=1).value is True
+    assert sheet.cell(row=3, column=1).data_type == "b"

--- a/tests/test_skill_xlsx.py
+++ b/tests/test_skill_xlsx.py
@@ -345,3 +345,49 @@ def test_as_text_leaves_non_string_values_alone(tmp_path: Path) -> None:
     assert sheet.cell(row=2, column=1).data_type == "n"
     assert sheet.cell(row=3, column=1).value is True
     assert sheet.cell(row=3, column=1).data_type == "b"
+
+
+def test_the_apostrophe_escape_and_as_text_produce_the_same_cell(tmp_path: Path) -> None:
+    """``SKILL.md`` offers two spellings of one request; they must agree.
+
+    Excel's leading apostrophe is the input escape for a formula-looking
+    value, so ``{"value": "'=hello", "as_text": true}`` asks for exactly what
+    ``{"value": "=hello", "as_text": true}`` asks for. Storing the apostrophe
+    as data left the two spellings on different cells -- one holding ``=hello``
+    with ``quotePrefix`` set, the other holding a literal ``'=hello``.
+    """
+    sheet = _edit_and_reload(
+        tmp_path,
+        [_set_cell(2, "=hello", as_text=True), _set_cell(3, "'=hello", as_text=True)],
+    )
+    plain = sheet.cell(row=2, column=1)
+    escaped = sheet.cell(row=3, column=1)
+
+    assert (escaped.value, escaped.data_type, escaped.quotePrefix) == (
+        plain.value,
+        plain.data_type,
+        plain.quotePrefix,
+    )
+    assert escaped.value == "=hello"
+    assert escaped.quotePrefix is True
+
+
+def test_a_value_that_genuinely_starts_with_an_apostrophe_keeps_it(tmp_path: Path) -> None:
+    """The escape is only consumed when it escapes a formula.
+
+    Stripping every leading apostrophe would turn ``'tis`` into ``tis`` --
+    trading the reported bug for a quieter one.
+    """
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "'tis", as_text=True)])
+    cell = sheet.cell(row=2, column=1)
+
+    assert cell.value == "'tis"
+    assert cell.data_type == "s"
+    assert cell.quotePrefix is False
+
+
+def test_the_apostrophe_escape_is_not_consumed_without_as_text(tmp_path: Path) -> None:
+    """Without the flag nothing is interpreted; the value is stored verbatim."""
+    sheet = _edit_and_reload(tmp_path, [_set_cell(2, "'=hello")])
+
+    assert sheet.cell(row=2, column=1).value == "'=hello"


### PR DESCRIPTION
## Summary

`_coerce` in `src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py` implemented `as_text: true` as `return "'" + value`. Excel's leading apostrophe is an *input-mode* escape typed into the formula bar, not cell content — in the file format the equivalent is the `quotePrefix` cell-style flag. Writing it into the string left the cell holding `'=hello` where the caller passed `=hello`.

The flag was also only consulted on the `startswith("=")` branch, so the ISO-8601 coercion below it ran unconditionally and there was no way to store a timestamp as text.

Verified on `upstream/main` (`cfba23c`), openpyxl 3.1.5:

```
as_text=True  "=hello"     -> value="'=hello"                         data_type='s' quotePrefix=False
as_text absen "=hello"     -> value='=hello'                          data_type='f' quotePrefix=False
as_text=True  ISO string   -> value=datetime.datetime(2026, 5, 6, 9, 0) data_type='d' quotePrefix=False
```

`SKILL.md:107-109` documents the flag as the way to write a literal `=hello`, and `inspect_xlsx` — the skill's own read path — reported `'=hello` back, so the corruption was visible through the documented interface.

After:

```
as_text "=hello"   value='=hello'              type='s' qp=True
no flag "=hello"   value='=hello'              type='f' qp=False
as_text ISO        value='2026-05-06T09:00:00' type='s' qp=False
no flag ISO        value=datetime(2026,5,6,9)  type='d' qp=False
as_text plain      value='plain'               type='s' qp=False
as_text int        value=42                    type='n' qp=False
```

## Changes

**`src/agentos/skills/bundled/xlsx/scripts/edit_xlsx.py`** (+24/-3)

- `_coerce`: `as_text` now returns the value untouched — no apostrophe prepended, and the ISO-8601 coercion skipped. The docstring explains why the escape cannot live in the data.
- `apply_ops`: keeps the cell returned by `ws.cell(...)` and, when `as_text` was asked for and the value is a string, sets `data_type = "s"` (assigning a `=`-prefixed string makes openpyxl record a formula) and `quotePrefix = True` for the formula-looking case only.

**`src/agentos/skills/bundled/xlsx/SKILL.md`** — the two bullets that describe the flag now match the behaviour: `as_text: true` stores the value unchanged with the escape on `quotePrefix`, and it also keeps an ISO-8601 string as text. Both documented spellings are named explicitly, since they now produce one cell.

> **Correction from an earlier revision of this PR.** That revision *removed* the claim that `{"value": "'=hello", "as_text": true}` is an equivalent spelling, arguing it is not one because the string does not start with `=` so the flag never applied. The review on #1358 is right that the two are meant to be one request, and the fix now makes them so: under `as_text` a leading apostrophe that escapes a formula is consumed and carried as `quotePrefix`, so both spellings land on the same cell. It is scoped to `'=`, so a value that genuinely opens with an apostrophe (`'tis`) keeps it, and nothing is consumed without the flag.

Deliberately unchanged, to keep the diff to this bug:

- The no-flag paths (`=…` → formula, ISO string → `datetime`) behave exactly as before.
- Non-string values are untouched; `as_text` is about text cells.
- The explicit-null behaviour is **not** altered. `ws.cell(..., value=None)` is still called in the same shape, so an explicit `null` remains a silent no-op — that is issue #1260, and I have PR #1266 open for it separately. I checked this rather than assuming: `{"value": None}` still leaves the previous cell content in place on this branch.

## Tests

**`tests/test_skill_xlsx.py`** — 7 new tests. The existing `test_text_escapes_formula` asserts `cell_value.lstrip("'") == "=hello"`, so it is indifferent to the apostrophe and passes before and after; I left it alone rather than rewriting an existing assertion to suit the fix.

*Regression tests — these 3 fail on `upstream/main` and pass with the fix:*

| Test | Covers |
|---|---|
| `test_as_text_keeps_the_formula_string_out_of_the_cell_value` | value is `=hello`, `data_type == "s"`, `quotePrefix is True` |
| `test_inspect_reports_the_escaped_formula_without_an_apostrophe` | the same cell read back through `inspect_xlsx`, the documented read path |
| `test_as_text_suppresses_the_iso_datetime_coercion` | `"2026-05-06T09:00:00"` with `as_text` stays a `str` |

*Guard tests — these pass in both states by construction; they pin the behaviour the fix must not disturb, and I am flagging that rather than counting them as regressions:*

| Test | Covers |
|---|---|
| `test_without_as_text_a_formula_string_stays_a_formula` | `data_type == "f"`, `quotePrefix is False` |
| `test_without_as_text_an_iso_string_still_becomes_a_datetime` | `datetime(2026, 5, 6, 9, 0)`, `data_type == "d"` |
| `test_as_text_does_not_flag_an_ordinary_string` | a plain string gets `data_type == "s"` but **not** `quotePrefix` |
| `test_as_text_leaves_non_string_values_alone` | `int` → `"n"`, `bool` → `"b"` |

Every test writes the workbook to disk and reloads it, so the assertions are about what the saved file actually contains rather than in-memory state. No `skipif`: all cases run on every platform.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9693 passed, 30 skipped**, 0 failed
- Self-check: reverted `edit_xlsx.py` with `git checkout upstream/main -- <file>` and confirmed the 3 regression tests fail without the fix.
- `ruff format --diff` reports no hunks in either changed file.

Fixes #1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

