### PR TITLE
fix(provider): classify 404 as MODEL_NOT_FOUND and enrich Gemini model error diagnostics

### DIFF
--- a/src/agentos/onboarding/provider_specs.py
+++ b/src/agentos/onboarding/provider_specs.py
@@ -145,6 +145,11 @@ def _default_direct_model(provider_id: str) -> str:
 
 
 def _model_description(spec: ProviderSpec, *, router_supported: bool) -> str:
+    if spec.provider_id == "gemini":
+        return (
+            "Optional direct fallback model (e.g. gemini-2.5-pro, gemini-2.5-flash, or "
+            "gemini-3.1-pro-preview). Leave blank to use the selected Pilot Router default tier."
+        )
     if router_supported:
         return (
             "Optional direct fallback model. Leave blank to use the selected "

--- a/src/agentos/provider/failures.py
+++ b/src/agentos/provider/failures.py
@@ -183,7 +183,15 @@ def classify_provider_error(
             return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate limit" in text or "rate_limit" in text:
             return ProviderFailureKind.RATE_LIMITED
-        if "no endpoints found" in text or "model not found" in text:
+        if (
+            status_code == 404
+            or "no endpoints found" in text
+            or "model not found" in text
+            or "model_not_found" in text
+            or "is not found" in text
+            or "does not exist" in text
+            or "not_found" in text
+        ):
             return ProviderFailureKind.MODEL_NOT_FOUND
         if "does not support" in text or "unsupported" in text:
             return ProviderFailureKind.UNSUPPORTED_FEATURE
@@ -201,6 +209,15 @@ def classify_provider_error(
             return ProviderFailureKind.AUTH_INVALID
         if status_code == 402 or "billing_error" in text:
             return ProviderFailureKind.INSUFFICIENT_CREDITS
+        if (
+            status_code == 404
+            or "not_found_error" in text
+            or "model_not_found" in text
+            or "model not found" in text
+            or "is not found" in text
+            or "not_found" in text
+        ):
+            return ProviderFailureKind.MODEL_NOT_FOUND
         if status_code == 429 or "rate_limit_error" in text:
             return ProviderFailureKind.RATE_LIMITED
         if status_code in _GATEWAY_TRANSIENT_STATUS_CODES or "overloaded_error" in text:

--- a/src/agentos/provider/openai.py
+++ b/src/agentos/provider/openai.py
@@ -119,10 +119,16 @@ def _http_error_body_text(body: bytes | str) -> str:
 
 def _format_chat_http_error(provider_kind: str, status_code: int, body: bytes | str) -> str:
     body_text = _http_error_body_text(body) or "empty response body"
-    return (
+    msg = (
         f"{_provider_display_name(provider_kind)} chat request failed "
         f"(HTTP {status_code}): {body_text}"
     )
+    if provider_kind == "gemini" and status_code == 404:
+        msg += (
+            " (Model not found. If your API key lacks access to the default tier, "
+            "set GEMINI_MODEL=gemini-3.1-pro-preview or gemini-2.5-flash.)"
+        )
+    return msg
 
 
 def _resolve_reasoning_effort(level: ThinkingLevel | None, budget: int) -> str:

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -183,3 +183,46 @@ def test_deepseek_insufficient_quota_is_credits() -> None:
         is ProviderFailureKind.INSUFFICIENT_CREDITS
     )
 
+
+def test_gemini_404_model_not_found_is_model_not_found() -> None:
+    """Gemini 404 with standard Google API error message is classified as MODEL_NOT_FOUND."""
+    from agentos.provider.failures import ProviderRecoveryAction, decide_recovery_action
+
+    kind = classify_provider_error(
+        provider_name="gemini",
+        status_code=404,
+        message=(
+            "models/gemini-2.5-pro is not found for API version v1beta, or is not supported "
+            "for generateContent. Call ListModels to see the list of available models."
+        ),
+    )
+    assert kind is ProviderFailureKind.MODEL_NOT_FOUND
+    assert decide_recovery_action(kind) is ProviderRecoveryAction.FALLBACK_PROVIDER
+
+
+def test_openai_compat_404_status_code_is_model_not_found() -> None:
+    """OpenAI-compatible 404 is classified as MODEL_NOT_FOUND."""
+    assert (
+        classify_provider_error(
+            provider_name="openai",
+            status_code=404,
+            message="The model `gpt-5-preview` does not exist or you do not have access to it.",
+        )
+        is ProviderFailureKind.MODEL_NOT_FOUND
+    )
+
+
+def test_gemini_format_chat_http_error_includes_model_guidance() -> None:
+    from agentos.provider.openai import _format_chat_http_error
+
+    err_msg = _format_chat_http_error(
+        "gemini",
+        404,
+        b'{"error":{"code":404,"message":"models/gemini-2.5-pro is not found"}}',
+    )
+    assert "Gemini chat request failed (HTTP 404)" in err_msg
+    assert "models/gemini-2.5-pro is not found" in err_msg
+    assert "GEMINI_MODEL=gemini-3.1-pro-preview" in err_msg
+
+
+


### PR DESCRIPTION
Fixes #1359

### Summary

When Google Gemini accounts access models not available on their tier (such as the default router model `gemini-2.5-pro` returning `models/gemini-2.5-pro is not found for API version v1beta`), the upstream API returns an HTTP 404 response.

Previously:
1. `classify_provider_error` only matched exact substrings like `"model not found"` or `"no endpoints found"`, causing Google-style `"is not found"` responses and HTTP 404 status codes to fall through to `ProviderFailureKind.UNKNOWN`.
2. As a result, the runtime did not trigger `ProviderRecoveryAction.FALLBACK_PROVIDER` to engage configured fallback models/providers.
3. Surfaced errors lacked actionable troubleshooting hints pointing users toward configuring accessible direct models (e.g. `GEMINI_MODEL=gemini-3.1-pro-preview` or `gemini-2.5-flash`).

### Changes

- **Provider Failure Classification** (`src/agentos/provider/failures.py`):
  - Added `status_code == 404` and phrases (`"is not found"`, `"does not exist"`, `"not_found"`) to `classify_provider_error` for OpenAI-compatible, Anthropic, and generic providers.
  - Automatically maps to `ProviderFailureKind.MODEL_NOT_FOUND` so `decide_recovery_action` returns `ProviderRecoveryAction.FALLBACK_PROVIDER`.
- **Diagnostic Formatting** (`src/agentos/provider/openai.py`):
  - Updated `_format_chat_http_error` to provide clear guidance for Gemini HTTP 404s advising how to override the model via `GEMINI_MODEL`.
- **Onboarding Catalog** (`src/agentos/onboarding/provider_specs.py`):
  - Updated Gemini model field description during onboarding to list common model choices (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`).
- **Tests** (`tests/test_provider_failures.py`):
  - Added regression tests verifying Google-style 404 payload classification as `MODEL_NOT_FOUND`, fallback recovery action mapping, and diagnostic message formatting.

### Verification

- `uv run ruff check src tests` (clean)
- `uv run mypy src/agentos --show-error-codes` (no issues across 623 files)
- `uv run pytest tests/test_provider_failures.py tests/test_provider_failure_classification.py -q` (122/122 passed)
- `uv run pytest -k "provider or onboarding" -q` (1,499 passed)

