### PR TITLE
fix(gateway): reject invalid maxMessages in sessions.truncate

### DIFF
--- a/src/agentos/gateway/rpc_sessions.py
+++ b/src/agentos/gateway/rpc_sessions.py
@@ -2252,6 +2252,8 @@ async def _handle_sessions_truncate(params: dict | None, ctx: RpcContext) -> dic
         raise KeyError("No session manager available")
 
     max_messages = (params or {}).get("maxMessages", 20)
+    if isinstance(max_messages, bool) or not isinstance(max_messages, int) or max_messages < 0:
+        raise ValueError("params.maxMessages must be a non-negative integer")
     force = bool((params or {}).get("force", False))
 
     turn_runner = ctx.turn_runner

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2100,6 +2100,33 @@ class TestSessionsCompact:
 
 class TestSessionsTruncate:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_max_messages",
+        [
+            True,  # bool is an int subclass: would silently become 1 (keep only newest)
+            False,  # would silently become 0 (recent = []): wipes the whole transcript
+            "20",  # non-int: previously reached manager.truncate()'s `< 0` check and
+            # raised an unhandled TypeError, leaking as INTERNAL_ERROR
+            -1,
+            2.5,
+        ],
+    )
+    async def test_truncate_rejects_invalid_max_messages(
+        self, dispatcher, ctx_with_sessions, session, bad_max_messages
+    ):
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.truncate",
+            {"key": session.session_key, "maxMessages": bad_max_messages},
+            ctx_with_sessions,
+        )
+
+        assert res.ok is False
+        assert res.error.code == "INVALID_REQUEST"
+        # The destructive truncate must never be attempted with a bad param.
+        assert ctx_with_sessions.session_manager.truncate_calls == []
+
+    @pytest.mark.asyncio
     async def test_truncate_valid_preserves_hard_truncate_semantics(
         self, dispatcher, ctx_with_sessions, session
     ):


### PR DESCRIPTION
## Linked issue
Fixes #1371
- [x] This pull request fully resolves the linked issue

## Summary
`sessions.truncate`'s `maxMessages` param had no type validation at all.
Since `bool` is a subclass of `int` in Python, this value flowed straight
into slicing/comparison logic downstream:

- `maxMessages: false` -> `max_messages == 0` -> `recent = []` -> the
  entire transcript is silently wiped, with `ok: true`.
- `maxMessages: true` -> equivalent to `entries[-1:]` -> only the single
  most recent message survives.
- A non-int (e.g. `"20"`) reached `session_manager.truncate()`'s own
  `if max_messages < 0` check and raised an unhandled `TypeError`, which
  the dispatcher's catch-all turned into a raw `INTERNAL_ERROR` leaking
  the Python error string.

Same class of bug as #1261 (bool leaking through an unguarded
`isinstance(x, int)` check), but landing on a destructive operation
instead of just a misleading error code.

## Fix
Added an upfront validation gate matching the established idiom already
used in `rpc_system.py` (`timeoutMs`, `intervalMs`):

    if isinstance(max_messages, bool) or not isinstance(max_messages, int) or max_messages < 0:
        raise ValueError("params.maxMessages must be a non-negative integer")

Boolean-exclusion is checked before the `< 0` comparison so the validator
itself can never raise `TypeError` on a non-int input (short-circuit
evaluation) — verified against every input class (bool, str, float, None,
negative int, very large int). `maxMessages: 0` is deliberately still
accepted, since it's an existing, intentional "wipe" operation already
gated by the checkpoint/force safety check above this line — not something
this fix should touch.

Alternatives considered and rejected: coercing instead of rejecting (would
keep the semantic bug — `int(False) == 0` still wipes the transcript);
catching `TypeError` around the downstream call instead of validating
upfront (misses the bool case entirely, since bool comparisons don't
raise); fixing inside `session/manager.py`'s `truncate()` instead of at
the RPC boundary (out of this lane's scope, and inconsistent with where
every sibling validation in this file already lives).

## Tests
Added `test_truncate_rejects_invalid_max_messages` (parametrized over
`True`, `False`, `"20"`, `-1`, `2.5`) to `tests/test_gateway/test_rpc_sessions.py`,
asserting:
- `error.code == "INVALID_REQUEST"` for every case
- `session_manager.truncate_calls == []` — the destructive call is never
  attempted with a bad param

Confirmed as a real regression guard by reverting the fix locally and
rerunning: all 5 cases failed on unpatched code, including the `False`
case actually completing with `ok: true` (not just a wrong error code —
the fake manager recorded a real truncate call).

Commands run:
  uv run ruff check src/agentos/gateway/rpc_sessions.py tests/test_gateway/test_rpc_sessions.py
  uv run ruff format --check src/agentos/gateway/rpc_sessions.py tests/test_gateway/test_rpc_sessions.py
  uv run mypy src/agentos/gateway/rpc_sessions.py --show-error-codes
  uv run pytest tests/test_gateway/test_rpc_sessions.py -v

Results: ruff clean, mypy "Success: no issues found in 1 source file",
pytest 103 passed (98 existing + 5 new). ruff format --check flags one
pre-existing, unrelated line elsewhere in the file — confirmed present on
unmodified main independent of this diff, not introduced by it.

Third-party origin: none.

Verification

- `pytest tests/test_gateway/test_rpc_sessions.py -q` → 103 passed
- `ruff check src tests` → clean
- No existing test modified.

Regression test added per AGENTS.md: `test_truncate_rejects_invalid_max_messages`,
parametrized over `True`, `False`, `"20"`, `-1`, `2.5`. It asserts both the
`INVALID_REQUEST` code and `truncate_calls == []` — the destructive call must
never be attempted with a bad param, not merely fail afterwards.

Why 0 stays valid

`maxMessages: 0` is the intentional wipe, already gated by the existing
checkpoint/force safety check, and the issue asks for it to keep working.
`test_truncate_refuses_stale_checkpoint_for_later_removed_messages` depends on 0
reaching that gate, so rejecting `< 1` here would require editing that test and
would silently remove the refusal it exists to guard. This validation rejects
bools, non-ints and negatives only.

Error message

`params.maxMessages must be a non-negative integer` follows the `params.X must
be ...` convention already used in `rpc_sessions.py` (lines 402, 405, 874), and
matches the message the issue specifies. `ValueError` maps to `INVALID_REQUEST`
via `rpc/registry.py`, so a string value now returns a clean validation error
instead of the `TypeError` that was leaking as `INTERNAL_ERROR`.