### PR TITLE
fix(mcp): clamp events_wait's per-call timeout exactly, not approxima…

### DIFF
--- a/src/agentos/mcp_server/bridge.py
+++ b/src/agentos/mcp_server/bridge.py
@@ -157,10 +157,18 @@ class AgentOSMCPBridge:
             )
             max_events = _clamp_limit(max_events, _MAX_EVENTS_WAIT_EVENTS)
             timeout_ms = min(max(0, timeout_ms), _MAX_EVENTS_WAIT_TIMEOUT_MS)
-            deadline = time.monotonic() + timeout_ms / 1000
+            effective_timeout_s = timeout_ms / 1000
+            deadline = time.monotonic() + effective_timeout_s
 
             while len(events) < max_events:
-                remaining = deadline - time.monotonic()
+                # min(..., effective_timeout_s): deadline - time.monotonic()
+                # can round *above* effective_timeout_s by a few nanoseconds
+                # of float error (two monotonic() readings added and
+                # subtracted back rarely cancel exactly at large clock
+                # values), which would hand recv_event a timeout a hair
+                # over the caller's clamp. The clamp is the contract; the
+                # min() makes it exact instead of "usually exact".
+                remaining = min(deadline - time.monotonic(), effective_timeout_s)
                 if remaining <= 0:
                     break
                 try:

--- a/tests/_symlink_support.py
+++ b/tests/_symlink_support.py
@@ -1,0 +1,41 @@
+"""Shared symlink-capability probe for tests that exercise real symlinks.
+
+Deliberately not named conftest.py: tests/test_skills/conftest.py already
+claims that bare module name, and neither tests/ nor its subdirectories
+carry __init__.py, so two files both named "conftest" would race for the
+same entry in sys.modules — whichever pytest imports first wins that name
+for the rest of the session, and any other file's `from conftest import X`
+resolves to whichever one won, not necessarily the one in the same
+directory. A uniquely-named module sidesteps that entirely.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+
+def _symlinks_supported() -> bool:
+    """Probe whether this process can actually create filesystem symlinks.
+
+    Windows requires SeCreateSymbolicLinkPrivilege — Developer Mode enabled,
+    or an elevated process — to call os.symlink(); without it every symlink
+    test fails identically with OSError: [WinError 1314]. Detected with a
+    real create-in-tempdir probe rather than a bare `sys.platform == "win32"`
+    check: Windows with Developer Mode on (or running elevated) supports
+    symlinks fine, and gating on OS name alone would skip tests that could
+    actually run there.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            target.write_text("x", encoding="utf-8")
+            (Path(tmp) / "link").symlink_to(target)
+        return True
+    except OSError:
+        return False
+
+
+#: Shared skip condition for tests that exercise real symlink creation.
+#: Usage: @pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="...")
+SYMLINKS_SUPPORTED = _symlinks_supported()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,3 +18,29 @@ os.environ.setdefault("AGENTOS_TURN_CALL_LOG", "0")
 # is cold. Default tests must stay offline; tests that exercise the refresh
 # opt back in with monkeypatch.setenv.
 os.environ.setdefault("AGENTOS_OPENCAP_LIVE_PRICING", "0")
