### PR TITLE
perf(gateway): bound the sessions.send freshness probe to one row

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -1080,7 +1080,20 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
         nonlocal message_text, persisted_entry, fresh_user_session
         get_transcript = getattr(ctx.session_manager, "get_transcript", None)
         if callable(get_transcript):
-            fresh_user_session = not bool(await get_transcript(key))
+            # Only emptiness is being asked, so one row answers it. Unbounded,
+            # this reads and deserialises the session's whole history on every
+            # user message -- `SessionStorage.get_transcript` turns `limit=None`
+            # into `LIMIT -1` and builds a `TranscriptEntry` per row. A 5k-entry
+            # session cost ~135ms against ~4ms for a single row, on the send
+            # path rather than a background job.
+            #
+            # The call is duck-typed, and session managers that predate the
+            # `limit` parameter (fakes included) accept the key alone, so the
+            # bound is only passed when the callable declares it.
+            if accepts_keyword_arg(get_transcript, "limit"):
+                fresh_user_session = not bool(await get_transcript(key, limit=1))
+            else:
+                fresh_user_session = not bool(await get_transcript(key))
         if raw_attachments:
             from agentos.gateway.transcripts import (
                 build_transcript_attachment_envelope,

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -776,6 +776,24 @@ class TestSessionsList:
         assert manager._storage.list_agent_tasks_calls == []
 
 
+class _LimitAwareSessionManager(FakeSessionManager):
+    """A session manager whose ``get_transcript`` declares the ``limit`` bound.
+
+    The plain :class:`FakeSessionManager` accepts the key alone, which is the
+    older duck-typed shape; this one records how the send path asked so the
+    bound itself can be asserted.
+    """
+
+    def __init__(self, sessions: list[FakeSession] | None = None) -> None:
+        super().__init__(sessions)
+        self.transcript_limits: list[int | None] = []
+
+    async def get_transcript(self, key: str, limit: int | None = None) -> list:
+        self.transcript_limits.append(limit)
+        entries = list(self.transcript)
+        return entries if limit is None else entries[:limit]
+
+
 class TestSessionsSend:
     @pytest.mark.asyncio
     async def test_send_valid(self, dispatcher, ctx_with_sessions, session):
@@ -852,6 +870,84 @@ class TestSessionsSend:
         assert (
             runtime.enqueue_calls[0]["envelope"].metadata.get("persisted_user_message_id") is None
         )
+
+    @pytest.mark.asyncio
+    async def test_send_probes_freshness_with_a_bounded_transcript_read(self, dispatcher):
+        """The freshness probe reads one row, not the whole history.
+
+        Only emptiness is being decided, but the unbounded read deserialised
+        every entry of the session on every user message -- on the send path,
+        so the cost grew with the conversation the user was still having.
+        """
+        session = FakeSession(session_key="agent:main:webchat:bounded-probe")
+        manager = _LimitAwareSessionManager([session])
+        manager.transcript = [SimpleNamespace(role="user", content=f"turn {i}") for i in range(500)]
+        runner = _RecordingTurnRunner()
+        ctx = make_ctx(session_manager=manager, task_runtime=None, turn_runner=runner)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.send",
+            {"key": session.session_key, "message": "hello"},
+            ctx,
+        )
+        task = get_agent_task_registry().get(session.session_key)
+        if task is not None:
+            await task
+
+        assert res.ok is True
+        assert manager.transcript_limits == [1]
+        assert runner.run_calls[0]["fresh_user_session"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_bounded_probe_still_reports_a_fresh_session(self, dispatcher):
+        """Bounding the read must not change the answer for an empty session."""
+        session = FakeSession(session_key="agent:main:webchat:bounded-fresh")
+        manager = _LimitAwareSessionManager([session])
+        manager.transcript = []
+        runner = _RecordingTurnRunner()
+        ctx = make_ctx(session_manager=manager, task_runtime=None, turn_runner=runner)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.send",
+            {"key": session.session_key, "message": "hello"},
+            ctx,
+        )
+        task = get_agent_task_registry().get(session.session_key)
+        if task is not None:
+            await task
+
+        assert res.ok is True
+        assert manager.transcript_limits == [1]
+        assert runner.run_calls[0]["fresh_user_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_omits_the_bound_for_a_manager_without_a_limit_parameter(self, dispatcher):
+        """A manager that predates ``limit`` is still called with the key alone.
+
+        The call is duck-typed, so passing the bound unconditionally would
+        raise ``TypeError`` against every such implementation rather than
+        merely reading more rows than needed.
+        """
+        session = FakeSession(session_key="agent:main:webchat:no-limit-param")
+        manager = FakeSessionManager([session])
+        manager.transcript = [SimpleNamespace(role="user", content="previous")]
+        runner = _RecordingTurnRunner()
+        ctx = make_ctx(session_manager=manager, task_runtime=None, turn_runner=runner)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.send",
+            {"key": session.session_key, "message": "hello"},
+            ctx,
+        )
+        task = get_agent_task_registry().get(session.session_key)
+        if task is not None:
+            await task
+
+        assert res.ok is True
+        assert runner.run_calls[0]["fresh_user_session"] is False
 
     @pytest.mark.asyncio
     async def test_send_marks_empty_transcript_as_fresh_user_session(self, dispatcher, session):


