### PR TITLE
fix(telegram): retry polling callbacks before advancing the poll offset

### DIFF
--- a/src/agentos/channels/_util.py
+++ b/src/agentos/channels/_util.py
@@ -117,6 +117,19 @@ class EventDedupeCache:
             self._seen.popitem(last=False)
         return True
 
+    def __contains__(self, event_id: str) -> bool:
+        """Non-mutating membership check.
+
+        A caller that needs to retry before marking an id as resolved (e.g.
+        a bounded retry loop) cannot use ``check_and_add`` for the initial
+        check: it marks the id as seen on the very first look, so a later
+        legitimate retry of the same id would be misread as a duplicate and
+        skipped instead of retried. This lets that caller peek first and
+        call ``check_and_add`` only once resolution (success or giving up)
+        actually happens.
+        """
+        return event_id in self._seen
+
 
 @dataclass
 class RateLimiter:

--- a/src/agentos/channels/telegram.py
+++ b/src/agentos/channels/telegram.py
@@ -189,6 +189,11 @@ class TelegramChannel:
     supports_slash_commands: bool = True
     typing_keepalive_interval_s: ClassVar[float] = 4.0
     MAX_FILE_BYTES: ClassVar[int] = 50 * 1024 * 1024
+    # Total attempts (including the first) a failing callback_query update
+    # gets across poll cycles before the poller gives up on it and advances
+    # past it anyway. Bounded so one permanently-failing callback cannot
+    # stall the whole poll loop behind it forever.
+    MAX_CALLBACK_ATTEMPTS: ClassVar[int] = 3
     policy: ChannelAccessPolicy = field(
         default_factory=lambda: ChannelAccessPolicy(
             dm_allowed=True,
@@ -205,6 +210,9 @@ class TelegramChannel:
     _poll_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _update_offset: int | None = field(default=None, init=False, repr=False)
     _dedupe: EventDedupeCache = field(init=False, repr=False)
+    # update_id -> attempts made so far for a callback_query that raised.
+    # Popped on success or once MAX_CALLBACK_ATTEMPTS is reached.
+    _callback_attempts: dict[int, int] = field(default_factory=dict, init=False, repr=False)
     _connected: bool = field(default=False, init=False, repr=False)
     _last_message_at: datetime | None = field(default=None, init=False, repr=False)
     _known_sender_profiles: dict[str, dict[str, str]] = field(
@@ -637,26 +645,87 @@ class TelegramChannel:
                 continue
             if not isinstance(updates, list):
                 updates = []
+            stalled = False
             for update in updates:
                 if not isinstance(update, dict):
                     continue
                 update_id = update.get("update_id")
+                if "callback_query" in update:
+                    if not await self._handle_polled_callback(update_id, update["callback_query"]):
+                        # Left un-acknowledged so the retry lands on the next
+                        # getUpdates call; stop here so nothing later in this
+                        # batch is processed ahead of the failed update.
+                        stalled = True
+                        break
+                    continue
                 if isinstance(update_id, int):
                     self._update_offset = update_id + 1
-                if "callback_query" in update:
-                    try:
-                        await self._handle_telegram_callback(update["callback_query"])
-                    except Exception as exc:
-                        log.warning("telegram.callback_query_handle_failed", error=str(exc))
-                    continue
                 try:
                     msg = self.parse_incoming(update)
                 except ValueError:
                     log.debug("telegram.unsupported_update_ignored", update_id=update_id)
                     continue
                 self.enqueue(msg)
-            if not updates:
+            if stalled or not updates:
                 await asyncio.sleep(self.config.poll_idle_sleep_s)
+
+    async def _handle_polled_callback(self, update_id: Any, cb: dict[str, Any]) -> bool:
+        """Handle one polled ``callback_query`` update.
+
+        Returns True once the offset may advance past *update_id* — the
+        callback was just handled, it was already resolved on a prior poll
+        (guards against a genuine Telegram redelivery of an id already
+        finished with; ``enqueue()`` gives the message path the same
+        protection via ``_dedupe``), or the retry budget is spent and it is
+        time to give up rather than stall the poll loop on one bad update
+        forever. Returns False to leave the update un-acknowledged: the
+        offset does not advance, so the next ``getUpdates`` call re-delivers
+        the same update for another attempt.
+        """
+        dedupe_key = f"callback:{update_id}" if isinstance(update_id, int) else None
+        if dedupe_key is not None and dedupe_key in self._dedupe:
+            self._advance_offset(update_id)
+            return True
+
+        try:
+            await self._handle_telegram_callback(cb)
+        except Exception as exc:
+            if not isinstance(update_id, int):
+                # No stable id to key a retry on; best effort as before.
+                log.warning("telegram.callback_query_handle_failed", error=str(exc))
+                return True
+            attempts = self._callback_attempts.get(update_id, 0) + 1
+            if attempts < self.MAX_CALLBACK_ATTEMPTS:
+                self._callback_attempts[update_id] = attempts
+                log.warning(
+                    "telegram.callback_query_handle_failed",
+                    error=str(exc),
+                    update_id=update_id,
+                    attempt=attempts,
+                    max_attempts=self.MAX_CALLBACK_ATTEMPTS,
+                )
+                return False
+            log.error(
+                "telegram.callback_query_permanently_failed",
+                error=str(exc),
+                update_id=update_id,
+                attempts=attempts,
+            )
+            self._callback_attempts.pop(update_id, None)
+            if dedupe_key is not None:
+                self._dedupe.check_and_add(dedupe_key)
+            self._advance_offset(update_id)
+            return True
+
+        self._callback_attempts.pop(update_id, None)
+        if dedupe_key is not None:
+            self._dedupe.check_and_add(dedupe_key)
+        self._advance_offset(update_id)
+        return True
+
+    def _advance_offset(self, update_id: Any) -> None:
+        if isinstance(update_id, int):
+            self._update_offset = update_id + 1
 
     def _get_updates_payload(self) -> dict[str, Any]:
         payload: dict[str, Any] = {

--- a/tests/test_channels/test_telegram_poll_callback_retry.py
+++ b/tests/test_channels/test_telegram_poll_callback_retry.py
@@ -1,0 +1,180 @@
+"""Telegram polling must not advance its offset before a callback_query
+succeeds (#1027).
+
+Advancing ``_update_offset`` before ``_handle_telegram_callback`` runs, and
+swallowing its exception, permanently loses the update on a transient
+failure: Telegram never redelivers an update_id once the poller has asked
+for anything past it. These tests cover the acceptance criteria from the
+issue: bounded retry without advancing past the failed update, later
+updates in the same batch held back until it resolves, no reprocessing once
+it does resolve, and a bounded give-up so one permanently-failing callback
+cannot stall the poll loop forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+
+import pytest
+
+from agentos.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+
+def _channel(**overrides: Any) -> TelegramChannel:
+    return TelegramChannel(TelegramChannelConfig(token="test-token", **overrides))
+
+
+@pytest.mark.asyncio
+async def test_handle_polled_callback_retries_before_advancing_offset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = _channel()
+    attempts = 0
+
+    async def flaky_handler(cb: dict) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient handler failure")
+
+    monkeypatch.setattr(channel, "_handle_telegram_callback", flaky_handler)
+
+    # First attempt fails: must not acknowledge past the failed update.
+    handled = await channel._handle_polled_callback(10, {"id": "cb-1"})
+    assert handled is False
+    assert channel._update_offset is None
+    assert channel._callback_attempts == {10: 1}
+
+    # Retry (the next poll cycle re-delivers the same update_id) succeeds.
+    handled = await channel._handle_polled_callback(10, {"id": "cb-1"})
+    assert handled is True
+    assert channel._update_offset == 11
+    assert channel._callback_attempts == {}
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_handle_polled_callback_gives_up_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = _channel()
+
+    async def always_fails(cb: dict) -> None:
+        raise RuntimeError("permanent handler failure")
+
+    monkeypatch.setattr(channel, "_handle_telegram_callback", always_fails)
+
+    for expected_attempt in range(1, TelegramChannel.MAX_CALLBACK_ATTEMPTS):
+        handled = await channel._handle_polled_callback(20, {"id": "cb-2"})
+        assert handled is False
+        assert channel._update_offset is None
+        assert channel._callback_attempts == {20: expected_attempt}
+
+    # The attempt that reaches the budget gives up instead of retrying
+    # again, so a permanently-failing callback cannot stall the loop.
+    handled = await channel._handle_polled_callback(20, {"id": "cb-2"})
+    assert handled is True
+    assert channel._update_offset == 21
+    assert channel._callback_attempts == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_polled_callback_does_not_reprocess_resolved_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = _channel()
+    calls = 0
+
+    async def handler(cb: dict) -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(channel, "_handle_telegram_callback", handler)
+
+    assert await channel._handle_polled_callback(30, {"id": "cb-3"}) is True
+    assert calls == 1
+
+    # A genuine redelivery of an update_id already resolved (e.g. Telegram
+    # resending after we've already advanced past it) must not double-fire
+    # the handler's side effects (double-answering the callback query,
+    # double-toggling an approval).
+    assert await channel._handle_polled_callback(30, {"id": "cb-3"}) is True
+    assert calls == 1
+    assert channel._update_offset == 31
+
+
+@pytest.mark.asyncio
+async def test_handle_polled_callback_without_int_update_id_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No stable id to retry against: fall back to the old best-effort
+    behavior (log and move on) rather than crash or stall forever."""
+    channel = _channel()
+
+    async def always_fails(cb: dict) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(channel, "_handle_telegram_callback", always_fails)
+
+    handled = await channel._handle_polled_callback(None, {"id": "cb-4"})
+    assert handled is True
+    assert channel._update_offset is None
+    assert channel._callback_attempts == {}
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_holds_back_later_updates_until_failed_one_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = _channel(poll_idle_sleep_s=0.01)
+    handled_ids: list[str] = []
+    failed_once = False
+
+    async def flaky_callback(cb: dict) -> None:
+        nonlocal failed_once
+        cb_id = cb["id"]
+        if cb_id == "cb-fail" and not failed_once:
+            failed_once = True
+            raise RuntimeError("transient handler failure")
+        handled_ids.append(cb_id)
+
+    monkeypatch.setattr(channel, "_handle_telegram_callback", flaky_callback)
+
+    batch = [
+        {"update_id": 1, "callback_query": {"id": "cb-fail"}},
+        {"update_id": 2, "callback_query": {"id": "cb-later"}},
+    ]
+    get_updates_calls: list[dict] = []
+
+    async def fake_api(method: str, payload: dict | None = None) -> Any:
+        if method == "getUpdates":
+            get_updates_calls.append(payload or {})
+            # Telegram keeps returning the same batch until our offset
+            # moves past update_id=1 -- exactly what "redelivery" means.
+            if (payload or {}).get("offset") is None:
+                return list(batch)
+            return []
+        return True
+
+    monkeypatch.setattr(channel, "_api", fake_api)
+
+    task = asyncio.create_task(channel._poll_loop())
+    try:
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if handled_ids == ["cb-fail", "cb-later"]:
+                break
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    # Both were eventually handled, cb-fail before cb-later, and only once
+    # each -- cb-later was never touched while cb-fail was still pending.
+    assert handled_ids == ["cb-fail", "cb-later"]
+    assert channel._update_offset == 3
+    # At least one getUpdates call happened with no offset yet (the failed
+    # attempt), proving the offset had not advanced past update_id=1.
+    assert any(call.get("offset") is None for call in get_updates_calls)


### PR DESCRIPTION
Summary
closes #1027 

Core fix: _handle_polled_callback only advances _update_offset past an update once it's actually resolved — success, or giving up after MAX_CALLBACK_ATTEMPTS (3) failures. _poll_loop breaks out of the batch on a still-retryable failure instead of continuing, so a later update in the same batch is never processed ahead of one still pending retry. The existing idle-sleep still runs either way, so retries are paced, not hot-looped.
Bounded retry: a permanently-failing callback gets 3 attempts total, then is logged at error and skipped — so one poison update can't stall the poll loop forever.
Dedup on the callback path: added a non-mutating __contains__ to EventDedupeCache (its existing check_and_add would have broken retries, since it marks an id seen on the very first look). The callback path now peeks before attempting and only marks resolved-or-given-up ids, so a genuine Telegram redelivery of an already-finished update doesn't double-handle it — without interfering with in-progress retries.
Webhook mode untouched, per the issue's explicit scope.
5 new regression tests, 4 confirmed to fail against the pre-fix code (the fifth — no stable id — is a defensive fallback case with no prior behavior to regress against). Full channels suite (422 tests) passes, ruff/mypy clean.