+
+
+def _symlinks_supported() -> bool:
+    """Probe whether this process can actually create filesystem symlinks.
+
+    Windows requires SeCreateSymbolicLinkPrivilege — Developer Mode enabled,
+    or an elevated process — to call os.symlink(); without it every symlink
+    test fails identically with OSError: [WinError 1314]. Detected with a
+    real create-in-tempdir probe rather than a bare `sys.platform == "win32"`
+    check: Windows with Developer Mode on (or running elevated) supports
+    symlinks fine, and gating on OS name alone would skip tests that could
+    actually run there.
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            target.write_text("x", encoding="utf-8")
+            (Path(tmp) / "link").symlink_to(target)
+        return True
+    except OSError:
+        return False
+
+
+#: Shared skip condition for tests that exercise real symlink creation.
+#: Usage: @pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="...")
+SYMLINKS_SUPPORTED = _symlinks_supported()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,29 +18,3 @@ os.environ.setdefault("AGENTOS_TURN_CALL_LOG", "0")
 # is cold. Default tests must stay offline; tests that exercise the refresh
 # opt back in with monkeypatch.setenv.
 os.environ.setdefault("AGENTOS_OPENCAP_LIVE_PRICING", "0")
-
-
-def _symlinks_supported() -> bool:
-    """Probe whether this process can actually create filesystem symlinks.
-
-    Windows requires SeCreateSymbolicLinkPrivilege — Developer Mode enabled,
-    or an elevated process — to call os.symlink(); without it every symlink
-    test fails identically with OSError: [WinError 1314]. Detected with a
-    real create-in-tempdir probe rather than a bare `sys.platform == "win32"`
-    check: Windows with Developer Mode on (or running elevated) supports
-    symlinks fine, and gating on OS name alone would skip tests that could
-    actually run there.
-    """
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
-            target = Path(tmp) / "target"
-            target.write_text("x", encoding="utf-8")
-            (Path(tmp) / "link").symlink_to(target)
-        return True
-    except OSError:
-        return False
-
-
-#: Shared skip condition for tests that exercise real symlink creation.
-#: Usage: @pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="...")
-SYMLINKS_SUPPORTED = _symlinks_supported()

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -392,6 +392,42 @@ async def test_events_wait_remaining_never_exceeds_effective_timeout(
 
 
 @pytest.mark.asyncio
+async def test_events_wait_remaining_pinned_clock_reading_from_1264(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1264's exact deterministic repro: a *single* time.monotonic() reading
+    used for both the deadline and the first "remaining" computation. Real
+    calls are microseconds apart, but the rounding artifact this guards
+    against doesn't need two different readings -- (t + 300.0) - t fails to
+    cancel back to exactly 300.0 for this specific t on its own, landing at
+    300.0000000000018 pre-fix. #1264 sampled ~400k plausible monotonic()
+    values and found this shape on about 1 in 1700 of them, which is what
+    made test_events_wait_clamps_effective_deadline (above) an intermittent
+    Windows CI flake on unrelated pull requests rather than a local
+    reproduction anyone could pin down.
+
+    Rebinds the module-level `time` name (as the other rounding test above
+    does) rather than mutating the real time module's .monotonic attribute,
+    which would also corrupt asyncio's own internal timing during the test.
+    """
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    class _FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return 16330.771337564662
+
+    monkeypatch.setattr(bridge_module, "time", _FakeTime())
+
+    await bridge.events_wait("agent:main:main", timeout_ms=3_600_000)
+
+    assert client.recv_timeouts
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout == bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
+
+
+@pytest.mark.asyncio
 async def test_events_wait_preserves_timeout_below_the_cap() -> None:
     client = RecordingEventClient()
     bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -357,6 +357,41 @@ async def test_events_wait_clamps_effective_deadline() -> None:
 
 
 @pytest.mark.asyncio
+async def test_events_wait_remaining_never_exceeds_effective_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """deadline - time.monotonic() can round a hair above the intended
+    clamp: two time.monotonic() readings added and then subtracted back
+    rarely cancel exactly in float64 once the clock's base value is large
+    (a long-uptime CI runner, say), so the per-call recv timeout must be
+    clamped explicitly rather than trusted to always come out <=
+    effective_timeout_s on its own."""
+    client = RecordingEventClient()
+    bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)
+
+    # First call computes the deadline; second computes the first
+    # "remaining", using a reading fractionally *before* the first -- the
+    # same shape a real float64 rounding artifact produces. Rebinding the
+    # module-level `time` name (rather than mutating the real time module)
+    # keeps this from also breaking asyncio's own internal timing.
+    readings = iter([1_000_000.0, 999_999.9999999])
+
+    class _FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return next(readings)
+
+    monkeypatch.setattr(bridge_module, "time", _FakeTime())
+
+    await bridge.events_wait("agent:main:main", timeout_ms=3_600_000)
+
+    assert client.recv_timeouts
+    first_timeout = client.recv_timeouts[0]
+    assert first_timeout is not None
+    assert first_timeout <= bridge_module._MAX_EVENTS_WAIT_TIMEOUT_MS / 1000
+
+
+@pytest.mark.asyncio
 async def test_events_wait_preserves_timeout_below_the_cap() -> None:
     client = RecordingEventClient()
     bridge = AgentOSMCPBridge(gateway_client_factory=lambda: client)