### PR DESCRIPTION
## Summary

`_persist_user_message` in `src/agentos/gateway/rpc_sessions.py` decided one boolean like this:

```python
get_transcript = getattr(ctx.session_manager, "get_transcript", None)
if callable(get_transcript):
    fresh_user_session = not bool(await get_transcript(key))
```

`SessionManager.get_transcript` defaults `limit` to `None`, and `SessionStorage.get_transcript` turns that into `LIMIT -1` (`storage.py:1243`, *"use -1 for unlimited"*), then builds a `TranscriptEntry` per row via `_deserialize_row`. So the session's entire history was read and deserialised to answer "is this transcript empty".

Measured on `upstream/main` (`cfba23c`) with a 5,000-entry session:

```
get_transcript()         ->  5000 rows    135.12 ms
get_transcript(limit=1)  ->     1 rows      4.39 ms
```

~31x, and it scales with the conversation. `_persist_user_message` runs on **every user message**, so this is not a background or list path — it sits on the send path of the conversation the user is currently having, and each of their turns gets slower as they talk.

Same waste #1186 describes for `sessions.preview`, different call site: PR #1187 changes line 2354 and the storage layer and does not touch this one.

## Changes

**`src/agentos/gateway/rpc_sessions.py`** (+13/-1)

```python
if _accepts_keyword_arg(get_transcript, "limit"):
    fresh_user_session = not bool(await get_transcript(key, limit=1))
else:
    fresh_user_session = not bool(await get_transcript(key))
```

The bound is not passed unconditionally on purpose. The call is duck-typed through `getattr`, and session managers that predate the `limit` parameter accept the key alone — the fake in `tests/test_gateway/test_rpc_sessions.py:211` is one, and `test_force_reset_drain.py` and `test_protocol_smoke.py` have others. Passing `limit=1` blind would turn "reads more rows than needed" into `TypeError` for all of them. `_accepts_keyword_arg` is already defined in this same file at line 66 and is the established convention here (it is used for `cancel`'s `source`/`reason` and for `compact_with_result`), so this reuses it rather than introducing a second pattern or a `try/except TypeError` that could swallow a genuine `TypeError` from inside the coroutine.

Nothing else changed: the resulting boolean, and everything downstream of `fresh_user_session`, is identical.

## Tests

**`tests/test_gateway/test_rpc_sessions.py`** — 3 new cases in `TestSessionsSend`, plus a `_LimitAwareSessionManager` that declares `limit` and records how the send path asked. All drive the real `sessions.send` dispatch and await the background task through `get_agent_task_registry()`, the same way the existing `fresh_user_session` tests do.

*Regression tests — these 2 fail on `upstream/main` (the probe is recorded as `[None]`) and pass with the fix:*

| Test | Covers |
|---|---|
| `test_send_probes_freshness_with_a_bounded_transcript_read` | 500-entry session → `transcript_limits == [1]` and `fresh_user_session is False` |
| `test_send_bounded_probe_still_reports_a_fresh_session` | empty session → `transcript_limits == [1]` and `fresh_user_session is True` |

*Guard test — passes in both states by construction; flagging that rather than counting it as a regression:*

| Test | Covers |
|---|---|
| `test_send_omits_the_bound_for_a_manager_without_a_limit_parameter` | a manager whose `get_transcript` takes the key alone still succeeds, and still reports `fresh_user_session is False` |

The two existing tests that assert this flag (`test_send_marks_empty_transcript_as_fresh_user_session`, `test_send_marks_non_empty_transcript_as_not_fresh_user_session`) were left untouched and still pass — they use the single-argument fake, so they exercise the fallback branch as a side effect.

## Status

- `uv run ruff check src tests` ✅
- `uv run mypy src/agentos --show-error-codes` ✅ (623 source files, no issues)
- `uv run pytest -q` ✅ **9689 passed, 30 skipped**, 0 failed
- Self-check: reverted `rpc_sessions.py` with `git checkout upstream/main -- <file>` and confirmed the 2 regression tests fail without the fix.
- `ruff format --diff` on the changed files reports one hunk, at `test_rpc_sessions.py:2148` — it is present on `upstream/main` unchanged and is not touched here. The lines added by this PR are format-clean.

Fixes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
