### PR TITLE
fix(tools): guard execute_code ephemeral tempdir cleanup against setup failures (#1248)

### DIFF
--- a/src/agentos/tools/builtin/code_exec.py
+++ b/src/agentos/tools/builtin/code_exec.py
@@ -634,21 +634,17 @@ async def execute_code(
         Path(ctx.workspace_dir).expanduser().resolve() if ctx and ctx.workspace_dir else None
     )
     cleanup_dir: str | None = None
-    if workspace is not None:
-        workspace.mkdir(parents=True, exist_ok=True)
-        workdir_path = workspace
-    elif runtime is not None and runtime.effective.sandbox_enabled:
-        workdir_path = runtime.workspace.expanduser().resolve()
-        workdir_path.mkdir(parents=True, exist_ok=True)
-    else:
-        workdir = tempfile.mkdtemp(prefix="agentos_exec_")
-        workdir_path = Path(workdir)
-        cleanup_dir = workdir
-    # Every exit from here on has to drop the ephemeral workdir. The
-    # sandbox branch below returns early on denial, backend failure,
-    # escalation denial, timeout and error, and each of those used to skip
-    # the cleanup that only guarded the non-sandbox path.
     try:
+        if workspace is not None:
+            workspace.mkdir(parents=True, exist_ok=True)
+            workdir_path = workspace
+        elif runtime is not None and runtime.effective.sandbox_enabled:
+            workdir_path = runtime.workspace.expanduser().resolve()
+            workdir_path.mkdir(parents=True, exist_ok=True)
+        else:
+            workdir = tempfile.mkdtemp(prefix="agentos_exec_")
+            workdir_path = Path(workdir)
+            cleanup_dir = workdir
         start_ns = time.monotonic_ns()
 
         safe_env = _build_safe_env()

--- a/tests/test_tools/test_code_exec_tempdir_cleanup.py
+++ b/tests/test_tools/test_code_exec_tempdir_cleanup.py
@@ -77,9 +77,7 @@ def _gate(monkeypatch: pytest.MonkeyPatch, result: object) -> None:
     monkeypatch.setattr(code_exec, "gate_action", _fake_gate)
 
 
-def test_denied_calls_leave_no_tempdir(
-    temp_root: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_denied_calls_leave_no_tempdir(temp_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _gate(monkeypatch, _denial())
 
     for index in range(5):
@@ -152,9 +150,7 @@ def test_escalated_subprocess_timeout_leaves_no_tempdir(
     monkeypatch.setattr(code_exec, "run_under_backend", _noted)
     monkeypatch.setattr(code_exec, "escalate_backend_denial", _escalate)
 
-    out = asyncio.run(
-        code_exec.execute_code("import time\ntime.sleep(30)", timeout=1)
-    )
+    out = asyncio.run(code_exec.execute_code("import time\ntime.sleep(30)", timeout=1))
     assert '"timed_out": true' in out
     assert _leaked(temp_root) == []
 
@@ -199,3 +195,19 @@ def test_configured_workspace_is_never_removed(
         current_tool_context.reset(token)
 
     assert keeper.read_text(encoding="utf-8") == "keep"
+
+
+def test_tempdir_cleanup_on_setup_exception(
+    temp_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ephemeral workdir must be cleaned up even if an exception occurs during setup."""
+
+    def _boom_env() -> dict[str, str]:
+        raise RuntimeError("setup env failure")
+
+    monkeypatch.setattr(code_exec, "_build_safe_env", _boom_env)
+
+    with pytest.raises(RuntimeError, match="setup env failure"):
+        asyncio.run(code_exec.execute_code("print(1)"))
+
+    assert _leaked(temp_root) == []


### PR DESCRIPTION
Fixes #1363
Fixes #1248

### Summary of Changes
- Move the `try:` block in `src/agentos/tools/builtin/code_exec.py` to encompass the workdir resolution and `tempfile.mkdtemp` allocation.
- Guarantees that any setup exception or early exit occurring after ephemeral workdir creation is properly cleaned up via `finally:`.
- Added unit test `test_tempdir_cleanup_on_setup_exception` to `tests/test_tools/test_code_exec_tempdir_cleanup.py`.

### Quality Gate Verification
- Passed `uv run pytest tests/test_tools/test_code_exec_tempdir_cleanup.py -q` (8/8 passed)
- Passed `uv run ruff check`
- Passed `uv run ruff format`
- Passed `uv run mypy`