--- a/tests/test_memory_curated_durability.py
+++ b/tests/test_memory_curated_durability.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 import pytest
-from conftest import SYMLINKS_SUPPORTED
+from _symlink_support import SYMLINKS_SUPPORTED
 
 from agentos.memory.curated import (
     _CONSOLIDATION_FAILURE_WINDOW_S,

--- a/tests/test_memory_curated_durability.py
+++ b/tests/test_memory_curated_durability.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 
 import pytest
+from conftest import SYMLINKS_SUPPORTED
 
 from agentos.memory.curated import (
     _CONSOLIDATION_FAILURE_WINDOW_S,
@@ -150,6 +151,7 @@ def test_drift_still_detected_and_backed_up(store: CuratedMemoryStore, tmp_path:
 # -- atomic replace preserves symlinks -------------------------------------
 
 
+@pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="platform/user lacks symlink privilege")
 def test_write_through_symlink_keeps_the_symlink(tmp_path: Path):
     """Deployments symlink MEMORY.md into dotfiles; a write must not detach it."""
     real_dir = tmp_path / "real"

--- a/tests/test_scheduler/test_script_jobs.py
+++ b/tests/test_scheduler/test_script_jobs.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from conftest import SYMLINKS_SUPPORTED
 
 from agentos.scheduler.delivery import DeliveryChain
 from agentos.scheduler.handlers import make_script_run_handler
@@ -100,6 +101,7 @@ def test_absolute_path_outside_scripts_dir_is_blocked(agentos_home):
         resolve_script_path("/etc/passwd")
 
 
+@pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="platform/user lacks symlink privilege")
 def test_symlink_escape_is_blocked(agentos_home, tmp_path):
     outside = tmp_path / "outside.py"
     outside.write_text("print('pwned')", encoding="utf-8")

--- a/tests/test_scheduler/test_script_jobs.py
+++ b/tests/test_scheduler/test_script_jobs.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from conftest import SYMLINKS_SUPPORTED
+from _symlink_support import SYMLINKS_SUPPORTED
 
 from agentos.scheduler.delivery import DeliveryChain
 from agentos.scheduler.handlers import make_script_run_handler

--- a/tests/test_skills_hub_download_security.py
+++ b/tests/test_skills_hub_download_security.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from conftest import SYMLINKS_SUPPORTED
+from _symlink_support import SYMLINKS_SUPPORTED
 
 from agentos.skills.hub import deps
 from agentos.skills.install_kinds import InstallSpecError

--- a/tests/test_skills_hub_download_security.py
+++ b/tests/test_skills_hub_download_security.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import SYMLINKS_SUPPORTED
 
 from agentos.skills.hub import deps
 from agentos.skills.install_kinds import InstallSpecError
@@ -67,6 +68,7 @@ def test_resolve_download_dest_accepts_a_plain_binary_name(fake_home: Path) -> N
     assert dest == fake_home / ".local" / "bin" / "ripgrep"
 
 
+@pytest.mark.skipif(not SYMLINKS_SUPPORTED, reason="platform/user lacks symlink privilege")
 def test_resolve_download_dest_refuses_to_write_through_a_symlink(fake_home: Path) -> None:
     outside = fake_home / "secret.txt"
     outside.write_text("original", encoding="utf-8")


### PR DESCRIPTION
…tely

Found while investigating an unrelated PR's CI failure on Windows: tests/test_mcp_server/test_bridge.py::test_events_wait_clamps_effective_deadline failed with "300.000000006 <= 300.0" is False.

events_wait computed deadline = time.monotonic() + effective_timeout_s, then remaining = deadline - time.monotonic() on each loop iteration. Two time.monotonic() readings added and then subtracted back do not always cancel exactly in float64 once the clock's base value is large (a long-uptime machine, e.g. a CI runner) — the addition and subtraction round at different magnitudes, leaving a residual error of a few nanoseconds. That residual can land on either side of zero, so remaining could come out a hair *above* the intended clamp instead of at or below it. This is a real, if tiny, correctness bug: the per-call recv_event timeout could exceed the caller-visible ceiling (_MAX_EVENTS_WAIT_TIMEOUT_MS) by a few nanoseconds — the test just happened to be what caught it, and only reliably on Windows, where the runner's specific monotonic-clock base value made the rounding land on the wrong side.

Fix: remaining = min(deadline - time.monotonic(), effective_timeout_s). The clamp is the contract; the min() makes the first iteration's remaining honor it exactly instead of "almost always."

Added a regression test that reproduces the failure deterministically (no reliance on real clock timing or CI environment specifics): fakes time.monotonic() with two readings whose difference is a well-known constant not exactly representable in float64, producing the same "~300.0000001" overshoot the flake did, every time. Confirmed to fail against the pre-fix code with the exact same assertion shape as the CI failure. Rebinds the module-level `time` name rather than mutating the real time module, so it does not also break asyncio's own internal timing during the test.

